### PR TITLE
chore(ci): add dependabot config for cargo and actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      cargo-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      github-actions:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` so Dependabot opens weekly update PRs for:

- **`cargo`** at the repo root — minor/patch updates grouped into one PR to keep noise low; majors land as individual PRs.
- **`github-actions`** — `directory` is `/` per Dependabot's schema for this ecosystem; Dependabot always scans `.github/workflows/` from the repo root. Minor/patch grouped likewise.

Both ecosystems use a `chore` commit prefix with scope, matching the Conventional Commits style required by `AGENTS.md`.

## Validation

Config-only change with no runtime impact, so smoke tests are skipped per `specs/shipping.md`. YAML follows the Dependabot v2 schema (`version: 2`, `package-ecosystem`, `directory`, `schedule.interval`, `groups`); GitHub validates the file on push and surfaces errors on the repo's Insights → Dependency graph → Dependabot tab. CI is green.

## Security

No security-relevant code changes — this only configures GitHub's first-party Dependabot service. Future dependency-bump PRs from Dependabot are themselves subject to normal CI and review, including the security review described in `specs/shipping.md`.

## Follow-ups

No follow-ups.