### PR TITLE
test(tui): end-to-end streaming tests against llmsim

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -181,7 +181,7 @@ pub struct ActivityStatus {
 }
 
 #[derive(Debug)]
-enum TurnEvent {
+pub(crate) enum TurnEvent {
     Lines(Vec<ChatLine>),
     Activity(ActivityStatus),
     /// Replace the live streaming preview shown above the input.
@@ -794,13 +794,13 @@ impl App {
 /// preview as soon as a matching `*.completed` arrives. Per-turn state
 /// — one `DeltaRouter` per `start_turn` invocation.
 #[derive(Default)]
-struct DeltaRouter {
+pub(crate) struct DeltaRouter {
     last_assistant_turn: Option<everruns_core::typed_id::TurnId>,
     last_thinking_turn: Option<everruns_core::typed_id::TurnId>,
     last_tool_call: Option<String>,
 }
 
-fn handle_live_event(
+pub(crate) fn handle_live_event(
     event: &RuntimeEvent,
     emitted_events: &mut HashSet<String>,
     router: &mut DeltaRouter,

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,9 @@ mod runtime;
 mod session_log;
 mod tools;
 
+#[cfg(test)]
+mod streaming_tests;
+
 use anyhow::Result;
 use app::{App, COMPOSER_VIEWPORT_HEIGHT};
 use approval::ApprovalGate;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -775,12 +775,42 @@ impl ModelState {
     }
 }
 
+/// Optional knobs for [`build`]. Lets the streaming integration tests
+/// replace the bundled llmsim config (which is sized for offline demos
+/// — too short and too fast to ever cross the runtime's 100ms delta
+/// batch window) with one that produces real multi-delta streams. All
+/// fields default to "no override" so callers that don't care keep the
+/// existing behavior.
+#[derive(Default)]
+pub struct BuildOptions {
+    pub llmsim_override: Option<LlmSimConfig>,
+}
+
 pub async fn build(
     workspace_root: PathBuf,
     provider: ProviderChoice,
     gate: Arc<ApprovalGate>,
     resume_session_id: Option<SessionId>,
     sessions_dir: PathBuf,
+) -> Result<BuiltRuntime> {
+    build_with_options(
+        workspace_root,
+        provider,
+        gate,
+        resume_session_id,
+        sessions_dir,
+        BuildOptions::default(),
+    )
+    .await
+}
+
+pub async fn build_with_options(
+    workspace_root: PathBuf,
+    provider: ProviderChoice,
+    gate: Arc<ApprovalGate>,
+    resume_session_id: Option<SessionId>,
+    sessions_dir: PathBuf,
+    options: BuildOptions,
 ) -> Result<BuiltRuntime> {
     let canonical_root = std::fs::canonicalize(&workspace_root)
         .with_context(|| format!("canonicalize workspace: {}", workspace_root.display()))?;
@@ -933,13 +963,14 @@ pub async fn build(
         });
     // Always register the llmsim driver so the `/model llmsim` switch works
     // mid-session, even if the user started with anthropic or openai.
-    builder = builder.llm_sim(
+    let llmsim_config = options.llmsim_override.unwrap_or_else(|| {
         LlmSimConfig::fixed(
             "I'm running in offline mode (llmsim — no API key set). \
              Set ANTHROPIC_API_KEY or OPENAI_API_KEY for real responses.",
         )
-        .with_model("llmsim-yolop"),
-    );
+        .with_model("llmsim-yolop")
+    });
+    builder = builder.llm_sim(llmsim_config);
     let runtime = builder.build().await?;
 
     let context = runtime.load_context(session_id).await?;

--- a/src/streaming_tests.rs
+++ b/src/streaming_tests.rs
@@ -1,0 +1,244 @@
+//! End-to-end streaming tests.
+//!
+//! These tests drive a real `InProcessRuntime` (via `runtime::build`)
+//! against the bundled llmsim driver, which emits real per-token chunks
+//! through its `TokenStreamBuilder`. We then assert the full pipeline:
+//!
+//!   llmsim driver chunks → reason atom → JsonlEventEmitter::emit →
+//!   broadcast channel → `app::handle_live_event` → `TurnEvent::Stream`
+//!
+//! The unit tests in `app.rs` cover the renderer in isolation with
+//! synthetic events; these tests cover the wiring that turns those
+//! synthetic assumptions into real behavior.
+
+use std::collections::HashSet;
+use std::time::Duration;
+
+use everruns_core::events::EventData;
+use tokio::sync::mpsc;
+
+use everruns_core::llmsim_driver::LlmSimConfig;
+
+use crate::app::{DeltaRouter, StreamKind, TurnEvent, handle_live_event};
+use crate::approval::ApprovalGate;
+use crate::runtime::{BuildOptions, ProviderChoice, build_with_options};
+
+/// Maximum wall time we wait for the llmsim turn to fully drain
+/// through the broadcast. The instant-latency llmsim profile finishes
+/// in <100ms locally; the buffer is generous so a slow CI box won't
+/// flake.
+const TURN_TIMEOUT: Duration = Duration::from_secs(15);
+
+async fn build_llmsim_runtime() -> crate::runtime::BuiltRuntime {
+    let workspace = tempfile::tempdir().expect("workspace tempdir");
+    let sessions = tempfile::tempdir().expect("sessions tempdir");
+    // tempdirs intentionally leak past the test body: the runtime
+    // canonicalizes the workspace path, so we keep the handle alive
+    // by std::mem::forget'ing it — these are tmpfs paths under the
+    // OS-managed temp tree, so the OS cleans them.
+    //
+    // Use a lorem-200 response with simulate_latency enabled
+    // (LatencyProfile::fast → ~1ms/token TBT). 200 tokens × 1ms ≈
+    // 200ms wall-clock, which crosses the reason atom's 100ms delta
+    // batch window twice. Without this the bundled fixed message
+    // streams in <1ms and the batcher coalesces every chunk into a
+    // single OutputMessageDelta.
+    let llmsim = LlmSimConfig::lorem(200)
+        .with_latency()
+        .with_model("llmsim-yolop");
+    let runtime = build_with_options(
+        workspace.path().to_path_buf(),
+        ProviderChoice::Sim,
+        ApprovalGate::auto(),
+        None,
+        sessions.path().to_path_buf(),
+        BuildOptions {
+            llmsim_override: Some(llmsim),
+        },
+    )
+    .await
+    .expect("build llmsim runtime");
+    std::mem::forget(workspace);
+    std::mem::forget(sessions);
+    runtime
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn llmsim_emits_multiple_output_message_deltas_on_broadcast() {
+    let runtime = build_llmsim_runtime().await;
+    let handles = runtime.handles.clone();
+    let mut live = handles.events.subscribe();
+
+    let session_id = handles.session_id;
+    let input = runtime.model.input_message("anything");
+    let runtime_clone = handles.runtime.clone();
+    let turn = tokio::spawn(async move { runtime_clone.run_turn(session_id, input).await });
+
+    let mut deltas: Vec<String> = Vec::new();
+    let mut got_completed = false;
+    let deadline = tokio::time::Instant::now() + TURN_TIMEOUT;
+    while !got_completed && tokio::time::Instant::now() < deadline {
+        let remaining = deadline - tokio::time::Instant::now();
+        match tokio::time::timeout(remaining, live.recv()).await {
+            Ok(Ok(event)) => match &event.data {
+                EventData::OutputMessageDelta(d) => deltas.push(d.accumulated.clone()),
+                EventData::OutputMessageCompleted(_) => got_completed = true,
+                _ => {}
+            },
+            Ok(Err(_)) | Err(_) => break,
+        }
+    }
+    turn.await.expect("turn join").expect("turn result");
+
+    assert!(
+        got_completed,
+        "did not receive OutputMessageCompleted within {TURN_TIMEOUT:?}; deltas={deltas:?}"
+    );
+    assert!(
+        deltas.len() >= 2,
+        "expected ≥2 OutputMessageDelta events from llmsim's token stream, got {}: {:?}",
+        deltas.len(),
+        deltas
+    );
+    // Accumulated text grows monotonically: each delta carries the
+    // running total, not just the new chunk. A regression here would
+    // mean the broadcast is reordering or replaying events.
+    for window in deltas.windows(2) {
+        assert!(
+            window[1].len() >= window[0].len(),
+            "accumulated text shrank between deltas: {:?} -> {:?}",
+            window[0],
+            window[1],
+        );
+    }
+    // The final accumulated text must be non-empty (llmsim has a fixed
+    // multi-word response wired in runtime::build).
+    let final_text = deltas.last().expect("at least one delta");
+    assert!(
+        !final_text.trim().is_empty(),
+        "final accumulated text was empty: {deltas:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn live_deltas_drive_streaming_preview_through_handle_live_event() {
+    // This is the meat of the test suite: take the actual events
+    // produced by llmsim and walk them through the same routing code
+    // the TUI uses. Asserts that a real provider's delta stream
+    // produces growing `StreamPreview::Assistant` previews and a
+    // clearing `Stream(None)` on completion.
+    let runtime = build_llmsim_runtime().await;
+    let handles = runtime.handles.clone();
+    let mut live = handles.events.subscribe();
+
+    let session_id = handles.session_id;
+    let input = runtime.model.input_message("anything");
+    let runtime_clone = handles.runtime.clone();
+    let turn = tokio::spawn(async move { runtime_clone.run_turn(session_id, input).await });
+
+    let (tx, mut rx) = mpsc::unbounded_channel::<TurnEvent>();
+    let mut emitted = HashSet::new();
+    let mut router = DeltaRouter::default();
+
+    let mut saw_completed_event = false;
+    let deadline = tokio::time::Instant::now() + TURN_TIMEOUT;
+    while !saw_completed_event && tokio::time::Instant::now() < deadline {
+        let remaining = deadline - tokio::time::Instant::now();
+        match tokio::time::timeout(remaining, live.recv()).await {
+            Ok(Ok(event)) => {
+                if event.session_id != session_id {
+                    continue;
+                }
+                let is_completion = matches!(
+                    event.data,
+                    EventData::OutputMessageCompleted(_) | EventData::OutputMessageReplaced(_)
+                );
+                handle_live_event(&event, &mut emitted, &mut router, &tx);
+                if is_completion {
+                    saw_completed_event = true;
+                }
+            }
+            Ok(Err(_)) | Err(_) => break,
+        }
+    }
+    turn.await.expect("turn join").expect("turn result");
+
+    // Drain any remaining TurnEvents the receiver hasn't consumed yet.
+    let mut previews: Vec<Option<crate::app::StreamPreview>> = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        if let TurnEvent::Stream(preview) = event {
+            previews.push(preview);
+        }
+    }
+
+    let assistant_previews: Vec<&crate::app::StreamPreview> = previews
+        .iter()
+        .filter_map(|p| p.as_ref())
+        .filter(|p| p.kind == StreamKind::Assistant)
+        .collect();
+    assert!(
+        assistant_previews.len() >= 2,
+        "expected ≥2 assistant stream previews from the real llmsim stream, got {}: {:?}",
+        assistant_previews.len(),
+        previews
+    );
+    // Accumulated preview text must grow monotonically — same
+    // invariant as the raw delta accumulator, but observed through the
+    // exact code path the TUI uses to render.
+    for window in assistant_previews.windows(2) {
+        assert!(
+            window[1].text.len() >= window[0].text.len(),
+            "preview text shrank between deltas: {:?} -> {:?}",
+            window[0].text,
+            window[1].text,
+        );
+    }
+    // The completion event must clear the preview at least once.
+    assert!(
+        previews.iter().any(|p| p.is_none()),
+        "expected Stream(None) to clear preview after completion; got {previews:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn broadcast_does_not_persist_delta_events_to_jsonl() {
+    // Cross-check the persistence claim from session_log.rs comments:
+    // delta events fan out to live subscribers but never hit disk.
+    // A regression here would balloon the on-disk session log O(n²).
+    // Subscribe before the turn so we can prove the broadcast did
+    // carry deltas — otherwise the "not on disk" assertion is
+    // vacuously true (no deltas to leak either way).
+    let runtime = build_llmsim_runtime().await;
+    let log_path = runtime.startup.session_log_path.clone();
+    let mut live = runtime.handles.events.subscribe();
+
+    let session_id = runtime.handles.session_id;
+    let input = runtime.model.input_message("anything");
+    runtime
+        .handles
+        .runtime
+        .run_turn(session_id, input)
+        .await
+        .expect("turn");
+
+    let mut saw_delta = false;
+    while let Ok(event) = live.try_recv() {
+        if matches!(event.data, EventData::OutputMessageDelta(_)) {
+            saw_delta = true;
+        }
+    }
+    assert!(
+        saw_delta,
+        "test setup expected at least one OutputMessageDelta on the broadcast",
+    );
+
+    let on_disk = std::fs::read_to_string(&log_path).expect("read session log");
+    assert!(
+        !on_disk.contains("\"type\":\"output.message.delta\""),
+        "JSONL log must not persist delta events: {on_disk}"
+    );
+    assert!(
+        !on_disk.contains("\"type\":\"tool.output.delta\""),
+        "JSONL log must not persist tool output delta events: {on_disk}"
+    );
+}


### PR DESCRIPTION
## Summary

Follow-up to #3. The original streaming PR shipped without exercising
the new code under a real provider — `--print` mode bypasses the TUI
entirely, and the default llmsim config streams its bundled fixed
message in under 1ms (well inside the reason atom's 100ms delta batch
window), so a single coalesced delta is the most we'd ever see.

This PR adds a `streaming_tests` module that drives a real
`InProcessRuntime` through the bundled llmsim provider and exercises
the full pipeline:

```
llmsim driver chunks
  → reason atom (100ms batcher)
  → JsonlEventEmitter::emit
  → broadcast channel
  → app::handle_live_event
  → TurnEvent::Stream
```

Three tests:

- `llmsim_emits_multiple_output_message_deltas_on_broadcast` —
  subscribe to `events.subscribe()`, run a turn, assert ≥2
  `OutputMessageDelta` events with monotonically growing accumulated
  text.
- `live_deltas_drive_streaming_preview_through_handle_live_event` —
  same setup, but feed each event through `handle_live_event` and
  assert that the `StreamPreview::Assistant` text grows monotonically
  and that `Stream(None)` clears after `OutputMessageCompleted`.
- `broadcast_does_not_persist_delta_events_to_jsonl` — verify the
  `session_log.rs` invariant that delta events fan out to subscribers
  but never reach disk. The test now also asserts that a delta was
  observed on the broadcast, so the on-disk check isn't vacuously
  true.

To force llmsim to actually emit multiple deltas, the tests need to
push the stream past the 100ms batch window. Added a `BuildOptions`
struct with a new `build_with_options` entrypoint (`build` delegates
to it with defaults) so tests can swap in
`LlmSimConfig::lorem(200).with_latency()`, which streams over ~200ms
on the `LatencyProfile::fast` profile.

`DeltaRouter`, `TurnEvent`, `StreamPreview`, and `handle_live_event`
are bumped to `pub(crate)` so the test module can drive them. No
public API change.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` — 58 pass (3 new streaming tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_012GLNAu3JCDim14UkeLRSM3)_