### PR TITLE
feat(session): persist reasoning artifacts for session restore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,14 +328,15 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.6.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec5470c94eddec899a8048070259e6209f04b367c4f05a455ed0a0c9075ceca"
+checksum = "fa7892a1440c479f5b70dfddf760fe9671c5436d4c7b5ba39bb05216e2e3f301"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64",
  "bigdecimal",
+ "bitflags 2.11.1",
  "chrono",
  "clap",
  "fancy-regex 0.18.0",
@@ -351,7 +352,6 @@ dependencies = [
  "num-traits",
  "os_display",
  "regex",
- "schemars",
  "serde",
  "serde_json",
  "sha1 0.11.0",
@@ -970,9 +970,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1078,9 +1078,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c9aaf7a32396d42f03e3e427b61a36e10d39fb63c88eb8b047451b9a3ae25ee"
+checksum = "3e70e8e2041fe7d54e21b98cb745e68a5b7e495b9518732128ff942e450b1385"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1096,18 +1096,18 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b93e70a767f2f32fc349aa5950948f4b135628076270cbcf40ee7ef5d66451"
+checksum = "9e2881eb1428385ff27ee91afa2d900c809d2ecbd021a0c3201e166515cfc6df"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-core"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b6c0a4d774f7855d3a3938c477b2f94719cd7c802d1f556f6948a09049f008"
+checksum = "7eedfb744efb3ec573f358de6874023fcd61514edd61293d1794e9103cc0ba07"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -1146,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa6799c5e47b4c0a63fb419e3c5e2fc2edffabaea46d6c3990f899a78e546a6"
+checksum = "348b733209e2809b64cb2c1277f1123f910ab7af3b4a2a85be3ce113c521e6e6"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1162,9 +1162,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7691b5e1042a75a0e2731588114a927e3eae5644ab164d7b9256fcdf645f16d6"
+checksum = "f3f5dadc11a5503e1ea708b596e3792a153a13edda0b6b22bfae710c4101ba4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1183,9 +1183,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267fb2dfb903df04d522dea902d70fbae7fdbbc574c693ea7bf350ebc2d9928b"
+checksum = "4ebecb7ede44ca4572473634e395fb1cfd52ba0e41fab32281e37cade9700c40"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1627,9 +1627,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2128,9 +2128,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
@@ -5340,18 +5340,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,11 @@ tokio = { version = "1.50", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-everruns-anthropic = "0.8.34"
-everruns-core = "0.8.34"
-everruns-openai = "0.8.34"
-everruns-runtime = "0.8.34"
-everruns-integrations-duckduckgo = "0.8.34"
+everruns-anthropic = "0.8.35"
+everruns-core = "0.8.35"
+everruns-openai = "0.8.35"
+everruns-runtime = "0.8.35"
+everruns-integrations-duckduckgo = "0.8.35"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -170,9 +170,32 @@ data directory:
 | Windows | `%APPDATA%\yolop\sessions\<session_id>\`                   |
 
 The event log lives at `<session_folder>/events.jsonl`. Tool output persisted
-by `tool_output_persistence` lives under `<session_folder>/outputs/`. The
-event file is created with `0o600` on Unix because session logs contain user
-prompts, tool arguments, and tool output.
+by `tool_output_persistence` lives under `<session_folder>/outputs/`. On Unix
+`events.jsonl` is created with `0o600` and its parent session folder is set
+to `0o700` (both owner-only) because session logs contain user prompts, tool
+arguments, tool output, and the reasoning artifacts discussed below.
+
+The event types kept on disk are those that round-trip into the
+conversation (`input.message`, `output.message.completed`,
+`tool.completed`) plus the agent reasoning artifacts yolop needs to
+restore the live transcript view and provider continuation state on
+resume (`reason.completed` carries the safe `text_preview` narration;
+`reason.item` carries opaque/encrypted reasoning context curated by the
+provider, such as OpenAI Responses reasoning items). Assistant
+`thinking` / `thinking_signature` are persisted alongside
+`output.message.completed` — providers that resume via encrypted
+reasoning continuation (e.g. OpenAI Responses replays
+`thinking_signature` as `encrypted_content`) cannot continue without
+them. Streaming `*.delta` events and lifecycle markers
+(`reason.started`, `reason.thinking.*`, `output.message.started`) are
+dropped from the log — they are live status signals only and the delta
+types would inflate the file O(n²) without adding resume value.
+
+This persistence contract is **local-store**, not user-facing transcript
+export. On Unix, the per-session folder is set to `0o700` and the
+`events.jsonl` file inside it to `0o600` on every open, both under the
+platform-native user data directory; treat the folder contents as
+sensitive (see [Sensitivity](#sensitivity) below).
 
 To continue a previous conversation:
 
@@ -192,6 +215,12 @@ event from a turn, which may include:
 - tool call arguments — paths and any string passed to `bash`, `write_file`,
   `edit_file`, `web_fetch`, etc.
 - tool output — `bash` stdout/stderr, file contents, HTTP response bodies
+- agent reasoning artifacts — `reason.completed.text_preview` narration,
+  `reason.item` opaque/encrypted reasoning context, and the `thinking` /
+  `thinking_signature` fields on assistant messages. Persisting these is
+  what lets `--session <id>` resume restore the transcript view and lets
+  providers (e.g. OpenAI Responses) continue encrypted reasoning across
+  resumes; they are deliberately not redacted from the local log.
 
 There is no retention policy or rotation. If a session should not be
 persisted, point `--session-dir` at a path you can wipe (e.g. a `tmpfs`) or

--- a/src/app.rs
+++ b/src/app.rs
@@ -900,6 +900,9 @@ pub fn lines_for_event(event: &RuntimeEvent) -> Vec<ChatLine> {
     match &event.data {
         EventData::ReasonStarted(_) => Vec::new(),
         EventData::ReasonCompleted(data) => {
+            // Render pre-tool-call narration. When there are no tool calls
+            // the final assistant message will arrive via the message loop
+            // shortly, so we'd duplicate it; keep the has_tool_calls gate.
             if data.success && data.has_tool_calls {
                 let mut lines = Vec::new();
                 if let Some(text) = data
@@ -918,6 +921,17 @@ pub fn lines_for_event(event: &RuntimeEvent) -> Vec<ChatLine> {
                 Vec::new()
             }
         }
+        EventData::ReasonItem(data) => data
+            .summary
+            .iter()
+            .filter_map(|segment| {
+                let trimmed = segment.trim();
+                (!trimmed.is_empty()).then(|| ChatLine {
+                    author: Author::Assistant,
+                    text: trimmed.to_string(),
+                })
+            })
+            .collect(),
         EventData::OutputMessageCompleted(_) => Vec::new(),
         EventData::ToolCompleted(data) => {
             if data.tool_name == "write_todos" {
@@ -2144,6 +2158,36 @@ mod tests {
                 .as_deref(),
             Some("planned 2 tool call(s)")
         );
+    }
+
+    #[test]
+    fn lines_for_event_renders_reason_item_summary_segments() {
+        use everruns_core::events::ReasonItemData;
+
+        let event = RuntimeEvent::new(
+            SessionId::new(),
+            EventContext::empty(),
+            ReasonItemData {
+                turn_id: TurnId::new(),
+                provider: "openai".to_string(),
+                model: Some("gpt-5".to_string()),
+                item_id: "rs_abc".to_string(),
+                encrypted_content: Some("opaque".to_string()),
+                summary: vec![
+                    "Considering file layout".to_string(),
+                    "".to_string(),
+                    "  Plan the read order  ".to_string(),
+                ],
+                token_count: None,
+            },
+        );
+
+        let lines = lines_for_event(&event);
+
+        assert_eq!(lines.len(), 2, "blank summary segments are dropped");
+        assert!(matches!(lines[0].author, Author::Assistant));
+        assert_eq!(lines[0].text, "Considering file layout");
+        assert_eq!(lines[1].text, "Plan the read order");
     }
 
     #[test]

--- a/src/session_log.rs
+++ b/src/session_log.rs
@@ -13,10 +13,14 @@
 // every line so a crash mid-session loses at most the event in flight.
 //
 // Concerns explicitly handled below:
-// * Owner-only on Unix: `events.jsonl` is opened with `0o600` and the
-//   per-session folder is `chmod`-ed to `0o700` on open. Session logs
-//   contain prompts, tool arguments, and tool output, plus the
-//   reasoning artifacts described below.
+// * Owner-only on Unix: `events.jsonl` is created with `0o600` and the
+//   file mode is re-tightened to `0o600` on every open; the per-session
+//   folder is `chmod`-ed to `0o700` on open as well. The re-tightening
+//   matters because `OpenOptionsExt::mode` only applies on create —
+//   without it, a legacy file or one loosened out-of-band would keep
+//   its prior mode on resume. Session logs contain prompts, tool
+//   arguments, and tool output, plus the reasoning artifacts described
+//   below.
 // * Replay keeps event types that (a) round-trip into the conversation
 //   (`input.message`, `output.message.completed`, `tool.completed`) and
 //   (b) the agent needs to restore the live transcript view and provider
@@ -277,6 +281,24 @@ impl JsonlEventEmitter {
         let mut file = opts.open(path).map_err(|e| {
             AgentLoopError::config(format!("open session log {}: {e}", path.display()))
         })?;
+
+        // Re-tighten the file mode on every open. `OpenOptionsExt::mode`
+        // only applies on create, so a legacy `events.jsonl` written
+        // before the owner-only contract — or one whose mode was loosened
+        // out-of-band — would otherwise keep its prior permissions on
+        // resume. Mirrors the directory tightening above.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(
+                |e| {
+                    AgentLoopError::config(format!(
+                        "tighten session log permissions on {}: {e}",
+                        path.display()
+                    ))
+                },
+            )?;
+        }
 
         // Advisory exclusive flock: prevents two `yolop --session <id>`
         // processes from interleaving writes on the same JSONL file.
@@ -616,6 +638,33 @@ mod tests {
         assert_eq!(
             file_mode, 0o600,
             "events.jsonl must be owner-only on Unix, got {file_mode:o}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn open_corrects_loose_events_jsonl_permissions_on_resume() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionId::from_seed(48224);
+        let session_dir = session_dir_path(dir.path(), session_id);
+        let path = session_log_path(&session_dir);
+
+        std::fs::create_dir_all(&session_dir).expect("pre-create");
+        std::fs::write(&path, "").expect("pre-create file");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))
+            .expect("loosen for test");
+
+        let _emitter = JsonlEventEmitter::open(&path, 1).expect("open");
+
+        let mode = std::fs::metadata(&path)
+            .expect("events.jsonl exists")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "resume must re-tighten an existing loose events.jsonl, got {mode:o}"
         );
     }
 

--- a/src/session_log.rs
+++ b/src/session_log.rs
@@ -13,16 +13,24 @@
 // every line so a crash mid-session loses at most the event in flight.
 //
 // Concerns explicitly handled below:
-// * 0o600 file mode on Unix (owner-only): session logs contain prompts,
-//   tool arguments, and tool output.
-// * Replay only keeps event types we can reconstruct into messages
-//   (`input.message`, `output.message.completed`, `tool.completed`).
+// * Owner-only on Unix: `events.jsonl` is opened with `0o600` and the
+//   per-session folder is `chmod`-ed to `0o700` on open. Session logs
+//   contain prompts, tool arguments, and tool output, plus the
+//   reasoning artifacts described below.
+// * Replay keeps event types that (a) round-trip into the conversation
+//   (`input.message`, `output.message.completed`, `tool.completed`) and
+//   (b) the agent needs to restore the live transcript view and provider
+//   continuation state on resume (`reason.completed`, `reason.item`).
 //   Streaming `*.delta` events have no replay value and would otherwise
 //   inflate the log O(n²) for long streamed responses.
-// * Assistant `thinking` / `thinking_signature` fields are stripped before
-//   JSONL persistence. The CLI keeps the live runtime event unchanged, but
-//   session logs are user-facing durable history and must not expose hidden
-//   model reasoning material.
+// * Assistant `thinking` / `thinking_signature` fields ARE persisted in
+//   yolop's per-session JSONL. The per-session folder is the local
+//   private session store (owner-only on Unix, see above) and provider
+//   continuation on resume requires the signature/encrypted_content
+//   (e.g. OpenAI Responses threads the encrypted reasoning context back
+//   via `thinking_signature`). The contract is local-store, not
+//   user-facing transcript export — see the yolop README for the
+//   public/private distinction.
 // * Replay rejects events whose `session_id` doesn't match the resumed
 //   session — guards against accidentally merging logs across sessions.
 // * On open, if the file does not end with `\n` (previous run crashed
@@ -45,9 +53,9 @@ use chrono::Utc;
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::events::{
     Event, EventData, EventRequest, INPUT_MESSAGE, OUTPUT_MESSAGE_COMPLETED,
-    OutputMessageCompletedData, TOOL_COMPLETED,
+    OutputMessageCompletedData, REASON_COMPLETED, REASON_ITEM, TOOL_COMPLETED,
 };
-use everruns_core::message::{ContentPart, Message, MessageRole};
+use everruns_core::message::{ContentPart, Message};
 use everruns_core::tools::ToolResultImage;
 use everruns_core::traits::EventEmitter;
 use everruns_core::typed_id::EventId;
@@ -189,15 +197,21 @@ pub fn replay(path: &Path, expected: SessionId) -> Result<ReplayedSession> {
     Ok(out)
 }
 
-/// Event types that are useful to keep on disk: they're the ones replay
-/// can map back into the conversation. Everything else (streaming
-/// `*.delta`, `*.started`, lifecycle, etc.) adds bytes without adding
-/// resume value, and the delta types in particular bloat the log
-/// O(n²) since each delta carries the accumulated text so far.
+/// Event types that are useful to keep on disk: those that replay can map
+/// back into the conversation (`input.message`, `output.message.completed`,
+/// `tool.completed`) plus the agent reasoning artifacts the CLI uses to
+/// restore the live transcript view and provider continuation state on
+/// resume (`reason.completed` carries the safe `text_preview` narration,
+/// `reason.item` carries opaque/encrypted reasoning context curated by the
+/// provider). Streaming `*.delta` events and pure lifecycle markers
+/// (`reason.started`, `reason.thinking.*`, `output.message.started`) are
+/// dropped — they are live status signals only and the delta types would
+/// bloat the log O(n²) since each delta carries the accumulated text so
+/// far.
 fn is_replay_relevant(event_type: &str) -> bool {
     matches!(
         event_type,
-        INPUT_MESSAGE | OUTPUT_MESSAGE_COMPLETED | TOOL_COMPLETED
+        INPUT_MESSAGE | OUTPUT_MESSAGE_COMPLETED | TOOL_COMPLETED | REASON_COMPLETED | REASON_ITEM
     )
 }
 
@@ -227,6 +241,25 @@ impl JsonlEventEmitter {
             std::fs::create_dir_all(parent).map_err(|e| {
                 AgentLoopError::config(format!("create session log dir {}: {e}", parent.display()))
             })?;
+            // Per-session folder is owner-only on Unix. The events.jsonl
+            // file gets `0o600` below, but the folder may also hold tool
+            // outputs (`/outputs/`) and other per-session artifacts;
+            // tightening the directory keeps every file inside private
+            // even if a caller later creates one without an explicit
+            // mode. Idempotent — set on every open so a session folder
+            // that pre-dates this change gets corrected next resume.
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)).map_err(
+                    |e| {
+                        AgentLoopError::config(format!(
+                            "tighten session dir permissions on {}: {e}",
+                            parent.display()
+                        ))
+                    },
+                )?;
+            }
         }
         let mut opts = OpenOptions::new();
         // `read(true)` is required so we can read the file's last byte
@@ -340,8 +373,14 @@ impl EventEmitter for JsonlEventEmitter {
         self.events.write().await.push(event.clone());
 
         if is_replay_relevant(&event.event_type) {
-            let persisted_event = event_for_session_log(&event);
-            let line = serde_json::to_string(&persisted_event).map_err(|e| {
+            // yolop's per-session JSONL is the local session store; we
+            // persist `thinking` / `thinking_signature` and opaque
+            // `reason.item` content as-is so provider continuation
+            // (e.g. OpenAI Responses replays encrypted reasoning via
+            // `thinking_signature`) works after `--session <id>` resume.
+            // Privacy lives in the 0o600 file mode and per-user
+            // platform data dir, not in field stripping.
+            let line = serde_json::to_string(&event).map_err(|e| {
                 AgentLoopError::config(format!("serialize event for session log: {e}"))
             })?;
             let mut file = self.file.lock().await;
@@ -355,21 +394,6 @@ impl EventEmitter for JsonlEventEmitter {
         // no receivers, which is the common steady state — ignore.
         let _ = self.live.send(event.clone());
         Ok(event)
-    }
-}
-
-fn event_for_session_log(event: &Event) -> Event {
-    let mut persisted = event.clone();
-    if let EventData::OutputMessageCompleted(data) = &mut persisted.data {
-        strip_hidden_thinking(&mut data.message);
-    }
-    persisted
-}
-
-fn strip_hidden_thinking(message: &mut Message) {
-    if message.role == MessageRole::Agent {
-        message.thinking = None;
-        message.thinking_signature = None;
     }
 }
 
@@ -563,8 +587,70 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[tokio::test]
-    async fn output_message_thinking_is_not_written_to_session_log() {
+    async fn open_tightens_session_dir_to_owner_only_on_unix() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionId::from_seed(48222);
+        let session_dir = session_dir_path(dir.path(), session_id);
+        let path = session_log_path(&session_dir);
+
+        let _emitter = JsonlEventEmitter::open(&path, 1).expect("open");
+
+        let mode = std::fs::metadata(&session_dir)
+            .expect("session dir exists")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            mode, 0o700,
+            "per-session folder must be owner-only on Unix, got {mode:o}"
+        );
+
+        let file_mode = std::fs::metadata(&path)
+            .expect("events.jsonl exists")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            file_mode, 0o600,
+            "events.jsonl must be owner-only on Unix, got {file_mode:o}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn open_corrects_loose_session_dir_permissions_on_resume() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionId::from_seed(48223);
+        let session_dir = session_dir_path(dir.path(), session_id);
+        let path = session_log_path(&session_dir);
+
+        std::fs::create_dir_all(&session_dir).expect("pre-create");
+        std::fs::set_permissions(&session_dir, std::fs::Permissions::from_mode(0o755))
+            .expect("loosen for test");
+
+        let _emitter = JsonlEventEmitter::open(&path, 1).expect("open");
+
+        let mode = std::fs::metadata(&session_dir)
+            .expect("session dir exists")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            mode, 0o700,
+            "resume must re-tighten an existing loose session folder, got {mode:o}"
+        );
+    }
+
+    #[tokio::test]
+    async fn output_message_thinking_is_persisted_for_provider_continuation() {
+        // yolop's per-session JSONL is the local session store: thinking
+        // and thinking_signature must round-trip so providers that thread
+        // encrypted reasoning context back (e.g. OpenAI Responses via
+        // `thinking_signature`) can continue across `--session <id>` resume.
         let dir = tempfile::tempdir().expect("tempdir");
         let session_id = SessionId::from_seed(4821);
         let session_dir = session_dir_path(dir.path(), session_id);
@@ -584,28 +670,122 @@ mod tests {
 
         let on_disk = std::fs::read_to_string(&path).expect("read");
         assert!(
-            !on_disk.contains("private model reasoning"),
-            "session log must not persist assistant thinking: {on_disk}"
+            on_disk.contains("private model reasoning"),
+            "session log must persist assistant thinking for restore: {on_disk}"
         );
         assert!(
-            !on_disk.contains("thinking_signature"),
-            "session log must not persist thinking signatures: {on_disk}"
+            on_disk.contains("encrypted-thinking-token"),
+            "session log must persist thinking_signature for provider continuation: {on_disk}"
         );
+
         let replayed = replay(&path, session_id).expect("replay");
         let replayed_message = replayed.messages.first().expect("message replayed");
-        assert!(replayed_message.thinking.is_none());
-        assert!(replayed_message.thinking_signature.is_none());
+        assert_eq!(
+            replayed_message.thinking.as_deref(),
+            Some("private model reasoning")
+        );
+        assert_eq!(
+            replayed_message.thinking_signature.as_deref(),
+            Some("encrypted-thinking-token")
+        );
+    }
 
-        let collected = emitter.collected_events().await;
-        match &collected[0].data {
-            EventData::OutputMessageCompleted(data) => {
+    #[tokio::test]
+    async fn reason_completed_event_is_persisted_and_replayed() {
+        use everruns_core::events::ReasonCompletedData;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionId::from_seed(4822);
+        let session_dir = session_dir_path(dir.path(), session_id);
+        let path = session_log_path(&session_dir);
+        let emitter = JsonlEventEmitter::open(&path, 1).expect("open");
+
+        let req = EventRequest::new(
+            session_id,
+            EventContext::default(),
+            ReasonCompletedData::success("Will read the lib.rs file", true, 1, Some(120), None),
+        );
+        emitter.emit(req).await.expect("emit");
+
+        let on_disk = std::fs::read_to_string(&path).expect("read");
+        assert!(
+            on_disk.contains("\"reason.completed\""),
+            "reason.completed should be persisted to JSONL: {on_disk}"
+        );
+        assert!(
+            on_disk.contains("Will read the lib.rs file"),
+            "text_preview narration should round-trip on disk: {on_disk}"
+        );
+
+        let replayed = replay(&path, session_id).expect("replay");
+        assert_eq!(replayed.events.len(), 1);
+        match &replayed.events[0].data {
+            EventData::ReasonCompleted(data) => {
                 assert_eq!(
-                    data.message.thinking.as_deref(),
-                    Some("private model reasoning")
+                    data.text_preview.as_deref(),
+                    Some("Will read the lib.rs file")
                 );
+                assert!(data.has_tool_calls);
+                assert_eq!(data.tool_call_count, 1);
             }
-            other => panic!("unexpected event data: {other:?}"),
+            other => panic!("expected ReasonCompleted, got {other:?}"),
         }
+        // reason.completed is not a conversation message — it must not
+        // pollute the replayed messages vec.
+        assert!(replayed.messages.is_empty());
+    }
+
+    #[tokio::test]
+    async fn reason_item_event_is_persisted_and_replayed() {
+        use everruns_core::events::ReasonItemData;
+        use everruns_core::typed_id::TurnId;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionId::from_seed(4823);
+        let session_dir = session_dir_path(dir.path(), session_id);
+        let path = session_log_path(&session_dir);
+        let emitter = JsonlEventEmitter::open(&path, 1).expect("open");
+
+        let req = EventRequest::new(
+            session_id,
+            EventContext::default(),
+            ReasonItemData {
+                turn_id: TurnId::new(),
+                provider: "openai".to_string(),
+                model: Some("gpt-5".to_string()),
+                item_id: "rs_abc123".to_string(),
+                encrypted_content: Some("opaque-encrypted-blob".to_string()),
+                summary: vec!["Considered file structure.".to_string()],
+                token_count: Some(42),
+            },
+        );
+        emitter.emit(req).await.expect("emit");
+
+        let on_disk = std::fs::read_to_string(&path).expect("read");
+        assert!(
+            on_disk.contains("\"reason.item\""),
+            "reason.item should be persisted: {on_disk}"
+        );
+        assert!(
+            on_disk.contains("opaque-encrypted-blob"),
+            "encrypted_content must round-trip for provider continuation: {on_disk}"
+        );
+
+        let replayed = replay(&path, session_id).expect("replay");
+        assert_eq!(replayed.events.len(), 1);
+        match &replayed.events[0].data {
+            EventData::ReasonItem(data) => {
+                assert_eq!(data.provider, "openai");
+                assert_eq!(data.item_id, "rs_abc123");
+                assert_eq!(
+                    data.encrypted_content.as_deref(),
+                    Some("opaque-encrypted-blob")
+                );
+                assert_eq!(data.summary, vec!["Considered file structure.".to_string()]);
+            }
+            other => panic!("expected ReasonItem, got {other:?}"),
+        }
+        assert!(replayed.messages.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Mirrors [everruns/everruns#1985](https://github.com/everruns/everruns/pull/1985) into yolop's standalone tree.

## What

Flip yolop's per-session JSONL persistence contract so the local session store retains every artifact `--session <id>` resume needs:

- `reason.completed` and `reason.item` events are now persisted (previously filtered as lifecycle noise).
- `thinking` / `thinking_signature` on assistant messages are persisted (previously stripped before write).
- The TUI's `lines_for_event` gains a `ReasonItem` arm that renders non-empty `summary` segments as assistant chat lines (live and on replay). `ReasonCompleted.text_preview` narration unchanged.
- The per-session folder is `chmod`-ed to `0o700` on every open on Unix (idempotent; corrects pre-existing loose folders on resume). `events.jsonl` continues to get `0o600`.
- `everruns-*` crates bumped `0.8.34` → `0.8.35` (see Risk below).

## Why

The previous contract dropped reasoning events and stripped `thinking` on the framing that session logs were user-facing durable history. That broke two flows:

1. **Provider continuation on resume.** OpenAI Responses threads its encrypted reasoning context back into the next turn via the assistant message's `thinking_signature` (rebuilt as a `Reasoning` input item). After resume, the stripped field meant the encrypted continuation was lost.
2. **Restored transcript review.** Resumed sessions only showed tool calls — pre-tool-call narration was gone because `reason.completed` was filtered out, and provider summaries (`reason.item.summary`) were never persisted or rendered.

The per-session folder is owner-only under the platform user-data dir. Treating that local store as the right home for these artifacts is the local-vs-public distinction the upstream PR articulates.

## How

- `src/session_log.rs`:
  - `is_replay_relevant` keeps `REASON_COMPLETED` and `REASON_ITEM` alongside the existing message/tool event triple. Streaming `*.delta` events and lifecycle markers stay filtered out.
  - Removed `event_for_session_log` / `strip_hidden_thinking` — `OutputMessageCompleted.message.thinking` and `thinking_signature` now round-trip on disk.
  - `JsonlEventEmitter::open` `chmod`-s the per-session folder to `0o700` on every open (Unix only). Idempotent so legacy folders get corrected next resume.
  - Header comment rewritten to document the local-store contract and the public/private split.
- `src/app.rs`:
  - `lines_for_event` gains a `ReasonItem` arm that renders non-empty `summary` segments. Replay path inherits this via `lines_for_replayed_event`'s fallthrough.
- `README.md`: "Session persistence" and "Sensitivity" sections updated.
- `Cargo.toml` / `Cargo.lock`: `everruns-*` bumped `0.8.34` → `0.8.35`.

## Risk

Low.

- **Read path is backwards-compatible.** Pre-change JSONL files (no reasoning events, stripped thinking) replay exactly as before — the new fields simply remain `None`. New sessions write a strict superset.
- **everruns-* version bump from 0.8.34 → 0.8.35 was required.** 0.8.34's `EventData` is `#[serde(untagged)]` and orders `OutputMessageStarted` before `ReasonItem`. With `provider`/`item_id`/`encrypted_content`/`summary` not declared as required by serde, a serialized `reason.item` JSON line would deserialize as `OutputMessageStarted` on replay, silently losing every reasoning-specific field. Caught by the new `reason_item_event_is_persisted_and_replayed` test. 0.8.35 fixes the variant ordering. Per AGENTS.md the `everruns-*` crates are bumped in lockstep.

## Security

Threat categories reviewed against `.agents/skills/ship/SKILL.md`:

- **TM-FS** — The persisted artifacts (encrypted reasoning blobs, thinking signatures, plaintext thinking, summary text) land in the per-session folder. The folder mode is *tightened* (now explicitly `0o700` on Unix; previously inherited from `create_dir_all`'s default umask-derived mode). `events.jsonl` continues to be `0o600`. No new file path, no new write surface. README "Sensitivity" section updated so users understand what is now stored.
- **TM-LLM** — Reasoning artifacts are local-only — never sent to a different provider, never reflected back into prompts on the same turn they arrived. On resume, the only consumer is the OpenAI Responses request builder in `everruns-openai`, which already accepts `thinking_signature` as `encrypted_content` — no new attack surface in prompt construction. API keys are unaffected; nothing about env-var handling or logging changed.
- **TM-BASH**, **TM-TOOL** — Not touched.
- **TM-DEP** — `everruns-*` bumped together (0.8.34 → 0.8.35) per AGENTS.md guidance. No new dependencies.

No new `THREAT` comments needed (no new mitigation contracts beyond the file-mode protection already documented).

## Validation

- `cargo fmt --check` — clean.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo test --all-features` — 60 unit tests + 3 integration tests pass (4 new unit tests + 2 new Unix-only dir-permission tests added).
- `cargo fetch --locked` — clean.
- Targeted tests added:
  - `output_message_thinking_is_persisted_for_provider_continuation` — inverts the previous strip-on-write expectation; asserts both `thinking` and `thinking_signature` round-trip through emit → JSONL → `replay`.
  - `reason_completed_event_is_persisted_and_replayed` — verifies `text_preview` and `tool_call_count` survive the round trip and that the event does not pollute the replayed messages vec.
  - `reason_item_event_is_persisted_and_replayed` — verifies opaque `encrypted_content`, provider/model metadata, and summary segments round-trip.
  - `lines_for_event_renders_reason_item_summary_segments` — UI render of the new `ReasonItem` arm; verifies blank segments are dropped and surrounding whitespace is trimmed.
  - `open_tightens_session_dir_to_owner_only_on_unix` and `open_corrects_loose_session_dir_permissions_on_resume` (Unix-only) — verify the new `chmod 0o700` behavior on first open and on resume.
- Offline smoke test: `yolop --provider llmsim --session-dir ./sessions -p "say hi"` then resumed with `--session <id> -p "and again"`. Resume reported `3 prior event(s)` — replay works. Session folder mode verified as `drwx------` (0o700).
- Live-provider smoke skipped: this PR does not change the runtime/provider code path that emits these events — only which events the persistence layer filters in and out. The unit tests cover both ends of the resume data flow (emit → JSONL → replay → events → UI render).

## Follow-ups

No follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_015uZLAWFMUacHLDrkzetH3o)_