### PR TITLE
chore(release): add release skill, spec, workflows, Homebrew tap

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: release
+description: Cut a new yolop release. Prepares the release PR, runs publish-readiness checks, monitors CI publish to crates.io and the everruns Homebrew tap. Use when the user asks to release, cut a version, publish, or ship to crates.io / brew.
+metadata:
+  internal: true
+user-invocable: true
+---
+
+# Release
+
+Goal: cut a new yolop release and verify it lands on **both** crates.io and
+the `everruns/homebrew-tap` Homebrew tap.
+
+This skill implements [`specs/release.md`](../../../specs/release.md). Keep
+operational guidance here. Keep design intent in the spec.
+
+## When To Use
+
+Use this skill when the user asks to:
+
+- release / cut a release / publish vX.Y.Z
+- ship to crates.io or Homebrew
+- prepare a release PR or a hotfix release
+
+For a generic "ship this change" request (PR → CI → merge of a non-release
+change), use [`/ship`](../ship/SKILL.md) instead.
+
+## Required Outcomes
+
+**All outcomes below are MANDATORY.**
+
+1. **The version is correct.** `Cargo.toml` and `Cargo.lock` agree on
+   `X.Y.Z`. `X.Y.Z` is strictly greater than the latest version on crates.io.
+2. **The changelog is honest.** `CHANGELOG.md` lists every commit landed
+   since the previous tag, in descending order, with PR numbers and authors.
+3. **Publish-readiness is proven before merge.** `cargo publish --dry-run -p
+   yolop` succeeds. The PR body includes a publish-readiness report.
+4. **CI publishes to both registries.** crates.io shows `X.Y.Z`. The
+   Homebrew tap's `Formula/yolop.rb` is bumped to `X.Y.Z`. A "release" is
+   not done until both are confirmed.
+5. **A failure rolls forward, not backward.** If a publish fails, open a
+   hotfix PR (or fix-forward in the same PR if not yet merged). Do not
+   leave the release half-shipped.
+
+## Operating Model
+
+- Releases are agent-prepared, human-merged, CI-published.
+- Start by gathering the unreleased commit set, not by guessing the version.
+- The agent never tags the release directly — `release.yml` does that when
+  the `chore(release): prepare vX.Y.Z` commit lands on `main`.
+- The agent never pushes to `everruns/homebrew-tap` directly —
+  `cli-binaries.yml` does that.
+
+## Step-By-Step
+
+### 0. Sync local state
+
+Shallow clones lie. Before counting commits, force a full history:
+
+```bash
+git fetch --unshallow origin main 2>/dev/null || git fetch origin main
+git fetch --tags
+```
+
+Cross-check the commit count if anything looks off:
+
+```bash
+LATEST=$(git describe --tags --abbrev=0)
+git log "$LATEST"..origin/main --oneline | wc -l
+gh api "repos/everruns/yolop/compare/$LATEST...main" --jq '.total_commits'
+```
+
+If those disagree, the clone is still shallow.
+
+### 1. Pick the version
+
+If the user gave a version, use it. Otherwise, propose based on the diff:
+
+- only `fix`, `docs`, `chore`, `refactor`, `test` commits → patch
+- one or more `feat` commits → minor
+- breaking changes flagged in commit bodies → major (or minor pre-1.0 with
+  an explicit `### Breaking Changes` block)
+
+Confirm with the user before proceeding.
+
+### 2. Update the changelog
+
+`CHANGELOG.md` lives at the repo root. Add a section at the top under any
+intro:
+
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+
+### Highlights
+
+- 2–5 bullets summarizing the most user-visible changes.
+
+### Breaking Changes
+
+- (only when applicable; required for MINOR / MAJOR with breakage)
+
+### What's Changed
+
+* feat(scope): description ([#42](https://github.com/everruns/yolop/pull/42)) by @contributor
+* fix(scope): description ([#41](https://github.com/everruns/yolop/pull/41)) by @contributor
+
+**Full Changelog**: https://github.com/everruns/yolop/compare/vA.B.C...vX.Y.Z
+```
+
+Build the PR list mechanically:
+
+```bash
+git log "$LATEST"..HEAD --pretty=format:'%s' --reverse \
+  | grep -v '^chore(release): prepare v'
+```
+
+Map commits to PRs via `gh pr list --state merged --base main --limit 200`
+when commit subjects don't carry the PR number.
+
+### 3. Bump the version
+
+Edit `Cargo.toml`:
+
+```toml
+[package]
+name = "yolop"
+version = "X.Y.Z"
+```
+
+Refresh the lockfile entry:
+
+```bash
+cargo update -p yolop
+```
+
+### 4. Run local verification
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features
+```
+
+### 5. Verify publish-readiness
+
+This is the step that catches what local tests don't — the `cargo publish`
+packaging boundary, missing files referenced by `Cargo.toml`, version drift:
+
+```bash
+cargo publish --dry-run -p yolop
+cargo search yolop --limit 1     # confirm CURRENT crates.io version < X.Y.Z
+grep '^version' Cargo.toml       # confirm reads X.Y.Z
+grep '"yolop"' Cargo.lock | head -1  # confirm reads X.Y.Z
+```
+
+If `cargo publish --dry-run` fails, fix the root cause and re-run. Do **not**
+open a release PR with a known-broken publish path.
+
+### 6. Commit and push
+
+Stage explicitly — never `git add .`:
+
+```bash
+git add CHANGELOG.md Cargo.toml Cargo.lock
+git commit -m "chore(release): prepare vX.Y.Z"
+git push -u origin "$(git branch --show-current)"
+```
+
+### 7. Open the PR
+
+Title: `chore(release): prepare vX.Y.Z` (under 70 chars).
+
+Body must include:
+
+- The full `## [X.Y.Z] - …` changelog section.
+- A **Publish-readiness** block:
+
+  ```markdown
+  ## Publish-readiness
+
+  - [x] `cargo fmt --check`
+  - [x] `cargo clippy --all-targets --all-features -- -D warnings`
+  - [x] `cargo test --all-features`
+  - [x] `cargo publish --dry-run -p yolop`
+  - [x] crates.io currently serves `A.B.C` → publishing `X.Y.Z`
+  - [x] `Cargo.toml` + `Cargo.lock` agree on `X.Y.Z`
+  ```
+
+- A **Post-merge plan** noting that `release.yml` will tag + dispatch
+  `publish.yml` and `cli-binaries.yml`.
+
+### 8. Monitor publishing after merge
+
+Subscribe to PR activity for the release PR so the loop wakes you on each
+workflow completion. Then watch:
+
+```bash
+gh run list --workflow=release.yml      --limit 1
+gh run list --workflow=publish.yml      --limit 1
+gh run list --workflow=cli-binaries.yml --limit 1
+```
+
+Confirm each finishes green, then run the post-release checks:
+
+```bash
+# crates.io
+cargo search yolop --limit 1   # shows X.Y.Z
+
+# GitHub Release
+gh release view "vX.Y.Z"       # tag + 3 tarballs + 3 sha256 files
+
+# Homebrew tap
+curl -sSfL https://raw.githubusercontent.com/everruns/homebrew-tap/main/Formula/yolop.rb \
+  | grep '^  version "'        # shows X.Y.Z
+```
+
+Declare **shipped** only when crates.io and the Homebrew tap both report
+`X.Y.Z`. If a workflow fails, inspect logs (`gh run view <id> --log-failed`)
+and either re-run (transient — network / registry propagation) or open a
+hotfix PR (packaging bug — see `specs/release.md` § Hotfix Releases).
+
+## Common Pitfalls
+
+- **Shallow clone.** Cloud sandboxes default to depth ≈ 50 and silently
+  drop older commits from `git log`. Always `git fetch --unshallow` first.
+- **Tag/Cargo drift.** A v0.4.0 → v0.4.1-style hotfix is almost always
+  caused by version drift between `Cargo.toml` and what `cargo publish`
+  actually sees. The dry-run catches it.
+- **Half-shipped releases.** crates.io publishes near-instantly; Homebrew
+  takes minutes (build + tap commit). Don't declare shipped until the tap
+  formula reflects the new version.
+- **Auto-merge.** Do not enable auto-merge on the release PR. A human must
+  click the squash button so a real reviewer sees the changelog.
+
+## Authentication
+
+Required repo secrets — set up once, see [`specs/release.md`](../../../specs/release.md)
+§ Authentication for the full table.
+
+- `CARGO_REGISTRY_TOKEN` — crates.io publish scope.
+- `DOPPLER_TOKEN` — service token; the Doppler config holds
+  `HOMEBREW_TAP_GITHUB_TOKEN`, a fine-grained PAT scoped to the tap repo
+  only.

--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -1,0 +1,220 @@
+# Prebuilt CLI binaries — dispatched by release.yml after the GitHub Release
+# is created. GITHUB_TOKEN-created releases don't fire `release: published`
+# (anti-recursion), so the release workflow dispatches this one explicitly.
+name: Publish CLI Binaries
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g., v0.2.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build CLI (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+            archive: yolop-aarch64-apple-darwin.tar.gz
+          - target: x86_64-apple-darwin
+            runner: macos-latest
+            archive: yolop-x86_64-apple-darwin.tar.gz
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            archive: yolop-x86_64-unknown-linux-gnu.tar.gz
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "cli-${{ matrix.target }}"
+
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }} -p yolop --locked
+
+      - name: Package binary
+        env:
+          TARGET: ${{ matrix.target }}
+          ARCHIVE: ${{ matrix.archive }}
+        run: |
+          cd "target/$TARGET/release"
+          tar czf "$GITHUB_WORKSPACE/$ARCHIVE" yolop
+          cd "$GITHUB_WORKSPACE"
+          # macOS ships shasum but not sha256sum by default; Linux is the
+          # opposite. Pick the one that exists so the workflow doesn't break
+          # if a runner image drops the other.
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "$ARCHIVE" > "$ARCHIVE.sha256"
+          else
+            shasum -a 256 "$ARCHIVE" > "$ARCHIVE.sha256"
+          fi
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          ARCHIVE: ${{ matrix.archive }}
+        run: |
+          gh release upload "$TAG" \
+            "$ARCHIVE" \
+            "$ARCHIVE.sha256" \
+            --clobber
+
+  update-homebrew:
+    name: Update Homebrew formula
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Download SHA256 checksums from release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          for target in aarch64-apple-darwin x86_64-apple-darwin x86_64-unknown-linux-gnu; do
+            gh release download "$TAG" \
+              --repo "$REPO" \
+              --pattern "yolop-${target}.tar.gz.sha256"
+          done
+
+      - name: Generate Homebrew formula
+        env:
+          TAG: ${{ inputs.tag }}
+          SERVER_URL: ${{ github.server_url }}
+          REPO: ${{ github.repository }}
+        run: |
+          VERSION="${TAG#v}"
+
+          for f in yolop-aarch64-apple-darwin.tar.gz.sha256 \
+                   yolop-x86_64-apple-darwin.tar.gz.sha256 \
+                   yolop-x86_64-unknown-linux-gnu.tar.gz.sha256; do
+            if [[ ! -s "$f" ]]; then
+              echo "::error::checksum file '$f' is missing or empty"
+              exit 1
+            fi
+          done
+
+          SHA_ARM64=$(awk '{print $1}' yolop-aarch64-apple-darwin.tar.gz.sha256)
+          SHA_X86_64_MACOS=$(awk '{print $1}' yolop-x86_64-apple-darwin.tar.gz.sha256)
+          SHA_LINUX=$(awk '{print $1}' yolop-x86_64-unknown-linux-gnu.tar.gz.sha256)
+
+          for var in SHA_ARM64 SHA_X86_64_MACOS SHA_LINUX; do
+            if [[ -z "${!var}" ]]; then
+              echo "::error::extracted $var is empty"
+              exit 1
+            fi
+          done
+
+          BASE_URL="${SERVER_URL}/${REPO}/releases/download/${TAG}"
+          HOMEPAGE="${SERVER_URL}/${REPO}"
+
+          cat > yolop.rb <<FORMULA
+          # typed: false
+          # frozen_string_literal: true
+
+          class Yolop < Formula
+            desc "Minimal terminal coding agent built on everruns-runtime"
+            homepage "${HOMEPAGE}"
+            version "${VERSION}"
+            license "MIT"
+
+            on_macos do
+              if Hardware::CPU.arm?
+                url "${BASE_URL}/yolop-aarch64-apple-darwin.tar.gz"
+                sha256 "${SHA_ARM64}"
+              else
+                url "${BASE_URL}/yolop-x86_64-apple-darwin.tar.gz"
+                sha256 "${SHA_X86_64_MACOS}"
+              end
+            end
+
+            on_linux do
+              depends_on arch: :x86_64
+              url "${BASE_URL}/yolop-x86_64-unknown-linux-gnu.tar.gz"
+              sha256 "${SHA_LINUX}"
+            end
+
+            def install
+              bin.install "yolop"
+            end
+
+            test do
+              assert_match version.to_s, shell_output("#{bin}/yolop --version")
+            end
+          end
+          FORMULA
+
+          # Strip the leading indentation that heredoc preserved.
+          sed -i 's/^          //' yolop.rb
+
+          echo "Generated formula:"
+          cat yolop.rb
+
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@v3
+
+      - name: Push formula to homebrew-tap
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          VERSION="${TAG#v}"
+
+          # Fetch the homebrew-tap PAT from Doppler. This token is a
+          # fine-grained PAT scoped to `everruns/homebrew-tap` only
+          # (Contents: read+write, Metadata: read), so a leak cannot
+          # touch this repo.
+          # `doppler secrets get --plain` appends a trailing newline; strip
+          # it so the PAT compares cleanly against `git credential` checks
+          # and add-mask sees the actual secret without the line break.
+          GH_PAT=$(doppler secrets get HOMEBREW_TAP_GITHUB_TOKEN --plain | tr -d '\n\r')
+          export GH_PAT
+          echo "::add-mask::$GH_PAT"
+
+          # Use askpass to keep the token out of clone/push URLs and logs.
+          ASKPASS_SCRIPT=$(mktemp)
+          cat > "$ASKPASS_SCRIPT" <<'EOF'
+          #!/usr/bin/env sh
+          case "$1" in
+            *Username*) echo "x-access-token" ;;
+            *Password*) echo "$GH_PAT" ;;
+          esac
+          EOF
+          chmod 700 "$ASKPASS_SCRIPT"
+          export GIT_ASKPASS="$ASKPASS_SCRIPT"
+          export GIT_TERMINAL_PROMPT=0
+          trap 'rm -f "$ASKPASS_SCRIPT"; unset GH_PAT' EXIT
+
+          git clone "https://github.com/everruns/homebrew-tap.git" tap
+          mkdir -p tap/Formula
+          cp yolop.rb tap/Formula/yolop.rb
+
+          cd tap
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/yolop.rb
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          git commit -m "yolop ${VERSION}"
+          git push origin main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,70 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish-yolop:
+    name: Publish yolop to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Verify version matches tag
+        env:
+          # `release.tag_name` is set for the `release: published` event.
+          # `ref_name` is set when this workflow is dispatched against a tag
+          # (the normal path — release.yml does `gh workflow run --ref vX.Y.Z`).
+          # Whichever is set is the authoritative tag; both falling back to
+          # empty means a manual dispatch against `main`, where there's no
+          # tag to verify against.
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+        run: |
+          if [ -n "$RELEASE_TAG" ]; then
+            TAG_VERSION="${RELEASE_TAG#v}"
+          elif [ "$REF_TYPE" = "tag" ] && [ -n "$REF_NAME" ]; then
+            TAG_VERSION="${REF_NAME#v}"
+          else
+            echo "Manual dispatch against a non-tag ref — skipping tag verification"
+            exit 0
+          fi
+          CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match Cargo.toml version ($CARGO_VERSION)"
+            exit 1
+          fi
+          echo "Version verified: $TAG_VERSION"
+
+      - name: Publish to crates.io
+        run: cargo publish --locked -p yolop
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  verify-publish:
+    name: Verify published version
+    runs-on: ubuntu-latest
+    needs: publish-yolop
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Wait for crates.io index propagation
+        run: sleep 60
+
+      - name: Verify crates.io serves the new version
+        run: |
+          EXPECTED=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "Expected version: $EXPECTED"
+          python3 scripts/verify_crates_publish.py --expected "$EXPECTED" yolop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,96 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    # Trigger on manual dispatch OR on a `chore(release): prepare v…` commit
+    # landing on main (post-squash-merge of the release PR).
+    # `head_commit` is null for workflow_dispatch; fall back to '' so
+    # `startsWith` doesn't trip on the null in that path.
+    if: "${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message || '', 'chore(release): prepare v') }}"
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Extract version
+        id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            # Manual trigger: read version from Cargo.toml
+            VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          else
+            # Push trigger: extract from the first line of the commit subject
+            FIRST_LINE=$(echo "$COMMIT_MSG" | head -1)
+            VERSION=$(echo "$FIRST_LINE" | sed -n 's/.*prepare v\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p')
+          fi
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not determine version"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION"   >> "$GITHUB_OUTPUT"
+          echo "Detected version: $VERSION"
+
+      - name: Verify version matches Cargo.toml
+        run: |
+          CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          if [ "${{ steps.version.outputs.version }}" != "$CARGO_VERSION" ]; then
+            echo "::error::Commit version (${{ steps.version.outputs.version }}) does not match Cargo.toml version ($CARGO_VERSION)"
+            exit 1
+          fi
+          echo "Version verified: $CARGO_VERSION"
+
+      - name: Extract release notes from CHANGELOG
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          # Capture content between this version's header and the next version header.
+          awk -v v="$VERSION" '
+            $0 ~ "^## \\[" v "\\]" { found=1; next }
+            found && /^## \[/      { exit }
+            found                  { print }
+          ' CHANGELOG.md > release_notes.md
+          if [ ! -s release_notes.md ]; then
+            echo "::error::No CHANGELOG section found for [$VERSION]. Add a '## [$VERSION] - YYYY-MM-DD' entry before tagging."
+            exit 1
+          fi
+          echo "Release notes extracted for v$VERSION"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: Release ${{ steps.version.outputs.tag }}
+          body_path: release_notes.md
+          draft: false
+          prerelease: false
+
+      # `release: published` does NOT fire for releases created with
+      # GITHUB_TOKEN (anti-recursion). Dispatch the downstream workflows
+      # explicitly so they run against the new tag's ref.
+      - name: Dispatch publish workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          gh workflow run publish.yml --ref "$TAG"
+
+      - name: Dispatch CLI binary builds
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          gh workflow run cli-binaries.yml --ref "$TAG" -f "tag=$TAG"

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 **/*.rs.bk
 Cargo.lock.bak
 
+# Python (scripts/verify_crates_publish.py is run by CI; local bytecode only)
+__pycache__/
+*.pyc
+
 # IDE
 .idea/
 .vscode/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ agent-like, stop and ask before committing.
 - Never merge red CI.
 - Before merge, prefer rebasing onto latest `origin/main`.
 
-## Shipping and maintenance
+## Shipping, maintenance, and releases
 
 - "Ship" means implement, gather evidence, perform a security review, open a
   mergeable PR, address every review comment, and merge only after CI is green.
@@ -96,6 +96,10 @@ agent-like, stop and ask before committing.
 - When asked for maintenance or release readiness, follow
   [`.agents/skills/maintenance/SKILL.md`](.agents/skills/maintenance/SKILL.md)
   and [`specs/maintenance.md`](specs/maintenance.md).
+- When asked to release, cut a version, or publish to crates.io / Homebrew,
+  follow [`.agents/skills/release/SKILL.md`](.agents/skills/release/SKILL.md)
+  and [`specs/release.md`](specs/release.md). Releases publish to both
+  crates.io and the `everruns/homebrew-tap` Homebrew tap.
 
 ## Upstream relationship
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable user-visible changes to yolop are recorded here.
+
+The format follows the [release spec](./specs/release.md): one section per
+released version, newest first, with a `### Highlights` summary, an optional
+`### Breaking Changes` block (required for MINOR/MAJOR with breakage), and a
+mechanical `### What's Changed` list of merged PRs.
+
+The first tagged release will be cut via [`/release`](./.agents/skills/release/SKILL.md);
+until then, the `Cargo.toml` version sits at `0.1.0` and unreleased changes
+accumulate below.
+
+## [Unreleased]
+
+### What's Changed
+
+* chore(release): add release skill, spec, workflows, and Homebrew tap publishing

--- a/README.md
+++ b/README.md
@@ -70,7 +70,19 @@ session    session_019e3db018a17450aba5407af5777237 (folder: …; log: …)
 
 ## Install
 
-From source:
+With Homebrew (macOS arm64/x86_64, Linux x86_64):
+
+```bash
+brew install everruns/tap/yolop
+```
+
+From crates.io:
+
+```bash
+cargo install yolop --locked
+```
+
+From git:
 
 ```bash
 cargo install --git https://github.com/everruns/yolop --locked
@@ -82,7 +94,8 @@ Or, from a local clone:
 cargo install --path . --locked
 ```
 
-That drops the `yolop` binary into `~/.cargo/bin/`.
+That drops the `yolop` binary into `~/.cargo/bin/` (or, for the Homebrew
+install, the Homebrew prefix on your `$PATH`).
 
 ## Run
 
@@ -233,6 +246,21 @@ Development setup, validation commands, and local smoke tests live in
 
 Please report vulnerabilities through [`SECURITY.md`](./SECURITY.md), and follow
 the project [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md) when participating.
+
+## Releases
+
+Yolop is released to two registries:
+
+- crates.io as the `yolop` crate (`cargo install yolop --locked`)
+- the `everruns/homebrew-tap` Homebrew tap (`brew install everruns/tap/yolop`)
+
+Releases are prepared by asking an agent ("cut release vX.Y.Z" / `/release`),
+which opens a `chore(release): prepare vX.Y.Z` PR. After a human squash-
+merges, [`.github/workflows/release.yml`](./.github/workflows/release.yml)
+tags the commit, creates the GitHub Release, and dispatches the publish and
+binary-build workflows. See [`specs/release.md`](./specs/release.md) for the
+full procedure and [`CHANGELOG.md`](./CHANGELOG.md) for what shipped in
+each version.
 
 ## License
 

--- a/scripts/verify_crates_publish.py
+++ b/scripts/verify_crates_publish.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Verify crates.io serves the expected version for one or more crates.
+
+crates.io's index propagation is eventually-consistent: a `cargo publish`
+that succeeded can take a minute or two before `GET /api/v1/crates/<name>`
+returns the new `max_version`. This script polls until it does, or fails
+after a bounded number of attempts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Callable
+
+
+USER_AGENT = "yolop-publish-verifier/1.0"
+
+
+class RegistryResponseError(RuntimeError):
+    """crates.io answered, but not with the shape we need yet."""
+
+
+@dataclass
+class HttpResponse:
+    status: int
+    body: bytes
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Verify crates.io publishes are visible at the expected version."
+    )
+    parser.add_argument("--expected", required=True, help="Expected published version")
+    parser.add_argument(
+        "--attempts",
+        type=int,
+        default=6,
+        help="Number of fetch attempts per crate after the initial workflow delay",
+    )
+    parser.add_argument(
+        "--delay-seconds",
+        type=float,
+        default=10.0,
+        help="Delay between retry attempts",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=30.0,
+        help="HTTP timeout per request",
+    )
+    parser.add_argument("crates", nargs="+", help="Crate names to verify")
+    return parser.parse_args()
+
+
+def fetch_response(crate: str, timeout_seconds: float) -> HttpResponse:
+    request = urllib.request.Request(
+        f"https://crates.io/api/v1/crates/{crate}",
+        headers={"User-Agent": USER_AGENT},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            return HttpResponse(status=response.status, body=response.read())
+    except urllib.error.HTTPError as error:
+        # HTTP-level errors (4xx/5xx) still have a body — let the parser
+        # decide whether to retry based on the registry's error payload.
+        return HttpResponse(status=error.code, body=error.read())
+    except (urllib.error.URLError, TimeoutError, ConnectionError) as error:
+        # DNS, connection reset, TLS, read timeout — transient. Re-raise as
+        # the retryable error so fetch_max_version_with_retries waits and
+        # tries again instead of failing the publish on a blip.
+        raise RegistryResponseError(
+            f"{crate}: crates.io request failed before a response was received: {error}"
+        ) from error
+
+
+def extract_max_version(crate: str, response: HttpResponse) -> str:
+    try:
+        payload = json.loads(response.body)
+    except json.JSONDecodeError as error:
+        raise RegistryResponseError(
+            f"{crate}: crates.io returned invalid JSON (status {response.status}): {error}"
+        ) from error
+
+    crate_data = payload.get("crate")
+    if response.status != 200:
+        detail = summarize_error_payload(payload)
+        raise RegistryResponseError(
+            f"{crate}: crates.io returned HTTP {response.status}: {detail}"
+        )
+    if not isinstance(crate_data, dict):
+        detail = summarize_error_payload(payload)
+        raise RegistryResponseError(
+            f"{crate}: crates.io payload missing 'crate' object: {detail}"
+        )
+    max_version = crate_data.get("max_version")
+    if not isinstance(max_version, str) or not max_version:
+        raise RegistryResponseError(
+            f"{crate}: crates.io payload missing 'crate.max_version'"
+        )
+    return max_version
+
+
+def summarize_error_payload(payload: object) -> str:
+    if isinstance(payload, dict):
+        errors = payload.get("errors")
+        if isinstance(errors, list) and errors:
+            details = [
+                error.get("detail", str(error))
+                for error in errors
+                if isinstance(error, dict)
+            ]
+            if details:
+                return "; ".join(details)
+        return json.dumps(payload, sort_keys=True)[:300]
+    return repr(payload)[:300]
+
+
+def fetch_max_version_with_retries(
+    crate: str,
+    attempts: int,
+    delay_seconds: float,
+    timeout_seconds: float,
+    fetcher: Callable[[str, float], HttpResponse] = fetch_response,
+) -> str:
+    last_error: RegistryResponseError | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            return extract_max_version(crate, fetcher(crate, timeout_seconds))
+        except RegistryResponseError as error:
+            last_error = error
+            if attempt == attempts:
+                break
+            print(
+                f"Retry {attempt}/{attempts - 1} for {crate}: {error}",
+                file=sys.stderr,
+            )
+            time.sleep(delay_seconds)
+
+    assert last_error is not None
+    raise last_error
+
+
+def main() -> int:
+    args = parse_args()
+    all_ok = True
+
+    for crate in args.crates:
+        actual = fetch_max_version_with_retries(
+            crate=crate,
+            attempts=args.attempts,
+            delay_seconds=args.delay_seconds,
+            timeout_seconds=args.timeout_seconds,
+        )
+        if actual == args.expected:
+            print(f"OK  {crate}@{actual} on crates.io")
+        else:
+            print(
+                f"FAIL {crate}: expected {args.expected}, got {actual}",
+                file=sys.stderr,
+            )
+            all_ok = False
+
+    if not all_ok:
+        print(
+            "::error::Some crates.io packages were not published correctly",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/specs/release.md
+++ b/specs/release.md
@@ -1,0 +1,268 @@
+# Release Specification
+
+## Abstract
+
+This spec defines how yolop is cut, published, and verified. Releases are
+agent-prepared, human-merged, and CI-published to two registries: crates.io
+and the `everruns/homebrew-tap` Homebrew tap.
+
+The canonical agent workflow lives in
+[`.agents/skills/release/SKILL.md`](../.agents/skills/release/SKILL.md). That
+skill is user-invocable as `/release`.
+
+## Versioning
+
+Yolop follows [Semantic Versioning](https://semver.org/):
+
+- **MAJOR** (X.0.0): incompatible CLI flags, removed providers, breaking config
+- **MINOR** (0.X.0): new features, new tools, new providers
+- **PATCH** (0.0.X): bug fixes, documentation, dependency bumps
+
+Pre-1.0 (current): minor bumps may carry breaking changes if they are flagged
+in the changelog.
+
+## Release Targets
+
+Every yolop release ships to:
+
+| Target          | Surface                                  | How users install                       |
+|-----------------|------------------------------------------|-----------------------------------------|
+| GitHub Release  | tag `vX.Y.Z`, source archive, binaries   | `gh release download vX.Y.Z`            |
+| crates.io       | `yolop` crate                            | `cargo install yolop --locked`          |
+| Homebrew tap    | formula at `everruns/homebrew-tap`       | `brew install everruns/tap/yolop`       |
+
+Prebuilt CLI binaries are produced for:
+
+| OS    | Target                       | Runner          |
+|-------|------------------------------|-----------------|
+| macOS | `aarch64-apple-darwin`       | `macos-latest`  |
+| macOS | `x86_64-apple-darwin`        | `macos-latest`  |
+| Linux | `x86_64-unknown-linux-gnu`   | `ubuntu-latest` |
+
+## Release Flow
+
+```
+┌──────────┐   ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌──────────┐
+│ Human    │   │ Agent    │   │ Agent    │   │ Human    │   │ CI       │   │ Agent    │
+│ asks     │──>│ prepares │──>│ verifies │──>│ merges   │──>│ tags +   │──>│ monitors │
+│ release  │   │ PR       │   │ publish  │   │ PR       │   │ publishes│   │ registries│
+└──────────┘   └──────────┘   └──────────┘   └──────────┘   └──────────┘   └──────────┘
+```
+
+Skipping `verify-can-publish` risks tagging a release that fails to publish.
+Skipping `monitor-published` risks declaring "shipped" while one of the two
+registries silently failed.
+
+### Human Steps
+
+1. **Ask the agent** to create a release:
+   - "Cut release v0.2.0"
+   - "Prepare a patch release"
+2. **Review the PR** the agent opens, including its publish-readiness report.
+3. **Squash and merge** — CI handles the GitHub Release, crates.io publish,
+   binary builds, and Homebrew formula update.
+4. **Ask the agent to monitor** (or let it auto-monitor if subscribed to PR
+   activity) until both registries report the new version.
+
+### Agent Steps
+
+When asked to release, the agent:
+
+0. **Ensure full git history.** Cloud sandboxes are often shallow-cloned,
+   which silently hides commits and yields a wrong commit count or changelog.
+   Run `git fetch --unshallow origin main 2>/dev/null || git fetch origin main`
+   before counting or listing commits.
+
+1. **Determine the version.** Use the version specified by the human, or
+   propose the next version based on the unreleased commits (patch / minor /
+   major) and confirm before proceeding.
+
+2. **Update `CHANGELOG.md`.** Add a `## [X.Y.Z] - YYYY-MM-DD` section, list
+   PRs in descending order with GitHub-style links and contributor handles,
+   end with `**Full Changelog**: URL`. For minor/major bumps, add an explicit
+   `### Breaking Changes` block with before/after migration snippets.
+
+3. **Bump the version** in `Cargo.toml` and regenerate `Cargo.lock`
+   (`cargo update -p yolop`).
+
+4. **Run local verification:**
+   - `cargo fmt --check`
+   - `cargo clippy --all-targets --all-features -- -D warnings`
+   - `cargo test`
+
+5. **Verify publish-readiness** (catches what local tests don't — the
+   `cargo publish` packaging step, missing files, version drift):
+   - `cargo publish --dry-run -p yolop` must succeed.
+   - Confirm `Cargo.toml` and `Cargo.lock` agree on `X.Y.Z`.
+   - Confirm `X.Y.Z` is greater than the latest published version on
+     crates.io (`cargo search yolop --limit 1`).
+   - If any check fails, fix the root cause and re-run before opening the
+     PR. **Do not** merge a release PR with a known-broken publish path.
+
+6. **Commit and push** the changes on a feature branch with message
+   `chore(release): prepare vX.Y.Z`.
+
+7. **Open a PR** titled `chore(release): prepare vX.Y.Z`. Include the
+   changelog excerpt and a **publish-readiness report** (which dry-runs ran,
+   what the registry currently shows).
+
+8. **Monitor post-merge publishing.** After the human squash-merges the PR:
+   - Watch `release.yml` complete and confirm tag `vX.Y.Z` + the GitHub
+     Release were created.
+   - Watch `publish.yml` and `cli-binaries.yml` to completion. Surface any
+     failure immediately.
+   - Run post-release verification (see below) and report which targets show
+     the new version.
+   - Only declare the release **shipped** when both crates.io and the
+     Homebrew tap report `X.Y.Z`. If one fails, open a hotfix PR rather
+     than leaving the release half-published.
+
+## CI Automation
+
+### `release.yml`
+
+- **Trigger**: push to `main` whose commit message starts with
+  `chore(release): prepare v`, or manual `workflow_dispatch`.
+- **Actions**: extracts the version from the commit subject, verifies it
+  matches `Cargo.toml`, extracts the matching `CHANGELOG.md` section as
+  release notes, creates the GitHub Release with tag `vX.Y.Z`, then
+  explicitly dispatches `publish.yml` and `cli-binaries.yml` against the
+  new tag.
+- **Why explicit dispatch**: a GitHub Release created with `GITHUB_TOKEN`
+  does not fire `release: published` events (anti-recursion), so the
+  downstream workflows must be kicked manually.
+
+### `publish.yml`
+
+- **Trigger**: `release: published`, or `workflow_dispatch --ref vX.Y.Z` from
+  `release.yml`.
+- **Actions**: installs the pinned Rust toolchain, verifies the tag matches
+  `Cargo.toml`, runs `cargo publish -p yolop`, then runs
+  `scripts/verify_crates_publish.py` to confirm crates.io serves the new
+  version.
+- **Secret**: `CARGO_REGISTRY_TOKEN`.
+
+### `cli-binaries.yml`
+
+- **Trigger**: `workflow_dispatch --ref vX.Y.Z` with the `tag` input, from
+  `release.yml`.
+- **Actions**: builds release binaries for the three CLI targets, packages
+  them as `yolop-<target>.tar.gz`, uploads tarballs and `.sha256` files to
+  the GitHub Release, then regenerates the Homebrew formula and pushes it
+  to `everruns/homebrew-tap`.
+- **Secret**: `DOPPLER_TOKEN`. The Doppler config holds
+  `HOMEBREW_TAP_GITHUB_TOKEN`, a fine-grained PAT scoped to
+  `everruns/homebrew-tap` only.
+
+## Pre-Release Checklist
+
+The agent verifies before opening the release PR:
+
+- [ ] All CI checks pass on `main`.
+- [ ] `cargo fmt`, `cargo clippy`, `cargo test` clean.
+- [ ] `CHANGELOG.md` has an entry for every commit since the last release.
+- [ ] `Cargo.toml` and `Cargo.lock` both read `X.Y.Z`.
+- [ ] `cargo publish --dry-run -p yolop` succeeds.
+- [ ] `X.Y.Z` is greater than the latest crates.io version.
+
+## Post-Release Verification
+
+Run after both publish workflows finish:
+
+```bash
+# crates.io
+cargo search yolop --limit 1                       # shows X.Y.Z
+
+# GitHub Release
+gh release view vX.Y.Z --repo everruns/yolop       # tarballs + checksums present
+
+# Homebrew tap
+curl -sSfL https://raw.githubusercontent.com/everruns/homebrew-tap/main/Formula/yolop.rb \
+  | grep '^  version "'                            # shows X.Y.Z
+
+# End-to-end install (optional, on macOS / Linux)
+brew untap everruns/tap 2>/dev/null; brew install everruns/tap/yolop
+yolop --version
+```
+
+If any registry is missing the new version, inspect the corresponding
+workflow run (`gh run view <run-id> --log-failed`) and either re-run
+(transient) or open a hotfix PR (packaging bug).
+
+## Changelog Format
+
+Follow the everruns convention:
+
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+
+### Highlights
+
+- 2–5 bullet points summarizing the most impactful changes.
+
+### Breaking Changes
+
+- **Short description**: what changed, why, migration.
+  - Before: `old_flag`
+  - After: `new_flag`
+
+### What's Changed
+
+* feat(scope): description ([#42](https://github.com/everruns/yolop/pull/42)) by @contributor
+* fix(scope): description ([#41](https://github.com/everruns/yolop/pull/41)) by @contributor
+
+**Full Changelog**: https://github.com/everruns/yolop/compare/vA.B.C...vX.Y.Z
+```
+
+Rules:
+
+- PRs listed newest-first by number.
+- `### Breaking Changes` only when present; required for MINOR or MAJOR.
+- `### Highlights` is the human summary; `### What's Changed` is the
+  mechanical PR list.
+
+## Hotfix Releases
+
+For urgent fixes:
+
+1. Ask agent: "Cut patch release vX.Y.Z+1 for the &lt;fix&gt;".
+2. Agent branches from the latest tag, cherry-picks the fix, runs the same
+   pre-release checklist, and opens the PR.
+3. Human reviews and merges.
+
+## Rollback
+
+If a published version is broken, yank it:
+
+```bash
+cargo yank --version X.Y.Z yolop
+```
+
+Yanked versions remain usable by existing `Cargo.lock` files but are not
+selected for new resolves. For Homebrew, push a follow-up commit to
+`everruns/homebrew-tap` that reverts `Formula/yolop.rb` to the previous
+release.
+
+## Authentication
+
+**Repo secrets** (Settings → Secrets and variables → Actions):
+
+| Secret                  | Used by              | Source                                                  |
+|-------------------------|----------------------|---------------------------------------------------------|
+| `CARGO_REGISTRY_TOKEN`  | `publish.yml`        | https://crates.io/settings/tokens — publish scope       |
+| `DOPPLER_TOKEN`         | `cli-binaries.yml`   | Doppler service token for the `release` config          |
+
+**Doppler secrets** (loaded by `cli-binaries.yml` via `doppler secrets get`):
+
+| Secret                       | Purpose                                                  |
+|------------------------------|----------------------------------------------------------|
+| `HOMEBREW_TAP_GITHUB_TOKEN`  | Fine-grained PAT scoped to `everruns/homebrew-tap` only. |
+
+Scoping the tap PAT to the tap repo means a leak cannot touch the main
+`yolop` repo.
+
+## Related
+
+- [`.agents/skills/release/SKILL.md`](../.agents/skills/release/SKILL.md)
+- [`specs/shipping.md`](./shipping.md)
+- [`specs/maintenance.md`](./maintenance.md)


### PR DESCRIPTION
## Summary

Stand up the release procedure for yolop, modeled on `everruns/bashkit`'s. Releases ship to **two registries** — crates.io as the `yolop` crate, and the `everruns/homebrew-tap` Homebrew tap (`brew install everruns/tap/yolop`).

The flow is agent-prepared, human-merged, CI-published:

```
human asks  →  /release prepares PR  →  agent verifies publish-readiness
                                                 ↓
                                       human squash-merges
                                                 ↓
release.yml tags vX.Y.Z & creates GitHub Release
                                                 ↓
       ├─ publish.yml         → crates.io
       └─ cli-binaries.yml    → 3 binaries + Homebrew tap formula bump
                                                 ↓
                                       agent confirms both
```

### Files added

- `specs/release.md` — versioning, registries, agent steps, CI surfaces, hotfix/rollback, secrets table
- `.agents/skills/release/SKILL.md` — user-invocable `/release` skill with mandatory outcomes and the step-by-step
- `.github/workflows/release.yml` — triggers on `chore(release): prepare v…` on `main` (or manual dispatch), tags + creates the GitHub Release, then explicitly dispatches the publish + binaries workflows (`GITHUB_TOKEN`-created releases don't fire `release: published`)
- `.github/workflows/publish.yml` — `cargo publish -p yolop` + readback verify
- `.github/workflows/cli-binaries.yml` — matrix build for `aarch64-apple-darwin`, `x86_64-apple-darwin`, `x86_64-unknown-linux-gnu`; tarballs + SHA256 uploaded to the release; Homebrew formula generated and pushed to `everruns/homebrew-tap` via a Doppler-fetched fine-grained PAT (askpass to keep the token out of URLs/logs)
- `scripts/verify_crates_publish.py` — polls `crates.io/api/v1/crates/yolop` with retries to absorb index propagation
- `CHANGELOG.md` — initial scaffold with `[Unreleased]`
- `README.md` — `brew install everruns/tap/yolop` install line, Releases section, project-layout refresh
- `AGENTS.md` — cross-link `/release` alongside `/ship` and `/maintenance`

### Required repo configuration (one-time, before the first cut)

| Secret                       | Where                       | Used by              |
|------------------------------|-----------------------------|----------------------|
| `CARGO_REGISTRY_TOKEN`       | GitHub repo secrets         | `publish.yml`        |
| `DOPPLER_TOKEN`              | GitHub repo secrets (exists)| `cli-binaries.yml`   |
| `HOMEBREW_TAP_GITHUB_TOKEN`  | Doppler config              | `cli-binaries.yml`   |

`HOMEBREW_TAP_GITHUB_TOKEN` should be a **fine-grained PAT scoped to `everruns/homebrew-tap` only** (Contents: read+write, Metadata: read), so a leak cannot touch the main repo.

Also requires the tap repo `github.com/everruns/homebrew-tap` to exist with a `Formula/` directory (the workflow `mkdir -p`s the dir if missing).

## Validation

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all-features` — 61 unit + 3 integration tests pass
- YAML parse: all 4 workflow files parse cleanly
- `python3 -m py_compile scripts/verify_crates_publish.py` — clean
- `crates.io/api/v1/crates/yolop` → 404 (name is unclaimed; first publish reserves it)

No runtime code changed, so the offline / live-provider smoke tests aren't applicable for this PR — the workflows themselves can only be exercised end-to-end by a real release commit landing on `main`.

## Security

- **TM-FS / TM-BASH / TM-LLM / TM-TOOL**: no runtime code changed; nothing to review.
- **TM-DEP**: no new Rust dependencies; the verify script uses stdlib only.
- **CI / secrets posture**:
  - `HOMEBREW_TAP_GITHUB_TOKEN` is fetched from Doppler at workflow time, masked via `::add-mask::`, fed to git through a tempfile `GIT_ASKPASS` script, and unset on EXIT via `trap`. The token never appears in clone/push URLs or logs.
  - `cli-binaries.yml` originally interpolated `${{ inputs.tag }}` and other GitHub context directly into `run:` shell scripts at template-render time — a malicious workflow_dispatch input could have broken out of the surrounding quotes (gated by repo write access, but still avoidable). Hardened in `ffbf51b` by binding inputs to step `env:` and referencing `$TAG` in shell, so user-controlled values never reach the YAML template-render boundary.
  - `release.yml`'s tag is derived from a sed regex restricted to `[0-9]+\.[0-9]+\.[0-9]+`, so its `steps.version.outputs.tag` cannot carry shell metacharacters even when interpolated.

## Follow-ups

- The first actual release (e.g. `v0.1.0`) is a separate task — invoke `/release` once the secrets above are configured.
- `everruns/homebrew-tap` needs to exist with a `Formula/` directory before the first `cli-binaries.yml` run (the workflow creates the dir on first push, but the repo itself must already be there).


---
_Generated by [Claude Code](https://claude.ai/code/session_01U6EBaxsDTsCTsoCjpJRUqw)_