### PR TITLE
fix(capabilities): rename environment context id

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ session    session_019e3db018a17450aba5407af5777237 (folder: …; log: …)
 - **Host bash tool** — `bash -lc` from the workspace root, with a 120 s
   wall-clock timeout and per-stream 1 MiB output cap.
 - **Curated capabilities** wired beyond the filesystem:
-  - `yolop_environment_context` — workspace root, shell, local date/timezone,
+  - `code_environment_context` — workspace root, shell, local date/timezone,
     Git identity and branch.
   - `agent_instructions` — re-reads `AGENTS.md` every turn.
   - `skills` — discovers `SKILL.md` files under `.agents/skills/<name>/`;

--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -22,7 +22,7 @@ use std::sync::{Arc, RwLock};
 
 // ---------- environment context ----------
 
-pub(crate) const ENVIRONMENT_CONTEXT_CAPABILITY_ID: &str = "yolop_environment_context";
+pub(crate) const ENVIRONMENT_CONTEXT_CAPABILITY_ID: &str = "code_environment_context";
 
 pub(crate) struct CodingCliEnvironmentCapability {
     base: EnvironmentContextBase,


### PR DESCRIPTION
## What
Rename the environment context capability ID from `yolop_environment_context` to `code_environment_context` and update the README capability list to match.

## Why
The capability ID should use the code-oriented name requested for the environment context surface.

## How
Updated the single capability ID constant and the matching user-facing README reference.

## Validation
- `rg -n "yolop_environment_context|code_environment_context|yolop_environment_contex|code_environment_contex" .`
- `git diff --check`
- `cargo fmt --check`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- --provider llmsim -p "hi"`

Live provider smoke note: `doppler run -- cargo run -- --provider openai -p "Reply exactly: ok"` could not start locally because Doppler has no project/fallback configured in this checkout. CI remains the live-provider source of truth.

## Security
Low risk. This changes only a static capability ID string and README documentation.

TM-LLM/TM-TOOL: reviewed capability registration impact; no prompt content, approval behavior, API key handling, tool schema, or provider configuration changed.

TM-FS/TM-BASH/TM-DEP: not touched; no filesystem permissions, shell execution behavior, dependency changes, or resource limits changed.

## Risk
- Low
- Existing consumers that explicitly reference the old capability ID will need to use `code_environment_context`.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
