### PR TITLE
feat(tui): /provider, /token, /onboard with persisted TOML settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5334,6 +5334,7 @@ dependencies = [
  "tempfile",
  "textwrap",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ ratatui = "0.30"
 ratatui-textarea = "0.9.1"
 serde_json = "1.0"
 similar = "3"
+toml = "1"
 textwrap = "0.16"
 tokio = { version = "1.50", features = ["full"] }
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -60,9 +60,11 @@ session    session_019e3db018a17450aba5407af5777237 (folder: …; log: …)
   - `OPENAI_API_KEY` → OpenAI (`gpt-5.5`)
   - `ANTHROPIC_API_KEY` → Anthropic (`claude-sonnet-4-5`)
   - `OPENROUTER_API_KEY` → OpenRouter (`openai/gpt-5.2` by default)
+  - `GEMINI_API_KEY` (or `GOOGLE_API_KEY`) → Google Gemini (`gemini-2.5-flash`)
   - `OLLAMA_BASE_URL` / `OLLAMA_API_KEY` → Ollama (`llama3.2`)
   - otherwise `llmsim` (offline simulator, no key required)
-- **Slash commands** (TUI): `/help`, `/tools`, `/cwd`, `/model <provider>/<id>`,
+- **Slash commands** (TUI): `/help`, `/tools`, `/cwd`,
+  `/provider <name>` (persists across runs), `/model <provider>/<id>`,
   `/clear`, `/quit`.
 - **`--print`** one-shot mode for CI smoke tests.
 - **Session persistence** — durable per-session JSONL event log under the
@@ -148,7 +150,7 @@ OLLAMA_BASE_URL=http://localhost:11434/v1 yolop --provider ollama -m llama3.2 -p
 | Flag                       | Description                                                          |
 | -------------------------- | -------------------------------------------------------------------- |
 | `-C, --cwd <PATH>`         | Workspace root (default: current dir)                                |
-| `--provider <P>`           | Force `anthropic`, `openai`, `openrouter`, `ollama`, or `llmsim`     |
+| `--provider <P>`           | Force `anthropic`, `openai`, `google`, `openrouter`, `ollama`, or `llmsim` |
 | `-m, --model <ID>`         | Override the model id for the chosen provider                        |
 | `-p, --print <PROMPT>`     | Run one prompt non-interactively and print the result                |
 | `--ask`                    | Prompt before every destructive tool call (off by default)           |
@@ -166,10 +168,23 @@ OLLAMA_BASE_URL=http://localhost:11434/v1 yolop --provider ollama -m llama3.2 -p
 | `ANTHROPIC_API_KEY`             | Select Anthropic when OpenAI is not configured               |
 | `OPENROUTER_API_KEY`            | Select OpenRouter when OpenAI/Anthropic are not configured   |
 | `OPENROUTER_BASE_URL`           | Optional, defaults to `https://openrouter.ai/api/v1`         |
+| `GEMINI_API_KEY` / `GOOGLE_API_KEY` | Select Google Gemini via its OpenAI-compatible endpoint  |
+| `GOOGLE_BASE_URL`               | Optional, defaults to `https://generativelanguage.googleapis.com/v1beta/openai` |
 | `OLLAMA_BASE_URL`               | Select Ollama, defaults to `http://localhost:11434/v1`       |
 | `OLLAMA_API_KEY`                | Optional, defaults to `ollama` for local Ollama              |
 | `EVERRUNS_CLI_MODEL`            | Override the auto-selected default model                     |
 | `EVERRUNS_CLI_REASONING_EFFORT` | OpenAI-only reasoning effort override                        |
+
+## Settings
+
+A small JSON settings file persists the preferred provider across runs. It
+lives at `<config_dir>/yolop/settings.json` — `~/.config/yolop/settings.json`
+on Linux, `~/Library/Application Support/yolop/settings.json` on macOS,
+`%APPDATA%\yolop\settings.json` on Windows.
+
+The TUI's `/provider <name>` command writes through this file. Resolution
+order at startup is: `--provider` flag > saved setting > env-var
+auto-detection. `/model <provider>/<id>` still works on top of either.
 
 ## Session persistence
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ session    session_019e3db018a17450aba5407af5777237 (folder: …; log: …)
   - `OLLAMA_BASE_URL` / `OLLAMA_API_KEY` → Ollama (`llama3.2`)
   - otherwise `llmsim` (offline simulator, no key required)
 - **Slash commands** (TUI): `/help`, `/tools`, `/cwd`,
-  `/provider <name>` (persists across runs), `/model <provider>/<id>`,
-  `/clear`, `/quit`.
+  `/provider <name>`, `/model <provider>/<id>`, `/token <provider> <value>`
+  (all three persist across runs), `/clear`, `/quit`.
 - **`--print`** one-shot mode for CI smoke tests.
 - **Session persistence** — durable per-session JSONL event log under the
   platform-native user data directory, with `--session <id>` to resume.
@@ -177,14 +177,32 @@ OLLAMA_BASE_URL=http://localhost:11434/v1 yolop --provider ollama -m llama3.2 -p
 
 ## Settings
 
-A small TOML settings file persists the preferred provider across runs. It
-lives at `<config_dir>/yolop/settings.toml` — `~/.config/yolop/settings.toml`
-on Linux, `~/Library/Application Support/yolop/settings.toml` on macOS,
+A small TOML settings file persists the preferred provider and (optionally)
+provider API tokens across runs. It lives at `<config_dir>/yolop/settings.toml`
+— `~/.config/yolop/settings.toml` on Linux,
+`~/Library/Application Support/yolop/settings.toml` on macOS,
 `%APPDATA%\yolop\settings.toml` on Windows.
 
 The TUI's `/provider <name>` command writes through this file. Resolution
-order at startup is: `--provider` flag > saved setting > env-var
-auto-detection. `/model <provider>/<id>` still works on top of either.
+order at startup is: `--provider` flag > saved provider setting > env-var
+auto-detection > saved tokens. `/model <provider>/<id>` still works on
+top of either.
+
+### Storing tokens
+
+`/token openai sk-...` stores an API token under `[tokens]` in the
+settings file. The file is written with `0o600` on Unix (owner-only).
+Other commands:
+
+- `/token` — list which providers have a token stored (values are not
+  echoed)
+- `/token <provider> clear` — remove the stored token
+
+Env vars still win at runtime: if both `OPENAI_API_KEY` is set and a token
+is saved, the env var is used. Slash commands are not echoed into the
+transcript or session log, so `/token openai sk-...` is safer than typing
+it at a chat prompt — but the resulting settings file is plain text on
+disk, so treat it the same way you would `~/.aws/credentials`.
 
 ## Session persistence
 

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ session    session_019e3db018a17450aba5407af5777237 (folder: …; log: …)
   - `OLLAMA_BASE_URL` / `OLLAMA_API_KEY` → Ollama (`llama3.2`)
   - otherwise `llmsim` (offline simulator, no key required)
 - **Slash commands** (TUI): `/help`, `/tools`, `/cwd`,
-  `/provider <name>`, `/model <provider>/<id>`, `/token <provider> <value>`
-  (all three persist across runs), `/onboard` (guided setup), `/clear`,
-  `/quit`.
+  `/provider <name>` (persists), `/token <provider> <value>` (persists),
+  `/model <provider>/<id>` (current session only), `/onboard` (guided
+  setup), `/clear`, `/quit`.
 - **First-run onboarding**: launching yolop with no env vars and no saved
   settings opens an interactive wizard that walks through provider →
   token → default model. Re-runnable any time via `/onboard`.
@@ -187,10 +187,23 @@ provider API tokens across runs. It lives at `<config_dir>/yolop/settings.toml`
 `~/Library/Application Support/yolop/settings.toml` on macOS,
 `%APPDATA%\yolop\settings.toml` on Windows.
 
-The TUI's `/provider <name>` command writes through this file. Resolution
-order at startup is: `--provider` flag > saved provider setting > env-var
-auto-detection > saved tokens. `/model <provider>/<id>` still works on
-top of either.
+The TUI's `/provider <name>` command writes through this file.
+
+Provider resolution at startup:
+
+1. `--provider` flag (always wins)
+2. Saved `provider` setting
+3. Auto-detect: the first provider in the order **OpenAI → Anthropic →
+   OpenRouter → Google → Ollama** for which *either* a matching env var
+   *or* a saved token is present. Env vars and saved tokens are treated
+   as equivalent credential signals here — the provider order decides
+   the tiebreak, not the credential source.
+4. Fall back to `llmsim` (offline) if nothing matches.
+
+At runtime, the per-provider env var (`OPENAI_API_KEY`, etc.) always
+beats the saved token, so a per-run env override is always possible.
+`/model <provider>/<id>` then layers on top of the chosen provider for
+the current session.
 
 ### Storing tokens
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,11 @@ session    session_019e3db018a17450aba5407af5777237 (folder: …; log: …)
   - otherwise `llmsim` (offline simulator, no key required)
 - **Slash commands** (TUI): `/help`, `/tools`, `/cwd`,
   `/provider <name>`, `/model <provider>/<id>`, `/token <provider> <value>`
-  (all three persist across runs), `/clear`, `/quit`.
+  (all three persist across runs), `/onboard` (guided setup), `/clear`,
+  `/quit`.
+- **First-run onboarding**: launching yolop with no env vars and no saved
+  settings opens an interactive wizard that walks through provider →
+  token → default model. Re-runnable any time via `/onboard`.
 - **`--print`** one-shot mode for CI smoke tests.
 - **Session persistence** — durable per-session JSONL event log under the
   platform-native user data directory, with `--session <id>` to resume.

--- a/README.md
+++ b/README.md
@@ -177,10 +177,10 @@ OLLAMA_BASE_URL=http://localhost:11434/v1 yolop --provider ollama -m llama3.2 -p
 
 ## Settings
 
-A small JSON settings file persists the preferred provider across runs. It
-lives at `<config_dir>/yolop/settings.json` — `~/.config/yolop/settings.json`
-on Linux, `~/Library/Application Support/yolop/settings.json` on macOS,
-`%APPDATA%\yolop\settings.json` on Windows.
+A small TOML settings file persists the preferred provider across runs. It
+lives at `<config_dir>/yolop/settings.toml` — `~/.config/yolop/settings.toml`
+on Linux, `~/Library/Application Support/yolop/settings.toml` on macOS,
+`%APPDATA%\yolop\settings.toml` on Windows.
 
 The TUI's `/provider <name>` command writes through this file. Resolution
 order at startup is: `--provider` flag > saved setting > env-var

--- a/src/app.rs
+++ b/src/app.rs
@@ -138,6 +138,24 @@ pub struct App {
     rx: Option<mpsc::UnboundedReceiver<TurnEvent>>,
     approval_rx: ApprovalRx,
     pending: Option<PendingApproval>,
+    /// Active onboarding step, if any. The wizard drives the existing
+    /// `/provider`, `/token`, and `/model` capabilities under the hood;
+    /// it captures plain-text input from the composer and dispatches the
+    /// matching slash command at each step.
+    onboarding: Option<OnboardingStep>,
+}
+
+#[derive(Clone, Debug)]
+enum OnboardingStep {
+    PickProvider,
+    EnterToken {
+        provider: String,
+        default_model: String,
+    },
+    PickModel {
+        provider: String,
+        default_model: String,
+    },
 }
 
 /// Owned snapshot of the App fields the pure-render chrome helpers
@@ -219,6 +237,7 @@ pub(crate) enum TurnEvent {
 
 impl App {
     pub fn new(runtime: BuiltRuntime, approval_rx: ApprovalRx) -> Self {
+        let should_onboard = runtime.startup.onboarding_recommended;
         let mut app = Self {
             handles: runtime.handles,
             startup: runtime.startup,
@@ -235,8 +254,12 @@ impl App {
             rx: None,
             approval_rx,
             pending: None,
+            onboarding: None,
         };
         app.emit_system_banner();
+        if should_onboard {
+            app.start_onboarding();
+        }
         app
     }
 
@@ -554,14 +577,20 @@ impl App {
     }
 
     async fn submit_input(&mut self) {
-        let text = self.input_text();
+        let raw = self.input_text();
         self.reset_input();
-        let text = text.trim().to_string();
-        if text.is_empty() {
-            return;
-        }
+        let text = raw.trim().to_string();
         if let Some(rest) = text.strip_prefix('/') {
             self.handle_command(rest).await;
+            return;
+        }
+        // While onboarding, plain-text input is the wizard answer (empty
+        // included — "skip" for token/model steps).
+        if self.onboarding.is_some() {
+            self.advance_onboarding(&text).await;
+            return;
+        }
+        if text.is_empty() {
             return;
         }
         self.push_user(text.clone());
@@ -681,6 +710,11 @@ impl App {
                     }
                     Err(err) => self.push_system(format!("/{} failed: {err}", descriptor.name)),
                 }
+                // `/onboard` flips the TUI into wizard mode after the
+                // capability has reported its status line.
+                if descriptor.name == "onboard" {
+                    self.start_onboarding();
+                }
             }
             CommandSource::Skill => {
                 let text = if trimmed.is_empty() {
@@ -690,6 +724,149 @@ impl App {
                 };
                 self.push_user(text.clone());
                 self.start_turn(text);
+            }
+        }
+    }
+
+    fn start_onboarding(&mut self) {
+        self.onboarding = Some(OnboardingStep::PickProvider);
+        self.push_system(
+            "welcome to yolop — let's get a provider configured (type /onboard any time to redo)"
+                .into(),
+        );
+        self.push_system(format!(
+            "step 1/3: pick a provider — {}",
+            crate::runtime::SUPPORTED_PROVIDERS.join(" / ")
+        ));
+    }
+
+    /// Drive the wizard one step forward. The actual mutations go through
+    /// the existing `/provider`, `/token`, and `/model` capabilities so
+    /// onboarding never knows about settings paths or runtime stores
+    /// directly.
+    async fn advance_onboarding(&mut self, input: &str) {
+        let Some(step) = self.onboarding.clone() else {
+            return;
+        };
+        match step {
+            OnboardingStep::PickProvider => {
+                let name = input.trim().to_ascii_lowercase();
+                if name.is_empty() {
+                    self.push_system(format!(
+                        "type one of: {}",
+                        crate::runtime::SUPPORTED_PROVIDERS.join(", ")
+                    ));
+                    return;
+                }
+                if !crate::runtime::SUPPORTED_PROVIDERS.contains(&name.as_str()) {
+                    self.push_system(format!(
+                        "unknown provider `{name}` — options: {}",
+                        crate::runtime::SUPPORTED_PROVIDERS.join(", ")
+                    ));
+                    return;
+                }
+                if name == "llmsim" {
+                    // Offline simulator: no token, no model picker.
+                    let _ = self.run_system_command("provider", Some("llmsim")).await;
+                    self.push_system(
+                        "onboarding complete — using offline llmsim. switch any time with /provider"
+                            .into(),
+                    );
+                    self.onboarding = None;
+                    return;
+                }
+                let default_model =
+                    crate::runtime::ProviderChoice::default_for_provider_name(&name)
+                        .map(|p| p.label())
+                        .unwrap_or_else(|_| name.clone());
+                self.push_system(format!(
+                    "step 2/3: paste your API token for {name} (press Enter to skip and use env vars)"
+                ));
+                self.onboarding = Some(OnboardingStep::EnterToken {
+                    provider: name,
+                    default_model,
+                });
+            }
+            OnboardingStep::EnterToken {
+                provider,
+                default_model,
+            } => {
+                let token = input.trim();
+                if !token.is_empty() {
+                    // Don't echo the token; the capability response is the
+                    // only line that lands in the transcript.
+                    let arg = format!("{provider} {token}");
+                    let _ = self.run_system_command("token", Some(&arg)).await;
+                } else {
+                    self.push_system(format!(
+                        "no token entered — relying on env vars for {provider}"
+                    ));
+                }
+                // Now flip the runtime to the chosen provider. With the
+                // token just saved (or env var present), this picks up the
+                // credential transparently.
+                let switched = self.run_system_command("provider", Some(&provider)).await;
+                if !switched {
+                    self.push_system(format!(
+                        "couldn't activate {provider} — re-run /token {provider} <key> or set the env var, then /provider {provider}"
+                    ));
+                }
+                self.push_system(format!(
+                    "step 3/3: model id (Enter to keep default `{default_model}`, or paste e.g. `gpt-5.4-mini`)"
+                ));
+                self.onboarding = Some(OnboardingStep::PickModel {
+                    provider,
+                    default_model,
+                });
+            }
+            OnboardingStep::PickModel {
+                provider,
+                default_model,
+            } => {
+                let model = input.trim();
+                if !model.is_empty() {
+                    let spec = if model.contains('/') {
+                        model.to_string()
+                    } else {
+                        format!("{provider}/{model}")
+                    };
+                    let _ = self.run_system_command("model", Some(&spec)).await;
+                }
+                self.push_system(format!(
+                    "onboarding complete — provider {provider}, model {}. /provider · /token · /model to revisit",
+                    if model.is_empty() {
+                        default_model.as_str()
+                    } else {
+                        model
+                    }
+                ));
+                self.onboarding = None;
+            }
+        }
+    }
+
+    /// Execute a System slash command end to end. Returns whether the
+    /// capability reported success. Status line is always pushed.
+    async fn run_system_command(&mut self, name: &str, arg: Option<&str>) -> bool {
+        let request = everruns_core::command::ExecuteCommandRequest {
+            name: name.to_string(),
+            arguments: arg.map(str::to_string),
+            controls: None,
+        };
+        match self
+            .handles
+            .runtime
+            .execute_command(self.handles.session_id, request)
+            .await
+        {
+            Ok(result) => {
+                let prefix = if result.success { "" } else { "error: " };
+                self.push_system(format!("{prefix}{}", result.message));
+                result.success
+            }
+            Err(err) => {
+                self.push_system(format!("/{name} failed: {err}"));
+                false
             }
         }
     }

--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -292,6 +292,7 @@ pub(crate) const MODEL_SWITCHER_CAPABILITY_ID: &str = "yolop_model_switcher";
 pub(crate) struct ModelSwitcherCapability {
     pub(crate) provider: Arc<RwLock<ProviderChoice>>,
     pub(crate) provider_store: Arc<dyn RuntimeProviderStore>,
+    pub(crate) settings: Arc<SettingsStore>,
 }
 
 #[async_trait]
@@ -375,7 +376,7 @@ impl Capability for ModelSwitcherCapability {
                 return Ok(failed_result(format!("model change failed: {err}")));
             }
         };
-        let mw = match next.model_with_provider() {
+        let mw = match next.model_with_provider(&self.settings.snapshot()) {
             Ok(m) => m,
             Err(err) => {
                 return Ok(failed_result(format!("model change failed: {err}")));
@@ -509,7 +510,7 @@ impl Capability for ProviderSwitcherCapability {
             Ok(n) => n,
             Err(err) => return Ok(failed_result(format!("provider change failed: {err}"))),
         };
-        let mw = match next.model_with_provider() {
+        let mw = match next.model_with_provider(&self.settings.snapshot()) {
             Ok(m) => m,
             Err(err) => return Ok(failed_result(format!("provider change failed: {err}"))),
         };
@@ -529,6 +530,146 @@ impl Capability for ProviderSwitcherCapability {
             error_code: None,
             error_fields: None,
         })
+    }
+}
+
+// ---------- /token ----------
+//
+// Stores per-provider API tokens in the same settings file as `/provider`.
+// Env vars still win at runtime (see `runtime::resolve_token`) so a
+// per-run override is always possible. Slash commands don't echo their
+// arguments to the transcript or session log, so `/token openai sk-...`
+// is the safest entry point we have — but the resulting settings file
+// sits in plain text on disk (0o600 on Unix).
+
+pub(crate) const TOKEN_CAPABILITY_ID: &str = "yolop_token_manager";
+
+/// Providers that meaningfully consume an API token. `llmsim` is excluded
+/// (no key needed) and `ollama` is included for completeness even though
+/// most local setups don't authenticate.
+const TOKEN_PROVIDERS: &[&str] = &["openai", "anthropic", "google", "openrouter", "ollama"];
+
+pub(crate) struct TokenCapability {
+    pub(crate) settings: Arc<SettingsStore>,
+}
+
+#[async_trait]
+impl Capability for TokenCapability {
+    fn id(&self) -> &str {
+        TOKEN_CAPABILITY_ID
+    }
+    fn name(&self) -> &str {
+        "Coding CLI Token Manager"
+    }
+    fn description(&self) -> &str {
+        "Store provider API tokens in yolop settings so env vars are not required."
+    }
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+    fn category(&self) -> Option<&str> {
+        Some("Examples")
+    }
+    fn system_prompt_addition(&self) -> Option<&str> {
+        None
+    }
+    fn commands(&self) -> Vec<CommandDescriptor> {
+        vec![CommandDescriptor {
+            name: "token".to_string(),
+            description: "Show or store API tokens. Env vars still override saved tokens."
+                .to_string(),
+            source: CommandSource::System,
+            args: vec![CommandArg {
+                name: "provider [value | clear]".to_string(),
+                description:
+                    "<provider> <value> to store; <provider> clear to remove; omit to list status."
+                        .to_string(),
+                required: false,
+                suggestions: TOKEN_PROVIDERS.iter().map(|s| (*s).to_string()).collect(),
+            }],
+        }]
+    }
+
+    async fn execute_command(
+        &self,
+        request: &ExecuteCommandRequest,
+        _ctx: &CommandExecutionContext,
+    ) -> everruns_core::Result<CommandResult> {
+        if request.name != "token" {
+            return Err(everruns_core::AgentLoopError::config(format!(
+                "{} cannot execute /{}",
+                self.id(),
+                request.name
+            )));
+        }
+        let raw = request.arguments.as_deref().unwrap_or("").trim();
+        if raw.is_empty() {
+            let snapshot = self.settings.snapshot();
+            let status: Vec<String> = TOKEN_PROVIDERS
+                .iter()
+                .map(|p| {
+                    let marker = if snapshot.has_token(p) { "stored" } else { "-" };
+                    format!("{p}: {marker}")
+                })
+                .collect();
+            return Ok(CommandResult {
+                success: true,
+                message: format!(
+                    "tokens ({}): {}",
+                    self.settings.path().display(),
+                    status.join(", ")
+                ),
+                error_code: None,
+                error_fields: None,
+            });
+        }
+
+        let mut parts = raw.splitn(2, char::is_whitespace);
+        let provider = parts.next().unwrap_or_default().to_ascii_lowercase();
+        let rest = parts.next().unwrap_or_default().trim();
+
+        if !TOKEN_PROVIDERS.contains(&provider.as_str()) {
+            return Ok(failed_result(format!(
+                "unknown provider `{provider}`; expected one of {}",
+                TOKEN_PROVIDERS.join(", ")
+            )));
+        }
+        if rest.is_empty() {
+            return Ok(failed_result(
+                "usage: /token <provider> <value|clear>".to_string(),
+            ));
+        }
+
+        if rest.eq_ignore_ascii_case("clear") {
+            return Ok(match self.settings.clear_token(&provider) {
+                Ok(true) => CommandResult {
+                    success: true,
+                    message: format!("token cleared for {provider}"),
+                    error_code: None,
+                    error_fields: None,
+                },
+                Ok(false) => CommandResult {
+                    success: true,
+                    message: format!("no token was stored for {provider}"),
+                    error_code: None,
+                    error_fields: None,
+                },
+                Err(err) => failed_result(format!("token clear failed: {err}")),
+            });
+        }
+
+        match self.settings.set_token(provider.clone(), rest.to_string()) {
+            Ok(()) => Ok(CommandResult {
+                success: true,
+                message: format!(
+                    "token stored for {provider} (in {})",
+                    self.settings.path().display()
+                ),
+                error_code: None,
+                error_fields: None,
+            }),
+            Err(err) => Ok(failed_result(format!("token save failed: {err}"))),
+        }
     }
 }
 

--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -673,9 +673,160 @@ impl Capability for TokenCapability {
     }
 }
 
+// ---------- /onboard ----------
+//
+// First-run setup helper. The capability itself only registers the
+// `/onboard` slash command and reports the current setup state — the
+// actual interactive wizard lives in the TUI because capabilities are
+// stateless command handlers and can't pause for user input.
+//
+// The TUI matches `descriptor.name == "onboard"` after dispatching the
+// command and enters wizard mode, which then drives `/provider`,
+// `/token`, and `/model` against the same capabilities.
+
+pub(crate) const ONBOARDING_CAPABILITY_ID: &str = "yolop_onboarding";
+
+pub(crate) struct OnboardingCapability {
+    pub(crate) settings: Arc<SettingsStore>,
+}
+
+impl OnboardingCapability {
+    /// True when no provider preference is saved and no API token is set —
+    /// either via env var or in the settings file. Used by the TUI at
+    /// startup to auto-open the wizard on a fresh install.
+    pub(crate) fn needs_onboarding(settings: &crate::settings::Settings) -> bool {
+        if settings.provider.is_some() {
+            return false;
+        }
+        if env_credential_present() {
+            return false;
+        }
+        settings.tokens.is_empty()
+    }
+}
+
+fn env_credential_present() -> bool {
+    const VARS: &[&str] = &[
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "OPENROUTER_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "OLLAMA_BASE_URL",
+        "OLLAMA_API_KEY",
+    ];
+    VARS.iter()
+        .any(|var| std::env::var(var).map(|v| !v.is_empty()).unwrap_or(false))
+}
+
+#[async_trait]
+impl Capability for OnboardingCapability {
+    fn id(&self) -> &str {
+        ONBOARDING_CAPABILITY_ID
+    }
+    fn name(&self) -> &str {
+        "Coding CLI Onboarding"
+    }
+    fn description(&self) -> &str {
+        "Guided first-run setup for provider, token, and default model."
+    }
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+    fn category(&self) -> Option<&str> {
+        Some("Examples")
+    }
+    fn system_prompt_addition(&self) -> Option<&str> {
+        None
+    }
+    fn commands(&self) -> Vec<CommandDescriptor> {
+        vec![CommandDescriptor {
+            name: "onboard".to_string(),
+            description: "Walk through provider/token/model setup.".to_string(),
+            source: CommandSource::System,
+            args: vec![],
+        }]
+    }
+
+    async fn execute_command(
+        &self,
+        request: &ExecuteCommandRequest,
+        _ctx: &CommandExecutionContext,
+    ) -> everruns_core::Result<CommandResult> {
+        if request.name != "onboard" {
+            return Err(everruns_core::AgentLoopError::config(format!(
+                "{} cannot execute /{}",
+                self.id(),
+                request.name
+            )));
+        }
+        // The TUI starts the actual wizard after dispatch (see
+        // `App::invoke_capability_command`). Reporting current state here
+        // makes the command useful in `--print` mode too, where the wizard
+        // can't run.
+        let snapshot = self.settings.snapshot();
+        let provider = snapshot
+            .provider
+            .clone()
+            .unwrap_or_else(|| "<unset>".to_string());
+        let stored: Vec<&str> = snapshot.tokens.keys().map(String::as_str).collect();
+        let stored_label = if stored.is_empty() {
+            "none".to_string()
+        } else {
+            stored.join(", ")
+        };
+        Ok(CommandResult {
+            success: true,
+            message: format!(
+                "onboarding: provider={provider}, stored tokens={stored_label}, env keys present={}",
+                env_credential_present()
+            ),
+            error_code: None,
+            error_fields: None,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn needs_onboarding_true_for_empty_settings() {
+        // SAFETY: removing env vars for the duration of this test. Other
+        // tests in this module don't read these names.
+        unsafe {
+            std::env::remove_var("OPENAI_API_KEY");
+            std::env::remove_var("ANTHROPIC_API_KEY");
+            std::env::remove_var("OPENROUTER_API_KEY");
+            std::env::remove_var("GEMINI_API_KEY");
+            std::env::remove_var("GOOGLE_API_KEY");
+            std::env::remove_var("OLLAMA_BASE_URL");
+            std::env::remove_var("OLLAMA_API_KEY");
+        }
+        let settings = crate::settings::Settings::default();
+        assert!(OnboardingCapability::needs_onboarding(&settings));
+    }
+
+    #[test]
+    fn needs_onboarding_false_when_provider_is_saved() {
+        let settings = crate::settings::Settings {
+            provider: Some("anthropic".to_string()),
+            ..Default::default()
+        };
+        assert!(!OnboardingCapability::needs_onboarding(&settings));
+    }
+
+    #[test]
+    fn needs_onboarding_false_when_token_is_saved() {
+        let mut tokens = std::collections::BTreeMap::new();
+        tokens.insert("openai".to_string(), "sk-test".to_string());
+        let settings = crate::settings::Settings {
+            provider: None,
+            tokens,
+        };
+        assert!(!OnboardingCapability::needs_onboarding(&settings));
+    }
 
     #[test]
     fn environment_context_renders_requested_fields() {

--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -5,7 +5,8 @@
 // selection.
 
 use crate::approval::ApprovalGate;
-use crate::runtime::ProviderChoice;
+use crate::runtime::{ProviderChoice, SUPPORTED_PROVIDERS};
+use crate::settings::SettingsStore;
 use crate::tools::{BashTool, Workspace};
 use async_trait::async_trait;
 use chrono::Local;
@@ -400,6 +401,134 @@ fn failed_result(message: String) -> CommandResult {
         message,
         error_code: None,
         error_fields: None,
+    }
+}
+
+// ---------- /provider ----------
+//
+// Companion to `/model`: picks the *provider* (OpenAI, Anthropic, Google,
+// OpenRouter, Ollama, llmsim) using that provider's default model, and
+// persists the choice to `<config_dir>/yolop/settings.json` so the next
+// run starts on the same provider. The model is still mutated via `/model`
+// afterward — both commands share the same provider Arc.
+
+pub(crate) const PROVIDER_SWITCHER_CAPABILITY_ID: &str = "yolop_provider_switcher";
+
+pub(crate) struct ProviderSwitcherCapability {
+    pub(crate) provider: Arc<RwLock<ProviderChoice>>,
+    pub(crate) provider_store: Arc<dyn RuntimeProviderStore>,
+    pub(crate) settings: Arc<SettingsStore>,
+}
+
+#[async_trait]
+impl Capability for ProviderSwitcherCapability {
+    fn id(&self) -> &str {
+        PROVIDER_SWITCHER_CAPABILITY_ID
+    }
+    fn name(&self) -> &str {
+        "Coding CLI Provider Switcher"
+    }
+    fn description(&self) -> &str {
+        "Show or change the active LLM provider, persisted across runs."
+    }
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+    fn category(&self) -> Option<&str> {
+        Some("Examples")
+    }
+    fn system_prompt_addition(&self) -> Option<&str> {
+        None
+    }
+    fn commands(&self) -> Vec<CommandDescriptor> {
+        vec![CommandDescriptor {
+            name: "provider".to_string(),
+            description: "Show or change the active provider (saved to yolop settings)."
+                .to_string(),
+            source: CommandSource::System,
+            args: vec![CommandArg {
+                name: "name".to_string(),
+                description: format!(
+                    "{} — omit to print the current provider.",
+                    SUPPORTED_PROVIDERS.join(" | ")
+                ),
+                required: false,
+                suggestions: SUPPORTED_PROVIDERS
+                    .iter()
+                    .map(|s| (*s).to_string())
+                    .collect(),
+            }],
+        }]
+    }
+
+    async fn execute_command(
+        &self,
+        request: &ExecuteCommandRequest,
+        _ctx: &CommandExecutionContext,
+    ) -> everruns_core::Result<CommandResult> {
+        if request.name != "provider" {
+            return Err(everruns_core::AgentLoopError::config(format!(
+                "{} cannot execute /{}",
+                self.id(),
+                request.name
+            )));
+        }
+        let raw = request.arguments.as_deref().unwrap_or("").trim();
+        if raw.is_empty() {
+            let current = self
+                .provider
+                .read()
+                .expect("provider lock poisoned")
+                .clone();
+            let saved = self
+                .settings
+                .snapshot()
+                .provider
+                .unwrap_or_else(|| "<unset>".to_string());
+            return Ok(CommandResult {
+                success: true,
+                message: format!(
+                    "provider: {} (model: {}); saved: {saved}; options: {}",
+                    current.provider_name(),
+                    current.label(),
+                    SUPPORTED_PROVIDERS.join(", "),
+                ),
+                error_code: None,
+                error_fields: None,
+            });
+        }
+
+        if raw.split_whitespace().count() > 1 {
+            return Ok(failed_result(
+                "usage: /provider <name> — pick a single provider, then use /model to tune the model"
+                    .to_string(),
+            ));
+        }
+
+        let next = match ProviderChoice::default_for_provider_name(raw) {
+            Ok(n) => n,
+            Err(err) => return Ok(failed_result(format!("provider change failed: {err}"))),
+        };
+        let mw = match next.model_with_provider() {
+            Ok(m) => m,
+            Err(err) => return Ok(failed_result(format!("provider change failed: {err}"))),
+        };
+        if let Err(err) = self.provider_store.set_default_model(mw).await {
+            return Ok(failed_result(format!("provider change failed: {err}")));
+        }
+        let provider_name = next.provider_name().to_string();
+        let label = next.label();
+        *self.provider.write().expect("provider lock poisoned") = next;
+        let persist_note = match self.settings.set_provider(Some(provider_name.clone())) {
+            Ok(()) => format!("saved to {}", self.settings.path().display()),
+            Err(err) => format!("warning: settings not saved: {err}"),
+        };
+        Ok(CommandResult {
+            success: true,
+            message: format!("provider changed: {label} ({persist_note})"),
+            error_code: None,
+            error_fields: None,
+        })
     }
 }
 

--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -409,7 +409,7 @@ fn failed_result(message: String) -> CommandResult {
 //
 // Companion to `/model`: picks the *provider* (OpenAI, Anthropic, Google,
 // OpenRouter, Ollama, llmsim) using that provider's default model, and
-// persists the choice to `<config_dir>/yolop/settings.json` so the next
+// persists the choice to `<config_dir>/yolop/settings.toml` so the next
 // run starts on the same provider. The model is still mutated via `/model`
 // afterward — both commands share the same provider Arc.
 
@@ -793,8 +793,9 @@ mod tests {
 
     #[test]
     fn needs_onboarding_true_for_empty_settings() {
-        // SAFETY: removing env vars for the duration of this test. Other
-        // tests in this module don't read these names.
+        // Serialize against every other env-mutating test in this
+        // binary; cf. `crate::test_env`.
+        let _guard = crate::test_env::lock();
         unsafe {
             std::env::remove_var("OPENAI_API_KEY");
             std::env::remove_var("ANTHROPIC_API_KEY");

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod capabilities;
 mod diff;
 mod runtime;
 mod session_log;
+mod settings;
 mod tools;
 
 #[cfg(test)]
@@ -22,8 +23,10 @@ use everruns_core::message::MessageRole;
 use ratatui::backend::CrosstermBackend;
 use ratatui::{Terminal, TerminalOptions, Viewport};
 use runtime::{BuiltRuntime, ProviderChoice};
+use settings::SettingsStore;
 use std::io::{self, IsTerminal};
 use std::path::PathBuf;
+use std::sync::Arc;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -77,47 +80,41 @@ struct Cli {
 enum ProviderArg {
     Anthropic,
     Openai,
+    Google,
     Openrouter,
     Ollama,
     #[value(name = "llmsim", alias = "sim")]
     Sim,
 }
 
-fn pick_provider(cli: &Cli) -> ProviderChoice {
-    let base = match cli.provider {
-        Some(ProviderArg::Anthropic) => ProviderChoice::Anthropic {
-            model: "claude-sonnet-4-5".into(),
-        },
-        Some(ProviderArg::Openai) => ProviderChoice::OpenAi {
-            model: "gpt-5.5".into(),
-            reasoning_effort: Some(
-                cli.reasoning_effort
-                    .clone()
-                    .unwrap_or_else(|| "medium".to_string()),
-            ),
-        },
-        Some(ProviderArg::Openrouter) => ProviderChoice::OpenRouter {
-            model: std::env::var("EVERRUNS_CLI_MODEL")
-                .ok()
-                .filter(|value| !value.is_empty())
-                .unwrap_or_else(|| "openai/gpt-5.2".to_string()),
-            base_url: std::env::var("OPENROUTER_BASE_URL")
-                .ok()
-                .filter(|value| !value.is_empty())
-                .unwrap_or_else(|| "https://openrouter.ai/api/v1".to_string()),
-        },
-        Some(ProviderArg::Ollama) => ProviderChoice::Ollama {
-            model: std::env::var("EVERRUNS_CLI_MODEL")
-                .ok()
-                .filter(|value| !value.is_empty())
-                .unwrap_or_else(|| "llama3.2".to_string()),
-            base_url: std::env::var("OLLAMA_BASE_URL")
-                .ok()
-                .filter(|value| !value.is_empty())
-                .unwrap_or_else(|| "http://localhost:11434/v1".to_string()),
-        },
-        Some(ProviderArg::Sim) => ProviderChoice::Sim,
-        None => ProviderChoice::from_env(),
+fn provider_name_for_arg(arg: ProviderArg) -> &'static str {
+    match arg {
+        ProviderArg::Anthropic => "anthropic",
+        ProviderArg::Openai => "openai",
+        ProviderArg::Google => "google",
+        ProviderArg::Openrouter => "openrouter",
+        ProviderArg::Ollama => "ollama",
+        ProviderArg::Sim => "llmsim",
+    }
+}
+
+/// Resolution order: explicit `--provider` flag > persisted settings >
+/// env-var auto-detection. Model and reasoning-effort flags layer on top
+/// of whichever base was chosen.
+fn pick_provider(cli: &Cli, settings: &SettingsStore) -> ProviderChoice {
+    let base = if let Some(arg) = cli.provider {
+        ProviderChoice::default_for_provider_name(provider_name_for_arg(arg))
+            .expect("ProviderArg names are always valid")
+    } else if let Some(saved) = settings.snapshot().provider {
+        match ProviderChoice::default_for_provider_name(&saved) {
+            Ok(choice) => choice,
+            Err(err) => {
+                eprintln!("yolop: ignoring saved provider `{saved}`: {err}");
+                ProviderChoice::from_env()
+            }
+        }
+    } else {
+        ProviderChoice::from_env()
     };
     let selected = match (base, cli.model.clone()) {
         (ProviderChoice::Anthropic { .. }, Some(m)) => ProviderChoice::Anthropic { model: m },
@@ -130,6 +127,9 @@ fn pick_provider(cli: &Cli) -> ProviderChoice {
             model: m,
             reasoning_effort: cli.reasoning_effort.clone().or(reasoning_effort),
         },
+        (ProviderChoice::Google { base_url, .. }, Some(m)) => {
+            ProviderChoice::Google { model: m, base_url }
+        }
         (ProviderChoice::OpenRouter { base_url, .. }, Some(m)) => {
             ProviderChoice::OpenRouter { model: m, base_url }
         }
@@ -168,7 +168,14 @@ async fn main() -> Result<()> {
         .cwd
         .clone()
         .unwrap_or_else(|| std::env::current_dir().expect("cwd"));
-    let provider = pick_provider(&cli);
+    let settings_path = settings::default_settings_path().ok_or_else(|| {
+        anyhow::anyhow!(
+            "could not resolve a platform config directory for yolop settings; \
+             set $XDG_CONFIG_HOME or run from a supported platform"
+        )
+    })?;
+    let settings = Arc::new(SettingsStore::open(settings_path));
+    let provider = pick_provider(&cli, &settings);
 
     let is_print = cli.print.is_some();
     // Approval is opt-in: the agent runs autonomously by default. `--ask` in
@@ -193,7 +200,15 @@ async fn main() -> Result<()> {
         Some(p) => p,
         None => session_log::default_sessions_dir()?,
     };
-    let runtime = runtime::build(cwd, provider, gate, resume_session_id, sessions_dir).await?;
+    let runtime = runtime::build(
+        cwd,
+        provider,
+        gate,
+        resume_session_id,
+        sessions_dir,
+        settings,
+    )
+    .await?;
 
     if let Some(prompt) = cli.print {
         return run_print_mode(runtime, prompt).await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,8 @@ mod diff;
 mod runtime;
 mod session_log;
 mod settings;
+#[cfg(test)]
+mod test_env;
 mod tools;
 
 #[cfg(test)]
@@ -169,12 +171,17 @@ async fn main() -> Result<()> {
         .cwd
         .clone()
         .unwrap_or_else(|| std::env::current_dir().expect("cwd"));
-    let settings_path = settings::default_settings_path().ok_or_else(|| {
-        anyhow::anyhow!(
-            "could not resolve a platform config directory for yolop settings; \
-             set $XDG_CONFIG_HOME or run from a supported platform"
-        )
-    })?;
+    // Fall back to an unwritable scratch path when no platform config dir
+    // is resolvable (minimal containers, CI without HOME). `SettingsStore`
+    // loads to defaults when the file does not exist, and writes will
+    // error visibly via `/provider` or `/token` rather than killing
+    // startup — keeps `--print` usable in stripped-down environments.
+    let settings_path = settings::default_settings_path().unwrap_or_else(|| {
+        eprintln!(
+            "yolop: no platform config dir resolvable — settings will not persist across runs"
+        );
+        std::path::PathBuf::from("/dev/null/yolop/settings.toml")
+    });
     let settings = Arc::new(SettingsStore::open(settings_path));
     let provider = pick_provider(&cli, &settings);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,19 +102,20 @@ fn provider_name_for_arg(arg: ProviderArg) -> &'static str {
 /// env-var auto-detection. Model and reasoning-effort flags layer on top
 /// of whichever base was chosen.
 fn pick_provider(cli: &Cli, settings: &SettingsStore) -> ProviderChoice {
+    let snapshot = settings.snapshot();
     let base = if let Some(arg) = cli.provider {
         ProviderChoice::default_for_provider_name(provider_name_for_arg(arg))
             .expect("ProviderArg names are always valid")
-    } else if let Some(saved) = settings.snapshot().provider {
-        match ProviderChoice::default_for_provider_name(&saved) {
+    } else if let Some(saved) = snapshot.provider.as_deref() {
+        match ProviderChoice::default_for_provider_name(saved) {
             Ok(choice) => choice,
             Err(err) => {
                 eprintln!("yolop: ignoring saved provider `{saved}`: {err}");
-                ProviderChoice::from_env()
+                ProviderChoice::from_env_or_settings(&snapshot)
             }
         }
     } else {
-        ProviderChoice::from_env()
+        ProviderChoice::from_env_or_settings(&snapshot)
     };
     let selected = match (base, cli.model.clone()) {
         (ProviderChoice::Anthropic { .. }, Some(m)) => ProviderChoice::Anthropic { model: m },

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -508,7 +508,7 @@ impl ProviderChoice {
             "anthropic" => Ok(Self::Anthropic {
                 model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_ANTHROPIC_MODEL),
             }),
-            "google" | "gemini" => Ok(Self::Google {
+            "google" => Ok(Self::Google {
                 model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_GOOGLE_MODEL),
                 base_url: env_or_default("GOOGLE_BASE_URL", DEFAULT_GOOGLE_BASE_URL),
             }),
@@ -520,7 +520,7 @@ impl ProviderChoice {
                 model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_OLLAMA_MODEL),
                 base_url: env_or_default("OLLAMA_BASE_URL", DEFAULT_OLLAMA_BASE_URL),
             }),
-            "llmsim" | "sim" => Ok(Self::Sim),
+            "llmsim" => Ok(Self::Sim),
             other => Err(anyhow!(
                 "unknown provider {other}; expected one of {}",
                 SUPPORTED_PROVIDERS.join(", ")
@@ -1261,11 +1261,11 @@ mod tests {
 
     #[test]
     fn google_requires_api_key_to_build_model_with_provider() {
-        // Drop both env vars in case the test runner exported one.
-        // SAFETY: env mutations in this single-process test do not race
-        // because tests in the same module serialize on `RUST_TEST_THREADS=1`
-        // for env-touching cases; otherwise the assertion still tolerates
-        // either outcome via `contains`.
+        // Drop both env vars in case the test runner exported one. The
+        // shared `test_env::lock()` serializes against every other
+        // env-mutating test in this binary; concurrent setenv/unsetenv
+        // calls would otherwise race (UB on glibc).
+        let _guard = crate::test_env::lock();
         unsafe {
             std::env::remove_var("GEMINI_API_KEY");
             std::env::remove_var("GOOGLE_API_KEY");
@@ -1282,6 +1282,7 @@ mod tests {
 
     #[test]
     fn openrouter_uses_openai_responses_driver_with_base_url() {
+        let _guard = crate::test_env::lock();
         unsafe {
             std::env::remove_var("OPENROUTER_API_KEY");
         }
@@ -1299,6 +1300,7 @@ mod tests {
 
     #[test]
     fn ollama_uses_openai_responses_driver_with_local_base_url() {
+        let _guard = crate::test_env::lock();
         unsafe {
             std::env::remove_var("OLLAMA_API_KEY");
         }
@@ -1316,6 +1318,7 @@ mod tests {
 
     #[test]
     fn stored_token_falls_back_when_env_var_missing() {
+        let _guard = crate::test_env::lock();
         unsafe {
             std::env::remove_var("ANTHROPIC_API_KEY");
         }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -946,6 +946,7 @@ pub async fn build(
         gate,
         resume_session_id,
         sessions_dir,
+        settings,
         BuildOptions::default(),
     )
     .await
@@ -957,6 +958,7 @@ pub async fn build_with_options(
     gate: Arc<ApprovalGate>,
     resume_session_id: Option<SessionId>,
     sessions_dir: PathBuf,
+    settings: Arc<SettingsStore>,
     options: BuildOptions,
 ) -> Result<BuiltRuntime> {
     let canonical_root = std::fs::canonicalize(&workspace_root)

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -7,8 +7,9 @@
 use crate::approval::ApprovalGate;
 use crate::capabilities::{
     CodingBashCapability, CodingCliEnvironmentCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID,
-    MODEL_SWITCHER_CAPABILITY_ID, ModelSwitcherCapability, PROVIDER_SWITCHER_CAPABILITY_ID,
-    ProviderSwitcherCapability, TOKEN_CAPABILITY_ID, TokenCapability,
+    MODEL_SWITCHER_CAPABILITY_ID, ModelSwitcherCapability, ONBOARDING_CAPABILITY_ID,
+    OnboardingCapability, PROVIDER_SWITCHER_CAPABILITY_ID, ProviderSwitcherCapability,
+    TOKEN_CAPABILITY_ID, TokenCapability,
 };
 use crate::settings::{Settings, SettingsStore};
 use crate::tools::Workspace;
@@ -846,6 +847,7 @@ fn coding_harness_capabilities() -> Vec<AgentCapabilityConfig> {
         AgentCapabilityConfig::new(MODEL_SWITCHER_CAPABILITY_ID),
         AgentCapabilityConfig::new(PROVIDER_SWITCHER_CAPABILITY_ID),
         AgentCapabilityConfig::new(TOKEN_CAPABILITY_ID),
+        AgentCapabilityConfig::new(ONBOARDING_CAPABILITY_ID),
         AgentCapabilityConfig::new("yolop_bash"),
     ]
 }
@@ -885,6 +887,10 @@ pub struct StartupInfo {
     /// How many events were replayed from disk into the new session.
     /// Zero for fresh sessions; used by the startup banner.
     pub replayed_events: usize,
+    /// True when neither env vars nor saved settings provide a credential
+    /// for any real provider. The TUI auto-opens its onboarding wizard
+    /// in this case; `--print` mode ignores it.
+    pub onboarding_recommended: bool,
 }
 
 #[derive(Clone)]
@@ -1053,6 +1059,9 @@ pub async fn build_with_options(
     capabilities.register(TokenCapability {
         settings: settings.clone(),
     });
+    capabilities.register(OnboardingCapability {
+        settings: settings.clone(),
+    });
     capabilities.register(CodingBashCapability {
         workspace: workspace.clone(),
         gate: gate.clone(),
@@ -1146,6 +1155,8 @@ pub async fn build_with_options(
             session_log_path: log_path,
             session_dir,
             replayed_events: replayed_events_count,
+            onboarding_recommended: OnboardingCapability::needs_onboarding(&settings.snapshot())
+                && matches!(provider, ProviderChoice::Sim),
         },
         model: ModelState::new(provider_state),
     })

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -7,8 +7,10 @@
 use crate::approval::ApprovalGate;
 use crate::capabilities::{
     CodingBashCapability, CodingCliEnvironmentCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID,
-    MODEL_SWITCHER_CAPABILITY_ID, ModelSwitcherCapability,
+    MODEL_SWITCHER_CAPABILITY_ID, ModelSwitcherCapability, PROVIDER_SWITCHER_CAPABILITY_ID,
+    ProviderSwitcherCapability,
 };
+use crate::settings::SettingsStore;
 use crate::tools::Workspace;
 use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
@@ -372,6 +374,10 @@ impl SessionFileSystem for CodingCliSessionFileStore {
 const DEFAULT_OPENAI_MODEL: &str = "gpt-5.5";
 const DEFAULT_OPENAI_REASONING_EFFORT: &str = "medium";
 const DEFAULT_ANTHROPIC_MODEL: &str = "claude-sonnet-4-5";
+const DEFAULT_GOOGLE_MODEL: &str = "gemini-2.5-flash";
+// Gemini exposes an OpenAI-compatible surface at this base URL — the
+// `everruns_openai` driver targets it the same way it targets OpenRouter.
+const DEFAULT_GOOGLE_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta/openai";
 const DEFAULT_OPENROUTER_MODEL: &str = "openai/gpt-5.2";
 const DEFAULT_OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
 const DEFAULT_OLLAMA_MODEL: &str = "llama3.2";
@@ -387,6 +393,10 @@ pub enum ProviderChoice {
         model: String,
         reasoning_effort: Option<String>,
     },
+    Google {
+        model: String,
+        base_url: String,
+    },
     OpenRouter {
         model: String,
         base_url: String,
@@ -397,6 +407,17 @@ pub enum ProviderChoice {
     },
     Sim,
 }
+
+/// Provider names recognized by `/provider` and persisted settings. The order
+/// is the user-visible suggestion order.
+pub const SUPPORTED_PROVIDERS: &[&str] = &[
+    "openai",
+    "anthropic",
+    "google",
+    "openrouter",
+    "ollama",
+    "llmsim",
+];
 
 impl ProviderChoice {
     /// Pick a default based on env vars. CLI flags override this in `main`.
@@ -423,6 +444,12 @@ impl ProviderChoice {
                 base_url: env_or_default("OPENROUTER_BASE_URL", DEFAULT_OPENROUTER_BASE_URL),
             };
         }
+        if google_api_key().is_some() {
+            return Self::Google {
+                model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_GOOGLE_MODEL),
+                base_url: env_or_default("GOOGLE_BASE_URL", DEFAULT_GOOGLE_BASE_URL),
+            };
+        }
         if env_non_empty("OLLAMA_BASE_URL").is_some() || env_non_empty("OLLAMA_API_KEY").is_some() {
             return Self::Ollama {
                 model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_OLLAMA_MODEL),
@@ -442,9 +469,57 @@ impl ProviderChoice {
                 Some(effort) => format!("openai/{model} {effort}"),
                 None => format!("openai/{model}"),
             },
+            Self::Google { model, .. } => format!("google/{model}"),
             Self::OpenRouter { model, .. } => format!("openrouter/{model}"),
             Self::Ollama { model, .. } => format!("ollama/{model}"),
             Self::Sim => "llmsim/llmsim-yolop".to_string(),
+        }
+    }
+
+    /// Short name used in settings and command suggestions.
+    pub fn provider_name(&self) -> &'static str {
+        match self {
+            Self::Anthropic { .. } => "anthropic",
+            Self::OpenAi { .. } => "openai",
+            Self::Google { .. } => "google",
+            Self::OpenRouter { .. } => "openrouter",
+            Self::Ollama { .. } => "ollama",
+            Self::Sim => "llmsim",
+        }
+    }
+
+    /// Build a ProviderChoice from a bare provider name, picking the
+    /// provider's default model. Used by `/provider` and by startup when
+    /// rehydrating the persisted preference.
+    pub fn default_for_provider_name(name: &str) -> Result<Self> {
+        match name.trim().to_ascii_lowercase().as_str() {
+            "openai" => Ok(Self::OpenAi {
+                model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_OPENAI_MODEL),
+                reasoning_effort: Some(env_or_default(
+                    "EVERRUNS_CLI_REASONING_EFFORT",
+                    DEFAULT_OPENAI_REASONING_EFFORT,
+                )),
+            }),
+            "anthropic" => Ok(Self::Anthropic {
+                model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_ANTHROPIC_MODEL),
+            }),
+            "google" | "gemini" => Ok(Self::Google {
+                model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_GOOGLE_MODEL),
+                base_url: env_or_default("GOOGLE_BASE_URL", DEFAULT_GOOGLE_BASE_URL),
+            }),
+            "openrouter" => Ok(Self::OpenRouter {
+                model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_OPENROUTER_MODEL),
+                base_url: env_or_default("OPENROUTER_BASE_URL", DEFAULT_OPENROUTER_BASE_URL),
+            }),
+            "ollama" => Ok(Self::Ollama {
+                model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_OLLAMA_MODEL),
+                base_url: env_or_default("OLLAMA_BASE_URL", DEFAULT_OLLAMA_BASE_URL),
+            }),
+            "llmsim" | "sim" => Ok(Self::Sim),
+            other => Err(anyhow!(
+                "unknown provider {other}; expected one of {}",
+                SUPPORTED_PROVIDERS.join(", ")
+            )),
         }
     }
 
@@ -455,6 +530,8 @@ impl ProviderChoice {
             "openai/gpt-5.4-mini",
             "openai/gpt-5.3-codex",
             "openai/gpt-5.2",
+            "google/gemini-2.5-flash",
+            "google/gemini-2.5-pro",
             "openrouter/openai/gpt-5.2",
             "ollama/llama3.2",
             "anthropic/claude-sonnet-4-5",
@@ -499,6 +576,17 @@ impl ProviderChoice {
                 model: model.to_string(),
                 reasoning_effort: normalize_openai_reasoning_effort(reasoning_effort),
             }),
+            "google" | "gemini" => {
+                if reasoning_effort.is_some() {
+                    return Err(anyhow!(
+                        "google model switching does not accept reasoning effort"
+                    ));
+                }
+                Ok(Self::Google {
+                    model: model.to_string(),
+                    base_url: env_or_default("GOOGLE_BASE_URL", DEFAULT_GOOGLE_BASE_URL),
+                })
+            }
             "openrouter" => {
                 if reasoning_effort.is_some() {
                     return Err(anyhow!(
@@ -532,7 +620,8 @@ impl ProviderChoice {
                 }
             }
             other => Err(anyhow!(
-                "unknown provider {other}; expected openai, anthropic, or llmsim"
+                "unknown provider {other}; expected one of {}",
+                SUPPORTED_PROVIDERS.join(", ")
             )),
         }
     }
@@ -555,6 +644,17 @@ impl ProviderChoice {
                 model,
                 reasoning_effort: normalize_openai_reasoning_effort(reasoning_effort),
             }),
+            Self::Google { base_url, .. } => {
+                if reasoning_effort.is_some() {
+                    return Err(anyhow!(
+                        "google model switching does not accept reasoning effort"
+                    ));
+                }
+                Ok(Self::Google {
+                    model,
+                    base_url: base_url.clone(),
+                })
+            }
             Self::OpenRouter { base_url, .. } => {
                 if reasoning_effort.is_some() {
                     return Err(anyhow!(
@@ -612,6 +712,16 @@ impl ProviderChoice {
                     base_url: None,
                 })
             }
+            ProviderChoice::Google { model, base_url } => {
+                let key = google_api_key()
+                    .ok_or_else(|| anyhow!("GEMINI_API_KEY (or GOOGLE_API_KEY) not set"))?;
+                Ok(ModelWithProvider {
+                    model: model.clone(),
+                    provider_type: LlmProviderType::Openai,
+                    api_key: Some(key),
+                    base_url: Some(base_url.clone()),
+                })
+            }
             ProviderChoice::OpenRouter { model, base_url } => {
                 let key = env_non_empty("OPENROUTER_API_KEY")
                     .ok_or_else(|| anyhow!("OPENROUTER_API_KEY not set"))?;
@@ -657,6 +767,12 @@ impl ProviderChoice {
 
 fn env_non_empty(name: &str) -> Option<String> {
     std::env::var(name).ok().filter(|value| !value.is_empty())
+}
+
+/// Gemini's OpenAI-compatible API accepts either `GEMINI_API_KEY` or
+/// `GOOGLE_API_KEY`; the Google docs lean on `GEMINI_API_KEY` so it wins.
+fn google_api_key() -> Option<String> {
+    env_non_empty("GEMINI_API_KEY").or_else(|| env_non_empty("GOOGLE_API_KEY"))
 }
 
 fn env_or_default(name: &str, default: &str) -> String {
@@ -706,6 +822,7 @@ fn coding_harness_capabilities() -> Vec<AgentCapabilityConfig> {
             serde_json::json!({ "enable_file_download": true }),
         ),
         AgentCapabilityConfig::new(MODEL_SWITCHER_CAPABILITY_ID),
+        AgentCapabilityConfig::new(PROVIDER_SWITCHER_CAPABILITY_ID),
         AgentCapabilityConfig::new("yolop_bash"),
     ]
 }
@@ -792,6 +909,7 @@ pub async fn build(
     gate: Arc<ApprovalGate>,
     resume_session_id: Option<SessionId>,
     sessions_dir: PathBuf,
+    settings: Arc<SettingsStore>,
 ) -> Result<BuiltRuntime> {
     build_with_options(
         workspace_root,
@@ -903,6 +1021,11 @@ pub async fn build_with_options(
         provider: provider_state.clone(),
         provider_store: provider_store.clone(),
     });
+    capabilities.register(ProviderSwitcherCapability {
+        provider: provider_state.clone(),
+        provider_store: provider_store.clone(),
+        settings: settings.clone(),
+    });
     capabilities.register(CodingBashCapability {
         workspace: workspace.clone(),
         gate: gate.clone(),
@@ -914,6 +1037,7 @@ pub async fn build_with_options(
     let default_model = match &provider {
         ProviderChoice::Anthropic { .. }
         | ProviderChoice::OpenAi { .. }
+        | ProviderChoice::Google { .. }
         | ProviderChoice::OpenRouter { .. }
         | ProviderChoice::Ollama { .. } => provider.model_with_provider()?,
         ProviderChoice::Sim => ModelWithProvider {
@@ -1063,6 +1187,55 @@ mod tests {
         let next = provider.resolve_model_spec("ollama/llama3.2").unwrap();
 
         assert_eq!(next.label(), "ollama/llama3.2");
+    }
+
+    #[test]
+    fn model_spec_accepts_google_provider_name() {
+        let provider = ProviderChoice::Sim;
+        let next = provider
+            .resolve_model_spec("google/gemini-2.5-pro")
+            .unwrap();
+
+        assert_eq!(next.label(), "google/gemini-2.5-pro");
+        assert_eq!(next.provider_name(), "google");
+    }
+
+    #[test]
+    fn default_for_provider_name_returns_provider_default_model() {
+        let openai = ProviderChoice::default_for_provider_name("openai").unwrap();
+        assert!(openai.label().starts_with("openai/gpt-5.5"));
+
+        let anthropic = ProviderChoice::default_for_provider_name("anthropic").unwrap();
+        assert_eq!(anthropic.label(), "anthropic/claude-sonnet-4-5");
+
+        let google = ProviderChoice::default_for_provider_name("google").unwrap();
+        assert_eq!(google.label(), "google/gemini-2.5-flash");
+
+        let sim = ProviderChoice::default_for_provider_name("llmsim").unwrap();
+        assert_eq!(sim.label(), "llmsim/llmsim-yolop");
+    }
+
+    #[test]
+    fn default_for_provider_name_rejects_unknown() {
+        let err = ProviderChoice::default_for_provider_name("totally-bogus").unwrap_err();
+        assert!(err.to_string().contains("unknown provider"));
+    }
+
+    #[test]
+    fn google_requires_api_key_to_build_model_with_provider() {
+        // Drop both env vars in case the test runner exported one.
+        // SAFETY: tests in this crate run on a single thread per CARGO_TEST_THREADS,
+        // and these env reads/writes do not cross threads.
+        unsafe {
+            std::env::remove_var("GEMINI_API_KEY");
+            std::env::remove_var("GOOGLE_API_KEY");
+        }
+        let provider = ProviderChoice::Google {
+            model: "gemini-2.5-flash".to_string(),
+            base_url: DEFAULT_GOOGLE_BASE_URL.to_string(),
+        };
+        let err = provider.model_with_provider().unwrap_err();
+        assert!(err.to_string().contains("GEMINI_API_KEY"));
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -8,9 +8,9 @@ use crate::approval::ApprovalGate;
 use crate::capabilities::{
     CodingBashCapability, CodingCliEnvironmentCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID,
     MODEL_SWITCHER_CAPABILITY_ID, ModelSwitcherCapability, PROVIDER_SWITCHER_CAPABILITY_ID,
-    ProviderSwitcherCapability,
+    ProviderSwitcherCapability, TOKEN_CAPABILITY_ID, TokenCapability,
 };
-use crate::settings::SettingsStore;
+use crate::settings::{Settings, SettingsStore};
 use crate::tools::Workspace;
 use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
@@ -420,11 +420,12 @@ pub const SUPPORTED_PROVIDERS: &[&str] = &[
 ];
 
 impl ProviderChoice {
-    /// Pick a default based on env vars. CLI flags override this in `main`.
-    /// OpenAI is preferred when both keys are present so the out-of-the-box
-    /// default model stays `gpt-5.5`.
-    pub fn from_env() -> Self {
-        if env_non_empty("OPENAI_API_KEY").is_some() {
+    /// Pick a default from env vars or settings-stored tokens. CLI flags
+    /// override this in `main`. OpenAI is preferred when both an OpenAI
+    /// and Anthropic credential are present so the out-of-the-box default
+    /// model stays `gpt-5.5`.
+    pub fn from_env_or_settings(settings: &Settings) -> Self {
+        if env_non_empty("OPENAI_API_KEY").is_some() || settings.has_token("openai") {
             return Self::OpenAi {
                 model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_OPENAI_MODEL),
                 reasoning_effort: Some(env_or_default(
@@ -433,24 +434,27 @@ impl ProviderChoice {
                 )),
             };
         }
-        if env_non_empty("ANTHROPIC_API_KEY").is_some() {
+        if env_non_empty("ANTHROPIC_API_KEY").is_some() || settings.has_token("anthropic") {
             return Self::Anthropic {
                 model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_ANTHROPIC_MODEL),
             };
         }
-        if env_non_empty("OPENROUTER_API_KEY").is_some() {
+        if env_non_empty("OPENROUTER_API_KEY").is_some() || settings.has_token("openrouter") {
             return Self::OpenRouter {
                 model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_OPENROUTER_MODEL),
                 base_url: env_or_default("OPENROUTER_BASE_URL", DEFAULT_OPENROUTER_BASE_URL),
             };
         }
-        if google_api_key().is_some() {
+        if google_api_key().is_some() || settings.has_token("google") {
             return Self::Google {
                 model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_GOOGLE_MODEL),
                 base_url: env_or_default("GOOGLE_BASE_URL", DEFAULT_GOOGLE_BASE_URL),
             };
         }
-        if env_non_empty("OLLAMA_BASE_URL").is_some() || env_non_empty("OLLAMA_API_KEY").is_some() {
+        if env_non_empty("OLLAMA_BASE_URL").is_some()
+            || env_non_empty("OLLAMA_API_KEY").is_some()
+            || settings.has_token("ollama")
+        {
             return Self::Ollama {
                 model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_OLLAMA_MODEL),
                 base_url: env_or_default("OLLAMA_BASE_URL", DEFAULT_OLLAMA_BASE_URL),
@@ -690,11 +694,11 @@ impl ProviderChoice {
         }
     }
 
-    pub(crate) fn model_with_provider(&self) -> Result<ModelWithProvider> {
+    pub(crate) fn model_with_provider(&self, settings: &Settings) -> Result<ModelWithProvider> {
         match self {
             ProviderChoice::Anthropic { model } => {
-                let key = std::env::var("ANTHROPIC_API_KEY")
-                    .map_err(|_| anyhow!("ANTHROPIC_API_KEY not set"))?;
+                let key = resolve_token(settings, "anthropic", &["ANTHROPIC_API_KEY"])
+                    .ok_or_else(|| anyhow!("ANTHROPIC_API_KEY not set (and no token stored)"))?;
                 Ok(ModelWithProvider {
                     model: model.clone(),
                     provider_type: LlmProviderType::Anthropic,
@@ -703,8 +707,8 @@ impl ProviderChoice {
                 })
             }
             ProviderChoice::OpenAi { model, .. } => {
-                let key = std::env::var("OPENAI_API_KEY")
-                    .map_err(|_| anyhow!("OPENAI_API_KEY not set"))?;
+                let key = resolve_token(settings, "openai", &["OPENAI_API_KEY"])
+                    .ok_or_else(|| anyhow!("OPENAI_API_KEY not set (and no token stored)"))?;
                 Ok(ModelWithProvider {
                     model: model.clone(),
                     provider_type: LlmProviderType::Openai,
@@ -713,8 +717,10 @@ impl ProviderChoice {
                 })
             }
             ProviderChoice::Google { model, base_url } => {
-                let key = google_api_key()
-                    .ok_or_else(|| anyhow!("GEMINI_API_KEY (or GOOGLE_API_KEY) not set"))?;
+                let key = resolve_token(settings, "google", &["GEMINI_API_KEY", "GOOGLE_API_KEY"])
+                    .ok_or_else(|| {
+                        anyhow!("GEMINI_API_KEY (or GOOGLE_API_KEY) not set (and no token stored)")
+                    })?;
                 Ok(ModelWithProvider {
                     model: model.clone(),
                     provider_type: LlmProviderType::Openai,
@@ -723,8 +729,8 @@ impl ProviderChoice {
                 })
             }
             ProviderChoice::OpenRouter { model, base_url } => {
-                let key = env_non_empty("OPENROUTER_API_KEY")
-                    .ok_or_else(|| anyhow!("OPENROUTER_API_KEY not set"))?;
+                let key = resolve_token(settings, "openrouter", &["OPENROUTER_API_KEY"])
+                    .ok_or_else(|| anyhow!("OPENROUTER_API_KEY not set (and no token stored)"))?;
                 Ok(ModelWithProvider {
                     model: model.clone(),
                     provider_type: LlmProviderType::Openai,
@@ -732,12 +738,16 @@ impl ProviderChoice {
                     base_url: Some(base_url.clone()),
                 })
             }
-            ProviderChoice::Ollama { model, base_url } => Ok(ModelWithProvider {
-                model: model.clone(),
-                provider_type: LlmProviderType::Openai,
-                api_key: Some(env_or_default("OLLAMA_API_KEY", DEFAULT_OLLAMA_API_KEY)),
-                base_url: Some(base_url.clone()),
-            }),
+            ProviderChoice::Ollama { model, base_url } => {
+                let key = resolve_token(settings, "ollama", &["OLLAMA_API_KEY"])
+                    .unwrap_or_else(|| DEFAULT_OLLAMA_API_KEY.to_string());
+                Ok(ModelWithProvider {
+                    model: model.clone(),
+                    provider_type: LlmProviderType::Openai,
+                    api_key: Some(key),
+                    base_url: Some(base_url.clone()),
+                })
+            }
             ProviderChoice::Sim => Ok(ModelWithProvider {
                 model: "llmsim-yolop".into(),
                 provider_type: LlmProviderType::LlmSim,
@@ -773,6 +783,18 @@ fn env_non_empty(name: &str) -> Option<String> {
 /// `GOOGLE_API_KEY`; the Google docs lean on `GEMINI_API_KEY` so it wins.
 fn google_api_key() -> Option<String> {
     env_non_empty("GEMINI_API_KEY").or_else(|| env_non_empty("GOOGLE_API_KEY"))
+}
+
+/// Env vars beat settings — a per-run override always wins over a saved
+/// token, so a developer can point yolop at a scratch key without editing
+/// the settings file.
+fn resolve_token(settings: &Settings, provider: &str, env_names: &[&str]) -> Option<String> {
+    for name in env_names {
+        if let Some(value) = env_non_empty(name) {
+            return Some(value);
+        }
+    }
+    settings.token_for(provider).map(str::to_string)
 }
 
 fn env_or_default(name: &str, default: &str) -> String {
@@ -823,6 +845,7 @@ fn coding_harness_capabilities() -> Vec<AgentCapabilityConfig> {
         ),
         AgentCapabilityConfig::new(MODEL_SWITCHER_CAPABILITY_ID),
         AgentCapabilityConfig::new(PROVIDER_SWITCHER_CAPABILITY_ID),
+        AgentCapabilityConfig::new(TOKEN_CAPABILITY_ID),
         AgentCapabilityConfig::new("yolop_bash"),
     ]
 }
@@ -1020,10 +1043,14 @@ pub async fn build_with_options(
     capabilities.register(ModelSwitcherCapability {
         provider: provider_state.clone(),
         provider_store: provider_store.clone(),
+        settings: settings.clone(),
     });
     capabilities.register(ProviderSwitcherCapability {
         provider: provider_state.clone(),
         provider_store: provider_store.clone(),
+        settings: settings.clone(),
+    });
+    capabilities.register(TokenCapability {
         settings: settings.clone(),
     });
     capabilities.register(CodingBashCapability {
@@ -1039,7 +1066,7 @@ pub async fn build_with_options(
         | ProviderChoice::OpenAi { .. }
         | ProviderChoice::Google { .. }
         | ProviderChoice::OpenRouter { .. }
-        | ProviderChoice::Ollama { .. } => provider.model_with_provider()?,
+        | ProviderChoice::Ollama { .. } => provider.model_with_provider(&settings.snapshot())?,
         ProviderChoice::Sim => ModelWithProvider {
             model: "llmsim-yolop".into(),
             provider_type: LlmProviderType::LlmSim,
@@ -1224,8 +1251,10 @@ mod tests {
     #[test]
     fn google_requires_api_key_to_build_model_with_provider() {
         // Drop both env vars in case the test runner exported one.
-        // SAFETY: tests in this crate run on a single thread per CARGO_TEST_THREADS,
-        // and these env reads/writes do not cross threads.
+        // SAFETY: env mutations in this single-process test do not race
+        // because tests in the same module serialize on `RUST_TEST_THREADS=1`
+        // for env-touching cases; otherwise the assertion still tolerates
+        // either outcome via `contains`.
         unsafe {
             std::env::remove_var("GEMINI_API_KEY");
             std::env::remove_var("GOOGLE_API_KEY");
@@ -1234,34 +1263,61 @@ mod tests {
             model: "gemini-2.5-flash".to_string(),
             base_url: DEFAULT_GOOGLE_BASE_URL.to_string(),
         };
-        let err = provider.model_with_provider().unwrap_err();
+        let err = provider
+            .model_with_provider(&Settings::default())
+            .unwrap_err();
         assert!(err.to_string().contains("GEMINI_API_KEY"));
     }
 
     #[test]
     fn openrouter_uses_openai_responses_driver_with_base_url() {
+        unsafe {
+            std::env::remove_var("OPENROUTER_API_KEY");
+        }
         let provider = ProviderChoice::OpenRouter {
             model: "openai/gpt-5.2".to_string(),
             base_url: DEFAULT_OPENROUTER_BASE_URL.to_string(),
         };
 
-        let err = provider.model_with_provider().unwrap_err();
+        let err = provider
+            .model_with_provider(&Settings::default())
+            .unwrap_err();
 
-        assert_eq!(err.to_string(), "OPENROUTER_API_KEY not set");
+        assert!(err.to_string().contains("OPENROUTER_API_KEY not set"));
     }
 
     #[test]
     fn ollama_uses_openai_responses_driver_with_local_base_url() {
+        unsafe {
+            std::env::remove_var("OLLAMA_API_KEY");
+        }
         let provider = ProviderChoice::Ollama {
             model: "llama3.2".to_string(),
             base_url: DEFAULT_OLLAMA_BASE_URL.to_string(),
         };
 
-        let model = provider.model_with_provider().unwrap();
+        let model = provider.model_with_provider(&Settings::default()).unwrap();
 
         assert_eq!(model.provider_type, LlmProviderType::Openai);
         assert_eq!(model.api_key, Some(DEFAULT_OLLAMA_API_KEY.to_string()));
         assert_eq!(model.base_url, Some(DEFAULT_OLLAMA_BASE_URL.to_string()));
+    }
+
+    #[test]
+    fn stored_token_falls_back_when_env_var_missing() {
+        unsafe {
+            std::env::remove_var("ANTHROPIC_API_KEY");
+        }
+        let mut settings = Settings::default();
+        settings
+            .tokens
+            .insert("anthropic".to_string(), "stored-anth-key".to_string());
+
+        let provider = ProviderChoice::Anthropic {
+            model: "claude-sonnet-4-5".to_string(),
+        };
+        let model = provider.model_with_provider(&settings).unwrap();
+        assert_eq!(model.api_key, Some("stored-anth-key".to_string()));
     }
 
     #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,10 +1,19 @@
-// Persistent yolop settings — currently just the preferred provider name.
+// Persistent yolop settings — preferred provider plus optional per-provider
+// API tokens.
 //
 // Stored at `<config_dir>/yolop/settings.toml` (`~/.config/yolop/settings.toml`
-// on Linux). The capability that owns `/provider` writes through
-// `SettingsStore` so the choice survives across runs.
+// on Linux). The capabilities that own `/provider` and `/token` write
+// through `SettingsStore` so user choices survive across runs.
+//
+// Tokens are written with 0o600 on Unix (owner-only) and are still less
+// secure than a real secret manager — they sit in plain text on disk. The
+// `/token <provider> clear` command removes a stored entry. Env vars
+// (OPENAI_API_KEY, ANTHROPIC_API_KEY, …) continue to take precedence so a
+// per-run override is always possible.
 
 use anyhow::{Context, Result};
+use std::collections::BTreeMap;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use toml::Table;
@@ -13,16 +22,24 @@ use toml::Value;
 #[derive(Debug, Clone, Default)]
 pub struct Settings {
     pub provider: Option<String>,
+    pub tokens: BTreeMap<String, String>,
 }
 
 impl Settings {
     pub fn from_table(table: &Table) -> Self {
-        Self {
-            provider: table
-                .get("provider")
-                .and_then(Value::as_str)
-                .map(str::to_string),
+        let provider = table
+            .get("provider")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let mut tokens = BTreeMap::new();
+        if let Some(t) = table.get("tokens").and_then(Value::as_table) {
+            for (k, v) in t {
+                if let Some(s) = v.as_str() {
+                    tokens.insert(k.clone(), s.to_string());
+                }
+            }
         }
+        Self { provider, tokens }
     }
 
     pub fn to_table(&self) -> Table {
@@ -30,7 +47,22 @@ impl Settings {
         if let Some(p) = &self.provider {
             table.insert("provider".to_string(), Value::String(p.clone()));
         }
+        if !self.tokens.is_empty() {
+            let mut tokens_table = Table::new();
+            for (k, v) in &self.tokens {
+                tokens_table.insert(k.clone(), Value::String(v.clone()));
+            }
+            table.insert("tokens".to_string(), Value::Table(tokens_table));
+        }
         table
+    }
+
+    pub fn token_for(&self, provider: &str) -> Option<&str> {
+        self.tokens.get(provider).map(String::as_str)
+    }
+
+    pub fn has_token(&self, provider: &str) -> bool {
+        self.tokens.contains_key(provider)
     }
 }
 
@@ -46,13 +78,28 @@ pub fn load_from(path: &Path) -> Settings {
     Settings::from_table(&table)
 }
 
+/// Write the settings file atomically-ish: open with `O_TRUNC` and mode
+/// 0o600 on Unix so the file is created owner-only from the first byte —
+/// avoids a brief window where the previous-version contents sit on disk
+/// with default 0o644 permissions while we still hold the tokens.
 fn save_to(path: &Path, settings: &Settings) -> Result<()> {
     if let Some(dir) = path.parent() {
         std::fs::create_dir_all(dir)
             .with_context(|| format!("create settings dir {}", dir.display()))?;
     }
     let toml_text = toml::to_string(&settings.to_table()).context("serialize settings")?;
-    std::fs::write(path, toml_text)
+
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    let mut file = opts
+        .open(path)
+        .with_context(|| format!("open settings {}", path.display()))?;
+    file.write_all(toml_text.as_bytes())
         .with_context(|| format!("write settings {}", path.display()))?;
     Ok(())
 }
@@ -87,6 +134,20 @@ impl SettingsStore {
         guard.provider = provider;
         save_to(&self.path, &guard)
     }
+
+    pub fn set_token(&self, provider: String, token: String) -> Result<()> {
+        let mut guard = self.inner.lock().expect("settings lock poisoned");
+        guard.tokens.insert(provider, token);
+        save_to(&self.path, &guard)
+    }
+
+    /// Returns whether a token was actually present before removal.
+    pub fn clear_token(&self, provider: &str) -> Result<bool> {
+        let mut guard = self.inner.lock().expect("settings lock poisoned");
+        let existed = guard.tokens.remove(provider).is_some();
+        save_to(&self.path, &guard)?;
+        Ok(existed)
+    }
 }
 
 #[cfg(test)]
@@ -94,7 +155,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn roundtrip_via_disk() {
+    fn provider_roundtrip_via_disk() {
         let tmp = tempfile::tempdir().expect("tmp");
         let path = tmp.path().join("nested").join("settings.toml");
         let store = SettingsStore::open(path.clone());
@@ -114,11 +175,68 @@ mod tests {
     }
 
     #[test]
+    fn token_roundtrip_via_disk() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join("settings.toml");
+        let store = SettingsStore::open(path.clone());
+        store
+            .set_token("openai".to_string(), "sk-test-abc".to_string())
+            .expect("save");
+        store
+            .set_token("anthropic".to_string(), "anthropic-key".to_string())
+            .expect("save");
+
+        let on_disk = std::fs::read_to_string(&path).expect("read");
+        assert!(
+            on_disk.contains("[tokens]") && on_disk.contains("openai = \"sk-test-abc\""),
+            "expected TOML tokens table, got: {on_disk}"
+        );
+
+        let reloaded = SettingsStore::open(path);
+        assert_eq!(reloaded.snapshot().token_for("openai"), Some("sk-test-abc"));
+        assert_eq!(
+            reloaded.snapshot().token_for("anthropic"),
+            Some("anthropic-key")
+        );
+        assert!(reloaded.snapshot().token_for("google").is_none());
+    }
+
+    #[test]
+    fn clearing_token_removes_only_that_entry() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join("settings.toml");
+        let store = SettingsStore::open(path.clone());
+        store
+            .set_token("openai".to_string(), "sk-1".to_string())
+            .expect("save");
+        store
+            .set_token("anthropic".to_string(), "anth-1".to_string())
+            .expect("save");
+
+        let removed = store.clear_token("openai").expect("clear");
+        assert!(removed);
+
+        let reloaded = SettingsStore::open(path);
+        assert!(reloaded.snapshot().token_for("openai").is_none());
+        assert_eq!(reloaded.snapshot().token_for("anthropic"), Some("anth-1"));
+    }
+
+    #[test]
+    fn clearing_absent_token_reports_false_but_succeeds() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join("settings.toml");
+        let store = SettingsStore::open(path);
+        let removed = store.clear_token("openai").expect("clear");
+        assert!(!removed);
+    }
+
+    #[test]
     fn missing_file_yields_default() {
         let tmp = tempfile::tempdir().expect("tmp");
         let path = tmp.path().join("absent.toml");
         let store = SettingsStore::open(path);
         assert!(store.snapshot().provider.is_none());
+        assert!(store.snapshot().tokens.is_empty());
     }
 
     #[test]
@@ -130,16 +248,19 @@ mod tests {
         assert!(store.snapshot().provider.is_none());
     }
 
+    #[cfg(unix)]
     #[test]
-    fn clearing_provider_persists_empty_table() {
+    fn save_writes_owner_only_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
         let tmp = tempfile::tempdir().expect("tmp");
         let path = tmp.path().join("settings.toml");
         let store = SettingsStore::open(path.clone());
         store
-            .set_provider(Some("openai".to_string()))
+            .set_token("openai".to_string(), "sk-test".to_string())
             .expect("save");
-        store.set_provider(None).expect("save");
-        let reloaded = SettingsStore::open(path);
-        assert!(reloaded.snapshot().provider.is_none());
+
+        let mode = std::fs::metadata(&path).expect("meta").permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,137 @@
+// Persistent yolop settings — currently just the preferred provider name.
+//
+// Stored at `<config_dir>/yolop/settings.json` (`~/.config/yolop/settings.json`
+// on Linux). The capability that owns `/provider` writes through
+// `SettingsStore` so the choice survives across runs.
+
+use anyhow::{Context, Result};
+use serde_json::{Map, Value};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+#[derive(Debug, Clone, Default)]
+pub struct Settings {
+    pub provider: Option<String>,
+}
+
+impl Settings {
+    pub fn from_json(value: &Value) -> Self {
+        Self {
+            provider: value
+                .get("provider")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+        }
+    }
+
+    pub fn to_json(&self) -> Value {
+        let mut obj = Map::new();
+        if let Some(p) = &self.provider {
+            obj.insert("provider".to_string(), Value::String(p.clone()));
+        }
+        Value::Object(obj)
+    }
+}
+
+pub fn default_settings_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|p| p.join("yolop").join("settings.json"))
+}
+
+pub fn load_from(path: &Path) -> Settings {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return Settings::default();
+    };
+    let value: Value = serde_json::from_str(&text).unwrap_or(Value::Null);
+    Settings::from_json(&value)
+}
+
+fn save_to(path: &Path, settings: &Settings) -> Result<()> {
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)
+            .with_context(|| format!("create settings dir {}", dir.display()))?;
+    }
+    let json = serde_json::to_string_pretty(&settings.to_json()).context("serialize settings")?;
+    std::fs::write(path, json).with_context(|| format!("write settings {}", path.display()))?;
+    Ok(())
+}
+
+/// Thread-safe handle shared across capabilities. The cached `Settings` is
+/// the source of truth in memory; mutations flush to disk synchronously so
+/// a crash mid-session leaves the on-disk file consistent.
+pub struct SettingsStore {
+    path: PathBuf,
+    inner: Mutex<Settings>,
+}
+
+impl SettingsStore {
+    pub fn open(path: PathBuf) -> Self {
+        let settings = load_from(&path);
+        Self {
+            path,
+            inner: Mutex::new(settings),
+        }
+    }
+
+    pub fn snapshot(&self) -> Settings {
+        self.inner.lock().expect("settings lock poisoned").clone()
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn set_provider(&self, provider: Option<String>) -> Result<()> {
+        let mut guard = self.inner.lock().expect("settings lock poisoned");
+        guard.provider = provider;
+        save_to(&self.path, &guard)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_via_disk() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join("nested").join("settings.json");
+        let store = SettingsStore::open(path.clone());
+        assert!(store.snapshot().provider.is_none());
+        store
+            .set_provider(Some("anthropic".to_string()))
+            .expect("save");
+
+        let reloaded = SettingsStore::open(path);
+        assert_eq!(reloaded.snapshot().provider.as_deref(), Some("anthropic"));
+    }
+
+    #[test]
+    fn missing_file_yields_default() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join("absent.json");
+        let store = SettingsStore::open(path);
+        assert!(store.snapshot().provider.is_none());
+    }
+
+    #[test]
+    fn malformed_file_yields_default() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join("settings.json");
+        std::fs::write(&path, "not json").expect("write");
+        let store = SettingsStore::open(path);
+        assert!(store.snapshot().provider.is_none());
+    }
+
+    #[test]
+    fn clearing_provider_persists_empty_object() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join("settings.json");
+        let store = SettingsStore::open(path.clone());
+        store
+            .set_provider(Some("openai".to_string()))
+            .expect("save");
+        store.set_provider(None).expect("save");
+        let reloaded = SettingsStore::open(path);
+        assert!(reloaded.snapshot().provider.is_none());
+    }
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,13 +1,14 @@
 // Persistent yolop settings — currently just the preferred provider name.
 //
-// Stored at `<config_dir>/yolop/settings.json` (`~/.config/yolop/settings.json`
+// Stored at `<config_dir>/yolop/settings.toml` (`~/.config/yolop/settings.toml`
 // on Linux). The capability that owns `/provider` writes through
 // `SettingsStore` so the choice survives across runs.
 
 use anyhow::{Context, Result};
-use serde_json::{Map, Value};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+use toml::Table;
+use toml::Value;
 
 #[derive(Debug, Clone, Default)]
 pub struct Settings {
@@ -15,34 +16,34 @@ pub struct Settings {
 }
 
 impl Settings {
-    pub fn from_json(value: &Value) -> Self {
+    pub fn from_table(table: &Table) -> Self {
         Self {
-            provider: value
+            provider: table
                 .get("provider")
                 .and_then(Value::as_str)
                 .map(str::to_string),
         }
     }
 
-    pub fn to_json(&self) -> Value {
-        let mut obj = Map::new();
+    pub fn to_table(&self) -> Table {
+        let mut table = Table::new();
         if let Some(p) = &self.provider {
-            obj.insert("provider".to_string(), Value::String(p.clone()));
+            table.insert("provider".to_string(), Value::String(p.clone()));
         }
-        Value::Object(obj)
+        table
     }
 }
 
 pub fn default_settings_path() -> Option<PathBuf> {
-    dirs::config_dir().map(|p| p.join("yolop").join("settings.json"))
+    dirs::config_dir().map(|p| p.join("yolop").join("settings.toml"))
 }
 
 pub fn load_from(path: &Path) -> Settings {
     let Ok(text) = std::fs::read_to_string(path) else {
         return Settings::default();
     };
-    let value: Value = serde_json::from_str(&text).unwrap_or(Value::Null);
-    Settings::from_json(&value)
+    let table: Table = toml::from_str(&text).unwrap_or_default();
+    Settings::from_table(&table)
 }
 
 fn save_to(path: &Path, settings: &Settings) -> Result<()> {
@@ -50,8 +51,9 @@ fn save_to(path: &Path, settings: &Settings) -> Result<()> {
         std::fs::create_dir_all(dir)
             .with_context(|| format!("create settings dir {}", dir.display()))?;
     }
-    let json = serde_json::to_string_pretty(&settings.to_json()).context("serialize settings")?;
-    std::fs::write(path, json).with_context(|| format!("write settings {}", path.display()))?;
+    let toml_text = toml::to_string(&settings.to_table()).context("serialize settings")?;
+    std::fs::write(path, toml_text)
+        .with_context(|| format!("write settings {}", path.display()))?;
     Ok(())
 }
 
@@ -94,12 +96,18 @@ mod tests {
     #[test]
     fn roundtrip_via_disk() {
         let tmp = tempfile::tempdir().expect("tmp");
-        let path = tmp.path().join("nested").join("settings.json");
+        let path = tmp.path().join("nested").join("settings.toml");
         let store = SettingsStore::open(path.clone());
         assert!(store.snapshot().provider.is_none());
         store
             .set_provider(Some("anthropic".to_string()))
             .expect("save");
+
+        let on_disk = std::fs::read_to_string(&path).expect("read");
+        assert!(
+            on_disk.contains("provider = \"anthropic\""),
+            "expected TOML key/value, got: {on_disk}"
+        );
 
         let reloaded = SettingsStore::open(path);
         assert_eq!(reloaded.snapshot().provider.as_deref(), Some("anthropic"));
@@ -108,7 +116,7 @@ mod tests {
     #[test]
     fn missing_file_yields_default() {
         let tmp = tempfile::tempdir().expect("tmp");
-        let path = tmp.path().join("absent.json");
+        let path = tmp.path().join("absent.toml");
         let store = SettingsStore::open(path);
         assert!(store.snapshot().provider.is_none());
     }
@@ -116,16 +124,16 @@ mod tests {
     #[test]
     fn malformed_file_yields_default() {
         let tmp = tempfile::tempdir().expect("tmp");
-        let path = tmp.path().join("settings.json");
-        std::fs::write(&path, "not json").expect("write");
+        let path = tmp.path().join("settings.toml");
+        std::fs::write(&path, "this = is = not = toml").expect("write");
         let store = SettingsStore::open(path);
         assert!(store.snapshot().provider.is_none());
     }
 
     #[test]
-    fn clearing_provider_persists_empty_object() {
+    fn clearing_provider_persists_empty_table() {
         let tmp = tempfile::tempdir().expect("tmp");
-        let path = tmp.path().join("settings.json");
+        let path = tmp.path().join("settings.toml");
         let store = SettingsStore::open(path.clone());
         store
             .set_provider(Some("openai".to_string()))

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -78,10 +78,12 @@ pub fn load_from(path: &Path) -> Settings {
     Settings::from_table(&table)
 }
 
-/// Write the settings file atomically-ish: open with `O_TRUNC` and mode
-/// 0o600 on Unix so the file is created owner-only from the first byte —
-/// avoids a brief window where the previous-version contents sit on disk
-/// with default 0o644 permissions while we still hold the tokens.
+/// Write the settings file in place, truncating + rewriting. On Unix the
+/// file is forced to mode 0o600 (owner-only) both at create time and
+/// after open, so pre-existing files written with a broader default mode
+/// are tightened on first save. The write is not crash-atomic — a power
+/// loss mid-`write_all` can leave a truncated TOML file; load tolerates
+/// that by falling back to defaults.
 fn save_to(path: &Path, settings: &Settings) -> Result<()> {
     if let Some(dir) = path.parent() {
         std::fs::create_dir_all(dir)
@@ -99,14 +101,25 @@ fn save_to(path: &Path, settings: &Settings) -> Result<()> {
     let mut file = opts
         .open(path)
         .with_context(|| format!("open settings {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // `mode()` on OpenOptions only applies when the file is created.
+        // If the user (or an older yolop) wrote settings.toml with the
+        // default 0o644, tighten it on every save so tokens never sit at
+        // world-readable permissions.
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("tighten settings permissions {}", path.display()))?;
+    }
     file.write_all(toml_text.as_bytes())
         .with_context(|| format!("write settings {}", path.display()))?;
     Ok(())
 }
 
 /// Thread-safe handle shared across capabilities. The cached `Settings` is
-/// the source of truth in memory; mutations flush to disk synchronously so
-/// a crash mid-session leaves the on-disk file consistent.
+/// the source of truth in memory; mutations flush to disk synchronously.
+/// The write is not crash-atomic — see `save_to` — but load tolerates a
+/// truncated file by falling back to defaults.
 pub struct SettingsStore {
     path: PathBuf,
     inner: Mutex<Settings>,
@@ -246,6 +259,27 @@ mod tests {
         std::fs::write(&path, "this = is = not = toml").expect("write");
         let store = SettingsStore::open(path);
         assert!(store.snapshot().provider.is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_tightens_permissions_on_preexisting_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join("settings.toml");
+        // Simulate a stale file from a previous yolop version that wrote
+        // settings with the default 0o644.
+        std::fs::write(&path, "provider = \"openai\"\n").expect("seed");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).expect("chmod");
+
+        let store = SettingsStore::open(path.clone());
+        store
+            .set_token("openai".to_string(), "sk-new".to_string())
+            .expect("save");
+
+        let mode = std::fs::metadata(&path).expect("meta").permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
     }
 
     #[cfg(unix)]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -78,18 +78,29 @@ pub fn load_from(path: &Path) -> Settings {
     Settings::from_table(&table)
 }
 
-/// Write the settings file in place, truncating + rewriting. On Unix the
-/// file is forced to mode 0o600 (owner-only) both at create time and
-/// after open, so pre-existing files written with a broader default mode
-/// are tightened on first save. The write is not crash-atomic — a power
-/// loss mid-`write_all` can leave a truncated TOML file; load tolerates
-/// that by falling back to defaults.
+/// Write the settings file atomically: stage into a sibling temp file,
+/// `fsync`, then `rename` over the target. POSIX `rename` is atomic, so
+/// concurrent readers and crashes see either the old contents or the
+/// fully written new contents — never a truncated TOML. The temp file is
+/// created with mode 0o600 on Unix, so the resulting file is owner-only
+/// regardless of any prior file's permissions.
 fn save_to(path: &Path, settings: &Settings) -> Result<()> {
-    if let Some(dir) = path.parent() {
-        std::fs::create_dir_all(dir)
-            .with_context(|| format!("create settings dir {}", dir.display()))?;
-    }
+    let parent = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+    std::fs::create_dir_all(&parent)
+        .with_context(|| format!("create settings dir {}", parent.display()))?;
     let toml_text = toml::to_string(&settings.to_table()).context("serialize settings")?;
+
+    let file_name = path
+        .file_name()
+        .with_context(|| format!("settings path has no file name: {}", path.display()))?;
+    let mut tmp_name = std::ffi::OsString::from(".");
+    tmp_name.push(file_name);
+    tmp_name.push(format!(".tmp.{}", std::process::id()));
+    let tmp_path = parent.join(tmp_name);
 
     let mut opts = std::fs::OpenOptions::new();
     opts.write(true).create(true).truncate(true);
@@ -98,28 +109,29 @@ fn save_to(path: &Path, settings: &Settings) -> Result<()> {
         use std::os::unix::fs::OpenOptionsExt;
         opts.mode(0o600);
     }
-    let mut file = opts
-        .open(path)
-        .with_context(|| format!("open settings {}", path.display()))?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        // `mode()` on OpenOptions only applies when the file is created.
-        // If the user (or an older yolop) wrote settings.toml with the
-        // default 0o644, tighten it on every save so tokens never sit at
-        // world-readable permissions.
-        file.set_permissions(std::fs::Permissions::from_mode(0o600))
-            .with_context(|| format!("tighten settings permissions {}", path.display()))?;
+    let write_result = (|| -> Result<()> {
+        let mut file = opts
+            .open(&tmp_path)
+            .with_context(|| format!("open temp settings {}", tmp_path.display()))?;
+        file.write_all(toml_text.as_bytes())
+            .with_context(|| format!("write temp settings {}", tmp_path.display()))?;
+        file.sync_all()
+            .with_context(|| format!("sync temp settings {}", tmp_path.display()))?;
+        Ok(())
+    })();
+    if let Err(e) = write_result {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(e);
     }
-    file.write_all(toml_text.as_bytes())
-        .with_context(|| format!("write settings {}", path.display()))?;
+    std::fs::rename(&tmp_path, path)
+        .with_context(|| format!("rename {} -> {}", tmp_path.display(), path.display()))?;
     Ok(())
 }
 
-/// Thread-safe handle shared across capabilities. The cached `Settings` is
-/// the source of truth in memory; mutations flush to disk synchronously.
-/// The write is not crash-atomic — see `save_to` — but load tolerates a
-/// truncated file by falling back to defaults.
+/// Thread-safe handle shared across capabilities. The cached `Settings`
+/// is the source of truth in memory; mutations flush to disk via an
+/// atomic temp-file + rename (see `save_to`), so readers and crashes
+/// never observe a partially written settings file.
 pub struct SettingsStore {
     path: PathBuf,
     inner: Mutex<Settings>,

--- a/src/streaming_tests.rs
+++ b/src/streaming_tests.rs
@@ -19,9 +19,12 @@ use tokio::sync::mpsc;
 
 use everruns_core::llmsim_driver::LlmSimConfig;
 
+use std::sync::Arc;
+
 use crate::app::{DeltaRouter, StreamKind, TurnEvent, handle_live_event};
 use crate::approval::ApprovalGate;
 use crate::runtime::{BuildOptions, ProviderChoice, build_with_options};
+use crate::settings::SettingsStore;
 
 /// Maximum wall time we wait for the llmsim turn to fully drain
 /// through the broadcast. The instant-latency llmsim profile finishes
@@ -46,12 +49,15 @@ async fn build_llmsim_runtime() -> crate::runtime::BuiltRuntime {
     let llmsim = LlmSimConfig::lorem(200)
         .with_latency()
         .with_model("llmsim-yolop");
+    let settings_path = sessions.path().join("settings.toml");
+    let settings = Arc::new(SettingsStore::open(settings_path));
     let runtime = build_with_options(
         workspace.path().to_path_buf(),
         ProviderChoice::Sim,
         ApprovalGate::auto(),
         None,
         sessions.path().to_path_buf(),
+        settings,
         BuildOptions {
             llmsim_override: Some(llmsim),
         },

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -1,0 +1,20 @@
+//! Process-wide mutex for tests that touch environment variables.
+//!
+//! Rust 1.85+ marks `std::env::set_var` / `remove_var` as `unsafe`
+//! because the underlying `setenv` / `unsetenv` are not thread-safe —
+//! concurrent calls (or a call concurrent with another thread's
+//! `getenv`) can segfault. Cargo's default test runner spawns multiple
+//! threads inside one process, so every env-touching test in this
+//! binary needs to serialize against every other env-touching test.
+//!
+//! Hold the guard from [`lock`] for the entire duration of any test
+//! that mutates the environment.
+
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+pub(crate) fn lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}


### PR DESCRIPTION
## Summary

Adds three new TUI capabilities — `/provider`, `/token`, `/onboard` — and persists the choices to `<config_dir>/yolop/settings.toml` (0o600 on Unix). A first-run wizard auto-launches when no env credential and no saved setting are present, walks the user through provider → token → default model, and drives the existing slash commands under the hood.

- **`/provider <name>`** — pick OpenAI, Anthropic, Google, OpenRouter, Ollama, llmsim. Saves to settings; `/model` still works on top.
- **`/token <provider> <value>`** — store API tokens in the settings file. `/token` lists status without revealing values; `/token <provider> clear` removes one. Env vars beat saved tokens at runtime.
- **`/onboard`** — re-runs the wizard. Auto-fires at startup when nothing is configured.
- **Google Gemini** support via its OpenAI-compatible endpoint (`GEMINI_API_KEY` or `GOOGLE_API_KEY`).

Implementation lives in four new pieces:
- `src/settings.rs` — `SettingsStore` over a TOML file, atomic temp-file + rename save with mode 0o600.
- `src/capabilities.rs` — `ProviderSwitcherCapability`, `TokenCapability`, `OnboardingCapability` (the latter exposes `needs_onboarding(&Settings)` used at startup).
- `src/runtime.rs` — registers the capabilities, plumbs settings through `model_with_provider`, exports `onboarding_recommended` via `StartupInfo`.
- `src/app.rs` — the wizard state machine; it doesn't push token text into the transcript.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] Manual TUI verification under tmux: no-creds launch auto-opens the wizard, walked through openai → token → default model, `settings.toml` on disk shows `provider = "openai"` and `[tokens] openai = "..."` with mode 600. Restart with the same config dir loads the saved provider and does not re-trigger the wizard.