### PR TITLE
test(approval,diff): add unit tests for gate semantics and diff helper

### DIFF
--- a/src/approval.rs
+++ b/src/approval.rs
@@ -121,3 +121,247 @@ impl FileApprovalGate for ApprovalGate {
         .await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_line_returns_first_line_only() {
+        assert_eq!(first_line("one\ntwo\nthree", 100), "one");
+    }
+
+    #[test]
+    fn first_line_truncates_with_ellipsis() {
+        let out = first_line("abcdefghij", 4);
+        assert_eq!(out, "abcd…");
+    }
+
+    #[test]
+    fn first_line_handles_empty_input() {
+        assert_eq!(first_line("", 10), "");
+    }
+
+    #[test]
+    fn first_line_does_not_truncate_within_limit() {
+        assert_eq!(first_line("hi", 10), "hi");
+    }
+
+    #[test]
+    fn headline_bash_uses_first_line() {
+        let req = ApprovalRequest::Bash {
+            command: "ls -la\nrm -rf /".into(),
+        };
+        assert_eq!(req.headline(), "run bash: ls -la");
+    }
+
+    #[test]
+    fn headline_file_write_says_create_when_no_before() {
+        let req = ApprovalRequest::FileWrite {
+            path: "/tmp/x".into(),
+            before: None,
+            after: "hello".into(),
+        };
+        assert_eq!(req.headline(), "create /tmp/x (5 bytes)");
+    }
+
+    #[test]
+    fn headline_file_write_says_edit_when_before_present() {
+        let req = ApprovalRequest::FileWrite {
+            path: "/tmp/x".into(),
+            before: Some("old".into()),
+            after: "newer".into(),
+        };
+        assert_eq!(req.headline(), "edit /tmp/x (5 bytes)");
+    }
+
+    #[test]
+    fn headline_file_delete_marks_recursive() {
+        let req = ApprovalRequest::FileDelete {
+            path: "/tmp/dir".into(),
+            recursive: true,
+        };
+        assert_eq!(req.headline(), "delete /tmp/dir (recursive)");
+    }
+
+    #[test]
+    fn headline_file_delete_non_recursive_has_no_suffix() {
+        let req = ApprovalRequest::FileDelete {
+            path: "/tmp/f".into(),
+            recursive: false,
+        };
+        assert_eq!(req.headline(), "delete /tmp/f");
+    }
+
+    #[test]
+    fn detail_bash_returns_full_command() {
+        let req = ApprovalRequest::Bash {
+            command: "line1\nline2".into(),
+        };
+        assert_eq!(req.detail(), "line1\nline2");
+    }
+
+    #[test]
+    fn detail_file_write_new_file_summarises_size() {
+        let req = ApprovalRequest::FileWrite {
+            path: "/tmp/x".into(),
+            before: None,
+            after: "abcd".into(),
+        };
+        assert_eq!(req.detail(), "(new file, 4 bytes)");
+    }
+
+    #[test]
+    fn detail_file_write_edit_renders_unified_diff() {
+        let req = ApprovalRequest::FileWrite {
+            path: "x".into(),
+            before: Some("hello\n".into()),
+            after: "world\n".into(),
+        };
+        let out = req.detail();
+        assert!(out.contains("--- a/x"), "missing a/ header: {out}");
+        assert!(out.contains("+++ b/x"), "missing b/ header: {out}");
+        assert!(out.contains("-hello"), "missing removal: {out}");
+        assert!(out.contains("+world"), "missing addition: {out}");
+    }
+
+    #[test]
+    fn detail_file_delete_is_empty() {
+        let req = ApprovalRequest::FileDelete {
+            path: "/x".into(),
+            recursive: false,
+        };
+        assert_eq!(req.detail(), "");
+    }
+
+    #[tokio::test]
+    async fn auto_gate_always_approves() {
+        let gate = ApprovalGate::auto();
+        assert!(
+            gate.approve(ApprovalRequest::Bash {
+                command: "rm -rf /".into(),
+            })
+            .await
+        );
+    }
+
+    #[tokio::test]
+    async fn channel_gate_forwards_request_and_returns_approval() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<(ApprovalRequest, oneshot::Sender<bool>)>();
+        let gate = ApprovalGate::channel(tx);
+
+        let approver = tokio::spawn(async move {
+            let (req, responder) = rx.recv().await.expect("request");
+            match req {
+                ApprovalRequest::Bash { command } => assert_eq!(command, "ls"),
+                other => panic!("unexpected request: {other:?}"),
+            }
+            responder.send(true).expect("send approval");
+        });
+
+        let approved = gate
+            .approve(ApprovalRequest::Bash {
+                command: "ls".into(),
+            })
+            .await;
+        approver.await.unwrap();
+        assert!(approved);
+    }
+
+    #[tokio::test]
+    async fn channel_gate_returns_false_on_denial() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<(ApprovalRequest, oneshot::Sender<bool>)>();
+        let gate = ApprovalGate::channel(tx);
+
+        tokio::spawn(async move {
+            let (_, responder) = rx.recv().await.unwrap();
+            responder.send(false).unwrap();
+        });
+
+        let approved = gate
+            .approve(ApprovalRequest::Bash {
+                command: "rm".into(),
+            })
+            .await;
+        assert!(!approved);
+    }
+
+    #[tokio::test]
+    async fn channel_gate_returns_false_when_receiver_dropped() {
+        let (tx, rx) = mpsc::unbounded_channel::<(ApprovalRequest, oneshot::Sender<bool>)>();
+        drop(rx);
+        let gate = ApprovalGate::channel(tx);
+
+        let approved = gate
+            .approve(ApprovalRequest::Bash {
+                command: "ls".into(),
+            })
+            .await;
+        assert!(!approved);
+    }
+
+    #[tokio::test]
+    async fn channel_gate_returns_false_when_responder_dropped() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<(ApprovalRequest, oneshot::Sender<bool>)>();
+        let gate = ApprovalGate::channel(tx);
+
+        tokio::spawn(async move {
+            let (_, responder) = rx.recv().await.unwrap();
+            drop(responder);
+        });
+
+        let approved = gate
+            .approve(ApprovalRequest::Bash {
+                command: "ls".into(),
+            })
+            .await;
+        assert!(!approved);
+    }
+
+    #[tokio::test]
+    async fn file_approval_gate_forwards_write_request() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<(ApprovalRequest, oneshot::Sender<bool>)>();
+        let gate = ApprovalGate::channel(tx);
+
+        tokio::spawn(async move {
+            let (req, responder) = rx.recv().await.unwrap();
+            match req {
+                ApprovalRequest::FileWrite {
+                    path,
+                    before,
+                    after,
+                } => {
+                    assert_eq!(path, "/tmp/x");
+                    assert_eq!(before.as_deref(), Some("old"));
+                    assert_eq!(after, "new");
+                }
+                other => panic!("expected FileWrite, got {other:?}"),
+            }
+            responder.send(true).unwrap();
+        });
+
+        let approved =
+            FileApprovalGate::approve_write(&*gate, "/tmp/x", Some("old".into()), "new").await;
+        assert!(approved);
+    }
+
+    #[tokio::test]
+    async fn file_approval_gate_forwards_delete_request() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<(ApprovalRequest, oneshot::Sender<bool>)>();
+        let gate = ApprovalGate::channel(tx);
+
+        tokio::spawn(async move {
+            let (req, responder) = rx.recv().await.unwrap();
+            match req {
+                ApprovalRequest::FileDelete { path, recursive } => {
+                    assert_eq!(path, "/tmp/dir");
+                    assert!(recursive);
+                }
+                other => panic!("expected FileDelete, got {other:?}"),
+            }
+            responder.send(true).unwrap();
+        });
+
+        assert!(FileApprovalGate::approve_delete(&*gate, "/tmp/dir", true).await);
+    }
+}

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -10,3 +10,52 @@ pub fn unified(old: &str, new: &str, label: &str, context: usize) -> String {
         .context_radius(context)
         .to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_uses_a_and_b_prefix_with_label() {
+        let out = unified("old\n", "new\n", "foo.txt", 3);
+        assert!(out.contains("--- a/foo.txt"), "missing a/ header: {out}");
+        assert!(out.contains("+++ b/foo.txt"), "missing b/ header: {out}");
+    }
+
+    #[test]
+    fn identical_input_produces_no_hunks() {
+        let out = unified("same\n", "same\n", "x", 3);
+        assert!(
+            !out.contains("@@"),
+            "expected no hunk markers for identical input: {out}"
+        );
+    }
+
+    #[test]
+    fn single_line_change_shows_minus_and_plus() {
+        let out = unified("hello\n", "world\n", "x", 3);
+        assert!(out.contains("-hello"), "missing -hello in {out}");
+        assert!(out.contains("+world"), "missing +world in {out}");
+    }
+
+    #[test]
+    fn context_radius_zero_omits_unchanged_neighbours() {
+        let old = "a\nb\nc\nd\ne\n";
+        let new = "a\nb\nCHANGED\nd\ne\n";
+        let out = unified(old, new, "x", 0);
+        // With zero context, surrounding unchanged lines must not appear as
+        // ` a` / ` b` / ` d` / ` e` context lines in the hunk body.
+        let context_line = out.lines().find(|l| l.starts_with(' '));
+        assert!(
+            context_line.is_none(),
+            "expected zero context lines, got: {context_line:?} in {out}"
+        );
+    }
+
+    #[test]
+    fn empty_old_treats_change_as_addition() {
+        let out = unified("", "new line\n", "x", 3);
+        assert!(out.contains("+new line"), "missing addition: {out}");
+        assert!(!out.contains("-new line"), "unexpected deletion: {out}");
+    }
+}


### PR DESCRIPTION
## Summary

Closes a coverage gap: `src/approval.rs` (123 lines) and `src/diff.rs` (12 lines) previously had zero tests despite being on the destructive-operation hot path.

Adds 25 new unit tests, all running offline in <1s:

**`src/approval.rs` (20 tests)**
- `ApprovalRequest::headline()` for every variant (Bash, FileWrite create/edit, FileDelete recursive/non-recursive)
- `ApprovalRequest::detail()` including the unified-diff branch for edits
- `first_line()` helper edge cases (truncation, multi-line, empty)
- `ApprovalGate::Auto` always approves
- `ApprovalGate::Channel` happy path (approve / deny), plus fails closed when the receiver is dropped or the responder is dropped
- `FileApprovalGate` impl forwards `approve_write`/`approve_delete` requests with the right payload

**`src/diff.rs` (5 tests)**
- a/ + b/ header prefix with label
- identical input produces no hunks
- single-line change emits `-`/`+`
- `context_radius(0)` omits unchanged neighbours
- empty-old input is treated as pure addition

## Validation

- `cargo test --bin yolop approval::` → 20 passed
- `cargo test --bin yolop diff::` → 5 passed
- `cargo test --bin yolop` → 86 passed, 0 failed
- `cargo fmt --check`, `cargo clippy --all-features -- -D warnings` clean

## Security

No security-relevant code changes — test-only additions, no production code or dependencies touched.

## Follow-ups

No follow-ups.