### PR TITLE
test(tools): cover bash approval-denial and bad-argument paths

### DIFF
--- a/src/tools.rs
+++ b/src/tools.rs
@@ -461,6 +461,146 @@ mod tests {
         );
     }
 
+    /// Spawn a background task that auto-responds to every approval
+    /// request with `decision`. Returns the gate to install on the tool.
+    fn auto_decision_gate(decision: bool) -> (Arc<ApprovalGate>, tokio::task::JoinHandle<()>) {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<(
+            ApprovalRequest,
+            tokio::sync::oneshot::Sender<bool>,
+        )>();
+        let handle = tokio::spawn(async move {
+            while let Some((_req, responder)) = rx.recv().await {
+                let _ = responder.send(decision);
+            }
+        });
+        (ApprovalGate::channel(tx), handle)
+    }
+
+    #[tokio::test]
+    async fn bash_tool_returns_error_when_user_denies() {
+        let dir = tempfile::tempdir().unwrap();
+        let (gate, approver) = auto_decision_gate(false);
+        let tool = BashTool::new(Workspace::new(dir.path().to_path_buf()), gate);
+
+        let result = tool.execute(json!({ "command": "echo hi" })).await;
+
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(
+                    msg.contains("user denied"),
+                    "expected denial error, got: {msg}"
+                );
+            }
+            other => panic!("expected ToolError, got: {other:?}"),
+        }
+        drop(tool);
+        approver.abort();
+    }
+
+    #[tokio::test]
+    async fn bash_tool_denial_does_not_execute_command() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("should-not-exist");
+        let (gate, approver) = auto_decision_gate(false);
+        let tool = BashTool::new(Workspace::new(dir.path().to_path_buf()), gate);
+
+        // If the command runs, the marker file will exist.
+        let cmd = format!("touch {}", marker.display());
+        let _ = tool.execute(json!({ "command": cmd })).await;
+
+        assert!(
+            !marker.exists(),
+            "command must not run after denial, but marker exists at {marker:?}"
+        );
+        approver.abort();
+    }
+
+    #[tokio::test]
+    async fn bash_tool_forwards_command_to_approval_gate() {
+        let dir = tempfile::tempdir().unwrap();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<(
+            ApprovalRequest,
+            tokio::sync::oneshot::Sender<bool>,
+        )>();
+        let gate = ApprovalGate::channel(tx);
+        let tool = BashTool::new(Workspace::new(dir.path().to_path_buf()), gate);
+
+        let approver = tokio::spawn(async move {
+            let (req, responder) = rx.recv().await.expect("approval request");
+            match req {
+                ApprovalRequest::Bash { command } => {
+                    assert_eq!(command, "echo captured");
+                }
+                other => panic!("expected Bash variant, got: {other:?}"),
+            }
+            responder.send(true).unwrap();
+        });
+
+        let result = tool.execute(json!({ "command": "echo captured" })).await;
+        approver.await.unwrap();
+
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("expected success after approval");
+        };
+        assert_eq!(value["exit_code"], 0);
+    }
+
+    #[tokio::test]
+    async fn bash_tool_returns_error_when_gate_channel_closed() {
+        // If the TUI tears down its approval channel mid-turn, the gate
+        // should fail closed (deny) rather than hang or panic.
+        let dir = tempfile::tempdir().unwrap();
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<(
+            ApprovalRequest,
+            tokio::sync::oneshot::Sender<bool>,
+        )>();
+        drop(rx);
+        let gate = ApprovalGate::channel(tx);
+        let tool = BashTool::new(Workspace::new(dir.path().to_path_buf()), gate);
+
+        let result = tool.execute(json!({ "command": "echo hi" })).await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("user denied"), "got: {msg}");
+            }
+            other => panic!("expected ToolError, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn bash_tool_missing_command_argument_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let tool = BashTool::new(
+            Workspace::new(dir.path().to_path_buf()),
+            ApprovalGate::auto(),
+        );
+
+        let result = tool.execute(json!({})).await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("command"), "got: {msg}");
+            }
+            other => panic!("expected ToolError, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn bash_tool_non_string_command_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let tool = BashTool::new(
+            Workspace::new(dir.path().to_path_buf()),
+            ApprovalGate::auto(),
+        );
+
+        let result = tool.execute(json!({ "command": 42 })).await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("command"), "got: {msg}");
+            }
+            other => panic!("expected ToolError, got: {other:?}"),
+        }
+    }
+
     #[tokio::test]
     async fn bash_explicit_full_returns_unlimited_inline_output() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -462,7 +462,9 @@ mod tests {
     }
 
     /// Spawn a background task that auto-responds to every approval
-    /// request with `decision`. Returns the gate to install on the tool.
+    /// request with `decision`. Returns the gate to install on the tool
+    /// along with the responder task's `JoinHandle` so callers can
+    /// `.abort()` it on test shutdown.
     fn auto_decision_gate(decision: bool) -> (Arc<ApprovalGate>, tokio::task::JoinHandle<()>) {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<(
             ApprovalRequest,
@@ -486,9 +488,9 @@ mod tests {
 
         match result {
             ToolExecutionResult::ToolError(msg) => {
-                assert!(
-                    msg.contains("user denied"),
-                    "expected denial error, got: {msg}"
+                assert_eq!(
+                    msg, "user denied bash command",
+                    "denial must return the exact documented error"
                 );
             }
             other => panic!("expected ToolError, got: {other:?}"),
@@ -561,7 +563,10 @@ mod tests {
         let result = tool.execute(json!({ "command": "echo hi" })).await;
         match result {
             ToolExecutionResult::ToolError(msg) => {
-                assert!(msg.contains("user denied"), "got: {msg}");
+                assert_eq!(
+                    msg, "user denied bash command",
+                    "dropped-channel gate must fail closed with the documented error"
+                );
             }
             other => panic!("expected ToolError, got: {other:?}"),
         }


### PR DESCRIPTION
## Summary

The existing `BashTool` tests all use `ApprovalGate::auto()` — meaning the denial path (where the gate returns `false`) had zero coverage despite being the safety-critical branch. This PR adds 6 tests that drive `BashTool` through a channel-based gate so the rejection semantics are pinned down.

### New tests in `src/tools.rs`

- `bash_tool_returns_error_when_user_denies` — denial returns the documented `"user denied bash command"` error
- `bash_tool_denial_does_not_execute_command` — verifies no filesystem side effect occurs (the tool would `touch` a marker file if it ran)
- `bash_tool_forwards_command_to_approval_gate` — captures the `ApprovalRequest::Bash` variant on the channel and asserts the command string matches
- `bash_tool_returns_error_when_gate_channel_closed` — TUI tear-down scenario: dropped receiver → gate fails closed
- `bash_tool_missing_command_argument_returns_error` — input validation at the trust boundary
- `bash_tool_non_string_command_returns_error` — defends against non-string `command` JSON values

Adds a `auto_decision_gate(decision)` test helper that spawns a background responder so individual tests stay focused on assertions.

## Validation

- `cargo test --bin yolop tools::tests::` → 12 passed, 2 ignored (pre-existing `#[ignore]` on EVE-489 tests), 0 failed
- `cargo test --bin yolop` → all green
- `cargo fmt --check`, `cargo clippy --all-features -- -D warnings` clean

## Security

Test-only changes — no modifications to `BashTool` production code. The denial/validation paths being asserted are the existing safety behaviour (TM-BASH: bounded execution + approval gate); this PR locks them in so a future regression cannot silently weaken them.

## Follow-ups

No follow-ups.