### PR TITLE
chore(ship): require comments addressed, answered inline, resolved

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -59,7 +59,7 @@ Use this skill when the user asks to:
 7. **The PR is mergeable and merged safely.**
    - Push the branch.
    - Create or update the PR.
-   - Address every review comment — including low-confidence suggestions, nits, and bot comments. Either apply the fix or reply with a clear explanation, then mark the thread resolved.
+   - Address every review comment — including low-confidence suggestions, nits, and bot comments. For each comment, either apply the fix or post a reply inline on the same thread with a clear explanation, then mark that thread resolved. No comment may be left unanswered or unresolved before merge.
    - Wait for CI to go green.
    - Merge with squash only after CI is green and the final review sweep is clean.
    - After merging, monitor main CI for the merge commit. If it fails, fix or revert promptly.

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -59,7 +59,7 @@ Use this skill when the user asks to:
 7. **The PR is mergeable and merged safely.**
    - Push the branch.
    - Create or update the PR.
-   - Address every review comment — including low-confidence suggestions, nits, and bot comments. For each comment, either apply the fix or post a reply inline on the same thread with a clear explanation, then mark that thread resolved. No comment may be left unanswered or unresolved before merge.
+   - Address every review comment — including low-confidence suggestions, nits, and bot comments. For each comment, post an inline reply on the same thread explaining the resolution (and apply a code change too when one is needed), then mark that thread resolved. An inline reply is required even when the fix is a pure code change; no comment may be left unanswered or unresolved before merge.
    - Wait for CI to go green.
    - Merge with squash only after CI is green and the final review sweep is clean.
    - After merging, monitor main CI for the merge commit. If it fails, fix or revert promptly.

--- a/specs/shipping.md
+++ b/specs/shipping.md
@@ -28,7 +28,7 @@ Every shipped change MUST satisfy ALL of these. These are mandatory, not suggest
 4. **Synced artifacts.** Affected artifacts are updated: README, AGENTS.md, specs. No code-duplicating prose.
 5. **Smoke test impacted functionality.** Mandatory unless the change is docs-only or config-only with explicit justification. For runtime changes, run at least one live-provider smoke through Doppler.
 6. **Follow-ups surfaced.** TODOs, partial fixes, declined suggestions, missed edges, and spec/doc drift are explicitly listed under **Follow-ups** in the PR body (or `"No follow-ups."` if none).
-7. **Safe merge.** PR uses the template, CI is green, every review comment is addressed, answered inline on its own thread (code change or written explanation), and marked resolved before merge. Merge is squash-only after a final clean comment sweep. Async reviewer bots get at least 2 minutes to comment after CI turns green.
+7. **Safe merge.** PR uses the template, CI is green, every review comment is addressed (via a code change when needed), answered inline on its own thread with a written reply, and marked resolved before merge. An inline reply is required even when the resolution is a pure code change. Merge is squash-only after a final clean comment sweep. Async reviewer bots get at least 2 minutes to comment after CI turns green.
 
 ## Constraints
 
@@ -37,7 +37,7 @@ Every shipped change MUST satisfy ALL of these. These are mandatory, not suggest
 - Bug fixes prefer a failing test before the fix when practical.
 - Docs-only or config-only changes may skip code tests if the choice is justified and the relevant lint/build was run.
 - Security review is mandatory for code, configuration, or infrastructure changes. Perceived low risk does not justify skipping it.
-- Every review comment must be explicitly addressed, answered inline on its own thread, and resolved before merge — including low-confidence suggestions, nits, and bot comments.
+- Every review comment must be explicitly addressed, answered inline on its own thread with a written reply (in addition to any code change), and resolved before merge — including low-confidence suggestions, nits, and bot comments.
 - Auto-merge is not used: async reviewer bots can post after the last push or after CI turns green.
 - If a blocker cannot be resolved safely by the agent alone, shipping stops and reports rather than guesses.
 

--- a/specs/shipping.md
+++ b/specs/shipping.md
@@ -28,7 +28,7 @@ Every shipped change MUST satisfy ALL of these. These are mandatory, not suggest
 4. **Synced artifacts.** Affected artifacts are updated: README, AGENTS.md, specs. No code-duplicating prose.
 5. **Smoke test impacted functionality.** Mandatory unless the change is docs-only or config-only with explicit justification. For runtime changes, run at least one live-provider smoke through Doppler.
 6. **Follow-ups surfaced.** TODOs, partial fixes, declined suggestions, missed edges, and spec/doc drift are explicitly listed under **Follow-ups** in the PR body (or `"No follow-ups."` if none).
-7. **Safe merge.** PR uses the template, CI is green, every review comment is explicitly resolved (code change or written explanation), merge is squash-only after a final clean comment sweep. Async reviewer bots get at least 2 minutes to comment after CI turns green.
+7. **Safe merge.** PR uses the template, CI is green, every review comment is addressed, answered inline on its own thread (code change or written explanation), and marked resolved before merge. Merge is squash-only after a final clean comment sweep. Async reviewer bots get at least 2 minutes to comment after CI turns green.
 
 ## Constraints
 
@@ -37,7 +37,7 @@ Every shipped change MUST satisfy ALL of these. These are mandatory, not suggest
 - Bug fixes prefer a failing test before the fix when practical.
 - Docs-only or config-only changes may skip code tests if the choice is justified and the relevant lint/build was run.
 - Security review is mandatory for code, configuration, or infrastructure changes. Perceived low risk does not justify skipping it.
-- Every review comment must be explicitly addressed before merge — including low-confidence suggestions, nits, and bot comments.
+- Every review comment must be explicitly addressed, answered inline on its own thread, and resolved before merge — including low-confidence suggestions, nits, and bot comments.
 - Auto-merge is not used: async reviewer bots can post after the last push or after CI turns green.
 - If a blocker cannot be resolved safely by the agent alone, shipping stops and reports rather than guesses.
 


### PR DESCRIPTION
## Summary

Tightens the ship skill and shipping spec so reviewers can see the bar
explicitly: every PR comment must be addressed, answered inline on its
own thread, and marked resolved before merge.

- `.agents/skills/ship/SKILL.md` — step 7 spells out inline reply + resolve, no comment left unanswered.
- `specs/shipping.md` — outcome 7 and the constraints bullet are updated to match.

## Validation

Docs/spec-only change. No code or config touched, so no cargo lint/test
is relevant. Confirmed `git diff origin/main...HEAD --stat` shows only
the two markdown files.

## Security

No security-relevant code changes — markdown-only edits to skill and
spec documents.

## Follow-ups

No follow-ups.


---
_Generated by [Claude Code](https://claude.ai/code/session_014nFQyZ32pdvF7wDHCiy1Av)_