### PR TITLE
chore(claude): disable AI attribution in commits and PR bodies

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "gitAttribution": false,
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}


### PR DESCRIPTION
## Summary

Adds `.claude/settings.json` mirroring [everruns/bashkit's config](https://github.com/everruns/bashkit/blob/main/.claude/settings.json) so Claude Code stops appending its `Generated by Claude Code` footer to commit messages and PR bodies. AGENTS.md already forbids that footer ("Never add Claude/session/AI attribution links in commits, PRs, docs, or code comments"), but until now we had no settings file to enforce it — the footer was sneaking into recent PRs and required manual stripping.

### What's in the file

```json
{
  "gitAttribution": false,
  "attribution": {
    "commit": "",
    "pr": ""
  }
}
```

- `gitAttribution: false` — drops the `Co-authored-by: Claude` trailer from commits.
- `attribution.commit: ""` — empty template overrides the default commit footer.
- `attribution.pr: ""` — empty template overrides the default PR-body footer.

### What's intentionally NOT mirrored

bashkit's settings.json also installs a `SessionStart` hook that runs `.claude/hooks/fix-git-identity.sh`. That script sources `scripts/lib/common.sh` (a bashkit-specific helper library), which yolop does not have. Reproducing it is out of scope; AGENTS.md's existing "real human user" policy already covers the human-identity requirement at the agent prompt level.

## Validation

- File is JSON-valid and small.
- No code changes; nothing to test in CI beyond the existing checks.

## Security

No security-relevant code changes — config-only addition. Cannot affect runtime behaviour of the yolop binary.

## Follow-ups

- If we later add a `scripts/lib/` directory with a `configure_commit_git_identity_if_needed` helper, we can also port bashkit's `fix-git-identity.sh` SessionStart hook. Deferred.