### PR TITLE
fix(tui): restore command suggestions

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -79,7 +79,7 @@ struct CommandSpec {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-struct CommandSuggestion {
+pub(crate) struct CommandSuggestion {
     completion: String,
     label: String,
 }
@@ -154,6 +154,7 @@ pub struct App {
 #[derive(Clone, Debug)]
 pub(crate) struct ViewState {
     pub stream_preview: Option<StreamPreview>,
+    pub command_suggestions: Vec<CommandSuggestion>,
     /// `true` while an approval prompt is waiting on user input. The
     /// renderer only needs the bit, not the responder channel.
     pub approval_pending: bool,
@@ -253,6 +254,11 @@ impl App {
     pub(crate) fn view_state(&self) -> ViewState {
         ViewState {
             stream_preview: self.stream_preview.clone(),
+            command_suggestions: if !self.busy && self.pending.is_none() {
+                self.suggestions()
+            } else {
+                Vec::new()
+            },
             approval_pending: self.pending.is_some(),
             busy: self.busy,
             busy_frame: self.busy_frame,
@@ -1435,8 +1441,8 @@ fn draw(f: &mut ratatui::Frame, app: &mut App) {
     draw_input(f, input_rect, app);
 }
 
-/// Render the non-input chrome (stream preview, message separator,
-/// status separator, session status) into `area` using `state`, and
+/// Render the non-input chrome (command suggestions / stream preview,
+/// message separator, status separator, session status) into `area` using `state`, and
 /// return the `Rect` where the caller should render the input widget
 /// (which needs `&mut` and so cannot be driven through `ViewState`).
 ///
@@ -1460,12 +1466,50 @@ pub(crate) fn draw_chrome(
         ])
         .split(area);
 
-    draw_stream_preview(f, chunks[0], state);
+    if state.command_suggestions.is_empty() {
+        draw_stream_preview(f, chunks[0], state);
+    } else {
+        draw_suggestions(f, chunks[0], &state.command_suggestions);
+    }
     draw_message_separator(f, chunks[1], state);
     draw_status_separator(f, chunks[3]);
     draw_session_status(f, chunks[4], state);
 
     chunks[2]
+}
+
+fn draw_suggestions(f: &mut ratatui::Frame, area: Rect, suggestions: &[CommandSuggestion]) {
+    if area.height == 0 || area.width == 0 {
+        return;
+    }
+    f.render_widget(
+        Paragraph::new(suggestion_preview_line(suggestions, area.width)),
+        area,
+    );
+}
+
+fn suggestion_preview_line(suggestions: &[CommandSuggestion], width: u16) -> Line<'static> {
+    let body = suggestions
+        .iter()
+        .map(|suggestion| suggestion.label.as_str())
+        .collect::<Vec<_>>()
+        .join("  ·  ");
+    let prefix = "Tab ";
+    let max_body = (width as usize)
+        .saturating_sub(prefix.chars().count() + 1)
+        .max(8);
+    Line::from(vec![
+        Span::styled(
+            prefix,
+            Style::default()
+                .fg(ACCENT_BLUE)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            truncate_end_chars(&body, max_body),
+            Style::default().fg(TEXT_MUTED),
+        ),
+    ])
 }
 
 fn draw_stream_preview(f: &mut ratatui::Frame, area: Rect, state: &ViewState) {
@@ -1517,6 +1561,23 @@ fn truncate_tail_chars(text: &str, max_chars: usize) -> String {
     let mut out = String::with_capacity(max_chars);
     out.push('…');
     out.extend(text.chars().skip(skip));
+    out
+}
+
+fn truncate_end_chars(text: &str, max_chars: usize) -> String {
+    let count = text.chars().count();
+    if count <= max_chars {
+        return text.to_string();
+    }
+    if max_chars == 0 {
+        return String::new();
+    }
+    if max_chars == 1 {
+        return "…".to_string();
+    }
+    let mut out = String::with_capacity(max_chars);
+    out.extend(text.chars().take(max_chars - 1));
+    out.push('…');
     out
 }
 
@@ -2054,6 +2115,26 @@ mod tests {
                 .any(|s| s.completion == "/model" || s.completion == "/model "),
             "capability-provided /model should appear in suggestions: {suggestions:?}"
         );
+    }
+
+    #[test]
+    fn suggestion_preview_line_shows_command_dropdown() {
+        let caps = vec![model_capability_command()];
+        let suggestions = command_suggestions("/m", &caps);
+        let rendered = line_text(&suggestion_preview_line(&suggestions, 96));
+
+        assert!(rendered.starts_with("Tab /model [spec]"));
+        assert!(rendered.contains("/model [spec]"));
+    }
+
+    #[test]
+    fn suggestion_preview_line_keeps_first_match_when_truncated() {
+        let caps = vec![model_capability_command()];
+        let suggestions = command_suggestions("/", &caps);
+        let rendered = line_text(&suggestion_preview_line(&suggestions, 18));
+
+        assert!(rendered.starts_with("Tab /help"));
+        assert!(rendered.ends_with('…'));
     }
 
     #[test]
@@ -2608,6 +2689,13 @@ mod tests {
         );
     }
 
+    fn line_text(line: &Line<'_>) -> String {
+        line.spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect::<String>()
+    }
+
     #[test]
     fn should_not_insert_chat_gap_inside_tool_blocks() {
         assert!(!should_insert_chat_gap(&Author::Tool, Some(&Author::Tool)));
@@ -2646,6 +2734,7 @@ mod tests {
     fn view_state_idle() -> ViewState {
         ViewState {
             stream_preview: None,
+            command_suggestions: Vec::new(),
             approval_pending: false,
             busy: false,
             busy_frame: 0,
@@ -2683,6 +2772,75 @@ mod tests {
                 row.trim_end().to_string()
             })
             .collect()
+    }
+
+    async fn app_with_llmsim() -> App {
+        let workspace = tempfile::tempdir().expect("workspace tempdir");
+        let sessions = tempfile::tempdir().expect("sessions tempdir");
+        let runtime = crate::runtime::build_with_options(
+            workspace.path().to_path_buf(),
+            crate::runtime::ProviderChoice::Sim,
+            crate::approval::ApprovalGate::auto(),
+            None,
+            sessions.path().to_path_buf(),
+            crate::runtime::BuildOptions::default(),
+        )
+        .await
+        .expect("build llmsim runtime");
+        std::mem::forget(workspace);
+        std::mem::forget(sessions);
+        let (_tx, rx) = mpsc::unbounded_channel();
+        App::new(runtime, rx)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn app_slash_input_renders_command_suggestions_end_to_end() {
+        let mut app = app_with_llmsim().await;
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('/'), KeyModifiers::empty()))
+            .await;
+
+        let state = app.view_state();
+        assert!(
+            state
+                .command_suggestions
+                .iter()
+                .any(|suggestion| suggestion.completion == "/help"),
+            "expected /help suggestion in view state: {:?}",
+            state.command_suggestions
+        );
+        let rows = render_chrome_lines(&state, 80, 5);
+        assert!(
+            rows[0].contains("Tab /help"),
+            "slash input should render command suggestions in chrome row: {:?}",
+            rows
+        );
+    }
+
+    #[test]
+    fn chrome_command_suggestions_override_stream_preview_row() {
+        let state = ViewState {
+            stream_preview: Some(StreamPreview {
+                kind: StreamKind::Assistant,
+                text: "streaming response".to_string(),
+            }),
+            command_suggestions: vec![CommandSuggestion {
+                completion: "/help".to_string(),
+                label: "/help    show commands".to_string(),
+            }],
+            ..view_state_idle()
+        };
+        let rows = render_chrome_lines(&state, 80, 5);
+        assert!(
+            rows[0].contains("Tab /help"),
+            "suggestions should render in the top chrome row: {:?}",
+            rows
+        );
+        assert!(
+            !rows[0].contains("agent"),
+            "command suggestions should replace the stream preview row: {}",
+            rows[0]
+        );
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -2689,6 +2689,13 @@ mod tests {
         );
     }
 
+    #[test]
+    fn truncate_end_handles_tiny_limits() {
+        assert_eq!(truncate_end_chars("hello", 0), "");
+        assert_eq!(truncate_end_chars("hello", 1), "…");
+        assert_eq!(truncate_end_chars("hello", 99), "hello");
+    }
+
     fn line_text(line: &Line<'_>) -> String {
         line.spans
             .iter()
@@ -2814,6 +2821,32 @@ mod tests {
             rows[0].contains("Tab /help"),
             "slash input should render command suggestions in chrome row: {:?}",
             rows
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn app_view_state_hides_command_suggestions_when_input_disabled() {
+        let mut app = app_with_llmsim().await;
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('/'), KeyModifiers::empty()))
+            .await;
+        assert!(
+            !app.view_state().command_suggestions.is_empty(),
+            "slash input should produce suggestions before input is disabled"
+        );
+
+        app.busy = true;
+        assert!(
+            app.view_state().command_suggestions.is_empty(),
+            "busy turns should not render suggestions"
+        );
+
+        app.busy = false;
+        let (responder, _rx) = oneshot::channel();
+        app.pending = Some(PendingApproval { responder });
+        assert!(
+            app.view_state().command_suggestions.is_empty(),
+            "approval prompts should not render suggestions"
         );
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -141,9 +141,10 @@ pub struct App {
 }
 
 /// Owned snapshot of the App fields the pure-render chrome helpers
-/// (stream preview, separators, session status) consume. Extracted from
-/// `App` so those helpers can be exercised by unit tests against
-/// `ratatui::backend::TestBackend` without standing up a full runtime.
+/// (command suggestions, stream preview, separators, session status)
+/// consume. Extracted from `App` so those helpers can be exercised by
+/// unit tests against `ratatui::backend::TestBackend` without standing
+/// up a full runtime.
 ///
 /// Owned rather than borrowed because building it does not need to
 /// borrow `App` for the duration of a draw: `draw_input` needs `&mut
@@ -1458,7 +1459,7 @@ pub(crate) fn draw_chrome(
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1),            // stream preview
+            Constraint::Length(1),            // suggestions / stream preview
             Constraint::Length(1),            // message separator
             Constraint::Length(input_height), // input (left to the caller)
             Constraint::Length(1),            // status separator
@@ -2781,7 +2782,13 @@ mod tests {
             .collect()
     }
 
-    async fn app_with_llmsim() -> App {
+    struct TestApp {
+        app: App,
+        _workspace: tempfile::TempDir,
+        _sessions: tempfile::TempDir,
+    }
+
+    async fn app_with_llmsim() -> TestApp {
         let workspace = tempfile::tempdir().expect("workspace tempdir");
         let sessions = tempfile::tempdir().expect("sessions tempdir");
         let runtime = crate::runtime::build_with_options(
@@ -2794,15 +2801,18 @@ mod tests {
         )
         .await
         .expect("build llmsim runtime");
-        std::mem::forget(workspace);
-        std::mem::forget(sessions);
         let (_tx, rx) = mpsc::unbounded_channel();
-        App::new(runtime, rx)
+        TestApp {
+            app: App::new(runtime, rx),
+            _workspace: workspace,
+            _sessions: sessions,
+        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn app_slash_input_renders_command_suggestions_end_to_end() {
-        let mut app = app_with_llmsim().await;
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
 
         app.handle_key(KeyEvent::new(KeyCode::Char('/'), KeyModifiers::empty()))
             .await;
@@ -2826,7 +2836,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn app_view_state_hides_command_suggestions_when_input_disabled() {
-        let mut app = app_with_llmsim().await;
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
 
         app.handle_key(KeyEvent::new(KeyCode::Char('/'), KeyModifiers::empty()))
             .await;
@@ -2874,6 +2885,44 @@ mod tests {
             "command suggestions should replace the stream preview row: {}",
             rows[0]
         );
+    }
+
+    #[test]
+    fn draw_suggestions_ignores_empty_areas() {
+        let suggestions = vec![CommandSuggestion {
+            completion: "/help".to_string(),
+            label: "/help    show commands".to_string(),
+        }];
+        let backend = TestBackend::new(4, 1);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+
+        terminal
+            .draw(|f| {
+                draw_suggestions(
+                    f,
+                    Rect {
+                        x: 0,
+                        y: 0,
+                        width: 0,
+                        height: 1,
+                    },
+                    &suggestions,
+                );
+                draw_suggestions(
+                    f,
+                    Rect {
+                        x: 0,
+                        y: 0,
+                        width: 4,
+                        height: 0,
+                    },
+                    &suggestions,
+                );
+            })
+            .expect("draw");
+
+        let buffer = terminal.backend().buffer();
+        assert_eq!(buffer[(0, 0)].symbol(), " ");
     }
 
     #[test]


### PR DESCRIPTION
## What
Restore the TUI command suggestion row so slash commands and capability-provided command arguments are visible again while typing.

## Why
The suggestion engine and Tab completion still existed, but the inline composer chrome no longer rendered the suggestions after the `ViewState`/`draw_chrome` split on `main`.

## How
- Carry command suggestions through `ViewState` when input is enabled.
- Render suggestions in the top chrome row, falling back to the stream preview when no suggestions are available.
- Add focused preview-line tests, chrome snapshot tests, and app-level key-input-to-rendered-buffer tests using the llmsim runtime.
- Address review coverage by testing disabled-input states and zero-area suggestion rendering.

## Risk
- Low
- TUI-only rendering path; command parsing and execution are unchanged.

## Security
- TM-FS: Not affected; no filesystem access behavior changed.
- TM-BASH: Not affected; no shell execution behavior changed.
- TM-LLM: Not affected; no prompt, provider, or key handling changed.
- TM-TOOL: Not affected; capability registration and execution are unchanged.
- TM-DEP: Not affected; no dependencies added or changed.
- Resource bounds: suggestions still come from the existing capped list and are truncated to terminal width before rendering.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test suggestion_preview --all-features`
- `cargo test chrome_command_suggestions_override_stream_preview_row --all-features`
- `cargo test app_slash_input_renders_command_suggestions_end_to_end --all-features`
- `cargo test truncate_end_handles_tiny_limits --all-features`
- `cargo test app_view_state_hides_command_suggestions_when_input_disabled --all-features`
- `cargo test draw_suggestions_ignores_empty_areas --all-features`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"`

CI evidence on PR #23 current head:
- `Format + Clippy`: passed
- `Build + Tests + Offline Smoke`: passed
- `Analyze (python)`: passed
- `Live OpenAI Smoke (Doppler)`: passed
- `codecov/patch`: passed

Local live-provider smoke was attempted with `doppler run -- cargo test --test integration -- --ignored`, but this checkout has no configured Doppler project or fallback file and `OPENAI_API_KEY` is not present in the local environment.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
