### PR TITLE
chore(claude): SessionStart hook to fix agent-set git identity

### DIFF
--- a/.claude/hooks/fix-git-identity.sh
+++ b/.claude/hooks/fix-git-identity.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# SessionStart hook: ensure git identity is the real human user, not the
+# Claude Code agent.
+#
+# Without this, commits written inside a Claude Code session land with
+# author = "Claude <noreply@anthropic.com>" (the agent's environment
+# default), which AGENTS.md forbids ("Commit attribution must be a real
+# human user"). GitHub's squash-merge then propagates that author as a
+# Co-authored-by trailer on the squash commit on main.
+#
+# This script runs once per session start. It only overrides the identity
+# when the current value is missing or matches a known agent pattern —
+# real human identities are left alone, so a contributor running yolop
+# locally with their own git config is unaffected.
+
+set -euo pipefail
+
+# No-op outside a git repo (e.g. someone running yolop in /tmp).
+git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+REAL_NAME="Mykhailo Chalyi"
+REAL_EMAIL="mike@chaliy.name"
+
+# Prefer the repo-local config, fall back to whatever git would resolve.
+current_email="$(git config --local user.email 2>/dev/null || true)"
+if [ -z "$current_email" ]; then
+    current_email="$(git config user.email 2>/dev/null || true)"
+fi
+
+is_agent_identity() {
+    case "$1" in
+        "" \
+        | noreply@anthropic.com \
+        | *@anthropic.com \
+        | claude@* \
+        | noreply@github.com \
+        | *bot@users.noreply.github.com)
+            return 0
+            ;;
+        *) return 1 ;;
+    esac
+}
+
+if is_agent_identity "$current_email"; then
+    git config --local user.name "$REAL_NAME"
+    git config --local user.email "$REAL_EMAIL"
+    echo "[claude] git identity set to ${REAL_NAME} <${REAL_EMAIL}>" >&2
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,5 +3,18 @@
   "attribution": {
     "commit": "",
     "pr": ""
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/fix-git-identity.sh"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

PR #22 added `.claude/settings.json` with `gitAttribution: false` + empty attribution templates, which stops the body footer and the Claude Code-injected `Co-authored-by` trailer. It does **not** change the git author field — so Claude Code commits still landed with `author = Claude <noreply@anthropic.com>`, which GitHub's squash-merge then propagated onto main as a `Co-authored-by: Claude` trailer on every PR squash commit (see #16, #17, #18, #19, #21, #22 on main).

This PR closes that loophole by porting the `SessionStart` hook bashkit uses (originally deferred in #22 because it depended on bashkit's `scripts/lib/common.sh`). The yolop version is self-contained.

### What's added

- **`.claude/hooks/fix-git-identity.sh`** — runs on session start, no-op outside a git repo, checks the repo-local `user.email`, and overrides it only if it's empty or matches a known agent pattern: `noreply@anthropic.com`, `*@anthropic.com`, `claude@*`, `noreply@github.com`, `*bot@users.noreply.github.com`. Real human identities are left alone, so a contributor running yolop locally with their own `git config user.email` is unaffected. Logs a single line to stderr when it overrides.
- **`.claude/settings.json`** — adds the `SessionStart` `hooks` entry pointing at the script (alongside the existing `gitAttribution`/`attribution` keys from #22).

The script is `chmod +x` and self-contained (no `scripts/lib/` dependency).

### Verification

Ran the hook locally with the bad identity in place:

```
BEFORE: noreply@anthropic.com
[claude] git identity set to Mykhailo Chalyi <mike@chaliy.name>
AFTER name : Mykhailo Chalyi
AFTER email: mike@chaliy.name
```

Second run is silent (idempotent). This commit itself was created after the hook ran — confirm the author with `git log -1` on the PR head: `Mykhailo Chalyi <mike@chaliy.name>` (not `Claude <noreply@anthropic.com>`).

## Security

Hook touches only `git config --local` — repo-scoped, no global config mutation, no external side effects. The agent-pattern allowlist is conservative: anything not on it is treated as a real human and left untouched.

## Follow-ups

Already-merged commits on main keep their `Co-authored-by: Claude` trailers; rewriting them needs a force-push, not worth the disruption. The hook stops the bleeding for all future PRs.