### PR TITLE
fix(app): pass SettingsStore to build_with_options in TUI test helper

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2968,12 +2968,16 @@ mod tests {
     async fn app_with_llmsim() -> TestApp {
         let workspace = tempfile::tempdir().expect("workspace tempdir");
         let sessions = tempfile::tempdir().expect("sessions tempdir");
+        let settings = std::sync::Arc::new(crate::settings::SettingsStore::open(
+            sessions.path().join("settings.toml"),
+        ));
         let runtime = crate::runtime::build_with_options(
             workspace.path().to_path_buf(),
             crate::runtime::ProviderChoice::Sim,
             crate::approval::ApprovalGate::auto(),
             None,
             sessions.path().to_path_buf(),
+            settings,
             crate::runtime::BuildOptions::default(),
         )
         .await


### PR DESCRIPTION
## Summary

CI on `main` has been red since ed83313 (PR #14, /provider /token /onboard).
That PR added the `settings: Arc<SettingsStore>` parameter to
`runtime::build_with_options` but missed one call site — the
`app_with_llmsim` test helper in `src/app.rs:2971`. Result: the test
binary fails to compile, so `cargo clippy --all-targets` and
`cargo test --all-features` both abort:

```
error[E0061]: this function takes 7 arguments but 6 arguments were supplied
    --> src/app.rs:2971:23
```

This PR opens a default-backed `SettingsStore` under the test's sessions
tempdir and forwards it as the new sixth argument, mirroring the pattern
already used in `src/streaming_tests.rs:52-60`.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all-features` — 136 passed, 2 ignored in the bin tests; 5 passed, 1 ignored in integration tests; 0 failed
- `cargo run -- --provider llmsim -p "hi"` — offline smoke test exits success=true

## Security

No security-relevant code changes — test-only diff. The new
`SettingsStore` is constructed against a per-test tempdir, scoped to the
test, and discarded with the workspace; it never touches the user's real
config dir.

## Follow-ups

No follow-ups.