### PR TITLE
feat(skills): source skills from workspace, global, and system scopes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1857,6 +1857,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5324,6 +5343,7 @@ dependencies = [
  "everruns-integrations-duckduckgo",
  "everruns-openai",
  "everruns-runtime",
+ "include_dir",
  "ratatui",
  "ratatui-textarea",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
 crossterm = "0.29"
 dirs = "6"
+include_dir = "0.7"
 ratatui = "0.30"
 ratatui-textarea = "0.9.1"
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -44,8 +44,11 @@ session    session_019e3db018a17450aba5407af5777237 (folder: …; log: …)
     config?") via `remember_your_memory` / `read_your_memory` /
     `write_your_memory`. See
     [`specs/your.md`](./specs/your.md).
-  - `skills` — discovers `SKILL.md` files under `.agents/skills/<name>/`;
-    exposes `list_skills` / `activate_skill`.
+  - `skills` — discovers `SKILL.md` files and exposes `list_skills` /
+    `activate_skill`. Three scopes are merged (most-specific wins):
+    **workspace** (`<workspace>/.agents/skills/<name>/`), **global**
+    (`<config_dir>/yolop/skills/<name>/`, installed once per user), and
+    **system** (pre-packed with the binary). See [`specs/skills.md`](specs/skills.md).
   - `infinity_context` — trims older history out of the live prompt while
     keeping it queryable via `query_history`.
   - `stateless_todo_list` — `write_todos` for multi-step tasks.

--- a/skills/joke/SKILL.md
+++ b/skills/joke/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: joke
+description: Generate an original, clean joke on demand. Use when the user asks for a joke, wants something funny, or says they need cheering up.
+user-invocable: true
+---
+
+# Joke
+
+Tell the user an original, genuinely funny joke. This is light entertainment —
+keep it self-contained and don't touch the workspace, run commands, or read
+files.
+
+## Arguments
+
+If `$ARGUMENTS` is provided, treat it as the topic or style to riff on (e.g.
+`programming`, `puns`, `dad joke about coffee`). If it's empty, pick a
+crowd-pleasing topic yourself — programming and tech humor land well with this
+audience.
+
+## How to deliver
+
+1. Write one joke. Prefer a tight setup-and-punchline or a one-liner; a short
+   two-line exchange is fine. Don't pad it with preamble.
+2. Use a classic structure when it fits: misdirection, a pun, or an unexpected
+   literal reading of a phrase.
+3. Land the punchline last — never explain the joke afterward.
+4. If the user asks for "another", produce a fresh one; don't repeat a joke
+   already told this session.
+
+## Keep it clean
+
+Keep it workplace-appropriate: no slurs, no targeting protected groups, nothing
+mean-spirited about a real, identifiable person. Self-deprecating and absurdist
+humor are great defaults.

--- a/specs/skills.md
+++ b/specs/skills.md
@@ -1,0 +1,65 @@
+# Skills Specification
+
+## Abstract
+
+Skills are instruction packages (`SKILL.md` files) the agent can discover and
+activate at runtime via the `list_skills` and `activate_skill` tools, plus a
+system-prompt listing of what's available.
+
+yolop **vendors** the upstream `skills` capability from `everruns-core`. The
+upstream capability scans a single virtual-filesystem path (`/.agents/skills`)
+through the session filesystem; that is too narrow for global and system scopes,
+and the embedded in-process runtime does not apply the `mounts()` mechanism the
+server uses to inject extra skills. yolop therefore owns the discovery loop and
+reads the scope folders directly from disk, while **reusing** the upstream
+`SKILL.md` parser, validator, and argument/variable substitution verbatim
+(`everruns_core::skill`). This spec owns the scope set and behavior; the
+`SKILL.md` format is owned upstream.
+
+> Forward plan: once this multi-source resolver is stable, the intent is to push
+> it upstream (a capability that accepts multiple labeled skill sources, and/or
+> the planned in-process "mount-overlay resolver") so the vendoring can be
+> retired and duplication removed.
+
+## Scopes
+
+A skill is a directory named for the skill, containing `SKILL.md`. Every scope
+resolves to a **real on-disk directory**:
+
+1. **Workspace** — `<workspace>/.agents/skills/<name>/`. Lives in the project
+   under version control; ships with the repo it belongs to.
+2. **Global** — `<config_dir>/yolop/skills/<name>/` (e.g.
+   `~/.config/yolop/skills/` on Linux), installed once per user and shared
+   across every workspace. Overridable with `YOLOP_GLOBAL_SKILLS_DIR`.
+3. **System** — pre-packed inside the yolop binary and materialized once to
+   `<data_dir>/yolop/system-skills/<name>/`. Always available. Overridable with
+   `YOLOP_SYSTEM_SKILLS_DIR` (used verbatim, no materialization).
+
+## Required Behavior
+
+1. **Merge.** `list_skills` and the system-prompt listing see skills from all
+   three scopes as one set; each entry is tagged with its scope.
+2. **Precedence.** When the same skill directory name exists in more than one
+   scope, the most specific wins: workspace shadows global shadows system.
+   Discovery de-duplicates by directory name in that order; `activate_skill`
+   resolves the same way.
+3. **Real paths.** Because every scope is a real directory, `${SKILL_DIR}` in an
+   activated skill expands to a path the host `bash` tool can read, so bundled
+   files work for all scopes.
+4. **No command execution on activation.** The `!`cmd`` substitution is never
+   expanded — activating a skill must not spawn a shell on the host (mirrors the
+   upstream trust gate; see `everruns-core` skills / EVE-388).
+5. **Writes stay in the workspace.** Global and system folders are read-only
+   inputs; only the workspace scope is edited through the agent's file tools.
+6. **Absent scopes are silent.** A missing global directory, or a failure to
+   materialize system skills, disables that scope without failing the session.
+7. **Materialization is safe.** System-skill materialization is idempotent and
+   concurrency-safe (atomic per-file writes, skipped when bytes are unchanged),
+   so parallel processes do not race on the shared cache directory.
+
+## Ownership Boundary
+
+- This spec and `crate::skills` own scope resolution, discovery, precedence, and
+  the two tools.
+- `everruns_core::skill` owns the `SKILL.md` format, parsing, validation, and
+  substitution.

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -4,6 +4,7 @@
 // module boundary here small; capability implementations live in submodules.
 
 mod host;
+pub mod skills;
 pub(crate) mod your;
 
 pub(crate) use host::{

--- a/src/capabilities/skills.rs
+++ b/src/capabilities/skills.rs
@@ -600,13 +600,20 @@ fn write_if_changed(target: &Path, contents: &[u8]) -> std::io::Result<()> {
         return Ok(());
     }
     let parent = target.parent().unwrap_or_else(|| Path::new("."));
+    // The temp name must be unique per *call*, not just per process: parallel
+    // materializations in the same process (e.g. concurrent tests) would
+    // otherwise derive the same temp path and clobber each other's rename. A
+    // process-wide counter disambiguates same-pid, same-target writers.
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = parent.join(format!(
-        ".{}.tmp-{}",
+        ".{}.tmp-{}-{}",
         target
             .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or("skill"),
-        std::process::id()
+        std::process::id(),
+        seq
     ));
     std::fs::write(&tmp, contents)?;
     std::fs::rename(&tmp, target)
@@ -746,8 +753,13 @@ mod tests {
 
     #[test]
     fn global_skills_dir_respects_env_override() {
+        // Serialize against every other env-mutating test in this binary; the
+        // guard is held for the whole window the var is set (set_var/remove_var
+        // are not thread-safe — see crate::test_env).
+        let _guard = crate::test_env::lock();
         let tmp = tempfile::tempdir().unwrap();
-        // SAFETY: single-threaded test; no other thread touches this env var here.
+        // SAFETY: the test_env lock guarantees no other thread touches the
+        // process environment for the duration of this test.
         unsafe { std::env::set_var(GLOBAL_SKILLS_DIR_ENV, tmp.path()) };
         let resolved = global_skills_dir();
         unsafe { std::env::remove_var(GLOBAL_SKILLS_DIR_ENV) };

--- a/src/capabilities/skills.rs
+++ b/src/capabilities/skills.rs
@@ -1,0 +1,756 @@
+// Skills — vendored from everruns-core's `SkillsCapability`, extended to source
+// skills from three real on-disk folders instead of the single session-VFS path
+// the upstream capability scans.
+//
+// Why vendored: the upstream `SkillsCapability` discovers skills by scanning one
+// path (`/.agents/skills`) through the session filesystem. Supporting global and
+// system scopes that way meant overlaying extra roots into that VFS path, which
+// loses scope identity and forced system skills onto disk awkwardly. yolop
+// instead owns the discovery loop and reads the scope folders directly. The
+// SKILL.md *parser/validator/substitution* are reused verbatim from
+// `everruns_core::skill` — only discovery and the two tools are reimplemented.
+//
+// Scopes (precedence: workspace > global > system; discovery de-dups by skill
+// directory name, so a nearer scope shadows a farther one):
+//   * workspace — `<workspace>/.agents/skills`
+//   * global    — `<config_dir>/yolop/skills` (override: YOLOP_GLOBAL_SKILLS_DIR)
+//   * system    — pre-packed in the binary, materialized once to
+//                 `<data_dir>/yolop/system-skills` (override: YOLOP_SYSTEM_SKILLS_DIR)
+//
+// Every scope resolves to a real directory, so `${SKILL_DIR}` in an activated
+// skill points at a real path the host `bash` tool can read — bundled files work
+// for all three scopes. Once this multi-source resolver proves out, it is the
+// natural thing to push upstream so the overlay/vendoring can be retired (see
+// `specs/skills.md`).
+
+use async_trait::async_trait;
+use everruns_core::ToolContext;
+use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
+use everruns_core::skill::{
+    SkillContext, expand_skill_arguments, parse_skill_md, substitute_activation_vars,
+    validate_skill_name,
+};
+use everruns_core::tool_types::ToolHints;
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use include_dir::{Dir, include_dir};
+use serde_json::{Value, json};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// Capability id — kept equal to the upstream constant so the harness capability
+/// wiring (`AgentCapabilityConfig::new(SKILLS_CAPABILITY_ID)`) still resolves.
+pub const SKILLS_CAPABILITY_ID: &str = "skills";
+
+/// Env override for the global skills directory.
+const GLOBAL_SKILLS_DIR_ENV: &str = "YOLOP_GLOBAL_SKILLS_DIR";
+/// Env override for the system skills directory (skips materialization).
+const SYSTEM_SKILLS_DIR_ENV: &str = "YOLOP_SYSTEM_SKILLS_DIR";
+
+/// Max skills listed in the system prompt (the rest are reachable via `list_skills`).
+const MAX_SKILLS_IN_PROMPT: usize = 15;
+/// Max description length in the system-prompt listing (truncated with "…").
+const MAX_DESCRIPTION_CHARS: usize = 76;
+
+/// System skills shipped inside the binary. The crate-root `skills/` directory is
+/// embedded at compile time so a `cargo install` / Homebrew build carries them.
+static SYSTEM_SKILLS: Dir<'static> = include_dir!("$CARGO_MANIFEST_DIR/skills");
+
+const SKILLS_SYSTEM_PROMPT: &str = "Skills are reusable instruction packs sourced \
+from your workspace, your global config, and ones built into yolop. Use `list_skills` \
+to see what's available and `activate_skill` (by name) to load one. Only activate \
+skills relevant to the current task.";
+
+/// Where a skill came from. Surfaced to the model so it can reason about trust
+/// and precedence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SkillScope {
+    Workspace,
+    Global,
+    System,
+}
+
+impl SkillScope {
+    fn label(self) -> &'static str {
+        match self {
+            SkillScope::Workspace => "workspace",
+            SkillScope::Global => "global",
+            SkillScope::System => "system",
+        }
+    }
+}
+
+/// The ordered set of skill folders for a session, highest precedence first.
+pub struct SkillSources {
+    roots: Vec<(SkillScope, PathBuf)>,
+}
+
+/// One discovered skill, after parsing its `SKILL.md`.
+struct DiscoveredSkill {
+    scope: SkillScope,
+    /// Directory name — the identifier used to activate the skill.
+    dir_name: String,
+    dir_path: PathBuf,
+    /// `None` when `SKILL.md` failed to parse (carried in `error` instead).
+    name: String,
+    description: String,
+    version: String,
+    user_invocable: bool,
+    disable_model_invocation: bool,
+    error: Option<String>,
+}
+
+impl SkillSources {
+    /// Resolve the workspace/global/system folders for `workspace_root`.
+    pub fn resolve(workspace_root: &Path) -> Self {
+        Self::from_dirs(
+            Some(workspace_root.join(".agents").join("skills")),
+            global_skills_dir(),
+            system_skills_dir(),
+        )
+    }
+
+    /// Build from explicit per-scope directories (used by `resolve` and tests).
+    /// Each is included only when it is an existing directory.
+    pub(crate) fn from_dirs(
+        workspace: Option<PathBuf>,
+        global: Option<PathBuf>,
+        system: Option<PathBuf>,
+    ) -> Self {
+        let mut roots = Vec::new();
+        for (scope, dir) in [
+            (SkillScope::Workspace, workspace),
+            (SkillScope::Global, global),
+            (SkillScope::System, system),
+        ] {
+            if let Some(dir) = dir.filter(|p| p.is_dir()) {
+                roots.push((scope, dir));
+            }
+        }
+        Self { roots }
+    }
+
+    /// Discover every unique skill across scopes, in precedence order. The first
+    /// occurrence of a directory name wins; later (farther-scope) duplicates are
+    /// dropped.
+    fn discover(&self) -> Vec<DiscoveredSkill> {
+        let mut seen = std::collections::HashSet::new();
+        let mut out = Vec::new();
+        for (scope, root) in &self.roots {
+            for dir_name in skill_dir_names(root) {
+                if !seen.insert(dir_name.clone()) {
+                    continue;
+                }
+                let dir_path = root.join(&dir_name);
+                let content =
+                    std::fs::read_to_string(dir_path.join("SKILL.md")).unwrap_or_default();
+                let discovered = match parse_skill_md(&content) {
+                    Ok(parsed) => DiscoveredSkill {
+                        scope: *scope,
+                        dir_name: dir_name.clone(),
+                        dir_path,
+                        name: parsed.name,
+                        description: parsed.description,
+                        version: parsed.version,
+                        user_invocable: parsed.user_invocable,
+                        disable_model_invocation: parsed.disable_model_invocation,
+                        error: None,
+                    },
+                    Err(errors) => DiscoveredSkill {
+                        scope: *scope,
+                        name: dir_name.clone(),
+                        dir_path,
+                        description: String::new(),
+                        version: String::new(),
+                        user_invocable: false,
+                        disable_model_invocation: false,
+                        error: Some(format!("Invalid SKILL.md: {}", errors.join(", "))),
+                        dir_name,
+                    },
+                };
+                out.push(discovered);
+            }
+        }
+        out
+    }
+
+    /// Locate the activatable skill named `dir_name`, honoring precedence.
+    /// Returns the scope, the skill directory, and the raw `SKILL.md` content.
+    fn locate(&self, dir_name: &str) -> Option<(SkillScope, PathBuf, String)> {
+        for (scope, root) in &self.roots {
+            let dir_path = root.join(dir_name);
+            let md_path = dir_path.join("SKILL.md");
+            if let Ok(content) = std::fs::read_to_string(&md_path) {
+                return Some((*scope, dir_path, content));
+            }
+        }
+        None
+    }
+}
+
+/// Immediate subdirectories of `root` that contain a `SKILL.md`, sorted for
+/// deterministic ordering.
+fn skill_dir_names(root: &Path) -> Vec<String> {
+    let mut names = Vec::new();
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return names;
+    };
+    for entry in entries.flatten() {
+        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        if !entry.path().join("SKILL.md").is_file() {
+            continue;
+        }
+        if let Ok(name) = entry.file_name().into_string() {
+            names.push(name);
+        }
+    }
+    names.sort();
+    names
+}
+
+fn truncate_description(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        return s.to_string();
+    }
+    let truncated: String = s.chars().take(max_chars.saturating_sub(1)).collect();
+    format!("{}…", truncated.trim_end())
+}
+
+// ============================================================================
+// Capability
+// ============================================================================
+
+/// yolop's skills capability: discovers + activates skills across the workspace,
+/// global, and system scopes.
+pub struct YolopSkillsCapability {
+    sources: Arc<SkillSources>,
+}
+
+impl YolopSkillsCapability {
+    pub fn new(sources: SkillSources) -> Self {
+        Self {
+            sources: Arc::new(sources),
+        }
+    }
+}
+
+#[async_trait]
+impl Capability for YolopSkillsCapability {
+    fn id(&self) -> &str {
+        SKILLS_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Agent Skills"
+    }
+
+    fn description(&self) -> &str {
+        "Discover and activate skills from the workspace, global config, and built-in (system) scopes."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("wand")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Skills")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(SKILLS_SYSTEM_PROMPT)
+    }
+
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        let mut prompt = String::from(SKILLS_SYSTEM_PROMPT);
+
+        // Skills the model may auto-invoke (i.e. not opted out).
+        let visible: Vec<DiscoveredSkill> = self
+            .sources
+            .discover()
+            .into_iter()
+            .filter(|s| s.error.is_none() && !s.disable_model_invocation)
+            .collect();
+
+        if !visible.is_empty() {
+            prompt.push_str("\n\nAvailable skills:\n");
+            for skill in visible.iter().take(MAX_SKILLS_IN_PROMPT) {
+                let desc = truncate_description(&skill.description, MAX_DESCRIPTION_CHARS);
+                let invocable = if skill.user_invocable {
+                    format!(" (/{})", skill.name)
+                } else {
+                    String::new()
+                };
+                prompt.push_str(&format!(
+                    "- **{}** [{}]: {}{}\n",
+                    skill.name,
+                    skill.scope.label(),
+                    desc,
+                    invocable
+                ));
+            }
+            if visible.len() > MAX_SKILLS_IN_PROMPT {
+                prompt.push_str(&format!(
+                    "\n({} more — use `list_skills` to see all)\n",
+                    visible.len() - MAX_SKILLS_IN_PROMPT
+                ));
+            }
+        }
+
+        Some(format!(
+            "<capability id=\"{}\">\n{}\n</capability>",
+            self.id(),
+            prompt
+        ))
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(ListSkillsTool {
+                sources: self.sources.clone(),
+            }),
+            Box::new(ActivateSkillTool {
+                sources: self.sources.clone(),
+            }),
+        ]
+    }
+}
+
+// ============================================================================
+// list_skills
+// ============================================================================
+
+struct ListSkillsTool {
+    sources: Arc<SkillSources>,
+}
+
+#[async_trait]
+impl Tool for ListSkillsTool {
+    fn name(&self) -> &str {
+        "list_skills"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("List Skills")
+    }
+
+    fn description(&self) -> &str {
+        "Discover available skills across the workspace, global, and system scopes. \
+         Returns each skill's name, description, and scope."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({ "type": "object", "properties": {}, "required": [] })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        let skills: Vec<Value> = self
+            .sources
+            .discover()
+            .into_iter()
+            .map(|s| match s.error {
+                Some(error) => json!({
+                    "name": s.dir_name,
+                    "scope": s.scope.label(),
+                    "path": s.dir_path.join("SKILL.md").display().to_string(),
+                    "error": error,
+                }),
+                None => json!({
+                    "name": s.name,
+                    "description": s.description,
+                    "scope": s.scope.label(),
+                    "version": s.version,
+                    "user_invocable": s.user_invocable,
+                    "disable_model_invocation": s.disable_model_invocation,
+                    "path": s.dir_path.join("SKILL.md").display().to_string(),
+                }),
+            })
+            .collect();
+
+        ToolExecutionResult::success(json!({
+            "count": skills.len(),
+            "skills": skills,
+        }))
+    }
+}
+
+// ============================================================================
+// activate_skill
+// ============================================================================
+
+struct ActivateSkillTool {
+    sources: Arc<SkillSources>,
+}
+
+#[async_trait]
+impl Tool for ActivateSkillTool {
+    fn name(&self) -> &str {
+        "activate_skill"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Activate Skill")
+    }
+
+    fn description(&self) -> &str {
+        "Activate a skill by name to load its full instructions. Skills are resolved \
+         across the workspace, global, and system scopes (workspace wins on conflict)."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The skill directory name (e.g., 'joke')"
+                },
+                "arguments": {
+                    "type": "string",
+                    "description": "Optional arguments to pass to the skill for $ARGUMENTS substitution"
+                }
+            },
+            "required": ["name"]
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+    }
+
+    fn requires_context(&self) -> bool {
+        // Only for the `${SESSION_ID}` activation variable; discovery itself reads
+        // real folders and needs no session context.
+        true
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "activate_skill requires session context and cannot run standalone.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let Some(name) = arguments.get("name").and_then(|v| v.as_str()) else {
+            return ToolExecutionResult::tool_error("Missing required parameter: name");
+        };
+        let skill_args = arguments
+            .get("arguments")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        // Reject path separators up front, then enforce the full skill-name rules
+        // (lowercase, digits, single hyphens, 1-64 chars).
+        if name.contains("..") || name.contains('/') || name.contains('\\') {
+            return ToolExecutionResult::tool_error(
+                "Invalid skill name. Must be a simple directory name without path separators.",
+            );
+        }
+        if let Err(errors) = validate_skill_name(name) {
+            return ToolExecutionResult::tool_error(format!(
+                "Invalid skill name '{name}': {}",
+                errors.join(", ")
+            ));
+        }
+
+        let Some((scope, dir_path, content)) = self.sources.locate(name) else {
+            return ToolExecutionResult::tool_error(format!(
+                "Skill '{name}' not found in any scope. Use list_skills to see what's available."
+            ));
+        };
+
+        match parse_skill_md(&content) {
+            Ok(parsed) => {
+                // Substitution pipeline: arguments ($ARGUMENTS, $N) then activation
+                // vars (${SESSION_ID}, ${SKILL_DIR}). `${SKILL_DIR}` is the real
+                // on-disk skill folder, so bundled files are reachable via `bash`.
+                //
+                // Command injection (!`cmd`) is intentionally NOT expanded: yolop
+                // mirrors upstream's conservative trust gate (see everruns-core
+                // skills.rs / EVE-388) — activating a skill must never spawn a
+                // shell on the host.
+                let expanded = expand_skill_arguments(&parsed.instructions, skill_args);
+                let substituted = substitute_activation_vars(
+                    &expanded,
+                    &context.session_id.to_string(),
+                    &dir_path.display().to_string(),
+                );
+                let instructions = format!(
+                    "<skill name=\"{}\">\n{}\n</skill>",
+                    parsed.name, substituted
+                );
+
+                let mut result = json!({
+                    "skill": parsed.name,
+                    "scope": scope.label(),
+                    "description": parsed.description,
+                    "instructions": instructions,
+                });
+                if parsed.context == SkillContext::Fork {
+                    result["context"] = json!("fork");
+                    result["agent"] = json!(parsed.agent.as_deref().unwrap_or("general-purpose"));
+                    if let Some(model) = &parsed.model {
+                        result["model"] = json!(model);
+                    }
+                }
+                ToolExecutionResult::success(result)
+            }
+            Err(errors) => ToolExecutionResult::tool_error(format!(
+                "Invalid SKILL.md for '{name}': {}",
+                errors.join(", ")
+            )),
+        }
+    }
+}
+
+// ============================================================================
+// Scope folder resolution + system-skill materialization
+// ============================================================================
+
+/// Global skills directory, or `None` when it does not exist.
+/// Honors `YOLOP_GLOBAL_SKILLS_DIR`; otherwise `<config_dir>/yolop/skills`.
+pub fn global_skills_dir() -> Option<PathBuf> {
+    let dir = match std::env::var(GLOBAL_SKILLS_DIR_ENV) {
+        Ok(value) if !value.is_empty() => PathBuf::from(value),
+        _ => dirs::config_dir()?.join("yolop").join("skills"),
+    };
+    dir.is_dir().then_some(dir)
+}
+
+/// System skills directory, materializing the embedded skills first.
+///
+/// Honors `YOLOP_SYSTEM_SKILLS_DIR` (used verbatim). Otherwise the embedded
+/// `skills/` tree is written to `<data_dir>/yolop/system-skills` and that path is
+/// returned. Materialization is idempotent and concurrency-safe (atomic per-file
+/// writes, skipping files already present with identical bytes), so parallel
+/// processes/tests do not race. Any failure is non-fatal: it logs and returns
+/// `None`, leaving the system scope unavailable.
+pub fn system_skills_dir() -> Option<PathBuf> {
+    if let Ok(value) = std::env::var(SYSTEM_SKILLS_DIR_ENV)
+        && !value.is_empty()
+    {
+        let dir = PathBuf::from(value);
+        return dir.is_dir().then_some(dir);
+    }
+
+    if SYSTEM_SKILLS.entries().is_empty() {
+        return None;
+    }
+
+    let dest = dirs::data_dir()?.join("yolop").join("system-skills");
+    match materialize_system_skills(&dest) {
+        Ok(()) => Some(dest),
+        Err(e) => {
+            tracing::warn!(error = %e, dest = %dest.display(), "failed to materialize system skills");
+            None
+        }
+    }
+}
+
+/// Write the embedded system skills into `dest` if absent or changed.
+fn materialize_system_skills(dest: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dest)?;
+    extract_dir(&SYSTEM_SKILLS, dest)
+}
+
+/// Recursively write an embedded `Dir` under `dest`. `include_dir` entry paths
+/// are relative to the embed root, so they map directly onto `dest`.
+fn extract_dir(dir: &Dir<'_>, dest: &Path) -> std::io::Result<()> {
+    for entry in dir.entries() {
+        let target = dest.join(entry.path());
+        match entry {
+            include_dir::DirEntry::Dir(subdir) => {
+                std::fs::create_dir_all(&target)?;
+                extract_dir(subdir, dest)?;
+            }
+            include_dir::DirEntry::File(file) => {
+                if let Some(parent) = target.parent() {
+                    std::fs::create_dir_all(parent)?;
+                }
+                write_if_changed(&target, file.contents())?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Atomically write `contents` to `target`, skipping the write when the file is
+/// already present with identical bytes. The atomic temp-then-rename keeps
+/// concurrent writers from observing a partial file.
+fn write_if_changed(target: &Path, contents: &[u8]) -> std::io::Result<()> {
+    if let Ok(existing) = std::fs::read(target)
+        && existing == contents
+    {
+        return Ok(());
+    }
+    let parent = target.parent().unwrap_or_else(|| Path::new("."));
+    let tmp = parent.join(format!(
+        ".{}.tmp-{}",
+        target
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("skill"),
+        std::process::id()
+    ));
+    std::fs::write(&tmp, contents)?;
+    std::fs::rename(&tmp, target)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_skill(root: &Path, dir: &str, name: &str, description: &str) {
+        let d = root.join(dir);
+        std::fs::create_dir_all(&d).unwrap();
+        std::fs::write(
+            d.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: {description}\n---\n\n# {name}\nbody\n"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn discover_merges_scopes_and_dedups_by_precedence() {
+        let ws = tempfile::tempdir().unwrap();
+        let gl = tempfile::tempdir().unwrap();
+        let sy = tempfile::tempdir().unwrap();
+        write_skill(ws.path(), "ws-only", "ws-only", "workspace skill");
+        write_skill(ws.path(), "shared", "shared", "from workspace");
+        write_skill(gl.path(), "global-only", "global-only", "global skill");
+        write_skill(gl.path(), "shared", "shared", "from global");
+        write_skill(sy.path(), "system-only", "system-only", "system skill");
+
+        let sources = SkillSources::from_dirs(
+            Some(ws.path().into()),
+            Some(gl.path().into()),
+            Some(sy.path().into()),
+        );
+        let found = sources.discover();
+        let names: std::collections::HashSet<&str> =
+            found.iter().map(|s| s.dir_name.as_str()).collect();
+        assert!(names.contains("ws-only"));
+        assert!(names.contains("global-only"));
+        assert!(names.contains("system-only"));
+
+        // `shared` resolves once, to the workspace scope.
+        let shared: Vec<&DiscoveredSkill> =
+            found.iter().filter(|s| s.dir_name == "shared").collect();
+        assert_eq!(shared.len(), 1);
+        assert_eq!(shared[0].scope, SkillScope::Workspace);
+        assert_eq!(shared[0].description, "from workspace");
+
+        let system = found.iter().find(|s| s.dir_name == "system-only").unwrap();
+        assert_eq!(system.scope, SkillScope::System);
+    }
+
+    #[test]
+    fn locate_prefers_workspace_then_falls_through() {
+        let ws = tempfile::tempdir().unwrap();
+        let gl = tempfile::tempdir().unwrap();
+        write_skill(ws.path(), "shared", "shared", "from workspace");
+        write_skill(gl.path(), "shared", "shared", "from global");
+        write_skill(gl.path(), "global-only", "global-only", "global skill");
+        let sources = SkillSources::from_dirs(Some(ws.path().into()), Some(gl.path().into()), None);
+
+        let (scope, _dir, content) = sources.locate("shared").unwrap();
+        assert_eq!(scope, SkillScope::Workspace);
+        assert!(content.contains("from workspace"));
+
+        let (scope, _dir, _content) = sources.locate("global-only").unwrap();
+        assert_eq!(scope, SkillScope::Global);
+
+        assert!(sources.locate("missing").is_none());
+    }
+
+    #[tokio::test]
+    async fn activate_substitutes_skill_dir_to_real_path() {
+        let gl = tempfile::tempdir().unwrap();
+        let d = gl.path().join("bundled");
+        std::fs::create_dir_all(&d).unwrap();
+        std::fs::write(
+            d.join("SKILL.md"),
+            "---\nname: bundled\ndescription: uses a bundled file\n---\n\nRead ${SKILL_DIR}/data.txt\n",
+        )
+        .unwrap();
+
+        let sources = SkillSources::from_dirs(None, Some(gl.path().into()), None);
+        let tool = ActivateSkillTool {
+            sources: Arc::new(sources),
+        };
+        let ctx = ToolContext::new(everruns_core::typed_id::SessionId::new());
+        let result = tool
+            .execute_with_context(json!({"name": "bundled"}), &ctx)
+            .await;
+        match result {
+            ToolExecutionResult::Success(v) => {
+                assert_eq!(v["scope"], "global");
+                let instructions = v["instructions"].as_str().unwrap();
+                // ${SKILL_DIR} expanded to the real on-disk directory.
+                assert!(instructions.contains(&d.display().to_string()));
+            }
+            other => panic!("expected success, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn activate_rejects_traversal_and_missing() {
+        let sources = SkillSources::from_dirs(None, None, None);
+        let tool = ActivateSkillTool {
+            sources: Arc::new(sources),
+        };
+        let ctx = ToolContext::new(everruns_core::typed_id::SessionId::new());
+
+        let bad = tool
+            .execute_with_context(json!({"name": "../etc"}), &ctx)
+            .await;
+        assert!(matches!(bad, ToolExecutionResult::ToolError(_)));
+
+        let missing = tool
+            .execute_with_context(json!({"name": "nope"}), &ctx)
+            .await;
+        match missing {
+            ToolExecutionResult::ToolError(m) => assert!(m.contains("not found")),
+            other => panic!("expected ToolError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn embedded_system_skills_materialize_idempotently() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("system-skills");
+        materialize_system_skills(&dest).unwrap();
+        let skill = dest.join("joke").join("SKILL.md");
+        assert!(skill.is_file());
+        let first = std::fs::read(&skill).unwrap();
+        // Second pass is a no-op write (identical bytes) and leaves content intact.
+        materialize_system_skills(&dest).unwrap();
+        assert_eq!(std::fs::read(&skill).unwrap(), first);
+    }
+
+    #[test]
+    fn global_skills_dir_respects_env_override() {
+        let tmp = tempfile::tempdir().unwrap();
+        // SAFETY: single-threaded test; no other thread touches this env var here.
+        unsafe { std::env::set_var(GLOBAL_SKILLS_DIR_ENV, tmp.path()) };
+        let resolved = global_skills_dir();
+        unsafe { std::env::remove_var(GLOBAL_SKILLS_DIR_ENV) };
+        assert_eq!(resolved.as_deref(), Some(tmp.path()));
+    }
+}

--- a/src/capabilities/skills.rs
+++ b/src/capabilities/skills.rs
@@ -765,4 +765,67 @@ mod tests {
         unsafe { std::env::remove_var(GLOBAL_SKILLS_DIR_ENV) };
         assert_eq!(resolved.as_deref(), Some(tmp.path()));
     }
+
+    #[tokio::test]
+    async fn list_skills_reports_scope_and_error_entries() {
+        let ws = tempfile::tempdir().unwrap();
+        let gl = tempfile::tempdir().unwrap();
+        write_skill(ws.path(), "good", "good", "a fine skill");
+        // A directory with a SKILL.md that fails to parse (missing frontmatter
+        // fields) is surfaced as an error entry, not silently dropped.
+        let broken = gl.path().join("broken");
+        std::fs::create_dir_all(&broken).unwrap();
+        std::fs::write(broken.join("SKILL.md"), "no frontmatter here").unwrap();
+
+        let tool = ListSkillsTool {
+            sources: Arc::new(SkillSources::from_dirs(
+                Some(ws.path().into()),
+                Some(gl.path().into()),
+                None,
+            )),
+        };
+        let ToolExecutionResult::Success(v) = tool.execute(json!({})).await else {
+            panic!("expected success");
+        };
+        assert_eq!(v["count"], 2);
+        let skills = v["skills"].as_array().unwrap();
+
+        let good = skills.iter().find(|s| s["name"] == "good").unwrap();
+        assert_eq!(good["scope"], "workspace");
+        assert_eq!(good["description"], "a fine skill");
+        assert!(good.get("error").is_none());
+
+        let broken = skills.iter().find(|s| s["name"] == "broken").unwrap();
+        assert_eq!(broken["scope"], "global");
+        assert!(
+            broken["error"]
+                .as_str()
+                .unwrap()
+                .contains("Invalid SKILL.md")
+        );
+    }
+
+    #[tokio::test]
+    async fn system_prompt_lists_visible_skills_and_filters_opted_out() {
+        let ws = tempfile::tempdir().unwrap();
+        write_skill(ws.path(), "shown", "shown", "appears in the prompt");
+        // disable-model-invocation skills are reachable via the tool but kept
+        // out of the model-facing prompt listing.
+        let hidden = ws.path().join("hidden");
+        std::fs::create_dir_all(&hidden).unwrap();
+        std::fs::write(
+            hidden.join("SKILL.md"),
+            "---\nname: hidden\ndescription: not auto-listed\ndisable-model-invocation: true\n---\n\nbody\n",
+        )
+        .unwrap();
+
+        let cap =
+            YolopSkillsCapability::new(SkillSources::from_dirs(Some(ws.path().into()), None, None));
+        let ctx =
+            SystemPromptContext::without_file_store(everruns_core::typed_id::SessionId::new());
+        let prompt = cap.system_prompt_contribution(&ctx).await.unwrap();
+
+        assert!(prompt.contains("**shown** [workspace]"));
+        assert!(!prompt.contains("hidden"));
+    }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -20,7 +20,7 @@ use everruns_core::capabilities::{
     AGENT_INSTRUCTIONS_CAPABILITY_ID, AgentInstructionsCapability, COMPACTION_CAPABILITY_ID,
     CompactionCapability, FileSystemCapability, INFINITY_CONTEXT_CAPABILITY_ID,
     InfinityContextCapability, LoopDetectionCapability, PROMPT_CACHING_CAPABILITY_ID,
-    PromptCachingCapability, SKILLS_CAPABILITY_ID, SkillsCapability, StatelessTodoListCapability,
+    PromptCachingCapability, SKILLS_CAPABILITY_ID, StatelessTodoListCapability,
     ToolOutputPersistenceCapability, WebFetchCapability,
 };
 use everruns_core::command::CommandDescriptor;
@@ -1055,7 +1055,10 @@ pub async fn build_with_options(
     // they target the real workspace transparently):
     //   * agent_instructions   — re-reads AGENTS.md every turn
     //   * session_file_system  — read/write/edit/list/grep/delete/stat tools
-    //   * skills               — discovers SKILL.md under /.agents/skills/
+    //
+    // Skills (vendored in `crate::capabilities::skills`, reads real folders):
+    //   * skills               — discovers SKILL.md across workspace / global /
+    //                            system scopes; list_skills + activate_skill
     //
     // Non-filesystem, but useful for a coding agent:
     //   * infinity_context     — keeps long sessions usable; adds query_history
@@ -1067,7 +1070,11 @@ pub async fn build_with_options(
     let mut capabilities = CapabilityRegistry::new();
     capabilities.register(AgentInstructionsCapability);
     capabilities.register(FileSystemCapability);
-    capabilities.register(SkillsCapability);
+    // Vendored, multi-scope skills capability: discovers SKILL.md across the
+    // workspace, the user's global config, and skills pre-packed with yolop.
+    capabilities.register(crate::capabilities::skills::YolopSkillsCapability::new(
+        crate::capabilities::skills::SkillSources::resolve(&canonical_root),
+    ));
     capabilities.register(InfinityContextCapability);
     capabilities.register(CompactionCapability);
     capabilities.register(StatelessTodoListCapability);


### PR DESCRIPTION
## What

Adds **global** and **system** skill scopes to yolop, on top of the existing workspace scope. Skills can now come from three real on-disk folders:

| Scope | Location | Override |
|---|---|---|
| workspace | `<workspace>/.agents/skills` | — |
| global | `<config_dir>/yolop/skills` | `YOLOP_GLOBAL_SKILLS_DIR` |
| system | embedded in the binary → materialized to `<data_dir>/yolop/system-skills` | `YOLOP_SYSTEM_SKILLS_DIR` |

Precedence is **workspace > global > system**; discovery de-dups by skill directory name. A built-in `joke` system skill ships as the bundled example.

## Why / how

The upstream `everruns-core` `SkillsCapability` scans a single session-VFS path (`/.agents/skills`) and the in-process runtime doesn't apply capability `mounts()`, so there was no clean way to inject extra scopes. yolop now **vendors** the capability (`src/capabilities/skills.rs`): it owns discovery + the `list_skills`/`activate_skill` tools and reads the scope folders directly from disk, while **reusing the upstream `SKILL.md` parser/validator/substitution verbatim** (`everruns_core::skill`) — no parser fork.

Benefits the vendoring unlocks:
- Every scope is a **real directory**, so `${SKILL_DIR}` resolves to a host path the `bash` tool can read — bundled files work for all scopes.
- **Scope is surfaced to the model** in `list_skills` and the system-prompt listing.
- System skills materialize **once**, idempotently, with atomic race-safe per-file writes (no per-session VFS pollution).

## Validation

- `cargo fmt --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test --all-features` ✅ — 157 + 5 pass, incl. 6 new skill tests (precedence dedup, `locate` fall-through, `${SKILL_DIR}`→real-path substitution, traversal rejection, idempotent materialization, env override)
- Live OpenAI smoke (rebased binary): `list_skills` reported `deploy-helper (global)` + `joke (system)` with correct scope labels; `activate_skill` loaded and ran the system `joke` skill.

## Security

Reviewed against the threat-model categories in `.agents/skills/ship/SKILL.md`:
- **TM-FS** — the write blocklist and file-store are **unchanged** (the registration is the only `runtime.rs` edit). New reads are scoped to the skill roots. `activate_skill` rejects path separators (`..`, `/`, `\`) and enforces `validate_skill_name`; `${SKILL_DIR}` is derived from a validated name joined to a fixed root.
- **TM-BASH** — untouched.
- **TM-LLM** — no key handling or logging; skill text is instruction content by design.
- **TM-TOOL** — the new capability exposes only read-only `list_skills`/`activate_skill`; no writes/exec. Command substitution (`` !`cmd` ``) is intentionally **not** expanded — activating a skill never spawns a shell (mirrors upstream's conservative trust gate).
- **TM-DEP** — one new crate, `include_dir = "0.7"`, to embed system skills at compile time. `everruns-*` versions unchanged.
- Resource use: discovery is bounded by the number of skill directories; materialization is idempotent and atomic.

## Follow-ups

- Push the multi-source resolver upstream (a capability accepting multiple labeled skill sources, and/or wiring `mounts()` for the in-process runtime) so the vendoring can be retired. Tracked in `specs/skills.md`.
- System-skill cache does not prune skills removed in a later yolop version (stale dirs linger harmlessly); a version-stamped cleanup is a possible later refinement.

https://claude.ai/code/session_01Ab3BwDLZUBgXBQN1fMPFrL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ab3BwDLZUBgXBQN1fMPFrL)_