### PR TITLE
feat(tui): consolidate provider setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,11 @@ session    session_019e3db018a17450aba5407af5777237 (folder: …; log: …)
   - `OPENROUTER_API_KEY` → OpenRouter (`openai/gpt-5.2` by default)
   - `GEMINI_API_KEY` (or `GOOGLE_API_KEY`) → Google Gemini (`gemini-2.5-flash`)
   - `OLLAMA_BASE_URL` / `OLLAMA_API_KEY` → Ollama (`llama3.2`)
-- **Slash commands** (TUI): `/help`, `/tools`, `/cwd`,
-  `/provider <name>` (persists), `/token <provider> <value>` (persists),
-  `/model <provider>/<id>` (current session only), `/onboard` (guided
-  setup), `/clear`, `/quit`.
-- **First-run onboarding**: launching yolop with no env vars and no saved
+- **Slash commands** (TUI): `/help`, `/tools`, `/cwd`, `/setup`,
+  `/clear`, `/quit`.
+- **Guided setup**: launching yolop with no env vars and no saved
   settings opens an interactive wizard that walks through provider →
-  token → default model. Re-runnable any time via `/onboard`.
+  API key → model. Re-runnable any time via `/setup`.
 - **`--print`** one-shot mode for CI smoke tests.
 - **Session persistence** — durable per-session JSONL event log under the
   platform-native user data directory, with `--session <id>` to resume.
@@ -193,7 +191,7 @@ provider API tokens across runs. It lives at `<config_dir>/yolop/settings.toml`
 `~/Library/Application Support/yolop/settings.toml` on macOS,
 `%APPDATA%\yolop\settings.toml` on Windows.
 
-The TUI's `/provider <name>` command writes through this file.
+The TUI's `/setup` command writes through this file.
 
 Provider resolution at startup:
 
@@ -205,29 +203,24 @@ Provider resolution at startup:
    as equivalent credential signals here — the provider order decides
    the tiebreak, not the credential source.
 4. Fall back to OpenAI's default model if nothing matches, then open
-   onboarding so a provider/token can be configured. `llmsim` remains
-   available explicitly via `--provider llmsim` or `/provider llmsim`.
+   setup so a provider/API key can be configured. `llmsim` remains
+   available explicitly via `--provider llmsim` or from `/setup`.
 
 At runtime, the per-provider env var (`OPENAI_API_KEY`, etc.) always
 beats the saved token, so a per-run env override is always possible.
-`/model <provider>/<id>` then layers on top of the chosen provider for
-the current session.
+The setup wizard can also switch models for the current session.
 
 ### Storing tokens
 
-`/token openai sk-...` stores an API token under `[tokens]` in the
-settings file. The file is written with `0o600` on Unix (owner-only).
-Other commands:
-
-- `/token` — list which providers have a token stored (values are not
-  echoed)
-- `/token <provider> clear` — remove the stored token
+`/setup` can store an API token under `[tokens]` in the settings file.
+The file is written with `0o600` on Unix (owner-only). Stored token values
+are not echoed.
 
 Env vars still win at runtime: if both `OPENAI_API_KEY` is set and a token
-is saved, the env var is used. Slash commands are not echoed into the
-transcript or session log, so `/token openai sk-...` is safer than typing
-it at a chat prompt — but the resulting settings file is plain text on
-disk, so treat it the same way you would `~/.aws/credentials`.
+is saved, the env var is used. Setup answers are not echoed into the
+transcript or session log, so pasting a key into `/setup` is safer than
+typing it at a chat prompt — but the resulting settings file is plain text
+on disk, so treat it the same way you would `~/.aws/credentials`.
 
 ## Session persistence
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -138,15 +138,13 @@ pub struct App {
     rx: Option<mpsc::UnboundedReceiver<TurnEvent>>,
     approval_rx: ApprovalRx,
     pending: Option<PendingApproval>,
-    /// Active onboarding step, if any. The wizard drives the existing
-    /// `/provider`, `/token`, and `/model` capabilities under the hood;
-    /// it captures plain-text input from the composer and dispatches the
-    /// matching slash command at each step.
-    onboarding: Option<OnboardingStep>,
+    /// Active setup step, if any. The wizard captures plain-text input from
+    /// the composer and dispatches internal `/setup` actions at each step.
+    setup: Option<SetupStep>,
 }
 
 #[derive(Clone, Debug)]
-enum OnboardingStep {
+enum SetupStep {
     PickProvider,
     EnterToken {
         provider: String,
@@ -239,7 +237,7 @@ pub(crate) enum TurnEvent {
 
 impl App {
     pub fn new(runtime: BuiltRuntime, approval_rx: ApprovalRx) -> Self {
-        let should_onboard = runtime.startup.onboarding_recommended;
+        let should_setup = runtime.startup.setup_recommended;
         let mut app = Self {
             handles: runtime.handles,
             startup: runtime.startup,
@@ -256,11 +254,11 @@ impl App {
             rx: None,
             approval_rx,
             pending: None,
-            onboarding: None,
+            setup: None,
         };
         app.emit_system_banner();
-        if should_onboard {
-            app.start_onboarding();
+        if should_setup {
+            app.start_setup();
         }
         app
     }
@@ -584,10 +582,10 @@ impl App {
             self.handle_command(rest).await;
             return;
         }
-        // While onboarding, plain-text input is the wizard answer (empty
+        // While setup is active, plain-text input is the wizard answer (empty
         // included — "skip" for token/model steps).
-        if self.onboarding.is_some() {
-            self.advance_onboarding(&text).await;
+        if self.setup.is_some() {
+            self.advance_setup(&text).await;
             return;
         }
         if text.is_empty() {
@@ -663,7 +661,7 @@ impl App {
     ///
     /// `System` commands execute through `runtime.execute_command` — the
     /// capability's own handler runs and the result is rendered inline. This
-    /// is the path `/model` now takes. `Skill` commands match the web UI's
+    /// is the path `/setup` now takes. `Skill` commands match the web UI's
     /// behavior: the literal `/name args` text is sent as a chat message so
     /// the LLM activates the skill.
     async fn invoke_capability_command(&mut self, descriptor: CommandDescriptor, args: String) {
@@ -710,10 +708,11 @@ impl App {
                     }
                     Err(err) => self.push_system(format!("/{} failed: {err}", descriptor.name)),
                 }
-                // `/onboard` flips the TUI into wizard mode after the
-                // capability has reported its status line.
-                if descriptor.name == "onboard" {
-                    self.start_onboarding();
+                // Plain `/setup` flips the TUI into wizard mode after the
+                // capability has reported its status line. Internal
+                // `/setup ...` forms are reserved for the wizard itself.
+                if descriptor.name == "setup" && trimmed.is_empty() {
+                    self.start_setup();
                 }
             }
             CommandSource::Skill => {
@@ -728,28 +727,24 @@ impl App {
         }
     }
 
-    fn start_onboarding(&mut self) {
-        self.onboarding = Some(OnboardingStep::PickProvider);
-        self.push_system(
-            "welcome to yolop — let's get a provider configured (type /onboard any time to redo)"
-                .into(),
-        );
+    fn start_setup(&mut self) {
+        self.setup = Some(SetupStep::PickProvider);
+        self.push_system("setup: configure provider, API key, and model".into());
         self.push_system(format!(
-            "step 1/3: pick a provider — {}",
+            "step 1/3: choose provider — {}",
             crate::runtime::SUPPORTED_PROVIDERS.join(" / ")
         ));
     }
 
-    /// Drive the wizard one step forward. The actual mutations go through
-    /// the existing `/provider`, `/token`, and `/model` capabilities so
-    /// onboarding never knows about settings paths or runtime stores
-    /// directly.
-    async fn advance_onboarding(&mut self, input: &str) {
-        let Some(step) = self.onboarding.clone() else {
+    /// Drive the setup wizard one step forward. State mutations go through the
+    /// single `/setup` capability so provider, token, and model setup have one
+    /// user-facing command.
+    async fn advance_setup(&mut self, input: &str) {
+        let Some(step) = self.setup.clone() else {
             return;
         };
         match step {
-            OnboardingStep::PickProvider => {
+            SetupStep::PickProvider => {
                 let name = input.trim().to_ascii_lowercase();
                 if name.is_empty() {
                     self.push_system(format!(
@@ -767,12 +762,11 @@ impl App {
                 }
                 if name == "llmsim" {
                     // Offline simulator: no token, no model picker.
-                    let _ = self.run_system_command("provider", Some("llmsim")).await;
-                    self.push_system(
-                        "onboarding complete — using offline llmsim. switch any time with /provider"
-                            .into(),
-                    );
-                    self.onboarding = None;
+                    let _ = self
+                        .run_system_command("setup", Some("provider llmsim"))
+                        .await;
+                    self.push_system("setup complete — using offline llmsim".into());
+                    self.setup = None;
                     return;
                 }
                 let default_model =
@@ -782,12 +776,12 @@ impl App {
                 self.push_system(format!(
                     "step 2/3: paste your API token for {name} (press Enter to skip and use env vars)"
                 ));
-                self.onboarding = Some(OnboardingStep::EnterToken {
+                self.setup = Some(SetupStep::EnterToken {
                     provider: name,
                     default_model,
                 });
             }
-            OnboardingStep::EnterToken {
+            SetupStep::EnterToken {
                 provider,
                 default_model,
             } => {
@@ -795,8 +789,8 @@ impl App {
                 if !token.is_empty() {
                     // Don't echo the token; the capability response is the
                     // only line that lands in the transcript.
-                    let arg = format!("{provider} {token}");
-                    let _ = self.run_system_command("token", Some(&arg)).await;
+                    let arg = format!("token {provider} {token}");
+                    let _ = self.run_system_command("setup", Some(&arg)).await;
                 } else {
                     self.push_system(format!(
                         "no token entered — relying on env vars for {provider}"
@@ -805,21 +799,27 @@ impl App {
                 // Now flip the runtime to the chosen provider. With the
                 // token just saved (or env var present), this picks up the
                 // credential transparently.
-                let switched = self.run_system_command("provider", Some(&provider)).await;
+                let arg = format!("provider {provider}");
+                let switched = self.run_system_command("setup", Some(&arg)).await;
                 if !switched {
                     self.push_system(format!(
-                        "couldn't activate {provider} — re-run /token {provider} <key> or set the env var, then /provider {provider}"
+                        "couldn't activate {provider} — paste a token now, or press Enter after setting the provider env var"
                     ));
+                    self.setup = Some(SetupStep::EnterToken {
+                        provider,
+                        default_model,
+                    });
+                    return;
                 }
                 self.push_system(format!(
-                    "step 3/3: model id (Enter to keep default `{default_model}`, or paste e.g. `gpt-5.4-mini`)"
+                    "step 3/3: model id (Enter to keep `{default_model}`, or paste e.g. `gpt-5.4-mini`)"
                 ));
-                self.onboarding = Some(OnboardingStep::PickModel {
+                self.setup = Some(SetupStep::PickModel {
                     provider,
                     default_model,
                 });
             }
-            OnboardingStep::PickModel {
+            SetupStep::PickModel {
                 provider,
                 default_model,
             } => {
@@ -830,17 +830,18 @@ impl App {
                     } else {
                         format!("{provider}/{model}")
                     };
-                    let _ = self.run_system_command("model", Some(&spec)).await;
+                    let arg = format!("model {spec}");
+                    let _ = self.run_system_command("setup", Some(&arg)).await;
                 }
                 self.push_system(format!(
-                    "onboarding complete — provider {provider}, model {}. /provider · /token · /model to revisit",
+                    "setup complete — provider {provider}, model {}. run /setup to change it",
                     if model.is_empty() {
                         default_model.as_str()
                     } else {
                         model
                     }
                 ));
-                self.onboarding = None;
+                self.setup = None;
             }
         }
     }
@@ -2253,22 +2254,28 @@ mod tests {
 
     use everruns_core::command::{CommandArg, CommandDescriptor, CommandSource};
 
-    fn model_capability_command() -> CommandDescriptor {
-        // Mirrors what `ModelSwitcherCapability::commands()` returns: the
-        // arg carries its own static suggestion list so the renderer can
-        // surface autocomplete entries straight from the descriptor.
+    fn setup_capability_command() -> CommandDescriptor {
         CommandDescriptor {
-            name: "model".to_string(),
-            description: "Show or change the active provider/model.".to_string(),
+            name: "setup".to_string(),
+            description: "Configure provider, API key, and model.".to_string(),
+            source: CommandSource::System,
+            args: vec![],
+        }
+    }
+
+    fn command_with_arg_suggestions() -> CommandDescriptor {
+        CommandDescriptor {
+            name: "pick".to_string(),
+            description: "Pick a value.".to_string(),
             source: CommandSource::System,
             args: vec![CommandArg {
-                name: "spec".to_string(),
-                description: "<provider>/<id>".to_string(),
+                name: "value".to_string(),
+                description: "value".to_string(),
                 required: false,
                 suggestions: vec![
-                    "openai/gpt-5.5".to_string(),
-                    "openai/gpt-5.4-mini".to_string(),
-                    "anthropic/claude-sonnet-4-5".to_string(),
+                    "alpha-one".to_string(),
+                    "alpha-two".to_string(),
+                    "beta-one".to_string(),
                 ],
             }],
         }
@@ -2276,31 +2283,31 @@ mod tests {
 
     #[test]
     fn command_suggestions_list_commands_for_slash() {
-        let caps = vec![model_capability_command()];
+        let caps = vec![setup_capability_command()];
         let suggestions = command_suggestions("/", &caps);
 
         assert!(suggestions.iter().any(|s| s.completion == "/help"));
         assert!(
             suggestions
                 .iter()
-                .any(|s| s.completion == "/model" || s.completion == "/model "),
-            "capability-provided /model should appear in suggestions: {suggestions:?}"
+                .any(|s| s.completion == "/setup" || s.completion == "/setup "),
+            "capability-provided /setup should appear in suggestions: {suggestions:?}"
         );
     }
 
     #[test]
     fn suggestion_preview_line_shows_command_dropdown() {
-        let caps = vec![model_capability_command()];
-        let suggestions = command_suggestions("/m", &caps);
+        let caps = vec![setup_capability_command()];
+        let suggestions = command_suggestions("/s", &caps);
         let rendered = line_text(&suggestion_preview_line(&suggestions, 96));
 
-        assert!(rendered.starts_with("Tab /model [spec]"));
-        assert!(rendered.contains("/model [spec]"));
+        assert!(rendered.starts_with("Tab /setup"));
+        assert!(rendered.contains("/setup"));
     }
 
     #[test]
     fn suggestion_preview_line_keeps_first_match_when_truncated() {
-        let caps = vec![model_capability_command()];
+        let caps = vec![setup_capability_command()];
         let suggestions = command_suggestions("/", &caps);
         let rendered = line_text(&suggestion_preview_line(&suggestions, 18));
 
@@ -2310,18 +2317,18 @@ mod tests {
 
     #[test]
     fn command_suggestions_filter_first_arg_by_prefix() {
-        // After `/model <prefix>`, the suggestion source must be the arg's
+        // After `/pick <prefix>`, the suggestion source must be the arg's
         // declared `suggestions` — read straight from the descriptor with
         // no extra plumbing.
-        let caps = vec![model_capability_command()];
-        let suggestions = command_suggestions("/model openai/gpt-5.", &caps);
+        let caps = vec![command_with_arg_suggestions()];
+        let suggestions = command_suggestions("/pick alpha-", &caps);
 
         assert_eq!(
             suggestions
                 .iter()
                 .map(|s| s.completion.as_str())
                 .collect::<Vec<_>>(),
-            vec!["/model openai/gpt-5.5", "/model openai/gpt-5.4-mini"]
+            vec!["/pick alpha-one", "/pick alpha-two"]
         );
     }
 
@@ -3005,6 +3012,46 @@ mod tests {
             rows[0].contains("Tab /help"),
             "slash input should render command suggestions in chrome row: {:?}",
             rows
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn setup_command_starts_guided_wizard() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+        app.lines.clear();
+
+        app.handle_command("setup").await;
+
+        assert!(matches!(app.setup, Some(SetupStep::PickProvider)));
+        assert!(
+            app.lines
+                .iter()
+                .any(|line| line.text == "setup: configure provider, API key, and model")
+        );
+        assert!(
+            app.lines
+                .iter()
+                .any(|line| line.text.starts_with("step 1/3: choose provider"))
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn setup_wizard_can_select_offline_provider() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.lines.clear();
+        app.setup = Some(SetupStep::PickProvider);
+
+        app.advance_setup("llmsim").await;
+
+        assert!(app.setup.is_none());
+        assert_eq!(app.model.provider_label(), "llmsim/llmsim-yolop");
+        assert!(
+            app.lines
+                .iter()
+                .any(|line| line.text == "setup complete — using offline llmsim")
         );
     }
 

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -9,8 +9,7 @@ use async_trait::async_trait;
 use chrono::Local;
 use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
 use everruns_core::command::{
-    CommandArg, CommandDescriptor, CommandExecutionContext, CommandResult, CommandSource,
-    ExecuteCommandRequest,
+    CommandDescriptor, CommandExecutionContext, CommandResult, CommandSource, ExecuteCommandRequest,
 };
 use everruns_core::tools::Tool;
 use everruns_runtime::RuntimeProviderStore;
@@ -277,31 +276,36 @@ impl Capability for CodingBashCapability {
     }
 }
 
-// ---------- /model ----------
+// ---------- /setup ----------
 //
-// Demonstrates the `Capability::execute_command` hook: `/model` lives entirely
-// outside the TUI's `handle_command` branches. The capability owns the runtime
-// provider store and shares an Arc<RwLock<ProviderChoice>> with the
-// UI-facing `ModelState` so the banner label stays in sync after a switch.
+// One user-facing command owns provider, token, and model setup. The TUI starts
+// an interactive wizard for `/setup`; the internal setup subcommands below let
+// that wizard mutate runtime state without exposing `/provider`, `/token`, and
+// `/model` as separate commands.
 
-pub(crate) const MODEL_SWITCHER_CAPABILITY_ID: &str = "yolop_model_switcher";
+pub(crate) const SETUP_CAPABILITY_ID: &str = "yolop_setup";
 
-pub(crate) struct ModelSwitcherCapability {
+/// Providers that meaningfully consume an API token. `llmsim` is excluded
+/// (no key needed) and `ollama` is included for completeness even though
+/// most local setups don't authenticate.
+const TOKEN_PROVIDERS: &[&str] = &["openai", "anthropic", "google", "openrouter", "ollama"];
+
+pub(crate) struct SetupCapability {
     pub(crate) provider: Arc<RwLock<ProviderChoice>>,
     pub(crate) provider_store: Arc<dyn RuntimeProviderStore>,
     pub(crate) settings: Arc<SettingsStore>,
 }
 
 #[async_trait]
-impl Capability for ModelSwitcherCapability {
+impl Capability for SetupCapability {
     fn id(&self) -> &str {
-        MODEL_SWITCHER_CAPABILITY_ID
+        SETUP_CAPABILITY_ID
     }
     fn name(&self) -> &str {
-        "Coding CLI Model Switcher"
+        "Coding CLI Setup"
     }
     fn description(&self) -> &str {
-        "Show or change the active provider/model via /model."
+        "Configure provider, API key, and model."
     }
     fn status(&self) -> CapabilityStatus {
         CapabilityStatus::Available
@@ -314,21 +318,10 @@ impl Capability for ModelSwitcherCapability {
     }
     fn commands(&self) -> Vec<CommandDescriptor> {
         vec![CommandDescriptor {
-            name: "model".to_string(),
-            description: "Show or change the active provider/model.".to_string(),
+            name: "setup".to_string(),
+            description: "Configure provider, API key, and model.".to_string(),
             source: CommandSource::System,
-            args: vec![CommandArg {
-                name: "spec".to_string(),
-                description: "<provider>/<id> — omit to print the current model.".to_string(),
-                required: false,
-                // Declarative completions so renderers can populate the
-                // autocomplete dropdown directly from the descriptor — no
-                // per-keystroke callback into the capability.
-                suggestions: ProviderChoice::model_suggestions()
-                    .iter()
-                    .map(|s| (*s).to_string())
-                    .collect(),
-            }],
+            args: vec![],
         }]
     }
 
@@ -337,7 +330,7 @@ impl Capability for ModelSwitcherCapability {
         request: &ExecuteCommandRequest,
         _ctx: &CommandExecutionContext,
     ) -> everruns_core::Result<CommandResult> {
-        if request.name != "model" {
+        if request.name != "setup" {
             return Err(everruns_core::AgentLoopError::config(format!(
                 "{} cannot execute /{}",
                 self.id(),
@@ -345,6 +338,90 @@ impl Capability for ModelSwitcherCapability {
             )));
         }
         let raw = request.arguments.as_deref().unwrap_or("").trim();
+        if raw.is_empty() || raw == "status" {
+            return Ok(self.status_result());
+        }
+
+        let mut parts = raw.splitn(2, char::is_whitespace);
+        let action = parts.next().unwrap_or_default();
+        let rest = parts.next().unwrap_or_default().trim();
+        match action {
+            "provider" => self.change_provider(rest).await,
+            "model" => self.change_model(rest).await,
+            "token" => self.change_token(rest),
+            _ => Ok(failed_result(
+                "usage: /setup — run guided setup; internal forms: status, provider <name>, token <provider> <value|clear>, model <id|provider/id> [openai-reasoning-effort]".to_string(),
+            )),
+        }
+    }
+}
+
+impl SetupCapability {
+    fn status_result(&self) -> CommandResult {
+        let current = self
+            .provider
+            .read()
+            .expect("provider lock poisoned")
+            .clone();
+        let snapshot = self.settings.snapshot();
+        let saved = snapshot
+            .provider
+            .clone()
+            .unwrap_or_else(|| "<unset>".to_string());
+        let stored: Vec<&str> = snapshot.tokens.keys().map(String::as_str).collect();
+        let stored_label = if stored.is_empty() {
+            "none".to_string()
+        } else {
+            stored.join(", ")
+        };
+        CommandResult {
+            success: true,
+            message: format!(
+                "setup: provider={} model={} saved={saved} stored tokens={stored_label} env keys present={}",
+                current.provider_name(),
+                current.label(),
+                env_credential_present()
+            ),
+            error_code: None,
+            error_fields: None,
+        }
+    }
+
+    async fn change_provider(&self, raw: &str) -> everruns_core::Result<CommandResult> {
+        if raw.is_empty() || raw.split_whitespace().count() > 1 {
+            return Ok(failed_result(format!(
+                "setup provider failed: choose one of {}",
+                SUPPORTED_PROVIDERS.join(", ")
+            )));
+        }
+
+        let next = match ProviderChoice::default_for_provider_name(raw) {
+            Ok(n) => n,
+            Err(err) => return Ok(failed_result(format!("setup provider failed: {err}"))),
+        };
+        let mw = match next.model_with_provider(&self.settings.snapshot()) {
+            Ok(m) => m,
+            Err(err) => return Ok(failed_result(format!("setup provider failed: {err}"))),
+        };
+        if let Err(err) = self.provider_store.set_default_model(mw).await {
+            return Ok(failed_result(format!("setup provider failed: {err}")));
+        }
+        let provider_name = next.provider_name().to_string();
+        let label = next.label();
+        *self.provider.write().expect("provider lock poisoned") = next;
+        let persist_note = match self.settings.set_provider(Some(provider_name.clone())) {
+            Ok(()) => format!("saved to {}", self.settings.path().display()),
+            Err(err) => format!("warning: settings not saved: {err}"),
+        };
+        Ok(CommandResult {
+            success: true,
+            message: format!("setup provider changed: {label} ({persist_note})"),
+            error_code: None,
+            error_fields: None,
+        })
+    }
+
+    async fn change_model(&self, raw: &str) -> everruns_core::Result<CommandResult> {
         if raw.is_empty() {
             let label = self
                 .provider
@@ -354,7 +431,7 @@ impl Capability for ModelSwitcherCapability {
             return Ok(CommandResult {
                 success: true,
                 message: format!(
-                    "model: {label}; suggestions: {}",
+                    "setup model: {label}; suggestions: {}",
                     ProviderChoice::model_suggestions().join(", ")
                 ),
                 error_code: None,
@@ -370,236 +447,29 @@ impl Capability for ModelSwitcherCapability {
         let next = match current.resolve_model_spec(raw) {
             Ok(n) => n,
             Err(err) => {
-                return Ok(failed_result(format!("model change failed: {err}")));
+                return Ok(failed_result(format!("setup model failed: {err}")));
             }
         };
         let mw = match next.model_with_provider(&self.settings.snapshot()) {
             Ok(m) => m,
             Err(err) => {
-                return Ok(failed_result(format!("model change failed: {err}")));
+                return Ok(failed_result(format!("setup model failed: {err}")));
             }
         };
         if let Err(err) = self.provider_store.set_default_model(mw).await {
-            return Ok(failed_result(format!("model change failed: {err}")));
+            return Ok(failed_result(format!("setup model failed: {err}")));
         }
         let label = next.label();
         *self.provider.write().expect("provider lock poisoned") = next;
         Ok(CommandResult {
             success: true,
-            message: format!("model changed: {label}"),
+            message: format!("setup model changed: {label}"),
             error_code: None,
             error_fields: None,
         })
     }
-}
 
-fn failed_result(message: String) -> CommandResult {
-    CommandResult {
-        success: false,
-        message,
-        error_code: None,
-        error_fields: None,
-    }
-}
-
-// ---------- /provider ----------
-//
-// Companion to `/model`: picks the *provider* (OpenAI, Anthropic, Google,
-// OpenRouter, Ollama, llmsim) using that provider's default model, and
-// persists the choice to `<config_dir>/yolop/settings.toml` so the next
-// run starts on the same provider. The model is still mutated via `/model`
-// afterward — both commands share the same provider Arc.
-
-pub(crate) const PROVIDER_SWITCHER_CAPABILITY_ID: &str = "yolop_provider_switcher";
-
-pub(crate) struct ProviderSwitcherCapability {
-    pub(crate) provider: Arc<RwLock<ProviderChoice>>,
-    pub(crate) provider_store: Arc<dyn RuntimeProviderStore>,
-    pub(crate) settings: Arc<SettingsStore>,
-}
-
-#[async_trait]
-impl Capability for ProviderSwitcherCapability {
-    fn id(&self) -> &str {
-        PROVIDER_SWITCHER_CAPABILITY_ID
-    }
-    fn name(&self) -> &str {
-        "Coding CLI Provider Switcher"
-    }
-    fn description(&self) -> &str {
-        "Show or change the active LLM provider, persisted across runs."
-    }
-    fn status(&self) -> CapabilityStatus {
-        CapabilityStatus::Available
-    }
-    fn category(&self) -> Option<&str> {
-        Some("Examples")
-    }
-    fn system_prompt_addition(&self) -> Option<&str> {
-        None
-    }
-    fn commands(&self) -> Vec<CommandDescriptor> {
-        vec![CommandDescriptor {
-            name: "provider".to_string(),
-            description: "Show or change the active provider (saved to yolop settings)."
-                .to_string(),
-            source: CommandSource::System,
-            args: vec![CommandArg {
-                name: "name".to_string(),
-                description: format!(
-                    "{} — omit to print the current provider.",
-                    SUPPORTED_PROVIDERS.join(" | ")
-                ),
-                required: false,
-                suggestions: SUPPORTED_PROVIDERS
-                    .iter()
-                    .map(|s| (*s).to_string())
-                    .collect(),
-            }],
-        }]
-    }
-
-    async fn execute_command(
-        &self,
-        request: &ExecuteCommandRequest,
-        _ctx: &CommandExecutionContext,
-    ) -> everruns_core::Result<CommandResult> {
-        if request.name != "provider" {
-            return Err(everruns_core::AgentLoopError::config(format!(
-                "{} cannot execute /{}",
-                self.id(),
-                request.name
-            )));
-        }
-        let raw = request.arguments.as_deref().unwrap_or("").trim();
-        if raw.is_empty() {
-            let current = self
-                .provider
-                .read()
-                .expect("provider lock poisoned")
-                .clone();
-            let saved = self
-                .settings
-                .snapshot()
-                .provider
-                .unwrap_or_else(|| "<unset>".to_string());
-            return Ok(CommandResult {
-                success: true,
-                message: format!(
-                    "provider: {} (model: {}); saved: {saved}; options: {}",
-                    current.provider_name(),
-                    current.label(),
-                    SUPPORTED_PROVIDERS.join(", "),
-                ),
-                error_code: None,
-                error_fields: None,
-            });
-        }
-
-        if raw.split_whitespace().count() > 1 {
-            return Ok(failed_result(
-                "usage: /provider <name> — pick a single provider, then use /model to tune the model"
-                    .to_string(),
-            ));
-        }
-
-        let next = match ProviderChoice::default_for_provider_name(raw) {
-            Ok(n) => n,
-            Err(err) => return Ok(failed_result(format!("provider change failed: {err}"))),
-        };
-        let mw = match next.model_with_provider(&self.settings.snapshot()) {
-            Ok(m) => m,
-            Err(err) => return Ok(failed_result(format!("provider change failed: {err}"))),
-        };
-        if let Err(err) = self.provider_store.set_default_model(mw).await {
-            return Ok(failed_result(format!("provider change failed: {err}")));
-        }
-        let provider_name = next.provider_name().to_string();
-        let label = next.label();
-        *self.provider.write().expect("provider lock poisoned") = next;
-        let persist_note = match self.settings.set_provider(Some(provider_name.clone())) {
-            Ok(()) => format!("saved to {}", self.settings.path().display()),
-            Err(err) => format!("warning: settings not saved: {err}"),
-        };
-        Ok(CommandResult {
-            success: true,
-            message: format!("provider changed: {label} ({persist_note})"),
-            error_code: None,
-            error_fields: None,
-        })
-    }
-}
-
-// ---------- /token ----------
-//
-// Stores per-provider API tokens in the same settings file as `/provider`.
-// Env vars still win at runtime (see `runtime::resolve_token`) so a
-// per-run override is always possible. Slash commands don't echo their
-// arguments to the transcript or session log, so `/token openai sk-...`
-// is the safest entry point we have — but the resulting settings file
-// sits in plain text on disk (0o600 on Unix).
-
-pub(crate) const TOKEN_CAPABILITY_ID: &str = "yolop_token_manager";
-
-/// Providers that meaningfully consume an API token. `llmsim` is excluded
-/// (no key needed) and `ollama` is included for completeness even though
-/// most local setups don't authenticate.
-const TOKEN_PROVIDERS: &[&str] = &["openai", "anthropic", "google", "openrouter", "ollama"];
-
-pub(crate) struct TokenCapability {
-    pub(crate) settings: Arc<SettingsStore>,
-}
-
-#[async_trait]
-impl Capability for TokenCapability {
-    fn id(&self) -> &str {
-        TOKEN_CAPABILITY_ID
-    }
-    fn name(&self) -> &str {
-        "Coding CLI Token Manager"
-    }
-    fn description(&self) -> &str {
-        "Store provider API tokens in yolop settings so env vars are not required."
-    }
-    fn status(&self) -> CapabilityStatus {
-        CapabilityStatus::Available
-    }
-    fn category(&self) -> Option<&str> {
-        Some("Examples")
-    }
-    fn system_prompt_addition(&self) -> Option<&str> {
-        None
-    }
-    fn commands(&self) -> Vec<CommandDescriptor> {
-        vec![CommandDescriptor {
-            name: "token".to_string(),
-            description: "Show or store API tokens. Env vars still override saved tokens."
-                .to_string(),
-            source: CommandSource::System,
-            args: vec![CommandArg {
-                name: "provider [value | clear]".to_string(),
-                description:
-                    "<provider> <value> to store; <provider> clear to remove; omit to list status."
-                        .to_string(),
-                required: false,
-                suggestions: TOKEN_PROVIDERS.iter().map(|s| (*s).to_string()).collect(),
-            }],
-        }]
-    }
-
-    async fn execute_command(
-        &self,
-        request: &ExecuteCommandRequest,
-        _ctx: &CommandExecutionContext,
-    ) -> everruns_core::Result<CommandResult> {
-        if request.name != "token" {
-            return Err(everruns_core::AgentLoopError::config(format!(
-                "{} cannot execute /{}",
-                self.id(),
-                request.name
-            )));
-        }
-        let raw = request.arguments.as_deref().unwrap_or("").trim();
+    fn change_token(&self, raw: &str) -> everruns_core::Result<CommandResult> {
         if raw.is_empty() {
             let snapshot = self.settings.snapshot();
             let status: Vec<String> = TOKEN_PROVIDERS
@@ -612,7 +482,7 @@ impl Capability for TokenCapability {
             return Ok(CommandResult {
                 success: true,
                 message: format!(
-                    "tokens ({}): {}",
+                    "setup tokens ({}): {}",
                     self.settings.path().display(),
                     status.join(", ")
                 ),
@@ -624,16 +494,15 @@ impl Capability for TokenCapability {
         let mut parts = raw.splitn(2, char::is_whitespace);
         let provider = parts.next().unwrap_or_default().to_ascii_lowercase();
         let rest = parts.next().unwrap_or_default().trim();
-
         if !TOKEN_PROVIDERS.contains(&provider.as_str()) {
             return Ok(failed_result(format!(
-                "unknown provider `{provider}`; expected one of {}",
+                "setup token failed: unknown provider `{provider}`; expected one of {}",
                 TOKEN_PROVIDERS.join(", ")
             )));
         }
         if rest.is_empty() {
             return Ok(failed_result(
-                "usage: /token <provider> <value|clear>".to_string(),
+                "setup token failed: expected <provider> <value|clear>".to_string(),
             ));
         }
 
@@ -641,17 +510,17 @@ impl Capability for TokenCapability {
             return Ok(match self.settings.clear_token(&provider) {
                 Ok(true) => CommandResult {
                     success: true,
-                    message: format!("token cleared for {provider}"),
+                    message: format!("setup token cleared for {provider}"),
                     error_code: None,
                     error_fields: None,
                 },
                 Ok(false) => CommandResult {
                     success: true,
-                    message: format!("no token was stored for {provider}"),
+                    message: format!("setup token: no token was stored for {provider}"),
                     error_code: None,
                     error_fields: None,
                 },
-                Err(err) => failed_result(format!("token clear failed: {err}")),
+                Err(err) => failed_result(format!("setup token clear failed: {err}")),
             });
         }
 
@@ -659,35 +528,27 @@ impl Capability for TokenCapability {
             Ok(()) => Ok(CommandResult {
                 success: true,
                 message: format!(
-                    "token stored for {provider} (in {})",
+                    "setup token stored for {provider} (in {})",
                     self.settings.path().display()
                 ),
                 error_code: None,
                 error_fields: None,
             }),
-            Err(err) => Ok(failed_result(format!("token save failed: {err}"))),
+            Err(err) => Ok(failed_result(format!("setup token save failed: {err}"))),
         }
     }
 }
 
-// ---------- /onboard ----------
-//
-// First-run setup helper. The capability itself only registers the
-// `/onboard` slash command and reports the current setup state — the
-// actual interactive wizard lives in the TUI because capabilities are
-// stateless command handlers and can't pause for user input.
-//
-// The TUI matches `descriptor.name == "onboard"` after dispatching the
-// command and enters wizard mode, which then drives `/provider`,
-// `/token`, and `/model` against the same capabilities.
-
-pub(crate) const ONBOARDING_CAPABILITY_ID: &str = "yolop_onboarding";
-
-pub(crate) struct OnboardingCapability {
-    pub(crate) settings: Arc<SettingsStore>,
+fn failed_result(message: String) -> CommandResult {
+    CommandResult {
+        success: false,
+        message,
+        error_code: None,
+        error_fields: None,
+    }
 }
 
-impl OnboardingCapability {
+impl SetupCapability {
     /// True when no provider preference is saved and no API token is set —
     /// either via env var or in the settings file. Used by the TUI at
     /// startup to auto-open the wizard on a fresh install.
@@ -716,74 +577,6 @@ fn env_credential_present() -> bool {
         .any(|var| std::env::var(var).map(|v| !v.is_empty()).unwrap_or(false))
 }
 
-#[async_trait]
-impl Capability for OnboardingCapability {
-    fn id(&self) -> &str {
-        ONBOARDING_CAPABILITY_ID
-    }
-    fn name(&self) -> &str {
-        "Coding CLI Onboarding"
-    }
-    fn description(&self) -> &str {
-        "Guided first-run setup for provider, token, and default model."
-    }
-    fn status(&self) -> CapabilityStatus {
-        CapabilityStatus::Available
-    }
-    fn category(&self) -> Option<&str> {
-        Some("Examples")
-    }
-    fn system_prompt_addition(&self) -> Option<&str> {
-        None
-    }
-    fn commands(&self) -> Vec<CommandDescriptor> {
-        vec![CommandDescriptor {
-            name: "onboard".to_string(),
-            description: "Walk through provider/token/model setup.".to_string(),
-            source: CommandSource::System,
-            args: vec![],
-        }]
-    }
-
-    async fn execute_command(
-        &self,
-        request: &ExecuteCommandRequest,
-        _ctx: &CommandExecutionContext,
-    ) -> everruns_core::Result<CommandResult> {
-        if request.name != "onboard" {
-            return Err(everruns_core::AgentLoopError::config(format!(
-                "{} cannot execute /{}",
-                self.id(),
-                request.name
-            )));
-        }
-        // The TUI starts the actual wizard after dispatch (see
-        // `App::invoke_capability_command`). Reporting current state here
-        // makes the command useful in `--print` mode too, where the wizard
-        // can't run.
-        let snapshot = self.settings.snapshot();
-        let provider = snapshot
-            .provider
-            .clone()
-            .unwrap_or_else(|| "<unset>".to_string());
-        let stored: Vec<&str> = snapshot.tokens.keys().map(String::as_str).collect();
-        let stored_label = if stored.is_empty() {
-            "none".to_string()
-        } else {
-            stored.join(", ")
-        };
-        Ok(CommandResult {
-            success: true,
-            message: format!(
-                "onboarding: provider={provider}, stored tokens={stored_label}, env keys present={}",
-                env_credential_present()
-            ),
-            error_code: None,
-            error_fields: None,
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -803,7 +596,7 @@ mod tests {
             std::env::remove_var("OLLAMA_API_KEY");
         }
         let settings = crate::settings::Settings::default();
-        assert!(OnboardingCapability::needs_onboarding(&settings));
+        assert!(SetupCapability::needs_onboarding(&settings));
     }
 
     #[test]
@@ -812,7 +605,7 @@ mod tests {
             provider: Some("anthropic".to_string()),
             ..Default::default()
         };
-        assert!(!OnboardingCapability::needs_onboarding(&settings));
+        assert!(!SetupCapability::needs_onboarding(&settings));
     }
 
     #[test]
@@ -823,7 +616,7 @@ mod tests {
             provider: None,
             tokens,
         };
-        assert!(!OnboardingCapability::needs_onboarding(&settings));
+        assert!(!SetupCapability::needs_onboarding(&settings));
     }
 
     #[test]

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -8,7 +8,5 @@ pub(crate) mod your;
 
 pub(crate) use host::{
     CodingBashCapability, CodingCliEnvironmentCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID,
-    MODEL_SWITCHER_CAPABILITY_ID, ModelSwitcherCapability, ONBOARDING_CAPABILITY_ID,
-    OnboardingCapability, PROVIDER_SWITCHER_CAPABILITY_ID, ProviderSwitcherCapability,
-    TOKEN_CAPABILITY_ID, TokenCapability,
+    SETUP_CAPABILITY_ID, SetupCapability,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,7 +174,7 @@ async fn main() -> Result<()> {
     // Fall back to an unwritable scratch path when no platform config dir
     // is resolvable (minimal containers, CI without HOME). `SettingsStore`
     // loads to defaults when the file does not exist, and writes will
-    // error visibly via `/provider` or `/token` rather than killing
+    // error visibly via `/setup` rather than killing
     // startup — keeps `--print` usable in stripped-down environments.
     let settings_path = settings::default_settings_path().unwrap_or_else(|| {
         eprintln!(

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -8,9 +8,7 @@ use crate::approval::ApprovalGate;
 use crate::capabilities::your::{YOUR_CAPABILITY_ID, YourCapability, YourStore};
 use crate::capabilities::{
     CodingBashCapability, CodingCliEnvironmentCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID,
-    MODEL_SWITCHER_CAPABILITY_ID, ModelSwitcherCapability, ONBOARDING_CAPABILITY_ID,
-    OnboardingCapability, PROVIDER_SWITCHER_CAPABILITY_ID, ProviderSwitcherCapability,
-    TOKEN_CAPABILITY_ID, TokenCapability,
+    SETUP_CAPABILITY_ID, SetupCapability,
 };
 use crate::settings::{Settings, SettingsStore};
 use crate::tools::Workspace;
@@ -410,7 +408,7 @@ pub enum ProviderChoice {
     Sim,
 }
 
-/// Provider names recognized by `/provider` and persisted settings. The order
+/// Provider names recognized by `/setup` and persisted settings. The order
 /// is the user-visible suggestion order.
 pub const SUPPORTED_PROVIDERS: &[&str] = &[
     "openai",
@@ -499,7 +497,7 @@ impl ProviderChoice {
     }
 
     /// Build a ProviderChoice from a bare provider name, picking the
-    /// provider's default model. Used by `/provider` and by startup when
+    /// provider's default model. Used by `/setup` and by startup when
     /// rehydrating the persisted preference.
     pub fn default_for_provider_name(name: &str) -> Result<Self> {
         match name.trim().to_ascii_lowercase().as_str() {
@@ -554,7 +552,7 @@ impl ProviderChoice {
         let reasoning_effort = parts.next().map(str::to_string);
         if parts.next().is_some() {
             return Err(anyhow!(
-                "too many model arguments; use `/model openai/gpt-5.5 medium`"
+                "too many model arguments; use `openai/gpt-5.5 medium`"
             ));
         }
         if let Some((provider, model)) = model_spec.split_once('/') {
@@ -879,10 +877,7 @@ fn coding_harness_capabilities() -> Vec<AgentCapabilityConfig> {
             "web_fetch",
             serde_json::json!({ "enable_file_download": true }),
         ),
-        AgentCapabilityConfig::new(MODEL_SWITCHER_CAPABILITY_ID),
-        AgentCapabilityConfig::new(PROVIDER_SWITCHER_CAPABILITY_ID),
-        AgentCapabilityConfig::new(TOKEN_CAPABILITY_ID),
-        AgentCapabilityConfig::new(ONBOARDING_CAPABILITY_ID),
+        AgentCapabilityConfig::new(SETUP_CAPABILITY_ID),
         AgentCapabilityConfig::new(YOUR_CAPABILITY_ID),
         AgentCapabilityConfig::new("yolop_bash"),
     ]
@@ -924,14 +919,14 @@ pub struct StartupInfo {
     /// Zero for fresh sessions; used by the startup banner.
     pub replayed_events: usize,
     /// True when neither env vars nor saved settings provide a credential
-    /// for any real provider. The TUI auto-opens its onboarding wizard
-    /// in this case; `--print` mode ignores it.
-    pub onboarding_recommended: bool,
+    /// for any real provider. The TUI auto-opens its setup wizard in this
+    /// case; `--print` mode ignores it.
+    pub setup_recommended: bool,
 }
 
 #[derive(Clone)]
 pub struct ModelState {
-    /// Shared with [`crate::capabilities::ModelSwitcherCapability`] so a successful `/model`
+    /// Shared with [`crate::capabilities::SetupCapability`] so a successful `/setup`
     /// invocation through `runtime.execute_command` immediately updates the
     /// banner label.
     provider: Arc<RwLock<ProviderChoice>>,
@@ -1043,7 +1038,7 @@ pub async fn build_with_options(
         .with_event_bus(event_bus)
         .with_message_store(message_store);
     // Shared between `ModelState` (for banner labels) and
-    // `ModelSwitcherCapability` (which mutates it on a successful `/model`).
+    // `SetupCapability` (which mutates it on a successful `/setup`).
     let provider_state = Arc::new(RwLock::new(provider.clone()));
     let provider_store = backends.provider_store.clone();
 
@@ -1077,27 +1072,16 @@ pub async fn build_with_options(
     capabilities.register(DuckDuckGoCapability);
     capabilities.register(WebFetchCapability::from_env());
     capabilities.register(CodingCliEnvironmentCapability::new(canonical_root.clone()));
-    // `/model` (below) is the example's capability-sourced slash command —
-    // it implements `Capability::execute_command` end to end. We deliberately
+    // `/setup` (below) is the capability-sourced slash command. It implements
+    // `Capability::execute_command` end to end. We deliberately
     // do NOT register `BtwCapability` here: the server's `/btw` flow has its
     // own bespoke executor in `SessionCommandService::execute_btw` (see
     // crates/server/src/domains/session_commands/service.rs) and the
     // capability does not implement `execute_command`, so dispatching it
     // through the embedded runtime would error.
-    capabilities.register(ModelSwitcherCapability {
+    capabilities.register(SetupCapability {
         provider: provider_state.clone(),
         provider_store: provider_store.clone(),
-        settings: settings.clone(),
-    });
-    capabilities.register(ProviderSwitcherCapability {
-        provider: provider_state.clone(),
-        provider_store: provider_store.clone(),
-        settings: settings.clone(),
-    });
-    capabilities.register(TokenCapability {
-        settings: settings.clone(),
-    });
-    capabilities.register(OnboardingCapability {
         settings: settings.clone(),
     });
     // `your` — global personalization. Its MEMORY.md lives beside
@@ -1115,7 +1099,7 @@ pub async fn build_with_options(
     everruns_anthropic::register_driver(&mut driver_registry);
     everruns_openai::register_driver(&mut driver_registry);
     let settings_snapshot = settings.snapshot();
-    let onboarding_recommended = OnboardingCapability::needs_onboarding(&settings_snapshot);
+    let setup_recommended = SetupCapability::needs_onboarding(&settings_snapshot);
     let default_model = match &provider {
         ProviderChoice::Anthropic { .. }
         | ProviderChoice::OpenAi { .. }
@@ -1123,7 +1107,7 @@ pub async fn build_with_options(
         | ProviderChoice::OpenRouter { .. }
         | ProviderChoice::Ollama { .. } => match provider.model_with_provider(&settings_snapshot) {
             Ok(model) => model,
-            Err(_) if onboarding_recommended => provider.model_without_stored_key(),
+            Err(_) if setup_recommended => provider.model_without_stored_key(),
             Err(err) => return Err(err),
         },
         ProviderChoice::Sim => ModelWithProvider {
@@ -1171,7 +1155,7 @@ pub async fn build_with_options(
             }
             s
         });
-    // Always register the llmsim driver so the `/model llmsim` switch works
+    // Always register the llmsim driver so `/setup` can switch to offline mode.
     // mid-session, even if the user started with anthropic or openai.
     let llmsim_config = options.llmsim_override.unwrap_or_else(|| {
         LlmSimConfig::fixed(
@@ -1205,7 +1189,7 @@ pub async fn build_with_options(
             session_log_path: log_path,
             session_dir,
             replayed_events: replayed_events_count,
-            onboarding_recommended,
+            setup_recommended,
         },
         model: ModelState::new(provider_state),
     })
@@ -1214,6 +1198,7 @@ pub async fn build_with_options(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use everruns_core::command::ExecuteCommandRequest;
 
     #[test]
     fn model_spec_can_switch_to_openai() {
@@ -1221,6 +1206,135 @@ mod tests {
         let next = provider.resolve_model_spec("openai/gpt-5.5").unwrap();
 
         assert_eq!(next.label(), "openai/gpt-5.5 medium");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn setup_is_the_only_provider_configuration_command() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+        let settings_for_assert = settings.clone();
+        let built = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Sim,
+            ApprovalGate::auto(),
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            BuildOptions::default(),
+        )
+        .await
+        .expect("build runtime");
+
+        let commands = built
+            .handles
+            .runtime
+            .list_commands(built.handles.session_id)
+            .await
+            .expect("commands");
+        let names: Vec<&str> = commands.iter().map(|c| c.name.as_str()).collect();
+
+        assert!(names.contains(&"setup"), "commands: {names:?}");
+        for removed in ["provider", "token", "model", "onboard"] {
+            assert!(
+                !names.contains(&removed),
+                "/{removed} should not be a visible setup command: {names:?}"
+            );
+        }
+
+        let status = built
+            .handles
+            .runtime
+            .execute_command(
+                built.handles.session_id,
+                ExecuteCommandRequest {
+                    name: "setup".to_string(),
+                    arguments: Some("status".to_string()),
+                    controls: None,
+                },
+            )
+            .await
+            .expect("setup status");
+        assert!(status.success);
+        assert!(status.message.starts_with("setup:"));
+
+        let store_token = built
+            .handles
+            .runtime
+            .execute_command(
+                built.handles.session_id,
+                ExecuteCommandRequest {
+                    name: "setup".to_string(),
+                    arguments: Some("token openai sk-test".to_string()),
+                    controls: None,
+                },
+            )
+            .await
+            .expect("store setup token");
+        assert!(store_token.success);
+        assert!(settings_for_assert.snapshot().has_token("openai"));
+
+        let clear_token = built
+            .handles
+            .runtime
+            .execute_command(
+                built.handles.session_id,
+                ExecuteCommandRequest {
+                    name: "setup".to_string(),
+                    arguments: Some("token openai clear".to_string()),
+                    controls: None,
+                },
+            )
+            .await
+            .expect("clear setup token");
+        assert!(clear_token.success);
+        assert!(!settings_for_assert.snapshot().has_token("openai"));
+
+        let provider = built
+            .handles
+            .runtime
+            .execute_command(
+                built.handles.session_id,
+                ExecuteCommandRequest {
+                    name: "setup".to_string(),
+                    arguments: Some("provider llmsim".to_string()),
+                    controls: None,
+                },
+            )
+            .await
+            .expect("setup provider");
+        assert!(provider.success);
+
+        let model = built
+            .handles
+            .runtime
+            .execute_command(
+                built.handles.session_id,
+                ExecuteCommandRequest {
+                    name: "setup".to_string(),
+                    arguments: Some("model llmsim/llmsim-yolop".to_string()),
+                    controls: None,
+                },
+            )
+            .await
+            .expect("setup model");
+        assert!(model.success);
+
+        let unknown = built
+            .handles
+            .runtime
+            .execute_command(
+                built.handles.session_id,
+                ExecuteCommandRequest {
+                    name: "setup".to_string(),
+                    arguments: Some("wat".to_string()),
+                    controls: None,
+                },
+            )
+            .await
+            .expect("unknown setup action");
+        assert!(!unknown.success);
+        assert!(unknown.message.contains("model <id|provider/id>"));
     }
 
     #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,12 +2,12 @@
 // API tokens.
 //
 // Stored at `<config_dir>/yolop/settings.toml` (`~/.config/yolop/settings.toml`
-// on Linux). The capabilities that own `/provider` and `/token` write
-// through `SettingsStore` so user choices survive across runs.
+// on Linux). The `/setup` capability writes through `SettingsStore` so user
+// choices survive across runs.
 //
 // Tokens are written with 0o600 on Unix (owner-only) and are still less
 // secure than a real secret manager — they sit in plain text on disk. The
-// `/token <provider> clear` command removes a stored entry. Env vars
+// `/setup` command can remove a stored entry. Env vars
 // (OPENAI_API_KEY, ANTHROPIC_API_KEY, …) continue to take precedence so a
 // per-run override is always possible.
 


### PR DESCRIPTION
## What
Collapse provider/model/token/onboarding setup into one visible TUI slash command: `/setup`.

## Why
The separate `/model`, `/provider`, `/token`, and `/onboard` commands exposed implementation details and made first-run/reconfiguration harder to discover.

## How
- Replaced the four visible setup capabilities with one `SetupCapability` that registers `/setup`.
- Kept provider, token, and model mutations as internal `/setup` actions used by the TUI wizard.
- Updated first-run setup copy, command suggestions, README docs, and tests.

## Risk
- Medium
- Existing users who knew the old slash commands now need `/setup`; yolop is pre-1.0 and the requested UX intentionally removes that split.
- Setup touches token storage paths, but token values are still not echoed to transcript/session logs and settings permissions remain unchanged.

## Security
- TM-LLM: API keys remain handled through setup command arguments that are not pushed as user chat lines; stored tokens still go through `SettingsStore` and are not logged by value.
- TM-TOOL: Capability registration is narrower: only `/setup` is declared; no new tool surface or approval bypass was added.
- TM-FS/TM-BASH/TM-DEP: No filesystem tool, bash execution, or dependency changes.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"` confirmed startup and advertised `commands /setup`
- GitHub Actions: Format + Clippy, Build + Tests + Offline Smoke, CodeQL, Codecov patch, and Live OpenAI Smoke (Doppler) all passed on the final commit.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered