### PR TITLE
fix(tui): keep escape from exiting yolop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,6 +515,12 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -987,6 +993,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dunce"
@@ -2240,7 +2252,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "winapi",
 ]
 
@@ -2342,13 +2354,25 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "memoffset",
 ]
@@ -2764,6 +2788,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.28.0",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2950,7 +2995,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -2991,7 +3036,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2",
@@ -3688,6 +3733,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3745,6 +3801,22 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -4033,7 +4105,7 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix",
+ "nix 0.29.0",
  "num-derive",
  "num-traits",
  "ordered-float",
@@ -5206,6 +5278,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5344,6 +5425,7 @@ dependencies = [
  "everruns-openai",
  "everruns-runtime",
  "include_dir",
+ "portable-pty",
  "ratatui",
  "ratatui-textarea",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ everruns-runtime = "0.8.36"
 everruns-integrations-duckduckgo = "0.8.36"
 
 [dev-dependencies]
+portable-pty = "0.9.0"
 tempfile = "3"
 
 [profile.release]

--- a/src/app.rs
+++ b/src/app.rs
@@ -2990,6 +2990,38 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn startup_banner_names_ctrl_c_and_ctrl_d_as_exit_keys() {
+        let fixture = app_with_llmsim().await;
+
+        assert!(
+            fixture
+                .app
+                .lines
+                .iter()
+                .any(|line| line.text.contains("Ctrl-C or Ctrl-D to exit")),
+            "startup banner should name Ctrl-C/Ctrl-D exits: {:?}",
+            fixture.app.lines
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn help_command_names_ctrl_c_and_ctrl_d_as_exit_keys() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.lines.clear();
+
+        app.handle_command("help").await;
+
+        assert!(
+            app.lines
+                .iter()
+                .any(|line| line.text.contains("exit: Ctrl-C / Ctrl-D")),
+            "help output should name Ctrl-C/Ctrl-D exits: {:?}",
+            app.lines
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn app_slash_input_renders_command_suggestions_end_to_end() {
         let mut fixture = app_with_llmsim().await;
         let app = &mut fixture.app;

--- a/src/app.rs
+++ b/src/app.rs
@@ -308,7 +308,9 @@ impl App {
                 .collect();
             self.push_system(format!("commands: {}", names.join(", ")));
         }
-        self.push_system("type /help for commands, Esc or Ctrl-D to exit; approvals: y / n".into());
+        self.push_system(
+            "type /help for commands, Ctrl-C or Ctrl-D to exit; approvals: y / n".into(),
+        );
     }
 
     fn push_user(&mut self, text: String) {
@@ -515,11 +517,6 @@ impl App {
             return;
         }
 
-        if matches!(key.code, KeyCode::Esc) {
-            self.should_quit = true;
-            return;
-        }
-
         if self.busy {
             // Block only input editing while a turn is running.
             return;
@@ -623,7 +620,9 @@ impl App {
                     "input: ←/→ edit · Alt/Shift-Enter newline · scroll: use the terminal scrollback"
                         .into(),
                 );
-                self.push_system("approvals: y allow · n / Esc deny · exit: Esc / Ctrl-D".into());
+                self.push_system(
+                    "approvals: y allow · n / Esc deny · exit: Ctrl-C / Ctrl-D".into(),
+                );
             }
             "tools" => {
                 self.push_system(format!("tools: {}", self.startup.tool_names.join(", ")));

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -11,6 +11,12 @@
 
 use std::path::PathBuf;
 use std::process::Command;
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
+use std::time::{Duration, Instant};
+use std::{io::Read, io::Write};
+
+use portable_pty::{Child, CommandBuilder, ExitStatus, NativePtySystem, PtySize, PtySystem};
 
 fn yolop_binary() -> PathBuf {
     // CARGO_BIN_EXE_<name> is set by Cargo for integration tests.
@@ -201,6 +207,49 @@ fn llmsim_unknown_session_id_is_invalid() {
     );
 }
 
+#[test]
+fn tui_escape_does_not_exit_and_ctrl_c_exits() {
+    let mut tui = spawn_tui_llmsim();
+    assert!(
+        tui.wait_for_output("type /help", Duration::from_secs(3)),
+        "TUI did not render startup banner: {}",
+        tui.output_text()
+    );
+
+    tui.write_input(b"\x1b");
+    assert!(
+        wait_for_exit(&mut *tui.child, Duration::from_millis(700)).is_none(),
+        "Esc should not exit the TUI: {}",
+        tui.output_text()
+    );
+
+    tui.write_input(b"\x03");
+    let status = tui.wait_or_kill(Duration::from_secs(3));
+    assert!(
+        status.success(),
+        "Ctrl-C should exit cleanly, got {status:?}: {}",
+        tui.output_text()
+    );
+}
+
+#[test]
+fn tui_double_ctrl_c_exits() {
+    let mut tui = spawn_tui_llmsim();
+    assert!(
+        tui.wait_for_output("type /help", Duration::from_secs(3)),
+        "TUI did not render startup banner: {}",
+        tui.output_text()
+    );
+
+    tui.write_input(b"\x03\x03");
+    let status = tui.wait_or_kill(Duration::from_secs(3));
+    assert!(
+        status.success(),
+        "double Ctrl-C should exit cleanly, got {status:?}: {}",
+        tui.output_text()
+    );
+}
+
 /// Parse the session id printed on the `session …` line of `--print` stdout.
 /// The line shape is:
 /// `session   <id> (folder: ...; log: ...; N prior event(s))`
@@ -258,6 +307,135 @@ fn strip_ansi(input: &str) -> String {
         i += 1;
     }
     out
+}
+
+struct TuiHarness {
+    child: Box<dyn Child + Send + Sync>,
+    writer: Box<dyn Write + Send>,
+    output_rx: Receiver<Vec<u8>>,
+    output: Vec<u8>,
+    _session_dir: tempfile::TempDir,
+    _home: tempfile::TempDir,
+}
+
+impl TuiHarness {
+    fn write_input(&mut self, bytes: &[u8]) {
+        self.writer.write_all(bytes).expect("write pty input");
+        self.writer.flush().expect("flush pty input");
+    }
+
+    fn wait_for_output(&mut self, needle: &str, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            self.drain_output();
+            if self.output_text().contains(needle) {
+                return true;
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+        self.drain_output();
+        self.output_text().contains(needle)
+    }
+
+    fn wait_or_kill(&mut self, timeout: Duration) -> ExitStatus {
+        if let Some(status) = wait_for_exit(&mut *self.child, timeout) {
+            return status;
+        }
+        let _ = self.child.kill();
+        panic!(
+            "TUI did not exit within {:?}: {}",
+            timeout,
+            self.output_text()
+        );
+    }
+
+    fn output_text(&mut self) -> String {
+        self.drain_output();
+        String::from_utf8_lossy(&self.output).into_owned()
+    }
+
+    fn drain_output(&mut self) {
+        while let Ok(chunk) = self.output_rx.try_recv() {
+            self.output.extend_from_slice(&chunk);
+        }
+    }
+}
+
+impl Drop for TuiHarness {
+    fn drop(&mut self) {
+        if matches!(self.child.try_wait(), Ok(None)) {
+            let _ = self.child.kill();
+        }
+    }
+}
+
+fn spawn_tui_llmsim() -> TuiHarness {
+    let session_dir = tempfile::tempdir().expect("session tempdir");
+    let home = tempfile::tempdir().expect("home tempdir");
+    let pty_system = NativePtySystem::default();
+    let pair = pty_system
+        .openpty(PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .expect("open pty");
+
+    let mut cmd = CommandBuilder::new(yolop_binary());
+    cmd.args(["--provider", "llmsim", "--session-dir"]);
+    cmd.arg(session_dir.path());
+    cmd.env("HOME", home.path());
+    cmd.env("XDG_CONFIG_HOME", home.path().join(".config"));
+    cmd.env("XDG_DATA_HOME", home.path().join(".local/share"));
+    cmd.env("TERM", "xterm-256color");
+    cmd.env_remove("OPENAI_API_KEY");
+    cmd.env_remove("ANTHROPIC_API_KEY");
+    cmd.env_remove("OPENROUTER_API_KEY");
+    cmd.env_remove("OLLAMA_BASE_URL");
+    cmd.env_remove("OLLAMA_API_KEY");
+
+    let child = pair.slave.spawn_command(cmd).expect("spawn yolop TUI");
+    drop(pair.slave);
+
+    let (output_tx, output_rx) = mpsc::channel();
+    let mut reader = pair.master.try_clone_reader().expect("clone pty reader");
+    thread::spawn(move || {
+        let mut buf = [0_u8; 4096];
+        while let Ok(n) = reader.read(&mut buf) {
+            if n == 0 {
+                break;
+            }
+            if output_tx.send(buf[..n].to_vec()).is_err() {
+                break;
+            }
+        }
+    });
+
+    let mut writer = pair.master.take_writer().expect("take pty writer");
+    writer
+        .write_all(b"\x1b[1;1R")
+        .expect("seed cursor position response");
+    writer.flush().expect("flush cursor position response");
+    TuiHarness {
+        child,
+        writer,
+        output_rx,
+        output: Vec::new(),
+        _session_dir: session_dir,
+        _home: home,
+    }
+}
+
+fn wait_for_exit(child: &mut dyn Child, timeout: Duration) -> Option<ExitStatus> {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if let Some(status) = child.try_wait().expect("poll child exit") {
+            return Some(status);
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+    child.try_wait().expect("poll child exit")
 }
 
 #[test]


### PR DESCRIPTION
## What
- Stop treating normal-mode `Esc` as a request to quit the TUI.
- Keep `Esc` as approval-deny behavior.
- Update in-app exit help to say `Ctrl-C` / `Ctrl-D`.
- Add PTY-backed integration coverage for `Esc`, single `Ctrl-C`, and double `Ctrl-C`.

## Why
`Esc` is easy to press while editing terminal input and should not close `yolop`. Exiting should be explicit through `Ctrl-C`, repeated `Ctrl-C`, `Ctrl-D`, or the slash exit commands.

## How
- Remove the normal-mode `KeyCode::Esc` branch in `App::handle_key`.
- Add `portable-pty` as a test-only dependency so integration tests can drive the real TUI binary through a pseudo-terminal.
- Isolate PTY tests with temporary `HOME`, config, data, and session directories.

## Risk
- Low
- Risk is limited to TUI key handling and integration-test infrastructure. Approval prompts still deny on `Esc`; normal input ignores `Esc`.

## Security
- TM-FS: no runtime filesystem behavior changed. New PTY tests isolate session/config paths in temp directories.
- TM-BASH: no shell execution behavior changed.
- TM-LLM: no prompt construction or provider secret handling changed; tests remove provider API env vars.
- TM-TOOL: no capability registration or approval-gate behavior changed except preserving approval `Esc` denial.
- TM-DEP: added test-only `portable-pty` to exercise real terminal input in e2e tests; it is not a runtime dependency.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --test integration`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"`

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
