### PR TITLE
chore(release): prepare v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,49 @@ The first tagged release will be cut via [`/release`](./.agents/skills/release/S
 until then, the `Cargo.toml` version sits at `0.1.0` and unreleased changes
 accumulate below.
 
-## [Unreleased]
+## [0.1.0] - 2026-05-31
+
+First public release of yolop — a minimal terminal coding agent built on
+[`everruns-runtime`](https://crates.io/crates/everruns-runtime).
+
+### Highlights
+
+- **Terminal coding agent.** A ratatui-based TUI that drives the everruns
+  runtime agent loop, with live streaming of delta events as the model works.
+- **Provider setup built in.** `/provider`, `/token`, and `/onboard` commands
+  configure OpenAI or Anthropic and persist settings to TOML; OpenAI is the
+  default provider, Anthropic the secondary.
+- **Session persistence.** Reasoning artifacts and the session log are
+  persisted, so sessions can be resumed with `--session`.
+- **Skills and personalization.** Skills are sourced from workspace, global,
+  and system scopes; a personalization layer adds a central memory surface.
+- **Offline smoke testing.** The bundled `llmsim` provider runs the full loop
+  with no API key (`yolop --provider llmsim -p "hi"`).
 
 ### What's Changed
 
-* chore(deps): bump everruns-* crates to 0.8.36
-* chore(release): add release skill, spec, workflows, and Homebrew tap publishing
+* chore(maintenance): refresh lockfile and re-enable EVE-489 tests ([#32](https://github.com/everruns/yolop/pull/32)) by @chaliy
+* test(agent): scripted llmsim scenario tests for the agent loop ([#31](https://github.com/everruns/yolop/pull/31)) by @chaliy
+* chore(deps): bump everruns-* crates to 0.8.36 ([#29](https://github.com/everruns/yolop/pull/29)) by @chaliy
+* feat(skills): source skills from workspace, global, and system scopes ([#28](https://github.com/everruns/yolop/pull/28)) by @chaliy
+* feat(your): personalization layer with central memory ([#26](https://github.com/everruns/yolop/pull/26)) by @chaliy
+* fix(app): pass SettingsStore to build_with_options in TUI test helper ([#25](https://github.com/everruns/yolop/pull/25)) by @chaliy
+* chore(claude): SessionStart hook to fix agent-set git identity ([#24](https://github.com/everruns/yolop/pull/24)) by @chaliy
+* chore(claude): disable AI attribution in commits and PR bodies ([#22](https://github.com/everruns/yolop/pull/22)) by @chaliy
+* refactor(tui): extract ViewState + snapshot-test the render chrome ([#21](https://github.com/everruns/yolop/pull/21)) by @chaliy
+* chore(ship): require comments addressed, answered inline, resolved ([#20](https://github.com/everruns/yolop/pull/20)) by @chaliy
+* test(session_log): cover replay edge cases for corrupt or partial logs ([#19](https://github.com/everruns/yolop/pull/19)) by @chaliy
+* test(integration): cover --session resume and malformed session-id ([#18](https://github.com/everruns/yolop/pull/18)) by @chaliy
+* test(tools): cover bash approval-denial and bad-argument paths ([#17](https://github.com/everruns/yolop/pull/17)) by @chaliy
+* test(approval,diff): add unit tests for gate semantics and diff helper ([#16](https://github.com/everruns/yolop/pull/16)) by @chaliy
+* feat(tui): /provider, /token, /onboard with persisted TOML settings ([#14](https://github.com/everruns/yolop/pull/14)) by @chaliy
+* chore(release): add release skill, spec, workflows, Homebrew tap ([#11](https://github.com/everruns/yolop/pull/11)) by @chaliy
+* feat(session): persist reasoning artifacts for session restore ([#10](https://github.com/everruns/yolop/pull/10)) by @chaliy
+* test(tui): end-to-end streaming tests against llmsim ([#9](https://github.com/everruns/yolop/pull/9)) by @chaliy
+* feat(tui): stream live delta events from the runtime ([#3](https://github.com/everruns/yolop/pull/3)) by @chaliy
+* chore(ci): add dependabot config for cargo and actions ([#2](https://github.com/everruns/yolop/pull/2)) by @chaliy
+* feat: port coding-cli from everruns to standalone yolop project ([#1](https://github.com/everruns/yolop/pull/1)) by @chaliy
+
+Additional changes landed via direct commits to `main`: TUI provider-setup
+consolidation, escape-key handling fix, command-suggestion restore, capability
+surface simplification, brand/logo assets, and README slimming.


### PR DESCRIPTION
First public release of **yolop** — initial publish to crates.io and the `everruns/homebrew-tap` Homebrew tap.

The version stays at `0.1.0` (already in `Cargo.toml`); this PR adds the `[0.1.0]` changelog section that `release.yml` extracts as the GitHub Release notes.

## [0.1.0] - 2026-05-31

### Highlights

- **Terminal coding agent.** A ratatui-based TUI that drives the everruns runtime agent loop, with live streaming of delta events.
- **Provider setup built in.** `/provider`, `/token`, `/onboard` configure OpenAI (default) or Anthropic and persist settings to TOML.
- **Session persistence.** Reasoning artifacts and the session log persist; resume with `--session`.
- **Skills and personalization.** Skills sourced from workspace, global, and system scopes; a personalization layer adds central memory.
- **Offline smoke testing.** Bundled `llmsim` provider runs the full loop with no API key.

### What's Changed

The full mechanical PR list (newest-first) is in [`CHANGELOG.md`](https://github.com/everruns/yolop/blob/claude/vibrant-allen-C1zj5/CHANGELOG.md) — 21 merged PRs (#1–#32) plus direct-to-main commits.

**Full Changelog**: https://github.com/everruns/yolop/commits/v0.1.0

## Publish-readiness

Run locally on this branch (cargo 1.94.1 stable):

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` — 172 unit + 7 integration passed (1 live-OpenAI test `#[ignore]`d as designed)
- [x] `cargo publish --dry-run -p yolop --locked` — packaged `yolop v0.1.0`, aborted at upload as expected
- [x] crates.io currently serves **nothing** for `yolop` → publishing `0.1.0` (initial release)
- [x] `Cargo.toml` + `Cargo.lock` agree on `0.1.0`
- [x] `release.yml` changelog extraction verified locally against the `[0.1.0]` section

### Pre-flight on CI config (initial release — extra scrutiny)

- [x] `release.yml`, `publish.yml`, `cli-binaries.yml` all present and reference the correct secrets.
- [x] `DOPPLER_TOKEN` is configured — CI's `live-smoke` job on `main` hard-fails when it is unset, and `main` is green, so the token is present. Same `DOPPLER_TOKEN` feeds `cli-binaries.yml` (which reads `HOMEBREW_TAP_GITHUB_TOKEN` from Doppler).
- [ ] `CARGO_REGISTRY_TOKEN` — used only by `publish.yml`, which has never run (this is the first release). **Please confirm this repo secret is set before merging** (Settings → Secrets and variables → Actions). It cannot be verified from CI history yet.

## Post-merge plan

On squash-merge of this `chore(release): prepare v0.1.0` commit to `main`:

1. `release.yml` extracts `0.1.0`, verifies it matches `Cargo.toml`, creates tag + GitHub Release `v0.1.0`, then dispatches `publish.yml` and `cli-binaries.yml` against the tag.
2. `publish.yml` runs `cargo publish` to crates.io and verifies propagation.
3. `cli-binaries.yml` builds the 3 target binaries, uploads tarballs + `.sha256` to the release, and pushes `Formula/yolop.rb` to `everruns/homebrew-tap`.

I'll monitor all three workflows and confirm crates.io **and** the Homebrew tap both report `0.1.0` before declaring it shipped.

Do **not** enable auto-merge — a human should click squash so a reviewer sees the changelog.