### PR TITLE
fix(tui): support mac multiline shortcut

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -450,6 +450,12 @@ impl App {
                     if key.kind == KeyEventKind::Release {
                         continue;
                     }
+                    if key.code == KeyCode::Esc
+                        && self.pending.is_none()
+                        && self.handle_escape_prefixed_enter().await?
+                    {
+                        continue;
+                    }
                     self.handle_key(key).await;
                 }
                 if self.should_quit {
@@ -466,6 +472,32 @@ impl App {
             }
         }
         Ok(())
+    }
+
+    async fn handle_escape_prefixed_enter(&mut self) -> Result<bool> {
+        if !event::poll(Duration::from_millis(25))? {
+            return Ok(false);
+        }
+
+        match event::read()? {
+            CrosstermEvent::Key(next) if next.kind == KeyEventKind::Release => Ok(false),
+            CrosstermEvent::Key(next) if next.code == KeyCode::Enter => {
+                self.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::ALT))
+                    .await;
+                Ok(true)
+            }
+            CrosstermEvent::Key(next) => {
+                self.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
+                    .await;
+                self.handle_key(next).await;
+                Ok(true)
+            }
+            _ => {
+                self.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
+                    .await;
+                Ok(true)
+            }
+        }
     }
 
     async fn emit_replayed_transcript(&mut self) {
@@ -571,6 +603,9 @@ impl App {
             {
                 self.submit_input().await;
             }
+            KeyCode::Enter => {
+                self.input.insert_newline();
+            }
             KeyCode::Tab => {
                 if let Some(suggestion) = self.suggestions().first() {
                     self.set_input_text(suggestion.completion.clone());
@@ -610,7 +645,7 @@ impl App {
     }
 
     fn input_height(&self) -> u16 {
-        1
+        self.input.lines().len().clamp(1, 3) as u16
     }
 
     async fn submit_input(&mut self) {
@@ -658,10 +693,10 @@ impl App {
                         .join(" · ");
                     self.push_system(format!("commands: {caps}"));
                 }
-                self.push_system(
-                    "input: ←/→ edit · Alt/Shift-Enter newline · scroll: use the terminal scrollback"
-                        .into(),
-                );
+                self.push_system(format!(
+                    "input: ←/→ edit · {} newline · scroll: use the terminal scrollback",
+                    newline_shortcut_hint()
+                ));
                 self.push_system(
                     "approvals: y allow · n / Esc deny · exit: Ctrl-C / Ctrl-D".into(),
                 );
@@ -1812,14 +1847,16 @@ pub(crate) fn draw_chrome(
     input_height: u16,
     state: &ViewState,
 ) -> Rect {
+    let preview_height = u16::from(input_height == 1);
+    let status_height = u16::from(input_height < 3);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1),            // suggestions / stream preview
-            Constraint::Length(1),            // message separator
-            Constraint::Length(input_height), // input (left to the caller)
-            Constraint::Length(1),            // status separator
-            Constraint::Length(1),            // session status
+            Constraint::Length(preview_height), // suggestions / stream preview
+            Constraint::Length(1),              // message separator
+            Constraint::Length(input_height),   // input (left to the caller)
+            Constraint::Length(status_height),  // status separator
+            Constraint::Length(1),              // session status
         ])
         .split(area);
 
@@ -2353,10 +2390,18 @@ fn message_separator_title(state: &ViewState) -> Line<'static> {
     Line::from(vec![
         Span::styled("─── ", Style::default().fg(ACCENT_BLUE)),
         Span::styled(
-            "(Enter to send, Alt/Shift-Enter for newline) ",
+            format!("(Enter to send, {} for newline) ", newline_shortcut_hint()),
             Style::default().fg(TEXT_MUTED),
         ),
     ])
+}
+
+fn newline_shortcut_hint() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "Option-Enter / Shift-Enter"
+    } else {
+        "Alt-Enter / Shift-Enter"
+    }
 }
 
 fn thinking_title(frame: u64, activity: &str) -> Line<'static> {
@@ -2600,6 +2645,16 @@ mod tests {
         }
 
         assert_eq!(input.lines(), ["abc", "d"]);
+    }
+
+    #[test]
+    fn newline_shortcut_hint_matches_host_os() {
+        let hint = newline_shortcut_hint();
+        if cfg!(target_os = "macos") {
+            assert_eq!(hint, "Option-Enter / Shift-Enter");
+        } else {
+            assert_eq!(hint, "Alt-Enter / Shift-Enter");
+        }
     }
 
     #[test]
@@ -3230,6 +3285,46 @@ mod tests {
             "slash input should render command suggestions in chrome row: {:?}",
             rows
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn modified_enter_inserts_newline_without_submitting() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+
+        for key in [
+            KeyEvent::new(KeyCode::Char('a'), KeyModifiers::empty()),
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::ALT),
+            KeyEvent::new(KeyCode::Char('b'), KeyModifiers::empty()),
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT),
+            KeyEvent::new(KeyCode::Char('c'), KeyModifiers::empty()),
+        ] {
+            app.handle_key(key).await;
+        }
+
+        assert_eq!(app.input_text(), "a\nb\nc");
+        assert_eq!(app.input_height(), 3);
+        assert!(
+            app.lines
+                .iter()
+                .all(|line| !matches!(line.author, Author::User)),
+            "modified Enter should edit the composer, not submit: {:?}",
+            app.lines
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn multiline_input_height_is_bounded() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+
+        assert_eq!(app.input_height(), 1);
+        app.input.insert_newline();
+        assert_eq!(app.input_height(), 2);
+        app.input.insert_newline();
+        assert_eq!(app.input_height(), 3);
+        app.input.insert_newline();
+        assert_eq!(app.input_height(), 3);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,13 +23,17 @@ use anyhow::Result;
 use app::{App, COMPOSER_VIEWPORT_HEIGHT};
 use approval::ApprovalGate;
 use clap::Parser;
+use crossterm::event::{
+    KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
+use crossterm::{execute, queue};
 use everruns_core::message::MessageRole;
 use ratatui::backend::CrosstermBackend;
 use ratatui::{Terminal, TerminalOptions, Viewport};
 use runtime::{BuiltRuntime, ProviderChoice};
 use settings::SettingsStore;
-use std::io::{self, IsTerminal};
+use std::io::{self, IsTerminal, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -235,6 +239,7 @@ async fn run_tui(
     )>,
 ) -> Result<()> {
     let mut raw_mode = RawModeGuard::new()?;
+    let mut keyboard_enhancements = KeyboardEnhancementGuard::new();
     let stdout = io::stdout();
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::with_options(
@@ -251,6 +256,7 @@ async fn run_tui(
 
     let cleanup_result = terminal.clear().and_then(|_| terminal.show_cursor());
     drop(terminal);
+    keyboard_enhancements.disable();
     raw_mode.disable()?;
     cleanup_result?;
 
@@ -289,6 +295,35 @@ impl Drop for RawModeGuard {
             let _ = disable_raw_mode();
             self.active = false;
         }
+    }
+}
+
+struct KeyboardEnhancementGuard {
+    active: bool,
+}
+
+impl KeyboardEnhancementGuard {
+    fn new() -> Self {
+        let flags = KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+            | KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES;
+        let mut stdout = io::stdout();
+        let active = execute!(stdout, PushKeyboardEnhancementFlags(flags)).is_ok();
+        Self { active }
+    }
+
+    fn disable(&mut self) {
+        if self.active {
+            let mut stdout = io::stdout();
+            let _ = queue!(stdout, PopKeyboardEnhancementFlags);
+            let _ = stdout.flush();
+            self.active = false;
+        }
+    }
+}
+
+impl Drop for KeyboardEnhancementGuard {
+    fn drop(&mut self) {
+        self.disable();
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -233,6 +233,44 @@ fn tui_escape_does_not_exit_and_ctrl_c_exits() {
 }
 
 #[test]
+fn tui_option_enter_sequence_inserts_newline_before_submit() {
+    let mut tui = spawn_tui_llmsim();
+    assert!(
+        tui.wait_for_output("type /help", Duration::from_secs(3)),
+        "TUI did not render startup banner: {}",
+        tui.output_text()
+    );
+
+    tui.write_input(b"one\x1b\r");
+    thread::sleep(Duration::from_millis(250));
+    let before_submit = tui.output_text();
+    assert!(
+        !before_submit.contains("you ›"),
+        "Option-Enter should keep composing, not submit: {before_submit}"
+    );
+
+    tui.write_input(b"two\r");
+    assert!(
+        tui.wait_for_output("you ›", Duration::from_secs(3)),
+        "plain Enter did not submit after multiline input: {}",
+        tui.output_text()
+    );
+    let after_submit = strip_ansi(&tui.output_text());
+    assert!(
+        after_submit.contains("one") && after_submit.contains("two"),
+        "submitted multiline text should render both lines: {after_submit}"
+    );
+
+    tui.write_input(b"\x03");
+    let status = tui.wait_or_kill(Duration::from_secs(3));
+    assert!(
+        status.success(),
+        "Ctrl-C should exit cleanly, got {status:?}: {}",
+        tui.output_text()
+    );
+}
+
+#[test]
 fn tui_double_ctrl_c_exits() {
     let mut tui = spawn_tui_llmsim();
     assert!(
@@ -372,6 +410,17 @@ impl Drop for TuiHarness {
 fn spawn_tui_llmsim() -> TuiHarness {
     let session_dir = tempfile::tempdir().expect("session tempdir");
     let home = tempfile::tempdir().expect("home tempdir");
+    for settings_dir in [
+        home.path().join(".config/yolop"),
+        home.path().join("Library/Application Support/yolop"),
+    ] {
+        std::fs::create_dir_all(&settings_dir).expect("create settings dir");
+        std::fs::write(
+            settings_dir.join("settings.toml"),
+            "provider = \"llmsim\"\n",
+        )
+        .expect("write settings");
+    }
     let pty_system = NativePtySystem::default();
     let pair = pty_system
         .openpty(PtySize {


### PR DESCRIPTION
## What
Fix multiline composer shortcuts so modified Enter inserts a newline instead of submitting, and show a macOS-aware Option-Enter hint.

## Why
The TUI advertised Alt/Shift-Enter for newline, which was confusing on macOS and did not reliably create visible multiline input.

## How
- Insert newlines explicitly for modified Enter.
- Handle macOS Option-Enter terminal sequences that arrive as Esc followed by Enter.
- Enable crossterm keyboard enhancement flags where supported and restore them on exit.
- Let the inline composer grow up to three rows so inserted newlines are visible.
- Add unit coverage and a PTY integration test for the Option-Enter sequence.

## Risk
- Low
- Could affect terminal key handling in unsupported terminals; cleanup restores the keyboard protocol state and plain Enter/Esc paths remain covered.

## Security
Reviewed TM-FS, TM-BASH, TM-LLM, TM-TOOL, and TM-DEP. This change does not alter filesystem access, shell execution, provider key handling, capability registration, or dependencies. The runtime change is limited to terminal keyboard protocol setup/cleanup and input editing.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo build --release`
- `cargo run -- --provider llmsim -p "hi"`
- `doppler run --project yolop --config ci -- cargo run -- --provider openai -p "Reply with one short sentence confirming the yolop live smoke works."`

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)