### PR TITLE
feat(setup): make attribution configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ session    session_019e3db018a17450aba5407af5777237 (folder: …; log: …)
 - **`--print`** one-shot mode for CI smoke tests.
 - **Session persistence** — durable per-session JSONL event log under the
   platform-native user data directory, with `--session <id>` to resume.
+- **Git attribution** — enabled by default and configurable. When yolop creates
+  commits, it keeps the user's git author/committer identity and appends
+  `Co-Authored-By: yolop <yolop@everruns.com>` once. Pull request descriptions
+  created or edited through `gh` get a `Generated with yolop` footer.
 
 ## Install
 
@@ -214,6 +218,10 @@ Provider resolution at startup:
 At runtime, the per-provider env var (`OPENAI_API_KEY`, etc.) always
 beats the saved token, so a per-run env override is always possible.
 The setup wizard can also switch models for the current session.
+
+Attribution is enabled by default. Run `/setup attribution off` to disable it
+for future turns and future sessions, or `/setup attribution on` to re-enable
+it. The saved TOML key is `attribution = false` when disabled.
 
 ### Storing tokens
 

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -20,6 +20,26 @@ use std::sync::{Arc, RwLock};
 // ---------- environment context ----------
 
 pub(crate) const ENVIRONMENT_CONTEXT_CAPABILITY_ID: &str = "code_environment_context";
+pub(crate) const ATTRIBUTION_CAPABILITY_ID: &str = "yolop_attribution";
+pub(crate) const YOLOP_ATTRIBUTION_TRAILER: &str = "Co-Authored-By: yolop <yolop@everruns.com>";
+pub(crate) const YOLOP_PR_ATTRIBUTION: &str = "Generated with yolop";
+
+fn yolop_attribution_prompt() -> String {
+    format!(
+        "\
+## Attribution
+
+When you create or amend commits for changes you made, keep the user's
+git author/committer identity intact and append this git trailer once:
+{YOLOP_ATTRIBUTION_TRAILER}
+
+When creating or editing pull request descriptions with `gh`, add this
+footer once:
+{YOLOP_PR_ATTRIBUTION}
+
+Do not add duplicate attribution or session links."
+    )
+}
 
 pub(crate) struct CodingCliEnvironmentCapability {
     base: EnvironmentContextBase,
@@ -70,6 +90,38 @@ impl Capability for CodingCliEnvironmentCapability {
 </environment_context>"
                 .to_string(),
         )
+    }
+}
+
+pub(crate) struct AttributionCapability {
+    pub(crate) settings: Arc<SettingsStore>,
+}
+
+#[async_trait]
+impl Capability for AttributionCapability {
+    fn id(&self) -> &str {
+        ATTRIBUTION_CAPABILITY_ID
+    }
+    fn name(&self) -> &str {
+        "Yolop Attribution"
+    }
+    fn description(&self) -> &str {
+        "Adds optional commit and pull request attribution guidance."
+    }
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+    fn category(&self) -> Option<&str> {
+        Some("Examples")
+    }
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        self.settings
+            .snapshot()
+            .attribution_enabled()
+            .then(yolop_attribution_prompt)
+    }
+    fn system_prompt_preview(&self) -> Option<String> {
+        Some(yolop_attribution_prompt())
     }
 }
 
@@ -349,8 +401,9 @@ impl Capability for SetupCapability {
             "provider" => self.change_provider(rest).await,
             "model" => self.change_model(rest).await,
             "token" => self.change_token(rest),
+            "attribution" => self.change_attribution(rest),
             _ => Ok(failed_result(
-                "usage: /setup — run guided setup; internal forms: status, provider <name>, token <provider> <value|clear>, model <id|provider/id> [openai-reasoning-effort]".to_string(),
+                "usage: /setup — run guided setup; internal forms: status, provider <name>, token <provider> <value|clear>, model <id|provider/id> [openai-reasoning-effort], attribution <on|off>".to_string(),
             )),
         }
     }
@@ -377,9 +430,10 @@ impl SetupCapability {
         CommandResult {
             success: true,
             message: format!(
-                "setup: provider={} model={} saved={saved} stored tokens={stored_label} env keys present={}",
+                "setup: provider={} model={} saved={saved} attribution={} stored tokens={stored_label} env keys present={}",
                 current.provider_name(),
                 current.label(),
+                on_off(snapshot.attribution_enabled()),
                 env_credential_present()
             ),
             error_code: None,
@@ -537,6 +591,55 @@ impl SetupCapability {
             Err(err) => Ok(failed_result(format!("setup token save failed: {err}"))),
         }
     }
+
+    fn change_attribution(&self, raw: &str) -> everruns_core::Result<CommandResult> {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("status") {
+            let enabled = self.settings.snapshot().attribution_enabled();
+            return Ok(CommandResult {
+                success: true,
+                message: format!(
+                    "setup attribution: {} ({})",
+                    on_off(enabled),
+                    self.settings.path().display()
+                ),
+                error_code: None,
+                error_fields: None,
+            });
+        }
+
+        let enabled = match parse_on_off(trimmed) {
+            Some(enabled) => enabled,
+            None => {
+                return Ok(failed_result(
+                    "setup attribution failed: expected on/off".to_string(),
+                ));
+            }
+        };
+        match self.settings.set_attribution(enabled) {
+            Ok(()) => Ok(CommandResult {
+                success: true,
+                message: format!("setup attribution: {}", on_off(enabled)),
+                error_code: None,
+                error_fields: None,
+            }),
+            Err(err) => Ok(failed_result(format!(
+                "setup attribution save failed: {err}"
+            ))),
+        }
+    }
+}
+
+fn parse_on_off(raw: &str) -> Option<bool> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "on" | "true" | "yes" | "1" => Some(true),
+        "off" | "false" | "no" | "0" => Some(false),
+        _ => None,
+    }
+}
+
+fn on_off(enabled: bool) -> &'static str {
+    if enabled { "on" } else { "off" }
 }
 
 fn failed_result(message: String) -> CommandResult {
@@ -615,8 +718,32 @@ mod tests {
         let settings = crate::settings::Settings {
             provider: None,
             tokens,
+            ..Default::default()
         };
         assert!(!SetupCapability::needs_onboarding(&settings));
+    }
+
+    #[tokio::test]
+    async fn attribution_prompt_follows_settings() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let settings = Arc::new(SettingsStore::open(tmp.path().join("settings.toml")));
+        let capability = AttributionCapability {
+            settings: settings.clone(),
+        };
+        let ctx =
+            SystemPromptContext::without_file_store(everruns_core::typed_id::SessionId::new());
+
+        let enabled = capability
+            .system_prompt_contribution(&ctx)
+            .await
+            .expect("enabled attribution prompt");
+        assert!(enabled.contains(YOLOP_ATTRIBUTION_TRAILER));
+        assert!(enabled.contains(YOLOP_PR_ATTRIBUTION));
+
+        settings
+            .set_attribution(false)
+            .expect("disable attribution");
+        assert!(capability.system_prompt_contribution(&ctx).await.is_none());
     }
 
     #[test]

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -8,6 +8,7 @@ pub mod skills;
 pub(crate) mod your;
 
 pub(crate) use host::{
-    CodingBashCapability, CodingCliEnvironmentCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID,
-    SETUP_CAPABILITY_ID, SetupCapability,
+    ATTRIBUTION_CAPABILITY_ID, AttributionCapability, CodingBashCapability,
+    CodingCliEnvironmentCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID, SETUP_CAPABILITY_ID,
+    SetupCapability,
 };

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -7,8 +7,9 @@
 use crate::approval::ApprovalGate;
 use crate::capabilities::your::{YOUR_CAPABILITY_ID, YourCapability, YourStore};
 use crate::capabilities::{
-    CodingBashCapability, CodingCliEnvironmentCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID,
-    SETUP_CAPABILITY_ID, SetupCapability,
+    ATTRIBUTION_CAPABILITY_ID, AttributionCapability, CodingBashCapability,
+    CodingCliEnvironmentCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID, SETUP_CAPABILITY_ID,
+    SetupCapability,
 };
 use crate::settings::{Settings, SettingsStore};
 use crate::tools::Workspace;
@@ -871,6 +872,7 @@ fn coding_harness_capabilities() -> Vec<AgentCapabilityConfig> {
         AgentCapabilityConfig::new(PROMPT_CACHING_CAPABILITY_ID),
         AgentCapabilityConfig::new("tool_output_persistence"),
         AgentCapabilityConfig::new("duckduckgo"),
+        AgentCapabilityConfig::new(ATTRIBUTION_CAPABILITY_ID),
         // enable_file_download=true: saved responses land on disk through
         // the platform filesystem stack, so the blocklist + approval gate apply.
         AgentCapabilityConfig::with_config(
@@ -1079,6 +1081,9 @@ pub async fn build_with_options(
     capabilities.register(DuckDuckGoCapability);
     capabilities.register(WebFetchCapability::from_env());
     capabilities.register(CodingCliEnvironmentCapability::new(canonical_root.clone()));
+    capabilities.register(AttributionCapability {
+        settings: settings.clone(),
+    });
     // `/setup` (below) is the capability-sourced slash command. It implements
     // `Capability::execute_command` end to end. We deliberately
     // do NOT register `BtwCapability` here: the server's `/btw` flow has its
@@ -1264,6 +1269,43 @@ mod tests {
             .expect("setup status");
         assert!(status.success);
         assert!(status.message.starts_with("setup:"));
+        assert!(
+            status.message.contains("attribution=on"),
+            "status: {}",
+            status.message
+        );
+
+        let disable_attribution = built
+            .handles
+            .runtime
+            .execute_command(
+                built.handles.session_id,
+                ExecuteCommandRequest {
+                    name: "setup".to_string(),
+                    arguments: Some("attribution off".to_string()),
+                    controls: None,
+                },
+            )
+            .await
+            .expect("disable setup attribution");
+        assert!(disable_attribution.success);
+        assert!(!settings_for_assert.snapshot().attribution_enabled());
+
+        let enable_attribution = built
+            .handles
+            .runtime
+            .execute_command(
+                built.handles.session_id,
+                ExecuteCommandRequest {
+                    name: "setup".to_string(),
+                    arguments: Some("attribution on".to_string()),
+                    controls: None,
+                },
+            )
+            .await
+            .expect("enable setup attribution");
+        assert!(enable_attribution.success);
+        assert!(settings_for_assert.snapshot().attribution_enabled());
 
         let store_token = built
             .handles
@@ -1709,6 +1751,16 @@ mod tests {
         assert!(
             ids.iter()
                 .any(|cap| cap.capability_id() == "loop_detection")
+        );
+    }
+
+    #[test]
+    fn coding_harness_enables_yolop_attribution() {
+        let ids = coding_harness_capabilities();
+
+        assert!(
+            ids.iter()
+                .any(|cap| cap.capability_id() == ATTRIBUTION_CAPABILITY_ID)
         );
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,5 +1,5 @@
-// Persistent yolop settings — preferred provider plus optional per-provider
-// API tokens.
+// Persistent yolop settings — preferred provider, optional per-provider
+// API tokens, and small behavior toggles.
 //
 // Stored at `<config_dir>/yolop/settings.toml` (`~/.config/yolop/settings.toml`
 // on Linux). The `/setup` capability writes through `SettingsStore` so user
@@ -19,10 +19,21 @@ use std::sync::Mutex;
 use toml::Table;
 use toml::Value;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct Settings {
     pub provider: Option<String>,
     pub tokens: BTreeMap<String, String>,
+    pub attribution: bool,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            provider: None,
+            tokens: BTreeMap::new(),
+            attribution: true,
+        }
+    }
 }
 
 impl Settings {
@@ -31,6 +42,10 @@ impl Settings {
             .get("provider")
             .and_then(Value::as_str)
             .map(str::to_string);
+        let attribution = table
+            .get("attribution")
+            .and_then(Value::as_bool)
+            .unwrap_or(true);
         let mut tokens = BTreeMap::new();
         if let Some(t) = table.get("tokens").and_then(Value::as_table) {
             for (k, v) in t {
@@ -39,13 +54,20 @@ impl Settings {
                 }
             }
         }
-        Self { provider, tokens }
+        Self {
+            provider,
+            tokens,
+            attribution,
+        }
     }
 
     pub fn to_table(&self) -> Table {
         let mut table = Table::new();
         if let Some(p) = &self.provider {
             table.insert("provider".to_string(), Value::String(p.clone()));
+        }
+        if !self.attribution {
+            table.insert("attribution".to_string(), Value::Boolean(false));
         }
         if !self.tokens.is_empty() {
             let mut tokens_table = Table::new();
@@ -63,6 +85,10 @@ impl Settings {
 
     pub fn has_token(&self, provider: &str) -> bool {
         self.tokens.contains_key(provider)
+    }
+
+    pub fn attribution_enabled(&self) -> bool {
+        self.attribution
     }
 }
 
@@ -160,6 +186,12 @@ impl SettingsStore {
         save_to(&self.path, &guard)
     }
 
+    pub fn set_attribution(&self, enabled: bool) -> Result<()> {
+        let mut guard = self.inner.lock().expect("settings lock poisoned");
+        guard.attribution = enabled;
+        save_to(&self.path, &guard)
+    }
+
     pub fn set_token(&self, provider: String, token: String) -> Result<()> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
         guard.tokens.insert(provider, token);
@@ -197,6 +229,31 @@ mod tests {
 
         let reloaded = SettingsStore::open(path);
         assert_eq!(reloaded.snapshot().provider.as_deref(), Some("anthropic"));
+    }
+
+    #[test]
+    fn attribution_defaults_to_enabled() {
+        let settings = Settings::from_table(&Table::new());
+
+        assert!(settings.attribution_enabled());
+        assert!(!settings.to_table().contains_key("attribution"));
+    }
+
+    #[test]
+    fn attribution_can_be_disabled_via_disk() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join("settings.toml");
+        let store = SettingsStore::open(path.clone());
+        store.set_attribution(false).expect("save");
+
+        let on_disk = std::fs::read_to_string(&path).expect("read");
+        assert!(
+            on_disk.contains("attribution = false"),
+            "expected attribution setting, got: {on_disk}"
+        );
+
+        let reloaded = SettingsStore::open(path);
+        assert!(!reloaded.snapshot().attribution_enabled());
     }
 
     #[test]


### PR DESCRIPTION
## What
Add a default-on attribution setting for yolop-generated git and GitHub work.

## Why
Users should be able to keep the attribution behavior enabled by default while opting out when they do not want commit trailers or PR footer guidance.

## How
- Add an `attribution` boolean to `settings.toml`, defaulting to enabled and only writing `attribution = false` when disabled.
- Add `/setup attribution on|off|status` handling.
- Move attribution guidance into a settings-backed capability so future turns respect the current setting.
- Document the toggle in `README.md` and cover defaults, persistence, command handling, and prompt injection in tests.

## Risk
- Low
- The main risk is prompt behavior drift: attribution guidance is now conditional rather than always present. Tests cover the enabled and disabled paths.

## Security
- TM-FS: settings writes continue through the existing atomic `SettingsStore` path and owner-only permissions; no filesystem blocklist behavior changed.
- TM-BASH: no shell tool behavior changed; timeout, output cap, and approval gate are untouched.
- TM-LLM: attribution text is a static prompt contribution gated by a boolean setting; no secrets are added to prompts or logs.
- TM-TOOL: the new capability only contributes prompt text and exposes no tools; `/setup attribution` validates on/off input before persisting.
- TM-DEP: no dependency changes.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"`
- Attempted `doppler run -- cargo run -- --provider openai -p "Reply with exactly: ok"`, but local Doppler is not configured for a project and has no fallback file.
- Attempted `cargo build --release`, but the local disk is full (`No space left on device`) after the dependency build started; CI should provide clean build coverage.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
