### PR TITLE
test(tui): isolate multiline composer shortcut

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4037,6 +4037,7 @@ mod tests {
     async fn modified_enter_inserts_newline_without_submitting() {
         let mut fixture = app_with_llmsim().await;
         let app = &mut fixture.app;
+        app.setup = None;
 
         for key in [
             KeyEvent::new(KeyCode::Char('a'), KeyModifiers::empty()),


### PR DESCRIPTION
## What
Fix the multiline shortcut test fixture on current `main` by disabling first-run setup before exercising composer key handling.

## Why
Main CI failed after PR #40 merged because the newer setup overlay state consumed the first typed character in `modified_enter_inserts_newline_without_submitting`, making the test assert `b\nc` instead of `a\nb\nc`.

## How
Set `app.setup = None` in the focused test, matching other composer-only tests that bypass setup state. Runtime behavior is unchanged.

## Risk
- Low
- Test-only fixture change.

## Security
No security-relevant code changes. This is a test-only state isolation fix and does not alter runtime filesystem, shell, provider-key, capability, dependency, or terminal behavior.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)