### PR TITLE
test(tui): isolate multiline shortcut test

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4037,6 +4037,7 @@ mod tests {
     async fn modified_enter_inserts_newline_without_submitting() {
         let mut fixture = app_with_llmsim().await;
         let app = &mut fixture.app;
+        app.setup = None;
 
         for key in [
             KeyEvent::new(KeyCode::Char('a'), KeyModifiers::empty()),


### PR DESCRIPTION
## What
Fix the multiline shortcut test that failed on `main` after PR #41 merged.

## Why
The test exercises normal composer input, but the test fixture starts with setup mode active. The first typed character was consumed by setup handling, so main CI failed with `left: "b\nc"` vs `right: "a\nb\nc"`.

## How
Explicitly disable setup mode in `modified_enter_inserts_newline_without_submitting`, matching the other composer-input tests that need normal input routing.

## Risk
- Low
- Test-only change. It narrows the test fixture state to the behavior under test.

## Security
No security-relevant code changes; this only adjusts a unit test fixture state.

## Validation
- `cargo fmt --check`
- `cargo test modified_enter_inserts_newline_without_submitting`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
