### PR TITLE
fix(setup): avoid recommending OpenAI

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -186,7 +186,7 @@ const PROVIDER_OPTIONS: &[ProviderOption] = &[
     ProviderOption {
         name: "openai",
         label: "OpenAI",
-        hint: "recommended",
+        hint: "GPT models",
     },
     ProviderOption {
         name: "anthropic",
@@ -4114,6 +4114,10 @@ mod tests {
         assert!(
             rows.iter().any(|line| line.contains("OpenAI")),
             "provider choices should be visible: {rows:?}"
+        );
+        assert!(
+            !rows.iter().any(|line| line.contains("recommended")),
+            "setup should not recommend a specific provider: {rows:?}"
         );
         assert!(
             rows.iter().any(|line| line.contains("Offline demo mode")),


### PR DESCRIPTION
## What
Updates the setup provider picker so OpenAI is described neutrally as `GPT models` instead of `recommended`.

## Why
The setup flow should not steer users toward one provider by labeling OpenAI as recommended.

## How
Changed the OpenAI provider hint text and added a regression assertion that the setup overlay does not render `recommended`.

## Risk
- Low
- User-visible setup copy changes only; provider selection behavior is unchanged.

## Security
Reviewed TM-FS, TM-BASH, TM-LLM, TM-TOOL, and TM-DEP. No filesystem access, shell execution, secret handling, capability registration, or dependency paths changed. No new data exposure or injection surface was introduced.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"`
- Attempted local Doppler live smoke with `doppler run -- cargo run -- --provider openai -p "hi"`; local Doppler is not configured with a project/fallback file. The PR CI `Live OpenAI Smoke (Doppler)` job should provide the required live-provider proof.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
