### PR TITLE
feat(acp): add Agent Client Protocol support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5428,6 +5428,7 @@ dependencies = [
  "portable-pty",
  "ratatui",
  "ratatui-textarea",
+ "serde",
  "serde_json",
  "similar 3.1.1",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ dirs = "6"
 include_dir = "0.7"
 ratatui = "0.30"
 ratatui-textarea = "0.9.1"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 similar = "3"
 toml = "1"

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ session    session_019e3db018a17450aba5407af5777237 (folder: …; log: …)
   opens the model picker directly, `/model <id>` opens it prefilled, and
   `/effort [level]` opens the OpenAI reasoning-effort picker.
 - **`--print`** one-shot mode for CI smoke tests.
+- **`--acp`** — speak the [Agent Client Protocol](https://agentclientprotocol.com)
+  over stdio so editors such as Zed can drive yolop as an external agent:
+  streaming message/thought chunks, tool calls, plans, and editor-mediated
+  permission prompts. See [`specs/acp.md`](./specs/acp.md).
 - **Session persistence** — durable per-session JSONL event log under the
   platform-native user data directory, with `--session <id>` to resume.
 - **Git attribution** — enabled by default and configurable. When yolop creates
@@ -162,6 +166,35 @@ Local Ollama:
 OLLAMA_BASE_URL=http://localhost:11434/v1 yolop --provider ollama -m llama3.2 -p "hi"
 ```
 
+## Editor integration (ACP)
+
+yolop implements the agent side of the [Agent Client
+Protocol](https://agentclientprotocol.com), so any ACP-compatible editor can
+drive it. Launch it with `--acp` and it speaks newline-delimited JSON-RPC 2.0
+over stdin/stdout (logs still go to stderr). The editor performs the
+`initialize` handshake, opens a session with `session/new`, and sends turns
+with `session/prompt`; yolop streams the turn back as `session/update`
+notifications (assistant text, reasoning, tool calls, plans) and asks the
+editor to approve destructive operations via `session/request_permission`.
+
+In Zed, add a custom agent server to `~/.config/zed/settings.json`:
+
+```json
+{
+  "agent_servers": {
+    "yolop": {
+      "command": "yolop",
+      "args": ["--acp"],
+      "env": { "OPENAI_API_KEY": "sk-..." }
+    }
+  }
+}
+```
+
+Then pick **yolop** in Zed's agent panel. The working directory and per-turn
+prompts come from the editor. See [`specs/acp.md`](./specs/acp.md) for the
+full protocol surface, mappings, and current limitations.
+
 ## Flags
 
 | Flag                       | Description                                                          |
@@ -170,6 +203,7 @@ OLLAMA_BASE_URL=http://localhost:11434/v1 yolop --provider ollama -m llama3.2 -p
 | `--provider <P>`           | Force `anthropic`, `openai`, `google`, `openrouter`, `ollama`, or `llmsim` |
 | `-m, --model <ID>`         | Override the model id for the chosen provider                        |
 | `-p, --print <PROMPT>`     | Run one prompt non-interactively and print the result                |
+| `--acp`                    | Speak the Agent Client Protocol over stdio (for editors like Zed)    |
 | `--ask`                    | Prompt before every destructive tool call (off by default)           |
 | `--session <ID>`           | Resume a previous session by id                                      |
 | `--session-dir <PATH>`     | Override the parent directory for session folders                    |

--- a/specs/acp.md
+++ b/specs/acp.md
@@ -1,0 +1,154 @@
+# ACP — Agent Client Protocol support
+
+Status: v1 implemented (agent side, stdio transport).
+
+## Why
+
+Yolop is a terminal agent, but the same agent loop is useful *inside* an
+editor. The [Agent Client Protocol](https://agentclientprotocol.com) (ACP) is
+the open, editor-neutral protocol — created by Zed — that lets a code editor
+(the **client**) drive an external coding agent (the **agent**) over stdio.
+Implementing the agent side means yolop drops into Zed (and any other ACP
+client) with no bespoke integration: the editor renders the conversation, tool
+calls, plans, and diffs in its own UI while yolop does the work.
+
+This is a promotion target for the same runtime that powers the TUI and
+`--print` mode — one agent, three front ends (TUI, one-shot, ACP).
+
+## What — scope of the layer
+
+`yolop --acp` turns the process into an ACP agent speaking **newline-delimited
+JSON-RPC 2.0** over stdin/stdout (one compact JSON object per line, no embedded
+newlines). Tracing still goes to stderr, so stdout stays a clean protocol
+channel.
+
+ACP protocol version: **1** (integer).
+
+### Lifecycle
+
+| Method | Direction | Behaviour |
+|--------|-----------|-----------|
+| `initialize` | client → agent | Negotiates protocol version and advertises agent capabilities. Echoes the client's version when supported, else advertises v1. |
+| `authenticate` | client → agent | No-op success: credentials come from the environment/settings the process already inherits, so `authMethods` is empty. |
+| `session/new` | client → agent | Builds a fresh runtime rooted at the client-supplied `cwd`; returns the everruns session id as the ACP `sessionId`. |
+| `session/prompt` | client → agent | Runs one turn, streams `session/update`s, and resolves a `stopReason`. |
+| `session/cancel` | client → agent | Notification. Abandons the in-flight turn for that session and resolves the prompt with `stopReason: "cancelled"`. |
+| `session/update` | agent → client | Notification. Streams the turn (see below). |
+| `session/request_permission` | agent → client | Asks the editor to approve a destructive operation (see Permissions). |
+
+`session/load` is **not** implemented: `loadSession` is advertised as `false`.
+Each ACP session builds its own runtime; prior ACP sessions are not rehydrated.
+(Yolop's own JSONL session logs are still written under the session dir and can
+be resumed by the CLI with `--session`.)
+
+### Streaming a turn
+
+While a turn runs, runtime events are translated into `session/update`
+notifications. The mapping is a pure, per-turn state machine
+(`acp::bridge::Translator`) so it is fully unit-testable:
+
+| Runtime event | ACP update |
+|---------------|-----------|
+| assistant text delta | `agent_message_chunk` (incremental) |
+| completed assistant message, when no deltas streamed | `agent_message_chunk` (whole text) — covers providers that don't stream |
+| thinking delta / reasoning summary | `agent_thought_chunk` |
+| tool started | `tool_call` (`status: in_progress`, mapped `kind`, `rawInput`) |
+| tool completed | `tool_call_update` (`status: completed`/`failed`, summary `content`) |
+| `write_todos` tool | `plan` (entries with status) instead of a raw tool call |
+
+Tool `kind` is mapped from the tool name (read/search/edit/delete/execute/fetch,
+else `other`). To avoid duplicating streamed text, a completed assistant message
+is only emitted as a chunk when no deltas streamed for it during the turn.
+
+### Stop reasons
+
+`session/prompt` resolves with:
+
+- `end_turn` — the turn completed (success, or a recoverable failure whose
+  error text is also streamed as an `agent_message_chunk`).
+- `cancelled` — a `session/cancel` arrived, or the turn task was dropped.
+
+The runtime does not expose token-limit or refusal outcomes distinctly, so
+`max_tokens`, `max_turn_requests`, and `refusal` are not currently produced.
+
+### Permissions
+
+Destructive operations (file writes, deletes, `bash`) flow through yolop's
+existing `ApprovalGate`. In ACP mode the gate is wired to the client: each
+request becomes a `session/request_permission` call offering **Allow** /
+**Reject** (`allow_once` / `reject_once`). The editor owns the human, which is
+the idiomatic ACP design. A `selected` "allow" proceeds; `reject`, `cancelled`,
+a malformed response, or a transport error all **deny** (fail-closed), matching
+the channel gate's existing semantics.
+
+## Architecture
+
+```
+src/acp/
+  mod.rs        # module root: production RuntimeFactory, run_stdio entry, e2e tests
+  protocol.rs   # serde types for the ACP wire format (camelCase fields, snake_case discriminators)
+  bridge.rs     # pure runtime-event → session/update translation (Translator)
+  server.rs     # JSON-RPC peer, dispatch, session map, turn streaming, permission bridge
+```
+
+Concurrency model in `server::serve`:
+
+- A single **writer task** serialises every outbound line so responses,
+  notifications, and agent→client requests never interleave.
+- The **read loop** never blocks on slow work — `session/prompt` runs in its own
+  task — so `session/cancel` and permission responses keep flowing during a
+  turn.
+- Agent→client requests (`session/request_permission`) are correlated by id
+  through a pending-response table the read loop resolves.
+
+`serve` is generic over the byte streams and a `RuntimeFactory`, so the binary
+wires it to real stdin/stdout with a provider-backed factory while tests drive
+it over `tokio::io::duplex` pipes with a scripted llmsim runtime.
+
+## Testing
+
+Three layers, all offline (no API key):
+
+1. **Wire types** (`protocol.rs`) — serde round-trips assert exact field casing
+   and discriminator values against the published schema.
+2. **Translation** (`bridge.rs`) — the `Translator` is exercised per event type
+   (deltas, tool lifecycle, todos→plan, dedup, streamed-vs-completed).
+3. **End-to-end** (`mod.rs`) — a real `serve` loop over duplex pipes driven by
+   an in-memory ACP client: the full `initialize` → `session/new` →
+   `session/prompt` handshake, unknown-method and unknown-session errors,
+   scripted tool calls (asserting `tool_call`/`tool_call_update` + permission
+   grant), and `write_todos` → `plan`.
+
+The binary itself is smoke-tested over real OS pipes in
+`tests/integration.rs` (`acp_stdio_handshake_smoke`), and a `#[ignore]`d
+real-provider test documents the live path.
+
+### Real-life testing in an editor
+
+Configure Zed to launch yolop as a custom agent (`~/.config/zed/settings.json`):
+
+```json
+{
+  "agent_servers": {
+    "yolop": {
+      "command": "yolop",
+      "args": ["--acp"],
+      "env": { "OPENAI_API_KEY": "sk-..." }
+    }
+  }
+}
+```
+
+Then pick **yolop** in Zed's agent panel. Any ACP-compatible client works the
+same way.
+
+## Non-goals (for now)
+
+- `session/load` / ACP session rehydration.
+- Client-provided filesystem (`fs/read_text_file`, `fs/write_text_file`):
+  yolop's runtime reads and writes the host disk directly under the workspace
+  root, so it does not route file ops back through the client.
+- Terminals, MCP-server pass-through, audio/image prompt content, and slash
+  commands (`available_commands_update`).
+- In-flight turn interruption beyond abandoning the task — the runtime has no
+  mid-turn cancellation hook yet.

--- a/src/acp/bridge.rs
+++ b/src/acp/bridge.rs
@@ -1,0 +1,449 @@
+//! Translation from everruns runtime events into ACP `session/update`s.
+//!
+//! The runtime emits a rich event stream (reasoning deltas, message deltas,
+//! tool lifecycle, todo writes). ACP wants a narrower vocabulary: assistant
+//! message chunks, thought chunks, tool calls, tool-call updates, and plans.
+//! [`Translator`] is the pure, per-turn state machine that performs that
+//! mapping. Keeping it free of I/O is what makes the wire behaviour fully
+//! unit-testable without a live model.
+
+use std::collections::HashSet;
+
+use everruns_core::events::{Event as RuntimeEvent, EventData, ToolCompletedData};
+use everruns_core::message::{ContentPart, MessageRole};
+use serde_json::Value;
+
+use super::protocol::{
+    ContentBlock, PlanEntry, PlanPriority, PlanStatus, SessionUpdate, ToolCallContent,
+    ToolCallStatus, ToolKind,
+};
+
+/// The runtime's todo tool. write_todos updates are surfaced as ACP plans
+/// rather than opaque tool calls so editors render them in their plan UI.
+const WRITE_TODOS: &str = "write_todos";
+
+/// Per-turn translator. Construct one per `session/prompt` so the
+/// per-message streaming flag and event-dedup set reset between turns.
+#[derive(Default)]
+pub struct Translator {
+    /// Whether the in-flight assistant message has streamed any delta. When
+    /// a provider streams (Anthropic), we forward deltas and suppress the
+    /// terminal full-text chunk to avoid duplication. When it does not
+    /// (fixed llmsim, some OpenAI paths), we synthesise one chunk from the
+    /// completed message instead.
+    current_message_streamed: bool,
+    /// Event ids already translated. The runtime can redeliver the same
+    /// event across the live broadcast and the catch-up drain; dedup keeps
+    /// the client from seeing doubles.
+    seen: HashSet<String>,
+}
+
+impl Translator {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Translate a single runtime event into zero or more ACP updates.
+    /// Returns an empty vec for events with no client-visible mapping.
+    pub fn on_event(&mut self, event: &RuntimeEvent) -> Vec<SessionUpdate> {
+        if !self.seen.insert(event.id.to_string()) {
+            return Vec::new();
+        }
+        match &event.data {
+            EventData::OutputMessageStarted(_) => {
+                self.current_message_streamed = false;
+                Vec::new()
+            }
+            EventData::OutputMessageDelta(data) => {
+                if data.delta.is_empty() {
+                    return Vec::new();
+                }
+                self.current_message_streamed = true;
+                vec![SessionUpdate::AgentMessageChunk {
+                    content: ContentBlock::text(&data.delta),
+                }]
+            }
+            EventData::OutputMessageCompleted(data) => {
+                if self.current_message_streamed {
+                    return Vec::new();
+                }
+                if data.message.role != MessageRole::Agent || data.message.has_tool_calls() {
+                    return Vec::new();
+                }
+                match data.message.text().map(str::trim) {
+                    Some(text) if !text.is_empty() => vec![SessionUpdate::AgentMessageChunk {
+                        content: ContentBlock::text(text),
+                    }],
+                    _ => Vec::new(),
+                }
+            }
+            EventData::ReasonThinkingDelta(data) => {
+                if data.delta.is_empty() {
+                    return Vec::new();
+                }
+                vec![SessionUpdate::AgentThoughtChunk {
+                    content: ContentBlock::text(&data.delta),
+                }]
+            }
+            EventData::ReasonItem(data) => data
+                .summary
+                .iter()
+                .filter_map(|segment| {
+                    let trimmed = segment.trim();
+                    (!trimmed.is_empty()).then(|| SessionUpdate::AgentThoughtChunk {
+                        content: ContentBlock::text(trimmed),
+                    })
+                })
+                .collect(),
+            EventData::ToolStarted(data) => {
+                let name = data.tool_call.name.as_str();
+                if name == WRITE_TODOS {
+                    return plan_from_value(&data.tool_call.arguments)
+                        .map(|entries| vec![SessionUpdate::Plan { entries }])
+                        .unwrap_or_default();
+                }
+                let title = data
+                    .narration
+                    .as_deref()
+                    .or(data.display_name.as_deref())
+                    .unwrap_or(name)
+                    .to_string();
+                vec![SessionUpdate::ToolCall {
+                    tool_call_id: data.tool_call.id.clone(),
+                    title,
+                    kind: tool_kind(name),
+                    status: ToolCallStatus::InProgress,
+                    raw_input: non_null(data.tool_call.arguments.clone()),
+                    content: Vec::new(),
+                }]
+            }
+            EventData::ToolCompleted(data) => {
+                if data.tool_name == WRITE_TODOS {
+                    // The result echoes the authoritative todo list with
+                    // updated statuses; re-emit the plan so the client's view
+                    // reflects completion.
+                    return result_value(data)
+                        .as_ref()
+                        .and_then(plan_from_value)
+                        .map(|entries| vec![SessionUpdate::Plan { entries }])
+                        .unwrap_or_default();
+                }
+                let status = if data.success {
+                    ToolCallStatus::Completed
+                } else {
+                    ToolCallStatus::Failed
+                };
+                let content = tool_result_content(data)
+                    .map(|block| vec![ToolCallContent::Content { content: block }])
+                    .unwrap_or_default();
+                vec![SessionUpdate::ToolCallUpdate {
+                    tool_call_id: data.tool_call_id.clone(),
+                    status: Some(status),
+                    content,
+                    raw_output: None,
+                }]
+            }
+            _ => Vec::new(),
+        }
+    }
+}
+
+/// Map a runtime tool name to an ACP tool kind so editors can pick the right
+/// affordance. Unknown tools fall back to `other`.
+fn tool_kind(name: &str) -> ToolKind {
+    match name {
+        "read_file" | "stat_file" | "list_directory" => ToolKind::Read,
+        "grep" | "grep_files" | "duckduckgo_search" => ToolKind::Search,
+        "edit_file" | "write_file" | "create_directory" => ToolKind::Edit,
+        "delete_file" => ToolKind::Delete,
+        "bash" => ToolKind::Execute,
+        "web_fetch" => ToolKind::Fetch,
+        _ => ToolKind::Other,
+    }
+}
+
+/// One concise text block summarising a finished tool call, or `None` when
+/// there is nothing worth surfacing.
+fn tool_result_content(data: &ToolCompletedData) -> Option<ContentBlock> {
+    let summary = crate::app::summarize_tool_result(data);
+    let trimmed = summary.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(ContentBlock::text(trimmed))
+    }
+}
+
+/// Parse the runtime's `{ "todos": [...] }` shape (used by both the
+/// write_todos arguments and its result) into ACP plan entries.
+fn plan_from_value(value: &Value) -> Option<Vec<PlanEntry>> {
+    let todos = value.get("todos")?.as_array()?;
+    let entries = todos
+        .iter()
+        .filter_map(|todo| {
+            let content = todo.get("content").and_then(Value::as_str)?;
+            if content.trim().is_empty() {
+                return None;
+            }
+            let status = match todo.get("status").and_then(Value::as_str) {
+                Some("completed") => PlanStatus::Completed,
+                Some("in_progress") => PlanStatus::InProgress,
+                _ => PlanStatus::Pending,
+            };
+            Some(PlanEntry {
+                content: content.to_string(),
+                priority: PlanPriority::Medium,
+                status,
+            })
+        })
+        .collect::<Vec<_>>();
+    Some(entries)
+}
+
+/// Decode the JSON payload a tool returned, if any. Mirrors the runtime's
+/// convention of stashing structured results as JSON text in the first
+/// content part.
+fn result_value(data: &ToolCompletedData) -> Option<Value> {
+    let parts = data.result.as_ref()?;
+    for part in parts {
+        if let ContentPart::Text(t) = part
+            && let Ok(v) = serde_json::from_str::<Value>(&t.text)
+        {
+            return Some(v);
+        }
+    }
+    None
+}
+
+fn non_null(value: Value) -> Option<Value> {
+    if value.is_null() { None } else { Some(value) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use everruns_core::events::{
+        Event, EventContext, OutputMessageCompletedData, OutputMessageDeltaData,
+        ReasonThinkingDeltaData, ToolCompletedData, ToolStartedData,
+    };
+    use everruns_core::message::Message;
+    use everruns_core::tool_types::ToolCall;
+    use everruns_core::typed_id::{EventId, SessionId, TurnId};
+    use serde_json::json;
+
+    fn event(data: EventData) -> Event {
+        Event {
+            id: EventId::new(),
+            event_type: data.event_type().to_string(),
+            ts: Utc::now(),
+            session_id: SessionId::new(),
+            context: EventContext::empty(),
+            data,
+            metadata: None,
+            tags: None,
+            sequence: None,
+        }
+    }
+
+    #[test]
+    fn streaming_deltas_become_message_chunks() {
+        let mut t = Translator::new();
+        let updates = t.on_event(&event(EventData::OutputMessageDelta(
+            OutputMessageDeltaData {
+                turn_id: TurnId::new(),
+                delta: "Hel".into(),
+                accumulated: "Hel".into(),
+            },
+        )));
+        assert_eq!(
+            updates,
+            vec![SessionUpdate::AgentMessageChunk {
+                content: ContentBlock::text("Hel")
+            }]
+        );
+    }
+
+    #[test]
+    fn completed_message_suppressed_after_streaming() {
+        let mut t = Translator::new();
+        let _ = t.on_event(&event(EventData::OutputMessageDelta(
+            OutputMessageDeltaData {
+                turn_id: TurnId::new(),
+                delta: "Hi".into(),
+                accumulated: "Hi".into(),
+            },
+        )));
+        let completed = t.on_event(&event(EventData::OutputMessageCompleted(
+            OutputMessageCompletedData {
+                message: Message::assistant("Hi"),
+                metadata: None,
+                usage: None,
+                error_code: None,
+                error_fields: None,
+            },
+        )));
+        assert!(
+            completed.is_empty(),
+            "streamed text must not be re-sent: {completed:?}"
+        );
+    }
+
+    #[test]
+    fn completed_message_synthesised_when_not_streamed() {
+        let mut t = Translator::new();
+        let updates = t.on_event(&event(EventData::OutputMessageCompleted(
+            OutputMessageCompletedData {
+                message: Message::assistant("full answer"),
+                metadata: None,
+                usage: None,
+                error_code: None,
+                error_fields: None,
+            },
+        )));
+        assert_eq!(
+            updates,
+            vec![SessionUpdate::AgentMessageChunk {
+                content: ContentBlock::text("full answer")
+            }]
+        );
+    }
+
+    #[test]
+    fn thinking_deltas_become_thought_chunks() {
+        let mut t = Translator::new();
+        let updates = t.on_event(&event(EventData::ReasonThinkingDelta(
+            ReasonThinkingDeltaData {
+                turn_id: TurnId::new(),
+                delta: "pondering".into(),
+                accumulated: "pondering".into(),
+            },
+        )));
+        assert_eq!(
+            updates,
+            vec![SessionUpdate::AgentThoughtChunk {
+                content: ContentBlock::text("pondering")
+            }]
+        );
+    }
+
+    #[test]
+    fn tool_started_maps_kind_and_in_progress_status() {
+        let mut t = Translator::new();
+        let updates = t.on_event(&event(EventData::ToolStarted(ToolStartedData {
+            tool_call: ToolCall {
+                id: "call_1".into(),
+                name: "bash".into(),
+                arguments: json!({ "command": "ls" }),
+            },
+            tool_call_fingerprint: None,
+            display_name: Some("Bash".into()),
+            narration: Some("Listing files".into()),
+        })));
+        assert_eq!(
+            updates,
+            vec![SessionUpdate::ToolCall {
+                tool_call_id: "call_1".into(),
+                title: "Listing files".into(),
+                kind: ToolKind::Execute,
+                status: ToolCallStatus::InProgress,
+                raw_input: Some(json!({ "command": "ls" })),
+                content: vec![],
+            }]
+        );
+    }
+
+    #[test]
+    fn tool_completed_failure_maps_to_failed_status() {
+        let mut t = Translator::new();
+        let updates = t.on_event(&event(EventData::ToolCompleted(ToolCompletedData {
+            tool_call_id: "call_1".into(),
+            tool_name: "bash".into(),
+            tool_call_fingerprint: None,
+            tool_result_fingerprint: None,
+            display_name: None,
+            success: false,
+            status: "error".into(),
+            result: None,
+            error: Some("boom".into()),
+            duration_ms: None,
+            capability_id: None,
+            capability_name: None,
+            narration: None,
+        })));
+        assert_eq!(updates.len(), 1);
+        match &updates[0] {
+            SessionUpdate::ToolCallUpdate {
+                tool_call_id,
+                status,
+                content,
+                ..
+            } => {
+                assert_eq!(tool_call_id, "call_1");
+                assert_eq!(*status, Some(ToolCallStatus::Failed));
+                assert_eq!(
+                    content,
+                    &vec![ToolCallContent::Content {
+                        content: ContentBlock::text("error: boom")
+                    }]
+                );
+            }
+            other => panic!("expected tool_call_update, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn write_todos_started_becomes_plan() {
+        let mut t = Translator::new();
+        let updates = t.on_event(&event(EventData::ToolStarted(ToolStartedData {
+            tool_call: ToolCall {
+                id: "call_todos".into(),
+                name: "write_todos".into(),
+                arguments: json!({
+                    "todos": [
+                        { "content": "first", "status": "completed" },
+                        { "content": "second", "status": "in_progress" },
+                        { "content": "third", "status": "pending" },
+                    ]
+                }),
+            },
+            tool_call_fingerprint: None,
+            display_name: None,
+            narration: None,
+        })));
+        assert_eq!(
+            updates,
+            vec![SessionUpdate::Plan {
+                entries: vec![
+                    PlanEntry {
+                        content: "first".into(),
+                        priority: PlanPriority::Medium,
+                        status: PlanStatus::Completed,
+                    },
+                    PlanEntry {
+                        content: "second".into(),
+                        priority: PlanPriority::Medium,
+                        status: PlanStatus::InProgress,
+                    },
+                    PlanEntry {
+                        content: "third".into(),
+                        priority: PlanPriority::Medium,
+                        status: PlanStatus::Pending,
+                    },
+                ]
+            }]
+        );
+    }
+
+    #[test]
+    fn duplicate_event_id_is_ignored() {
+        let mut t = Translator::new();
+        let ev = event(EventData::OutputMessageDelta(OutputMessageDeltaData {
+            turn_id: TurnId::new(),
+            delta: "x".into(),
+            accumulated: "x".into(),
+        }));
+        assert_eq!(t.on_event(&ev).len(), 1);
+        assert_eq!(t.on_event(&ev).len(), 0, "second delivery must be ignored");
+    }
+}

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -1,0 +1,418 @@
+//! Agent Client Protocol (ACP) support.
+//!
+//! ACP lets editors such as Zed drive yolop as an external agent over stdio
+//! using newline-delimited JSON-RPC 2.0. Run it with `yolop --acp`; the editor
+//! spawns that process, performs the `initialize` handshake, opens sessions
+//! with `session/new`, and sends turns with `session/prompt`. yolop streams the
+//! turn back as `session/update` notifications and delegates destructive-action
+//! approval to the editor via `session/request_permission`.
+//!
+//! See `specs/acp.md` for the full surface and `README.md` for editor setup.
+//!
+//! Module layout:
+//!   * [`protocol`] — serde types for the ACP wire format.
+//!   * [`bridge`] — pure translation of runtime events into `session/update`s.
+//!   * [`server`] — the JSON-RPC peer, dispatch, and turn streaming.
+
+mod bridge;
+mod protocol;
+mod server;
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::approval::ApprovalGate;
+use crate::runtime::{self, BuiltRuntime, ProviderChoice};
+use crate::settings::SettingsStore;
+
+pub use server::{RuntimeFactory, serve};
+
+/// Production [`RuntimeFactory`]: builds a real provider-backed runtime rooted
+/// at the client-supplied `cwd` for each `session/new`. The provider, settings,
+/// and session-log directory come from the CLI invocation and are shared
+/// across every session the client opens.
+struct ConfigRuntimeFactory {
+    provider: ProviderChoice,
+    settings: Arc<SettingsStore>,
+    sessions_dir: PathBuf,
+}
+
+#[async_trait]
+impl RuntimeFactory for ConfigRuntimeFactory {
+    async fn build(&self, cwd: PathBuf, gate: Arc<ApprovalGate>) -> Result<BuiltRuntime> {
+        runtime::build(
+            cwd,
+            self.provider.clone(),
+            gate,
+            None,
+            self.sessions_dir.clone(),
+            self.settings.clone(),
+        )
+        .await
+    }
+}
+
+/// Serve the ACP agent over this process's stdin/stdout until the client
+/// disconnects. Tracing still writes to stderr, keeping stdout clean for the
+/// protocol.
+pub async fn run_stdio(
+    provider: ProviderChoice,
+    settings: Arc<SettingsStore>,
+    sessions_dir: PathBuf,
+) -> Result<()> {
+    let factory = Arc::new(ConfigRuntimeFactory {
+        provider,
+        settings,
+        sessions_dir,
+    });
+    serve(tokio::io::stdin(), tokio::io::stdout(), factory).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::{BuildOptions, build_with_options};
+    use everruns_core::llmsim_driver::{LlmSimConfig, SimToolCall, SimTurn};
+    use serde_json::{Value, json};
+    use std::time::Duration;
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, DuplexStream, Lines};
+
+    /// Scripted [`RuntimeFactory`] for tests: each session gets its own
+    /// offline llmsim runtime rooted at the supplied `cwd`. The session-log
+    /// directory is a kept tempdir (OS cleans `/tmp`) so it outlives the
+    /// runtime, which canonicalizes and retains its paths.
+    struct ScriptedFactory {
+        config: LlmSimConfig,
+    }
+
+    #[async_trait]
+    impl RuntimeFactory for ScriptedFactory {
+        async fn build(&self, cwd: PathBuf, gate: Arc<ApprovalGate>) -> Result<BuiltRuntime> {
+            let sessions = tempfile::tempdir().expect("sessions tempdir").keep();
+            let settings = Arc::new(SettingsStore::open(sessions.join("settings.toml")));
+            build_with_options(
+                cwd,
+                ProviderChoice::Sim,
+                gate,
+                None,
+                sessions,
+                settings,
+                BuildOptions {
+                    llmsim_override: Some(self.config.clone().with_model("llmsim-yolop")),
+                },
+            )
+            .await
+        }
+    }
+
+    /// In-memory ACP client driving the agent over a pair of duplex pipes.
+    struct TestClient {
+        writer: DuplexStream,
+        reader: Lines<BufReader<DuplexStream>>,
+        next_id: i64,
+        /// Notifications collected while waiting for responses.
+        notifications: Vec<Value>,
+        /// How the client answers `session/request_permission` requests.
+        permission_allow: bool,
+    }
+
+    impl TestClient {
+        /// Spawn `serve` against this scripted factory and return a connected
+        /// client. The server task runs until the client's write half drops.
+        fn spawn(config: LlmSimConfig, permission_allow: bool) -> Self {
+            let (client_w, agent_r) = tokio::io::duplex(64 * 1024);
+            let (agent_w, client_r) = tokio::io::duplex(64 * 1024);
+            let factory = Arc::new(ScriptedFactory { config });
+            tokio::spawn(async move {
+                let _ = serve(agent_r, agent_w, factory).await;
+            });
+            Self {
+                writer: client_w,
+                reader: BufReader::new(client_r).lines(),
+                next_id: 0,
+                notifications: Vec::new(),
+                permission_allow,
+            }
+        }
+
+        fn alloc_id(&mut self) -> i64 {
+            let id = self.next_id;
+            self.next_id += 1;
+            id
+        }
+
+        async fn send(&mut self, value: Value) {
+            let line = value.to_string();
+            self.writer.write_all(line.as_bytes()).await.unwrap();
+            self.writer.write_all(b"\n").await.unwrap();
+            self.writer.flush().await.unwrap();
+        }
+
+        async fn next_message(&mut self) -> Value {
+            let line = tokio::time::timeout(Duration::from_secs(15), self.reader.next_line())
+                .await
+                .expect("timed out waiting for agent message")
+                .expect("read agent line")
+                .expect("agent closed stream");
+            serde_json::from_str(&line).expect("agent line is valid json")
+        }
+
+        /// Send a request and pump messages until its response arrives.
+        /// Notifications are buffered; permission requests are auto-answered
+        /// per `permission_allow`.
+        async fn request(&mut self, method: &str, params: Value) -> Value {
+            let id = self.alloc_id();
+            self.send(json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "method": method,
+                "params": params,
+            }))
+            .await;
+            loop {
+                let message = self.next_message().await;
+                if message.get("id").and_then(Value::as_i64) == Some(id)
+                    && (message.get("result").is_some() || message.get("error").is_some())
+                {
+                    return message;
+                }
+                self.handle_incoming(message).await;
+            }
+        }
+
+        async fn handle_incoming(&mut self, message: Value) {
+            let method = message.get("method").and_then(Value::as_str);
+            match method {
+                Some("session/request_permission") => {
+                    let id = message.get("id").cloned().unwrap_or(Value::Null);
+                    let option_id = if self.permission_allow {
+                        "allow"
+                    } else {
+                        "reject"
+                    };
+                    self.send(json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": { "outcome": { "outcome": "selected", "optionId": option_id } },
+                    }))
+                    .await;
+                }
+                Some("session/update") => {
+                    self.notifications.push(message);
+                }
+                _ => {}
+            }
+        }
+
+        /// Collect every `session/update` whose `sessionUpdate` matches.
+        fn updates_of_kind(&self, kind: &str) -> Vec<Value> {
+            self.notifications
+                .iter()
+                .filter_map(|n| n.get("params"))
+                .filter(|p| {
+                    p.get("update")
+                        .and_then(|u| u.get("sessionUpdate"))
+                        .and_then(Value::as_str)
+                        == Some(kind)
+                })
+                .cloned()
+                .collect()
+        }
+
+        /// All assistant text streamed during the session, concatenated.
+        fn assistant_text(&self) -> String {
+            self.updates_of_kind("agent_message_chunk")
+                .iter()
+                .filter_map(|p| {
+                    p.get("update")
+                        .and_then(|u| u.get("content"))
+                        .and_then(|c| c.get("text"))
+                        .and_then(Value::as_str)
+                        .map(str::to_string)
+                })
+                .collect::<Vec<_>>()
+                .join("")
+        }
+
+        async fn initialize(&mut self) -> Value {
+            self.request(
+                "initialize",
+                json!({
+                    "protocolVersion": 1,
+                    "clientCapabilities": { "fs": { "readTextFile": true, "writeTextFile": true } },
+                }),
+            )
+            .await
+        }
+
+        async fn new_session(&mut self) -> String {
+            let cwd = tempfile::tempdir().expect("cwd tempdir").keep();
+            let response = self
+                .request(
+                    "session/new",
+                    json!({ "cwd": cwd.to_str().unwrap(), "mcpServers": [] }),
+                )
+                .await;
+            response["result"]["sessionId"]
+                .as_str()
+                .expect("sessionId in response")
+                .to_string()
+        }
+    }
+
+    fn fixed(text: &str) -> LlmSimConfig {
+        LlmSimConfig::fixed(text)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn initialize_advertises_protocol_version_and_capabilities() {
+        let mut client = TestClient::spawn(fixed("hi"), true);
+        let response = client.initialize().await;
+        assert_eq!(response["result"]["protocolVersion"], 1);
+        assert_eq!(
+            response["result"]["agentCapabilities"]["loadSession"],
+            false
+        );
+        assert_eq!(
+            response["result"]["agentCapabilities"]["promptCapabilities"]["embeddedContext"],
+            true
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn full_handshake_then_prompt_streams_text_and_ends_turn() {
+        let mut client = TestClient::spawn(fixed("hello from acp"), true);
+        client.initialize().await;
+        let session_id = client.new_session().await;
+
+        let response = client
+            .request(
+                "session/prompt",
+                json!({
+                    "sessionId": session_id,
+                    "prompt": [{ "type": "text", "text": "say hi" }],
+                }),
+            )
+            .await;
+
+        assert_eq!(response["result"]["stopReason"], "end_turn");
+        assert!(
+            client.assistant_text().contains("hello from acp"),
+            "expected streamed assistant text, got notifications: {:?}",
+            client.notifications
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn unknown_method_returns_method_not_found() {
+        let mut client = TestClient::spawn(fixed("hi"), true);
+        client.initialize().await;
+        let response = client.request("does/not/exist", json!({})).await;
+        assert_eq!(response["error"]["code"], -32601);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn prompt_to_unknown_session_is_invalid_params() {
+        let mut client = TestClient::spawn(fixed("hi"), true);
+        client.initialize().await;
+        let response = client
+            .request(
+                "session/prompt",
+                json!({ "sessionId": "session_does_not_exist", "prompt": [] }),
+            )
+            .await;
+        assert_eq!(response["error"]["code"], -32602);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn scripted_tool_call_streams_tool_updates_when_permission_granted() {
+        // First scripted turn writes a marker file via bash; second closes
+        // the loop with plain text. The bash write is gated through the
+        // approval channel, which the client grants.
+        let marker = "acp_tool_ran.marker";
+        let config = LlmSimConfig::scripted(vec![
+            SimTurn::ToolCalls(vec![SimToolCall {
+                name: "bash".to_string(),
+                arguments: json!({ "command": format!("touch {marker}") }),
+                id: None,
+            }]),
+            SimTurn::Assistant("tool done".to_string()),
+        ]);
+        let mut client = TestClient::spawn(config, true);
+        client.initialize().await;
+        let session_id = client.new_session().await;
+
+        let response = client
+            .request(
+                "session/prompt",
+                json!({
+                    "sessionId": session_id,
+                    "prompt": [{ "type": "text", "text": "run the tool" }],
+                }),
+            )
+            .await;
+
+        assert_eq!(response["result"]["stopReason"], "end_turn");
+        let tool_calls = client.updates_of_kind("tool_call");
+        assert!(
+            !tool_calls.is_empty(),
+            "expected a tool_call update, got: {:?}",
+            client.notifications
+        );
+        assert_eq!(
+            tool_calls[0]["update"]["kind"], "execute",
+            "bash should map to execute kind"
+        );
+        let updates = client.updates_of_kind("tool_call_update");
+        assert!(
+            updates.iter().any(|u| u["update"]["status"] == "completed"),
+            "expected a completed tool_call_update, got: {:?}",
+            client.notifications
+        );
+        assert!(client.assistant_text().contains("tool done"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn write_todos_tool_call_streams_plan_update() {
+        let config = LlmSimConfig::scripted(vec![
+            SimTurn::ToolCalls(vec![SimToolCall {
+                name: "write_todos".to_string(),
+                arguments: json!({
+                    "todos": [
+                        { "content": "step one", "status": "in_progress", "activeForm": "doing one" },
+                        { "content": "step two", "status": "pending", "activeForm": "doing two" },
+                    ]
+                }),
+                id: None,
+            }]),
+            SimTurn::Assistant("planned".to_string()),
+        ]);
+        let mut client = TestClient::spawn(config, true);
+        client.initialize().await;
+        let session_id = client.new_session().await;
+
+        client
+            .request(
+                "session/prompt",
+                json!({
+                    "sessionId": session_id,
+                    "prompt": [{ "type": "text", "text": "make a plan" }],
+                }),
+            )
+            .await;
+
+        let plans = client.updates_of_kind("plan");
+        assert!(
+            !plans.is_empty(),
+            "expected a plan update, got: {:?}",
+            client.notifications
+        );
+        let entries = plans[0]["update"]["entries"].as_array().unwrap();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0]["content"], "step one");
+        assert_eq!(entries[0]["status"], "in_progress");
+    }
+}

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -415,4 +415,104 @@ mod tests {
         assert_eq!(entries[0]["content"], "step one");
         assert_eq!(entries[0]["status"], "in_progress");
     }
+
+    /// Regression: if the client disconnects while an agent→client request is
+    /// in flight (a forwarded `session/request_permission` that never gets an
+    /// answer), `serve` must still return rather than deadlock on the awaiting
+    /// permission task. Without `fail_all_pending` + the fail-fast send in
+    /// `Peer::request`, this hangs forever.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn disconnect_during_permission_lets_serve_return() {
+        // First turn issues a bash tool call, which is gated and forwarded to
+        // the client as a permission request the client deliberately ignores.
+        let config = LlmSimConfig::scripted(vec![
+            SimTurn::ToolCalls(vec![SimToolCall {
+                name: "bash".to_string(),
+                arguments: json!({ "command": "true" }),
+                id: None,
+            }]),
+            SimTurn::Assistant("after".to_string()),
+        ]);
+
+        let (mut client_w, agent_r) = tokio::io::duplex(64 * 1024);
+        let (agent_w, client_r) = tokio::io::duplex(64 * 1024);
+        let factory = Arc::new(ScriptedFactory { config });
+        let server = tokio::spawn(async move { serve(agent_r, agent_w, factory).await });
+        let mut reader = BufReader::new(client_r).lines();
+
+        async fn send(w: &mut DuplexStream, value: Value) {
+            let line = value.to_string();
+            w.write_all(line.as_bytes()).await.unwrap();
+            w.write_all(b"\n").await.unwrap();
+            w.flush().await.unwrap();
+        }
+        async fn next(reader: &mut Lines<BufReader<DuplexStream>>) -> Value {
+            let line = tokio::time::timeout(Duration::from_secs(15), reader.next_line())
+                .await
+                .expect("timed out")
+                .expect("read line")
+                .expect("stream open");
+            serde_json::from_str(&line).expect("valid json")
+        }
+        async fn await_id(reader: &mut Lines<BufReader<DuplexStream>>, id: i64) -> Value {
+            loop {
+                let msg = next(reader).await;
+                if msg.get("id").and_then(Value::as_i64) == Some(id)
+                    && (msg.get("result").is_some() || msg.get("error").is_some())
+                {
+                    return msg;
+                }
+            }
+        }
+
+        send(
+            &mut client_w,
+            json!({ "jsonrpc": "2.0", "id": 0, "method": "initialize", "params": { "protocolVersion": 1 } }),
+        )
+        .await;
+        await_id(&mut reader, 0).await;
+
+        let cwd = tempfile::tempdir().expect("cwd tempdir").keep();
+        send(
+            &mut client_w,
+            json!({ "jsonrpc": "2.0", "id": 1, "method": "session/new", "params": { "cwd": cwd.to_str().unwrap() } }),
+        )
+        .await;
+        let session_id = await_id(&mut reader, 1).await["result"]["sessionId"]
+            .as_str()
+            .expect("sessionId")
+            .to_string();
+
+        // Send a prompt but never read its response: we want to disconnect
+        // mid-turn, while the permission request is outstanding.
+        send(
+            &mut client_w,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/prompt",
+                "params": { "sessionId": session_id, "prompt": [{ "type": "text", "text": "go" }] },
+            }),
+        )
+        .await;
+
+        // Wait until the agent forwards the permission request, then drop the
+        // client's write half to simulate a disconnect without answering it.
+        loop {
+            let msg = next(&mut reader).await;
+            if msg.get("method").and_then(Value::as_str) == Some("session/request_permission") {
+                break;
+            }
+        }
+        drop(client_w);
+        drop(reader);
+
+        // The server must wind down: the pending permission fails (deny), the
+        // tool errors, the turn finishes, and `serve` returns.
+        tokio::time::timeout(Duration::from_secs(10), server)
+            .await
+            .expect("serve must return after disconnect, not hang")
+            .expect("serve task joins")
+            .expect("serve returns Ok");
+    }
 }

--- a/src/acp/protocol.rs
+++ b/src/acp/protocol.rs
@@ -1,0 +1,482 @@
+//! Wire types for the Agent Client Protocol (ACP).
+//!
+//! ACP is the JSON-RPC 2.0 protocol spoken between a code editor (the
+//! *client*, e.g. Zed) and a coding agent (yolop, the *agent*) over stdio,
+//! one JSON object per line (newline-delimited). These structs map 1:1 to
+//! the schema published at <https://agentclientprotocol.com>. Only the
+//! subset yolop implements is modelled here; unknown fields on inbound
+//! messages are ignored so newer clients keep working.
+//!
+//! Field casing follows the spec exactly: object keys are camelCase and the
+//! `sessionUpdate` / `type` / `kind` / `status` discriminators are
+//! snake_case. The matching `#[serde(rename_all = ...)]` attributes encode
+//! that, so the Rust side stays idiomatic snake_case.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Protocol version yolop implements. ACP versions are integers; v1 is the
+/// current stable major. We echo back the client's requested version when it
+/// is one we support, and otherwise advertise this.
+pub const PROTOCOL_VERSION: i64 = 1;
+
+// ---------- initialize ----------
+
+/// Inbound `initialize` params. yolop only needs the requested protocol
+/// version; the client's capabilities (`clientCapabilities`, `clientInfo`)
+/// are accepted and ignored — serde drops unknown fields by default — because
+/// yolop's runtime touches the host disk directly rather than routing file
+/// ops back through the client.
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct InitializeParams {
+    #[serde(default)]
+    pub protocol_version: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InitializeResult {
+    pub protocol_version: i64,
+    pub agent_capabilities: AgentCapabilities,
+    pub auth_methods: Vec<AuthMethod>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCapabilities {
+    pub load_session: bool,
+    pub prompt_capabilities: PromptCapabilities,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PromptCapabilities {
+    pub image: bool,
+    pub audio: bool,
+    pub embedded_context: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthMethod {
+    pub id: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+// ---------- session/new ----------
+
+/// Inbound `session/new` params. yolop uses `cwd` to root the new runtime;
+/// `mcpServers` and `additionalDirectories` are accepted and ignored (no MCP
+/// pass-through yet — serde drops unmodelled fields).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NewSessionParams {
+    pub cwd: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NewSessionResult {
+    pub session_id: String,
+}
+
+// ---------- session/prompt ----------
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PromptParams {
+    pub session_id: String,
+    #[serde(default)]
+    pub prompt: Vec<Value>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PromptResult {
+    pub stop_reason: StopReason,
+}
+
+/// Why a prompt turn ended. Mirrors ACP's `StopReason`. yolop currently only
+/// resolves `EndTurn` and `Cancelled`; the token-limit and refusal variants
+/// exist to model the wire enum completely (the runtime doesn't surface those
+/// outcomes distinctly yet).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[allow(dead_code)]
+pub enum StopReason {
+    EndTurn,
+    MaxTokens,
+    MaxTurnRequests,
+    Refusal,
+    Cancelled,
+}
+
+// ---------- session/cancel ----------
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CancelParams {
+    pub session_id: String,
+}
+
+// ---------- session/update notification ----------
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionNotification {
+    pub session_id: String,
+    pub update: SessionUpdate,
+}
+
+/// A streaming update emitted mid-turn. The `sessionUpdate` discriminator
+/// selects the variant.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(tag = "sessionUpdate", rename_all = "snake_case")]
+pub enum SessionUpdate {
+    AgentMessageChunk {
+        content: ContentBlock,
+    },
+    AgentThoughtChunk {
+        content: ContentBlock,
+    },
+    ToolCall {
+        #[serde(rename = "toolCallId")]
+        tool_call_id: String,
+        title: String,
+        kind: ToolKind,
+        status: ToolCallStatus,
+        #[serde(rename = "rawInput", skip_serializing_if = "Option::is_none")]
+        raw_input: Option<Value>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        content: Vec<ToolCallContent>,
+    },
+    ToolCallUpdate {
+        #[serde(rename = "toolCallId")]
+        tool_call_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        status: Option<ToolCallStatus>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        content: Vec<ToolCallContent>,
+        #[serde(rename = "rawOutput", skip_serializing_if = "Option::is_none")]
+        raw_output: Option<Value>,
+    },
+    Plan {
+        entries: Vec<PlanEntry>,
+    },
+}
+
+/// A content block. yolop only ever emits text blocks; the spec also defines
+/// image/audio/resource blocks.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ContentBlock {
+    Text { text: String },
+}
+
+impl ContentBlock {
+    pub fn text(text: impl Into<String>) -> Self {
+        Self::Text { text: text.into() }
+    }
+}
+
+/// Categorises a tool call so editors can pick an icon/affordance. The full
+/// ACP vocabulary is modelled; yolop's tool-name mapping doesn't currently
+/// emit every variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[allow(dead_code)]
+pub enum ToolKind {
+    Read,
+    Edit,
+    Delete,
+    Move,
+    Search,
+    Execute,
+    Think,
+    Fetch,
+    Other,
+}
+
+/// Lifecycle status of a tool call. yolop emits `InProgress` then
+/// `Completed`/`Failed`; `Pending` rounds out the wire enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[allow(dead_code)]
+pub enum ToolCallStatus {
+    Pending,
+    InProgress,
+    Completed,
+    Failed,
+}
+
+/// Content attached to a tool call. yolop emits the `content` variant
+/// (wrapping a text block); the `diff` variant is modelled for completeness
+/// and future structured-diff support (the spec also defines `terminal`).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[allow(dead_code)]
+pub enum ToolCallContent {
+    Content { content: ContentBlock },
+    Diff(ToolCallDiff),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolCallDiff {
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub old_text: Option<String>,
+    pub new_text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PlanEntry {
+    pub content: String,
+    pub priority: PlanPriority,
+    pub status: PlanStatus,
+}
+
+/// Plan-entry priority. yolop's todo tool has no priority concept, so it
+/// always emits `Medium`; the other variants exist to model the wire enum
+/// completely.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[allow(dead_code)]
+pub enum PlanPriority {
+    High,
+    Medium,
+    Low,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanStatus {
+    Pending,
+    InProgress,
+    Completed,
+}
+
+// ---------- session/request_permission ----------
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RequestPermissionParams {
+    pub session_id: String,
+    pub tool_call: Value,
+    pub options: Vec<PermissionOption>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PermissionOption {
+    pub option_id: String,
+    pub name: String,
+    pub kind: PermissionOptionKind,
+}
+
+/// Kinds of permission option an agent can offer. yolop offers a single
+/// allow/reject pair (`AllowOnce`/`RejectOnce`); the "always" variants exist
+/// to model the wire enum completely.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[allow(dead_code)]
+pub enum PermissionOptionKind {
+    AllowOnce,
+    AllowAlways,
+    RejectOnce,
+    RejectAlways,
+}
+
+/// Client's answer to a permission request. The `outcome` discriminator is
+/// either `selected` (with the chosen `optionId`) or `cancelled`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RequestPermissionResult {
+    pub outcome: PermissionOutcome,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum PermissionOutcome {
+    Selected {
+        #[serde(rename = "optionId")]
+        option_id: String,
+    },
+    Cancelled,
+}
+
+/// Extract the concatenated plain text from an inbound prompt's content
+/// blocks, ignoring non-text blocks (images, resources). Newline-joined so a
+/// multi-block prompt reads naturally.
+pub fn prompt_text(blocks: &[Value]) -> String {
+    let mut parts = Vec::new();
+    for block in blocks {
+        if block.get("type").and_then(Value::as_str) == Some("text")
+            && let Some(text) = block.get("text").and_then(Value::as_str)
+        {
+            parts.push(text.to_string());
+        }
+    }
+    parts.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn initialize_result_serializes_camel_case() {
+        let result = InitializeResult {
+            protocol_version: PROTOCOL_VERSION,
+            agent_capabilities: AgentCapabilities {
+                load_session: false,
+                prompt_capabilities: PromptCapabilities {
+                    image: false,
+                    audio: false,
+                    embedded_context: true,
+                },
+            },
+            auth_methods: vec![],
+        };
+        let v = serde_json::to_value(&result).unwrap();
+        assert_eq!(v["protocolVersion"], 1);
+        assert_eq!(v["agentCapabilities"]["loadSession"], false);
+        assert_eq!(
+            v["agentCapabilities"]["promptCapabilities"]["embeddedContext"],
+            true
+        );
+        assert!(v["authMethods"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn agent_message_chunk_uses_snake_case_discriminator() {
+        let update = SessionUpdate::AgentMessageChunk {
+            content: ContentBlock::text("hi"),
+        };
+        let v = serde_json::to_value(&update).unwrap();
+        assert_eq!(v["sessionUpdate"], "agent_message_chunk");
+        assert_eq!(v["content"]["type"], "text");
+        assert_eq!(v["content"]["text"], "hi");
+    }
+
+    #[test]
+    fn tool_call_serializes_camel_case_ids_and_snake_case_enums() {
+        let update = SessionUpdate::ToolCall {
+            tool_call_id: "call_1".into(),
+            title: "Run bash".into(),
+            kind: ToolKind::Execute,
+            status: ToolCallStatus::InProgress,
+            raw_input: Some(json!({ "command": "ls" })),
+            content: vec![],
+        };
+        let v = serde_json::to_value(&update).unwrap();
+        assert_eq!(v["sessionUpdate"], "tool_call");
+        assert_eq!(v["toolCallId"], "call_1");
+        assert_eq!(v["kind"], "execute");
+        assert_eq!(v["status"], "in_progress");
+        assert_eq!(v["rawInput"]["command"], "ls");
+        // Empty content is omitted from the wire form.
+        assert!(v.get("content").is_none());
+    }
+
+    #[test]
+    fn tool_call_update_omits_empty_optionals() {
+        let update = SessionUpdate::ToolCallUpdate {
+            tool_call_id: "call_1".into(),
+            status: Some(ToolCallStatus::Completed),
+            content: vec![ToolCallContent::Content {
+                content: ContentBlock::text("done"),
+            }],
+            raw_output: None,
+        };
+        let v = serde_json::to_value(&update).unwrap();
+        assert_eq!(v["sessionUpdate"], "tool_call_update");
+        assert_eq!(v["status"], "completed");
+        assert_eq!(v["content"][0]["type"], "content");
+        assert_eq!(v["content"][0]["content"]["text"], "done");
+        assert!(v.get("rawOutput").is_none());
+    }
+
+    #[test]
+    fn diff_content_serializes_camel_case_text_fields() {
+        let content = ToolCallContent::Diff(ToolCallDiff {
+            path: "src/x.rs".into(),
+            old_text: Some("a".into()),
+            new_text: "b".into(),
+        });
+        let v = serde_json::to_value(&content).unwrap();
+        assert_eq!(v["type"], "diff");
+        assert_eq!(v["path"], "src/x.rs");
+        assert_eq!(v["oldText"], "a");
+        assert_eq!(v["newText"], "b");
+    }
+
+    #[test]
+    fn plan_entry_enums_are_snake_case() {
+        let entry = PlanEntry {
+            content: "do it".into(),
+            priority: PlanPriority::Medium,
+            status: PlanStatus::InProgress,
+        };
+        let v = serde_json::to_value(&entry).unwrap();
+        assert_eq!(v["priority"], "medium");
+        assert_eq!(v["status"], "in_progress");
+    }
+
+    #[test]
+    fn stop_reason_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_value(StopReason::EndTurn).unwrap(),
+            json!("end_turn")
+        );
+        assert_eq!(
+            serde_json::to_value(StopReason::MaxTurnRequests).unwrap(),
+            json!("max_turn_requests")
+        );
+    }
+
+    #[test]
+    fn initialize_params_tolerate_missing_and_unknown_fields() {
+        // Empty params: protocol version absent.
+        let empty: InitializeParams = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(empty.protocol_version, None);
+        // Client capabilities and clientInfo are accepted and ignored.
+        let full: InitializeParams = serde_json::from_value(json!({
+            "protocolVersion": 1,
+            "clientCapabilities": { "fs": { "readTextFile": true, "writeTextFile": true } },
+            "clientInfo": { "name": "zed" }
+        }))
+        .unwrap();
+        assert_eq!(full.protocol_version, Some(1));
+    }
+
+    #[test]
+    fn prompt_text_concatenates_text_blocks_only() {
+        let blocks = vec![
+            json!({ "type": "text", "text": "hello" }),
+            json!({ "type": "image", "data": "..." }),
+            json!({ "type": "text", "text": "world" }),
+        ];
+        assert_eq!(prompt_text(&blocks), "hello\nworld");
+    }
+
+    #[test]
+    fn permission_outcome_parses_selected_and_cancelled() {
+        let selected: RequestPermissionResult = serde_json::from_value(
+            json!({ "outcome": { "outcome": "selected", "optionId": "ok" } }),
+        )
+        .unwrap();
+        match selected.outcome {
+            PermissionOutcome::Selected { option_id } => assert_eq!(option_id, "ok"),
+            _ => panic!("expected selected"),
+        }
+        let cancelled: RequestPermissionResult =
+            serde_json::from_value(json!({ "outcome": { "outcome": "cancelled" } })).unwrap();
+        assert!(matches!(cancelled.outcome, PermissionOutcome::Cancelled));
+    }
+}

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -1,0 +1,548 @@
+//! ACP server: the JSON-RPC peer and request dispatch.
+//!
+//! yolop acts as an ACP *agent*: it reads newline-delimited JSON-RPC 2.0
+//! messages from a client (an editor such as Zed) and drives the everruns
+//! runtime in response. [`serve`] owns the read loop and is generic over the
+//! byte streams and a [`RuntimeFactory`], so the production binary wires it to
+//! real stdin/stdout while tests drive it over in-memory pipes with a scripted
+//! runtime.
+//!
+//! Concurrency model:
+//!   * A single writer task serialises every outbound line (responses,
+//!     notifications, and agent→client requests) so writes never interleave.
+//!   * The read loop never blocks on slow work — `session/prompt` runs in its
+//!     own task — so `session/cancel` and permission responses keep flowing
+//!     while a turn is in progress.
+//!   * Agent→client requests (`session/request_permission`) are correlated by
+//!     id through a pending map the read loop resolves when the response
+//!     arrives.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::time::Duration;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::sync::{mpsc, oneshot};
+
+use crate::approval::{ApprovalGate, ApprovalRequest};
+use crate::runtime::{BuiltRuntime, ModelState, RuntimeHandles};
+
+use super::bridge::Translator;
+use super::protocol::{
+    self, AgentCapabilities, InitializeParams, InitializeResult, NewSessionParams,
+    NewSessionResult, PermissionOption, PermissionOptionKind, PermissionOutcome,
+    PromptCapabilities, PromptParams, PromptResult, RequestPermissionParams,
+    RequestPermissionResult, SessionNotification, SessionUpdate, StopReason,
+};
+
+/// JSON-RPC error codes used in agent responses.
+const METHOD_NOT_FOUND: i64 = -32601;
+const INVALID_PARAMS: i64 = -32602;
+const INTERNAL_ERROR: i64 = -32603;
+
+/// How often the prompt loop wakes to check whether the turn task finished,
+/// in case the final event was already drained from the broadcast.
+const TURN_POLL_INTERVAL: Duration = Duration::from_millis(150);
+
+/// Builds a runtime for a freshly opened ACP session. Abstracted so tests can
+/// substitute a scripted llmsim runtime for the real provider wiring.
+#[async_trait]
+pub trait RuntimeFactory: Send + Sync + 'static {
+    async fn build(&self, cwd: PathBuf, gate: Arc<ApprovalGate>) -> Result<BuiltRuntime>;
+}
+
+struct RpcError {
+    code: i64,
+    message: String,
+}
+
+impl RpcError {
+    fn new(code: i64, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+/// The JSON-RPC peer: a serialised outbound channel plus a pending-request
+/// table for agent→client calls.
+struct Peer {
+    out: mpsc::UnboundedSender<String>,
+    next_id: AtomicI64,
+    pending: StdMutex<HashMap<i64, oneshot::Sender<std::result::Result<Value, RpcError>>>>,
+}
+
+impl Peer {
+    fn send_value(&self, value: Value) {
+        // Compact serialization keeps each message on a single line, as the
+        // ndjson transport requires.
+        let _ = self.out.send(value.to_string());
+    }
+
+    fn respond_ok(&self, id: Value, result: Value) {
+        self.send_value(json!({ "jsonrpc": "2.0", "id": id, "result": result }));
+    }
+
+    fn respond_err(&self, id: Value, code: i64, message: &str) {
+        self.send_value(json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": { "code": code, "message": message },
+        }));
+    }
+
+    fn notify(&self, method: &str, params: Value) {
+        self.send_value(json!({ "jsonrpc": "2.0", "method": method, "params": params }));
+    }
+
+    fn session_update(&self, session_id: &str, update: SessionUpdate) {
+        let params = serde_json::to_value(SessionNotification {
+            session_id: session_id.to_string(),
+            update,
+        })
+        .expect("session notification serializes");
+        self.notify("session/update", params);
+    }
+
+    /// Issue an agent→client request and await its response.
+    async fn request(&self, method: &str, params: Value) -> std::result::Result<Value, RpcError> {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = oneshot::channel();
+        self.pending.lock().unwrap().insert(id, tx);
+        self.send_value(json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        }));
+        rx.await
+            .unwrap_or_else(|_| Err(RpcError::new(INTERNAL_ERROR, "connection closed")))
+    }
+
+    /// Resolve a pending agent→client request from an inbound response.
+    fn route_response(&self, id: i64, result: std::result::Result<Value, RpcError>) {
+        if let Some(tx) = self.pending.lock().unwrap().remove(&id) {
+            let _ = tx.send(result);
+        }
+    }
+}
+
+/// State for one open ACP session: the runtime handles plus a one-shot cancel
+/// channel armed for the duration of each in-flight prompt.
+struct Session {
+    acp_id: String,
+    handles: RuntimeHandles,
+    model: ModelState,
+    cancel: StdMutex<Option<oneshot::Sender<()>>>,
+}
+
+impl Session {
+    /// Arm a fresh cancel channel for a new prompt, returning the receiver the
+    /// prompt loop selects on. Replaces any stale sender.
+    fn arm_cancel(&self) -> oneshot::Receiver<()> {
+        let (tx, rx) = oneshot::channel();
+        *self.cancel.lock().unwrap() = Some(tx);
+        rx
+    }
+
+    fn trigger_cancel(&self) {
+        if let Some(tx) = self.cancel.lock().unwrap().take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+struct Server<F: RuntimeFactory> {
+    peer: Arc<Peer>,
+    factory: Arc<F>,
+    sessions: StdMutex<HashMap<String, Arc<Session>>>,
+}
+
+impl<F: RuntimeFactory> Server<F> {
+    fn session(&self, id: &str) -> Option<Arc<Session>> {
+        self.sessions.lock().unwrap().get(id).cloned()
+    }
+}
+
+/// Run the ACP agent over the given byte streams until the client closes its
+/// end (EOF on `reader`). Returns once the read loop ends.
+pub async fn serve<R, W, F>(reader: R, writer: W, factory: Arc<F>) -> Result<()>
+where
+    R: AsyncRead + Unpin + Send + 'static,
+    W: AsyncWrite + Unpin + Send + 'static,
+    F: RuntimeFactory,
+{
+    // Single writer task: every outbound line funnels through here so
+    // notifications, responses, and requests never interleave on the wire.
+    let (out_tx, mut out_rx) = mpsc::unbounded_channel::<String>();
+    let writer_task = tokio::spawn(async move {
+        let mut writer = writer;
+        while let Some(line) = out_rx.recv().await {
+            if writer.write_all(line.as_bytes()).await.is_err()
+                || writer.write_all(b"\n").await.is_err()
+                || writer.flush().await.is_err()
+            {
+                break;
+            }
+        }
+    });
+
+    let server = Arc::new(Server {
+        peer: Arc::new(Peer {
+            out: out_tx,
+            next_id: AtomicI64::new(1),
+            pending: StdMutex::new(HashMap::new()),
+        }),
+        factory,
+        sessions: StdMutex::new(HashMap::new()),
+    });
+
+    let mut lines = BufReader::new(reader).lines();
+    while let Some(line) = lines.next_line().await? {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let message: Value = match serde_json::from_str(&line) {
+            Ok(value) => value,
+            Err(err) => {
+                tracing::warn!(%err, "acp: dropping unparseable line");
+                continue;
+            }
+        };
+        dispatch(server.clone(), message);
+    }
+
+    drop(server);
+    let _ = writer_task.await;
+    Ok(())
+}
+
+/// Classify an inbound message and route it. Requests are handled in spawned
+/// tasks so the read loop keeps draining (essential for cancel + permission
+/// flows during a long prompt). Responses resolve pending agent→client calls.
+fn dispatch<F: RuntimeFactory>(server: Arc<Server<F>>, message: Value) {
+    let has_method = message.get("method").and_then(Value::as_str).is_some();
+    if has_method {
+        let id = message.get("id").cloned();
+        match id {
+            Some(id) if !id.is_null() => {
+                tokio::spawn(handle_request(server, id, message));
+            }
+            _ => handle_notification(&server, &message),
+        }
+        return;
+    }
+    // Otherwise it is a response to one of our outbound requests.
+    if let Some(id) = message.get("id").and_then(Value::as_i64) {
+        if let Some(error) = message.get("error") {
+            let code = error
+                .get("code")
+                .and_then(Value::as_i64)
+                .unwrap_or(INTERNAL_ERROR);
+            let msg = error
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("request failed")
+                .to_string();
+            server
+                .peer
+                .route_response(id, Err(RpcError::new(code, msg)));
+        } else {
+            let result = message.get("result").cloned().unwrap_or(Value::Null);
+            server.peer.route_response(id, Ok(result));
+        }
+    }
+}
+
+async fn handle_request<F: RuntimeFactory>(server: Arc<Server<F>>, id: Value, message: Value) {
+    let method = message
+        .get("method")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let params = message.get("params").cloned().unwrap_or(Value::Null);
+
+    let outcome = match method.as_str() {
+        "initialize" => handle_initialize(params),
+        "authenticate" => Ok(json!({})),
+        "session/new" => handle_new_session(&server, params).await,
+        "session/prompt" => handle_prompt(&server, params).await,
+        other => Err(RpcError::new(
+            METHOD_NOT_FOUND,
+            format!("unknown method: {other}"),
+        )),
+    };
+
+    match outcome {
+        Ok(result) => server.peer.respond_ok(id, result),
+        Err(err) => server.peer.respond_err(id, err.code, &err.message),
+    }
+}
+
+fn handle_notification<F: RuntimeFactory>(server: &Arc<Server<F>>, message: &Value) {
+    let method = message
+        .get("method")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if method == "session/cancel" {
+        let params = message.get("params").cloned().unwrap_or(Value::Null);
+        if let Ok(parsed) = serde_json::from_value::<protocol::CancelParams>(params)
+            && let Some(session) = server.session(&parsed.session_id)
+        {
+            session.trigger_cancel();
+        }
+    }
+}
+
+fn handle_initialize(params: Value) -> std::result::Result<Value, RpcError> {
+    let params: InitializeParams = serde_json::from_value(params)
+        .map_err(|e| RpcError::new(INVALID_PARAMS, format!("initialize: {e}")))?;
+    // Echo a supported version: honour the client's request when it is one we
+    // speak, otherwise advertise our own.
+    let version = match params.protocol_version {
+        Some(v) if v == protocol::PROTOCOL_VERSION => v,
+        _ => protocol::PROTOCOL_VERSION,
+    };
+    let result = InitializeResult {
+        protocol_version: version,
+        agent_capabilities: AgentCapabilities {
+            // yolop builds a fresh runtime per session and does not yet
+            // rehydrate prior ACP sessions, so loadSession stays false.
+            load_session: false,
+            prompt_capabilities: PromptCapabilities {
+                image: false,
+                audio: false,
+                embedded_context: true,
+            },
+        },
+        // No auth handshake: credentials come from the environment/settings
+        // the agent process already inherits.
+        auth_methods: vec![],
+    };
+    Ok(serde_json::to_value(result).expect("initialize result serializes"))
+}
+
+async fn handle_new_session<F: RuntimeFactory>(
+    server: &Arc<Server<F>>,
+    params: Value,
+) -> std::result::Result<Value, RpcError> {
+    let params: NewSessionParams = serde_json::from_value(params)
+        .map_err(|e| RpcError::new(INVALID_PARAMS, format!("session/new: {e}")))?;
+    let cwd = PathBuf::from(&params.cwd);
+
+    // Delegate destructive-operation approval to the client via
+    // `session/request_permission`. The editor owns the human, so this is the
+    // idiomatic ACP behaviour.
+    let (gate_tx, mut approval_rx) =
+        mpsc::unbounded_channel::<(ApprovalRequest, oneshot::Sender<bool>)>();
+    let gate = ApprovalGate::channel(gate_tx);
+
+    let built = server
+        .factory
+        .build(cwd, gate)
+        .await
+        .map_err(|e| RpcError::new(INTERNAL_ERROR, format!("build runtime: {e}")))?;
+
+    let acp_id = built.handles.session_id.to_string();
+    let session = Arc::new(Session {
+        acp_id: acp_id.clone(),
+        handles: built.handles,
+        model: built.model,
+        cancel: StdMutex::new(None),
+    });
+    server
+        .sessions
+        .lock()
+        .unwrap()
+        .insert(acp_id.clone(), session);
+
+    // Forward every approval request to the client as a permission prompt for
+    // the lifetime of the session.
+    let peer = server.peer.clone();
+    let permission_session = acp_id.clone();
+    tokio::spawn(async move {
+        while let Some((request, responder)) = approval_rx.recv().await {
+            let allowed = request_permission(&peer, &permission_session, &request).await;
+            let _ = responder.send(allowed);
+        }
+    });
+
+    let result = NewSessionResult { session_id: acp_id };
+    Ok(serde_json::to_value(result).expect("new session result serializes"))
+}
+
+async fn handle_prompt<F: RuntimeFactory>(
+    server: &Arc<Server<F>>,
+    params: Value,
+) -> std::result::Result<Value, RpcError> {
+    let params: PromptParams = serde_json::from_value(params)
+        .map_err(|e| RpcError::new(INVALID_PARAMS, format!("session/prompt: {e}")))?;
+    let session = server
+        .session(&params.session_id)
+        .ok_or_else(|| RpcError::new(INVALID_PARAMS, "unknown session id"))?;
+    let prompt = protocol::prompt_text(&params.prompt);
+
+    let stop_reason = run_prompt(server.peer.clone(), session, prompt).await;
+    let result = PromptResult { stop_reason };
+    Ok(serde_json::to_value(result).expect("prompt result serializes"))
+}
+
+/// Drive one prompt turn: stream the runtime's events to the client as
+/// `session/update`s and resolve a stop reason. Honours `session/cancel`.
+async fn run_prompt(peer: Arc<Peer>, session: Arc<Session>, prompt: String) -> StopReason {
+    let handles = session.handles.clone();
+    let session_id = handles.session_id;
+    let acp_id = session.acp_id.clone();
+
+    // Subscribe before launching the turn so no early events are missed; the
+    // broadcast only delivers events emitted after `subscribe`.
+    let mut live = handles.events.subscribe();
+    let events_before = handles.runtime.events().await.map(|e| e.len()).unwrap_or(0);
+
+    let input = session.model.input_message(prompt);
+    let runtime = handles.runtime.clone();
+    let turn = tokio::spawn(async move { runtime.run_turn(session_id, input).await });
+
+    let mut translator = Translator::new();
+    let mut cancel_rx = session.arm_cancel();
+    let mut cancelled = false;
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = &mut cancel_rx => {
+                cancelled = true;
+                break;
+            }
+            recv = live.recv() => match recv {
+                Ok(event) => {
+                    if event.session_id == session_id {
+                        for update in translator.on_event(&event) {
+                            peer.session_update(&acp_id, update);
+                        }
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
+                    // Overflow: catch up from the canonical event log and
+                    // resubscribe at the current head.
+                    live = handles.events.subscribe();
+                    drain_events(&peer, &handles, events_before, &mut translator, &acp_id).await;
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            },
+            _ = tokio::time::sleep(TURN_POLL_INTERVAL) => {
+                if turn.is_finished() {
+                    break;
+                }
+            }
+        }
+    }
+
+    // Flush any tail events emitted between the last poll and completion. The
+    // translator dedups by event id, so already-streamed events are skipped.
+    drain_events(&peer, &handles, events_before, &mut translator, &acp_id).await;
+
+    if cancelled {
+        // run_turn has no in-flight cancellation hook; abandon the task and
+        // report cancelled. The runtime may finish in the background but its
+        // remaining events are ignored.
+        turn.abort();
+        return StopReason::Cancelled;
+    }
+
+    match turn.await {
+        Ok(Ok(result)) if result.success => StopReason::EndTurn,
+        Ok(Ok(result)) => {
+            if let Some(error) = result.error {
+                peer.session_update(
+                    &acp_id,
+                    SessionUpdate::AgentMessageChunk {
+                        content: protocol::ContentBlock::text(format!("turn error: {error}")),
+                    },
+                );
+            }
+            StopReason::EndTurn
+        }
+        Ok(Err(err)) => {
+            peer.session_update(
+                &acp_id,
+                SessionUpdate::AgentMessageChunk {
+                    content: protocol::ContentBlock::text(format!("turn failed: {err}")),
+                },
+            );
+            StopReason::EndTurn
+        }
+        Err(_) => StopReason::Cancelled,
+    }
+}
+
+/// Feed every not-yet-seen runtime event through the translator and emit the
+/// resulting updates. Used to recover from broadcast lag and to flush the
+/// turn's tail.
+async fn drain_events(
+    peer: &Arc<Peer>,
+    handles: &RuntimeHandles,
+    events_before: usize,
+    translator: &mut Translator,
+    acp_id: &str,
+) {
+    let events = handles.runtime.events().await.unwrap_or_default();
+    for event in events.iter().skip(events_before) {
+        if event.session_id != handles.session_id {
+            continue;
+        }
+        for update in translator.on_event(event) {
+            peer.session_update(acp_id, update);
+        }
+    }
+}
+
+/// Ask the client to approve a destructive operation. Maps the client's
+/// selection back to a boolean. Any error or cancellation denies the
+/// operation, matching the channel gate's fail-closed default.
+async fn request_permission(peer: &Arc<Peer>, session_id: &str, request: &ApprovalRequest) -> bool {
+    const ALLOW: &str = "allow";
+    const REJECT: &str = "reject";
+
+    let params = RequestPermissionParams {
+        session_id: session_id.to_string(),
+        tool_call: json!({ "toolCallId": "pending", "title": request.headline() }),
+        options: vec![
+            PermissionOption {
+                option_id: ALLOW.to_string(),
+                name: "Allow".to_string(),
+                kind: PermissionOptionKind::AllowOnce,
+            },
+            PermissionOption {
+                option_id: REJECT.to_string(),
+                name: "Reject".to_string(),
+                kind: PermissionOptionKind::RejectOnce,
+            },
+        ],
+    };
+    let params = serde_json::to_value(params).expect("permission params serialize");
+
+    match peer.request("session/request_permission", params).await {
+        Ok(value) => match serde_json::from_value::<RequestPermissionResult>(value) {
+            Ok(result) => match result.outcome {
+                PermissionOutcome::Selected { option_id } => option_id == ALLOW,
+                PermissionOutcome::Cancelled => false,
+            },
+            Err(err) => {
+                tracing::warn!(%err, "acp: malformed permission response; denying");
+                false
+            }
+        },
+        Err(err) => {
+            tracing::warn!(code = err.code, message = %err.message, "acp: permission request failed; denying");
+            false
+        }
+    }
+}

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -111,17 +111,26 @@ impl Peer {
         self.notify("session/update", params);
     }
 
-    /// Issue an agent→client request and await its response.
+    /// Issue an agent→client request and await its response. Fails fast (rather
+    /// than awaiting forever) if the outbound channel is already closed — the
+    /// writer task has exited, so no response can ever arrive.
     async fn request(&self, method: &str, params: Value) -> std::result::Result<Value, RpcError> {
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let (tx, rx) = oneshot::channel();
         self.pending.lock().unwrap().insert(id, tx);
-        self.send_value(json!({
+        let line = json!({
             "jsonrpc": "2.0",
             "id": id,
             "method": method,
             "params": params,
-        }));
+        })
+        .to_string();
+        if self.out.send(line).is_err() {
+            // Connection gone: don't leak the pending entry or block on a
+            // response that will never come.
+            self.pending.lock().unwrap().remove(&id);
+            return Err(RpcError::new(INTERNAL_ERROR, "connection closed"));
+        }
         rx.await
             .unwrap_or_else(|_| Err(RpcError::new(INTERNAL_ERROR, "connection closed")))
     }
@@ -130,6 +139,16 @@ impl Peer {
     fn route_response(&self, id: i64, result: std::result::Result<Value, RpcError>) {
         if let Some(tx) = self.pending.lock().unwrap().remove(&id) {
             let _ = tx.send(result);
+        }
+    }
+
+    /// Fail every in-flight agent→client request. Called once the connection
+    /// ends so awaiting tasks (e.g. a forwarded `session/request_permission`)
+    /// unwind instead of deadlocking and holding the server alive.
+    fn fail_all_pending(&self) {
+        let drained: Vec<_> = self.pending.lock().unwrap().drain().collect();
+        for (_, tx) in drained {
+            let _ = tx.send(Err(RpcError::new(INTERNAL_ERROR, "connection closed")));
         }
     }
 }
@@ -205,23 +224,29 @@ where
     });
 
     let mut lines = BufReader::new(reader).lines();
-    while let Some(line) = lines.next_line().await? {
-        if line.trim().is_empty() {
-            continue;
-        }
-        let message: Value = match serde_json::from_str(&line) {
-            Ok(value) => value,
-            Err(err) => {
-                tracing::warn!(%err, "acp: dropping unparseable line");
-                continue;
+    let read_result = loop {
+        match lines.next_line().await {
+            Ok(Some(line)) => {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                match serde_json::from_str::<Value>(&line) {
+                    Ok(message) => dispatch(server.clone(), message),
+                    Err(err) => tracing::warn!(%err, "acp: dropping unparseable line"),
+                }
             }
-        };
-        dispatch(server.clone(), message);
-    }
+            Ok(None) => break Ok(()),
+            Err(err) => break Err(err),
+        }
+    };
 
+    // Connection ended: fail any in-flight agent→client requests so awaiting
+    // tasks (a forwarded permission prompt, a streaming turn) unwind instead of
+    // deadlocking and holding the writer task — and thus `serve` — open.
+    server.peer.fail_all_pending();
     drop(server);
     let _ = writer_task.await;
-    Ok(())
+    read_result.map_err(Into::into)
 }
 
 /// Classify an inbound message and route it. Requests are handled in spawned

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 // Decision: support both interactive TUI and a `--print` one-shot mode so the
 // example is testable in CI and easy to demo against a real codebase.
 
+mod acp;
 mod app;
 mod approval;
 mod capabilities;
@@ -63,6 +64,14 @@ struct Cli {
     /// Run a single prompt non-interactively and print the result. Useful for CI smoke tests.
     #[arg(short = 'p', long)]
     print: Option<String>,
+
+    /// Speak the Agent Client Protocol (ACP) over stdio instead of launching
+    /// the TUI. Editors such as Zed spawn `yolop --acp` and drive it as an
+    /// external agent. Builds one runtime per ACP session (cwd comes from the
+    /// client); the `-C/--cwd`, `--print`, `--ask`, and `--session` flags are
+    /// ignored in this mode. See `specs/acp.md`.
+    #[arg(long, conflicts_with = "print")]
+    acp: bool,
 
     /// Prompt for y/n before every destructive tool call (write/edit/delete/bash).
     /// Off by default — the agent acts autonomously. Ignored in `--print` mode
@@ -215,6 +224,13 @@ async fn main() -> Result<()> {
         Some(p) => p,
         None => session_log::default_sessions_dir()?,
     };
+
+    // ACP mode builds runtimes per session (cwd arrives via `session/new`), so
+    // it bypasses the up-front runtime build, the approval gate, and the TUI.
+    if cli.acp {
+        return acp::run_stdio(provider, settings, sessions_dir).await;
+    }
+
     let runtime = runtime::build(
         cwd,
         provider,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -487,6 +487,220 @@ fn wait_for_exit(child: &mut dyn Child, timeout: Duration) -> Option<ExitStatus>
     child.try_wait().expect("poll child exit")
 }
 
+/// Result of one scripted ACP handshake against the real binary.
+struct AcpHandshake {
+    init: serde_json::Value,
+    session_id: String,
+    prompt: serde_json::Value,
+    /// All `agent_message_chunk` text streamed during the prompt, concatenated.
+    assistant_text: String,
+    /// True if the process exited cleanly after stdin was closed.
+    exited_cleanly: bool,
+}
+
+/// Spawn `yolop --acp <provider>` over real OS stdin/stdout pipes and drive the
+/// full JSON-RPC handshake: initialize → session/new → session/prompt, closing
+/// stdin to let the agent exit. Returns the responses and streamed text so
+/// callers can assert per-provider behaviour. Exercises the binary's actual
+/// ACP wiring, not just the in-process `serve` tests.
+fn run_acp_handshake(provider: &str, prompt_text: &str) -> AcpHandshake {
+    use std::io::BufRead;
+    use std::process::{Command as StdCommand, Stdio};
+
+    let session_dir = tempfile::tempdir().expect("session tempdir");
+    let workspace = tempfile::tempdir().expect("workspace tempdir");
+
+    let mut child = StdCommand::new(yolop_binary())
+        .args([
+            "--acp",
+            "--provider",
+            provider,
+            "--session-dir",
+            session_dir.path().to_str().unwrap(),
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn yolop --acp");
+
+    let mut stdin = child.stdin.take().expect("acp stdin");
+    let (line_tx, line_rx) = mpsc::channel::<String>();
+    let stdout = child.stdout.take().expect("acp stdout");
+    let reader = thread::spawn(move || {
+        let mut buf = std::io::BufReader::new(stdout);
+        loop {
+            let mut line = String::new();
+            match buf.read_line(&mut line) {
+                Ok(0) => break,
+                Ok(_) => {
+                    if line_tx.send(line).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let send = |stdin: &mut std::process::ChildStdin, value: serde_json::Value| {
+        let line = format!("{value}\n");
+        stdin.write_all(line.as_bytes()).expect("write acp request");
+        stdin.flush().expect("flush acp request");
+    };
+
+    // Collect lines until one parses to a JSON object with the given response
+    // id (carrying result or error). `agent_message_chunk` notifications seen
+    // along the way are accumulated into `assistant_text`.
+    let assistant_text = std::cell::RefCell::new(String::new());
+    let await_response = |rx: &Receiver<String>, id: i64| -> serde_json::Value {
+        let deadline = Instant::now() + Duration::from_secs(60);
+        while Instant::now() < deadline {
+            match rx.recv_timeout(Duration::from_millis(500)) {
+                Ok(line) => {
+                    let Ok(value) = serde_json::from_str::<serde_json::Value>(line.trim()) else {
+                        continue;
+                    };
+                    if value["params"]["update"]["sessionUpdate"] == "agent_message_chunk"
+                        && let Some(text) = value["params"]["update"]["content"]["text"].as_str()
+                    {
+                        assistant_text.borrow_mut().push_str(text);
+                    }
+                    if value.get("id").and_then(serde_json::Value::as_i64) == Some(id)
+                        && (value.get("result").is_some() || value.get("error").is_some())
+                    {
+                        return value;
+                    }
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => continue,
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        }
+        panic!("timed out awaiting acp response id={id}");
+    };
+
+    send(
+        &mut stdin,
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": 1,
+                "clientCapabilities": { "fs": { "readTextFile": true, "writeTextFile": true } }
+            }
+        }),
+    );
+    let init = await_response(&line_rx, 0);
+
+    send(
+        &mut stdin,
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/new",
+            "params": { "cwd": workspace.path().to_str().unwrap(), "mcpServers": [] }
+        }),
+    );
+    let new_session = await_response(&line_rx, 1);
+    let session_id = new_session["result"]["sessionId"]
+        .as_str()
+        .unwrap_or_else(|| panic!("sessionId in response: {new_session}"))
+        .to_string();
+
+    send(
+        &mut stdin,
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/prompt",
+            "params": {
+                "sessionId": session_id,
+                "prompt": [{ "type": "text", "text": prompt_text }]
+            }
+        }),
+    );
+    let prompt = await_response(&line_rx, 2);
+
+    // Closing stdin makes the agent's read loop hit EOF and exit cleanly.
+    drop(stdin);
+    let status = wait_for_process_exit(&mut child, Duration::from_secs(10));
+    let _ = reader.join();
+
+    AcpHandshake {
+        init,
+        session_id,
+        prompt,
+        assistant_text: assistant_text.into_inner(),
+        exited_cleanly: status.map(|s| s.success()).unwrap_or(false),
+    }
+}
+
+#[test]
+fn acp_stdio_handshake_smoke() {
+    // env_remove on the parent process is unnecessary: --provider llmsim wins,
+    // and the offline driver needs no key.
+    let result = run_acp_handshake("llmsim", "hi");
+    assert_eq!(
+        result.init["result"]["protocolVersion"], 1,
+        "initialize response: {}",
+        result.init
+    );
+    assert!(
+        result.session_id.starts_with("session_"),
+        "unexpected session id: {}",
+        result.session_id
+    );
+    assert_eq!(
+        result.prompt["result"]["stopReason"], "end_turn",
+        "prompt response: {}",
+        result.prompt
+    );
+    assert!(
+        !result.assistant_text.is_empty(),
+        "expected a streamed agent_message_chunk"
+    );
+    assert!(
+        result.exited_cleanly,
+        "yolop --acp should exit cleanly after stdin close"
+    );
+}
+
+#[test]
+#[ignore = "requires OPENAI_API_KEY; run under doppler with --ignored"]
+fn acp_openai_handshake_smoke() {
+    let Ok(_) = std::env::var("OPENAI_API_KEY") else {
+        panic!("OPENAI_API_KEY required for live ACP smoke test");
+    };
+    let result = run_acp_handshake("openai", "Reply with exactly the single word: pong");
+    assert_eq!(
+        result.prompt["result"]["stopReason"], "end_turn",
+        "prompt response: {}",
+        result.prompt
+    );
+    assert!(
+        result.assistant_text.to_lowercase().contains("pong"),
+        "expected `pong` in streamed assistant text, got: {:?}",
+        result.assistant_text
+    );
+    assert!(result.exited_cleanly, "agent should exit cleanly");
+}
+
+fn wait_for_process_exit(
+    child: &mut std::process::Child,
+    timeout: Duration,
+) -> Option<std::process::ExitStatus> {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        match child.try_wait().expect("poll acp child") {
+            Some(status) => return Some(status),
+            None => thread::sleep(Duration::from_millis(20)),
+        }
+    }
+    let _ = child.kill();
+    child.try_wait().expect("poll acp child after kill")
+}
+
 #[test]
 #[ignore = "requires OPENAI_API_KEY; run under doppler with --ignored"]
 fn openai_print_smoke() {


### PR DESCRIPTION
## What

Implements the **agent side of the [Agent Client Protocol](https://agentclientprotocol.com)** (ACP), the editor-neutral JSON-RPC-over-stdio protocol created by Zed. `yolop --acp` turns the process into an ACP agent so editors (Zed, and any ACP client) can drive the same everruns runtime that powers the TUI and `--print` — one agent, three front ends.

- Methods: `initialize`, `authenticate`, `session/new`, `session/prompt`, `session/cancel`.
- Streams turns as `session/update` notifications: `agent_message_chunk`, `agent_thought_chunk`, `tool_call` / `tool_call_update` (with tool-kind mapping), and `write_todos` → `plan`.
- Delegates destructive-action approval to the editor via `session/request_permission` (fail-closed: reject/cancel/error → deny), reusing the existing `ApprovalGate`.
- Transport is newline-delimited JSON-RPC 2.0 over stdin/stdout; tracing stays on stderr so stdout is a clean protocol channel.

New `src/acp/` module:
- `protocol.rs` — serde wire types, verified field-by-field against the canonical schema (camelCase fields, snake_case discriminators, integer protocol version 1).
- `bridge.rs` — pure, per-turn `Translator` mapping runtime events → updates (no I/O → fully unit-testable).
- `server.rs` — JSON-RPC peer: single serialized writer task, non-blocking read loop, per-session runtimes, live turn streaming, id-correlated agent→client requests. `serve()` is generic over the byte streams and a `RuntimeFactory`.
- `mod.rs` — production factory, `run_stdio` entry, and end-to-end tests.

## Why

The agent loop is useful inside an editor, not just a terminal. ACP is the open standard for that, so implementing the agent side gives yolop drop-in editor integration with no bespoke glue.

## Validation

- `cargo fmt --check` — clean.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo test --all-features` — **215** unit/lib + **9** integration tests pass (2 ignored: live-provider).
- Test layers (all offline, no API key):
  1. **Wire types** — serde round-trips assert exact casing and discriminator values.
  2. **Translation** — per-event cases (deltas, tool lifecycle, todos→plan, dedup, streamed-vs-completed message).
  3. **End-to-end over real byte streams** — `serve` over `tokio::io::duplex` driven by an in-memory ACP client: full `initialize → session/new → session/prompt` handshake, unknown-method (`-32601`) and unknown-session (`-32602`) errors, a scripted bash tool call asserting `tool_call`/`tool_call_update` + permission grant, and `write_todos` → `plan`.
  4. **Real binary over OS pipes** — `tests/integration.rs::acp_stdio_handshake_smoke` spawns `yolop --acp` and drives the handshake over actual stdin/stdout, asserting a streamed `agent_message_chunk`, `stopReason: end_turn`, and clean exit on stdin close.
- Manually drove the compiled binary through the full handshake and confirmed the streamed `agent_message_chunk` + `end_turn` + clean exit.
- Offline binary smoke (`cargo run -- --provider llmsim -p "hi"`) still works.
- A `#[ignore]`d `acp_openai_handshake_smoke` documents the live path; it runs in CI's live-smoke job under `DOPPLER_TOKEN`. This sandbox has no Doppler/keys, so the live run is deferred to CI.

## Security

ACP is an additive front end; it does not change the filesystem, bash, or capability wiring.

- **TM-FS** — `session/new` builds runtimes through the same `runtime::build`, which canonicalizes `cwd` and layers `WriteBlocklistFileStore` + `ApprovalGatingFileStore`. The write blocklist (`.git/`, `node_modules/`, `target/`, …) and unrestricted-read-within-workspace model are unchanged. The client-supplied `cwd` is the same trust model as `-C/--cwd` (the editor is the user's).
- **TM-BASH** — no changes to `tools.rs`; timeouts/output caps/approval gating preserved. In ACP mode the gate forwards to the editor.
- **TM-LLM** — keys resolved exactly as before (env/settings), never logged. The ACP layer never serializes keys into protocol messages; tracing logs only error codes/parse failures. Permission prompts carry the same headline text the existing approval UI shows.
- **TM-TOOL** — no new capabilities registered.
- **TM-DEP** — adds `serde` (derive) as a **direct** dependency; it was already present transitively (via `serde_json`/`everruns-*`), so no new supply-chain surface. No `everruns-*` version changes.
- Trust-boundary handling: malformed JSON lines are logged and skipped; unknown methods/params/sessions return JSON-RPC errors rather than panicking. Pending-request and writer tasks unwind cleanly on disconnect.

## Follow-ups

- **Session eviction** — open ACP sessions accumulate in the server map for the connection's lifetime (no `session/load`/close in ACP v1). Bounded by the trusted local client; revisit if multi-session churn becomes real.
- **Mid-turn cancellation** — `session/cancel` abandons the turn task and reports `cancelled`; the underlying runtime has no in-flight cancellation hook yet, so it may finish in the background (events ignored).
- **Richer tool content** — structured ACP `diff` content and `rawOutput` for tool updates (currently a concise text summary).
- Client-provided filesystem (`fs/read_text_file`/`fs/write_text_file`), MCP pass-through, and `available_commands_update` are out of scope for v1 (documented in `specs/acp.md`).

Spec: `specs/acp.md`. Editor setup: README **Editor integration (ACP)**.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qs6SChFJ5xtVWrCMosqtt7)_