### PR TITLE
feat(cli): add zed acp integration command

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,15 +177,26 @@ with `session/prompt`; yolop streams the turn back as `session/update`
 notifications (assistant text, reasoning, tool calls, plans) and asks the
 editor to approve destructive operations via `session/request_permission`.
 
-In Zed, add a custom agent server to `~/.config/zed/settings.json`:
+To set up Zed:
+
+```bash
+yolop into zed
+```
+
+That adds a custom ACP agent server to `~/.config/zed/settings.json` using the
+current yolop executable. Re-running the command updates the existing `yolop`
+entry while preserving its `env` and other extra settings.
+
+Manual equivalent:
 
 ```json
 {
   "agent_servers": {
     "yolop": {
+      "type": "custom",
       "command": "yolop",
       "args": ["--acp"],
-      "env": { "OPENAI_API_KEY": "sk-..." }
+      "env": {}
     }
   }
 }
@@ -208,6 +219,12 @@ full protocol surface, mappings, and current limitations.
 | `--session <ID>`           | Resume a previous session by id                                      |
 | `--session-dir <PATH>`     | Override the parent directory for session folders                    |
 | `--reasoning-effort <E>`   | OpenAI reasoning effort (`low` / `medium` / `high`)                  |
+
+## Commands
+
+| Command            | Description                                     |
+| ------------------ | ----------------------------------------------- |
+| `yolop into zed`   | Configure yolop as a custom ACP agent in Zed    |
 
 `RUST_LOG` is honored for the underlying tracing layer (writes to stderr).
 

--- a/specs/acp.md
+++ b/specs/acp.md
@@ -125,15 +125,23 @@ real-provider test documents the live path.
 
 ### Real-life testing in an editor
 
-Configure Zed to launch yolop as a custom agent (`~/.config/zed/settings.json`):
+Configure Zed to launch yolop as a custom agent:
+
+```bash
+yolop into zed
+```
+
+This writes the equivalent `agent_servers.yolop` entry to
+`~/.config/zed/settings.json`:
 
 ```json
 {
   "agent_servers": {
     "yolop": {
+      "type": "custom",
       "command": "yolop",
       "args": ["--acp"],
-      "env": { "OPENAI_API_KEY": "sk-..." }
+      "env": {}
     }
   }
 }

--- a/src/into.rs
+++ b/src/into.rs
@@ -1,0 +1,445 @@
+use anyhow::{Context, Result, bail};
+use serde_json::{Map, Value, json};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug)]
+pub struct ZedIntoOptions {
+    pub settings_path: Option<PathBuf>,
+    pub agent_name: String,
+    pub command: PathBuf,
+    pub force: bool,
+}
+
+#[derive(Debug)]
+pub struct ZedIntoResult {
+    pub settings_path: PathBuf,
+    pub agent_name: String,
+    pub command: String,
+    pub status: IntoStatus,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IntoStatus {
+    Created,
+    Updated,
+    Unchanged,
+}
+
+pub fn into_zed(options: ZedIntoOptions) -> Result<ZedIntoResult> {
+    if options.agent_name.trim().is_empty() {
+        bail!("agent server name cannot be empty");
+    }
+
+    let settings_path = options
+        .settings_path
+        .unwrap_or_else(default_zed_settings_path);
+    let command = path_to_json_string(&options.command)?;
+    let desired = zed_agent_server(&command);
+    let existing_text = match std::fs::read_to_string(&settings_path) {
+        Ok(text) => Some(text),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("read Zed settings file {}", settings_path.display()));
+        }
+    };
+    let mut root = match existing_text.as_deref() {
+        Some(text) if !text.trim().is_empty() => parse_zed_settings(text)
+            .with_context(|| format!("parse Zed settings file {}", settings_path.display()))?,
+        _ => json!({}),
+    };
+
+    let root_object = root
+        .as_object_mut()
+        .context("Zed settings root must be a JSON object")?;
+    let agent_servers = root_object
+        .entry("agent_servers")
+        .or_insert_with(|| Value::Object(Map::new()));
+    let agent_servers = agent_servers
+        .as_object_mut()
+        .context("Zed settings `agent_servers` must be a JSON object")?;
+
+    let status = merge_agent_server(agent_servers, &options.agent_name, desired, options.force)?;
+
+    if status != IntoStatus::Unchanged {
+        let rendered = render_settings(&root, existing_text.as_deref())?;
+        write_file_atomically(&settings_path, rendered.as_bytes())?;
+    }
+
+    Ok(ZedIntoResult {
+        settings_path,
+        agent_name: options.agent_name,
+        command,
+        status,
+    })
+}
+
+fn zed_agent_server(command: &str) -> Value {
+    json!({
+        "type": "custom",
+        "command": command,
+        "args": ["--acp"],
+        "env": {}
+    })
+}
+
+fn merge_agent_server(
+    agent_servers: &mut Map<String, Value>,
+    agent_name: &str,
+    desired: Value,
+    force: bool,
+) -> Result<IntoStatus> {
+    let Some(current) = agent_servers.get_mut(agent_name) else {
+        agent_servers.insert(agent_name.to_string(), desired);
+        return Ok(IntoStatus::Created);
+    };
+
+    if current == &desired {
+        return Ok(IntoStatus::Unchanged);
+    }
+
+    if force {
+        *current = desired;
+        return Ok(IntoStatus::Updated);
+    }
+
+    let Some(current_object) = current.as_object_mut() else {
+        bail!("Zed agent_servers.{agent_name} is not an object; re-run with --force to replace it");
+    };
+    let desired_object = desired
+        .as_object()
+        .expect("desired Zed agent server is an object");
+    let mut changed = false;
+    for key in ["type", "command", "args"] {
+        if current_object.get(key) != desired_object.get(key) {
+            current_object.insert(
+                key.to_string(),
+                desired_object.get(key).expect("desired key exists").clone(),
+            );
+            changed = true;
+        }
+    }
+    if !current_object.contains_key("env") {
+        current_object.insert("env".to_string(), json!({}));
+        changed = true;
+    }
+
+    Ok(if changed {
+        IntoStatus::Updated
+    } else {
+        IntoStatus::Unchanged
+    })
+}
+
+fn default_zed_settings_path() -> PathBuf {
+    if let Some(config_home) = std::env::var_os("XDG_CONFIG_HOME")
+        && !config_home.is_empty()
+    {
+        return PathBuf::from(config_home).join("zed").join("settings.json");
+    }
+    if let Some(home) = std::env::var_os("HOME")
+        && !home.is_empty()
+    {
+        return PathBuf::from(home)
+            .join(".config")
+            .join("zed")
+            .join("settings.json");
+    }
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("zed")
+        .join("settings.json")
+}
+
+fn path_to_json_string(path: &Path) -> Result<String> {
+    path.to_str()
+        .map(str::to_string)
+        .with_context(|| format!("command path is not valid UTF-8: {}", path.display()))
+}
+
+fn parse_zed_settings(text: &str) -> Result<Value> {
+    let without_comments = strip_jsonc_comments(text);
+    let strict_json = strip_trailing_commas(&without_comments);
+    Ok(serde_json::from_str(&strict_json)?)
+}
+
+fn render_settings(root: &Value, original_text: Option<&str>) -> Result<String> {
+    let mut rendered = String::new();
+    if let Some(header) = original_text.and_then(leading_comment_header) {
+        rendered.push_str(header);
+        if !rendered.ends_with('\n') {
+            rendered.push('\n');
+        }
+    }
+    rendered.push_str(&serde_json::to_string_pretty(root).context("serialize Zed settings")?);
+    rendered.push('\n');
+    Ok(rendered)
+}
+
+fn leading_comment_header(text: &str) -> Option<&str> {
+    let idx = text.find('{')?;
+    let header = &text[..idx];
+    if header.trim().is_empty() {
+        return None;
+    }
+    if header.lines().all(|line| {
+        let trimmed = line.trim();
+        trimmed.is_empty() || trimmed.starts_with("//")
+    }) {
+        Some(header)
+    } else {
+        None
+    }
+}
+
+fn strip_jsonc_comments(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    let mut in_string = false;
+    let mut escaped = false;
+
+    while let Some(ch) = chars.next() {
+        if in_string {
+            out.push(ch);
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+
+        if ch == '"' {
+            in_string = true;
+            out.push(ch);
+            continue;
+        }
+
+        if ch == '/' {
+            match chars.peek().copied() {
+                Some('/') => {
+                    chars.next();
+                    for comment_ch in chars.by_ref() {
+                        if comment_ch == '\n' {
+                            out.push('\n');
+                            break;
+                        }
+                    }
+                }
+                Some('*') => {
+                    chars.next();
+                    let mut previous = '\0';
+                    for comment_ch in chars.by_ref() {
+                        if comment_ch == '\n' {
+                            out.push('\n');
+                        }
+                        if previous == '*' && comment_ch == '/' {
+                            break;
+                        }
+                        previous = comment_ch;
+                    }
+                }
+                _ => out.push(ch),
+            }
+            continue;
+        }
+
+        out.push(ch);
+    }
+
+    out
+}
+
+fn strip_trailing_commas(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    let mut in_string = false;
+    let mut escaped = false;
+
+    'outer: while let Some(ch) = chars.next() {
+        if in_string {
+            out.push(ch);
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+
+        if ch == '"' {
+            in_string = true;
+            out.push(ch);
+            continue;
+        }
+
+        if ch == ',' {
+            let mut lookahead = chars.clone();
+            while let Some(next) = lookahead.peek().copied() {
+                if next.is_whitespace() {
+                    lookahead.next();
+                    continue;
+                }
+                if next == '}' || next == ']' {
+                    chars = lookahead;
+                    continue 'outer;
+                }
+                break;
+            }
+        }
+
+        out.push(ch);
+    }
+
+    out
+}
+
+fn write_file_atomically(path: &Path, content: &[u8]) -> Result<()> {
+    let parent = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(parent)
+        .with_context(|| format!("create Zed settings dir {}", parent.display()))?;
+    let file_name = path
+        .file_name()
+        .with_context(|| format!("Zed settings path has no file name: {}", path.display()))?;
+    let mut tmp_name = std::ffi::OsString::from(".");
+    tmp_name.push(file_name);
+    tmp_name.push(format!(".tmp.{}", std::process::id()));
+    let tmp_path = parent.join(tmp_name);
+
+    let write_result = std::fs::write(&tmp_path, content)
+        .with_context(|| format!("write temp Zed settings {}", tmp_path.display()));
+    if let Err(err) = write_result {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(err);
+    }
+    std::fs::rename(&tmp_path, path)
+        .with_context(|| format!("rename {} -> {}", tmp_path.display(), path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn into_at(path: PathBuf, command: &str, force: bool) -> Result<ZedIntoResult> {
+        into_zed(ZedIntoOptions {
+            settings_path: Some(path),
+            agent_name: "yolop".to_string(),
+            command: PathBuf::from(command),
+            force,
+        })
+    }
+
+    #[test]
+    fn zed_into_creates_missing_settings_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("zed/settings.json");
+
+        let result = into_at(path.clone(), "/bin/yolop", false).expect("into");
+
+        assert_eq!(result.status, IntoStatus::Created);
+        let value: Value =
+            serde_json::from_str(&std::fs::read_to_string(path).expect("settings")).unwrap();
+        assert_eq!(
+            value["agent_servers"]["yolop"],
+            json!({
+                "type": "custom",
+                "command": "/bin/yolop",
+                "args": ["--acp"],
+                "env": {}
+            })
+        );
+    }
+
+    #[test]
+    fn zed_into_preserves_existing_settings_and_header_comments() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("settings.json");
+        std::fs::write(
+            &path,
+            "// Zed settings\n{\n  \"theme\": \"One Dark\",\n  \"agent_servers\": {},\n}\n",
+        )
+        .expect("write settings");
+
+        let result = into_at(path.clone(), "/bin/yolop", false).expect("into");
+
+        assert_eq!(result.status, IntoStatus::Created);
+        let text = std::fs::read_to_string(path).expect("settings");
+        assert!(text.starts_with("// Zed settings\n"));
+        let parsed = parse_zed_settings(&text).expect("parse");
+        assert_eq!(parsed["theme"], "One Dark");
+        assert_eq!(parsed["agent_servers"]["yolop"]["args"], json!(["--acp"]));
+    }
+
+    #[test]
+    fn zed_into_updates_existing_object_and_preserves_env() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("settings.json");
+        std::fs::write(
+            &path,
+            r#"{"agent_servers":{"yolop":{"type":"custom","command":"old","args":["--old"],"env":{"OPENAI_API_KEY":"keep"},"default_model":"gpt-test"}}}"#,
+        )
+        .expect("write settings");
+
+        let result = into_at(path.clone(), "/bin/yolop", false).expect("into");
+
+        assert_eq!(result.status, IntoStatus::Updated);
+        let parsed = parse_zed_settings(&std::fs::read_to_string(path).unwrap()).unwrap();
+        assert_eq!(parsed["agent_servers"]["yolop"]["command"], "/bin/yolop");
+        assert_eq!(parsed["agent_servers"]["yolop"]["args"], json!(["--acp"]));
+        assert_eq!(
+            parsed["agent_servers"]["yolop"]["env"]["OPENAI_API_KEY"],
+            "keep"
+        );
+        assert_eq!(
+            parsed["agent_servers"]["yolop"]["default_model"],
+            "gpt-test"
+        );
+    }
+
+    #[test]
+    fn zed_into_leaves_matching_object_unchanged_even_with_env() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("settings.json");
+        std::fs::write(
+            &path,
+            r#"{"agent_servers":{"yolop":{"type":"custom","command":"/bin/yolop","args":["--acp"],"env":{"OPENAI_API_KEY":"keep"}}}}"#,
+        )
+        .expect("write settings");
+
+        let result = into_at(path, "/bin/yolop", false).expect("into");
+
+        assert_eq!(result.status, IntoStatus::Unchanged);
+    }
+
+    #[test]
+    fn zed_into_refuses_non_object_entry_without_force() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("settings.json");
+        std::fs::write(&path, r#"{"agent_servers":{"yolop":"old"}}"#).expect("write settings");
+
+        let err = into_at(path, "/bin/yolop", false).expect_err("expected conflict");
+
+        assert!(err.to_string().contains("--force"));
+    }
+
+    #[test]
+    fn zed_into_replaces_non_object_entry_with_force() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("settings.json");
+        std::fs::write(&path, r#"{"agent_servers":{"yolop":"old"}}"#).expect("write settings");
+
+        let result = into_at(path.clone(), "/bin/yolop", true).expect("into");
+
+        assert_eq!(result.status, IntoStatus::Updated);
+        let parsed = parse_zed_settings(&std::fs::read_to_string(path).unwrap()).unwrap();
+        assert_eq!(parsed["agent_servers"]["yolop"]["command"], "/bin/yolop");
+    }
+}

--- a/src/into.rs
+++ b/src/into.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result, bail};
 use serde_json::{Map, Value, json};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug)]
@@ -313,11 +314,27 @@ fn write_file_atomically(path: &Path, content: &[u8]) -> Result<()> {
     tmp_name.push(format!(".tmp.{}", std::process::id()));
     let tmp_path = parent.join(tmp_name);
 
-    let write_result = std::fs::write(&tmp_path, content)
-        .with_context(|| format!("write temp Zed settings {}", tmp_path.display()));
+    let write_result = (|| -> Result<()> {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&tmp_path)
+            .with_context(|| format!("open temp Zed settings {}", tmp_path.display()))?;
+        file.write_all(content)
+            .with_context(|| format!("write temp Zed settings {}", tmp_path.display()))?;
+        file.sync_all()
+            .with_context(|| format!("sync temp Zed settings {}", tmp_path.display()))?;
+        Ok(())
+    })();
     if let Err(err) = write_result {
         let _ = std::fs::remove_file(&tmp_path);
         return Err(err);
+    }
+    #[cfg(windows)]
+    if path.exists() {
+        std::fs::remove_file(path)
+            .with_context(|| format!("remove existing Zed settings {}", path.display()))?;
     }
     std::fs::rename(&tmp_path, path)
         .with_context(|| format!("rename {} -> {}", tmp_path.display(), path.display()))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod app;
 mod approval;
 mod capabilities;
 mod diff;
+mod into;
 mod runtime;
 mod session_log;
 mod settings;
@@ -23,7 +24,7 @@ mod agent_scenarios;
 use anyhow::Result;
 use app::{App, COMPOSER_VIEWPORT_HEIGHT};
 use approval::ApprovalGate;
-use clap::Parser;
+use clap::{Args, Parser, Subcommand};
 use crossterm::event::{
     KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
 };
@@ -45,6 +46,9 @@ use std::sync::Arc;
     about = "Yolop coding agent — embedded terminal agent built on everruns-runtime"
 )]
 struct Cli {
+    #[command(subcommand)]
+    command: Option<Commands>,
+
     /// Workspace root the agent operates inside (default: current dir)
     #[arg(short = 'C', long = "cwd")]
     cwd: Option<PathBuf>,
@@ -92,6 +96,43 @@ struct Cli {
     /// `%APPDATA%\yolop\sessions\` on Windows).
     #[arg(long)]
     session_dir: Option<PathBuf>,
+}
+
+#[derive(Subcommand, Debug)]
+enum Commands {
+    /// Add yolop into supported editors.
+    Into(IntoCommand),
+}
+
+#[derive(Args, Debug)]
+struct IntoCommand {
+    #[command(subcommand)]
+    target: IntoTarget,
+}
+
+#[derive(Subcommand, Debug)]
+enum IntoTarget {
+    /// Configure Zed to launch yolop as a custom ACP agent.
+    Zed(ZedIntoArgs),
+}
+
+#[derive(Args, Debug)]
+struct ZedIntoArgs {
+    /// Zed settings file to update (default: ~/.config/zed/settings.json).
+    #[arg(long = "settings")]
+    settings_path: Option<PathBuf>,
+
+    /// Agent server name to write under `agent_servers`.
+    #[arg(long, default_value = "yolop")]
+    name: String,
+
+    /// Command path Zed should spawn (default: this yolop executable).
+    #[arg(long)]
+    command: Option<PathBuf>,
+
+    /// Replace an existing `agent_servers.<name>` entry instead of preserving its env/extra fields.
+    #[arg(long)]
+    force: bool,
 }
 
 #[derive(clap::ValueEnum, Debug, Clone, Copy)]
@@ -183,6 +224,10 @@ async fn main() -> Result<()> {
         .init();
 
     let cli = Cli::parse();
+    if let Some(command) = cli.command {
+        return run_command(command);
+    }
+
     let cwd = cli
         .cwd
         .clone()
@@ -245,6 +290,50 @@ async fn main() -> Result<()> {
         return run_print_mode(runtime, prompt).await;
     }
     run_tui(runtime, approval_rx).await
+}
+
+fn run_command(command: Commands) -> Result<()> {
+    match command {
+        Commands::Into(into) => match into.target {
+            IntoTarget::Zed(args) => {
+                let command = match args.command {
+                    Some(path) => path,
+                    None => std::env::current_exe().unwrap_or_else(|_| PathBuf::from("yolop")),
+                };
+                let result = into::into_zed(into::ZedIntoOptions {
+                    settings_path: args.settings_path,
+                    agent_name: args.name,
+                    command,
+                    force: args.force,
+                })?;
+                match result.status {
+                    into::IntoStatus::Unchanged => {
+                        println!(
+                            "yolop: Zed already has `{}` configured at {}",
+                            result.agent_name,
+                            result.settings_path.display()
+                        );
+                    }
+                    into::IntoStatus::Created => {
+                        println!(
+                            "yolop: added `{}` ACP agent to {}",
+                            result.agent_name,
+                            result.settings_path.display()
+                        );
+                    }
+                    into::IntoStatus::Updated => {
+                        println!(
+                            "yolop: updated `{}` ACP agent in {}",
+                            result.agent_name,
+                            result.settings_path.display()
+                        );
+                    }
+                }
+                println!("yolop: Zed command: {} --acp", result.command);
+                Ok(())
+            }
+        },
+    }
 }
 
 async fn run_tui(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -58,6 +58,42 @@ fn version_flag_succeeds() {
 }
 
 #[test]
+fn into_zed_command_writes_acp_settings() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let settings = tmp.path().join("zed/settings.json");
+
+    let output = Command::new(yolop_binary())
+        .args([
+            "into",
+            "zed",
+            "--settings",
+            settings.to_str().unwrap(),
+            "--command",
+            "/tmp/yolop",
+        ])
+        .output()
+        .expect("spawn yolop into zed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "into zed failed: stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        stdout.contains("added `yolop` ACP agent"),
+        "unexpected into stdout: {stdout}"
+    );
+    let value: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(settings).expect("settings")).unwrap();
+    assert_eq!(value["agent_servers"]["yolop"]["type"], "custom");
+    assert_eq!(value["agent_servers"]["yolop"]["command"], "/tmp/yolop");
+    assert_eq!(
+        value["agent_servers"]["yolop"]["args"],
+        serde_json::json!(["--acp"])
+    );
+}
+
+#[test]
 fn llmsim_print_smoke() {
     // The llmsim provider needs no API key and returns deterministic output.
     // We point --session-dir at a temp dir so the test never touches the


### PR DESCRIPTION
## What
Add `yolop into zed`, a CLI command that configures Zed to launch yolop as a custom ACP agent.

## Why
Users should not have to hand-edit Zed settings to use yolop over ACP.

## How
- Add a top-level `into zed` command.
- Write or update `agent_servers.yolop` in Zed settings with `type = custom`, the current yolop executable, and `--acp` args.
- Re-running the command updates the existing yolop entry while preserving `env` and extra Zed settings.
- Add focused unit and integration tests, plus README/spec documentation.

## Risk
- Low
- Main risk is writing malformed or unexpected Zed settings. Mitigated by JSON/JSONC parsing tests, atomic writes, temp-file smoke tests, and preserving existing `env`/extra fields on normal updates.

## Security
- TM-FS: The new command writes only to the user-selected/default Zed settings path. It does not alter yolop workspace filesystem tools or write blocklists.
- TM-BASH: No shell execution behavior changes.
- TM-LLM: No prompt construction, provider auth, API key logging, or session JSONL behavior changes. Existing Zed `env` settings are preserved and not printed.
- TM-TOOL: No runtime capability registration changes.
- TM-DEP: No new dependencies.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo build --release`
- `cargo run -- --provider llmsim -p "hi"`
- `cargo run -- into zed --settings /tmp/yolop-zed-settings-ship.json --command /tmp/yolop`
- `cargo run -- into zed --settings /tmp/yolop-zed-settings-ship.json --command /tmp/yolop2`

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
