### PR TITLE
feat(acp): enrich slash command support

### DIFF
--- a/specs/acp.md
+++ b/specs/acp.md
@@ -31,7 +31,7 @@ ACP protocol version: **1** (integer).
 | `initialize` | client → agent | Negotiates protocol version and advertises agent capabilities. Echoes the client's version when supported, else advertises v1. |
 | `authenticate` | client → agent | No-op success: credentials come from the environment/settings the process already inherits, so `authMethods` is empty. |
 | `session/new` | client → agent | Builds a fresh runtime rooted at the client-supplied `cwd`; returns the everruns session id as the ACP `sessionId`. |
-| `session/prompt` | client → agent | Runs one turn, streams `session/update`s, and resolves a `stopReason`. |
+| `session/prompt` | client → agent | Runs one turn, or executes a recognised `/command`; streams `session/update`s, and resolves a `stopReason`. |
 | `session/cancel` | client → agent | Notification. Abandons the in-flight turn for that session and resolves the prompt with `stopReason: "cancelled"`. |
 | `session/update` | agent → client | Notification. Streams the turn (see below). |
 | `session/request_permission` | agent → client | Asks the editor to approve a destructive operation (see Permissions). |
@@ -59,6 +59,23 @@ notifications. The mapping is a pure, per-turn state machine
 Tool `kind` is mapped from the tool name (read/search/edit/delete/execute/fetch,
 else `other`). To avoid duplicating streamed text, a completed assistant message
 is only emitted as a chunk when no deltas streamed for it during the turn.
+
+After `session/new`, yolop sends `available_commands_update` with
+capability-sourced slash commands such as `/setup` and user-invocable skill
+commands. ACP clients run commands by sending their literal text in
+`session/prompt` (for example, `/setup status`). System commands execute
+through `runtime.execute_command` and stream a command-shaped `tool_call` /
+`tool_call_update` pair with structured `rawInput`, `rawOutput`, and text
+`content`; skill commands are forwarded as prompt text so the model can activate
+the skill.
+
+ACP v1 command input only standardises an unstructured `input.hint`. yolop also
+adds compatible extension metadata under `_meta["yolop.dev/command"]` so richer
+clients can render command argument suggestions (for example `/setup status`,
+`/setup provider openai`, or `/setup effort high`). Standard clients ignore
+this metadata and still see the command name, description, and hint. After a
+system command runs, yolop re-emits `available_commands_update` so clients can
+refresh any state-sensitive command UI.
 
 ### Stop reasons
 
@@ -117,7 +134,7 @@ Three layers, all offline (no API key):
    an in-memory ACP client: the full `initialize` → `session/new` →
    `session/prompt` handshake, unknown-method and unknown-session errors,
    scripted tool calls (asserting `tool_call`/`tool_call_update` + permission
-   grant), and `write_todos` → `plan`.
+   grant), `write_todos` → `plan`, and command advertisement/execution.
 
 The binary itself is smoke-tested over real OS pipes in
 `tests/integration.rs` (`acp_stdio_handshake_smoke`), and a `#[ignore]`d
@@ -148,7 +165,6 @@ same way.
 - Client-provided filesystem (`fs/read_text_file`, `fs/write_text_file`):
   yolop's runtime reads and writes the host disk directly under the workspace
   root, so it does not route file ops back through the client.
-- Terminals, MCP-server pass-through, audio/image prompt content, and slash
-  commands (`available_commands_update`).
+- Terminals, MCP-server pass-through, and audio/image prompt content.
 - In-flight turn interruption beyond abandoning the task — the runtime has no
   mid-turn cancellation hook yet.

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -256,10 +256,13 @@ mod tests {
                     json!({ "cwd": cwd.to_str().unwrap(), "mcpServers": [] }),
                 )
                 .await;
-            response["result"]["sessionId"]
+            let session_id = response["result"]["sessionId"]
                 .as_str()
                 .expect("sessionId in response")
-                .to_string()
+                .to_string();
+            let update = self.next_message().await;
+            self.handle_incoming(update).await;
+            session_id
         }
     }
 

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -307,6 +307,88 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn new_session_advertises_available_commands() {
+        let mut client = TestClient::spawn(fixed("hi"), true);
+        client.initialize().await;
+        client.new_session().await;
+
+        let command_updates = client.updates_of_kind("available_commands_update");
+        assert!(
+            !command_updates.is_empty(),
+            "expected available_commands_update, got: {:?}",
+            client.notifications
+        );
+        let commands = command_updates[0]["update"]["availableCommands"]
+            .as_array()
+            .expect("availableCommands array");
+        assert!(
+            commands.iter().any(|c| c["name"] == "setup"),
+            "expected /setup to be advertised, got: {commands:?}"
+        );
+        let setup = commands
+            .iter()
+            .find(|c| c["name"] == "setup")
+            .expect("setup command");
+        let suggestions = setup["_meta"]["yolop.dev/command"]["args"][0]["suggestions"]
+            .as_array()
+            .expect("setup suggestions");
+        assert!(
+            suggestions.iter().any(|s| s == "status")
+                && suggestions.iter().any(|s| s == "provider openai"),
+            "expected setup choices in command metadata, got: {setup:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn slash_system_command_executes_without_model_turn() {
+        let mut client = TestClient::spawn(fixed("model should not run"), true);
+        client.initialize().await;
+        let session_id = client.new_session().await;
+
+        let response = client
+            .request(
+                "session/prompt",
+                json!({
+                    "sessionId": session_id,
+                    "prompt": [{ "type": "text", "text": "/setup status" }],
+                }),
+            )
+            .await;
+
+        assert_eq!(response["result"]["stopReason"], "end_turn");
+        let tool_calls = client.updates_of_kind("tool_call");
+        assert!(
+            tool_calls
+                .iter()
+                .any(|u| u["update"]["title"] == "/setup status"
+                    && u["update"]["rawInput"]["command"] == "setup"),
+            "expected command tool_call, got notifications: {:?}",
+            client.notifications
+        );
+        let tool_updates = client.updates_of_kind("tool_call_update");
+        let completed = tool_updates
+            .iter()
+            .find(|u| u["update"]["status"] == "completed")
+            .expect("completed command tool update");
+        assert!(
+            completed["update"]["content"][0]["content"]["text"]
+                .as_str()
+                .is_some_and(|text| text.contains("setup: provider=")),
+            "expected setup status in command output, got: {completed:?}"
+        );
+        assert_eq!(completed["update"]["rawOutput"]["success"], true);
+        assert!(
+            !client.assistant_text().contains("model should not run"),
+            "slash command should not invoke the model"
+        );
+        assert!(
+            client.updates_of_kind("available_commands_update").len() >= 2,
+            "expected command refresh after execution, got: {:?}",
+            client.notifications
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn unknown_method_returns_method_not_found() {
         let mut client = TestClient::spawn(fixed("hi"), true);
         client.initialize().await;

--- a/src/acp/protocol.rs
+++ b/src/acp/protocol.rs
@@ -47,6 +47,8 @@ pub struct InitializeResult {
 pub struct AgentCapabilities {
     pub load_session: bool,
     pub prompt_capabilities: PromptCapabilities,
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -166,6 +168,12 @@ pub enum SessionUpdate {
     Plan {
         entries: Vec<PlanEntry>,
     },
+    AvailableCommandsUpdate {
+        #[serde(rename = "availableCommands")]
+        available_commands: Vec<AvailableCommand>,
+        #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+        meta: Option<Value>,
+    },
 }
 
 /// A content block. yolop only ever emits text blocks; the spec also defines
@@ -260,6 +268,25 @@ pub enum PlanStatus {
     Completed,
 }
 
+// ---------- available_commands_update ----------
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AvailableCommand {
+    pub name: String,
+    pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input: Option<AvailableCommandInput>,
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AvailableCommandInput {
+    pub hint: String,
+}
+
 // ---------- session/request_permission ----------
 
 #[derive(Debug, Clone, Serialize)]
@@ -340,6 +367,7 @@ mod tests {
                     audio: false,
                     embedded_context: true,
                 },
+                meta: None,
             },
             auth_methods: vec![],
         };
@@ -426,6 +454,42 @@ mod tests {
         let v = serde_json::to_value(&entry).unwrap();
         assert_eq!(v["priority"], "medium");
         assert_eq!(v["status"], "in_progress");
+    }
+
+    #[test]
+    fn available_commands_update_serializes_command_list() {
+        let update = SessionUpdate::AvailableCommandsUpdate {
+            available_commands: vec![AvailableCommand {
+                name: "setup".into(),
+                description: "Configure provider.".into(),
+                input: Some(AvailableCommandInput {
+                    hint: "provider, token, model".into(),
+                }),
+                meta: Some(json!({
+                    "yolop.dev/command": {
+                        "args": [
+                            {
+                                "name": "action",
+                                "suggestions": ["status", "provider openai"]
+                            }
+                        ]
+                    }
+                })),
+            }],
+            meta: Some(json!({ "yolop.dev/acp": { "argSuggestions": true } })),
+        };
+        let v = serde_json::to_value(&update).unwrap();
+        assert_eq!(v["sessionUpdate"], "available_commands_update");
+        assert_eq!(v["availableCommands"][0]["name"], "setup");
+        assert_eq!(
+            v["availableCommands"][0]["input"]["hint"],
+            "provider, token, model"
+        );
+        assert_eq!(
+            v["availableCommands"][0]["_meta"]["yolop.dev/command"]["args"][0]["suggestions"][0],
+            "status"
+        );
+        assert_eq!(v["_meta"]["yolop.dev/acp"]["argSuggestions"], true);
     }
 
     #[test]

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -26,6 +26,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use everruns_core::command::{CommandDescriptor, CommandSource, ExecuteCommandRequest};
 use serde_json::{Value, json};
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::sync::{mpsc, oneshot};
@@ -35,10 +36,11 @@ use crate::runtime::{BuiltRuntime, ModelState, RuntimeHandles};
 
 use super::bridge::Translator;
 use super::protocol::{
-    self, AgentCapabilities, InitializeParams, InitializeResult, NewSessionParams,
-    NewSessionResult, PermissionOption, PermissionOptionKind, PermissionOutcome,
-    PromptCapabilities, PromptParams, PromptResult, RequestPermissionParams,
-    RequestPermissionResult, SessionNotification, SessionUpdate, StopReason,
+    self, AgentCapabilities, AvailableCommand, AvailableCommandInput, InitializeParams,
+    InitializeResult, NewSessionParams, NewSessionResult, PermissionOption, PermissionOptionKind,
+    PermissionOutcome, PromptCapabilities, PromptParams, PromptResult, RequestPermissionParams,
+    RequestPermissionResult, SessionNotification, SessionUpdate, StopReason, ToolCallContent,
+    ToolCallStatus, ToolKind,
 };
 
 /// JSON-RPC error codes used in agent responses.
@@ -159,6 +161,7 @@ struct Session {
     acp_id: String,
     handles: RuntimeHandles,
     model: ModelState,
+    commands: StdMutex<Vec<CommandDescriptor>>,
     cancel: StdMutex<Option<oneshot::Sender<()>>>,
 }
 
@@ -346,6 +349,13 @@ fn handle_initialize(params: Value) -> std::result::Result<Value, RpcError> {
                 audio: false,
                 embedded_context: true,
             },
+            meta: Some(json!({
+                "yolop.dev/acp": {
+                    "commandMetadata": true,
+                    "commandArgSuggestions": true,
+                    "commandToolLifecycle": true
+                }
+            })),
         },
         // No auth handshake: credentials come from the environment/settings
         // the agent process already inherits.
@@ -376,10 +386,12 @@ async fn handle_new_session<F: RuntimeFactory>(
         .map_err(|e| RpcError::new(INTERNAL_ERROR, format!("build runtime: {e}")))?;
 
     let acp_id = built.handles.session_id.to_string();
+    let commands = built.startup.capability_commands.clone();
     let session = Arc::new(Session {
         acp_id: acp_id.clone(),
         handles: built.handles,
         model: built.model,
+        commands: StdMutex::new(commands.clone()),
         cancel: StdMutex::new(None),
     });
     server
@@ -387,6 +399,18 @@ async fn handle_new_session<F: RuntimeFactory>(
         .lock()
         .unwrap()
         .insert(acp_id.clone(), session);
+
+    server.peer.session_update(
+        &acp_id,
+        SessionUpdate::AvailableCommandsUpdate {
+            available_commands: available_commands(&commands),
+            meta: Some(json!({
+                "yolop.dev/acp": {
+                    "argSuggestions": true
+                }
+            })),
+        },
+    );
 
     // Forward every approval request to the client as a permission prompt for
     // the lifetime of the session.
@@ -414,9 +438,222 @@ async fn handle_prompt<F: RuntimeFactory>(
         .ok_or_else(|| RpcError::new(INVALID_PARAMS, "unknown session id"))?;
     let prompt = protocol::prompt_text(&params.prompt);
 
-    let stop_reason = run_prompt(server.peer.clone(), session, prompt).await;
+    let stop_reason = match parse_slash_command(&prompt) {
+        Some((name, args)) => run_slash_command(server.peer.clone(), session, name, args).await,
+        None => run_prompt(server.peer.clone(), session, prompt).await,
+    };
     let result = PromptResult { stop_reason };
     Ok(serde_json::to_value(result).expect("prompt result serializes"))
+}
+
+fn available_commands(commands: &[CommandDescriptor]) -> Vec<AvailableCommand> {
+    commands
+        .iter()
+        .map(|command| AvailableCommand {
+            name: command.name.clone(),
+            description: command.description.clone(),
+            input: command_input(command),
+            meta: command_meta(command),
+        })
+        .collect()
+}
+
+fn command_input(command: &CommandDescriptor) -> Option<AvailableCommandInput> {
+    if command.args.is_empty() {
+        return None;
+    }
+    let hint = command
+        .args
+        .iter()
+        .map(|arg| {
+            if arg.description.trim().is_empty() {
+                arg.name.as_str()
+            } else {
+                arg.description.as_str()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    Some(AvailableCommandInput { hint })
+}
+
+fn command_meta(command: &CommandDescriptor) -> Option<Value> {
+    if command.args.is_empty() {
+        return None;
+    }
+    let source = match command.source {
+        CommandSource::System => "system",
+        CommandSource::Skill => "skill",
+    };
+    Some(json!({
+        "yolop.dev/command": {
+            "source": source,
+            "args": command.args.iter().map(|arg| {
+                json!({
+                    "name": arg.name,
+                    "description": arg.description,
+                    "required": arg.required,
+                    "suggestions": arg.suggestions,
+                })
+            }).collect::<Vec<_>>()
+        }
+    }))
+}
+
+fn parse_slash_command(prompt: &str) -> Option<(String, String)> {
+    let trimmed = prompt.trim();
+    let rest = trimmed.strip_prefix('/')?.trim_start();
+    let mut parts = rest.splitn(2, char::is_whitespace);
+    let name = parts.next()?.trim();
+    if name.is_empty() {
+        return None;
+    }
+    let args = parts.next().unwrap_or_default().trim();
+    Some((name.to_string(), args.to_string()))
+}
+
+async fn run_slash_command(
+    peer: Arc<Peer>,
+    session: Arc<Session>,
+    name: String,
+    args: String,
+) -> StopReason {
+    let commands = session.commands.lock().unwrap().clone();
+    let Some(descriptor) = commands.iter().find(|c| c.name == name).cloned() else {
+        peer.session_update(
+            &session.acp_id,
+            SessionUpdate::AgentMessageChunk {
+                content: protocol::ContentBlock::text(format!("unknown command: /{name}")),
+            },
+        );
+        return StopReason::EndTurn;
+    };
+
+    let required_missing = descriptor
+        .args
+        .iter()
+        .any(|a| a.required && args.is_empty());
+    if required_missing {
+        let needed = descriptor
+            .args
+            .iter()
+            .filter(|a| a.required)
+            .map(|a| a.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        peer.session_update(
+            &session.acp_id,
+            SessionUpdate::AgentMessageChunk {
+                content: protocol::ContentBlock::text(format!("/{name} requires: {needed}")),
+            },
+        );
+        return StopReason::EndTurn;
+    }
+
+    match descriptor.source {
+        CommandSource::System => {
+            let tool_call_id = format!("command_{}", peer.next_id.fetch_add(1, Ordering::Relaxed));
+            peer.session_update(
+                &session.acp_id,
+                SessionUpdate::ToolCall {
+                    tool_call_id: tool_call_id.clone(),
+                    title: command_title(&descriptor.name, &args),
+                    kind: ToolKind::Other,
+                    status: ToolCallStatus::InProgress,
+                    raw_input: Some(json!({
+                        "command": descriptor.name,
+                        "arguments": if args.is_empty() { Value::Null } else { Value::String(args.clone()) },
+                        "source": "system",
+                    })),
+                    content: Vec::new(),
+                },
+            );
+
+            let request = ExecuteCommandRequest {
+                name: descriptor.name.clone(),
+                arguments: if args.is_empty() { None } else { Some(args) },
+                controls: None,
+            };
+            let (success, message, raw_output) = match session
+                .handles
+                .runtime
+                .execute_command(session.handles.session_id, request)
+                .await
+            {
+                Ok(result) => {
+                    let prefix = if result.success { "" } else { "error: " };
+                    (
+                        result.success,
+                        format!("{prefix}{}", result.message),
+                        serde_json::to_value(result).expect("command result serializes"),
+                    )
+                }
+                Err(err) => (
+                    false,
+                    format!("/{name} failed: {err}"),
+                    json!({ "success": false, "message": format!("{err}") }),
+                ),
+            };
+            peer.session_update(
+                &session.acp_id,
+                SessionUpdate::ToolCallUpdate {
+                    tool_call_id,
+                    status: Some(if success {
+                        ToolCallStatus::Completed
+                    } else {
+                        ToolCallStatus::Failed
+                    }),
+                    content: vec![ToolCallContent::Content {
+                        content: protocol::ContentBlock::text(message),
+                    }],
+                    raw_output: Some(raw_output),
+                },
+            );
+            refresh_available_commands(&peer, &session).await;
+            StopReason::EndTurn
+        }
+        CommandSource::Skill => {
+            let text = if args.is_empty() {
+                format!("/{name}")
+            } else {
+                format!("/{name} {args}")
+            };
+            run_prompt(peer, session, text).await
+        }
+    }
+}
+
+fn command_title(name: &str, args: &str) -> String {
+    if args.is_empty() {
+        format!("/{name}")
+    } else {
+        format!("/{name} {args}")
+    }
+}
+
+async fn refresh_available_commands(peer: &Arc<Peer>, session: &Arc<Session>) {
+    match session
+        .handles
+        .runtime
+        .list_commands(session.handles.session_id)
+        .await
+    {
+        Ok(commands) => {
+            *session.commands.lock().unwrap() = commands.clone();
+            peer.session_update(
+                &session.acp_id,
+                SessionUpdate::AvailableCommandsUpdate {
+                    available_commands: available_commands(&commands),
+                    meta: Some(json!({
+                        "yolop.dev/acp": {
+                            "argSuggestions": true
+                        }
+                    })),
+                },
+            );
+        }
+        Err(err) => tracing::warn!(%err, "acp: command refresh failed"),
+    }
 }
 
 /// Drive one prompt turn: stream the runtime's events to the client as

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -297,10 +297,29 @@ async fn handle_request<F: RuntimeFactory>(server: Arc<Server<F>>, id: Value, me
         .to_string();
     let params = message.get("params").cloned().unwrap_or(Value::Null);
 
+    if method == "session/new" {
+        match handle_new_session(&server, params).await {
+            Ok(result) => {
+                let session_id = result
+                    .get("sessionId")
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+                server.peer.respond_ok(id, result);
+                if let Some(session_id) = session_id
+                    && let Some(session) = server.session(&session_id)
+                {
+                    let commands = session.commands.lock().unwrap().clone();
+                    notify_available_commands(&server.peer, &session_id, &commands);
+                }
+            }
+            Err(err) => server.peer.respond_err(id, err.code, &err.message),
+        }
+        return;
+    }
+
     let outcome = match method.as_str() {
         "initialize" => handle_initialize(params),
         "authenticate" => Ok(json!({})),
-        "session/new" => handle_new_session(&server, params).await,
         "session/prompt" => handle_prompt(&server, params).await,
         other => Err(RpcError::new(
             METHOD_NOT_FOUND,
@@ -400,18 +419,6 @@ async fn handle_new_session<F: RuntimeFactory>(
         .unwrap()
         .insert(acp_id.clone(), session);
 
-    server.peer.session_update(
-        &acp_id,
-        SessionUpdate::AvailableCommandsUpdate {
-            available_commands: available_commands(&commands),
-            meta: Some(json!({
-                "yolop.dev/acp": {
-                    "argSuggestions": true
-                }
-            })),
-        },
-    );
-
     // Forward every approval request to the client as a permission prompt for
     // the lifetime of the session.
     let peer = server.peer.clone();
@@ -475,6 +482,20 @@ fn command_input(command: &CommandDescriptor) -> Option<AvailableCommandInput> {
         .collect::<Vec<_>>()
         .join(", ");
     Some(AvailableCommandInput { hint })
+}
+
+fn notify_available_commands(peer: &Arc<Peer>, session_id: &str, commands: &[CommandDescriptor]) {
+    peer.session_update(
+        session_id,
+        SessionUpdate::AvailableCommandsUpdate {
+            available_commands: available_commands(commands),
+            meta: Some(json!({
+                "yolop.dev/acp": {
+                    "argSuggestions": true
+                }
+            })),
+        },
+    );
 }
 
 fn command_meta(command: &CommandDescriptor) -> Option<Value> {
@@ -640,17 +661,7 @@ async fn refresh_available_commands(peer: &Arc<Peer>, session: &Arc<Session>) {
     {
         Ok(commands) => {
             *session.commands.lock().unwrap() = commands.clone();
-            peer.session_update(
-                &session.acp_id,
-                SessionUpdate::AvailableCommandsUpdate {
-                    available_commands: available_commands(&commands),
-                    meta: Some(json!({
-                        "yolop.dev/acp": {
-                            "argSuggestions": true
-                        }
-                    })),
-                },
-            );
+            notify_available_commands(peer, &session.acp_id, &commands);
         }
         Err(err) => tracing::warn!(%err, "acp: command refresh failed"),
     }

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -415,19 +415,15 @@ fn setup_command_arg() -> CommandArg {
     let mut suggestions = vec![
         "status".to_string(),
         "model".to_string(),
-        "token openai ".to_string(),
-        "token anthropic ".to_string(),
-        "token google ".to_string(),
-        "token openrouter ".to_string(),
-        "token ollama ".to_string(),
-        "token openai clear".to_string(),
-        "token anthropic clear".to_string(),
-        "token google clear".to_string(),
-        "token openrouter clear".to_string(),
-        "token ollama clear".to_string(),
         "attribution on".to_string(),
         "attribution off".to_string(),
     ];
+    suggestions.extend(TOKEN_PROVIDERS.iter().flat_map(|provider| {
+        [
+            format!("token {provider} "),
+            format!("token {provider} clear"),
+        ]
+    }));
     suggestions.extend(
         SUPPORTED_PROVIDERS
             .iter()

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -9,7 +9,8 @@ use async_trait::async_trait;
 use chrono::Local;
 use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
 use everruns_core::command::{
-    CommandDescriptor, CommandExecutionContext, CommandResult, CommandSource, ExecuteCommandRequest,
+    CommandArg, CommandDescriptor, CommandExecutionContext, CommandResult, CommandSource,
+    ExecuteCommandRequest,
 };
 use everruns_core::tools::Tool;
 use everruns_runtime::RuntimeProviderStore;
@@ -373,7 +374,7 @@ impl Capability for SetupCapability {
             name: "setup".to_string(),
             description: "Configure provider, API key, and model.".to_string(),
             source: CommandSource::System,
-            args: vec![],
+            args: vec![setup_command_arg()],
         }]
     }
 
@@ -407,6 +408,49 @@ impl Capability for SetupCapability {
                 "usage: /setup — run guided setup; internal forms: status, provider <name>, token <provider> <value|clear>, model <id|provider/id> [openai-reasoning-effort], effort <openai-reasoning-effort>, attribution <on|off>".to_string(),
             )),
         }
+    }
+}
+
+fn setup_command_arg() -> CommandArg {
+    let mut suggestions = vec![
+        "status".to_string(),
+        "model".to_string(),
+        "token openai ".to_string(),
+        "token anthropic ".to_string(),
+        "token google ".to_string(),
+        "token openrouter ".to_string(),
+        "token ollama ".to_string(),
+        "token openai clear".to_string(),
+        "token anthropic clear".to_string(),
+        "token google clear".to_string(),
+        "token openrouter clear".to_string(),
+        "token ollama clear".to_string(),
+        "attribution on".to_string(),
+        "attribution off".to_string(),
+    ];
+    suggestions.extend(
+        SUPPORTED_PROVIDERS
+            .iter()
+            .map(|provider| format!("provider {provider}")),
+    );
+    suggestions.extend(
+        ProviderChoice::model_suggestions()
+            .iter()
+            .copied()
+            .map(|model| format!("model {model}")),
+    );
+    suggestions.extend(
+        ProviderChoice::reasoning_effort_suggestions()
+            .iter()
+            .copied()
+            .map(|effort| format!("effort {effort}")),
+    );
+
+    CommandArg {
+        name: "action".to_string(),
+        description: "status | provider <name> | token <provider> <value|clear> | model <id|provider/id> | effort <level> | attribution <on|off>".to_string(),
+        required: false,
+        suggestions,
     }
 }
 


### PR DESCRIPTION
## What
Add richer ACP slash command support for yolop:

- advertise capability commands with standard available_commands_update
- expose yolop command metadata and argument suggestions under _meta
- execute system slash commands as command-shaped tool_call / tool_call_update updates
- refresh available commands after system command execution
- document the ACP command behavior and coverage

## Why
ACP clients can list commands today, but users need a better command experience: choices where clients support them, structured command lifecycle output, and refreshed command state after command execution.

## How
The ACP server now stores per-session command descriptors, serializes them into standard ACP command updates plus yolop _meta, intercepts literal slash prompts before model turns, runs system commands through runtime.execute_command, and emits tool lifecycle updates with rawInput/rawOutput. /setup now publishes its supported action suggestions from the existing setup provider/model/effort lists.

## Risk
- Low / Medium / High: Medium
- What can break: ACP clients that strictly reject unknown _meta fields or command tool_call updates could render less gracefully. Standard clients should ignore _meta and keep seeing the command name, description, and hint.

## Security
- TM-FS: No filesystem access path changes.
- TM-BASH: No bash tool or approval-gate changes.
- TM-LLM: Slash system commands bypass model turns intentionally; command metadata contains provider/model/action strings only. Setup token command output still reports only stored/cleared status and never echoes token values.
- TM-TOOL: No new capabilities; command execution uses existing runtime.execute_command dispatch.
- TM-DEP: No dependency changes.

## Validation
- cargo fmt --check
- cargo test acp::
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features
- cargo build --release
- cargo run -- --provider llmsim -p "hi"
- Attempted: doppler run -- cargo test --all-features --test integration acp_openai_handshake_smoke -- --ignored; blocked locally because this checkout has no Doppler project/fallback configured. CI has the DOPPLER_TOKEN-backed live smoke job.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories