### PR TITLE
fix(ci): drop redundant version from generated Homebrew formula

### DIFF
--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -102,8 +102,6 @@ jobs:
           SERVER_URL: ${{ github.server_url }}
           REPO: ${{ github.repository }}
         run: |
-          VERSION="${TAG#v}"
-
           for f in yolop-aarch64-apple-darwin.tar.gz.sha256 \
                    yolop-x86_64-apple-darwin.tar.gz.sha256 \
                    yolop-x86_64-unknown-linux-gnu.tar.gz.sha256; do
@@ -134,7 +132,10 @@ jobs:
           class Yolop < Formula
             desc "Minimal terminal coding agent built on everruns-runtime"
             homepage "${HOMEPAGE}"
-            version "${VERSION}"
+            # No explicit `version` — Homebrew scans it from the download URL
+            # (the release tag in the path). Setting it again trips
+            # `brew audit` with "version is redundant with version scanned
+            # from URL".
             license "MIT"
 
             on_macos do

--- a/specs/release.md
+++ b/specs/release.md
@@ -179,7 +179,7 @@ gh release view vX.Y.Z --repo everruns/yolop       # tarballs + checksums presen
 # Homebrew tap — the formula has no explicit `version`; Homebrew scans it
 # from the release tag in the download URL, so verify that instead.
 curl -sSfL https://raw.githubusercontent.com/everruns/homebrew-tap/main/Formula/yolop.rb \
-  | grep -oE 'download/v[0-9][^/]*'                 # shows vX.Y.Z
+  | grep -oE 'download/v[0-9][^/]*' | sed 's|download/||'   # shows vX.Y.Z
 
 # End-to-end install (optional, on macOS / Linux)
 brew untap everruns/tap 2>/dev/null; brew install everruns/tap/yolop

--- a/specs/release.md
+++ b/specs/release.md
@@ -176,9 +176,10 @@ cargo search yolop --limit 1                       # shows X.Y.Z
 # GitHub Release
 gh release view vX.Y.Z --repo everruns/yolop       # tarballs + checksums present
 
-# Homebrew tap
+# Homebrew tap — the formula has no explicit `version`; Homebrew scans it
+# from the release tag in the download URL, so verify that instead.
 curl -sSfL https://raw.githubusercontent.com/everruns/homebrew-tap/main/Formula/yolop.rb \
-  | grep '^  version "'                            # shows X.Y.Z
+  | grep -oE 'download/v[0-9][^/]*'                 # shows vX.Y.Z
 
 # End-to-end install (optional, on macOS / Linux)
 brew untap everruns/tap 2>/dev/null; brew install everruns/tap/yolop


### PR DESCRIPTION
## What

The `update-homebrew` job in `cli-binaries.yml` generated a formula with an
explicit `version "${VERSION}"`. `brew audit` rejects this because Homebrew
already scans the version from the download URL (the release tag in the
path), failing with:

```
Error: Stable: `version 0.2.0` is redundant with version scanned from URL
```

This removes the `version` line (and the now-unused `VERSION` var in that
step) so Homebrew derives the version itself. The `test do` block's
`version.to_s` resolves from the scanned URL version, and `VERSION` is still
used for the tap commit message.

The release spec's verification snippet grepped `^  version "` from the
published formula, which would now match nothing — updated it to check the
tag in the download URL instead.

## Why

Tap audits fail with exit code 1 on every release, blocking the Homebrew
publish path. The `version` field was duplicating information Homebrew
computes on its own.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses.
- Simulated the heredoc generation locally: formula is well-formed with no
  `version` line; `download/v0.2.0` is present in the URL, which is exactly
  the value the audit log reported as the scanned version.
- Config/CI-only change — no Rust runtime affected, so no binary smoke test.

## Security

No security-relevant code changes. The Doppler token / tap-PAT handling in
the push step is untouched; this only alters the generated formula text.

## Follow-ups

No follow-ups. The `bashkit 0.9.0` redundancy in the shared tap audit lives
in a different formula/repo and is out of scope here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHiQJVGGnsWNimpmT2uCpU)_