### PR TITLE
refactor(commands): make all slash commands capability-based

### DIFF
--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -102,6 +102,7 @@ mod tests {
                 settings,
                 BuildOptions {
                     llmsim_override: Some(self.config.clone().with_model("llmsim-yolop")),
+                    ..BuildOptions::default()
                 },
             )
             .await

--- a/src/agent_scenarios.rs
+++ b/src/agent_scenarios.rs
@@ -58,6 +58,7 @@ async fn build_scripted_runtime(config: LlmSimConfig) -> (BuiltRuntime, std::pat
         settings,
         BuildOptions {
             llmsim_override: Some(llmsim),
+            ..BuildOptions::default()
         },
     )
     .await

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,6 +4,7 @@
 // bottom, with approvals handled through the same status delimiter.
 
 use crate::approval::ApprovalRequest;
+use crate::host_ui::UiCommand;
 use crate::runtime::{BuiltRuntime, ModelState, RuntimeHandles, StartupInfo};
 use anyhow::Result;
 use crossterm::event::{
@@ -74,56 +75,11 @@ struct PendingApproval {
     responder: oneshot::Sender<bool>,
 }
 
-#[derive(Clone, Copy)]
-struct CommandSpec {
-    name: &'static str,
-    usage: &'static str,
-    description: &'static str,
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct CommandSuggestion {
     completion: String,
     label: String,
 }
-
-const COMMANDS: &[CommandSpec] = &[
-    CommandSpec {
-        name: "help",
-        usage: "/help",
-        description: "show commands",
-    },
-    CommandSpec {
-        name: "tools",
-        usage: "/tools",
-        description: "list available tools",
-    },
-    CommandSpec {
-        name: "cwd",
-        usage: "/cwd",
-        description: "show workspace root",
-    },
-    CommandSpec {
-        name: "model",
-        usage: "/model [id]",
-        description: "show or switch model",
-    },
-    CommandSpec {
-        name: "effort",
-        usage: "/effort [level]",
-        description: "show or set OpenAI reasoning effort",
-    },
-    CommandSpec {
-        name: "clear",
-        usage: "/clear",
-        description: "clear transcript",
-    },
-    CommandSpec {
-        name: "quit",
-        usage: "/quit",
-        description: "exit",
-    },
-];
 
 pub const COMPOSER_VIEWPORT_HEIGHT: u16 = 18;
 const COMPACT_CHROME_HEIGHT: u16 = 5;
@@ -160,6 +116,10 @@ pub struct App {
     /// handling so provider, token, and model setup never echo through the
     /// normal chat composer.
     setup: Option<SetupStep>,
+    /// Terminal-side commands emitted by `ClientCommandsCapability` (via
+    /// `runtime.execute_command`). Drained in the event loop; see
+    /// [`App::apply_ui_command`].
+    ui_rx: mpsc::UnboundedReceiver<UiCommand>,
 }
 
 #[derive(Clone, Debug)]
@@ -379,6 +339,7 @@ impl App {
             approval_rx,
             pending: None,
             setup: None,
+            ui_rx: runtime.ui_rx,
         };
         app.emit_system_banner();
         if should_setup {
@@ -507,7 +468,13 @@ impl App {
                 }
             }
 
-            // 2) drain pending approval requests
+            // 2) drain terminal-side commands emitted by capabilities
+            if let Ok(command) = self.ui_rx.try_recv() {
+                self.apply_ui_command(command);
+                continue;
+            }
+
+            // 3) drain pending approval requests
             if self.pending.is_none()
                 && let Ok((req, responder)) = self.approval_rx.try_recv()
             {
@@ -523,7 +490,7 @@ impl App {
                 self.pending = Some(PendingApproval { responder });
             }
 
-            // 3) keystrokes. Mouse wheel/drag stays native terminal behavior
+            // 4) keystrokes. Mouse wheel/drag stays native terminal behavior
             // because the transcript lives in scrollback, not in this viewport.
             let mut poll_timeout = Duration::from_millis(80);
             while event::poll(poll_timeout)? {
@@ -749,76 +716,81 @@ impl App {
         self.start_turn(text);
     }
 
+    /// Dispatch a slash command. Every command — including the terminal-side
+    /// ones (help/tools/cwd/model/effort/clear/quit) — is now a capability
+    /// command, so this is a single uniform lookup against the registry. The
+    /// terminal-side commands take effect via `UiCommand`s their capability
+    /// emits while executing (drained in the event loop); see
+    /// [`App::apply_ui_command`].
     async fn handle_command(&mut self, cmd: &str) {
         let cmd = cmd.trim();
         let mut parts = cmd.splitn(2, char::is_whitespace);
         let head = parts.next().unwrap_or_default();
         let arg = parts.next().unwrap_or_default().trim();
-        match head {
-            "help" => {
-                self.push_system(
-                    COMMANDS
-                        .iter()
-                        .map(|cmd| cmd.usage)
-                        .collect::<Vec<_>>()
-                        .join(" · "),
-                );
-                if !self.startup.capability_commands.is_empty() {
-                    let caps = self
-                        .startup
-                        .capability_commands
-                        .iter()
-                        .map(capability_command_usage)
-                        .collect::<Vec<_>>()
-                        .join(" · ");
-                    self.push_system(format!("commands: {caps}"));
-                }
-                self.push_system(format!(
-                    "input: ←/→ edit · {} newline · scroll: use the terminal scrollback",
-                    newline_shortcut_hint()
-                ));
-                self.push_system(
-                    "approvals: y allow · n / Esc deny · exit: Ctrl-C / Ctrl-D".into(),
-                );
-            }
-            "tools" => {
+        // `/exit` is an accepted alias for the declared `/quit`.
+        let name = if head == "exit" { "quit" } else { head };
+
+        if let Some(descriptor) = self
+            .startup
+            .capability_commands
+            .iter()
+            .find(|c| c.name == name)
+            .cloned()
+        {
+            self.invoke_capability_command(descriptor, arg.to_string())
+                .await;
+        } else {
+            self.push_system(format!("unknown command: /{head}"));
+        }
+    }
+
+    /// Apply a terminal-side command emitted by a capability. This is the only
+    /// place the host interprets the `UiCommand` vocabulary; capabilities
+    /// declare commands and request effects, the host performs them.
+    fn apply_ui_command(&mut self, command: UiCommand) {
+        match command {
+            UiCommand::ShowHelp => self.show_help(),
+            UiCommand::ShowTools => {
                 self.push_system(format!("tools: {}", self.startup.tool_names.join(", ")));
             }
-            "cwd" => {
+            UiCommand::ShowCwd => {
                 self.push_system(format!(
                     "workspace root: {}",
                     self.startup.workspace_root.display()
                 ));
             }
-            "model" => {
-                if arg.is_empty() {
-                    self.start_model_setup();
-                } else {
-                    self.start_model_setup_with_arg(arg);
-                }
-            }
-            "effort" => self.start_effort_setup(arg),
-            "clear" => {
+            UiCommand::ClearTranscript => {
                 self.lines.clear();
                 self.printed_lines = 0;
                 self.emit_system_banner();
             }
-            "quit" | "exit" => self.should_quit = true,
-            other => {
-                if let Some(descriptor) = self
-                    .startup
-                    .capability_commands
-                    .iter()
-                    .find(|c| c.name == other)
-                    .cloned()
-                {
-                    self.invoke_capability_command(descriptor, arg.to_string())
-                        .await;
-                } else {
-                    self.push_system(format!("unknown command: /{other}"));
-                }
+            UiCommand::Quit => self.should_quit = true,
+            UiCommand::OpenModelOverlay { arg } => match arg {
+                Some(arg) => self.start_model_setup_with_arg(&arg),
+                None => self.start_model_setup(),
+            },
+            UiCommand::OpenEffortOverlay { arg } => {
+                self.start_effort_setup(arg.as_deref().unwrap_or(""))
             }
         }
+    }
+
+    fn show_help(&mut self) {
+        if !self.startup.capability_commands.is_empty() {
+            let caps = self
+                .startup
+                .capability_commands
+                .iter()
+                .map(capability_command_usage)
+                .collect::<Vec<_>>()
+                .join(" · ");
+            self.push_system(format!("commands: {caps}"));
+        }
+        self.push_system(format!(
+            "input: ←/→ edit · {} newline · scroll: use the terminal scrollback",
+            newline_shortcut_hint()
+        ));
+        self.push_system("approvals: y allow · n / Esc deny · exit: Ctrl-C / Ctrl-D".into());
     }
 
     /// Dispatch a capability-provided slash command.
@@ -872,8 +844,13 @@ impl App {
                     .await;
                 match result {
                     Ok(result) => {
-                        let prefix = if result.success { "" } else { "error: " };
-                        self.push_system(format!("{prefix}{}", result.message));
+                        // Client-executed commands (help/clear/model/…) apply
+                        // their effect via a `UiCommand` and return an empty
+                        // message; don't render a blank line for those.
+                        if !result.message.is_empty() {
+                            let prefix = if result.success { "" } else { "error: " };
+                            self.push_system(format!("{prefix}{}", result.message));
+                        }
                     }
                     Err(err) => self.push_system(format!("/{} failed: {err}", descriptor.name)),
                 }
@@ -2143,28 +2120,12 @@ fn command_suggestions(
             .collect();
     }
 
-    let mut out: Vec<CommandSuggestion> = COMMANDS
-        .iter()
-        .filter(|cmd| cmd.name.starts_with(rest))
-        .map(|cmd| CommandSuggestion {
-            completion: cmd
-                .usage
-                .split_whitespace()
-                .next()
-                .unwrap_or(cmd.usage)
-                .to_string(),
-            label: format!("{}    {}", cmd.usage, cmd.description),
-        })
-        .collect();
-
-    // Capability-provided commands. Names that collide with a built-in CLI
-    // command are skipped (built-in wins) so the local handler keeps running.
-    let builtin_names: std::collections::HashSet<&str> = COMMANDS.iter().map(|c| c.name).collect();
+    // Every command is capability-provided now (the TUI's terminal-side
+    // commands come from `ClientCommandsCapability`), so there is a single
+    // source of truth to filter and present.
+    let mut out: Vec<CommandSuggestion> = Vec::new();
     for descriptor in capability_commands {
         if !descriptor.name.starts_with(rest) {
-            continue;
-        }
-        if builtin_names.contains(descriptor.name.as_str()) {
             continue;
         }
         let usage = capability_command_usage(descriptor);
@@ -3561,6 +3522,30 @@ mod tests {
         }
     }
 
+    /// The terminal-side command descriptors as declared by
+    /// `ClientCommandsCapability` (help/tools/cwd/model/effort/clear/quit).
+    /// These now flow through the same registry as every other command, so
+    /// suggestion tests source them the same way the running TUI does.
+    fn client_command_descriptors() -> Vec<CommandDescriptor> {
+        use everruns_core::capabilities::Capability;
+        struct NoopUi;
+        impl crate::host_ui::HostUi for NoopUi {
+            fn send(&self, _: crate::host_ui::UiCommand) {}
+        }
+        crate::capabilities::client_commands::ClientCommandsCapability::new(std::sync::Arc::new(
+            NoopUi,
+        ))
+        .commands()
+    }
+
+    /// Client commands plus a representative capability command, in the order
+    /// the TUI would see them at startup.
+    fn caps_with_client_commands(extra: Vec<CommandDescriptor>) -> Vec<CommandDescriptor> {
+        let mut caps = client_command_descriptors();
+        caps.extend(extra);
+        caps
+    }
+
     fn command_with_arg_suggestions() -> CommandDescriptor {
         CommandDescriptor {
             name: "pick".to_string(),
@@ -3581,7 +3566,7 @@ mod tests {
 
     #[test]
     fn command_suggestions_list_commands_for_slash() {
-        let caps = vec![setup_capability_command()];
+        let caps = caps_with_client_commands(vec![setup_capability_command()]);
         let suggestions = command_suggestions("/", &caps);
 
         assert!(suggestions.iter().any(|s| s.completion == "/help"));
@@ -3605,7 +3590,7 @@ mod tests {
 
     #[test]
     fn suggestion_preview_line_keeps_first_match_when_truncated() {
-        let caps = vec![setup_capability_command()];
+        let caps = caps_with_client_commands(vec![setup_capability_command()]);
         let suggestions = command_suggestions("/", &caps);
         let rendered = line_text(&suggestion_preview_line(&suggestions, 18));
 
@@ -3675,13 +3660,14 @@ mod tests {
     }
 
     #[test]
-    fn builtin_commands_win_over_capability_with_same_name() {
-        // A capability that accidentally declares /help must not shadow the
-        // built-in handler: the built-in suggestion (no trailing space, no
-        // args) should be the only one returned for that name.
+    fn suggestions_come_solely_from_the_command_registry() {
+        // There are no hard-coded built-ins anymore: every command — including
+        // /help — is a capability command (the TUI's come from
+        // `ClientCommandsCapability`). So suggestions reflect exactly the
+        // descriptor list, one entry per declared command.
         let caps = vec![CommandDescriptor {
             name: "help".to_string(),
-            description: "shadow help".to_string(),
+            description: "show commands".to_string(),
             source: CommandSource::System,
             args: vec![],
         }];
@@ -4356,7 +4342,10 @@ mod tests {
             None,
             sessions.path().to_path_buf(),
             settings,
-            crate::runtime::BuildOptions::default(),
+            crate::runtime::BuildOptions {
+                client_commands: true,
+                ..crate::runtime::BuildOptions::default()
+            },
         )
         .await
         .expect("build llmsim runtime");
@@ -4365,6 +4354,20 @@ mod tests {
             app: App::new(runtime, rx),
             _workspace: workspace,
             _sessions: sessions,
+        }
+    }
+
+    impl App {
+        /// Test-only: dispatch a slash command and pump any `UiCommand`s it
+        /// emits, mirroring what the event loop does between frames. Needed
+        /// because terminal-side commands now take effect asynchronously via
+        /// the host UI channel rather than synchronously inside
+        /// `handle_command`.
+        async fn dispatch_command_for_test(&mut self, cmd: &str) {
+            self.handle_command(cmd).await;
+            while let Ok(command) = self.ui_rx.try_recv() {
+                self.apply_ui_command(command);
+            }
         }
     }
 
@@ -4404,7 +4407,7 @@ mod tests {
         let app = &mut fixture.app;
         app.lines.clear();
 
-        app.handle_command("help").await;
+        app.dispatch_command_for_test("help").await;
 
         assert!(
             app.lines
@@ -4683,7 +4686,7 @@ mod tests {
         let app = &mut fixture.app;
         app.lines.clear();
 
-        app.handle_command("model").await;
+        app.dispatch_command_for_test("model").await;
 
         assert!(matches!(
             app.setup,
@@ -4705,7 +4708,8 @@ mod tests {
 
         app.handle_command("setup token openai sk-test").await;
         app.lines.clear();
-        app.handle_command("model openai/gpt-5.4 high").await;
+        app.dispatch_command_for_test("model openai/gpt-5.4 high")
+            .await;
 
         assert_eq!(app.model.provider_label(), "llmsim/llmsim-yolop");
         assert!(matches!(
@@ -4743,7 +4747,7 @@ mod tests {
             .await
             .expect("set openai model");
         app.lines.clear();
-        app.handle_command("effort high").await;
+        app.dispatch_command_for_test("effort high").await;
 
         assert_eq!(app.model.provider_label(), "openai/gpt-5.4 medium");
         assert!(matches!(

--- a/src/app.rs
+++ b/src/app.rs
@@ -468,9 +468,16 @@ impl App {
                 }
             }
 
-            // 2) drain terminal-side commands emitted by capabilities
-            if let Ok(command) = self.ui_rx.try_recv() {
+            // 2) drain terminal-side commands emitted by capabilities. Apply
+            // every queued command before re-rendering so a burst (or a future
+            // capability that emits more than one) doesn't cost a full
+            // flush/draw per command, matching the test dispatch helper.
+            let mut applied_ui_command = false;
+            while let Ok(command) = self.ui_rx.try_recv() {
                 self.apply_ui_command(command);
+                applied_ui_command = true;
+            }
+            if applied_ui_command {
                 continue;
             }
 

--- a/src/capabilities/client_commands.rs
+++ b/src/capabilities/client_commands.rs
@@ -1,0 +1,122 @@
+//! Client-executed slash commands for the TUI host.
+//!
+//! `help`, `tools`, `cwd`, `model`, `effort`, `clear`, and `quit` act on the
+//! terminal, not the agent runtime. They are declared here as ordinary
+//! capability commands so they share the single command registry — palette,
+//! `/help`, and completion all read `runtime.list_commands` — and dispatched
+//! through the injected [`HostUi`] port: `execute_command` translates each
+//! command into a [`UiCommand`] that the terminal event loop applies. The
+//! runtime never performs the effect; it only routes the invocation.
+//!
+//! Because the effect lives entirely in the host, this capability is only
+//! registered for the TUI (see [`crate::runtime::BuildOptions`]); ACP and
+//! `--print` hosts, which have no overlay/transcript to drive, omit it.
+
+use crate::host_ui::{HostUi, UiCommand};
+use async_trait::async_trait;
+use everruns_core::capabilities::{Capability, CapabilityStatus};
+use everruns_core::command::{
+    CommandArg, CommandDescriptor, CommandExecutionContext, CommandResult, CommandSource,
+    ExecuteCommandRequest,
+};
+use std::sync::Arc;
+
+pub(crate) const CLIENT_COMMANDS_CAPABILITY_ID: &str = "yolop_client_commands";
+
+pub(crate) struct ClientCommandsCapability {
+    ui: Arc<dyn HostUi>,
+}
+
+impl ClientCommandsCapability {
+    pub(crate) fn new(ui: Arc<dyn HostUi>) -> Self {
+        Self { ui }
+    }
+}
+
+#[async_trait]
+impl Capability for ClientCommandsCapability {
+    fn id(&self) -> &str {
+        CLIENT_COMMANDS_CAPABILITY_ID
+    }
+    fn name(&self) -> &str {
+        "Client Commands"
+    }
+    fn description(&self) -> &str {
+        "Terminal-side slash commands (help, tools, cwd, model, effort, clear, quit)."
+    }
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+    fn category(&self) -> Option<&str> {
+        Some("Examples")
+    }
+    fn system_prompt_addition(&self) -> Option<&str> {
+        None
+    }
+
+    fn commands(&self) -> Vec<CommandDescriptor> {
+        vec![
+            cmd("help", "show commands", &[]),
+            cmd("tools", "list available tools", &[]),
+            cmd("cwd", "show workspace root", &[]),
+            cmd("model", "show or switch model", &[opt("id")]),
+            cmd("effort", "show or set reasoning effort", &[opt("level")]),
+            cmd("clear", "clear transcript", &[]),
+            cmd("quit", "exit", &[]),
+        ]
+    }
+
+    async fn execute_command(
+        &self,
+        request: &ExecuteCommandRequest,
+        _ctx: &CommandExecutionContext,
+    ) -> everruns_core::Result<CommandResult> {
+        let arg = request
+            .arguments
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+        let command = match request.name.as_str() {
+            "help" => UiCommand::ShowHelp,
+            "tools" => UiCommand::ShowTools,
+            "cwd" => UiCommand::ShowCwd,
+            "clear" => UiCommand::ClearTranscript,
+            "quit" => UiCommand::Quit,
+            "model" => UiCommand::OpenModelOverlay { arg },
+            "effort" => UiCommand::OpenEffortOverlay { arg },
+            other => {
+                return Err(everruns_core::AgentLoopError::config(format!(
+                    "{} cannot execute /{other}",
+                    self.id()
+                )));
+            }
+        };
+        self.ui.send(command);
+        // The host event loop applies the effect; nothing to render inline.
+        Ok(CommandResult {
+            success: true,
+            message: String::new(),
+            error_code: None,
+            error_fields: None,
+        })
+    }
+}
+
+fn cmd(name: &str, description: &str, args: &[CommandArg]) -> CommandDescriptor {
+    CommandDescriptor {
+        name: name.to_string(),
+        description: description.to_string(),
+        source: CommandSource::System,
+        args: args.to_vec(),
+    }
+}
+
+fn opt(name: &str) -> CommandArg {
+    CommandArg {
+        name: name.to_string(),
+        description: name.to_string(),
+        required: false,
+        suggestions: Vec::new(),
+    }
+}

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -3,10 +3,12 @@
 // These are host/example behavior rather than runtime primitives. Keep the
 // module boundary here small; capability implementations live in submodules.
 
+pub(crate) mod client_commands;
 mod host;
 pub mod skills;
 pub(crate) mod your;
 
+pub(crate) use client_commands::{CLIENT_COMMANDS_CAPABILITY_ID, ClientCommandsCapability};
 pub(crate) use host::{
     ATTRIBUTION_CAPABILITY_ID, AttributionCapability, CodingBashCapability,
     CodingCliEnvironmentCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID, SETUP_CAPABILITY_ID,

--- a/src/host_ui.rs
+++ b/src/host_ui.rs
@@ -1,0 +1,59 @@
+//! Host UI port for client-executed slash commands.
+//!
+//! A handful of slash commands act on the terminal client itself — clear the
+//! transcript, open the model/effort overlay, print local info, quit — rather
+//! than on the agent runtime. They are nonetheless ordinary capabilities (see
+//! [`crate::capabilities::ClientCommandsCapability`]) so that every command
+//! lives in one registry. Their `execute_command` runs on the runtime's task
+//! and cannot touch the TUI directly, so it instead calls this port, which
+//! forwards a typed [`UiCommand`] to the terminal event loop over a channel.
+//! The loop is the only thing that can perform the effect, so it applies it.
+
+use tokio::sync::mpsc;
+
+/// A request from a client-executed capability command to the terminal host.
+/// Variants name *what* should happen; the host decides *how* to render it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum UiCommand {
+    /// Print the command palette / input help.
+    ShowHelp,
+    /// Print the list of available tools.
+    ShowTools,
+    /// Print the workspace root.
+    ShowCwd,
+    /// Clear the transcript buffer.
+    ClearTranscript,
+    /// Exit the application.
+    Quit,
+    /// Open the interactive model picker. `arg` pre-seeds the selection.
+    OpenModelOverlay { arg: Option<String> },
+    /// Open the interactive reasoning-effort picker. `arg` pre-seeds it.
+    OpenEffortOverlay { arg: Option<String> },
+}
+
+/// What a client-executed command can ask the host UI to do. Implemented per
+/// host (the TUI's [`TuiHandle`]); a host that cannot honor client commands
+/// simply never registers the capability that depends on this port.
+pub trait HostUi: Send + Sync {
+    fn send(&self, command: UiCommand);
+}
+
+/// TUI implementation of [`HostUi`]: every call is a non-blocking channel
+/// send. The matching receiver is drained by the `App` event loop.
+pub struct TuiHandle {
+    tx: mpsc::UnboundedSender<UiCommand>,
+}
+
+impl TuiHandle {
+    pub fn new(tx: mpsc::UnboundedSender<UiCommand>) -> Self {
+        Self { tx }
+    }
+}
+
+impl HostUi for TuiHandle {
+    fn send(&self, command: UiCommand) {
+        // The receiver lives as long as the `App`; a failed send only happens
+        // during shutdown, where dropping the command is the correct behavior.
+        let _ = self.tx.send(command);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod app;
 mod approval;
 mod capabilities;
 mod diff;
+mod host_ui;
 mod into;
 mod runtime;
 mod session_log;
@@ -276,13 +277,21 @@ async fn main() -> Result<()> {
         return acp::run_stdio(provider, settings, sessions_dir).await;
     }
 
-    let runtime = runtime::build(
+    // Only the interactive TUI can apply terminal-side commands (overlays,
+    // transcript clear, quit), so only it enables `ClientCommandsCapability`.
+    // `--print` is one-shot and never dispatches them.
+    let interactive = cli.print.is_none();
+    let runtime = runtime::build_with_options(
         cwd,
         provider,
         gate,
         resume_session_id,
         sessions_dir,
         settings,
+        runtime::BuildOptions {
+            client_commands: interactive,
+            ..Default::default()
+        },
     )
     .await?;
 
@@ -457,6 +466,7 @@ async fn run_print_mode(runtime: BuiltRuntime, prompt: String) -> Result<()> {
         handles,
         startup,
         model,
+        ui_rx: _,
     } = runtime;
     let color = io::stdout().is_terminal();
     println!("{}", paint(color, "90", &format!("› {prompt}")));

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1009,8 +1009,9 @@ pub struct BuildOptions {
     pub llmsim_override: Option<LlmSimConfig>,
     /// Register [`ClientCommandsCapability`], which contributes the
     /// terminal-side slash commands (help/tools/cwd/model/effort/clear/quit)
-    /// and drives them through the host UI channel. Only the TUI host can
-    /// honor these, so ACP / `--print` / tests leave this `false`.
+    /// and drives them through the host UI channel. Only a host that can apply
+    /// the effects sets this: the interactive TUI (and the `app` unit tests
+    /// that exercise it). ACP and `--print` leave it `false`.
     pub client_commands: bool,
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -7,10 +7,11 @@
 use crate::approval::ApprovalGate;
 use crate::capabilities::your::{YOUR_CAPABILITY_ID, YourCapability, YourStore};
 use crate::capabilities::{
-    ATTRIBUTION_CAPABILITY_ID, AttributionCapability, CodingBashCapability,
-    CodingCliEnvironmentCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID, SETUP_CAPABILITY_ID,
-    SetupCapability,
+    ATTRIBUTION_CAPABILITY_ID, AttributionCapability, CLIENT_COMMANDS_CAPABILITY_ID,
+    ClientCommandsCapability, CodingBashCapability, CodingCliEnvironmentCapability,
+    ENVIRONMENT_CONTEXT_CAPABILITY_ID, SETUP_CAPABILITY_ID, SetupCapability,
 };
+use crate::host_ui::{HostUi, TuiHandle, UiCommand};
 use crate::settings::{Settings, SettingsStore};
 use crate::tools::Workspace;
 use anyhow::{Context, Result, anyhow};
@@ -46,6 +47,7 @@ use crate::session_log::{
 };
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
+use tokio::sync::mpsc;
 
 // The harness prompt is the durable instruction surface — borrowed in shape
 // from `crates/server/src/harnesses/coding_container.rs` and trimmed for
@@ -870,8 +872,16 @@ fn normalize_openai_reasoning_effort(reasoning_effort: Option<String>) -> Option
     )
 }
 
-fn coding_harness_capabilities() -> Vec<AgentCapabilityConfig> {
-    vec![
+fn coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabilityConfig> {
+    let mut caps = Vec::new();
+    // Terminal-side commands lead the registry so the most-typed commands
+    // (/help, /clear, /quit, …) surface first in the palette. Enabled only
+    // when the host registered the capability that backs them (the TUI);
+    // enabling an unregistered id would have nothing to dispatch to.
+    if client_commands {
+        caps.push(AgentCapabilityConfig::new(CLIENT_COMMANDS_CAPABILITY_ID));
+    }
+    caps.extend([
         AgentCapabilityConfig::new(ENVIRONMENT_CONTEXT_CAPABILITY_ID),
         // Pick up CLAUDE.md / .agents.md alongside AGENTS.md, live-reloaded.
         AgentCapabilityConfig::with_config(
@@ -908,7 +918,8 @@ fn coding_harness_capabilities() -> Vec<AgentCapabilityConfig> {
         AgentCapabilityConfig::new(SETUP_CAPABILITY_ID),
         AgentCapabilityConfig::new(YOUR_CAPABILITY_ID),
         AgentCapabilityConfig::new("yolop_bash"),
-    ]
+    ]);
+    caps
 }
 
 // ---------- runtime wiring result ----------
@@ -917,6 +928,11 @@ pub struct BuiltRuntime {
     pub handles: RuntimeHandles,
     pub startup: StartupInfo,
     pub model: ModelState,
+    /// Receiver for terminal-side commands emitted by
+    /// [`ClientCommandsCapability`]. The TUI drains it in its event loop;
+    /// other hosts ignore it. Empty/never-written when
+    /// [`BuildOptions::client_commands`] is `false`.
+    pub ui_rx: mpsc::UnboundedReceiver<UiCommand>,
 }
 
 #[derive(Clone)]
@@ -934,9 +950,11 @@ pub struct StartupInfo {
     pub tool_names: Vec<String>,
     /// Slash commands contributed by registered capabilities (via
     /// `Capability::commands()`). Resolved once at startup against this
-    /// session's harness/agent chain; surfaced in the TUI's command palette
-    /// alongside the CLI's built-in `/help`, `/tools`, `/cwd`, `/clear`,
-    /// `/quit` (which remain CLI-local).
+    /// session's harness/agent chain; this is the single source of truth for
+    /// the command palette, `/help`, and completion. For the TUI host it
+    /// includes the terminal-side commands (`/help`, `/tools`, `/cwd`,
+    /// `/model`, `/effort`, `/clear`, `/quit`) contributed by
+    /// `ClientCommandsCapability`.
     pub capability_commands: Vec<CommandDescriptor>,
     /// On-disk JSONL log for this session. Populated even for fresh ids
     /// so the startup banner can show where new events are being written.
@@ -989,6 +1007,11 @@ impl ModelState {
 #[derive(Default)]
 pub struct BuildOptions {
     pub llmsim_override: Option<LlmSimConfig>,
+    /// Register [`ClientCommandsCapability`], which contributes the
+    /// terminal-side slash commands (help/tools/cwd/model/effort/clear/quit)
+    /// and drives them through the host UI channel. Only the TUI host can
+    /// honor these, so ACP / `--print` / tests leave this `false`.
+    pub client_commands: bool,
 }
 
 pub async fn build(
@@ -1132,6 +1155,15 @@ pub async fn build_with_options(
         workspace: workspace.clone(),
         gate: gate.clone(),
     });
+    // Terminal-side slash commands. Registered only when the host can apply
+    // their effects (the TUI). The capability declares help/tools/cwd/model/
+    // effort/clear/quit and forwards each invocation as a `UiCommand` down
+    // `ui_tx`; the `App` event loop drains `ui_rx` and performs the effect.
+    let (ui_tx, ui_rx) = mpsc::unbounded_channel::<UiCommand>();
+    if options.client_commands {
+        let ui: Arc<dyn HostUi> = Arc::new(TuiHandle::new(ui_tx));
+        capabilities.register(ClientCommandsCapability::new(ui));
+    }
 
     let mut driver_registry = DriverRegistry::new();
     everruns_anthropic::register_driver(&mut driver_registry);
@@ -1170,7 +1202,7 @@ pub async fn build_with_options(
     // runtime owns. `session_id(...)` pins the id so resume can re-attach
     // to the same JSONL log (filename encodes the id).
     let session_title = format!("yolop @ {}", canonical_root.display());
-    let harness_capabilities = coding_harness_capabilities();
+    let harness_capabilities = coding_harness_capabilities(options.client_commands);
 
     let mut builder = InProcessRuntimeBuilder::new()
         .platform_definition(platform)
@@ -1230,6 +1262,7 @@ pub async fn build_with_options(
             setup_recommended,
         },
         model: ModelState::new(provider_state),
+        ui_rx,
     })
 }
 
@@ -1814,7 +1847,7 @@ mod tests {
 
     #[test]
     fn coding_harness_enables_tool_output_persistence() {
-        let ids = coding_harness_capabilities();
+        let ids = coding_harness_capabilities(false);
 
         assert!(
             ids.iter()
@@ -1824,7 +1857,7 @@ mod tests {
 
     #[test]
     fn coding_harness_enables_loop_detection() {
-        let ids = coding_harness_capabilities();
+        let ids = coding_harness_capabilities(false);
 
         assert!(
             ids.iter()
@@ -1834,11 +1867,29 @@ mod tests {
 
     #[test]
     fn coding_harness_enables_yolop_attribution() {
-        let ids = coding_harness_capabilities();
+        let ids = coding_harness_capabilities(false);
 
         assert!(
             ids.iter()
                 .any(|cap| cap.capability_id() == ATTRIBUTION_CAPABILITY_ID)
+        );
+    }
+
+    #[test]
+    fn coding_harness_gates_client_commands_on_flag() {
+        let without = coding_harness_capabilities(false);
+        assert!(
+            !without
+                .iter()
+                .any(|cap| cap.capability_id() == CLIENT_COMMANDS_CAPABILITY_ID),
+            "client commands must stay off for hosts that can't apply them"
+        );
+
+        let with = coding_harness_capabilities(true);
+        assert!(
+            with.iter()
+                .any(|cap| cap.capability_id() == CLIENT_COMMANDS_CAPABILITY_ID),
+            "the TUI host enables the terminal-side commands"
         );
     }
 

--- a/src/streaming_tests.rs
+++ b/src/streaming_tests.rs
@@ -60,6 +60,7 @@ async fn build_llmsim_runtime() -> crate::runtime::BuiltRuntime {
         settings,
         BuildOptions {
             llmsim_override: Some(llmsim),
+            ..BuildOptions::default()
         },
     )
     .await


### PR DESCRIPTION
## What

Unifies the TUI's slash commands onto the capability model. The built-in
commands (`help`, `tools`, `cwd`, `model`, `effort`, `clear`, `quit`) lived in
a hard-coded `COMMANDS` array dispatched by a name-keyed `match` in `App`,
parallel to the capability-sourced registry. Now every command is a capability
command, so `runtime.list_commands` is the single source of truth for the
palette, `/help`, and completion.

New pieces:

- **`src/host_ui.rs`** — `UiCommand` (the terminal-effect vocabulary), the
  `HostUi` port trait, and `TuiHandle` (a channel-backed adapter).
- **`src/capabilities/client_commands.rs`** — `ClientCommandsCapability`
  declares the terminal-side commands as ordinary `System` commands and, on
  execute, forwards a typed `UiCommand` down a channel instead of returning
  text.

Flow: `App.handle_command` → `runtime.execute_command` → capability emits a
`UiCommand` → the `App` event loop drains it (`apply_ui_command`) and performs
the effect. The runtime only routes; the host performs effects it alone can
reach (open an overlay, clear the transcript, quit).

## Why

The terminal-side commands can't execute in the runtime — their effect is on
the TUI surface, which `execute_command` (a `CommandResult` string) can't
touch. Rather than keep a second, non-capability command path, we inject a
host UI port into the capability — the same dependency-injection pattern
`SetupCapability` already uses for its stores. This keeps commands fully
pluggable (remove the capability → its commands disappear from the UI; swap it
→ they reroute) and **needs no `everruns-core` change**. A prior proposal to
add a `CommandSource::External` variant upstream (Linear EVE-520) was canceled
as unnecessary once this design landed.

Gating: `BuildOptions::client_commands` enables the capability only for the
interactive TUI. ACP and `--print` hosts, which have no overlay or transcript
to drive, omit it so they don't advertise commands they can't run.

## Validation

- `cargo test --all-features` — 237 passed, 2 ignored (live-provider), 0 failed
- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- Smoke (`cargo run -- --provider llmsim -p "hi"`): binary starts; print-mode
  banner correctly lists only `/setup` (client commands gated off), while the
  TUI lists the full set with terminal commands first.
- Updated affected tests; terminal-side commands now take effect via the host
  channel, so a test pump helper drains it after dispatch. Added coverage for
  the harness gating (`coding_harness_gates_client_commands_on_flag`).

## Security

No security-relevant code changes.

- **TM-FS / TM-BASH** — `tools.rs` untouched; write blocklist and bash
  bounded-execution model unchanged.
- **TM-LLM** — no key handling or prompt construction; `UiCommand` carries no
  secrets.
- **TM-TOOL** — `ClientCommandsCapability` registers no tools and bypasses no
  approval gate; the model/effort/setup overlays it opens reuse existing
  `SetupStep` machinery with the same validation. The `ui_rx` channel is
  user-driven (one message per typed command, drained every frame), not
  attacker-controllable.
- **TM-DEP** — no new crates (`tokio::sync::mpsc` already in use); no
  `everruns-*` version changes.

## Follow-ups

No follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNLvp2SGuDgEJBPM1ngugB)_