### PR TITLE
docs(commands): add command spec, cover client cmds, require tests

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -36,27 +36,41 @@ Use this skill when the user asks to:
    - Confirm the requested behavior is actually implemented.
    - Validation must match risk. For bugs, prefer a failing test first when practical.
 
-3. **The changed code is fit to merge.**
+3. **The changed feature is tested before merge.**
+   - Every behavior change MUST be covered by an automated test that exercises
+     the new or changed behavior directly — not merely adjacent code that still
+     compiles. Add or update the test as part of the change.
+   - The test must actually drive the feature's entry point (e.g. dispatch the
+     command, call the handler, run the turn), not just assert on a constructor.
+   - If a behavior is genuinely impractical to cover automatically, say so
+     explicitly in the PR body, describe the manual verification you performed
+     instead, and list the gap under **Follow-ups**. "Hard to test" is not a
+     silent pass.
+   - Docs-only or config-only changes with no behavior change are exempt (state
+     why).
+
+4. **The changed code is fit to merge.**
    - Simplify obvious duplication or accidental complexity.
    - Perform the structured security review below.
    - Fix issues you find and refresh the evidence.
 
-4. **Relevant artifacts stay in sync.**
+5. **Relevant artifacts stay in sync.**
    - Update only the artifacts affected by the change: `specs/`, `AGENTS.md`, `README.md`.
 
-5. **Smoke test impacted functionality.**
-   - Always smoke test the flows affected by the change end-to-end.
+6. **Smoke test impacted functionality.**
+   - Always smoke test the flows affected by the change end-to-end. This is in
+     addition to, not a substitute for, the automated feature test in outcome 3.
    - For changes that touch the agent loop, run `doppler run -- cargo run -- --provider openai -p "<focused prompt>"` and read the output.
    - For offline-safe changes, `cargo run -- --provider llmsim -p "hi"` is enough to prove the binary still starts.
    - Docs-only or config-only changes that do not affect runtime may skip smoke testing with explicit justification.
 
-6. **Follow-ups are surfaced, not silently dropped.**
+7. **Follow-ups are surfaced, not silently dropped.**
    - Default to implementing everything in scope before merging.
    - For each candidate, decide explicitly: **implement now** (preferred) or **defer**.
    - For anything deferred, list it under a **Follow-ups** section in the PR body with a one-line rationale.
    - If there are no follow-ups, state "No follow-ups." in the PR body.
 
-7. **The PR is mergeable and merged safely.**
+8. **The PR is mergeable and merged safely.**
    - Push the branch.
    - Create or update the PR.
    - Address every review comment — including low-confidence suggestions, nits, and bot comments. For each comment, post an inline reply on the same thread explaining the resolution (and apply a code change too when one is needed), then mark that thread resolved. An inline reply is required even when the fix is a pure code change; no comment may be left unanswered or unresolved before merge.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,8 +89,9 @@ agent-like, stop and ask before committing.
 
 ## Shipping, maintenance, and releases
 
-- "Ship" means implement, gather evidence, perform a security review, open a
-  mergeable PR, address every review comment, and merge only after CI is green.
+- "Ship" means implement, test the changed feature with an automated test that
+  exercises it, gather evidence, perform a security review, open a mergeable PR,
+  address every review comment, and merge only after CI is green.
 - When asked to ship, follow [`.agents/skills/ship/SKILL.md`](.agents/skills/ship/SKILL.md)
   and [`specs/shipping.md`](specs/shipping.md).
 - When asked for maintenance or release readiness, follow

--- a/specs/commands.md
+++ b/specs/commands.md
@@ -3,10 +3,17 @@
 ## Abstract
 
 yolop exposes user actions as **slash commands**. Every command is contributed
-by a **capability** (`Capability::commands()`), so a single registry —
-`runtime.list_commands(session_id)` — is the source of truth for the command
-palette, `/help`, and completion across every host (the TUI and the ACP
-server). There is no hard-coded command table.
+by a **capability** (`Capability::commands()`), so each host's command surface
+is sourced solely from `runtime.list_commands(session_id)` — the source of
+truth for that host's palette, `/help`, and completion. There is no hard-coded
+command table on any host.
+
+The *set* of commands differs by host, because capabilities are gated per
+session (see [Host gating](#required-behavior)). The TUI registers the
+terminal-side commands and so lists them; the ACP server and `--print` do not,
+so those commands never appear in their advertised command lists. What is
+common is the mechanism: whatever a host advertises comes from its registry,
+never a parallel hard-coded list.
 
 A command's `CommandSource` declares *who executes it*. yolop uses three
 execution targets; the third (client/terminal) is a yolop convention layered on

--- a/specs/commands.md
+++ b/specs/commands.md
@@ -1,0 +1,84 @@
+# Commands Specification
+
+## Abstract
+
+yolop exposes user actions as **slash commands**. Every command is contributed
+by a **capability** (`Capability::commands()`), so a single registry —
+`runtime.list_commands(session_id)` — is the source of truth for the command
+palette, `/help`, and completion across every host (the TUI and the ACP
+server). There is no hard-coded command table.
+
+A command's `CommandSource` declares *who executes it*. yolop uses three
+execution targets; the third (client/terminal) is a yolop convention layered on
+top of the runtime's two, not a separate `CommandSource` variant.
+
+## Execution targets
+
+1. **System** — the **runtime** executes it via `runtime.execute_command`,
+   returning a `CommandResult { success, message }` the host renders inline.
+   Example: `/setup` and its subcommands mutate provider/model/token settings.
+
+2. **Skill** — the **LLM** executes it. The literal `/name args` text is
+   forwarded as a chat turn so the model activates the skill. Skill commands are
+   contributed by the skills capability (see [`skills.md`](./skills.md)).
+
+3. **Client (terminal-side)** — the **host** executes it, because the effect is
+   on the terminal surface the runtime cannot reach (open an overlay, clear the
+   transcript, quit, print local info). These are declared as ordinary `System`
+   commands; on execute, their capability emits a typed `UiCommand` through an
+   injected host UI port instead of returning text. The host's event loop drains
+   the port and applies the effect. Commands: `/help`, `/tools`, `/cwd`,
+   `/model`, `/effort`, `/clear`, `/quit`.
+
+## Why client commands use a host port, not a new `CommandSource`
+
+The runtime's `execute_command` can only return a `CommandResult` string; it has
+no way to clear a transcript or open an overlay. Rather than add a second,
+non-capability command path in the host, yolop injects a host UI port
+(`HostUi`) into the capability at construction — the same dependency-injection
+pattern `SetupCapability` already uses for its settings/provider stores. The
+capability requests an effect (`UiCommand`); the host — the only thing that can
+— performs it. This keeps all commands in one registry, keeps them pluggable
+(remove the capability and its commands disappear from the UI; swap it and they
+reroute), and requires **no `everruns-core` change**.
+
+A *portable, plugin-contributed* client command — one that arbitrary hosts honor
+without each implementing a shared port — would instead need a first-class
+`CommandSource::External` upstream. That was proposed (Linear EVE-520) and
+**canceled** as unnecessary for yolop, whose terminal commands are
+host-intrinsic. The note is kept here so the rationale is not lost if the
+portable case ever arises.
+
+## Required behavior
+
+1. **Single registry.** The palette, `/help`, and completion read only
+   `runtime.list_commands`. Removing a capability removes its commands; no host
+   keeps a parallel list.
+2. **Uniform dispatch.** The host looks a typed command up in the registry and
+   routes by `CommandSource`: `System`/client → `runtime.execute_command`;
+   `Skill` → forward as a chat turn. `/exit` is an accepted alias for `/quit`.
+3. **Client effects are host-applied.** A client command's `execute_command`
+   returns an empty `CommandResult` and emits a `UiCommand`; the host applies
+   every queued `UiCommand` before the next render. The `UiCommand` vocabulary
+   is the shared contract between client capabilities and the host — a genuinely
+   new on-screen effect is a host change, not a drop-in.
+4. **Host gating.** Client commands are enabled only for a host that can apply
+   them. `BuildOptions::client_commands` registers `ClientCommandsCapability`
+   and enables its harness id; the interactive TUI sets it, while ACP and
+   `--print` leave it off and therefore neither advertise nor dispatch terminal
+   commands. See [`acp.md`](./acp.md) for how the remaining `System`/`Skill`
+   commands surface over ACP.
+
+## Ownership boundary
+
+- `CommandDescriptor`, `CommandSource` (`System`/`Skill`), `CommandResult`, and
+  `execute_command` are owned by `everruns-core`.
+- This spec owns yolop's command surface: the single-registry contract, the
+  client/terminal execution target, the `HostUi`/`UiCommand` port, and the host
+  gating. The terminal commands themselves live in
+  `src/capabilities/client_commands.rs`; the port lives in `src/host_ui.rs`.
+
+## Related
+
+- [`skills.md`](./skills.md) — `Skill`-source commands.
+- [`acp.md`](./acp.md) — how commands surface over the ACP transport.

--- a/specs/shipping.md
+++ b/specs/shipping.md
@@ -24,11 +24,12 @@ Every shipped change MUST satisfy ALL of these. These are mandatory, not suggest
 
 1. **Safe branch state.** No shipping from `main` or `master`. Working tree clean before final push. Prefer rebasing onto latest `origin/main` before merge.
 2. **Goal achieved with evidence.** The requested behavior is implemented and validated with proof matching the risk.
-3. **Merge-ready code.** Touched code is reviewed for avoidable complexity. A structured security review is performed (see `.agents/skills/ship/SKILL.md` § Security Review). Issues are addressed or explicitly blocked.
-4. **Synced artifacts.** Affected artifacts are updated: README, AGENTS.md, specs. No code-duplicating prose.
-5. **Smoke test impacted functionality.** Mandatory unless the change is docs-only or config-only with explicit justification. For runtime changes, run at least one live-provider smoke through Doppler.
-6. **Follow-ups surfaced.** TODOs, partial fixes, declined suggestions, missed edges, and spec/doc drift are explicitly listed under **Follow-ups** in the PR body (or `"No follow-ups."` if none).
-7. **Safe merge.** PR uses the template, CI is green, every review comment is addressed (via a code change when needed), answered inline on its own thread with a written reply, and marked resolved before merge. An inline reply is required even when the resolution is a pure code change. Merge is squash-only after a final clean comment sweep. Async reviewer bots get at least 2 minutes to comment after CI turns green.
+3. **Feature tested before merge.** Every behavior change is covered by an automated test that exercises the new or changed behavior directly — driving its real entry point, not merely adjacent code that still compiles — added or updated as part of the change. A behavior that is genuinely impractical to test automatically is the only exception: the PR body must say so, describe the manual verification performed instead, and list the gap under **Follow-ups**. Docs-only or config-only changes with no behavior change are exempt with stated justification.
+4. **Merge-ready code.** Touched code is reviewed for avoidable complexity. A structured security review is performed (see `.agents/skills/ship/SKILL.md` § Security Review). Issues are addressed or explicitly blocked.
+5. **Synced artifacts.** Affected artifacts are updated: README, AGENTS.md, specs. No code-duplicating prose.
+6. **Smoke test impacted functionality.** In addition to the automated test in outcome 3, smoke test the affected flows end-to-end. Mandatory unless the change is docs-only or config-only with explicit justification. For runtime changes, run at least one live-provider smoke through Doppler.
+7. **Follow-ups surfaced.** TODOs, partial fixes, declined suggestions, missed edges, and spec/doc drift are explicitly listed under **Follow-ups** in the PR body (or `"No follow-ups."` if none).
+8. **Safe merge.** PR uses the template, CI is green, every review comment is addressed (via a code change when needed), answered inline on its own thread with a written reply, and marked resolved before merge. An inline reply is required even when the resolution is a pure code change. Merge is squash-only after a final clean comment sweep. Async reviewer bots get at least 2 minutes to comment after CI turns green.
 
 ## Constraints
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -4426,6 +4426,85 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cwd_command_prints_workspace_root() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.lines.clear();
+
+        app.dispatch_command_for_test("cwd").await;
+
+        let root = app.startup.workspace_root.display().to_string();
+        assert!(
+            app.lines
+                .iter()
+                .any(|line| line.text.contains("workspace root:") && line.text.contains(&root)),
+            "cwd should print the workspace root: {:?}",
+            app.lines
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn tools_command_lists_available_tools() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.lines.clear();
+
+        app.dispatch_command_for_test("tools").await;
+
+        // The llmsim runtime registers the standard coding toolset, so the
+        // listing must be non-empty and name a known tool.
+        assert!(
+            app.lines
+                .iter()
+                .any(|line| line.text.starts_with("tools:") && line.text.contains("bash")),
+            "tools should list available tools: {:?}",
+            app.lines
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn clear_command_wipes_transcript_and_re_emits_banner() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.push_system("sentinel line that must be cleared".into());
+
+        app.dispatch_command_for_test("clear").await;
+
+        assert!(
+            !app.lines
+                .iter()
+                .any(|line| line.text.contains("sentinel line")),
+            "clear should wipe prior transcript lines: {:?}",
+            app.lines
+        );
+        assert_eq!(app.printed_lines, 0, "clear should reset the print cursor");
+        // The banner is re-emitted so the cleared screen still shows context.
+        assert!(
+            app.lines
+                .iter()
+                .any(|line| line.text.contains("type /help")),
+            "clear should re-emit the startup banner: {:?}",
+            app.lines
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn quit_command_and_exit_alias_request_shutdown() {
+        for command in ["quit", "exit"] {
+            let mut fixture = app_with_llmsim().await;
+            let app = &mut fixture.app;
+            assert!(!app.should_quit);
+
+            app.dispatch_command_for_test(command).await;
+
+            assert!(
+                app.should_quit,
+                "/{command} should request shutdown via the UI channel"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn app_slash_input_renders_command_suggestions_end_to_end() {
         let mut fixture = app_with_llmsim().await;
         let app = &mut fixture.app;

--- a/src/app.rs
+++ b/src/app.rs
@@ -4467,6 +4467,10 @@ mod tests {
         let mut fixture = app_with_llmsim().await;
         let app = &mut fixture.app;
         app.push_system("sentinel line that must be cleared".into());
+        // Advance the print cursor so the reset assertion below actually
+        // guards the behavior rather than passing on the initial value.
+        app.printed_lines = app.lines.len();
+        assert_ne!(app.printed_lines, 0);
 
         app.dispatch_command_for_test("clear").await;
 


### PR DESCRIPTION
## What

Follow-up to #55 (the slash-command capability refactor), addressing two gaps surfaced in review:

1. **No architecture spec.** The command model lived only in code comments.
2. **Coverage gap.** The `/clear`, `/quit`, `/tools`, `/cwd` terminal commands reused the new channel plumbing but weren't asserted through it.

And a process fix requested by the maintainer:

3. **Ship workflow didn't require feature testing.** Smoke testing was mandated; an automated test exercising the changed behavior was not.

### Changes

- **`specs/commands.md`** (new) — documents the command architecture: the single registry (`runtime.list_commands` as source of truth), the three execution targets (`System` / `Skill` / client-via-`HostUi`-port), *why* client commands use an injected host port instead of an upstream `CommandSource` variant, the TUI/ACP gating, and the canceled EVE-520 rationale so it isn't lost.
- **`src/app.rs`** — adds dispatch tests for `/cwd`, `/tools`, `/clear`, `/quit` (and the `/exit` alias), driving each through the full `handle_command → execute_command → UiCommand → apply_ui_command` path. Closes the gap I flagged on #55.
- **`.agents/skills/ship/SKILL.md`, `specs/shipping.md`, `AGENTS.md`** — make "the changed feature is covered by an automated test that exercises it" an explicit **required outcome before merge**, distinct from (and in addition to) smoke testing, with a narrow, must-be-declared exception for behaviors genuinely impractical to test.

## Validation

- `cargo test --all-features` — 241 passed (231 + 10), 2 ignored (live-provider), 0 failed. The 4 new terminal-command tests pass.
- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- Offline smoke (`--provider llmsim -p "hi"`) — binary starts; print-mode gating intact (lists only `/setup`).

## Security

No security-relevant code changes — additions are a spec, test code, and process docs; no runtime/`tools.rs`/key-handling changes.

## Follow-ups

No follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNLvp2SGuDgEJBPM1ngugB)_