### PR TITLE
fix(ci): don't fail build when Codecov upload lacks token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           files: lcov.info
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage artifact


### PR DESCRIPTION
## Summary

- Dependabot PRs don't receive repository secrets, so `codecov/codecov-action` fails when it tries to upload coverage for a protected branch without a token
- Changed `fail_ci_if_error: true` → `fail_ci_if_error: false` so transient or token-gated Codecov failures don't block CI
- Coverage is still generated and uploaded as an artifact on every run

## Test plan

- [ ] CI passes on this PR (no Codecov token available, upload should warn but not fail)
- [ ] After merge, re-run CI on dependabot PR #58 to confirm it goes green

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkiwHrtruqiSGs423nGGdW)_