### PR TITLE
fix(tui): simplify composer newline shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ session    session_019e3db018a17450aba5407af5777237 (folder: …; log: …)
 
 ## Features
 
-- **TUI** chat (ratatui): scrolling transcript, single-line composer, status
+- **TUI** chat (ratatui): scrolling transcript, multiline composer, status
   bar, optional modal approval bar.
 - **Real-filesystem tools** through the built-in `session_file_system`
   capability layered over `RealDiskFileStore`: `read_file`, `write_file`,

--- a/src/app.rs
+++ b/src/app.rs
@@ -83,6 +83,7 @@ pub(crate) struct CommandSuggestion {
 
 pub const COMPOSER_VIEWPORT_HEIGHT: u16 = 18;
 const COMPACT_CHROME_HEIGHT: u16 = 5;
+const MAX_INPUT_HEIGHT: u16 = 12;
 const ACCENT_BLUE: Color = Color::Rgb(45, 91, 158);
 const ACCENT_GOLD: Color = Color::Rgb(126, 94, 19);
 const TEXT_PRIMARY: Color = Color::Rgb(230, 230, 232);
@@ -656,15 +657,11 @@ impl App {
             return;
         }
         match key.code {
-            KeyCode::Enter
-                if !key
-                    .modifiers
-                    .intersects(KeyModifiers::ALT | KeyModifiers::SHIFT) =>
-            {
-                self.submit_input().await;
+            KeyCode::Enter if key.modifiers.contains(KeyModifiers::SHIFT) => {
+                self.input.insert_newline();
             }
             KeyCode::Enter => {
-                self.input.insert_newline();
+                self.submit_input().await;
             }
             KeyCode::Tab => {
                 if let Some(suggestion) = self.suggestions().first() {
@@ -705,7 +702,7 @@ impl App {
     }
 
     fn input_height(&self) -> u16 {
-        self.input.lines().len().clamp(1, 3) as u16
+        self.input.lines().len().clamp(1, MAX_INPUT_HEIGHT as usize) as u16
     }
 
     async fn submit_input(&mut self) {
@@ -2444,7 +2441,7 @@ fn draw(f: &mut ratatui::Frame, app: &mut App) {
     let input_height = app.input_height();
     let area = f.area();
     let state = app.view_state();
-    let chrome_area = bottom_rect(area, COMPACT_CHROME_HEIGHT);
+    let chrome_area = bottom_rect(area, chrome_height(input_height));
     let transcript_area = Rect {
         height: area.height.saturating_sub(chrome_area.height),
         ..area
@@ -2465,6 +2462,10 @@ fn bottom_rect(area: Rect, height: u16) -> Rect {
         height,
         ..area
     }
+}
+
+fn chrome_height(input_height: u16) -> u16 {
+    COMPACT_CHROME_HEIGHT.max(input_height.saturating_add(2))
 }
 
 fn clear_transcript_viewport(f: &mut ratatui::Frame, area: Rect) {
@@ -3433,11 +3434,7 @@ fn message_separator_title(state: &ViewState) -> Line<'static> {
 }
 
 fn newline_shortcut_hint() -> &'static str {
-    if cfg!(target_os = "macos") {
-        "Option-Enter / Shift-Enter"
-    } else {
-        "Alt-Enter / Shift-Enter"
-    }
+    "Shift-Enter"
 }
 
 fn thinking_title(frame: u64, activity: &str) -> Line<'static> {
@@ -3709,13 +3706,8 @@ mod tests {
     }
 
     #[test]
-    fn newline_shortcut_hint_matches_host_os() {
-        let hint = newline_shortcut_hint();
-        if cfg!(target_os = "macos") {
-            assert_eq!(hint, "Option-Enter / Shift-Enter");
-        } else {
-            assert_eq!(hint, "Alt-Enter / Shift-Enter");
-        }
+    fn newline_shortcut_hint_uses_shift_enter_only() {
+        assert_eq!(newline_shortcut_hint(), "Shift-Enter");
     }
 
     #[test]
@@ -4535,14 +4527,14 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn modified_enter_inserts_newline_without_submitting() {
+    async fn shift_enter_inserts_newline_without_submitting() {
         let mut fixture = app_with_llmsim().await;
         let app = &mut fixture.app;
         app.setup = None;
 
         for key in [
             KeyEvent::new(KeyCode::Char('a'), KeyModifiers::empty()),
-            KeyEvent::new(KeyCode::Enter, KeyModifiers::ALT),
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT),
             KeyEvent::new(KeyCode::Char('b'), KeyModifiers::empty()),
             KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT),
             KeyEvent::new(KeyCode::Char('c'), KeyModifiers::empty()),
@@ -4556,7 +4548,7 @@ mod tests {
             app.lines
                 .iter()
                 .all(|line| !matches!(line.author, Author::User)),
-            "modified Enter should edit the composer, not submit: {:?}",
+            "Shift-Enter should edit the composer, not submit: {:?}",
             app.lines
         );
     }
@@ -4584,12 +4576,12 @@ mod tests {
         let app = &mut fixture.app;
 
         assert_eq!(app.input_height(), 1);
+        for expected in 2..=MAX_INPUT_HEIGHT {
+            app.input.insert_newline();
+            assert_eq!(app.input_height(), expected);
+        }
         app.input.insert_newline();
-        assert_eq!(app.input_height(), 2);
-        app.input.insert_newline();
-        assert_eq!(app.input_height(), 3);
-        app.input.insert_newline();
-        assert_eq!(app.input_height(), 3);
+        assert_eq!(app.input_height(), MAX_INPUT_HEIGHT);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/app.rs
+++ b/src/app.rs
@@ -657,7 +657,7 @@ impl App {
             return;
         }
         match key.code {
-            KeyCode::Enter if key.modifiers.contains(KeyModifiers::SHIFT) => {
+            KeyCode::Enter if key.modifiers == KeyModifiers::SHIFT => {
                 self.input.insert_newline();
             }
             KeyCode::Enter => {
@@ -4549,6 +4549,30 @@ mod tests {
                 .iter()
                 .all(|line| !matches!(line.author, Author::User)),
             "Shift-Enter should edit the composer, not submit: {:?}",
+            app.lines
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn alt_shift_enter_submits_instead_of_inserting_newline() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::empty()))
+            .await;
+        app.handle_key(KeyEvent::new(
+            KeyCode::Enter,
+            KeyModifiers::ALT | KeyModifiers::SHIFT,
+        ))
+        .await;
+
+        assert_eq!(app.input_text(), "");
+        assert!(
+            app.lines
+                .iter()
+                .any(|line| matches!(line.author, Author::User) && line.text == "a"),
+            "Alt-Shift-Enter should submit the composer: {:?}",
             app.lines
         );
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -269,7 +269,7 @@ fn tui_escape_does_not_exit_and_ctrl_c_exits() {
 }
 
 #[test]
-fn tui_option_enter_sequence_inserts_newline_before_submit() {
+fn tui_alt_enter_sequence_submits_like_enter() {
     let mut tui = spawn_tui_llmsim();
     assert!(
         tui.wait_for_output("type /help", Duration::from_secs(3)),
@@ -278,23 +278,27 @@ fn tui_option_enter_sequence_inserts_newline_before_submit() {
     );
 
     tui.write_input(b"one\x1b\r");
-    thread::sleep(Duration::from_millis(250));
-    let before_submit = tui.output_text();
     assert!(
-        !before_submit.contains("you ›"),
-        "Option-Enter should keep composing, not submit: {before_submit}"
+        tui.wait_for_output("one", Duration::from_secs(3)),
+        "Alt-Enter should submit like Enter: {}",
+        tui.output_text()
+    );
+    assert!(
+        tui.wait_for_output("offline mode", Duration::from_secs(3)),
+        "first turn did not complete before second input: {}",
+        tui.output_text()
     );
 
     tui.write_input(b"two\r");
     assert!(
-        tui.wait_for_output("you ›", Duration::from_secs(3)),
-        "plain Enter did not submit after multiline input: {}",
+        tui.wait_for_output("two", Duration::from_secs(3)),
+        "plain Enter did not submit second input: {}",
         tui.output_text()
     );
     let after_submit = strip_ansi(&tui.output_text());
     assert!(
         after_submit.contains("one") && after_submit.contains("two"),
-        "submitted multiline text should render both lines: {after_submit}"
+        "submitted text should render both turns: {after_submit}"
     );
 
     tui.write_input(b"\x03");


### PR DESCRIPTION
## What
Simplify the TUI composer newline shortcut to Shift-Enter only and grow the multiline composer from 3 rows to 12 rows.

## Why
The old Option/Alt-Enter plus Shift-Enter contract was noisy, and a 3-line composer is too small for realistic prompts.

## How
- Treat only Shift-Enter as newline insertion; Enter and Alt/Option-Enter submit.
- Cap composer height at 12 rows and grow the bottom chrome with the input area.
- Update TUI regression coverage and README wording.

## Risk
- Low
- Affected surface is limited to TUI key handling, composer layout, tests, and one README feature bullet.
- Alt/Option-Enter intentionally changes behavior from newline insertion to submit.

## Security
- TM-FS: no filesystem tool changes.
- TM-BASH: no shell execution changes.
- TM-LLM: no prompt construction, provider secret, or session logging changes.
- TM-TOOL: no capability registration changes.
- TM-DEP: no dependency changes.
- Resource exhaustion reviewed: larger composer remains bounded at 12 rows inside the existing 18-row inline viewport.

## Validation
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features
- cargo run -- --provider llmsim --session-dir <tempdir> -p hi
- Attempted live Doppler smoke: blocked locally by Doppler project config (`You must specify a project`; no fallback file).

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (none yet)
