### PR TITLE
feat(cli): add version metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ full protocol surface, mappings, and current limitations.
 
 | Command            | Description                                     |
 | ------------------ | ----------------------------------------------- |
+| `yolop version`    | Print yolop, commit, and runtime versions       |
 | `yolop into zed`   | Configure yolop as a custom ACP agent in Zed    |
 
 `RUST_LOG` is honored for the underlying tracing layer (writes to stderr).

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,98 @@
+use std::env;
+use std::fs;
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=Cargo.lock");
+    println!("cargo:rerun-if-changed=Cargo.toml");
+    println!("cargo:rerun-if-env-changed=YOLOP_GIT_SHA");
+    emit_git_rerun_paths();
+
+    let git_sha = env::var("YOLOP_GIT_SHA")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| git_short_sha().unwrap_or_else(|| "unknown".to_string()));
+    println!("cargo:rustc-env=YOLOP_GIT_SHA={git_sha}");
+
+    let runtime_version = cargo_lock_package_version("everruns-runtime")
+        .or_else(|| cargo_toml_dependency_version("everruns-runtime"))
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=YOLOP_EVERRUNS_RUNTIME_VERSION={runtime_version}");
+}
+
+fn git_short_sha() -> Option<String> {
+    git_output(&["rev-parse", "--short=12", "HEAD"])
+}
+
+fn emit_git_rerun_paths() {
+    if let Some(head) = git_output(&["rev-parse", "--git-path", "HEAD"]) {
+        println!("cargo:rerun-if-changed={head}");
+    }
+    if let Some(packed_refs) = git_output(&["rev-parse", "--git-path", "packed-refs"]) {
+        println!("cargo:rerun-if-changed={packed_refs}");
+    }
+    if let Some(head_ref) = git_output(&["symbolic-ref", "-q", "HEAD"])
+        && let Some(ref_path) = git_output(&["rev-parse", "--git-path", &head_ref])
+    {
+        println!("cargo:rerun-if-changed={ref_path}");
+    }
+}
+
+fn git_output(args: &[&str]) -> Option<String> {
+    let output = Command::new("git").args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    (!stdout.is_empty()).then_some(stdout)
+}
+
+fn cargo_lock_package_version(package_name: &str) -> Option<String> {
+    let lock = fs::read_to_string("Cargo.lock").ok()?;
+    let mut in_package = false;
+    let mut matched_name = false;
+
+    for line in lock.lines().map(str::trim) {
+        if line == "[[package]]" {
+            in_package = true;
+            matched_name = false;
+            continue;
+        }
+        if !in_package {
+            continue;
+        }
+        if let Some(name) = quoted_value(line, "name") {
+            matched_name = name == package_name;
+            continue;
+        }
+        if matched_name && let Some(version) = quoted_value(line, "version") {
+            return Some(version.to_string());
+        }
+    }
+    None
+}
+
+fn cargo_toml_dependency_version(package_name: &str) -> Option<String> {
+    let manifest = fs::read_to_string("Cargo.toml").ok()?;
+    for line in manifest.lines().map(str::trim) {
+        if !line.starts_with(package_name) {
+            continue;
+        }
+        if let Some((_, raw_version)) = line.split_once('=') {
+            let version = raw_version.trim().trim_matches('"');
+            if !version.is_empty() {
+                return Some(version.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn quoted_value<'a>(line: &'a str, key: &str) -> Option<&'a str> {
+    let (raw_key, raw_value) = line.split_once('=')?;
+    if raw_key.trim() != key {
+        return None;
+    }
+    raw_value.trim().strip_prefix('"')?.strip_suffix('"')
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod settings;
 #[cfg(test)]
 mod test_env;
 mod tools;
+mod version;
 
 #[cfg(test)]
 mod streaming_tests;
@@ -43,7 +44,7 @@ use std::sync::Arc;
 #[derive(Parser, Debug)]
 #[command(
     name = "yolop",
-    version,
+    version = version::VERSION_DETAILS,
     about = "Yolop coding agent — embedded terminal agent built on everruns-runtime"
 )]
 struct Cli {
@@ -101,6 +102,8 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Commands {
+    /// Print version information.
+    Version,
     /// Add yolop into supported editors.
     Into(IntoCommand),
 }
@@ -303,6 +306,10 @@ async fn main() -> Result<()> {
 
 fn run_command(command: Commands) -> Result<()> {
     match command {
+        Commands::Version => {
+            println!("{}", version::VERSION_LINE);
+            Ok(())
+        }
         Commands::Into(into) => match into.target {
             IntoTarget::Zed(args) => {
                 let command = match args.command {

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,18 @@
+pub const VERSION_DETAILS: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    " (commit ",
+    env!("YOLOP_GIT_SHA"),
+    ", everruns-runtime ",
+    env!("YOLOP_EVERRUNS_RUNTIME_VERSION"),
+    ")"
+);
+
+pub const VERSION_LINE: &str = concat!(
+    "yolop ",
+    env!("CARGO_PKG_VERSION"),
+    " (commit ",
+    env!("YOLOP_GIT_SHA"),
+    ", everruns-runtime ",
+    env!("YOLOP_EVERRUNS_RUNTIME_VERSION"),
+    ")"
+);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -51,9 +51,32 @@ fn version_flag_succeeds() {
         .expect("spawn yolop --version");
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_version_output(&stdout);
+}
+
+#[test]
+fn version_command_succeeds() {
+    let output = Command::new(yolop_binary())
+        .arg("version")
+        .output()
+        .expect("spawn yolop version");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_version_output(&stdout);
+}
+
+fn assert_version_output(stdout: &str) {
     assert!(
         stdout.contains("yolop"),
         "version output missing binary name: {stdout}"
+    );
+    assert!(
+        stdout.contains("commit "),
+        "version output missing commit SHA: {stdout}"
+    );
+    assert!(
+        stdout.contains("everruns-runtime "),
+        "version output missing runtime version: {stdout}"
     );
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -71,6 +71,10 @@ fn assert_version_output(stdout: &str) {
         "version output missing binary name: {stdout}"
     );
     assert!(
+        stdout.contains(env!("CARGO_PKG_VERSION")),
+        "version output missing package version: {stdout}"
+    );
+    assert!(
         stdout.contains("commit "),
         "version output missing commit SHA: {stdout}"
     );


### PR DESCRIPTION
## What
Add richer version metadata to the CLI:
- `yolop --version` now includes the package version, commit SHA, and `everruns-runtime` version.
- `yolop version` prints the same information.
- README and integration tests cover the new command surface.

## Why
Users need a quick way to confirm exactly which yolop build and runtime dependency they are running.

## How
A build script records the short git SHA and resolved `everruns-runtime` version from `Cargo.lock`, then exposes those values through compile-time env vars used by the CLI.

## Risk
- Low
- Build metadata could show `unknown` if built outside a git checkout or without manifest metadata available; the binary still builds and runs.

## Security
Reviewed TM-FS, TM-BASH, TM-LLM, TM-TOOL, and TM-DEP. This change adds build-time metadata collection only: static `git` invocations, local manifest/lockfile reads, no runtime shell/filesystem/tool behavior changes, no provider key handling, no new dependencies.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories