### PR TITLE
chore(deps): bump softprops/action-gh-release from 2 to 3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
           echo "Release notes extracted for v$VERSION"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: Release ${{ steps.version.outputs.tag }}


### PR DESCRIPTION
## What

Bumps `softprops/action-gh-release` from `v2` to `v3` in `.github/workflows/release.yml`.

## Why

`v3.0.0` is a major release that moves the action runtime from Node 20 to Node 24. The release job runs on `ubuntu-latest`, which already supports the Node 24 Actions runtime, so the upgrade is safe and keeps us off the soon-to-be-deprecated Node 20 line.

This **supersedes #58**. That Dependabot PR carries the identical one-line change, but its branch cannot go green: Dependabot PRs run without access to repository secrets, so the `CODECOV_TOKEN` is empty and the `codecov/codecov-action` step (`fail_ci_if_error: true`) hard-fails with `Token required because branch is protected`. The build and tests themselves passed on #58. Landing the change from a same-repo branch lets CI run with secrets and go green.

## Validation

- This is a **CI-config-only** change. The `action-gh-release` step is invoked solely by the release workflow, which triggers on a `chore(release): prepare v…` commit landing on `main` or a manual `workflow_dispatch` — never on PR CI. There is no runtime, binary, or test surface to exercise, so no automated test is added (per the shipping spec's config-only exemption).
- Confirmed `v3` is the current floating major tag and that `ubuntu-latest` provides the Node 24 runtime the new release requires.
- Full PR CI is green on this branch: Format + Clippy, Build + Tests + Offline Smoke (Codecov upload included), Live OpenAI Smoke, and CodeQL.

## Security

No security-relevant code changes. CI-config-only: swaps a pinned major tag for a release-only workflow step. No filesystem, shell, LLM, capability, or dependency-crate surface is touched.

## Follow-ups

- The Codecov upload step (`.github/workflows/ci.yml`) fails on Dependabot and fork PRs because the `CODECOV_TOKEN` secret is unavailable there while `fail_ci_if_error: true`. Gating that step on token availability (as the `live-smoke` job already does for `DOPPLER_TOKEN`) would let future Dependabot PRs go green. Deferred — out of scope for a dependency bump and worth its own focused PR.