### PR TITLE
feat(mcp): MCP server support with approval-gated tool calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 everruns-anthropic = "0.8.38"
 everruns-core = "0.8.38"
 everruns-openai = "0.8.38"
-everruns-runtime = "0.8.38"
+# `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
+# everruns server/worker never enable it (specs/mcp.md, upstream runtime-mcp.md D2).
+everruns-runtime = { version = "0.8.38", features = ["mcp-stdio"] }
 everruns-integrations-duckduckgo = "0.8.38"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -295,13 +295,15 @@ shape that every MCP client understands. Two scopes are read and merged
   `command`.
 - String values support `${VAR}` expansion from the environment, so secrets
   stay out of the file (an unset `${VAR}` is left as-is so it's easy to spot).
-- Discovered tools are exposed to the model as `mcp__<server>__<tool>`.
+- Discovered tools are exposed to the model as `mcp_<server>__<tool>`.
 - `/mcp` lists the configured servers.
 
 Trust model: HTTP requests keep yolop's DNS-pinned SSRF protection; stdio
 servers run local processes you listed yourself, so authoring `.mcp.json` is
-the act of consent. MCP tool calls do not yet go through the interactive
-`bash`/file-write approval prompt — see [`specs/mcp.md`](specs/mcp.md).
+the act of consent. With `--ask`, every non-readonly MCP tool call goes through
+the same approval prompt as `bash` and file writes (readonly tools run free);
+without `--ask` it auto-approves, like the rest of yolop. See
+[`specs/mcp.md`](specs/mcp.md).
 
 ## Settings
 

--- a/README.md
+++ b/README.md
@@ -72,8 +72,11 @@ session    session_019e3db018a17450aba5407af5777237 (folder: …; log: …)
   - `OPENROUTER_API_KEY` → OpenRouter (`openai/gpt-5.2` by default)
   - `GEMINI_API_KEY` (or `GOOGLE_API_KEY`) → Google Gemini (`gemini-2.5-flash`)
   - `OLLAMA_BASE_URL` / `OLLAMA_API_KEY` → Ollama (`llama3.2`)
-- **Slash commands** (TUI): `/help`, `/tools`, `/cwd`, `/setup`, `/model`,
-  `/effort`, `/clear`, `/quit`.
+- **Slash commands** (TUI): `/help`, `/tools`, `/mcp`, `/cwd`, `/setup`,
+  `/model`, `/effort`, `/clear`, `/quit`.
+- **MCP servers**: extra tools from local (stdio) or remote (HTTP) [Model
+  Context Protocol](https://modelcontextprotocol.io) servers, configured via
+  `.mcp.json` (see [MCP servers](#mcp-servers)).
 - **Guided setup**: launching yolop with no env vars and no saved
   settings opens a keyboard-driven setup overlay for provider → API key →
   model. Re-running `/setup` opens the same provider setup flow, `/model`
@@ -258,6 +261,47 @@ full protocol surface, mappings, and current limitations.
 | `OLLAMA_API_KEY`                | Optional, defaults to `ollama` for local Ollama              |
 | `EVERRUNS_CLI_MODEL`            | Override the auto-selected default model                     |
 | `EVERRUNS_CLI_REASONING_EFFORT` | OpenAI-only reasoning effort override                        |
+
+## MCP servers
+
+Yolop can pull in extra tools from [Model Context Protocol](https://modelcontextprotocol.io)
+servers — both remote (Streamable **HTTP**) and local (**stdio**, a child
+process). Configure them in a `.mcp.json` file using the standard `mcpServers`
+shape that every MCP client understands. Two scopes are read and merged
+(workspace overrides global by name):
+
+- **workspace**: `<workspace_root>/.mcp.json`
+- **global**: `<config_dir>/yolop/mcp.json` (e.g. `~/.config/yolop/mcp.json`)
+
+```json
+{
+  "mcpServers": {
+    "docs": {
+      "type": "http",
+      "url": "https://example.com/mcp",
+      "headers": { "Authorization": "Bearer ${DOCS_TOKEN}" }
+    },
+    "fs": {
+      "type": "stdio",
+      "command": "mcp-server-filesystem",
+      "args": ["${WORKSPACE}"],
+      "env": { "RUST_LOG": "info" }
+    }
+  }
+}
+```
+
+- `type` defaults to `http`; HTTP servers need a `url`, stdio servers need a
+  `command`.
+- String values support `${VAR}` expansion from the environment, so secrets
+  stay out of the file (an unset `${VAR}` is left as-is so it's easy to spot).
+- Discovered tools are exposed to the model as `mcp__<server>__<tool>`.
+- `/mcp` lists the configured servers.
+
+Trust model: HTTP requests keep yolop's DNS-pinned SSRF protection; stdio
+servers run local processes you listed yourself, so authoring `.mcp.json` is
+the act of consent. MCP tool calls do not yet go through the interactive
+`bash`/file-write approval prompt — see [`specs/mcp.md`](specs/mcp.md).
 
 ## Settings
 

--- a/specs/mcp.md
+++ b/specs/mcp.md
@@ -1,6 +1,6 @@
 # MCP — Model Context Protocol client support
 
-Status: v1 implemented (HTTP + stdio, workspace + global config).
+Status: v1 implemented (HTTP + stdio, workspace + global config, approval gating).
 
 ## Why
 
@@ -30,9 +30,16 @@ path, so MCP tools flow through the same agent loop as the built-in tools.
   the file. Unset placeholders are left intact so the gap is debuggable.
 - **Discovery + execution**: the runtime discovers each server's tools live
   (`tools/list`) and routes `mcp_*` tool calls to the MCP executor. Tool names
-  are prefixed (`mcp__<server>__<tool>`) by the runtime to avoid collisions.
+  are prefixed (`mcp_<server>__<tool>`) by the runtime to avoid collisions.
 - **Visibility**: `/mcp` lists the configured servers; configured server names
   also appear in `StartupInfo`.
+- **Approval gating**: `McpApprovalCapability` contributes a `PreToolUseHook`
+  (via the `Capability::pre_tool_use_hooks` seam, everruns 0.8.38+) that routes
+  every non-readonly `mcp_*` call through the same `ApprovalGate` as `bash`,
+  honoring the readonly hint the runtime derives from MCP tool annotations.
+  Registered only when MCP servers are configured; a no-op when the gate is
+  `Auto` (no `--ask`, and `--print`). Non-MCP tools keep their own gates and
+  are not double-prompted.
 
 Config shape:
 
@@ -54,18 +61,14 @@ Config shape:
 - **HTTP** keeps the runtime's DNS-pinned SSRF protection — no relaxation.
 - **stdio** spawns local processes the user explicitly listed in their own
   `.mcp.json`. Authoring that file is the act of consent, mirroring how other
-  MCP clients treat a project-scoped server list. yolop does not yet add a
-  per-tool interactive approval prompt for MCP calls (the in-process runtime
-  exposes no capability-level pre-tool hook today); MCP tools therefore run
-  without the `bash`/file-write approval gate.
+  MCP clients treat a project-scoped server list.
+- **Per-call approval**: with `--ask`, every non-readonly MCP tool call is
+  gated through the `ApprovalGate` (see "Approval gating" above), the same as
+  `bash` and file writes. Without `--ask` (and in `--print`) the gate
+  auto-approves, consistent with yolop acting autonomously by default.
 
 ## Non-goals (for now)
 
-- Per-tool interactive approval of MCP calls. Tracked as a follow-up — the
-  clean fix is an upstream `Capability::pre_tool_use_hooks()` seam (or a
-  server-level consent prompt persisted in settings) so yolop can route
-  `mcp_*` calls through its `ApprovalGate` honoring the readonly/destructive
-  `ToolHints` that the runtime already derives from MCP annotations.
 - OAuth (browser/device-code) for remote servers. API-key/bearer via `headers`
   (with `${VAR}` expansion) covers the common case; the runtime exposes an
   `mcp_auth_provider()` seam for a future env/device-code provider.
@@ -81,4 +84,5 @@ Config shape:
 | Config loading (scopes, merge, `${VAR}`) | `src/mcp_config.rs` |
 | Wiring into the session | `src/runtime.rs` (`session_mcp_servers`, `StartupInfo.mcp_server_names`) |
 | `/mcp` command | `src/capabilities/client_commands.rs`, `src/host_ui.rs`, `src/app.rs` |
+| Approval gating | `McpApprovalCapability` in `src/capabilities/host.rs`; `ApprovalRequest::McpTool` in `src/approval.rs` |
 | Client / transports / executor | upstream `everruns-mcp`, `everruns-runtime` (`mcp-stdio` feature) |

--- a/specs/mcp.md
+++ b/specs/mcp.md
@@ -1,0 +1,84 @@
+# MCP — Model Context Protocol client support
+
+Status: v1 implemented (HTTP + stdio, workspace + global config).
+
+## Why
+
+[MCP](https://modelcontextprotocol.io) is the open standard for giving an agent
+extra tools — local (filesystem, git, sqlite) or remote (docs, issue trackers).
+Supporting it lets yolop use the same `.mcp.json` server catalog that every
+other MCP client understands, with no bespoke per-tool integration.
+
+The MCP **client** lives upstream in `everruns-mcp` (transport-agnostic) and is
+wired into the in-process `everruns-runtime`; see the upstream
+`specs/runtime-mcp.md` decision record. Yolop does not implement the protocol
+itself — it configures servers and consumes the runtime's discovery + execution
+path, so MCP tools flow through the same agent loop as the built-in tools.
+
+## What — scope of the layer
+
+- **Transports**: remote **Streamable HTTP** (always available) and local
+  **stdio** (child process). stdio rides the runtime's `mcp-stdio` cargo
+  feature, which yolop enables; the hosted everruns product compiles it out.
+- **Configuration**: a `.mcp.json` file using the `mcpServers` object shape.
+  Two scopes are read and merged (`merge_scoped_mcp_servers`):
+  - **global**: `<config_dir>/yolop/mcp.json` (e.g. `~/.config/yolop/mcp.json`)
+  - **workspace**: `<workspace_root>/.mcp.json` — overrides global by name.
+  A malformed file warns and is skipped rather than failing startup.
+- **Secrets via env**: string fields support `${VAR}` expansion from the
+  environment (`"Authorization": "Bearer ${DOCS_TOKEN}"`), so tokens stay out of
+  the file. Unset placeholders are left intact so the gap is debuggable.
+- **Discovery + execution**: the runtime discovers each server's tools live
+  (`tools/list`) and routes `mcp_*` tool calls to the MCP executor. Tool names
+  are prefixed (`mcp__<server>__<tool>`) by the runtime to avoid collisions.
+- **Visibility**: `/mcp` lists the configured servers; configured server names
+  also appear in `StartupInfo`.
+
+Config shape:
+
+```json
+{
+  "mcpServers": {
+    "docs": { "type": "http", "url": "https://example.com/mcp",
+              "headers": { "Authorization": "Bearer ${DOCS_TOKEN}" } },
+    "fs":   { "type": "stdio", "command": "mcp-server-filesystem",
+              "args": ["${WORKSPACE}"], "env": { "RUST_LOG": "info" } }
+  }
+}
+```
+
+`type` defaults to `http`; for HTTP, `url` is required.
+
+## Trust model
+
+- **HTTP** keeps the runtime's DNS-pinned SSRF protection — no relaxation.
+- **stdio** spawns local processes the user explicitly listed in their own
+  `.mcp.json`. Authoring that file is the act of consent, mirroring how other
+  MCP clients treat a project-scoped server list. yolop does not yet add a
+  per-tool interactive approval prompt for MCP calls (the in-process runtime
+  exposes no capability-level pre-tool hook today); MCP tools therefore run
+  without the `bash`/file-write approval gate.
+
+## Non-goals (for now)
+
+- Per-tool interactive approval of MCP calls. Tracked as a follow-up — the
+  clean fix is an upstream `Capability::pre_tool_use_hooks()` seam (or a
+  server-level consent prompt persisted in settings) so yolop can route
+  `mcp_*` calls through its `ApprovalGate` honoring the readonly/destructive
+  `ToolHints` that the runtime already derives from MCP annotations.
+- OAuth (browser/device-code) for remote servers. API-key/bearer via `headers`
+  (with `${VAR}` expansion) covers the common case; the runtime exposes an
+  `mcp_auth_provider()` seam for a future env/device-code provider.
+- MCP **resources** and **prompts** (tools are the 90% case).
+- ACP MCP pass-through: `mcpServers` supplied by an ACP client is still
+  accepted-and-ignored (see `src/acp/protocol.rs`); only yolop's own
+  `.mcp.json` is honored.
+
+## Where it lives
+
+| Concern | Location |
+|---------|----------|
+| Config loading (scopes, merge, `${VAR}`) | `src/mcp_config.rs` |
+| Wiring into the session | `src/runtime.rs` (`session_mcp_servers`, `StartupInfo.mcp_server_names`) |
+| `/mcp` command | `src/capabilities/client_commands.rs`, `src/host_ui.rs`, `src/app.rs` |
+| Client / transports / executor | upstream `everruns-mcp`, `everruns-runtime` (`mcp-stdio` feature) |

--- a/src/app.rs
+++ b/src/app.rs
@@ -757,6 +757,20 @@ impl App {
             UiCommand::ShowTools => {
                 self.push_system(format!("tools: {}", self.startup.tool_names.join(", ")));
             }
+            UiCommand::ShowMcp => {
+                if self.startup.mcp_server_names.is_empty() {
+                    self.push_system(
+                        "no MCP servers configured (add them to .mcp.json in the workspace \
+                         root or ~/.config/yolop/mcp.json)"
+                            .into(),
+                    );
+                } else {
+                    self.push_system(format!(
+                        "MCP servers: {}",
+                        self.startup.mcp_server_names.join(", ")
+                    ));
+                }
+            }
             UiCommand::ShowCwd => {
                 self.push_system(format!(
                     "workspace root: {}",
@@ -2146,7 +2160,10 @@ fn command_suggestions(
         });
     }
 
-    out.truncate(8);
+    // Keep the dropdown bounded but large enough to show every built-in
+    // command (8 client commands + capability commands like /setup) for a
+    // bare `/`, so none is hidden behind the cap.
+    out.truncate(12);
     out
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -759,11 +759,13 @@ impl App {
             }
             UiCommand::ShowMcp => {
                 if self.startup.mcp_server_names.is_empty() {
-                    self.push_system(
+                    let global = crate::mcp_config::global_mcp_config_path()
+                        .map(|p| p.display().to_string())
+                        .unwrap_or_else(|| "the yolop config dir".to_string());
+                    self.push_system(format!(
                         "no MCP servers configured (add them to .mcp.json in the workspace \
-                         root or ~/.config/yolop/mcp.json)"
-                            .into(),
-                    );
+                         root or {global})"
+                    ));
                 } else {
                     self.push_system(format!(
                         "MCP servers: {}",

--- a/src/approval.rs
+++ b/src/approval.rs
@@ -25,6 +25,13 @@ pub enum ApprovalRequest {
         path: String,
         recursive: bool,
     },
+    /// A tool call from an MCP server (`mcp_<server>__<tool>`). Gated because
+    /// MCP tools run through the runtime's executor, outside the bash/file
+    /// gates; read-only tools are filtered out before reaching here.
+    McpTool {
+        name: String,
+        arguments: serde_json::Value,
+    },
 }
 
 impl ApprovalRequest {
@@ -43,6 +50,10 @@ impl ApprovalRequest {
                 let r = if *recursive { " (recursive)" } else { "" };
                 format!("delete {path}{r}")
             }
+            Self::McpTool { name, .. } => match everruns_core::parse_mcp_tool_name(name) {
+                Some((server, tool)) => format!("call MCP tool {server} / {tool}"),
+                None => format!("call MCP tool {name}"),
+            },
         }
     }
 
@@ -59,6 +70,9 @@ impl ApprovalRequest {
                 None => format!("(new file, {} bytes)", after.len()),
             },
             Self::FileDelete { .. } => String::new(),
+            Self::McpTool { arguments, .. } => {
+                serde_json::to_string_pretty(arguments).unwrap_or_else(|_| arguments.to_string())
+            }
         }
     }
 }

--- a/src/capabilities/client_commands.rs
+++ b/src/capabilities/client_commands.rs
@@ -42,7 +42,7 @@ impl Capability for ClientCommandsCapability {
         "Client Commands"
     }
     fn description(&self) -> &str {
-        "Terminal-side slash commands (help, tools, cwd, model, effort, clear, quit)."
+        "Terminal-side slash commands (help, tools, mcp, cwd, model, effort, clear, quit)."
     }
     fn status(&self) -> CapabilityStatus {
         CapabilityStatus::Available
@@ -58,6 +58,7 @@ impl Capability for ClientCommandsCapability {
         vec![
             cmd("help", "show commands", &[]),
             cmd("tools", "list available tools", &[]),
+            cmd("mcp", "list configured MCP servers", &[]),
             cmd("cwd", "show workspace root", &[]),
             cmd("model", "show or switch model", &[opt("id")]),
             cmd("effort", "show or set reasoning effort", &[opt("level")]),
@@ -80,6 +81,7 @@ impl Capability for ClientCommandsCapability {
         let command = match request.name.as_str() {
             "help" => UiCommand::ShowHelp,
             "tools" => UiCommand::ShowTools,
+            "mcp" => UiCommand::ShowMcp,
             "cwd" => UiCommand::ShowCwd,
             "clear" => UiCommand::ClearTranscript,
             "quit" => UiCommand::Quit,

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -877,11 +877,13 @@ mod tests {
     /// A gate that denies every request, so we can prove the hook blocks (and
     /// that bypassed tools are *not* sent to it).
     fn deny_gate() -> Arc<ApprovalGate> {
-        let (tx, mut rx) =
-            tokio::sync::mpsc::unbounded_channel::<(crate::approval::ApprovalRequest, _)>();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<(
+            crate::approval::ApprovalRequest,
+            tokio::sync::oneshot::Sender<bool>,
+        )>();
         tokio::spawn(async move {
             while let Some((_req, responder)) = rx.recv().await {
-                let _ = tokio::sync::oneshot::Sender::send(responder, false);
+                let _ = responder.send(false);
             }
         });
         ApprovalGate::channel(tx)

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -329,6 +329,91 @@ impl Capability for CodingBashCapability {
     }
 }
 
+// ---------- MCP approval ----------
+//
+// MCP tools execute through the runtime's executor, so they bypass the bash
+// and filesystem approval gates. This capability closes that gap uniformly via
+// the `pre_tool_use_hooks` seam (everruns 0.8.38+): every `mcp_*` tool call is
+// routed through the same `ApprovalGate` as bash, honoring the readonly hint
+// the runtime derives from MCP tool annotations. Non-MCP tools are left to
+// their own gates so they aren't prompted twice. When the gate is `Auto` (no
+// `--ask`, and `--print`), this is a no-op — consistent with yolop acting
+// autonomously by default.
+
+pub(crate) const MCP_APPROVAL_CAPABILITY_ID: &str = "yolop_mcp_approval";
+
+pub(crate) struct McpApprovalCapability {
+    pub(crate) gate: Arc<ApprovalGate>,
+}
+
+impl Capability for McpApprovalCapability {
+    fn id(&self) -> &str {
+        MCP_APPROVAL_CAPABILITY_ID
+    }
+    fn name(&self) -> &str {
+        "MCP Approval"
+    }
+    fn description(&self) -> &str {
+        "Routes MCP tool calls through the approval gate (readonly tools run free)."
+    }
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+    fn category(&self) -> Option<&str> {
+        Some("Examples")
+    }
+    fn system_prompt_addition(&self) -> Option<&str> {
+        None
+    }
+    fn pre_tool_use_hooks(&self) -> Vec<Arc<dyn everruns_core::atoms::PreToolUseHook>> {
+        vec![Arc::new(McpApprovalHook {
+            gate: self.gate.clone(),
+        })]
+    }
+}
+
+struct McpApprovalHook {
+    gate: Arc<ApprovalGate>,
+}
+
+#[async_trait]
+impl everruns_core::atoms::PreToolUseHook for McpApprovalHook {
+    async fn before_exec(
+        &self,
+        tool_call: everruns_core::ToolCall,
+        tool_def: &everruns_core::ToolDefinition,
+        _context: &everruns_core::ToolContext,
+    ) -> everruns_core::atoms::PreToolUseDecision {
+        use everruns_core::atoms::PreToolUseDecision;
+
+        // Only gate MCP tools; bash and filesystem writes keep their own gates.
+        if !everruns_core::is_mcp_tool(&tool_call.name) {
+            return PreToolUseDecision::Continue(tool_call);
+        }
+        // Read-only tools (per MCP annotations → ToolHints) run without a prompt.
+        if tool_def.hints().readonly == Some(true) {
+            return PreToolUseDecision::Continue(tool_call);
+        }
+
+        let approved = self
+            .gate
+            .approve(crate::approval::ApprovalRequest::McpTool {
+                name: tool_call.name.clone(),
+                arguments: tool_call.arguments.clone(),
+            })
+            .await;
+        if approved {
+            PreToolUseDecision::Continue(tool_call)
+        } else {
+            PreToolUseDecision::Block {
+                reason: format!("user denied MCP tool call: {}", tool_call.name),
+                user_message: Some("denied".into()),
+                tool_call,
+            }
+        }
+    }
+}
+
 // ---------- /setup ----------
 //
 // One user-facing command owns provider, token, and model setup. The TUI starts
@@ -757,6 +842,91 @@ fn env_credential_present() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---------- MCP approval hook ----------
+
+    use everruns_core::atoms::{PreToolUseDecision, PreToolUseHook};
+    use everruns_core::tool_types::{BuiltinTool, ToolHints};
+    use everruns_core::typed_id::SessionId;
+    use everruns_core::{ToolCall, ToolContext, ToolDefinition};
+
+    fn tool_def(name: &str, readonly: Option<bool>) -> ToolDefinition {
+        ToolDefinition::Builtin(BuiltinTool {
+            name: name.to_string(),
+            display_name: None,
+            description: String::new(),
+            parameters: serde_json::json!({}),
+            policy: Default::default(),
+            category: None,
+            deferrable: Default::default(),
+            hints: ToolHints {
+                readonly,
+                ..Default::default()
+            },
+        })
+    }
+
+    fn tool_call(name: &str) -> ToolCall {
+        ToolCall {
+            id: "call_1".into(),
+            name: name.to_string(),
+            arguments: serde_json::json!({"k": "v"}),
+        }
+    }
+
+    /// A gate that denies every request, so we can prove the hook blocks (and
+    /// that bypassed tools are *not* sent to it).
+    fn deny_gate() -> Arc<ApprovalGate> {
+        let (tx, mut rx) =
+            tokio::sync::mpsc::unbounded_channel::<(crate::approval::ApprovalRequest, _)>();
+        tokio::spawn(async move {
+            while let Some((_req, responder)) = rx.recv().await {
+                let _ = tokio::sync::oneshot::Sender::send(responder, false);
+            }
+        });
+        ApprovalGate::channel(tx)
+    }
+
+    async fn decide(gate: Arc<ApprovalGate>, def: &ToolDefinition, call: ToolCall) -> bool {
+        let hook = McpApprovalHook { gate };
+        let ctx = ToolContext::new(SessionId::new());
+        matches!(
+            hook.before_exec(call, def, &ctx).await,
+            PreToolUseDecision::Continue(_)
+        )
+    }
+
+    #[tokio::test]
+    async fn mcp_approval_hook_blocks_denied_mcp_tool() {
+        let def = tool_def("mcp_docs__search", None);
+        let allowed = decide(deny_gate(), &def, tool_call("mcp_docs__search")).await;
+        assert!(!allowed, "a denied MCP tool must be blocked");
+    }
+
+    #[tokio::test]
+    async fn mcp_approval_hook_allows_approved_mcp_tool() {
+        let def = tool_def("mcp_docs__search", None);
+        // Auto gate approves everything.
+        let allowed = decide(ApprovalGate::auto(), &def, tool_call("mcp_docs__search")).await;
+        assert!(allowed, "an approved MCP tool must continue");
+    }
+
+    #[tokio::test]
+    async fn mcp_approval_hook_skips_readonly_mcp_tool() {
+        // Readonly tools continue without consulting the (denying) gate.
+        let def = tool_def("mcp_docs__search", Some(true));
+        let allowed = decide(deny_gate(), &def, tool_call("mcp_docs__search")).await;
+        assert!(allowed, "readonly MCP tools should not be gated");
+    }
+
+    #[tokio::test]
+    async fn mcp_approval_hook_ignores_non_mcp_tool() {
+        // Non-MCP tools (bash, files) keep their own gates and pass through here
+        // even when this gate would deny.
+        let def = tool_def("bash", None);
+        let allowed = decide(deny_gate(), &def, tool_call("bash")).await;
+        assert!(allowed, "non-MCP tools must not be gated by this hook");
+    }
 
     #[test]
     fn needs_onboarding_true_for_empty_settings() {

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -11,6 +11,6 @@ pub(crate) mod your;
 pub(crate) use client_commands::{CLIENT_COMMANDS_CAPABILITY_ID, ClientCommandsCapability};
 pub(crate) use host::{
     ATTRIBUTION_CAPABILITY_ID, AttributionCapability, CodingBashCapability,
-    CodingCliEnvironmentCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID, SETUP_CAPABILITY_ID,
-    SetupCapability,
+    CodingCliEnvironmentCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID, MCP_APPROVAL_CAPABILITY_ID,
+    McpApprovalCapability, SETUP_CAPABILITY_ID, SetupCapability,
 };

--- a/src/host_ui.rs
+++ b/src/host_ui.rs
@@ -19,6 +19,8 @@ pub enum UiCommand {
     ShowHelp,
     /// Print the list of available tools.
     ShowTools,
+    /// Print the configured MCP servers.
+    ShowMcp,
     /// Print the workspace root.
     ShowCwd,
     /// Clear the transcript buffer.

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod capabilities;
 mod diff;
 mod host_ui;
 mod into;
+mod mcp_config;
 mod runtime;
 mod session_log;
 mod settings;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,9 @@ mod version;
 mod streaming_tests;
 
 #[cfg(test)]
+mod mcp_e2e_tests;
+
+#[cfg(test)]
 mod agent_scenarios;
 
 use anyhow::Result;

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -1,0 +1,281 @@
+//! Load MCP servers from `.mcp.json` (workspace + global, merged).
+//!
+//! The file shape matches the `mcpServers` object every MCP client
+//! understands, so a project's `.mcp.json` works across tools:
+//!
+//! ```json
+//! {
+//!   "mcpServers": {
+//!     "docs": { "type": "http", "url": "https://example.com/mcp",
+//!               "headers": { "Authorization": "Bearer ${DOCS_TOKEN}" } },
+//!     "fs":   { "type": "stdio", "command": "mcp-server-filesystem",
+//!               "args": ["${WORKSPACE}"] }
+//!   }
+//! }
+//! ```
+//!
+//! Two scopes are read and merged (global first, workspace second, so a
+//! project can override a global server of the same name):
+//!
+//! - **global**: `<config_dir>/yolop/mcp.json` (e.g. `~/.config/yolop/mcp.json`)
+//! - **workspace**: `<workspace_root>/.mcp.json`
+//!
+//! String values support `${VAR}` environment expansion (matching how every
+//! other MCP client lets you keep secrets out of the file). Both remote HTTP
+//! and local stdio servers are supported; stdio requires the runtime's
+//! `mcp-stdio` feature, which yolop enables.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use everruns_core::{ScopedMcpServer, ScopedMcpServers, merge_scoped_mcp_servers};
+use serde::Deserialize;
+
+/// File name read from the workspace root.
+pub const MCP_CONFIG_FILE: &str = ".mcp.json";
+
+#[derive(Debug, Deserialize)]
+struct McpConfigFile {
+    #[serde(default, rename = "mcpServers")]
+    mcp_servers: ScopedMcpServers,
+}
+
+/// Path to the global MCP config (`<config_dir>/yolop/mcp.json`), if a config
+/// directory can be resolved on this platform.
+pub fn global_mcp_config_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|p| p.join("yolop").join("mcp.json"))
+}
+
+/// Load the effective scoped MCP servers for a workspace: the global config
+/// overlaid by the workspace `.mcp.json`. Missing files contribute nothing;
+/// `${VAR}` placeholders in string fields are expanded from the environment.
+pub fn load_mcp_servers(workspace_root: &Path) -> Result<ScopedMcpServers> {
+    let global = match global_mcp_config_path() {
+        Some(path) => read_config(&path)?,
+        None => ScopedMcpServers::default(),
+    };
+    let workspace = read_config(&workspace_root.join(MCP_CONFIG_FILE))?;
+    let mut merged = merge_scoped_mcp_servers(&global, &workspace);
+    for server in merged.values_mut() {
+        expand_server_env(server);
+    }
+    Ok(merged)
+}
+
+/// Read one `.mcp.json`-shaped file. Absent file → no servers.
+fn read_config(path: &Path) -> Result<ScopedMcpServers> {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(ScopedMcpServers::default());
+        }
+        Err(error) => return Err(error).with_context(|| format!("reading {}", path.display())),
+    };
+    let config: McpConfigFile =
+        serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))?;
+    Ok(config.mcp_servers)
+}
+
+/// Expand `${VAR}` references in every string field of a scoped server, so
+/// secrets and paths can come from the environment instead of the file.
+fn expand_server_env(server: &mut ScopedMcpServer) {
+    server.url = expand_env(&server.url);
+    server.command = server.command.as_deref().map(expand_env);
+    for arg in &mut server.args {
+        *arg = expand_env(arg);
+    }
+    replace_values(&mut server.headers);
+    replace_values(&mut server.env);
+}
+
+fn replace_values(map: &mut HashMap<String, String>) {
+    for value in map.values_mut() {
+        *value = expand_env(value);
+    }
+}
+
+/// Replace `${VAR}` occurrences with the value of `VAR` from the environment.
+/// Unset variables are left untouched (so a stray placeholder is visible in
+/// `/mcp` output and discovery errors rather than silently blanked).
+fn expand_env(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut rest = input;
+    while let Some(start) = rest.find("${") {
+        out.push_str(&rest[..start]);
+        let after = &rest[start + 2..];
+        match after.find('}') {
+            Some(end) => {
+                let name = &after[..end];
+                match std::env::var(name) {
+                    Ok(value) => out.push_str(&value),
+                    Err(_) => {
+                        // Leave the original `${VAR}` so the gap is debuggable.
+                        out.push_str(&rest[start..start + 2 + end + 1]);
+                    }
+                }
+                rest = &after[end + 1..];
+            }
+            None => {
+                // No closing brace: emit the rest verbatim.
+                out.push_str(&rest[start..]);
+                rest = "";
+            }
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::McpServerTransportType;
+
+    fn write(dir: &Path, contents: &str) {
+        std::fs::write(dir.join(MCP_CONFIG_FILE), contents).unwrap();
+    }
+
+    #[test]
+    fn missing_file_yields_no_servers() {
+        let dir = tempfile::tempdir().unwrap();
+        let servers = load_mcp_servers(dir.path()).unwrap();
+        assert!(servers.is_empty());
+    }
+
+    #[test]
+    fn parses_http_server_with_headers() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            r#"{ "mcpServers": {
+                "docs": {
+                    "type": "http",
+                    "url": "https://example.com/mcp",
+                    "headers": { "Authorization": "Bearer t0ken" }
+                }
+            }}"#,
+        );
+
+        let servers = load_mcp_servers(dir.path()).unwrap();
+        let docs = servers.get("docs").expect("docs server");
+        assert_eq!(docs.transport_type, McpServerTransportType::Http);
+        assert_eq!(docs.url, "https://example.com/mcp");
+        assert_eq!(
+            docs.headers.get("Authorization").map(String::as_str),
+            Some("Bearer t0ken")
+        );
+        assert!(docs.tool_discovery, "tool discovery defaults on");
+    }
+
+    #[test]
+    fn type_defaults_to_http() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            r#"{ "mcpServers": { "b": { "url": "https://b.example.com/mcp" } } }"#,
+        );
+        let servers = load_mcp_servers(dir.path()).unwrap();
+        assert_eq!(servers["b"].transport_type, McpServerTransportType::Http);
+    }
+
+    #[test]
+    fn empty_object_is_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "{}");
+        assert!(load_mcp_servers(dir.path()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn malformed_json_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "{ not json");
+        assert!(load_mcp_servers(dir.path()).is_err());
+    }
+
+    #[test]
+    fn parses_stdio_server() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            r#"{ "mcpServers": {
+                "fs": {
+                    "type": "stdio",
+                    "command": "mcp-server-filesystem",
+                    "args": ["/work"],
+                    "env": { "RUST_LOG": "info" }
+                }
+            }}"#,
+        );
+
+        let servers = load_mcp_servers(dir.path()).unwrap();
+        let fs = servers.get("fs").expect("fs server");
+        assert_eq!(fs.transport_type, McpServerTransportType::Stdio);
+        assert_eq!(fs.command.as_deref(), Some("mcp-server-filesystem"));
+        assert_eq!(fs.args, vec!["/work".to_string()]);
+        assert_eq!(fs.env.get("RUST_LOG").map(String::as_str), Some("info"));
+    }
+
+    #[test]
+    fn expands_env_placeholders() {
+        // SAFETY: single-threaded test; restores nothing it doesn't own.
+        unsafe {
+            std::env::set_var("YOLOP_TEST_MCP_TOKEN", "s3cret");
+            std::env::set_var("YOLOP_TEST_MCP_ROOT", "/srv/work");
+        }
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            r#"{ "mcpServers": {
+                "docs": {
+                    "type": "http",
+                    "url": "https://example.com/mcp",
+                    "headers": { "Authorization": "Bearer ${YOLOP_TEST_MCP_TOKEN}" }
+                },
+                "fs": {
+                    "type": "stdio",
+                    "command": "mcp-server-filesystem",
+                    "args": ["${YOLOP_TEST_MCP_ROOT}"]
+                }
+            }}"#,
+        );
+
+        let servers = load_mcp_servers(dir.path()).unwrap();
+        assert_eq!(
+            servers["docs"]
+                .headers
+                .get("Authorization")
+                .map(String::as_str),
+            Some("Bearer s3cret")
+        );
+        assert_eq!(servers["fs"].args, vec!["/srv/work".to_string()]);
+    }
+
+    #[test]
+    fn unset_env_placeholder_is_left_intact() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            r#"{ "mcpServers": {
+                "docs": { "type": "http", "url": "https://example.com/${YOLOP_UNSET_VAR_XYZ}" }
+            }}"#,
+        );
+        let servers = load_mcp_servers(dir.path()).unwrap();
+        assert_eq!(
+            servers["docs"].url,
+            "https://example.com/${YOLOP_UNSET_VAR_XYZ}"
+        );
+    }
+
+    #[test]
+    fn expand_env_handles_multiple_and_adjacent() {
+        unsafe {
+            std::env::set_var("YOLOP_TEST_A", "a");
+            std::env::set_var("YOLOP_TEST_B", "b");
+        }
+        assert_eq!(expand_env("${YOLOP_TEST_A}-${YOLOP_TEST_B}"), "a-b");
+        assert_eq!(expand_env("x${YOLOP_TEST_A}${YOLOP_TEST_B}y"), "xaby");
+        assert_eq!(expand_env("no placeholders"), "no placeholders");
+        assert_eq!(expand_env("${unterminated"), "${unterminated");
+    }
+}

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -20,9 +20,11 @@
 //! - **global**: `<config_dir>/yolop/mcp.json` (e.g. `~/.config/yolop/mcp.json`)
 //! - **workspace**: `<workspace_root>/.mcp.json`
 //!
-//! String values support `${VAR}` environment expansion (matching how every
-//! other MCP client lets you keep secrets out of the file). Both remote HTTP
-//! and local stdio servers are supported; stdio requires the runtime's
+//! Each scope is best-effort: a missing file contributes nothing, and a
+//! malformed file is warned about and skipped so it cannot mask the other
+//! scope. String values support `${VAR}` environment expansion (matching how
+//! every other MCP client lets you keep secrets out of the file). Both remote
+//! HTTP and local stdio servers are supported; stdio requires the runtime's
 //! `mcp-stdio` feature, which yolop enables.
 
 use std::collections::HashMap;
@@ -48,22 +50,40 @@ pub fn global_mcp_config_path() -> Option<PathBuf> {
 }
 
 /// Load the effective scoped MCP servers for a workspace: the global config
-/// overlaid by the workspace `.mcp.json`. Missing files contribute nothing;
-/// `${VAR}` placeholders in string fields are expanded from the environment.
-pub fn load_mcp_servers(workspace_root: &Path) -> Result<ScopedMcpServers> {
-    let global = match global_mcp_config_path() {
-        Some(path) => read_config(&path)?,
-        None => ScopedMcpServers::default(),
-    };
-    let workspace = read_config(&workspace_root.join(MCP_CONFIG_FILE))?;
+/// overlaid by the workspace `.mcp.json`, with `${VAR}` placeholders expanded
+/// from the environment. Each scope is best-effort (a malformed or unreadable
+/// file is warned about and skipped), so one bad file never masks the other.
+pub fn load_mcp_servers(workspace_root: &Path) -> ScopedMcpServers {
+    load_merged(global_mcp_config_path().as_deref(), workspace_root)
+}
+
+/// Merge an explicit global path (or none) with the workspace `.mcp.json`.
+/// Split out from [`load_mcp_servers`] so tests can pin both scopes and stay
+/// independent of the host's real `<config_dir>/yolop/mcp.json`.
+fn load_merged(global_path: Option<&Path>, workspace_root: &Path) -> ScopedMcpServers {
+    let global = global_path.map(read_scope).unwrap_or_default();
+    let workspace = read_scope(&workspace_root.join(MCP_CONFIG_FILE));
     let mut merged = merge_scoped_mcp_servers(&global, &workspace);
     for server in merged.values_mut() {
         expand_server_env(server);
     }
-    Ok(merged)
+    merged
 }
 
-/// Read one `.mcp.json`-shaped file. Absent file → no servers.
+/// Read one scope, downgrading any read/parse failure to a warning + no
+/// servers so a malformed file in one scope cannot sink the other.
+fn read_scope(path: &Path) -> ScopedMcpServers {
+    match read_config(path) {
+        Ok(servers) => servers,
+        Err(error) => {
+            tracing::warn!(path = %path.display(), %error, "ignoring malformed MCP config");
+            ScopedMcpServers::default()
+        }
+    }
+}
+
+/// Read one `.mcp.json`-shaped file. Absent file → no servers; malformed file
+/// → error (callers decide whether to skip it).
 fn read_config(path: &Path) -> Result<ScopedMcpServers> {
     let raw = match std::fs::read_to_string(path) {
         Ok(raw) => raw,
@@ -136,11 +156,16 @@ mod tests {
         std::fs::write(dir.join(MCP_CONFIG_FILE), contents).unwrap();
     }
 
+    /// Workspace-only load with no global scope — deterministic regardless of
+    /// the host's real `<config_dir>/yolop/mcp.json`.
+    fn load_workspace(dir: &Path) -> ScopedMcpServers {
+        load_merged(None, dir)
+    }
+
     #[test]
     fn missing_file_yields_no_servers() {
         let dir = tempfile::tempdir().unwrap();
-        let servers = load_mcp_servers(dir.path()).unwrap();
-        assert!(servers.is_empty());
+        assert!(load_workspace(dir.path()).is_empty());
     }
 
     #[test]
@@ -157,7 +182,7 @@ mod tests {
             }}"#,
         );
 
-        let servers = load_mcp_servers(dir.path()).unwrap();
+        let servers = load_workspace(dir.path());
         let docs = servers.get("docs").expect("docs server");
         assert_eq!(docs.transport_type, McpServerTransportType::Http);
         assert_eq!(docs.url, "https://example.com/mcp");
@@ -175,7 +200,7 @@ mod tests {
             dir.path(),
             r#"{ "mcpServers": { "b": { "url": "https://b.example.com/mcp" } } }"#,
         );
-        let servers = load_mcp_servers(dir.path()).unwrap();
+        let servers = load_workspace(dir.path());
         assert_eq!(servers["b"].transport_type, McpServerTransportType::Http);
     }
 
@@ -183,14 +208,36 @@ mod tests {
     fn empty_object_is_ok() {
         let dir = tempfile::tempdir().unwrap();
         write(dir.path(), "{}");
-        assert!(load_mcp_servers(dir.path()).unwrap().is_empty());
+        assert!(load_workspace(dir.path()).is_empty());
     }
 
     #[test]
-    fn malformed_json_is_an_error() {
+    fn malformed_json_is_an_error_at_the_scope_level() {
+        // `read_config` surfaces the parse error...
         let dir = tempfile::tempdir().unwrap();
         write(dir.path(), "{ not json");
-        assert!(load_mcp_servers(dir.path()).is_err());
+        assert!(read_config(&dir.path().join(MCP_CONFIG_FILE)).is_err());
+    }
+
+    #[test]
+    fn malformed_scope_is_skipped_not_fatal() {
+        // ...but a malformed file in one scope must not mask the other. A bad
+        // global config still lets a valid workspace `.mcp.json` load.
+        let global = tempfile::tempdir().unwrap();
+        let global_path = global.path().join("mcp.json");
+        std::fs::write(&global_path, "{ not json").unwrap();
+
+        let workspace = tempfile::tempdir().unwrap();
+        write(
+            workspace.path(),
+            r#"{ "mcpServers": { "ws": { "url": "https://ws.example.com/mcp" } } }"#,
+        );
+
+        let servers = load_merged(Some(&global_path), workspace.path());
+        assert!(
+            servers.contains_key("ws"),
+            "valid workspace server survives a malformed global config: {servers:?}"
+        );
     }
 
     #[test]
@@ -208,7 +255,7 @@ mod tests {
             }}"#,
         );
 
-        let servers = load_mcp_servers(dir.path()).unwrap();
+        let servers = load_workspace(dir.path());
         let fs = servers.get("fs").expect("fs server");
         assert_eq!(fs.transport_type, McpServerTransportType::Stdio);
         assert_eq!(fs.command.as_deref(), Some("mcp-server-filesystem"));
@@ -218,7 +265,8 @@ mod tests {
 
     #[test]
     fn expands_env_placeholders() {
-        // SAFETY: single-threaded test; restores nothing it doesn't own.
+        // Serialize against every other env-mutating test in this binary.
+        let _guard = crate::test_env::lock();
         unsafe {
             std::env::set_var("YOLOP_TEST_MCP_TOKEN", "s3cret");
             std::env::set_var("YOLOP_TEST_MCP_ROOT", "/srv/work");
@@ -240,7 +288,7 @@ mod tests {
             }}"#,
         );
 
-        let servers = load_mcp_servers(dir.path()).unwrap();
+        let servers = load_workspace(dir.path());
         assert_eq!(
             servers["docs"]
                 .headers
@@ -249,10 +297,18 @@ mod tests {
             Some("Bearer s3cret")
         );
         assert_eq!(servers["fs"].args, vec!["/srv/work".to_string()]);
+        unsafe {
+            std::env::remove_var("YOLOP_TEST_MCP_TOKEN");
+            std::env::remove_var("YOLOP_TEST_MCP_ROOT");
+        }
     }
 
     #[test]
     fn unset_env_placeholder_is_left_intact() {
+        let _guard = crate::test_env::lock();
+        unsafe {
+            std::env::remove_var("YOLOP_UNSET_VAR_XYZ");
+        }
         let dir = tempfile::tempdir().unwrap();
         write(
             dir.path(),
@@ -260,7 +316,7 @@ mod tests {
                 "docs": { "type": "http", "url": "https://example.com/${YOLOP_UNSET_VAR_XYZ}" }
             }}"#,
         );
-        let servers = load_mcp_servers(dir.path()).unwrap();
+        let servers = load_workspace(dir.path());
         assert_eq!(
             servers["docs"].url,
             "https://example.com/${YOLOP_UNSET_VAR_XYZ}"
@@ -269,6 +325,7 @@ mod tests {
 
     #[test]
     fn expand_env_handles_multiple_and_adjacent() {
+        let _guard = crate::test_env::lock();
         unsafe {
             std::env::set_var("YOLOP_TEST_A", "a");
             std::env::set_var("YOLOP_TEST_B", "b");
@@ -277,5 +334,9 @@ mod tests {
         assert_eq!(expand_env("x${YOLOP_TEST_A}${YOLOP_TEST_B}y"), "xaby");
         assert_eq!(expand_env("no placeholders"), "no placeholders");
         assert_eq!(expand_env("${unterminated"), "${unterminated");
+        unsafe {
+            std::env::remove_var("YOLOP_TEST_A");
+            std::env::remove_var("YOLOP_TEST_B");
+        }
     }
 }

--- a/src/mcp_e2e_tests.rs
+++ b/src/mcp_e2e_tests.rs
@@ -9,8 +9,10 @@
 //! The server writes a marker file on each call, so we assert *via the
 //! filesystem* whether a tool actually executed.
 //!
-//! Skipped (with a warning) when `python3` is unavailable so a Python-less CI
-//! box does not fail.
+//! `python3` is required. In CI (`CI` env set) a missing `python3` is a hard
+//! failure — silently skipping would let the test report green without
+//! exercising anything (cf. the live-smoke job in `.github/workflows/ci.yml`).
+//! On a local box without `python3` the tests skip with a warning.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -25,12 +27,28 @@ use crate::settings::SettingsStore;
 
 const TURN_TIMEOUT: Duration = Duration::from_secs(20);
 
-/// Resolve `python3` from `PATH`, or `None` to skip.
+/// Resolve `python3` from `PATH`.
 fn python3() -> Option<PathBuf> {
     let paths = std::env::var_os("PATH")?;
     std::env::split_paths(&paths)
         .map(|dir| dir.join("python3"))
         .find(|candidate| candidate.is_file())
+}
+
+/// Resolve `python3`, deciding whether a miss is a skip or a failure. In CI
+/// (`CI` env set) a missing `python3` panics — a silently green check would not
+/// be exercising anything (matching the live-smoke job's stance in
+/// `.github/workflows/ci.yml`). Locally it skips with a warning.
+fn require_python3(test: &str) -> Option<PathBuf> {
+    if let Some(python) = python3() {
+        return Some(python);
+    }
+    assert!(
+        std::env::var_os("CI").is_none(),
+        "{test}: python3 is required to run the MCP e2e tests in CI but was not found on PATH",
+    );
+    eprintln!("skipping {test}: python3 not found (set CI=1 to make this a hard failure)");
+    None
 }
 
 fn fixture_server() -> PathBuf {
@@ -130,8 +148,7 @@ async fn run_turn(runtime: &BuiltRuntime, text: &str) -> everruns_runtime::TurnR
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn mcp_tool_executes_over_real_stdio_server() {
-    let Some(python) = python3() else {
-        eprintln!("skipping mcp_tool_executes_over_real_stdio_server: python3 not found");
+    let Some(python) = require_python3("mcp_tool_executes_over_real_stdio_server") else {
         return;
     };
     let marker = tempfile::tempdir().expect("marker").keep();
@@ -162,8 +179,7 @@ async fn mcp_tool_executes_over_real_stdio_server() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn mcp_tool_blocked_when_approval_denied() {
-    let Some(python) = python3() else {
-        eprintln!("skipping mcp_tool_blocked_when_approval_denied: python3 not found");
+    let Some(python) = require_python3("mcp_tool_blocked_when_approval_denied") else {
         return;
     };
     let marker = tempfile::tempdir().expect("marker").keep();
@@ -186,8 +202,7 @@ async fn mcp_tool_blocked_when_approval_denied() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn readonly_mcp_tool_runs_without_approval() {
-    let Some(python) = python3() else {
-        eprintln!("skipping readonly_mcp_tool_runs_without_approval: python3 not found");
+    let Some(python) = require_python3("readonly_mcp_tool_runs_without_approval") else {
         return;
     };
     let marker = tempfile::tempdir().expect("marker").keep();

--- a/src/mcp_e2e_tests.rs
+++ b/src/mcp_e2e_tests.rs
@@ -1,0 +1,206 @@
+//! Black-box end-to-end MCP tests.
+//!
+//! These spin up a **real** stdio MCP server (the small Python fixture in
+//! `tests/fixtures/mcp_echo_server.py`) and drive a real `InProcessRuntime`
+//! against it, with the bundled llmsim scripted to call the server's tools.
+//! Nothing here is mocked except the LLM: live `tools/list` discovery, the
+//! annotation→`ToolHints` mapping, the `McpApprovalCapability` pre-tool hook,
+//! and real `tools/call` execution over the stdio transport all run for real.
+//! The server writes a marker file on each call, so we assert *via the
+//! filesystem* whether a tool actually executed.
+//!
+//! Skipped (with a warning) when `python3` is unavailable so a Python-less CI
+//! box does not fail.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use everruns_core::llmsim_driver::{LlmSimConfig, SimToolCall, SimTurn};
+use serde_json::json;
+
+use crate::approval::{ApprovalGate, ApprovalRequest};
+use crate::runtime::{BuildOptions, BuiltRuntime, ProviderChoice, build_with_options};
+use crate::settings::SettingsStore;
+
+const TURN_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Resolve `python3` from `PATH`, or `None` to skip.
+fn python3() -> Option<PathBuf> {
+    let paths = std::env::var_os("PATH")?;
+    std::env::split_paths(&paths)
+        .map(|dir| dir.join("python3"))
+        .find(|candidate| candidate.is_file())
+}
+
+fn fixture_server() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/mcp_echo_server.py")
+}
+
+/// The prefixed tool name the runtime exposes for `<server>`/`<tool>`
+/// (`mcp_<server>__<tool>`); both names here sanitize to themselves.
+fn mcp_tool(server: &str, tool: &str) -> String {
+    format!("mcp_{server}__{tool}")
+}
+
+/// A channel gate that denies every request, plus a task that answers `false`.
+/// Used to prove blocking — and that readonly/non-MCP tools never reach it.
+fn deny_gate() -> Arc<ApprovalGate> {
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<(
+        ApprovalRequest,
+        tokio::sync::oneshot::Sender<bool>,
+    )>();
+    tokio::spawn(async move {
+        while let Some((_req, responder)) = rx.recv().await {
+            let _ = responder.send(false);
+        }
+    });
+    ApprovalGate::channel(tx)
+}
+
+/// One scripted tool call followed by a closing assistant turn.
+fn script(tool: &str, message: &str) -> LlmSimConfig {
+    LlmSimConfig::scripted(vec![
+        SimTurn::ToolCalls(vec![SimToolCall {
+            name: tool.to_string(),
+            arguments: json!({ "message": message }),
+            id: None,
+        }]),
+        SimTurn::Assistant("done".to_string()),
+    ])
+}
+
+/// Build a runtime whose workspace `.mcp.json` points the `echo` server at the
+/// Python fixture, passing `marker_dir` so calls leave a filesystem trace.
+async fn build_runtime(
+    config: LlmSimConfig,
+    gate: Arc<ApprovalGate>,
+    marker_dir: &Path,
+    python: &Path,
+) -> BuiltRuntime {
+    let workspace_root = tempfile::tempdir().expect("workspace").keep();
+    let sessions_root = tempfile::tempdir().expect("sessions").keep();
+
+    let mcp_json = json!({
+        "mcpServers": {
+            "echo": {
+                "type": "stdio",
+                "command": python.to_str().unwrap(),
+                "args": [
+                    fixture_server().to_str().unwrap(),
+                    marker_dir.to_str().unwrap(),
+                ]
+            }
+        }
+    });
+    std::fs::write(
+        workspace_root.join(".mcp.json"),
+        serde_json::to_vec_pretty(&mcp_json).unwrap(),
+    )
+    .expect("write .mcp.json");
+
+    let settings = Arc::new(SettingsStore::open(sessions_root.join("settings.toml")));
+    build_with_options(
+        workspace_root,
+        ProviderChoice::Sim,
+        gate,
+        None,
+        sessions_root,
+        settings,
+        BuildOptions {
+            llmsim_override: Some(config.with_model("llmsim-yolop")),
+            ..BuildOptions::default()
+        },
+    )
+    .await
+    .expect("build runtime")
+}
+
+async fn run_turn(runtime: &BuiltRuntime, text: &str) -> everruns_runtime::TurnResult {
+    let session_id = runtime.handles.session_id;
+    let input = runtime.model.input_message(text.to_string());
+    tokio::time::timeout(
+        TURN_TIMEOUT,
+        runtime.handles.runtime.run_turn(session_id, input),
+    )
+    .await
+    .expect("run_turn timed out")
+    .expect("run_turn errored")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mcp_tool_executes_over_real_stdio_server() {
+    let Some(python) = python3() else {
+        eprintln!("skipping mcp_tool_executes_over_real_stdio_server: python3 not found");
+        return;
+    };
+    let marker = tempfile::tempdir().expect("marker").keep();
+    let tool = mcp_tool("echo", "echo");
+    let runtime = build_runtime(
+        script(&tool, "hello-mcp"),
+        ApprovalGate::auto(),
+        &marker,
+        &python,
+    )
+    .await;
+
+    let result = run_turn(&runtime, "use the echo tool").await;
+
+    assert!(result.success, "turn must succeed: {result:?}");
+    assert_eq!(result.tool_calls_count, 1, "exactly one MCP call expected");
+    let called = marker.join("echo.called");
+    assert!(
+        called.exists(),
+        "the real MCP server must have executed tools/call (marker missing)"
+    );
+    let body = std::fs::read_to_string(&called).unwrap();
+    assert!(
+        body.contains("hello-mcp"),
+        "server should receive the call arguments: {body}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mcp_tool_blocked_when_approval_denied() {
+    let Some(python) = python3() else {
+        eprintln!("skipping mcp_tool_blocked_when_approval_denied: python3 not found");
+        return;
+    };
+    let marker = tempfile::tempdir().expect("marker").keep();
+    let tool = mcp_tool("echo", "echo");
+    let runtime = build_runtime(script(&tool, "nope"), deny_gate(), &marker, &python).await;
+
+    let result = run_turn(&runtime, "use the echo tool").await;
+
+    // The turn still completes — the block surfaces to the model as a tool
+    // error and the scripted assistant turn closes the loop.
+    assert!(
+        result.success,
+        "turn completes after a blocked tool: {result:?}"
+    );
+    assert!(
+        !marker.join("echo.called").exists(),
+        "a denied MCP tool must NOT reach the server"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn readonly_mcp_tool_runs_without_approval() {
+    let Some(python) = python3() else {
+        eprintln!("skipping readonly_mcp_tool_runs_without_approval: python3 not found");
+        return;
+    };
+    let marker = tempfile::tempdir().expect("marker").keep();
+    // `peek` advertises `readOnlyHint: true`; even under a denying gate it must
+    // run, proving the annotation→hint→hook-skip chain end to end.
+    let tool = mcp_tool("echo", "peek");
+    let runtime = build_runtime(script(&tool, "ok"), deny_gate(), &marker, &python).await;
+
+    let result = run_turn(&runtime, "peek at it").await;
+
+    assert!(result.success, "turn must succeed: {result:?}");
+    assert!(
+        marker.join("peek.called").exists(),
+        "a readonly MCP tool must run even with a denying gate"
+    );
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -33,8 +33,8 @@ use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, InitialFile, Se
 use everruns_core::typed_id::SessionId;
 use everruns_core::{
     AgentCapabilityConfig, CapabilityRegistry, Controls, InputMessage, ModelWithProvider,
-    PlatformDefinition, ReasoningConfig, SessionFileSystem, SessionFileSystemFactory,
-    SessionFileSystemFactoryContext,
+    PlatformDefinition, ReasoningConfig, ScopedMcpServers, SessionFileSystem,
+    SessionFileSystemFactory, SessionFileSystemFactoryContext,
 };
 use everruns_integrations_duckduckgo::DuckDuckGoCapability;
 use everruns_runtime::{
@@ -968,6 +968,10 @@ pub struct StartupInfo {
     /// for any real provider. The TUI auto-opens its setup wizard in this
     /// case; `--print` mode ignores it.
     pub setup_recommended: bool,
+    /// Names of MCP servers configured for this session from `.mcp.json`
+    /// (global + workspace, merged). Source for the `/mcp` command and the
+    /// startup banner. Empty when no servers are configured.
+    pub mcp_server_names: Vec<String>,
 }
 
 #[derive(Clone)]
@@ -1047,6 +1051,19 @@ pub async fn build_with_options(
     let canonical_root = std::fs::canonicalize(&workspace_root)
         .with_context(|| format!("canonicalize workspace: {}", workspace_root.display()))?;
     let workspace = Workspace::new(canonical_root.clone());
+
+    // MCP servers from `.mcp.json` (global + workspace, merged). A malformed
+    // config should not sink the whole session, so we warn and continue with
+    // no servers rather than failing startup.
+    let mcp_servers: ScopedMcpServers = match crate::mcp_config::load_mcp_servers(&canonical_root) {
+        Ok(servers) => servers,
+        Err(error) => {
+            tracing::warn!(%error, "failed to load .mcp.json; continuing without MCP servers");
+            ScopedMcpServers::default()
+        }
+    };
+    let mut mcp_server_names: Vec<String> = mcp_servers.keys().cloned().collect();
+    mcp_server_names.sort();
 
     // Pin the SessionId so resume can re-attach to the same session folder
     // (directory name is the session id).
@@ -1204,6 +1221,7 @@ pub async fn build_with_options(
     // to the same JSONL log (filename encodes the id).
     let session_title = format!("yolop @ {}", canonical_root.display());
     let harness_capabilities = coding_harness_capabilities(options.client_commands);
+    let session_mcp_servers = mcp_servers.clone();
 
     let mut builder = InProcessRuntimeBuilder::new()
         .platform_definition(platform)
@@ -1219,6 +1237,7 @@ pub async fn build_with_options(
                 .agent_description("Reads, edits, and runs commands inside a project workspace.")
                 .session_id(session_id)
                 .session_title(session_title.clone())
+                .session_mcp_servers(session_mcp_servers.clone())
                 .tag("example")
                 .tag("coding");
             for cap in harness_capabilities {
@@ -1261,6 +1280,7 @@ pub async fn build_with_options(
             session_dir,
             replayed_events: replayed_events_count,
             setup_recommended,
+            mcp_server_names,
         },
         model: ModelState::new(provider_state),
         ui_rx,
@@ -1278,6 +1298,39 @@ mod tests {
         let next = provider.resolve_model_spec("openai/gpt-5.5").unwrap();
 
         assert_eq!(next.label(), "openai/gpt-5.5 medium");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn build_wires_mcp_servers_from_dot_mcp_json() {
+        // A workspace `.mcp.json` should flow through build() into the session
+        // and surface in startup info (the source for `/mcp`). build() does not
+        // contact the server, so this stays offline.
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        std::fs::write(
+            workspace.path().join(".mcp.json"),
+            r#"{ "mcpServers": { "docs": { "type": "http", "url": "https://example.com/mcp" } } }"#,
+        )
+        .expect("write .mcp.json");
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+
+        let built = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Sim,
+            ApprovalGate::auto(),
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            BuildOptions::default(),
+        )
+        .await
+        .expect("build runtime");
+
+        assert!(
+            built.startup.mcp_server_names.contains(&"docs".to_string()),
+            "mcp servers: {:?}",
+            built.startup.mcp_server_names
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1059,16 +1059,10 @@ pub async fn build_with_options(
         .with_context(|| format!("canonicalize workspace: {}", workspace_root.display()))?;
     let workspace = Workspace::new(canonical_root.clone());
 
-    // MCP servers from `.mcp.json` (global + workspace, merged). A malformed
-    // config should not sink the whole session, so we warn and continue with
-    // no servers rather than failing startup.
-    let mcp_servers: ScopedMcpServers = match crate::mcp_config::load_mcp_servers(&canonical_root) {
-        Ok(servers) => servers,
-        Err(error) => {
-            tracing::warn!(%error, "failed to load .mcp.json; continuing without MCP servers");
-            ScopedMcpServers::default()
-        }
-    };
+    // MCP servers from `.mcp.json` (global + workspace, merged). Loading is
+    // best-effort per scope: a malformed file is warned about and skipped, so
+    // it never sinks the session or masks the other scope.
+    let mcp_servers: ScopedMcpServers = crate::mcp_config::load_mcp_servers(&canonical_root);
     let mut mcp_server_names: Vec<String> = mcp_servers.keys().cloned().collect();
     mcp_server_names.sort();
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -9,7 +9,8 @@ use crate::capabilities::your::{YOUR_CAPABILITY_ID, YourCapability, YourStore};
 use crate::capabilities::{
     ATTRIBUTION_CAPABILITY_ID, AttributionCapability, CLIENT_COMMANDS_CAPABILITY_ID,
     ClientCommandsCapability, CodingBashCapability, CodingCliEnvironmentCapability,
-    ENVIRONMENT_CONTEXT_CAPABILITY_ID, SETUP_CAPABILITY_ID, SetupCapability,
+    ENVIRONMENT_CONTEXT_CAPABILITY_ID, MCP_APPROVAL_CAPABILITY_ID, McpApprovalCapability,
+    SETUP_CAPABILITY_ID, SetupCapability,
 };
 use crate::host_ui::{HostUi, TuiHandle, UiCommand};
 use crate::settings::{Settings, SettingsStore};
@@ -872,7 +873,10 @@ fn normalize_openai_reasoning_effort(reasoning_effort: Option<String>) -> Option
     )
 }
 
-fn coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabilityConfig> {
+fn coding_harness_capabilities(
+    client_commands: bool,
+    mcp_approval: bool,
+) -> Vec<AgentCapabilityConfig> {
     let mut caps = Vec::new();
     // Terminal-side commands lead the registry so the most-typed commands
     // (/help, /clear, /quit, …) surface first in the palette. Enabled only
@@ -919,6 +923,9 @@ fn coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabilityConf
         AgentCapabilityConfig::new(YOUR_CAPABILITY_ID),
         AgentCapabilityConfig::new("yolop_bash"),
     ]);
+    if mcp_approval {
+        caps.push(AgentCapabilityConfig::new(MCP_APPROVAL_CAPABILITY_ID));
+    }
     caps
 }
 
@@ -1173,6 +1180,13 @@ pub async fn build_with_options(
         workspace: workspace.clone(),
         gate: gate.clone(),
     });
+    // Gate MCP tool calls (which execute via the runtime, outside the bash/file
+    // gates) through the same ApprovalGate. Registered + activated only when MCP
+    // servers are configured, so it adds nothing when MCP is unused.
+    let has_mcp_servers = !mcp_servers.is_empty();
+    if has_mcp_servers {
+        capabilities.register(McpApprovalCapability { gate: gate.clone() });
+    }
     // Terminal-side slash commands. Registered only when the host can apply
     // their effects (the TUI). The capability declares help/tools/cwd/model/
     // effort/clear/quit and forwards each invocation as a `UiCommand` down
@@ -1220,7 +1234,8 @@ pub async fn build_with_options(
     // runtime owns. `session_id(...)` pins the id so resume can re-attach
     // to the same JSONL log (filename encodes the id).
     let session_title = format!("yolop @ {}", canonical_root.display());
-    let harness_capabilities = coding_harness_capabilities(options.client_commands);
+    let harness_capabilities =
+        coding_harness_capabilities(options.client_commands, has_mcp_servers);
     let session_mcp_servers = mcp_servers.clone();
 
     let mut builder = InProcessRuntimeBuilder::new()
@@ -1901,7 +1916,7 @@ mod tests {
 
     #[test]
     fn coding_harness_enables_tool_output_persistence() {
-        let ids = coding_harness_capabilities(false);
+        let ids = coding_harness_capabilities(false, false);
 
         assert!(
             ids.iter()
@@ -1911,7 +1926,7 @@ mod tests {
 
     #[test]
     fn coding_harness_enables_loop_detection() {
-        let ids = coding_harness_capabilities(false);
+        let ids = coding_harness_capabilities(false, false);
 
         assert!(
             ids.iter()
@@ -1921,7 +1936,7 @@ mod tests {
 
     #[test]
     fn coding_harness_enables_yolop_attribution() {
-        let ids = coding_harness_capabilities(false);
+        let ids = coding_harness_capabilities(false, false);
 
         assert!(
             ids.iter()
@@ -1930,8 +1945,26 @@ mod tests {
     }
 
     #[test]
+    fn coding_harness_gates_mcp_approval_on_flag() {
+        let without = coding_harness_capabilities(false, false);
+        assert!(
+            !without
+                .iter()
+                .any(|cap| cap.capability_id() == MCP_APPROVAL_CAPABILITY_ID),
+            "MCP approval must stay off when no MCP servers are configured"
+        );
+
+        let with = coding_harness_capabilities(false, true);
+        assert!(
+            with.iter()
+                .any(|cap| cap.capability_id() == MCP_APPROVAL_CAPABILITY_ID),
+            "MCP approval activates when MCP servers are configured"
+        );
+    }
+
+    #[test]
     fn coding_harness_gates_client_commands_on_flag() {
-        let without = coding_harness_capabilities(false);
+        let without = coding_harness_capabilities(false, false);
         assert!(
             !without
                 .iter()
@@ -1939,7 +1972,7 @@ mod tests {
             "client commands must stay off for hosts that can't apply them"
         );
 
-        let with = coding_harness_capabilities(true);
+        let with = coding_harness_capabilities(true, false);
         assert!(
             with.iter()
                 .any(|cap| cap.capability_id() == CLIENT_COMMANDS_CAPABILITY_ID),

--- a/tests/fixtures/mcp_echo_server.py
+++ b/tests/fixtures/mcp_echo_server.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Minimal real MCP server over stdio, for yolop's black-box MCP tests.
+
+Speaks newline-delimited JSON-RPC 2.0 on stdin/stdout (the MCP stdio
+transport). Advertises two tools:
+
+  - ``echo`` — non-readonly (``readOnlyHint: false``, ``destructiveHint: true``)
+  - ``peek`` — readonly (``readOnlyHint: true``)
+
+On every ``tools/call`` it writes ``<marker_dir>/<tool>.called`` containing the
+received arguments, so a test can prove (via the filesystem) whether the tool
+actually executed. ``argv[1]`` is the marker directory.
+
+The everruns stdio transport spawns a fresh process per request, performs the
+``initialize`` handshake, issues one request, then kills the process — so a
+simple read/respond loop is sufficient.
+"""
+
+import json
+import os
+import sys
+
+
+def send(obj):
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+
+
+TOOLS = [
+    {
+        "name": "echo",
+        "description": "Echo back the message.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"message": {"type": "string"}},
+            "required": ["message"],
+        },
+        "annotations": {"readOnlyHint": False, "destructiveHint": True},
+    },
+    {
+        "name": "peek",
+        "description": "Read-only peek at the message.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"message": {"type": "string"}},
+        },
+        "annotations": {"readOnlyHint": True},
+    },
+]
+
+
+def main():
+    marker_dir = sys.argv[1] if len(sys.argv) > 1 else None
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except ValueError:
+            continue
+        method = msg.get("method")
+        mid = msg.get("id")
+        if method == "initialize":
+            send({
+                "jsonrpc": "2.0",
+                "id": mid,
+                "result": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "yolop-echo", "version": "0"},
+                },
+            })
+        elif method == "notifications/initialized":
+            continue
+        elif method == "tools/list":
+            send({"jsonrpc": "2.0", "id": mid, "result": {"tools": TOOLS}})
+        elif method == "tools/call":
+            params = msg.get("params") or {}
+            name = params.get("name", "")
+            args = params.get("arguments") or {}
+            if marker_dir:
+                try:
+                    with open(os.path.join(marker_dir, name + ".called"), "w") as fh:
+                        json.dump(args, fh)
+                except OSError:
+                    pass
+            text = args.get("message", "")
+            send({
+                "jsonrpc": "2.0",
+                "id": mid,
+                "result": {
+                    "content": [{"type": "text", "text": "echoed: " + str(text)}],
+                    "isError": False,
+                },
+            })
+        elif mid is not None:
+            send({
+                "jsonrpc": "2.0",
+                "id": mid,
+                "error": {"code": -32601, "message": "method not found"},
+            })
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/mcp_echo_server.py
+++ b/tests/fixtures/mcp_echo_server.py
@@ -84,6 +84,8 @@ def main():
                     with open(os.path.join(marker_dir, name + ".called"), "w") as fh:
                         json.dump(args, fh)
                 except OSError:
+                    # Marker persistence is best-effort test instrumentation; a
+                    # filesystem hiccup must not break the MCP tools/call reply.
                     pass
             text = args.get("message", "")
             send({


### PR DESCRIPTION
## What

Add Model Context Protocol (MCP) support to yolop: the agent can use tools from local (stdio) and remote (HTTP) MCP servers, configured via `.mcp.json`, with MCP tool calls gated through the same approval flow as `bash` and file writes.

- **Config** (`src/mcp_config.rs`): reads `.mcp.json` (`mcpServers` shape) from two merged scopes — workspace `<root>/.mcp.json` and global `~/.config/yolop/mcp.json` (workspace overrides by name) — with `${VAR}` environment expansion in string fields. A malformed file warns and is skipped, not fatal.
- **Wiring** (`src/runtime.rs`): discovered servers flow into the session via `session_mcp_servers`; the runtime does live `tools/list` discovery and routes `mcp_<server>__<tool>` calls. Server names surface in `StartupInfo`; `/mcp` lists them.
- **Approval** (`src/capabilities/host.rs`): `McpApprovalCapability` contributes a `PreToolUseHook` (the upstream `Capability::pre_tool_use_hooks` seam, everruns 0.8.38) that routes every **non-readonly** `mcp_*` call through the `ApprovalGate`, honoring the readonly hint the runtime derives from MCP tool annotations. Registered only when MCP servers are configured; a no-op when the gate is `Auto` (no `--ask`, and `--print`). Non-MCP tools keep their own gates (no double prompt).
- `Cargo.toml`: enable the runtime's `mcp-stdio` feature for local-process servers.

## Why

MCP is the standard way to extend an agent with tools. Without it yolop needed a bespoke integration per tool. The execution path (`everruns-mcp` + runtime) already existed upstream; this wires yolop to it and closes the one gap that mattered for a host with disk/shell access — MCP tools execute through the runtime's executor, so they previously bypassed yolop's approval gate. The new pre-tool hook closes that uniformly.

## How it was validated

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo test --all-features` — 261 tests pass. New coverage:
  - config parsing (http/stdio/defaults/empty/malformed) + `${VAR}` expansion (set/unset/adjacent);
  - approval hook unit tests (block on deny, allow on approve, skip readonly, ignore non-MCP);
  - harness activation (`coding_harness_gates_mcp_approval_on_flag`);
  - `.mcp.json` → session wiring.
- **Black-box e2e** (`src/mcp_e2e_tests.rs` + `tests/fixtures/mcp_echo_server.py`): a real stdio MCP server (Python, real newline-delimited JSON-RPC) driven by a real `InProcessRuntime` (llmsim scripted to call it). Nothing mocked but the LLM. Three scenarios, asserted via a filesystem marker the server writes on each call:
  - `echo` executes for real over stdio and receives the arguments;
  - under a denying gate the call **never reaches the server** (approval blocks MCP end-to-end);
  - a `readOnlyHint: true` tool runs **even under a denying gate** (annotation → hint → hook-skip chain).
  These hard-fail in CI if `python3` is missing (no silent green); they skip-with-warning only on a local box without python3.
- **Live smoke** (real OpenAI gpt-5.5 against the real echo server): the model discovered and called `mcp_echo__echo` (`tool_calls=1`), the server executed (marker `{"message":"shiptest-live"}`), and the model reported back `echoed: shiptest-live`.
- Offline smoke: `cargo run -- --provider llmsim -p "hi"` starts and completes.

## Security

Reviewed against the threat-model categories in the ship skill:

- **TM-FS**: write blocklist and read scope unchanged. `mcp_config` only *reads* `.mcp.json` (workspace + config dir). No new write paths.
- **TM-BASH**: `tools.rs` / BashTool untouched; bounded-execution model preserved.
- **TM-LLM / key handling**: `${VAR}` expansion injects env values into MCP server config (headers/args/env) sent to the configured server — expected, and never logged by yolop. `/mcp` shows only server **names**, not headers/config. The approval `detail()` renders model-authored tool-call **arguments** (same posture as showing a bash command), not server credentials. No keys written to session JSONL by this change.
- **TM-TOOL**: the new capability *is* the approval integration; MCP tools now go through the gate instead of around it. Registered only when MCP servers are configured.
- **TM-DEP**: no new yolop crates; `everruns-mcp` arrives transitively; `everruns-*` already bumped together to 0.8.38 on main. Only the `mcp-stdio` feature flag is added.
- **Known limitation (documented in `specs/mcp.md`)**: the readonly bypass trusts the server-declared `readOnlyHint`, so a hostile server could under-declare to skip the prompt. The trust boundary is that the user authored `.mcp.json` (consent), and stdio is compiled out of hosted builds. HTTP keeps the runtime's DNS-pinned SSRF protection.

## Docs

`README.md` (MCP section + `/mcp` + trust model) and `specs/mcp.md` (new) updated. No prose duplicating code.

## Follow-ups

- OAuth (browser/device-code) for remote servers — `headers` + `${VAR}` covers API-key/bearer today; the runtime exposes an `mcp_auth_provider()` seam for later.
- A live HTTP-transport e2e (the e2e here exercises stdio; HTTP is covered by `everruns-mcp`'s own tests).
- MCP resources/prompts (tools are the 90% case).
- Optionally route bash/file approvals through the same `pre_tool_use_hooks` seam to retire the per-tool gates — purely a consolidation, no behavior change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JYhUrvS59rhJLuaTciSWjr)_