### PR TITLE
feat(tool-search): vendor provider-agnostic deferred tool loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,11 @@ session    session_019e3db018a17450aba5407af5777237 (folder: …; log: …)
   - `web_fetch` — HTTP GET/HEAD with optional markdown/text conversion.
   - `tool_output_persistence` — large bash output spilled to disk under
     `/outputs/` inside the current session folder.
-  - `openai_tool_search` — deferred tool loading: on OpenAI GPT-5.4+/5.5 the
-    model fetches tool schemas on demand instead of receiving all of them
-    upfront, saving input tokens. A self-disabling no-op on every other
-    provider/model. See [`specs/tool-search.md`](./specs/tool-search.md).
+  - `tool_search` — provider-agnostic deferred tool loading (vendored). Core
+    file/shell tools stay fully loaded; long-tail tools are hidden until the
+    model loads them on demand via a `tool_search` tool, saving input tokens.
+    Works on every provider/model. See
+    [`specs/tool-search.md`](./specs/tool-search.md).
 - **Approval prompts (opt-in via `--ask`)**. Off by default: yolop acts
   autonomously. `--ask` prompts y/n before every write/edit/delete and every
   bash command, with a unified diff for writes. `--print` mode always

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ session    session_019e3db018a17450aba5407af5777237 (folder: …; log: …)
   - `web_fetch` — HTTP GET/HEAD with optional markdown/text conversion.
   - `tool_output_persistence` — large bash output spilled to disk under
     `/outputs/` inside the current session folder.
+  - `openai_tool_search` — deferred tool loading: on OpenAI GPT-5.4+/5.5 the
+    model fetches tool schemas on demand instead of receiving all of them
+    upfront, saving input tokens. A self-disabling no-op on every other
+    provider/model. See [`specs/tool-search.md`](./specs/tool-search.md).
 - **Approval prompts (opt-in via `--ask`)**. Off by default: yolop acts
   autonomously. `--ask` prompts y/n before every write/edit/delete and every
   bash command, with a unified diff for writes. `--print` mode always

--- a/specs/tool-search.md
+++ b/specs/tool-search.md
@@ -1,46 +1,66 @@
 # `tool_search` — deferred tool loading
 
-Status: v1 implemented.
+Status: v1 implemented (vendored, provider-agnostic).
 
 ## Why
 
 Yolop ships ~17 always-on tools (file ops, bash, search, todos, skills,
-memory, web fetch). Every turn sends every tool's full JSON schema to the
-model upfront, which costs input tokens on each request and grows worse as
-new tools (e.g. MCP servers) are added.
+memory, web fetch). Sending every tool's full JSON schema on every turn costs
+input tokens and scales badly as tools are added (e.g. MCP servers).
 
-Deferred tool loading — OpenAI's Responses-API "tool search" — lets the model
-fetch a tool's full schema on demand instead. Tools are grouped into
-namespaces by capability category and exposed as name-only stubs plus a
-`tool_search` activator; the model loads schemas only for the tools it
-actually needs. This is a pure token optimization with no behavior change.
+Deferred tool loading hides the parameter schemas of rarely-used tools until
+the model asks for them, cutting per-turn token cost while keeping every tool
+callable.
 
 ## What
 
-Yolop enables the `openai_tool_search` capability
-(`OpenAiToolSearchCapability`) from `everruns-core` in the coding harness for
-both hosts (TUI and `--print`/ACP). It is wired in `src/runtime.rs`:
-registered in the capability registry and listed in
-`coding_harness_capabilities`.
+The capability is **vendored** in `src/capabilities/tool_search.rs` (id
+`yolop_tool_search`) rather than taken from `everruns-core`, because neither
+upstream option works for yolop's models:
 
-Key properties (enforced by the runtime, not by yolop):
+- `openai_tool_search` uses OpenAI's native Responses `tool_search`, which
+  fails with a `server_error` on the reasoning models that advertise it
+  (gpt-5.4 family; gpt-5.5 was gated off). See EVE-521.
+- `GenericToolSearchCapability` defers schemas client-side but its hook is
+  *stateless* — it re-stubs every deferrable tool on every iteration. Because
+  structured tool calling makes the model emit arguments against the
+  *registered* (stub) schema, the model calls every deferred tool with `{}`
+  and can never pass parameters. Verified live: 20+ iterations, all empty.
 
-- **OpenAI-only.** The mechanism is a native OpenAI Responses-API feature.
-  The runtime keeps it enabled only for models whose profile advertises
-  `tool_search` support — currently the **GPT-5.4 family and GPT-5.5/5.5-pro**.
-  Yolop's default model (`gpt-5.5`) qualifies.
-- **Self-disabling no-op elsewhere.** For Anthropic, Google/Gemini,
-  OpenRouter, Ollama, llmsim, and older GPT models, the runtime silently
-  clears the config and sends full schemas as before. No error, no crash.
-- **Threshold-gated.** Below `DEFAULT_TOOL_SEARCH_THRESHOLD` (15) tools, full
-  schemas are still sent even when the capability is on. Yolop's surface
-  (~17) sits above the threshold, so deferral is effective on supported
-  models. A test guards that the surface stays above the threshold; if it
-  ever drops below, set an explicit lower threshold via capability config.
+The vendored version keeps the client-side approach (so it is
+provider-agnostic) and adds the two things that make it actually work:
+
+1. **Progressive disclosure.** A shared "revealed" set is threaded through the
+   schema hook and the `tool_search` tool. When the model calls `tool_search`,
+   the matched tools are recorded as revealed. The reason atom re-assembles
+   turn context — and re-runs the hook — on every iteration, so on the *next*
+   step the revealed tools are advertised with their full, authoritative
+   schemas and the model can pass real arguments. Tool execution always uses
+   the real tools; only the advertised schema changes.
+
+2. **Core-tool allowlist.** The hot-path file/shell tools (`read_file`,
+   `write_file`, `edit_file`, `list_directory`, `grep_files`, `bash`) always
+   keep full schemas, so the agent is never crippled and common work needs no
+   search. The long tail (search, web fetch, memory, skills, history, todos)
+   is deferred until requested.
+
+Deferral activates only once the total tool count crosses
+`DEFAULT_TOOL_SEARCH_THRESHOLD` (15); below that, full schemas fit comfortably.
+
+## Provider support
+
+Works on every provider/model because it only rewrites the standard `tools`
+array — no driver or native-feature dependency. Validated end-to-end (a
+deferred web-search tool loaded via `tool_search` and called with correct
+arguments) on:
+
+- OpenAI `gpt-5.5` (default) and `gpt-5.4`
+- Anthropic `claude-sonnet`
+- NVIDIA Nemotron via OpenRouter
 
 ## Non-goals
 
-- No per-provider reimplementation. Anthropic has its own server-side tool
-  search, but yolop does not wire it — non-OpenAI providers get full schemas.
-- No tools of its own. The capability only reshapes the outgoing request; it
-  adds nothing to yolop's tool surface.
+- No native/server-side tool search. The native OpenAI path stays unused until
+  EVE-521 is fixed upstream.
+- The capability adds exactly one tool (`tool_search`); it does not otherwise
+  change yolop's tool surface.

--- a/specs/tool-search.md
+++ b/specs/tool-search.md
@@ -1,0 +1,46 @@
+# `tool_search` — deferred tool loading
+
+Status: v1 implemented.
+
+## Why
+
+Yolop ships ~17 always-on tools (file ops, bash, search, todos, skills,
+memory, web fetch). Every turn sends every tool's full JSON schema to the
+model upfront, which costs input tokens on each request and grows worse as
+new tools (e.g. MCP servers) are added.
+
+Deferred tool loading — OpenAI's Responses-API "tool search" — lets the model
+fetch a tool's full schema on demand instead. Tools are grouped into
+namespaces by capability category and exposed as name-only stubs plus a
+`tool_search` activator; the model loads schemas only for the tools it
+actually needs. This is a pure token optimization with no behavior change.
+
+## What
+
+Yolop enables the `openai_tool_search` capability
+(`OpenAiToolSearchCapability`) from `everruns-core` in the coding harness for
+both hosts (TUI and `--print`/ACP). It is wired in `src/runtime.rs`:
+registered in the capability registry and listed in
+`coding_harness_capabilities`.
+
+Key properties (enforced by the runtime, not by yolop):
+
+- **OpenAI-only.** The mechanism is a native OpenAI Responses-API feature.
+  The runtime keeps it enabled only for models whose profile advertises
+  `tool_search` support — currently the **GPT-5.4 family and GPT-5.5/5.5-pro**.
+  Yolop's default model (`gpt-5.5`) qualifies.
+- **Self-disabling no-op elsewhere.** For Anthropic, Google/Gemini,
+  OpenRouter, Ollama, llmsim, and older GPT models, the runtime silently
+  clears the config and sends full schemas as before. No error, no crash.
+- **Threshold-gated.** Below `DEFAULT_TOOL_SEARCH_THRESHOLD` (15) tools, full
+  schemas are still sent even when the capability is on. Yolop's surface
+  (~17) sits above the threshold, so deferral is effective on supported
+  models. A test guards that the surface stays above the threshold; if it
+  ever drops below, set an explicit lower threshold via capability config.
+
+## Non-goals
+
+- No per-provider reimplementation. Anthropic has its own server-side tool
+  search, but yolop does not wire it — non-OpenAI providers get full schemas.
+- No tools of its own. The capability only reshapes the outgoing request; it
+  adds nothing to yolop's tool surface.

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -6,6 +6,7 @@
 pub(crate) mod client_commands;
 mod host;
 pub mod skills;
+pub(crate) mod tool_search;
 pub(crate) mod your;
 
 pub(crate) use client_commands::{CLIENT_COMMANDS_CAPABILITY_ID, ClientCommandsCapability};
@@ -14,3 +15,4 @@ pub(crate) use host::{
     CodingCliEnvironmentCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID, MCP_APPROVAL_CAPABILITY_ID,
     McpApprovalCapability, SETUP_CAPABILITY_ID, SetupCapability,
 };
+pub(crate) use tool_search::{TOOL_SEARCH_CAPABILITY_ID, ToolSearchCapability};

--- a/src/capabilities/tool_search.rs
+++ b/src/capabilities/tool_search.rs
@@ -32,6 +32,13 @@
 // Provider-agnostic: it only rewrites the standard `tools` array, so it works
 // on OpenAI (gpt-5.4/5.5), Anthropic, and OpenAI-compatible backends such as
 // OpenRouter (e.g. NVIDIA Nemotron) without any driver support.
+//
+// TODO(EVE-521): this whole module is a temporary vendor. Upstream is renaming
+// `GenericToolSearchCapability` to `everruns_core::capabilities::ToolSearchCapability`.
+// Once that ships the progressive-disclosure fix (revealed-set + core
+// allowlist, or equivalent), delete this file and register the upstream
+// `ToolSearchCapability` in `runtime.rs` instead. Keep the `yolop_tool_search`
+// id wiring until then so the harness selects this implementation.
 
 use async_trait::async_trait;
 use everruns_core::capabilities::{Capability, CapabilityStatus, ToolDefinitionHook};
@@ -45,6 +52,8 @@ use std::sync::{Arc, Mutex};
 
 /// Capability id. Distinct from upstream `tool_search` / `openai_tool_search`
 /// so the harness selects this vendored implementation unambiguously.
+// TODO(EVE-521): drop the `yolop_` prefix and use the upstream `tool_search`
+// id once `everruns_core::capabilities::ToolSearchCapability` ships the fix.
 pub const TOOL_SEARCH_CAPABILITY_ID: &str = "yolop_tool_search";
 
 /// Name of the tool the model calls to load deferred schemas.
@@ -73,6 +82,10 @@ const ALWAYS_FULL: &[&str] = &[
 /// Names of tools the model has loaded via `tool_search` this session. Shared
 /// (by `Arc`) between the capability, its schema hook, and its tool so a reveal
 /// during tool execution is visible to the next context assembly.
+//
+// TODO(EVE-521): this revealed-set is the progressive-disclosure mechanism that
+// upstream's `ToolSearchCapability` lacks. Once upstream adopts it, this type
+// and its plumbing go away with the rest of the module.
 type RevealedTools = Arc<Mutex<HashSet<String>>>;
 
 /// Provider-agnostic deferred tool loading with progressive disclosure.

--- a/src/capabilities/tool_search.rs
+++ b/src/capabilities/tool_search.rs
@@ -479,7 +479,7 @@ mod tests {
         // One over (16): the long tail defers.
         let over = hook.transform(tool_set(10));
         assert!(
-            over.iter().any(|t| is_stubbed(t)),
+            over.iter().any(is_stubbed),
             "strictly above the threshold the long tail must defer"
         );
     }

--- a/src/capabilities/tool_search.rs
+++ b/src/capabilities/tool_search.rs
@@ -193,8 +193,10 @@ struct DeferSchemaHook {
 
 impl ToolDefinitionHook for DeferSchemaHook {
     fn transform(&self, tools: Vec<ToolDefinition>) -> Vec<ToolDefinition> {
-        // Below the threshold full schemas fit comfortably; don't defer.
-        if tools.len() < self.threshold {
+        // Defer only once the surface strictly exceeds the threshold; at or
+        // below it the full catalogue fits comfortably. Matches the docs and
+        // the `tool_surface_exceeds_tool_search_threshold` runtime test.
+        if tools.len() <= self.threshold {
             return tools;
         }
         let revealed = self.revealed.lock().expect("revealed tools lock poisoned");
@@ -243,8 +245,9 @@ pub struct ToolSearchTool {
 
 impl ToolSearchTool {
     /// Rank `defs` against `query` by keyword overlap and return the best
-    /// matches (with full schemas). An empty query lists everything so the
-    /// model can browse. The search tool itself is always excluded.
+    /// matches (with full schemas), capped at `MAX_SEARCH_RESULTS`. An empty
+    /// query returns the first `MAX_SEARCH_RESULTS` tools in registry order so
+    /// the model can browse. The search tool itself is always excluded.
     fn search(defs: &[ToolDefinition], query: &str) -> Vec<Value> {
         let terms: Vec<String> = query
             .split_whitespace()
@@ -459,6 +462,25 @@ mod tests {
         assert!(
             out.iter().all(|t| !is_stubbed(t)),
             "nothing should defer below threshold"
+        );
+    }
+
+    #[test]
+    fn deferral_activates_strictly_above_threshold() {
+        let cap = ToolSearchCapability::with_threshold(15);
+        let hook = &cap.tool_definition_hooks()[0];
+        // Exactly at the threshold (6 core + 9 = 15): nothing defers.
+        let at = hook.transform(tool_set(9));
+        assert_eq!(at.len(), 15);
+        assert!(
+            at.iter().all(|t| !is_stubbed(t)),
+            "at the threshold the full catalogue must fit; no deferral"
+        );
+        // One over (16): the long tail defers.
+        let over = hook.transform(tool_set(10));
+        assert!(
+            over.iter().any(|t| is_stubbed(t)),
+            "strictly above the threshold the long tail must defer"
         );
     }
 

--- a/src/capabilities/tool_search.rs
+++ b/src/capabilities/tool_search.rs
@@ -1,0 +1,526 @@
+// Vendored, stateful tool-search capability (provider-agnostic deferred tool
+// loading).
+//
+// Background: everruns ships two deferral capabilities. `openai_tool_search`
+// uses OpenAI's native Responses `tool_search` and currently fails with a
+// `server_error` on the reasoning models that advertise it (EVE-521). The
+// generic `everruns_core::capabilities::GenericToolSearchCapability` defers
+// schemas client-side, but its `DeferSchemaHook` is *stateless*: it re-stubs
+// every deferrable tool on every reason iteration. Because OpenAI/Anthropic
+// structured tool calling makes the model emit arguments against the tool's
+// *registered* schema (the empty stub), the model calls every deferred tool
+// with `{}` and can never pass parameters — even after `tool_search` returns
+// the real schema as text. Verified live on gpt-5.4/gpt-5.5: 20+ iterations,
+// every tool call empty. See EVE-521 for the full evidence.
+//
+// This vendored version fixes that with two changes:
+//
+//   1. Progressive disclosure (the real fix). A shared `RevealedTools` set is
+//      threaded through the hook and the `tool_search` tool. When the model
+//      calls `tool_search`, the matched tools are recorded as "revealed". The
+//      reason atom re-assembles turn context (and re-runs this hook) on every
+//      iteration, so on the *next* iteration the revealed tools are advertised
+//      with their full, authoritative schemas — and the model can finally pass
+//      arguments. Tool execution always uses the real tools, so only the
+//      advertised schema ever changes.
+//
+//   2. A core-tool allowlist. The hot-path file/shell tools keep full schemas
+//      always, so the agent is never crippled while the long tail (search,
+//      memory, skills, history, todos) stays deferred until needed. This also
+//      slashes the number of `tool_search` round-trips.
+//
+// Provider-agnostic: it only rewrites the standard `tools` array, so it works
+// on OpenAI (gpt-5.4/5.5), Anthropic, and OpenAI-compatible backends such as
+// OpenRouter (e.g. NVIDIA Nemotron) without any driver support.
+
+use async_trait::async_trait;
+use everruns_core::capabilities::{Capability, CapabilityStatus, ToolDefinitionHook};
+use everruns_core::mcp_server::is_mcp_tool;
+use everruns_core::tool_types::{BuiltinTool, DeferrablePolicy, ToolDefinition, ToolHints};
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::ToolContext;
+use serde_json::{Value, json};
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
+
+/// Capability id. Distinct from upstream `tool_search` / `openai_tool_search`
+/// so the harness selects this vendored implementation unambiguously.
+pub const TOOL_SEARCH_CAPABILITY_ID: &str = "yolop_tool_search";
+
+/// Name of the tool the model calls to load deferred schemas.
+pub const TOOL_SEARCH_TOOL_NAME: &str = "tool_search";
+
+/// Default minimum total tool count before deferral kicks in. Below this the
+/// full catalogue fits comfortably and deferral only adds round-trips.
+pub const DEFAULT_TOOL_SEARCH_THRESHOLD: usize = 15;
+
+/// Max tools returned (and revealed) by a single `tool_search` call.
+const MAX_SEARCH_RESULTS: usize = 12;
+
+/// Hot-path tools that always keep their full schemas, so the agent can read,
+/// edit, search, and run commands without a `tool_search` round-trip. The long
+/// tail is deferred until the model asks for it. Keep this list small — every
+/// entry is a tool the model pays full-schema tokens for on every turn.
+const ALWAYS_FULL: &[&str] = &[
+    "read_file",
+    "write_file",
+    "edit_file",
+    "list_directory",
+    "grep_files",
+    "bash",
+];
+
+/// Names of tools the model has loaded via `tool_search` this session. Shared
+/// (by `Arc`) between the capability, its schema hook, and its tool so a reveal
+/// during tool execution is visible to the next context assembly.
+type RevealedTools = Arc<Mutex<HashSet<String>>>;
+
+/// Provider-agnostic deferred tool loading with progressive disclosure.
+pub struct ToolSearchCapability {
+    threshold: usize,
+    revealed: RevealedTools,
+}
+
+impl ToolSearchCapability {
+    pub fn new() -> Self {
+        Self::with_threshold(DEFAULT_TOOL_SEARCH_THRESHOLD)
+    }
+
+    pub fn with_threshold(threshold: usize) -> Self {
+        Self {
+            threshold,
+            revealed: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+}
+
+impl Default for ToolSearchCapability {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+const SYSTEM_PROMPT: &str = "Some of your tools are loaded lazily to save context: you can see their \
+names and descriptions, but their parameter schemas show as \"hidden\" until you load them. To use a \
+hidden tool, first call `tool_search` with a short query (for example \"search the web\" or \"read \
+memory\"); it returns the matching tools with their full JSON parameter schemas. On your next step \
+the tool's real parameters become available — then call it with correct arguments. Core file and \
+shell tools are always fully loaded and never need a search.";
+
+#[async_trait]
+impl Capability for ToolSearchCapability {
+    fn id(&self) -> &str {
+        TOOL_SEARCH_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Tool Search"
+    }
+
+    fn description(&self) -> &str {
+        "Provider-agnostic deferred tool loading. Hides long-tail tool parameter \
+         schemas until the model loads them via the tool_search tool, reducing \
+         token usage. Works on any model."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Optimization")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(SYSTEM_PROMPT)
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![Box::new(ToolSearchTool {
+            revealed: self.revealed.clone(),
+        })]
+    }
+
+    fn tool_definition_hooks(&self) -> Vec<Arc<dyn ToolDefinitionHook>> {
+        vec![Arc::new(DeferSchemaHook {
+            threshold: self.threshold,
+            revealed: self.revealed.clone(),
+        })]
+    }
+}
+
+// ============================================================================
+// DeferSchemaHook — strips parameter schemas from deferrable, unrevealed tools
+// ============================================================================
+
+fn deferred_stub_schema() -> Value {
+    json!({
+        "type": "object",
+        "description": "Parameters hidden to save context. Call tool_search to load the full schema before using this tool.",
+    })
+}
+
+/// Returns true when a tool must always keep its full schema: the search tool
+/// itself, the core allowlist, tools that opt out via `DeferrablePolicy::Never`,
+/// MCP tools (executed via registry proxies built from these definitions), and
+/// any tool already revealed via `tool_search` this session.
+fn keep_full(tool: &ToolDefinition, revealed: &HashSet<String>) -> bool {
+    let name = tool.name();
+    name == TOOL_SEARCH_TOOL_NAME
+        || ALWAYS_FULL.contains(&name)
+        || matches!(tool.deferrable(), DeferrablePolicy::Never)
+        || is_mcp_tool(name)
+        || revealed.contains(name)
+}
+
+struct DeferSchemaHook {
+    threshold: usize,
+    revealed: RevealedTools,
+}
+
+impl ToolDefinitionHook for DeferSchemaHook {
+    fn transform(&self, tools: Vec<ToolDefinition>) -> Vec<ToolDefinition> {
+        // Below the threshold full schemas fit comfortably; don't defer.
+        if tools.len() < self.threshold {
+            return tools;
+        }
+        let revealed = self.revealed.lock().expect("revealed tools lock poisoned");
+        tools
+            .into_iter()
+            .map(|tool| {
+                if keep_full(&tool, &revealed) {
+                    tool
+                } else {
+                    strip_parameters(tool)
+                }
+            })
+            .collect()
+    }
+
+    // Mutually exclusive with the native (openai) tool_search request shaping.
+    fn applies_with_native_tool_search(&self) -> bool {
+        false
+    }
+}
+
+/// Replace a tool's parameter schema with the deferred stub, keeping name,
+/// description, policy, category, and hints intact.
+fn strip_parameters(tool: ToolDefinition) -> ToolDefinition {
+    match tool {
+        ToolDefinition::Builtin(mut b) => {
+            b.parameters = deferred_stub_schema();
+            ToolDefinition::Builtin(b)
+        }
+        ToolDefinition::ClientSide(mut c) => {
+            c.parameters = deferred_stub_schema();
+            ToolDefinition::ClientSide(c)
+        }
+    }
+}
+
+// ============================================================================
+// Tool: tool_search
+// ============================================================================
+
+/// Tool that returns full parameter schemas for tools matching a query and
+/// records them as revealed so the schema hook stops stubbing them.
+pub struct ToolSearchTool {
+    revealed: RevealedTools,
+}
+
+impl ToolSearchTool {
+    /// Rank `defs` against `query` by keyword overlap and return the best
+    /// matches (with full schemas). An empty query lists everything so the
+    /// model can browse. The search tool itself is always excluded.
+    fn search(defs: &[ToolDefinition], query: &str) -> Vec<Value> {
+        let terms: Vec<String> = query
+            .split_whitespace()
+            .map(|t| {
+                t.trim_matches(|c: char| !c.is_alphanumeric())
+                    .to_lowercase()
+            })
+            .filter(|t| !t.is_empty())
+            .collect();
+
+        let mut scored: Vec<(usize, &ToolDefinition)> = defs
+            .iter()
+            .filter(|d| d.name() != TOOL_SEARCH_TOOL_NAME)
+            .filter_map(|d| {
+                if terms.is_empty() {
+                    return Some((0, d));
+                }
+                let haystack = format!("{} {}", d.name(), d.description()).to_lowercase();
+                let score = terms.iter().filter(|t| haystack.contains(*t)).count();
+                (score > 0).then_some((score, d))
+            })
+            .collect();
+
+        // Stable sort by descending score; equal scores keep registry order.
+        scored.sort_by_key(|entry| std::cmp::Reverse(entry.0));
+
+        scored
+            .into_iter()
+            .take(MAX_SEARCH_RESULTS)
+            .map(|(_, d)| {
+                json!({
+                    "name": d.name(),
+                    "description": d.description(),
+                    "parameters": d.parameters(),
+                })
+            })
+            .collect()
+    }
+}
+
+#[async_trait]
+impl Tool for ToolSearchTool {
+    fn name(&self) -> &str {
+        TOOL_SEARCH_TOOL_NAME
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Tool Search")
+    }
+
+    fn description(&self) -> &str {
+        "Search the available tools by keyword and load their full parameter \
+         schemas. Returns matching tools with their names, descriptions, and JSON \
+         parameter schemas. Call this before using any tool whose parameters show \
+         as hidden."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Keywords describing the tool or capability you need (e.g. 'search the web', 'read memory', 'list skills')."
+                }
+            },
+            "required": ["query"],
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+    }
+
+    // Never defer the search tool's own schema.
+    fn to_definition(&self) -> ToolDefinition {
+        ToolDefinition::Builtin(BuiltinTool {
+            name: self.name().to_string(),
+            display_name: self.display_name().map(str::to_string),
+            description: self.description().to_string(),
+            parameters: self.parameters_schema(),
+            policy: self.policy(),
+            category: None,
+            deferrable: DeferrablePolicy::Never,
+            hints: self.hints(),
+        })
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "tool_search requires tool execution context and cannot run standalone.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let query = arguments
+            .get("query")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim();
+
+        let Some(registry) = &context.tool_registry else {
+            return ToolExecutionResult::tool_error(
+                "Tool registry not available in this context. tool_search requires worker-side tool execution.",
+            );
+        };
+
+        let defs = registry.tool_definitions();
+        let matches = Self::search(&defs, query);
+
+        if matches.is_empty() {
+            // No keyword hits — surface the catalogue (names only) so the model
+            // can refine its query instead of dead-ending.
+            let names: Vec<&str> = defs
+                .iter()
+                .map(|d| d.name())
+                .filter(|n| *n != TOOL_SEARCH_TOOL_NAME)
+                .collect();
+            return ToolExecutionResult::success(json!({
+                "query": query,
+                "tools": [],
+                "message": "No tools matched the query. Try a different keyword.",
+                "available_tools": names,
+            }));
+        }
+
+        // Record the matched tools as revealed so the schema hook advertises
+        // their full schemas on the next reason iteration. This is what lets
+        // the model actually pass arguments to them.
+        let revealed_now: Vec<String> = matches
+            .iter()
+            .filter_map(|t| t.get("name").and_then(Value::as_str).map(str::to_string))
+            .collect();
+        {
+            let mut revealed = self.revealed.lock().expect("revealed tools lock poisoned");
+            for name in &revealed_now {
+                revealed.insert(name.clone());
+            }
+        }
+
+        ToolExecutionResult::success(json!({
+            "query": query,
+            "tools": matches,
+            "loaded": revealed_now,
+            "message": "Full schemas loaded. You can now call these tools with correct arguments.",
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::tool_types::ToolPolicy;
+
+    fn builtin(name: &str, deferrable: DeferrablePolicy) -> ToolDefinition {
+        ToolDefinition::Builtin(BuiltinTool {
+            name: name.to_string(),
+            display_name: None,
+            description: format!("{name} description"),
+            parameters: json!({
+                "type": "object",
+                "properties": { "path": { "type": "string" } },
+                "required": ["path"]
+            }),
+            policy: ToolPolicy::default(),
+            category: None,
+            deferrable,
+            hints: ToolHints::default(),
+        })
+    }
+
+    fn is_stubbed(tool: &ToolDefinition) -> bool {
+        tool.parameters()
+            .get("properties")
+            .and_then(Value::as_object)
+            .is_none_or(|p| p.is_empty())
+    }
+
+    /// Build a tool set above the threshold: the 6 core tools plus N long-tail
+    /// tools so deferral activates.
+    fn tool_set(extra: usize) -> Vec<ToolDefinition> {
+        let mut tools: Vec<ToolDefinition> = ALWAYS_FULL
+            .iter()
+            .map(|n| builtin(n, DeferrablePolicy::default()))
+            .collect();
+        for i in 0..extra {
+            tools.push(builtin(
+                &format!("longtail_{i}"),
+                DeferrablePolicy::default(),
+            ));
+        }
+        tools
+    }
+
+    #[test]
+    fn below_threshold_keeps_all_full_schemas() {
+        let cap = ToolSearchCapability::new();
+        let hook = &cap.tool_definition_hooks()[0];
+        // 6 core + 3 = 9 tools, below the default threshold of 15.
+        let out = hook.transform(tool_set(3));
+        assert!(
+            out.iter().all(|t| !is_stubbed(t)),
+            "nothing should defer below threshold"
+        );
+    }
+
+    #[test]
+    fn core_tools_keep_full_schemas_long_tail_is_deferred() {
+        let cap = ToolSearchCapability::new();
+        let hook = &cap.tool_definition_hooks()[0];
+        let out = hook.transform(tool_set(12)); // 18 tools, above threshold
+        for t in &out {
+            if ALWAYS_FULL.contains(&t.name()) {
+                assert!(
+                    !is_stubbed(t),
+                    "core tool {} must keep full schema",
+                    t.name()
+                );
+            } else {
+                assert!(
+                    is_stubbed(t),
+                    "long-tail tool {} must be deferred",
+                    t.name()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn revealing_a_tool_restores_its_full_schema_next_pass() {
+        let cap = ToolSearchCapability::new();
+        let hook = &cap.tool_definition_hooks()[0];
+
+        // First pass: longtail_0 is deferred.
+        let before = hook.transform(tool_set(12));
+        let deferred = before.iter().find(|t| t.name() == "longtail_0").unwrap();
+        assert!(
+            is_stubbed(deferred),
+            "precondition: longtail_0 starts deferred"
+        );
+
+        // Simulate tool_search revealing it (what execute_with_context does).
+        cap.revealed
+            .lock()
+            .unwrap()
+            .insert("longtail_0".to_string());
+
+        // Next pass (same hook, re-run by the reason atom): full schema restored.
+        let after = hook.transform(tool_set(12));
+        let revealed = after.iter().find(|t| t.name() == "longtail_0").unwrap();
+        assert!(
+            !is_stubbed(revealed),
+            "revealed tool must regain its full schema"
+        );
+        // Other long-tail tools stay deferred.
+        let other = after.iter().find(|t| t.name() == "longtail_1").unwrap();
+        assert!(
+            is_stubbed(other),
+            "unrevealed long-tail tools stay deferred"
+        );
+    }
+
+    #[test]
+    fn search_ranks_by_keyword_and_returns_full_schema() {
+        let defs = tool_set(12);
+        let results = ToolSearchTool::search(&defs, "grep");
+        assert!(!results.is_empty());
+        assert_eq!(results[0]["name"], "grep_files");
+        // Returned schema is the real one, not the stub.
+        assert!(results[0]["parameters"]["properties"]["path"].is_object());
+    }
+
+    #[test]
+    fn search_excludes_itself_and_lists_on_empty_query() {
+        let defs = tool_set(2);
+        let results = ToolSearchTool::search(&defs, "");
+        let names: Vec<&str> = results.iter().filter_map(|r| r["name"].as_str()).collect();
+        assert!(!names.contains(&TOOL_SEARCH_TOOL_NAME));
+        assert!(names.contains(&"read_file"));
+    }
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -910,9 +910,10 @@ fn coding_harness_capabilities(
         AgentCapabilityConfig::new("stateless_todo_list"),
         AgentCapabilityConfig::new("loop_detection"),
         AgentCapabilityConfig::new(PROMPT_CACHING_CAPABILITY_ID),
-        // Provider-agnostic deferred tool loading (default threshold: 15
-        // tools). Core tools stay fully loaded; the long tail is stubbed until
-        // the model loads it via the `tool_search` tool. Works on every model.
+        // Provider-agnostic deferred tool loading. Core tools stay fully
+        // loaded; the long tail is stubbed until the model loads it via the
+        // `tool_search` tool. Works on every model. Default threshold is 15
+        // tools (see DEFAULT_TOOL_SEARCH_THRESHOLD).
         AgentCapabilityConfig::new(TOOL_SEARCH_CAPABILITY_ID),
         AgentCapabilityConfig::new("tool_output_persistence"),
         AgentCapabilityConfig::new("duckduckgo"),
@@ -1975,7 +1976,8 @@ mod tests {
             tool_count > DEFAULT_TOOL_SEARCH_THRESHOLD,
             "tool surface ({tool_count}) must exceed the tool_search threshold \
              ({DEFAULT_TOOL_SEARCH_THRESHOLD}) for deferred loading to activate; \
-             lower the threshold via capability config if the surface shrinks"
+             if the surface shrinks, lower the threshold via \
+             ToolSearchCapability::with_threshold (or DEFAULT_TOOL_SEARCH_THRESHOLD)"
         );
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -10,7 +10,7 @@ use crate::capabilities::{
     ATTRIBUTION_CAPABILITY_ID, AttributionCapability, CLIENT_COMMANDS_CAPABILITY_ID,
     ClientCommandsCapability, CodingBashCapability, CodingCliEnvironmentCapability,
     ENVIRONMENT_CONTEXT_CAPABILITY_ID, MCP_APPROVAL_CAPABILITY_ID, McpApprovalCapability,
-    SETUP_CAPABILITY_ID, SetupCapability,
+    SETUP_CAPABILITY_ID, SetupCapability, TOOL_SEARCH_CAPABILITY_ID, ToolSearchCapability,
 };
 use crate::host_ui::{HostUi, TuiHandle, UiCommand};
 use crate::settings::{Settings, SettingsStore};
@@ -20,10 +20,9 @@ use async_trait::async_trait;
 use everruns_core::capabilities::{
     AGENT_INSTRUCTIONS_CAPABILITY_ID, AgentInstructionsCapability, COMPACTION_CAPABILITY_ID,
     CompactionCapability, FileSystemCapability, INFINITY_CONTEXT_CAPABILITY_ID,
-    InfinityContextCapability, LoopDetectionCapability, OPENAI_TOOL_SEARCH_CAPABILITY_ID,
-    OpenAiToolSearchCapability, PROMPT_CACHING_CAPABILITY_ID, PromptCachingCapability,
-    SKILLS_CAPABILITY_ID, StatelessTodoListCapability, ToolOutputPersistenceCapability,
-    WebFetchCapability,
+    InfinityContextCapability, LoopDetectionCapability, PROMPT_CACHING_CAPABILITY_ID,
+    PromptCachingCapability, SKILLS_CAPABILITY_ID, StatelessTodoListCapability,
+    ToolOutputPersistenceCapability, WebFetchCapability,
 };
 use everruns_core::command::CommandDescriptor;
 use everruns_core::error::AgentLoopError;
@@ -911,10 +910,10 @@ fn coding_harness_capabilities(
         AgentCapabilityConfig::new("stateless_todo_list"),
         AgentCapabilityConfig::new("loop_detection"),
         AgentCapabilityConfig::new(PROMPT_CACHING_CAPABILITY_ID),
-        // Deferred tool loading on supported models (default threshold: 15
-        // tools). yolop exposes ~17 tools, so this activates on OpenAI
-        // GPT-5.4+/5.5 and is silently ignored elsewhere.
-        AgentCapabilityConfig::new(OPENAI_TOOL_SEARCH_CAPABILITY_ID),
+        // Provider-agnostic deferred tool loading (default threshold: 15
+        // tools). Core tools stay fully loaded; the long tail is stubbed until
+        // the model loads it via the `tool_search` tool. Works on every model.
+        AgentCapabilityConfig::new(TOOL_SEARCH_CAPABILITY_ID),
         AgentCapabilityConfig::new("tool_output_persistence"),
         AgentCapabilityConfig::new("duckduckgo"),
         AgentCapabilityConfig::new(ATTRIBUTION_CAPABILITY_ID),
@@ -1150,11 +1149,12 @@ pub async fn build_with_options(
     capabilities.register(StatelessTodoListCapability);
     capabilities.register(LoopDetectionCapability);
     capabilities.register(PromptCachingCapability::new());
-    // Deferred tool loading (schemas fetched on demand). Pure optimization:
-    // the runtime self-disables it for any model whose profile lacks
-    // tool_search support (everything except OpenAI GPT-5.4+/5.5), so it is a
-    // no-op for Anthropic/Google/OpenRouter/Ollama/llmsim.
-    capabilities.register(OpenAiToolSearchCapability::new());
+    // Provider-agnostic deferred tool loading (vendored, see
+    // `capabilities::tool_search`). Keeps core file/shell tools fully loaded
+    // and defers the long tail behind a `tool_search` tool, revealing real
+    // schemas progressively. Works on every provider/model — unlike the native
+    // `openai_tool_search`, whose Responses round-trip is broken (EVE-521).
+    capabilities.register(ToolSearchCapability::new());
     capabilities.register(ToolOutputPersistenceCapability);
     capabilities.register(DuckDuckGoCapability);
     capabilities.register(WebFetchCapability::from_env());
@@ -1930,13 +1930,13 @@ mod tests {
 
     #[test]
     fn coding_harness_enables_tool_search() {
-        // Deferred tool loading must be wired for both hosts — it is a
-        // model-gated no-op, so there is no reason to scope it to the TUI.
+        // Deferred tool loading must be wired for both hosts — it works on
+        // every provider, so there is no reason to scope it to the TUI.
         for client_commands in [false, true] {
             let ids = coding_harness_capabilities(client_commands);
             assert!(
                 ids.iter()
-                    .any(|cap| cap.capability_id() == OPENAI_TOOL_SEARCH_CAPABILITY_ID),
+                    .any(|cap| cap.capability_id() == TOOL_SEARCH_CAPABILITY_ID),
                 "tool_search must be enabled (client_commands={client_commands})"
             );
         }
@@ -1949,7 +1949,7 @@ mod tests {
     /// helping and this test fails loudly so the threshold can be revisited.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn tool_surface_exceeds_tool_search_threshold() {
-        use everruns_core::capabilities::DEFAULT_TOOL_SEARCH_THRESHOLD;
+        use crate::capabilities::tool_search::DEFAULT_TOOL_SEARCH_THRESHOLD;
 
         let workspace = tempfile::tempdir().expect("workspace");
         let sessions = tempfile::tempdir().expect("sessions");

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1929,6 +1929,53 @@ mod tests {
     }
 
     #[test]
+    fn coding_harness_enables_tool_search() {
+        // Deferred tool loading must be wired for both hosts — it is a
+        // model-gated no-op, so there is no reason to scope it to the TUI.
+        for client_commands in [false, true] {
+            let ids = coding_harness_capabilities(client_commands);
+            assert!(
+                ids.iter()
+                    .any(|cap| cap.capability_id() == OPENAI_TOOL_SEARCH_CAPABILITY_ID),
+                "tool_search must be enabled (client_commands={client_commands})"
+            );
+        }
+    }
+
+    /// Tool search only activates once the tool surface crosses
+    /// `DEFAULT_TOOL_SEARCH_THRESHOLD`; below it, full schemas are sent even
+    /// with the capability on. This guards the integration: if yolop's tool
+    /// count ever drops below the threshold, deferred loading silently stops
+    /// helping and this test fails loudly so the threshold can be revisited.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn tool_surface_exceeds_tool_search_threshold() {
+        use everruns_core::capabilities::DEFAULT_TOOL_SEARCH_THRESHOLD;
+
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+        let built = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Sim,
+            ApprovalGate::auto(),
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            BuildOptions::default(),
+        )
+        .await
+        .expect("build runtime");
+
+        let tool_count = built.startup.tool_names.len();
+        assert!(
+            tool_count > DEFAULT_TOOL_SEARCH_THRESHOLD,
+            "tool surface ({tool_count}) must exceed the tool_search threshold \
+             ({DEFAULT_TOOL_SEARCH_THRESHOLD}) for deferred loading to activate; \
+             lower the threshold via capability config if the surface shrinks"
+        );
+    }
+
+    #[test]
     fn coding_harness_enables_loop_detection() {
         let ids = coding_harness_capabilities(false, false);
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1154,6 +1154,8 @@ pub async fn build_with_options(
     // and defers the long tail behind a `tool_search` tool, revealing real
     // schemas progressively. Works on every provider/model — unlike the native
     // `openai_tool_search`, whose Responses round-trip is broken (EVE-521).
+    // TODO(EVE-521): replace with the upstream `ToolSearchCapability` (renamed
+    // from `GenericToolSearchCapability`) once it ships progressive disclosure.
     capabilities.register(ToolSearchCapability::new());
     capabilities.register(ToolOutputPersistenceCapability);
     capabilities.register(DuckDuckGoCapability);

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -20,9 +20,10 @@ use async_trait::async_trait;
 use everruns_core::capabilities::{
     AGENT_INSTRUCTIONS_CAPABILITY_ID, AgentInstructionsCapability, COMPACTION_CAPABILITY_ID,
     CompactionCapability, FileSystemCapability, INFINITY_CONTEXT_CAPABILITY_ID,
-    InfinityContextCapability, LoopDetectionCapability, PROMPT_CACHING_CAPABILITY_ID,
-    PromptCachingCapability, SKILLS_CAPABILITY_ID, StatelessTodoListCapability,
-    ToolOutputPersistenceCapability, WebFetchCapability,
+    InfinityContextCapability, LoopDetectionCapability, OPENAI_TOOL_SEARCH_CAPABILITY_ID,
+    OpenAiToolSearchCapability, PROMPT_CACHING_CAPABILITY_ID, PromptCachingCapability,
+    SKILLS_CAPABILITY_ID, StatelessTodoListCapability, ToolOutputPersistenceCapability,
+    WebFetchCapability,
 };
 use everruns_core::command::CommandDescriptor;
 use everruns_core::error::AgentLoopError;
@@ -910,6 +911,10 @@ fn coding_harness_capabilities(
         AgentCapabilityConfig::new("stateless_todo_list"),
         AgentCapabilityConfig::new("loop_detection"),
         AgentCapabilityConfig::new(PROMPT_CACHING_CAPABILITY_ID),
+        // Deferred tool loading on supported models (default threshold: 15
+        // tools). yolop exposes ~17 tools, so this activates on OpenAI
+        // GPT-5.4+/5.5 and is silently ignored elsewhere.
+        AgentCapabilityConfig::new(OPENAI_TOOL_SEARCH_CAPABILITY_ID),
         AgentCapabilityConfig::new("tool_output_persistence"),
         AgentCapabilityConfig::new("duckduckgo"),
         AgentCapabilityConfig::new(ATTRIBUTION_CAPABILITY_ID),
@@ -1145,6 +1150,11 @@ pub async fn build_with_options(
     capabilities.register(StatelessTodoListCapability);
     capabilities.register(LoopDetectionCapability);
     capabilities.register(PromptCachingCapability::new());
+    // Deferred tool loading (schemas fetched on demand). Pure optimization:
+    // the runtime self-disables it for any model whose profile lacks
+    // tool_search support (everything except OpenAI GPT-5.4+/5.5), so it is a
+    // no-op for Anthropic/Google/OpenRouter/Ollama/llmsim.
+    capabilities.register(OpenAiToolSearchCapability::new());
     capabilities.register(ToolOutputPersistenceCapability);
     capabilities.register(DuckDuckGoCapability);
     capabilities.register(WebFetchCapability::from_env());

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1932,15 +1932,17 @@ mod tests {
 
     #[test]
     fn coding_harness_enables_tool_search() {
-        // Deferred tool loading must be wired for both hosts — it works on
-        // every provider, so there is no reason to scope it to the TUI.
+        // Deferred tool loading must be wired for every host configuration —
+        // it works on every provider, so there is no reason to scope it.
         for client_commands in [false, true] {
-            let ids = coding_harness_capabilities(client_commands);
-            assert!(
-                ids.iter()
-                    .any(|cap| cap.capability_id() == TOOL_SEARCH_CAPABILITY_ID),
-                "tool_search must be enabled (client_commands={client_commands})"
-            );
+            for mcp_approval in [false, true] {
+                let ids = coding_harness_capabilities(client_commands, mcp_approval);
+                assert!(
+                    ids.iter()
+                        .any(|cap| cap.capability_id() == TOOL_SEARCH_CAPABILITY_ID),
+                    "tool_search must be enabled (client_commands={client_commands}, mcp_approval={mcp_approval})"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## What

Adds **provider-agnostic deferred tool loading** to yolop via a vendored, stateful `tool_search` capability (`src/capabilities/tool_search.rs`, id `yolop_tool_search`). Long-tail tool parameter schemas are hidden until the model loads them on demand through a `tool_search` tool, cutting per-turn input tokens; core file/shell tools always stay fully loaded.

## Why vendor instead of using everruns?

Neither upstream option works for yolop's models (tracked in EVE-521):

- **`openai_tool_search`** (native OpenAI Responses): `server_error` during reasoning on the gpt-5.4 family (gpt-5.5 was gated off, not fixed).
- **`GenericToolSearchCapability`** (client-side): its schema hook is *stateless* — it re-stubs every deferrable tool every iteration. Because structured tool calling makes the model emit arguments against the *registered* (stubbed) schema, the model calls every deferred tool with `{}` and can never pass parameters. Verified live: 20+ iterations, all-empty args.

The vendored version keeps the provider-agnostic client-side approach and adds the two things that make it actually work:

1. **Progressive disclosure** — a shared `revealed` set threaded through the schema hook and the `tool_search` tool. The reason atom re-assembles context (re-running the hook) each iteration, so a tool loaded via `tool_search` is advertised with its full, authoritative schema on the *next* step — and the model passes real arguments. Tool execution always uses the real tools; only the advertised schema changes.
2. **Core-tool allowlist** — `read_file`, `write_file`, `edit_file`, `list_directory`, `grep_files`, `bash` keep full schemas always, so the agent is never crippled and round-trips stay low.

## Validation

Automated: `cargo fmt`, `cargo clippy -D warnings`, **258 unit + 11 integration tests** (incl. 5 new tests: threshold gating, core allowlist, and the progressive-disclosure reveal). Real-provider integration tests pass under Doppler.

End-to-end live (a **deferred** web-search tool loaded via `tool_search`, then called with real arguments):

| Model | Result |
|---|---|
| OpenAI gpt-5.5 (default) | ✅ `tool_search`→`duckduckgo_search {"query":…}` / `web_fetch {"url":…}` |
| OpenAI gpt-5.4 | ✅ real args |
| Anthropic claude-sonnet | ✅ real args (re-confirmed post-rebase) |
| NVIDIA Nemotron (OpenRouter) | ✅ `tool_search`→`duckduckgo_search {"query":…}` |

## Security

- **TM-TOOL**: the `tool_search` tool is read-only (returns schemas), requires execution context, and never bypasses the approval gate or write blocklist. Deferral only changes the *advertised* schema — execution always uses the real, gated tools. MCP tools are kept full-schema (`is_mcp_tool`) so the MCP act-path proxies are unaffected.
- **TM-FS / TM-BASH / TM-LLM**: no changes to the write blocklist, bash bounds, or key handling.
- **TM-DEP**: no new crates; builds on existing `everruns_core` public API.

## Follow-ups

- **TODO(EVE-521)** markers mark this module as a temporary vendor. Upstream is renaming `GenericToolSearchCapability` → `ToolSearchCapability` and will adopt the progressive-disclosure fix; once it ships, delete this module and register the upstream `ToolSearchCapability`. Tracked in EVE-521.
- The native `openai_tool_search` round-trip remains broken on the gpt-5.4 family (separate upstream fix, EVE-521).

🤖 Generated with yolop


---
_Generated by [Claude Code](https://claude.ai/code/session_01N6MWfN6bmri28MkZ329JDi)_