### PR TITLE
refactor(acp): use upstream protocol sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "agent-client-protocol"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d197653697b91b3a2cfb579d061a3388cda9fdc79cb6f9393da65cbad46baf8"
+dependencies = [
+ "agent-client-protocol-derive",
+ "agent-client-protocol-schema",
+ "async-process",
+ "blocking",
+ "futures",
+ "futures-concurrency",
+ "jsonrpcmsg",
+ "rustc-hash 2.1.2",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "shell-words",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "agent-client-protocol-derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e4fbf6733a900814fb921b2aac06612e15b42020b76a356fbc1192e725cebc"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "agent-client-protocol-schema"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d419a87e28240978e4bfdf2a5b91bccb95ae8d5b06e10721bb07c449b9f43dd"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "strum 0.28.0",
+ "tracing",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,6 +213,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +234,71 @@ dependencies = [
  "compression-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -197,6 +322,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -437,6 +568,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,6 +599,15 @@ checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -652,6 +805,15 @@ name = "compression-core"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "const-oid"
@@ -907,6 +1069,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -929,6 +1092,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1075,6 +1239,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1278,7 +1463,7 @@ dependencies = [
  "futures",
  "rand 0.8.6",
  "reqwest 0.13.4",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -1399,6 +1584,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-concurrency"
+version = "7.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "futures-core",
+ "futures-lite",
+ "pin-project",
+ "smallvec",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1420,6 +1618,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1539,12 +1750,18 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1577,6 +1794,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1905,6 +2128,17 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
@@ -1994,7 +2228,7 @@ dependencies = [
  "bytes",
  "foldhash 0.1.5",
  "hifijson",
- "indexmap",
+ "indexmap 2.14.0",
  "jaq-core",
  "jaq-std",
  "num-bigint",
@@ -2130,6 +2364,16 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonrpcmsg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d833a15225c779251e13929203518c2ff26e2fe0f322d584b213f4f4dad37bd"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2581,6 +2825,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2697,7 +2947,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -2779,6 +3029,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2786,6 +3047,20 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3184,7 +3459,7 @@ dependencies = [
  "itertools",
  "kasuari",
  "lru",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
@@ -3249,7 +3524,7 @@ dependencies = [
  "itertools",
  "line-clipping",
  "ratatui-core",
- "strum",
+ "strum 0.27.2",
  "time",
  "unicode-segmentation",
  "unicode-width",
@@ -3585,6 +3860,18 @@ dependencies = [
 
 [[package]]
 name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
@@ -3736,12 +4023,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -3985,7 +4304,16 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -3993,6 +4321,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -4227,12 +4567,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -4240,6 +4582,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"
@@ -4335,6 +4687,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -4346,7 +4699,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
@@ -4455,7 +4808,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -4877,7 +5230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4916,7 +5269,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -5336,7 +5689,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -5367,7 +5720,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -5386,7 +5739,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -5429,6 +5782,7 @@ dependencies = [
 name = "yolop"
 version = "0.2.0"
 dependencies = [
+ "agent-client-protocol",
  "anyhow",
  "async-trait",
  "chrono",
@@ -5440,6 +5794,7 @@ dependencies = [
  "everruns-integrations-duckduckgo",
  "everruns-openai",
  "everruns-runtime",
+ "futures",
  "include_dir",
  "portable-pty",
  "ratatui",
@@ -5450,6 +5805,7 @@ dependencies = [
  "tempfile",
  "textwrap",
  "tokio",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ name = "yolop"
 path = "src/main.rs"
 
 [dependencies]
+agent-client-protocol = "0.13.1"
 anyhow = "1.0"
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
@@ -28,6 +29,7 @@ similar = "3"
 toml = "1"
 textwrap = "0.16"
 tokio = { version = "1.50", features = ["full"] }
+tokio-util = { version = "0.7", features = ["compat"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
@@ -38,6 +40,7 @@ everruns-openai = "0.8.38"
 # everruns server/worker never enable it (specs/mcp.md, upstream runtime-mcp.md D2).
 everruns-runtime = { version = "0.8.38", features = ["mcp-stdio"] }
 everruns-integrations-duckduckgo = "0.8.38"
+futures = "0.3"
 
 [dev-dependencies]
 portable-pty = "0.9.0"

--- a/specs/acp.md
+++ b/specs/acp.md
@@ -103,20 +103,21 @@ the channel gate's existing semantics.
 ```
 src/acp/
   mod.rs        # module root: production RuntimeFactory, run_stdio entry, e2e tests
-  protocol.rs   # serde types for the ACP wire format (camelCase fields, snake_case discriminators)
+  protocol.rs   # SDK-backed ACP schema shim plus yolop helpers
   bridge.rs     # pure runtime-event → session/update translation (Translator)
-  server.rs     # JSON-RPC peer, dispatch, session map, turn streaming, permission bridge
+  server.rs     # SDK transport/dispatch wiring, session map, turn streaming, permission bridge
 ```
 
 Concurrency model in `server::serve`:
 
-- A single **writer task** serialises every outbound line so responses,
-  notifications, and agent→client requests never interleave.
-- The **read loop** never blocks on slow work — `session/prompt` runs in its own
-  task — so `session/cancel` and permission responses keep flowing during a
-  turn.
-- Agent→client requests (`session/request_permission`) are correlated by id
-  through a pending-response table the read loop resolves.
+- The upstream Rust SDK owns newline JSON-RPC parsing, serialization, typed
+  request dispatch, response correlation, and `session/request_permission`
+  replies.
+- `session/prompt` runs in its own Tokio task so SDK dispatch keeps processing
+  `session/cancel` notifications and permission responses during a turn.
+- `serve` uses the SDK `Lines` transport with an EOF signal so a client
+  disconnect still winds the agent process down even if a permission request is
+  outstanding.
 
 `serve` is generic over the byte streams and a `RuntimeFactory`, so the binary
 wires it to real stdin/stdout with a provider-backed factory while tests drive
@@ -126,8 +127,8 @@ it over `tokio::io::duplex` pipes with a scripted llmsim runtime.
 
 Three layers, all offline (no API key):
 
-1. **Wire types** (`protocol.rs`) — serde round-trips assert exact field casing
-   and discriminator values against the published schema.
+1. **Wire types** (`protocol.rs`) — SDK schema round-trips assert exact field
+   casing and discriminator values against the published schema.
 2. **Translation** (`bridge.rs`) — the `Translator` is exercised per event type
    (deltas, tool lifecycle, todos→plan, dedup, streamed-vs-completed).
 3. **End-to-end** (`mod.rs`) — a real `serve` loop over duplex pipes driven by

--- a/src/acp/bridge.rs
+++ b/src/acp/bridge.rs
@@ -14,8 +14,8 @@ use everruns_core::message::{ContentPart, MessageRole};
 use serde_json::Value;
 
 use super::protocol::{
-    ContentBlock, PlanEntry, PlanPriority, PlanStatus, SessionUpdate, ToolCallContent,
-    ToolCallStatus, ToolKind,
+    self, ContentBlock, Plan, PlanEntry, PlanEntryPriority, PlanEntryStatus, SessionUpdate,
+    ToolCall, ToolCallContent, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind,
 };
 
 /// The runtime's todo tool. write_todos updates are surfaced as ACP plans
@@ -59,9 +59,9 @@ impl Translator {
                     return Vec::new();
                 }
                 self.current_message_streamed = true;
-                vec![SessionUpdate::AgentMessageChunk {
-                    content: ContentBlock::text(&data.delta),
-                }]
+                vec![SessionUpdate::AgentMessageChunk(protocol::text_chunk(
+                    &data.delta,
+                ))]
             }
             EventData::OutputMessageCompleted(data) => {
                 if self.current_message_streamed {
@@ -71,9 +71,9 @@ impl Translator {
                     return Vec::new();
                 }
                 match data.message.text().map(str::trim) {
-                    Some(text) if !text.is_empty() => vec![SessionUpdate::AgentMessageChunk {
-                        content: ContentBlock::text(text),
-                    }],
+                    Some(text) if !text.is_empty() => {
+                        vec![SessionUpdate::AgentMessageChunk(protocol::text_chunk(text))]
+                    }
                     _ => Vec::new(),
                 }
             }
@@ -81,25 +81,24 @@ impl Translator {
                 if data.delta.is_empty() {
                     return Vec::new();
                 }
-                vec![SessionUpdate::AgentThoughtChunk {
-                    content: ContentBlock::text(&data.delta),
-                }]
+                vec![SessionUpdate::AgentThoughtChunk(protocol::text_chunk(
+                    &data.delta,
+                ))]
             }
             EventData::ReasonItem(data) => data
                 .summary
                 .iter()
                 .filter_map(|segment| {
                     let trimmed = segment.trim();
-                    (!trimmed.is_empty()).then(|| SessionUpdate::AgentThoughtChunk {
-                        content: ContentBlock::text(trimmed),
-                    })
+                    (!trimmed.is_empty())
+                        .then(|| SessionUpdate::AgentThoughtChunk(protocol::text_chunk(trimmed)))
                 })
                 .collect(),
             EventData::ToolStarted(data) => {
                 let name = data.tool_call.name.as_str();
                 if name == WRITE_TODOS {
                     return plan_from_value(&data.tool_call.arguments)
-                        .map(|entries| vec![SessionUpdate::Plan { entries }])
+                        .map(|entries| vec![SessionUpdate::Plan(Plan::new(entries))])
                         .unwrap_or_default();
                 }
                 let title = data
@@ -108,14 +107,12 @@ impl Translator {
                     .or(data.display_name.as_deref())
                     .unwrap_or(name)
                     .to_string();
-                vec![SessionUpdate::ToolCall {
-                    tool_call_id: data.tool_call.id.clone(),
-                    title,
-                    kind: tool_kind(name),
-                    status: ToolCallStatus::InProgress,
-                    raw_input: non_null(data.tool_call.arguments.clone()),
-                    content: Vec::new(),
-                }]
+                vec![SessionUpdate::ToolCall(
+                    ToolCall::new(data.tool_call.id.clone(), title)
+                        .kind(tool_kind(name))
+                        .status(ToolCallStatus::InProgress)
+                        .raw_input(non_null(data.tool_call.arguments.clone())),
+                )]
             }
             EventData::ToolCompleted(data) => {
                 if data.tool_name == WRITE_TODOS {
@@ -125,7 +122,7 @@ impl Translator {
                     return result_value(data)
                         .as_ref()
                         .and_then(plan_from_value)
-                        .map(|entries| vec![SessionUpdate::Plan { entries }])
+                        .map(|entries| vec![SessionUpdate::Plan(Plan::new(entries))])
                         .unwrap_or_default();
                 }
                 let status = if data.success {
@@ -134,14 +131,12 @@ impl Translator {
                     ToolCallStatus::Failed
                 };
                 let content = tool_result_content(data)
-                    .map(|block| vec![ToolCallContent::Content { content: block }])
+                    .map(|block| vec![ToolCallContent::Content(protocol::Content::new(block))])
                     .unwrap_or_default();
-                vec![SessionUpdate::ToolCallUpdate {
-                    tool_call_id: data.tool_call_id.clone(),
-                    status: Some(status),
-                    content,
-                    raw_output: None,
-                }]
+                vec![SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+                    data.tool_call_id.clone(),
+                    ToolCallUpdateFields::new().status(status).content(content),
+                ))]
             }
             _ => Vec::new(),
         }
@@ -170,7 +165,7 @@ fn tool_result_content(data: &ToolCompletedData) -> Option<ContentBlock> {
     if trimmed.is_empty() {
         None
     } else {
-        Some(ContentBlock::text(trimmed))
+        Some(protocol::text_block(trimmed))
     }
 }
 
@@ -186,15 +181,11 @@ fn plan_from_value(value: &Value) -> Option<Vec<PlanEntry>> {
                 return None;
             }
             let status = match todo.get("status").and_then(Value::as_str) {
-                Some("completed") => PlanStatus::Completed,
-                Some("in_progress") => PlanStatus::InProgress,
-                _ => PlanStatus::Pending,
+                Some("completed") => PlanEntryStatus::Completed,
+                Some("in_progress") => PlanEntryStatus::InProgress,
+                _ => PlanEntryStatus::Pending,
             };
-            Some(PlanEntry {
-                content: content.to_string(),
-                priority: PlanPriority::Medium,
-                status,
-            })
+            Some(PlanEntry::new(content, PlanEntryPriority::Medium, status))
         })
         .collect::<Vec<_>>();
     Some(entries)
@@ -258,9 +249,9 @@ mod tests {
         )));
         assert_eq!(
             updates,
-            vec![SessionUpdate::AgentMessageChunk {
-                content: ContentBlock::text("Hel")
-            }]
+            vec![SessionUpdate::AgentMessageChunk(protocol::text_chunk(
+                "Hel"
+            ))]
         );
     }
 
@@ -303,9 +294,9 @@ mod tests {
         )));
         assert_eq!(
             updates,
-            vec![SessionUpdate::AgentMessageChunk {
-                content: ContentBlock::text("full answer")
-            }]
+            vec![SessionUpdate::AgentMessageChunk(protocol::text_chunk(
+                "full answer"
+            ))]
         );
     }
 
@@ -321,9 +312,9 @@ mod tests {
         )));
         assert_eq!(
             updates,
-            vec![SessionUpdate::AgentThoughtChunk {
-                content: ContentBlock::text("pondering")
-            }]
+            vec![SessionUpdate::AgentThoughtChunk(protocol::text_chunk(
+                "pondering"
+            ))]
         );
     }
 
@@ -342,14 +333,12 @@ mod tests {
         })));
         assert_eq!(
             updates,
-            vec![SessionUpdate::ToolCall {
-                tool_call_id: "call_1".into(),
-                title: "Listing files".into(),
-                kind: ToolKind::Execute,
-                status: ToolCallStatus::InProgress,
-                raw_input: Some(json!({ "command": "ls" })),
-                content: vec![],
-            }]
+            vec![SessionUpdate::ToolCall(
+                protocol::ToolCall::new("call_1", "Listing files")
+                    .kind(ToolKind::Execute)
+                    .status(ToolCallStatus::InProgress)
+                    .raw_input(json!({ "command": "ls" })),
+            )]
         );
     }
 
@@ -373,19 +362,12 @@ mod tests {
         })));
         assert_eq!(updates.len(), 1);
         match &updates[0] {
-            SessionUpdate::ToolCallUpdate {
-                tool_call_id,
-                status,
-                content,
-                ..
-            } => {
-                assert_eq!(tool_call_id, "call_1");
-                assert_eq!(*status, Some(ToolCallStatus::Failed));
+            SessionUpdate::ToolCallUpdate(update) => {
+                assert_eq!(update.tool_call_id.to_string(), "call_1");
+                assert_eq!(update.fields.status, Some(ToolCallStatus::Failed));
                 assert_eq!(
-                    content,
-                    &vec![ToolCallContent::Content {
-                        content: ContentBlock::text("error: boom")
-                    }]
+                    update.fields.content,
+                    Some(vec![protocol::content("error: boom")])
                 );
             }
             other => panic!("expected tool_call_update, got {other:?}"),
@@ -413,25 +395,19 @@ mod tests {
         })));
         assert_eq!(
             updates,
-            vec![SessionUpdate::Plan {
-                entries: vec![
-                    PlanEntry {
-                        content: "first".into(),
-                        priority: PlanPriority::Medium,
-                        status: PlanStatus::Completed,
-                    },
-                    PlanEntry {
-                        content: "second".into(),
-                        priority: PlanPriority::Medium,
-                        status: PlanStatus::InProgress,
-                    },
-                    PlanEntry {
-                        content: "third".into(),
-                        priority: PlanPriority::Medium,
-                        status: PlanStatus::Pending,
-                    },
-                ]
-            }]
+            vec![SessionUpdate::Plan(Plan::new(vec![
+                PlanEntry::new(
+                    "first",
+                    PlanEntryPriority::Medium,
+                    PlanEntryStatus::Completed,
+                ),
+                PlanEntry::new(
+                    "second",
+                    PlanEntryPriority::Medium,
+                    PlanEntryStatus::InProgress,
+                ),
+                PlanEntry::new("third", PlanEntryPriority::Medium, PlanEntryStatus::Pending,),
+            ]))]
         );
     }
 

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -10,9 +10,9 @@
 //! See `specs/acp.md` for the full surface and `README.md` for editor setup.
 //!
 //! Module layout:
-//!   * [`protocol`] — serde types for the ACP wire format.
+//!   * [`protocol`] — SDK schema re-exports plus small yolop helpers.
 //!   * [`bridge`] — pure translation of runtime events into `session/update`s.
-//!   * [`server`] — the JSON-RPC peer, dispatch, and turn streaming.
+//!   * [`server`] — SDK-backed transport/dispatch plus turn streaming.
 
 mod bridge;
 mod protocol;
@@ -75,10 +75,21 @@ pub async fn run_stdio(
 mod tests {
     use super::*;
     use crate::runtime::{BuildOptions, build_with_options};
+    use agent_client_protocol::schema::{
+        InitializeRequest, InitializeResponse, NewSessionRequest, PromptRequest,
+        RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
+        SelectedPermissionOutcome, SessionId, SessionUpdate,
+    };
+    use agent_client_protocol::{
+        Agent, ByteStreams, Client, ConnectionTo, JsonRpcRequest, SessionMessage,
+    };
     use everruns_core::llmsim_driver::{LlmSimConfig, SimToolCall, SimTurn};
+    use futures::Future;
+    use serde::{Deserialize, Serialize};
     use serde_json::{Value, json};
     use std::time::Duration;
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, DuplexStream, Lines};
+    use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
     /// Scripted [`RuntimeFactory`] for tests: each session gets its own
     /// offline llmsim runtime rooted at the supplied `cwd`. The session-log
@@ -109,163 +120,162 @@ mod tests {
         }
     }
 
-    /// In-memory ACP client driving the agent over a pair of duplex pipes.
-    struct TestClient {
-        writer: DuplexStream,
-        reader: Lines<BufReader<DuplexStream>>,
-        next_id: i64,
-        /// Notifications collected while waiting for responses.
-        notifications: Vec<Value>,
-        /// How the client answers `session/request_permission` requests.
-        permission_allow: bool,
+    struct SdkClient {
+        cx: ConnectionTo<Agent>,
+        init: InitializeResponse,
     }
 
-    impl TestClient {
-        /// Spawn `serve` against this scripted factory and return a connected
-        /// client. The server task runs until the client's write half drops.
-        fn spawn(config: LlmSimConfig, permission_allow: bool) -> Self {
-            let (client_w, agent_r) = tokio::io::duplex(64 * 1024);
-            let (agent_w, client_r) = tokio::io::duplex(64 * 1024);
-            let factory = Arc::new(ScriptedFactory { config });
-            tokio::spawn(async move {
-                let _ = serve(agent_r, agent_w, factory).await;
-            });
-            Self {
-                writer: client_w,
-                reader: BufReader::new(client_r).lines(),
-                next_id: 0,
-                notifications: Vec::new(),
-                permission_allow,
-            }
-        }
-
-        fn alloc_id(&mut self) -> i64 {
-            let id = self.next_id;
-            self.next_id += 1;
-            id
-        }
-
-        async fn send(&mut self, value: Value) {
-            let line = value.to_string();
-            self.writer.write_all(line.as_bytes()).await.unwrap();
-            self.writer.write_all(b"\n").await.unwrap();
-            self.writer.flush().await.unwrap();
-        }
-
-        async fn next_message(&mut self) -> Value {
-            let line = tokio::time::timeout(Duration::from_secs(15), self.reader.next_line())
+    impl SdkClient {
+        async fn new_session(
+            &self,
+        ) -> agent_client_protocol::Result<agent_client_protocol::ActiveSession<'static, Agent>>
+        {
+            let cwd = tempfile::tempdir().expect("cwd tempdir").keep();
+            self.cx
+                .build_session_from(NewSessionRequest::new(cwd))
+                .block_task()
+                .start_session()
                 .await
-                .expect("timed out waiting for agent message")
-                .expect("read agent line")
-                .expect("agent closed stream");
-            serde_json::from_str(&line).expect("agent line is valid json")
         }
 
-        /// Send a request and pump messages until its response arrives.
-        /// Notifications are buffered; permission requests are auto-answered
-        /// per `permission_allow`.
-        async fn request(&mut self, method: &str, params: Value) -> Value {
-            let id = self.alloc_id();
-            self.send(json!({
-                "jsonrpc": "2.0",
-                "id": id,
-                "method": method,
-                "params": params,
-            }))
-            .await;
-            loop {
-                let message = self.next_message().await;
-                if message.get("id").and_then(Value::as_i64) == Some(id)
-                    && (message.get("result").is_some() || message.get("error").is_some())
-                {
-                    return message;
-                }
-                self.handle_incoming(message).await;
-            }
+        async fn prompt(
+            session: &mut agent_client_protocol::ActiveSession<'static, Agent>,
+            prompt: &str,
+        ) -> agent_client_protocol::Result<PromptRun> {
+            session.send_prompt(prompt)?;
+            collect_prompt_run(session).await
         }
+    }
 
-        async fn handle_incoming(&mut self, message: Value) {
-            let method = message.get("method").and_then(Value::as_str);
-            match method {
-                Some("session/request_permission") => {
-                    let id = message.get("id").cloned().unwrap_or(Value::Null);
-                    let option_id = if self.permission_allow {
-                        "allow"
-                    } else {
-                        "reject"
-                    };
-                    self.send(json!({
-                        "jsonrpc": "2.0",
-                        "id": id,
-                        "result": { "outcome": { "outcome": "selected", "optionId": option_id } },
-                    }))
-                    .await;
-                }
-                Some("session/update") => {
-                    self.notifications.push(message);
-                }
-                _ => {}
-            }
-        }
+    struct PromptRun {
+        stop_reason: agent_client_protocol::schema::StopReason,
+        updates: Vec<Value>,
+    }
 
-        /// Collect every `session/update` whose `sessionUpdate` matches.
-        fn updates_of_kind(&self, kind: &str) -> Vec<Value> {
-            self.notifications
+    impl PromptRun {
+        fn updates_of_kind(&self, kind: &str) -> Vec<&Value> {
+            self.updates
                 .iter()
-                .filter_map(|n| n.get("params"))
-                .filter(|p| {
-                    p.get("update")
-                        .and_then(|u| u.get("sessionUpdate"))
-                        .and_then(Value::as_str)
-                        == Some(kind)
-                })
-                .cloned()
+                .filter(|u| u.get("sessionUpdate").and_then(Value::as_str) == Some(kind))
                 .collect()
         }
 
-        /// All assistant text streamed during the session, concatenated.
         fn assistant_text(&self) -> String {
             self.updates_of_kind("agent_message_chunk")
                 .iter()
-                .filter_map(|p| {
-                    p.get("update")
-                        .and_then(|u| u.get("content"))
+                .filter_map(|u| {
+                    u.get("content")
                         .and_then(|c| c.get("text"))
                         .and_then(Value::as_str)
-                        .map(str::to_string)
                 })
                 .collect::<Vec<_>>()
                 .join("")
         }
+    }
 
-        async fn initialize(&mut self) -> Value {
-            self.request(
-                "initialize",
-                json!({
-                    "protocolVersion": 1,
-                    "clientCapabilities": { "fs": { "readTextFile": true, "writeTextFile": true } },
-                }),
+    async fn with_sdk_client<T, F, Fut>(config: LlmSimConfig, permission_allow: bool, op: F) -> T
+    where
+        F: FnOnce(SdkClient) -> Fut + Send + 'static,
+        Fut: Future<Output = agent_client_protocol::Result<T>> + Send + 'static,
+        T: Send + 'static,
+    {
+        let (client_w, agent_r) = tokio::io::duplex(64 * 1024);
+        let (agent_w, client_r) = tokio::io::duplex(64 * 1024);
+        let factory = Arc::new(ScriptedFactory { config });
+        tokio::spawn(async move {
+            let _ = serve(agent_r, agent_w, factory).await;
+        });
+        let transport = ByteStreams::new(client_w.compat_write(), client_r.compat());
+
+        Client
+            .builder()
+            .name("test-client")
+            .on_receive_request(
+                async move |_params: RequestPermissionRequest, responder, _cx| {
+                    let option_id = if permission_allow { "allow" } else { "reject" };
+                    responder.respond(RequestPermissionResponse::new(
+                        RequestPermissionOutcome::Selected(SelectedPermissionOutcome::new(
+                            option_id,
+                        )),
+                    ))
+                },
+                agent_client_protocol::on_receive_request!(),
             )
+            .connect_with(transport, async move |cx| {
+                let init = cx
+                    .send_request(InitializeRequest::new(protocol::PROTOCOL_VERSION))
+                    .block_task()
+                    .await?;
+                op(SdkClient { cx, init }).await
+            })
             .await
-        }
+            .expect("SDK ACP client run")
+    }
 
-        async fn new_session(&mut self) -> String {
-            let cwd = tempfile::tempdir().expect("cwd tempdir").keep();
-            let response = self
-                .request(
-                    "session/new",
-                    json!({ "cwd": cwd.to_str().unwrap(), "mcpServers": [] }),
-                )
-                .await;
-            let session_id = response["result"]["sessionId"]
-                .as_str()
-                .expect("sessionId in response")
-                .to_string();
-            let update = self.next_message().await;
-            self.handle_incoming(update).await;
-            session_id
+    async fn collect_prompt_run(
+        session: &mut agent_client_protocol::ActiveSession<'static, Agent>,
+    ) -> agent_client_protocol::Result<PromptRun> {
+        let mut updates = Vec::new();
+        loop {
+            match tokio::time::timeout(Duration::from_secs(15), session.read_update()).await {
+                Ok(Ok(SessionMessage::SessionMessage(dispatch))) => {
+                    let message = dispatch.to_untyped_message()?;
+                    if message.method() == "session/update" {
+                        let notification: agent_client_protocol::schema::SessionNotification =
+                            serde_json::from_value(message.params().clone())?;
+                        updates.push(serde_json::to_value(notification.update)?);
+                    }
+                }
+                Ok(Ok(SessionMessage::StopReason(stop_reason))) => {
+                    return Ok(PromptRun {
+                        stop_reason,
+                        updates,
+                    });
+                }
+                Ok(Ok(_)) => {}
+                Ok(Err(err)) => return Err(err),
+                Err(_) => {
+                    return Err(agent_client_protocol::Error::internal_error()
+                        .data("timed out waiting for prompt update"));
+                }
+            }
         }
     }
+
+    async fn collect_available_commands(
+        session: &mut agent_client_protocol::ActiveSession<'static, Agent>,
+    ) -> agent_client_protocol::Result<Vec<Value>> {
+        tokio::time::timeout(Duration::from_secs(15), async {
+            loop {
+                let update = match session.read_update().await {
+                    Ok(SessionMessage::SessionMessage(dispatch)) => {
+                        let message = dispatch.to_untyped_message()?;
+                        if message.method() != "session/update" {
+                            continue;
+                        }
+                        let notification: agent_client_protocol::schema::SessionNotification =
+                            serde_json::from_value(message.params().clone())?;
+                        notification.update
+                    }
+                    Ok(SessionMessage::StopReason(_)) => continue,
+                    Ok(_) => continue,
+                    Err(err) => return Err(err),
+                };
+                if matches!(update, SessionUpdate::AvailableCommandsUpdate(_)) {
+                    return Ok(vec![serde_json::to_value(update)?]);
+                }
+            }
+        })
+        .await
+        .map_err(|_| {
+            agent_client_protocol::Error::internal_error()
+                .data("timed out waiting for available_commands_update")
+        })?
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
+    #[request(method = "does/not/exist", response = Value)]
+    struct UnknownRequest {}
 
     fn fixed(text: &str) -> LlmSimConfig {
         LlmSimConfig::fixed(text)
@@ -273,56 +283,44 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn initialize_advertises_protocol_version_and_capabilities() {
-        let mut client = TestClient::spawn(fixed("hi"), true);
-        let response = client.initialize().await;
-        assert_eq!(response["result"]["protocolVersion"], 1);
-        assert_eq!(
-            response["result"]["agentCapabilities"]["loadSession"],
-            false
-        );
-        assert_eq!(
-            response["result"]["agentCapabilities"]["promptCapabilities"]["embeddedContext"],
-            true
-        );
+        let init =
+            with_sdk_client(fixed("hi"), true, |client| async move { Ok(client.init) }).await;
+        assert_eq!(init.protocol_version, protocol::PROTOCOL_VERSION);
+        assert!(!init.agent_capabilities.load_session);
+        assert!(init.agent_capabilities.prompt_capabilities.embedded_context);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn full_handshake_then_prompt_streams_text_and_ends_turn() {
-        let mut client = TestClient::spawn(fixed("hello from acp"), true);
-        client.initialize().await;
-        let session_id = client.new_session().await;
+        let run = with_sdk_client(fixed("hello from acp"), true, |client| async move {
+            let mut session = client.new_session().await?;
+            SdkClient::prompt(&mut session, "say hi").await
+        })
+        .await;
 
-        let response = client
-            .request(
-                "session/prompt",
-                json!({
-                    "sessionId": session_id,
-                    "prompt": [{ "type": "text", "text": "say hi" }],
-                }),
-            )
-            .await;
-
-        assert_eq!(response["result"]["stopReason"], "end_turn");
+        assert_eq!(
+            run.stop_reason,
+            agent_client_protocol::schema::StopReason::EndTurn
+        );
         assert!(
-            client.assistant_text().contains("hello from acp"),
-            "expected streamed assistant text, got notifications: {:?}",
-            client.notifications
+            run.assistant_text().contains("hello from acp"),
+            "expected streamed assistant text, got updates: {:?}",
+            run.updates
         );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn new_session_advertises_available_commands() {
-        let mut client = TestClient::spawn(fixed("hi"), true);
-        client.initialize().await;
-        client.new_session().await;
-
-        let command_updates = client.updates_of_kind("available_commands_update");
+        let command_updates = with_sdk_client(fixed("hi"), true, |client| async move {
+            let mut session = client.new_session().await?;
+            collect_available_commands(&mut session).await
+        })
+        .await;
         assert!(
             !command_updates.is_empty(),
-            "expected available_commands_update, got: {:?}",
-            client.notifications
+            "expected available_commands_update"
         );
-        let commands = command_updates[0]["update"]["availableCommands"]
+        let commands = command_updates[0]["availableCommands"]
             .as_array()
             .expect("availableCommands array");
         assert!(
@@ -345,72 +343,70 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn slash_system_command_executes_without_model_turn() {
-        let mut client = TestClient::spawn(fixed("model should not run"), true);
-        client.initialize().await;
-        let session_id = client.new_session().await;
+        let run = with_sdk_client(fixed("model should not run"), true, |client| async move {
+            let mut session = client.new_session().await?;
+            let _ = collect_available_commands(&mut session).await?;
+            SdkClient::prompt(&mut session, "/setup status").await
+        })
+        .await;
 
-        let response = client
-            .request(
-                "session/prompt",
-                json!({
-                    "sessionId": session_id,
-                    "prompt": [{ "type": "text", "text": "/setup status" }],
-                }),
-            )
-            .await;
-
-        assert_eq!(response["result"]["stopReason"], "end_turn");
-        let tool_calls = client.updates_of_kind("tool_call");
+        assert_eq!(
+            run.stop_reason,
+            agent_client_protocol::schema::StopReason::EndTurn
+        );
+        let tool_calls = run.updates_of_kind("tool_call");
         assert!(
             tool_calls
                 .iter()
-                .any(|u| u["update"]["title"] == "/setup status"
-                    && u["update"]["rawInput"]["command"] == "setup"),
-            "expected command tool_call, got notifications: {:?}",
-            client.notifications
+                .any(|u| u["title"] == "/setup status" && u["rawInput"]["command"] == "setup"),
+            "expected command tool_call, got updates: {:?}",
+            run.updates
         );
-        let tool_updates = client.updates_of_kind("tool_call_update");
+        let tool_updates = run.updates_of_kind("tool_call_update");
         let completed = tool_updates
             .iter()
-            .find(|u| u["update"]["status"] == "completed")
+            .find(|u| u["status"] == "completed")
             .expect("completed command tool update");
         assert!(
-            completed["update"]["content"][0]["content"]["text"]
+            completed["content"][0]["content"]["text"]
                 .as_str()
                 .is_some_and(|text| text.contains("setup: provider=")),
             "expected setup status in command output, got: {completed:?}"
         );
-        assert_eq!(completed["update"]["rawOutput"]["success"], true);
+        assert_eq!(completed["rawOutput"]["success"], true);
         assert!(
-            !client.assistant_text().contains("model should not run"),
+            !run.assistant_text().contains("model should not run"),
             "slash command should not invoke the model"
         );
-        assert!(
-            client.updates_of_kind("available_commands_update").len() >= 2,
-            "expected command refresh after execution, got: {:?}",
-            client.notifications
-        );
+        assert!(!run.updates_of_kind("available_commands_update").is_empty());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn unknown_method_returns_method_not_found() {
-        let mut client = TestClient::spawn(fixed("hi"), true);
-        client.initialize().await;
-        let response = client.request("does/not/exist", json!({})).await;
-        assert_eq!(response["error"]["code"], -32601);
+        let err = with_sdk_client(fixed("hi"), true, |client| async move {
+            match client.cx.send_request(UnknownRequest {}).block_task().await {
+                Ok(_) => panic!("unknown method unexpectedly succeeded"),
+                Err(err) => Ok(err),
+            }
+        })
+        .await;
+        assert_eq!(err.code, agent_client_protocol::ErrorCode::MethodNotFound);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn prompt_to_unknown_session_is_invalid_params() {
-        let mut client = TestClient::spawn(fixed("hi"), true);
-        client.initialize().await;
-        let response = client
-            .request(
-                "session/prompt",
-                json!({ "sessionId": "session_does_not_exist", "prompt": [] }),
-            )
-            .await;
-        assert_eq!(response["error"]["code"], -32602);
+        let err = with_sdk_client(fixed("hi"), true, |client| async move {
+            let request = PromptRequest::new(
+                SessionId::new("session_does_not_exist"),
+                vec!["hello".to_string().into()],
+            );
+            match client.cx.send_request(request).block_task().await {
+                Ok(_) => panic!("unknown session unexpectedly succeeded"),
+                Err(err) => Ok(err),
+            }
+        })
+        .await;
+        assert_eq!(err.code, agent_client_protocol::ErrorCode::InvalidParams);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -427,38 +423,34 @@ mod tests {
             }]),
             SimTurn::Assistant("tool done".to_string()),
         ]);
-        let mut client = TestClient::spawn(config, true);
-        client.initialize().await;
-        let session_id = client.new_session().await;
+        let run = with_sdk_client(config, true, |client| async move {
+            let mut session = client.new_session().await?;
+            let _ = collect_available_commands(&mut session).await?;
+            SdkClient::prompt(&mut session, "run the tool").await
+        })
+        .await;
 
-        let response = client
-            .request(
-                "session/prompt",
-                json!({
-                    "sessionId": session_id,
-                    "prompt": [{ "type": "text", "text": "run the tool" }],
-                }),
-            )
-            .await;
-
-        assert_eq!(response["result"]["stopReason"], "end_turn");
-        let tool_calls = client.updates_of_kind("tool_call");
+        assert_eq!(
+            run.stop_reason,
+            agent_client_protocol::schema::StopReason::EndTurn
+        );
+        let tool_calls = run.updates_of_kind("tool_call");
         assert!(
             !tool_calls.is_empty(),
             "expected a tool_call update, got: {:?}",
-            client.notifications
+            run.updates
         );
         assert_eq!(
-            tool_calls[0]["update"]["kind"], "execute",
+            tool_calls[0]["kind"], "execute",
             "bash should map to execute kind"
         );
-        let updates = client.updates_of_kind("tool_call_update");
+        let updates = run.updates_of_kind("tool_call_update");
         assert!(
-            updates.iter().any(|u| u["update"]["status"] == "completed"),
+            updates.iter().any(|u| u["status"] == "completed"),
             "expected a completed tool_call_update, got: {:?}",
-            client.notifications
+            run.updates
         );
-        assert!(client.assistant_text().contains("tool done"));
+        assert!(run.assistant_text().contains("tool done"));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -476,27 +468,20 @@ mod tests {
             }]),
             SimTurn::Assistant("planned".to_string()),
         ]);
-        let mut client = TestClient::spawn(config, true);
-        client.initialize().await;
-        let session_id = client.new_session().await;
+        let run = with_sdk_client(config, true, |client| async move {
+            let mut session = client.new_session().await?;
+            let _ = collect_available_commands(&mut session).await?;
+            SdkClient::prompt(&mut session, "make a plan").await
+        })
+        .await;
 
-        client
-            .request(
-                "session/prompt",
-                json!({
-                    "sessionId": session_id,
-                    "prompt": [{ "type": "text", "text": "make a plan" }],
-                }),
-            )
-            .await;
-
-        let plans = client.updates_of_kind("plan");
+        let plans = run.updates_of_kind("plan");
         assert!(
             !plans.is_empty(),
             "expected a plan update, got: {:?}",
-            client.notifications
+            run.updates
         );
-        let entries = plans[0]["update"]["entries"].as_array().unwrap();
+        let entries = plans[0]["entries"].as_array().unwrap();
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0]["content"], "step one");
         assert_eq!(entries[0]["status"], "in_progress");
@@ -561,7 +546,7 @@ mod tests {
         let cwd = tempfile::tempdir().expect("cwd tempdir").keep();
         send(
             &mut client_w,
-            json!({ "jsonrpc": "2.0", "id": 1, "method": "session/new", "params": { "cwd": cwd.to_str().unwrap() } }),
+            json!({ "jsonrpc": "2.0", "id": 1, "method": "session/new", "params": { "cwd": cwd.to_str().unwrap(), "mcpServers": [] } }),
         )
         .await;
         let session_id = await_id(&mut reader, 1).await["result"]["sessionId"]

--- a/src/acp/protocol.rs
+++ b/src/acp/protocol.rs
@@ -1,351 +1,52 @@
-//! Wire types for the Agent Client Protocol (ACP).
+//! ACP schema types sourced from the upstream Rust SDK.
 //!
-//! ACP is the JSON-RPC 2.0 protocol spoken between a code editor (the
-//! *client*, e.g. Zed) and a coding agent (yolop, the *agent*) over stdio,
-//! one JSON object per line (newline-delimited). These structs map 1:1 to
-//! the schema published at <https://agentclientprotocol.com>. Only the
-//! subset yolop implements is modelled here; unknown fields on inbound
-//! messages are ignored so newer clients keep working.
-//!
-//! Field casing follows the spec exactly: object keys are camelCase and the
-//! `sessionUpdate` / `type` / `kind` / `status` discriminators are
-//! snake_case. The matching `#[serde(rename_all = ...)]` attributes encode
-//! that, so the Rust side stays idiomatic snake_case.
+//! yolop still owns its runtime bridge and server loop, but the wire data model
+//! comes from `agent-client-protocol` so schema changes are not mirrored by hand.
 
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
+pub use agent_client_protocol::schema::{
+    AgentCapabilities, AuthenticateRequest as AuthenticateParams,
+    AuthenticateResponse as AuthenticateResult, AvailableCommand, AvailableCommandInput,
+    AvailableCommandsUpdate, CancelNotification, Content, ContentBlock, ContentChunk,
+    InitializeRequest as InitializeParams, InitializeResponse as InitializeResult,
+    NewSessionRequest as NewSessionParams, NewSessionResponse as NewSessionResult,
+    PermissionOption, PermissionOptionKind, Plan, PlanEntry, PlanEntryPriority, PlanEntryStatus,
+    PromptCapabilities, PromptRequest as PromptParams, PromptResponse as PromptResult,
+    ProtocolVersion, RequestPermissionOutcome as PermissionOutcome,
+    RequestPermissionRequest as RequestPermissionParams, SessionNotification, SessionUpdate,
+    StopReason, TextContent, ToolCall, ToolCallContent, ToolCallStatus, ToolCallUpdate,
+    ToolCallUpdateFields, ToolKind, UnstructuredCommandInput,
+};
+use serde_json::{Map, Value};
 
-/// Protocol version yolop implements. ACP versions are integers; v1 is the
-/// current stable major. We echo back the client's requested version when it
-/// is one we support, and otherwise advertise this.
-pub const PROTOCOL_VERSION: i64 = 1;
+pub const PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V1;
 
-// ---------- initialize ----------
-
-/// Inbound `initialize` params. yolop only needs the requested protocol
-/// version; the client's capabilities (`clientCapabilities`, `clientInfo`)
-/// are accepted and ignored — serde drops unknown fields by default — because
-/// yolop's runtime touches the host disk directly rather than routing file
-/// ops back through the client.
-#[derive(Debug, Clone, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct InitializeParams {
-    #[serde(default)]
-    pub protocol_version: Option<i64>,
+pub fn text_block(text: impl Into<String>) -> ContentBlock {
+    ContentBlock::Text(TextContent::new(text))
 }
 
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct InitializeResult {
-    pub protocol_version: i64,
-    pub agent_capabilities: AgentCapabilities,
-    pub auth_methods: Vec<AuthMethod>,
+pub fn text_chunk(text: impl Into<String>) -> ContentChunk {
+    ContentChunk::new(text_block(text))
 }
 
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AgentCapabilities {
-    pub load_session: bool,
-    pub prompt_capabilities: PromptCapabilities,
-    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
-    pub meta: Option<Value>,
+pub fn content(text: impl Into<String>) -> ToolCallContent {
+    ToolCallContent::Content(Content::new(text_block(text)))
 }
 
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PromptCapabilities {
-    pub image: bool,
-    pub audio: bool,
-    pub embedded_context: bool,
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AuthMethod {
-    pub id: String,
-    pub name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-}
-
-// ---------- session/new ----------
-
-/// Inbound `session/new` params. yolop uses `cwd` to root the new runtime;
-/// `mcpServers` and `additionalDirectories` are accepted and ignored (no MCP
-/// pass-through yet — serde drops unmodelled fields).
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct NewSessionParams {
-    pub cwd: String,
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct NewSessionResult {
-    pub session_id: String,
-}
-
-// ---------- session/prompt ----------
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PromptParams {
-    pub session_id: String,
-    #[serde(default)]
-    pub prompt: Vec<Value>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PromptResult {
-    pub stop_reason: StopReason,
-}
-
-/// Why a prompt turn ended. Mirrors ACP's `StopReason`. yolop currently only
-/// resolves `EndTurn` and `Cancelled`; the token-limit and refusal variants
-/// exist to model the wire enum completely (the runtime doesn't surface those
-/// outcomes distinctly yet).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-#[allow(dead_code)]
-pub enum StopReason {
-    EndTurn,
-    MaxTokens,
-    MaxTurnRequests,
-    Refusal,
-    Cancelled,
-}
-
-// ---------- session/cancel ----------
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CancelParams {
-    pub session_id: String,
-}
-
-// ---------- session/update notification ----------
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SessionNotification {
-    pub session_id: String,
-    pub update: SessionUpdate,
-}
-
-/// A streaming update emitted mid-turn. The `sessionUpdate` discriminator
-/// selects the variant.
-#[derive(Debug, Clone, PartialEq, Serialize)]
-#[serde(tag = "sessionUpdate", rename_all = "snake_case")]
-pub enum SessionUpdate {
-    AgentMessageChunk {
-        content: ContentBlock,
-    },
-    AgentThoughtChunk {
-        content: ContentBlock,
-    },
-    ToolCall {
-        #[serde(rename = "toolCallId")]
-        tool_call_id: String,
-        title: String,
-        kind: ToolKind,
-        status: ToolCallStatus,
-        #[serde(rename = "rawInput", skip_serializing_if = "Option::is_none")]
-        raw_input: Option<Value>,
-        #[serde(skip_serializing_if = "Vec::is_empty")]
-        content: Vec<ToolCallContent>,
-    },
-    ToolCallUpdate {
-        #[serde(rename = "toolCallId")]
-        tool_call_id: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        status: Option<ToolCallStatus>,
-        #[serde(skip_serializing_if = "Vec::is_empty")]
-        content: Vec<ToolCallContent>,
-        #[serde(rename = "rawOutput", skip_serializing_if = "Option::is_none")]
-        raw_output: Option<Value>,
-    },
-    Plan {
-        entries: Vec<PlanEntry>,
-    },
-    AvailableCommandsUpdate {
-        #[serde(rename = "availableCommands")]
-        available_commands: Vec<AvailableCommand>,
-        #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
-        meta: Option<Value>,
-    },
-}
-
-/// A content block. yolop only ever emits text blocks; the spec also defines
-/// image/audio/resource blocks.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub enum ContentBlock {
-    Text { text: String },
-}
-
-impl ContentBlock {
-    pub fn text(text: impl Into<String>) -> Self {
-        Self::Text { text: text.into() }
+pub fn meta(value: Value) -> Option<Map<String, Value>> {
+    match value {
+        Value::Object(map) => Some(map),
+        _ => None,
     }
-}
-
-/// Categorises a tool call so editors can pick an icon/affordance. The full
-/// ACP vocabulary is modelled; yolop's tool-name mapping doesn't currently
-/// emit every variant.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-#[allow(dead_code)]
-pub enum ToolKind {
-    Read,
-    Edit,
-    Delete,
-    Move,
-    Search,
-    Execute,
-    Think,
-    Fetch,
-    Other,
-}
-
-/// Lifecycle status of a tool call. yolop emits `InProgress` then
-/// `Completed`/`Failed`; `Pending` rounds out the wire enum.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-#[allow(dead_code)]
-pub enum ToolCallStatus {
-    Pending,
-    InProgress,
-    Completed,
-    Failed,
-}
-
-/// Content attached to a tool call. yolop emits the `content` variant
-/// (wrapping a text block); the `diff` variant is modelled for completeness
-/// and future structured-diff support (the spec also defines `terminal`).
-#[derive(Debug, Clone, PartialEq, Serialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-#[allow(dead_code)]
-pub enum ToolCallContent {
-    Content { content: ContentBlock },
-    Diff(ToolCallDiff),
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ToolCallDiff {
-    pub path: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub old_text: Option<String>,
-    pub new_text: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PlanEntry {
-    pub content: String,
-    pub priority: PlanPriority,
-    pub status: PlanStatus,
-}
-
-/// Plan-entry priority. yolop's todo tool has no priority concept, so it
-/// always emits `Medium`; the other variants exist to model the wire enum
-/// completely.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-#[allow(dead_code)]
-pub enum PlanPriority {
-    High,
-    Medium,
-    Low,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum PlanStatus {
-    Pending,
-    InProgress,
-    Completed,
-}
-
-// ---------- available_commands_update ----------
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AvailableCommand {
-    pub name: String,
-    pub description: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub input: Option<AvailableCommandInput>,
-    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
-    pub meta: Option<Value>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AvailableCommandInput {
-    pub hint: String,
-}
-
-// ---------- session/request_permission ----------
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct RequestPermissionParams {
-    pub session_id: String,
-    pub tool_call: Value,
-    pub options: Vec<PermissionOption>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PermissionOption {
-    pub option_id: String,
-    pub name: String,
-    pub kind: PermissionOptionKind,
-}
-
-/// Kinds of permission option an agent can offer. yolop offers a single
-/// allow/reject pair (`AllowOnce`/`RejectOnce`); the "always" variants exist
-/// to model the wire enum completely.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-#[allow(dead_code)]
-pub enum PermissionOptionKind {
-    AllowOnce,
-    AllowAlways,
-    RejectOnce,
-    RejectAlways,
-}
-
-/// Client's answer to a permission request. The `outcome` discriminator is
-/// either `selected` (with the chosen `optionId`) or `cancelled`.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct RequestPermissionResult {
-    pub outcome: PermissionOutcome,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "outcome", rename_all = "snake_case")]
-pub enum PermissionOutcome {
-    Selected {
-        #[serde(rename = "optionId")]
-        option_id: String,
-    },
-    Cancelled,
 }
 
 /// Extract the concatenated plain text from an inbound prompt's content
 /// blocks, ignoring non-text blocks (images, resources). Newline-joined so a
 /// multi-block prompt reads naturally.
-pub fn prompt_text(blocks: &[Value]) -> String {
+pub fn prompt_text(blocks: &[ContentBlock]) -> String {
     let mut parts = Vec::new();
     for block in blocks {
-        if block.get("type").and_then(Value::as_str) == Some("text")
-            && let Some(text) = block.get("text").and_then(Value::as_str)
-        {
-            parts.push(text.to_string());
+        if let ContentBlock::Text(text) = block {
+            parts.push(text.text.clone());
         }
     }
     parts.join("\n")
@@ -357,20 +58,12 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn initialize_result_serializes_camel_case() {
-        let result = InitializeResult {
-            protocol_version: PROTOCOL_VERSION,
-            agent_capabilities: AgentCapabilities {
-                load_session: false,
-                prompt_capabilities: PromptCapabilities {
-                    image: false,
-                    audio: false,
-                    embedded_context: true,
-                },
-                meta: None,
-            },
-            auth_methods: vec![],
-        };
+    fn sdk_initialize_result_serializes_camel_case() {
+        let result = InitializeResult::new(PROTOCOL_VERSION).agent_capabilities(
+            AgentCapabilities::new()
+                .load_session(false)
+                .prompt_capabilities(PromptCapabilities::new().embedded_context(true)),
+        );
         let v = serde_json::to_value(&result).unwrap();
         assert_eq!(v["protocolVersion"], 1);
         assert_eq!(v["agentCapabilities"]["loadSession"], false);
@@ -382,10 +75,9 @@ mod tests {
     }
 
     #[test]
-    fn agent_message_chunk_uses_snake_case_discriminator() {
-        let update = SessionUpdate::AgentMessageChunk {
-            content: ContentBlock::text("hi"),
-        };
+    fn sdk_message_chunk_uses_snake_case_discriminator() {
+        let update =
+            agent_client_protocol::schema::SessionUpdate::AgentMessageChunk(text_chunk("hi"));
         let v = serde_json::to_value(&update).unwrap();
         assert_eq!(v["sessionUpdate"], "agent_message_chunk");
         assert_eq!(v["content"]["type"], "text");
@@ -393,153 +85,30 @@ mod tests {
     }
 
     #[test]
-    fn tool_call_serializes_camel_case_ids_and_snake_case_enums() {
-        let update = SessionUpdate::ToolCall {
-            tool_call_id: "call_1".into(),
-            title: "Run bash".into(),
-            kind: ToolKind::Execute,
-            status: ToolCallStatus::InProgress,
-            raw_input: Some(json!({ "command": "ls" })),
-            content: vec![],
-        };
-        let v = serde_json::to_value(&update).unwrap();
-        assert_eq!(v["sessionUpdate"], "tool_call");
-        assert_eq!(v["toolCallId"], "call_1");
-        assert_eq!(v["kind"], "execute");
-        assert_eq!(v["status"], "in_progress");
-        assert_eq!(v["rawInput"]["command"], "ls");
-        // Empty content is omitted from the wire form.
-        assert!(v.get("content").is_none());
-    }
-
-    #[test]
-    fn tool_call_update_omits_empty_optionals() {
-        let update = SessionUpdate::ToolCallUpdate {
-            tool_call_id: "call_1".into(),
-            status: Some(ToolCallStatus::Completed),
-            content: vec![ToolCallContent::Content {
-                content: ContentBlock::text("done"),
-            }],
-            raw_output: None,
-        };
-        let v = serde_json::to_value(&update).unwrap();
-        assert_eq!(v["sessionUpdate"], "tool_call_update");
-        assert_eq!(v["status"], "completed");
-        assert_eq!(v["content"][0]["type"], "content");
-        assert_eq!(v["content"][0]["content"]["text"], "done");
-        assert!(v.get("rawOutput").is_none());
-    }
-
-    #[test]
-    fn diff_content_serializes_camel_case_text_fields() {
-        let content = ToolCallContent::Diff(ToolCallDiff {
-            path: "src/x.rs".into(),
-            old_text: Some("a".into()),
-            new_text: "b".into(),
-        });
-        let v = serde_json::to_value(&content).unwrap();
-        assert_eq!(v["type"], "diff");
-        assert_eq!(v["path"], "src/x.rs");
-        assert_eq!(v["oldText"], "a");
-        assert_eq!(v["newText"], "b");
-    }
-
-    #[test]
-    fn plan_entry_enums_are_snake_case() {
-        let entry = PlanEntry {
-            content: "do it".into(),
-            priority: PlanPriority::Medium,
-            status: PlanStatus::InProgress,
-        };
-        let v = serde_json::to_value(&entry).unwrap();
-        assert_eq!(v["priority"], "medium");
-        assert_eq!(v["status"], "in_progress");
-    }
-
-    #[test]
-    fn available_commands_update_serializes_command_list() {
-        let update = SessionUpdate::AvailableCommandsUpdate {
-            available_commands: vec![AvailableCommand {
-                name: "setup".into(),
-                description: "Configure provider.".into(),
-                input: Some(AvailableCommandInput {
-                    hint: "provider, token, model".into(),
-                }),
-                meta: Some(json!({
-                    "yolop.dev/command": {
-                        "args": [
-                            {
-                                "name": "action",
-                                "suggestions": ["status", "provider openai"]
-                            }
-                        ]
-                    }
-                })),
-            }],
-            meta: Some(json!({ "yolop.dev/acp": { "argSuggestions": true } })),
-        };
-        let v = serde_json::to_value(&update).unwrap();
-        assert_eq!(v["sessionUpdate"], "available_commands_update");
-        assert_eq!(v["availableCommands"][0]["name"], "setup");
-        assert_eq!(
-            v["availableCommands"][0]["input"]["hint"],
-            "provider, token, model"
-        );
-        assert_eq!(
-            v["availableCommands"][0]["_meta"]["yolop.dev/command"]["args"][0]["suggestions"][0],
-            "status"
-        );
-        assert_eq!(v["_meta"]["yolop.dev/acp"]["argSuggestions"], true);
-    }
-
-    #[test]
-    fn stop_reason_serializes_snake_case() {
-        assert_eq!(
-            serde_json::to_value(StopReason::EndTurn).unwrap(),
-            json!("end_turn")
-        );
-        assert_eq!(
-            serde_json::to_value(StopReason::MaxTurnRequests).unwrap(),
-            json!("max_turn_requests")
-        );
-    }
-
-    #[test]
-    fn initialize_params_tolerate_missing_and_unknown_fields() {
-        // Empty params: protocol version absent.
-        let empty: InitializeParams = serde_json::from_value(json!({})).unwrap();
-        assert_eq!(empty.protocol_version, None);
-        // Client capabilities and clientInfo are accepted and ignored.
-        let full: InitializeParams = serde_json::from_value(json!({
-            "protocolVersion": 1,
-            "clientCapabilities": { "fs": { "readTextFile": true, "writeTextFile": true } },
-            "clientInfo": { "name": "zed" }
-        }))
-        .unwrap();
-        assert_eq!(full.protocol_version, Some(1));
-    }
-
-    #[test]
     fn prompt_text_concatenates_text_blocks_only() {
         let blocks = vec![
-            json!({ "type": "text", "text": "hello" }),
-            json!({ "type": "image", "data": "..." }),
-            json!({ "type": "text", "text": "world" }),
+            text_block("hello"),
+            ContentBlock::Image(agent_client_protocol::schema::ImageContent::new(
+                "image/png",
+                "...",
+            )),
+            text_block("world"),
         ];
         assert_eq!(prompt_text(&blocks), "hello\nworld");
     }
 
     #[test]
     fn permission_outcome_parses_selected_and_cancelled() {
-        let selected: RequestPermissionResult = serde_json::from_value(
-            json!({ "outcome": { "outcome": "selected", "optionId": "ok" } }),
-        )
-        .unwrap();
+        let selected: agent_client_protocol::schema::RequestPermissionResponse =
+            serde_json::from_value(
+                json!({ "outcome": { "outcome": "selected", "optionId": "ok" } }),
+            )
+            .unwrap();
         match selected.outcome {
-            PermissionOutcome::Selected { option_id } => assert_eq!(option_id, "ok"),
+            PermissionOutcome::Selected(outcome) => assert_eq!(outcome.option_id.to_string(), "ok"),
             _ => panic!("expected selected"),
         }
-        let cancelled: RequestPermissionResult =
+        let cancelled: agent_client_protocol::schema::RequestPermissionResponse =
             serde_json::from_value(json!({ "outcome": { "outcome": "cancelled" } })).unwrap();
         assert!(matches!(cancelled.outcome, PermissionOutcome::Cancelled));
     }

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -1,21 +1,19 @@
-//! ACP server: the JSON-RPC peer and request dispatch.
+//! ACP server: SDK transport/dispatch plus yolop session execution.
 //!
 //! yolop acts as an ACP *agent*: it reads newline-delimited JSON-RPC 2.0
-//! messages from a client (an editor such as Zed) and drives the everruns
-//! runtime in response. [`serve`] owns the read loop and is generic over the
-//! byte streams and a [`RuntimeFactory`], so the production binary wires it to
-//! real stdin/stdout while tests drive it over in-memory pipes with a scripted
+//! messages from a client (an editor such as Zed) through the upstream ACP SDK
+//! and drives the everruns runtime in response. [`serve`] is generic over byte
+//! streams and a [`RuntimeFactory`], so the production binary wires it to real
+//! stdin/stdout while tests drive it over in-memory pipes with a scripted
 //! runtime.
 //!
 //! Concurrency model:
-//!   * A single writer task serialises every outbound line (responses,
-//!     notifications, and agent→client requests) so writes never interleave.
-//!   * The read loop never blocks on slow work — `session/prompt` runs in its
-//!     own task — so `session/cancel` and permission responses keep flowing
-//!     while a turn is in progress.
-//!   * Agent→client requests (`session/request_permission`) are correlated by
-//!     id through a pending map the read loop resolves when the response
-//!     arrives.
+//!   * The SDK serialises outbound lines, dispatches typed requests, and
+//!     correlates responses.
+//!   * `session/prompt` runs in its own Tokio task, so `session/cancel` and
+//!     permission responses keep flowing while a turn is in progress.
+//!   * Agent→client requests (`session/request_permission`) use the SDK's typed
+//!     request API.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -24,29 +22,28 @@ use std::sync::Mutex as StdMutex;
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::time::Duration;
 
+use agent_client_protocol::{Agent, Client, ConnectionTo, Lines, Responder};
 use anyhow::Result;
 use async_trait::async_trait;
 use everruns_core::command::{CommandDescriptor, CommandSource, ExecuteCommandRequest};
+use futures::{AsyncBufReadExt, AsyncWriteExt, StreamExt};
 use serde_json::{Value, json};
-use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{mpsc, oneshot};
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use crate::approval::{ApprovalGate, ApprovalRequest};
 use crate::runtime::{BuiltRuntime, ModelState, RuntimeHandles};
 
 use super::bridge::Translator;
 use super::protocol::{
-    self, AgentCapabilities, AvailableCommand, AvailableCommandInput, InitializeParams,
-    InitializeResult, NewSessionParams, NewSessionResult, PermissionOption, PermissionOptionKind,
-    PermissionOutcome, PromptCapabilities, PromptParams, PromptResult, RequestPermissionParams,
-    RequestPermissionResult, SessionNotification, SessionUpdate, StopReason, ToolCallContent,
-    ToolCallStatus, ToolKind,
+    self, AgentCapabilities, AuthenticateParams, AuthenticateResult, AvailableCommand,
+    AvailableCommandInput, InitializeParams, InitializeResult, NewSessionParams, NewSessionResult,
+    PermissionOption, PermissionOptionKind, PermissionOutcome, PromptCapabilities, PromptParams,
+    PromptResult, RequestPermissionParams, SessionNotification, SessionUpdate, StopReason,
+    ToolCall, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind,
+    UnstructuredCommandInput,
 };
-
-/// JSON-RPC error codes used in agent responses.
-const METHOD_NOT_FOUND: i64 = -32601;
-const INVALID_PARAMS: i64 = -32602;
-const INTERNAL_ERROR: i64 = -32603;
 
 /// How often the prompt loop wakes to check whether the turn task finished,
 /// in case the final event was already drained from the broadcast.
@@ -59,98 +56,17 @@ pub trait RuntimeFactory: Send + Sync + 'static {
     async fn build(&self, cwd: PathBuf, gate: Arc<ApprovalGate>) -> Result<BuiltRuntime>;
 }
 
-struct RpcError {
-    code: i64,
-    message: String,
-}
-
-impl RpcError {
-    fn new(code: i64, message: impl Into<String>) -> Self {
-        Self {
-            code,
-            message: message.into(),
-        }
-    }
-}
-
-/// The JSON-RPC peer: a serialised outbound channel plus a pending-request
-/// table for agent→client calls.
+/// SDK connection wrapper plus yolop-local ids for synthetic command tool calls.
 struct Peer {
-    out: mpsc::UnboundedSender<String>,
-    next_id: AtomicI64,
-    pending: StdMutex<HashMap<i64, oneshot::Sender<std::result::Result<Value, RpcError>>>>,
+    cx: ConnectionTo<Client>,
+    next_id: Arc<AtomicI64>,
 }
 
 impl Peer {
-    fn send_value(&self, value: Value) {
-        // Compact serialization keeps each message on a single line, as the
-        // ndjson transport requires.
-        let _ = self.out.send(value.to_string());
-    }
-
-    fn respond_ok(&self, id: Value, result: Value) {
-        self.send_value(json!({ "jsonrpc": "2.0", "id": id, "result": result }));
-    }
-
-    fn respond_err(&self, id: Value, code: i64, message: &str) {
-        self.send_value(json!({
-            "jsonrpc": "2.0",
-            "id": id,
-            "error": { "code": code, "message": message },
-        }));
-    }
-
-    fn notify(&self, method: &str, params: Value) {
-        self.send_value(json!({ "jsonrpc": "2.0", "method": method, "params": params }));
-    }
-
     fn session_update(&self, session_id: &str, update: SessionUpdate) {
-        let params = serde_json::to_value(SessionNotification {
-            session_id: session_id.to_string(),
-            update,
-        })
-        .expect("session notification serializes");
-        self.notify("session/update", params);
-    }
-
-    /// Issue an agent→client request and await its response. Fails fast (rather
-    /// than awaiting forever) if the outbound channel is already closed — the
-    /// writer task has exited, so no response can ever arrive.
-    async fn request(&self, method: &str, params: Value) -> std::result::Result<Value, RpcError> {
-        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
-        let (tx, rx) = oneshot::channel();
-        self.pending.lock().unwrap().insert(id, tx);
-        let line = json!({
-            "jsonrpc": "2.0",
-            "id": id,
-            "method": method,
-            "params": params,
-        })
-        .to_string();
-        if self.out.send(line).is_err() {
-            // Connection gone: don't leak the pending entry or block on a
-            // response that will never come.
-            self.pending.lock().unwrap().remove(&id);
-            return Err(RpcError::new(INTERNAL_ERROR, "connection closed"));
-        }
-        rx.await
-            .unwrap_or_else(|_| Err(RpcError::new(INTERNAL_ERROR, "connection closed")))
-    }
-
-    /// Resolve a pending agent→client request from an inbound response.
-    fn route_response(&self, id: i64, result: std::result::Result<Value, RpcError>) {
-        if let Some(tx) = self.pending.lock().unwrap().remove(&id) {
-            let _ = tx.send(result);
-        }
-    }
-
-    /// Fail every in-flight agent→client request. Called once the connection
-    /// ends so awaiting tasks (e.g. a forwarded `session/request_permission`)
-    /// unwind instead of deadlocking and holding the server alive.
-    fn fail_all_pending(&self) {
-        let drained: Vec<_> = self.pending.lock().unwrap().drain().collect();
-        for (_, tx) in drained {
-            let _ = tx.send(Err(RpcError::new(INTERNAL_ERROR, "connection closed")));
+        let notification = SessionNotification::new(session_id.to_string(), update);
+        if let Err(err) = self.cx.send_notification(notification) {
+            tracing::warn!(%err, "acp: failed to send session update");
         }
     }
 }
@@ -182,7 +98,6 @@ impl Session {
 }
 
 struct Server<F: RuntimeFactory> {
-    peer: Arc<Peer>,
     factory: Arc<F>,
     sessions: StdMutex<HashMap<String, Arc<Session>>>,
 }
@@ -194,202 +109,189 @@ impl<F: RuntimeFactory> Server<F> {
 }
 
 /// Run the ACP agent over the given byte streams until the client closes its
-/// end (EOF on `reader`). Returns once the read loop ends.
+/// end (EOF on `reader`). Returns once the SDK connection winds down.
 pub async fn serve<R, W, F>(reader: R, writer: W, factory: Arc<F>) -> Result<()>
 where
     R: AsyncRead + Unpin + Send + 'static,
     W: AsyncWrite + Unpin + Send + 'static,
     F: RuntimeFactory,
 {
-    // Single writer task: every outbound line funnels through here so
-    // notifications, responses, and requests never interleave on the wire.
-    let (out_tx, mut out_rx) = mpsc::unbounded_channel::<String>();
-    let writer_task = tokio::spawn(async move {
-        let mut writer = writer;
-        while let Some(line) = out_rx.recv().await {
-            if writer.write_all(line.as_bytes()).await.is_err()
-                || writer.write_all(b"\n").await.is_err()
-                || writer.flush().await.is_err()
-            {
-                break;
-            }
-        }
-    });
-
     let server = Arc::new(Server {
-        peer: Arc::new(Peer {
-            out: out_tx,
-            next_id: AtomicI64::new(1),
-            pending: StdMutex::new(HashMap::new()),
-        }),
         factory,
         sessions: StdMutex::new(HashMap::new()),
     });
-
-    let mut lines = BufReader::new(reader).lines();
-    let read_result = loop {
-        match lines.next_line().await {
-            Ok(Some(line)) => {
-                if line.trim().is_empty() {
-                    continue;
-                }
-                match serde_json::from_str::<Value>(&line) {
-                    Ok(message) => dispatch(server.clone(), message),
-                    Err(err) => tracing::warn!(%err, "acp: dropping unparseable line"),
-                }
-            }
-            Ok(None) => break Ok(()),
-            Err(err) => break Err(err),
-        }
-    };
-
-    // Connection ended: fail any in-flight agent→client requests so awaiting
-    // tasks (a forwarded permission prompt, a streaming turn) unwind instead of
-    // deadlocking and holding the writer task — and thus `serve` — open.
-    server.peer.fail_all_pending();
-    drop(server);
-    let _ = writer_task.await;
-    read_result.map_err(Into::into)
-}
-
-/// Classify an inbound message and route it. Requests are handled in spawned
-/// tasks so the read loop keeps draining (essential for cancel + permission
-/// flows during a long prompt). Responses resolve pending agent→client calls.
-fn dispatch<F: RuntimeFactory>(server: Arc<Server<F>>, message: Value) {
-    let has_method = message.get("method").and_then(Value::as_str).is_some();
-    if has_method {
-        let id = message.get("id").cloned();
-        match id {
-            Some(id) if !id.is_null() => {
-                tokio::spawn(handle_request(server, id, message));
-            }
-            _ => handle_notification(&server, &message),
-        }
-        return;
-    }
-    // Otherwise it is a response to one of our outbound requests.
-    if let Some(id) = message.get("id").and_then(Value::as_i64) {
-        if let Some(error) = message.get("error") {
-            let code = error
-                .get("code")
-                .and_then(Value::as_i64)
-                .unwrap_or(INTERNAL_ERROR);
-            let msg = error
-                .get("message")
-                .and_then(Value::as_str)
-                .unwrap_or("request failed")
-                .to_string();
-            server
-                .peer
-                .route_response(id, Err(RpcError::new(code, msg)));
-        } else {
-            let result = message.get("result").cloned().unwrap_or(Value::Null);
-            server.peer.route_response(id, Ok(result));
-        }
-    }
-}
-
-async fn handle_request<F: RuntimeFactory>(server: Arc<Server<F>>, id: Value, message: Value) {
-    let method = message
-        .get("method")
-        .and_then(Value::as_str)
-        .unwrap_or_default()
-        .to_string();
-    let params = message.get("params").cloned().unwrap_or(Value::Null);
-
-    if method == "session/new" {
-        match handle_new_session(&server, params).await {
-            Ok(result) => {
-                let session_id = result
-                    .get("sessionId")
-                    .and_then(Value::as_str)
-                    .map(str::to_string);
-                server.peer.respond_ok(id, result);
-                if let Some(session_id) = session_id
-                    && let Some(session) = server.session(&session_id)
-                {
-                    let commands = session.commands.lock().unwrap().clone();
-                    notify_available_commands(&server.peer, &session_id, &commands);
+    let next_tool_id = Arc::new(AtomicI64::new(1));
+    let (eof_tx, eof_rx) = oneshot::channel::<()>();
+    let incoming_lines = futures::io::BufReader::new(reader.compat()).lines();
+    let incoming = futures::stream::unfold(
+        (incoming_lines, Some(eof_tx)),
+        |(mut lines, mut eof_tx)| async move {
+            match lines.next().await {
+                Some(line) => Some((line, (lines, eof_tx))),
+                None => {
+                    if let Some(tx) = eof_tx.take() {
+                        let _ = tx.send(());
+                    }
+                    None
                 }
             }
-            Err(err) => server.peer.respond_err(id, err.code, &err.message),
+        },
+    );
+    let outgoing = futures::sink::unfold(
+        writer.compat_write(),
+        async move |mut writer, line: String| {
+            writer.write_all(line.as_bytes()).await?;
+            writer.write_all(b"\n").await?;
+            writer.flush().await?;
+            Ok::<_, std::io::Error>(writer)
+        },
+    );
+    let transport = Lines::new(outgoing, incoming);
+
+    let result = Agent
+        .builder()
+        .name("yolop")
+        .on_receive_request(
+            async |params: InitializeParams, responder, _cx| {
+                responder.respond(handle_initialize(params))
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .on_receive_request(
+            async |_params: AuthenticateParams, responder, _cx| {
+                responder.respond(AuthenticateResult::new())
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let server = server.clone();
+                let next_tool_id = next_tool_id.clone();
+                async move |params: NewSessionParams, responder, cx| {
+                    let peer = Arc::new(Peer {
+                        cx: cx.clone(),
+                        next_id: next_tool_id.clone(),
+                    });
+                    match handle_new_session(&server, peer.clone(), params).await {
+                        Ok(result) => {
+                            let session_id = result.session_id.to_string();
+                            responder.respond(result)?;
+                            if let Some(session) = server.session(&session_id) {
+                                let commands = session.commands.lock().unwrap().clone();
+                                notify_available_commands(&peer, &session_id, &commands);
+                            }
+                        }
+                        Err(err) => responder.respond_with_error(err)?,
+                    }
+                    Ok(())
+                }
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let server = server.clone();
+                let next_tool_id = next_tool_id.clone();
+                async move |params: PromptParams, responder, cx| {
+                    let peer = Arc::new(Peer {
+                        cx: cx.clone(),
+                        next_id: next_tool_id.clone(),
+                    });
+                    tokio::spawn({
+                        let server = server.clone();
+                        async move {
+                            respond_prompt(&server, peer, params, responder).await;
+                        }
+                    });
+                    Ok(())
+                }
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .on_receive_notification(
+            {
+                let server = server.clone();
+                async move |params: protocol::CancelNotification, _cx| {
+                    if let Some(session) = server.session(&params.session_id.to_string()) {
+                        session.trigger_cancel();
+                    }
+                    Ok(())
+                }
+            },
+            agent_client_protocol::on_receive_notification!(),
+        )
+        .connect_with(transport, async move |_cx| {
+            let _ = eof_rx.await;
+            Ok(())
+        })
+        .await;
+
+    match result {
+        Ok(()) => Ok(()),
+        Err(err) if is_client_disconnect_error(&err) => {
+            tracing::debug!(%err, "acp: client disconnected while transport was closing");
+            Ok(())
         }
-        return;
-    }
-
-    let outcome = match method.as_str() {
-        "initialize" => handle_initialize(params),
-        "authenticate" => Ok(json!({})),
-        "session/prompt" => handle_prompt(&server, params).await,
-        other => Err(RpcError::new(
-            METHOD_NOT_FOUND,
-            format!("unknown method: {other}"),
-        )),
-    };
-
-    match outcome {
-        Ok(result) => server.peer.respond_ok(id, result),
-        Err(err) => server.peer.respond_err(id, err.code, &err.message),
+        Err(err) => Err(err.into()),
     }
 }
 
-fn handle_notification<F: RuntimeFactory>(server: &Arc<Server<F>>, message: &Value) {
-    let method = message
-        .get("method")
-        .and_then(Value::as_str)
-        .unwrap_or_default();
-    if method == "session/cancel" {
-        let params = message.get("params").cloned().unwrap_or(Value::Null);
-        if let Ok(parsed) = serde_json::from_value::<protocol::CancelParams>(params)
-            && let Some(session) = server.session(&parsed.session_id)
-        {
-            session.trigger_cancel();
-        }
+fn invalid_params(message: impl Into<String>) -> agent_client_protocol::Error {
+    agent_client_protocol::Error::invalid_params().data(message.into())
+}
+
+fn internal_error(message: impl Into<String>) -> agent_client_protocol::Error {
+    agent_client_protocol::Error::internal_error().data(message.into())
+}
+
+fn is_client_disconnect_error(err: &agent_client_protocol::Error) -> bool {
+    err.code == agent_client_protocol::ErrorCode::InternalError
+        && err.data.as_ref().is_some_and(value_mentions_broken_pipe)
+}
+
+fn value_mentions_broken_pipe(value: &Value) -> bool {
+    match value {
+        Value::String(text) => text.to_ascii_lowercase().contains("broken pipe"),
+        Value::Array(values) => values.iter().any(value_mentions_broken_pipe),
+        Value::Object(map) => map.values().any(value_mentions_broken_pipe),
+        _ => false,
     }
 }
 
-fn handle_initialize(params: Value) -> std::result::Result<Value, RpcError> {
-    let params: InitializeParams = serde_json::from_value(params)
-        .map_err(|e| RpcError::new(INVALID_PARAMS, format!("initialize: {e}")))?;
+fn handle_initialize(params: InitializeParams) -> InitializeResult {
     // Echo a supported version: honour the client's request when it is one we
     // speak, otherwise advertise our own.
     let version = match params.protocol_version {
-        Some(v) if v == protocol::PROTOCOL_VERSION => v,
+        v if v == protocol::PROTOCOL_VERSION => v,
         _ => protocol::PROTOCOL_VERSION,
     };
-    let result = InitializeResult {
-        protocol_version: version,
-        agent_capabilities: AgentCapabilities {
+    InitializeResult::new(version).agent_capabilities(
+        AgentCapabilities::new()
             // yolop builds a fresh runtime per session and does not yet
             // rehydrate prior ACP sessions, so loadSession stays false.
-            load_session: false,
-            prompt_capabilities: PromptCapabilities {
-                image: false,
-                audio: false,
-                embedded_context: true,
-            },
-            meta: Some(json!({
+            .load_session(false)
+            .prompt_capabilities(
+                PromptCapabilities::new()
+                    .image(false)
+                    .audio(false)
+                    .embedded_context(true),
+            )
+            .meta(protocol::meta(json!({
                 "yolop.dev/acp": {
                     "commandMetadata": true,
                     "commandArgSuggestions": true,
                     "commandToolLifecycle": true
                 }
-            })),
-        },
-        // No auth handshake: credentials come from the environment/settings
-        // the agent process already inherits.
-        auth_methods: vec![],
-    };
-    Ok(serde_json::to_value(result).expect("initialize result serializes"))
+            }))),
+    )
 }
 
 async fn handle_new_session<F: RuntimeFactory>(
     server: &Arc<Server<F>>,
-    params: Value,
-) -> std::result::Result<Value, RpcError> {
-    let params: NewSessionParams = serde_json::from_value(params)
-        .map_err(|e| RpcError::new(INVALID_PARAMS, format!("session/new: {e}")))?;
-    let cwd = PathBuf::from(&params.cwd);
+    peer: Arc<Peer>,
+    params: NewSessionParams,
+) -> std::result::Result<NewSessionResult, agent_client_protocol::Error> {
+    let cwd = params.cwd;
 
     // Delegate destructive-operation approval to the client via
     // `session/request_permission`. The editor owns the human, so this is the
@@ -402,7 +304,7 @@ async fn handle_new_session<F: RuntimeFactory>(
         .factory
         .build(cwd, gate)
         .await
-        .map_err(|e| RpcError::new(INTERNAL_ERROR, format!("build runtime: {e}")))?;
+        .map_err(|e| internal_error(format!("build runtime: {e}")))?;
 
     let acp_id = built.handles.session_id.to_string();
     let commands = built.startup.capability_commands.clone();
@@ -421,7 +323,6 @@ async fn handle_new_session<F: RuntimeFactory>(
 
     // Forward every approval request to the client as a permission prompt for
     // the lifetime of the session.
-    let peer = server.peer.clone();
     let permission_session = acp_id.clone();
     tokio::spawn(async move {
         while let Some((request, responder)) = approval_rx.recv().await {
@@ -430,37 +331,50 @@ async fn handle_new_session<F: RuntimeFactory>(
         }
     });
 
-    let result = NewSessionResult { session_id: acp_id };
-    Ok(serde_json::to_value(result).expect("new session result serializes"))
+    Ok(NewSessionResult::new(acp_id))
 }
 
 async fn handle_prompt<F: RuntimeFactory>(
     server: &Arc<Server<F>>,
-    params: Value,
-) -> std::result::Result<Value, RpcError> {
-    let params: PromptParams = serde_json::from_value(params)
-        .map_err(|e| RpcError::new(INVALID_PARAMS, format!("session/prompt: {e}")))?;
+    peer: Arc<Peer>,
+    params: PromptParams,
+) -> std::result::Result<PromptResult, agent_client_protocol::Error> {
+    let session_id = params.session_id.to_string();
     let session = server
-        .session(&params.session_id)
-        .ok_or_else(|| RpcError::new(INVALID_PARAMS, "unknown session id"))?;
+        .session(&session_id)
+        .ok_or_else(|| invalid_params("unknown session id"))?;
     let prompt = protocol::prompt_text(&params.prompt);
 
     let stop_reason = match parse_slash_command(&prompt) {
-        Some((name, args)) => run_slash_command(server.peer.clone(), session, name, args).await,
-        None => run_prompt(server.peer.clone(), session, prompt).await,
+        Some((name, args)) => run_slash_command(peer, session, name, args).await,
+        None => run_prompt(peer, session, prompt).await,
     };
-    let result = PromptResult { stop_reason };
-    Ok(serde_json::to_value(result).expect("prompt result serializes"))
+    Ok(PromptResult::new(stop_reason))
+}
+
+async fn respond_prompt<F: RuntimeFactory>(
+    server: &Arc<Server<F>>,
+    peer: Arc<Peer>,
+    params: PromptParams,
+    responder: Responder<PromptResult>,
+) {
+    match handle_prompt(server, peer, params).await {
+        Ok(result) => {
+            let _ = responder.respond(result);
+        }
+        Err(err) => {
+            let _ = responder.respond_with_error(err);
+        }
+    }
 }
 
 fn available_commands(commands: &[CommandDescriptor]) -> Vec<AvailableCommand> {
     commands
         .iter()
-        .map(|command| AvailableCommand {
-            name: command.name.clone(),
-            description: command.description.clone(),
-            input: command_input(command),
-            meta: command_meta(command),
+        .map(|command| {
+            AvailableCommand::new(command.name.clone(), command.description.clone())
+                .input(command_input(command))
+                .meta(command_meta(command))
         })
         .collect()
 }
@@ -481,24 +395,27 @@ fn command_input(command: &CommandDescriptor) -> Option<AvailableCommandInput> {
         })
         .collect::<Vec<_>>()
         .join(", ");
-    Some(AvailableCommandInput { hint })
+    Some(AvailableCommandInput::Unstructured(
+        UnstructuredCommandInput::new(hint),
+    ))
 }
 
 fn notify_available_commands(peer: &Arc<Peer>, session_id: &str, commands: &[CommandDescriptor]) {
     peer.session_update(
         session_id,
-        SessionUpdate::AvailableCommandsUpdate {
-            available_commands: available_commands(commands),
-            meta: Some(json!({
-                "yolop.dev/acp": {
-                    "argSuggestions": true
-                }
-            })),
-        },
+        SessionUpdate::AvailableCommandsUpdate(
+            protocol::AvailableCommandsUpdate::new(available_commands(commands)).meta(
+                protocol::meta(json!({
+                    "yolop.dev/acp": {
+                        "argSuggestions": true
+                    }
+                })),
+            ),
+        ),
     );
 }
 
-fn command_meta(command: &CommandDescriptor) -> Option<Value> {
+fn command_meta(command: &CommandDescriptor) -> Option<serde_json::Map<String, Value>> {
     if command.args.is_empty() {
         return None;
     }
@@ -506,7 +423,7 @@ fn command_meta(command: &CommandDescriptor) -> Option<Value> {
         CommandSource::System => "system",
         CommandSource::Skill => "skill",
     };
-    Some(json!({
+    protocol::meta(json!({
         "yolop.dev/command": {
             "source": source,
             "args": command.args.iter().map(|arg| {
@@ -543,9 +460,9 @@ async fn run_slash_command(
     let Some(descriptor) = commands.iter().find(|c| c.name == name).cloned() else {
         peer.session_update(
             &session.acp_id,
-            SessionUpdate::AgentMessageChunk {
-                content: protocol::ContentBlock::text(format!("unknown command: /{name}")),
-            },
+            SessionUpdate::AgentMessageChunk(protocol::text_chunk(format!(
+                "unknown command: /{name}"
+            ))),
         );
         return StopReason::EndTurn;
     };
@@ -564,9 +481,9 @@ async fn run_slash_command(
             .join(", ");
         peer.session_update(
             &session.acp_id,
-            SessionUpdate::AgentMessageChunk {
-                content: protocol::ContentBlock::text(format!("/{name} requires: {needed}")),
-            },
+            SessionUpdate::AgentMessageChunk(protocol::text_chunk(format!(
+                "/{name} requires: {needed}"
+            ))),
         );
         return StopReason::EndTurn;
     }
@@ -576,18 +493,16 @@ async fn run_slash_command(
             let tool_call_id = format!("command_{}", peer.next_id.fetch_add(1, Ordering::Relaxed));
             peer.session_update(
                 &session.acp_id,
-                SessionUpdate::ToolCall {
-                    tool_call_id: tool_call_id.clone(),
-                    title: command_title(&descriptor.name, &args),
-                    kind: ToolKind::Other,
-                    status: ToolCallStatus::InProgress,
-                    raw_input: Some(json!({
+                SessionUpdate::ToolCall(
+                    ToolCall::new(tool_call_id.clone(), command_title(&descriptor.name, &args))
+                        .kind(ToolKind::Other)
+                        .status(ToolCallStatus::InProgress)
+                        .raw_input(json!({
                         "command": descriptor.name,
                         "arguments": if args.is_empty() { Value::Null } else { Value::String(args.clone()) },
                         "source": "system",
                     })),
-                    content: Vec::new(),
-                },
+                ),
             );
 
             let request = ExecuteCommandRequest {
@@ -617,18 +532,17 @@ async fn run_slash_command(
             };
             peer.session_update(
                 &session.acp_id,
-                SessionUpdate::ToolCallUpdate {
+                SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
                     tool_call_id,
-                    status: Some(if success {
-                        ToolCallStatus::Completed
-                    } else {
-                        ToolCallStatus::Failed
-                    }),
-                    content: vec![ToolCallContent::Content {
-                        content: protocol::ContentBlock::text(message),
-                    }],
-                    raw_output: Some(raw_output),
-                },
+                    ToolCallUpdateFields::new()
+                        .status(if success {
+                            ToolCallStatus::Completed
+                        } else {
+                            ToolCallStatus::Failed
+                        })
+                        .content(vec![protocol::content(message)])
+                        .raw_output(raw_output),
+                )),
             );
             refresh_available_commands(&peer, &session).await;
             StopReason::EndTurn
@@ -736,9 +650,9 @@ async fn run_prompt(peer: Arc<Peer>, session: Arc<Session>, prompt: String) -> S
             if let Some(error) = result.error {
                 peer.session_update(
                     &acp_id,
-                    SessionUpdate::AgentMessageChunk {
-                        content: protocol::ContentBlock::text(format!("turn error: {error}")),
-                    },
+                    SessionUpdate::AgentMessageChunk(protocol::text_chunk(format!(
+                        "turn error: {error}"
+                    ))),
                 );
             }
             StopReason::EndTurn
@@ -746,9 +660,9 @@ async fn run_prompt(peer: Arc<Peer>, session: Arc<Session>, prompt: String) -> S
         Ok(Err(err)) => {
             peer.session_update(
                 &acp_id,
-                SessionUpdate::AgentMessageChunk {
-                    content: protocol::ContentBlock::text(format!("turn failed: {err}")),
-                },
+                SessionUpdate::AgentMessageChunk(protocol::text_chunk(format!(
+                    "turn failed: {err}"
+                ))),
             );
             StopReason::EndTurn
         }
@@ -784,37 +698,26 @@ async fn request_permission(peer: &Arc<Peer>, session_id: &str, request: &Approv
     const ALLOW: &str = "allow";
     const REJECT: &str = "reject";
 
-    let params = RequestPermissionParams {
-        session_id: session_id.to_string(),
-        tool_call: json!({ "toolCallId": "pending", "title": request.headline() }),
-        options: vec![
-            PermissionOption {
-                option_id: ALLOW.to_string(),
-                name: "Allow".to_string(),
-                kind: PermissionOptionKind::AllowOnce,
-            },
-            PermissionOption {
-                option_id: REJECT.to_string(),
-                name: "Reject".to_string(),
-                kind: PermissionOptionKind::RejectOnce,
-            },
+    let params = RequestPermissionParams::new(
+        session_id.to_string(),
+        ToolCallUpdate::new(
+            "pending",
+            ToolCallUpdateFields::new().title(request.headline()),
+        ),
+        vec![
+            PermissionOption::new(ALLOW, "Allow", PermissionOptionKind::AllowOnce),
+            PermissionOption::new(REJECT, "Reject", PermissionOptionKind::RejectOnce),
         ],
-    };
-    let params = serde_json::to_value(params).expect("permission params serialize");
+    );
 
-    match peer.request("session/request_permission", params).await {
-        Ok(value) => match serde_json::from_value::<RequestPermissionResult>(value) {
-            Ok(result) => match result.outcome {
-                PermissionOutcome::Selected { option_id } => option_id == ALLOW,
-                PermissionOutcome::Cancelled => false,
-            },
-            Err(err) => {
-                tracing::warn!(%err, "acp: malformed permission response; denying");
-                false
-            }
+    match peer.cx.send_request(params).block_task().await {
+        Ok(result) => match result.outcome {
+            PermissionOutcome::Selected(outcome) => outcome.option_id.to_string() == ALLOW,
+            PermissionOutcome::Cancelled => false,
+            _ => false,
         },
         Err(err) => {
-            tracing::warn!(code = err.code, message = %err.message, "acp: permission request failed; denying");
+            tracing::warn!(%err, "acp: permission request failed; denying");
             false
         }
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -753,6 +753,26 @@ fn acp_openai_handshake_smoke() {
     assert!(result.exited_cleanly, "agent should exit cleanly");
 }
 
+#[test]
+#[ignore = "requires ANTHROPIC_API_KEY; run under doppler with --ignored"]
+fn acp_anthropic_handshake_smoke() {
+    let Ok(_) = std::env::var("ANTHROPIC_API_KEY") else {
+        panic!("ANTHROPIC_API_KEY required for live ACP smoke test");
+    };
+    let result = run_acp_handshake("anthropic", "Reply with exactly the single word: pong");
+    assert_eq!(
+        result.prompt["result"]["stopReason"], "end_turn",
+        "prompt response: {}",
+        result.prompt
+    );
+    assert!(
+        result.assistant_text.to_lowercase().contains("pong"),
+        "expected `pong` in streamed assistant text, got: {:?}",
+        result.assistant_text
+    );
+    assert!(result.exited_cleanly, "agent should exit cleanly");
+}
+
 fn wait_for_process_exit(
     child: &mut std::process::Child,
     timeout: Duration,


### PR DESCRIPTION
## What
Refactor ACP support to use the upstream `agent-client-protocol` Rust SDK instead of yolop-owned JSON-RPC/schema plumbing.

## Why
Yolop had a custom ACP wire model and dispatcher. That meant schema changes, request routing, response correlation, and permission replies had to be mirrored by hand. Using the SDK keeps yolop closer to the published ACP implementation and reduces local protocol code.

## How
- Added `agent-client-protocol` and async compatibility deps.
- Replaced `src/acp/protocol.rs` custom wire structs with SDK schema re-exports plus small yolop helpers.
- Moved `src/acp/server.rs` to SDK `Agent` typed handlers, SDK `Lines` transport, SDK notifications, and SDK typed `session/request_permission` requests.
- Kept yolop-specific runtime/session/turn logic in the ACP server.
- Refactored in-memory ACP tests to use the SDK `Client`, typed requests, typed permission responses, and active-session update routing.
- Added an ignored Anthropic ACP smoke test for secondary live-provider ACP validation.

## Risk
- Medium
- ACP clients could be affected by stricter SDK schema handling or transport behavior.
- Mitigation: offline ACP unit/integration coverage, stdio binary ACP smoke, live OpenAI and Anthropic ACP smokes, and disconnect regression coverage.

## Security
- TM-FS: No new filesystem capabilities. ACP still builds the existing runtime rooted at client `cwd`; file operations remain governed by existing runtime/tool policy.
- TM-BASH: No change to bash execution. Destructive actions still flow through `ApprovalGate`; SDK permission requests fail closed on cancellation/errors.
- TM-LLM: No secrets are logged or persisted by this change. Live smoke tests read provider keys from process env via Doppler only.
- TM-TOOL: No new tool capabilities are registered. Existing command/tool update metadata is still emitted as ACP `_meta`/raw JSON.
- TM-DEP: New dependency is `agent-client-protocol` to replace custom ACP schema/dispatch; `futures` and `tokio-util` are used for SDK line transport over Tokio streams.

## Validation
- `git fetch origin main && git rebase origin/main`
- `cargo fetch --locked`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"`
- `doppler run --project yolop --config ci -- cargo run -- --provider anthropic -p "Reply with exactly: ok"`
- `doppler run --project yolop --config ci -- cargo test --test integration acp_anthropic_handshake_smoke -- --ignored`
- `doppler run --project yolop --config ci -- cargo test --test integration acp_openai_handshake_smoke -- --ignored`
- GitHub CI: all checks green on `6723fc8`, including Live OpenAI Smoke.

## Follow-ups
- Consider filing/upstreaming an ACP SDK transport issue for broken-pipe-on-client-close behavior; yolop now normalizes that path locally.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered