### PR TITLE
chore(deps): bump everruns to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.38"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a9efe15d0cb0a857f1b2c8871e0ff4d55ce6961838eaa49d3cbdd007860d6d"
+checksum = "57f9cb3f09e58ce7e04d1835f84c41f8a356cebaec17ec24f322d05511241906"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1293,18 +1293,18 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.8.38"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ba2c9cb4dc638e2d0ddaa23b62c714103d6af818fbf5f7604085923a1ade5c5"
+checksum = "e3495ad83dfb6500df5fe10a88b86346e6aa59c861dbf4f5a21698715ccd8f00"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-core"
-version = "0.8.38"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7f3e511de898e73008b35c1d276f096f6c8828e193b56007a8ca75a95964d3"
+checksum = "cf18c513a47443103e14be2d466b07f1d4016d17a1b8e674c725739e5e379f8d"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -1343,9 +1343,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.8.38"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de6d79df50e7867cc04dcd1f61b5d219a5fc64d419e654248ad854ed76d40732"
+checksum = "f1697167ea52ea63b74e89b12a8ad30c2b33d799780b013cc8a769aad3159f3a"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1359,9 +1359,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.8.38"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220913b1a3308564601c2001e96568a8ba9c7490bb313b1f442d7122db539271"
+checksum = "a771838aa949510b081044950566e2bb7784b731055a32b153f8906abc1a4909"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1374,9 +1374,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.38"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3e314ea7661e6a4f616a26c6b9e06a857ca9f09a34aa149cc3dd9b99373e0f2"
+checksum = "27f19e7f3c3324288e0f3d495f203f8e4fc1f496856f49fd3a26edaee58239e0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1395,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.8.38"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4014b0cc539cc6ca48e08114bf7ba003898861a1317918128a8d161ae995f5"
+checksum = "9770ad2cfcb4755e3551d65cae1c1ca22decd18b81bed80ae042b67834849fcd"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,13 +33,13 @@ tokio-util = { version = "0.7", features = ["compat"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-everruns-anthropic = "0.8.38"
-everruns-core = "0.8.38"
-everruns-openai = "0.8.38"
+everruns-anthropic = "0.9.0"
+everruns-core = "0.9.0"
+everruns-openai = "0.9.0"
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (specs/mcp.md, upstream runtime-mcp.md D2).
-everruns-runtime = { version = "0.8.38", features = ["mcp-stdio"] }
-everruns-integrations-duckduckgo = "0.8.38"
+everruns-runtime = { version = "0.9.0", features = ["mcp-stdio"] }
+everruns-integrations-duckduckgo = "0.9.0"
 futures = "0.3"
 
 [dev-dependencies]

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -863,6 +863,7 @@ mod tests {
                 readonly,
                 ..Default::default()
             },
+            full_parameters: None,
         })
     }
 

--- a/src/capabilities/tool_search.rs
+++ b/src/capabilities/tool_search.rs
@@ -37,7 +37,7 @@
 // on OpenAI (gpt-5.4/5.5), Anthropic, and OpenAI-compatible backends such as
 // OpenRouter (e.g. NVIDIA Nemotron) without any driver support.
 //
-// TODO(EVE-521): this whole module is a temporary vendor. As of 0.9.0 upstream
+// TODO(EVE-527): this whole module is a temporary vendor. As of 0.9.0 upstream
 // has renamed `GenericToolSearchCapability` to
 // `everruns_core::capabilities::ToolSearchCapability`, but it still defers with
 // the stateless `DeferSchemaHook` above and has *not* shipped the
@@ -45,7 +45,8 @@
 // structured callers. Once upstream ships that fix (revealed-set + core
 // allowlist, or equivalent), delete this file and register the upstream
 // `ToolSearchCapability` in `runtime.rs` instead. Keep the `yolop_tool_search`
-// id wiring until then so the harness selects this implementation.
+// id wiring until then so the harness selects this implementation. (EVE-521 is
+// the related, separate native-`openai_tool_search` server_error.)
 
 use async_trait::async_trait;
 use everruns_core::capabilities::{Capability, CapabilityStatus, ToolDefinitionHook};
@@ -59,7 +60,7 @@ use std::sync::{Arc, Mutex};
 
 /// Capability id. Distinct from upstream `tool_search` / `openai_tool_search`
 /// so the harness selects this vendored implementation unambiguously.
-// TODO(EVE-521): drop the `yolop_` prefix and use the upstream `tool_search`
+// TODO(EVE-527): drop the `yolop_` prefix and use the upstream `tool_search`
 // id once `everruns_core::capabilities::ToolSearchCapability` ships the fix.
 pub const TOOL_SEARCH_CAPABILITY_ID: &str = "yolop_tool_search";
 
@@ -90,7 +91,7 @@ const ALWAYS_FULL: &[&str] = &[
 /// (by `Arc`) between the capability, its schema hook, and its tool so a reveal
 /// during tool execution is visible to the next context assembly.
 //
-// TODO(EVE-521): this revealed-set is the progressive-disclosure mechanism that
+// TODO(EVE-527): this revealed-set is the progressive-disclosure mechanism that
 // upstream's `ToolSearchCapability` lacks. Once upstream adopts it, this type
 // and its plumbing go away with the rest of the module.
 type RevealedTools = Arc<Mutex<HashSet<String>>>;

--- a/src/capabilities/tool_search.rs
+++ b/src/capabilities/tool_search.rs
@@ -4,9 +4,13 @@
 // Background: everruns ships two deferral capabilities. `openai_tool_search`
 // uses OpenAI's native Responses `tool_search` and currently fails with a
 // `server_error` on the reasoning models that advertise it (EVE-521). The
-// generic `everruns_core::capabilities::GenericToolSearchCapability` defers
-// schemas client-side, but its `DeferSchemaHook` is *stateless*: it re-stubs
-// every deferrable tool on every reason iteration. Because OpenAI/Anthropic
+// generic `everruns_core::capabilities::ToolSearchCapability` (renamed from
+// `GenericToolSearchCapability` in 0.9.0) defers schemas client-side, but its
+// `DeferSchemaHook` is *stateless*: it re-stubs every deferrable tool on every
+// reason iteration. 0.9.0 added a `full_parameters` field so its `tool_search`
+// can echo the real schema back *as text*, but that does not help structured
+// callers (see below) — the registered schema the model sees stays the stub.
+// Because OpenAI/Anthropic
 // structured tool calling makes the model emit arguments against the tool's
 // *registered* schema (the empty stub), the model calls every deferred tool
 // with `{}` and can never pass parameters — even after `tool_search` returns
@@ -33,9 +37,12 @@
 // on OpenAI (gpt-5.4/5.5), Anthropic, and OpenAI-compatible backends such as
 // OpenRouter (e.g. NVIDIA Nemotron) without any driver support.
 //
-// TODO(EVE-521): this whole module is a temporary vendor. Upstream is renaming
-// `GenericToolSearchCapability` to `everruns_core::capabilities::ToolSearchCapability`.
-// Once that ships the progressive-disclosure fix (revealed-set + core
+// TODO(EVE-521): this whole module is a temporary vendor. As of 0.9.0 upstream
+// has renamed `GenericToolSearchCapability` to
+// `everruns_core::capabilities::ToolSearchCapability`, but it still defers with
+// the stateless `DeferSchemaHook` above and has *not* shipped the
+// progressive-disclosure fix — so it still regresses to empty tool calls on
+// structured callers. Once upstream ships that fix (revealed-set + core
 // allowlist, or equivalent), delete this file and register the upstream
 // `ToolSearchCapability` in `runtime.rs` instead. Keep the `yolop_tool_search`
 // id wiring until then so the harness selects this implementation.

--- a/src/capabilities/tool_search.rs
+++ b/src/capabilities/tool_search.rs
@@ -336,6 +336,7 @@ impl Tool for ToolSearchTool {
             category: None,
             deferrable: DeferrablePolicy::Never,
             hints: self.hints(),
+            full_parameters: None,
         })
     }
 
@@ -427,6 +428,7 @@ mod tests {
             category: None,
             deferrable,
             hints: ToolHints::default(),
+            full_parameters: None,
         })
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1172,8 +1172,9 @@ pub async fn build_with_options(
     // and defers the long tail behind a `tool_search` tool, revealing real
     // schemas progressively. Works on every provider/model — unlike the native
     // `openai_tool_search`, whose Responses round-trip is broken (EVE-521).
-    // TODO(EVE-521): replace with the upstream `ToolSearchCapability` (renamed
-    // from `GenericToolSearchCapability`) once it ships progressive disclosure.
+    // TODO(EVE-521): the upstream `ToolSearchCapability` (renamed from
+    // `GenericToolSearchCapability` in 0.9.0) still defers statelessly and lacks
+    // progressive disclosure; replace this vendor once upstream ships that fix.
     capabilities.register(ToolSearchCapability::new());
     capabilities.register(ToolOutputPersistenceCapability);
     capabilities.register(DuckDuckGoCapability);

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1172,7 +1172,7 @@ pub async fn build_with_options(
     // and defers the long tail behind a `tool_search` tool, revealing real
     // schemas progressively. Works on every provider/model — unlike the native
     // `openai_tool_search`, whose Responses round-trip is broken (EVE-521).
-    // TODO(EVE-521): the upstream `ToolSearchCapability` (renamed from
+    // TODO(EVE-527): the upstream `ToolSearchCapability` (renamed from
     // `GenericToolSearchCapability` in 0.9.0) still defers statelessly and lacks
     // progressive disclosure; replace this vendor once upstream ships that fix.
     capabilities.register(ToolSearchCapability::new());


### PR DESCRIPTION
## What

Bumps all `everruns-*` crates from `0.8.38` to `0.9.0`, in lockstep:
`-core`, `-runtime`, `-anthropic`, `-openai`, `-integrations-duckduckgo` (and
transitive `-config`/`-mcp`). Lockfile updated to match.

The 0.9.0 release adds a non-serialized `full_parameters` field to
`BuiltinTool`/`ClientSideTool`. yolop constructs these tool definitions at three
sites (the vendored `tool_search` tool, its test helper, and the host capability
test), so each now sets `full_parameters: None`. yolop does its own deferral and
keeps the registry definitions intact, so `None` is correct — no behavior change.

## Why not adopt upstream's new deferral?

0.9.0 ships a renamed, provider-agnostic `ToolSearchCapability` (formerly
`GenericToolSearchCapability`) and the `full_parameters` plumbing — but its
`DeferSchemaHook` is **still stateless** and has **no progressive disclosure**.
The new `full_parameters` field only lets the upstream `tool_search` tool echo a
deferred tool's real schema back *as text*. That is exactly the design
**EVE-521** documents as broken for structured tool callers: the model emits
arguments against the *registered* schema, which stays the empty stub, so it
keeps calling deferred tools with `{}` (verified live on gpt-5.4/5.5).

yolop's vendored `tool_search` fixes this with a shared revealed-set
(progressive disclosure) plus a core-tool allowlist — neither of which upstream
0.9.0 has. So the vendor must stay. This PR updates the vendor's header comment
and repoints the tracking `TODO`s to **EVE-527** (filed for the upstream
progressive-disclosure gap, with a link back to this vendored implementation as
the reference). EVE-521 — which is closed and covered the *separate* native
`openai_tool_search` `server_error` — is no longer the tracking issue for vendor
removal; only the genuinely native-path references to it remain in the code.

## Validation

- `cargo fmt --check` ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓
- `cargo test --all-features` ✓ — 253 + 15 (1 ignored) tests pass
- Offline smoke: `cargo run -- --provider llmsim -p "hi"` ✓ — binary starts,
  registers the full tool set incl. `tool_search`, completes the turn

The new `full_parameters: None` sites are exercised by the existing
`tool_search` tests, which build `BuiltinTool` definitions and run the
`DeferSchemaHook` over them. The remaining edits are comment-only.

## Security

TM-DEP is the only relevant category. All `everruns-*` crates are bumped
together (no mismatched-version soft API break); no new crates added; checksums
in `Cargo.lock` updated from the official crates.io index. No filesystem, shell,
LLM-key, or capability-registration code changed (remaining edits are comments).

## Follow-ups

- **EVE-527** — drop the vendored `src/capabilities/tool_search.rs` and register
  upstream `ToolSearchCapability` once upstream ships progressive disclosure
  (revealed-set + core allowlist, or equivalent). Deferred — the fix is not in
  0.9.0. Tracked by `TODO(EVE-527)` in `tool_search.rs` and `runtime.rs`.
