### PR TITLE
feat(models): add Claude Fable 5 to Anthropic model options

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1038,6 +1038,11 @@ impl App {
                     label: "claude-sonnet-4-6".to_string(),
                     hint: "newer Sonnet option",
                 },
+                ModelOption {
+                    spec: Some("anthropic/claude-fable-5".to_string()),
+                    label: "claude-fable-5".to_string(),
+                    hint: "most powerful Claude model",
+                },
             ],
             "google" => vec![
                 ModelOption {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -542,6 +542,7 @@ impl ProviderChoice {
             "anthropic/claude-haiku-4-5",
             "anthropic/claude-sonnet-4-6",
             "anthropic/claude-opus-4-6",
+            "anthropic/claude-fable-5",
             "llmsim/llmsim-yolop",
         ]
     }
@@ -1554,6 +1555,18 @@ mod tests {
             .unwrap();
 
         assert_eq!(next.label(), "anthropic/claude-sonnet-4-5");
+    }
+
+    #[test]
+    fn model_suggestions_include_claude_fable_5() {
+        // Fable 5 rejects budget thinking and sampling params; yolop sends
+        // neither for Anthropic, so the published driver works as-is.
+        assert!(ProviderChoice::model_suggestions().contains(&"anthropic/claude-fable-5"));
+
+        let next = ProviderChoice::Sim
+            .resolve_model_spec("anthropic/claude-fable-5")
+            .unwrap();
+        assert_eq!(next.label(), "anthropic/claude-fable-5");
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds `anthropic/claude-fable-5` (Claude Fable 5) to the model surface, mirroring upstream everruns/everruns#2083:

- `src/runtime.rs` — added to `ProviderChoice::model_suggestions()` (powers `/model` suggestions), plus a unit test asserting the suggestion exists and resolves to the Anthropic provider via `resolve_model_spec`.
- `src/app.rs` — added a `claude-fable-5` option ("most powerful Claude model") to the `/setup` Anthropic model picker.

## Why

Claude Fable 5 (`claude-fable-5`) is Anthropic's newest top-tier model. The upstream PR put the heavy lifting (model profile registry entry, adaptive-thinking driver refactor) into the everruns crates, but those changes are not yet in a published release — crates.io's latest is `everruns-*` 0.9.0, which yolop already pins, and AGENTS.md requires lockstep with published versions. The published 0.9.0 Anthropic driver works for Fable 5 as-is: yolop never sets reasoning effort or temperature for Anthropic, so requests omit both `thinking` and sampling parameters — exactly what Fable 5 requires (it rejects `budget_tokens`, `temperature`/`top_p`/`top_k`, and explicit `thinking: disabled` with a 400).

The default Anthropic model stays `claude-sonnet-4-5`, matching upstream, which also did not make Fable the default.

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo test --all-features` — 216 + 15 tests pass, including the new `model_suggestions_include_claude_fable_5`.
- Live smoke through Doppler: `cargo run -- --provider anthropic --model claude-fable-5 -p "say hi in three words"` → `success=true`; a second run exercising a tool call (`list_directory`) → `success=true iterations=2 tool_calls=1` with a correct answer.

## Risks

Low. The change is two static string-list additions plus a test; no driver, tool, or agent-loop code is touched. If the published driver's behavior toward Fable 5 ever changes, it will come through an `everruns-*` version bump, not this code.

## Security

No security-relevant code changes: the diff adds entries to two static model-suggestion lists and a unit test. Reviewed against the ship-skill categories anyway — TM-FS/TM-BASH/TM-TOOL untouched (no filesystem, shell, or capability code in the diff); TM-LLM unaffected (no key handling or prompt construction changes; model id is a plain string passed to the existing driver); TM-DEP unaffected (no dependency changes).

## Follow-ups

- Bump `everruns-*` crates once a release containing everruns/everruns#2083 is published, to pick up the Fable 5 model profile and adaptive-thinking (`output_config.effort`) support in the Anthropic driver.
- The `/setup` picker entry in `src/app.rs` is a static list rendered by the modal; it is exercised by the live smoke test but not by a dedicated automated UI test (consistent with the existing entries, which have none).