### PR TITLE
fix(acp): remove approval-looking tool kinds

### DIFF
--- a/specs/acp.md
+++ b/specs/acp.md
@@ -51,13 +51,14 @@ notifications. The mapping is a pure, per-turn state machine
 | assistant text delta | `agent_message_chunk` (incremental) |
 | completed assistant message, when no deltas streamed | `agent_message_chunk` (whole text) — covers providers that don't stream |
 | thinking delta / reasoning summary | `agent_thought_chunk` |
-| tool started | `tool_call` (`status: in_progress`, mapped `kind`, `rawInput`) |
+| tool started | `tool_call` (`status: in_progress`, `rawInput`, no approval-oriented `kind`) |
 | tool completed | `tool_call_update` (`status: completed`/`failed`, summary `content`) |
 | `write_todos` tool | `plan` (entries with status) instead of a raw tool call |
 
-Tool `kind` is mapped from the tool name (read/search/edit/delete/execute/fetch,
-else `other`). To avoid duplicating streamed text, a completed assistant message
-is only emitted as a chunk when no deltas streamed for it during the turn.
+Yolop omits ACP `kind` for runtime tools because tools run autonomously and some
+clients attach approval-looking affordances to execute/edit/delete categories.
+To avoid duplicating streamed text, a completed assistant message is only
+emitted as a chunk when no deltas streamed for it during the turn.
 
 After `session/new`, yolop sends `available_commands_update` with
 capability-sourced slash commands such as `/setup` and user-invocable skill

--- a/src/acp/bridge.rs
+++ b/src/acp/bridge.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 
 use super::protocol::{
     self, ContentBlock, Plan, PlanEntry, PlanEntryPriority, PlanEntryStatus, SessionUpdate,
-    ToolCall, ToolCallContent, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind,
+    ToolCall, ToolCallContent, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
 };
 
 /// The runtime's todo tool. write_todos updates are surfaced as ACP plans
@@ -109,7 +109,6 @@ impl Translator {
                     .to_string();
                 vec![SessionUpdate::ToolCall(
                     ToolCall::new(data.tool_call.id.clone(), title)
-                        .kind(tool_kind(name))
                         .status(ToolCallStatus::InProgress)
                         .raw_input(non_null(data.tool_call.arguments.clone())),
                 )]
@@ -140,20 +139,6 @@ impl Translator {
             }
             _ => Vec::new(),
         }
-    }
-}
-
-/// Map a runtime tool name to an ACP tool kind so editors can pick the right
-/// affordance. Unknown tools fall back to `other`.
-fn tool_kind(name: &str) -> ToolKind {
-    match name {
-        "read_file" | "stat_file" | "list_directory" => ToolKind::Read,
-        "grep" | "grep_files" | "duckduckgo_search" => ToolKind::Search,
-        "edit_file" | "write_file" | "create_directory" => ToolKind::Edit,
-        "delete_file" => ToolKind::Delete,
-        "bash" => ToolKind::Execute,
-        "web_fetch" => ToolKind::Fetch,
-        _ => ToolKind::Other,
     }
 }
 
@@ -319,7 +304,7 @@ mod tests {
     }
 
     #[test]
-    fn tool_started_maps_kind_and_in_progress_status() {
+    fn tool_started_uses_in_progress_status_without_kind() {
         let mut t = Translator::new();
         let updates = t.on_event(&event(EventData::ToolStarted(ToolStartedData {
             tool_call: ToolCall {
@@ -335,10 +320,15 @@ mod tests {
             updates,
             vec![SessionUpdate::ToolCall(
                 protocol::ToolCall::new("call_1", "Listing files")
-                    .kind(ToolKind::Execute)
                     .status(ToolCallStatus::InProgress)
                     .raw_input(json!({ "command": "ls" })),
             )]
+        );
+        let serialized = serde_json::to_value(&updates[0]).unwrap();
+        assert_eq!(serialized["status"], "in_progress");
+        assert!(
+            serialized.get("kind").is_none(),
+            "autonomous tools must not advertise approval-looking categories: {serialized}"
         );
     }
 

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -422,9 +422,10 @@ mod tests {
             "expected a tool_call update, got: {:?}",
             run.updates
         );
-        assert_eq!(
-            tool_calls[0]["kind"], "execute",
-            "bash should map to execute kind"
+        assert!(
+            tool_calls[0].get("kind").is_none(),
+            "autonomous tools should not advertise approval-looking ACP kinds: {:?}",
+            tool_calls[0]
         );
         let updates = run.updates_of_kind("tool_call_update");
         assert!(


### PR DESCRIPTION
## What
Remove ACP `kind` from runtime tool-call start updates so autonomous tools do not advertise execute/edit/delete categories that clients can render with approval-looking UI. Update ACP tests and spec text to lock in the new wire contract.

## Why
Yolop no longer has a per-call approval model, but ACP clients can still surface approval-style affordances from tool categories. Runtime tools should present as already-running autonomous work.

## How
- Stop mapping runtime tool names to ACP `ToolKind` in `acp::bridge::Translator`.
- Keep `status: in_progress`, titles, and `rawInput` so clients still show activity and details.
- Update ACP unit/integration assertions and `specs/acp.md`.

## Risk
- Low
- ACP clients lose category-specific icons for runtime tools, but this avoids misleading approval UI. Tool titles, status, raw input, completion status, and result content remain intact.

## Security
No new filesystem, shell, LLM prompt, capability, or dependency surface. Existing autonomous execution model and write blocklist are unchanged; this only removes ACP presentation metadata.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --all-features acp::bridge::tests::tool_started_uses_in_progress_status_without_kind`
- `cargo test --all-features acp::tests::scripted_tool_call_streams_tool_updates`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (216 unit tests; 15 integration tests passed, 1 ignored requiring Anthropic key)
- `cargo run -- --provider llmsim -p "hi"`

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

## Follow-ups
No follow-ups.