### PR TITLE
feat(openrouter): support reasoning effort

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ tools. See [`specs/mcp.md`](specs/mcp.md).
 | `--acp`                    | Speak the Agent Client Protocol over stdio (for editors like Zed)    |
 | `--session <ID>`           | Resume a previous session by id                                      |
 | `--session-dir <PATH>`     | Override the parent directory for session folders                    |
-| `--reasoning-effort <E>`   | OpenAI/OpenRouter reasoning effort (`low` / `medium` / `high`)       |
+| `--reasoning-effort <E>`   | OpenAI/OpenRouter reasoning effort (`minimal` / `low` / `medium` / `high`) |
 
 ### Commands
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ tools. See [`specs/mcp.md`](specs/mcp.md).
 | `--acp`                    | Speak the Agent Client Protocol over stdio (for editors like Zed)    |
 | `--session <ID>`           | Resume a previous session by id                                      |
 | `--session-dir <PATH>`     | Override the parent directory for session folders                    |
-| `--reasoning-effort <E>`   | OpenAI reasoning effort (`low` / `medium` / `high`)                  |
+| `--reasoning-effort <E>`   | OpenAI/OpenRouter reasoning effort (`low` / `medium` / `high`)       |
 
 ### Commands
 
@@ -216,7 +216,7 @@ tools. See [`specs/mcp.md`](specs/mcp.md).
 | `OLLAMA_BASE_URL`               | Select Ollama, defaults to `http://localhost:11434/v1`       |
 | `OLLAMA_API_KEY`                | Optional, defaults to `ollama` for local Ollama              |
 | `EVERRUNS_CLI_MODEL`            | Override the auto-selected default model                     |
-| `EVERRUNS_CLI_REASONING_EFFORT` | OpenAI-only reasoning effort override                        |
+| `EVERRUNS_CLI_REASONING_EFFORT` | OpenAI/OpenRouter reasoning effort override                  |
 
 ### Settings
 
@@ -226,9 +226,9 @@ provider API tokens across runs: `<config_dir>/yolop/settings.toml` —
 `~/Library/Application Support/yolop/settings.toml` on macOS,
 `%APPDATA%\yolop\settings.toml` on Windows.
 
-The TUI's `/setup`, `/model`, and `/effort` commands update the active
-provider, saved API keys, current model, OpenAI reasoning effort, or offline
-demo mode.
+The TUI's `/setup`, `/model`, and `/effort` commands can update the active
+provider, saved API keys, current model, OpenAI/OpenRouter reasoning effort,
+or offline demo mode. Saved provider/API-key choices are written to this file.
 
 Provider resolution at startup:
 
@@ -240,8 +240,11 @@ Provider resolution at startup:
 4. Fall back to OpenAI's default model and open setup so a provider/API key
    can be configured
 
-At runtime, the per-provider env var (`OPENAI_API_KEY`, etc.) always beats
-the saved token, so a per-run env override is always possible.
+At runtime, the per-provider env var (`OPENAI_API_KEY`, etc.) always
+beats the saved token, so a per-run env override is always possible.
+The setup wizard can also switch models for the current session. OpenAI and
+OpenRouter reasoning effort can be changed at runtime with the `/effort` modal
+or `/setup effort <level>` (for example, `high` or `medium`).
 
 `/setup` can store an API token under `[tokens]` in the settings file. The
 file is written with `0o600` on Unix (owner-only) and stored token values are

--- a/src/app.rs
+++ b/src/app.rs
@@ -2662,11 +2662,17 @@ fn setup_overlay_content(app: &App) -> (Vec<Line<'static>>, Option<(usize, usize
             ));
             lines.push(Line::from(""));
             let label = app.model.provider_label();
-            let current = if label.starts_with("openai/") || label.starts_with("openrouter/") {
+            let current = if label.starts_with("openai/") {
                 label
                     .split_whitespace()
                     .nth(1)
                     .unwrap_or("medium")
+                    .to_string()
+            } else if label.starts_with("openrouter/") {
+                label
+                    .split_whitespace()
+                    .nth(1)
+                    .unwrap_or_default()
                     .to_string()
             } else {
                 String::new()
@@ -4832,6 +4838,31 @@ mod tests {
                 .any(|line| line.text == "setup complete: openai/gpt-5.4 high"),
             "effort modal should report completion: {:?}",
             app.lines
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn effort_modal_does_not_mark_unset_openrouter_effort_current() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.lines.clear();
+        app.setup = None;
+
+        app.handle_command("setup token openrouter sk-test").await;
+        app.run_setup_command(Some("model openrouter/nvidia/nemotron-3-super-120b-a12b"))
+            .await
+            .expect("set openrouter model");
+        app.lines.clear();
+        app.dispatch_command_for_test("effort").await;
+
+        assert_eq!(
+            app.model.provider_label(),
+            "openrouter/nvidia/nemotron-3-super-120b-a12b"
+        );
+        let rendered = setup_overlay_text(app);
+        assert!(
+            !rendered.iter().any(|line| line.contains("· current")),
+            "unset OpenRouter effort should not render a current marker: {rendered:?}"
         );
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -896,7 +896,7 @@ impl App {
 
     fn current_effort_index(&self) -> usize {
         let label = self.model.provider_label();
-        if !label.starts_with("openai/") {
+        if !label.starts_with("openai/") && !label.starts_with("openrouter/") {
             return effort_index("medium").unwrap_or(0);
         }
         label
@@ -1061,6 +1061,11 @@ impl App {
                     spec: Some("openrouter/openai/gpt-5.2".to_string()),
                     label: "openai/gpt-5.2".to_string(),
                     hint: "default OpenRouter model",
+                },
+                ModelOption {
+                    spec: Some("openrouter/nvidia/nemotron-3-super-120b-a12b high".to_string()),
+                    label: "nvidia/nemotron-3-super-120b-a12b".to_string(),
+                    hint: "reasoning model through OpenRouter",
                 },
                 ModelOption {
                     spec: Some("openrouter/anthropic/claude-sonnet-4-5".to_string()),
@@ -2653,12 +2658,12 @@ fn setup_overlay_content(app: &App) -> (Vec<Line<'static>>, Option<(usize, usize
         Some(SetupStep::PickEffort { selected, error }) => {
             lines.push(setup_title("Select Reasoning Effort"));
             lines.push(setup_hint(
-                "OpenAI reasoning effort. Applies to this session and future sessions.",
+                "OpenAI/OpenRouter reasoning effort. Applies to this session and future sessions.",
             ));
             lines.push(Line::from(""));
-            let current = if app.model.provider_label().starts_with("openai/") {
-                app.model
-                    .provider_label()
+            let label = app.model.provider_label();
+            let current = if label.starts_with("openai/") || label.starts_with("openrouter/") {
+                label
                     .split_whitespace()
                     .nth(1)
                     .unwrap_or("medium")

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -400,7 +400,7 @@ impl Capability for SetupCapability {
             "token" => self.change_token(rest),
             "attribution" => self.change_attribution(rest),
             _ => Ok(failed_result(
-                "usage: /setup — run guided setup; internal forms: status, provider <name>, token <provider> <value|clear>, model <id|provider/id> [openai-reasoning-effort], effort <openai-reasoning-effort>, attribution <on|off>".to_string(),
+                "usage: /setup — run guided setup; internal forms: status, provider <name>, token <provider> <value|clear>, model <id|provider/id> [reasoning-effort], effort <reasoning-effort>, attribution <on|off>".to_string(),
             )),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,6 +161,7 @@ fn provider_name_for_arg(arg: ProviderArg) -> &'static str {
 /// of whichever base was chosen.
 fn pick_provider(cli: &Cli, settings: &SettingsStore) -> ProviderChoice {
     let snapshot = settings.snapshot();
+    let cli_reasoning_effort = runtime::normalize_reasoning_effort(cli.reasoning_effort.clone());
     let base = if let Some(arg) = cli.provider {
         ProviderChoice::default_for_provider_name(provider_name_for_arg(arg))
             .expect("ProviderArg names are always valid")
@@ -184,7 +185,7 @@ fn pick_provider(cli: &Cli, settings: &SettingsStore) -> ProviderChoice {
             Some(m),
         ) => ProviderChoice::OpenAi {
             model: m,
-            reasoning_effort: cli.reasoning_effort.clone().or(reasoning_effort),
+            reasoning_effort: cli_reasoning_effort.clone().or(reasoning_effort),
         },
         (ProviderChoice::Google { base_url, .. }, Some(m)) => {
             ProviderChoice::Google { model: m, base_url }
@@ -199,14 +200,14 @@ fn pick_provider(cli: &Cli, settings: &SettingsStore) -> ProviderChoice {
         ) => ProviderChoice::OpenRouter {
             model: m,
             base_url,
-            reasoning_effort: cli.reasoning_effort.clone().or(reasoning_effort),
+            reasoning_effort: cli_reasoning_effort.clone().or(reasoning_effort),
         },
         (ProviderChoice::Ollama { base_url, .. }, Some(m)) => {
             ProviderChoice::Ollama { model: m, base_url }
         }
         (other, _) => other,
     };
-    match (selected, cli.reasoning_effort.clone()) {
+    match (selected, cli_reasoning_effort) {
         (
             ProviderChoice::OpenAi {
                 model,
@@ -614,5 +615,50 @@ fn paint(enabled: bool, code: &str, text: &str) -> String {
         format!("\x1b[{code}m{text}\x1b[0m")
     } else {
         text.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cli_with_reasoning_effort(reasoning_effort: Option<&str>) -> Cli {
+        Cli {
+            command: None,
+            cwd: None,
+            provider: Some(ProviderArg::Openrouter),
+            model: Some("nvidia/nemotron-3-super-120b-a12b".to_string()),
+            reasoning_effort: reasoning_effort.map(str::to_string),
+            print: None,
+            acp: false,
+            session: None,
+            session_dir: None,
+        }
+    }
+
+    #[test]
+    fn pick_provider_normalizes_cli_reasoning_effort() {
+        let tmp = tempfile::tempdir().expect("settings tempdir");
+        let settings = SettingsStore::open(tmp.path().join("settings.toml"));
+
+        let provider = pick_provider(&cli_with_reasoning_effort(Some(" HIGH ")), &settings);
+
+        assert_eq!(
+            provider.label(),
+            "openrouter/nvidia/nemotron-3-super-120b-a12b high"
+        );
+    }
+
+    #[test]
+    fn pick_provider_ignores_blank_cli_reasoning_effort() {
+        let tmp = tempfile::tempdir().expect("settings tempdir");
+        let settings = SettingsStore::open(tmp.path().join("settings.toml"));
+
+        let provider = pick_provider(&cli_with_reasoning_effort(Some("  ")), &settings);
+
+        assert_eq!(
+            provider.label(),
+            "openrouter/nvidia/nemotron-3-super-120b-a12b"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ struct Cli {
     #[arg(short, long)]
     model: Option<String>,
 
-    /// OpenAI reasoning effort for model calls (default: medium)
+    /// Reasoning effort for OpenAI and OpenRouter model calls
     #[arg(long)]
     reasoning_effort: Option<String>,
 
@@ -189,9 +189,18 @@ fn pick_provider(cli: &Cli, settings: &SettingsStore) -> ProviderChoice {
         (ProviderChoice::Google { base_url, .. }, Some(m)) => {
             ProviderChoice::Google { model: m, base_url }
         }
-        (ProviderChoice::OpenRouter { base_url, .. }, Some(m)) => {
-            ProviderChoice::OpenRouter { model: m, base_url }
-        }
+        (
+            ProviderChoice::OpenRouter {
+                base_url,
+                reasoning_effort,
+                ..
+            },
+            Some(m),
+        ) => ProviderChoice::OpenRouter {
+            model: m,
+            base_url,
+            reasoning_effort: cli.reasoning_effort.clone().or(reasoning_effort),
+        },
         (ProviderChoice::Ollama { base_url, .. }, Some(m)) => {
             ProviderChoice::Ollama { model: m, base_url }
         }
@@ -206,6 +215,18 @@ fn pick_provider(cli: &Cli, settings: &SettingsStore) -> ProviderChoice {
             effort,
         ) => ProviderChoice::OpenAi {
             model,
+            reasoning_effort: effort.or(reasoning_effort),
+        },
+        (
+            ProviderChoice::OpenRouter {
+                model,
+                base_url,
+                reasoning_effort,
+            },
+            effort,
+        ) => ProviderChoice::OpenRouter {
+            model,
+            base_url,
             reasoning_effort: effort.or(reasoning_effort),
         },
         (other, _) => other,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -371,7 +371,7 @@ impl SessionFileSystem for CodingCliSessionFileStore {
 
 const DEFAULT_OPENAI_MODEL: &str = "gpt-5.5";
 const DEFAULT_OPENAI_REASONING_EFFORT: &str = "medium";
-const OPENAI_REASONING_EFFORT_SUGGESTIONS: &[&str] = &["minimal", "low", "medium", "high"];
+const REASONING_EFFORT_SUGGESTIONS: &[&str] = &["minimal", "low", "medium", "high"];
 const DEFAULT_ANTHROPIC_MODEL: &str = "claude-sonnet-4-5";
 const DEFAULT_GOOGLE_MODEL: &str = "gemini-2.5-flash";
 // Gemini exposes an OpenAI-compatible surface at this base URL, driven through
@@ -401,6 +401,7 @@ pub enum ProviderChoice {
     OpenRouter {
         model: String,
         base_url: String,
+        reasoning_effort: Option<String>,
     },
     Ollama {
         model: String,
@@ -438,6 +439,9 @@ impl ProviderChoice {
             return Self::OpenRouter {
                 model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_OPENROUTER_MODEL),
                 base_url: env_or_default("OPENROUTER_BASE_URL", DEFAULT_OPENROUTER_BASE_URL),
+                reasoning_effort: normalize_reasoning_effort(env_non_empty(
+                    "EVERRUNS_CLI_REASONING_EFFORT",
+                )),
             };
         }
         if google_api_key().is_some() || settings.has_token("google") {
@@ -479,7 +483,14 @@ impl ProviderChoice {
                 None => format!("openai/{model}"),
             },
             Self::Google { model, .. } => format!("google/{model}"),
-            Self::OpenRouter { model, .. } => format!("openrouter/{model}"),
+            Self::OpenRouter {
+                model,
+                reasoning_effort,
+                ..
+            } => match reasoning_effort {
+                Some(effort) => format!("openrouter/{model} {effort}"),
+                None => format!("openrouter/{model}"),
+            },
             Self::Ollama { model, .. } => format!("ollama/{model}"),
             Self::Sim => "llmsim/llmsim-yolop".to_string(),
         }
@@ -513,6 +524,9 @@ impl ProviderChoice {
             "openrouter" => Ok(Self::OpenRouter {
                 model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_OPENROUTER_MODEL),
                 base_url: env_or_default("OPENROUTER_BASE_URL", DEFAULT_OPENROUTER_BASE_URL),
+                reasoning_effort: normalize_reasoning_effort(env_non_empty(
+                    "EVERRUNS_CLI_REASONING_EFFORT",
+                )),
             }),
             "ollama" => Ok(Self::Ollama {
                 model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_OLLAMA_MODEL),
@@ -536,6 +550,7 @@ impl ProviderChoice {
             "google/gemini-2.5-flash",
             "google/gemini-2.5-pro",
             "openrouter/openai/gpt-5.2",
+            "openrouter/nvidia/nemotron-3-super-120b-a12b high",
             "ollama/llama3.2",
             "anthropic/claude-sonnet-4-5",
             "anthropic/claude-opus-4-5",
@@ -591,17 +606,11 @@ impl ProviderChoice {
                     base_url: env_or_default("GOOGLE_BASE_URL", DEFAULT_GOOGLE_BASE_URL),
                 })
             }
-            "openrouter" => {
-                if reasoning_effort.is_some() {
-                    return Err(anyhow!(
-                        "openrouter model switching does not accept reasoning effort"
-                    ));
-                }
-                Ok(Self::OpenRouter {
-                    model: model.to_string(),
-                    base_url: env_or_default("OPENROUTER_BASE_URL", DEFAULT_OPENROUTER_BASE_URL),
-                })
-            }
+            "openrouter" => Ok(Self::OpenRouter {
+                model: model.to_string(),
+                base_url: env_or_default("OPENROUTER_BASE_URL", DEFAULT_OPENROUTER_BASE_URL),
+                reasoning_effort: normalize_reasoning_effort(reasoning_effort),
+            }),
             "ollama" => {
                 if reasoning_effort.is_some() {
                     return Err(anyhow!(
@@ -659,17 +668,11 @@ impl ProviderChoice {
                     base_url: base_url.clone(),
                 })
             }
-            Self::OpenRouter { base_url, .. } => {
-                if reasoning_effort.is_some() {
-                    return Err(anyhow!(
-                        "openrouter model switching does not accept reasoning effort"
-                    ));
-                }
-                Ok(Self::OpenRouter {
-                    model,
-                    base_url: base_url.clone(),
-                })
-            }
+            Self::OpenRouter { base_url, .. } => Ok(Self::OpenRouter {
+                model,
+                base_url: base_url.clone(),
+                reasoning_effort: normalize_reasoning_effort(reasoning_effort),
+            }),
             Self::Ollama { base_url, .. } => {
                 if reasoning_effort.is_some() {
                     return Err(anyhow!(
@@ -699,8 +702,8 @@ impl ProviderChoice {
         let effort = parts.next().unwrap_or_default();
         if effort.is_empty() || parts.next().is_some() {
             return Err(anyhow!(
-                "expected one OpenAI reasoning effort (suggestions: {})",
-                OPENAI_REASONING_EFFORT_SUGGESTIONS.join(", ")
+                "expected one reasoning effort (suggestions: {})",
+                REASONING_EFFORT_SUGGESTIONS.join(", ")
             ));
         }
         match self {
@@ -708,15 +711,22 @@ impl ProviderChoice {
                 model: model.clone(),
                 reasoning_effort: normalize_openai_reasoning_effort(Some(effort.to_string())),
             }),
+            Self::OpenRouter {
+                model, base_url, ..
+            } => Ok(Self::OpenRouter {
+                model: model.clone(),
+                base_url: base_url.clone(),
+                reasoning_effort: normalize_reasoning_effort(Some(effort.to_string())),
+            }),
             other => Err(anyhow!(
-                "reasoning effort only applies to OpenAI models (current provider: {})",
+                "reasoning effort only applies to OpenAI and OpenRouter models (current provider: {})",
                 other.provider_name()
             )),
         }
     }
 
     pub(crate) fn reasoning_effort_suggestions() -> &'static [&'static str] {
-        OPENAI_REASONING_EFFORT_SUGGESTIONS
+        REASONING_EFFORT_SUGGESTIONS
     }
 
     pub(crate) fn model_with_provider(&self, settings: &Settings) -> Result<ModelWithProvider> {
@@ -753,7 +763,9 @@ impl ProviderChoice {
                     base_url: Some(base_url.clone()),
                 })
             }
-            ProviderChoice::OpenRouter { model, base_url } => {
+            ProviderChoice::OpenRouter {
+                model, base_url, ..
+            } => {
                 let key = resolve_token(settings, "openrouter", &["OPENROUTER_API_KEY"])
                     .ok_or_else(|| anyhow!("OPENROUTER_API_KEY not set (and no token stored)"))?;
                 Ok(ModelWithProvider {
@@ -812,7 +824,9 @@ impl ProviderChoice {
             },
             // OpenRouter must use Chat Completions, not the Open Responses API —
             // see the keyed path in `model_with_provider` for the full rationale.
-            ProviderChoice::OpenRouter { model, base_url } => ModelWithProvider {
+            ProviderChoice::OpenRouter {
+                model, base_url, ..
+            } => ModelWithProvider {
                 model: model.clone(),
                 provider_type: LlmProviderType::OpenaiCompletions,
                 api_key: None,
@@ -835,11 +849,16 @@ impl ProviderChoice {
 
     fn input_message(&self, text: impl Into<String>) -> InputMessage {
         let mut input = InputMessage::user(text);
-        if let Self::OpenAi {
-            reasoning_effort: Some(effort),
-            ..
-        } = self
-        {
+        let reasoning_effort = match self {
+            Self::OpenAi {
+                reasoning_effort, ..
+            }
+            | Self::OpenRouter {
+                reasoning_effort, ..
+            } => reasoning_effort.as_ref(),
+            _ => None,
+        };
+        if let Some(effort) = reasoning_effort {
             input.controls = Some(Controls {
                 reasoning: Some(ReasoningConfig {
                     effort: Some(effort.clone()),
@@ -878,11 +897,17 @@ fn env_or_default(name: &str, default: &str) -> String {
 }
 
 fn normalize_openai_reasoning_effort(reasoning_effort: Option<String>) -> Option<String> {
-    Some(
+    normalize_reasoning_effort(Some(
         reasoning_effort
             .filter(|effort| !effort.trim().is_empty())
             .unwrap_or_else(|| DEFAULT_OPENAI_REASONING_EFFORT.to_string()),
-    )
+    ))
+}
+
+fn normalize_reasoning_effort(reasoning_effort: Option<String>) -> Option<String> {
+    reasoning_effort
+        .map(|effort| effort.trim().to_ascii_lowercase())
+        .filter(|effort| !effort.is_empty())
 }
 
 fn coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabilityConfig> {
@@ -1602,6 +1627,19 @@ mod tests {
     }
 
     #[test]
+    fn model_spec_accepts_openrouter_reasoning_effort() {
+        let provider = ProviderChoice::Sim;
+        let next = provider
+            .resolve_model_spec("openrouter/nvidia/nemotron-3-super-120b-a12b high")
+            .unwrap();
+
+        assert_eq!(
+            next.label(),
+            "openrouter/nvidia/nemotron-3-super-120b-a12b high"
+        );
+    }
+
+    #[test]
     fn model_spec_accepts_ollama_provider_name() {
         let provider = ProviderChoice::Sim;
         let next = provider.resolve_model_spec("ollama/llama3.2").unwrap();
@@ -1689,6 +1727,7 @@ mod tests {
         let provider = ProviderChoice::OpenRouter {
             model: "openai/gpt-5.2".to_string(),
             base_url: DEFAULT_OPENROUTER_BASE_URL.to_string(),
+            reasoning_effort: None,
         };
 
         let err = provider
@@ -1710,6 +1749,7 @@ mod tests {
         let provider = ProviderChoice::OpenRouter {
             model: "nvidia/nemotron-3-ultra-550b-a55b".to_string(),
             base_url: DEFAULT_OPENROUTER_BASE_URL.to_string(),
+            reasoning_effort: None,
         };
 
         let model = provider.model_with_provider(&Settings::default()).unwrap();
@@ -1788,13 +1828,31 @@ mod tests {
     }
 
     #[test]
-    fn reasoning_effort_rejects_non_openai_provider() {
+    fn reasoning_effort_can_update_current_openrouter_model() {
+        let provider = ProviderChoice::OpenRouter {
+            model: "nvidia/nemotron-3-super-120b-a12b".to_string(),
+            base_url: DEFAULT_OPENROUTER_BASE_URL.to_string(),
+            reasoning_effort: Some("medium".to_string()),
+        };
+        let next = provider.resolve_reasoning_effort("high").unwrap();
+
+        assert_eq!(
+            next.label(),
+            "openrouter/nvidia/nemotron-3-super-120b-a12b high"
+        );
+    }
+
+    #[test]
+    fn reasoning_effort_rejects_unsupported_provider() {
         let provider = ProviderChoice::Anthropic {
             model: "claude-sonnet-4-5".to_string(),
         };
         let err = provider.resolve_reasoning_effort("high").unwrap_err();
 
-        assert!(err.to_string().contains("only applies to OpenAI"));
+        assert!(
+            err.to_string()
+                .contains("only applies to OpenAI and OpenRouter")
+        );
     }
 
     #[tokio::test]
@@ -1956,6 +2014,25 @@ mod tests {
                 .and_then(|controls| controls.reasoning)
                 .and_then(|reasoning| reasoning.effort),
             Some("medium".to_string())
+        );
+    }
+
+    #[test]
+    fn openrouter_input_message_carries_reasoning_effort() {
+        let provider = ProviderChoice::OpenRouter {
+            model: "nvidia/nemotron-3-super-120b-a12b".to_string(),
+            base_url: DEFAULT_OPENROUTER_BASE_URL.to_string(),
+            reasoning_effort: Some("high".to_string()),
+        };
+
+        let input = provider.input_message("hello");
+
+        assert_eq!(
+            input
+                .controls
+                .and_then(|controls| controls.reasoning)
+                .and_then(|reasoning| reasoning.effort),
+            Some("high".to_string())
         );
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -904,7 +904,7 @@ fn normalize_openai_reasoning_effort(reasoning_effort: Option<String>) -> Option
     ))
 }
 
-fn normalize_reasoning_effort(reasoning_effort: Option<String>) -> Option<String> {
+pub(crate) fn normalize_reasoning_effort(reasoning_effort: Option<String>) -> Option<String> {
     reasoning_effort
         .map(|effort| effort.trim().to_ascii_lowercase())
         .filter(|effort| !effort.is_empty())


### PR DESCRIPTION
## What
Allow OpenRouter provider selections to carry reasoning effort, including `/model openrouter/<id> <effort>`, `/effort <level>`, `--reasoning-effort`, and `EVERRUNS_CLI_REASONING_EFFORT`.

## Why
OpenRouter reasoning models such as NVIDIA Nemotron advertise reasoning controls, but yolop previously gated effort levels to OpenAI only.

## How
- Add optional `reasoning_effort` state to `ProviderChoice::OpenRouter`.
- Thread OpenRouter effort through CLI/model parsing, `/setup effort`, labels, and `InputMessage.controls.reasoning`.
- Add Nemotron 3 Super as an OpenRouter model-picker suggestion.
- Update README and setup help wording from OpenAI-only to OpenAI/OpenRouter.
- Add runtime tests for OpenRouter model-spec effort, `/effort`, and input control injection.

## Risk
- Low / Medium / High: Low
- What can break: OpenRouter model labels/settings around optional effort. The change is opt-in for OpenRouter, so arbitrary OpenRouter models do not receive reasoning controls unless explicitly configured.

## Security
- TM-LLM: Reviewed provider/key handling. No API keys are logged or persisted by this change; `EVERRUNS_CLI_REASONING_EFFORT` is read from process env only and carries a non-secret effort string.
- TM-FS, TM-BASH, TM-TOOL: No changes to filesystem access, shell execution, approval behavior, tool registration, or blocklists.
- TM-DEP: No dependency changes.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"`
- `doppler run --project yolop --config ci -- cargo run -- --provider openai -p "Reply with exactly: openrouter effort smoke ok"`

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)