### PR TITLE
chore(deps): bump agent-client-protocol to 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,9 +71,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d197653697b91b3a2cfb579d061a3388cda9fdc79cb6f9393da65cbad46baf8"
+checksum = "5efba6592048ef8a9ac97de8d79b2d9933d8ac4d94f7a2de102348fed0c61103"
 dependencies = [
  "agent-client-protocol-derive",
  "agent-client-protocol-schema",
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-derive"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e4fbf6733a900814fb921b2aac06612e15b42020b76a356fbc1192e725cebc"
+checksum = "4d176a10d4cb06e0262a738c3c5bf21ff0968db13a666e31cbca94a3d3d72e7c"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "0.13.5"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d419a87e28240978e4bfdf2a5b91bccb95ae8d5b06e10721bb07c449b9f43dd"
+checksum = "c290bfa00c6b52339db66f8e9cf711d5f08530800529f7d619ff24d6cba253d0"
 dependencies = [
  "anyhow",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ name = "yolop"
 path = "src/main.rs"
 
 [dependencies]
-agent-client-protocol = "0.13.1"
+agent-client-protocol = "0.14.0"
 anyhow = "1.0"
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
## What

Bumps the direct dependency `agent-client-protocol` from `0.13.1` to `0.14.0`. The lockfile updates accordingly: `agent-client-protocol-derive` 0.13.1 → 0.14.0 and `agent-client-protocol-schema` 0.13.5 → 0.13.6.

## Why

0.14.0 is the latest published release of the official ACP SDK that backs yolop's ACP agent surface (`src/acp/`). Staying current keeps the wire data model and SDK transport in step with upstream. The `everruns-*` family is unaffected and remains in lockstep at 0.9.0 (already the latest published).

## Validation

The bump required **zero source changes** — 0.14.0 is API-compatible with how yolop uses the SDK (`src/acp/{protocol,server,bridge,mod}.rs`).

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all-features` — 216 + 15 pass, 1 ignored (the live-provider `acp_openai_handshake_smoke`, which self-skips with no API key)
- `cargo run -- --provider llmsim -p "hi"` — binary starts, runs a full turn, exits 0

The existing ACP test suite is the regression evidence here: schema round-trips (`protocol.rs`), the pure event→`session/update` translator (`bridge.rs`), and the full end-to-end `initialize → session/new → session/prompt` handshake driven through the SDK over duplex pipes (`mod.rs`) all pass against 0.14.0, proving the SDK upgrade is behavior-preserving. No new behavior is introduced, so no new test was added.

## Security

TM-DEP is the only relevant category. The diff is `Cargo.toml` + `Cargo.lock` only — no filesystem, shell, LLM-key-handling, or capability-registration code is touched. No new crates are added; this is a version bump of the existing, trusted official ACP SDK, with checksums changing as expected for a legitimate registry pull. Other threat-model categories (TM-FS, TM-BASH, TM-LLM, TM-TOOL) have no code surface in this change.

## Note on release-age floor

`agent-client-protocol` 0.14.0 was published 2026-06-05 — 4 days before this change. The maintenance spec sets a ≥7-day release-age floor for minor/major bumps to avoid landing same-day yanks. This lands 3 days under that floor as a deliberate, approved exception: the same-day-yank risk the floor mitigates has passed, the bump is clean, and the upgrade was explicitly requested.

## Follow-ups

No follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1cjprzkpCqVgVm6JmU5oo)_