### PR TITLE
fix(tui): survive transient terminal I/O failures in the event loop

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -75,6 +75,12 @@ pub(crate) struct CommandSuggestion {
 }
 
 pub const COMPOSER_VIEWPORT_HEIGHT: u16 = 18;
+/// Consecutive failed event-loop iterations tolerated before the terminal is
+/// considered gone and the error becomes fatal. The slowest failure mode (an
+/// unanswered cursor-position query) blocks ~2s per attempt inside crossterm,
+/// so this bounds a permanently dead terminal to ~10s before exit while
+/// letting a briefly unresponsive emulator recover.
+const MAX_TERMINAL_IO_FAILURES: usize = 5;
 const COMPACT_CHROME_HEIGHT: u16 = 5;
 const MAX_INPUT_HEIGHT: u16 = 12;
 const ACCENT_BLUE: Color = Color::Rgb(45, 91, 158);
@@ -401,87 +407,129 @@ impl App {
         B::Error: std::error::Error + Send + Sync + 'static,
     {
         self.emit_replayed_transcript().await;
+        // Terminal I/O fails transiently in the wild, so one failed loop
+        // iteration must not end the session. The motivating case:
+        // xterm.js-backed hosts (ttyd, vhs recordings) resize the PTY
+        // mid-session, ratatui re-anchors the inline viewport by querying
+        // the cursor position (`CSI 6n`), and crossterm abandons that query
+        // after 2s if the emulator is too busy (reflowing scrollback,
+        // screencasting) to answer in time. Propagating that error killed
+        // the TUI right as turns completed, while tmux — which answers the
+        // query itself, instantly — never showed the bug.
+        //
+        // Retrying is safe because a failed iteration mutates no app state:
+        // the failed resize/draw is simply re-attempted next frame, and the
+        // terminal answers once it catches up. Only a run of consecutive
+        // failures (terminal actually gone, e.g. PTY closed) is fatal.
+        let mut io_failures = 0usize;
         loop {
             if self.busy {
                 self.busy_frame = self.busy_frame.wrapping_add(1);
             }
-            self.flush_transcript(terminal)?;
-            terminal.draw(|f| draw(f, self))?;
-
-            // 1) drain background turn events
-            if let Some(rx) = self.rx.as_mut() {
-                match rx.try_recv() {
-                    Ok(TurnEvent::Lines(lines)) => {
-                        self.lines.extend(lines);
-                        continue;
+            match self.run_loop_iteration(terminal).await {
+                Ok(()) => io_failures = 0,
+                Err(err) => {
+                    io_failures += 1;
+                    if io_failures >= MAX_TERMINAL_IO_FAILURES {
+                        return Err(err);
                     }
-                    Ok(TurnEvent::Activity(activity)) => {
-                        if !activity.fallback || self.turn_activity.is_none() {
-                            self.turn_activity = Some(activity.text);
-                        }
-                        continue;
-                    }
-                    Ok(TurnEvent::Stream(preview)) => {
-                        self.stream_preview = preview;
-                        continue;
-                    }
-                    Ok(TurnEvent::Done) => {
-                        self.busy = false;
-                        self.busy_frame = 0;
-                        self.turn_activity = None;
-                        self.stream_preview = None;
-                        self.rx = None;
-                        continue;
-                    }
-                    Ok(TurnEvent::Failed(err)) => {
-                        self.busy = false;
-                        self.busy_frame = 0;
-                        self.turn_activity = None;
-                        self.stream_preview = None;
-                        self.rx = None;
-                        self.push_system(format!("turn failed: {err}"));
-                        continue;
-                    }
-                    Err(mpsc::error::TryRecvError::Empty) => {}
-                    Err(mpsc::error::TryRecvError::Disconnected) => {
-                        self.busy = false;
-                        self.turn_activity = None;
-                        self.stream_preview = None;
-                        self.rx = None;
-                    }
+                    tracing::warn!(
+                        "terminal i/o failed ({io_failures}/{MAX_TERMINAL_IO_FAILURES}): {err:#}"
+                    );
                 }
             }
-
-            // 2) drain terminal-side commands emitted by capabilities. Apply
-            // every queued command before re-rendering so a burst (or a future
-            // capability that emits more than one) doesn't cost a full
-            // flush/draw per command, matching the test dispatch helper.
-            let mut applied_ui_command = false;
-            while let Ok(command) = self.ui_rx.try_recv() {
-                self.apply_ui_command(command);
-                applied_ui_command = true;
+            if self.should_quit {
+                return Ok(());
             }
-            if applied_ui_command {
-                continue;
-            }
+        }
+    }
 
-            // 3) keystrokes. Mouse wheel/drag stays native terminal behavior
-            // because the transcript lives in scrollback, not in this viewport.
-            let mut poll_timeout = Duration::from_millis(80);
-            while event::poll(poll_timeout)? {
-                poll_timeout = Duration::ZERO;
-                if let CrosstermEvent::Key(key) = event::read()? {
-                    if key.kind == KeyEventKind::Release {
-                        continue;
-                    }
-                    if key.code == KeyCode::Esc && self.handle_escape_prefixed_enter().await? {
-                        continue;
-                    }
-                    self.handle_key(key).await;
+    /// One iteration of the event loop: render, then drain at most one
+    /// class of pending work (turn events, UI commands, keystrokes).
+    ///
+    /// Invariant: every terminal read/write the TUI performs belongs in
+    /// here (or below), never directly in [`App::run`], so it is covered
+    /// by `run`'s retry policy. A bare `?` on terminal I/O outside this
+    /// function reintroduces the bug where one slow terminal reply exits
+    /// the whole session.
+    async fn run_loop_iteration<B>(&mut self, terminal: &mut Terminal<B>) -> Result<()>
+    where
+        B: Backend,
+        B::Error: std::error::Error + Send + Sync + 'static,
+    {
+        self.flush_transcript(terminal)?;
+        terminal.draw(|f| draw(f, self))?;
+
+        // 1) drain background turn events
+        if let Some(rx) = self.rx.as_mut() {
+            match rx.try_recv() {
+                Ok(TurnEvent::Lines(lines)) => {
+                    self.lines.extend(lines);
+                    return Ok(());
                 }
-                if self.should_quit {
-                    break;
+                Ok(TurnEvent::Activity(activity)) => {
+                    if !activity.fallback || self.turn_activity.is_none() {
+                        self.turn_activity = Some(activity.text);
+                    }
+                    return Ok(());
                 }
+                Ok(TurnEvent::Stream(preview)) => {
+                    self.stream_preview = preview;
+                    return Ok(());
+                }
+                Ok(TurnEvent::Done) => {
+                    self.busy = false;
+                    self.busy_frame = 0;
+                    self.turn_activity = None;
+                    self.stream_preview = None;
+                    self.rx = None;
+                    return Ok(());
+                }
+                Ok(TurnEvent::Failed(err)) => {
+                    self.busy = false;
+                    self.busy_frame = 0;
+                    self.turn_activity = None;
+                    self.stream_preview = None;
+                    self.rx = None;
+                    self.push_system(format!("turn failed: {err}"));
+                    return Ok(());
+                }
+                Err(mpsc::error::TryRecvError::Empty) => {}
+                Err(mpsc::error::TryRecvError::Disconnected) => {
+                    self.busy = false;
+                    self.turn_activity = None;
+                    self.stream_preview = None;
+                    self.rx = None;
+                }
+            }
+        }
+
+        // 2) drain terminal-side commands emitted by capabilities. Apply
+        // every queued command before re-rendering so a burst (or a future
+        // capability that emits more than one) doesn't cost a full
+        // flush/draw per command, matching the test dispatch helper.
+        let mut applied_ui_command = false;
+        while let Ok(command) = self.ui_rx.try_recv() {
+            self.apply_ui_command(command);
+            applied_ui_command = true;
+        }
+        if applied_ui_command {
+            return Ok(());
+        }
+
+        // 3) keystrokes. Mouse wheel/drag stays native terminal behavior
+        // because the transcript lives in scrollback, not in this viewport.
+        let mut poll_timeout = Duration::from_millis(80);
+        while event::poll(poll_timeout)? {
+            poll_timeout = Duration::ZERO;
+            if let CrosstermEvent::Key(key) = event::read()? {
+                if key.kind == KeyEventKind::Release {
+                    continue;
+                }
+                if key.code == KeyCode::Esc && self.handle_escape_prefixed_enter().await? {
+                    continue;
+                }
+                self.handle_key(key).await;
             }
             if self.should_quit {
                 break;

--- a/src/app.rs
+++ b/src/app.rs
@@ -417,10 +417,14 @@ impl App {
         // the TUI right as turns completed, while tmux — which answers the
         // query itself, instantly — never showed the bug.
         //
-        // Retrying is safe because a failed iteration mutates no app state:
-        // the failed resize/draw is simply re-attempted next frame, and the
-        // terminal answers once it catches up. Only a run of consecutive
-        // failures (terminal actually gone, e.g. PTY closed) is fatal.
+        // Retrying is safe because a failed iteration loses nothing and is
+        // re-attempted next frame once the terminal catches up. Worst case
+        // it leaves cosmetic artifacts: `flush_transcript` only advances
+        // `printed_lines` after every chunk landed, so a flush interrupted
+        // mid-way re-inserts its lines on retry (briefly duplicated
+        // scrollback during a terminal hiccup), and the spinner skips the
+        // frames spent failing. Only a run of consecutive failures
+        // (terminal actually gone, e.g. PTY closed) is fatal.
         let mut io_failures = 0usize;
         loop {
             if self.busy {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -23,7 +23,9 @@ use std::thread;
 use std::time::{Duration, Instant};
 use std::{io::Read, io::Write};
 
-use portable_pty::{Child, CommandBuilder, ExitStatus, NativePtySystem, PtySize, PtySystem};
+use portable_pty::{
+    Child, CommandBuilder, ExitStatus, MasterPty, NativePtySystem, PtySize, PtySystem,
+};
 
 fn yolop_binary() -> PathBuf {
     // CARGO_BIN_EXE_<name> is set by Cargo for integration tests.
@@ -345,6 +347,53 @@ fn tui_alt_enter_sequence_submits_like_enter() {
 }
 
 #[test]
+fn tui_survives_slow_cursor_position_reply_after_resize() {
+    // Regression test for the TUI dying right around turn completion under
+    // xterm.js-backed terminals (ttyd / vhs recordings). Those emulators
+    // resize the PTY mid-session (fit-addon re-measuring once the scrollbar
+    // appears or fonts settle) and can be slow to answer the `CSI 6n`
+    // cursor-position query ratatui issues to re-anchor the inline viewport
+    // after a resize — crossterm gives up on that query after 2 seconds.
+    // That transient failure must not exit the TUI.
+    let mut tui = spawn_tui_llmsim();
+    assert!(
+        tui.wait_for_output("type /help", Duration::from_secs(3)),
+        "TUI did not render startup banner: {}",
+        tui.output_text()
+    );
+
+    tui.write_input(b"hi\r");
+    assert!(
+        tui.wait_for_output("offline mode", Duration::from_secs(5)),
+        "turn did not complete: {}",
+        tui.output_text()
+    );
+
+    // Shrink the PTY by one column, like xterm.js does when its scrollbar
+    // appears as the transcript first overflows. The harness deliberately
+    // does NOT answer the cursor-position query this triggers, emulating a
+    // busy emulator. crossterm's 2s query timeout fires at least once.
+    tui.resize(79, 24);
+    assert!(
+        wait_for_exit(&mut *tui.child, Duration::from_secs(5)).is_none(),
+        "TUI exited after an unanswered cursor-position query: {}",
+        tui.output_text()
+    );
+
+    // The emulator catches up: answer the (retried) query, then Ctrl-C. The
+    // reply must come first — the event loop is blocked inside the cursor
+    // query until it arrives.
+    tui.write_input(b"\x1b[1;1R");
+    tui.write_input(b"\x03");
+    let status = tui.wait_or_kill(Duration::from_secs(10));
+    assert!(
+        status.success(),
+        "Ctrl-C should exit cleanly after recovery, got {status:?}: {}",
+        tui.output_text()
+    );
+}
+
+#[test]
 fn tui_double_ctrl_c_exits() {
     let mut tui = spawn_tui_llmsim();
     assert!(
@@ -423,6 +472,7 @@ fn strip_ansi(input: &str) -> String {
 
 struct TuiHarness {
     child: Box<dyn Child + Send + Sync>,
+    master: Box<dyn MasterPty + Send>,
     writer: Box<dyn Write + Send>,
     output_rx: Receiver<Vec<u8>>,
     output: Vec<u8>,
@@ -434,6 +484,17 @@ impl TuiHarness {
     fn write_input(&mut self, bytes: &[u8]) {
         self.writer.write_all(bytes).expect("write pty input");
         self.writer.flush().expect("flush pty input");
+    }
+
+    fn resize(&mut self, cols: u16, rows: u16) {
+        self.master
+            .resize(PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("resize pty");
     }
 
     fn wait_for_output(&mut self, needle: &str, timeout: Duration) -> bool {
@@ -542,6 +603,7 @@ fn spawn_tui_llmsim() -> TuiHarness {
     writer.flush().expect("flush cursor position response");
     TuiHarness {
         child,
+        master: pair.master,
         writer,
         output_rx,
         output: Vec::new(),


### PR DESCRIPTION
## What

The TUI event loop treated any terminal I/O error as fatal: one failed `flush_transcript`/`draw`/`event::poll` iteration propagated out of `App::run` and exited the session. Now the loop body lives in `run_loop_iteration`, and `App::run` retries failed iterations, bailing only after 5 consecutive failures (`MAX_TERMINAL_IO_FAILURES`, each internally capped at 2s by crossterm — ~10s worst case for a genuinely dead terminal). Failures are logged via `tracing::warn`.

## Why

Reproducible crash under xterm.js-backed terminals (ttyd, vhs recordings — observed while recording the README demo: 2 of 4 vhs runs dropped to the shell right at turn completion, while the same run under tmux never died). The chain:

1. xterm.js hosts resize the PTY mid-session (fit-addon re-measuring once the scrollbar appears as the transcript first overflows — i.e., right at turn completion).
2. ratatui re-anchors the inline viewport after a resize by querying the cursor position (`CSI 6n`); crossterm abandons that query after 2s.
3. A headless Chromium busy reflowing scrollback and screencasting misses the 2s window; the error escaped `App::run` and exited the TUI. The session log looked fine because the turn had already been persisted.

tmux masks the bug: it answers the cursor query itself, instantly.

Retrying is safe because a failed iteration mutates no app state — the resize/draw is re-attempted on the next frame once the emulator catches up.

## Validation

- New regression test `tui_survives_slow_cursor_position_reply_after_resize` drives the real binary in a PTY: completes an llmsim turn, shrinks the PTY without answering the triggered cursor query, asserts the TUI survives the timeout and still exits cleanly on Ctrl-C after a late reply. **Fails on `main`** (TUI exits ~2.1s after the resize) — reproducing the vhs symptom exactly.
- `TuiHarness` gained a `resize()` helper (PTY `TIOCSWINSZ`), the hook for encoding future hostile-terminal scenarios.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features` (222 unit + 17 integration) all green after rebase onto latest `main`.
- Offline smoke: `cargo run -- --provider llmsim -p "hi"` → `done success=true`. Doppler is unavailable in this environment, so the live-provider smoke is covered by CI's live-smoke job.

## Risks

- A genuinely dead terminal now takes up to ~10s to exit instead of 2s; the retry counter bounds it and the cap is a single constant.
- Failure logs are invisible at the default `RUST_LOG=error` (deliberate: warn-level so they never scribble over a raw-mode UI; opt in with `RUST_LOG=warn`).

## Security

No security-relevant code changes: TUI event-loop control flow and a test-only harness extension. No filesystem, shell, capability, or dependency changes (`MasterPty` comes from the existing `portable-pty` dev-dependency). The new warn log carries only crossterm/ratatui I/O error text — no key material flows through that path. The retry loop is bounded (TM resource-exhaustion check).

## Follow-ups

- Add more hostile-terminal regression tests on the new harness hook (garbage escape bytes, resize storms, stdin EOF mid-turn) — deferred to keep this PR a focused bug fix.
- Optional non-required CI smoke job that runs the vhs tape and asserts yolop only exits via the scripted quit — needs ttyd + Chromium in CI; value/flakiness trade-off to be decided.
- Consider an upstream ratatui issue: tolerate a failed cursor-position report on inline-viewport `autoresize` instead of surfacing it as a draw error.