### PR TITLE
fix(tui): anchor startup composer at bottom

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -367,6 +367,7 @@ async fn run_tui(runtime: BuiltRuntime) -> Result<()> {
             viewport: Viewport::Inline(COMPOSER_VIEWPORT_HEIGHT),
         },
     )?;
+    anchor_inline_viewport_at_bottom(&mut terminal)?;
 
     let mut app = App::new(runtime);
     let result = app.run(&mut terminal).await;
@@ -387,6 +388,30 @@ async fn run_tui(runtime: BuiltRuntime) -> Result<()> {
         print_centered_ukraine_banner();
     }
     result
+}
+
+fn anchor_inline_viewport_at_bottom<B>(terminal: &mut Terminal<B>) -> Result<()>
+where
+    B: ratatui::backend::Backend,
+    B::Error: std::error::Error + Send + Sync + 'static,
+{
+    let terminal_height = terminal.size()?.height;
+    let viewport_area = terminal.get_frame().area();
+    let blank_lines =
+        blank_lines_after_inline_viewport(viewport_area.y, viewport_area.height, terminal_height);
+    if blank_lines == 0 {
+        return Ok(());
+    }
+    terminal.insert_before(blank_lines, |_| {})?;
+    Ok(())
+}
+
+fn blank_lines_after_inline_viewport(
+    viewport_top: u16,
+    viewport_height: u16,
+    terminal_height: u16,
+) -> u16 {
+    terminal_height.saturating_sub(viewport_top.saturating_add(viewport_height))
 }
 
 struct RawModeGuard {
@@ -660,5 +685,21 @@ mod tests {
             provider.label(),
             "openrouter/nvidia/nemotron-3-super-120b-a12b"
         );
+    }
+
+    #[test]
+    fn inline_viewport_anchor_fills_space_above_bottom_target() {
+        assert_eq!(blank_lines_after_inline_viewport(4, 18, 60), 38);
+    }
+
+    #[test]
+    fn inline_viewport_anchor_does_not_scroll_when_already_low_enough() {
+        assert_eq!(blank_lines_after_inline_viewport(42, 18, 60), 0);
+        assert_eq!(blank_lines_after_inline_viewport(50, 18, 60), 0);
+    }
+
+    #[test]
+    fn inline_viewport_anchor_handles_small_terminals() {
+        assert_eq!(blank_lines_after_inline_viewport(0, 18, 10), 0);
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -302,6 +302,11 @@ fn tui_escape_does_not_exit_and_ctrl_c_exits() {
         "Ctrl-C should exit cleanly, got {status:?}: {}",
         tui.output_text()
     );
+    assert!(
+        tui.output_text().contains("Resume with yolop --session"),
+        "Ctrl-C cleanup should print resume hint: {}",
+        tui.output_text()
+    );
 }
 
 #[test]
@@ -394,6 +399,76 @@ fn tui_survives_slow_cursor_position_reply_after_resize() {
 }
 
 #[test]
+fn tui_startup_anchors_composer_from_top_in_tall_terminal() {
+    let mut tui = spawn_tui_llmsim_with(TuiSpawnOptions {
+        rows: 40,
+        cols: 100,
+        cursor_row: 1,
+    });
+    assert!(
+        tui.wait_for_output("type /help", Duration::from_secs(3)),
+        "TUI did not render startup banner: {}",
+        tui.output_text()
+    );
+
+    assert_cursor_near_bottom(&mut tui, 40);
+}
+
+#[test]
+fn tui_startup_anchors_composer_when_prompt_is_already_near_bottom() {
+    let mut tui = spawn_tui_llmsim_with(TuiSpawnOptions {
+        rows: 24,
+        cols: 80,
+        cursor_row: 23,
+    });
+    assert!(
+        tui.wait_for_output("type /help", Duration::from_secs(3)),
+        "TUI did not render startup banner: {}",
+        tui.output_text()
+    );
+
+    assert_cursor_near_bottom(&mut tui, 24);
+}
+
+#[test]
+fn tui_startup_anchors_composer_in_short_terminal() {
+    let mut tui = spawn_tui_llmsim_with(TuiSpawnOptions {
+        rows: 8,
+        cols: 80,
+        cursor_row: 1,
+    });
+    assert!(
+        tui.wait_for_output("type /help", Duration::from_secs(3)),
+        "TUI did not render startup banner: {}",
+        tui.output_text()
+    );
+
+    assert_cursor_near_bottom(&mut tui, 8);
+}
+
+#[test]
+fn tui_setup_overlay_renders_in_real_pty() {
+    let mut tui = spawn_tui_llmsim();
+    assert!(
+        tui.wait_for_output("type /help", Duration::from_secs(3)),
+        "TUI did not render startup banner: {}",
+        tui.output_text()
+    );
+
+    tui.write_input(b"/setup\r");
+    assert!(
+        tui.wait_for_output("Set Up Yolop", Duration::from_secs(3)),
+        "/setup should render setup overlay: {}",
+        tui.output_text()
+    );
+    assert!(
+        tui.wait_for_output("Esc cancel", Duration::from_secs(3)),
+        "/setup footer should render without clipping: {}",
+        tui.output_text()
+    );
+}
+
+#[test]
 fn tui_double_ctrl_c_exits() {
     let mut tui = spawn_tui_llmsim();
     assert!(
@@ -408,6 +483,17 @@ fn tui_double_ctrl_c_exits() {
         status.success(),
         "double Ctrl-C should exit cleanly, got {status:?}: {}",
         tui.output_text()
+    );
+}
+
+fn assert_cursor_near_bottom(tui: &mut TuiHarness, rows: u16) {
+    let output = tui.output_text();
+    let cursor_row = max_absolute_cursor_row(output.as_bytes())
+        .unwrap_or_else(|| panic!("missing cursor move in TUI output: {output}"));
+    let minimum_row = rows.saturating_sub(2).max(1);
+    assert!(
+        cursor_row >= minimum_row,
+        "composer cursor should be near terminal bottom (row {cursor_row}, expected >= {minimum_row}): {output}"
     );
 }
 
@@ -470,6 +556,43 @@ fn strip_ansi(input: &str) -> String {
     out
 }
 
+fn max_absolute_cursor_row(output: &[u8]) -> Option<u16> {
+    let mut row = None;
+    let mut i = 0;
+    while i + 2 < output.len() {
+        if output[i] != 0x1b || output[i + 1] != b'[' {
+            i += 1;
+            continue;
+        }
+        let start = i + 2;
+        let mut end = start;
+        while end < output.len() && !matches!(output[end], 0x40..=0x7e) {
+            end += 1;
+        }
+        if end == output.len() {
+            break;
+        }
+        let final_byte = output[end];
+        if matches!(final_byte, b'H' | b'f') {
+            let params = std::str::from_utf8(&output[start..end]).ok()?;
+            if !params.starts_with('?') {
+                let parsed = params
+                    .split(';')
+                    .next()
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or("1")
+                    .parse::<u16>()
+                    .ok();
+                if let Some(parsed) = parsed {
+                    row = Some(row.map_or(parsed, |current: u16| current.max(parsed)));
+                }
+            }
+        }
+        i = end + 1;
+    }
+    row
+}
+
 struct TuiHarness {
     child: Box<dyn Child + Send + Sync>,
     master: Box<dyn MasterPty + Send>,
@@ -478,6 +601,23 @@ struct TuiHarness {
     output: Vec<u8>,
     _session_dir: tempfile::TempDir,
     _home: tempfile::TempDir,
+}
+
+#[derive(Clone, Copy)]
+struct TuiSpawnOptions {
+    rows: u16,
+    cols: u16,
+    cursor_row: u16,
+}
+
+impl Default for TuiSpawnOptions {
+    fn default() -> Self {
+        Self {
+            rows: 24,
+            cols: 80,
+            cursor_row: 1,
+        }
+    }
 }
 
 impl TuiHarness {
@@ -543,6 +683,10 @@ impl Drop for TuiHarness {
 }
 
 fn spawn_tui_llmsim() -> TuiHarness {
+    spawn_tui_llmsim_with(TuiSpawnOptions::default())
+}
+
+fn spawn_tui_llmsim_with(options: TuiSpawnOptions) -> TuiHarness {
     let session_dir = tempfile::tempdir().expect("session tempdir");
     let home = tempfile::tempdir().expect("home tempdir");
     for settings_dir in [
@@ -559,8 +703,8 @@ fn spawn_tui_llmsim() -> TuiHarness {
     let pty_system = NativePtySystem::default();
     let pair = pty_system
         .openpty(PtySize {
-            rows: 24,
-            cols: 80,
+            rows: options.rows,
+            cols: options.cols,
             pixel_width: 0,
             pixel_height: 0,
         })
@@ -597,8 +741,9 @@ fn spawn_tui_llmsim() -> TuiHarness {
     });
 
     let mut writer = pair.master.take_writer().expect("take pty writer");
+    let cursor_row = options.cursor_row.clamp(1, options.rows.max(1));
     writer
-        .write_all(b"\x1b[1;1R")
+        .write_all(format!("\x1b[{cursor_row};1R").as_bytes())
         .expect("seed cursor position response");
     writer.flush().expect("flush cursor position response");
     TuiHarness {


### PR DESCRIPTION
## What
Fixes TUI startup positioning so the inline composer/status viewport is pushed to the terminal bottom after ratatui creates it, even when yolop starts from a prompt near the top of a tall terminal.

Adds PTY regression coverage for top-start, bottom-start, short-terminal startup, real `/setup` overlay rendering, and Ctrl-C cleanup/resume output.

## Why
The inline viewport is anchored relative to the current cursor. Startup transcript output could leave the composer chrome too high in the terminal instead of at the bottom.

## How
- After constructing the ratatui inline terminal, compute how much screen remains below the viewport.
- Use `insert_before` with blank rows to move the viewport to the bottom without issuing another cursor-position query.
- Extend the PTY harness to vary terminal size and initial cursor row.

## Risk
- Low
- TUI startup layout could still differ in unusual terminal emulators, but the change uses ratatui inline viewport APIs and keeps existing resize recovery behavior covered.

## Security
- No security-relevant code changes. This only changes terminal viewport placement and integration tests.
- TM-FS: no filesystem access changes.
- TM-BASH: no shell execution changes.
- TM-LLM: no prompt, provider, key, or session-log changes.
- TM-TOOL: no capability registration changes.
- TM-DEP: no dependency changes.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test tui_startup_anchors_composer`
- `cargo test tui_`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"`

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)