### PR TITLE
fix(model): use raw model ids in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,9 +242,10 @@ Provider resolution at startup:
 
 At runtime, the per-provider env var (`OPENAI_API_KEY`, etc.) always
 beats the saved token, so a per-run env override is always possible.
-The setup wizard can also switch models for the current session. OpenAI and
-OpenRouter reasoning effort can be changed at runtime with the `/effort` modal
-or `/setup effort <level>` (for example, `high` or `medium`).
+The setup wizard can also switch models for the current session, and
+`/model <id>` opens the model picker prefilled for the active provider.
+OpenAI and OpenRouter reasoning effort can be changed at runtime with the
+`/effort` modal or `/setup effort <level>` (for example, `high` or `medium`).
 
 `/setup` can store an API token under `[tokens]` in the settings file. The
 file is written with `0o600` on Unix (owner-only) and stored token values are

--- a/src/app.rs
+++ b/src/app.rs
@@ -890,10 +890,8 @@ impl App {
 
     fn start_model_setup(&mut self) {
         let provider = self.current_provider_name();
-        let selected = model_index_for_label(
-            &self.model.provider_label(),
-            &Self::model_options(&provider),
-        );
+        let selected =
+            model_index_for_label(&self.model.model_id(), &Self::model_options(&provider));
         self.setup = Some(SetupStep::PickModel {
             provider,
             selected,
@@ -908,12 +906,7 @@ impl App {
             self.start_model_setup();
             return;
         }
-        let provider = spec
-            .split('/')
-            .next()
-            .filter(|part| !part.trim().is_empty() && spec.contains('/'))
-            .map(str::to_string)
-            .unwrap_or_else(|| self.current_provider_name());
+        let provider = self.current_provider_name();
         let options = Self::model_options(&provider);
         let selected = model_index_for_label(spec, &options);
         let custom = if options
@@ -1044,94 +1037,94 @@ impl App {
         let mut models = match provider {
             "openai" => vec![
                 ModelOption {
-                    spec: Some("openai/gpt-5.5 medium".to_string()),
+                    spec: Some("gpt-5.5".to_string()),
                     label: "gpt-5.5".to_string(),
                     hint: "frontier model for complex coding",
                 },
                 ModelOption {
-                    spec: Some("openai/gpt-5.4".to_string()),
+                    spec: Some("gpt-5.4".to_string()),
                     label: "gpt-5.4".to_string(),
                     hint: "strong everyday model",
                 },
                 ModelOption {
-                    spec: Some("openai/gpt-5.4-mini".to_string()),
+                    spec: Some("gpt-5.4-mini".to_string()),
                     label: "gpt-5.4-mini".to_string(),
                     hint: "fast and cost-efficient",
                 },
                 ModelOption {
-                    spec: Some("openai/gpt-5.3-codex".to_string()),
+                    spec: Some("gpt-5.3-codex".to_string()),
                     label: "gpt-5.3-codex".to_string(),
                     hint: "coding-optimized model",
                 },
                 ModelOption {
-                    spec: Some("openai/gpt-5.2".to_string()),
+                    spec: Some("gpt-5.2".to_string()),
                     label: "gpt-5.2".to_string(),
                     hint: "optimized for long-running agents",
                 },
             ],
             "anthropic" => vec![
                 ModelOption {
-                    spec: Some("anthropic/claude-sonnet-4-5".to_string()),
+                    spec: Some("claude-sonnet-4-5".to_string()),
                     label: "claude-sonnet-4-5".to_string(),
                     hint: "best default Claude model",
                 },
                 ModelOption {
-                    spec: Some("anthropic/claude-opus-4-5".to_string()),
+                    spec: Some("claude-opus-4-5".to_string()),
                     label: "claude-opus-4-5".to_string(),
                     hint: "more capable for complex work",
                 },
                 ModelOption {
-                    spec: Some("anthropic/claude-haiku-4-5".to_string()),
+                    spec: Some("claude-haiku-4-5".to_string()),
                     label: "claude-haiku-4-5".to_string(),
                     hint: "fast answers",
                 },
                 ModelOption {
-                    spec: Some("anthropic/claude-sonnet-4-6".to_string()),
+                    spec: Some("claude-sonnet-4-6".to_string()),
                     label: "claude-sonnet-4-6".to_string(),
                     hint: "newer Sonnet option",
                 },
                 ModelOption {
-                    spec: Some("anthropic/claude-fable-5".to_string()),
+                    spec: Some("claude-fable-5".to_string()),
                     label: "claude-fable-5".to_string(),
                     hint: "most powerful Claude model",
                 },
             ],
             "google" => vec![
                 ModelOption {
-                    spec: Some("google/gemini-2.5-flash".to_string()),
+                    spec: Some("gemini-2.5-flash".to_string()),
                     label: "gemini-2.5-flash".to_string(),
                     hint: "fast Gemini default",
                 },
                 ModelOption {
-                    spec: Some("google/gemini-2.5-pro".to_string()),
+                    spec: Some("gemini-2.5-pro".to_string()),
                     label: "gemini-2.5-pro".to_string(),
                     hint: "more capable Gemini model",
                 },
             ],
             "openrouter" => vec![
                 ModelOption {
-                    spec: Some("openrouter/openai/gpt-5.2".to_string()),
+                    spec: Some("openai/gpt-5.2".to_string()),
                     label: "openai/gpt-5.2".to_string(),
                     hint: "default OpenRouter model",
                 },
                 ModelOption {
-                    spec: Some("openrouter/nvidia/nemotron-3-super-120b-a12b high".to_string()),
+                    spec: Some("nvidia/nemotron-3-super-120b-a12b high".to_string()),
                     label: "nvidia/nemotron-3-super-120b-a12b".to_string(),
                     hint: "reasoning model through OpenRouter",
                 },
                 ModelOption {
-                    spec: Some("openrouter/anthropic/claude-sonnet-4-5".to_string()),
+                    spec: Some("anthropic/claude-sonnet-4-5".to_string()),
                     label: "anthropic/claude-sonnet-4-5".to_string(),
                     hint: "Claude through OpenRouter",
                 },
             ],
             "ollama" => vec![ModelOption {
-                spec: Some("ollama/llama3.2".to_string()),
+                spec: Some("llama3.2".to_string()),
                 label: "llama3.2".to_string(),
                 hint: "local default model",
             }],
             _ => vec![ModelOption {
-                spec: Some("llmsim/llmsim-yolop".to_string()),
+                spec: Some("llmsim-yolop".to_string()),
                 label: "llmsim-yolop".to_string(),
                 hint: "offline demo model",
             }],
@@ -1230,7 +1223,7 @@ impl App {
         }
 
         let default_model = crate::runtime::ProviderChoice::default_for_provider_name(option.name)
-            .map(|p| p.label())
+            .map(|p| p.model_id().to_string())
             .unwrap_or_else(|_| option.name.to_string());
 
         if option.name == "ollama" {
@@ -1583,15 +1576,7 @@ impl App {
     }
 
     async fn save_model_and_finish(&mut self, provider: &str, spec: &str, selected: usize) {
-        let model_spec = if spec.contains('/') {
-            spec.to_string()
-        } else {
-            format!("{provider}/{spec}")
-        };
-        match self
-            .run_setup_command(Some(&format!("model {model_spec}")))
-            .await
-        {
+        match self.run_setup_command(Some(&format!("model {spec}"))).await {
             Ok(()) => {
                 self.setup = None;
                 self.push_system(format!("setup complete: {}", self.model.provider_label()));
@@ -4714,7 +4699,7 @@ mod tests {
         let app = &mut fixture.app;
         app.setup = Some(SetupStep::Credential {
             provider: "openai".to_string(),
-            default_model: "openai/gpt-5.5 medium".to_string(),
+            default_model: "gpt-5.5".to_string(),
             selected: 0,
             error: None,
         });
@@ -4737,7 +4722,7 @@ mod tests {
         app.lines.clear();
         app.setup = Some(SetupStep::TokenInput {
             provider: "openai".to_string(),
-            default_model: "openai/gpt-5.5 medium".to_string(),
+            default_model: "gpt-5.5".to_string(),
             token: String::new(),
             error: None,
         });
@@ -4818,6 +4803,34 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn model_command_preselects_current_raw_model_id() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.lines.clear();
+        app.setup = None;
+
+        app.handle_command("setup token openai sk-test").await;
+        app.run_setup_command(Some("provider openai"))
+            .await
+            .expect("set openai provider");
+        app.run_setup_command(Some("model gpt-5.4"))
+            .await
+            .expect("set openai model");
+        app.lines.clear();
+
+        app.dispatch_command_for_test("model").await;
+
+        assert!(matches!(
+            app.setup,
+            Some(SetupStep::PickModel {
+                ref provider,
+                selected,
+                ..
+            }) if provider == "openai" && selected == 1
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn model_command_with_arg_opens_prefilled_model_modal() {
         let mut fixture = app_with_llmsim().await;
         let app = &mut fixture.app;
@@ -4825,18 +4838,20 @@ mod tests {
         app.setup = None;
 
         app.handle_command("setup token openai sk-test").await;
+        app.run_setup_command(Some("provider openai"))
+            .await
+            .expect("set openai provider");
         app.lines.clear();
-        app.dispatch_command_for_test("model openai/gpt-5.4 high")
-            .await;
+        app.dispatch_command_for_test("model gpt-5.4 high").await;
 
-        assert_eq!(app.model.provider_label(), "llmsim/llmsim-yolop");
+        assert_eq!(app.model.provider_label(), "openai/gpt-5.5 medium");
         assert!(matches!(
             app.setup,
             Some(SetupStep::PickModel {
                 ref provider,
                 ref custom,
                 ..
-            }) if provider == "openai" && custom.as_deref() == Some("openai/gpt-5.4 high")
+            }) if provider == "openai" && custom.as_deref() == Some("gpt-5.4 high")
         ));
 
         app.handle_setup_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()))
@@ -4861,7 +4876,10 @@ mod tests {
         app.setup = None;
 
         app.handle_command("setup token openai sk-test").await;
-        app.run_setup_command(Some("model openai/gpt-5.4"))
+        app.run_setup_command(Some("provider openai"))
+            .await
+            .expect("set openai provider");
+        app.run_setup_command(Some("model gpt-5.4"))
             .await
             .expect("set openai model");
         app.lines.clear();
@@ -4901,7 +4919,10 @@ mod tests {
         app.setup = None;
 
         app.handle_command("setup token openrouter sk-test").await;
-        app.run_setup_command(Some("model openrouter/nvidia/nemotron-3-super-120b-a12b"))
+        app.run_setup_command(Some("provider openrouter"))
+            .await
+            .expect("set openrouter provider");
+        app.run_setup_command(Some("model nvidia/nemotron-3-super-120b-a12b"))
             .await
             .expect("set openrouter model");
         app.lines.clear();

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -400,7 +400,7 @@ impl Capability for SetupCapability {
             "token" => self.change_token(rest),
             "attribution" => self.change_attribution(rest),
             _ => Ok(failed_result(
-                "usage: /setup — run guided setup; internal forms: status, provider <name>, token <provider> <value|clear>, model <id|provider/id> [reasoning-effort], effort <reasoning-effort>, attribution <on|off>".to_string(),
+                "usage: /setup — run guided setup; internal forms: status, provider <name>, token <provider> <value|clear>, model <id> [reasoning-effort], effort <reasoning-effort>, attribution <on|off>".to_string(),
             )),
         }
     }
@@ -425,8 +425,9 @@ fn setup_command_arg() -> CommandArg {
             .map(|provider| format!("provider {provider}")),
     );
     suggestions.extend(
-        ProviderChoice::model_suggestions()
+        SUPPORTED_PROVIDERS
             .iter()
+            .flat_map(|provider| ProviderChoice::model_suggestions_for_provider(provider))
             .copied()
             .map(|model| format!("model {model}")),
     );
@@ -439,7 +440,7 @@ fn setup_command_arg() -> CommandArg {
 
     CommandArg {
         name: "action".to_string(),
-        description: "status | provider <name> | token <provider> <value|clear> | model <id|provider/id> | effort <level> | attribution <on|off>".to_string(),
+        description: "status | provider <name> | token <provider> <value|clear> | model <id> | effort <level> | attribution <on|off>".to_string(),
         required: false,
         suggestions,
     }
@@ -513,17 +514,17 @@ impl SetupCapability {
 
     async fn change_model(&self, raw: &str) -> everruns_core::Result<CommandResult> {
         if raw.is_empty() {
-            let label = self
+            let current = self
                 .provider
                 .read()
                 .expect("provider lock poisoned")
-                .label();
+                .clone();
+            let label = current.label();
+            let suggestions =
+                ProviderChoice::model_suggestions_for_provider(current.provider_name()).join(", ");
             return Ok(CommandResult {
                 success: true,
-                message: format!(
-                    "setup model: {label}; suggestions: {}",
-                    ProviderChoice::model_suggestions().join(", ")
-                ),
+                message: format!("setup model: {label}; suggestions: {suggestions}"),
                 error_code: None,
                 error_fields: None,
             });

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -540,26 +540,44 @@ impl ProviderChoice {
         }
     }
 
-    pub fn model_suggestions() -> &'static [&'static str] {
-        &[
-            "openai/gpt-5.5 medium",
-            "openai/gpt-5.4",
-            "openai/gpt-5.4-mini",
-            "openai/gpt-5.3-codex",
-            "openai/gpt-5.2",
-            "google/gemini-2.5-flash",
-            "google/gemini-2.5-pro",
-            "openrouter/openai/gpt-5.2",
-            "openrouter/nvidia/nemotron-3-super-120b-a12b high",
-            "ollama/llama3.2",
-            "anthropic/claude-sonnet-4-5",
-            "anthropic/claude-opus-4-5",
-            "anthropic/claude-haiku-4-5",
-            "anthropic/claude-sonnet-4-6",
-            "anthropic/claude-opus-4-6",
-            "anthropic/claude-fable-5",
-            "llmsim/llmsim-yolop",
-        ]
+    pub fn model_id(&self) -> &str {
+        match self {
+            Self::Anthropic { model }
+            | Self::OpenAi { model, .. }
+            | Self::Google { model, .. }
+            | Self::OpenRouter { model, .. }
+            | Self::Ollama { model, .. } => model,
+            Self::Sim => "llmsim-yolop",
+        }
+    }
+
+    pub fn model_suggestions_for_provider(provider: &str) -> &'static [&'static str] {
+        match provider {
+            "openai" => &[
+                "gpt-5.5",
+                "gpt-5.4",
+                "gpt-5.4-mini",
+                "gpt-5.3-codex",
+                "gpt-5.2",
+            ],
+            "anthropic" => &[
+                "claude-sonnet-4-5",
+                "claude-opus-4-5",
+                "claude-haiku-4-5",
+                "claude-sonnet-4-6",
+                "claude-opus-4-6",
+                "claude-fable-5",
+            ],
+            "google" => &["gemini-2.5-flash", "gemini-2.5-pro"],
+            "openrouter" => &[
+                "openai/gpt-5.2",
+                "nvidia/nemotron-3-super-120b-a12b high",
+                "anthropic/claude-sonnet-4-5",
+            ],
+            "ollama" => &["llama3.2"],
+            "llmsim" => &["llmsim-yolop"],
+            _ => &[],
+        }
     }
 
     pub(crate) fn resolve_model_spec(&self, spec: &str) -> Result<Self> {
@@ -568,75 +586,9 @@ impl ProviderChoice {
         let model_spec = parts.next().unwrap_or_default();
         let reasoning_effort = parts.next().map(str::to_string);
         if parts.next().is_some() {
-            return Err(anyhow!(
-                "too many model arguments; use `openai/gpt-5.5 medium`"
-            ));
-        }
-        if let Some((provider, model)) = model_spec.split_once('/') {
-            return Self::from_provider_model(provider, model, reasoning_effort);
+            return Err(anyhow!("too many model arguments; use `gpt-5.5 medium`"));
         }
         self.with_current_provider_model(model_spec.to_string(), reasoning_effort)
-    }
-
-    fn from_provider_model(
-        provider: &str,
-        model: &str,
-        reasoning_effort: Option<String>,
-    ) -> Result<Self> {
-        let model = model.trim();
-        if model.is_empty() {
-            return Err(anyhow!("model id is required"));
-        }
-        match provider.trim().to_ascii_lowercase().as_str() {
-            "anthropic" => Ok(Self::Anthropic {
-                model: model.to_string(),
-            }),
-            "openai" => Ok(Self::OpenAi {
-                model: model.to_string(),
-                reasoning_effort: normalize_openai_reasoning_effort(reasoning_effort),
-            }),
-            "google" | "gemini" => {
-                if reasoning_effort.is_some() {
-                    return Err(anyhow!(
-                        "google model switching does not accept reasoning effort"
-                    ));
-                }
-                Ok(Self::Google {
-                    model: model.to_string(),
-                    base_url: env_or_default("GOOGLE_BASE_URL", DEFAULT_GOOGLE_BASE_URL),
-                })
-            }
-            "openrouter" => Ok(Self::OpenRouter {
-                model: model.to_string(),
-                base_url: env_or_default("OPENROUTER_BASE_URL", DEFAULT_OPENROUTER_BASE_URL),
-                reasoning_effort: normalize_reasoning_effort(reasoning_effort),
-            }),
-            "ollama" => {
-                if reasoning_effort.is_some() {
-                    return Err(anyhow!(
-                        "ollama model switching does not accept reasoning effort"
-                    ));
-                }
-                Ok(Self::Ollama {
-                    model: model.to_string(),
-                    base_url: env_or_default("OLLAMA_BASE_URL", DEFAULT_OLLAMA_BASE_URL),
-                })
-            }
-            "llmsim" | "sim" => {
-                if reasoning_effort.is_some() {
-                    return Err(anyhow!("offline llmsim does not support reasoning effort"));
-                }
-                if model == "llmsim-yolop" {
-                    Ok(Self::Sim)
-                } else {
-                    Err(anyhow!("offline llmsim only supports llmsim-yolop"))
-                }
-            }
-            other => Err(anyhow!(
-                "unknown provider {other}; expected one of {}",
-                SUPPORTED_PROVIDERS.join(", ")
-            )),
-        }
     }
 
     fn with_current_provider_model(
@@ -644,6 +596,9 @@ impl ProviderChoice {
         model: String,
         reasoning_effort: Option<String>,
     ) -> Result<Self> {
+        if model.trim().is_empty() {
+            return Err(anyhow!("model id is required"));
+        }
         match self {
             Self::Anthropic { .. } => {
                 if reasoning_effort.is_some() {
@@ -1037,6 +992,14 @@ impl ModelState {
             .label()
     }
 
+    pub fn model_id(&self) -> String {
+        self.provider
+            .read()
+            .expect("provider lock poisoned")
+            .model_id()
+            .to_string()
+    }
+
     pub fn input_message(&self, text: impl Into<String>) -> InputMessage {
         self.provider
             .read()
@@ -1334,11 +1297,14 @@ mod tests {
     use everruns_core::command::ExecuteCommandRequest;
 
     #[test]
-    fn model_spec_can_switch_to_openai() {
+    fn model_spec_rejects_invalid_current_provider_model() {
         let provider = ProviderChoice::Sim;
-        let next = provider.resolve_model_spec("openai/gpt-5.5").unwrap();
+        let err = provider.resolve_model_spec("openai/gpt-5.5").unwrap_err();
 
-        assert_eq!(next.label(), "openai/gpt-5.5 medium");
+        assert!(
+            err.to_string()
+                .contains("offline llmsim only supports llmsim-yolop")
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1475,6 +1441,21 @@ mod tests {
         assert!(store_token.success);
         assert!(settings_for_assert.snapshot().has_token("openai"));
 
+        let set_provider = built
+            .handles
+            .runtime
+            .execute_command(
+                built.handles.session_id,
+                ExecuteCommandRequest {
+                    name: "setup".to_string(),
+                    arguments: Some("provider openai".to_string()),
+                    controls: None,
+                },
+            )
+            .await
+            .expect("setup openai provider");
+        assert!(set_provider.success);
+
         let model_effort_base = built
             .handles
             .runtime
@@ -1482,7 +1463,7 @@ mod tests {
                 built.handles.session_id,
                 ExecuteCommandRequest {
                     name: "setup".to_string(),
-                    arguments: Some("model openai/gpt-5.4".to_string()),
+                    arguments: Some("model gpt-5.4".to_string()),
                     controls: None,
                 },
             )
@@ -1544,7 +1525,7 @@ mod tests {
                 built.handles.session_id,
                 ExecuteCommandRequest {
                     name: "setup".to_string(),
-                    arguments: Some("model llmsim/llmsim-yolop".to_string()),
+                    arguments: Some("model llmsim-yolop".to_string()),
                     controls: None,
                 },
             )
@@ -1566,11 +1547,11 @@ mod tests {
             .await
             .expect("unknown setup action");
         assert!(!unknown.success);
-        assert!(unknown.message.contains("model <id|provider/id>"));
+        assert!(unknown.message.contains("model <id>"));
     }
 
     #[test]
-    fn model_spec_can_switch_to_anthropic() {
+    fn model_spec_treats_slashes_as_current_provider_model_id() {
         let provider = ProviderChoice::OpenAi {
             model: "gpt-5.5".to_string(),
             reasoning_effort: Some("medium".to_string()),
@@ -1579,18 +1560,21 @@ mod tests {
             .resolve_model_spec("anthropic/claude-sonnet-4-5")
             .unwrap();
 
-        assert_eq!(next.label(), "anthropic/claude-sonnet-4-5");
+        assert_eq!(next.label(), "openai/anthropic/claude-sonnet-4-5 medium");
     }
 
     #[test]
     fn model_suggestions_include_claude_fable_5() {
         // Fable 5 rejects budget thinking and sampling params; yolop sends
         // neither for Anthropic, so the published driver works as-is.
-        assert!(ProviderChoice::model_suggestions().contains(&"anthropic/claude-fable-5"));
+        assert!(
+            ProviderChoice::model_suggestions_for_provider("anthropic").contains(&"claude-fable-5")
+        );
 
-        let next = ProviderChoice::Sim
-            .resolve_model_spec("anthropic/claude-fable-5")
-            .unwrap();
+        let provider = ProviderChoice::Anthropic {
+            model: "claude-sonnet-4-5".to_string(),
+        };
+        let next = provider.resolve_model_spec("claude-fable-5").unwrap();
         assert_eq!(next.label(), "anthropic/claude-fable-5");
     }
 
@@ -1606,31 +1590,39 @@ mod tests {
     }
 
     #[test]
-    fn model_spec_accepts_llmsim_provider_name() {
-        let provider = ProviderChoice::OpenAi {
-            model: "gpt-5.5".to_string(),
-            reasoning_effort: Some("medium".to_string()),
-        };
-        let next = provider.resolve_model_spec("llmsim/llmsim-yolop").unwrap();
+    fn model_spec_accepts_llmsim_model_id() {
+        let provider = ProviderChoice::Sim;
+        let next = provider.resolve_model_spec("llmsim-yolop").unwrap();
 
         assert_eq!(next.label(), "llmsim/llmsim-yolop");
     }
 
     #[test]
-    fn model_spec_accepts_openrouter_provider_name() {
-        let provider = ProviderChoice::Sim;
+    fn model_spec_accepts_openrouter_model_id_with_slash() {
+        let provider = ProviderChoice::OpenRouter {
+            model: "openai/gpt-5.2".to_string(),
+            base_url: DEFAULT_OPENROUTER_BASE_URL.to_string(),
+            reasoning_effort: None,
+        };
         let next = provider
-            .resolve_model_spec("openrouter/openai/gpt-5.2")
+            .resolve_model_spec("nvidia/nemotron-3-ultra-550b-a55b:free")
             .unwrap();
 
-        assert_eq!(next.label(), "openrouter/openai/gpt-5.2");
+        assert_eq!(
+            next.label(),
+            "openrouter/nvidia/nemotron-3-ultra-550b-a55b:free"
+        );
     }
 
     #[test]
     fn model_spec_accepts_openrouter_reasoning_effort() {
-        let provider = ProviderChoice::Sim;
+        let provider = ProviderChoice::OpenRouter {
+            model: "openai/gpt-5.2".to_string(),
+            base_url: DEFAULT_OPENROUTER_BASE_URL.to_string(),
+            reasoning_effort: None,
+        };
         let next = provider
-            .resolve_model_spec("openrouter/nvidia/nemotron-3-super-120b-a12b high")
+            .resolve_model_spec("nvidia/nemotron-3-super-120b-a12b high")
             .unwrap();
 
         assert_eq!(
@@ -1640,19 +1632,23 @@ mod tests {
     }
 
     #[test]
-    fn model_spec_accepts_ollama_provider_name() {
-        let provider = ProviderChoice::Sim;
-        let next = provider.resolve_model_spec("ollama/llama3.2").unwrap();
+    fn model_spec_accepts_ollama_model_id() {
+        let provider = ProviderChoice::Ollama {
+            model: "llama3.2".to_string(),
+            base_url: DEFAULT_OLLAMA_BASE_URL.to_string(),
+        };
+        let next = provider.resolve_model_spec("llama3.3").unwrap();
 
-        assert_eq!(next.label(), "ollama/llama3.2");
+        assert_eq!(next.label(), "ollama/llama3.3");
     }
 
     #[test]
-    fn model_spec_accepts_google_provider_name() {
-        let provider = ProviderChoice::Sim;
-        let next = provider
-            .resolve_model_spec("google/gemini-2.5-pro")
-            .unwrap();
+    fn model_spec_accepts_google_model_id() {
+        let provider = ProviderChoice::Google {
+            model: "gemini-2.5-flash".to_string(),
+            base_url: DEFAULT_GOOGLE_BASE_URL.to_string(),
+        };
+        let next = provider.resolve_model_spec("gemini-2.5-pro").unwrap();
 
         assert_eq!(next.label(), "google/gemini-2.5-pro");
         assert_eq!(next.provider_name(), "google");
@@ -1810,8 +1806,11 @@ mod tests {
 
     #[test]
     fn model_spec_accepts_openai_reasoning_effort() {
-        let provider = ProviderChoice::Sim;
-        let next = provider.resolve_model_spec("openai/gpt-5.5 high").unwrap();
+        let provider = ProviderChoice::OpenAi {
+            model: "gpt-5.4".to_string(),
+            reasoning_effort: Some("medium".to_string()),
+        };
+        let next = provider.resolve_model_spec("gpt-5.5 high").unwrap();
 
         assert_eq!(next.label(), "openai/gpt-5.5 high");
     }


### PR DESCRIPTION
## What
- Make `/model <id>` and `/setup model <id>` treat the argument as a raw model id for the active provider.
- Keep status/display labels as `provider/model`, including OpenRouter reasoning effort.
- Update setup/model suggestions, tests, and README wording.

## Why
OpenRouter model ids contain slashes, so the old `provider/model` parser made inputs like `nvidia/...` look like provider switches and forced confusing double prefixes.

## How
- Removed provider-prefix parsing from the shared model spec parser.
- Made setup model options provider-aware raw ids.
- Preserved latest `main` OpenRouter reasoning-effort support while rebasing.
- Updated command help and docs to advertise `model <id>`.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"`
- `doppler run --project yolop --config ci -- cargo run -- --provider openai -p "Reply with exactly: ok"`
- `doppler run --project yolop --config ci -- cargo test --all-features --test integration`

## Risk
- Medium: intentional slash-command behavior change. Provider switching now belongs in `/setup provider`; `/model` no longer uses a provider prefix to switch providers.
- CLI `--provider ... -m ...` remains unchanged.

## Security
- TM-LLM: reviewed provider/model parsing and display labels; no API key logging or session persistence changes.
- TM-FS, TM-BASH, TM-TOOL: not touched.
- TM-DEP: no dependency changes.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)