### PR TITLE
feat(models): list provider models live from models APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5790,6 +5790,7 @@ dependencies = [
  "portable-pty",
  "ratatui",
  "ratatui-textarea",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ crossterm = "0.29"
 dirs = "6"
 include_dir = "0.7"
 ratatui = "0.30"
+# Already in the tree via the everruns driver crates; used directly only for
+# the OpenAI-compatible `GET <base>/models` discovery fallback.
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 ratatui-textarea = "0.9.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -230,6 +230,14 @@ The TUI's `/setup`, `/model`, and `/effort` commands can update the active
 provider, saved API keys, current model, OpenAI/OpenRouter reasoning effort,
 or offline demo mode. Saved provider/API-key choices are written to this file.
 
+The model picker queries the provider's models API live (OpenAI, Anthropic,
+and OpenRouter via the everruns drivers; Ollama, Gemini, and other
+OpenAI-compatible endpoints via `GET <base>/models`), enriched with
+human-readable names and descriptions from the everruns model profiles. A
+curated shortlist is shown until the API responds — or instead of it, when
+listing is unavailable — and the "Custom..." entry always accepts any model
+id.
+
 Provider resolution at startup:
 
 1. `--provider` flag (always wins)

--- a/src/app.rs
+++ b/src/app.rs
@@ -1271,8 +1271,15 @@ impl App {
                     });
                 }
             }
-            // Listing unsupported (or empty): keep the curated fallback.
-            Ok(_) => {}
+            // Listing unsupported (or empty): cache the curated fallback so
+            // reopening the picker doesn't re-query an API that can't answer.
+            // Errors are deliberately not cached — the next picker open retries.
+            Ok(_) => {
+                self.model_catalog.insert(
+                    discovery.provider.clone(),
+                    Self::fallback_model_options(&discovery.provider),
+                );
+            }
             Err(mut err) => {
                 if let Some(SetupStep::PickModel {
                     provider, error, ..
@@ -5520,6 +5527,12 @@ mod tests {
 
         let options = app.model_options("ollama");
         assert_eq!(options[0].spec.as_deref(), Some("llama3.2"));
+
+        // The unsupported outcome is cached so reopening the picker doesn't
+        // re-query an API that can't answer.
+        app.model_discovery_enabled = true;
+        app.request_model_discovery("ollama");
+        assert!(!app.is_fetching_models("ollama"));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/app.rs
+++ b/src/app.rs
@@ -21,7 +21,8 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget};
 use ratatui_textarea::{CursorMove, TextArea, WrapMode};
 use serde_json::Value;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::broadcast;
 use tokio::sync::mpsc;
@@ -120,6 +121,27 @@ pub struct App {
     /// `runtime.execute_command`). Drained in the event loop; see
     /// [`App::apply_ui_command`].
     ui_rx: mpsc::UnboundedReceiver<UiCommand>,
+    /// Settings store shared with the runtime; used to resolve credentials
+    /// when querying provider models APIs.
+    settings: Arc<crate::settings::SettingsStore>,
+    /// Models discovered from each provider's models API, keyed by provider
+    /// name. Once populated, replaces the curated fallback list in the
+    /// model picker.
+    model_catalog: HashMap<String, Vec<ModelOption>>,
+    /// Providers with an in-flight models API fetch.
+    model_fetches_in_flight: HashSet<String>,
+    /// Disabled in unit tests so opening the picker never spawns real
+    /// network requests.
+    model_discovery_enabled: bool,
+    models_tx: mpsc::UnboundedSender<ModelDiscovery>,
+    models_rx: mpsc::UnboundedReceiver<ModelDiscovery>,
+}
+
+/// Result of one background models API fetch. `Ok(None)` means the provider
+/// does not support listing; the picker keeps the curated fallback list.
+struct ModelDiscovery {
+    provider: String,
+    result: Result<Option<Vec<ModelOption>>, String>,
 }
 
 #[derive(Clone, Debug)]
@@ -208,7 +230,7 @@ enum CredentialAction {
 struct ModelOption {
     spec: Option<String>,
     label: String,
-    hint: &'static str,
+    hint: String,
 }
 
 struct EffortOption {
@@ -319,6 +341,7 @@ pub(crate) enum TurnEvent {
 impl App {
     pub fn new(runtime: BuiltRuntime) -> Self {
         let should_setup = runtime.startup.setup_recommended;
+        let (models_tx, models_rx) = mpsc::unbounded_channel::<ModelDiscovery>();
         let mut app = Self {
             handles: runtime.handles,
             startup: runtime.startup,
@@ -335,6 +358,12 @@ impl App {
             rx: None,
             setup: None,
             ui_rx: runtime.ui_rx,
+            settings: runtime.settings,
+            model_catalog: HashMap::new(),
+            model_fetches_in_flight: HashSet::new(),
+            model_discovery_enabled: true,
+            models_tx,
+            models_rx,
         };
         app.emit_system_banner();
         if should_setup {
@@ -523,7 +552,17 @@ impl App {
             return Ok(());
         }
 
-        // 3) keystrokes. Mouse wheel/drag stays native terminal behavior
+        // 3) drain finished models API fetches so an open picker refreshes.
+        let mut applied_model_discovery = false;
+        while let Ok(discovery) = self.models_rx.try_recv() {
+            self.apply_model_discovery(discovery);
+            applied_model_discovery = true;
+        }
+        if applied_model_discovery {
+            return Ok(());
+        }
+
+        // 4) keystrokes. Mouse wheel/drag stays native terminal behavior
         // because the transcript lives in scrollback, not in this viewport.
         let mut poll_timeout = Duration::from_millis(80);
         while event::poll(poll_timeout)? {
@@ -892,8 +931,9 @@ impl App {
 
     fn start_model_setup(&mut self) {
         let provider = self.current_provider_name();
+        self.request_model_discovery(&provider);
         let selected =
-            model_index_for_label(&self.model.model_id(), &Self::model_options(&provider));
+            model_index_for_label(&self.model.model_id(), &self.model_options(&provider));
         self.setup = Some(SetupStep::PickModel {
             provider,
             selected,
@@ -909,7 +949,8 @@ impl App {
             return;
         }
         let provider = self.current_provider_name();
-        let options = Self::model_options(&provider);
+        self.request_model_discovery(&provider);
+        let options = self.model_options(&provider);
         let selected = model_index_for_label(spec, &options);
         let custom = if options
             .get(selected)
@@ -1035,108 +1076,214 @@ impl App {
         ]
     }
 
-    fn model_options(provider: &str) -> Vec<ModelOption> {
+    /// Options for the model picker: models discovered live from the
+    /// provider's models API when available, otherwise the curated
+    /// fallback list.
+    fn model_options(&self, provider: &str) -> Vec<ModelOption> {
+        match self.model_catalog.get(provider) {
+            Some(options) => options.clone(),
+            None => Self::fallback_model_options(provider),
+        }
+    }
+
+    /// Curated static list, used until (or instead of) live discovery —
+    /// e.g. before the models API responds, when the provider does not
+    /// support listing, or when the query fails.
+    fn fallback_model_options(provider: &str) -> Vec<ModelOption> {
         let mut models = match provider {
             "openai" => vec![
                 ModelOption {
                     spec: Some("gpt-5.5".to_string()),
                     label: "gpt-5.5".to_string(),
-                    hint: "frontier model for complex coding",
+                    hint: "frontier model for complex coding".to_string(),
                 },
                 ModelOption {
                     spec: Some("gpt-5.4".to_string()),
                     label: "gpt-5.4".to_string(),
-                    hint: "strong everyday model",
+                    hint: "strong everyday model".to_string(),
                 },
                 ModelOption {
                     spec: Some("gpt-5.4-mini".to_string()),
                     label: "gpt-5.4-mini".to_string(),
-                    hint: "fast and cost-efficient",
+                    hint: "fast and cost-efficient".to_string(),
                 },
                 ModelOption {
                     spec: Some("gpt-5.3-codex".to_string()),
                     label: "gpt-5.3-codex".to_string(),
-                    hint: "coding-optimized model",
+                    hint: "coding-optimized model".to_string(),
                 },
                 ModelOption {
                     spec: Some("gpt-5.2".to_string()),
                     label: "gpt-5.2".to_string(),
-                    hint: "optimized for long-running agents",
+                    hint: "optimized for long-running agents".to_string(),
                 },
             ],
             "anthropic" => vec![
                 ModelOption {
                     spec: Some("claude-sonnet-4-5".to_string()),
                     label: "claude-sonnet-4-5".to_string(),
-                    hint: "best default Claude model",
+                    hint: "best default Claude model".to_string(),
                 },
                 ModelOption {
                     spec: Some("claude-opus-4-5".to_string()),
                     label: "claude-opus-4-5".to_string(),
-                    hint: "more capable for complex work",
+                    hint: "more capable for complex work".to_string(),
                 },
                 ModelOption {
                     spec: Some("claude-haiku-4-5".to_string()),
                     label: "claude-haiku-4-5".to_string(),
-                    hint: "fast answers",
+                    hint: "fast answers".to_string(),
                 },
                 ModelOption {
                     spec: Some("claude-sonnet-4-6".to_string()),
                     label: "claude-sonnet-4-6".to_string(),
-                    hint: "newer Sonnet option",
+                    hint: "newer Sonnet option".to_string(),
                 },
                 ModelOption {
                     spec: Some("claude-fable-5".to_string()),
                     label: "claude-fable-5".to_string(),
-                    hint: "most powerful Claude model",
+                    hint: "most powerful Claude model".to_string(),
                 },
             ],
             "google" => vec![
                 ModelOption {
                     spec: Some("gemini-2.5-flash".to_string()),
                     label: "gemini-2.5-flash".to_string(),
-                    hint: "fast Gemini default",
+                    hint: "fast Gemini default".to_string(),
                 },
                 ModelOption {
                     spec: Some("gemini-2.5-pro".to_string()),
                     label: "gemini-2.5-pro".to_string(),
-                    hint: "more capable Gemini model",
+                    hint: "more capable Gemini model".to_string(),
                 },
             ],
             "openrouter" => vec![
                 ModelOption {
                     spec: Some("openai/gpt-5.2".to_string()),
                     label: "openai/gpt-5.2".to_string(),
-                    hint: "default OpenRouter model",
+                    hint: "default OpenRouter model".to_string(),
                 },
                 ModelOption {
                     spec: Some("nvidia/nemotron-3-super-120b-a12b high".to_string()),
                     label: "nvidia/nemotron-3-super-120b-a12b".to_string(),
-                    hint: "reasoning model through OpenRouter",
+                    hint: "reasoning model through OpenRouter".to_string(),
                 },
                 ModelOption {
                     spec: Some("anthropic/claude-sonnet-4-5".to_string()),
                     label: "anthropic/claude-sonnet-4-5".to_string(),
-                    hint: "Claude through OpenRouter",
+                    hint: "Claude through OpenRouter".to_string(),
                 },
             ],
             "ollama" => vec![ModelOption {
                 spec: Some("llama3.2".to_string()),
                 label: "llama3.2".to_string(),
-                hint: "local default model",
+                hint: "local default model".to_string(),
             }],
             _ => vec![ModelOption {
                 spec: Some("llmsim-yolop".to_string()),
                 label: "llmsim-yolop".to_string(),
-                hint: "offline demo model",
+                hint: "offline demo model".to_string(),
             }],
         };
-        models.push(ModelOption {
-            spec: None,
-            label: "Custom...".to_string(),
-            hint: "paste a model id",
-        });
+        models.push(custom_model_option());
         models
+    }
+
+    fn is_fetching_models(&self, provider: &str) -> bool {
+        self.model_fetches_in_flight.contains(provider)
+    }
+
+    /// Kick off a background fetch of the provider's models API, if one is
+    /// not already cached or in flight. The result lands on `models_rx`
+    /// and is applied between frames; the picker shows the fallback list
+    /// (plus a loading hint) in the meantime.
+    fn request_model_discovery(&mut self, provider: &str) {
+        if !self.model_discovery_enabled
+            || provider == "llmsim"
+            || self.model_catalog.contains_key(provider)
+            || self.model_fetches_in_flight.contains(provider)
+        {
+            return;
+        }
+        // Prefer the live provider choice (it carries any custom base URL);
+        // fall back to the provider's defaults when picking across providers.
+        let choice = if self.current_provider_name() == provider {
+            self.model.provider_choice()
+        } else {
+            match crate::runtime::ProviderChoice::default_for_provider_name(provider) {
+                Ok(choice) => choice,
+                Err(_) => return,
+            }
+        };
+        self.model_fetches_in_flight.insert(provider.to_string());
+        let tx = self.models_tx.clone();
+        let settings = self.settings.clone();
+        let provider_name = provider.to_string();
+        tokio::spawn(async move {
+            let result = match tokio::time::timeout(
+                Duration::from_secs(10),
+                crate::capabilities::model_discovery::discover_provider_models(
+                    &choice,
+                    &settings.snapshot(),
+                ),
+            )
+            .await
+            {
+                Ok(Ok(Some(models))) => Ok(Some(model_options_from_discovered(models))),
+                Ok(Ok(None)) => Ok(None),
+                Ok(Err(err)) => Err(err.to_string()),
+                Err(_) => Err("models API request timed out".to_string()),
+            };
+            let _ = tx.send(ModelDiscovery {
+                provider: provider_name,
+                result,
+            });
+        });
+    }
+
+    /// Apply a finished models API fetch: cache the options and re-anchor
+    /// an open picker for that provider on the refreshed list.
+    fn apply_model_discovery(&mut self, discovery: ModelDiscovery) {
+        self.model_fetches_in_flight.remove(&discovery.provider);
+        match discovery.result {
+            // > 1 because the list always ends with the "Custom..." entry.
+            Ok(Some(options)) if options.len() > 1 => {
+                self.model_catalog
+                    .insert(discovery.provider.clone(), options);
+                if let Some(SetupStep::PickModel {
+                    provider,
+                    custom,
+                    error,
+                    ..
+                }) = self.setup.clone()
+                    && provider == discovery.provider
+                    && custom.is_none()
+                {
+                    let selected = model_index_for_label(
+                        &self.model.model_id(),
+                        &self.model_options(&provider),
+                    );
+                    self.setup = Some(SetupStep::PickModel {
+                        provider,
+                        selected,
+                        custom,
+                        error,
+                    });
+                }
+            }
+            // Listing unsupported (or empty): keep the curated fallback.
+            Ok(_) => {}
+            Err(mut err) => {
+                if let Some(SetupStep::PickModel {
+                    provider, error, ..
+                }) = self.setup.as_mut()
+                    && *provider == discovery.provider
+                {
+                    err.truncate(120);
+                    *error = Some(format!("model list unavailable: {err}"));
+                }
+            }
+        }
     }
 
     async fn handle_setup_key(&mut self, key: KeyEvent) {
@@ -1234,6 +1381,7 @@ impl App {
                 .await
             {
                 Ok(()) => {
+                    self.request_model_discovery(option.name);
                     self.setup = Some(SetupStep::PickModel {
                         provider: option.name.to_string(),
                         selected: 0,
@@ -1321,8 +1469,9 @@ impl App {
                 .await
             {
                 Ok(()) => {
+                    self.request_model_discovery(&provider);
                     let selected =
-                        model_index_for_label(&default_model, &Self::model_options(&provider));
+                        model_index_for_label(&default_model, &self.model_options(&provider));
                     self.setup = Some(SetupStep::PickModel {
                         provider,
                         selected,
@@ -1417,8 +1566,9 @@ impl App {
                     .await
                 {
                     Ok(()) => {
+                        self.request_model_discovery(&provider);
                         let selected =
-                            model_index_for_label(&default_model, &Self::model_options(&provider));
+                            model_index_for_label(&default_model, &self.model_options(&provider));
                         self.setup = Some(SetupStep::PickModel {
                             provider,
                             selected,
@@ -1467,7 +1617,7 @@ impl App {
         selected: usize,
         custom: Option<String>,
     ) {
-        let options = Self::model_options(&provider);
+        let options = self.model_options(&provider);
         if let Some(mut value) = custom {
             match key.code {
                 KeyCode::Esc => {
@@ -1555,7 +1705,7 @@ impl App {
     }
 
     async fn confirm_model(&mut self, provider: String, selected: usize) {
-        let options = Self::model_options(&provider);
+        let options = self.model_options(&provider);
         let Some(option) = options.get(selected) else {
             self.setup = Some(SetupStep::PickModel {
                 provider,
@@ -2743,7 +2893,7 @@ fn setup_overlay_content(app: &App) -> (Vec<Line<'static>>, Option<(usize, usize
                 App::provider_label(provider)
             )));
             lines.push(Line::from(""));
-            let options = App::model_options(provider);
+            let options = app.model_options(provider);
             if let Some(value) = custom {
                 let input = format!("› {value}");
                 cursor = Some((3, input.chars().count()));
@@ -2757,13 +2907,24 @@ fn setup_overlay_content(app: &App) -> (Vec<Line<'static>>, Option<(usize, usize
                     Span::styled(value.clone(), Style::default().fg(TEXT_PRIMARY)),
                 ]));
             } else {
-                for (idx, option) in options.iter().enumerate() {
+                if app.is_fetching_models(provider) {
+                    lines.push(setup_hint("fetching models from the provider API…"));
+                }
+                let total = options.len();
+                let (start, end) = model_window(*selected, total, MAX_VISIBLE_MODEL_ROWS);
+                if start > 0 {
+                    lines.push(setup_hint(&format!("↑ {start} more")));
+                }
+                for (idx, option) in options.iter().enumerate().take(end).skip(start) {
                     let current = app.model.provider_label();
                     let mut hint = option.hint.to_string();
                     if option.spec.as_deref() == Some(current.as_str()) {
                         hint.push_str(" · current");
                     }
                     lines.push(setup_row(idx == *selected, idx + 1, &option.label, &hint));
+                }
+                if end < total {
+                    lines.push(setup_hint(&format!("↓ {} more", total - end)));
                 }
             }
             push_setup_error(&mut lines, error.as_deref());
@@ -3422,6 +3583,59 @@ fn model_index_for_label(label: &str, options: &[ModelOption]) -> usize {
         .unwrap_or(0)
 }
 
+fn custom_model_option() -> ModelOption {
+    ModelOption {
+        spec: None,
+        label: "Custom...".to_string(),
+        hint: "paste a model id".to_string(),
+    }
+}
+
+/// Convert models discovered from a provider's models API (already enriched
+/// with core profile names/descriptions) into picker options, keeping the
+/// trailing "Custom..." escape hatch.
+fn model_options_from_discovered(
+    models: Vec<crate::capabilities::model_discovery::DiscoveredProviderModel>,
+) -> Vec<ModelOption> {
+    /// OpenRouter descriptions run to paragraphs; the hint shares one row
+    /// with the model id, so keep it short.
+    const MAX_HINT_CHARS: usize = 72;
+
+    let mut options: Vec<ModelOption> = models
+        .into_iter()
+        .map(|model| {
+            let mut hint = match (model.display_name, model.description) {
+                (Some(name), Some(description)) => format!("{name} · {description}"),
+                (Some(name), None) => name,
+                (None, Some(description)) => description,
+                (None, None) => String::new(),
+            };
+            if hint.chars().count() > MAX_HINT_CHARS {
+                hint = hint.chars().take(MAX_HINT_CHARS - 1).collect::<String>() + "…";
+            }
+            ModelOption {
+                spec: Some(model.model_id.clone()),
+                label: model.model_id,
+                hint,
+            }
+        })
+        .collect();
+    options.push(custom_model_option());
+    options
+}
+
+/// Discovered model lists can be hundreds of entries (OpenRouter), far more
+/// than the setup panel can show. Window the list around the selection.
+const MAX_VISIBLE_MODEL_ROWS: usize = 8;
+
+fn model_window(selected: usize, total: usize, max_rows: usize) -> (usize, usize) {
+    if total <= max_rows {
+        return (0, total);
+    }
+    let start = selected.saturating_sub(max_rows / 2).min(total - max_rows);
+    (start, start + max_rows)
+}
+
 fn effort_index(value: &str) -> Option<usize> {
     EFFORT_OPTIONS
         .iter()
@@ -3602,6 +3816,7 @@ fn display_path(path: &std::path::Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::capabilities::model_discovery::DiscoveredProviderModel;
     use everruns_core::events::{
         EventContext, InputMessageData, OutputMessageCompletedData, OutputMessageStartedData,
         ReasonCompletedData,
@@ -4441,8 +4656,11 @@ mod tests {
         )
         .await
         .expect("build llmsim runtime");
+        let mut app = App::new(runtime);
+        // Never let unit tests hit real provider models APIs.
+        app.model_discovery_enabled = false;
         TestApp {
-            app: App::new(runtime),
+            app,
             _workspace: workspace,
             _sessions: sessions,
         }
@@ -5205,6 +5423,129 @@ mod tests {
                 .any(|line| line.text.starts_with("setup provider changed:")),
             "wizard should hide internal setup command success output"
         );
+    }
+
+    fn discovered(model_id: &str, display_name: Option<&str>) -> DiscoveredProviderModel {
+        DiscoveredProviderModel {
+            model_id: model_id.to_string(),
+            display_name: display_name.map(str::to_string),
+            description: None,
+        }
+    }
+
+    #[test]
+    fn model_window_centers_selection_in_long_lists() {
+        assert_eq!(model_window(0, 5, 8), (0, 5));
+        assert_eq!(model_window(0, 300, 8), (0, 8));
+        assert_eq!(model_window(150, 300, 8), (146, 154));
+        assert_eq!(model_window(299, 300, 8), (292, 300));
+    }
+
+    #[test]
+    fn discovered_models_convert_to_options_with_custom_escape_hatch() {
+        let mut described = discovered("openai/gpt-5.2", Some("OpenAI: GPT-5.2"));
+        described.description = Some("optimized for long-running agents".to_string());
+        let options = model_options_from_discovered(vec![
+            described,
+            discovered("nvidia/nemotron-3-super-120b-a12b", None),
+        ]);
+
+        assert_eq!(options.len(), 3);
+        assert_eq!(options[0].spec.as_deref(), Some("openai/gpt-5.2"));
+        assert_eq!(options[0].label, "openai/gpt-5.2");
+        assert_eq!(
+            options[0].hint,
+            "OpenAI: GPT-5.2 · optimized for long-running agents"
+        );
+        assert_eq!(
+            options[1].spec.as_deref(),
+            Some("nvidia/nemotron-3-super-120b-a12b")
+        );
+        assert!(options[2].spec.is_none(), "last option must stay Custom...");
+    }
+
+    #[test]
+    fn discovered_model_hints_are_truncated_for_one_row_display() {
+        let mut model = discovered("verbose/model", None);
+        model.description = Some("x".repeat(200));
+
+        let options = model_options_from_discovered(vec![model]);
+
+        assert!(
+            options[0].hint.chars().count() <= 72,
+            "hint must fit one picker row: {} chars",
+            options[0].hint.chars().count()
+        );
+        assert!(options[0].hint.ends_with('…'));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn discovered_models_replace_fallback_options_in_open_picker() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = Some(SetupStep::PickModel {
+            provider: "openrouter".to_string(),
+            selected: 0,
+            custom: None,
+            error: None,
+        });
+
+        app.apply_model_discovery(ModelDiscovery {
+            provider: "openrouter".to_string(),
+            result: Ok(Some(model_options_from_discovered(vec![
+                discovered("zai/glm-5", None),
+                discovered("moon/kimi-k3", None),
+            ]))),
+        });
+
+        let options = app.model_options("openrouter");
+        assert_eq!(options.len(), 3);
+        assert_eq!(options[0].spec.as_deref(), Some("zai/glm-5"));
+        let rendered = setup_overlay_text(app);
+        assert!(
+            rendered.iter().any(|line| line.contains("zai/glm-5")),
+            "open picker should render discovered models: {rendered:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn unsupported_model_discovery_keeps_fallback_options() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+
+        app.apply_model_discovery(ModelDiscovery {
+            provider: "ollama".to_string(),
+            result: Ok(None),
+        });
+
+        let options = app.model_options("ollama");
+        assert_eq!(options[0].spec.as_deref(), Some("llama3.2"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn failed_model_discovery_surfaces_error_in_open_picker() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = Some(SetupStep::PickModel {
+            provider: "openai".to_string(),
+            selected: 0,
+            custom: None,
+            error: None,
+        });
+
+        app.apply_model_discovery(ModelDiscovery {
+            provider: "openai".to_string(),
+            result: Err("connection refused".to_string()),
+        });
+
+        assert!(matches!(
+            app.setup,
+            Some(SetupStep::PickModel { ref error, .. })
+                if error.as_deref() == Some("model list unavailable: connection refused")
+        ));
+        // The curated list must remain usable after a failed fetch.
+        let options = app.model_options("openai");
+        assert_eq!(options[0].spec.as_deref(), Some("gpt-5.5"));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -520,11 +520,12 @@ impl SetupCapability {
                 .expect("provider lock poisoned")
                 .clone();
             let label = current.label();
-            let suggestions =
-                ProviderChoice::model_suggestions_for_provider(current.provider_name()).join(", ");
             return Ok(CommandResult {
                 success: true,
-                message: format!("setup model: {label}; suggestions: {suggestions}"),
+                message: format!(
+                    "setup model: {label}; {}",
+                    self.model_suggestions_message(&current).await
+                ),
                 error_code: None,
                 error_fields: None,
             });
@@ -558,6 +559,40 @@ impl SetupCapability {
             error_code: None,
             error_fields: None,
         })
+    }
+
+    /// Live model suggestions for the current provider, queried from its
+    /// models API; falls back to the curated static list when the provider
+    /// does not support listing (or the query fails/times out).
+    async fn model_suggestions_message(&self, current: &ProviderChoice) -> String {
+        const MODEL_SUGGESTION_LIMIT: usize = 20;
+        const DISCOVERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+        let discovered = tokio::time::timeout(
+            DISCOVERY_TIMEOUT,
+            super::model_discovery::discover_provider_models(current, &self.settings.snapshot()),
+        )
+        .await;
+        if let Ok(Ok(Some(models))) = discovered
+            && !models.is_empty()
+        {
+            let provider = current.provider_name();
+            let shown: Vec<&str> = models
+                .iter()
+                .take(MODEL_SUGGESTION_LIMIT)
+                .map(|model| model.model_id.as_str())
+                .collect();
+            let suffix = if models.len() > MODEL_SUGGESTION_LIMIT {
+                format!(" … and {} more", models.len() - MODEL_SUGGESTION_LIMIT)
+            } else {
+                String::new()
+            };
+            return format!("models from {provider} API: {}{suffix}", shown.join(", "));
+        }
+        format!(
+            "suggestions: {}",
+            ProviderChoice::model_suggestions_for_provider(current.provider_name()).join(", ")
+        )
     }
 
     async fn change_effort(&self, raw: &str) -> everruns_core::Result<CommandResult> {

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -5,6 +5,7 @@
 
 pub(crate) mod client_commands;
 mod host;
+pub(crate) mod model_discovery;
 pub mod skills;
 pub(crate) mod tool_search;
 pub(crate) mod your;

--- a/src/capabilities/model_discovery.rs
+++ b/src/capabilities/model_discovery.rs
@@ -1,0 +1,315 @@
+// Provider model discovery.
+//
+// Queries the provider's models API through the everruns drivers
+// (`LlmDriver::list_models`), falling back to a direct OpenAI-compatible
+// `GET <base>/models` for custom endpoints the drivers decline (Ollama,
+// Gemini's OpenAI surface, proxies). Discovered models are enriched with
+// the everruns-core model profile registry so the UI can show human-readable
+// names and descriptions even when the provider's API returns bare ids.
+
+use crate::runtime::ProviderChoice;
+use crate::settings::Settings;
+use anyhow::{Context, Result, anyhow};
+use everruns_core::get_model_profile;
+use everruns_core::llm_driver_registry::{
+    DiscoveredModel, DriverRegistry, ProviderConfig, ProviderType,
+};
+use everruns_core::llm_models::LlmProviderType;
+
+/// One model offered by a provider, ready for display: bare id plus
+/// human-readable metadata merged from the provider's API response and the
+/// everruns-core profile registry.
+#[derive(Clone, Debug)]
+pub(crate) struct DiscoveredProviderModel {
+    pub model_id: String,
+    pub display_name: Option<String>,
+    pub description: Option<String>,
+}
+
+/// Query the provider's models API for the given choice. Returns `Ok(None)`
+/// when the provider (or its custom endpoint) does not support model
+/// listing; callers should fall back to curated suggestions in that case.
+pub(crate) async fn discover_provider_models(
+    choice: &ProviderChoice,
+    settings: &Settings,
+) -> Result<Option<Vec<DiscoveredProviderModel>>> {
+    if matches!(choice, ProviderChoice::Sim) {
+        return Ok(None);
+    }
+    let target = choice.model_with_provider(settings)?;
+    let provider_type = match target.provider_type {
+        LlmProviderType::Openai => ProviderType::OpenAI,
+        LlmProviderType::AzureOpenai => ProviderType::AzureOpenAI,
+        LlmProviderType::OpenaiCompletions => ProviderType::OpenAICompletions,
+        LlmProviderType::Anthropic => ProviderType::Anthropic,
+        LlmProviderType::Gemini => ProviderType::Gemini,
+        LlmProviderType::LlmSim => return Ok(None),
+    };
+    let mut config = ProviderConfig::new(provider_type);
+    if let Some(key) = &target.api_key {
+        config = config.with_api_key(key);
+    }
+    if let Some(base_url) = &target.base_url {
+        config = config.with_base_url(base_url);
+    }
+
+    let mut registry = DriverRegistry::new();
+    everruns_anthropic::register_driver(&mut registry);
+    everruns_openai::register_driver(&mut registry);
+    let driver = registry.create_driver(&config)?;
+
+    let models = match driver.list_models().await? {
+        Some(models) => Some(models),
+        // The everruns drivers decline discovery for unrecognized custom
+        // endpoints (Ollama, Gemini's OpenAI-compatible surface, custom
+        // OpenRouter proxies). Those endpoints still expose the
+        // OpenAI-compatible `GET <base>/models`, so query it directly.
+        None => match &target.base_url {
+            Some(base_url) => {
+                list_openai_compatible_models(base_url, target.api_key.as_deref()).await?
+            }
+            None => None,
+        },
+    };
+    let Some(mut models) = models else {
+        return Ok(None);
+    };
+
+    for model in models.iter_mut() {
+        // Gemini's OpenAI-compatible surface reports ids as `models/<id>`;
+        // the bare id is what chat calls (and profile lookups) expect.
+        if let Some(bare) = model.model_id.strip_prefix("models/") {
+            model.model_id = bare.to_string();
+        }
+    }
+    models.sort_by(|a, b| {
+        b.created_at
+            .cmp(&a.created_at)
+            .then_with(|| a.model_id.cmp(&b.model_id))
+    });
+    Ok(Some(enrich_with_profiles(&target.provider_type, models)))
+}
+
+/// Merge each discovered model with metadata from the everruns-core model
+/// profile registry. The core profile wins for descriptions (curated, short);
+/// the provider's API response wins for display names (it knows its own
+/// catalog best — e.g. OpenRouter's `name` field), with the core profile
+/// filling the gap for APIs that return bare ids (e.g. OpenAI).
+fn enrich_with_profiles(
+    provider_type: &LlmProviderType,
+    models: Vec<DiscoveredModel>,
+) -> Vec<DiscoveredProviderModel> {
+    models
+        .into_iter()
+        .map(|model| {
+            let core_profile = get_model_profile(provider_type, &model.model_id);
+            let api_profile = model.discovered_profile;
+            let display_name = model
+                .display_name
+                .filter(|name| !name.is_empty() && *name != model.model_id)
+                .or_else(|| core_profile.as_ref().map(|profile| profile.name.clone()));
+            let description = core_profile
+                .as_ref()
+                .and_then(|profile| profile.description.clone())
+                .or_else(|| {
+                    api_profile
+                        .as_ref()
+                        .and_then(|profile| profile.description.clone())
+                });
+            DiscoveredProviderModel {
+                model_id: model.model_id,
+                display_name,
+                description,
+            }
+        })
+        .collect()
+}
+
+#[derive(serde::Deserialize)]
+struct OpenAiCompatibleModelsResponse {
+    data: Vec<OpenAiCompatibleModel>,
+}
+
+#[derive(serde::Deserialize)]
+struct OpenAiCompatibleModel {
+    id: String,
+    #[serde(default)]
+    created: Option<i64>,
+    #[serde(default)]
+    owned_by: Option<String>,
+}
+
+/// Discovery fallback for OpenAI-compatible endpoints the everruns drivers
+/// don't recognize: `GET <base>/models` with bearer auth.
+async fn list_openai_compatible_models(
+    base_url: &str,
+    api_key: Option<&str>,
+) -> Result<Option<Vec<DiscoveredModel>>> {
+    let url = format!("{}/models", base_url.trim_end_matches('/'));
+    let mut request = reqwest::Client::new().get(&url);
+    if let Some(key) = api_key {
+        request = request.bearer_auth(key);
+    }
+    let response = request
+        .send()
+        .await
+        .with_context(|| format!("fetch models from {url}"))?;
+    if !response.status().is_success() {
+        return Err(anyhow!(
+            "models API at {url} returned {}",
+            response.status()
+        ));
+    }
+    let parsed: OpenAiCompatibleModelsResponse = response
+        .json()
+        .await
+        .with_context(|| format!("parse models response from {url}"))?;
+    let models = parsed
+        .data
+        .into_iter()
+        .map(|model| DiscoveredModel {
+            created_at: model
+                .created
+                .and_then(|ts| chrono::DateTime::from_timestamp(ts, 0)),
+            display_name: None,
+            owned_by: model.owned_by,
+            model_id: model.id,
+            discovered_profile: None,
+        })
+        .collect();
+    Ok(Some(models))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bare_discovered(model_id: &str) -> DiscoveredModel {
+        DiscoveredModel {
+            model_id: model_id.to_string(),
+            display_name: None,
+            created_at: None,
+            owned_by: None,
+            discovered_profile: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn discovery_is_unsupported_for_llmsim() {
+        // The offline simulator has no models API; discovery must signal
+        // "unsupported" (not error) so callers keep their curated lists.
+        let result = discover_provider_models(&ProviderChoice::Sim, &Settings::default())
+            .await
+            .expect("llmsim discovery should not error");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn enrichment_fills_names_and_descriptions_from_core_profiles() {
+        // OpenAI's models API returns bare ids; the core profile registry
+        // supplies the human-readable name and description.
+        let enriched =
+            enrich_with_profiles(&LlmProviderType::Openai, vec![bare_discovered("gpt-5.5")]);
+
+        assert_eq!(enriched.len(), 1);
+        assert_eq!(enriched[0].model_id, "gpt-5.5");
+        assert_eq!(enriched[0].display_name.as_deref(), Some("GPT-5.5"));
+        assert!(
+            enriched[0]
+                .description
+                .as_deref()
+                .is_some_and(|description| description.contains("flagship")),
+            "core profile description should be carried over: {:?}",
+            enriched[0].description
+        );
+    }
+
+    #[test]
+    fn enrichment_prefers_api_display_name_over_core_profile() {
+        let mut model = bare_discovered("gpt-5.5");
+        model.display_name = Some("GPT-5.5 (via gateway)".to_string());
+
+        let enriched = enrich_with_profiles(&LlmProviderType::Openai, vec![model]);
+
+        assert_eq!(
+            enriched[0].display_name.as_deref(),
+            Some("GPT-5.5 (via gateway)")
+        );
+    }
+
+    #[test]
+    fn enrichment_keeps_unknown_models_with_bare_ids() {
+        let enriched = enrich_with_profiles(
+            &LlmProviderType::Openai,
+            vec![bare_discovered("totally-new-model")],
+        );
+
+        assert_eq!(enriched[0].model_id, "totally-new-model");
+        assert!(enriched[0].display_name.is_none());
+        assert!(enriched[0].description.is_none());
+    }
+
+    /// Drivers decline listing for unrecognized custom endpoints (here: a
+    /// localhost "Ollama"); discovery must then query the OpenAI-compatible
+    /// `GET <base>/models` itself.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn discovery_falls_back_to_openai_compatible_endpoint() {
+        use std::io::{Read, Write};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind mock server");
+        let addr = listener.local_addr().expect("mock server addr");
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let mut buf = [0u8; 4096];
+            let _ = stream.read(&mut buf);
+            let body = r#"{"object":"list","data":[
+                {"id":"llama3.2:latest","object":"model","created":1700000000,"owned_by":"library"},
+                {"id":"models/qwen3","object":"model"}
+            ]}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write response");
+        });
+
+        let provider = ProviderChoice::Ollama {
+            model: "llama3.2".to_string(),
+            base_url: format!("http://{addr}/v1"),
+        };
+        let models = discover_provider_models(&provider, &Settings::default())
+            .await
+            .expect("fallback discovery should succeed")
+            .expect("openai-compatible endpoint lists models");
+        server.join().expect("mock server thread");
+
+        let ids: Vec<&str> = models.iter().map(|m| m.model_id.as_str()).collect();
+        assert!(ids.contains(&"llama3.2:latest"), "ids: {ids:?}");
+        // Gemini-style `models/` prefixes are normalized to bare ids.
+        assert!(ids.contains(&"qwen3"), "ids: {ids:?}");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires OPENROUTER_API_KEY; performs a live models API call"]
+    async fn discovery_openrouter_live() {
+        if std::env::var("OPENROUTER_API_KEY")
+            .map(|v| v.is_empty())
+            .unwrap_or(true)
+        {
+            eprintln!("skipping: OPENROUTER_API_KEY not set");
+            return;
+        }
+        let provider = ProviderChoice::default_for_provider_name("openrouter").unwrap();
+        let models = discover_provider_models(&provider, &Settings::default())
+            .await
+            .expect("openrouter discovery should succeed")
+            .expect("openrouter supports model listing");
+        assert!(!models.is_empty(), "openrouter should report models");
+        assert!(
+            models.iter().all(|m| !m.model_id.is_empty()),
+            "every discovered model needs an id"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -496,7 +496,7 @@ async fn run_print_mode(runtime: BuiltRuntime, prompt: String) -> Result<()> {
         handles,
         startup,
         model,
-        ui_rx: _,
+        ..
     } = runtime;
     let color = io::stdout().is_terminal();
     println!("{}", paint(color, "90", &format!("› {prompt}")));

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -926,6 +926,9 @@ pub struct BuiltRuntime {
     pub handles: RuntimeHandles,
     pub startup: StartupInfo,
     pub model: ModelState,
+    /// Settings store shared with the runtime capabilities. The TUI uses it
+    /// to resolve credentials when querying provider models APIs.
+    pub settings: Arc<SettingsStore>,
     /// Receiver for terminal-side commands emitted by
     /// [`ClientCommandsCapability`]. The TUI drains it in its event loop;
     /// other hosts ignore it. Empty/never-written when
@@ -998,6 +1001,15 @@ impl ModelState {
             .expect("provider lock poisoned")
             .model_id()
             .to_string()
+    }
+
+    /// Snapshot of the current provider choice (including any custom base
+    /// URL), e.g. for model discovery against the live configuration.
+    pub fn provider_choice(&self) -> ProviderChoice {
+        self.provider
+            .read()
+            .expect("provider lock poisoned")
+            .clone()
     }
 
     pub fn input_message(&self, text: impl Into<String>) -> InputMessage {
@@ -1287,6 +1299,7 @@ pub async fn build_with_options(
             mcp_server_names,
         },
         model: ModelState::new(provider_state),
+        settings,
         ui_rx,
     })
 }


### PR DESCRIPTION
## Summary

The model picker and `/setup model` previously offered only a hardcoded model list, which was stale for fast-moving catalogs like OpenRouter and useless for custom endpoints. This change queries each provider's models API live:

- New `src/capabilities/model_discovery.rs` encapsulates discovery: it goes through the everruns drivers (`LlmDriver::list_models`) and falls back to a direct OpenAI-compatible `GET <base>/models` for custom endpoints the drivers decline (Ollama, Gemini's OpenAI surface, proxies).
- Discovered models are enriched with the everruns-core model profile registry for human-readable names/descriptions (API display name wins for names, core profile wins for descriptions), normalized (`models/` prefix stripped), and sorted newest-first.
- The TUI picker fetches asynchronously off the UI thread (10s timeout), caches per provider, shows the curated shortlist while loading or when listing is unsupported/failed, windows long lists (OpenRouter) with scroll indicators, and keeps the "Custom..." escape hatch.
- `/setup model` without an argument now suggests live models (5s timeout) with curated fallback.
- `reqwest` becomes a direct dependency (same version/features already in-tree via the everruns driver crates) solely for the OpenAI-compatible fallback.

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features` — all green (256 passed, 2 ignored).
- Feature tests drive the real entry points: discovery unit tests cover profile enrichment precedence and the OpenAI-compatible fallback against a local mock HTTP server; app tests cover picker replacement with discovered models, unsupported-discovery fallback, error surfacing, and hint truncation.
- Live proof via Doppler: `discovery_openrouter_live` passed against the real OpenRouter models API (non-empty catalog, valid ids).
- End-to-end smoke via Doppler: `cargo run -- --provider openai -p "Reply with exactly: SMOKE-OK"` → `SMOKE-OK`, `success=true`.

## Security

- **TM-LLM**: API keys flow only into `ProviderConfig` / bearer auth headers for the user-configured endpoint; never logged or written to session files. Error messages include the URL and HTTP status only.
- **TM-DEP**: `reqwest 0.13` promoted from transitive to direct dependency, pinned to the same rustls-only feature set the everruns drivers already use; no new code in the tree.
- **Resource exhaustion**: both discovery call sites are timeout-bounded (10s TUI background fetch, 5s `/setup` suggestions); results are cached per provider so the picker doesn't re-fetch on every open.
- **TM-FS / TM-BASH / TM-TOOL**: untouched — no filesystem, shell, or capability-registration changes.

## Follow-ups

No follow-ups.