### PR TITLE
feat(acp): load persisted sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,10 @@ Protocol](https://agentclientprotocol.com). Launch it with `--acp` and it
 speaks newline-delimited JSON-RPC 2.0 over stdin/stdout: the editor performs
 the `initialize` handshake, opens a session with `session/new`, and sends
 turns with `session/prompt`; yolop streams back assistant text, reasoning,
-tool calls, and plans as `session/update` notifications.
+tool calls, and plans as `session/update` notifications. Editors can also
+load an existing yolop session with `session/load`; yolop replays the persisted
+conversation history and continues from the same JSONL session log used by
+CLI `--session`.
 
 To set up Zed:
 

--- a/specs/acp.md
+++ b/specs/acp.md
@@ -31,14 +31,15 @@ ACP protocol version: **1** (integer).
 | `initialize` | client → agent | Negotiates protocol version and advertises agent capabilities. Echoes the client's version when supported, else advertises v1. |
 | `authenticate` | client → agent | No-op success: credentials come from the environment/settings the process already inherits, so `authMethods` is empty. |
 | `session/new` | client → agent | Builds a fresh runtime rooted at the client-supplied `cwd`; returns the everruns session id as the ACP `sessionId`. |
+| `session/load` | client → agent | Rehydrates an existing yolop JSONL session for the supplied `sessionId` and `cwd`, replays persisted conversation history as `session/update` notifications, and then returns success. |
 | `session/prompt` | client → agent | Runs one turn, or executes a recognised `/command`; streams `session/update`s, and resolves a `stopReason`. |
 | `session/cancel` | client → agent | Notification. Abandons the in-flight turn for that session and resolves the prompt with `stopReason: "cancelled"`. |
 | `session/update` | agent → client | Notification. Streams the turn (see below). |
 
-`session/load` is **not** implemented: `loadSession` is advertised as `false`.
-Each ACP session builds its own runtime; prior ACP sessions are not rehydrated.
-(Yolop's own JSONL session logs are still written under the session dir and can
-be resumed by the CLI with `--session`.)
+`loadSession` is advertised as `true`. `session/load` uses the same JSONL
+replay path as CLI `--session`: prior user and assistant messages are streamed
+back to the editor before the response, and the loaded runtime then continues
+appending to the same session folder.
 
 ### Streaming a turn
 
@@ -128,9 +129,10 @@ Three layers, all offline (no API key):
    (deltas, tool lifecycle, todos→plan, dedup, streamed-vs-completed).
 3. **End-to-end** (`mod.rs`) — a real `serve` loop over duplex pipes driven by
    an in-memory ACP client: the full `initialize` → `session/new` →
-   `session/prompt` handshake, unknown-method and unknown-session errors,
-   scripted tool calls (asserting `tool_call`/`tool_call_update`),
-   `write_todos` → `plan`, and command advertisement/execution.
+   `session/prompt` handshake, `session/load` history replay across an ACP
+   server restart, unknown-method and unknown-session errors, scripted tool
+   calls (asserting `tool_call`/`tool_call_update`), `write_todos` → `plan`,
+   and command advertisement/execution.
 
 The binary itself is smoke-tested over real OS pipes in
 `tests/integration.rs` (`acp_stdio_handshake_smoke`), and a real-provider test
@@ -166,7 +168,6 @@ same way.
 
 ## Non-goals (for now)
 
-- `session/load` / ACP session rehydration.
 - Client-provided filesystem (`fs/read_text_file`, `fs/write_text_file`):
   yolop's runtime reads and writes the host disk directly under the workspace
   root, so it does not route file ops back through the client.

--- a/src/acp/bridge.rs
+++ b/src/acp/bridge.rs
@@ -36,11 +36,23 @@ pub struct Translator {
     /// event across the live broadcast and the catch-up drain; dedup keeps
     /// the client from seeing doubles.
     seen: HashSet<String>,
+    /// Replay mode is used only for `session/load`, where ACP requires the
+    /// agent to stream the historical user turns back to the client. Live
+    /// `session/prompt` handling leaves this off because the client already
+    /// has the prompt it just sent.
+    replay_input_messages: bool,
 }
 
 impl Translator {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn for_replay() -> Self {
+        Self {
+            replay_input_messages: true,
+            ..Self::default()
+        }
     }
 
     /// Translate a single runtime event into zero or more ACP updates.
@@ -50,6 +62,20 @@ impl Translator {
             return Vec::new();
         }
         match &event.data {
+            EventData::InputMessage(data) => {
+                if !self.replay_input_messages {
+                    return Vec::new();
+                }
+                if data.message.role != MessageRole::User {
+                    return Vec::new();
+                }
+                match data.message.text().map(str::trim) {
+                    Some(text) if !text.is_empty() => {
+                        vec![SessionUpdate::UserMessageChunk(protocol::text_chunk(text))]
+                    }
+                    _ => Vec::new(),
+                }
+            }
             EventData::OutputMessageStarted(_) => {
                 self.current_message_streamed = false;
                 Vec::new()
@@ -411,5 +437,28 @@ mod tests {
         }));
         assert_eq!(t.on_event(&ev).len(), 1);
         assert_eq!(t.on_event(&ev).len(), 0, "second delivery must be ignored");
+    }
+
+    #[test]
+    fn replay_mode_emits_user_messages() {
+        let mut t = Translator::for_replay();
+        let updates = t.on_event(&event(EventData::InputMessage(
+            everruns_core::events::InputMessageData::new(Message::user("prior prompt")),
+        )));
+        assert_eq!(
+            updates,
+            vec![SessionUpdate::UserMessageChunk(protocol::text_chunk(
+                "prior prompt"
+            ))]
+        );
+    }
+
+    #[test]
+    fn live_mode_suppresses_user_messages() {
+        let mut t = Translator::new();
+        let updates = t.on_event(&event(EventData::InputMessage(
+            everruns_core::events::InputMessageData::new(Message::user("current prompt")),
+        )));
+        assert!(updates.is_empty());
     }
 }

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -24,7 +24,9 @@ use anyhow::Result;
 use async_trait::async_trait;
 
 use crate::runtime::{self, BuiltRuntime, ProviderChoice};
+use crate::session_log::{legacy_session_log_path, session_dir_path, session_log_path};
 use crate::settings::SettingsStore;
+use everruns_core::typed_id::SessionId as RuntimeSessionId;
 
 pub use server::{RuntimeFactory, serve};
 
@@ -40,11 +42,21 @@ struct ConfigRuntimeFactory {
 
 #[async_trait]
 impl RuntimeFactory for ConfigRuntimeFactory {
-    async fn build(&self, cwd: PathBuf) -> Result<BuiltRuntime> {
+    fn session_exists(&self, session_id: RuntimeSessionId) -> bool {
+        let session_dir = session_dir_path(&self.sessions_dir, session_id);
+        session_log_path(&session_dir).exists()
+            || legacy_session_log_path(&self.sessions_dir, session_id).exists()
+    }
+
+    async fn build(
+        &self,
+        cwd: PathBuf,
+        resume_session_id: Option<RuntimeSessionId>,
+    ) -> Result<BuiltRuntime> {
         runtime::build(
             cwd,
             self.provider.clone(),
-            None,
+            resume_session_id,
             self.sessions_dir.clone(),
             self.settings.clone(),
         )
@@ -93,19 +105,29 @@ mod tests {
     /// runtime, which canonicalizes and retains its paths.
     struct ScriptedFactory {
         config: LlmSimConfig,
+        sessions_dir: PathBuf,
+        settings: Arc<SettingsStore>,
     }
 
     #[async_trait]
     impl RuntimeFactory for ScriptedFactory {
-        async fn build(&self, cwd: PathBuf) -> Result<BuiltRuntime> {
-            let sessions = tempfile::tempdir().expect("sessions tempdir").keep();
-            let settings = Arc::new(SettingsStore::open(sessions.join("settings.toml")));
+        fn session_exists(&self, session_id: RuntimeSessionId) -> bool {
+            let session_dir = session_dir_path(&self.sessions_dir, session_id);
+            session_log_path(&session_dir).exists()
+                || legacy_session_log_path(&self.sessions_dir, session_id).exists()
+        }
+
+        async fn build(
+            &self,
+            cwd: PathBuf,
+            resume_session_id: Option<RuntimeSessionId>,
+        ) -> Result<BuiltRuntime> {
             build_with_options(
                 cwd,
                 ProviderChoice::Sim,
-                None,
-                sessions,
-                settings,
+                resume_session_id,
+                self.sessions_dir.clone(),
+                self.settings.clone(),
                 BuildOptions {
                     llmsim_override: Some(self.config.clone().with_model("llmsim-yolop")),
                     ..BuildOptions::default()
@@ -176,7 +198,13 @@ mod tests {
     {
         let (client_w, agent_r) = tokio::io::duplex(64 * 1024);
         let (agent_w, client_r) = tokio::io::duplex(64 * 1024);
-        let factory = Arc::new(ScriptedFactory { config });
+        let sessions = tempfile::tempdir().expect("sessions tempdir").keep();
+        let settings = Arc::new(SettingsStore::open(sessions.join("settings.toml")));
+        let factory = Arc::new(ScriptedFactory {
+            config,
+            sessions_dir: sessions,
+            settings,
+        });
         tokio::spawn(async move {
             let _ = serve(agent_r, agent_w, factory).await;
         });
@@ -257,6 +285,71 @@ mod tests {
         })?
     }
 
+    async fn send_json(w: &mut DuplexStream, value: Value) {
+        let line = value.to_string();
+        w.write_all(line.as_bytes()).await.unwrap();
+        w.write_all(b"\n").await.unwrap();
+        w.flush().await.unwrap();
+    }
+
+    async fn next_json(reader: &mut Lines<BufReader<DuplexStream>>) -> Value {
+        let line = tokio::time::timeout(Duration::from_secs(15), reader.next_line())
+            .await
+            .expect("timed out")
+            .expect("read line")
+            .expect("stream open");
+        serde_json::from_str(&line).expect("valid json")
+    }
+
+    async fn collect_until_response_id(
+        reader: &mut Lines<BufReader<DuplexStream>>,
+        id: i64,
+    ) -> (Value, Vec<Value>) {
+        let mut updates = Vec::new();
+        loop {
+            let msg = next_json(reader).await;
+            if msg.get("method").and_then(Value::as_str) == Some("session/update") {
+                updates.push(msg);
+                continue;
+            }
+            if msg.get("id").and_then(Value::as_i64) == Some(id)
+                && (msg.get("result").is_some() || msg.get("error").is_some())
+            {
+                return (msg, updates);
+            }
+        }
+    }
+
+    fn start_raw_server(
+        config: LlmSimConfig,
+        sessions_dir: PathBuf,
+    ) -> (
+        DuplexStream,
+        Lines<BufReader<DuplexStream>>,
+        tokio::task::JoinHandle<Result<()>>,
+    ) {
+        let (client_w, agent_r) = tokio::io::duplex(64 * 1024);
+        let (agent_w, client_r) = tokio::io::duplex(64 * 1024);
+        let settings = Arc::new(SettingsStore::open(sessions_dir.join("settings.toml")));
+        let factory = Arc::new(ScriptedFactory {
+            config,
+            sessions_dir,
+            settings,
+        });
+        let server = tokio::spawn(async move { serve(agent_r, agent_w, factory).await });
+        (client_w, BufReader::new(client_r).lines(), server)
+    }
+
+    fn update_texts(updates: &[Value], kind: &str) -> Vec<String> {
+        updates
+            .iter()
+            .filter_map(|msg| msg.get("params")?.get("update")?.as_object())
+            .filter(|update| update.get("sessionUpdate").and_then(Value::as_str) == Some(kind))
+            .filter_map(|update| update.get("content")?.get("text").and_then(Value::as_str))
+            .map(str::to_string)
+            .collect()
+    }
+
     #[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
     #[request(method = "does/not/exist", response = Value)]
     struct UnknownRequest {}
@@ -269,8 +362,127 @@ mod tests {
     async fn initialize_advertises_protocol_version_and_capabilities() {
         let init = with_sdk_client(fixed("hi"), |client| async move { Ok(client.init) }).await;
         assert_eq!(init.protocol_version, protocol::PROTOCOL_VERSION);
-        assert!(!init.agent_capabilities.load_session);
+        assert!(init.agent_capabilities.load_session);
         assert!(init.agent_capabilities.prompt_capabilities.embedded_context);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn load_session_replays_history_and_continues_turns() {
+        let sessions = tempfile::tempdir().expect("sessions tempdir");
+        let sessions_dir = sessions.path().to_path_buf();
+        let cwd = tempfile::tempdir().expect("cwd tempdir").keep();
+
+        let (mut first_w, mut first_reader, first_server) =
+            start_raw_server(fixed("first answer"), sessions_dir.clone());
+        send_json(
+            &mut first_w,
+            json!({ "jsonrpc": "2.0", "id": 0, "method": "initialize", "params": { "protocolVersion": 1 } }),
+        )
+        .await;
+        let (init, _) = collect_until_response_id(&mut first_reader, 0).await;
+        assert_eq!(init["result"]["agentCapabilities"]["loadSession"], true);
+
+        send_json(
+            &mut first_w,
+            json!({ "jsonrpc": "2.0", "id": 1, "method": "session/new", "params": { "cwd": cwd.to_str().unwrap(), "mcpServers": [] } }),
+        )
+        .await;
+        let (new_session, _) = collect_until_response_id(&mut first_reader, 1).await;
+        let session_id = new_session["result"]["sessionId"]
+            .as_str()
+            .expect("sessionId")
+            .to_string();
+
+        send_json(
+            &mut first_w,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/prompt",
+                "params": { "sessionId": session_id, "prompt": [{ "type": "text", "text": "first prompt" }] },
+            }),
+        )
+        .await;
+        let (prompt_response, first_updates) =
+            collect_until_response_id(&mut first_reader, 2).await;
+        assert!(prompt_response.get("result").is_some());
+        assert!(
+            update_texts(&first_updates, "agent_message_chunk")
+                .iter()
+                .any(|text| text.contains("first answer")),
+            "expected first prompt response in updates: {first_updates:?}"
+        );
+
+        drop(first_w);
+        drop(first_reader);
+        tokio::time::timeout(Duration::from_secs(10), first_server)
+            .await
+            .expect("first server must stop")
+            .expect("first server joins")
+            .expect("first server returns Ok");
+
+        let (mut second_w, mut second_reader, second_server) =
+            start_raw_server(fixed("second answer"), sessions_dir);
+        send_json(
+            &mut second_w,
+            json!({ "jsonrpc": "2.0", "id": 10, "method": "initialize", "params": { "protocolVersion": 1 } }),
+        )
+        .await;
+        let _ = collect_until_response_id(&mut second_reader, 10).await;
+
+        send_json(
+            &mut second_w,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 11,
+                "method": "session/load",
+                "params": { "sessionId": session_id, "cwd": cwd.to_str().unwrap(), "mcpServers": [] },
+            }),
+        )
+        .await;
+        let (load_response, replay_updates) =
+            collect_until_response_id(&mut second_reader, 11).await;
+        assert!(load_response.get("result").is_some());
+        assert!(
+            update_texts(&replay_updates, "user_message_chunk")
+                .iter()
+                .any(|text| text.contains("first prompt")),
+            "expected replayed user message, got: {replay_updates:?}"
+        );
+        assert!(
+            update_texts(&replay_updates, "agent_message_chunk")
+                .iter()
+                .any(|text| text.contains("first answer")),
+            "expected replayed agent message, got: {replay_updates:?}"
+        );
+
+        send_json(
+            &mut second_w,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 12,
+                "method": "session/prompt",
+                "params": { "sessionId": session_id, "prompt": [{ "type": "text", "text": "second prompt" }] },
+            }),
+        )
+        .await;
+        let (second_prompt, second_updates) =
+            collect_until_response_id(&mut second_reader, 12).await;
+        assert!(second_prompt.get("result").is_some());
+        assert!(
+            update_texts(&second_updates, "agent_message_chunk")
+                .iter()
+                .any(|text| text.contains("second answer")),
+            "expected loaded session to accept a new prompt, got: {second_updates:?}"
+        );
+
+        drop(second_w);
+        drop(second_reader);
+        tokio::time::timeout(Duration::from_secs(10), second_server)
+            .await
+            .expect("second server must stop")
+            .expect("second server joins")
+            .expect("second server returns Ok");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -393,6 +605,46 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn load_unknown_session_is_invalid_params() {
+        let sessions = tempfile::tempdir().expect("sessions tempdir");
+        let cwd = tempfile::tempdir().expect("cwd tempdir").keep();
+        let (mut client_w, mut reader, server) =
+            start_raw_server(fixed("hi"), sessions.path().to_path_buf());
+
+        send_json(
+            &mut client_w,
+            json!({ "jsonrpc": "2.0", "id": 0, "method": "initialize", "params": { "protocolVersion": 1 } }),
+        )
+        .await;
+        let _ = collect_until_response_id(&mut reader, 0).await;
+
+        send_json(
+            &mut client_w,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "session/load",
+                "params": { "sessionId": "session_does_not_exist", "cwd": cwd.to_str().unwrap(), "mcpServers": [] },
+            }),
+        )
+        .await;
+        let (response, updates) = collect_until_response_id(&mut reader, 1).await;
+        assert!(
+            updates.is_empty(),
+            "unknown load should not replay: {updates:?}"
+        );
+        assert_eq!(response["error"]["code"], -32602);
+
+        drop(client_w);
+        drop(reader);
+        tokio::time::timeout(Duration::from_secs(10), server)
+            .await
+            .expect("server must stop")
+            .expect("server joins")
+            .expect("server returns Ok");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn scripted_tool_call_streams_tool_updates() {
         // First scripted turn writes a marker file via bash; second closes
         // the loop with plain text. The bash write runs autonomously.
@@ -488,7 +740,13 @@ mod tests {
 
         let (mut client_w, agent_r) = tokio::io::duplex(64 * 1024);
         let (agent_w, client_r) = tokio::io::duplex(64 * 1024);
-        let factory = Arc::new(ScriptedFactory { config });
+        let sessions = tempfile::tempdir().expect("sessions tempdir").keep();
+        let settings = Arc::new(SettingsStore::open(sessions.join("settings.toml")));
+        let factory = Arc::new(ScriptedFactory {
+            config,
+            sessions_dir: sessions,
+            settings,
+        });
         let server = tokio::spawn(async move { serve(agent_r, agent_w, factory).await });
         let mut reader = BufReader::new(client_r).lines();
 

--- a/src/acp/protocol.rs
+++ b/src/acp/protocol.rs
@@ -8,6 +8,7 @@ pub use agent_client_protocol::schema::{
     AuthenticateResponse as AuthenticateResult, AvailableCommand, AvailableCommandInput,
     AvailableCommandsUpdate, CancelNotification, Content, ContentBlock, ContentChunk,
     InitializeRequest as InitializeParams, InitializeResponse as InitializeResult,
+    LoadSessionRequest as LoadSessionParams, LoadSessionResponse as LoadSessionResult,
     NewSessionRequest as NewSessionParams, NewSessionResponse as NewSessionResult, Plan, PlanEntry,
     PlanEntryPriority, PlanEntryStatus, PromptCapabilities, PromptRequest as PromptParams,
     PromptResponse as PromptResult, ProtocolVersion, SessionNotification, SessionUpdate,
@@ -58,12 +59,12 @@ mod tests {
     fn sdk_initialize_result_serializes_camel_case() {
         let result = InitializeResult::new(PROTOCOL_VERSION).agent_capabilities(
             AgentCapabilities::new()
-                .load_session(false)
+                .load_session(true)
                 .prompt_capabilities(PromptCapabilities::new().embedded_context(true)),
         );
         let v = serde_json::to_value(&result).unwrap();
         assert_eq!(v["protocolVersion"], 1);
-        assert_eq!(v["agentCapabilities"]["loadSession"], false);
+        assert_eq!(v["agentCapabilities"]["loadSession"], true);
         assert_eq!(
             v["agentCapabilities"]["promptCapabilities"]["embeddedContext"],
             true

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -24,6 +24,7 @@ use agent_client_protocol::{Agent, Client, ConnectionTo, Lines, Responder};
 use anyhow::Result;
 use async_trait::async_trait;
 use everruns_core::command::{CommandDescriptor, CommandSource, ExecuteCommandRequest};
+use everruns_core::typed_id::SessionId as RuntimeSessionId;
 use futures::{AsyncBufReadExt, AsyncWriteExt, StreamExt};
 use serde_json::{Value, json};
 use tokio::io::{AsyncRead, AsyncWrite};
@@ -35,10 +36,10 @@ use crate::runtime::{BuiltRuntime, ModelState, RuntimeHandles};
 use super::bridge::Translator;
 use super::protocol::{
     self, AgentCapabilities, AuthenticateParams, AuthenticateResult, AvailableCommand,
-    AvailableCommandInput, InitializeParams, InitializeResult, NewSessionParams, NewSessionResult,
-    PromptCapabilities, PromptParams, PromptResult, SessionNotification, SessionUpdate, StopReason,
-    ToolCall, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind,
-    UnstructuredCommandInput,
+    AvailableCommandInput, InitializeParams, InitializeResult, LoadSessionParams,
+    LoadSessionResult, NewSessionParams, NewSessionResult, PromptCapabilities, PromptParams,
+    PromptResult, SessionNotification, SessionUpdate, StopReason, ToolCall, ToolCallStatus,
+    ToolCallUpdate, ToolCallUpdateFields, ToolKind, UnstructuredCommandInput,
 };
 
 /// How often the prompt loop wakes to check whether the turn task finished,
@@ -49,7 +50,13 @@ const TURN_POLL_INTERVAL: Duration = Duration::from_millis(150);
 /// substitute a scripted llmsim runtime for the real provider wiring.
 #[async_trait]
 pub trait RuntimeFactory: Send + Sync + 'static {
-    async fn build(&self, cwd: PathBuf) -> Result<BuiltRuntime>;
+    fn session_exists(&self, session_id: RuntimeSessionId) -> bool;
+
+    async fn build(
+        &self,
+        cwd: PathBuf,
+        resume_session_id: Option<RuntimeSessionId>,
+    ) -> Result<BuiltRuntime>;
 }
 
 /// SDK connection wrapper plus yolop-local ids for synthetic command tool calls.
@@ -188,6 +195,30 @@ where
             {
                 let server = server.clone();
                 let next_tool_id = next_tool_id.clone();
+                async move |params: LoadSessionParams, responder, cx| {
+                    let peer = Arc::new(Peer {
+                        cx: cx.clone(),
+                        next_id: next_tool_id.clone(),
+                    });
+                    match handle_load_session(&server, &peer, params).await {
+                        Ok((result, session_id)) => {
+                            responder.respond(result)?;
+                            if let Some(session) = server.session(&session_id) {
+                                let commands = session.commands.lock().unwrap().clone();
+                                notify_available_commands(&peer, &session_id, &commands);
+                            }
+                        }
+                        Err(err) => responder.respond_with_error(err)?,
+                    }
+                    Ok(())
+                }
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let server = server.clone();
+                let next_tool_id = next_tool_id.clone();
                 async move |params: PromptParams, responder, cx| {
                     let peer = Arc::new(Peer {
                         cx: cx.clone(),
@@ -263,9 +294,7 @@ fn handle_initialize(params: InitializeParams) -> InitializeResult {
     };
     InitializeResult::new(version).agent_capabilities(
         AgentCapabilities::new()
-            // yolop builds a fresh runtime per session and does not yet
-            // rehydrate prior ACP sessions, so loadSession stays false.
-            .load_session(false)
+            .load_session(true)
             .prompt_capabilities(
                 PromptCapabilities::new()
                     .image(false)
@@ -290,10 +319,50 @@ async fn handle_new_session<F: RuntimeFactory>(
 
     let built = server
         .factory
-        .build(cwd)
+        .build(cwd, None)
         .await
         .map_err(|e| internal_error(format!("build runtime: {e}")))?;
 
+    let acp_id = register_session(server, built);
+
+    Ok(NewSessionResult::new(acp_id))
+}
+
+async fn handle_load_session<F: RuntimeFactory>(
+    server: &Arc<Server<F>>,
+    peer: &Arc<Peer>,
+    params: LoadSessionParams,
+) -> std::result::Result<(LoadSessionResult, String), agent_client_protocol::Error> {
+    let requested_id = params.session_id.to_string();
+    let resume_session_id = requested_id
+        .parse::<RuntimeSessionId>()
+        .map_err(|e| invalid_params(format!("invalid session id `{requested_id}`: {e}")))?;
+
+    let session = match server.session(&requested_id) {
+        Some(session) => session,
+        None => {
+            if !server.factory.session_exists(resume_session_id) {
+                return Err(invalid_params(format!(
+                    "unknown session id `{requested_id}`"
+                )));
+            }
+            let built = server
+                .factory
+                .build(params.cwd, Some(resume_session_id))
+                .await
+                .map_err(|e| internal_error(format!("load runtime: {e}")))?;
+            let acp_id = register_session(server, built);
+            server
+                .session(&acp_id)
+                .ok_or_else(|| internal_error("loaded session was not registered"))?
+        }
+    };
+
+    replay_session_history(peer, &session).await?;
+    Ok((LoadSessionResult::new(), session.acp_id.clone()))
+}
+
+fn register_session<F: RuntimeFactory>(server: &Arc<Server<F>>, built: BuiltRuntime) -> String {
     let acp_id = built.handles.session_id.to_string();
     let commands = built.startup.capability_commands.clone();
     let session = Arc::new(Session {
@@ -309,7 +378,29 @@ async fn handle_new_session<F: RuntimeFactory>(
         .unwrap()
         .insert(acp_id.clone(), session);
 
-    Ok(NewSessionResult::new(acp_id))
+    acp_id
+}
+
+async fn replay_session_history(
+    peer: &Arc<Peer>,
+    session: &Arc<Session>,
+) -> std::result::Result<(), agent_client_protocol::Error> {
+    let events = session
+        .handles
+        .runtime
+        .events()
+        .await
+        .map_err(|e| internal_error(format!("load session history: {e}")))?;
+    let mut translator = Translator::for_replay();
+    for event in events {
+        if event.session_id != session.handles.session_id {
+            continue;
+        }
+        for update in translator.on_event(&event) {
+            peer.session_update(&session.acp_id, update);
+        }
+    }
+    Ok(())
 }
 
 async fn handle_prompt<F: RuntimeFactory>(

--- a/src/app.rs
+++ b/src/app.rs
@@ -4594,19 +4594,32 @@ mod tests {
             .expect("first turn");
         drop(first);
 
-        let resumed = crate::runtime::build_with_options(
-            workspace.path().to_path_buf(),
-            crate::runtime::ProviderChoice::Sim,
-            Some(session_id),
-            sessions.path().to_path_buf(),
-            settings,
-            crate::runtime::BuildOptions {
-                client_commands: true,
-                ..crate::runtime::BuildOptions::default()
-            },
-        )
-        .await
-        .expect("build resumed runtime");
+        let mut resumed = None;
+        for _ in 0..20 {
+            match crate::runtime::build_with_options(
+                workspace.path().to_path_buf(),
+                crate::runtime::ProviderChoice::Sim,
+                Some(session_id),
+                sessions.path().to_path_buf(),
+                settings.clone(),
+                crate::runtime::BuildOptions {
+                    client_commands: true,
+                    ..crate::runtime::BuildOptions::default()
+                },
+            )
+            .await
+            {
+                Ok(runtime) => {
+                    resumed = Some(runtime);
+                    break;
+                }
+                Err(err) if err.to_string().contains("another yolop process") => {
+                    tokio::time::sleep(Duration::from_millis(25)).await;
+                }
+                Err(err) => panic!("build resumed runtime: {err}"),
+            }
+        }
+        let resumed = resumed.expect("build resumed runtime after releasing first log lock");
         assert!(
             resumed.startup.replayed_events > 0,
             "resume should report replayed events"


### PR DESCRIPTION
## What
Add ACP `session/load` support so editors can rehydrate existing yolop sessions.

## Why
Yolop already persists CLI sessions in JSONL and advertises ACP editor integration. Editor clients could create new sessions, but could not load prior yolop sessions across restarts.

## How
- Advertise `loadSession: true` during ACP initialization.
- Add a typed `session/load` handler that validates the requested session id, rebuilds the runtime with the existing JSONL session id, replays stored user/assistant history as `session/update` notifications, then accepts normal `session/prompt` turns.
- Add replay-mode translation for stored user messages without echoing live prompt input back to clients.
- Keep README and `specs/acp.md` in sync.
- Stabilize an existing resume test by waiting briefly for the previous runtime's advisory log lock to release.

## Risk
- Medium
- ACP clients now receive replayed history for loaded sessions; malformed or unknown session ids return `invalid_params` instead of silently creating an empty runtime.
- Session replay uses the existing owner-only JSONL session store and does not add new persistence or secret handling.

## Security
- TM-FS: No change to workspace read/write tool routing or write blocklist. `session/load` only checks for an existing session log under yolop's configured sessions directory and reuses the existing runtime replay path.
- TM-BASH: No change to shell execution, timeout, or output cap behavior.
- TM-LLM: No new API-key handling. Replay streams already-persisted local session history to the ACP client that requested that session id.
- TM-TOOL: No new model tools or capabilities registered.
- TM-DEP: No dependency changes.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test acp --all-features`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"`
- `doppler run --project yolop --config ci -- cargo run -- --provider openai -p "Reply with exactly: yolop live smoke ok"`

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
