### PR TITLE
feat(skills): manage workspace and global skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,10 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   [`specs/your.md`](./specs/your.md).
 - **Skills** — `SKILL.md` files discovered from workspace
   (`.agents/skills/`), global (`<config_dir>/yolop/skills/`), and system
-  (bundled) scopes, exposed via `list_skills` / `activate_skill`. See
-  [`specs/skills.md`](./specs/skills.md).
+  (bundled) scopes, exposed via `list_skills`, `read_skill`, `write_skill`,
+  and `activate_skill`. Workspace/global skills installed after startup are
+  available immediately; the bundled `skill-management` skill covers search,
+  npx-style imports, and upgrades. See [`specs/skills.md`](./specs/skills.md).
 - **Infinity context** — older history is trimmed out of the live prompt but
   stays queryable via `query_history`, so long sessions don't hit the wall.
 - **Tool search** — provider-agnostic deferred tool loading: core file/shell

--- a/skills/skill-management/SKILL.md
+++ b/skills/skill-management/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: skill-management
+description: Install, inspect, update, or search for Yolop skills in workspace and global scopes. Use when the user asks to manage skills, import a skill from a registry or GitHub, or upgrade skills.
+user-invocable: true
+---
+
+# Skill Management
+
+Use this skill when the user wants to customize Yolop with skills.
+
+## Ground Rules
+
+- Installed skills are directories with a `SKILL.md`.
+- Workspace skills live under `.agents/skills/<name>/`.
+- Global skills live under Yolop's config directory, normally
+  `<config_dir>/yolop/skills/<name>/`.
+- System skills are built into Yolop and are read-only.
+- Workspace skills shadow global skills; global skills shadow system skills.
+- New or changed workspace/global skills are available immediately through
+  `list_skills` and `activate_skill`; do not ask the user to restart Yolop.
+
+## Inspect
+
+1. Call `list_skills` to see installed skills and scopes.
+2. Call `read_skill` before modifying an existing skill.
+3. Prefer editing the nearest scope that matches the user's intent:
+   workspace/local for project-specific behavior, global for cross-project
+   behavior.
+
+## Install Or Modify
+
+Use `write_skill` with:
+
+- `scope`: `workspace`/`local` or `global`
+- `name`: the skill directory name
+- `skill_md`: the full `SKILL.md` contents
+- `files`: optional bundled files keyed by relative path
+
+`write_skill` validates the skill name, parses `SKILL.md`, rejects path
+traversal in bundled files, and writes the skill atomically.
+
+## Import From npx-Style Sources
+
+If the user mentions an `npx skill add ...` command, reconstruct the install
+without requiring `npx` or the package:
+
+1. Identify the package, registry, or repository that command would fetch.
+2. Fetch the relevant `SKILL.md` and bundled files from the source.
+3. Preserve the upstream skill directory name unless the user asks to rename it.
+4. Install with `write_skill`.
+5. Call `list_skills` afterward and report the installed scope/path.
+
+If the source is ambiguous or private and cannot be fetched, ask for the exact
+repository, package, archive, or file contents.
+
+## Search
+
+For public skills, search in this order:
+
+1. Known registry or site named by the user, such as `skills.sh`.
+2. GitHub repositories and paths containing `SKILL.md`.
+3. General web search for the skill topic plus `SKILL.md`.
+
+Prefer source URLs that expose the actual files. Do not install from a summary
+page unless you can retrieve the real `SKILL.md` and any referenced files.
+
+## Upgrade
+
+For one skill:
+
+1. `read_skill` to capture the current scope, path, and any local changes.
+2. Fetch the current upstream version.
+3. Compare with the installed version when practical.
+4. Use `write_skill` to update the same scope.
+5. `activate_skill` or `list_skills` to verify it loads.
+
+For all skills:
+
+1. `list_skills`.
+2. Upgrade only skills with an identifiable upstream source or enough user
+   context to locate one.
+3. Skip read-only system skills unless Yolop itself is being updated.
+4. Report skipped skills with the reason, especially when no source is known.
+
+Never silently overwrite a clearly user-customized skill with unrelated
+registry content. If the intended upstream is uncertain, ask first.

--- a/specs/skills.md
+++ b/specs/skills.md
@@ -2,9 +2,9 @@
 
 ## Abstract
 
-Skills are instruction packages (`SKILL.md` files) the agent can discover and
-activate at runtime via the `list_skills` and `activate_skill` tools, plus a
-system-prompt listing of what's available.
+Skills are instruction packages (`SKILL.md` files) the agent can discover,
+activate, and manage at runtime via skills tools, plus a system-prompt listing
+of what's available.
 
 yolop **vendors** the upstream `skills` capability from `everruns-core`. The
 upstream capability scans a single virtual-filesystem path (`/.agents/skills`)
@@ -49,17 +49,33 @@ resolves to a **real on-disk directory**:
 4. **No command execution on activation.** The `!`cmd`` substitution is never
    expanded — activating a skill must not spawn a shell on the host (mirrors the
    upstream trust gate; see `everruns-core` skills / EVE-388).
-5. **Writes stay in the workspace.** Global and system folders are read-only
-   inputs; only the workspace scope is edited through the agent's file tools.
-6. **Absent scopes are silent.** A missing global directory, or a failure to
-   materialize system skills, disables that scope without failing the session.
-7. **Materialization is safe.** System-skill materialization is idempotent and
+5. **Writes are explicit.** Normal file tools edit only the workspace. The
+   dedicated `write_skill` tool may write workspace or global skills when the
+   user asks Yolop to install or modify skills. System skills are read-only.
+6. **Hot install.** Workspace and global scope paths are kept even when the
+   directories do not exist yet. Discovery reads the filesystem on each
+   `list_skills`, `read_skill`, and `activate_skill` call, so a skill installed
+   after Yolop starts is available without restarting.
+7. **Manage workspace/global skills.** `read_skill` returns an installed
+   skill's `SKILL.md` and file manifest. `write_skill` installs or updates a
+   skill in the workspace (`workspace`/`local`) or global (`global`) scope.
+   `write_skill` validates the skill name and `SKILL.md`, requires the
+   frontmatter `name` to match the directory name, bounds extra files, rejects
+   path traversal, and never writes system skills.
+8. **Absent scopes are silent.** A missing workspace/global directory is simply
+   empty until a skill is installed. A failure to materialize system skills
+   disables that scope without failing the session.
+9. **Materialization is safe.** System-skill materialization is idempotent and
    concurrency-safe (atomic per-file writes, skipped when bytes are unchanged),
    so parallel processes do not race on the shared cache directory.
+10. **Management guidance is bundled.** Yolop ships a `skill-management` system
+    skill that tells the agent how to inspect, install, search for, and upgrade
+    skills, including reconstructing `npx skill add ...` style installs by
+    fetching source files directly and writing them with `write_skill`.
 
 ## Ownership Boundary
 
 - This spec and `crate::skills` own scope resolution, discovery, precedence, and
-  the two tools.
+  the skills tools.
 - `everruns_core::skill` owns the `SKILL.md` format, parsing, validation, and
   substitution.

--- a/specs/your.md
+++ b/specs/your.md
@@ -34,7 +34,7 @@ existing `settings.toml`:
 <config_dir>/yolop/
   settings.toml      # provider + tokens (pre-existing)
   MEMORY.md          # v1: durable cross-session user memory
-  skills/            # roadmap: global, always-available skills
+  skills/            # global, always-available skills
 ```
 
 The capability must always be able to **describe itself** — what it is, where
@@ -88,7 +88,7 @@ validate it, and write it through hook config tools rather than storing a
 memory note that says "avoid git". See [`hooks.md`](./hooks.md) for the hook
 tool design and scope rules.
 
-## Roadmap (not yet implemented)
+## Roadmap
 
 The roadmap rides on everruns' existing extension points rather than inventing
 yolop-specific formats.
@@ -102,11 +102,10 @@ yolop-specific formats.
   central config dir and registers them into every session, so a user can add
   global capabilities without rebuilding yolop. Compiled (built-in)
   capabilities remain the path for behavior that needs real Rust.
-- **Global skills** — fall out of the above: a declarative capability's
-  `skills` are mounted at everruns' `SKILLS_DISCOVERY_PATH`
-  (`/.agents/skills`) so the built-in `skills` capability lists/activates
-  them in every session. This is also where memory that has outgrown a few
-  bullets gets promoted to.
+- **Declarative capability skills** — global skills are already discovered
+  directly from `<config_dir>/yolop/skills`. A future declarative capability
+  layer can also contribute skills into that same global personalization model.
+  This is where memory that has outgrown a few bullets gets promoted to.
 - **Hooks** — `your` should configure global and workspace hooks through
   structured hook tools, using the scope and merge contract in
   [`hooks.md`](./hooks.md).

--- a/src/capabilities/skills.rs
+++ b/src/capabilities/skills.rs
@@ -34,6 +34,9 @@ use everruns_core::tool_types::ToolHints;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use include_dir::{Dir, include_dir};
 use serde_json::{Value, json};
+use std::ffi::OsString;
+use std::io::Write;
+use std::path::Component;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -50,6 +53,10 @@ const SYSTEM_SKILLS_DIR_ENV: &str = "YOLOP_SYSTEM_SKILLS_DIR";
 const MAX_SKILLS_IN_PROMPT: usize = 15;
 /// Max description length in the system-prompt listing (truncated with "…").
 const MAX_DESCRIPTION_CHARS: usize = 76;
+/// Defensive cap for extra files installed with a skill.
+const MAX_EXTRA_SKILL_FILES: usize = 64;
+/// Defensive cap for one skill file body.
+const MAX_SKILL_FILE_BYTES: usize = 1024 * 1024;
 
 /// System skills shipped inside the binary. The crate-root `skills/` directory is
 /// embedded at compile time so a `cargo install` / Homebrew build carries them.
@@ -110,7 +117,9 @@ impl SkillSources {
     }
 
     /// Build from explicit per-scope directories (used by `resolve` and tests).
-    /// Each is included only when it is an existing directory.
+    /// Missing directories are kept so a skill installed later in the same
+    /// process becomes discoverable on the next `list_skills`/`activate_skill`
+    /// call without restarting yolop.
     pub(crate) fn from_dirs(
         workspace: Option<PathBuf>,
         global: Option<PathBuf>,
@@ -122,7 +131,7 @@ impl SkillSources {
             (SkillScope::Global, global),
             (SkillScope::System, system),
         ] {
-            if let Some(dir) = dir.filter(|p| p.is_dir()) {
+            if let Some(dir) = dir {
                 roots.push((scope, dir));
             }
         }
@@ -184,6 +193,13 @@ impl SkillSources {
             }
         }
         None
+    }
+
+    fn root_for(&self, requested: SkillWriteScope) -> Option<PathBuf> {
+        let wanted = requested.skill_scope();
+        self.roots
+            .iter()
+            .find_map(|(scope, root)| (*scope == wanted).then(|| root.clone()))
     }
 }
 
@@ -313,6 +329,12 @@ impl Capability for YolopSkillsCapability {
             Box::new(ListSkillsTool {
                 sources: self.sources.clone(),
             }),
+            Box::new(ReadSkillTool {
+                sources: self.sources.clone(),
+            }),
+            Box::new(WriteSkillTool {
+                sources: self.sources.clone(),
+            }),
             Box::new(ActivateSkillTool {
                 sources: self.sources.clone(),
             }),
@@ -381,6 +403,301 @@ impl Tool for ListSkillsTool {
             "count": skills.len(),
             "skills": skills,
         }))
+    }
+}
+
+// ============================================================================
+// read_skill
+// ============================================================================
+
+struct ReadSkillTool {
+    sources: Arc<SkillSources>,
+}
+
+#[async_trait]
+impl Tool for ReadSkillTool {
+    fn name(&self) -> &str {
+        "read_skill"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Read Skill")
+    }
+
+    fn description(&self) -> &str {
+        "Read one installed skill's SKILL.md and file manifest. Use before modifying \
+         or upgrading a workspace/global skill."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The skill directory name."
+                },
+                "scope": {
+                    "type": "string",
+                    "enum": ["workspace", "local", "global", "system"],
+                    "description": "Optional scope to read from. Omit to use normal precedence."
+                }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+    }
+
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let Some(name) = arguments.get("name").and_then(|v| v.as_str()) else {
+            return ToolExecutionResult::tool_error("Missing required parameter: name");
+        };
+        if let Err(e) = validate_requested_skill_name(name) {
+            return ToolExecutionResult::tool_error(e);
+        }
+
+        let located = match arguments.get("scope").and_then(|v| v.as_str()) {
+            Some(raw) => {
+                let Some(scope) = SkillReadScope::parse(raw) else {
+                    return ToolExecutionResult::tool_error(
+                        "'scope' must be one of workspace, local, global, or system",
+                    );
+                };
+                self.sources
+                    .roots
+                    .iter()
+                    .find(|(candidate, _)| *candidate == scope.skill_scope())
+                    .and_then(|(scope, root)| {
+                        let dir_path = root.join(name);
+                        std::fs::read_to_string(dir_path.join("SKILL.md"))
+                            .ok()
+                            .map(|content| (*scope, dir_path, content))
+                    })
+            }
+            None => self.sources.locate(name),
+        };
+
+        let Some((scope, dir_path, content)) = located else {
+            return ToolExecutionResult::tool_error(format!(
+                "Skill '{name}' not found. Use list_skills to see what's available."
+            ));
+        };
+
+        ToolExecutionResult::success(json!({
+            "name": name,
+            "scope": scope.label(),
+            "path": dir_path.join("SKILL.md").display().to_string(),
+            "skill_md": content,
+            "files": skill_file_manifest(&dir_path),
+        }))
+    }
+}
+
+// ============================================================================
+// write_skill
+// ============================================================================
+
+struct WriteSkillTool {
+    sources: Arc<SkillSources>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SkillWriteScope {
+    Workspace,
+    Global,
+}
+
+impl SkillWriteScope {
+    fn parse(raw: &str) -> Option<Self> {
+        match raw {
+            "workspace" | "local" => Some(Self::Workspace),
+            "global" => Some(Self::Global),
+            _ => None,
+        }
+    }
+
+    fn skill_scope(self) -> SkillScope {
+        match self {
+            Self::Workspace => SkillScope::Workspace,
+            Self::Global => SkillScope::Global,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        self.skill_scope().label()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SkillReadScope {
+    Workspace,
+    Global,
+    System,
+}
+
+impl SkillReadScope {
+    fn parse(raw: &str) -> Option<Self> {
+        match raw {
+            "workspace" | "local" => Some(Self::Workspace),
+            "global" => Some(Self::Global),
+            "system" => Some(Self::System),
+            _ => None,
+        }
+    }
+
+    fn skill_scope(self) -> SkillScope {
+        match self {
+            Self::Workspace => SkillScope::Workspace,
+            Self::Global => SkillScope::Global,
+            Self::System => SkillScope::System,
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for WriteSkillTool {
+    fn name(&self) -> &str {
+        "write_skill"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Write Skill")
+    }
+
+    fn description(&self) -> &str {
+        "Install or update a skill in the current workspace or global yolop config. \
+         Provide the full SKILL.md and optional bundled files. Use this to recreate \
+         skills from a registry/GitHub source without requiring npx."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "scope": {
+                    "type": "string",
+                    "enum": ["workspace", "local", "global"],
+                    "description": "Where to write the skill. 'local' is an alias for 'workspace'."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Skill directory name. Must match the SKILL.md frontmatter name."
+                },
+                "skill_md": {
+                    "type": "string",
+                    "description": "The complete SKILL.md contents, including frontmatter."
+                },
+                "files": {
+                    "type": "object",
+                    "description": "Optional bundled files to write under the skill directory, keyed by relative path. Do not include SKILL.md here.",
+                    "additionalProperties": { "type": "string" }
+                },
+                "overwrite": {
+                    "type": "boolean",
+                    "description": "Whether to replace existing files. Defaults to true."
+                }
+            },
+            "required": ["scope", "name", "skill_md"],
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default().with_idempotent(true)
+    }
+
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let Some(scope_raw) = arguments.get("scope").and_then(|v| v.as_str()) else {
+            return ToolExecutionResult::tool_error("'scope' is required");
+        };
+        let Some(scope) = SkillWriteScope::parse(scope_raw) else {
+            return ToolExecutionResult::tool_error(
+                "'scope' must be one of workspace, local, or global",
+            );
+        };
+        let Some(name) = arguments.get("name").and_then(|v| v.as_str()) else {
+            return ToolExecutionResult::tool_error("'name' is required");
+        };
+        if let Err(e) = validate_requested_skill_name(name) {
+            return ToolExecutionResult::tool_error(e);
+        }
+        let Some(skill_md) = arguments.get("skill_md").and_then(|v| v.as_str()) else {
+            return ToolExecutionResult::tool_error("'skill_md' is required");
+        };
+        if skill_md.len() > MAX_SKILL_FILE_BYTES {
+            return ToolExecutionResult::tool_error(format!(
+                "'skill_md' exceeds the {MAX_SKILL_FILE_BYTES} byte limit"
+            ));
+        }
+
+        let parsed = match parse_skill_md(skill_md) {
+            Ok(parsed) => parsed,
+            Err(errors) => {
+                return ToolExecutionResult::tool_error(format!(
+                    "Invalid SKILL.md: {}",
+                    errors.join(", ")
+                ));
+            }
+        };
+        if parsed.name != name {
+            return ToolExecutionResult::tool_error(format!(
+                "'name' must match SKILL.md frontmatter name (got '{}')",
+                parsed.name
+            ));
+        }
+
+        let Some(root) = self.sources.root_for(scope) else {
+            return ToolExecutionResult::tool_error(format!(
+                "{} skills directory is unavailable on this host",
+                scope.label()
+            ));
+        };
+        let skill_dir = root.join(name);
+        let overwrite = arguments
+            .get("overwrite")
+            .and_then(Value::as_bool)
+            .unwrap_or(true);
+        let files = match collect_extra_files(arguments.get("files")) {
+            Ok(files) => files,
+            Err(e) => return ToolExecutionResult::tool_error(e),
+        };
+
+        if !overwrite && skill_dir.exists() {
+            return ToolExecutionResult::tool_error(format!(
+                "Skill '{}' already exists in {} scope; pass overwrite=true to update it",
+                name,
+                scope.label()
+            ));
+        }
+
+        let write_result = (|| -> std::io::Result<()> {
+            prepare_skill_dir(&root, &skill_dir)?;
+            std::fs::create_dir_all(&skill_dir)?;
+            save_skill_file(&skill_dir.join("SKILL.md"), skill_md)?;
+            for (rel, content) in &files {
+                let target = checked_skill_file_path(&skill_dir, rel)?;
+                save_skill_file(&target, content)?;
+            }
+            Ok(())
+        })();
+
+        match write_result {
+            Ok(()) => ToolExecutionResult::success(json!({
+                "ok": true,
+                "name": name,
+                "scope": scope.label(),
+                "path": skill_dir.join("SKILL.md").display().to_string(),
+                "files_written": files.len() + 1,
+                "message": "skill written; it is discoverable immediately via list_skills and activate_skill",
+            })),
+            Err(e) => ToolExecutionResult::tool_error(format!("could not write skill: {e}")),
+        }
     }
 }
 
@@ -523,14 +840,15 @@ impl Tool for ActivateSkillTool {
 // Scope folder resolution + system-skill materialization
 // ============================================================================
 
-/// Global skills directory, or `None` when it does not exist.
+/// Global skills directory, or `None` when no platform config directory exists.
 /// Honors `YOLOP_GLOBAL_SKILLS_DIR`; otherwise `<config_dir>/yolop/skills`.
+/// The path is returned even when absent so newly installed global skills become
+/// available without restarting the process.
 pub fn global_skills_dir() -> Option<PathBuf> {
-    let dir = match std::env::var(GLOBAL_SKILLS_DIR_ENV) {
+    Some(match std::env::var(GLOBAL_SKILLS_DIR_ENV) {
         Ok(value) if !value.is_empty() => PathBuf::from(value),
         _ => dirs::config_dir()?.join("yolop").join("skills"),
-    };
-    dir.is_dir().then_some(dir)
+    })
 }
 
 /// System skills directory, materializing the embedded skills first.
@@ -617,6 +935,179 @@ fn write_if_changed(target: &Path, contents: &[u8]) -> std::io::Result<()> {
     ));
     std::fs::write(&tmp, contents)?;
     std::fs::rename(&tmp, target)
+}
+
+fn validate_requested_skill_name(name: &str) -> Result<(), String> {
+    if name.contains("..") || name.contains('/') || name.contains('\\') {
+        return Err(
+            "Invalid skill name. Must be a simple directory name without path separators."
+                .to_string(),
+        );
+    }
+    validate_skill_name(name)
+        .map_err(|errors| format!("Invalid skill name '{name}': {}", errors.join(", ")))
+}
+
+fn collect_extra_files(value: Option<&Value>) -> Result<Vec<(PathBuf, String)>, String> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    let Some(map) = value.as_object() else {
+        return Err("'files' must be an object of relative path to string content".to_string());
+    };
+    if map.len() > MAX_EXTRA_SKILL_FILES {
+        return Err(format!(
+            "'files' contains too many entries (max {MAX_EXTRA_SKILL_FILES})"
+        ));
+    }
+
+    let mut out = Vec::with_capacity(map.len());
+    for (raw_path, value) in map {
+        let Some(content) = value.as_str() else {
+            return Err(format!("file '{raw_path}' content must be a string"));
+        };
+        if content.len() > MAX_SKILL_FILE_BYTES {
+            return Err(format!(
+                "file '{raw_path}' exceeds the {MAX_SKILL_FILE_BYTES} byte limit"
+            ));
+        }
+        let rel = validate_skill_file_path(raw_path)?;
+        out.push((rel, content.to_string()));
+    }
+    Ok(out)
+}
+
+fn validate_skill_file_path(raw: &str) -> Result<PathBuf, String> {
+    if raw.trim().is_empty() || raw.contains('\\') {
+        return Err(format!("invalid skill file path '{raw}'"));
+    }
+    let path = PathBuf::from(raw);
+    if path == Path::new("SKILL.md") || path.is_absolute() {
+        return Err(format!("invalid skill file path '{raw}'"));
+    }
+    for component in path.components() {
+        match component {
+            Component::Normal(_) => {}
+            _ => return Err(format!("invalid skill file path '{raw}'")),
+        }
+    }
+    Ok(path)
+}
+
+fn save_skill_file(path: &Path, content: &str) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    if let Ok(existing) = std::fs::read_to_string(path)
+        && existing == content
+    {
+        return Ok(());
+    }
+
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path.file_name().unwrap_or_default();
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut tmp_name = OsString::from(".");
+    tmp_name.push(file_name);
+    tmp_name.push(format!(".tmp.{}-{seq}", std::process::id()));
+    let tmp_path = parent.join(tmp_name);
+    let write_result = (|| -> std::io::Result<()> {
+        let mut file = std::fs::File::create(&tmp_path)?;
+        file.write_all(content.as_bytes())?;
+        file.sync_all()?;
+        Ok(())
+    })();
+    if let Err(e) = write_result {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(e);
+    }
+    std::fs::rename(&tmp_path, path)
+}
+
+fn prepare_skill_dir(root: &Path, skill_dir: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(root)?;
+    reject_symlink(skill_dir)?;
+    std::fs::create_dir_all(skill_dir)?;
+
+    let root = root.canonicalize()?;
+    let skill_dir = skill_dir.canonicalize()?;
+    if !skill_dir.starts_with(&root) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "skill directory resolves outside the configured skills root",
+        ));
+    }
+    Ok(())
+}
+
+fn checked_skill_file_path(skill_dir: &Path, rel: &Path) -> std::io::Result<PathBuf> {
+    let target = skill_dir.join(rel);
+    reject_symlink(&target)?;
+    let parent = target.parent().unwrap_or(skill_dir);
+    std::fs::create_dir_all(parent)?;
+
+    let skill_dir = skill_dir.canonicalize()?;
+    let parent = parent.canonicalize()?;
+    if !parent.starts_with(&skill_dir) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "skill file path resolves outside the skill directory",
+        ));
+    }
+    Ok(target)
+}
+
+fn reject_symlink(path: &Path) -> std::io::Result<()> {
+    let Ok(metadata) = std::fs::symlink_metadata(path) else {
+        return Ok(());
+    };
+    if metadata.file_type().is_symlink() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!("refusing to write through symlink {}", path.display()),
+        ));
+    }
+    Ok(())
+}
+
+fn skill_file_manifest(dir_path: &Path) -> Vec<Value> {
+    let mut out = Vec::new();
+    collect_skill_manifest_entries(dir_path, dir_path, &mut out);
+    out.sort_by_key(|entry| {
+        entry
+            .get("path")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string()
+    });
+    out
+}
+
+fn collect_skill_manifest_entries(root: &Path, dir: &Path, out: &mut Vec<Value>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_dir() {
+            collect_skill_manifest_entries(root, &path, out);
+            continue;
+        }
+        if !file_type.is_file() {
+            continue;
+        }
+        let Ok(rel) = path.strip_prefix(root) else {
+            continue;
+        };
+        out.push(json!({
+            "path": rel.display().to_string(),
+            "bytes": entry.metadata().map(|m| m.len()).unwrap_or(0),
+        }));
+    }
 }
 
 #[cfg(test)]
@@ -806,6 +1297,178 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn global_skill_created_after_sources_are_built_is_listed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing_global = tmp.path().join("global-skills");
+        let tool = ListSkillsTool {
+            sources: Arc::new(SkillSources::from_dirs(
+                None,
+                Some(missing_global.clone()),
+                None,
+            )),
+        };
+
+        let ToolExecutionResult::Success(v) = tool.execute(json!({})).await else {
+            panic!("expected success");
+        };
+        assert_eq!(v["count"], 0);
+
+        write_skill(
+            &missing_global,
+            "hot-install",
+            "hot-install",
+            "installed after startup",
+        );
+        let ToolExecutionResult::Success(v) = tool.execute(json!({})).await else {
+            panic!("expected success");
+        };
+        assert_eq!(v["count"], 1);
+        assert_eq!(v["skills"][0]["name"], "hot-install");
+        assert_eq!(v["skills"][0]["scope"], "global");
+    }
+
+    #[tokio::test]
+    async fn write_skill_installs_global_skill_readable_without_restart() {
+        let ws = tempfile::tempdir().unwrap();
+        let gl = tempfile::tempdir().unwrap();
+        let sources = Arc::new(SkillSources::from_dirs(
+            Some(ws.path().into()),
+            Some(gl.path().into()),
+            None,
+        ));
+        let writer = WriteSkillTool {
+            sources: sources.clone(),
+        };
+        let skill_md =
+            "---\nname: new-skill\ndescription: installed by tool\n---\n\n# New\nUse data.txt\n";
+
+        let res = writer
+            .execute(json!({
+                "scope": "global",
+                "name": "new-skill",
+                "skill_md": skill_md,
+                "files": {
+                    "data.txt": "hello"
+                }
+            }))
+            .await;
+        assert!(res.is_success(), "got: {res:?}");
+        assert_eq!(
+            std::fs::read_to_string(gl.path().join("new-skill").join("SKILL.md")).unwrap(),
+            skill_md
+        );
+
+        let reader = ReadSkillTool {
+            sources: sources.clone(),
+        };
+        let ToolExecutionResult::Success(v) = reader.execute(json!({"name": "new-skill"})).await
+        else {
+            panic!("expected read success");
+        };
+        assert_eq!(v["scope"], "global");
+        assert_eq!(v["skill_md"], skill_md);
+        assert_eq!(v["files"][0]["path"], "SKILL.md");
+
+        let lister = ListSkillsTool { sources };
+        let ToolExecutionResult::Success(v) = lister.execute(json!({})).await else {
+            panic!("expected list success");
+        };
+        let skill = v["skills"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|s| s["name"] == "new-skill")
+            .unwrap();
+        assert_eq!(skill["scope"], "global");
+    }
+
+    #[tokio::test]
+    async fn write_skill_rejects_unsafe_paths_and_readonly_scopes() {
+        let ws = tempfile::tempdir().unwrap();
+        let writer = WriteSkillTool {
+            sources: Arc::new(SkillSources::from_dirs(Some(ws.path().into()), None, None)),
+        };
+        let skill_md = "---\nname: safe-skill\ndescription: safe\n---\n\nbody\n";
+
+        let system = writer
+            .execute(json!({
+                "scope": "system",
+                "name": "safe-skill",
+                "skill_md": skill_md,
+            }))
+            .await;
+        assert!(system.is_error());
+
+        let traversal = writer
+            .execute(json!({
+                "scope": "workspace",
+                "name": "safe-skill",
+                "skill_md": skill_md,
+                "files": {
+                    "../escape.txt": "nope"
+                }
+            }))
+            .await;
+        assert!(traversal.is_error());
+        assert!(!ws.path().join("escape.txt").exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_skill_rejects_symlinked_skill_dir() {
+        use std::os::unix::fs::symlink;
+
+        let ws = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        symlink(outside.path(), ws.path().join("linked-skill")).unwrap();
+        let writer = WriteSkillTool {
+            sources: Arc::new(SkillSources::from_dirs(Some(ws.path().into()), None, None)),
+        };
+        let skill_md = "---\nname: linked-skill\ndescription: linked\n---\n\nbody\n";
+
+        let res = writer
+            .execute(json!({
+                "scope": "workspace",
+                "name": "linked-skill",
+                "skill_md": skill_md,
+            }))
+            .await;
+
+        assert!(res.is_error(), "got: {res:?}");
+        assert!(!outside.path().join("SKILL.md").exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_skill_rejects_symlinked_extra_file_parent() {
+        use std::os::unix::fs::symlink;
+
+        let ws = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let skill_dir = ws.path().join("safe-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        symlink(outside.path(), skill_dir.join("data")).unwrap();
+        let writer = WriteSkillTool {
+            sources: Arc::new(SkillSources::from_dirs(Some(ws.path().into()), None, None)),
+        };
+        let skill_md = "---\nname: safe-skill\ndescription: safe\n---\n\nbody\n";
+
+        let res = writer
+            .execute(json!({
+                "scope": "workspace",
+                "name": "safe-skill",
+                "skill_md": skill_md,
+                "files": {
+                    "data/escape.txt": "nope"
+                }
+            }))
+            .await;
+
+        assert!(res.is_error(), "got: {res:?}");
+        assert!(!outside.path().join("escape.txt").exists());
+    }
+
+    #[tokio::test]
     async fn system_prompt_lists_visible_skills_and_filters_opted_out() {
         let ws = tempfile::tempdir().unwrap();
         write_skill(ws.path(), "shown", "shown", "appears in the prompt");
@@ -827,5 +1490,22 @@ mod tests {
 
         assert!(prompt.contains("**shown** [workspace]"));
         assert!(!prompt.contains("hidden"));
+    }
+
+    #[test]
+    fn capability_exposes_skill_management_tools() {
+        let ws = tempfile::tempdir().unwrap();
+        let cap =
+            YolopSkillsCapability::new(SkillSources::from_dirs(Some(ws.path().into()), None, None));
+        let names = cap
+            .tools()
+            .iter()
+            .map(|tool| tool.name().to_string())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            names,
+            vec!["list_skills", "read_skill", "write_skill", "activate_skill"]
+        );
     }
 }


### PR DESCRIPTION
## What
Add runtime skill management for Yolop:

- keep workspace/global skill roots active even when the directories are created after startup
- add `read_skill` and `write_skill` tools alongside `list_skills` / `activate_skill`
- bundle a `skill-management` system skill for search, npx-style imports, and one/all skill upgrades
- update README and specs for the new behavior

## Why
Skills are the main customization surface. A globally installed skill should become usable immediately, and Yolop needs first-class ways to inspect, install, and modify workspace/global skills without depending on external `npx` tooling.

## How
`SkillSources` now keeps configured roots even if they do not exist yet, and discovery continues to read disk on each tool call. `write_skill` validates skill names and SKILL.md frontmatter, bounds bundled file writes, rejects traversal/absolute paths, refuses symlink write escapes, and writes only workspace or global scopes. System skills stay read-only. The bundled `skill-management` skill provides the progressive workflow for search/import/upgrade cases where a dedicated registry protocol would be premature.

Validation:

- `cargo fmt --check`
- `cargo test --all-features capabilities::skills`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo run -- --provider openai -p "Use list_skills and tell me whether skill-management is available. Keep the answer to one sentence."` confirmed `skill-management` is available as a system skill after one `list_skills` tool call

Security:

- TM-FS: normal file tools remain workspace-scoped; the new explicit `write_skill` path writes only configured workspace/global skill roots, validates skill names, rejects traversal/absolute bundled paths, rejects symlinked skill dirs/targets and symlinked bundled-file parents, and enforces file count/size caps. System skills remain read-only.
- TM-TOOL: new skill tools are bounded to skill management and do not expand activation shell substitutions.
- TM-BASH: no shell execution changes.
- TM-LLM: no API key handling or logging changes.
- TM-DEP: no dependency changes.

Follow-ups:

No follow-ups.

## Risk
- Medium
- Adds a new explicit global write surface for skills. The write target is constrained to Yolop's configured global skills directory and covered by tests for hot-install discovery, read/write behavior, traversal rejection, and symlink escape rejection.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
