### PR TITLE
feat(hooks): support scoped user hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
 - **MCP servers** — extra tools from local (stdio) or remote (HTTP)
   [Model Context Protocol](https://modelcontextprotocol.io) servers via
   `.mcp.json` (see [MCP servers](#mcp-servers)).
+- **Hooks** — workspace and global hook files can block, mutate, or audit
+  agent actions through the upstream `user_hooks` capability. Configure them
+  by chatting with yolop or by editing `hooks.json`. See
+  [`docs/features/hooks.md`](./docs/features/hooks.md).
 - **Editor integration** — `--acp` speaks the
   [Agent Client Protocol](https://agentclientprotocol.com) over stdio, so
   editors such as Zed can drive yolop as an external agent (see

--- a/docs/features/hooks.md
+++ b/docs/features/hooks.md
@@ -1,0 +1,139 @@
+---
+title: Hooks
+description: Configure Yolop to block, mutate, or audit actions with workspace and global hook files.
+---
+
+Hooks let you attach deterministic automation to Yolop's agent loop. They are
+useful when an instruction is too important to leave as a preference: block a
+class of shell commands, rewrite unsafe tool arguments, or record an audit event
+outside the model.
+
+Yolop uses the upstream `everruns-core` `user_hooks` capability. The local
+Yolop layer only discovers hook files, merges workspace and global scopes, and
+lets `your` configure those files from natural language.
+
+## How it works
+
+```mermaid
+flowchart LR
+  User["User: yolop setup a hook"] --> Your["your personalization"]
+  Your --> Tools["validate_your_hook / upsert_your_hook"]
+  Tools --> Files["hooks.json"]
+  Files --> Runtime["user_hooks capability"]
+  Runtime --> Decision{"Hook decision"}
+  Decision -->|allow| Continue["run action"]
+  Decision -->|block| Stop["stop action"]
+  Decision -->|mutate| Rewrite["rewrite action/result"]
+```
+
+The model interprets the request, but it does not hand-edit hook JSON. The
+embedded `yolop-hooks` skill maps common requests to hook specs, and the
+`your` tools validate and write the config atomically.
+
+## Scopes
+
+| Scope | Path | Use for |
+|---|---|---|
+| Global | `<config_dir>/yolop/hooks.json` | Personal Yolop behavior across all workspaces |
+| Workspace | `<workspace>/.agents/hooks.json` | Project-owned policy that can be reviewed with the repo |
+
+Workspace hooks override global hooks with the same `id`. A workspace file can
+also disable a lower-precedence global hook by listing the id in `disabled`.
+
+## Configure from chat
+
+Ask Yolop directly:
+
+```text
+yolop setup a hook to prevent calls to git
+```
+
+Yolop should translate that into a `pre_tool_use` hook and save it through
+`upsert_your_hook`. If the scope is ambiguous and the hook blocks a broad class
+of normal coding actions, Yolop should ask whether the hook is global or just
+for the current workspace.
+
+## Configure by file
+
+```json
+{
+  "hooks": [
+    {
+      "id": "block-git",
+      "event": "pre_tool_use",
+      "matcher": {
+        "tool_name": "bash",
+        "args_jsonpath": "$.command",
+        "match_regex": "(^|[;&|()[:space:]])git([[:space:]]|$)"
+      },
+      "executor": {
+        "type": "bash",
+        "command": "printf '%s\\n' '{\"decision\":\"block\",\"reason\":\"git command blocked by hook\",\"user_message\":\"Blocked by your Yolop hook: git commands are disabled.\"}'"
+      },
+      "timeout_ms": 1000,
+      "on_error": "block",
+      "description": "Block bash commands that invoke git"
+    }
+  ],
+  "disabled": [],
+  "disabled_contributions": []
+}
+```
+
+## Events
+
+Yolop accepts the upstream `user_hooks` event names. Tool-call hooks are the
+primary v1 surface.
+
+| Event | Can block? | Can mutate? | Typical use |
+|---|---|---|---|
+| `pre_tool_use` | yes | yes | Block or rewrite tool calls |
+| `post_tool_use` | no | yes | Rewrite tool results |
+| `user_prompt_submit` | yes | yes | Reject or rewrite inbound prompts |
+| `turn_end` | no | no | Advisory reporting after a turn |
+| `session_start` | no | no | Advisory setup or audit |
+| `session_end` | no | no | Advisory cleanup |
+
+Tool events can match on exact tool name, restricted tool glob, and simple
+argument JSON paths. Regexes use Rust's `regex` crate.
+
+## Hook decisions
+
+A bash hook prints one JSON decision to stdout:
+
+```json
+{ "decision": "allow" }
+```
+
+```json
+{
+  "decision": "block",
+  "reason": "git command blocked by hook",
+  "user_message": "Blocked by your Yolop hook: git commands are disabled."
+}
+```
+
+```json
+{
+  "decision": "mutate",
+  "patch": { "arguments": { "command": "cargo fmt --check" } }
+}
+```
+
+If stdout is empty, exit code `0` means allow and non-zero means block with
+stderr as the reason. Non-JSON stdout is treated as a hook error.
+
+## Trust model
+
+Hooks are code execution. Global hooks are personal config. Workspace hooks are
+project policy, similar to checked-in build scripts or `.mcp.json` stdio
+servers. Review them before using an unfamiliar repository.
+
+The hook executor is bounded by the upstream `user_hooks` implementation:
+validated specs, timeout limits, output caps, and structured decisions. Yolop
+does not add a second hook engine.
+
+## Related
+
+- [`specs/hooks.md`](../../specs/hooks.md)
+- [`specs/your.md`](../../specs/your.md)

--- a/skills/yolop-hooks/SKILL.md
+++ b/skills/yolop-hooks/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: yolop-hooks
+description: Configure Yolop hooks from natural-language self-configuration requests, especially block, allow, mutate, or audit rules around tool calls.
+user-invocable: false
+---
+
+# Yolop Hooks
+
+Use this skill when the user asks Yolop to configure its own behavior with
+hooks, for example:
+
+- "yolop setup a hook to prevent calls to git"
+- "block yourself from running terraform apply in this repo"
+- "add a workspace hook that audits shell commands"
+- "remove the hook that blocks cargo publish"
+
+Hooks are real configuration. Do not treat these requests as memory or as a
+soft preference. Use the `your` hook tools:
+
+1. Build a candidate hook spec.
+2. Call `validate_your_hook`.
+3. Call `upsert_your_hook` after validation succeeds.
+4. Use `list_your_hooks` to inspect current state or confirm effective config.
+5. Use `remove_your_hook` when the user asks to remove or disable a hook.
+
+## Scope
+
+Choose the narrowest scope that matches the request.
+
+- Use `workspace` when the user says "this repo", "this project",
+  "workspace", or references project policy.
+- Use `global` when the user says "yolop", "your", "always", "everywhere",
+  or frames the rule as a personal preference.
+- Ask once if the rule would block broad normal coding behavior and the scope
+  is ambiguous.
+
+## Common Recipes
+
+Block any Bash command that invokes `git`:
+
+```json
+{
+  "id": "block-git",
+  "event": "pre_tool_use",
+  "matcher": {
+    "tool_name": "bash",
+    "args_jsonpath": "$.command",
+    "match_regex": "(^|[;&|()[:space:]])git([[:space:]]|$)"
+  },
+  "executor": {
+    "type": "bash",
+    "command": "printf '%s\\n' '{\"decision\":\"block\",\"reason\":\"git command blocked by hook\",\"user_message\":\"Blocked by your Yolop hook: git commands are disabled.\"}'"
+  },
+  "timeout_ms": 1000,
+  "on_error": "block",
+  "description": "Block bash commands that invoke git"
+}
+```
+
+Block mutating `git` commands but allow read-only status/log/diff:
+
+```json
+{
+  "id": "block-mutating-git",
+  "event": "pre_tool_use",
+  "matcher": {
+    "tool_name": "bash",
+    "args_jsonpath": "$.command",
+    "match_regex": "(^|[;&|()[:space:]])git[[:space:]]+(add|am|apply|bisect|branch|checkout|cherry-pick|clean|commit|fetch|merge|mv|pull|push|rebase|reset|restore|revert|rm|switch|tag)([[:space:]]|$)"
+  },
+  "executor": {
+    "type": "bash",
+    "command": "printf '%s\\n' '{\"decision\":\"block\",\"reason\":\"mutating git command blocked by hook\",\"user_message\":\"Blocked by your Yolop hook: mutating git commands are disabled.\"}'"
+  },
+  "timeout_ms": 1000,
+  "on_error": "block",
+  "description": "Block mutating git commands"
+}
+```
+
+Block publishing commands:
+
+```json
+{
+  "id": "block-publish",
+  "event": "pre_tool_use",
+  "matcher": {
+    "tool_name": "bash",
+    "args_jsonpath": "$.command",
+    "match_regex": "(^|[;&|()[:space:]])(cargo publish|npm publish|pnpm publish)([[:space:]]|$)"
+  },
+  "executor": {
+    "type": "bash",
+    "command": "printf '%s\\n' '{\"decision\":\"block\",\"reason\":\"publish command blocked by hook\",\"user_message\":\"Blocked by your Yolop hook: publish commands are disabled.\"}'"
+  },
+  "timeout_ms": 1000,
+  "on_error": "block",
+  "description": "Block package publishing commands"
+}
+```
+
+Audit Bash commands without blocking:
+
+```json
+{
+  "id": "audit-bash",
+  "event": "pre_tool_use",
+  "matcher": {
+    "tool_name": "bash"
+  },
+  "executor": {
+    "type": "bash",
+    "command": "printf '%s\\n' \"$EVERRUNS_HOOK_PAYLOAD_JSON\" >> .agents/hook-audit.jsonl && printf '%s\\n' '{\"decision\":\"allow\"}'"
+  },
+  "timeout_ms": 1000,
+  "on_error": "warn",
+  "description": "Append Bash tool calls to .agents/hook-audit.jsonl"
+}
+```
+
+## Rules
+
+- Prefer stable ids such as `block-git`, `block-mutating-git`, or
+  `audit-bash`; stable ids make overrides and removal possible.
+- Prefer `pre_tool_use` for blocking or mutating model-authored tool calls.
+- Use `on_error: "block"` for safety-critical hooks and `on_error: "warn"`
+  for audit hooks.
+- Keep hook commands short. For complex logic, point the executor at a checked
+  in script instead of embedding a large shell program.
+- Do not put secrets in `hooks.json`; hook scripts can read environment
+  variables at runtime.

--- a/specs/hooks.md
+++ b/specs/hooks.md
@@ -1,0 +1,258 @@
+# Hooks Specification
+
+Status: v1 implemented for scoped config loading, `your` self-configuration,
+and upstream `user_hooks` registration.
+
+## Why
+
+Hooks let users run deterministic automation at well-defined points in an
+agent session without turning that automation into model instructions. Common
+uses include rejecting dangerous shell commands, formatting after edits,
+recording audit events, or enforcing project-specific checks before a turn
+continues.
+
+yolop should not invent a second hook engine. `everruns-core` already ships the
+`user_hooks` capability, `UserHookSpec`, and adapters for tool and lifecycle
+events. yolop owns only the local config discovery and merge policy for global
+and workspace files.
+
+The implementation must therefore route through the upstream mechanism:
+`hooks.json` is parsed into the upstream `user_hooks` capability config and
+registered with `AgentCapabilityConfig::with_config("user_hooks", ...)`.
+
+## Scope
+
+Two user-authored scopes are supported:
+
+1. **Global** — `<config_dir>/yolop/hooks.json`.
+   Personal automation shared across every workspace.
+2. **Workspace** — `<workspace>/.agents/hooks.json`.
+   Project-owned automation that can be reviewed and committed with the repo.
+
+The config format is JSON because the upstream `user_hooks` capability already
+owns a JSON schema for `UserHookSpec`. yolop reads the two files, merges them
+into one effective `user_hooks` capability config, then registers
+`UserHooksCapability` in the session harness only when the effective config is
+non-empty.
+
+Missing files are silent. A malformed file is warned and skipped; it must not
+prevent the other scope from loading or prevent yolop from starting.
+
+## Config Shape
+
+Each file uses the same envelope:
+
+```json
+{
+  "hooks": [
+    {
+      "id": "format-after-edit",
+      "event": "post_tool_use",
+      "matcher": { "tool_name_glob": "edit_file|write_file" },
+      "executor": { "type": "bash", "command": "cargo fmt --check" },
+      "timeout_ms": 10000,
+      "on_error": "warn",
+      "description": "check formatting after file edits"
+    }
+  ],
+  "disabled": ["global-hook-id"],
+  "disabled_contributions": ["capability_id:hook_id"]
+}
+```
+
+`hooks` is the upstream `Vec<UserHookSpec>`.
+
+`disabled` is yolop-owned. It removes hook entries from lower-precedence
+scopes by explicit `id`. It is intentionally scoped to user-authored global and
+workspace hooks, not capability-bundled hooks.
+
+`disabled_contributions` is passed through to upstream `user_hooks` unchanged.
+It mutes capability-contributed hook ids such as `capability_id:hook_id`.
+
+Hooks without `id` are legal but append-only: they cannot be overridden or
+disabled by another scope. Project and global hooks that need stable merge
+behavior should always set `id`.
+
+## Merge
+
+Merge order is global first, workspace second:
+
+1. Load global hooks.
+2. Load workspace hooks.
+3. Apply each higher-precedence file's `disabled` list to lower-precedence
+   hooks.
+4. For hooks with the same explicit `id`, the higher-precedence hook replaces
+   the lower-precedence hook.
+5. Preserve file order within each scope for hooks that remain.
+6. Concatenate `disabled_contributions` from both scopes and pass the list to
+   the upstream capability.
+
+This matches yolop's existing extension model: workspace scope is most
+specific, global scope is user-wide, and absent or broken optional extension
+files do not sink startup.
+
+## Natural-Language Setup
+
+Hook setup is part of yolop self-configuration. A user should be able to say:
+
+> yolop setup a hook to prevent calls to git
+
+and have yolop create a real hook config entry rather than merely remembering a
+preference. The natural-language layer belongs in `YourCapability`, because
+that capability is the place users address yolop itself.
+
+The reliable design is **prompt/skill for interpretation, tools for writes**:
+
+- The `your` prompt teaches the model that requests like "configure yolop",
+  "set up your hooks", or "prevent yourself from calling X" are
+  self-configuration requests.
+- The embedded `yolop-hooks` skill holds examples that map common intents to
+  hook specs, so the prompt stays short and examples are loaded on demand.
+- Structured `your` tools perform the actual mutation. They read, validate,
+  merge, and atomically write `hooks.json`, then return the effective hook id
+  and scope. The model should not hand-edit hook JSON through generic file
+  tools for global self-configuration.
+
+Initial tool surface:
+
+- `list_your_hooks` — show effective hooks, their scope, event, matcher, and
+  source file.
+- `upsert_your_hook` — create or replace one hook by `id`.
+- `remove_your_hook` — remove or disable one hook by `id`.
+- `validate_your_hook` — validate a candidate spec without writing it.
+
+`upsert_your_hook` accepts an explicit `scope`:
+
+- `global` writes `<config_dir>/yolop/hooks.json`.
+- `workspace` writes `<workspace>/.agents/hooks.json`.
+
+If the user says "yolop", "your", or otherwise frames the request as a
+personal preference, default to `global`. If the user says "this repo",
+"workspace", or "project", use `workspace`. If the requested hook would block a
+broad class of normal coding actions and the scope is ambiguous, ask once for
+scope instead of guessing.
+
+Example generated hook for "prevent calls to git":
+
+```json
+{
+  "id": "block-git",
+  "event": "pre_tool_use",
+  "matcher": {
+    "tool_name": "bash",
+    "args_jsonpath": "$.command",
+    "match_regex": "(^|[;&|()[:space:]])git([[:space:]]|$)"
+  },
+  "executor": {
+    "type": "bash",
+    "command": "printf '%s\\n' '{\"decision\":\"block\",\"reason\":\"git command blocked by hook\",\"user_message\":\"Blocked by your yolop hook: git commands are disabled.\"}'"
+  },
+  "timeout_ms": 1000,
+  "on_error": "block",
+  "description": "Block bash commands that invoke git"
+}
+```
+
+The model may offer to refine the matcher for narrower cases, such as allowing
+read-only `git status` while blocking mutating commands.
+
+## Events
+
+Yolop accepts the six upstream hook event names in config. Firing behavior is
+owned by the upstream `everruns-core` runtime; the primary supported Yolop use
+case in v1 is `pre_tool_use` / `post_tool_use` policy around tool calls.
+
+| Event | Blocking | Mutation | Purpose |
+|-------|----------|----------|---------|
+| `session_start` | no | no | Advisory setup/audit at session creation. |
+| `user_prompt_submit` | yes | yes | Reject or rewrite the inbound user prompt. |
+| `pre_tool_use` | yes | yes | Inspect, block, or rewrite a model-authored tool call. |
+| `post_tool_use` | no | yes | Inspect or rewrite a completed tool result. |
+| `turn_end` | no | no | Advisory reporting after a turn completes. |
+| `session_end` | no | no | Advisory cleanup/audit at session close. |
+
+Tool-event matchers use the upstream restricted matcher shape:
+
+- `tool_name` for exact match.
+- `tool_name_glob` for alternation (`a|b`) or trailing-prefix (`mcp_*`).
+- `args_jsonpath` for simple dot-path extraction from tool arguments.
+- `match_regex` or `deny_regex`, but never both.
+
+## Executor Contract
+
+v1 supports only `executor.type = "bash"`, matching upstream. The runtime
+passes the hook payload through environment variables:
+
+- `EVERRUNS_HOOK_PAYLOAD_JSON`
+- `EVERRUNS_HOOK_PAYLOAD_PATH`
+- `EVERRUNS_HOOK_EVENT`
+- `EVERRUNS_HOOK_ID`
+- `EVERRUNS_HOOK_SESSION_ID`
+- `EVERRUNS_HOOK_TURN_ID` when available
+- `EVERRUNS_HOOK_TOOL_NAME` and `EVERRUNS_HOOK_TOOL_CALL_ID` on tool events
+
+The hook prints a JSON decision on stdout:
+
+```json
+{ "decision": "allow" }
+```
+
+```json
+{ "decision": "block", "reason": "dangerous command", "user_message": "Blocked by hook." }
+```
+
+```json
+{ "decision": "mutate", "patch": { "arguments": { "command": "cargo fmt --check" } } }
+```
+
+If stdout is empty, exit code `0` means allow and non-zero means error. The
+default timeout is 5 seconds. Valid timeout range is 100 ms through 30 seconds.
+Hook output is capped by the upstream executor.
+
+## Trust Model
+
+Hooks are code execution. Workspace hooks are therefore a project trust signal,
+similar to a committed build script or MCP stdio server list. Global hooks are
+personal and live under the user's config dir.
+
+v1 behavior:
+
+- Keep hooks opt-in by file presence; no generated default hooks.
+- Show configured hook counts and scopes in `--print` startup diagnostics.
+- Run hooks through the upstream `user_hooks` capability instead of the model.
+- Never hide hook failures: warn on skipped config and record runtime hook
+  errors through existing event/log surfaces.
+- Keep environment expansion out of `hooks.json`; users can read env vars from
+  their bash script instead of storing secrets in config.
+
+## Implementation Plan
+
+Implemented:
+
+1. `src/hooks_config.rs` parses the two scope files into a yolop-owned
+   envelope, validates each hook through `UserHookSpec::validate`, and produces
+   an effective upstream `UserHooksConfig`.
+2. `src/runtime.rs` registers `everruns_core::capabilities::UserHooksCapability`
+   and enables it with `AgentCapabilityConfig::with_config("user_hooks", ...)`
+   only when hooks are configured.
+3. `StartupInfo` includes effective hook counts; `--print` shows loaded hooks.
+4. `YourCapability` includes the hook self-configuration tools described in
+   [Natural-Language Setup](#natural-language-setup).
+5. `skills/yolop-hooks/SKILL.md` ships the self-configuration recipes used for
+   natural-language hook setup.
+6. Tests cover merge behavior, `your` hook tools, and a scripted llmsim
+   `pre_tool_use` hook that blocks a matching `bash` tool call.
+
+Follow-up:
+
+- Add an embedded `your` skill with more hook recipes once the minimal tool
+  surface has settled.
+
+## Non-goals
+
+- No new hook events beyond upstream's six-event contract.
+- No per-hook approval prompt. The act of writing the config is consent.
+- No secret storage in hook config.
+- No TOML format until there is a concrete reason to diverge from upstream's
+  JSON schema.
+- No separate yolop-only hook executor.

--- a/specs/your.md
+++ b/specs/your.md
@@ -75,6 +75,19 @@ syntax required:
   or to edit precisely).
 - `write_your_memory` — replace the whole file, for reorganizing or removing.
 
+## Self-Configuration Pattern
+
+Natural language is the user interface, but durable configuration changes
+should go through purpose-built tools. The `your` prompt decides whether a user
+is asking to configure yolop itself; embedded `your` skills can provide
+examples and recipes; tools perform validated writes to stable config files.
+
+For example, "yolop setup a hook to prevent calls to git" is a
+self-configuration request. `your` should translate it into a hook spec,
+validate it, and write it through hook config tools rather than storing a
+memory note that says "avoid git". See [`hooks.md`](./hooks.md) for the hook
+tool design and scope rules.
+
 ## Roadmap (not yet implemented)
 
 The roadmap rides on everruns' existing extension points rather than inventing
@@ -94,9 +107,9 @@ yolop-specific formats.
   (`/.agents/skills`) so the built-in `skills` capability lists/activates
   them in every session. This is also where memory that has outgrown a few
   bullets gets promoted to.
-- **Hooks** — once yolop grows a hook system, `your` configures global hooks
-  from the same central dir (and, where everruns exposes hook contributions
-  on capabilities, via declarative definitions).
+- **Hooks** — `your` should configure global and workspace hooks through
+  structured hook tools, using the scope and merge contract in
+  [`hooks.md`](./hooks.md).
 - **General config** — map natural-language requests ("set yolop blue") onto
   real settings as those settings come to exist. Until a knob exists, the
   preference is recorded in memory and honored on a best-effort basis.

--- a/src/agent_scenarios.rs
+++ b/src/agent_scenarios.rs
@@ -42,8 +42,16 @@ const TURN_TIMEOUT: Duration = Duration::from_secs(15);
 /// assert on filesystem side effects (scripted bash tool calls) can read
 /// files back.
 async fn build_scripted_runtime(config: LlmSimConfig) -> (BuiltRuntime, std::path::PathBuf) {
+    build_scripted_runtime_with_workspace(config, |_| {}).await
+}
+
+async fn build_scripted_runtime_with_workspace(
+    config: LlmSimConfig,
+    setup_workspace: impl FnOnce(&std::path::Path),
+) -> (BuiltRuntime, std::path::PathBuf) {
     let workspace_root = tempfile::tempdir().expect("workspace tempdir").keep();
     let sessions_root = tempfile::tempdir().expect("sessions tempdir").keep();
+    setup_workspace(&workspace_root);
 
     let llmsim = config.with_model("llmsim-yolop");
     let settings_path = sessions_root.join("settings.toml");
@@ -132,6 +140,63 @@ async fn scripted_tool_call_executes_bash_then_assistant_completes() {
     assert!(
         workspace.join(marker).exists(),
         "BashTool must have run the scripted command and created {marker:?} in {workspace:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn workspace_hook_blocks_matching_bash_call() {
+    let marker = "git_hook_should_block.marker";
+    let cmd = format!("git status > {marker}");
+    let (runtime, workspace) = build_scripted_runtime_with_workspace(
+        LlmSimConfig::scripted(vec![
+            SimTurn::ToolCalls(vec![SimToolCall {
+                name: "bash".to_string(),
+                arguments: json!({ "command": cmd }),
+                id: None,
+            }]),
+            SimTurn::Assistant("git was blocked".to_string()),
+        ]),
+        |workspace| {
+            let hooks_dir = workspace.join(".agents");
+            std::fs::create_dir_all(&hooks_dir).expect("create hooks dir");
+            std::fs::write(
+                hooks_dir.join("hooks.json"),
+                r#"{
+                  "hooks": [
+                    {
+                      "id": "block-git",
+                      "event": "pre_tool_use",
+                      "matcher": {
+                        "tool_name": "bash",
+                        "args_jsonpath": "$.command",
+                        "match_regex": "(^|[;&|()[:space:]])git([[:space:]]|$)"
+                      },
+                      "executor": {
+                        "type": "bash",
+                        "command": "printf '%s\\n' '{\"decision\":\"block\",\"reason\":\"git blocked by test hook\",\"user_message\":\"git is blocked\"}'"
+                      },
+                      "timeout_ms": 1000,
+                      "on_error": "block",
+                      "description": "Block git"
+                    }
+                  ]
+                }"#,
+            )
+            .expect("write hooks config");
+        },
+    )
+    .await;
+
+    let result = run_single_turn(&runtime, "try git").await;
+
+    assert!(result.success, "agent should continue after blocked tool");
+    assert!(
+        !workspace.join(marker).exists(),
+        "pre_tool_use hook must block bash before it creates {marker:?}"
+    );
+    assert_eq!(
+        runtime.startup.hook_count, 1,
+        "workspace hook should be loaded into startup info"
     );
 }
 

--- a/src/capabilities/your.rs
+++ b/src/capabilities/your.rs
@@ -15,6 +15,7 @@
 // See specs/your.md for the full vision (global skills, hooks, user-defined
 // capabilities) — all of which hang off the same central config dir.
 
+use crate::hooks_config::{HookScope, HooksStore};
 use crate::settings::SettingsStore;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -189,8 +190,10 @@ fn render_memory_block(memory_path: &Path, content: &str) -> String {
          \"remember that I prefer X\" — treat it as a GLOBAL personalization request about \
          yolop, NOT a change to the current project. Persist durable user preferences with \
          the `remember_your_memory` tool, reorganize with `write_your_memory`, and read the \
-         full set with `read_your_memory`. Project-specific guidance belongs in the repo's \
-         AGENTS.md, not here.\n",
+         full set with `read_your_memory`. Configure hook requests such as \"yolop setup a \
+         hook to prevent calls to git\" with `validate_your_hook` and `upsert_your_hook`, not \
+         by adding a memory note. Project-specific guidance belongs in the repo's AGENTS.md, \
+         not here.\n",
     );
     out.push_str(&format!("memory file: {}\n", memory_path.display()));
 
@@ -222,6 +225,7 @@ fn render_memory_block(memory_path: &Path, content: &str) -> String {
 
 pub(crate) struct YourCapability {
     pub(crate) memory: Arc<YourStore>,
+    pub(crate) hooks: Arc<HooksStore>,
 }
 
 #[async_trait]
@@ -273,6 +277,18 @@ yolop's personalization layer (global). Use `remember_your_memory` / `read_your_
             }),
             Box::new(WriteMemoryTool {
                 memory: self.memory.clone(),
+            }),
+            Box::new(ListHooksTool {
+                hooks: self.hooks.clone(),
+            }),
+            Box::new(ValidateHookTool {
+                hooks: self.hooks.clone(),
+            }),
+            Box::new(UpsertHookTool {
+                hooks: self.hooks.clone(),
+            }),
+            Box::new(RemoveHookTool {
+                hooks: self.hooks.clone(),
             }),
         ]
     }
@@ -411,6 +427,206 @@ impl Tool for WriteMemoryTool {
     }
 }
 
+struct ListHooksTool {
+    hooks: Arc<HooksStore>,
+}
+
+#[async_trait]
+impl Tool for ListHooksTool {
+    fn name(&self) -> &str {
+        "list_your_hooks"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("List hooks")
+    }
+    fn description(&self) -> &str {
+        "List yolop hook self-configuration from global and workspace hook config. Use for \
+         \"what hooks are configured?\" or before changing an existing hook."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({ "type": "object", "properties": {}, "additionalProperties": false })
+    }
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        let effective = self.hooks.effective();
+        ToolExecutionResult::success(json!({
+            "ok": true,
+            "global_path": effective.global_path.display().to_string(),
+            "workspace_path": effective.workspace_path.display().to_string(),
+            "count": effective.hooks.len(),
+            "scope_counts": effective.scope_counts(),
+            "hooks": effective.summaries(),
+        }))
+    }
+}
+
+struct ValidateHookTool {
+    hooks: Arc<HooksStore>,
+}
+
+#[async_trait]
+impl Tool for ValidateHookTool {
+    fn name(&self) -> &str {
+        "validate_your_hook"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Validate hook")
+    }
+    fn description(&self) -> &str {
+        "Validate a candidate yolop hook spec without writing it. Use before `upsert_your_hook`, \
+         especially when translating a natural-language request into hook JSON."
+    }
+    fn parameters_schema(&self) -> Value {
+        hook_value_schema()
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let hook = match arguments.get("hook") {
+            Some(hook) => hook.clone(),
+            None => return ToolExecutionResult::tool_error("'hook' is required"),
+        };
+        match self.hooks.validate_hook(&hook) {
+            Ok(entry) => ToolExecutionResult::success(json!({
+                "ok": true,
+                "hook": entry.to_validation_json(),
+            })),
+            Err(error) => ToolExecutionResult::tool_error(format!("invalid hook: {error}")),
+        }
+    }
+}
+
+struct UpsertHookTool {
+    hooks: Arc<HooksStore>,
+}
+
+#[async_trait]
+impl Tool for UpsertHookTool {
+    fn name(&self) -> &str {
+        "upsert_your_hook"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Save hook")
+    }
+    fn description(&self) -> &str {
+        "Create or replace one yolop hook by id. Use global scope for personal yolop behavior \
+         and workspace scope for project-owned hook config. Validates before writing."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "scope": {
+                    "type": "string",
+                    "enum": ["global", "workspace"],
+                    "description": "Where to write the hook. Use global for personal yolop configuration; workspace for this repo."
+                },
+                "hook": {
+                    "type": "object",
+                    "description": "A UserHookSpec object with a stable id."
+                }
+            },
+            "required": ["scope", "hook"],
+            "additionalProperties": false
+        })
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let scope = match parse_scope_arg(&arguments) {
+            Ok(scope) => scope,
+            Err(error) => return ToolExecutionResult::tool_error(error),
+        };
+        let hook = match arguments.get("hook") {
+            Some(hook) => hook.clone(),
+            None => return ToolExecutionResult::tool_error("'hook' is required"),
+        };
+        match self.hooks.upsert_hook(scope, hook) {
+            Ok(entry) => ToolExecutionResult::success(json!({
+                "ok": true,
+                "message": format!("saved {} hook", scope.as_str()),
+                "hook": entry.to_summary_json(),
+                "path": self.hooks.path_for(scope).display().to_string(),
+            })),
+            Err(error) => ToolExecutionResult::tool_error(format!("could not save hook: {error}")),
+        }
+    }
+}
+
+struct RemoveHookTool {
+    hooks: Arc<HooksStore>,
+}
+
+#[async_trait]
+impl Tool for RemoveHookTool {
+    fn name(&self) -> &str {
+        "remove_your_hook"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Remove hook")
+    }
+    fn description(&self) -> &str {
+        "Remove one yolop hook by id from the selected scope. Workspace removal also writes a \
+         disabled marker so a lower-precedence global hook with the same id stays disabled."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "scope": {
+                    "type": "string",
+                    "enum": ["global", "workspace"]
+                },
+                "id": {
+                    "type": "string",
+                    "description": "Stable hook id to remove or disable."
+                }
+            },
+            "required": ["scope", "id"],
+            "additionalProperties": false
+        })
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let scope = match parse_scope_arg(&arguments) {
+            Ok(scope) => scope,
+            Err(error) => return ToolExecutionResult::tool_error(error),
+        };
+        let id = match arguments.get("id").and_then(Value::as_str) {
+            Some(id) if !id.trim().is_empty() => id,
+            _ => return ToolExecutionResult::tool_error("'id' is required"),
+        };
+        match self.hooks.remove_hook(scope, id) {
+            Ok(removed) => ToolExecutionResult::success(json!({
+                "ok": true,
+                "removed": removed,
+                "id": id,
+                "scope": scope.as_str(),
+                "path": self.hooks.path_for(scope).display().to_string(),
+            })),
+            Err(error) => {
+                ToolExecutionResult::tool_error(format!("could not remove hook: {error}"))
+            }
+        }
+    }
+}
+
+fn parse_scope_arg(arguments: &Value) -> std::result::Result<HookScope, String> {
+    let scope = arguments
+        .get("scope")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "'scope' is required".to_string())?;
+    HookScope::parse(scope).map_err(|error| error.to_string())
+}
+
+fn hook_value_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "hook": {
+                "type": "object",
+                "description": "A UserHookSpec object."
+            }
+        },
+        "required": ["hook"],
+        "additionalProperties": false
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -419,6 +635,12 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tmp");
         let path = tmp.path().join("MEMORY.md");
         let store = YourStore::open(path);
+        (tmp, store)
+    }
+
+    fn hooks_in_tmp() -> (tempfile::TempDir, HooksStore) {
+        let tmp = tempfile::tempdir().expect("hooks tmp");
+        let store = HooksStore::new(tmp.path().join("hooks.json"), tmp.path().join("workspace"));
         (tmp, store)
     }
 
@@ -481,8 +703,10 @@ mod tests {
     #[test]
     fn capability_exposes_your_named_tools_without_slash_command() {
         let (_tmp, store) = store_in_tmp();
+        let (_hooks_tmp, hooks) = hooks_in_tmp();
         let capability = YourCapability {
             memory: Arc::new(store),
+            hooks: Arc::new(hooks),
         };
 
         let names = capability
@@ -496,10 +720,33 @@ mod tests {
             vec![
                 "remember_your_memory",
                 "read_your_memory",
-                "write_your_memory"
+                "write_your_memory",
+                "list_your_hooks",
+                "validate_your_hook",
+                "upsert_your_hook",
+                "remove_your_hook"
             ]
         );
         assert!(capability.commands().is_empty());
+    }
+
+    fn block_git_hook() -> Value {
+        json!({
+            "id": "block-git",
+            "event": "pre_tool_use",
+            "matcher": {
+                "tool_name": "bash",
+                "args_jsonpath": "$.command",
+                "match_regex": "(^|[;&|()[:space:]])git([[:space:]]|$)"
+            },
+            "executor": {
+                "type": "bash",
+                "command": "printf '%s\\n' '{\"decision\":\"block\",\"reason\":\"blocked\"}'"
+            },
+            "timeout_ms": 1000,
+            "on_error": "block",
+            "description": "Block git"
+        })
     }
 
     #[tokio::test]
@@ -569,6 +816,40 @@ mod tests {
         assert!(res.is_success());
         let text = format!("{res:?}");
         assert!(text.contains("Memory is getting large"), "got: {text}");
+    }
+
+    #[tokio::test]
+    async fn hook_tools_validate_save_list_and_remove() {
+        let (_tmp, hooks) = hooks_in_tmp();
+        let hooks = Arc::new(hooks);
+        let validate = ValidateHookTool {
+            hooks: hooks.clone(),
+        };
+        let validated = validate.execute(json!({ "hook": block_git_hook() })).await;
+        assert!(validated.is_success());
+
+        let upsert = UpsertHookTool {
+            hooks: hooks.clone(),
+        };
+        let saved = upsert
+            .execute(json!({ "scope": "global", "hook": block_git_hook() }))
+            .await;
+        assert!(saved.is_success());
+
+        let list = ListHooksTool {
+            hooks: hooks.clone(),
+        };
+        let listed = list.execute(json!({})).await;
+        assert!(listed.is_success());
+
+        let remove = RemoveHookTool {
+            hooks: hooks.clone(),
+        };
+        let removed = remove
+            .execute(json!({ "scope": "global", "id": "block-git" }))
+            .await;
+        assert!(removed.is_success());
+        assert!(hooks.effective().hooks.is_empty());
     }
 
     #[test]

--- a/src/hooks_config.rs
+++ b/src/hooks_config.rs
@@ -1,0 +1,596 @@
+//! Workspace/global hook config loading for yolop.
+//!
+//! The hook engine itself lives in `everruns-core` (`user_hooks`). yolop owns
+//! only local config discovery, scope merge, and the `your` tools that write
+//! those config files.
+
+use crate::settings::SettingsStore;
+use anyhow::{Context, Result, anyhow};
+use everruns_core::user_hook_types::UserHookSpec;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+pub const GLOBAL_HOOKS_FILE_NAME: &str = "hooks.json";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HookScope {
+    Global,
+    Workspace,
+}
+
+impl HookScope {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            HookScope::Global => "global",
+            HookScope::Workspace => "workspace",
+        }
+    }
+
+    pub fn parse(raw: &str) -> Result<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "global" => Ok(Self::Global),
+            "workspace" => Ok(Self::Workspace),
+            other => Err(anyhow!(
+                "unknown hook scope `{other}`; expected global or workspace"
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default)]
+pub struct HooksFile {
+    pub hooks: Vec<Value>,
+    pub disabled: Vec<String>,
+    pub disabled_contributions: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolvedHook {
+    pub scope: HookScope,
+    pub path: PathBuf,
+    pub hook: Value,
+    pub id: Option<String>,
+    pub event: String,
+    pub description: Option<String>,
+    pub matcher: Value,
+}
+
+impl ResolvedHook {
+    fn from_value(scope: HookScope, path: PathBuf, hook: Value) -> Result<Self> {
+        let spec = parse_hook_spec(&hook)?;
+        Ok(Self {
+            scope,
+            path,
+            hook,
+            id: spec.id.clone(),
+            event: spec.event.as_str().to_string(),
+            description: spec.description.clone(),
+            matcher: serde_json::to_value(&spec.matcher).unwrap_or_else(|_| json!({})),
+        })
+    }
+
+    pub fn to_summary_json(&self) -> Value {
+        json!({
+            "id": self.id,
+            "scope": self.scope.as_str(),
+            "event": self.event,
+            "matcher": self.matcher,
+            "description": self.description,
+            "path": self.path.display().to_string(),
+        })
+    }
+
+    pub fn to_validation_json(&self) -> Value {
+        json!({
+            "id": self.id,
+            "event": self.event,
+            "matcher": self.matcher,
+            "description": self.description,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct EffectiveHooks {
+    pub global_path: PathBuf,
+    pub workspace_path: PathBuf,
+    pub hooks: Vec<ResolvedHook>,
+    pub disabled_contributions: Vec<String>,
+}
+
+impl EffectiveHooks {
+    pub fn is_empty(&self) -> bool {
+        self.hooks.is_empty() && self.disabled_contributions.is_empty()
+    }
+
+    pub fn capability_config(&self) -> Value {
+        json!({
+            "hooks": self.hooks.iter().map(|entry| entry.hook.clone()).collect::<Vec<_>>(),
+            "disabled_contributions": self.disabled_contributions,
+        })
+    }
+
+    pub fn scope_counts(&self) -> BTreeMap<String, usize> {
+        let mut counts = BTreeMap::new();
+        for hook in &self.hooks {
+            *counts.entry(hook.scope.as_str().to_string()).or_insert(0) += 1;
+        }
+        counts
+    }
+
+    pub fn summaries(&self) -> Vec<Value> {
+        self.hooks
+            .iter()
+            .map(ResolvedHook::to_summary_json)
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ScopedHooksFile {
+    scope: HookScope,
+    path: PathBuf,
+    file: HooksFile,
+}
+
+#[derive(Debug, Clone)]
+pub struct HooksStore {
+    global_path: PathBuf,
+    workspace_path: PathBuf,
+}
+
+impl HooksStore {
+    pub fn new(global_path: PathBuf, workspace_root: PathBuf) -> Self {
+        Self {
+            global_path,
+            workspace_path: workspace_hooks_config_path(&workspace_root),
+        }
+    }
+
+    pub fn beside_settings(settings: &SettingsStore, workspace_root: PathBuf) -> Self {
+        Self::new(
+            global_hooks_config_path_beside_settings(settings),
+            workspace_root,
+        )
+    }
+
+    pub fn path_for(&self, scope: HookScope) -> &Path {
+        match scope {
+            HookScope::Global => &self.global_path,
+            HookScope::Workspace => &self.workspace_path,
+        }
+    }
+
+    pub fn effective(&self) -> EffectiveHooks {
+        load_merged(Some(&self.global_path), &self.workspace_path)
+    }
+
+    pub fn validate_hook(&self, hook: &Value) -> Result<ResolvedHook> {
+        ResolvedHook::from_value(HookScope::Global, self.global_path.clone(), hook.clone())
+    }
+
+    pub fn upsert_hook(&self, scope: HookScope, hook: Value) -> Result<ResolvedHook> {
+        let parsed = parse_hook_spec(&hook)?;
+        let id = parsed
+            .id
+            .as_deref()
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .ok_or_else(|| anyhow!("hook id is required for upsert"))?
+            .to_string();
+
+        let path = self.path_for(scope).to_path_buf();
+        let mut file = read_config_strict(&path)?;
+        file.hooks
+            .retain(|existing| hook_id(existing).as_deref() != Some(id.as_str()));
+        file.disabled.retain(|disabled| disabled != &id);
+        file.hooks.push(hook.clone());
+        save_config(&path, &file)?;
+
+        ResolvedHook::from_value(scope, path, hook)
+    }
+
+    pub fn remove_hook(&self, scope: HookScope, id: &str) -> Result<bool> {
+        let id = id.trim();
+        if id.is_empty() {
+            return Err(anyhow!("hook id is required"));
+        }
+        let path = self.path_for(scope).to_path_buf();
+        let mut file = read_config_strict(&path)?;
+        let before = file.hooks.len();
+        file.hooks
+            .retain(|existing| hook_id(existing).as_deref() != Some(id));
+        let removed = before != file.hooks.len();
+
+        if scope == HookScope::Workspace && !file.disabled.iter().any(|disabled| disabled == id) {
+            file.disabled.push(id.to_string());
+        }
+        save_config(&path, &file)?;
+        Ok(removed)
+    }
+}
+
+pub fn global_hooks_config_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|p| p.join("yolop").join(GLOBAL_HOOKS_FILE_NAME))
+}
+
+pub fn global_hooks_config_path_beside_settings(settings: &SettingsStore) -> PathBuf {
+    settings
+        .path()
+        .parent()
+        .map(|p| p.join(GLOBAL_HOOKS_FILE_NAME))
+        .unwrap_or_else(|| PathBuf::from(GLOBAL_HOOKS_FILE_NAME))
+}
+
+pub fn workspace_hooks_config_path(workspace_root: &Path) -> PathBuf {
+    workspace_root.join(".agents").join(GLOBAL_HOOKS_FILE_NAME)
+}
+
+fn load_merged(global_path: Option<&Path>, workspace_path: &Path) -> EffectiveHooks {
+    let global = global_path
+        .map(|path| read_scope_best_effort(HookScope::Global, path))
+        .unwrap_or_else(|| ScopedHooksFile {
+            scope: HookScope::Global,
+            path: global_hooks_config_path()
+                .unwrap_or_else(|| PathBuf::from(GLOBAL_HOOKS_FILE_NAME)),
+            file: HooksFile::default(),
+        });
+    let workspace = read_scope_best_effort(HookScope::Workspace, workspace_path);
+
+    let mut hooks = resolve_scope_hooks(&global);
+    for disabled in &workspace.file.disabled {
+        hooks.retain(|entry| entry.id.as_deref() != Some(disabled.as_str()));
+    }
+    for entry in resolve_scope_hooks(&workspace) {
+        if let Some(id) = entry.id.as_deref() {
+            hooks.retain(|existing| existing.id.as_deref() != Some(id));
+        }
+        hooks.push(entry);
+    }
+
+    let mut disabled_contributions = global.file.disabled_contributions.clone();
+    disabled_contributions.extend(workspace.file.disabled_contributions.clone());
+
+    EffectiveHooks {
+        global_path: global.path,
+        workspace_path: workspace.path,
+        hooks,
+        disabled_contributions,
+    }
+}
+
+fn resolve_scope_hooks(scope_file: &ScopedHooksFile) -> Vec<ResolvedHook> {
+    let mut out = Vec::new();
+    for hook in &scope_file.file.hooks {
+        match ResolvedHook::from_value(scope_file.scope, scope_file.path.clone(), hook.clone()) {
+            Ok(entry) => out.push(entry),
+            Err(error) => tracing::warn!(
+                path = %scope_file.path.display(),
+                scope = scope_file.scope.as_str(),
+                %error,
+                "ignoring invalid hook entry"
+            ),
+        }
+    }
+    out
+}
+
+fn read_scope_best_effort(scope: HookScope, path: &Path) -> ScopedHooksFile {
+    match read_config_strict(path) {
+        Ok(file) => ScopedHooksFile {
+            scope,
+            path: path.to_path_buf(),
+            file,
+        },
+        Err(error) => {
+            tracing::warn!(
+                path = %path.display(),
+                scope = scope.as_str(),
+                %error,
+                "ignoring malformed hooks config"
+            );
+            ScopedHooksFile {
+                scope,
+                path: path.to_path_buf(),
+                file: HooksFile::default(),
+            }
+        }
+    }
+}
+
+fn read_config_strict(path: &Path) -> Result<HooksFile> {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(HooksFile::default());
+        }
+        Err(error) => return Err(error).with_context(|| format!("reading {}", path.display())),
+    };
+    serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))
+}
+
+fn save_config(path: &Path, config: &HooksFile) -> Result<()> {
+    let parent = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+    std::fs::create_dir_all(&parent)
+        .with_context(|| format!("create hooks dir {}", parent.display()))?;
+
+    let content = serde_json::to_string_pretty(config).context("serialize hooks config")?;
+    let file_name = path
+        .file_name()
+        .with_context(|| format!("hooks path has no file name: {}", path.display()))?;
+    let mut tmp_name = std::ffi::OsString::from(".");
+    tmp_name.push(file_name);
+    tmp_name.push(format!(".tmp.{}", std::process::id()));
+    let tmp_path = parent.join(tmp_name);
+
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create(true).truncate(true);
+
+    let write_result = (|| -> Result<()> {
+        let mut file = opts
+            .open(&tmp_path)
+            .with_context(|| format!("open temp hooks config {}", tmp_path.display()))?;
+        file.write_all(content.as_bytes())
+            .with_context(|| format!("write temp hooks config {}", tmp_path.display()))?;
+        file.write_all(b"\n")
+            .with_context(|| format!("write temp hooks config {}", tmp_path.display()))?;
+        file.sync_all()
+            .with_context(|| format!("sync temp hooks config {}", tmp_path.display()))?;
+        Ok(())
+    })();
+    if let Err(error) = write_result {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(error);
+    }
+    #[cfg(windows)]
+    match std::fs::remove_file(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(error).with_context(|| format!("remove {}", path.display()));
+        }
+    }
+    if let Err(error) = std::fs::rename(&tmp_path, path) {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(error)
+            .with_context(|| format!("rename {} -> {}", tmp_path.display(), path.display()));
+    }
+    Ok(())
+}
+
+fn parse_hook_spec(hook: &Value) -> Result<UserHookSpec> {
+    let spec: UserHookSpec = serde_json::from_value(hook.clone()).context("parse hook spec")?;
+    spec.validate().context("validate hook spec")?;
+    Ok(spec)
+}
+
+fn hook_id(hook: &Value) -> Option<String> {
+    hook.get("id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .map(str::to_string)
+        .filter(|id| !id.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn block_git_hook(id: &str) -> Value {
+        json!({
+            "id": id,
+            "event": "pre_tool_use",
+            "matcher": {
+                "tool_name": "bash",
+                "args_jsonpath": "$.command",
+                "match_regex": "(^|[;&|()[:space:]])git([[:space:]]|$)"
+            },
+            "executor": {
+                "type": "bash",
+                "command": "printf '%s\\n' '{\"decision\":\"block\",\"reason\":\"blocked\"}'"
+            },
+            "timeout_ms": 1000,
+            "on_error": "block",
+            "description": "Block git"
+        })
+    }
+
+    fn malformed_hook(id: &str) -> Value {
+        json!({
+            "id": id,
+            "event": "not_a_hook_event",
+            "matcher": { "tool_name": "bash" },
+            "executor": { "type": "bash", "command": "true" }
+        })
+    }
+
+    #[test]
+    fn missing_scopes_load_empty() {
+        let global = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let effective = load_merged(Some(&global.path().join("hooks.json")), workspace.path());
+
+        assert!(effective.is_empty());
+        assert_eq!(effective.hooks.len(), 0);
+    }
+
+    #[test]
+    fn workspace_overrides_global_by_id() {
+        let global = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let global_path = global.path().join("hooks.json");
+        let workspace_path = workspace.path().join("hooks.json");
+        std::fs::write(
+            &global_path,
+            serde_json::to_string(&HooksFile {
+                hooks: vec![block_git_hook("shared")],
+                ..HooksFile::default()
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        let mut ws_hook = block_git_hook("shared");
+        ws_hook["description"] = json!("Workspace hook wins");
+        std::fs::write(
+            &workspace_path,
+            serde_json::to_string(&HooksFile {
+                hooks: vec![ws_hook],
+                ..HooksFile::default()
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        let effective = load_merged(Some(&global_path), &workspace_path);
+
+        assert_eq!(effective.hooks.len(), 1);
+        assert_eq!(effective.hooks[0].scope, HookScope::Workspace);
+        assert_eq!(
+            effective.hooks[0].description.as_deref(),
+            Some("Workspace hook wins")
+        );
+    }
+
+    #[test]
+    fn workspace_disabled_removes_global_hook() {
+        let global = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let global_path = global.path().join("hooks.json");
+        let workspace_path = workspace.path().join("hooks.json");
+        std::fs::write(
+            &global_path,
+            serde_json::to_string(&HooksFile {
+                hooks: vec![block_git_hook("block-git")],
+                ..HooksFile::default()
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            &workspace_path,
+            serde_json::to_string(&HooksFile {
+                disabled: vec!["block-git".to_string()],
+                ..HooksFile::default()
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        let effective = load_merged(Some(&global_path), &workspace_path);
+
+        assert!(effective.hooks.is_empty());
+    }
+
+    #[test]
+    fn invalid_hook_entry_does_not_sink_valid_entries() {
+        let global = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let global_path = global.path().join("hooks.json");
+        std::fs::write(
+            &global_path,
+            serde_json::to_string(&HooksFile {
+                hooks: vec![malformed_hook("bad"), block_git_hook("good")],
+                ..HooksFile::default()
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        let effective = load_merged(Some(&global_path), workspace.path());
+
+        assert_eq!(effective.hooks.len(), 1);
+        assert_eq!(effective.hooks[0].id.as_deref(), Some("good"));
+    }
+
+    #[test]
+    fn upsert_and_remove_match_malformed_existing_entries_by_raw_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = HooksStore::new(tmp.path().join("hooks.json"), tmp.path().join("ws"));
+        std::fs::write(
+            store.path_for(HookScope::Global),
+            serde_json::to_string(&HooksFile {
+                hooks: vec![malformed_hook("block-git")],
+                ..HooksFile::default()
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        store
+            .upsert_hook(HookScope::Global, block_git_hook("block-git"))
+            .expect("replace malformed hook");
+        let on_disk: HooksFile = serde_json::from_str(
+            &std::fs::read_to_string(store.path_for(HookScope::Global)).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(on_disk.hooks.len(), 1);
+        assert_eq!(hook_id(&on_disk.hooks[0]).as_deref(), Some("block-git"));
+        assert_eq!(on_disk.hooks[0]["event"], json!("pre_tool_use"));
+
+        std::fs::write(
+            store.path_for(HookScope::Global),
+            serde_json::to_string(&HooksFile {
+                hooks: vec![malformed_hook("broken")],
+                ..HooksFile::default()
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(
+            store
+                .remove_hook(HookScope::Global, "broken")
+                .expect("remove malformed hook")
+        );
+        let on_disk: HooksFile = serde_json::from_str(
+            &std::fs::read_to_string(store.path_for(HookScope::Global)).unwrap(),
+        )
+        .unwrap();
+        assert!(on_disk.hooks.is_empty());
+    }
+
+    #[test]
+    fn upsert_hook_requires_id_and_persists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = HooksStore::new(tmp.path().join("hooks.json"), tmp.path().join("ws"));
+
+        let upserted = store
+            .upsert_hook(HookScope::Global, block_git_hook("block-git"))
+            .expect("upsert hook");
+
+        assert_eq!(upserted.id.as_deref(), Some("block-git"));
+        let on_disk =
+            std::fs::read_to_string(store.path_for(HookScope::Global)).expect("read hooks");
+        assert!(on_disk.contains("\"block-git\""));
+    }
+
+    #[test]
+    fn remove_workspace_hook_adds_disable_marker() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = HooksStore::new(tmp.path().join("hooks.json"), tmp.path().join("ws"));
+        store
+            .upsert_hook(HookScope::Workspace, block_git_hook("block-git"))
+            .expect("upsert hook");
+
+        assert!(
+            store
+                .remove_hook(HookScope::Workspace, "block-git")
+                .expect("remove")
+        );
+
+        let on_disk =
+            std::fs::read_to_string(store.path_for(HookScope::Workspace)).expect("read hooks");
+        assert!(on_disk.contains("\"disabled\""));
+        assert!(on_disk.contains("\"block-git\""));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 mod acp;
 mod app;
 mod capabilities;
+mod hooks_config;
 mod host_ui;
 mod into;
 mod mcp_config;
@@ -531,6 +532,13 @@ async fn run_print_mode(runtime: BuiltRuntime, prompt: String) -> Result<()> {
             .map(|c| format!("/{}", c.name))
             .collect();
         println!("{} {}", paint(color, "90", "commands"), names.join(", "));
+    }
+    if startup.hook_configured {
+        println!(
+            "{}     {}",
+            paint(color, "90", "hooks"),
+            startup.hook_summary()
+        );
     }
     println!();
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -21,7 +21,7 @@ use everruns_core::capabilities::{
     CompactionCapability, FileSystemCapability, INFINITY_CONTEXT_CAPABILITY_ID,
     InfinityContextCapability, LoopDetectionCapability, PROMPT_CACHING_CAPABILITY_ID,
     PromptCachingCapability, SKILLS_CAPABILITY_ID, StatelessTodoListCapability,
-    ToolOutputPersistenceCapability, WebFetchCapability,
+    ToolOutputPersistenceCapability, UserHooksCapability, WebFetchCapability,
 };
 use everruns_core::command::CommandDescriptor;
 use everruns_core::error::AgentLoopError;
@@ -865,7 +865,10 @@ pub(crate) fn normalize_reasoning_effort(reasoning_effort: Option<String>) -> Op
         .filter(|effort| !effort.is_empty())
 }
 
-fn coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabilityConfig> {
+fn coding_harness_capabilities(
+    client_commands: bool,
+    hook_config: Option<serde_json::Value>,
+) -> Vec<AgentCapabilityConfig> {
     let mut caps = Vec::new();
     // Terminal-side commands lead the registry so the most-typed commands
     // (/help, /clear, /quit, …) surface first in the palette. Enabled only
@@ -917,6 +920,9 @@ fn coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabilityConf
         AgentCapabilityConfig::new(YOUR_CAPABILITY_ID),
         AgentCapabilityConfig::new("yolop_bash"),
     ]);
+    if let Some(config) = hook_config {
+        caps.push(AgentCapabilityConfig::with_config("user_hooks", config));
+    }
     caps
 }
 
@@ -973,6 +979,38 @@ pub struct StartupInfo {
     /// (global + workspace, merged). Source for the `/mcp` command and the
     /// startup banner. Empty when no servers are configured.
     pub mcp_server_names: Vec<String>,
+    /// Effective user hooks loaded from global/workspace config.
+    pub hook_count: usize,
+    pub hook_scope_counts: std::collections::BTreeMap<String, usize>,
+    pub disabled_hook_contribution_count: usize,
+    pub hook_configured: bool,
+}
+
+impl StartupInfo {
+    pub fn hook_summary(&self) -> String {
+        if !self.hook_configured {
+            return "none".to_string();
+        }
+        let scopes = self
+            .hook_scope_counts
+            .iter()
+            .map(|(scope, count)| format!("{scope}:{count}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let hooks = if scopes.is_empty() {
+            self.hook_count.to_string()
+        } else {
+            format!("{} ({scopes})", self.hook_count)
+        };
+        if self.disabled_hook_contribution_count == 0 {
+            hooks
+        } else {
+            format!(
+                "{hooks}, {} disabled contribution(s)",
+                self.disabled_hook_contribution_count
+            )
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -1073,6 +1111,16 @@ pub async fn build_with_options(
     let mcp_servers: ScopedMcpServers = crate::mcp_config::load_mcp_servers(&canonical_root);
     let mut mcp_server_names: Vec<String> = mcp_servers.keys().cloned().collect();
     mcp_server_names.sort();
+    let hooks_store = Arc::new(crate::hooks_config::HooksStore::beside_settings(
+        &settings,
+        canonical_root.clone(),
+    ));
+    let effective_hooks = hooks_store.effective();
+    let hook_count = effective_hooks.hooks.len();
+    let hook_scope_counts = effective_hooks.scope_counts();
+    let disabled_hook_contribution_count = effective_hooks.disabled_contributions.len();
+    let hook_configured = !effective_hooks.is_empty();
+    let hook_capability_config = hook_configured.then(|| effective_hooks.capability_config());
 
     // Pin the SessionId so resume can re-attach to the same session folder
     // (directory name is the session id).
@@ -1140,6 +1188,8 @@ pub async fn build_with_options(
     //   * loop_detection       — safety net against repeated identical tool calls
     //   * prompt_caching       — Anthropic prompt caching; free token savings
     //   * duckduckgo           — free web search (`duckduckgo_search`); no API key
+    //   * user_hooks           — executes user-authored hook specs loaded from
+    //                            global/workspace hook config
     let mut capabilities = CapabilityRegistry::new();
     capabilities.register(AgentInstructionsCapability);
     capabilities.register(FileSystemCapability);
@@ -1163,6 +1213,7 @@ pub async fn build_with_options(
     // progressive disclosure; replace this vendor once upstream ships that fix.
     capabilities.register(ToolSearchCapability::new());
     capabilities.register(ToolOutputPersistenceCapability);
+    capabilities.register(UserHooksCapability);
     capabilities.register(DuckDuckGoCapability);
     capabilities.register(WebFetchCapability::from_env());
     capabilities.register(CodingCliEnvironmentCapability::new(canonical_root.clone()));
@@ -1186,6 +1237,7 @@ pub async fn build_with_options(
     // tests isolates memory automatically.
     capabilities.register(YourCapability {
         memory: Arc::new(YourStore::beside_settings(&settings)),
+        hooks: hooks_store,
     });
     capabilities.register(CodingBashCapability {
         workspace: workspace.clone(),
@@ -1236,7 +1288,8 @@ pub async fn build_with_options(
     // runtime owns. `session_id(...)` pins the id so resume can re-attach
     // to the same JSONL log (filename encodes the id).
     let session_title = format!("yolop @ {}", canonical_root.display());
-    let harness_capabilities = coding_harness_capabilities(options.client_commands);
+    let harness_capabilities =
+        coding_harness_capabilities(options.client_commands, hook_capability_config);
     let session_mcp_servers = mcp_servers.clone();
 
     let mut builder = InProcessRuntimeBuilder::new()
@@ -1297,6 +1350,10 @@ pub async fn build_with_options(
             replayed_events: replayed_events_count,
             setup_recommended,
             mcp_server_names,
+            hook_count,
+            hook_scope_counts,
+            disabled_hook_contribution_count,
+            hook_configured,
         },
         model: ModelState::new(provider_state),
         settings,
@@ -2050,7 +2107,7 @@ mod tests {
 
     #[test]
     fn coding_harness_enables_tool_output_persistence() {
-        let ids = coding_harness_capabilities(false);
+        let ids = coding_harness_capabilities(false, None);
 
         assert!(
             ids.iter()
@@ -2063,7 +2120,7 @@ mod tests {
         // Deferred tool loading must be wired for every host configuration —
         // it works on every provider, so there is no reason to scope it.
         for client_commands in [false, true] {
-            let ids = coding_harness_capabilities(client_commands);
+            let ids = coding_harness_capabilities(client_commands, None);
             assert!(
                 ids.iter()
                     .any(|cap| cap.capability_id() == TOOL_SEARCH_CAPABILITY_ID),
@@ -2107,7 +2164,7 @@ mod tests {
 
     #[test]
     fn coding_harness_enables_loop_detection() {
-        let ids = coding_harness_capabilities(false);
+        let ids = coding_harness_capabilities(false, None);
 
         assert!(
             ids.iter()
@@ -2117,7 +2174,7 @@ mod tests {
 
     #[test]
     fn coding_harness_enables_yolop_attribution() {
-        let ids = coding_harness_capabilities(false);
+        let ids = coding_harness_capabilities(false, None);
 
         assert!(
             ids.iter()
@@ -2127,7 +2184,7 @@ mod tests {
 
     #[test]
     fn coding_harness_gates_client_commands_on_flag() {
-        let without = coding_harness_capabilities(false);
+        let without = coding_harness_capabilities(false, None);
         assert!(
             !without
                 .iter()
@@ -2135,7 +2192,7 @@ mod tests {
             "client commands must stay off for hosts that can't apply them"
         );
 
-        let with = coding_harness_capabilities(true);
+        let with = coding_harness_capabilities(true, None);
         assert!(
             with.iter()
                 .any(|cap| cap.capability_id() == CLIENT_COMMANDS_CAPABILITY_ID),


### PR DESCRIPTION
## What
- Adds workspace/global hooks config loading and merge behavior.
- Registers upstream `user_hooks` capability when config exists.
- Adds `your` hook tools plus a bundled hook recipe skill.
- Adds `docs/features/hooks.md`, `specs/hooks.md`, and related README/spec updates.

## Why
Enable “yolop setup a hook to prevent calls to git” style self-configuration and committed workspace hook policy without a Yolop-specific hook engine.

## How
- `src/hooks_config.rs` validates and merges hook specs into upstream `user_hooks` config.
- Runtime registers `UserHooksCapability` and startup hook summaries.
- `YourCapability` validates/upserts/removes hook config by scope.
- `skills/yolop-hooks/SKILL.md` provides common natural-language setup recipes.
- Scripted llmsim coverage proves a workspace `pre_tool_use` hook blocks a matching bash command.

## Risk
- Medium
- Hooks are code execution, but execution is delegated to upstream `user_hooks`; Yolop only writes/loads validated config. Workspace hooks are reviewable project files.

## Security
- TM-TOOL: `user_hooks` is enabled only with config and uses upstream validation/adapters.
- TM-FS: new writes are limited to global/workspace `hooks.json` via explicit tools; no change to file tool write blocklist.
- TM-BASH: no change to host `BashTool`; hook execution remains upstream bounded executor with timeouts/output caps.
- TM-LLM: no secrets are logged or stored; no env expansion in `hooks.json`.
- TM-DEP: no new dependencies.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test hook`
- `cargo test skills`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"`
- Doppler live smoke attempted but local Doppler config is missing (`You must specify a project`). Existing all-features integration tests include OpenAI/OpenRouter smokes and passed.

## Follow-ups
- No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
