### PR TITLE
feat(setup): connection status, fast model pick, custom endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,13 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
 | OpenRouter | `OPENROUTER_API_KEY`                  | `openai/gpt-5.2`  |
 | Google     | `GEMINI_API_KEY` / `GOOGLE_API_KEY`   | `gemini-2.5-flash` |
 | Ollama     | `OLLAMA_BASE_URL` / `OLLAMA_API_KEY`  | `llama3.2`        |
+| Custom     | `CUSTOM_BASE_URL` (+ optional `CUSTOM_API_KEY`) | — (set via `/setup`) |
 | llmsim     | none (offline simulator)              | —                 |
 
 Pick explicitly with `--provider`, override the model with `-m/--model`.
+**Custom** is any OpenAI-compatible Chat Completions endpoint (vLLM,
+llama.cpp, LM Studio, hosted gateways, …): point `CUSTOM_BASE_URL` at it or
+configure the base URL, optional key, and model interactively via `/setup`.
 
 ### Git attribution
 
@@ -186,13 +190,13 @@ tools. See [`specs/mcp.md`](specs/mcp.md).
 | Flag                       | Description                                                          |
 | -------------------------- | -------------------------------------------------------------------- |
 | `-C, --cwd <PATH>`         | Workspace root (default: current dir)                                |
-| `--provider <P>`           | Force `anthropic`, `openai`, `google`, `openrouter`, `ollama`, or `llmsim` |
+| `--provider <P>`           | Force `anthropic`, `openai`, `google`, `openrouter`, `ollama`, `custom`, or `llmsim` |
 | `-m, --model <ID>`         | Override the model id for the chosen provider                        |
 | `-p, --print <PROMPT>`     | Run one prompt non-interactively and print the result                |
 | `--acp`                    | Speak the Agent Client Protocol over stdio (for editors like Zed)    |
 | `--session <ID>`           | Resume a previous session by id                                      |
 | `--session-dir <PATH>`     | Override the parent directory for session folders                    |
-| `--reasoning-effort <E>`   | OpenAI/OpenRouter reasoning effort (`minimal` / `low` / `medium` / `high`) |
+| `--reasoning-effort <E>`   | OpenAI/OpenRouter/custom reasoning effort (`minimal` / `low` / `medium` / `high`) |
 
 ### Commands
 
@@ -215,35 +219,44 @@ tools. See [`specs/mcp.md`](specs/mcp.md).
 | `GOOGLE_BASE_URL`               | Optional, defaults to `https://generativelanguage.googleapis.com/v1beta/openai` |
 | `OLLAMA_BASE_URL`               | Select Ollama, defaults to `http://localhost:11434/v1`       |
 | `OLLAMA_API_KEY`                | Optional, defaults to `ollama` for local Ollama              |
-| `EVERRUNS_CLI_MODEL`            | Override the auto-selected default model                     |
-| `EVERRUNS_CLI_REASONING_EFFORT` | OpenAI/OpenRouter reasoning effort override                  |
+| `CUSTOM_BASE_URL`               | Select the custom OpenAI-compatible endpoint (beats the saved base URL) |
+| `CUSTOM_API_KEY`                | Optional key for the custom endpoint (a placeholder is sent otherwise) |
+| `EVERRUNS_CLI_MODEL`            | Override the auto-selected default model (beats the saved model) |
+| `EVERRUNS_CLI_REASONING_EFFORT` | OpenAI/OpenRouter/custom reasoning effort override           |
 
 ### Settings
 
-A small TOML settings file persists the preferred provider and (optionally)
-provider API tokens across runs: `<config_dir>/yolop/settings.toml` —
+A small TOML settings file persists the preferred provider, per-provider
+model picks, custom endpoint base URLs, and (optionally) provider API tokens
+across runs: `<config_dir>/yolop/settings.toml` —
 `~/.config/yolop/settings.toml` on Linux,
 `~/Library/Application Support/yolop/settings.toml` on macOS,
 `%APPDATA%\yolop\settings.toml` on Windows.
 
-The TUI's `/setup`, `/model`, and `/effort` commands can update the active
-provider, saved API keys, current model, OpenAI/OpenRouter reasoning effort,
-or offline demo mode. Saved provider/API-key choices are written to this file.
+The TUI's `/setup`, `/model`, and `/effort` commands update the active
+provider, saved API keys, current model, reasoning effort, or offline demo
+mode. The `/setup` provider picker shows which providers are already
+connected (env key, saved key, or no key needed); selecting a connected one
+jumps straight to model selection, and `c` opens key/base-URL configuration
+for any provider. Provider, model, and custom base URL choices are written
+to this file.
 
 Provider resolution at startup:
 
 1. `--provider` flag (always wins)
 2. Saved `provider` setting
 3. Auto-detect: the first provider in the order **OpenAI → Anthropic →
-   OpenRouter → Google → Ollama** with either a matching env var or a saved
-   token (the provider order decides the tiebreak, not the credential source)
+   OpenRouter → Google → Ollama → Custom** with either a matching env var or
+   a saved token/base URL (the provider order decides the tiebreak, not the
+   credential source)
 4. Fall back to OpenAI's default model and open setup so a provider/API key
    can be configured
 
-At runtime, the per-provider env var (`OPENAI_API_KEY`, etc.) always
-beats the saved token, so a per-run env override is always possible.
-The setup wizard can also switch models for the current session. OpenAI and
-OpenRouter reasoning effort can be changed at runtime with the `/effort` modal
+The model saved by `/setup model` for the resolved provider is restored,
+unless `-m/--model` or `EVERRUNS_CLI_MODEL` overrides it. At runtime, the
+per-provider env var (`OPENAI_API_KEY`, etc.) always beats the saved token,
+so a per-run env override is always possible. OpenAI, OpenRouter, and custom
+endpoint reasoning effort can be changed at runtime with the `/effort` modal
 or `/setup effort <level>` (for example, `high` or `medium`).
 
 `/setup` can store an API token under `[tokens]` in the settings file. The

--- a/src/app.rs
+++ b/src/app.rs
@@ -5484,6 +5484,43 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn setup_model_picker_preset_selection_applies_and_persists() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.lines.clear();
+        app.settings
+            .set_token("openai".to_string(), "sk-test".to_string())
+            .expect("save token");
+        app.setup = Some(SetupStep::PickModel {
+            provider: "openai".to_string(),
+            selected: 0,
+            custom: None,
+            error: None,
+        });
+
+        // Navigate to the second preset (gpt-5.4) and confirm it.
+        app.handle_setup_key(KeyEvent::new(KeyCode::Down, KeyModifiers::empty()))
+            .await;
+        app.handle_setup_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()))
+            .await;
+
+        assert!(app.setup.is_none(), "wizard should finish: {:?}", app.setup);
+        assert_eq!(app.model.provider_label(), "openai/gpt-5.4 medium");
+        assert!(
+            app.lines
+                .iter()
+                .any(|line| line.text == "setup complete: openai/gpt-5.4 medium"),
+            "completion line should report the picked model: {:?}",
+            app.lines
+        );
+        // The pick persists, so the next run restores it (see
+        // pick_provider_applies_saved_model_for_saved_provider in main.rs).
+        let snapshot = app.settings.snapshot();
+        assert_eq!(snapshot.provider.as_deref(), Some("openai"));
+        assert_eq!(snapshot.model_for("openai"), Some("openai/gpt-5.4 medium"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn setup_c_key_opens_credential_panel_even_when_connected() {
         let mut fixture = app_with_llmsim().await;
         let app = &mut fixture.app;

--- a/src/app.rs
+++ b/src/app.rs
@@ -116,6 +116,9 @@ pub struct App {
     /// handling so provider, token, and model setup never echo through the
     /// normal chat composer.
     setup: Option<SetupStep>,
+    /// Shared settings store (same instance `SetupCapability` writes). Read
+    /// by the setup overlay to show which providers are already connected.
+    settings: std::sync::Arc<crate::settings::SettingsStore>,
     /// Terminal-side commands emitted by `ClientCommandsCapability` (via
     /// `runtime.execute_command`). Drained in the event loop; see
     /// [`App::apply_ui_command`].
@@ -127,15 +130,18 @@ enum SetupStep {
     Provider {
         selected: usize,
     },
+    /// Endpoint base URL for the generic OpenAI-compatible provider.
+    BaseUrlInput {
+        value: String,
+        error: Option<String>,
+    },
     Credential {
         provider: String,
-        default_model: String,
         selected: usize,
         error: Option<String>,
     },
     TokenInput {
         provider: String,
-        default_model: String,
         token: String,
         error: Option<String>,
     },
@@ -184,9 +190,14 @@ const PROVIDER_OPTIONS: &[ProviderOption] = &[
         hint: "local OpenAI-compatible server",
     },
     ProviderOption {
+        name: "custom",
+        label: "Custom endpoint",
+        hint: "any OpenAI-compatible URL",
+    },
+    ProviderOption {
         name: "llmsim",
         label: "Offline demo mode",
-        hint: "no API key",
+        hint: "canned offline responses",
     },
 ];
 
@@ -334,6 +345,7 @@ impl App {
             stream_preview: None,
             rx: None,
             setup: None,
+            settings: runtime.settings,
             ui_rx: runtime.ui_rx,
         };
         app.emit_system_banner();
@@ -892,16 +904,7 @@ impl App {
 
     fn start_model_setup(&mut self) {
         let provider = self.current_provider_name();
-        let selected = model_index_for_label(
-            &self.model.provider_label(),
-            &Self::model_options(&provider),
-        );
-        self.setup = Some(SetupStep::PickModel {
-            provider,
-            selected,
-            custom: None,
-            error: None,
-        });
+        self.open_model_step(&provider);
     }
 
     fn start_model_setup_with_arg(&mut self, raw: &str) {
@@ -950,7 +953,10 @@ impl App {
 
     fn current_effort_index(&self) -> usize {
         let label = self.model.provider_label();
-        if !label.starts_with("openai/") && !label.starts_with("openrouter/") {
+        if !label.starts_with("openai/")
+            && !label.starts_with("openrouter/")
+            && !label.starts_with("custom/")
+        {
             return effort_index("medium").unwrap_or(0);
         }
         label
@@ -993,7 +999,33 @@ impl App {
             "google" => &["GEMINI_API_KEY", "GOOGLE_API_KEY"],
             "openrouter" => &["OPENROUTER_API_KEY"],
             "ollama" => &["OLLAMA_BASE_URL", "OLLAMA_API_KEY"],
+            "custom" => &["CUSTOM_API_KEY"],
             _ => &[],
+        }
+    }
+
+    /// Connection status shown in the provider picker. `true` means the
+    /// provider can be used right away (setup may jump straight to model
+    /// selection); the string is the short status appended to the row hint.
+    fn provider_status(settings: &crate::settings::Settings, provider: &str) -> (bool, String) {
+        match provider {
+            "llmsim" | "ollama" => (true, "✓ no key needed".to_string()),
+            "custom" => {
+                if crate::runtime::custom_base_url(settings).is_some() {
+                    (true, "✓ base URL set".to_string())
+                } else {
+                    (false, "needs base URL".to_string())
+                }
+            }
+            _ => {
+                if let Some(env) = Self::detected_env_var(provider) {
+                    (true, format!("✓ {env}"))
+                } else if settings.has_token(provider) {
+                    (true, "✓ saved key".to_string())
+                } else {
+                    (false, "needs API key".to_string())
+                }
+            }
         }
     }
 
@@ -1010,14 +1042,27 @@ impl App {
 
     fn credential_options(provider: &str) -> Vec<CredentialOption> {
         let env_names = Self::provider_env_names(provider);
-        let env_label = match env_names {
-            [] => "Use environment".to_string(),
-            [one] => format!("Use {one} from environment"),
-            many => format!("Use {} from environment", many.join(" / ")),
+        // The custom endpoint treats a key as optional: most local servers
+        // accept any bearer token, so the first option proceeds with the env
+        // key when present and a placeholder otherwise.
+        let env_label = if provider == "custom" {
+            "Continue without key".to_string()
+        } else {
+            match env_names {
+                [] => "Use environment".to_string(),
+                [one] => format!("Use {one} from environment"),
+                many => format!("Use {} from environment", many.join(" / ")),
+            }
         };
         let env_hint = Self::detected_env_var(provider)
             .map(|name| format!("{name} detected"))
-            .unwrap_or_else(|| "not detected yet".to_string());
+            .unwrap_or_else(|| {
+                if provider == "custom" {
+                    "fine for endpoints without auth".to_string()
+                } else {
+                    "not detected yet".to_string()
+                }
+            });
         vec![
             CredentialOption {
                 id: CredentialAction::UseEnv,
@@ -1132,6 +1177,9 @@ impl App {
                 label: "llama3.2".to_string(),
                 hint: "local default model",
             }],
+            // No preset list exists for an arbitrary endpoint; only the
+            // trailing "Custom..." free-form entry is offered.
+            "custom" => Vec::new(),
             _ => vec![ModelOption {
                 spec: Some("llmsim/llmsim-yolop".to_string()),
                 label: "llmsim-yolop".to_string(),
@@ -1154,23 +1202,18 @@ impl App {
             SetupStep::Provider { selected } => {
                 self.handle_provider_key(key, selected).await;
             }
+            SetupStep::BaseUrlInput { value, .. } => {
+                self.handle_base_url_key(key, value).await;
+            }
             SetupStep::Credential {
-                provider,
-                default_model,
-                selected,
-                ..
+                provider, selected, ..
             } => {
-                self.handle_credential_key(key, provider, default_model, selected)
-                    .await;
+                self.handle_credential_key(key, provider, selected).await;
             }
             SetupStep::TokenInput {
-                provider,
-                default_model,
-                token,
-                ..
+                provider, token, ..
             } => {
-                self.handle_token_key(key, provider, default_model, token)
-                    .await;
+                self.handle_token_key(key, provider, token).await;
             }
             SetupStep::PickModel {
                 provider,
@@ -1201,6 +1244,9 @@ impl App {
                     selected: (selected + 1).min(PROVIDER_OPTIONS.len().saturating_sub(1)),
                 });
             }
+            KeyCode::Char('c') => {
+                self.open_provider_config(selected);
+            }
             KeyCode::Char(ch) if ch.is_ascii_digit() => {
                 if let Some(index) = digit_index(ch, PROVIDER_OPTIONS.len()) {
                     self.confirm_provider(index).await;
@@ -1213,6 +1259,9 @@ impl App {
         }
     }
 
+    /// Enter on a provider row. Already-connected providers switch
+    /// immediately and jump straight to model selection; the rest go
+    /// through credential (or base URL) configuration first.
     async fn confirm_provider(&mut self, selected: usize) {
         let option = PROVIDER_OPTIONS
             .get(selected)
@@ -1231,46 +1280,155 @@ impl App {
             return;
         }
 
-        let default_model = crate::runtime::ProviderChoice::default_for_provider_name(option.name)
-            .map(|p| p.label())
-            .unwrap_or_else(|_| option.name.to_string());
-
-        if option.name == "ollama" {
-            match self
-                .run_setup_command(Some(&format!("provider {}", option.name)))
-                .await
-            {
-                Ok(()) => {
-                    self.setup = Some(SetupStep::PickModel {
-                        provider: option.name.to_string(),
-                        selected: 0,
-                        custom: None,
-                        error: None,
-                    });
-                }
-                Err(error) => {
-                    self.setup = Some(SetupStep::Provider { selected });
-                    self.push_system(format!("setup failed: {error}"));
-                }
-            }
+        let (connected, _) = Self::provider_status(&self.settings.snapshot(), option.name);
+        if !connected {
+            self.open_provider_config(selected);
             return;
         }
 
-        self.setup = Some(SetupStep::Credential {
-            provider: option.name.to_string(),
-            default_model,
-            selected: 0,
+        if option.name == "custom" {
+            // Best-effort switch: it fails harmlessly when no model is saved
+            // yet, and the model step right after sets provider + model.
+            let _ = self.run_setup_command(Some("provider custom")).await;
+            self.open_model_step("custom");
+            return;
+        }
+
+        match self
+            .run_setup_command(Some(&format!("provider {}", option.name)))
+            .await
+        {
+            Ok(()) => self.open_model_step(option.name),
+            Err(error) => {
+                // A connected-looking provider that still fails to switch
+                // (stale key, unreachable endpoint) lands on the credential
+                // step where the user can fix it.
+                self.setup = Some(SetupStep::Credential {
+                    provider: option.name.to_string(),
+                    selected: 0,
+                    error: Some(error),
+                });
+            }
+        }
+    }
+
+    /// `c` on a provider row: configure credentials (or the endpoint base
+    /// URL for the custom provider) even when already connected — e.g. to
+    /// replace or clear a saved key.
+    fn open_provider_config(&mut self, selected: usize) {
+        let option = PROVIDER_OPTIONS
+            .get(selected)
+            .unwrap_or(&PROVIDER_OPTIONS[0]);
+        match option.name {
+            "llmsim" => {}
+            "custom" => self.open_base_url_step(),
+            _ => {
+                self.setup = Some(SetupStep::Credential {
+                    provider: option.name.to_string(),
+                    selected: 0,
+                    error: None,
+                });
+            }
+        }
+    }
+
+    fn open_base_url_step(&mut self) {
+        let value = crate::runtime::custom_base_url(&self.settings.snapshot()).unwrap_or_default();
+        self.setup = Some(SetupStep::BaseUrlInput { value, error: None });
+    }
+
+    /// Open the model picker for `provider`, preselecting the active model.
+    /// For the custom provider there is no preset list, so the free-form
+    /// input opens directly, prefilled with the current or saved model.
+    fn open_model_step(&mut self, provider: &str) {
+        if provider == "custom" {
+            self.setup = Some(SetupStep::PickModel {
+                provider: "custom".to_string(),
+                selected: 0,
+                custom: Some(self.custom_model_prefill()),
+                error: None,
+            });
+            return;
+        }
+        let selected =
+            model_index_for_label(&self.model.provider_label(), &Self::model_options(provider));
+        self.setup = Some(SetupStep::PickModel {
+            provider: provider.to_string(),
+            selected,
+            custom: None,
             error: None,
         });
     }
 
-    async fn handle_credential_key(
-        &mut self,
-        key: KeyEvent,
-        provider: String,
-        default_model: String,
-        selected: usize,
-    ) {
+    fn custom_model_prefill(&self) -> String {
+        let label = self.model.provider_label();
+        if let Some(rest) = label.strip_prefix("custom/") {
+            return rest.to_string();
+        }
+        self.settings
+            .snapshot()
+            .model_for("custom")
+            .and_then(|spec| spec.strip_prefix("custom/"))
+            .unwrap_or_default()
+            .to_string()
+    }
+
+    async fn handle_base_url_key(&mut self, key: KeyEvent, mut value: String) {
+        match key.code {
+            KeyCode::Esc => {
+                self.setup = Some(SetupStep::Provider {
+                    selected: PROVIDER_OPTIONS
+                        .iter()
+                        .position(|option| option.name == "custom")
+                        .unwrap_or(0),
+                });
+            }
+            KeyCode::Enter => {
+                let trimmed = value.trim().to_string();
+                if trimmed.is_empty() {
+                    self.setup = Some(SetupStep::BaseUrlInput {
+                        value,
+                        error: Some(
+                            "enter a base URL like http://localhost:8000/v1, or press Esc"
+                                .to_string(),
+                        ),
+                    });
+                    return;
+                }
+                match self
+                    .run_setup_command(Some(&format!("url custom {trimmed}")))
+                    .await
+                {
+                    Ok(()) => {
+                        self.setup = Some(SetupStep::Credential {
+                            provider: "custom".to_string(),
+                            selected: 0,
+                            error: None,
+                        });
+                    }
+                    Err(error) => {
+                        self.setup = Some(SetupStep::BaseUrlInput {
+                            value,
+                            error: Some(error),
+                        });
+                    }
+                }
+            }
+            KeyCode::Backspace => {
+                value.pop();
+                self.setup = Some(SetupStep::BaseUrlInput { value, error: None });
+            }
+            KeyCode::Char(_) => {
+                if let KeyCode::Char(ch) = normalize_printable_key(key).code {
+                    value.push(ch);
+                }
+                self.setup = Some(SetupStep::BaseUrlInput { value, error: None });
+            }
+            _ => {}
+        }
+    }
+
+    async fn handle_credential_key(&mut self, key: KeyEvent, provider: String, selected: usize) {
         let options = Self::credential_options(&provider);
         match key.code {
             KeyCode::Esc => {
@@ -1284,7 +1442,6 @@ impl App {
             KeyCode::Up | KeyCode::Char('k') => {
                 self.setup = Some(SetupStep::Credential {
                     provider,
-                    default_model,
                     selected: selected.saturating_sub(1),
                     error: None,
                 });
@@ -1292,64 +1449,54 @@ impl App {
             KeyCode::Down | KeyCode::Char('j') => {
                 self.setup = Some(SetupStep::Credential {
                     provider,
-                    default_model,
                     selected: (selected + 1).min(options.len().saturating_sub(1)),
                     error: None,
                 });
             }
             KeyCode::Char(ch) if ch.is_ascii_digit() => {
                 if let Some(index) = digit_index(ch, options.len()) {
-                    self.confirm_credential(provider, default_model, index)
-                        .await;
+                    self.confirm_credential(provider, index).await;
                 }
             }
             KeyCode::Enter => {
-                self.confirm_credential(provider, default_model, selected)
-                    .await;
+                self.confirm_credential(provider, selected).await;
             }
             _ => {}
         }
     }
 
-    async fn confirm_credential(
-        &mut self,
-        provider: String,
-        default_model: String,
-        selected: usize,
-    ) {
+    async fn confirm_credential(&mut self, provider: String, selected: usize) {
         let options = Self::credential_options(&provider);
         let action = options
             .get(selected)
             .map(|option| option.id)
             .unwrap_or(CredentialAction::UseEnv);
         match action {
-            CredentialAction::UseEnv => match self
-                .run_setup_command(Some(&format!("provider {provider}")))
-                .await
-            {
-                Ok(()) => {
-                    let selected =
-                        model_index_for_label(&default_model, &Self::model_options(&provider));
-                    self.setup = Some(SetupStep::PickModel {
-                        provider,
-                        selected,
-                        custom: None,
-                        error: None,
-                    });
+            CredentialAction::UseEnv => {
+                // The custom provider can't be switched to until a model is
+                // chosen, so the validation switch is deferred to the model
+                // step (its key is optional anyway).
+                if provider == "custom" {
+                    self.open_model_step("custom");
+                    return;
                 }
-                Err(error) => {
-                    self.setup = Some(SetupStep::Credential {
-                        provider,
-                        default_model,
-                        selected,
-                        error: Some(error),
-                    });
+                match self
+                    .run_setup_command(Some(&format!("provider {provider}")))
+                    .await
+                {
+                    Ok(()) => self.open_model_step(&provider),
+                    Err(error) => {
+                        self.setup = Some(SetupStep::Credential {
+                            provider,
+                            selected,
+                            error: Some(error),
+                        });
+                    }
                 }
-            },
+            }
             CredentialAction::PasteKey => {
                 self.setup = Some(SetupStep::TokenInput {
                     provider,
-                    default_model,
                     token: String::new(),
                     error: None,
                 });
@@ -1372,7 +1519,6 @@ impl App {
                     Err(error) => {
                         self.setup = Some(SetupStep::Credential {
                             provider,
-                            default_model,
                             selected,
                             error: Some(error),
                         });
@@ -1382,18 +1528,11 @@ impl App {
         }
     }
 
-    async fn handle_token_key(
-        &mut self,
-        key: KeyEvent,
-        provider: String,
-        default_model: String,
-        mut token: String,
-    ) {
+    async fn handle_token_key(&mut self, key: KeyEvent, provider: String, mut token: String) {
         match key.code {
             KeyCode::Esc => {
                 self.setup = Some(SetupStep::Credential {
                     provider,
-                    default_model,
                     selected: 1,
                     error: None,
                 });
@@ -1403,9 +1542,8 @@ impl App {
                 if trimmed.is_empty() {
                     self.setup = Some(SetupStep::TokenInput {
                         provider,
-                        default_model,
                         token,
-                        error: Some("paste a key, or press Esc to go back".to_string()),
+                        error: Some("API key is empty — paste a key, or press Esc".to_string()),
                     });
                     return;
                 }
@@ -1413,30 +1551,26 @@ impl App {
                 if let Err(error) = self.run_setup_command(Some(&save_arg)).await {
                     self.setup = Some(SetupStep::TokenInput {
                         provider,
-                        default_model,
                         token: String::new(),
                         error: Some(error),
                     });
+                    return;
+                }
+                // Custom defers the provider switch to the model step (no
+                // model is known yet); other providers validate the new key
+                // by switching now.
+                if provider == "custom" {
+                    self.open_model_step("custom");
                     return;
                 }
                 match self
                     .run_setup_command(Some(&format!("provider {provider}")))
                     .await
                 {
-                    Ok(()) => {
-                        let selected =
-                            model_index_for_label(&default_model, &Self::model_options(&provider));
-                        self.setup = Some(SetupStep::PickModel {
-                            provider,
-                            selected,
-                            custom: None,
-                            error: None,
-                        });
-                    }
+                    Ok(()) => self.open_model_step(&provider),
                     Err(error) => {
                         self.setup = Some(SetupStep::TokenInput {
                             provider,
-                            default_model,
                             token: String::new(),
                             error: Some(error),
                         });
@@ -1447,7 +1581,6 @@ impl App {
                 token.pop();
                 self.setup = Some(SetupStep::TokenInput {
                     provider,
-                    default_model,
                     token,
                     error: None,
                 });
@@ -1458,7 +1591,6 @@ impl App {
                 }
                 self.setup = Some(SetupStep::TokenInput {
                     provider,
-                    default_model,
                     token,
                     error: None,
                 });
@@ -1478,6 +1610,17 @@ impl App {
         if let Some(mut value) = custom {
             match key.code {
                 KeyCode::Esc => {
+                    // The custom provider has no preset list to fall back to,
+                    // so Esc returns to the provider picker instead.
+                    if provider == "custom" {
+                        self.setup = Some(SetupStep::Provider {
+                            selected: PROVIDER_OPTIONS
+                                .iter()
+                                .position(|option| option.name == "custom")
+                                .unwrap_or(0),
+                        });
+                        return;
+                    }
                     self.setup = Some(SetupStep::PickModel {
                         provider,
                         selected,
@@ -2672,21 +2815,44 @@ fn setup_overlay_content(app: &App) -> (Vec<Line<'static>>, Option<(usize, usize
     match app.setup.as_ref() {
         Some(SetupStep::Provider { selected }) => {
             lines.push(setup_title("Set Up Yolop"));
-            lines.push(setup_hint("Choose provider, credentials, and model."));
+            lines.push(setup_hint(
+                "Connected providers jump straight to model selection.",
+            ));
             lines.push(Line::from(""));
             let current = app.current_provider_name();
+            let snapshot = app.settings.snapshot();
             for (idx, option) in PROVIDER_OPTIONS.iter().enumerate() {
-                let mut hint = option.hint.to_string();
+                let (_, status) = App::provider_status(&snapshot, option.name);
+                let mut hint = format!("{} · {status}", option.hint);
                 if option.name == current {
                     hint.push_str(" · current");
-                }
-                if let Some(env) = App::detected_env_var(option.name) {
-                    hint.push_str(&format!(" · {env} detected"));
                 }
                 lines.push(setup_row(idx == *selected, idx + 1, option.label, &hint));
             }
             lines.push(Line::from(""));
-            lines.push(setup_footer("Enter confirm · ↑/↓ move · Esc cancel"));
+            lines.push(setup_footer(
+                "Enter select · c configure key/URL · ↑/↓ move · Esc cancel",
+            ));
+        }
+        Some(SetupStep::BaseUrlInput { value, error }) => {
+            lines.push(setup_title("Custom OpenAI-Compatible Endpoint"));
+            lines.push(setup_hint(
+                "Base URL of the API, e.g. http://localhost:8000/v1 — saved to settings.toml.",
+            ));
+            lines.push(Line::from(""));
+            let input = format!("› {value}");
+            cursor = Some((3, input.chars().count()));
+            lines.push(Line::from(vec![
+                Span::styled(
+                    "› ",
+                    Style::default()
+                        .fg(ACCENT_BLUE)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(value.clone(), Style::default().fg(TEXT_PRIMARY)),
+            ]));
+            push_setup_error(&mut lines, error.as_deref());
+            lines.push(setup_footer("Enter save · Esc back"));
         }
         Some(SetupStep::Credential {
             provider,
@@ -2753,10 +2919,15 @@ fn setup_overlay_content(app: &App) -> (Vec<Line<'static>>, Option<(usize, usize
             error,
         }) => {
             lines.push(setup_title("Select Model"));
-            lines.push(setup_hint(&format!(
-                "{} models. Applies to this session and future sessions.",
-                App::provider_label(provider)
-            )));
+            lines.push(setup_hint(&if provider == "custom" {
+                "Model id served by your endpoint. Applies to this session and future sessions."
+                    .to_string()
+            } else {
+                format!(
+                    "{} models. Applies to this session and future sessions.",
+                    App::provider_label(provider)
+                )
+            }));
             lines.push(Line::from(""));
             let options = App::model_options(provider);
             if let Some(value) = custom {
@@ -2787,7 +2958,7 @@ fn setup_overlay_content(app: &App) -> (Vec<Line<'static>>, Option<(usize, usize
         Some(SetupStep::PickEffort { selected, error }) => {
             lines.push(setup_title("Select Reasoning Effort"));
             lines.push(setup_hint(
-                "OpenAI/OpenRouter reasoning effort. Applies to this session and future sessions.",
+                "Applies to OpenAI, OpenRouter, and custom endpoints — this session and future sessions.",
             ));
             lines.push(Line::from(""));
             let label = app.model.provider_label();
@@ -2797,7 +2968,7 @@ fn setup_overlay_content(app: &App) -> (Vec<Line<'static>>, Option<(usize, usize
                     .nth(1)
                     .unwrap_or("medium")
                     .to_string()
-            } else if label.starts_with("openrouter/") {
+            } else if label.starts_with("openrouter/") || label.starts_with("custom/") {
                 label
                     .split_whitespace()
                     .nth(1)
@@ -5053,9 +5224,13 @@ mod tests {
 
         app.handle_command("setup").await;
 
+        let llmsim_index = PROVIDER_OPTIONS
+            .iter()
+            .position(|option| option.name == "llmsim")
+            .expect("llmsim provider option");
         assert!(matches!(
             app.setup,
-            Some(SetupStep::Provider { selected: 5 })
+            Some(SetupStep::Provider { selected }) if selected == llmsim_index
         ));
         assert!(
             app.lines.is_empty(),
@@ -5099,8 +5274,20 @@ mod tests {
         );
     }
 
+    // Holding the env lock across awaits is deliberate: the overlay reads
+    // env vars throughout the test, so releasing early would let another
+    // env-mutating test change them mid-assertion. The guard owner always
+    // makes progress, so this cannot deadlock.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn setup_provider_picker_enters_credential_panel() {
+        // Serialize against other env-mutating tests; a present
+        // OPENAI_API_KEY would make the provider "connected" and skip the
+        // credential panel entirely.
+        let _guard = crate::test_env::lock();
+        unsafe {
+            std::env::remove_var("OPENAI_API_KEY");
+        }
         let mut fixture = app_with_llmsim().await;
         let app = &mut fixture.app;
         app.lines.clear();
@@ -5138,7 +5325,6 @@ mod tests {
         let app = &mut fixture.app;
         app.setup = Some(SetupStep::Credential {
             provider: "openai".to_string(),
-            default_model: "openai/gpt-5.5 medium".to_string(),
             selected: 0,
             error: None,
         });
@@ -5161,7 +5347,6 @@ mod tests {
         app.lines.clear();
         app.setup = Some(SetupStep::TokenInput {
             provider: "openai".to_string(),
-            default_model: "openai/gpt-5.5 medium".to_string(),
             token: String::new(),
             error: None,
         });
@@ -5202,7 +5387,13 @@ mod tests {
         let mut fixture = app_with_llmsim().await;
         let app = &mut fixture.app;
         app.lines.clear();
-        app.setup = Some(SetupStep::Provider { selected: 5 });
+        let llmsim_index = PROVIDER_OPTIONS
+            .iter()
+            .position(|option| option.name == "llmsim")
+            .expect("llmsim provider option");
+        app.setup = Some(SetupStep::Provider {
+            selected: llmsim_index,
+        });
 
         app.handle_setup_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()))
             .await;
@@ -5220,6 +5411,174 @@ mod tests {
                 .any(|line| line.text.starts_with("setup provider changed:")),
             "wizard should hide internal setup command success output"
         );
+    }
+
+    // See setup_provider_picker_enters_credential_panel for why the env
+    // lock is held across awaits.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn setup_provider_picker_shows_connection_status() {
+        let _guard = crate::test_env::lock();
+        unsafe {
+            std::env::remove_var("OPENAI_API_KEY");
+            std::env::remove_var("CUSTOM_BASE_URL");
+        }
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = Some(SetupStep::Provider { selected: 0 });
+
+        let rendered = setup_overlay_text(app);
+        let openai_row = rendered
+            .iter()
+            .find(|line| line.contains("OpenAI") && !line.contains("compatible"))
+            .expect("openai row");
+        assert!(
+            openai_row.contains("needs API key"),
+            "unconnected provider should say so: {openai_row:?}"
+        );
+        let custom_row = rendered
+            .iter()
+            .find(|line| line.contains("Custom endpoint"))
+            .expect("custom row");
+        assert!(
+            custom_row.contains("needs base URL"),
+            "custom without URL should say so: {custom_row:?}"
+        );
+
+        app.settings
+            .set_token("openai".to_string(), "sk-test".to_string())
+            .expect("save token");
+        let rendered = setup_overlay_text(app);
+        let openai_row = rendered
+            .iter()
+            .find(|line| line.contains("OpenAI") && !line.contains("compatible"))
+            .expect("openai row");
+        assert!(
+            openai_row.contains("✓ saved key"),
+            "saved key should mark the provider connected: {openai_row:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn setup_connected_provider_jumps_straight_to_model_picker() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.lines.clear();
+        app.settings
+            .set_token("openai".to_string(), "sk-test".to_string())
+            .expect("save token");
+        app.setup = Some(SetupStep::Provider { selected: 0 });
+
+        app.handle_setup_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()))
+            .await;
+
+        assert!(
+            matches!(
+                app.setup,
+                Some(SetupStep::PickModel { ref provider, .. }) if provider == "openai"
+            ),
+            "connected provider should skip the credential step: {:?}",
+            app.setup
+        );
+        assert_eq!(app.model.provider_label(), "openai/gpt-5.5 medium");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn setup_c_key_opens_credential_panel_even_when_connected() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.settings
+            .set_token("openai".to_string(), "sk-test".to_string())
+            .expect("save token");
+        app.setup = Some(SetupStep::Provider { selected: 0 });
+
+        app.handle_setup_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::empty()))
+            .await;
+
+        assert!(
+            matches!(
+                app.setup,
+                Some(SetupStep::Credential { ref provider, .. }) if provider == "openai"
+            ),
+            "c should open credential config: {:?}",
+            app.setup
+        );
+    }
+
+    // See setup_provider_picker_enters_credential_panel for why the env
+    // lock is held across awaits.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn setup_custom_endpoint_flow_collects_url_and_model() {
+        let _guard = crate::test_env::lock();
+        unsafe {
+            std::env::remove_var("CUSTOM_BASE_URL");
+            std::env::remove_var("CUSTOM_API_KEY");
+        }
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.lines.clear();
+        let custom_index = PROVIDER_OPTIONS
+            .iter()
+            .position(|option| option.name == "custom")
+            .expect("custom provider option");
+        app.setup = Some(SetupStep::Provider {
+            selected: custom_index,
+        });
+
+        // Not connected yet → Enter opens the base URL input.
+        app.handle_setup_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()))
+            .await;
+        assert!(
+            matches!(app.setup, Some(SetupStep::BaseUrlInput { .. })),
+            "custom without URL should ask for one: {:?}",
+            app.setup
+        );
+
+        for ch in "http://localhost:8000/v1".chars() {
+            app.handle_setup_key(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::empty()))
+                .await;
+        }
+        app.handle_setup_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()))
+            .await;
+        assert!(
+            matches!(
+                app.setup,
+                Some(SetupStep::Credential { ref provider, selected: 0, .. }) if provider == "custom"
+            ),
+            "saved URL should advance to the credential step: {:?}",
+            app.setup
+        );
+
+        // "Continue without key" → free-form model input.
+        app.handle_setup_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()))
+            .await;
+        assert!(
+            matches!(
+                app.setup,
+                Some(SetupStep::PickModel { ref provider, custom: Some(_), .. })
+                    if provider == "custom"
+            ),
+            "custom should open the model input directly: {:?}",
+            app.setup
+        );
+
+        for ch in "qwen3-coder".chars() {
+            app.handle_setup_key(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::empty()))
+                .await;
+        }
+        app.handle_setup_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()))
+            .await;
+
+        assert!(app.setup.is_none(), "wizard should finish: {:?}", app.setup);
+        assert_eq!(app.model.provider_label(), "custom/qwen3-coder");
+        let snapshot = app.settings.snapshot();
+        assert_eq!(
+            snapshot.base_url_for("custom"),
+            Some("http://localhost:8000/v1")
+        );
+        assert_eq!(snapshot.provider.as_deref(), Some("custom"));
+        assert_eq!(snapshot.model_for("custom"), Some("custom/qwen3-coder"));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -908,8 +908,10 @@ fn env_credential_present() -> bool {
         "GOOGLE_API_KEY",
         "OLLAMA_BASE_URL",
         "OLLAMA_API_KEY",
+        // CUSTOM_API_KEY is deliberately absent: the custom endpoint is
+        // unusable without a base URL, so a stray key alone must not
+        // suppress first-run onboarding.
         "CUSTOM_BASE_URL",
-        "CUSTOM_API_KEY",
     ];
     VARS.iter()
         .any(|var| std::env::var(var).map(|v| !v.is_empty()).unwrap_or(false))
@@ -932,9 +934,40 @@ mod tests {
             std::env::remove_var("GOOGLE_API_KEY");
             std::env::remove_var("OLLAMA_BASE_URL");
             std::env::remove_var("OLLAMA_API_KEY");
+            std::env::remove_var("CUSTOM_BASE_URL");
+            std::env::remove_var("CUSTOM_API_KEY");
         }
         let settings = crate::settings::Settings::default();
         assert!(SetupCapability::needs_onboarding(&settings));
+    }
+
+    #[test]
+    fn needs_onboarding_ignores_custom_api_key_without_base_url() {
+        // A stray CUSTOM_API_KEY is not a usable credential: without a base
+        // URL the custom provider cannot run, so onboarding must still open.
+        let _guard = crate::test_env::lock();
+        unsafe {
+            std::env::remove_var("OPENAI_API_KEY");
+            std::env::remove_var("ANTHROPIC_API_KEY");
+            std::env::remove_var("OPENROUTER_API_KEY");
+            std::env::remove_var("GEMINI_API_KEY");
+            std::env::remove_var("GOOGLE_API_KEY");
+            std::env::remove_var("OLLAMA_BASE_URL");
+            std::env::remove_var("OLLAMA_API_KEY");
+            std::env::remove_var("CUSTOM_BASE_URL");
+            std::env::set_var("CUSTOM_API_KEY", "sk-orphan");
+        }
+        let settings = crate::settings::Settings::default();
+        assert!(SetupCapability::needs_onboarding(&settings));
+
+        unsafe {
+            std::env::set_var("CUSTOM_BASE_URL", "http://localhost:8000/v1");
+        }
+        assert!(!SetupCapability::needs_onboarding(&settings));
+        unsafe {
+            std::env::remove_var("CUSTOM_BASE_URL");
+            std::env::remove_var("CUSTOM_API_KEY");
+        }
     }
 
     #[test]

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -334,9 +334,20 @@ impl Capability for CodingBashCapability {
 pub(crate) const SETUP_CAPABILITY_ID: &str = "yolop_setup";
 
 /// Providers that meaningfully consume an API token. `llmsim` is excluded
-/// (no key needed) and `ollama` is included for completeness even though
-/// most local setups don't authenticate.
-const TOKEN_PROVIDERS: &[&str] = &["openai", "anthropic", "google", "openrouter", "ollama"];
+/// (no key needed); `ollama` and `custom` are included for completeness even
+/// though most local setups don't authenticate.
+const TOKEN_PROVIDERS: &[&str] = &[
+    "openai",
+    "anthropic",
+    "google",
+    "openrouter",
+    "ollama",
+    "custom",
+];
+
+/// Providers whose endpoint base URL is user configuration stored in
+/// settings (vs. a compiled-in default with env override).
+const BASE_URL_PROVIDERS: &[&str] = &["custom"];
 
 pub(crate) struct SetupCapability {
     pub(crate) provider: Arc<RwLock<ProviderChoice>>,
@@ -398,9 +409,10 @@ impl Capability for SetupCapability {
             "model" => self.change_model(rest).await,
             "effort" => self.change_effort(rest).await,
             "token" => self.change_token(rest),
+            "url" => self.change_base_url(rest),
             "attribution" => self.change_attribution(rest),
             _ => Ok(failed_result(
-                "usage: /setup — run guided setup; internal forms: status, provider <name>, token <provider> <value|clear>, model <id|provider/id> [reasoning-effort], effort <reasoning-effort>, attribution <on|off>".to_string(),
+                "usage: /setup — run guided setup; internal forms: status, provider <name>, token <provider> <value|clear>, url <provider> <base-url|clear>, model <id|provider/id> [reasoning-effort], effort <reasoning-effort>, attribution <on|off>".to_string(),
             )),
         }
     }
@@ -419,6 +431,11 @@ fn setup_command_arg() -> CommandArg {
             format!("token {provider} clear"),
         ]
     }));
+    suggestions.extend(
+        BASE_URL_PROVIDERS
+            .iter()
+            .flat_map(|provider| [format!("url {provider} "), format!("url {provider} clear")]),
+    );
     suggestions.extend(
         SUPPORTED_PROVIDERS
             .iter()
@@ -439,7 +456,7 @@ fn setup_command_arg() -> CommandArg {
 
     CommandArg {
         name: "action".to_string(),
-        description: "status | provider <name> | token <provider> <value|clear> | model <id|provider/id> | effort <level> | attribution <on|off>".to_string(),
+        description: "status | provider <name> | token <provider> <value|clear> | url <provider> <base-url|clear> | model <id|provider/id> | effort <level> | attribution <on|off>".to_string(),
         required: false,
         suggestions,
     }
@@ -486,7 +503,7 @@ impl SetupCapability {
         }
 
         let next = match ProviderChoice::default_for_provider_name(raw) {
-            Ok(n) => n,
+            Ok(n) => n.with_saved_model(&self.settings.snapshot()),
             Err(err) => return Ok(failed_result(format!("setup provider failed: {err}"))),
         };
         let mw = match next.model_with_provider(&self.settings.snapshot()) {
@@ -550,13 +567,30 @@ impl SetupCapability {
             return Ok(failed_result(format!("setup model failed: {err}")));
         }
         let label = next.label();
+        let persist_note = self.persist_model_choice(&next);
         *self.provider.write().expect("provider lock poisoned") = next;
         Ok(CommandResult {
             success: true,
-            message: format!("setup model changed: {label}"),
+            message: format!("setup model changed: {label}{persist_note}"),
             error_code: None,
             error_fields: None,
         })
+    }
+
+    /// Persist a model switch: the provider preference and the full
+    /// `provider/model [effort]` label, so both survive a restart (the model
+    /// picker promises "future sessions"). Best-effort — a failed save is
+    /// reported in the message but never blocks the in-session switch.
+    fn persist_model_choice(&self, next: &ProviderChoice) -> String {
+        let provider_name = next.provider_name().to_string();
+        let result = self
+            .settings
+            .set_provider(Some(provider_name.clone()))
+            .and_then(|()| self.settings.set_model(provider_name, next.label()));
+        match result {
+            Ok(()) => String::new(),
+            Err(err) => format!(" (warning: settings not saved: {err})"),
+        }
     }
 
     async fn change_effort(&self, raw: &str) -> everruns_core::Result<CommandResult> {
@@ -583,10 +617,11 @@ impl SetupCapability {
             Err(err) => return Ok(failed_result(format!("setup effort failed: {err}"))),
         };
         let label = next.label();
+        let persist_note = self.persist_model_choice(&next);
         *self.provider.write().expect("provider lock poisoned") = next;
         Ok(CommandResult {
             success: true,
-            message: format!("setup effort changed: {label}"),
+            message: format!("setup effort changed: {label}{persist_note}"),
             error_code: None,
             error_fields: None,
         })
@@ -658,6 +693,68 @@ impl SetupCapability {
                 error_fields: None,
             }),
             Err(err) => Ok(failed_result(format!("setup token save failed: {err}"))),
+        }
+    }
+
+    fn change_base_url(&self, raw: &str) -> everruns_core::Result<CommandResult> {
+        let mut parts = raw.splitn(2, char::is_whitespace);
+        let provider = parts.next().unwrap_or_default().to_ascii_lowercase();
+        let rest = parts.next().unwrap_or_default().trim();
+        if !BASE_URL_PROVIDERS.contains(&provider.as_str()) {
+            return Ok(failed_result(format!(
+                "setup url failed: unknown provider `{provider}`; expected one of {}",
+                BASE_URL_PROVIDERS.join(", ")
+            )));
+        }
+        if rest.is_empty() {
+            let snapshot = self.settings.snapshot();
+            let current = snapshot
+                .base_url_for(&provider)
+                .unwrap_or("<unset>")
+                .to_string();
+            return Ok(CommandResult {
+                success: true,
+                message: format!("setup url for {provider}: {current}"),
+                error_code: None,
+                error_fields: None,
+            });
+        }
+        if rest.eq_ignore_ascii_case("clear") {
+            return Ok(match self.settings.clear_base_url(&provider) {
+                Ok(true) => CommandResult {
+                    success: true,
+                    message: format!("setup url cleared for {provider}"),
+                    error_code: None,
+                    error_fields: None,
+                },
+                Ok(false) => CommandResult {
+                    success: true,
+                    message: format!("setup url: no base URL was stored for {provider}"),
+                    error_code: None,
+                    error_fields: None,
+                },
+                Err(err) => failed_result(format!("setup url clear failed: {err}")),
+            });
+        }
+        if !rest.starts_with("http://") && !rest.starts_with("https://") {
+            return Ok(failed_result(
+                "setup url failed: base URL must start with http:// or https://".to_string(),
+            ));
+        }
+        match self
+            .settings
+            .set_base_url(provider.clone(), rest.to_string())
+        {
+            Ok(()) => Ok(CommandResult {
+                success: true,
+                message: format!(
+                    "setup url stored for {provider} (in {})",
+                    self.settings.path().display()
+                ),
+                error_code: None,
+                error_fields: None,
+            }),
+            Err(err) => Ok(failed_result(format!("setup url save failed: {err}"))),
         }
     }
 
@@ -744,6 +841,8 @@ fn env_credential_present() -> bool {
         "GOOGLE_API_KEY",
         "OLLAMA_BASE_URL",
         "OLLAMA_API_KEY",
+        "CUSTOM_BASE_URL",
+        "CUSTOM_API_KEY",
     ];
     VARS.iter()
         .any(|var| std::env::var(var).map(|v| !v.is_empty()).unwrap_or(false))

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,8 @@ enum ProviderArg {
     Google,
     Openrouter,
     Ollama,
+    /// Generic OpenAI-compatible endpoint (CUSTOM_BASE_URL / saved base URL).
+    Custom,
     #[value(name = "llmsim", alias = "sim")]
     Sim,
 }
@@ -152,6 +154,7 @@ fn provider_name_for_arg(arg: ProviderArg) -> &'static str {
         ProviderArg::Google => "google",
         ProviderArg::Openrouter => "openrouter",
         ProviderArg::Ollama => "ollama",
+        ProviderArg::Custom => "custom",
         ProviderArg::Sim => "llmsim",
     }
 }
@@ -176,6 +179,9 @@ fn pick_provider(cli: &Cli, settings: &SettingsStore) -> ProviderChoice {
     } else {
         ProviderChoice::from_env_or_settings(&snapshot)
     };
+    // A model persisted by `/setup model` for the chosen provider wins over
+    // the provider default; CLI flags still override it below.
+    let base = base.with_saved_model(&snapshot);
     let selected = match (base, cli.model.clone()) {
         (ProviderChoice::Anthropic { .. }, Some(m)) => ProviderChoice::Anthropic { model: m },
         (
@@ -205,6 +211,15 @@ fn pick_provider(cli: &Cli, settings: &SettingsStore) -> ProviderChoice {
         (ProviderChoice::Ollama { base_url, .. }, Some(m)) => {
             ProviderChoice::Ollama { model: m, base_url }
         }
+        (
+            ProviderChoice::Custom {
+                reasoning_effort, ..
+            },
+            Some(m),
+        ) => ProviderChoice::Custom {
+            model: m,
+            reasoning_effort: cli_reasoning_effort.clone().or(reasoning_effort),
+        },
         (other, _) => other,
     };
     match (selected, cli_reasoning_effort) {
@@ -228,6 +243,16 @@ fn pick_provider(cli: &Cli, settings: &SettingsStore) -> ProviderChoice {
         ) => ProviderChoice::OpenRouter {
             model,
             base_url,
+            reasoning_effort: effort.or(reasoning_effort),
+        },
+        (
+            ProviderChoice::Custom {
+                model,
+                reasoning_effort,
+            },
+            effort,
+        ) => ProviderChoice::Custom {
+            model,
             reasoning_effort: effort.or(reasoning_effort),
         },
         (other, _) => other,
@@ -496,6 +521,7 @@ async fn run_print_mode(runtime: BuiltRuntime, prompt: String) -> Result<()> {
         handles,
         startup,
         model,
+        settings: _,
         ui_rx: _,
     } = runtime;
     let color = io::stdout().is_terminal();
@@ -685,6 +711,37 @@ mod tests {
             provider.label(),
             "openrouter/nvidia/nemotron-3-super-120b-a12b"
         );
+    }
+
+    #[test]
+    fn pick_provider_applies_saved_model_for_saved_provider() {
+        let _guard = crate::test_env::lock();
+        unsafe {
+            std::env::remove_var("EVERRUNS_CLI_MODEL");
+        }
+        let tmp = tempfile::tempdir().expect("settings tempdir");
+        let path = tmp.path().join("settings.toml");
+        std::fs::write(
+            &path,
+            "provider = \"openai\"\n\n[models]\nopenai = \"openai/gpt-5.4 high\"\n",
+        )
+        .expect("write settings");
+        let settings = SettingsStore::open(path);
+        let cli = Cli {
+            command: None,
+            cwd: None,
+            provider: None,
+            model: None,
+            reasoning_effort: None,
+            print: None,
+            acp: false,
+            session: None,
+            session_dir: None,
+        };
+
+        let provider = pick_provider(&cli, &settings);
+
+        assert_eq!(provider.label(), "openai/gpt-5.4 high");
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -384,6 +384,9 @@ const DEFAULT_OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
 const DEFAULT_OLLAMA_MODEL: &str = "llama3.2";
 const DEFAULT_OLLAMA_BASE_URL: &str = "http://localhost:11434/v1";
 const DEFAULT_OLLAMA_API_KEY: &str = "ollama";
+// Generic OpenAI-compatible servers usually ignore the bearer token, but the
+// OpenAI client requires one — same trick as Ollama's placeholder key.
+const DEFAULT_CUSTOM_API_KEY: &str = "unused";
 
 #[derive(Clone, Debug)]
 pub enum ProviderChoice {
@@ -407,6 +410,16 @@ pub enum ProviderChoice {
         model: String,
         base_url: String,
     },
+    /// Generic OpenAI-compatible endpoint (vLLM, llama.cpp, LM Studio,
+    /// hosted gateways, …). Unlike the other variants the base URL is not
+    /// carried here: it is user configuration, resolved from
+    /// `CUSTOM_BASE_URL` or the settings file at request-build time in
+    /// [`Self::model_with_provider`], so a bare `custom/model` spec can be
+    /// parsed without access to settings.
+    Custom {
+        model: String,
+        reasoning_effort: Option<String>,
+    },
     Sim,
 }
 
@@ -418,6 +431,7 @@ pub const SUPPORTED_PROVIDERS: &[&str] = &[
     "google",
     "openrouter",
     "ollama",
+    "custom",
     "llmsim",
 ];
 
@@ -459,6 +473,14 @@ impl ProviderChoice {
                 base_url: env_or_default("OLLAMA_BASE_URL", DEFAULT_OLLAMA_BASE_URL),
             };
         }
+        if env_non_empty("CUSTOM_BASE_URL").is_some() || settings.base_url_for("custom").is_some() {
+            return Self::Custom {
+                model: env_or_default("EVERRUNS_CLI_MODEL", ""),
+                reasoning_effort: normalize_reasoning_effort(env_non_empty(
+                    "EVERRUNS_CLI_REASONING_EFFORT",
+                )),
+            };
+        }
         Self::default_openai()
     }
 
@@ -492,6 +514,13 @@ impl ProviderChoice {
                 None => format!("openrouter/{model}"),
             },
             Self::Ollama { model, .. } => format!("ollama/{model}"),
+            Self::Custom {
+                model,
+                reasoning_effort,
+            } => match reasoning_effort {
+                Some(effort) => format!("custom/{model} {effort}"),
+                None => format!("custom/{model}"),
+            },
             Self::Sim => "llmsim/llmsim-yolop".to_string(),
         }
     }
@@ -504,6 +533,7 @@ impl ProviderChoice {
             Self::Google { .. } => "google",
             Self::OpenRouter { .. } => "openrouter",
             Self::Ollama { .. } => "ollama",
+            Self::Custom { .. } => "custom",
             Self::Sim => "llmsim",
         }
     }
@@ -532,11 +562,37 @@ impl ProviderChoice {
                 model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_OLLAMA_MODEL),
                 base_url: env_or_default("OLLAMA_BASE_URL", DEFAULT_OLLAMA_BASE_URL),
             }),
+            // No sensible default model exists for an arbitrary endpoint; an
+            // empty model is rejected later by `model_with_provider` so the
+            // setup wizard (or a saved model from settings) must fill it in.
+            "custom" => Ok(Self::Custom {
+                model: env_or_default("EVERRUNS_CLI_MODEL", ""),
+                reasoning_effort: normalize_reasoning_effort(env_non_empty(
+                    "EVERRUNS_CLI_REASONING_EFFORT",
+                )),
+            }),
             "llmsim" => Ok(Self::Sim),
             other => Err(anyhow!(
                 "unknown provider {other}; expected one of {}",
                 SUPPORTED_PROVIDERS.join(", ")
             )),
+        }
+    }
+
+    /// Overlay the model spec persisted for this provider in settings, if
+    /// any. `EVERRUNS_CLI_MODEL` keeps precedence (env beats settings,
+    /// matching token resolution); a stored spec that fails to parse or
+    /// names a different provider is ignored rather than fatal.
+    pub fn with_saved_model(self, settings: &Settings) -> Self {
+        if env_non_empty("EVERRUNS_CLI_MODEL").is_some() {
+            return self;
+        }
+        let Some(spec) = settings.model_for(self.provider_name()) else {
+            return self;
+        };
+        match self.resolve_model_spec(spec) {
+            Ok(saved) if saved.provider_name() == self.provider_name() => saved,
+            _ => self,
         }
     }
 
@@ -622,6 +678,10 @@ impl ProviderChoice {
                     base_url: env_or_default("OLLAMA_BASE_URL", DEFAULT_OLLAMA_BASE_URL),
                 })
             }
+            "custom" => Ok(Self::Custom {
+                model: model.to_string(),
+                reasoning_effort: normalize_reasoning_effort(reasoning_effort),
+            }),
             "llmsim" | "sim" => {
                 if reasoning_effort.is_some() {
                     return Err(anyhow!("offline llmsim does not support reasoning effort"));
@@ -684,6 +744,10 @@ impl ProviderChoice {
                     base_url: base_url.clone(),
                 })
             }
+            Self::Custom { .. } => Ok(Self::Custom {
+                model,
+                reasoning_effort: normalize_reasoning_effort(reasoning_effort),
+            }),
             Self::Sim => {
                 if reasoning_effort.is_some() {
                     return Err(anyhow!("offline llmsim does not support reasoning effort"));
@@ -718,8 +782,12 @@ impl ProviderChoice {
                 base_url: base_url.clone(),
                 reasoning_effort: normalize_reasoning_effort(Some(effort.to_string())),
             }),
+            Self::Custom { model, .. } => Ok(Self::Custom {
+                model: model.clone(),
+                reasoning_effort: normalize_reasoning_effort(Some(effort.to_string())),
+            }),
             other => Err(anyhow!(
-                "reasoning effort only applies to OpenAI and OpenRouter models (current provider: {})",
+                "reasoning effort only applies to OpenAI, OpenRouter, and custom models (current provider: {})",
                 other.provider_name()
             )),
         }
@@ -793,6 +861,27 @@ impl ProviderChoice {
                     base_url: Some(base_url.clone()),
                 })
             }
+            ProviderChoice::Custom { model, .. } => {
+                let base_url = custom_base_url(settings).ok_or_else(|| {
+                    anyhow!("custom endpoint base URL not set (set CUSTOM_BASE_URL or run /setup)")
+                })?;
+                if model.trim().is_empty() {
+                    return Err(anyhow!(
+                        "custom endpoint model not set (run /setup or pass --model)"
+                    ));
+                }
+                // Chat Completions is the lowest common denominator that
+                // virtually every OpenAI-compatible server implements; the
+                // Responses driver would break on most of them.
+                let key = resolve_token(settings, "custom", &["CUSTOM_API_KEY"])
+                    .unwrap_or_else(|| DEFAULT_CUSTOM_API_KEY.to_string());
+                Ok(ModelWithProvider {
+                    model: model.clone(),
+                    provider_type: LlmProviderType::OpenaiCompletions,
+                    api_key: Some(key),
+                    base_url: Some(base_url),
+                })
+            }
             ProviderChoice::Sim => Ok(ModelWithProvider {
                 model: "llmsim-yolop".into(),
                 provider_type: LlmProviderType::LlmSim,
@@ -838,6 +927,12 @@ impl ProviderChoice {
                 api_key: Some(DEFAULT_OLLAMA_API_KEY.to_string()),
                 base_url: Some(base_url.clone()),
             },
+            ProviderChoice::Custom { model, .. } => ModelWithProvider {
+                model: model.clone(),
+                provider_type: LlmProviderType::OpenaiCompletions,
+                api_key: None,
+                base_url: env_non_empty("CUSTOM_BASE_URL"),
+            },
             ProviderChoice::Sim => ModelWithProvider {
                 model: "llmsim-yolop".into(),
                 provider_type: LlmProviderType::LlmSim,
@@ -854,6 +949,9 @@ impl ProviderChoice {
                 reasoning_effort, ..
             }
             | Self::OpenRouter {
+                reasoning_effort, ..
+            }
+            | Self::Custom {
                 reasoning_effort, ..
             } => reasoning_effort.as_ref(),
             _ => None,
@@ -878,6 +976,12 @@ fn env_non_empty(name: &str) -> Option<String> {
 /// `GOOGLE_API_KEY`; the Google docs lean on `GEMINI_API_KEY` so it wins.
 fn google_api_key() -> Option<String> {
     env_non_empty("GEMINI_API_KEY").or_else(|| env_non_empty("GOOGLE_API_KEY"))
+}
+
+/// Base URL for the generic OpenAI-compatible provider. Env beats the
+/// settings file, mirroring token resolution.
+pub(crate) fn custom_base_url(settings: &Settings) -> Option<String> {
+    env_non_empty("CUSTOM_BASE_URL").or_else(|| settings.base_url_for("custom").map(str::to_string))
 }
 
 /// Env vars beat settings — a per-run override always wins over a saved
@@ -971,6 +1075,9 @@ pub struct BuiltRuntime {
     pub handles: RuntimeHandles,
     pub startup: StartupInfo,
     pub model: ModelState,
+    /// Shared settings store, also held by `SetupCapability`. The TUI reads
+    /// it to show per-provider connection status in the setup overlay.
+    pub settings: Arc<SettingsStore>,
     /// Receiver for terminal-side commands emitted by
     /// [`ClientCommandsCapability`]. The TUI drains it in its event loop;
     /// other hosts ignore it. Empty/never-written when
@@ -1235,7 +1342,8 @@ pub async fn build_with_options(
         | ProviderChoice::OpenAi { .. }
         | ProviderChoice::Google { .. }
         | ProviderChoice::OpenRouter { .. }
-        | ProviderChoice::Ollama { .. } => match provider.model_with_provider(&settings_snapshot) {
+        | ProviderChoice::Ollama { .. }
+        | ProviderChoice::Custom { .. } => match provider.model_with_provider(&settings_snapshot) {
             Ok(model) => model,
             Err(_) if setup_recommended => provider.model_without_stored_key(),
             Err(err) => return Err(err),
@@ -1324,6 +1432,7 @@ pub async fn build_with_options(
             mcp_server_names,
         },
         model: ModelState::new(provider_state),
+        settings,
         ui_rx,
     })
 }
@@ -1569,6 +1678,72 @@ mod tests {
         assert!(unknown.message.contains("model <id|provider/id>"));
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn setup_url_and_custom_model_persist_through_settings() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+        let settings_for_assert = settings.clone();
+        let built = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Sim,
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            BuildOptions::default(),
+        )
+        .await
+        .expect("build runtime");
+        let run = |arg: &str| {
+            let runtime = built.handles.runtime.clone();
+            let session_id = built.handles.session_id;
+            let arg = arg.to_string();
+            async move {
+                runtime
+                    .execute_command(
+                        session_id,
+                        ExecuteCommandRequest {
+                            name: "setup".to_string(),
+                            arguments: Some(arg),
+                            controls: None,
+                        },
+                    )
+                    .await
+                    .expect("execute setup")
+            }
+        };
+
+        let bad_provider = run("url ollama http://localhost:1234/v1").await;
+        assert!(!bad_provider.success, "{}", bad_provider.message);
+
+        let bad_scheme = run("url custom ftp://example.com").await;
+        assert!(!bad_scheme.success, "{}", bad_scheme.message);
+
+        let stored = run("url custom http://localhost:8000/v1").await;
+        assert!(stored.success, "{}", stored.message);
+        assert_eq!(
+            settings_for_assert.snapshot().base_url_for("custom"),
+            Some("http://localhost:8000/v1")
+        );
+
+        let model = run("model custom/qwen3-coder").await;
+        assert!(model.success, "{}", model.message);
+        assert_eq!(built.model.provider_label(), "custom/qwen3-coder");
+        // Model switches persist so the choice survives a restart.
+        let snapshot = settings_for_assert.snapshot();
+        assert_eq!(snapshot.provider.as_deref(), Some("custom"));
+        assert_eq!(snapshot.model_for("custom"), Some("custom/qwen3-coder"));
+
+        let cleared = run("url custom clear").await;
+        assert!(cleared.success, "{}", cleared.message);
+        assert!(
+            settings_for_assert
+                .snapshot()
+                .base_url_for("custom")
+                .is_none()
+        );
+    }
+
     #[test]
     fn model_spec_can_switch_to_anthropic() {
         let provider = ProviderChoice::OpenAi {
@@ -1684,11 +1859,100 @@ mod tests {
             std::env::remove_var("GOOGLE_API_KEY");
             std::env::remove_var("OLLAMA_BASE_URL");
             std::env::remove_var("OLLAMA_API_KEY");
+            std::env::remove_var("CUSTOM_BASE_URL");
         }
 
         let provider = ProviderChoice::from_env_or_settings(&Settings::default());
 
         assert_eq!(provider.provider_name(), "openai");
+    }
+
+    #[test]
+    fn model_spec_accepts_custom_provider_name_with_effort() {
+        let provider = ProviderChoice::Sim;
+        let next = provider
+            .resolve_model_spec("custom/qwen3-coder high")
+            .unwrap();
+
+        assert_eq!(next.label(), "custom/qwen3-coder high");
+        assert_eq!(next.provider_name(), "custom");
+    }
+
+    #[test]
+    fn custom_model_with_provider_resolves_saved_base_url_and_placeholder_key() {
+        let _guard = crate::test_env::lock();
+        unsafe {
+            std::env::remove_var("CUSTOM_BASE_URL");
+            std::env::remove_var("CUSTOM_API_KEY");
+        }
+        let mut settings = Settings::default();
+        settings
+            .base_urls
+            .insert("custom".to_string(), "http://localhost:8000/v1".to_string());
+
+        let provider = ProviderChoice::Custom {
+            model: "qwen3-coder".to_string(),
+            reasoning_effort: None,
+        };
+        let mw = provider.model_with_provider(&settings).unwrap();
+
+        assert_eq!(mw.model, "qwen3-coder");
+        assert_eq!(mw.base_url.as_deref(), Some("http://localhost:8000/v1"));
+        assert_eq!(mw.api_key.as_deref(), Some(DEFAULT_CUSTOM_API_KEY));
+    }
+
+    #[test]
+    fn custom_model_with_provider_requires_base_url_and_model() {
+        let _guard = crate::test_env::lock();
+        unsafe {
+            std::env::remove_var("CUSTOM_BASE_URL");
+            std::env::remove_var("CUSTOM_API_KEY");
+        }
+        let no_url = ProviderChoice::Custom {
+            model: "qwen3-coder".to_string(),
+            reasoning_effort: None,
+        };
+        let err = no_url
+            .model_with_provider(&Settings::default())
+            .unwrap_err();
+        assert!(err.to_string().contains("base URL"), "got: {err}");
+
+        let mut settings = Settings::default();
+        settings
+            .base_urls
+            .insert("custom".to_string(), "http://localhost:8000/v1".to_string());
+        let no_model = ProviderChoice::Custom {
+            model: String::new(),
+            reasoning_effort: None,
+        };
+        let err = no_model.model_with_provider(&settings).unwrap_err();
+        assert!(err.to_string().contains("model not set"), "got: {err}");
+    }
+
+    #[test]
+    fn with_saved_model_overlays_persisted_spec_for_same_provider() {
+        let _guard = crate::test_env::lock();
+        unsafe {
+            std::env::remove_var("EVERRUNS_CLI_MODEL");
+        }
+        let mut settings = Settings::default();
+        settings
+            .models
+            .insert("openai".to_string(), "openai/gpt-5.4 high".to_string());
+        // A spec saved under the wrong key must not switch providers.
+        settings
+            .models
+            .insert("anthropic".to_string(), "openai/gpt-5.5".to_string());
+
+        let openai = ProviderChoice::default_for_provider_name("openai")
+            .unwrap()
+            .with_saved_model(&settings);
+        assert_eq!(openai.label(), "openai/gpt-5.4 high");
+
+        let anthropic = ProviderChoice::default_for_provider_name("anthropic")
+            .unwrap()
+            .with_saved_model(&settings);
+        assert_eq!(anthropic.label(), "anthropic/claude-sonnet-4-5");
     }
 
     #[test]
@@ -1851,7 +2115,7 @@ mod tests {
 
         assert!(
             err.to_string()
-                .contains("only applies to OpenAI and OpenRouter")
+                .contains("only applies to OpenAI, OpenRouter, and custom")
         );
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -473,7 +473,15 @@ impl ProviderChoice {
                 base_url: env_or_default("OLLAMA_BASE_URL", DEFAULT_OLLAMA_BASE_URL),
             };
         }
-        if env_non_empty("CUSTOM_BASE_URL").is_some() || settings.base_url_for("custom").is_some() {
+        // The custom endpoint has no default model, so it is auto-selected
+        // only when a model is also known (env override or a persisted
+        // `[models].custom` pick — applied by the caller's
+        // `with_saved_model`). Otherwise a non-interactive run would send a
+        // Chat Completions request with an empty model id.
+        if (env_non_empty("CUSTOM_BASE_URL").is_some() || settings.base_url_for("custom").is_some())
+            && (env_non_empty("EVERRUNS_CLI_MODEL").is_some()
+                || settings.model_for("custom").is_some())
+        {
             return Self::Custom {
                 model: env_or_default("EVERRUNS_CLI_MODEL", ""),
                 reasoning_effort: normalize_reasoning_effort(env_non_empty(
@@ -1893,6 +1901,43 @@ mod tests {
         let provider = ProviderChoice::from_env_or_settings(&Settings::default());
 
         assert_eq!(provider.provider_name(), "openai");
+    }
+
+    #[test]
+    fn from_env_or_settings_picks_custom_only_when_a_model_is_known() {
+        let _guard = crate::test_env::lock();
+        unsafe {
+            std::env::remove_var("OPENAI_API_KEY");
+            std::env::remove_var("ANTHROPIC_API_KEY");
+            std::env::remove_var("OPENROUTER_API_KEY");
+            std::env::remove_var("GEMINI_API_KEY");
+            std::env::remove_var("GOOGLE_API_KEY");
+            std::env::remove_var("OLLAMA_BASE_URL");
+            std::env::remove_var("OLLAMA_API_KEY");
+            std::env::remove_var("CUSTOM_BASE_URL");
+            std::env::remove_var("EVERRUNS_CLI_MODEL");
+        }
+        let mut settings = Settings::default();
+        settings
+            .base_urls
+            .insert("custom".to_string(), "http://localhost:8000/v1".to_string());
+
+        // A base URL alone is not enough — with no model known, a
+        // non-interactive run would send an empty model id. Fall back.
+        let provider = ProviderChoice::from_env_or_settings(&settings);
+        assert_eq!(provider.provider_name(), "openai");
+
+        // With a persisted model the custom endpoint is auto-selected (the
+        // caller's `with_saved_model` fills the model in).
+        settings
+            .models
+            .insert("custom".to_string(), "qwen3-coder".to_string());
+        let provider = ProviderChoice::from_env_or_settings(&settings);
+        assert_eq!(provider.provider_name(), "custom");
+        assert_eq!(
+            provider.with_saved_model(&settings).label(),
+            "custom/qwen3-coder"
+        );
     }
 
     #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -24,8 +24,9 @@ use toml::Value;
 pub struct Settings {
     pub provider: Option<String>,
     pub tokens: BTreeMap<String, String>,
-    /// Last model spec chosen per provider (full `provider/model [effort]`
-    /// label). Lets `/setup model` survive restarts and provider switches.
+    /// Last model spec chosen per provider, in the provider-relative
+    /// `model [effort]` form `/setup model` accepts. Lets a model pick
+    /// survive restarts and provider switches.
     pub models: BTreeMap<String, String>,
     /// Endpoint base URLs keyed by provider. Today only `custom` (the
     /// generic OpenAI-compatible provider) writes here.
@@ -365,7 +366,7 @@ mod tests {
         let path = tmp.path().join("settings.toml");
         let store = SettingsStore::open(path.clone());
         store
-            .set_model("openai".to_string(), "openai/gpt-5.5 high".to_string())
+            .set_model("openai".to_string(), "gpt-5.5 high".to_string())
             .expect("save model");
         store
             .set_base_url("custom".to_string(), "http://localhost:8000/v1".to_string())
@@ -378,7 +379,7 @@ mod tests {
         let reloaded = SettingsStore::open(path);
         assert_eq!(
             reloaded.snapshot().model_for("openai"),
-            Some("openai/gpt-5.5 high")
+            Some("gpt-5.5 high")
         );
         assert_eq!(
             reloaded.snapshot().base_url_for("custom"),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,5 +1,6 @@
 // Persistent yolop settings — preferred provider, optional per-provider
-// API tokens, and small behavior toggles.
+// API tokens, per-provider model picks, custom endpoint base URLs, and
+// small behavior toggles.
 //
 // Stored at `<config_dir>/yolop/settings.toml` (`~/.config/yolop/settings.toml`
 // on Linux). The `/setup` capability writes through `SettingsStore` so user
@@ -23,6 +24,12 @@ use toml::Value;
 pub struct Settings {
     pub provider: Option<String>,
     pub tokens: BTreeMap<String, String>,
+    /// Last model spec chosen per provider (full `provider/model [effort]`
+    /// label). Lets `/setup model` survive restarts and provider switches.
+    pub models: BTreeMap<String, String>,
+    /// Endpoint base URLs keyed by provider. Today only `custom` (the
+    /// generic OpenAI-compatible provider) writes here.
+    pub base_urls: BTreeMap<String, String>,
     pub attribution: bool,
 }
 
@@ -31,6 +38,8 @@ impl Default for Settings {
         Self {
             provider: None,
             tokens: BTreeMap::new(),
+            models: BTreeMap::new(),
+            base_urls: BTreeMap::new(),
             attribution: true,
         }
     }
@@ -46,17 +55,22 @@ impl Settings {
             .get("attribution")
             .and_then(Value::as_bool)
             .unwrap_or(true);
-        let mut tokens = BTreeMap::new();
-        if let Some(t) = table.get("tokens").and_then(Value::as_table) {
-            for (k, v) in t {
-                if let Some(s) = v.as_str() {
-                    tokens.insert(k.clone(), s.to_string());
+        let string_map = |key: &str| {
+            let mut map = BTreeMap::new();
+            if let Some(t) = table.get(key).and_then(Value::as_table) {
+                for (k, v) in t {
+                    if let Some(s) = v.as_str() {
+                        map.insert(k.clone(), s.to_string());
+                    }
                 }
             }
-        }
+            map
+        };
         Self {
             provider,
-            tokens,
+            tokens: string_map("tokens"),
+            models: string_map("models"),
+            base_urls: string_map("base_urls"),
             attribution,
         }
     }
@@ -69,13 +83,18 @@ impl Settings {
         if !self.attribution {
             table.insert("attribution".to_string(), Value::Boolean(false));
         }
-        if !self.tokens.is_empty() {
-            let mut tokens_table = Table::new();
-            for (k, v) in &self.tokens {
-                tokens_table.insert(k.clone(), Value::String(v.clone()));
+        let mut insert_map = |key: &str, map: &BTreeMap<String, String>| {
+            if !map.is_empty() {
+                let mut t = Table::new();
+                for (k, v) in map {
+                    t.insert(k.clone(), Value::String(v.clone()));
+                }
+                table.insert(key.to_string(), Value::Table(t));
             }
-            table.insert("tokens".to_string(), Value::Table(tokens_table));
-        }
+        };
+        insert_map("tokens", &self.tokens);
+        insert_map("models", &self.models);
+        insert_map("base_urls", &self.base_urls);
         table
     }
 
@@ -85,6 +104,14 @@ impl Settings {
 
     pub fn has_token(&self, provider: &str) -> bool {
         self.tokens.contains_key(provider)
+    }
+
+    pub fn model_for(&self, provider: &str) -> Option<&str> {
+        self.models.get(provider).map(String::as_str)
+    }
+
+    pub fn base_url_for(&self, provider: &str) -> Option<&str> {
+        self.base_urls.get(provider).map(String::as_str)
     }
 
     pub fn attribution_enabled(&self) -> bool {
@@ -205,6 +232,26 @@ impl SettingsStore {
         save_to(&self.path, &guard)?;
         Ok(existed)
     }
+
+    pub fn set_model(&self, provider: String, spec: String) -> Result<()> {
+        let mut guard = self.inner.lock().expect("settings lock poisoned");
+        guard.models.insert(provider, spec);
+        save_to(&self.path, &guard)
+    }
+
+    pub fn set_base_url(&self, provider: String, url: String) -> Result<()> {
+        let mut guard = self.inner.lock().expect("settings lock poisoned");
+        guard.base_urls.insert(provider, url);
+        save_to(&self.path, &guard)
+    }
+
+    /// Returns whether a base URL was actually present before removal.
+    pub fn clear_base_url(&self, provider: &str) -> Result<bool> {
+        let mut guard = self.inner.lock().expect("settings lock poisoned");
+        let existed = guard.base_urls.remove(provider).is_some();
+        save_to(&self.path, &guard)?;
+        Ok(existed)
+    }
 }
 
 #[cfg(test)]
@@ -310,6 +357,47 @@ mod tests {
         let store = SettingsStore::open(path);
         let removed = store.clear_token("openai").expect("clear");
         assert!(!removed);
+    }
+
+    #[test]
+    fn model_and_base_url_roundtrip_via_disk() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join("settings.toml");
+        let store = SettingsStore::open(path.clone());
+        store
+            .set_model("openai".to_string(), "openai/gpt-5.5 high".to_string())
+            .expect("save model");
+        store
+            .set_base_url("custom".to_string(), "http://localhost:8000/v1".to_string())
+            .expect("save base url");
+
+        let on_disk = std::fs::read_to_string(&path).expect("read");
+        assert!(on_disk.contains("[models]"), "got: {on_disk}");
+        assert!(on_disk.contains("[base_urls]"), "got: {on_disk}");
+
+        let reloaded = SettingsStore::open(path);
+        assert_eq!(
+            reloaded.snapshot().model_for("openai"),
+            Some("openai/gpt-5.5 high")
+        );
+        assert_eq!(
+            reloaded.snapshot().base_url_for("custom"),
+            Some("http://localhost:8000/v1")
+        );
+        assert!(reloaded.snapshot().model_for("anthropic").is_none());
+    }
+
+    #[test]
+    fn clearing_base_url_reports_presence() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join("settings.toml");
+        let store = SettingsStore::open(path);
+        assert!(!store.clear_base_url("custom").expect("clear absent"));
+        store
+            .set_base_url("custom".to_string(), "http://localhost:1234/v1".to_string())
+            .expect("save");
+        assert!(store.clear_base_url("custom").expect("clear present"));
+        assert!(store.snapshot().base_url_for("custom").is_none());
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -25,10 +25,11 @@ use std::sync::mpsc::{self, Receiver};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use support::mock_openai::MockOpenAiServer;
 use support::strip_ansi;
 use support::tui_harness::{
     TuiSpawnOptions, assert_cursor_near_bottom, spawn_tui_llmsim, spawn_tui_llmsim_with,
-    wait_for_exit,
+    spawn_tui_llmsim_with_settings, wait_for_exit,
 };
 
 fn yolop_binary() -> PathBuf {
@@ -478,6 +479,150 @@ fn tui_setup_overlay_renders_in_real_pty() {
         tui.wait_for_output("Esc cancel", Duration::from_secs(3)),
         "/setup footer should render without clipping: {}",
         tui.output_text()
+    );
+}
+
+/// Drive the real TUI binary through the whole model-selection flow:
+/// `/setup` → quick-select a provider that is already connected (saved key)
+/// → the wizard jumps straight to the model picker → quick-select a preset
+/// model → the switch is announced and persisted to settings.toml.
+#[test]
+fn tui_setup_selects_model_for_connected_provider_in_real_pty() {
+    let mut tui = spawn_tui_llmsim_with_settings(
+        &yolop_binary(),
+        TuiSpawnOptions::default(),
+        "provider = \"llmsim\"\n\n[tokens]\nopenai = \"sk-test\"\n",
+    );
+    assert!(
+        tui.wait_for_output("type /help", Duration::from_secs(3)),
+        "TUI did not render startup banner: {}",
+        tui.output_text()
+    );
+
+    tui.write_input(b"/setup\r");
+    assert!(
+        tui.wait_for_output("Set Up Yolop", Duration::from_secs(3)),
+        "/setup should render the provider picker: {}",
+        tui.output_text()
+    );
+    assert!(
+        tui.wait_for_output("saved key", Duration::from_secs(3)),
+        "OpenAI should show as connected via the saved key: {}",
+        tui.output_text()
+    );
+
+    // Quick-select OpenAI (row 1). It is connected, so the wizard must skip
+    // the credential step and open the model picker directly. ratatui only
+    // repaints changed cells, so wait for a string unique to the model list
+    // ("Select Model" partially overlaps the previous title and never
+    // appears contiguously in the raw PTY stream).
+    tui.write_input(b"1");
+    assert!(
+        tui.wait_for_output("gpt-5.4-mini", Duration::from_secs(3)),
+        "connected provider should jump straight to model selection: {}",
+        tui.output_text()
+    );
+    let before_pick = strip_ansi(&tui.output_text());
+    assert!(
+        !before_pick.contains("API Key for OpenAI"),
+        "credential step should be skipped for a connected provider: {before_pick}"
+    );
+
+    // Quick-select the second preset (gpt-5.4).
+    tui.write_input(b"2");
+    assert!(
+        tui.wait_for_output(
+            "setup complete: openai/gpt-5.4 medium",
+            Duration::from_secs(3)
+        ),
+        "model selection should complete with the picked model: {}",
+        tui.output_text()
+    );
+
+    let settings =
+        std::fs::read_to_string(tui.settings_path()).expect("read settings written by the TUI");
+    assert!(
+        settings.contains("provider = \"openai\""),
+        "provider switch should persist: {settings}"
+    );
+    assert!(
+        settings.contains("openai = \"openai/gpt-5.4 medium\""),
+        "picked model should persist under [models]: {settings}"
+    );
+
+    tui.write_input(b"\x03");
+    let status = tui.wait_or_kill(Duration::from_secs(3));
+    assert!(
+        status.success(),
+        "Ctrl-C should exit cleanly, got {status:?}: {}",
+        tui.output_text()
+    );
+}
+
+/// A model picked via `/setup model` must be restored on the next run and
+/// actually sent to the provider. Seeds settings the way the wizard writes
+/// them (custom provider, saved base URL + model), runs one `--print` turn
+/// against a mock OpenAI-compatible server, and asserts the request body
+/// carries the saved model id.
+#[test]
+fn print_mode_sends_saved_model_selection_to_endpoint() {
+    let mock = MockOpenAiServer::spawn("hello from custom endpoint");
+    let home = tempfile::tempdir().expect("home tempdir");
+    let sessions = tempfile::tempdir().expect("sessions tempdir");
+    let settings_toml = format!(
+        "provider = \"custom\"\n\n[base_urls]\ncustom = \"{}\"\n\n[models]\ncustom = \"custom/picked-model-x\"\n",
+        mock.base_url
+    );
+    for settings_dir in [
+        home.path().join(".config/yolop"),
+        home.path().join("Library/Application Support/yolop"),
+    ] {
+        std::fs::create_dir_all(&settings_dir).expect("create settings dir");
+        std::fs::write(settings_dir.join("settings.toml"), &settings_toml).expect("write settings");
+    }
+
+    let output = Command::new(yolop_binary())
+        .args([
+            "--session-dir",
+            sessions.path().to_str().unwrap(),
+            "-p",
+            "hi",
+        ])
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join(".config"))
+        .env("XDG_DATA_HOME", home.path().join(".local/share"))
+        .env_remove("OPENAI_API_KEY")
+        .env_remove("ANTHROPIC_API_KEY")
+        .env_remove("OPENROUTER_API_KEY")
+        .env_remove("GEMINI_API_KEY")
+        .env_remove("GOOGLE_API_KEY")
+        .env_remove("OLLAMA_BASE_URL")
+        .env_remove("OLLAMA_API_KEY")
+        .env_remove("CUSTOM_BASE_URL")
+        .env_remove("CUSTOM_API_KEY")
+        .env_remove("EVERRUNS_CLI_MODEL")
+        .env_remove("EVERRUNS_CLI_REASONING_EFFORT")
+        .output()
+        .expect("spawn yolop against mock endpoint");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "saved-model run failed: stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        stdout.contains("custom/picked-model-x"),
+        "startup banner should show the restored model: {stdout}"
+    );
+    assert!(
+        stdout.contains("hello from custom endpoint"),
+        "mock reply should reach the transcript: {stdout}"
+    );
+
+    let request = mock.next_request(Duration::from_secs(5));
+    assert_eq!(
+        request["model"], "picked-model-x",
+        "request must carry the saved model id: {request}"
     );
 }
 

--- a/tests/support/mock_openai.rs
+++ b/tests/support/mock_openai.rs
@@ -1,0 +1,137 @@
+//! Minimal OpenAI-compatible Chat Completions mock for integration tests.
+//!
+//! Binds an ephemeral localhost port and answers `POST */chat/completions`
+//! with a fixed assistant reply, echoing every parsed request body to the
+//! test through a channel so assertions can inspect what the driver actually
+//! sent (model id, messages, stream flag, …). Handles both streaming (SSE)
+//! and non-streaming requests, so it keeps working whichever mode the
+//! Chat Completions driver picks.
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::thread;
+use std::time::Duration;
+
+pub struct MockOpenAiServer {
+    /// Base URL ending in `/v1`, ready for `CUSTOM_BASE_URL` / settings.
+    pub base_url: String,
+    requests: Receiver<serde_json::Value>,
+}
+
+impl MockOpenAiServer {
+    pub fn spawn(reply_text: &str) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock server");
+        let addr = listener.local_addr().expect("mock server addr");
+        let (tx, requests) = mpsc::channel();
+        let reply_text = reply_text.to_string();
+        thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(stream) = stream else { break };
+                // Serial handling is fine: the driver sends one request at a
+                // time and each response closes the connection.
+                handle_connection(stream, &tx, &reply_text);
+            }
+        });
+        Self {
+            base_url: format!("http://{addr}/v1"),
+            requests,
+        }
+    }
+
+    /// Next request body the server received, or panic after `timeout`.
+    pub fn next_request(&self, timeout: Duration) -> serde_json::Value {
+        self.requests
+            .recv_timeout(timeout)
+            .expect("mock server should receive a chat completions request")
+    }
+}
+
+fn handle_connection(mut stream: TcpStream, tx: &Sender<serde_json::Value>, reply_text: &str) {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .expect("set read timeout");
+    let Some(body) = read_request_body(&mut stream) else {
+        return;
+    };
+    let Ok(request) = serde_json::from_slice::<serde_json::Value>(&body) else {
+        return;
+    };
+    let model = request["model"].as_str().unwrap_or("m").to_string();
+    let streaming = request["stream"].as_bool().unwrap_or(false);
+    let _ = tx.send(request);
+
+    if streaming {
+        let chunk = serde_json::json!({
+            "id": "c1", "object": "chat.completion.chunk", "created": 0, "model": model,
+            "choices": [{ "index": 0,
+                "delta": { "role": "assistant", "content": reply_text },
+                "finish_reason": null }],
+        });
+        let done = serde_json::json!({
+            "id": "c1", "object": "chat.completion.chunk", "created": 0, "model": model,
+            "choices": [{ "index": 0, "delta": {}, "finish_reason": "stop" }],
+            "usage": { "prompt_tokens": 1, "completion_tokens": 5, "total_tokens": 6 },
+        });
+        let body = format!("data: {chunk}\n\ndata: {done}\n\ndata: [DONE]\n\n");
+        let _ = write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+    } else {
+        let response = serde_json::json!({
+            "id": "c1", "object": "chat.completion", "created": 0, "model": model,
+            "choices": [{ "index": 0,
+                "message": { "role": "assistant", "content": reply_text },
+                "finish_reason": "stop" }],
+            "usage": { "prompt_tokens": 1, "completion_tokens": 5, "total_tokens": 6 },
+        });
+        let body = response.to_string();
+        let _ = write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+    }
+    let _ = stream.flush();
+}
+
+/// Read one HTTP request and return its body (requires Content-Length, which
+/// reqwest always sends for JSON bodies).
+fn read_request_body(stream: &mut TcpStream) -> Option<Vec<u8>> {
+    let mut buf = Vec::new();
+    let mut chunk = [0_u8; 4096];
+    let header_end = loop {
+        if let Some(pos) = find_header_end(&buf) {
+            break pos;
+        }
+        let n = stream.read(&mut chunk).ok()?;
+        if n == 0 {
+            return None;
+        }
+        buf.extend_from_slice(&chunk[..n]);
+    };
+    let headers = String::from_utf8_lossy(&buf[..header_end]);
+    let content_length: usize = headers
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse().ok())?
+        })
+        .unwrap_or(0);
+    let body_start = header_end + 4;
+    while buf.len() < body_start + content_length {
+        let n = stream.read(&mut chunk).ok()?;
+        if n == 0 {
+            return None;
+        }
+        buf.extend_from_slice(&chunk[..n]);
+    }
+    Some(buf[body_start..body_start + content_length].to_vec())
+}
+
+fn find_header_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == b"\r\n\r\n")
+}

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,3 +1,4 @@
+pub mod mock_openai;
 pub mod tui_harness;
 
 /// Strip ANSI CSI sequences from terminal output.

--- a/tests/support/tui_harness.rs
+++ b/tests/support/tui_harness.rs
@@ -41,6 +41,12 @@ impl TuiHarness {
         self.writer.flush().expect("flush pty input");
     }
 
+    /// The settings.toml the spawned TUI reads and writes (Linux config
+    /// layout; the harness seeds the macOS path with the same content).
+    pub fn settings_path(&self) -> PathBuf {
+        self._home.path().join(".config/yolop/settings.toml")
+    }
+
     pub fn resize(&mut self, cols: u16, rows: u16) {
         self.master
             .resize(PtySize {
@@ -102,6 +108,14 @@ pub fn spawn_tui_llmsim(binary: &PathBuf) -> TuiHarness {
 }
 
 pub fn spawn_tui_llmsim_with(binary: &PathBuf, options: TuiSpawnOptions) -> TuiHarness {
+    spawn_tui_llmsim_with_settings(binary, options, "provider = \"llmsim\"\n")
+}
+
+pub fn spawn_tui_llmsim_with_settings(
+    binary: &PathBuf,
+    options: TuiSpawnOptions,
+    settings_toml: &str,
+) -> TuiHarness {
     let session_dir = tempfile::tempdir().expect("session tempdir");
     let home = tempfile::tempdir().expect("home tempdir");
     for settings_dir in [
@@ -109,11 +123,7 @@ pub fn spawn_tui_llmsim_with(binary: &PathBuf, options: TuiSpawnOptions) -> TuiH
         home.path().join("Library/Application Support/yolop"),
     ] {
         std::fs::create_dir_all(&settings_dir).expect("create settings dir");
-        std::fs::write(
-            settings_dir.join("settings.toml"),
-            "provider = \"llmsim\"\n",
-        )
-        .expect("write settings");
+        std::fs::write(settings_dir.join("settings.toml"), settings_toml).expect("write settings");
     }
     let pty_system = NativePtySystem::default();
     let pair = pty_system
@@ -135,8 +145,14 @@ pub fn spawn_tui_llmsim_with(binary: &PathBuf, options: TuiSpawnOptions) -> TuiH
     cmd.env_remove("OPENAI_API_KEY");
     cmd.env_remove("ANTHROPIC_API_KEY");
     cmd.env_remove("OPENROUTER_API_KEY");
+    cmd.env_remove("GEMINI_API_KEY");
+    cmd.env_remove("GOOGLE_API_KEY");
     cmd.env_remove("OLLAMA_BASE_URL");
     cmd.env_remove("OLLAMA_API_KEY");
+    cmd.env_remove("CUSTOM_BASE_URL");
+    cmd.env_remove("CUSTOM_API_KEY");
+    cmd.env_remove("EVERRUNS_CLI_MODEL");
+    cmd.env_remove("EVERRUNS_CLI_REASONING_EFFORT");
 
     let child = pair.slave.spawn_command(cmd).expect("spawn yolop TUI");
     drop(pair.slave);


### PR DESCRIPTION
## Summary

Redesigns `/setup` around connection state and adds a generic OpenAI-compatible provider:

- **Connection status in the provider picker** — each row shows whether the provider is usable right now: `✓ OPENAI_API_KEY` (env), `✓ saved key`, `✓ no key needed` (Ollama/llmsim), `✓ base URL set` (custom), or `needs API key` / `needs base URL`.
- **Fast path to model selection** — Enter on a connected provider switches to it and jumps straight to the model picker; the credential step only appears for unconnected providers (or explicitly via the new `c` key, which opens key/base-URL configuration even when connected).
- **New `custom` provider** — any OpenAI-compatible Chat Completions endpoint (vLLM, llama.cpp, LM Studio, gateways). Base URL from `CUSTOM_BASE_URL` or settings (`[base_urls]`, managed by a new wizard step / `setup url custom <url|clear>`), optional `CUSTOM_API_KEY` (placeholder sent otherwise), free-form model id. Reasoning effort passes through like OpenRouter. Live model discovery (#82) works against it via the OpenAI-compatible `GET /models` fallback.
- **Model picks now actually persist** — the picker has always claimed "applies to future sessions", but `/setup model` never persisted anything. Model and effort choices are now saved per provider under `[models]` (provider-relative `model [effort]` specs, matching #82's format) and restored at startup; `-m/--model` and `EVERRUNS_CLI_MODEL` still override.
- `setup provider <name> [model]` switches provider and model atomically — needed by the custom wizard, whose provider-relative `setup model` form has no provider context before the first switch. A bare `provider custom` with no saved model fails with a pointer to `/setup`.
- Fixes a latent #82 regression: the model picker's `· current` marker compared provider-relative specs against the full `provider/model effort` label and never matched.

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features` — green (262 unit + 23 integration, 2 ignored).
- Feature tests drive the real entry points:
  - PTY integration test runs the actual binary through the whole flow: `/setup` → connected provider (saved key) → fast path into the model picker (credential panel asserted absent) → digit-select a preset → `setup complete: openai/gpt-5.4 medium` → settings.toml contains the persisted provider + model.
  - New `tests/support/mock_openai.rs` (local mock Chat Completions server, SSE + JSON): a print-mode run with a saved custom-provider model asserts the HTTP request body carries the picked model id and the reply lands in the transcript.
  - App tests: provider rows show connection status; fast path skips credentials; `c` opens credential config; full custom wizard (URL → no-key → model input) persists base URL + provider + model; preset selection persists.
  - Runtime/host tests: `url` subcommand validation (provider allowlist, http(s)-only, clear), atomic `provider custom <model>`, bare-switch failure without a model, saved-model rehydration precedence (`EVERRUNS_CLI_MODEL` &gt; saved &gt; default).
- Smoke: `cargo run -- --provider llmsim -p "hi"` ✓; `CUSTOM_BASE_URL=… --provider custom -m demo-model -p "hi"` against the mock server returns the mock reply ✓; live `doppler run -- cargo run -- --provider openai -p "Reply with exactly: SMOKE-OK"` → `SMOKE-OK`, `success=true` ✓.

## Security

- **TM-LLM** — keys/base URLs flow only through `SettingsStore` (0o600, atomic rename) and `ModelWithProvider`; token input is masked in the TUI and never echoed to the transcript; the wizard suppresses internal command output so `setup token …` arguments never render. `url` rejects non-http(s) schemes. Env vars keep precedence over saved values.
- **TM-DEP** — no new dependencies (the test mock server is std-only).
- **TM-FS / TM-BASH / TM-TOOL** — untouched: no filesystem, shell, or capability-registration changes.
- Input validation: provider names checked against allowlists (`TOKEN_PROVIDERS`, `BASE_URL_PROVIDERS`); empty model ids rejected on provider/model switch; malformed saved specs are ignored at rehydrate rather than fatal.

## Follow-ups

No follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_015iWkuX2Xs8fAs3Mf6d7mQq)_