### PR TITLE
chore(deps): bump everruns crates to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f9cb3f09e58ce7e04d1835f84c41f8a356cebaec17ec24f322d05511241906"
+checksum = "9959d933eb5dfd655016e48a4f04b3110d80d79001734c7e970baeace4fd9264"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1293,18 +1293,18 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3495ad83dfb6500df5fe10a88b86346e6aa59c861dbf4f5a21698715ccd8f00"
+checksum = "1815c265fcf5fff18ffb10abd543ff2ec14a80e8db69f5f923c5d1ae654c9ba6"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-core"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf18c513a47443103e14be2d466b07f1d4016d17a1b8e674c725739e5e379f8d"
+checksum = "276f7367df0b2471e7fb89bb04c94ddfacc2f448e79eafbe4c7eb79b98ae1f8b"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -1334,6 +1334,7 @@ dependencies = [
  "similar",
  "thiserror 2.0.18",
  "tokio",
+ "toml 0.8.23",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -1343,9 +1344,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1697167ea52ea63b74e89b12a8ad30c2b33d799780b013cc8a769aad3159f3a"
+checksum = "1f03baebe37835c5abd8a14abd9eb31eb8f7b407235eb90a3a042b0c520810d7"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1359,9 +1360,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a771838aa949510b081044950566e2bb7784b731055a32b153f8906abc1a4909"
+checksum = "1cf93bffba1d5be0f5a62ea0f9e25a67cf43d88137bf804db429edb79ef0488e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1374,9 +1375,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f19e7f3c3324288e0f3d495f203f8e4fc1f496856f49fd3a26edaee58239e0"
+checksum = "066bfedc504e1807483a35656c77d729aedb063e112d9ab446b4fd2d0df4b494"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1395,9 +1396,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9770ad2cfcb4755e3551d65cae1c1ca22decd18b81bed80ae042b67834849fcd"
+checksum = "82c48703734251977d551b207fd484b8bffe338b769ec512e163e060c500108c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2470,7 +2471,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tiktoken-rs",
  "tokio",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -4003,6 +4004,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -4686,17 +4696,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4709,13 +4740,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -5633,6 +5684,15 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
@@ -5797,7 +5857,7 @@ dependencies = [
  "textwrap",
  "tokio",
  "tokio-util",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,13 +37,13 @@ tokio-util = { version = "0.7", features = ["compat"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-everruns-anthropic = "0.9.0"
-everruns-core = "0.9.0"
-everruns-openai = "0.9.0"
+everruns-anthropic = "0.10.0"
+everruns-core = "0.10.0"
+everruns-openai = "0.10.0"
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (specs/mcp.md, upstream runtime-mcp.md D2).
-everruns-runtime = { version = "0.9.0", features = ["mcp-stdio"] }
-everruns-integrations-duckduckgo = "0.9.0"
+everruns-runtime = { version = "0.10.0", features = ["mcp-stdio"] }
+everruns-integrations-duckduckgo = "0.10.0"
 futures = "0.3"
 
 [dev-dependencies]

--- a/src/capabilities/model_discovery.rs
+++ b/src/capabilities/model_discovery.rs
@@ -43,7 +43,10 @@ pub(crate) async fn discover_provider_models(
         LlmProviderType::OpenaiCompletions => ProviderType::OpenAICompletions,
         LlmProviderType::Anthropic => ProviderType::Anthropic,
         LlmProviderType::Gemini => ProviderType::Gemini,
-        LlmProviderType::LlmSim => return Ok(None),
+        LlmProviderType::Openrouter => ProviderType::OpenRouter,
+        // Yolop never constructs Bedrock (no Bedrock driver is registered
+        // below); treat discovery as unsupported rather than erroring.
+        LlmProviderType::Bedrock | LlmProviderType::LlmSim => return Ok(None),
     };
     let mut config = ProviderConfig::new(provider_type);
     if let Some(key) = &target.api_key {


### PR DESCRIPTION
## What

Bump all five `everruns-*` crates together from 0.9.0 to 0.10.0 (latest on crates.io), keeping yolop in lockstep with the published runtime.

## Why

0.10.0 adds first-class `Openrouter` and `Bedrock` variants to `LlmProviderType`, which made the provider match in `model_discovery.rs` non-exhaustive. The only code change is the new match arms:

- `Openrouter` maps to the registry's new `ProviderType::OpenRouter` (registered by `everruns_openai::register_driver`).
- `Bedrock` reports discovery as unsupported (like llmsim) — yolop registers no Bedrock driver.

Yolop's OpenRouter provider choice deliberately stays on the Chat Completions driver (`LlmProviderType::OpenaiCompletions`); the documented rationale in `runtime.rs` (OpenRouter's stateless `/responses` endpoint losing history after turn 1) still applies, so the new upstream `OpenRouterLlmDriver` was not adopted in this bump.

## Validation

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all-features` — 279 unit + 23 integration tests pass, 1 ignored (live OpenRouter)
- `doppler run -- cargo test --all-features --test integration` — pass with live keys loaded
- Offline smoke: `cargo run -- --provider llmsim -p "hi"` — success
- Live smoke: `doppler run -- cargo run -- --provider openai -p "..."` — success, correct reply

Note on test coverage: the two new match arms are unreachable through yolop's `ProviderChoice` entry point (no choice produces a `Openrouter` or `Bedrock` `provider_type`), so they cannot be driven by an automated test today; the existing discovery tests cover all reachable arms, and the full suite plus live smokes exercise the bumped runtime end-to-end.

## Security

- **TM-DEP**: all `everruns-*` crates bumped together (no version skew). New transitive deps in the lockfile (`toml 0.8`, `toml_edit`, `winnow`, `serde_spanned`, `toml_datetime`, `toml_write`) come from `everruns-config`'s TOML parsing — standard, widely-used crates.
- **TM-FS**: `DEFAULT_WRITE_BLOCKLIST` in everruns-runtime 0.10.0 still covers `.git`, `node_modules`, `target`, `dist`, `build`, `.next`, `.venv`, `venv`, `.tox`, `.gradle` at any depth; yolop's `WriteBlocklistFileStore` wiring is unchanged and its tests pass.
- **TM-BASH / TM-TOOL / TM-LLM**: no yolop changes to shell execution, capability registration, or key handling; keys continue to be read from process env/settings only.

## Follow-ups

- Evaluate adopting upstream's new `OpenRouterLlmDriver` (Responses API) for yolop's OpenRouter provider if/when OpenRouter's `/responses` endpoint stores responses; for now Chat Completions remains correct.

---
_Generated by [Claude Code](https://claude.ai/code/session_014UnLFENTmWtWCkoRntDAT8)_