### PR TITLE
feat(openrouter): use first-class OpenRouter Responses driver

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -375,9 +375,8 @@ const REASONING_EFFORT_SUGGESTIONS: &[&str] = &["minimal", "low", "medium", "hig
 const DEFAULT_ANTHROPIC_MODEL: &str = "claude-sonnet-4-5";
 const DEFAULT_GOOGLE_MODEL: &str = "gemini-2.5-flash";
 // Gemini exposes an OpenAI-compatible surface at this base URL, driven through
-// `everruns_openai`. (OpenRouter is OpenAI-compatible too, but it needs the
-// Chat Completions driver — see `model_with_provider` — because its Responses
-// endpoint is stateless.)
+// `everruns_openai`. (OpenRouter has its own first-class driver since
+// everruns 0.10 — see `model_with_provider`.)
 const DEFAULT_GOOGLE_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta/openai";
 const DEFAULT_OPENROUTER_MODEL: &str = "openai/gpt-5.2";
 const DEFAULT_OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
@@ -809,15 +808,16 @@ impl ProviderChoice {
                     .ok_or_else(|| anyhow!("OPENROUTER_API_KEY not set (and no token stored)"))?;
                 Ok(ModelWithProvider {
                     model: model.clone(),
-                    // Chat Completions, not the Open Responses API. OpenRouter's
-                    // /responses endpoint is stateless: it accepts
-                    // `previous_response_id` but silently ignores it (responses are
-                    // never stored), so the Responses driver — which chains turns by
-                    // id and sends only the newest item — loses the task and history
-                    // after turn 1. The model then loops on read-only exploration and
-                    // never makes progress. Chat Completions replays the full
-                    // conversation each turn, which is what OpenRouter supports.
-                    provider_type: LlmProviderType::OpenaiCompletions,
+                    // First-class OpenRouter driver (everruns 0.10+). It speaks
+                    // OpenRouter's OpenAI-compatible Responses API but knows the
+                    // endpoint is stateless (`previous_response_id` is silently
+                    // ignored), so it replays the full transcript each turn
+                    // instead of chaining by response id, and it looks up model
+                    // profiles under the OpenRouter provider so OpenAI-only
+                    // extensions (native phases, hosted tool_search) are never
+                    // sent to the gateway. This replaces the earlier Chat
+                    // Completions workaround for the stateless endpoint.
+                    provider_type: LlmProviderType::Openrouter,
                     api_key: Some(key),
                     base_url: Some(base_url.clone()),
                 })
@@ -880,13 +880,13 @@ impl ProviderChoice {
                 api_key: None,
                 base_url: Some(base_url.clone()),
             },
-            // OpenRouter must use Chat Completions, not the Open Responses API —
-            // see the keyed path in `model_with_provider` for the full rationale.
+            // First-class OpenRouter driver — see the keyed path in
+            // `model_with_provider` for the full rationale.
             ProviderChoice::OpenRouter {
                 model, base_url, ..
             } => ModelWithProvider {
                 model: model.clone(),
-                provider_type: LlmProviderType::OpenaiCompletions,
+                provider_type: LlmProviderType::Openrouter,
                 api_key: None,
                 base_url: Some(base_url.clone()),
             },
@@ -2154,10 +2154,12 @@ mod tests {
     }
 
     #[test]
-    fn openrouter_uses_chat_completions_driver_not_responses() {
-        // OpenRouter's /responses endpoint ignores `previous_response_id`, which
-        // breaks the Open Responses driver's turn chaining. We must route through
-        // the stateless Chat Completions driver instead.
+    fn openrouter_uses_first_class_openrouter_driver() {
+        // OpenRouter routes through the first-class OpenRouter provider type
+        // (everruns 0.10+): the driver replays the full transcript each turn
+        // (the /responses endpoint ignores `previous_response_id`) and resolves
+        // model profiles under the OpenRouter provider, so OpenAI-only
+        // extensions are never sent to the gateway.
         let _guard = crate::test_env::lock();
         unsafe {
             std::env::set_var("OPENROUTER_API_KEY", "test-or-key");
@@ -2173,7 +2175,7 @@ mod tests {
             std::env::remove_var("OPENROUTER_API_KEY");
         }
 
-        assert_eq!(model.provider_type, LlmProviderType::OpenaiCompletions);
+        assert_eq!(model.provider_type, LlmProviderType::Openrouter);
         assert_eq!(model.api_key, Some("test-or-key".to_string()));
         assert_eq!(
             model.base_url,
@@ -2181,10 +2183,10 @@ mod tests {
         );
 
         // The keyless fallback path must agree, so /setup and startup don't
-        // silently revert to the Responses driver.
+        // silently fall back to a different driver.
         assert_eq!(
             provider.model_without_stored_key().provider_type,
-            LlmProviderType::OpenaiCompletions
+            LlmProviderType::Openrouter
         );
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -13,8 +13,8 @@
 //
 //     YOLOP_REQUIRE_LIVE_TESTS=1 doppler run -- cargo test --test integration
 //
-// The OpenRouter tests default to a Nemotron 3 model and guard the Chat
-// Completions tool-calling path (everruns EVE-522 / EVE-523).
+// The OpenRouter tests default to a Nemotron 3 model and guard the OpenRouter
+// driver's tool-calling and turn-chaining path (everruns EVE-522 / EVE-523).
 
 mod support;
 
@@ -1074,16 +1074,17 @@ fn openrouter_print_smoke() {
 /// and EVE-523).
 ///
 /// OpenRouter's `/responses` endpoint is stateless (it ignores
-/// `previous_response_id`), so yolop routes OpenRouter through the Chat
-/// Completions driver. On that path, OpenRouter/DeepInfra streams an empty
-/// `content: ""` in the same chunk as `finish_reason: "tool_calls"`, which used
-/// to make the runtime silently drop the tool call — the agent would emit a
-/// `read_file` call, never execute it, and end the turn with no action.
+/// `previous_response_id`). Yolop routes OpenRouter through the first-class
+/// OpenRouter Responses driver (everruns 0.10+), which replays the full
+/// transcript each turn instead of chaining by response id. History loss on
+/// this path is silent: the agent emits a tool call, the result never reaches
+/// the next turn, and the model loops without making progress.
 ///
 /// This test seeds a unique sentinel in a workspace file and asks the model to
 /// read it back. The sentinel is *not* in the prompt, so it can only appear in
 /// the answer if `read_file` actually executed and its result flowed back into
-/// the next turn. A regression on either bug makes this fail.
+/// the next turn. A regression on tool-call streaming or turn chaining makes
+/// this fail.
 #[test]
 fn openrouter_tool_call_executes_end_to_end() {
     let Some(_) = live_key_or_skip("OPENROUTER_API_KEY") else {


### PR DESCRIPTION
## What

Switch yolop's OpenRouter provider from the Chat Completions workaround (`LlmProviderType::OpenaiCompletions`) to the first-class `LlmProviderType::Openrouter` driver introduced in everruns 0.10.

## Why

The Chat Completions routing existed because OpenRouter's `/responses` endpoint is stateless — it accepts `previous_response_id` but silently ignores it, so the Responses driver used to lose the conversation after turn 1. The new `OpenRouterLlmDriver` solves this properly:

- it replays the **full transcript** every turn instead of chaining by response id (`endpoint_persists_responses` treats OpenRouter as stateless), and
- it resolves model profiles under the OpenRouter provider type, so OpenAI-only Responses extensions (native phases, hosted tool_search) are never sent to the gateway, while `anthropic/*` and `openai/*` ids served through OpenRouter get correct profile metadata.

Changes are confined to the two `provider_type` assignments in `runtime.rs` (keyed and keyless paths), the routing-rationale comments, and the test/doc text that asserted the old routing.

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all-features` — 279 unit + 23 integration tests pass
- `openrouter_uses_first_class_openrouter_driver` (renamed/updated) asserts both keyed and keyless paths produce `LlmProviderType::Openrouter`
- **Live, via Doppler** (the risk surface is the wire behavior, so these matter most):
  - `YOLOP_REQUIRE_LIVE_TESTS=1 doppler run -- cargo test --test integration openrouter` — both live tests pass, including `openrouter_tool_call_executes_end_to_end`, whose unique sentinel can only appear in the answer if the tool result survived into the next turn through the stateless endpoint
  - `cargo test discovery_openrouter_live -- --ignored` — model listing works through the new driver
  - Manual multi-step smoke: two sequential `read_file` calls plus arithmetic over their contents through `--provider openrouter` — completed with `success=true iterations=2 tool_calls=2` and the correct answer

## Security

- **TM-LLM**: only the provider-type enum value changes; API key resolution (`OPENROUTER_API_KEY` / stored token) is untouched, the key still goes to the same `openrouter.ai` gateway (now `/responses` instead of `/chat/completions`), and the driver redacts the key in `Debug` output.
- **TM-FS / TM-BASH / TM-TOOL / TM-DEP**: not touched — no filesystem, shell, capability, or dependency changes.

## Follow-ups

No follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_014UnLFENTmWtWCkoRntDAT8)_