### PR TITLE
feat(setup): add Opus 4.7/4.8 and 1M ids to anthropic shortlist

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -642,7 +642,14 @@ impl ProviderChoice {
                 "claude-haiku-4-5",
                 "claude-sonnet-4-6",
                 "claude-opus-4-6",
+                "claude-opus-4-7",
+                "claude-opus-4-8",
                 "claude-fable-5",
+                // `[1m]` ids are the 1M-context twins of the 200K base models;
+                // the everruns-anthropic driver strips the suffix on the wire
+                // and requests the window via the `context-1m` beta header.
+                "claude-fable-5[1m]",
+                "claude-opus-4-8[1m]",
             ],
             "google" => &["gemini-2.5-flash", "gemini-2.5-pro"],
             "openrouter" => &[
@@ -1848,6 +1855,22 @@ mod tests {
         };
         let next = provider.resolve_model_spec("claude-fable-5").unwrap();
         assert_eq!(next.label(), "anthropic/claude-fable-5");
+    }
+
+    #[test]
+    fn model_suggestions_include_1m_context_variants() {
+        // The `[1m]` ids resolve through the normal Anthropic model-spec path;
+        // the driver handles the suffix (bare id on the wire + `context-1m`
+        // beta header), so yolop only needs to offer them in the picker.
+        let suggestions = ProviderChoice::model_suggestions_for_provider("anthropic");
+        assert!(suggestions.contains(&"claude-fable-5[1m]"));
+        assert!(suggestions.contains(&"claude-opus-4-8[1m]"));
+
+        let provider = ProviderChoice::Anthropic {
+            model: "claude-sonnet-4-5".to_string(),
+        };
+        let next = provider.resolve_model_spec("claude-fable-5[1m]").unwrap();
+        assert_eq!(next.label(), "anthropic/claude-fable-5[1m]");
     }
 
     #[test]


### PR DESCRIPTION
## What

Refresh the curated Anthropic model shortlist (the offline fallback shown in `/setup` before/instead of live model discovery) with the models everruns 0.10 added profiles for: `claude-opus-4-7`, `claude-opus-4-8`, and the 1M-context twins `claude-fable-5[1m]` and `claude-opus-4-8[1m]`.

## Why

everruns 0.10 ships profiles for the `[1m]` large-context model ids. The everruns-anthropic driver fully handles them — it strips the suffix on the wire and requests the 1M window via the `context-1m` beta header — so yolop only needs to offer the ids in the picker. The curated list was also missing the Opus 4.7/4.8 base models entirely; users without a working models-API connection never saw them.

Only the two newest flagships get `[1m]` entries to keep the shortlist tight; live discovery and the "Custom..." entry cover the rest.

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all-features` — 280 unit + 23 integration tests pass, including the new `model_suggestions_include_1m_context_variants` test that drives `resolve_model_spec("claude-fable-5[1m]")` through the real model-switch entry point
- Live, via Doppler: `--provider anthropic --model "claude-fable-5[1m]"` and `--model "claude-opus-4-8"` both complete a print-mode turn with `success=true` (proves the beta-header path works with a real key, not just that the ids parse)

## Security

No security-relevant code changes: the diff adds entries to a static suggestion list and a test. No key handling, filesystem, shell, or dependency surface is touched.

## Follow-ups

- `DEFAULT_ANTHROPIC_MODEL` is still `claude-sonnet-4-5`; bumping the default is a product decision deliberately not bundled into this list refresh.

---
_Generated by [Claude Code](https://claude.ai/code/session_014UnLFENTmWtWCkoRntDAT8)_