### PR TITLE
docs(readme): document EVERRUNS_SYSTEM_ALLOWLIST_ENABLED

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,11 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   timeout and per-stream 1 MiB output cap; large output is spilled to disk
   under the session folder and stays readable.
 - **Web** — `web_fetch` (HTTP GET/HEAD with markdown/text conversion, DNS-pinned
-  SSRF protection) and `duckduckgo_search` (free, no API key).
+  SSRF protection) and `duckduckgo_search` (free, no API key). Setting
+  `EVERRUNS_SYSTEM_ALLOWLIST_ENABLED=true` restricts `web_fetch` to the
+  runtime's curated allowlist of well-known public resources (package
+  registries, source hosting, AI/cloud provider APIs, OS mirrors); off by
+  default.
 
 ### Context engineering
 


### PR DESCRIPTION
## What

Document the `EVERRUNS_SYSTEM_ALLOWLIST_ENABLED` environment variable in the README's Tools section.

## Why

everruns 0.10 added an optional, host-curated egress allowlist ("green list" of package registries, source hosting, AI/cloud provider APIs, OS mirrors). Yolop's `web_fetch` capability picks it up from the environment automatically — no yolop code involved — so the only gap was discoverability.

## Validation

Docs-only change, no behavior change, so code tests are exempt — but the documented claim itself was verified live before writing it down: with `EVERRUNS_SYSTEM_ALLOWLIST_ENABLED=true`, a `web_fetch` of `https://example.com` through `--provider openai` returns "Endpoint blocked by system policy: … not on the deployment's system allowlist", and the flag is off by default (unset env leaves behavior unchanged).

## Security

No security-relevant code changes — README prose only. The documented flag is itself a hardening feature (TM-FS/network egress adjacent) enforced inside everruns-core.

## Follow-ups

No follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_014UnLFENTmWtWCkoRntDAT8)_