### PR TITLE
fix(tui): tolerate unanswered cursor queries, unpin ratatui 0.30.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "strum 0.28.0",
+ "strum",
  "tracing",
 ]
 
@@ -192,7 +192,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -203,7 +203,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -211,6 +211,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "async-channel"
@@ -628,6 +637,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,6 +905,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1135,7 +1156,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1229,7 +1250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1444,6 +1465,12 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
@@ -1789,6 +1816,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -2493,11 +2525,11 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -2653,7 +2685,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2822,6 +2854,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad5fd71b79026fb918650dde6d125000a233764f1c2f1659a1c71118e33ea08f"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3434,9 +3490,9 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ratatui"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+checksum = "1695748e3a735b34968c887ceea5a380b43545903868ae8f5b666593100f6b68"
 dependencies = [
  "instability",
  "ratatui-core",
@@ -3444,22 +3500,26 @@ dependencies = [
  "ratatui-macros",
  "ratatui-termwiz",
  "ratatui-widgets",
+ "serde",
 ]
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+checksum = "42d3603f354bba8c595fa47860e60142d7372b7210c27044c6a7d0e1a4336b44"
 dependencies = [
  "bitflags 2.13.0",
  "compact_str",
- "hashbrown 0.16.1",
+ "critical-section",
+ "hashbrown 0.17.1",
  "indoc",
  "itertools",
  "kasuari",
  "lru",
- "strum 0.27.2",
+ "palette",
+ "serde",
+ "strum",
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
@@ -3468,9 +3528,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-crossterm"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+checksum = "2b2867bedcbd6a690ca4f8672a687b730ec07660c79844517b084311b529980c"
 dependencies = [
  "cfg-if",
  "crossterm",
@@ -3480,9 +3540,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-macros"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+checksum = "80fac59720679490d89d200df411faa249be728681adcabed3d047ae72c48f1d"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
@@ -3490,9 +3550,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-termwiz"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+checksum = "386b8ff8f74ed749509391c56d549761a2fcdb408e1f42e467286bcb7dac8967"
 dependencies = [
  "ratatui-core",
  "termwiz",
@@ -3513,18 +3573,19 @@ dependencies = [
 
 [[package]]
 name = "ratatui-widgets"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+checksum = "7ef4f17dd7ac3abf5adc2b920a03c61eee4bfe6a88fa5191936895525371d79c"
 dependencies = [
  "bitflags 2.13.0",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indoc",
  "instability",
  "itertools",
  "line-clipping",
  "ratatui-core",
- "strum 0.27.2",
+ "serde",
+ "strum",
  "time",
  "unicode-segmentation",
  "unicode-width",
@@ -3739,7 +3800,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3807,7 +3868,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4267,7 +4328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4300,32 +4361,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-dependencies = [
- "strum_macros 0.27.2",
-]
-
-[[package]]
-name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros 0.28.0",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "strum_macros",
 ]
 
 [[package]]
@@ -4419,7 +4459,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5446,7 +5486,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5848,7 +5888,6 @@ dependencies = [
  "include_dir",
  "portable-pty",
  "ratatui",
- "ratatui-core",
  "ratatui-textarea",
  "reqwest 0.13.4",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,14 +23,7 @@ clap = { version = "4.5", features = ["derive"] }
 crossterm = "0.29"
 dirs = "6"
 include_dir = "0.7"
-# ratatui-core 0.1.1 (pulled in by the ratatui 0.30.1 family) probes the kitty
-# keyboard protocol before the first draw, which stalls startup when the
-# terminal never replies and breaks every PTY integration test. Pin the exact
-# versions so non-`--locked` builds (e.g. `cargo install yolop`) cannot float
-# onto the broken releases; the ratatui-core pin cascades to the rest of the
-# family. Tracked in #91 — drop both pins once it is resolved.
-ratatui = "=0.30.0"
-ratatui-core = "=0.1.0"
+ratatui = "0.30"
 # Already in the tree via the everruns driver crates; used directly only for
 # the OpenAI-compatible `GET <base>/models` discovery fallback.
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -393,18 +393,29 @@ async fn run_tui(runtime: BuiltRuntime) -> Result<()> {
             viewport: Viewport::Inline(COMPOSER_VIEWPORT_HEIGHT),
         },
     )?;
-    anchor_inline_viewport_at_bottom(&mut terminal)?;
+    // Anchoring is cosmetic. Since ratatui 0.30.1 `insert_before` snapshots
+    // the cursor (via `Terminal::clear`) with a blocking `CSI 6n` query that
+    // slow emulators (ttyd / xterm.js) may not answer before crossterm's ~2s
+    // timeout. Start unanchored rather than dying.
+    if let Err(err) = anchor_inline_viewport_at_bottom(&mut terminal) {
+        tracing::warn!("inline viewport anchoring failed, starting unanchored: {err:#}");
+    }
 
     let mut app = App::new(runtime);
     let result = app.run(&mut terminal).await;
     let show_resume_hint = app.should_show_resume_hint();
     let session_id = app.session_id();
 
-    let cleanup_result = terminal.clear().and_then(|_| terminal.show_cursor());
+    // Cosmetic cleanup must not turn a successful session into an error
+    // exit: since ratatui 0.30.1 `Terminal::clear` issues the same blocking
+    // cursor query as anchoring above. Raw-mode restore below still fails
+    // hard — leaving the terminal unusable is worth a nonzero exit.
+    if let Err(err) = terminal.clear().and_then(|_| terminal.show_cursor()) {
+        tracing::warn!("terminal cleanup failed: {err:#}");
+    }
     drop(terminal);
     keyboard_enhancements.disable();
     raw_mode.disable()?;
-    cleanup_result?;
 
     if show_resume_hint {
         println!();

--- a/src/main.rs
+++ b/src/main.rs
@@ -408,10 +408,15 @@ async fn run_tui(runtime: BuiltRuntime) -> Result<()> {
 
     // Cosmetic cleanup must not turn a successful session into an error
     // exit: since ratatui 0.30.1 `Terminal::clear` issues the same blocking
-    // cursor query as anchoring above. Raw-mode restore below still fails
+    // cursor query as anchoring above. The two steps are independent —
+    // restoring the cursor is a plain escape write that should still happen
+    // when the clear's query times out. Raw-mode restore below still fails
     // hard — leaving the terminal unusable is worth a nonzero exit.
-    if let Err(err) = terminal.clear().and_then(|_| terminal.show_cursor()) {
-        tracing::warn!("terminal cleanup failed: {err:#}");
+    if let Err(err) = terminal.clear() {
+        tracing::warn!("terminal clear failed: {err:#}");
+    }
+    if let Err(err) = terminal.show_cursor() {
+        tracing::warn!("cursor restore failed: {err:#}");
     }
     drop(terminal);
     keyboard_enhancements.disable();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -383,6 +383,7 @@ fn tui_survives_slow_cursor_position_reply_after_resize() {
     // appears as the transcript first overflows. The harness deliberately
     // does NOT answer the cursor-position query this triggers, emulating a
     // busy emulator. crossterm's 2s query timeout fires at least once.
+    tui.set_answer_cursor_queries(false);
     tui.resize(79, 24);
     assert!(
         wait_for_exit(&mut *tui.child, Duration::from_secs(5)).is_none(),
@@ -390,15 +391,79 @@ fn tui_survives_slow_cursor_position_reply_after_resize() {
         tui.output_text()
     );
 
-    // The emulator catches up: answer the (retried) query, then Ctrl-C. The
-    // reply must come first — the event loop is blocked inside the cursor
-    // query until it arrives.
+    // The emulator catches up: answer the (retried) query by hand, resume
+    // answering future queries, then Ctrl-C. The manual reply must come
+    // first — the event loop is blocked inside the cursor query until it
+    // arrives, and the harness responder only answers queries it sees after
+    // being re-enabled.
     tui.write_input(b"\x1b[1;1R");
+    tui.set_answer_cursor_queries(true);
     tui.write_input(b"\x03");
     let status = tui.wait_or_kill(Duration::from_secs(10));
     assert!(
         status.success(),
         "Ctrl-C should exit cleanly after recovery, got {status:?}: {}",
+        tui.output_text()
+    );
+}
+
+// ratatui 0.30.1 `Terminal::clear` snapshots the cursor with a blocking
+// `CSI 6n` query, and the inline viewport calls `clear` inside
+// `insert_before` — so viewport anchoring, every transcript flush, and exit
+// cleanup all issue cursor-position queries beyond the one
+// `Terminal::with_options` always made. A slow emulator (ttyd / xterm.js,
+// see the resize test above) may answer the first query and then go silent.
+// These paths are cosmetic: crossterm's ~2s per-query timeout must degrade
+// the session, not kill it. The two tests below pin that down for startup
+// and for exit.
+
+#[test]
+fn tui_starts_when_emulator_answers_only_the_first_cursor_query() {
+    let mut tui = spawn_tui_llmsim_with(
+        &yolop_binary(),
+        TuiSpawnOptions {
+            cursor_reply_budget: 1,
+            ..TuiSpawnOptions::default()
+        },
+    );
+    // Every unanswered query eats a ~2s crossterm timeout before yolop moves
+    // on, so the banner can take several stalls to appear. The point is that
+    // it appears at all instead of the process dying at anchor time.
+    assert!(
+        tui.wait_for_output("type /help", Duration::from_secs(20)),
+        "TUI did not render startup banner despite anchoring query going unanswered: {}",
+        tui.output_text()
+    );
+    assert!(
+        wait_for_exit(&mut *tui.child, Duration::from_millis(200)).is_none(),
+        "TUI exited after unanswered cursor-position queries: {}",
+        tui.output_text()
+    );
+}
+
+#[test]
+fn tui_exits_cleanly_when_emulator_stops_answering_cursor_queries() {
+    let mut tui = spawn_tui_llmsim(&yolop_binary());
+    assert!(
+        tui.wait_for_output("type /help", Duration::from_secs(3)),
+        "TUI did not render startup banner: {}",
+        tui.output_text()
+    );
+
+    // The emulator goes silent after startup; Ctrl-C's terminal cleanup
+    // (`Terminal::clear`) gets no answer to its cursor query. The session
+    // was successful, so the exit must still be clean.
+    tui.set_answer_cursor_queries(false);
+    tui.write_input(b"\x03");
+    let status = tui.wait_or_kill(Duration::from_secs(10));
+    assert!(
+        status.success(),
+        "Ctrl-C should exit cleanly despite cleanup query going unanswered, got {status:?}: {}",
+        tui.output_text()
+    );
+    assert!(
+        tui.output_text().contains("Resume with yolop --session"),
+        "cleanup should still print resume hint: {}",
         tui.output_text()
     );
 }
@@ -411,6 +476,7 @@ fn tui_startup_anchors_composer_from_top_in_tall_terminal() {
             rows: 40,
             cols: 100,
             cursor_row: 1,
+            ..TuiSpawnOptions::default()
         },
     );
     assert!(
@@ -430,6 +496,7 @@ fn tui_startup_anchors_composer_when_prompt_is_already_near_bottom() {
             rows: 24,
             cols: 80,
             cursor_row: 23,
+            ..TuiSpawnOptions::default()
         },
     );
     assert!(
@@ -449,6 +516,7 @@ fn tui_startup_anchors_composer_in_short_terminal() {
             rows: 8,
             cols: 80,
             cursor_row: 1,
+            ..TuiSpawnOptions::default()
         },
     );
     assert!(

--- a/tests/support/tui_harness.rs
+++ b/tests/support/tui_harness.rs
@@ -1,6 +1,8 @@
 use std::io::{Read, Write};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::mpsc::{self, Receiver};
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -11,9 +13,10 @@ use portable_pty::{
 pub struct TuiHarness {
     pub child: Box<dyn Child + Send + Sync>,
     master: Box<dyn MasterPty + Send>,
-    writer: Box<dyn Write + Send>,
+    writer: Arc<Mutex<Box<dyn Write + Send>>>,
     output_rx: Receiver<Vec<u8>>,
     output: Vec<u8>,
+    answer_cursor_queries: Arc<AtomicBool>,
     _session_dir: tempfile::TempDir,
     _home: tempfile::TempDir,
 }
@@ -23,6 +26,10 @@ pub struct TuiSpawnOptions {
     pub rows: u16,
     pub cols: u16,
     pub cursor_row: u16,
+    /// How many `CSI 6n` cursor-position queries the harness answers before
+    /// going silent, emulating an emulator that stops replying mid-session.
+    /// `usize::MAX` (the default) answers every query like a real terminal.
+    pub cursor_reply_budget: usize,
 }
 
 impl Default for TuiSpawnOptions {
@@ -31,14 +38,23 @@ impl Default for TuiSpawnOptions {
             rows: 24,
             cols: 80,
             cursor_row: 1,
+            cursor_reply_budget: usize::MAX,
         }
     }
 }
 
 impl TuiHarness {
     pub fn write_input(&mut self, bytes: &[u8]) {
-        self.writer.write_all(bytes).expect("write pty input");
-        self.writer.flush().expect("flush pty input");
+        let mut writer = self.writer.lock().expect("lock pty writer");
+        writer.write_all(bytes).expect("write pty input");
+        writer.flush().expect("flush pty input");
+    }
+
+    /// Pause or resume the harness answering `CSI 6n` cursor-position
+    /// queries. Pausing emulates a busy terminal emulator that stops
+    /// replying (see `tui_survives_slow_cursor_position_reply_after_resize`).
+    pub fn set_answer_cursor_queries(&self, answer: bool) {
+        self.answer_cursor_queries.store(answer, Ordering::SeqCst);
     }
 
     /// The settings.toml the spawned TUI reads and writes (Linux config
@@ -157,13 +173,56 @@ pub fn spawn_tui_llmsim_with_settings(
     let child = pair.slave.spawn_command(cmd).expect("spawn yolop TUI");
     drop(pair.slave);
 
+    let writer = Arc::new(Mutex::new(
+        pair.master.take_writer().expect("take pty writer"),
+    ));
+    let answer_cursor_queries = Arc::new(AtomicBool::new(true));
+
+    // Real terminals answer every `CSI 6n` cursor-position query; ratatui's
+    // inline viewport issues them at init, inside `insert_before` (via
+    // `Terminal::clear`), and on resize. The reader thread plays terminal:
+    // it scans the output stream for queries and replies with the configured
+    // cursor row, unless paused or out of budget.
     let (output_tx, output_rx) = mpsc::channel();
     let mut reader = pair.master.try_clone_reader().expect("clone pty reader");
+    let responder_writer = Arc::clone(&writer);
+    let responder_enabled = Arc::clone(&answer_cursor_queries);
+    let cursor_row = options.cursor_row.clamp(1, options.rows.max(1));
+    let reply_budget = AtomicUsize::new(options.cursor_reply_budget);
     thread::spawn(move || {
+        const QUERY: &[u8] = b"\x1b[6n";
         let mut buf = [0_u8; 4096];
+        // Carry the unmatched tail across reads so a query split between
+        // chunks is still recognized.
+        let mut pending: Vec<u8> = Vec::new();
         while let Ok(n) = reader.read(&mut buf) {
             if n == 0 {
                 break;
+            }
+            pending.extend_from_slice(&buf[..n]);
+            let mut queries = 0;
+            while let Some(at) = find_subsequence(&pending, QUERY) {
+                pending.drain(..at + QUERY.len());
+                queries += 1;
+            }
+            let keep = pending.len().min(QUERY.len() - 1);
+            let tail: Vec<u8> = pending[pending.len() - keep..].to_vec();
+            pending = tail;
+            for _ in 0..queries {
+                if !responder_enabled.load(Ordering::SeqCst) {
+                    continue;
+                }
+                if reply_budget
+                    .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |budget| {
+                        (budget > 0).then(|| budget.saturating_sub(1))
+                    })
+                    .is_err()
+                {
+                    continue;
+                }
+                let mut writer = responder_writer.lock().expect("lock pty writer");
+                let _ = writer.write_all(format!("\x1b[{cursor_row};1R").as_bytes());
+                let _ = writer.flush();
             }
             if output_tx.send(buf[..n].to_vec()).is_err() {
                 break;
@@ -171,21 +230,22 @@ pub fn spawn_tui_llmsim_with_settings(
         }
     });
 
-    let mut writer = pair.master.take_writer().expect("take pty writer");
-    let cursor_row = options.cursor_row.clamp(1, options.rows.max(1));
-    writer
-        .write_all(format!("\x1b[{cursor_row};1R").as_bytes())
-        .expect("seed cursor position response");
-    writer.flush().expect("flush cursor position response");
     TuiHarness {
         child,
         master: pair.master,
         writer,
         output_rx,
         output: Vec::new(),
+        answer_cursor_queries,
         _session_dir: session_dir,
         _home: home,
     }
+}
+
+fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
 }
 
 pub fn wait_for_exit(child: &mut dyn Child, timeout: Duration) -> Option<ExitStatus> {


### PR DESCRIPTION
## What

Deep-dive into #91 (the ratatui 0.30.1 holdback) plus the fix that lets the family be unpinned.

### Root cause (corrects the original #91 diagnosis)

Instrumented backtraces (patched `CrosstermBackend::get_cursor_position` capturing `Backtrace::force_capture`) show that **ratatui-core 0.1.1 made `Terminal::clear()` snapshot/restore the cursor**, which issues a blocking `CSI 6n` query (`buffers.rs:148`) — and the inline viewport's `insert_before` calls `clear()` internally (`inline.rs:212`). Startup viewport anchoring, every transcript flush, and exit cleanup each gained a blocking cursor-position round trip beyond the single query `with_options` always made. It was never a kitty-protocol probe; the `[>9u` in the failing output is yolop's own `KeyboardEnhancementGuard`.

The PTY harness seeded exactly one CPR reply, so the second startup query hit crossterm's ~2s timeout, errored out of `anchor_inline_viewport_at_bottom`, and the binary exited before drawing the banner. Real terminals answer every CPR query — interactive use was never broken — but slow emulators (ttyd / xterm.js, the class the existing resize regression test defends against) could now die at startup or report a failed exit after a successful session.

### Changes

1. **Harness**: the PTY reader thread now answers every `CSI 6n` like a real terminal — pausable (`set_answer_cursor_queries`) and budget-limited (`cursor_reply_budget`) so the slow-emulator tests can still withhold replies deliberately. The one-shot seeded reply is gone.
2. **Hardening** (`src/main.rs`): viewport anchoring at startup and `terminal.clear()`/`show_cursor()` at exit are cosmetic — an unanswered cursor query now degrades the session (~2s stall + `tracing::warn`) instead of killing it. Raw-mode restore still fails hard. This extends the existing slow-emulator stance documented in `tui_survives_slow_cursor_position_reply_after_resize`.
3. **Unpin**: the exact `ratatui`/`ratatui-core` pins from #92 are dropped; family updated to 0.30.1 / 0.1.1.

## Validation

- Failing tests first: the two new regression tests (`tui_starts_when_emulator_answers_only_the_first_cursor_query`, `tui_exits_cleanly_when_emulator_stops_answering_cursor_queries`) fail without the hardening, pass with it.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` clean.
- `cargo test --all-features`: 280 unit + 25 integration passed (12 TUI PTY tests, all against ratatui 0.30.1), 1 ignored (needs `ANTHROPIC_API_KEY`). The TUI suite also got faster (~6.5s vs ~13s) since the responder answers queries immediately.
- Offline smoke (`--provider llmsim -p "hi"`) and live smoke (`doppler run -- … --provider openai`) both pass.

## Security

TM-DEP: ratatui family 0.30.0→0.30.1 adds six transitive crates (`palette`, `palette_derive`, `fast-srgb8`, `approx`, `by_address`, `critical-section` — ratatui's own color-handling stack) and drops `strum`/`strum_macros`; `everruns-*` unchanged at 0.10.0. Code changes are error-tolerance in cosmetic terminal-cleanup paths and test-only harness work — no trust-boundary, filesystem, shell, or key-handling changes (TM-FS/TM-BASH/TM-LLM/TM-TOOL untouched).

## Follow-ups

- Consider raising upstream that `Terminal::clear()` performing blocking terminal I/O (and `insert_before` calling it per transcript flush) landed in a ratatui-core **patch** release; in CPR-less environments every inline-viewport flush now stalls ~2s.

Closes #91.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BWNkfLX1r3sKb5AUzBJTmd)_