### PR TITLE
feat(config): schema-described settings with get_config/set_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,9 @@ Provider resolution at startup:
    can be configured
 
 The model saved by `/setup model` for the resolved provider is restored,
-unless `-m/--model` or `EVERRUNS_CLI_MODEL` overrides it. At runtime, the
+unless `-m/--model` or `EVERRUNS_CLI_MODEL` overrides it. When the resolved
+provider has no saved model, the global `default_model` setting (if set) is
+applied as a cross-provider fallback. At runtime, the
 per-provider env var (`OPENAI_API_KEY`, etc.) always beats the saved token,
 so a per-run env override is always possible. `/model <id>` opens the model
 picker prefilled for the active provider. OpenAI, OpenRouter, and custom
@@ -317,6 +319,13 @@ or `/setup effort <level>` (for example, `high` or `medium`).
 file is written with `0o600` on Unix (owner-only) and stored token values are
 never echoed — but it is plain text on disk, so treat it the same way you
 would `~/.aws/credentials`.
+
+The settings file is also **schema-described**: every key carries a title,
+description, type, default, and examples (see `specs/configuration.md`). yolop
+itself can read and edit it through the `get_config` and `set_config` tools or
+the `yolop-config` skill — for example, "use anthropic by default", "store my
+OpenAI key", or "set the default model to gpt-5.5 high". Unknown keys in the
+file are ignored, never fatal, so the format stays forward-compatible.
 
 ### Session persistence
 

--- a/skills/yolop-config/SKILL.md
+++ b/skills/yolop-config/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: yolop-config
+description: View and change yolop's own configuration — default provider and model, per-provider API tokens and models, endpoint base URLs, and attribution. Use when the user asks to configure yolop, set a default provider/model, store an API key, point at a custom endpoint, or asks "what is your config / what can you configure".
+user-invocable: true
+---
+
+# Yolop configuration
+
+yolop stores its settings in a single TOML file (`settings.toml` in the yolop
+config dir). The file is loaded tolerantly — unknown keys are ignored, never
+fatal — and every known key carries semantics (title, description, type,
+default, examples) that you can read at runtime. This skill is the entry point
+for inspecting and editing that configuration the way a user describes it.
+
+Do not hand-edit the TOML with the file tools. Use the schema-aware tools so
+values are validated and persisted atomically.
+
+## Inspect
+
+1. Call `get_config` with no arguments to list **every** configuration key with
+   its meaning, type, default, examples, and current value. Secrets (API
+   tokens) are shown only as `stored` / `unset`, never echoed.
+2. Call `get_config` with a single `key` (e.g. `default_provider`,
+   `models.anthropic`, `tokens.openai`) to focus on one entry.
+
+Lead with `get_config` whenever you are unsure of the exact key name or the
+accepted values — the returned schema is the source of truth, so you never have
+to guess.
+
+## Change
+
+Call `set_config` with a `key` and a `value`:
+
+- `set_config key=default_provider value=anthropic` — the default provider when
+  neither `--provider` nor an env credential forces a choice.
+- `set_config key=default_model value="claude-sonnet-4-5"` — global fallback
+  model for the active provider. A per-provider pick wins over it.
+- `set_config key=models.openai value="gpt-5.5 high"` — remember a model for one
+  provider (survives provider switches). The spec is `model [reasoning-effort]`.
+- `set_config key=tokens.anthropic value=…` — store an API token (owner-only on
+  disk). Environment variables still override stored tokens.
+- `set_config key=base_urls.custom value=http://localhost:8000/v1` — endpoint
+  for the OpenAI-compatible `custom` provider.
+- `set_config key=attribution value=off` — turn commit/PR attribution on/off.
+
+Pass `value=clear` to unset an optional or secret key
+(e.g. `set_config key=tokens.openai value=clear`).
+
+Provider and model edits are persisted and take effect on the **next run**. To
+switch the *live* model in the current session, use the interactive `/setup`
+command instead.
+
+## Related surfaces
+
+- **Durable preferences / memory** ("remember that I prefer terse answers"):
+  these are not config keys. Use the `remember_your_memory` /
+  `write_your_memory` tools (the `your` personalization layer), not
+  `set_config`.
+- **Behavioral hooks** (block/allow/audit tool calls): use the `yolop-hooks`
+  skill and the `*_your_hook` tools.
+- **Interactive provider/model setup**: the `/setup` command runs a guided
+  wizard and switches the live model immediately.

--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -1,0 +1,108 @@
+# Configuration schema
+
+Status: v1 implemented.
+
+## Why
+
+yolop's settings live in one TOML file (`settings.toml` in the platform config
+dir). Loading is deliberately tolerant — unknown keys are ignored, never fatal
+(see `Settings::from_table`) — so a user or another tool can add keys without
+breaking yolop. The cost of that tolerance is that the file carries no
+*semantics*: nothing tells the agent (or the user) what a key means, what type
+it takes, what its default is, or how to set it safely.
+
+The configuration schema fills that gap. It is an **informational** schema: it
+never makes loading stricter, it adds meaning. That meaning is what lets the
+agent edit yolop's own configuration the way a user describes it ("use anthropic
+by default", "store my OpenAI key", "point at my local endpoint") instead of
+forcing slash-command syntax.
+
+## What
+
+### Schema registry — single source of truth
+
+`src/config_schema.rs` is a compile-time registry of `ConfigField`s. Each field
+carries a canonical `key`, `aliases`, `title`, `description`, value `kind`
+(`text` / `bool` / `secret`), effective `default`, `examples`, and whether it is
+`provider_scoped` (addressed as `<key>.<provider>`). This one registry feeds
+every configuration surface — the tools below and the `yolop-config` skill — so
+there is no second place to keep in sync.
+
+Keys are addressed the way a human would name them:
+
+| Key                       | Type   | Meaning                                                        |
+|---------------------------|--------|----------------------------------------------------------------|
+| `default_provider`        | text   | Provider used when neither `--provider` nor an env credential forces a choice. Stored on disk as `provider`. |
+| `default_model`           | text   | Global fallback model spec for the active provider; a per-provider pick wins over it. |
+| `models.<provider>`       | text   | Per-provider model spec, survives provider switches.           |
+| `tokens.<provider>`       | secret | Provider API token (owner-only on disk; env vars override).    |
+| `base_urls.<provider>`    | text   | Endpoint base URL (used by the `custom` provider).             |
+| `approval_mode`           | text   | Soft-approval paranoia level (`protective` / `normal` / `off`). |
+| `attribution`             | bool   | Commit/PR attribution on/off.                                  |
+
+`default_provider` and `default_model` are surfaced under those human-friendly
+names. On disk `default_provider` is the long-standing top-level `provider`
+key; `set_config` routes the alias to that one stored field so provider state
+never diverges. `default_model` is a real new top-level key, applied as a
+cross-provider fallback in `ProviderChoice::with_saved_model`.
+
+### Tools
+
+The `config` capability (`src/capabilities/config.rs`) exposes two tools backed
+by the schema:
+
+- **`get_config`** — with no argument, returns every key with its semantics and
+  current value; with a `key`, returns just that entry. Secrets are reported as
+  `stored` / `unset`, never echoed.
+- **`set_config`** — validates a `key`/`value` against the schema and persists
+  through `SettingsStore` (atomic write, owner-only). `value=clear` unsets an
+  optional or secret key.
+
+Both honor aliases and validate provider segments against the supported-provider
+list. Provider/model edits take effect on the next run; `/setup` remains the way
+to switch the *live* model mid-session.
+
+### Configuration as a service
+
+Configuration is exposed to the rest of the agent as a **service** so that
+capabilities can read it without re-parsing the TOML or reaching into store
+internals. `src/config_service.rs` defines the `ConfigService` trait:
+
+- typed getters (`default_provider`, `default_model`, `attribution_enabled`,
+  `token_present`, `model_for`, `base_url_for`), and
+- a generic `current(key)` that reads any value by its schema key (e.g.
+  `models.openai`), with secrets reduced to `stored`/`unset`.
+
+`SettingsStore` implements `ConfigService`, so the single shared handle that
+backs writes also serves reads. Capabilities that only *read* config take an
+`Arc<dyn ConfigService>`; capabilities that *write* (setup, config) keep the
+concrete `SettingsStore`. `AttributionCapability` reads whether attribution is
+enabled through the service, and `ApprovalCapability` reads its soft-approval
+paranoia level (`approval_mode`) through `ConfigService::approval_mode()` each
+turn — it keeps the concrete store only for its `set_approval_mode` write tool.
+`approval_mode` is also a first-class schema key, so `get_config`/`set_config`
+manage it alongside everything else.
+
+The per-target read helpers (`current_value`, `scoped_current`) live in the
+service module so the `config` tools and any other consumer share one
+implementation; secret redaction and unsupported-provider filtering therefore
+apply uniformly wherever config is read.
+
+### Context delivery
+
+The schema reaches the agent two ways:
+
+1. An always-on pointer: `ConfigCapability::system_prompt_contribution` adds a
+   compact note (settings path + "use `get_config`/`set_config` or the
+   `yolop-config` skill") to every turn.
+2. The `yolop-config` built-in skill (`skills/yolop-config/SKILL.md`) is the
+   detailed, on-demand reference. It instructs the agent to read the live schema
+   via `get_config` rather than duplicating key lists, and points at the
+   adjacent surfaces (`your` memory, `yolop-hooks`, `/setup`).
+
+## Boundaries
+
+Configuration is distinct from the neighbouring personalization surfaces:
+durable preferences are `your` **memory**, behavioral rules are **hooks**, and
+interactive live provider/model switching is **`/setup`**. `set_config` is only
+for the typed settings keys above.

--- a/src/capabilities/approval.rs
+++ b/src/capabilities/approval.rs
@@ -19,6 +19,7 @@
 // yolop in natural language ("yolop, be more careful") — with the
 // `set_approval_mode` tool.
 
+use crate::config_service::ConfigService;
 use crate::settings::{ApprovalMode, SettingsStore};
 use async_trait::async_trait;
 use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
@@ -80,6 +81,9 @@ asking\", \"yolo mode\"), call `set_approval_mode` to update the level.\n\
 }
 
 pub(crate) struct ApprovalCapability {
+    /// Reads the paranoia level through the shared config service each turn.
+    pub(crate) config: Arc<dyn ConfigService>,
+    /// Concrete store for the `set_approval_mode` write tool.
     pub(crate) settings: Arc<SettingsStore>,
 }
 
@@ -102,9 +106,10 @@ impl Capability for ApprovalCapability {
     }
 
     async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
-        // Read the level live each turn so `/setup approval` and
-        // `set_approval_mode` take effect on the very next turn.
-        render_approval_block(self.settings.snapshot().approval_mode())
+        // Read the level live each turn through the config service so
+        // `/setup approval`, `set_approval_mode`, and `set_config approval_mode`
+        // all take effect on the very next turn.
+        render_approval_block(self.config.approval_mode())
     }
 
     fn system_prompt_preview(&self) -> Option<String> {
@@ -284,7 +289,10 @@ mod tests {
     #[test]
     fn capability_exposes_both_tools() {
         let (_tmp, settings) = store_in_tmp();
-        let cap = ApprovalCapability { settings };
+        let cap = ApprovalCapability {
+            config: settings.clone(),
+            settings,
+        };
         let names: Vec<String> = cap.tools().iter().map(|t| t.name().to_string()).collect();
         assert_eq!(names, vec!["record_approval", "set_approval_mode"]);
         assert!(cap.commands().is_empty());
@@ -294,6 +302,7 @@ mod tests {
     async fn contribution_follows_settings() {
         let (_tmp, settings) = store_in_tmp();
         let cap = ApprovalCapability {
+            config: settings.clone(),
             settings: settings.clone(),
         };
         let ctx =

--- a/src/capabilities/config.rs
+++ b/src/capabilities/config.rs
@@ -1,0 +1,581 @@
+// The `config` capability — schema-described, human-friendly editing of the
+// yolop settings file.
+//
+// `settings.toml` is loaded tolerantly (unknown keys are ignored, never
+// fatal). This capability layers *semantics* on top of that file via the
+// informational schema in `crate::config_schema`: it exposes `get_config` (read
+// the schema + current values) and `set_config` (validate + persist any known
+// key) so the agent can configure yolop the way a user describes it, and it
+// drops a short always-on pointer into the system prompt so the agent knows the
+// configuration surface exists.
+//
+// Provider/model edits are persisted here and take effect on the next run; use
+// the interactive `/setup` command to switch the *live* model mid-session.
+
+use crate::config_schema::{KeyTarget, ValueKind, known_keys, parse_key, schema};
+use crate::config_service::{current_value, scoped_current};
+use crate::runtime::SUPPORTED_PROVIDERS;
+use crate::settings::{ApprovalMode, Settings, SettingsStore};
+use async_trait::async_trait;
+use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use serde_json::{Value, json};
+use std::sync::Arc;
+
+pub(crate) const CONFIG_CAPABILITY_ID: &str = "yolop_config";
+
+pub(crate) struct ConfigCapability {
+    pub(crate) settings: Arc<SettingsStore>,
+}
+
+#[async_trait]
+impl Capability for ConfigCapability {
+    fn id(&self) -> &str {
+        CONFIG_CAPABILITY_ID
+    }
+    fn name(&self) -> &str {
+        "Configuration"
+    }
+    fn description(&self) -> &str {
+        "Schema-described, human-friendly editing of yolop's settings file."
+    }
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+    fn category(&self) -> Option<&str> {
+        Some("Personalization")
+    }
+
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        Some(format!(
+            "<capability id=\"{}\">\nyolop's settings live at {} and are schema-described \
+             (default provider/model, per-provider API tokens and models, endpoint base URLs, \
+             attribution). To inspect or change any of it, call `get_config` (lists every key \
+             with its meaning and current value) and `set_config` (validates and persists a \
+             key), or activate the `yolop-config` skill. Unknown keys in the file are ignored, \
+             never fatal. Provider/model edits apply on the next run; use `/setup` to switch the \
+             live model now.\n</capability>",
+            self.id(),
+            self.settings.path().display()
+        ))
+    }
+
+    fn system_prompt_preview(&self) -> Option<String> {
+        Some(
+            "<capability id=\"yolop_config\">\nyolop's settings are schema-described; use \
+             `get_config` / `set_config` or the `yolop-config` skill to view and edit them.\n\
+             </capability>"
+                .to_string(),
+        )
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(GetConfigTool {
+                settings: self.settings.clone(),
+            }),
+            Box::new(SetConfigTool {
+                settings: self.settings.clone(),
+            }),
+        ]
+    }
+}
+
+// ---------- field rendering ----------
+//
+// The per-target read helpers (`current_value`, `scoped_current`) live in
+// `crate::config_service` so any capability can reuse them through the
+// `ConfigService`; here we only assemble the schema-described field view.
+
+/// JSON description of a schema field, optionally with its current value(s).
+fn field_json(settings: &Settings, field: &crate::config_schema::ConfigField) -> Value {
+    let current = if field.provider_scoped {
+        scoped_current(settings, field.key)
+    } else {
+        // Scalar fields map 1:1 to a target keyed by `field.key`.
+        let target = parse_key(field.key).expect("schema key parses");
+        current_value(settings, &target)
+    };
+    json!({
+        "key": field.key,
+        "aliases": field.aliases,
+        "title": field.title,
+        "description": field.description,
+        "type": field.kind.as_str(),
+        "secret": field.kind == ValueKind::Secret,
+        "provider_scoped": field.provider_scoped,
+        "default": field.default,
+        "examples": field.examples,
+        "current": current,
+    })
+}
+
+// ---------- get_config ----------
+
+struct GetConfigTool {
+    settings: Arc<SettingsStore>,
+}
+
+#[async_trait]
+impl Tool for GetConfigTool {
+    fn name(&self) -> &str {
+        "get_config"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Get config")
+    }
+    fn description(&self) -> &str {
+        "Inspect yolop configuration. With no `key`, returns every configuration key with its \
+         title, description, type, default, examples, and current value (secrets redacted). \
+         With a `key` (e.g. `default_provider`, `tokens.openai`), returns just that entry."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "description": "Optional single key to describe, e.g. `default_model` or `models.anthropic`."
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let settings = self.settings.snapshot();
+        let path = self.settings.path().display().to_string();
+
+        if let Some(key) = arguments.get("key").and_then(Value::as_str) {
+            let key = key.trim();
+            if !key.is_empty() {
+                let target = match parse_key(key) {
+                    Ok(t) => t,
+                    Err(err) => return ToolExecutionResult::tool_error(err),
+                };
+                let field = target.field();
+                let mut entry = field_json(&settings, field);
+                // For a provider-scoped single key, narrow `current` to the
+                // requested provider while preserving the whole-table view
+                // under `table` (field_json seeded `current` with the table).
+                if field.provider_scoped {
+                    if let Value::Object(map) = &mut entry {
+                        let table = map.get("current").cloned().unwrap_or(Value::Null);
+                        map.insert("table".to_string(), table);
+                        map.insert("key".to_string(), Value::String(key.to_string()));
+                    }
+                    entry["current"] = current_value(&settings, &target);
+                }
+                return ToolExecutionResult::success(json!({
+                    "settings_path": path,
+                    "field": entry,
+                }));
+            }
+        }
+
+        let fields: Vec<Value> = schema().iter().map(|f| field_json(&settings, f)).collect();
+        ToolExecutionResult::success(json!({
+            "settings_path": path,
+            "fields": fields,
+            "note": "Set any key with `set_config`. Provider/model edits apply on the next run; \
+                     use /setup to switch the live model now. Unknown keys in the file are ignored.",
+        }))
+    }
+}
+
+// ---------- set_config ----------
+
+struct SetConfigTool {
+    settings: Arc<SettingsStore>,
+}
+
+#[async_trait]
+impl Tool for SetConfigTool {
+    fn name(&self) -> &str {
+        "set_config"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Set config")
+    }
+    fn description(&self) -> &str {
+        "Set or clear a yolop configuration value, validated against the schema and persisted to \
+         the settings file. `key` is a schema key (e.g. `default_provider`, `default_model`, \
+         `models.openai`, `tokens.anthropic`, `base_urls.custom`, `attribution`). Pass `clear` as \
+         the value to remove an optional/secret key. Run `get_config` first to see valid keys."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "description": "Schema key, e.g. `default_provider` or `tokens.openai`."
+                },
+                "value": {
+                    "type": "string",
+                    "description": "New value, or `clear` to unset an optional/secret key."
+                }
+            },
+            "required": ["key", "value"],
+            "additionalProperties": false
+        })
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let key = match arguments.get("key").and_then(Value::as_str) {
+            Some(k) if !k.trim().is_empty() => k.trim(),
+            _ => {
+                return ToolExecutionResult::tool_error(format!(
+                    "'key' is required; known keys: {}",
+                    known_keys()
+                ));
+            }
+        };
+        let value = match arguments.get("value").and_then(Value::as_str) {
+            Some(v) => v.trim(),
+            None => {
+                return ToolExecutionResult::tool_error(
+                    "'value' is required (use `clear` to unset)",
+                );
+            }
+        };
+        let target = match parse_key(key) {
+            Ok(t) => t,
+            Err(err) => return ToolExecutionResult::tool_error(err),
+        };
+        let clearing = value.eq_ignore_ascii_case("clear");
+        if value.is_empty() {
+            return ToolExecutionResult::tool_error(
+                "empty value; provide a value or `clear` to unset".to_string(),
+            );
+        }
+
+        let result = self.apply(&target, value, clearing);
+        match result {
+            Ok(message) => ToolExecutionResult::success(json!({
+                "ok": true,
+                "key": key,
+                "message": message,
+                "settings_path": self.settings.path().display().to_string(),
+            })),
+            Err(err) => ToolExecutionResult::tool_error(err),
+        }
+    }
+}
+
+impl SetConfigTool {
+    fn apply(&self, target: &KeyTarget, value: &str, clearing: bool) -> Result<String, String> {
+        let path = self.settings.path().display().to_string();
+        let saved = |what: String| format!("{what} (saved to {path})");
+        let map_err = |e: anyhow::Error| format!("could not save settings: {e}");
+
+        match target {
+            KeyTarget::DefaultProvider => {
+                if clearing {
+                    self.settings.set_provider(None).map_err(map_err)?;
+                    return Ok(saved(
+                        "cleared default_provider; it will be auto-detected from credentials"
+                            .to_string(),
+                    ));
+                }
+                let provider = value.to_ascii_lowercase();
+                if !SUPPORTED_PROVIDERS.contains(&provider.as_str()) {
+                    return Err(format!(
+                        "unknown provider `{provider}`; expected one of {}",
+                        SUPPORTED_PROVIDERS.join(", ")
+                    ));
+                }
+                self.settings
+                    .set_provider(Some(provider.clone()))
+                    .map_err(map_err)?;
+                Ok(saved(format!(
+                    "default_provider = {provider}; applies on the next run (use /setup to switch now)"
+                )))
+            }
+            KeyTarget::DefaultModel => {
+                if clearing {
+                    self.settings.set_default_model(None).map_err(map_err)?;
+                    return Ok(saved("cleared default_model".to_string()));
+                }
+                self.settings
+                    .set_default_model(Some(value.to_string()))
+                    .map_err(map_err)?;
+                Ok(saved(format!(
+                    "default_model = {value}; applies on the next run (use /setup to switch now)"
+                )))
+            }
+            KeyTarget::Attribution => {
+                let enabled = parse_on_off(value)
+                    .ok_or_else(|| "attribution expects on/off (true/false, yes/no)".to_string())?;
+                self.settings.set_attribution(enabled).map_err(map_err)?;
+                Ok(saved(format!("attribution = {}", on_off(enabled))))
+            }
+            KeyTarget::ApprovalMode => {
+                let mode = ApprovalMode::parse(value).ok_or_else(|| {
+                    "approval_mode expects protective, normal, or off".to_string()
+                })?;
+                self.settings.set_approval_mode(mode).map_err(map_err)?;
+                Ok(saved(format!(
+                    "approval_mode = {}; applies next turn",
+                    mode.as_str()
+                )))
+            }
+            KeyTarget::Model(provider) => {
+                if clearing {
+                    let existed = self.settings.clear_model(provider).map_err(map_err)?;
+                    return Ok(saved(if existed {
+                        format!("cleared models.{provider}")
+                    } else {
+                        format!("models.{provider} was already unset")
+                    }));
+                }
+                self.settings
+                    .set_model(provider.clone(), value.to_string())
+                    .map_err(map_err)?;
+                Ok(saved(format!(
+                    "models.{provider} = {value}; applies on the next run for that provider"
+                )))
+            }
+            KeyTarget::Token(provider) => {
+                if clearing {
+                    let existed = self.settings.clear_token(provider).map_err(map_err)?;
+                    return Ok(saved(if existed {
+                        format!("cleared tokens.{provider}")
+                    } else {
+                        format!("tokens.{provider} was already unset")
+                    }));
+                }
+                self.settings
+                    .set_token(provider.clone(), value.to_string())
+                    .map_err(map_err)?;
+                // Never echo the secret back.
+                Ok(saved(format!("stored API token for {provider}")))
+            }
+            KeyTarget::BaseUrl(provider) => {
+                if clearing {
+                    let existed = self.settings.clear_base_url(provider).map_err(map_err)?;
+                    return Ok(saved(if existed {
+                        format!("cleared base_urls.{provider}")
+                    } else {
+                        format!("base_urls.{provider} was already unset")
+                    }));
+                }
+                if !value.starts_with("http://") && !value.starts_with("https://") {
+                    return Err("base URL must start with http:// or https://".to_string());
+                }
+                self.settings
+                    .set_base_url(provider.clone(), value.to_string())
+                    .map_err(map_err)?;
+                Ok(saved(format!("base_urls.{provider} = {value}")))
+            }
+        }
+    }
+}
+
+fn parse_on_off(raw: &str) -> Option<bool> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "on" | "true" | "yes" | "1" => Some(true),
+        "off" | "false" | "no" | "0" => Some(false),
+        _ => None,
+    }
+}
+
+fn on_off(enabled: bool) -> &'static str {
+    if enabled { "on" } else { "off" }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store() -> (tempfile::TempDir, Arc<SettingsStore>) {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let store = Arc::new(SettingsStore::open(tmp.path().join("settings.toml")));
+        (tmp, store)
+    }
+
+    #[tokio::test]
+    async fn set_config_persists_default_provider_and_model() {
+        let (_tmp, settings) = store();
+        let tool = SetConfigTool {
+            settings: settings.clone(),
+        };
+
+        let r = tool
+            .execute(json!({ "key": "default_provider", "value": "anthropic" }))
+            .await;
+        assert!(matches!(r, ToolExecutionResult::Success(_)));
+        assert_eq!(settings.snapshot().provider.as_deref(), Some("anthropic"));
+
+        // Alias `model` routes to default_model.
+        tool.execute(json!({ "key": "model", "value": "claude-opus-4-5" }))
+            .await;
+        assert_eq!(settings.snapshot().default_model(), Some("claude-opus-4-5"));
+    }
+
+    #[tokio::test]
+    async fn set_config_rejects_unknown_provider_and_key() {
+        let (_tmp, settings) = store();
+        let tool = SetConfigTool { settings };
+
+        let bad_provider = tool
+            .execute(json!({ "key": "default_provider", "value": "nope" }))
+            .await;
+        assert!(matches!(bad_provider, ToolExecutionResult::ToolError(_)));
+
+        let bad_key = tool
+            .execute(json!({ "key": "frobnicate", "value": "x" }))
+            .await;
+        assert!(matches!(bad_key, ToolExecutionResult::ToolError(_)));
+    }
+
+    #[tokio::test]
+    async fn set_config_routes_approval_mode() {
+        let (_tmp, settings) = store();
+        let tool = SetConfigTool {
+            settings: settings.clone(),
+        };
+        let ok = tool
+            .execute(json!({ "key": "approval_mode", "value": "protective" }))
+            .await;
+        assert!(matches!(ok, ToolExecutionResult::Success(_)));
+        assert_eq!(
+            settings.snapshot().approval_mode(),
+            crate::settings::ApprovalMode::Protective
+        );
+
+        // Alias and lenient synonyms route through the same path.
+        tool.execute(json!({ "key": "approval", "value": "yolo" }))
+            .await;
+        assert_eq!(
+            settings.snapshot().approval_mode(),
+            crate::settings::ApprovalMode::Off
+        );
+
+        let bad = tool
+            .execute(json!({ "key": "approval_mode", "value": "whenever" }))
+            .await;
+        assert!(matches!(bad, ToolExecutionResult::ToolError(_)));
+    }
+
+    #[tokio::test]
+    async fn set_config_validates_base_url_scheme() {
+        let (_tmp, settings) = store();
+        let tool = SetConfigTool { settings };
+        let r = tool
+            .execute(json!({ "key": "base_urls.custom", "value": "localhost:8000" }))
+            .await;
+        assert!(matches!(r, ToolExecutionResult::ToolError(_)));
+    }
+
+    #[tokio::test]
+    async fn set_and_clear_token_roundtrip() {
+        let (_tmp, settings) = store();
+        let tool = SetConfigTool {
+            settings: settings.clone(),
+        };
+        tool.execute(json!({ "key": "tokens.openai", "value": "sk-secret" }))
+            .await;
+        assert!(settings.snapshot().has_token("openai"));
+
+        tool.execute(json!({ "key": "tokens.openai", "value": "clear" }))
+            .await;
+        assert!(!settings.snapshot().has_token("openai"));
+    }
+
+    #[tokio::test]
+    async fn get_config_redacts_tokens() {
+        let (_tmp, settings) = store();
+        settings
+            .set_token("openai".to_string(), "sk-secret".to_string())
+            .unwrap();
+        let tool = GetConfigTool {
+            settings: settings.clone(),
+        };
+        let r = tool.execute(json!({ "key": "tokens.openai" })).await;
+        let ToolExecutionResult::Success(value) = r else {
+            panic!("expected success");
+        };
+        let text = value.to_string();
+        assert!(
+            !text.contains("sk-secret"),
+            "token value must be redacted: {text}"
+        );
+        assert!(text.contains("stored"));
+    }
+
+    #[tokio::test]
+    async fn get_config_lists_all_fields() {
+        let (_tmp, settings) = store();
+        let tool = GetConfigTool { settings };
+        let ToolExecutionResult::Success(value) = tool.execute(json!({})).await else {
+            panic!("expected success");
+        };
+        let fields = value["fields"].as_array().expect("fields array");
+        assert_eq!(fields.len(), schema().len());
+    }
+
+    #[tokio::test]
+    async fn get_config_renders_attribution_as_bool() {
+        let (_tmp, settings) = store();
+        let tool = GetConfigTool { settings };
+        let ToolExecutionResult::Success(value) =
+            tool.execute(json!({ "key": "attribution" })).await
+        else {
+            panic!("expected success");
+        };
+        // type=bool, so `current` must be a real JSON boolean, not "on"/"off".
+        assert_eq!(value["field"]["type"], "bool");
+        assert_eq!(value["field"]["current"], Value::Bool(true));
+    }
+
+    #[tokio::test]
+    async fn get_config_scoped_key_keeps_table_and_narrows_current() {
+        let (_tmp, settings) = store();
+        settings
+            .set_model("openai".to_string(), "gpt-5.5 high".to_string())
+            .unwrap();
+        settings
+            .set_model("anthropic".to_string(), "claude-opus-4-5".to_string())
+            .unwrap();
+        let tool = GetConfigTool { settings };
+        let ToolExecutionResult::Success(value) =
+            tool.execute(json!({ "key": "models.openai" })).await
+        else {
+            panic!("expected success");
+        };
+        // `current` is narrowed to the requested provider...
+        assert_eq!(value["field"]["current"], "gpt-5.5 high");
+        // ...while the whole-table view is preserved under `table`.
+        assert_eq!(value["field"]["table"]["openai"], "gpt-5.5 high");
+        assert_eq!(value["field"]["table"]["anthropic"], "claude-opus-4-5");
+    }
+
+    #[tokio::test]
+    async fn get_config_table_omits_unsupported_providers() {
+        let (_tmp, settings) = store();
+        // Tolerant loading can leave entries for providers set_config cannot
+        // address; get_config must not list them. Exercised via the full
+        // listing, whose `models` field renders the whole table.
+        settings
+            .set_model("openai".to_string(), "gpt-5.5".to_string())
+            .unwrap();
+        settings
+            .set_model("frobnicate".to_string(), "whatever".to_string())
+            .unwrap();
+        let tool = GetConfigTool { settings };
+        let ToolExecutionResult::Success(value) = tool.execute(json!({})).await else {
+            panic!("expected success");
+        };
+        let models = value["fields"]
+            .as_array()
+            .expect("fields array")
+            .iter()
+            .find(|f| f["key"] == "models")
+            .expect("models field present");
+        assert_eq!(models["current"]["openai"], "gpt-5.5");
+        assert!(
+            models["current"].get("frobnicate").is_none(),
+            "unsupported provider must be omitted: {}",
+            models["current"]
+        );
+    }
+}

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -1,6 +1,7 @@
 // Host/example capabilities for yolop: local environment context, bash, and
 // TUI-facing slash commands that mutate this process's provider selection.
 
+use crate::config_service::ConfigService;
 use crate::runtime::{ProviderChoice, SUPPORTED_PROVIDERS};
 use crate::settings::{ApprovalMode, SettingsStore};
 use crate::tools::{BashTool, Workspace};
@@ -94,7 +95,9 @@ impl Capability for CodingCliEnvironmentCapability {
 }
 
 pub(crate) struct AttributionCapability {
-    pub(crate) settings: Arc<SettingsStore>,
+    /// Reads through the shared config service rather than the concrete store —
+    /// it only needs to know whether attribution is enabled.
+    pub(crate) config: Arc<dyn ConfigService>,
 }
 
 #[async_trait]
@@ -115,8 +118,7 @@ impl Capability for AttributionCapability {
         Some("Examples")
     }
     async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
-        self.settings
-            .snapshot()
+        self.config
             .attribution_enabled()
             .then(yolop_attribution_prompt)
     }
@@ -1035,7 +1037,7 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tmp");
         let settings = Arc::new(SettingsStore::open(tmp.path().join("settings.toml")));
         let capability = AttributionCapability {
-            settings: settings.clone(),
+            config: settings.clone(),
         };
         let ctx =
             SystemPromptContext::without_file_store(everruns_core::typed_id::SessionId::new());

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -5,6 +5,7 @@
 
 pub(crate) mod approval;
 pub(crate) mod client_commands;
+pub(crate) mod config;
 mod host;
 pub(crate) mod model_discovery;
 pub mod skills;
@@ -13,6 +14,7 @@ pub(crate) mod your;
 
 pub(crate) use approval::{APPROVAL_CAPABILITY_ID, ApprovalCapability};
 pub(crate) use client_commands::{CLIENT_COMMANDS_CAPABILITY_ID, ClientCommandsCapability};
+pub(crate) use config::{CONFIG_CAPABILITY_ID, ConfigCapability};
 pub(crate) use host::{
     ATTRIBUTION_CAPABILITY_ID, AttributionCapability, CodingBashCapability,
     CodingCliEnvironmentCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID, SETUP_CAPABILITY_ID,

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -1,0 +1,327 @@
+//! Informational schema for the yolop settings file (`settings.toml`).
+//!
+//! The schema is *informational*, not a validator. Loading settings never
+//! checks against it and never rejects unknown keys (see
+//! [`crate::settings::Settings::from_table`]), so a user or another tool can
+//! drop extra keys into the file without breaking yolop. What the schema adds
+//! is **semantics**: a title, description, type, default, and examples for
+//! every known configuration key. That lets the agent explain and edit
+//! configuration in a human-friendly way through the `get_config` /
+//! `set_config` tools and the `yolop-config` skill — the schema here is the
+//! single source of truth those surfaces render.
+//!
+//! Keys are addressed the way a human would name them. Scalar keys are plain
+//! (`default_provider`, `attribution`); per-provider tables are addressed with
+//! a dotted provider segment (`tokens.openai`, `models.anthropic`).
+
+use crate::runtime::SUPPORTED_PROVIDERS;
+
+/// The kind of value a configuration key accepts. Drives validation in
+/// `set_config` and how `get_config` renders the current value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ValueKind {
+    /// A free-form string: provider name, model spec, URL, …
+    Text,
+    /// An on/off boolean.
+    Bool,
+    /// A secret string (an API token). `get_config` never echoes the value,
+    /// only whether one is stored.
+    Secret,
+}
+
+impl ValueKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ValueKind::Text => "text",
+            ValueKind::Bool => "bool",
+            ValueKind::Secret => "secret",
+        }
+    }
+}
+
+/// One described configuration key. Every field is `&'static` so the whole
+/// schema is a compile-time constant.
+pub struct ConfigField {
+    /// Canonical name the agent/user addresses. For provider-scoped tables
+    /// this is the bare table name (e.g. `tokens`); see `provider_scoped`.
+    pub key: &'static str,
+    /// Alternative names accepted when reading or writing this key.
+    pub aliases: &'static [&'static str],
+    pub title: &'static str,
+    pub description: &'static str,
+    pub kind: ValueKind,
+    /// Effective default when the key is unset — for display only.
+    pub default: Option<&'static str>,
+    pub examples: &'static [&'static str],
+    /// When true the key names a `[table]` whose entries are keyed by
+    /// provider, so it is addressed as `<key>.<provider>`.
+    pub provider_scoped: bool,
+}
+
+/// The full configuration schema. Order is the user-facing display order.
+pub fn schema() -> &'static [ConfigField] {
+    // Note: `default_provider` and `default_model` are surfaced under those
+    // human-friendly names; on disk `default_provider` is the top-level
+    // `provider` key (its long-standing TOML name). `set_config` routes the
+    // alias to the one stored field so there is never divergent provider state.
+    const FIELDS: &[ConfigField] = &[
+        ConfigField {
+            key: "default_provider",
+            aliases: &["provider"],
+            title: "Default provider",
+            description: "The model provider used when neither the --provider flag nor an \
+                          environment credential forces a choice. Stored on disk as the \
+                          `provider` key.",
+            kind: ValueKind::Text,
+            default: Some("openai (auto-detected from available credentials)"),
+            examples: &["anthropic", "openai", "google", "openrouter", "ollama"],
+            provider_scoped: false,
+        },
+        ConfigField {
+            key: "default_model",
+            aliases: &["model"],
+            title: "Default model",
+            description: "Global fallback model spec applied to the active provider when that \
+                          provider has no per-provider entry under `models`. Provider-relative, \
+                          same `model [reasoning-effort]` form `/setup model` accepts. A \
+                          per-provider `models.<provider>` pick always wins over this.",
+            kind: ValueKind::Text,
+            default: Some("the active provider's built-in default model"),
+            examples: &["claude-sonnet-4-5", "gpt-5.5 high", "gemini-2.5-pro"],
+            provider_scoped: false,
+        },
+        ConfigField {
+            key: "models",
+            aliases: &["model_for"],
+            title: "Per-provider model",
+            description: "Model spec remembered for a specific provider, so a pick survives \
+                          restarts and provider switches. Addressed as `models.<provider>`.",
+            kind: ValueKind::Text,
+            default: None,
+            examples: &[
+                "models.openai = gpt-5.5 high",
+                "models.anthropic = claude-opus-4-5",
+            ],
+            provider_scoped: true,
+        },
+        ConfigField {
+            key: "tokens",
+            aliases: &["token"],
+            title: "Provider API token",
+            description: "API token for a provider, stored owner-only (0o600). Environment \
+                          variables (OPENAI_API_KEY, ANTHROPIC_API_KEY, …) always override the \
+                          stored value. Addressed as `tokens.<provider>`.",
+            kind: ValueKind::Secret,
+            default: None,
+            examples: &["tokens.openai = sk-…", "tokens.anthropic = …"],
+            provider_scoped: true,
+        },
+        ConfigField {
+            key: "base_urls",
+            aliases: &["base_url", "url"],
+            title: "Provider endpoint base URL",
+            description: "Endpoint base URL for a provider. Used by the `custom` \
+                          OpenAI-compatible provider (vLLM, llama.cpp, LM Studio, gateways). \
+                          Addressed as `base_urls.<provider>`; must start with http:// or https://.",
+            kind: ValueKind::Text,
+            default: None,
+            examples: &["base_urls.custom = http://localhost:8000/v1"],
+            provider_scoped: true,
+        },
+        ConfigField {
+            key: "approval_mode",
+            aliases: &["approval"],
+            title: "Soft-approval paranoia level",
+            description: "How cautious yolop is about confirming critical actions: `protective` \
+                          asks before any state change, `normal` asks only before destructive or \
+                          outward-facing actions, `off` never asks. Common synonyms like \
+                          `paranoid` and `yolo` are also accepted.",
+            kind: ValueKind::Text,
+            default: Some("normal"),
+            examples: &["protective", "normal", "off"],
+            provider_scoped: false,
+        },
+        ConfigField {
+            key: "attribution",
+            aliases: &[],
+            title: "Commit & PR attribution",
+            description: "When on, yolop appends a Co-Authored-By git trailer to commits it \
+                          makes and a footer to PR descriptions it writes.",
+            kind: ValueKind::Bool,
+            default: Some("on"),
+            examples: &["on", "off"],
+            provider_scoped: false,
+        },
+    ];
+    FIELDS
+}
+
+/// A parsed, routable configuration target. `set_config`/`get_config` match on
+/// this rather than re-parsing key strings.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum KeyTarget {
+    DefaultProvider,
+    DefaultModel,
+    Attribution,
+    ApprovalMode,
+    /// Per-provider model spec, for the named provider.
+    Model(String),
+    /// Per-provider API token.
+    Token(String),
+    /// Per-provider endpoint base URL.
+    BaseUrl(String),
+}
+
+impl KeyTarget {
+    /// The schema field describing this target.
+    pub fn field(&self) -> &'static ConfigField {
+        let key = match self {
+            KeyTarget::DefaultProvider => "default_provider",
+            KeyTarget::DefaultModel => "default_model",
+            KeyTarget::Attribution => "attribution",
+            KeyTarget::ApprovalMode => "approval_mode",
+            KeyTarget::Model(_) => "models",
+            KeyTarget::Token(_) => "tokens",
+            KeyTarget::BaseUrl(_) => "base_urls",
+        };
+        schema()
+            .iter()
+            .find(|f| f.key == key)
+            .expect("KeyTarget always maps to a schema field")
+    }
+}
+
+/// Parse a human-supplied key (with aliases) into a routable target. Provider
+/// segments are validated against the supported provider list.
+pub fn parse_key(input: &str) -> Result<KeyTarget, String> {
+    let norm = input.trim().to_ascii_lowercase();
+    if norm.is_empty() {
+        return Err(format!("empty config key; known keys: {}", known_keys()));
+    }
+    let (head, sub) = match norm.split_once('.') {
+        Some((h, t)) => (h, Some(t.trim())),
+        None => (norm.as_str(), None),
+    };
+
+    let scalar = |target: KeyTarget| -> Result<KeyTarget, String> {
+        if sub.is_some() {
+            return Err(format!(
+                "`{head}` is a scalar key and takes no `.<provider>` segment"
+            ));
+        }
+        Ok(target)
+    };
+    let scoped = |make: fn(String) -> KeyTarget| -> Result<KeyTarget, String> {
+        let provider = sub.filter(|s| !s.is_empty()).ok_or_else(|| {
+            format!("`{head}` is per-provider; address it as `{head}.<provider>`")
+        })?;
+        if !SUPPORTED_PROVIDERS.contains(&provider) {
+            return Err(format!(
+                "unknown provider `{provider}`; expected one of {}",
+                SUPPORTED_PROVIDERS.join(", ")
+            ));
+        }
+        Ok(make(provider.to_string()))
+    };
+
+    match head {
+        "default_provider" | "provider" => scalar(KeyTarget::DefaultProvider),
+        "default_model" | "model" => scalar(KeyTarget::DefaultModel),
+        "attribution" => scalar(KeyTarget::Attribution),
+        "approval_mode" | "approval" => scalar(KeyTarget::ApprovalMode),
+        "models" | "model_for" => scoped(KeyTarget::Model),
+        "tokens" | "token" => scoped(KeyTarget::Token),
+        "base_urls" | "base_url" | "url" => scoped(KeyTarget::BaseUrl),
+        _ => Err(format!(
+            "unknown config key `{input}`; known keys: {}",
+            known_keys()
+        )),
+    }
+}
+
+/// Comma-separated list of canonical keys, for error messages.
+pub fn known_keys() -> String {
+    schema()
+        .iter()
+        .map(|f| {
+            if f.provider_scoped {
+                format!("{}.<provider>", f.key)
+            } else {
+                f.key.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn aliases_resolve_to_canonical_targets() {
+        assert_eq!(parse_key("provider").unwrap(), KeyTarget::DefaultProvider);
+        assert_eq!(
+            parse_key("default_provider").unwrap(),
+            KeyTarget::DefaultProvider
+        );
+        assert_eq!(parse_key("model").unwrap(), KeyTarget::DefaultModel);
+        assert_eq!(parse_key("default_model").unwrap(), KeyTarget::DefaultModel);
+        assert_eq!(parse_key("approval").unwrap(), KeyTarget::ApprovalMode);
+        assert_eq!(parse_key("approval_mode").unwrap(), KeyTarget::ApprovalMode);
+    }
+
+    #[test]
+    fn provider_scoped_keys_parse_and_validate() {
+        assert_eq!(
+            parse_key("tokens.openai").unwrap(),
+            KeyTarget::Token("openai".to_string())
+        );
+        assert_eq!(
+            parse_key("url.custom").unwrap(),
+            KeyTarget::BaseUrl("custom".to_string())
+        );
+        assert_eq!(
+            parse_key("Models.Anthropic").unwrap(),
+            KeyTarget::Model("anthropic".to_string())
+        );
+    }
+
+    #[test]
+    fn scalar_key_rejects_provider_segment() {
+        assert!(parse_key("attribution.openai").is_err());
+        assert!(parse_key("default_model.openai").is_err());
+    }
+
+    #[test]
+    fn provider_scoped_requires_segment_and_known_provider() {
+        assert!(parse_key("tokens").unwrap_err().contains("per-provider"));
+        assert!(
+            parse_key("tokens.nope")
+                .unwrap_err()
+                .contains("unknown provider")
+        );
+    }
+
+    #[test]
+    fn unknown_key_lists_known_keys() {
+        let err = parse_key("frobnicate").unwrap_err();
+        assert!(err.contains("default_provider"));
+        assert!(err.contains("tokens.<provider>"));
+    }
+
+    #[test]
+    fn every_target_maps_to_a_field() {
+        for target in [
+            KeyTarget::DefaultProvider,
+            KeyTarget::DefaultModel,
+            KeyTarget::Attribution,
+            KeyTarget::ApprovalMode,
+            KeyTarget::Model("openai".into()),
+            KeyTarget::Token("openai".into()),
+            KeyTarget::BaseUrl("custom".into()),
+        ] {
+            let _ = target.field();
+        }
+    }
+}

--- a/src/config_service.rs
+++ b/src/config_service.rs
@@ -1,0 +1,193 @@
+// Configuration as a service.
+//
+// A read-oriented handle over the settings file that any capability can depend
+// on to read schema-described configuration — typed getters plus a generic
+// `current(key)` keyed by the schema in `crate::config_schema`. It is backed by
+// the shared `SettingsStore` (the single writer), so reads always reflect the
+// latest persisted state without each capability re-parsing the TOML or
+// reaching into store internals.
+//
+// Capabilities that only *read* config (e.g. attribution, and a future
+// approval/mode capability) take an `Arc<dyn ConfigService>` instead of an
+// `Arc<SettingsStore>`; capabilities that *write* (setup, config) keep the
+// concrete store. `SettingsStore` implements `ConfigService`, so the same
+// shared handle satisfies both.
+
+use crate::config_schema::{KeyTarget, parse_key};
+use crate::runtime::SUPPORTED_PROVIDERS;
+use crate::settings::{ApprovalMode, Settings, SettingsStore};
+use serde_json::Value;
+
+/// Read-only view of yolop configuration, injectable into capabilities.
+///
+/// Typed getters cover the common cases; `current` reads any key by its schema
+/// name so a capability can consume configuration it does not own without
+/// knowing the storage layout. Secrets are never returned in the clear.
+///
+/// This is a deliberately broad service contract: some getters exist for future
+/// read-only consumers and are not yet wired into a caller, so `dead_code` is
+/// allowed on the trait surface.
+#[allow(dead_code)]
+pub trait ConfigService: Send + Sync {
+    /// Current in-memory settings snapshot (the source of truth in memory).
+    fn snapshot(&self) -> Settings;
+
+    /// The soft-approval paranoia level.
+    fn approval_mode(&self) -> ApprovalMode {
+        self.snapshot().approval_mode()
+    }
+
+    /// The configured default provider, if any.
+    fn default_provider(&self) -> Option<String> {
+        self.snapshot().provider
+    }
+
+    /// The global fallback model spec, if any.
+    fn default_model(&self) -> Option<String> {
+        self.snapshot().default_model
+    }
+
+    /// Whether commit/PR attribution is enabled.
+    fn attribution_enabled(&self) -> bool {
+        self.snapshot().attribution_enabled()
+    }
+
+    /// Whether an API token is stored for `provider` (presence only).
+    fn token_present(&self, provider: &str) -> bool {
+        self.snapshot().has_token(provider)
+    }
+
+    /// The per-provider model spec, if any.
+    fn model_for(&self, provider: &str) -> Option<String> {
+        self.snapshot().model_for(provider).map(str::to_string)
+    }
+
+    /// The per-provider endpoint base URL, if any.
+    fn base_url_for(&self, provider: &str) -> Option<String> {
+        self.snapshot().base_url_for(provider).map(str::to_string)
+    }
+
+    /// Read any configuration value by its schema key (e.g. `default_provider`,
+    /// `models.openai`). Secrets are reduced to `stored`/`unset`. Returns the
+    /// schema validation error for unknown or malformed keys.
+    fn current(&self, key: &str) -> Result<Value, String> {
+        let target = parse_key(key)?;
+        Ok(current_value(&self.snapshot(), &target))
+    }
+}
+
+impl ConfigService for SettingsStore {
+    fn snapshot(&self) -> Settings {
+        SettingsStore::snapshot(self)
+    }
+}
+
+/// The current value of a single target, with secrets reduced to presence only.
+pub(crate) fn current_value(settings: &Settings, target: &KeyTarget) -> Value {
+    match target {
+        KeyTarget::DefaultProvider => settings
+            .provider
+            .clone()
+            .map(Value::String)
+            .unwrap_or(Value::Null),
+        KeyTarget::DefaultModel => settings
+            .default_model()
+            .map(|s| Value::String(s.to_string()))
+            .unwrap_or(Value::Null),
+        KeyTarget::Attribution => Value::Bool(settings.attribution_enabled()),
+        KeyTarget::ApprovalMode => Value::String(settings.approval_mode().as_str().to_string()),
+        KeyTarget::Model(p) => settings
+            .model_for(p)
+            .map(|s| Value::String(s.to_string()))
+            .unwrap_or(Value::Null),
+        KeyTarget::Token(p) => Value::String(
+            if settings.has_token(p) {
+                "stored"
+            } else {
+                "unset"
+            }
+            .to_string(),
+        ),
+        KeyTarget::BaseUrl(p) => settings
+            .base_url_for(p)
+            .map(|s| Value::String(s.to_string()))
+            .unwrap_or(Value::Null),
+    }
+}
+
+/// Full current state of a provider-scoped table (secrets redacted). Only
+/// supported providers are listed, so reads stay consistent with the providers
+/// `set_config` can address — tolerant loading may leave unknown provider
+/// entries in the file, but they are not manageable here.
+pub(crate) fn scoped_current(settings: &Settings, key: &str) -> Value {
+    let mut map = serde_json::Map::new();
+    let supported = |provider: &String| SUPPORTED_PROVIDERS.contains(&provider.as_str());
+    match key {
+        "tokens" => {
+            for provider in settings.tokens.keys().filter(|p| supported(p)) {
+                map.insert(provider.clone(), Value::String("stored".to_string()));
+            }
+        }
+        "models" => {
+            for (provider, spec) in settings.models.iter().filter(|(p, _)| supported(p)) {
+                map.insert(provider.clone(), Value::String(spec.clone()));
+            }
+        }
+        "base_urls" => {
+            for (provider, url) in settings.base_urls.iter().filter(|(p, _)| supported(p)) {
+                map.insert(provider.clone(), Value::String(url.clone()));
+            }
+        }
+        _ => {}
+    }
+    Value::Object(map)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn service_reads_typed_and_by_key() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let store = Arc::new(SettingsStore::open(tmp.path().join("settings.toml")));
+        store.set_provider(Some("anthropic".to_string())).unwrap();
+        store
+            .set_default_model(Some("claude-sonnet-4-5".to_string()))
+            .unwrap();
+        store
+            .set_token("openai".to_string(), "sk-secret".to_string())
+            .unwrap();
+        store
+            .set_model("openai".to_string(), "gpt-5.5 high".to_string())
+            .unwrap();
+        store
+            .set_base_url("custom".to_string(), "http://localhost:8000/v1".to_string())
+            .unwrap();
+
+        // Inject as the trait object capabilities would receive.
+        let svc: Arc<dyn ConfigService> = store.clone();
+        assert_eq!(svc.default_provider().as_deref(), Some("anthropic"));
+        assert_eq!(svc.default_model().as_deref(), Some("claude-sonnet-4-5"));
+        assert!(svc.token_present("openai"));
+        assert!(svc.attribution_enabled());
+        assert_eq!(svc.model_for("openai").as_deref(), Some("gpt-5.5 high"));
+        assert_eq!(
+            svc.base_url_for("custom").as_deref(),
+            Some("http://localhost:8000/v1")
+        );
+
+        // Generic schema-keyed read, with secrets reduced to presence.
+        assert_eq!(svc.current("default_provider").unwrap(), "anthropic");
+        assert_eq!(svc.current("tokens.openai").unwrap(), "stored");
+        assert!(
+            !svc.current("tokens.openai")
+                .unwrap()
+                .to_string()
+                .contains("sk-secret"),
+            "secret value must never be returned"
+        );
+        assert!(svc.current("frobnicate").is_err());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@
 mod acp;
 mod app;
 mod capabilities;
+mod config_schema;
+mod config_service;
 mod hooks_config;
 mod host_ui;
 mod into;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -7,9 +7,10 @@
 use crate::capabilities::your::{YOUR_CAPABILITY_ID, YourCapability, YourStore};
 use crate::capabilities::{
     APPROVAL_CAPABILITY_ID, ATTRIBUTION_CAPABILITY_ID, ApprovalCapability, AttributionCapability,
-    CLIENT_COMMANDS_CAPABILITY_ID, ClientCommandsCapability, CodingBashCapability,
-    CodingCliEnvironmentCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID, SETUP_CAPABILITY_ID,
-    SetupCapability, TOOL_SEARCH_CAPABILITY_ID, ToolSearchCapability,
+    CLIENT_COMMANDS_CAPABILITY_ID, CONFIG_CAPABILITY_ID, ClientCommandsCapability,
+    CodingBashCapability, CodingCliEnvironmentCapability, ConfigCapability,
+    ENVIRONMENT_CONTEXT_CAPABILITY_ID, SETUP_CAPABILITY_ID, SetupCapability,
+    TOOL_SEARCH_CAPABILITY_ID, ToolSearchCapability,
 };
 use crate::host_ui::{HostUi, TuiHandle, UiCommand};
 use crate::settings::{Settings, SettingsStore};
@@ -595,7 +596,12 @@ impl ProviderChoice {
         if env_non_empty("EVERRUNS_CLI_MODEL").is_some() {
             return self;
         }
-        let Some(spec) = settings.model_for(self.provider_name()) else {
+        // A per-provider pick wins; the global `default_model` is the
+        // cross-provider fallback when this provider has no saved model.
+        let Some(spec) = settings
+            .model_for(self.provider_name())
+            .or_else(|| settings.default_model())
+        else {
             return self;
         };
         match self.resolve_model_spec(spec) {
@@ -1042,6 +1048,7 @@ fn coding_harness_capabilities(
             serde_json::json!({ "enable_file_download": true }),
         ),
         AgentCapabilityConfig::new(SETUP_CAPABILITY_ID),
+        AgentCapabilityConfig::new(CONFIG_CAPABILITY_ID),
         AgentCapabilityConfig::new(YOUR_CAPABILITY_ID),
         // Soft approval: injects spoken-consent guidance for critical actions,
         // tuned by the central `approval_mode` setting (off contributes nothing).
@@ -1346,8 +1353,11 @@ pub async fn build_with_options(
     capabilities.register(DuckDuckGoCapability);
     capabilities.register(WebFetchCapability::from_env());
     capabilities.register(CodingCliEnvironmentCapability::new(canonical_root.clone()));
+    // Read-only consumer of the shared config service. `SettingsStore`
+    // implements `ConfigService`, so the same handle that backs writes also
+    // serves reads to capabilities that don't need the concrete store.
     capabilities.register(AttributionCapability {
-        settings: settings.clone(),
+        config: settings.clone(),
     });
     // `/setup` (below) is the capability-sourced slash command. It implements
     // `Capability::execute_command` end to end. We deliberately
@@ -1361,6 +1371,12 @@ pub async fn build_with_options(
         provider_store: provider_store.clone(),
         settings: settings.clone(),
     });
+    // Schema-described, human-friendly config editing (`get_config` /
+    // `set_config`) plus an always-on pointer into the system prompt. Persists
+    // to the same `settings.toml`; provider/model edits take effect next run.
+    capabilities.register(ConfigCapability {
+        settings: settings.clone(),
+    });
     // `your` — global personalization. Its MEMORY.md lives beside
     // settings.toml in the yolop config dir, so a tempdir settings path in
     // tests isolates memory automatically.
@@ -1371,6 +1387,7 @@ pub async fn build_with_options(
     // Soft approval — spoken-consent guidance + audit tool, gated by the
     // central `approval_mode` setting (read live each turn).
     capabilities.register(ApprovalCapability {
+        config: settings.clone(),
         settings: settings.clone(),
     });
     capabilities.register(CodingBashCapability {
@@ -2164,6 +2181,33 @@ mod tests {
             .unwrap()
             .with_saved_model(&settings);
         assert_eq!(anthropic.label(), "anthropic/claude-sonnet-4-5");
+    }
+
+    #[test]
+    fn with_saved_model_falls_back_to_global_default_model() {
+        let _guard = crate::test_env::lock();
+        unsafe {
+            std::env::remove_var("EVERRUNS_CLI_MODEL");
+        }
+        let mut settings = Settings {
+            default_model: Some("claude-opus-4-5".to_string()),
+            ..Default::default()
+        };
+
+        // No per-provider entry, so the global default_model is applied.
+        let anthropic = ProviderChoice::default_for_provider_name("anthropic")
+            .unwrap()
+            .with_saved_model(&settings);
+        assert_eq!(anthropic.label(), "anthropic/claude-opus-4-5");
+
+        // A per-provider pick still wins over the global default.
+        settings
+            .models
+            .insert("anthropic".to_string(), "claude-haiku-4-5".to_string());
+        let anthropic = ProviderChoice::default_for_provider_name("anthropic")
+            .unwrap()
+            .with_saved_model(&settings);
+        assert_eq!(anthropic.label(), "anthropic/claude-haiku-4-5");
     }
 
     #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -69,12 +69,18 @@ impl std::fmt::Display for ApprovalMode {
 
 #[derive(Debug, Clone)]
 pub struct Settings {
+    /// The default provider used when neither `--provider` nor an env
+    /// credential forces a choice. Schema-described as `default_provider`.
     pub provider: Option<String>,
     pub tokens: BTreeMap<String, String>,
     /// Last model spec chosen per provider, in the provider-relative
     /// `model [effort]` form `/setup model` accepts. Lets a model pick
     /// survive restarts and provider switches.
     pub models: BTreeMap<String, String>,
+    /// Global fallback model spec applied to the active provider when no
+    /// per-provider `[models]` entry exists. Provider-relative, same form as
+    /// `[models]` (`gpt-5.5 high`). A per-provider pick always wins over this.
+    pub default_model: Option<String>,
     /// Endpoint base URLs keyed by provider. Today only `custom` (the
     /// generic OpenAI-compatible provider) writes here.
     pub base_urls: BTreeMap<String, String>,
@@ -90,6 +96,7 @@ impl Default for Settings {
             provider: None,
             tokens: BTreeMap::new(),
             models: BTreeMap::new(),
+            default_model: None,
             base_urls: BTreeMap::new(),
             attribution: true,
             approval_mode: ApprovalMode::Normal,
@@ -101,6 +108,10 @@ impl Settings {
     pub fn from_table(table: &Table) -> Self {
         let provider = table
             .get("provider")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let default_model = table
+            .get("default_model")
             .and_then(Value::as_str)
             .map(str::to_string);
         let attribution = table
@@ -127,6 +138,7 @@ impl Settings {
             provider,
             tokens: string_map("tokens"),
             models: string_map("models"),
+            default_model,
             base_urls: string_map("base_urls"),
             attribution,
             approval_mode,
@@ -137,6 +149,9 @@ impl Settings {
         let mut table = Table::new();
         if let Some(p) = &self.provider {
             table.insert("provider".to_string(), Value::String(p.clone()));
+        }
+        if let Some(m) = &self.default_model {
+            table.insert("default_model".to_string(), Value::String(m.clone()));
         }
         if !self.attribution {
             table.insert("attribution".to_string(), Value::Boolean(false));
@@ -173,6 +188,10 @@ impl Settings {
 
     pub fn model_for(&self, provider: &str) -> Option<&str> {
         self.models.get(provider).map(String::as_str)
+    }
+
+    pub fn default_model(&self) -> Option<&str> {
+        self.default_model.as_deref()
     }
 
     pub fn base_url_for(&self, provider: &str) -> Option<&str> {
@@ -311,6 +330,21 @@ impl SettingsStore {
     pub fn set_model(&self, provider: String, spec: String) -> Result<()> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
         guard.models.insert(provider, spec);
+        save_to(&self.path, &guard)
+    }
+
+    /// Returns whether a per-provider model was actually present before removal.
+    pub fn clear_model(&self, provider: &str) -> Result<bool> {
+        let mut guard = self.inner.lock().expect("settings lock poisoned");
+        let existed = guard.models.remove(provider).is_some();
+        save_to(&self.path, &guard)?;
+        Ok(existed)
+    }
+
+    /// Set or clear the global fallback model spec (`default_model`).
+    pub fn set_default_model(&self, spec: Option<String>) -> Result<()> {
+        let mut guard = self.inner.lock().expect("settings lock poisoned");
+        guard.default_model = spec.filter(|s| !s.trim().is_empty());
         save_to(&self.path, &guard)
     }
 
@@ -506,6 +540,50 @@ mod tests {
             Some("http://localhost:8000/v1")
         );
         assert!(reloaded.snapshot().model_for("anthropic").is_none());
+    }
+
+    #[test]
+    fn default_model_roundtrips_and_clears() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join("settings.toml");
+        let store = SettingsStore::open(path.clone());
+        assert!(store.snapshot().default_model().is_none());
+
+        store
+            .set_default_model(Some("claude-sonnet-4-5".to_string()))
+            .expect("save default model");
+        let on_disk = std::fs::read_to_string(&path).expect("read");
+        assert!(
+            on_disk.contains("default_model = \"claude-sonnet-4-5\""),
+            "expected default_model key, got: {on_disk}"
+        );
+
+        let reloaded = SettingsStore::open(path.clone());
+        assert_eq!(
+            reloaded.snapshot().default_model(),
+            Some("claude-sonnet-4-5")
+        );
+
+        // Empty/whitespace clears, and the key drops out of the TOML.
+        reloaded
+            .set_default_model(Some("  ".to_string()))
+            .expect("clear");
+        assert!(reloaded.snapshot().default_model().is_none());
+        let on_disk = std::fs::read_to_string(&path).expect("read");
+        assert!(!on_disk.contains("default_model"), "got: {on_disk}");
+    }
+
+    #[test]
+    fn clearing_model_reports_presence() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join("settings.toml");
+        let store = SettingsStore::open(path);
+        assert!(!store.clear_model("openai").expect("clear absent"));
+        store
+            .set_model("openai".to_string(), "gpt-5.5 high".to_string())
+            .expect("save");
+        assert!(store.clear_model("openai").expect("clear present"));
+        assert!(store.snapshot().model_for("openai").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds an **informational** configuration schema so yolop can explain and edit its
own settings the way a user describes them — without making settings loading any
stricter (unknown keys are still ignored, never fatal) — and exposes that
configuration as a read-only **service** other capabilities consume.

- **`src/config_schema.rs`** — a compile-time registry of every settings key
  (`title`, `description`, type `text`/`bool`/`secret`, default, examples,
  aliases, provider-scoping). Single source of truth for the tools, the service,
  and the skill; `parse_key` resolves aliases and validates providers.
- **`src/capabilities/config.rs`** — the `config` capability with two tools:
  - `get_config` — lists every key with its meaning + current value (tokens
    shown only as `stored`/`unset`); or one key by name.
  - `set_config` — schema-validated, persisted atomically via `SettingsStore`.
  Plus an always-on system-prompt pointer.
- **`src/config_service.rs`** — `ConfigService`, a read-oriented trait (typed
  getters + a generic `current(key)`, secrets reduced to presence).
  `SettingsStore` implements it, so the shared write handle also serves reads.
  Read-only capabilities take `Arc<dyn ConfigService>`.
- **Service consumers** — `AttributionCapability` reads `attribution` through the
  service, and **`ApprovalCapability` reads its `approval_mode` paranoia level
  through `ConfigService::approval_mode()`** each turn (keeping the concrete
  store only for its `set_approval_mode` write tool). `approval_mode` is now a
  first-class schema key, so `get_config`/`set_config` manage it alongside
  everything else.
- **`default_model`** — new top-level key: a global cross-provider model fallback
  applied in `ProviderChoice::with_saved_model` when the active provider has no
  per-provider pick. The existing `provider` key is surfaced as
  `default_provider` via an alias.
- **`skills/yolop-config/SKILL.md`** — on-demand reference; reads the live schema
  via `get_config`.
- **Docs** — `specs/configuration.md` (incl. "Configuration as a service") and
  README notes.

Rebased onto latest `main` (now includes the soft-approval capability from #98),
which is why `ApprovalCapability` is wired to the service here.

## Why

`settings.toml` loaded tolerantly but carried no semantics, and capabilities had
no shared way to read it. The schema gives config human meaning (editable in
natural language, forward-compatible); the service gives capabilities a single,
typed, redaction-aware read surface — the approval capability is the first
concrete consumer.

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`
  — clean.
- `cargo test --all-features` — 309 unit + 25 integration tests pass, 0 failures.
- Tests exercise real entry points: `set_config`/`get_config` execute paths
  (default_provider/default_model/approval_mode routing, alias resolution,
  unknown-key/provider rejection, base-URL scheme, token roundtrip + redaction,
  attribution as a JSON bool, table preservation + unsupported-provider
  filtering); `config_schema` parsing; `ConfigService` typed + schema-keyed reads
  (secret never returned); `settings` `default_model`/`clear_model` roundtrip;
  `with_saved_model` default_model fallback; approval capability reading via the
  service.
- **Offline smoke**: binary starts; `get_config`/`set_config` registered.
- **Live OpenAI smoke**: the agent drove `get_config` end-to-end and reported the
  schema semantics without mutating anything.

## Security

- **TM-FS** — write blocklist unchanged; config tools never write workspace
  files. Writes go only through `SettingsStore` (atomic, `0o600`, config dir).
- **TM-BASH** — no change to the bounded shell-execution model.
- **TM-LLM** — secrets never logged or echoed; tokens reduced to `stored`/`unset`
  by both the tools and the service; the always-on pointer includes only the
  settings *path*. Env keys still override and are read from process env.
- **TM-TOOL** — new capabilities respect the write blocklist.
- **TM-DEP** — no new dependencies.

## Follow-ups

- `default_provider` is an alias of the on-disk `provider` key, not a rename
  (pre-1.0, so a rename is an option later).
- A few `ConfigService` getters are intentionally ahead of their first consumer
  (`#[allow(dead_code)]` on the trait, documented inline).
- `get_config`/`set_config` may sit behind `tool_search` above the ~15-tool
  threshold; the always-on pointer and skill keep them discoverable.