### PR TITLE
feat(approval): add soft-approval capability with paranoia levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   into `.git/`, `node_modules/`, `target/`, `dist/`, `build/`, `.next/`,
   `.venv/`, `venv/`, `.tox/`, `.gradle/` at any depth; reads are unrestricted
   inside the workspace.
+- **Soft approval** — an optional spoken-consent layer for critical actions.
+  yolop batches the safe work and pauses to ask, in plain chat, only before
+  destructive or outward-facing steps; you approve by replying "yes". The
+  paranoia level (`protective` / `normal` / `off`) is shown in the status bar
+  and set with `/setup approval <level>` (or just by telling yolop to be more
+  or less careful). See [Soft approval](#soft-approval) below.
 - **TUI chat** (ratatui): scrolling transcript, multiline composer, status
   bar, slash commands (`/help`, `/tools`, `/mcp`, `/cwd`, `/setup`, `/model`,
   `/effort`, `/clear`, `/quit`).
@@ -131,6 +137,31 @@ your git author/committer identity and appends
 `Co-Authored-By: yolop <yolop@everruns.com>` once. PR descriptions created or
 edited through `gh` get a `Generated with yolop` footer. Disable with
 `/setup attribution off`.
+
+### Soft approval
+
+Soft approval is prompt-engineering, not a hard gate: yolop is told, in its
+system prompt, to batch safe work and pause for **spoken** consent only at the
+critical moments. The model decides what is critical; you approve in plain
+language ("yes", "approved"); each granted approval is recorded to the session
+event log for audit (via the `record_approval` tool). There is no separate
+approval UI — consent lives in the conversation.
+
+A single central level, `approval_mode`, tunes how cautious yolop is:
+
+| Level        | yolop pauses before…                                                  |
+|--------------|------------------------------------------------------------------------|
+| `protective` | any state-changing action (writes, commits, pushes, installs)          |
+| `normal`     | only destructive/irreversible or outward-facing actions (the default)  |
+| `off`        | nothing — fully autonomous, no soft-approval prompt                     |
+
+The current level is always shown in the status bar. Change it with
+`/setup approval <protective\|normal\|off>`, or just ask yolop to be more or
+less careful ("stop asking me", "yolo mode") — it switches the level itself.
+The setting is saved to `settings.toml`, so it persists across sessions.
+
+Soft approval is judgement, not a guarantee. For deterministic enforcement
+(hard-blocking a tool), use [hooks](specs/hooks.md); the two compose.
 
 ## Editor integration (ACP)
 
@@ -240,8 +271,9 @@ tools. See [`specs/mcp.md`](specs/mcp.md).
 ### Settings
 
 A small TOML settings file persists the preferred provider, per-provider
-model picks, custom endpoint base URLs, and (optionally) provider API tokens
-across runs: `<config_dir>/yolop/settings.toml` —
+model picks, custom endpoint base URLs, the soft-approval level
+(`approval_mode`), and (optionally) provider API tokens across runs:
+`<config_dir>/yolop/settings.toml` —
 `~/.config/yolop/settings.toml` on Linux,
 `~/Library/Application Support/yolop/settings.toml` on macOS,
 `%APPDATA%\yolop\settings.toml` on Windows.

--- a/specs/approval.md
+++ b/specs/approval.md
@@ -1,0 +1,84 @@
+# `approval` — soft approval
+
+Status: v1 implemented.
+
+## Why
+
+A coding agent runs tools that touch the real host: it writes files, deletes
+things, commits, pushes, installs packages. Users want a say before the
+risky ones — but a hard, per-call yes/no gate is miserable. It interrupts safe
+work, can't be reasoned about, and trains users to reflexively approve.
+
+Soft approval takes the opposite tack. It is **prompt-engineering, not a
+permission gate**: yolop is told, in its system prompt, to batch safe work and
+to pause for spoken consent only at the genuinely critical moments. The model
+decides what is critical; the user approves in plain language ("yes",
+"approved"); the granted approval is logged for audit. There is no separate
+approval UI to wire up — consent lives in the conversation.
+
+## What
+
+### Levels
+
+A single central setting, `approval_mode`, picks how cautious yolop is:
+
+| Level        | yolop pauses before…                                            |
+|--------------|-----------------------------------------------------------------|
+| `protective` | any state-changing action (writes, commits, pushes, installs, non-read-only `bash`) |
+| `normal`     | only clearly destructive/irreversible or outward-facing actions (default) |
+| `off`        | nothing — yolop acts autonomously, no soft-approval prompt at all |
+
+The level is **central configuration**: it lives in `settings.toml`
+(`approval_mode = "protective"`) next to the other yolop settings, so it is
+cross-session and global, not per-project. `normal` is the default and is
+omitted from the file to keep it sparse.
+
+### System-prompt injection
+
+The `yolop_approval` capability reads the level **live each turn** and
+contributes a `<soft_approval>` block to the system prompt:
+
+- `off` contributes nothing.
+- `normal` / `protective` inject the threshold for that level plus the
+  operating rules: plan first and **batch** the safe steps without pausing
+  (read-only inspection never needs approval); stop before a critical action,
+  briefly justify it (the "proof") and ask one short question; treat an
+  affirmative chat reply as the approval; record it; then proceed. A single
+  approval covers the action described, not unrelated later ones, and a
+  user-granted category exemption ("you don't need to ask for commits") is
+  honored without re-asking.
+
+Reading the level live means `/setup approval` and `set_approval_mode` take
+effect on the very next turn without a restart.
+
+### Audit
+
+Approvals are auditable through the existing per-session event log. The
+`record_approval` tool is called right after the user consents; because every
+tool call already persists a `tool.completed` line to the session's
+`events.jsonl`, the approval — its description, optional detail, and a
+timestamp — lands in that durable, owner-only log for free. No separate audit
+store is introduced.
+
+### Configuration surfaces
+
+The paranoia level can be changed three ways, all writing the same setting:
+
+- **Status bar** — the current level is always shown in the session status
+  line (`approval <level>`), so it is visible at a glance.
+- **`/setup approval <protective|normal|off>`** — the explicit command form,
+  alongside the other `/setup` knobs; bare `/setup approval` reports the
+  current level.
+- **Natural language** — because users address yolop directly ("be more
+  careful", "stop asking me", "yolo mode"), the `set_approval_mode` tool lets
+  the model switch the level in response, the same way the `your` layer
+  handles other "configure yolop itself" requests.
+
+## Non-goals
+
+- **Not a hard sandbox.** Soft approval cannot *prevent* a tool call; it asks
+  the model to. Hard enforcement belongs to hooks (see `specs/hooks.md`), which
+  can block a tool deterministically. The two compose: hooks for guarantees,
+  soft approval for judgement.
+- **No bespoke approval UI.** Consent is spoken in chat; there is deliberately
+  no modal or button.

--- a/src/app.rs
+++ b/src/app.rs
@@ -295,6 +295,9 @@ pub(crate) struct ViewState {
     pub workspace_root: std::path::PathBuf,
     pub session_id: SessionId,
     pub lines_count: usize,
+    /// Current soft-approval level (`protective` / `normal` / `off`), shown
+    /// in the session status bar so the paranoia level is always visible.
+    pub approval_mode: String,
 }
 
 /// What kind of delta is currently being streamed. Only the assistant
@@ -407,6 +410,12 @@ impl App {
             workspace_root: self.startup.workspace_root.clone(),
             session_id: self.handles.session_id,
             lines_count: self.lines.len(),
+            approval_mode: self
+                .settings
+                .snapshot()
+                .approval_mode()
+                .as_str()
+                .to_string(),
         }
     }
 
@@ -3964,6 +3973,8 @@ fn draw_session_status(f: &mut ratatui::Frame, area: Rect, state: &ViewState) {
                 format!("{} msgs", state.lines_count),
                 Style::default().fg(TEXT_MUTED),
             ),
+            Span::styled("  ·  approval ", Style::default().fg(TEXT_DIM)),
+            Span::styled(state.approval_mode.clone(), Style::default().fg(TEXT_MUTED)),
             Span::styled("  ·  session ", Style::default().fg(TEXT_DIM)),
             Span::styled(
                 state.session_id.to_string(),
@@ -4750,6 +4761,7 @@ mod tests {
             workspace_root: std::path::PathBuf::from("/tmp/ws"),
             session_id: SessionId::from_seed(770001),
             lines_count: 3,
+            approval_mode: "normal".to_string(),
         }
     }
 
@@ -6327,7 +6339,9 @@ mod tests {
             lines_count: 42,
             ..view_state_idle()
         };
-        let rows = render_chrome_lines(&state, 120, 5);
+        // Wide enough for the full status line (model · workspace · msgs ·
+        // approval · session <id>) without truncating the long session id.
+        let rows = render_chrome_lines(&state, 160, 5);
         let status = &rows[4];
         assert!(
             status.contains("anthropic/claude-sonnet-4-5"),
@@ -6340,6 +6354,10 @@ mod tests {
         assert!(
             status.contains("42 msgs"),
             "status should include message count: {status}"
+        );
+        assert!(
+            status.contains("approval normal"),
+            "status should include the soft-approval level: {status}"
         );
         assert!(
             status.contains("session "),

--- a/src/capabilities/approval.rs
+++ b/src/capabilities/approval.rs
@@ -141,7 +141,9 @@ impl Tool for RecordApprovalTool {
     fn description(&self) -> &str {
         "Record that the user just gave spoken approval for a critical action, for the audit \
          trail. Call this immediately after the user says yes/approved and before carrying the \
-         action out. Pass a concise, specific description of exactly what was approved."
+         action out. Pass a concise, specific description of exactly what was approved. These \
+         arguments are written to the session log, so do NOT include secrets (API keys, tokens, \
+         passwords); describe the action and redact any sensitive values."
     }
     fn parameters_schema(&self) -> Value {
         json!({
@@ -149,11 +151,11 @@ impl Tool for RecordApprovalTool {
             "properties": {
                 "action": {
                     "type": "string",
-                    "description": "The specific action the user approved, e.g. \"force-push branch feature/x to origin\"."
+                    "description": "The specific action the user approved, e.g. \"force-push branch feature/x to origin\". Do not embed secrets."
                 },
                 "detail": {
                     "type": "string",
-                    "description": "Optional extra context: the exact command, affected paths, or scope of the approval."
+                    "description": "Optional extra context: the command, affected paths, or scope of the approval. Redact any secrets (keys/tokens/passwords) before passing them — this is logged."
                 }
             },
             "required": ["action"],
@@ -208,10 +210,14 @@ impl Tool for SetApprovalModeTool {
         json!({
             "type": "object",
             "properties": {
+                // Kept as a free string (not an `enum`) so the lenient
+                // `ApprovalMode::parse` aliases — the same ones `/setup
+                // approval` and settings.toml accept — are reachable here too;
+                // a hard enum would silently shadow them. Unknown values are
+                // rejected in `execute`.
                 "mode": {
                     "type": "string",
-                    "enum": ["protective", "normal", "off"],
-                    "description": "The new approval level."
+                    "description": "The new approval level: 'protective', 'normal', or 'off' (common synonyms like 'paranoid' or 'yolo' are also accepted)."
                 }
             },
             "required": ["mode"],
@@ -323,7 +329,13 @@ mod tests {
             settings: settings.clone(),
         };
 
-        let res = tool.execute(json!({ "mode": "protective" })).await;
+        let res = tool.execute(json!({ "mode": "off" })).await;
+        assert!(res.is_success());
+        assert_eq!(settings.snapshot().approval_mode(), ApprovalMode::Off);
+
+        // Aliases accepted by `ApprovalMode::parse` reach the tool too, since
+        // the schema is a lenient string rather than a canonical-only enum.
+        let res = tool.execute(json!({ "mode": "paranoid" })).await;
         assert!(res.is_success());
         assert_eq!(
             settings.snapshot().approval_mode(),

--- a/src/capabilities/approval.rs
+++ b/src/capabilities/approval.rs
@@ -1,0 +1,340 @@
+// The `approval` capability — yolop's soft-approval (spoken-consent) layer.
+//
+// "Soft approval" is prompt-engineering, not a hard permission gate. Rather
+// than block each tool call behind an interactive yes/no, this capability
+// injects guidance into the system prompt that asks the model to:
+//
+//   * batch safe / read-only work and run it without interruption;
+//   * recognize the small set of critical actions (destructive, irreversible,
+//     or outward-facing) and, before those, state a brief justification and
+//     ask the user for approval in plain language;
+//   * treat an affirmative chat reply ("yes", "approved", "go ahead") as the
+//     approval — there is no separate UI to click;
+//   * record each granted approval with `record_approval`, which lands a
+//     `tool.completed` line in the per-session `events.jsonl` audit log.
+//
+// The paranoia level is central configuration (`approval_mode` in
+// settings.toml, see `crate::settings::ApprovalMode`), surfaced in the status
+// bar, switchable with `/setup approval <level>` and — because users address
+// yolop in natural language ("yolop, be more careful") — with the
+// `set_approval_mode` tool.
+
+use crate::settings::{ApprovalMode, SettingsStore};
+use async_trait::async_trait;
+use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use serde_json::{Value, json};
+use std::sync::Arc;
+
+pub(crate) const APPROVAL_CAPABILITY_ID: &str = "yolop_approval";
+
+/// Render the `<soft_approval>` system-prompt block for a given level.
+/// Pure so the per-mode branch logic is unit-testable without a
+/// `SystemPromptContext`. Returns `None` for [`ApprovalMode::Off`], which
+/// contributes nothing to the prompt.
+fn render_approval_block(mode: ApprovalMode) -> Option<String> {
+    let threshold = match mode {
+        ApprovalMode::Off => return None,
+        ApprovalMode::Protective => {
+            "PROTECTIVE — the bar is low. Ask before ANY action that changes \
+             state on the host: writing or deleting files, `git` commits/pushes, \
+             installing or removing packages, network calls with side effects, or \
+             running a `bash` command that is not plainly read-only."
+        }
+        ApprovalMode::Normal => {
+            "NORMAL — ask only before clearly DANGEROUS actions: destructive or \
+             irreversible operations (deleting files, `rm -rf`, dropping data, \
+             `git reset --hard`, force-push, history rewrites) and outward-facing \
+             ones (pushing, publishing, opening PRs, sending mail, deploying). \
+             Ordinary edits and local commits proceed without asking."
+        }
+    };
+
+    Some(format!(
+        "<soft_approval>\n\
+Soft-approval is active at level {level}.\n\
+\n\
+{threshold}\n\
+\n\
+How to operate:\n\
+- Plan first, then BATCH the safe steps and run them without pausing. Do NOT \
+ask for approval before every tool call — that defeats the purpose. Read-only \
+inspection (reading, listing, grepping, status checks) never needs approval.\n\
+- When you reach a critical action, STOP before running it. Briefly justify it \
+to the user (what you will do, why, and what is at risk — the \"proof\"), then \
+ask for approval in one short question and wait.\n\
+- A plain affirmative reply (\"yes\", \"approved\", \"go ahead\", \"do it\") is \
+the approval; a negative or hesitant reply is not. There is no separate \
+approval UI — consent is spoken in chat.\n\
+- Immediately after the user approves, call `record_approval` with a concise \
+description of exactly what was approved, then carry it out. This writes the \
+approval to the session audit log.\n\
+- One approval covers the specific action described, not unrelated later \
+actions. If the user pre-authorizes a category (\"you don't need to ask for \
+git commits\"), honor it for that category without re-asking.\n\
+- If the user asks to change how cautious you are (\"be more careful\", \"stop \
+asking\", \"yolo mode\"), call `set_approval_mode` to update the level.\n\
+</soft_approval>",
+        level = mode.as_str(),
+    ))
+}
+
+pub(crate) struct ApprovalCapability {
+    pub(crate) settings: Arc<SettingsStore>,
+}
+
+#[async_trait]
+impl Capability for ApprovalCapability {
+    fn id(&self) -> &str {
+        APPROVAL_CAPABILITY_ID
+    }
+    fn name(&self) -> &str {
+        "Soft Approval"
+    }
+    fn description(&self) -> &str {
+        "Spoken-consent approval for critical actions, tuned by a central paranoia level."
+    }
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+    fn category(&self) -> Option<&str> {
+        Some("Safety")
+    }
+
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        // Read the level live each turn so `/setup approval` and
+        // `set_approval_mode` take effect on the very next turn.
+        render_approval_block(self.settings.snapshot().approval_mode())
+    }
+
+    fn system_prompt_preview(&self) -> Option<String> {
+        // Show the normal-level block; `off` would contribute nothing.
+        render_approval_block(ApprovalMode::Normal)
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(RecordApprovalTool),
+            Box::new(SetApprovalModeTool {
+                settings: self.settings.clone(),
+            }),
+        ]
+    }
+}
+
+// ---------- tools ----------
+
+/// Records that the user verbally approved a specific critical action. The
+/// tool itself only echoes the record back; the durable audit entry is the
+/// `tool.completed` event this call produces in the per-session `events.jsonl`
+/// log, which captures the arguments (what was approved) and a timestamp.
+struct RecordApprovalTool;
+
+#[async_trait]
+impl Tool for RecordApprovalTool {
+    fn name(&self) -> &str {
+        "record_approval"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Record approval")
+    }
+    fn description(&self) -> &str {
+        "Record that the user just gave spoken approval for a critical action, for the audit \
+         trail. Call this immediately after the user says yes/approved and before carrying the \
+         action out. Pass a concise, specific description of exactly what was approved."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "description": "The specific action the user approved, e.g. \"force-push branch feature/x to origin\"."
+                },
+                "detail": {
+                    "type": "string",
+                    "description": "Optional extra context: the exact command, affected paths, or scope of the approval."
+                }
+            },
+            "required": ["action"],
+            "additionalProperties": false
+        })
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let action = match arguments.get("action").and_then(Value::as_str) {
+            Some(a) if !a.trim().is_empty() => a.trim(),
+            _ => {
+                return ToolExecutionResult::tool_error(
+                    "'action' is required and must describe what was approved",
+                );
+            }
+        };
+        let detail = arguments
+            .get("detail")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|d| !d.is_empty());
+        ToolExecutionResult::success(json!({
+            "ok": true,
+            "recorded": true,
+            "action": action,
+            "detail": detail,
+            "message": format!("approval recorded: {action}"),
+        }))
+    }
+}
+
+/// Switches the central soft-approval level. Backs natural-language requests
+/// ("yolop, be more careful", "stop asking me") so the user can tune yolop's
+/// paranoia without remembering the `/setup` form.
+struct SetApprovalModeTool {
+    settings: Arc<SettingsStore>,
+}
+
+#[async_trait]
+impl Tool for SetApprovalModeTool {
+    fn name(&self) -> &str {
+        "set_approval_mode"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Set approval level")
+    }
+    fn description(&self) -> &str {
+        "Set yolop's soft-approval paranoia level. Use when the user asks you to be more or less \
+         cautious about confirming actions. `protective` asks before any state change, `normal` \
+         asks only before destructive or outward-facing actions, `off` never asks."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "mode": {
+                    "type": "string",
+                    "enum": ["protective", "normal", "off"],
+                    "description": "The new approval level."
+                }
+            },
+            "required": ["mode"],
+            "additionalProperties": false
+        })
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let raw = match arguments.get("mode").and_then(Value::as_str) {
+            Some(m) => m,
+            None => return ToolExecutionResult::tool_error("'mode' is required"),
+        };
+        let mode = match ApprovalMode::parse(raw) {
+            Some(mode) => mode,
+            None => {
+                return ToolExecutionResult::tool_error(format!(
+                    "unknown approval level '{raw}'; expected protective, normal, or off"
+                ));
+            }
+        };
+        match self.settings.set_approval_mode(mode) {
+            Ok(()) => ToolExecutionResult::success(json!({
+                "ok": true,
+                "mode": mode.as_str(),
+                "message": format!("approval level set to {mode}"),
+            })),
+            Err(e) => {
+                ToolExecutionResult::tool_error(format!("could not save approval level: {e}"))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store_in_tmp() -> (tempfile::TempDir, Arc<SettingsStore>) {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let store = Arc::new(SettingsStore::open(tmp.path().join("settings.toml")));
+        (tmp, store)
+    }
+
+    #[test]
+    fn off_contributes_no_prompt() {
+        assert!(render_approval_block(ApprovalMode::Off).is_none());
+    }
+
+    #[test]
+    fn normal_and_protective_render_expected_guidance() {
+        let normal = render_approval_block(ApprovalMode::Normal).expect("normal block");
+        assert!(normal.starts_with("<soft_approval>"));
+        assert!(normal.contains("level normal"));
+        assert!(normal.contains("NORMAL"));
+        // The core behaviors must be spelled out.
+        assert!(normal.contains("BATCH"));
+        assert!(normal.contains("record_approval"));
+        assert!(normal.ends_with("</soft_approval>"));
+
+        let protective = render_approval_block(ApprovalMode::Protective).expect("protective block");
+        assert!(protective.contains("level protective"));
+        assert!(protective.contains("PROTECTIVE"));
+    }
+
+    #[test]
+    fn capability_exposes_both_tools() {
+        let (_tmp, settings) = store_in_tmp();
+        let cap = ApprovalCapability { settings };
+        let names: Vec<String> = cap.tools().iter().map(|t| t.name().to_string()).collect();
+        assert_eq!(names, vec!["record_approval", "set_approval_mode"]);
+        assert!(cap.commands().is_empty());
+    }
+
+    #[tokio::test]
+    async fn contribution_follows_settings() {
+        let (_tmp, settings) = store_in_tmp();
+        let cap = ApprovalCapability {
+            settings: settings.clone(),
+        };
+        let ctx =
+            SystemPromptContext::without_file_store(everruns_core::typed_id::SessionId::new());
+
+        // Default (normal) contributes a block.
+        assert!(cap.system_prompt_contribution(&ctx).await.is_some());
+
+        // Off suppresses it.
+        settings
+            .set_approval_mode(ApprovalMode::Off)
+            .expect("set off");
+        assert!(cap.system_prompt_contribution(&ctx).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn record_approval_requires_action_and_echoes_it() {
+        let tool = RecordApprovalTool;
+        assert!(tool.execute(json!({ "action": "  " })).await.is_error());
+
+        let res = tool
+            .execute(json!({ "action": "force-push feature/x", "detail": "git push -f" }))
+            .await;
+        assert!(res.is_success());
+        let text = format!("{res:?}");
+        assert!(text.contains("force-push feature/x"));
+    }
+
+    #[tokio::test]
+    async fn set_approval_mode_updates_settings_and_rejects_garbage() {
+        let (_tmp, settings) = store_in_tmp();
+        let tool = SetApprovalModeTool {
+            settings: settings.clone(),
+        };
+
+        let res = tool.execute(json!({ "mode": "protective" })).await;
+        assert!(res.is_success());
+        assert_eq!(
+            settings.snapshot().approval_mode(),
+            ApprovalMode::Protective
+        );
+
+        assert!(tool.execute(json!({ "mode": "whenever" })).await.is_error());
+        // Unchanged after a rejected value.
+        assert_eq!(
+            settings.snapshot().approval_mode(),
+            ApprovalMode::Protective
+        );
+    }
+}

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -2,7 +2,7 @@
 // TUI-facing slash commands that mutate this process's provider selection.
 
 use crate::runtime::{ProviderChoice, SUPPORTED_PROVIDERS};
-use crate::settings::SettingsStore;
+use crate::settings::{ApprovalMode, SettingsStore};
 use crate::tools::{BashTool, Workspace};
 use async_trait::async_trait;
 use chrono::Local;
@@ -411,8 +411,9 @@ impl Capability for SetupCapability {
             "token" => self.change_token(rest),
             "url" => self.change_base_url(rest),
             "attribution" => self.change_attribution(rest),
+            "approval" => self.change_approval(rest),
             _ => Ok(failed_result(
-                "usage: /setup — run guided setup; internal forms: status, provider <name> [model], token <provider> <value|clear>, url <provider> <base-url|clear>, model <id> [reasoning-effort], effort <reasoning-effort>, attribution <on|off>".to_string(),
+                "usage: /setup — run guided setup; internal forms: status, provider <name> [model], token <provider> <value|clear>, url <provider> <base-url|clear>, model <id> [reasoning-effort], effort <reasoning-effort>, attribution <on|off>, approval <protective|normal|off>".to_string(),
             )),
         }
     }
@@ -424,6 +425,9 @@ fn setup_command_arg() -> CommandArg {
         "model".to_string(),
         "attribution on".to_string(),
         "attribution off".to_string(),
+        "approval protective".to_string(),
+        "approval normal".to_string(),
+        "approval off".to_string(),
     ];
     suggestions.extend(TOKEN_PROVIDERS.iter().flat_map(|provider| {
         [
@@ -457,7 +461,7 @@ fn setup_command_arg() -> CommandArg {
 
     CommandArg {
         name: "action".to_string(),
-        description: "status | provider <name> [model] | token <provider> <value|clear> | url <provider> <base-url|clear> | model <id> | effort <level> | attribution <on|off>".to_string(),
+        description: "status | provider <name> [model] | token <provider> <value|clear> | url <provider> <base-url|clear> | model <id> | effort <level> | attribution <on|off> | approval <protective|normal|off>".to_string(),
         required: false,
         suggestions,
     }
@@ -484,10 +488,11 @@ impl SetupCapability {
         CommandResult {
             success: true,
             message: format!(
-                "setup: provider={} model={} saved={saved} attribution={} stored tokens={stored_label} env keys present={}",
+                "setup: provider={} model={} saved={saved} attribution={} approval={} stored tokens={stored_label} env keys present={}",
                 current.provider_name(),
                 current.label(),
                 on_off(snapshot.attribution_enabled()),
+                snapshot.approval_mode(),
                 env_credential_present()
             ),
             error_code: None,
@@ -859,6 +864,40 @@ impl SetupCapability {
             Err(err) => Ok(failed_result(format!(
                 "setup attribution save failed: {err}"
             ))),
+        }
+    }
+
+    fn change_approval(&self, raw: &str) -> everruns_core::Result<CommandResult> {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("status") {
+            return Ok(CommandResult {
+                success: true,
+                message: format!(
+                    "setup approval: {} (protective | normal | off) ({})",
+                    self.settings.snapshot().approval_mode(),
+                    self.settings.path().display()
+                ),
+                error_code: None,
+                error_fields: None,
+            });
+        }
+
+        let mode = match ApprovalMode::parse(trimmed) {
+            Some(mode) => mode,
+            None => {
+                return Ok(failed_result(
+                    "setup approval failed: expected protective, normal, or off".to_string(),
+                ));
+            }
+        };
+        match self.settings.set_approval_mode(mode) {
+            Ok(()) => Ok(CommandResult {
+                success: true,
+                message: format!("setup approval: {mode}"),
+                error_code: None,
+                error_fields: None,
+            }),
+            Err(err) => Ok(failed_result(format!("setup approval save failed: {err}"))),
         }
     }
 }

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -3,6 +3,7 @@
 // These are host/example behavior rather than runtime primitives. Keep the
 // module boundary here small; capability implementations live in submodules.
 
+pub(crate) mod approval;
 pub(crate) mod client_commands;
 mod host;
 pub(crate) mod model_discovery;
@@ -10,6 +11,7 @@ pub mod skills;
 pub(crate) mod tool_search;
 pub(crate) mod your;
 
+pub(crate) use approval::{APPROVAL_CAPABILITY_ID, ApprovalCapability};
 pub(crate) use client_commands::{CLIENT_COMMANDS_CAPABILITY_ID, ClientCommandsCapability};
 pub(crate) use host::{
     ATTRIBUTION_CAPABILITY_ID, AttributionCapability, CodingBashCapability,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -6,10 +6,10 @@
 
 use crate::capabilities::your::{YOUR_CAPABILITY_ID, YourCapability, YourStore};
 use crate::capabilities::{
-    ATTRIBUTION_CAPABILITY_ID, AttributionCapability, CLIENT_COMMANDS_CAPABILITY_ID,
-    ClientCommandsCapability, CodingBashCapability, CodingCliEnvironmentCapability,
-    ENVIRONMENT_CONTEXT_CAPABILITY_ID, SETUP_CAPABILITY_ID, SetupCapability,
-    TOOL_SEARCH_CAPABILITY_ID, ToolSearchCapability,
+    APPROVAL_CAPABILITY_ID, ATTRIBUTION_CAPABILITY_ID, ApprovalCapability, AttributionCapability,
+    CLIENT_COMMANDS_CAPABILITY_ID, ClientCommandsCapability, CodingBashCapability,
+    CodingCliEnvironmentCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID, SETUP_CAPABILITY_ID,
+    SetupCapability, TOOL_SEARCH_CAPABILITY_ID, ToolSearchCapability,
 };
 use crate::host_ui::{HostUi, TuiHandle, UiCommand};
 use crate::settings::{Settings, SettingsStore};
@@ -1043,6 +1043,9 @@ fn coding_harness_capabilities(
         ),
         AgentCapabilityConfig::new(SETUP_CAPABILITY_ID),
         AgentCapabilityConfig::new(YOUR_CAPABILITY_ID),
+        // Soft approval: injects spoken-consent guidance for critical actions,
+        // tuned by the central `approval_mode` setting (off contributes nothing).
+        AgentCapabilityConfig::new(APPROVAL_CAPABILITY_ID),
         AgentCapabilityConfig::new("yolop_bash"),
     ]);
     if let Some(config) = hook_config {
@@ -1364,6 +1367,11 @@ pub async fn build_with_options(
     capabilities.register(YourCapability {
         memory: Arc::new(YourStore::beside_settings(&settings)),
         hooks: hooks_store,
+    });
+    // Soft approval — spoken-consent guidance + audit tool, gated by the
+    // central `approval_mode` setting (read live each turn).
+    capabilities.register(ApprovalCapability {
+        settings: settings.clone(),
     });
     capabilities.register(CodingBashCapability {
         workspace: workspace.clone(),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1597,6 +1597,11 @@ mod tests {
             "status: {}",
             status.message
         );
+        assert!(
+            status.message.contains("approval=normal"),
+            "status should report the default approval level: {}",
+            status.message
+        );
 
         let disable_attribution = built
             .handles
@@ -1629,6 +1634,47 @@ mod tests {
             .expect("enable setup attribution");
         assert!(enable_attribution.success);
         assert!(settings_for_assert.snapshot().attribution_enabled());
+
+        // `/setup approval <level>` drives the soft-approval level through the
+        // same command entry point and persists it.
+        let set_approval = built
+            .handles
+            .runtime
+            .execute_command(
+                built.handles.session_id,
+                ExecuteCommandRequest {
+                    name: "setup".to_string(),
+                    arguments: Some("approval protective".to_string()),
+                    controls: None,
+                },
+            )
+            .await
+            .expect("set setup approval");
+        assert!(set_approval.success);
+        assert_eq!(
+            settings_for_assert.snapshot().approval_mode(),
+            crate::settings::ApprovalMode::Protective
+        );
+
+        let bad_approval = built
+            .handles
+            .runtime
+            .execute_command(
+                built.handles.session_id,
+                ExecuteCommandRequest {
+                    name: "setup".to_string(),
+                    arguments: Some("approval whenever".to_string()),
+                    controls: None,
+                },
+            )
+            .await
+            .expect("reject bad approval level");
+        assert!(!bad_approval.success);
+        // An invalid level leaves the prior selection untouched.
+        assert_eq!(
+            settings_for_assert.snapshot().approval_mode(),
+            crate::settings::ApprovalMode::Protective
+        );
 
         let store_token = built
             .handles

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -20,6 +20,53 @@ use std::sync::Mutex;
 use toml::Table;
 use toml::Value;
 
+/// How aggressively yolop pauses for spoken ("soft") approval before
+/// running critical actions. Soft approval is prompt-engineering, not a
+/// hard gate: the chosen level is injected into the system prompt so the
+/// model itself decides when to ask, batches safe calls, and the user
+/// approves in plain text ("yes", "approved"). See `capabilities::approval`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ApprovalMode {
+    /// Ask before any state-changing action — the lowest threshold.
+    Protective,
+    /// Ask only before clearly destructive, irreversible, or outward-facing
+    /// actions. The default.
+    #[default]
+    Normal,
+    /// Never pause for approval; act autonomously.
+    Off,
+}
+
+impl ApprovalMode {
+    /// Canonical lowercase name, as written to settings.toml and shown in
+    /// the status bar.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ApprovalMode::Protective => "protective",
+            ApprovalMode::Normal => "normal",
+            ApprovalMode::Off => "off",
+        }
+    }
+
+    /// Parse a user- or config-supplied level. Accepts the canonical names
+    /// plus a few intuitive aliases so natural-language requests ("be more
+    /// paranoid", "yolo mode") and config files both resolve.
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "protective" | "strict" | "paranoid" | "high" | "careful" => Some(Self::Protective),
+            "normal" | "default" | "medium" | "standard" => Some(Self::Normal),
+            "off" | "none" | "yolo" | "disabled" | "low" => Some(Self::Off),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for ApprovalMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Settings {
     pub provider: Option<String>,
@@ -32,6 +79,9 @@ pub struct Settings {
     /// generic OpenAI-compatible provider) writes here.
     pub base_urls: BTreeMap<String, String>,
     pub attribution: bool,
+    /// Soft-approval paranoia level, injected into the system prompt each
+    /// turn. Central, cross-session, surfaced in the status bar.
+    pub approval_mode: ApprovalMode,
 }
 
 impl Default for Settings {
@@ -42,6 +92,7 @@ impl Default for Settings {
             models: BTreeMap::new(),
             base_urls: BTreeMap::new(),
             attribution: true,
+            approval_mode: ApprovalMode::Normal,
         }
     }
 }
@@ -56,6 +107,11 @@ impl Settings {
             .get("attribution")
             .and_then(Value::as_bool)
             .unwrap_or(true);
+        let approval_mode = table
+            .get("approval_mode")
+            .and_then(Value::as_str)
+            .and_then(ApprovalMode::parse)
+            .unwrap_or_default();
         let string_map = |key: &str| {
             let mut map = BTreeMap::new();
             if let Some(t) = table.get(key).and_then(Value::as_table) {
@@ -73,6 +129,7 @@ impl Settings {
             models: string_map("models"),
             base_urls: string_map("base_urls"),
             attribution,
+            approval_mode,
         }
     }
 
@@ -83,6 +140,13 @@ impl Settings {
         }
         if !self.attribution {
             table.insert("attribution".to_string(), Value::Boolean(false));
+        }
+        // Only persist a non-default level so settings.toml stays sparse.
+        if self.approval_mode != ApprovalMode::Normal {
+            table.insert(
+                "approval_mode".to_string(),
+                Value::String(self.approval_mode.as_str().to_string()),
+            );
         }
         let mut insert_map = |key: &str, map: &BTreeMap<String, String>| {
             if !map.is_empty() {
@@ -117,6 +181,10 @@ impl Settings {
 
     pub fn attribution_enabled(&self) -> bool {
         self.attribution
+    }
+
+    pub fn approval_mode(&self) -> ApprovalMode {
+        self.approval_mode
     }
 }
 
@@ -220,6 +288,12 @@ impl SettingsStore {
         save_to(&self.path, &guard)
     }
 
+    pub fn set_approval_mode(&self, mode: ApprovalMode) -> Result<()> {
+        let mut guard = self.inner.lock().expect("settings lock poisoned");
+        guard.approval_mode = mode;
+        save_to(&self.path, &guard)
+    }
+
     pub fn set_token(&self, provider: String, token: String) -> Result<()> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
         guard.tokens.insert(provider, token);
@@ -302,6 +376,52 @@ mod tests {
 
         let reloaded = SettingsStore::open(path);
         assert!(!reloaded.snapshot().attribution_enabled());
+    }
+
+    #[test]
+    fn approval_mode_defaults_to_normal_and_is_omitted() {
+        let settings = Settings::from_table(&Table::new());
+        assert_eq!(settings.approval_mode(), ApprovalMode::Normal);
+        // The default level is not written, keeping settings.toml sparse.
+        assert!(!settings.to_table().contains_key("approval_mode"));
+    }
+
+    #[test]
+    fn approval_mode_roundtrips_via_disk() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join("settings.toml");
+        let store = SettingsStore::open(path.clone());
+        store
+            .set_approval_mode(ApprovalMode::Protective)
+            .expect("save");
+
+        let on_disk = std::fs::read_to_string(&path).expect("read");
+        assert!(
+            on_disk.contains("approval_mode = \"protective\""),
+            "expected approval level, got: {on_disk}"
+        );
+
+        let reloaded = SettingsStore::open(path);
+        assert_eq!(
+            reloaded.snapshot().approval_mode(),
+            ApprovalMode::Protective
+        );
+    }
+
+    #[test]
+    fn approval_mode_parses_canonical_names_and_aliases() {
+        assert_eq!(
+            ApprovalMode::parse("protective"),
+            Some(ApprovalMode::Protective)
+        );
+        assert_eq!(
+            ApprovalMode::parse("Paranoid"),
+            Some(ApprovalMode::Protective)
+        );
+        assert_eq!(ApprovalMode::parse(" normal "), Some(ApprovalMode::Normal));
+        assert_eq!(ApprovalMode::parse("yolo"), Some(ApprovalMode::Off));
+        assert_eq!(ApprovalMode::parse("off"), Some(ApprovalMode::Off));
+        assert!(ApprovalMode::parse("sometimes").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds **soft approval** — a spoken-consent layer for critical actions. Instead of hard-gating each tool call behind a yes/no, yolop is told in its system prompt to batch the safe work and pause for plain-language approval ("yes") only before destructive or outward-facing steps. The model decides what is critical; the user approves in chat; each approval is recorded for audit.

A single central setting, `approval_mode`, tunes the paranoia:

| Level | yolop pauses before… |
|---|---|
| `protective` | any state-changing action (writes, commits, pushes, installs) |
| `normal` | only destructive/irreversible or outward-facing actions (**default**) |
| `off` | nothing — fully autonomous, no soft-approval prompt |

### Surfaces
- **System prompt** (`src/capabilities/approval.rs`) — `ApprovalCapability` injects a mode-dependent `<soft_approval>` block, read **live each turn** (so changes take effect next turn). `off` contributes nothing.
- **Tools** — `record_approval` logs the granted approval; `set_approval_mode` backs natural-language requests ("be more careful", "yolo mode").
- **`/setup approval <level>`** + status line, and the level is shown in the TUI status bar.
- **Persistence** — `approval_mode` in `settings.toml` (omitted when default, kept sparse).

## Why

`normal`-by-default keeps yolop autonomous for ordinary edits while drawing a line at the genuinely risky, hard-to-reverse, or outward-facing actions — without the friction of per-call prompts. The level is central config (cross-session, global), tunable three ways including in plain language, mirroring how the `your` layer handles "configure yolop itself" requests. See [`specs/approval.md`](specs/approval.md).

## Audit

No new audit store. `record_approval` is a tool, so each call automatically persists a `tool.completed` line — the approved action text + timestamp — to the session's owner-only `events.jsonl`.

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings` — clean.
- `cargo test --all-features` — 289 unit + 23 integration tests pass.
- **Feature tests**: per-mode prompt rendering (incl. `off` → none), both tools' `execute` paths (settings update + input rejection), `system_prompt_contribution` following settings live, status-bar rendering, settings round-trip via disk, and **`/setup approval` driven end-to-end through `runtime.execute_command`** (valid level persists + shows in `/setup status`; invalid level rejected, prior selection untouched).
- **Live smoke (openai, gpt-5.5)**:
  - `rm -rf /tmp/demo-dir` → yolop stated the destructive justification and **paused for approval** instead of running it (0 tool calls).
  - "count the Rust files" → ran `find … | wc -l` **immediately, no pause** — proving it doesn't over-ask.

## Security

Reviewed per the shipping categories:
- **TM-FS** — write blocklist untouched. `record_approval` writes nothing; `set_approval_mode` writes only `settings.toml` (config dir, atomic 0o600) — no workspace writes.
- **TM-LLM** — no secrets in the prompt block or tool output; no new logging of keys.
- **TM-TOOL** — both new tools respect the write blocklist (no fs writes into the workspace).
- **TM-DEP** — no new dependencies.
- Input validation at the boundary: `ApprovalMode::parse` rejects unknown levels; `record_approval` requires a non-empty `action`.

## Follow-ups

No follow-ups. Soft approval is judgement, not a hard gate; deterministic enforcement remains the job of hooks, and the two compose (documented in the spec/README).


---
_Generated by [Claude Code](https://claude.ai/code/session_01GRSxaBeHVVRMbwkJ3sBfu9)_