### PR TITLE
refactor(config): rename provider key, slim ConfigService

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ id.
 Provider resolution at startup:
 
 1. `--provider` flag (always wins)
-2. Saved `provider` setting
+2. Saved `default_provider` setting (the legacy `provider` key is still read)
 3. Auto-detect: the first provider in the order **OpenAI → Anthropic →
    OpenRouter → Google → Ollama → Custom** with either a matching env var or
    a saved token/base URL (the provider order decides the tiebreak, not the

--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -32,7 +32,7 @@ Keys are addressed the way a human would name them:
 
 | Key                       | Type   | Meaning                                                        |
 |---------------------------|--------|----------------------------------------------------------------|
-| `default_provider`        | text   | Provider used when neither `--provider` nor an env credential forces a choice. Stored on disk as `provider`. |
+| `default_provider`        | text   | Provider used when no `--provider` flag is given; takes precedence over env auto-detection. |
 | `default_model`           | text   | Global fallback model spec for the active provider; a per-provider pick wins over it. |
 | `models.<provider>`       | text   | Per-provider model spec, survives provider switches.           |
 | `tokens.<provider>`       | secret | Provider API token (owner-only on disk; env vars override).    |

--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -40,11 +40,10 @@ Keys are addressed the way a human would name them:
 | `approval_mode`           | text   | Soft-approval paranoia level (`protective` / `normal` / `off`). |
 | `attribution`             | bool   | Commit/PR attribution on/off.                                  |
 
-`default_provider` and `default_model` are surfaced under those human-friendly
-names. On disk `default_provider` is the long-standing top-level `provider`
-key; `set_config` routes the alias to that one stored field so provider state
-never diverges. `default_model` is a real new top-level key, applied as a
-cross-provider fallback in `ProviderChoice::with_saved_model`.
+`default_provider` is persisted under that name on disk; the legacy `provider`
+key is still read (and accepted as an alias) so pre-rename settings files keep
+working. `default_model` is applied as a cross-provider fallback in
+`ProviderChoice::with_saved_model`.
 
 ### Tools
 
@@ -68,18 +67,23 @@ Configuration is exposed to the rest of the agent as a **service** so that
 capabilities can read it without re-parsing the TOML or reaching into store
 internals. `src/config_service.rs` defines the `ConfigService` trait:
 
-- typed getters (`default_provider`, `default_model`, `attribution_enabled`,
-  `token_present`, `model_for`, `base_url_for`), and
 - a generic `current(key)` that reads any value by its schema key (e.g.
-  `models.openai`), with secrets reduced to `stored`/`unset`.
+  `models.openai`), with secrets reduced to `stored`/`unset`, and
+- the two semantic getters that have dedicated consumers
+  (`attribution_enabled`, `approval_mode`).
+
+The surface is kept minimal: `current(key)` covers arbitrary reads, so a
+capability adds a typed getter only when it grows a real need rather than
+carrying speculative methods.
 
 `SettingsStore` implements `ConfigService`, so the single shared handle that
 backs writes also serves reads. Capabilities that only *read* config take an
 `Arc<dyn ConfigService>`; capabilities that *write* (setup, config) keep the
 concrete `SettingsStore`. `AttributionCapability` reads whether attribution is
-enabled through the service, and `ApprovalCapability` reads its soft-approval
-paranoia level (`approval_mode`) through `ConfigService::approval_mode()` each
-turn — it keeps the concrete store only for its `set_approval_mode` write tool.
+enabled through the service; `ApprovalCapability` reads its soft-approval
+paranoia level through `ConfigService::approval_mode()` each turn (keeping the
+concrete store only for its `set_approval_mode` write tool); and the `config`
+capability's `get_config` reads single values through `ConfigService::current`.
 `approval_mode` is also a first-class schema key, so `get_config`/`set_config`
 manage it alongside everything else.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -5883,7 +5883,7 @@ mod tests {
         // The pick persists, so the next run restores it (see
         // pick_provider_applies_saved_model_for_saved_provider in main.rs).
         let snapshot = app.settings.snapshot();
-        assert_eq!(snapshot.provider.as_deref(), Some("openai"));
+        assert_eq!(snapshot.default_provider.as_deref(), Some("openai"));
         assert_eq!(snapshot.model_for("openai"), Some("gpt-5.4 medium"));
     }
 
@@ -5994,7 +5994,7 @@ mod tests {
             snapshot.base_url_for("custom"),
             Some("http://localhost:8000/v1")
         );
-        assert_eq!(snapshot.provider.as_deref(), Some("custom"));
+        assert_eq!(snapshot.default_provider.as_deref(), Some("custom"));
         assert_eq!(snapshot.model_for("custom"), Some("qwen3-coder"));
     }
 

--- a/src/capabilities/config.rs
+++ b/src/capabilities/config.rs
@@ -13,7 +13,7 @@
 // the interactive `/setup` command to switch the *live* model mid-session.
 
 use crate::config_schema::{KeyTarget, ValueKind, known_keys, parse_key, schema};
-use crate::config_service::{current_value, scoped_current};
+use crate::config_service::{ConfigService, current_value, scoped_current};
 use crate::runtime::SUPPORTED_PROVIDERS;
 use crate::settings::{ApprovalMode, Settings, SettingsStore};
 use async_trait::async_trait;
@@ -154,17 +154,19 @@ impl Tool for GetConfigTool {
                 };
                 let field = target.field();
                 let mut entry = field_json(&settings, field);
-                // For a provider-scoped single key, narrow `current` to the
-                // requested provider while preserving the whole-table view
-                // under `table` (field_json seeded `current` with the table).
-                if field.provider_scoped {
-                    if let Value::Object(map) = &mut entry {
-                        let table = map.get("current").cloned().unwrap_or(Value::Null);
-                        map.insert("table".to_string(), table);
-                        map.insert("key".to_string(), Value::String(key.to_string()));
-                    }
-                    entry["current"] = current_value(&settings, &target);
+                // Read the single value through the config service (the same
+                // path any capability uses), which narrows a provider-scoped
+                // key to the requested provider. For those keys, preserve the
+                // whole-table view that field_json seeded into `current`.
+                let value = self.settings.current(key).unwrap_or(Value::Null);
+                if field.provider_scoped
+                    && let Value::Object(map) = &mut entry
+                {
+                    let table = map.get("current").cloned().unwrap_or(Value::Null);
+                    map.insert("table".to_string(), table);
+                    map.insert("key".to_string(), Value::String(key.to_string()));
                 }
+                entry["current"] = value;
                 return ToolExecutionResult::success(json!({
                     "settings_path": path,
                     "field": entry,
@@ -270,7 +272,7 @@ impl SetConfigTool {
         match target {
             KeyTarget::DefaultProvider => {
                 if clearing {
-                    self.settings.set_provider(None).map_err(map_err)?;
+                    self.settings.set_default_provider(None).map_err(map_err)?;
                     return Ok(saved(
                         "cleared default_provider; it will be auto-detected from credentials"
                             .to_string(),
@@ -284,7 +286,7 @@ impl SetConfigTool {
                     ));
                 }
                 self.settings
-                    .set_provider(Some(provider.clone()))
+                    .set_default_provider(Some(provider.clone()))
                     .map_err(map_err)?;
                 Ok(saved(format!(
                     "default_provider = {provider}; applies on the next run (use /setup to switch now)"
@@ -403,7 +405,10 @@ mod tests {
             .execute(json!({ "key": "default_provider", "value": "anthropic" }))
             .await;
         assert!(matches!(r, ToolExecutionResult::Success(_)));
-        assert_eq!(settings.snapshot().provider.as_deref(), Some("anthropic"));
+        assert_eq!(
+            settings.snapshot().default_provider.as_deref(),
+            Some("anthropic")
+        );
 
         // Alias `model` routes to default_model.
         tool.execute(json!({ "key": "model", "value": "claude-opus-4-5" }))

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -478,7 +478,7 @@ impl SetupCapability {
             .clone();
         let snapshot = self.settings.snapshot();
         let saved = snapshot
-            .provider
+            .default_provider
             .clone()
             .unwrap_or_else(|| "<unset>".to_string());
         let stored: Vec<&str> = snapshot.tokens.keys().map(String::as_str).collect();
@@ -552,9 +552,10 @@ impl SetupCapability {
                 .set_model(provider_name.clone(), next.model_spec())
         };
         *self.provider.write().expect("provider lock poisoned") = next;
-        let persist_note = match model_persist
-            .and_then(|()| self.settings.set_provider(Some(provider_name.clone())))
-        {
+        let persist_note = match model_persist.and_then(|()| {
+            self.settings
+                .set_default_provider(Some(provider_name.clone()))
+        }) {
             Ok(()) => format!("saved to {}", self.settings.path().display()),
             Err(err) => format!("warning: settings not saved: {err}"),
         };
@@ -625,7 +626,7 @@ impl SetupCapability {
         let provider_name = next.provider_name().to_string();
         let result = self
             .settings
-            .set_provider(Some(provider_name.clone()))
+            .set_default_provider(Some(provider_name.clone()))
             .and_then(|()| self.settings.set_model(provider_name, next.model_spec()));
         match result {
             Ok(()) => String::new(),
@@ -930,7 +931,7 @@ impl SetupCapability {
     /// either via env var or in the settings file. Used by the TUI at
     /// startup to auto-open the wizard on a fresh install.
     pub(crate) fn needs_onboarding(settings: &crate::settings::Settings) -> bool {
-        if settings.provider.is_some() {
+        if settings.default_provider.is_some() {
             return false;
         }
         if env_credential_present() {
@@ -1014,7 +1015,7 @@ mod tests {
     #[test]
     fn needs_onboarding_false_when_provider_is_saved() {
         let settings = crate::settings::Settings {
-            provider: Some("anthropic".to_string()),
+            default_provider: Some("anthropic".to_string()),
             ..Default::default()
         };
         assert!(!SetupCapability::needs_onboarding(&settings));
@@ -1025,7 +1026,7 @@ mod tests {
         let mut tokens = std::collections::BTreeMap::new();
         tokens.insert("openai".to_string(), "sk-test".to_string());
         let settings = crate::settings::Settings {
-            provider: None,
+            default_provider: None,
             tokens,
             ..Default::default()
         };

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -65,9 +65,10 @@ pub fn schema() -> &'static [ConfigField] {
             key: "default_provider",
             aliases: &["provider"],
             title: "Default provider",
-            description: "The model provider used when neither the --provider flag nor an \
-                          environment credential forces a choice. Persisted as `default_provider` \
-                          (the legacy `provider` key is still read, and accepted as an alias).",
+            description: "The model provider used when no --provider flag is given. A value set \
+                          here takes precedence over environment-credential auto-detection, which \
+                          applies only when this is unset. Persisted as `default_provider` (the \
+                          legacy `provider` key is still read, and accepted as an alias).",
             kind: ValueKind::Text,
             default: Some("openai (auto-detected from available credentials)"),
             examples: &["anthropic", "openai", "google", "openrouter", "ollama"],

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -60,18 +60,14 @@ pub struct ConfigField {
 
 /// The full configuration schema. Order is the user-facing display order.
 pub fn schema() -> &'static [ConfigField] {
-    // Note: `default_provider` and `default_model` are surfaced under those
-    // human-friendly names; on disk `default_provider` is the top-level
-    // `provider` key (its long-standing TOML name). `set_config` routes the
-    // alias to the one stored field so there is never divergent provider state.
     const FIELDS: &[ConfigField] = &[
         ConfigField {
             key: "default_provider",
             aliases: &["provider"],
             title: "Default provider",
             description: "The model provider used when neither the --provider flag nor an \
-                          environment credential forces a choice. Stored on disk as the \
-                          `provider` key.",
+                          environment credential forces a choice. Persisted as `default_provider` \
+                          (the legacy `provider` key is still read, and accepted as an alias).",
             kind: ValueKind::Text,
             default: Some("openai (auto-detected from available credentials)"),
             examples: &["anthropic", "openai", "google", "openrouter", "ollama"],

--- a/src/config_service.rs
+++ b/src/config_service.rs
@@ -20,51 +20,25 @@ use serde_json::Value;
 
 /// Read-only view of yolop configuration, injectable into capabilities.
 ///
-/// Typed getters cover the common cases; `current` reads any key by its schema
-/// name so a capability can consume configuration it does not own without
-/// knowing the storage layout. Secrets are never returned in the clear.
-///
-/// This is a deliberately broad service contract: some getters exist for future
-/// read-only consumers and are not yet wired into a caller, so `dead_code` is
-/// allowed on the trait surface.
-#[allow(dead_code)]
+/// `current` reads any value by its schema key so a capability can consume
+/// configuration it does not own without knowing the storage layout; the two
+/// semantic getters cover the prompt-shaping reads that have dedicated
+/// consumers. Secrets are never returned in the clear. Capabilities add a typed
+/// getter here when they grow a real need rather than carrying speculative
+/// surface.
 pub trait ConfigService: Send + Sync {
     /// Current in-memory settings snapshot (the source of truth in memory).
     fn snapshot(&self) -> Settings;
 
-    /// The soft-approval paranoia level.
+    /// The soft-approval paranoia level (consumed by `ApprovalCapability`).
     fn approval_mode(&self) -> ApprovalMode {
         self.snapshot().approval_mode()
     }
 
-    /// The configured default provider, if any.
-    fn default_provider(&self) -> Option<String> {
-        self.snapshot().provider
-    }
-
-    /// The global fallback model spec, if any.
-    fn default_model(&self) -> Option<String> {
-        self.snapshot().default_model
-    }
-
-    /// Whether commit/PR attribution is enabled.
+    /// Whether commit/PR attribution is enabled (consumed by
+    /// `AttributionCapability`).
     fn attribution_enabled(&self) -> bool {
         self.snapshot().attribution_enabled()
-    }
-
-    /// Whether an API token is stored for `provider` (presence only).
-    fn token_present(&self, provider: &str) -> bool {
-        self.snapshot().has_token(provider)
-    }
-
-    /// The per-provider model spec, if any.
-    fn model_for(&self, provider: &str) -> Option<String> {
-        self.snapshot().model_for(provider).map(str::to_string)
-    }
-
-    /// The per-provider endpoint base URL, if any.
-    fn base_url_for(&self, provider: &str) -> Option<String> {
-        self.snapshot().base_url_for(provider).map(str::to_string)
     }
 
     /// Read any configuration value by its schema key (e.g. `default_provider`,
@@ -86,7 +60,7 @@ impl ConfigService for SettingsStore {
 pub(crate) fn current_value(settings: &Settings, target: &KeyTarget) -> Value {
     match target {
         KeyTarget::DefaultProvider => settings
-            .provider
+            .default_provider
             .clone()
             .map(Value::String)
             .unwrap_or(Value::Null),
@@ -149,37 +123,32 @@ mod tests {
     use std::sync::Arc;
 
     #[test]
-    fn service_reads_typed_and_by_key() {
+    fn service_reads_semantic_getters_and_by_key() {
         let tmp = tempfile::tempdir().expect("tmp");
         let store = Arc::new(SettingsStore::open(tmp.path().join("settings.toml")));
-        store.set_provider(Some("anthropic".to_string())).unwrap();
         store
-            .set_default_model(Some("claude-sonnet-4-5".to_string()))
+            .set_default_provider(Some("anthropic".to_string()))
             .unwrap();
         store
             .set_token("openai".to_string(), "sk-secret".to_string())
             .unwrap();
         store
-            .set_model("openai".to_string(), "gpt-5.5 high".to_string())
-            .unwrap();
-        store
-            .set_base_url("custom".to_string(), "http://localhost:8000/v1".to_string())
+            .set_approval_mode(crate::settings::ApprovalMode::Protective)
             .unwrap();
 
         // Inject as the trait object capabilities would receive.
         let svc: Arc<dyn ConfigService> = store.clone();
-        assert_eq!(svc.default_provider().as_deref(), Some("anthropic"));
-        assert_eq!(svc.default_model().as_deref(), Some("claude-sonnet-4-5"));
-        assert!(svc.token_present("openai"));
+        // Semantic getters used by the prompt-shaping capabilities.
         assert!(svc.attribution_enabled());
-        assert_eq!(svc.model_for("openai").as_deref(), Some("gpt-5.5 high"));
         assert_eq!(
-            svc.base_url_for("custom").as_deref(),
-            Some("http://localhost:8000/v1")
+            svc.approval_mode(),
+            crate::settings::ApprovalMode::Protective
         );
 
-        // Generic schema-keyed read, with secrets reduced to presence.
+        // Generic schema-keyed read covers everything else, with secrets
+        // reduced to presence.
         assert_eq!(svc.current("default_provider").unwrap(), "anthropic");
+        assert_eq!(svc.current("approval_mode").unwrap(), "protective");
         assert_eq!(svc.current("tokens.openai").unwrap(), "stored");
         assert!(
             !svc.current("tokens.openai")

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,7 +171,7 @@ fn pick_provider(cli: &Cli, settings: &SettingsStore) -> ProviderChoice {
     let base = if let Some(arg) = cli.provider {
         ProviderChoice::default_for_provider_name(provider_name_for_arg(arg))
             .expect("ProviderArg names are always valid")
-    } else if let Some(saved) = snapshot.provider.as_deref() {
+    } else if let Some(saved) = snapshot.default_provider.as_deref() {
         match ProviderChoice::default_for_provider_name(saved) {
             Ok(choice) => choice,
             Err(err) => {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1882,7 +1882,7 @@ mod tests {
         assert_eq!(built.model.provider_label(), "custom/qwen3-coder");
         // Model switches persist so the choice survives a restart.
         let snapshot = settings_for_assert.snapshot();
-        assert_eq!(snapshot.provider.as_deref(), Some("custom"));
+        assert_eq!(snapshot.default_provider.as_deref(), Some("custom"));
         assert_eq!(snapshot.model_for("custom"), Some("qwen3-coder"));
 
         // With a model saved, the bare switch now works too.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -70,8 +70,9 @@ impl std::fmt::Display for ApprovalMode {
 #[derive(Debug, Clone)]
 pub struct Settings {
     /// The default provider used when neither `--provider` nor an env
-    /// credential forces a choice. Schema-described as `default_provider`.
-    pub provider: Option<String>,
+    /// credential forces a choice. Persisted as the `default_provider` key
+    /// (the legacy `provider` key is still read for backward compatibility).
+    pub default_provider: Option<String>,
     pub tokens: BTreeMap<String, String>,
     /// Last model spec chosen per provider, in the provider-relative
     /// `model [effort]` form `/setup model` accepts. Lets a model pick
@@ -93,7 +94,7 @@ pub struct Settings {
 impl Default for Settings {
     fn default() -> Self {
         Self {
-            provider: None,
+            default_provider: None,
             tokens: BTreeMap::new(),
             models: BTreeMap::new(),
             default_model: None,
@@ -106,8 +107,11 @@ impl Default for Settings {
 
 impl Settings {
     pub fn from_table(table: &Table) -> Self {
-        let provider = table
-            .get("provider")
+        // Read the current `default_provider` key, falling back to the legacy
+        // `provider` key so pre-rename settings files keep working.
+        let default_provider = table
+            .get("default_provider")
+            .or_else(|| table.get("provider"))
             .and_then(Value::as_str)
             .map(str::to_string);
         let default_model = table
@@ -135,7 +139,7 @@ impl Settings {
             map
         };
         Self {
-            provider,
+            default_provider,
             tokens: string_map("tokens"),
             models: string_map("models"),
             default_model,
@@ -147,8 +151,8 @@ impl Settings {
 
     pub fn to_table(&self) -> Table {
         let mut table = Table::new();
-        if let Some(p) = &self.provider {
-            table.insert("provider".to_string(), Value::String(p.clone()));
+        if let Some(p) = &self.default_provider {
+            table.insert("default_provider".to_string(), Value::String(p.clone()));
         }
         if let Some(m) = &self.default_model {
             table.insert("default_model".to_string(), Value::String(m.clone()));
@@ -295,9 +299,9 @@ impl SettingsStore {
         &self.path
     }
 
-    pub fn set_provider(&self, provider: Option<String>) -> Result<()> {
+    pub fn set_default_provider(&self, provider: Option<String>) -> Result<()> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
-        guard.provider = provider;
+        guard.default_provider = provider;
         save_to(&self.path, &guard)
     }
 
@@ -368,23 +372,39 @@ mod tests {
     use super::*;
 
     #[test]
-    fn provider_roundtrip_via_disk() {
+    fn default_provider_roundtrip_via_disk() {
         let tmp = tempfile::tempdir().expect("tmp");
         let path = tmp.path().join("nested").join("settings.toml");
         let store = SettingsStore::open(path.clone());
-        assert!(store.snapshot().provider.is_none());
+        assert!(store.snapshot().default_provider.is_none());
         store
-            .set_provider(Some("anthropic".to_string()))
+            .set_default_provider(Some("anthropic".to_string()))
             .expect("save");
 
         let on_disk = std::fs::read_to_string(&path).expect("read");
         assert!(
-            on_disk.contains("provider = \"anthropic\""),
+            on_disk.contains("default_provider = \"anthropic\""),
             "expected TOML key/value, got: {on_disk}"
         );
 
         let reloaded = SettingsStore::open(path);
-        assert_eq!(reloaded.snapshot().provider.as_deref(), Some("anthropic"));
+        assert_eq!(
+            reloaded.snapshot().default_provider.as_deref(),
+            Some("anthropic")
+        );
+    }
+
+    #[test]
+    fn legacy_provider_key_is_still_read() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join("settings.toml");
+        // A settings file written before the rename uses the bare `provider` key.
+        std::fs::write(&path, "provider = \"anthropic\"\n").expect("seed");
+        let store = SettingsStore::open(path);
+        assert_eq!(
+            store.snapshot().default_provider.as_deref(),
+            Some("anthropic")
+        );
     }
 
     #[test]
@@ -604,7 +624,7 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tmp");
         let path = tmp.path().join("absent.toml");
         let store = SettingsStore::open(path);
-        assert!(store.snapshot().provider.is_none());
+        assert!(store.snapshot().default_provider.is_none());
         assert!(store.snapshot().tokens.is_empty());
     }
 
@@ -614,7 +634,7 @@ mod tests {
         let path = tmp.path().join("settings.toml");
         std::fs::write(&path, "this = is = not = toml").expect("write");
         let store = SettingsStore::open(path);
-        assert!(store.snapshot().provider.is_none());
+        assert!(store.snapshot().default_provider.is_none());
     }
 
     #[cfg(unix)]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -69,8 +69,9 @@ impl std::fmt::Display for ApprovalMode {
 
 #[derive(Debug, Clone)]
 pub struct Settings {
-    /// The default provider used when neither `--provider` nor an env
-    /// credential forces a choice. Persisted as the `default_provider` key
+    /// The default provider, used when no `--provider` flag is given. A value
+    /// here takes precedence over environment-credential auto-detection, which
+    /// applies only when this is unset. Persisted as the `default_provider` key
     /// (the legacy `provider` key is still read for backward compatibility).
     pub default_provider: Option<String>,
     pub tokens: BTreeMap<String, String>,


### PR DESCRIPTION
## What

Follow-ups to the config schema/service work (#97), implementing three of the
documented follow-ups.

1. **Rename the on-disk default-provider key `provider` → `default_provider`** —
   the `Settings` field, the `SettingsStore::set_default_provider` setter, and
   the serialized TOML key. The schema already surfaced it as `default_provider`;
   now the disk key matches. **Backward-compatible read**: `from_table` reads
   `default_provider` and falls back to the legacy `provider` key, and `provider`
   stays a schema alias — so existing settings files keep working.

2. **Slim `ConfigService` to its consumed surface** — `snapshot`, the generic
   `current(key)` reader, and the two semantic getters with real callers
   (`attribution_enabled`, `approval_mode`). Removed the speculative typed
   getters (`default_provider`/`default_model`/`model_for`/`base_url_for`/
   `token_present`) and the `#[allow(dead_code)]`. Capabilities add a typed
   getter when they grow a real need; arbitrary reads go through `current(key)`.

3. **Route `get_config`'s single-key read through `ConfigService::current`** — the
   config tool now reads config through the service like any other consumer
   (which also gives `current()` a live, non-test caller).

## Why

These tighten the surface introduced in #97: the on-disk key now matches its
schema name, the service exposes only what's actually used (no dead-code
allowance), and the config read-tool dogfoods the service read path.

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`
  — clean.
- `cargo test --all-features` — 310 unit + 25 integration tests pass, 0 failures.
- New `legacy_provider_key_is_still_read` test proves a pre-rename
  `provider = "..."` file loads into `default_provider`; `default_provider`
  roundtrip test asserts the new key is written.
- **Offline smoke**: binary starts; config + approval tools registered.
- **Live OpenAI smoke**: agent used `set_config` to set `approval_mode=protective`,
  `get_config` to read it back as `protective` (exercising the routed
  `ConfigService::current` path), then reset it — `done success=true`.

## Security

No security-relevant behavior change. Config writes still go only through
`SettingsStore` (atomic, `0o600`, config dir); secrets remain redacted to
`stored`/`unset` by `current_value`; no new dependencies. The legacy-key read
is a plain key lookup with no new trust boundary.

## Follow-ups

No follow-ups. (The remaining items from #97 — always-loading the config tools,
and routing write-coupled capabilities like `SetupCapability` through the
service — were intentionally not selected for this batch.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GrRjt46PKgMe2unVRZNAYu)_