### PR TITLE
chore(release): prepare v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,87 @@ mechanical `### What's Changed` list of merged PRs.
 Releases are cut via [`/release`](./.agents/skills/release/SKILL.md), which
 tags the version and publishes to crates.io and the Homebrew tap.
 
+## [0.3.0] - 2026-06-11
+
+### Highlights
+
+- **Soft approval with paranoia levels.** yolop batches safe work and pauses
+  for plain-language consent only before destructive or outward-facing steps.
+  A central `approval_mode` (protective/normal/off) tunes the threshold and is
+  configurable via `/setup approval` or the `set_approval_mode` tool.
+- **MCP server support.** External MCP servers can be wired in, with
+  provider-agnostic deferred tool loading (tool search) to keep large tool
+  sets out of the prompt until needed.
+- **ACP matured.** A `zed` integration command, persisted-session loading,
+  enriched slash-command support, and a move to the upstream
+  `agent-client-protocol` SDK.
+- **Live model discovery and better providers.** Models are listed live from
+  provider APIs; OpenRouter gets a first-class Responses driver with
+  reasoning-effort support; the Anthropic shortlist adds Claude Fable 5 and
+  Opus 4.7/4.8 (incl. 1M-context ids).
+- **Configurable everything.** Schema-described settings with
+  `get_config`/`set_config`, workspace + global skills management, and scoped
+  user hooks.
+
+### Breaking Changes
+
+- **Tool-call approval gating removed** ([#69](https://github.com/everruns/yolop/pull/69)):
+  the opt-in `--ask` flag and its per-tool-call approval gate (TUI prompt, MCP
+  pre-tool hook, ACP `session/request_permission` bridge) are gone. yolop was
+  already autonomous by default, so default behavior is unchanged.
+  - Before: `yolop --ask` gated every tool call behind y/n approval.
+  - After: use the soft-approval layer ([#98](https://github.com/everruns/yolop/pull/98)) —
+    set `approval_mode` to `protective` via `/setup approval` for
+    consent-before-critical-actions behavior.
+
+### What's Changed
+
+* feat(approval): add soft-approval capability with paranoia levels ([#98](https://github.com/everruns/yolop/pull/98)) by @chaliy
+* feat(config): schema-described settings with get_config/set_config ([#97](https://github.com/everruns/yolop/pull/97)) by @chaliy
+* fix(tui): tolerate unanswered cursor queries, unpin ratatui 0.30.1 ([#96](https://github.com/everruns/yolop/pull/96)) by @chaliy
+* chore(maintenance): harden maintenance docs, refresh deps ([#92](https://github.com/everruns/yolop/pull/92)) by @chaliy
+* docs(readme): document EVERRUNS_SYSTEM_ALLOWLIST_ENABLED ([#90](https://github.com/everruns/yolop/pull/90)) by @chaliy
+* feat(setup): add Opus 4.7/4.8 and 1M ids to anthropic shortlist ([#89](https://github.com/everruns/yolop/pull/89)) by @chaliy
+* feat(openrouter): use first-class OpenRouter Responses driver ([#88](https://github.com/everruns/yolop/pull/88)) by @chaliy
+* chore(deps): bump everruns crates to 0.10.0 ([#87](https://github.com/everruns/yolop/pull/87)) by @chaliy
+* feat(setup): connection status, fast model pick, custom endpoint ([#86](https://github.com/everruns/yolop/pull/86)) by @chaliy
+* feat(hooks): support scoped user hooks ([#85](https://github.com/everruns/yolop/pull/85)) by @chaliy
+* feat(skills): manage workspace and global skills ([#84](https://github.com/everruns/yolop/pull/84)) by @chaliy
+* feat(acp): load persisted sessions ([#83](https://github.com/everruns/yolop/pull/83)) by @chaliy
+* feat(models): list provider models live from models APIs ([#82](https://github.com/everruns/yolop/pull/82)) by @chaliy
+* fix(model): use raw model ids in setup ([#81](https://github.com/everruns/yolop/pull/81)) by @chaliy
+* fix(tui): show resumed history in composer view ([#80](https://github.com/everruns/yolop/pull/80)) by @chaliy
+* test(tui): in-process turn/resume tests and shared PTY harness ([#79](https://github.com/everruns/yolop/pull/79)) by @chaliy
+* fix(tui): anchor startup composer at bottom ([#78](https://github.com/everruns/yolop/pull/78)) by @chaliy
+* fix(tui): survive transient terminal I/O failures in event loop ([#77](https://github.com/everruns/yolop/pull/77)) by @chaliy
+* chore(deps): bump agent-client-protocol to 0.14.0 ([#76](https://github.com/everruns/yolop/pull/76)) by @chaliy
+* feat(openrouter): support reasoning effort ([#75](https://github.com/everruns/yolop/pull/75)) by @chaliy
+* docs(readme): restore demo gif for inline rendering ([#74](https://github.com/everruns/yolop/pull/74)) by @chaliy
+* fix(acp): remove approval-looking tool kinds ([#73](https://github.com/everruns/yolop/pull/73)) by @chaliy
+* docs(readme): swap demo gif for mp4 video ([#72](https://github.com/everruns/yolop/pull/72)) by @chaliy
+* docs(readme): reposition as full coding agent with demo recording ([#71](https://github.com/everruns/yolop/pull/71)) by @chaliy
+* feat(models): add Claude Fable 5 to Anthropic model options ([#70](https://github.com/everruns/yolop/pull/70)) by @chaliy
+* refactor(approval): remove tool-call approval gating ([#69](https://github.com/everruns/yolop/pull/69)) by @chaliy
+* chore(deps): bump everruns to 0.9.0 ([#68](https://github.com/everruns/yolop/pull/68)) by @chaliy
+* refactor(acp): use upstream protocol sdk ([#67](https://github.com/everruns/yolop/pull/67)) by @chaliy
+* feat(tool-search): vendor provider-agnostic deferred tool loading ([#66](https://github.com/everruns/yolop/pull/66)) by @chaliy
+* feat(mcp): MCP server support with approval-gated tool calls ([#65](https://github.com/everruns/yolop/pull/65)) by @chaliy
+* fix(openrouter): use Chat Completions so tool calls work ([#64](https://github.com/everruns/yolop/pull/64)) by @chaliy
+* chore(deps): bump everruns-* to 0.8.38 ([#63](https://github.com/everruns/yolop/pull/63)) by @chaliy
+* chore(deps): bump softprops/action-gh-release from 2 to 3 ([#62](https://github.com/everruns/yolop/pull/62)) by @chaliy
+* feat(cli): add version metadata ([#61](https://github.com/everruns/yolop/pull/61)) by @chaliy
+* fix(tui): simplify composer newline shortcut ([#60](https://github.com/everruns/yolop/pull/60)) by @chaliy
+* docs(commands): add command spec, cover client commands, require tests ([#57](https://github.com/everruns/yolop/pull/57)) by @chaliy
+* chore(deps): bump everruns crates to 0.8.37 ([#56](https://github.com/everruns/yolop/pull/56)) by @chaliy
+* refactor(commands): make all slash commands capability-based ([#55](https://github.com/everruns/yolop/pull/55)) by @chaliy
+* docs(readme): document Homebrew tap trust ([#54](https://github.com/everruns/yolop/pull/54)) by @chaliy
+* fix(setup): keep hint separated from overflowing credential label ([#53](https://github.com/everruns/yolop/pull/53)) by @chaliy
+* fix(ci): drop redundant version from generated Homebrew formula ([#52](https://github.com/everruns/yolop/pull/52)) by @chaliy
+* feat(acp): enrich slash command support ([#51](https://github.com/everruns/yolop/pull/51)) by @chaliy
+* feat(cli): add zed acp integration command ([#50](https://github.com/everruns/yolop/pull/50)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/yolop/compare/v0.2.0...v0.3.0
+
 ## [0.2.0] - 2026-06-03
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5870,7 +5870,7 @@ dependencies = [
 
 [[package]]
 name = "yolop"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yolop"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license = "MIT"
 description = "Yolop — a terminal coding agent built on everruns-runtime"


### PR DESCRIPTION
## [0.3.0] - 2026-06-11

### Highlights

- **Soft approval with paranoia levels.** yolop batches safe work and pauses for plain-language consent only before destructive or outward-facing steps. A central `approval_mode` (protective/normal/off) tunes the threshold and is configurable via `/setup approval` or the `set_approval_mode` tool.
- **MCP server support.** External MCP servers can be wired in, with provider-agnostic deferred tool loading (tool search) to keep large tool sets out of the prompt until needed.
- **ACP matured.** A `zed` integration command, persisted-session loading, enriched slash-command support, and a move to the upstream `agent-client-protocol` SDK.
- **Live model discovery and better providers.** Models are listed live from provider APIs; OpenRouter gets a first-class Responses driver with reasoning-effort support; the Anthropic shortlist adds Claude Fable 5 and Opus 4.7/4.8 (incl. 1M-context ids).
- **Configurable everything.** Schema-described settings with `get_config`/`set_config`, workspace + global skills management, and scoped user hooks.

### Breaking Changes

- **Tool-call approval gating removed** ([#69](https://github.com/everruns/yolop/pull/69)): the opt-in `--ask` flag and its per-tool-call approval gate (TUI prompt, MCP pre-tool hook, ACP `session/request_permission` bridge) are gone. yolop was already autonomous by default, so default behavior is unchanged.
  - Before: `yolop --ask` gated every tool call behind y/n approval.
  - After: use the soft-approval layer ([#98](https://github.com/everruns/yolop/pull/98)) — set `approval_mode` to `protective` via `/setup approval` for consent-before-critical-actions behavior.

### What's Changed

* feat(approval): add soft-approval capability with paranoia levels ([#98](https://github.com/everruns/yolop/pull/98)) by @chaliy
* feat(config): schema-described settings with get_config/set_config ([#97](https://github.com/everruns/yolop/pull/97)) by @chaliy
* fix(tui): tolerate unanswered cursor queries, unpin ratatui 0.30.1 ([#96](https://github.com/everruns/yolop/pull/96)) by @chaliy
* chore(maintenance): harden maintenance docs, refresh deps ([#92](https://github.com/everruns/yolop/pull/92)) by @chaliy
* docs(readme): document EVERRUNS_SYSTEM_ALLOWLIST_ENABLED ([#90](https://github.com/everruns/yolop/pull/90)) by @chaliy
* feat(setup): add Opus 4.7/4.8 and 1M ids to anthropic shortlist ([#89](https://github.com/everruns/yolop/pull/89)) by @chaliy
* feat(openrouter): use first-class OpenRouter Responses driver ([#88](https://github.com/everruns/yolop/pull/88)) by @chaliy
* chore(deps): bump everruns crates to 0.10.0 ([#87](https://github.com/everruns/yolop/pull/87)) by @chaliy
* feat(setup): connection status, fast model pick, custom endpoint ([#86](https://github.com/everruns/yolop/pull/86)) by @chaliy
* feat(hooks): support scoped user hooks ([#85](https://github.com/everruns/yolop/pull/85)) by @chaliy
* feat(skills): manage workspace and global skills ([#84](https://github.com/everruns/yolop/pull/84)) by @chaliy
* feat(acp): load persisted sessions ([#83](https://github.com/everruns/yolop/pull/83)) by @chaliy
* feat(models): list provider models live from models APIs ([#82](https://github.com/everruns/yolop/pull/82)) by @chaliy
* fix(model): use raw model ids in setup ([#81](https://github.com/everruns/yolop/pull/81)) by @chaliy
* fix(tui): show resumed history in composer view ([#80](https://github.com/everruns/yolop/pull/80)) by @chaliy
* test(tui): in-process turn/resume tests and shared PTY harness ([#79](https://github.com/everruns/yolop/pull/79)) by @chaliy
* fix(tui): anchor startup composer at bottom ([#78](https://github.com/everruns/yolop/pull/78)) by @chaliy
* fix(tui): survive transient terminal I/O failures in event loop ([#77](https://github.com/everruns/yolop/pull/77)) by @chaliy
* chore(deps): bump agent-client-protocol to 0.14.0 ([#76](https://github.com/everruns/yolop/pull/76)) by @chaliy
* feat(openrouter): support reasoning effort ([#75](https://github.com/everruns/yolop/pull/75)) by @chaliy
* docs(readme): restore demo gif for inline rendering ([#74](https://github.com/everruns/yolop/pull/74)) by @chaliy
* fix(acp): remove approval-looking tool kinds ([#73](https://github.com/everruns/yolop/pull/73)) by @chaliy
* docs(readme): swap demo gif for mp4 video ([#72](https://github.com/everruns/yolop/pull/72)) by @chaliy
* docs(readme): reposition as full coding agent with demo recording ([#71](https://github.com/everruns/yolop/pull/71)) by @chaliy
* feat(models): add Claude Fable 5 to Anthropic model options ([#70](https://github.com/everruns/yolop/pull/70)) by @chaliy
* refactor(approval): remove tool-call approval gating ([#69](https://github.com/everruns/yolop/pull/69)) by @chaliy
* chore(deps): bump everruns to 0.9.0 ([#68](https://github.com/everruns/yolop/pull/68)) by @chaliy
* refactor(acp): use upstream protocol sdk ([#67](https://github.com/everruns/yolop/pull/67)) by @chaliy
* feat(tool-search): vendor provider-agnostic deferred tool loading ([#66](https://github.com/everruns/yolop/pull/66)) by @chaliy
* feat(mcp): MCP server support with approval-gated tool calls ([#65](https://github.com/everruns/yolop/pull/65)) by @chaliy
* fix(openrouter): use Chat Completions so tool calls work ([#64](https://github.com/everruns/yolop/pull/64)) by @chaliy
* chore(deps): bump everruns-* to 0.8.38 ([#63](https://github.com/everruns/yolop/pull/63)) by @chaliy
* chore(deps): bump softprops/action-gh-release from 2 to 3 ([#62](https://github.com/everruns/yolop/pull/62)) by @chaliy
* feat(cli): add version metadata ([#61](https://github.com/everruns/yolop/pull/61)) by @chaliy
* fix(tui): simplify composer newline shortcut ([#60](https://github.com/everruns/yolop/pull/60)) by @chaliy
* docs(commands): add command spec, cover client commands, require tests ([#57](https://github.com/everruns/yolop/pull/57)) by @chaliy
* chore(deps): bump everruns crates to 0.8.37 ([#56](https://github.com/everruns/yolop/pull/56)) by @chaliy
* refactor(commands): make all slash commands capability-based ([#55](https://github.com/everruns/yolop/pull/55)) by @chaliy
* docs(readme): document Homebrew tap trust ([#54](https://github.com/everruns/yolop/pull/54)) by @chaliy
* fix(setup): keep hint separated from overflowing credential label ([#53](https://github.com/everruns/yolop/pull/53)) by @chaliy
* fix(ci): drop redundant version from generated Homebrew formula ([#52](https://github.com/everruns/yolop/pull/52)) by @chaliy
* feat(acp): enrich slash command support ([#51](https://github.com/everruns/yolop/pull/51)) by @chaliy
* feat(cli): add zed acp integration command ([#50](https://github.com/everruns/yolop/pull/50)) by @chaliy

**Full Changelog**: https://github.com/everruns/yolop/compare/v0.2.0...v0.3.0

## Publish-readiness

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` — 334 passed, 0 failed, 2 ignored (provider smoke tests requiring API keys)
- [x] `cargo publish --dry-run -p yolop`
- [x] crates.io currently serves `0.2.0` → publishing `0.3.0`
- [x] `Cargo.toml` + `Cargo.lock` agree on `0.3.0`

## Post-merge plan

When this PR lands on `main`, `release.yml` extracts `v0.3.0` from the commit subject, creates the GitHub Release + tag, then dispatches `publish.yml` (crates.io) and `cli-binaries.yml` (binaries + Homebrew tap bump). I will monitor all three workflows and verify both registries serve `0.3.0` before declaring the release shipped.

> Note: per the release skill, do **not** enable auto-merge — a human squash-merges after reviewing the changelog.

---
_Generated by [Claude Code](https://claude.ai/code/session_013p1DjweRw6VmV1fFiJU9V4)_