### PR TITLE
refactor(setup): read config through ConfigService

### DIFF
--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -77,13 +77,15 @@ capability adds a typed getter only when it grows a real need rather than
 carrying speculative methods.
 
 `SettingsStore` implements `ConfigService`, so the single shared handle that
-backs writes also serves reads. Capabilities that only *read* config take an
-`Arc<dyn ConfigService>`; capabilities that *write* (setup, config) keep the
-concrete `SettingsStore`. `AttributionCapability` reads whether attribution is
-enabled through the service; `ApprovalCapability` reads its soft-approval
-paranoia level through `ConfigService::approval_mode()` each turn (keeping the
-concrete store only for its `set_approval_mode` write tool); and the `config`
-capability's `get_config` reads single values through `ConfigService::current`.
+backs writes also serves reads. Read-only capabilities take only an
+`Arc<dyn ConfigService>`; write-coupled capabilities hold both — reads go
+through the service handle, writes through the concrete `SettingsStore` — so the
+read/write split is explicit at the type level. `AttributionCapability` reads
+whether attribution is enabled through the service; `ApprovalCapability` reads
+its soft-approval paranoia level through `ConfigService::approval_mode()` each
+turn; the `config` capability's `get_config` reads single values through
+`ConfigService::current`; and `SetupCapability` reads provider/token/model state
+through its config handle while persisting `/setup` changes through the store.
 `approval_mode` is also a first-class schema key, so `get_config`/`set_config`
 manage it alongside everything else.
 

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -354,6 +354,9 @@ const BASE_URL_PROVIDERS: &[&str] = &["custom"];
 pub(crate) struct SetupCapability {
     pub(crate) provider: Arc<RwLock<ProviderChoice>>,
     pub(crate) provider_store: Arc<dyn RuntimeProviderStore>,
+    /// Reads current configuration through the shared config service…
+    pub(crate) config: Arc<dyn ConfigService>,
+    /// …and writes provider/token/model choices through the concrete store.
     pub(crate) settings: Arc<SettingsStore>,
 }
 
@@ -476,7 +479,7 @@ impl SetupCapability {
             .read()
             .expect("provider lock poisoned")
             .clone();
-        let snapshot = self.settings.snapshot();
+        let snapshot = self.config.snapshot();
         let saved = snapshot
             .default_provider
             .clone()
@@ -518,7 +521,7 @@ impl SetupCapability {
         }
 
         let next = match ProviderChoice::default_for_provider_name(name) {
-            Ok(n) => n.with_saved_model(&self.settings.snapshot()),
+            Ok(n) => n.with_saved_model(&self.config.snapshot()),
             Err(err) => return Ok(failed_result(format!("setup provider failed: {err}"))),
         };
         let next = if model_spec.is_empty() {
@@ -534,7 +537,7 @@ impl SetupCapability {
                 "setup provider failed: no model configured for {name}; pick one with /setup"
             )));
         }
-        let mw = match next.model_with_provider(&self.settings.snapshot()) {
+        let mw = match next.model_with_provider(&self.config.snapshot()) {
             Ok(m) => m,
             Err(err) => return Ok(failed_result(format!("setup provider failed: {err}"))),
         };
@@ -597,7 +600,7 @@ impl SetupCapability {
                 return Ok(failed_result(format!("setup model failed: {err}")));
             }
         };
-        let mw = match next.model_with_provider(&self.settings.snapshot()) {
+        let mw = match next.model_with_provider(&self.config.snapshot()) {
             Ok(m) => m,
             Err(err) => {
                 return Ok(failed_result(format!("setup model failed: {err}")));
@@ -643,7 +646,7 @@ impl SetupCapability {
 
         let discovered = tokio::time::timeout(
             DISCOVERY_TIMEOUT,
-            super::model_discovery::discover_provider_models(current, &self.settings.snapshot()),
+            super::model_discovery::discover_provider_models(current, &self.config.snapshot()),
         )
         .await;
         if let Ok(Ok(Some(models))) = discovered
@@ -704,7 +707,7 @@ impl SetupCapability {
 
     fn change_token(&self, raw: &str) -> everruns_core::Result<CommandResult> {
         if raw.is_empty() {
-            let snapshot = self.settings.snapshot();
+            let snapshot = self.config.snapshot();
             let status: Vec<String> = TOKEN_PROVIDERS
                 .iter()
                 .map(|p| {
@@ -782,7 +785,7 @@ impl SetupCapability {
             )));
         }
         if rest.is_empty() {
-            let snapshot = self.settings.snapshot();
+            let snapshot = self.config.snapshot();
             let current = snapshot
                 .base_url_for(&provider)
                 .unwrap_or("<unset>")
@@ -836,7 +839,7 @@ impl SetupCapability {
     fn change_attribution(&self, raw: &str) -> everruns_core::Result<CommandResult> {
         let trimmed = raw.trim();
         if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("status") {
-            let enabled = self.settings.snapshot().attribution_enabled();
+            let enabled = self.config.attribution_enabled();
             return Ok(CommandResult {
                 success: true,
                 message: format!(
@@ -877,7 +880,7 @@ impl SetupCapability {
                 success: true,
                 message: format!(
                     "setup approval: {} (protective | normal | off) ({})",
-                    self.settings.snapshot().approval_mode(),
+                    self.config.approval_mode(),
                     self.settings.path().display()
                 ),
                 error_code: None,

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -520,8 +520,11 @@ impl SetupCapability {
             )));
         }
 
+        // One snapshot reused across both reads in this command: consistent and
+        // avoids cloning the full Settings (token strings included) twice.
+        let snapshot = self.config.snapshot();
         let next = match ProviderChoice::default_for_provider_name(name) {
-            Ok(n) => n.with_saved_model(&self.config.snapshot()),
+            Ok(n) => n.with_saved_model(&snapshot),
             Err(err) => return Ok(failed_result(format!("setup provider failed: {err}"))),
         };
         let next = if model_spec.is_empty() {
@@ -537,7 +540,7 @@ impl SetupCapability {
                 "setup provider failed: no model configured for {name}; pick one with /setup"
             )));
         }
-        let mw = match next.model_with_provider(&self.config.snapshot()) {
+        let mw = match next.model_with_provider(&snapshot) {
             Ok(m) => m,
             Err(err) => return Ok(failed_result(format!("setup provider failed: {err}"))),
         };

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1369,6 +1369,7 @@ pub async fn build_with_options(
     capabilities.register(SetupCapability {
         provider: provider_state.clone(),
         provider_store: provider_store.clone(),
+        config: settings.clone(),
         settings: settings.clone(),
     });
     // Schema-described, human-friendly config editing (`get_config` /


### PR DESCRIPTION
## What

The remaining follow-up from #97/#99: route the write-coupled `SetupCapability`'s
config **reads** through `ConfigService`, so every capability that reads config
now does so through the service.

- `SetupCapability` gains an `Arc<dyn ConfigService>` field for reads, alongside
  its existing `Arc<SettingsStore>` for writes. The read/write split is now
  explicit at the type level, matching `AttributionCapability` /
  `ApprovalCapability`.
- All `/setup` status and resolution reads go through the config handle: typed
  getters for attribution (`attribution_enabled`) and approval
  (`approval_mode`), and `snapshot()` for the composite provider/token/model
  reads. Writes (`set_default_provider`, `set_token`, `set_model`,
  `set_base_url`, `set_attribution`, `set_approval_mode`, `clear_*`) still go
  through the concrete store.
- Spec updated to describe the pattern (read-only caps hold only a service
  handle; write-coupled caps hold both).

## Why

Consistency: after #97/#99, `Attribution`, `Approval`, and the `config` tool
read through the service, but `SetupCapability` still reached into the concrete
store for reads. This makes the read side uniform and the read/write
responsibilities legible from the field types.

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`
  — clean.
- `cargo test --all-features` — 310 unit + 25 integration tests pass, 0 failures.
- Behavior-preserving: the same `SettingsStore` backs both handles, so reads
  return identical values. The existing `/setup` integration test drives
  `setup token/provider/model` end-to-end through the registered capability,
  exercising the config-routed reads (`change_provider` → `self.config.snapshot()`).
- **Offline smoke**: binary starts cleanly.

## Security

No security-relevant change. No behavior change, no new dependencies; config
writes remain on `SettingsStore` (atomic, `0o600`); secrets still redacted on
read.

## Follow-ups

No follow-ups. (The one remaining item from the original list — always-loading
`get_config`/`set_config` so they never defer behind `tool_search` — was not
selected.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GrRjt46PKgMe2unVRZNAYu)_