### PR TITLE
chore(ci): bump codecov-action v4→v7, set fail_ci_if_error false

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           files: lcov.info
-          fail_ci_if_error: false
+          fail_ci_if_error: ${{ github.event_name == 'push' }}
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,10 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           files: lcov.info
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage artifact


### PR DESCRIPTION
## Summary

Supersedes dependabot #94.

- Bumps `codecov/codecov-action` from v4 to v7 (latest stable)
- Sets `fail_ci_if_error: false` — codecov@v7 requires a token for protected-branch uploads, but GitHub restricts secrets on `pull_request` events (including dependabot PRs), so those runs were failing. Coverage upload is metrics, not a build gate.

## Test plan

- [ ] CI green on this PR
- [ ] CI green on next push to main
- [ ] Coverage still uploads on push-to-main runs (where `CODECOV_TOKEN` is available)

---
_Generated by [Claude Code](https://claude.ai/code/session_0176KduRuo2xwm9Tz12uBaQg)_