### PR TITLE
fix(tool-search): defer MCP tool schemas like the long tail

### DIFF
--- a/specs/tool-search.md
+++ b/specs/tool-search.md
@@ -42,7 +42,11 @@ provider-agnostic) and adds the two things that make it actually work:
    `write_file`, `edit_file`, `list_directory`, `grep_files`, `bash`) always
    keep full schemas, so the agent is never crippled and common work needs no
    search. The long tail (search, web fetch, memory, skills, history, todos)
-   is deferred until requested.
+   is deferred until requested. **MCP server tools defer on the same footing**:
+   with many configured servers their schemas are the largest and least-used
+   part of the surface, so only their names and descriptions ride each turn
+   until `tool_search` loads a schema. (Execution still routes through the real
+   registry proxy, so a stubbed MCP tool call works once revealed.)
 
 Deferral activates only once the total tool count crosses
 `DEFAULT_TOOL_SEARCH_THRESHOLD` (15); below that, full schemas fit comfortably.

--- a/src/capabilities/tool_search.rs
+++ b/src/capabilities/tool_search.rs
@@ -50,7 +50,6 @@
 
 use async_trait::async_trait;
 use everruns_core::capabilities::{Capability, CapabilityStatus, ToolDefinitionHook};
-use everruns_core::mcp_server::is_mcp_tool;
 use everruns_core::tool_types::{BuiltinTool, DeferrablePolicy, ToolDefinition, ToolHints};
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
@@ -183,14 +182,20 @@ fn deferred_stub_schema() -> Value {
 
 /// Returns true when a tool must always keep its full schema: the search tool
 /// itself, the core allowlist, tools that opt out via `DeferrablePolicy::Never`,
-/// MCP tools (executed via registry proxies built from these definitions), and
-/// any tool already revealed via `tool_search` this session.
+/// and any tool already revealed via `tool_search` this session.
+///
+/// MCP tools are deliberately *not* exempt: with many configured servers (we've
+/// seen setups with dozens) their full JSON schemas dominate the per-turn tool
+/// payload, yet most go unused on any given turn. Deferring them keeps only
+/// their name + description until the model loads the schema via `tool_search`,
+/// exactly like the built-in long tail. Deferral only rewrites the *advertised*
+/// schema; execution still routes through the real registry proxy, so stubbing
+/// an MCP tool never breaks its call once revealed.
 fn keep_full(tool: &ToolDefinition, revealed: &HashSet<String>) -> bool {
     let name = tool.name();
     name == TOOL_SEARCH_TOOL_NAME
         || ALWAYS_FULL.contains(&name)
         || matches!(tool.deferrable(), DeferrablePolicy::Never)
-        || is_mcp_tool(name)
         || revealed.contains(name)
 }
 
@@ -514,6 +519,41 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn mcp_tools_defer_above_threshold_and_reveal_after_search() {
+        let cap = ToolSearchCapability::new();
+        let hook = &cap.tool_definition_hooks()[0];
+        // 18 long-tail/core tools plus one MCP tool, above the threshold.
+        let build = || {
+            let mut tools = tool_set(12);
+            tools.push(builtin("mcp_docs__search", DeferrablePolicy::default()));
+            tools
+        };
+
+        // MCP tools defer like the rest of the long tail (no special exemption).
+        let before = hook.transform(build());
+        let mcp = before
+            .iter()
+            .find(|t| t.name() == "mcp_docs__search")
+            .unwrap();
+        assert!(is_stubbed(mcp), "MCP tool must defer above threshold");
+
+        // Once revealed via tool_search it regains its full schema next pass.
+        cap.revealed
+            .lock()
+            .unwrap()
+            .insert("mcp_docs__search".to_string());
+        let after = hook.transform(build());
+        let mcp = after
+            .iter()
+            .find(|t| t.name() == "mcp_docs__search")
+            .unwrap();
+        assert!(
+            !is_stubbed(mcp),
+            "revealed MCP tool must regain full schema"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

MCP server tools were exempt from `tool_search` schema deferral (`keep_full` short-circuited on `is_mcp_tool`). This drops that exemption so MCP tools defer like the built-in long tail: only their name + description are advertised each turn until the model loads the full schema via `tool_search`.

## Why

Schema deferral exists precisely because the tool surface "scales badly as tools are added (e.g. MCP servers)" (`specs/tool-search.md`). But MCP tools were the one part of the surface *exempted* from it. With many configured servers (we discussed setups with dozens), their full JSON schemas are the largest and least-used part of the per-turn tool payload — exactly the case deferral is meant to handle. The exemption defeated the feature's headline motivation.

Deferral only rewrites the *advertised* schema; execution still routes through the real registry proxy, so a stubbed MCP tool call works once the model reveals it via `tool_search`. The original exemption comment cited this proxy path as the reason for caution, but it isn't a blocker — it's the same mechanism that already makes deferral safe for built-in tools.

## How validated

- **Automated (outcome 3):** new unit test `mcp_tools_defer_above_threshold_and_reveal_after_search` drives the `DeferSchemaHook` directly — asserts an `mcp_*` tool is stubbed above the threshold and regains its full schema after being revealed. The other 8 tool-search tests still pass.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo test --all-features` (tool_search + runtime): 9 passed.
- **Smoke (outcome 6):** `cargo run -- --provider llmsim -p "hi"` starts the binary and assembles the full 28-tool surface with the changed hook. Doppler is not available in this container, so the live-provider smoke runs in CI (`DOPPLER_TOKEN`). No MCP servers are configured in this workspace, so live MCP deferral is not exercised end-to-end here — the unit test covers it directly.

## Security

TM-LLM / TM-TOOL: the change *reduces* what is advertised to the model and adds no new trust boundary, dependency, or write path. Tool execution, the write blocklist, and key handling are untouched. No security-relevant exposure.

## Follow-ups

- **Upstream `everruns/everruns` (`crates/runtime/src/mcp.rs`):** MCP `tools/list` discovery is re-run *serially per turn* with no cache. Two improvements belong upstream and cannot be made from this repo: (1) concurrent discovery (`join_all` instead of the serial loop) to bound per-turn latency to the slowest server; (2) a per-session TTL cache (already listed as a follow-up in upstream `specs/runtime-mcp.md`). This PR addresses the per-turn *prompt-size* cost; those address the per-turn *discovery* cost.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VaFJS3k7JPMTZd3cqAkygb)_