### PR TITLE
feat(tui): add shell command alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   and set with `/setup approval <level>` (or just by telling yolop to be more
   or less careful). See [Soft approval](#soft-approval) below.
 - **TUI chat** (ratatui): scrolling transcript, multiline composer, status
-  bar, slash commands (`/help`, `/tools`, `/mcp`, `/cwd`, `/setup`, `/model`,
-  `/effort`, `/clear`, `/quit`) and natural-language requests for terminal
-  actions such as "exit" or "clear the screen".
+  bar, commands (`/help`, `/tools`, `/mcp`, `/cwd`, `/setup`, `/model`,
+  `/effort`, `!shell <command>`, `/clear`, `/quit`) and natural-language
+  requests for terminal actions such as "exit" or "clear the screen".
 - **Planning** — `write_todos` keeps multi-step tasks on track, and
   loop detection stops the model from retrying the same failing tool call.
 - **One-shot mode** — `--print` runs a single prompt non-interactively, for

--- a/specs/commands.md
+++ b/specs/commands.md
@@ -2,8 +2,10 @@
 
 ## Abstract
 
-yolop exposes user actions as **slash commands**. Every command is contributed
-by a **capability** (`Capability::commands()`), so each host's command surface
+yolop exposes user actions as **commands**. Most are slash commands; the TUI
+also accepts `!shell <command>` as the terminal-local shell alias for the same
+capability command as `/shell`. Every command is contributed by a **capability**
+(`Capability::commands()`), so each host's command surface
 is sourced solely from `runtime.list_commands(session_id)` — the source of
 truth for that host's palette, `/help`, and completion. There is no hard-coded
 command table on any host.
@@ -35,7 +37,8 @@ top of the runtime's two, not a separate `CommandSource` variant.
    commands; on execute, their capability emits a typed `UiCommand` through an
    injected host UI port instead of returning text. The host's event loop drains
    the port and applies the effect. Commands: `/help`, `/tools`, `/mcp`,
-   `/cwd`, `/model`, `/effort`, `/clear`, `/quit`.
+   `/cwd`, `/model`, `/effort`, `!shell <command>` (also accepted as
+   `/shell`), `/clear`, `/quit`.
 
 ## Why client commands use a host port, not a new `CommandSource`
 
@@ -63,7 +66,9 @@ portable case ever arises.
    keeps a parallel list.
 2. **Uniform dispatch.** The host looks a typed command up in the registry and
    routes by `CommandSource`: `System`/client → `runtime.execute_command`;
-   `Skill` → forward as a chat turn. `/exit` is an accepted alias for `/quit`.
+   `Skill` → forward as a chat turn. `/exit` is an accepted alias for `/quit`,
+   and `!shell <command>` is accepted as the TUI spelling of the client-side
+   `/shell <command>` descriptor.
 3. **Client effects are host-applied.** A client command's `execute_command`
    returns an empty `CommandResult` and emits a `UiCommand`; the host applies
    every queued `UiCommand` before the next render. The `UiCommand` vocabulary

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -5,6 +5,7 @@
 
 use crate::host_ui::UiCommand;
 use crate::runtime::{BuiltRuntime, ModelState, RuntimeHandles, StartupInfo};
+use crate::tools::{BashTool, Workspace};
 use anyhow::Result;
 use crossterm::event::{
     self, Event as CrosstermEvent, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
@@ -12,6 +13,7 @@ use crossterm::event::{
 use everruns_core::command::{CommandDescriptor, CommandSource};
 use everruns_core::events::{Event as RuntimeEvent, EventData, ToolCompletedData};
 use everruns_core::message::{ContentPart, Message, MessageRole};
+use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::typed_id::SessionId;
 use ratatui::Terminal;
 use ratatui::backend::Backend;
@@ -448,7 +450,7 @@ impl App {
                 .startup
                 .capability_commands
                 .iter()
-                .map(|c| format!("/{}", c.name))
+                .map(capability_command_display_usage)
                 .collect();
             self.push_system(format!("commands: {}", names.join(", ")));
         }
@@ -779,6 +781,14 @@ impl App {
         let raw = self.input_text();
         self.reset_input();
         let text = raw.trim().to_string();
+        if let Some(command) = parse_bang_shell_command(&text) {
+            if command.is_empty() {
+                self.push_system("usage: !shell <command>".into());
+            } else {
+                self.handle_shell_alias(command.to_string()).await;
+            }
+            return;
+        }
         if let Some(rest) = text.strip_prefix('/') {
             self.handle_command(rest).await;
             return;
@@ -791,7 +801,7 @@ impl App {
     }
 
     /// Dispatch a slash command. Every command — including the terminal-side
-    /// ones (help/tools/cwd/model/effort/clear/quit) — is now a capability
+    /// ones (help/tools/cwd/model/effort/clear/shell/quit) — is now a capability
     /// command, so this is a single uniform lookup against the registry. The
     /// terminal-side commands take effect via `UiCommand`s their capability
     /// emits while executing (drained in the event loop); see
@@ -815,6 +825,23 @@ impl App {
                 .await;
         } else {
             self.push_system(format!("unknown command: /{head}"));
+        }
+    }
+
+    /// Dispatch the TUI's `!shell <command>` alias through the same capability
+    /// descriptor as `/shell`, so registration, required-arg validation, and
+    /// host gating keep one source of truth.
+    async fn handle_shell_alias(&mut self, command: String) {
+        if let Some(descriptor) = self
+            .startup
+            .capability_commands
+            .iter()
+            .find(|c| c.name == "shell")
+            .cloned()
+        {
+            self.invoke_capability_command(descriptor, command).await;
+        } else {
+            self.push_system("unknown command: !shell".into());
         }
     }
 
@@ -854,6 +881,7 @@ impl App {
                 self.printed_lines = 0;
                 self.emit_system_banner();
             }
+            UiCommand::RunShell { command } => self.start_shell_command(command),
             UiCommand::Quit => self.should_quit = true,
             UiCommand::OpenModelOverlay { arg } => match arg {
                 Some(arg) => self.start_model_setup_with_arg(&arg),
@@ -972,6 +1000,31 @@ impl App {
                 self.start_turn(text);
             }
         }
+    }
+
+    fn start_shell_command(&mut self, command: String) {
+        let workspace_root = self.startup.workspace_root.clone();
+        let display_command = command.clone();
+        let (tx, rx) = mpsc::unbounded_channel::<TurnEvent>();
+        self.rx = Some(rx);
+        self.busy = true;
+        self.turn_activity = Some("running shell command".into());
+        self.stream_preview = None;
+        self.push_user(format!("!shell {display_command}"));
+
+        tokio::spawn(async move {
+            let tool = BashTool::new(Workspace::new(workspace_root));
+            let result = tool
+                .execute(serde_json::json!({
+                    "command": command,
+                    // Direct shell output is not persisted through a tool-call
+                    // lifecycle, so render a useful bounded window inline.
+                    "output": "normal",
+                }))
+                .await;
+            let _ = tx.send(TurnEvent::Lines(shell_result_lines(result)));
+            let _ = tx.send(TurnEvent::Done);
+        });
     }
 
     fn start_turn(&mut self, prompt: String) {
@@ -1122,10 +1175,97 @@ pub(crate) struct DeltaRouter {
     last_tool_call: Option<String>,
 }
 
+fn parse_bang_shell_command(input: &str) -> Option<&str> {
+    let rest = input.trim().strip_prefix("!shell")?;
+    if rest.is_empty() {
+        return Some("");
+    }
+    rest.chars()
+        .next()
+        .is_some_and(char::is_whitespace)
+        .then(|| rest.trim())
+}
+
+fn shell_result_lines(result: ToolExecutionResult) -> Vec<ChatLine> {
+    match result {
+        ToolExecutionResult::Success(value) => shell_success_lines(&value),
+        ToolExecutionResult::SuccessWithImages { result, .. } => shell_success_lines(&result),
+        ToolExecutionResult::ToolError(message) => vec![ChatLine {
+            author: Author::System,
+            text: format!("shell failed: {message}"),
+        }],
+        ToolExecutionResult::InternalError(_) => vec![ChatLine {
+            author: Author::System,
+            text: "shell failed: internal error".into(),
+        }],
+        ToolExecutionResult::ConnectionRequired { provider } => vec![ChatLine {
+            author: Author::System,
+            text: format!("shell failed: connection required for {provider}"),
+        }],
+    }
+}
+
+fn shell_success_lines(value: &Value) -> Vec<ChatLine> {
+    let exit_code = value.get("exit_code").and_then(Value::as_i64).unwrap_or(-1);
+    let success = value
+        .get("success")
+        .and_then(Value::as_bool)
+        .unwrap_or(exit_code == 0);
+    let mut out = vec![ChatLine {
+        author: Author::Tool,
+        text: format!("shell exited with code {exit_code}"),
+    }];
+
+    for (label, author) in [
+        ("stdout", Author::ToolDetail),
+        ("stderr", Author::ToolDetail),
+    ] {
+        if let Some(text) = value.get(label).and_then(Value::as_str) {
+            let text = text.trim_end();
+            if !text.is_empty() {
+                out.push(ChatLine {
+                    author,
+                    text: format!("{label}:\n{text}"),
+                });
+            }
+        }
+    }
+    if value
+        .get("truncated")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+        || value
+            .get("output_limited")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    {
+        out.push(ChatLine {
+            author: Author::System,
+            text: "shell output was truncated".into(),
+        });
+    }
+    if out.len() == 1 {
+        out.push(ChatLine {
+            author: Author::ToolDetail,
+            text: "(no output)".into(),
+        });
+    }
+    if !success {
+        out.push(ChatLine {
+            author: Author::System,
+            text: "shell command exited non-zero".into(),
+        });
+    }
+    out
+}
+
 fn command_suggestions(
     input: &str,
     capability_commands: &[CommandDescriptor],
 ) -> Vec<CommandSuggestion> {
+    if let Some(rest) = input.strip_prefix('!') {
+        return bang_command_suggestions(rest, capability_commands);
+    }
     let Some(rest) = input.strip_prefix('/') else {
         return Vec::new();
     };
@@ -1176,15 +1316,46 @@ fn command_suggestions(
     }
 
     // Keep the dropdown bounded but large enough to show every built-in
-    // command (8 client commands + capability commands like /setup) for a
+    // command (9 client commands + capability commands like /setup) for a
     // bare `/`, so none is hidden behind the cap.
     out.truncate(12);
     out
 }
 
+fn bang_command_suggestions(
+    rest: &str,
+    capability_commands: &[CommandDescriptor],
+) -> Vec<CommandSuggestion> {
+    let Some(descriptor) = capability_commands.iter().find(|c| c.name == "shell") else {
+        return Vec::new();
+    };
+    if rest.contains(char::is_whitespace) || !descriptor.name.starts_with(rest) {
+        return Vec::new();
+    }
+    vec![CommandSuggestion {
+        completion: "!shell ".to_string(),
+        label: format!(
+            "{}    {}",
+            capability_command_display_usage(descriptor),
+            descriptor.description
+        ),
+    }]
+}
+
+fn capability_command_display_usage(descriptor: &CommandDescriptor) -> String {
+    capability_command_usage_with_prefix(
+        descriptor,
+        if descriptor.name == "shell" { "!" } else { "/" },
+    )
+}
+
 fn capability_command_usage(descriptor: &CommandDescriptor) -> String {
+    capability_command_usage_with_prefix(descriptor, "/")
+}
+
+fn capability_command_usage_with_prefix(descriptor: &CommandDescriptor, prefix: &str) -> String {
     if descriptor.args.is_empty() {
-        format!("/{}", descriptor.name)
+        format!("{prefix}{}", descriptor.name)
     } else {
         let args = descriptor
             .args
@@ -1198,7 +1369,7 @@ fn capability_command_usage(descriptor: &CommandDescriptor) -> String {
             })
             .collect::<Vec<_>>()
             .join(" ");
-        format!("/{} {args}", descriptor.name)
+        format!("{prefix}{} {args}", descriptor.name)
     }
 }
 
@@ -1304,7 +1475,7 @@ mod tests {
     }
 
     /// The terminal-side command descriptors as declared by
-    /// `ClientCommandsCapability` (help/tools/cwd/model/effort/clear/quit).
+    /// `ClientCommandsCapability` (help/tools/cwd/model/effort/clear/shell/quit).
     /// These now flow through the same registry as every other command, so
     /// suggestion tests source them the same way the running TUI does.
     fn client_command_descriptors() -> Vec<CommandDescriptor> {
@@ -1415,6 +1586,30 @@ mod tests {
 
         let suggestions = command_suggestions("/echo hello", &caps);
         assert!(suggestions.is_empty(), "got: {suggestions:?}");
+    }
+
+    #[test]
+    fn bang_shell_parser_accepts_only_shell_command_alias() {
+        assert_eq!(parse_bang_shell_command("!shell"), Some(""));
+        assert_eq!(parse_bang_shell_command("  !shell   pwd  "), Some("pwd"));
+        assert_eq!(
+            parse_bang_shell_command("!shell	printf hi"),
+            Some("printf hi")
+        );
+        assert_eq!(parse_bang_shell_command("!shellshock echo no"), None);
+        assert_eq!(parse_bang_shell_command("!"), None);
+    }
+
+    #[test]
+    fn bang_shell_suggestions_use_client_command_registry() {
+        let caps = caps_with_client_commands(vec![setup_capability_command()]);
+        let suggestions = command_suggestions("!s", &caps);
+
+        assert_eq!(suggestions.len(), 1, "got: {suggestions:?}");
+        assert_eq!(suggestions[0].completion, "!shell ");
+        assert!(suggestions[0].label.starts_with("!shell <command>"));
+        assert!(command_suggestions("!shell echo", &caps).is_empty());
+        assert!(command_suggestions("!s", &[setup_capability_command()]).is_empty());
     }
 
     #[test]
@@ -2152,6 +2347,10 @@ mod tests {
         /// `handle_command`.
         async fn dispatch_command_for_test(&mut self, cmd: &str) {
             self.handle_command(cmd).await;
+            self.pump_ui_commands_for_test();
+        }
+
+        fn pump_ui_commands_for_test(&mut self) {
             while let Ok(command) = self.ui_rx.try_recv() {
                 self.apply_ui_command(command);
             }
@@ -2258,6 +2457,57 @@ mod tests {
         );
         assert!(!app.busy);
         assert!(app.stream_preview.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn bang_shell_input_runs_shell_from_workspace_without_model_turn() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+        app.lines.clear();
+        app.set_input_text(
+            "!shell printf shell-output > shell-marker.txt && cat shell-marker.txt".into(),
+        );
+
+        app.submit_input().await;
+        app.pump_ui_commands_for_test();
+
+        assert!(
+            app.busy,
+            "!shell should run as a bounded background command"
+        );
+        app.pump_turn_until_idle_for_test().await;
+
+        let marker = app.startup.workspace_root.join("shell-marker.txt");
+        assert_eq!(
+            std::fs::read_to_string(marker).expect("shell marker"),
+            "shell-output"
+        );
+        assert!(
+            app.lines.iter().any(|line| {
+                matches!(line.author, Author::User)
+                    && line
+                        .text
+                        .starts_with("!shell printf shell-output > shell-marker.txt")
+            }),
+            "the submitted shell command should be echoed in the transcript: {:?}",
+            app.lines
+        );
+        assert!(
+            app.lines
+                .iter()
+                .any(|line| matches!(line.author, Author::ToolDetail)
+                    && line.text.contains("shell-output")),
+            "shell stdout should render in the transcript: {:?}",
+            app.lines
+        );
+        assert!(
+            !app.lines
+                .iter()
+                .any(|line| matches!(line.author, Author::Assistant)),
+            "!shell should not start a model turn: {:?}",
+            app.lines
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -801,7 +801,7 @@ impl App {
     }
 
     /// Dispatch a slash command. Every command — including the terminal-side
-    /// ones (help/tools/cwd/model/effort/clear/shell/quit) — is now a capability
+    /// ones (help/tools/mcp/cwd/model/effort/clear/shell/quit) — is now a capability
     /// command, so this is a single uniform lookup against the registry. The
     /// terminal-side commands take effect via `UiCommand`s their capability
     /// emits while executing (drained in the event loop); see

--- a/src/capabilities/client_commands.rs
+++ b/src/capabilities/client_commands.rs
@@ -285,6 +285,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn run_yolop_command_rejects_shell_dispatch() {
+        let ui = Arc::new(RecordingUi::default());
+        let tool = RunYolopCommandTool { ui: ui.clone() };
+
+        let result = tool
+            .execute(json!({
+                "command": "shell",
+                "arguments": "echo should-not-run"
+            }))
+            .await;
+
+        assert!(result.is_error(), "tool result: {result:?}");
+        assert_eq!(ui.take(), Vec::<UiCommand>::new());
+    }
+
+    #[tokio::test]
     async fn run_yolop_command_preserves_model_argument() {
         let ui = Arc::new(RecordingUi::default());
         let tool = RunYolopCommandTool { ui: ui.clone() };

--- a/src/capabilities/client_commands.rs
+++ b/src/capabilities/client_commands.rs
@@ -1,7 +1,7 @@
 //! Client-executed slash commands for the TUI host.
 //!
-//! `help`, `tools`, `cwd`, `model`, `effort`, `clear`, and `quit` act on the
-//! terminal, not the agent runtime. They are declared here as ordinary
+//! `help`, `tools`, `mcp`, `cwd`, `model`, `effort`, `clear`, `/shell`, and
+//! `quit` act on the terminal, not the agent runtime. They are declared here as ordinary
 //! capability commands so they share the single command registry — palette,
 //! `/help`, and completion all read `runtime.list_commands` — and dispatched
 //! through the injected [`HostUi`] port: `execute_command` translates each
@@ -52,7 +52,7 @@ impl Capability for ClientCommandsCapability {
         "Client Commands"
     }
     fn description(&self) -> &str {
-        "Terminal-side slash commands (help, tools, mcp, cwd, model, effort, clear, quit)."
+        "Terminal-side commands (help, tools, mcp, cwd, model, effort, clear, shell, quit)."
     }
     fn status(&self) -> CapabilityStatus {
         CapabilityStatus::Available
@@ -112,6 +112,11 @@ fn command_descriptors() -> Vec<CommandDescriptor> {
         cmd("model", "show or switch model", &[opt("id")]),
         cmd("effort", "show or set reasoning effort", &[opt("level")]),
         cmd("clear", "clear transcript", &[]),
+        cmd(
+            "shell",
+            "run shell command from workspace root",
+            &[required("command")],
+        ),
         cmd("quit", "exit", &[]),
     ]
 }
@@ -123,6 +128,9 @@ fn ui_command_for(name: &str, arg: Option<String>) -> Option<UiCommand> {
         "mcp" => Some(UiCommand::ShowMcp),
         "cwd" => Some(UiCommand::ShowCwd),
         "clear" => Some(UiCommand::ClearTranscript),
+        "shell" => Some(UiCommand::RunShell {
+            command: arg.unwrap_or_default(),
+        }),
         "quit" => Some(UiCommand::Quit),
         "model" => Some(UiCommand::OpenModelOverlay { arg }),
         "effort" => Some(UiCommand::OpenEffortOverlay { arg }),
@@ -177,6 +185,11 @@ impl Tool for RunYolopCommandTool {
         };
         let stripped = raw.trim_start_matches('/');
         let name = if stripped == "exit" { "quit" } else { stripped };
+        if name == "shell" {
+            return ToolExecutionResult::tool_error(
+                "shell commands must be typed directly as !shell <command> or /shell <command>",
+            );
+        }
         let arg = arguments
             .get("arguments")
             .and_then(Value::as_str)
@@ -211,10 +224,18 @@ fn cmd(name: &str, description: &str, args: &[CommandArg]) -> CommandDescriptor 
 }
 
 fn opt(name: &str) -> CommandArg {
+    arg(name, false)
+}
+
+fn required(name: &str) -> CommandArg {
+    arg(name, true)
+}
+
+fn arg(name: &str, required: bool) -> CommandArg {
     CommandArg {
         name: name.to_string(),
         description: name.to_string(),
-        required: false,
+        required,
         suggestions: Vec::new(),
     }
 }

--- a/src/host_ui.rs
+++ b/src/host_ui.rs
@@ -1,8 +1,9 @@
 //! Host UI port for client-executed slash commands.
 //!
 //! A handful of slash commands act on the terminal client itself — clear the
-//! transcript, open the model/effort overlay, print local info, quit — rather
-//! than on the agent runtime. They are nonetheless ordinary capabilities (see
+//! transcript, open the model/effort overlay, run a local shell command, print
+//! local info, quit — rather than on the agent runtime. They are nonetheless
+//! ordinary capabilities (see
 //! [`crate::capabilities::ClientCommandsCapability`]) so that every command
 //! lives in one registry. Their `execute_command` runs on the runtime's task
 //! and cannot touch the TUI directly, so it instead calls this port, which
@@ -25,6 +26,8 @@ pub enum UiCommand {
     ShowCwd,
     /// Clear the transcript buffer.
     ClearTranscript,
+    /// Run a shell command from the workspace root.
+    RunShell { command: String },
     /// Exit the application.
     Quit,
     /// Open the interactive model picker. `arg` pre-seeds the selection.

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1095,9 +1095,10 @@ pub struct StartupInfo {
     /// `Capability::commands()`). Resolved once at startup against this
     /// session's harness/agent chain; this is the single source of truth for
     /// the command palette, `/help`, and completion. For the TUI host it
-    /// includes the terminal-side commands (`/help`, `/tools`, `/cwd`,
-    /// `/model`, `/effort`, `/clear`, `!shell`, `/quit`) contributed by
-    /// `ClientCommandsCapability`.
+    /// includes the terminal-side commands (`/help`, `/tools`, `/mcp`,
+    /// `/cwd`, `/model`, `/effort`, `/clear`, `/shell`, `/quit`) contributed by
+    /// `ClientCommandsCapability`; the TUI also accepts `!shell` as the local
+    /// shell alias for `/shell`.
     pub capability_commands: Vec<CommandDescriptor>,
     /// On-disk JSONL log for this session. Populated even for fresh ids
     /// so the startup banner can show where new events are being written.
@@ -1204,7 +1205,7 @@ impl ModelState {
 pub struct BuildOptions {
     pub llmsim_override: Option<LlmSimConfig>,
     /// Register [`ClientCommandsCapability`], which contributes the
-    /// terminal-side commands (help/tools/cwd/model/effort/clear/shell/quit)
+    /// terminal-side commands (help/tools/mcp/cwd/model/effort/clear/shell/quit)
     /// and drives them through the host UI channel. Only a host that can apply
     /// the effects sets this: the interactive TUI (and the `app` unit tests
     /// that exercise it). ACP and `--print` leave it `false`.
@@ -1395,7 +1396,7 @@ pub async fn build_with_options(
         workspace: workspace.clone(),
     });
     // Terminal-side commands. Registered only when the host can apply
-    // their effects (the TUI). The capability declares help/tools/cwd/model/
+    // their effects (the TUI). The capability declares help/tools/mcp/cwd/model/
     // effort/clear/shell/quit and forwards each invocation as a `UiCommand` down
     // `ui_tx`; the `App` event loop drains `ui_rx` and performs the effect.
     let (ui_tx, ui_rx) = mpsc::unbounded_channel::<UiCommand>();

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1002,7 +1002,7 @@ fn coding_harness_capabilities(
 ) -> Vec<AgentCapabilityConfig> {
     let mut caps = Vec::new();
     // Terminal-side commands lead the registry so the most-typed commands
-    // (/help, /clear, /quit, …) surface first in the palette. Enabled only
+    // (/help, !shell, /clear, /quit, …) surface first in the palette. Enabled only
     // when the host registered the capability that backs them (the TUI);
     // enabling an unregistered id would have nothing to dispatch to.
     if client_commands {
@@ -1096,7 +1096,7 @@ pub struct StartupInfo {
     /// session's harness/agent chain; this is the single source of truth for
     /// the command palette, `/help`, and completion. For the TUI host it
     /// includes the terminal-side commands (`/help`, `/tools`, `/cwd`,
-    /// `/model`, `/effort`, `/clear`, `/quit`) contributed by
+    /// `/model`, `/effort`, `/clear`, `!shell`, `/quit`) contributed by
     /// `ClientCommandsCapability`.
     pub capability_commands: Vec<CommandDescriptor>,
     /// On-disk JSONL log for this session. Populated even for fresh ids
@@ -1204,7 +1204,7 @@ impl ModelState {
 pub struct BuildOptions {
     pub llmsim_override: Option<LlmSimConfig>,
     /// Register [`ClientCommandsCapability`], which contributes the
-    /// terminal-side slash commands (help/tools/cwd/model/effort/clear/quit)
+    /// terminal-side commands (help/tools/cwd/model/effort/clear/shell/quit)
     /// and drives them through the host UI channel. Only a host that can apply
     /// the effects sets this: the interactive TUI (and the `app` unit tests
     /// that exercise it). ACP and `--print` leave it `false`.
@@ -1394,9 +1394,9 @@ pub async fn build_with_options(
     capabilities.register(CodingBashCapability {
         workspace: workspace.clone(),
     });
-    // Terminal-side slash commands. Registered only when the host can apply
+    // Terminal-side commands. Registered only when the host can apply
     // their effects (the TUI). The capability declares help/tools/cwd/model/
-    // effort/clear/quit and forwards each invocation as a `UiCommand` down
+    // effort/clear/shell/quit and forwards each invocation as a `UiCommand` down
     // `ui_tx`; the `App` event loop drains `ui_rx` and performs the effect.
     let (ui_tx, ui_rx) = mpsc::unbounded_channel::<UiCommand>();
     if options.client_commands {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -747,6 +747,41 @@ fn tui_submit_turn_renders_assistant_in_scrollback() {
 }
 
 #[test]
+fn tui_bang_shell_runs_shell_without_model_turn() {
+    let mut tui = spawn_tui_llmsim(&yolop_binary());
+    assert!(
+        tui.wait_for_output("type /help", Duration::from_secs(3)),
+        "TUI did not render startup banner: {}",
+        tui.output_text()
+    );
+
+    tui.write_input(b"!shell printf shell-pty-output\r");
+    assert!(
+        tui.wait_for_output("shell exited with code 0", Duration::from_secs(5)),
+        "!shell did not complete: {}",
+        tui.output_text()
+    );
+
+    let transcript = strip_ansi(&tui.output_text());
+    assert!(
+        transcript.contains("stdout:") && transcript.contains("shell-pty-output"),
+        "!shell stdout should render in scrollback: {transcript}"
+    );
+    assert!(
+        !transcript.contains("offline mode"),
+        "!shell should not invoke llmsim/model turn: {transcript}"
+    );
+
+    tui.write_input(b"");
+    let status = tui.wait_or_kill(Duration::from_secs(3));
+    assert!(
+        status.success(),
+        "Ctrl-C should exit cleanly, got {status:?}: {}",
+        tui.output_text()
+    );
+}
+
+#[test]
 fn tui_double_ctrl_c_exits() {
     let mut tui = spawn_tui_llmsim(&yolop_binary());
     assert!(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -772,11 +772,11 @@ fn tui_bang_shell_runs_shell_without_model_turn() {
         "!shell should not invoke llmsim/model turn: {transcript}"
     );
 
-    tui.write_input(b"\x03");
+    tui.write_input(b"\x03\x03");
     let status = tui.wait_or_kill(Duration::from_secs(3));
     assert!(
         status.success(),
-        "Ctrl-C should exit cleanly, got {status:?}: {}",
+        "double Ctrl-C should exit cleanly, got {status:?}: {}",
         tui.output_text()
     );
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -772,7 +772,7 @@ fn tui_bang_shell_runs_shell_without_model_turn() {
         "!shell should not invoke llmsim/model turn: {transcript}"
     );
 
-    tui.write_input(b"");
+    tui.write_input(b"\x03");
     let status = tui.wait_or_kill(Duration::from_secs(3));
     assert!(
         status.success(),


### PR DESCRIPTION
## Summary
- add a TUI-only `!shell <command>` alias backed by the existing client command registry
- execute shell commands through the existing bounded `BashTool` from the workspace root and render stdout/stderr in the transcript without starting a model turn
- document the command surface in README/specs and cover parsing, suggestions, submit-path behavior, PTY smoke, and the LLM-facing command-tool boundary

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features bang_shell`
- `cargo test --all-features run_yolop_command`
- `cargo test --all-features -- --test-threads=1 --skip tui_setup_selects_model_for_connected_provider_in_real_pty`
  - Note: `tui_setup_selects_model_for_connected_provider_in_real_pty` also fails on clean `main` because the provider switch is not persisted.
- `cargo test --all-features` (parallel) was also run; it hit existing PTY concurrency flakes where multiple TUI tests timed out before the startup banner. The same tests pass serialized, including the new `!shell` PTY test.
- `cargo run -- --provider llmsim -p "hi"`
- `cargo build --release`

## Security
- TM-BASH: `!shell` reuses the existing `BashTool`, preserving its 120s timeout and bounded inline output modes; no new process runner was introduced.
- TM-FS: shell execution runs from the existing workspace root abstraction. This intentionally exposes local shell power to the TUI user only and does not add ACP/print-model access.
- TM-LLM: shell command output is rendered directly to the local transcript and does not start a model turn; the model-facing `run_yolop_command` tool explicitly rejects `shell` so shell execution remains user-typed via `!shell`/`/shell`.
- TM-TOOL/TM-DEP: no new dependencies or write-capable capabilities beyond the existing client-command host port.

## Follow-ups
No follow-ups.
