### PR TITLE
Let prompts invoke TUI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   or less careful). See [Soft approval](#soft-approval) below.
 - **TUI chat** (ratatui): scrolling transcript, multiline composer, status
   bar, slash commands (`/help`, `/tools`, `/mcp`, `/cwd`, `/setup`, `/model`,
-  `/effort`, `/clear`, `/quit`).
+  `/effort`, `/clear`, `/quit`) and natural-language requests for terminal
+  actions such as "exit" or "clear the screen".
 - **Planning** — `write_todos` keeps multi-step tasks on track, and
   loop detection stops the model from retrying the same failing tool call.
 - **One-shot mode** — `--print` runs a single prompt non-interactively, for

--- a/specs/commands.md
+++ b/specs/commands.md
@@ -34,8 +34,8 @@ top of the runtime's two, not a separate `CommandSource` variant.
    transcript, quit, print local info). These are declared as ordinary `System`
    commands; on execute, their capability emits a typed `UiCommand` through an
    injected host UI port instead of returning text. The host's event loop drains
-   the port and applies the effect. Commands: `/help`, `/tools`, `/cwd`,
-   `/model`, `/effort`, `/clear`, `/quit`.
+   the port and applies the effect. Commands: `/help`, `/tools`, `/mcp`,
+   `/cwd`, `/model`, `/effort`, `/clear`, `/quit`.
 
 ## Why client commands use a host port, not a new `CommandSource`
 
@@ -69,7 +69,14 @@ portable case ever arises.
    every queued `UiCommand` before the next render. The `UiCommand` vocabulary
    is the shared contract between client capabilities and the host — a genuinely
    new on-screen effect is a host change, not a drop-in.
-4. **Host gating.** Client commands are enabled only for a host that can apply
+4. **Natural-language dispatch.** In the interactive TUI, the same client
+   capability exposes a model-facing `run_yolop_command` tool and a prompt
+   contribution listing the terminal commands. When the user asks for a
+   terminal-side action in ordinary prose (for example, "exit"), the model
+   invokes that tool; the tool emits the same `UiCommand` as the slash-command
+   path. The tool is TUI-gated with the capability and does not create a
+   second command registry.
+5. **Host gating.** Client commands are enabled only for a host that can apply
    them. `BuildOptions::client_commands` registers `ClientCommandsCapability`
    and enables its harness id; the interactive TUI sets it, while ACP and
    `--print` leave it off and therefore neither advertise nor dispatch terminal

--- a/src/agent_scenarios.rs
+++ b/src/agent_scenarios.rs
@@ -24,6 +24,7 @@ use std::time::Duration;
 use everruns_core::llmsim_driver::{LlmSimConfig, OnExhausted, SimError, SimToolCall, SimTurn};
 use serde_json::json;
 
+use crate::host_ui::UiCommand;
 use crate::runtime::{BuildOptions, BuiltRuntime, ProviderChoice, build_with_options};
 use crate::settings::SettingsStore;
 
@@ -49,11 +50,24 @@ async fn build_scripted_runtime_with_workspace(
     config: LlmSimConfig,
     setup_workspace: impl FnOnce(&std::path::Path),
 ) -> (BuiltRuntime, std::path::PathBuf) {
+    build_scripted_runtime_with_workspace_and_options(
+        config,
+        setup_workspace,
+        BuildOptions::default(),
+    )
+    .await
+}
+
+async fn build_scripted_runtime_with_workspace_and_options(
+    config: LlmSimConfig,
+    setup_workspace: impl FnOnce(&std::path::Path),
+    mut options: BuildOptions,
+) -> (BuiltRuntime, std::path::PathBuf) {
     let workspace_root = tempfile::tempdir().expect("workspace tempdir").keep();
     let sessions_root = tempfile::tempdir().expect("sessions tempdir").keep();
     setup_workspace(&workspace_root);
 
-    let llmsim = config.with_model("llmsim-yolop");
+    options.llmsim_override = Some(config.with_model("llmsim-yolop"));
     let settings_path = sessions_root.join("settings.toml");
     let settings = Arc::new(SettingsStore::open(settings_path));
     let runtime = build_with_options(
@@ -62,10 +76,7 @@ async fn build_scripted_runtime_with_workspace(
         None,
         sessions_root,
         settings,
-        BuildOptions {
-            llmsim_override: Some(llmsim),
-            ..BuildOptions::default()
-        },
+        options,
     )
     .await
     .expect("build scripted llmsim runtime");
@@ -108,6 +119,39 @@ async fn scripted_assistant_text_returns_success_with_no_tools() {
         result.iterations >= 1,
         "agent loop must record at least one iteration: {result:?}"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn scripted_prompt_command_tool_queues_quit_ui_command() {
+    let (mut runtime, _ws) = build_scripted_runtime_with_workspace_and_options(
+        LlmSimConfig::scripted(vec![
+            SimTurn::ToolCalls(vec![SimToolCall {
+                name: "run_yolop_command".to_string(),
+                arguments: json!({ "command": "exit" }),
+                id: None,
+            }]),
+            SimTurn::Assistant("exiting".to_string()),
+        ]),
+        |_| {},
+        BuildOptions {
+            client_commands: true,
+            ..BuildOptions::default()
+        },
+    )
+    .await;
+
+    let result = run_single_turn(&runtime, "exit").await;
+
+    assert!(
+        result.success,
+        "prompt command turn must succeed: {result:?}"
+    );
+    assert_eq!(
+        result.tool_calls_count, 1,
+        "natural-language command should run through the tool entry point"
+    );
+    let command = runtime.ui_rx.try_recv().expect("queued UI command");
+    assert_eq!(command, UiCommand::Quit);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/capabilities/client_commands.rs
+++ b/src/capabilities/client_commands.rs
@@ -19,9 +19,19 @@ use everruns_core::command::{
     CommandArg, CommandDescriptor, CommandExecutionContext, CommandResult, CommandSource,
     ExecuteCommandRequest,
 };
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use serde_json::{Value, json};
 use std::sync::Arc;
 
 pub(crate) const CLIENT_COMMANDS_CAPABILITY_ID: &str = "yolop_client_commands";
+
+const CLIENT_COMMANDS_PROMPT: &str = r#"<capability id="yolop_client_commands">
+The interactive terminal has slash commands: `/help`, `/tools`, `/mcp`, `/cwd`,
+`/model [id]`, `/effort [level]`, `/clear`, and `/quit` (`/exit` is an alias).
+When the user asks in natural language for one of these terminal actions — for
+example "exit", "clear the screen", "show tools", or "switch model" — call
+`run_yolop_command`; do not merely tell the user to type the slash command.
+</capability>"#;
 
 pub(crate) struct ClientCommandsCapability {
     ui: Arc<dyn HostUi>,
@@ -51,20 +61,17 @@ impl Capability for ClientCommandsCapability {
         Some("Examples")
     }
     fn system_prompt_addition(&self) -> Option<&str> {
-        None
+        Some(CLIENT_COMMANDS_PROMPT)
     }
 
     fn commands(&self) -> Vec<CommandDescriptor> {
-        vec![
-            cmd("help", "show commands", &[]),
-            cmd("tools", "list available tools", &[]),
-            cmd("mcp", "list configured MCP servers", &[]),
-            cmd("cwd", "show workspace root", &[]),
-            cmd("model", "show or switch model", &[opt("id")]),
-            cmd("effort", "show or set reasoning effort", &[opt("level")]),
-            cmd("clear", "clear transcript", &[]),
-            cmd("quit", "exit", &[]),
-        ]
+        command_descriptors()
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![Box::new(RunYolopCommandTool {
+            ui: self.ui.clone(),
+        })]
     }
 
     async fn execute_command(
@@ -78,22 +85,13 @@ impl Capability for ClientCommandsCapability {
             .map(str::trim)
             .filter(|s| !s.is_empty())
             .map(str::to_string);
-        let command = match request.name.as_str() {
-            "help" => UiCommand::ShowHelp,
-            "tools" => UiCommand::ShowTools,
-            "mcp" => UiCommand::ShowMcp,
-            "cwd" => UiCommand::ShowCwd,
-            "clear" => UiCommand::ClearTranscript,
-            "quit" => UiCommand::Quit,
-            "model" => UiCommand::OpenModelOverlay { arg },
-            "effort" => UiCommand::OpenEffortOverlay { arg },
-            other => {
-                return Err(everruns_core::AgentLoopError::config(format!(
-                    "{} cannot execute /{other}",
-                    self.id()
-                )));
-            }
-        };
+        let command = ui_command_for(&request.name, arg).ok_or_else(|| {
+            everruns_core::AgentLoopError::config(format!(
+                "{} cannot execute /{}",
+                self.id(),
+                request.name
+            ))
+        })?;
         self.ui.send(command);
         // The host event loop applies the effect; nothing to render inline.
         Ok(CommandResult {
@@ -102,6 +100,104 @@ impl Capability for ClientCommandsCapability {
             error_code: None,
             error_fields: None,
         })
+    }
+}
+
+fn command_descriptors() -> Vec<CommandDescriptor> {
+    vec![
+        cmd("help", "show commands", &[]),
+        cmd("tools", "list available tools", &[]),
+        cmd("mcp", "list configured MCP servers", &[]),
+        cmd("cwd", "show workspace root", &[]),
+        cmd("model", "show or switch model", &[opt("id")]),
+        cmd("effort", "show or set reasoning effort", &[opt("level")]),
+        cmd("clear", "clear transcript", &[]),
+        cmd("quit", "exit", &[]),
+    ]
+}
+
+fn ui_command_for(name: &str, arg: Option<String>) -> Option<UiCommand> {
+    match name {
+        "help" => Some(UiCommand::ShowHelp),
+        "tools" => Some(UiCommand::ShowTools),
+        "mcp" => Some(UiCommand::ShowMcp),
+        "cwd" => Some(UiCommand::ShowCwd),
+        "clear" => Some(UiCommand::ClearTranscript),
+        "quit" => Some(UiCommand::Quit),
+        "model" => Some(UiCommand::OpenModelOverlay { arg }),
+        "effort" => Some(UiCommand::OpenEffortOverlay { arg }),
+        _ => None,
+    }
+}
+
+struct RunYolopCommandTool {
+    ui: Arc<dyn HostUi>,
+}
+
+#[async_trait]
+impl Tool for RunYolopCommandTool {
+    fn name(&self) -> &str {
+        "run_yolop_command"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Run yolop command")
+    }
+
+    fn description(&self) -> &str {
+        "Run an interactive yolop slash command on behalf of a natural-language user request. \
+         Use this when the user asks to exit, clear the transcript, show help/tools/MCP/cwd, \
+         or open/switch model or reasoning effort. Accepts command names without the leading \
+         slash; `exit` is accepted as an alias for `quit`."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "Slash command name, with or without the leading slash.",
+                    "enum": ["help", "tools", "mcp", "cwd", "model", "effort", "clear", "quit", "exit"]
+                },
+                "arguments": {
+                    "type": "string",
+                    "description": "Optional command arguments, e.g. a model id for /model or level for /effort."
+                }
+            },
+            "required": ["command"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let raw = match arguments.get("command").and_then(Value::as_str) {
+            Some(raw) if !raw.trim().is_empty() => raw.trim(),
+            _ => return ToolExecutionResult::tool_error("'command' is required"),
+        };
+        let stripped = raw.trim_start_matches('/');
+        let name = if stripped == "exit" { "quit" } else { stripped };
+        let arg = arguments
+            .get("arguments")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+
+        let Some(command) = ui_command_for(name, arg.clone()) else {
+            return ToolExecutionResult::tool_error(format!("unknown yolop command: /{stripped}"));
+        };
+
+        self.ui.send(command);
+        let rendered = match &arg {
+            Some(arg) => format!("/{name} {arg}"),
+            None => format!("/{name}"),
+        };
+        ToolExecutionResult::success(json!({
+            "success": true,
+            "command": rendered,
+            "message": "command queued for the interactive terminal host"
+        }))
     }
 }
 
@@ -120,5 +216,71 @@ fn opt(name: &str) -> CommandArg {
         description: name.to_string(),
         required: false,
         suggestions: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Default)]
+    struct RecordingUi {
+        commands: Mutex<Vec<UiCommand>>,
+    }
+
+    impl RecordingUi {
+        fn take(&self) -> Vec<UiCommand> {
+            std::mem::take(&mut *self.commands.lock().expect("commands lock"))
+        }
+    }
+
+    impl HostUi for RecordingUi {
+        fn send(&self, command: UiCommand) {
+            self.commands.lock().expect("commands lock").push(command);
+        }
+    }
+
+    #[test]
+    fn prompt_tells_model_to_run_natural_language_commands() {
+        let ui = Arc::new(RecordingUi::default());
+        let capability = ClientCommandsCapability::new(ui);
+        let prompt = capability.system_prompt_addition().expect("prompt");
+
+        assert!(prompt.contains("run_yolop_command"));
+        assert!(prompt.contains("/quit"));
+        assert!(prompt.contains("/exit"));
+    }
+
+    #[tokio::test]
+    async fn run_yolop_command_exit_alias_queues_quit() {
+        let ui = Arc::new(RecordingUi::default());
+        let tool = RunYolopCommandTool { ui: ui.clone() };
+
+        let result = tool.execute(json!({ "command": "/exit" })).await;
+
+        assert!(result.is_success(), "tool result: {result:?}");
+        assert_eq!(ui.take(), vec![UiCommand::Quit]);
+    }
+
+    #[tokio::test]
+    async fn run_yolop_command_preserves_model_argument() {
+        let ui = Arc::new(RecordingUi::default());
+        let tool = RunYolopCommandTool { ui: ui.clone() };
+
+        let result = tool
+            .execute(json!({
+                "command": "model",
+                "arguments": "openai/gpt-5.4"
+            }))
+            .await;
+
+        assert!(result.is_success(), "tool result: {result:?}");
+        assert_eq!(
+            ui.take(),
+            vec![UiCommand::OpenModelOverlay {
+                arg: Some("openai/gpt-5.4".to_string())
+            }]
+        );
     }
 }

--- a/src/capabilities/tool_search.rs
+++ b/src/capabilities/tool_search.rs
@@ -74,9 +74,10 @@ pub const DEFAULT_TOOL_SEARCH_THRESHOLD: usize = 15;
 const MAX_SEARCH_RESULTS: usize = 12;
 
 /// Hot-path tools that always keep their full schemas, so the agent can read,
-/// edit, search, and run commands without a `tool_search` round-trip. The long
-/// tail is deferred until the model asks for it. Keep this list small — every
-/// entry is a tool the model pays full-schema tokens for on every turn.
+/// edit, search, run shell commands, and invoke TUI commands without a
+/// `tool_search` round-trip. The long tail is deferred until the model asks for
+/// it. Keep this list small — every entry is a tool the model pays full-schema
+/// tokens for on every turn.
 const ALWAYS_FULL: &[&str] = &[
     "read_file",
     "write_file",
@@ -84,6 +85,7 @@ const ALWAYS_FULL: &[&str] = &[
     "list_directory",
     "grep_files",
     "bash",
+    "run_yolop_command",
 ];
 
 /// Names of tools the model has loaded via `tool_search` this session. Shared
@@ -452,8 +454,8 @@ mod tests {
             .is_none_or(|p| p.is_empty())
     }
 
-    /// Build a tool set above the threshold: the 6 core tools plus N long-tail
-    /// tools so deferral activates.
+    /// Build a tool set above the threshold: the always-full tools plus N
+    /// long-tail tools so deferral activates.
     fn tool_set(extra: usize) -> Vec<ToolDefinition> {
         let mut tools: Vec<ToolDefinition> = ALWAYS_FULL
             .iter()
@@ -472,8 +474,8 @@ mod tests {
     fn below_threshold_keeps_all_full_schemas() {
         let cap = ToolSearchCapability::new();
         let hook = &cap.tool_definition_hooks()[0];
-        // 6 core + 3 = 9 tools, below the default threshold of 15.
-        let out = hook.transform(tool_set(3));
+        let extra = DEFAULT_TOOL_SEARCH_THRESHOLD - ALWAYS_FULL.len() - 3;
+        let out = hook.transform(tool_set(extra));
         assert!(
             out.iter().all(|t| !is_stubbed(t)),
             "nothing should defer below threshold"
@@ -484,15 +486,16 @@ mod tests {
     fn deferral_activates_strictly_above_threshold() {
         let cap = ToolSearchCapability::with_threshold(15);
         let hook = &cap.tool_definition_hooks()[0];
-        // Exactly at the threshold (6 core + 9 = 15): nothing defers.
-        let at = hook.transform(tool_set(9));
-        assert_eq!(at.len(), 15);
+        // Exactly at the threshold: nothing defers.
+        let at_threshold_extra = DEFAULT_TOOL_SEARCH_THRESHOLD - ALWAYS_FULL.len();
+        let at = hook.transform(tool_set(at_threshold_extra));
+        assert_eq!(at.len(), DEFAULT_TOOL_SEARCH_THRESHOLD);
         assert!(
             at.iter().all(|t| !is_stubbed(t)),
             "at the threshold the full catalogue must fit; no deferral"
         );
-        // One over (16): the long tail defers.
-        let over = hook.transform(tool_set(10));
+        // One over: the long tail defers.
+        let over = hook.transform(tool_set(at_threshold_extra + 1));
         assert!(
             over.iter().any(is_stubbed),
             "strictly above the threshold the long tail must defer"
@@ -503,7 +506,7 @@ mod tests {
     fn core_tools_keep_full_schemas_long_tail_is_deferred() {
         let cap = ToolSearchCapability::new();
         let hook = &cap.tool_definition_hooks()[0];
-        let out = hook.transform(tool_set(12)); // 18 tools, above threshold
+        let out = hook.transform(tool_set(12));
         for t in &out {
             if ALWAYS_FULL.contains(&t.name()) {
                 assert!(
@@ -525,7 +528,7 @@ mod tests {
     fn mcp_tools_defer_above_threshold_and_reveal_after_search() {
         let cap = ToolSearchCapability::new();
         let hook = &cap.tool_definition_hooks()[0];
-        // 18 long-tail/core tools plus one MCP tool, above the threshold.
+        // Always-full/long-tail tools plus one MCP tool, above the threshold.
         let build = || {
             let mut tools = tool_set(12);
             tools.push(builtin("mcp_docs__search", DeferrablePolicy::default()));


### PR DESCRIPTION
## Summary
- add a TUI-gated `run_yolop_command` tool to dispatch natural-language requests like “exit” through the existing client-command/`UiCommand` path
- add client command prompt guidance and keep the command tool schema hot-loaded
- cover prompt-command dispatch with unit tests and a scripted llmsim agent-loop test
- document the natural-language command path in the README and command spec

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -q scripted_prompt_command_tool_queues_quit_ui_command --all-features`
- `cargo test -q run_yolop_command --all-features`
- `cargo test --all-features --bin yolop`
- `cargo test --all-features --test integration -- --test-threads=1 --skip tui_setup_selects_model_for_connected_provider_in_real_pty`
- `cargo run -- --provider llmsim -p "hi"`

## Notes
- `cargo test --all-features` passes unit tests but the integration test `tui_setup_selects_model_for_connected_provider_in_real_pty` fails locally; reproduced the same failure on untouched `main`.
- Parallel PTY integration runs can race on startup banner rendering; the same tests pass when run individually/serially.
- `doppler run -- cargo run -- --provider openai -p ...` is blocked locally by Doppler config: `You must specify a project`.
- `cargo build --release` was attempted twice but exceeded the 120s command timeout in this environment.
