### PR TITLE
fix(tui): stop mirroring flushed transcript lines

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2399,6 +2399,31 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn inline_viewport_does_not_mirror_flushed_transcript_lines() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+        app.lines.clear();
+        app.push_user("Do something".into());
+        app.lines.push(ChatLine {
+            author: Author::Assistant,
+            text: "Done.".into(),
+        });
+        app.printed_lines = app.lines.len();
+
+        let rows = render_app_lines(app, 96, COMPOSER_VIEWPORT_HEIGHT);
+
+        assert!(
+            !rows.iter().any(|row| row.contains("Do something")),
+            "flushed user transcript should stay in scrollback only: {rows:?}"
+        );
+        assert!(
+            !rows.iter().any(|row| row.contains("Done.")),
+            "flushed assistant transcript should stay in scrollback only: {rows:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn inline_viewport_uses_recent_transcript_tail() {
         let mut fixture = app_with_llmsim().await;
         let app = &mut fixture.app;

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -83,8 +83,13 @@ pub(crate) fn recent_transcript_lines(
     let mut total_lines = 0;
     let mut newer_author: Option<Author> = None;
 
+    // Already-flushed lines live in native scrollback; mirroring them here
+    // makes prompts and outputs appear twice until the next redraw.
+    let pending_start = app.printed_lines.min(app.lines.len());
     for chat in app
         .lines
+        .get(pending_start..)
+        .unwrap_or_default()
         .iter()
         .rev()
         .filter(|line| !matches!(line.author, Author::System))

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -86,10 +86,7 @@ pub(crate) fn recent_transcript_lines(
     // Already-flushed lines live in native scrollback; mirroring them here
     // makes prompts and outputs appear twice until the next redraw.
     let pending_start = app.printed_lines.min(app.lines.len());
-    for chat in app
-        .lines
-        .get(pending_start..)
-        .unwrap_or_default()
+    for chat in app.lines[pending_start..]
         .iter()
         .rev()
         .filter(|line| !matches!(line.author, Author::System))

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -602,7 +602,7 @@ fn tui_setup_selects_model_for_connected_provider_in_real_pty() {
     while Instant::now() < deadline
         && !std::fs::read_to_string(tui.settings_path())
             .unwrap_or_default()
-            .contains("provider = \"openai\"")
+            .contains("default_provider = \"openai\"")
     {
         thread::sleep(Duration::from_millis(20));
     }
@@ -626,7 +626,7 @@ fn tui_setup_selects_model_for_connected_provider_in_real_pty() {
     let settings =
         std::fs::read_to_string(tui.settings_path()).expect("read settings written by the TUI");
     assert!(
-        settings.contains("provider = \"openai\""),
+        settings.contains("default_provider = \"openai\""),
         "provider switch should persist: {settings}"
     );
     assert!(

--- a/tests/support/tui_harness.rs
+++ b/tests/support/tui_harness.rs
@@ -57,9 +57,16 @@ impl TuiHarness {
         self.answer_cursor_queries.store(answer, Ordering::SeqCst);
     }
 
-    /// The settings.toml the spawned TUI reads and writes (Linux config
-    /// layout; the harness seeds the macOS path with the same content).
+    /// The settings.toml the spawned TUI reads and writes.
     pub fn settings_path(&self) -> PathBuf {
+        #[cfg(target_os = "macos")]
+        {
+            self._home
+                .path()
+                .join("Library/Application Support/yolop/settings.toml")
+        }
+
+        #[cfg(not(target_os = "macos"))]
         self._home.path().join(".config/yolop/settings.toml")
     }
 


### PR DESCRIPTION
## What
Fixes duplicate TUI transcript rendering by keeping already-flushed transcript lines in native terminal scrollback only, instead of also repainting them inside the inline viewport.

## Why
User prompts and outputs could appear twice, then disappear and reappear, because the same transcript entry was both inserted into scrollback and mirrored in the inline viewport tail.

## How
- Filters recent inline transcript rendering to only lines after `printed_lines`.
- Adds a regression test that marks transcript entries flushed and verifies they are not mirrored in the viewport.
- Updates the PTY setup test harness to read the platform-native settings path on macOS and assert the current `default_provider` setting key.

## Risk
- Low
- TUI-only rendering path; flushed transcript entries remain in native scrollback, and pending entries can still render before flush.

## Security
No security-relevant behavior change. Reviewed TM-FS, TM-BASH, TM-LLM, TM-TOOL, and TM-DEP: no tool execution, file access, prompt/API-key handling, capability registration, or dependency changes.

## Validation
- `cargo fmt --check`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- --provider llmsim -p "hi"`

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
