### PR TITLE
feat(commands): add direct shell command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   or less careful). See [Soft approval](#soft-approval) below.
 - **TUI chat** (ratatui): scrolling transcript, multiline composer, status
   bar, slash commands (`/help`, `/tools`, `/mcp`, `/cwd`, `/setup`, `/model`,
-  `/effort`, `/clear`, `/quit`).
+  `/effort`, `/shell`, `/clear`, `/quit`), plus `!<command>` as a direct shell
+  shortcut.
 - **Planning** — `write_todos` keeps multi-step tasks on track, and
   loop detection stops the model from retrying the same failing tool call.
 - **One-shot mode** — `--print` runs a single prompt non-interactively, for
@@ -65,7 +66,8 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   `grep_files`, `delete_file`, `stat_file`, backed by the real workspace disk.
 - **Shell** — `bash -lc` from the workspace root, with a 120 s wall-clock
   timeout and per-stream 1 MiB output cap; large output is spilled to disk
-  under the session folder and stays readable.
+  under the session folder and stays readable. Use `/shell <command>` or
+  `!<command>` in interactive sessions to run a command directly.
 - **Web** — `web_fetch` (HTTP GET/HEAD with markdown/text conversion, DNS-pinned
   SSRF protection) and `duckduckgo_search` (free, no API key). Setting
   `EVERRUNS_SYSTEM_ALLOWLIST_ENABLED=true` restricts `web_fetch` to the

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   `grep_files`, `delete_file`, `stat_file`, backed by the real workspace disk.
 - **Shell** — `bash -lc` from the workspace root, with a 120 s wall-clock
   timeout and per-stream 1 MiB output cap; large output is spilled to disk
-  under the session folder and stays readable. Use `/shell <command>` or
-  `!<command>` in interactive sessions to run a command directly.
+  under the session folder and stays readable for model tool calls. Use
+  `/shell <command>` or `!<command>` in interactive sessions to run a command
+  directly with bounded inline output.
 - **Web** — `web_fetch` (HTTP GET/HEAD with markdown/text conversion, DNS-pinned
   SSRF protection) and `duckduckgo_search` (free, no API key). Setting
   `EVERRUNS_SYSTEM_ALLOWLIST_ENABLED=true` restricts `web_fetch` to the

--- a/specs/acp.md
+++ b/specs/acp.md
@@ -64,11 +64,12 @@ emitted as a chunk when no deltas streamed for it during the turn.
 After `session/new`, yolop sends `available_commands_update` with
 capability-sourced slash commands such as `/setup` and user-invocable skill
 commands. ACP clients run commands by sending their literal text in
-`session/prompt` (for example, `/setup status`). System commands execute
-through `runtime.execute_command` and stream a command-shaped `tool_call` /
-`tool_call_update` pair with structured `rawInput`, `rawOutput`, and text
-`content`; skill commands are forwarded as prompt text so the model can activate
-the skill.
+`session/prompt` (for example, `/setup status`). `!<command>` and
+`!shell <command>` are accepted shortcuts for `/shell <command>`. System
+commands execute through `runtime.execute_command` and stream a command-shaped
+`tool_call` / `tool_call_update` pair with structured `rawInput`, `rawOutput`,
+and text `content`; skill commands are forwarded as prompt text so the model
+can activate the skill.
 
 ACP v1 command input only standardises an unstructured `input.hint`. yolop also
 adds compatible extension metadata under `_meta["yolop.dev/command"]` so richer

--- a/specs/commands.md
+++ b/specs/commands.md
@@ -23,7 +23,8 @@ top of the runtime's two, not a separate `CommandSource` variant.
 
 1. **System** — the **runtime** executes it via `runtime.execute_command`,
    returning a `CommandResult { success, message }` the host renders inline.
-   Example: `/setup` and its subcommands mutate provider/model/token settings.
+   Example: `/setup` and its subcommands mutate provider/model/token settings;
+   `/shell <command>` runs the existing bounded bash tool.
 
 2. **Skill** — the **LLM** executes it. The literal `/name args` text is
    forwarded as a chat turn so the model activates the skill. Skill commands are
@@ -64,6 +65,8 @@ portable case ever arises.
 2. **Uniform dispatch.** The host looks a typed command up in the registry and
    routes by `CommandSource`: `System`/client → `runtime.execute_command`;
    `Skill` → forward as a chat turn. `/exit` is an accepted alias for `/quit`.
+   Interactive hosts also accept `!<command>` and `!shell <command>` as
+   shortcuts for `/shell <command>`.
 3. **Client effects are host-applied.** A client command's `execute_command`
    returns an empty `CommandResult` and emits a `UiCommand`; the host applies
    every queued `UiCommand` before the next render. The `UiCommand` vocabulary

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -522,6 +522,10 @@ mod tests {
             commands.iter().any(|c| c["name"] == "setup"),
             "expected /setup to be advertised, got: {commands:?}"
         );
+        assert!(
+            commands.iter().any(|c| c["name"] == "shell"),
+            "expected /shell to be advertised, got: {commands:?}"
+        );
         let setup = commands
             .iter()
             .find(|c| c["name"] == "setup")
@@ -574,6 +578,46 @@ mod tests {
             "slash command should not invoke the model"
         );
         assert!(!run.updates_of_kind("available_commands_update").is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn bang_shell_command_executes_without_model_turn() {
+        let run = with_sdk_client(fixed("model should not run"), |client| async move {
+            let mut session = client.new_session().await?;
+            let _ = collect_available_commands(&mut session).await?;
+            SdkClient::prompt(&mut session, "!printf acp-shell").await
+        })
+        .await;
+
+        assert_eq!(
+            run.stop_reason,
+            agent_client_protocol::schema::StopReason::EndTurn
+        );
+        let tool_calls = run.updates_of_kind("tool_call");
+        assert!(
+            tool_calls
+                .iter()
+                .any(|u| u["title"] == "!shell printf acp-shell"
+                    && u["rawInput"]["command"] == "shell"),
+            "expected shell command tool_call, got updates: {:?}",
+            run.updates
+        );
+        let tool_updates = run.updates_of_kind("tool_call_update");
+        let completed = tool_updates
+            .iter()
+            .find(|u| u["status"] == "completed")
+            .expect("completed command tool update");
+        assert!(
+            completed["content"][0]["content"]["text"]
+                .as_str()
+                .is_some_and(|text| text.contains("acp-shell")),
+            "expected shell output in command content, got: {completed:?}"
+        );
+        assert_eq!(completed["rawOutput"]["success"], true);
+        assert!(
+            !run.assistant_text().contains("model should not run"),
+            "bang shell command should not invoke the model"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -414,8 +414,8 @@ async fn handle_prompt<F: RuntimeFactory>(
         .ok_or_else(|| invalid_params("unknown session id"))?;
     let prompt = protocol::prompt_text(&params.prompt);
 
-    let stop_reason = match parse_slash_command(&prompt) {
-        Some((name, args)) => run_slash_command(peer, session, name, args).await,
+    let stop_reason = match parse_command_prompt(&prompt) {
+        Some(command) => run_slash_command(peer, session, command).await,
         None => run_prompt(peer, session, prompt).await,
     };
     Ok(PromptResult::new(stop_reason))
@@ -507,24 +507,65 @@ fn command_meta(command: &CommandDescriptor) -> Option<serde_json::Map<String, V
     }))
 }
 
-fn parse_slash_command(prompt: &str) -> Option<(String, String)> {
+#[derive(Debug, PartialEq, Eq)]
+struct ParsedCommand {
+    name: String,
+    args: String,
+    title: String,
+}
+
+fn parse_command_prompt(prompt: &str) -> Option<ParsedCommand> {
     let trimmed = prompt.trim();
-    let rest = trimmed.strip_prefix('/')?.trim_start();
+    if let Some(rest) = trimmed.strip_prefix('/') {
+        return parse_slash_command(rest.trim_start());
+    }
+    if let Some(rest) = trimmed.strip_prefix('!') {
+        return Some(parse_shell_shortcut(rest));
+    }
+    None
+}
+
+fn parse_slash_command(rest: &str) -> Option<ParsedCommand> {
     let mut parts = rest.splitn(2, char::is_whitespace);
     let name = parts.next()?.trim();
     if name.is_empty() {
         return None;
     }
     let args = parts.next().unwrap_or_default().trim();
-    Some((name.to_string(), args.to_string()))
+    Some(ParsedCommand {
+        name: name.to_string(),
+        args: args.to_string(),
+        title: command_title("/", name, args),
+    })
+}
+
+fn parse_shell_shortcut(rest: &str) -> ParsedCommand {
+    let args = rest
+        .trim_start()
+        .strip_prefix("shell")
+        .and_then(|tail| {
+            tail.chars()
+                .next()
+                .is_none_or(char::is_whitespace)
+                .then_some(tail)
+        })
+        .unwrap_or(rest)
+        .trim();
+    ParsedCommand {
+        name: "shell".to_string(),
+        args: args.to_string(),
+        title: command_title("!", "shell", args),
+    }
 }
 
 async fn run_slash_command(
     peer: Arc<Peer>,
     session: Arc<Session>,
-    name: String,
-    args: String,
+    command: ParsedCommand,
 ) -> StopReason {
+    let name = command.name;
+    let args = command.args;
+    let title = command.title;
     let commands = session.commands.lock().unwrap().clone();
     let Some(descriptor) = commands.iter().find(|c| c.name == name).cloned() else {
         peer.session_update(
@@ -563,7 +604,7 @@ async fn run_slash_command(
             peer.session_update(
                 &session.acp_id,
                 SessionUpdate::ToolCall(
-                    ToolCall::new(tool_call_id.clone(), command_title(&descriptor.name, &args))
+                    ToolCall::new(tool_call_id.clone(), title)
                         .kind(ToolKind::Other)
                         .status(ToolCallStatus::InProgress)
                         .raw_input(json!({
@@ -627,11 +668,11 @@ async fn run_slash_command(
     }
 }
 
-fn command_title(name: &str, args: &str) -> String {
+fn command_title(prefix: &str, name: &str, args: &str) -> String {
     if args.is_empty() {
-        format!("/{name}")
+        format!("{prefix}{name}")
     } else {
-        format!("/{name} {args}")
+        format!("{prefix}{name} {args}")
     }
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -779,6 +779,10 @@ impl App {
         let raw = self.input_text();
         self.reset_input();
         let text = raw.trim().to_string();
+        if let Some(rest) = text.strip_prefix('!') {
+            self.handle_shell_shortcut(rest).await;
+            return;
+        }
         if let Some(rest) = text.strip_prefix('/') {
             self.handle_command(rest).await;
             return;
@@ -816,6 +820,32 @@ impl App {
         } else {
             self.push_system(format!("unknown command: /{head}"));
         }
+    }
+
+    async fn handle_shell_shortcut(&mut self, input: &str) {
+        let Some(descriptor) = self
+            .startup
+            .capability_commands
+            .iter()
+            .find(|c| c.name == "shell")
+            .cloned()
+        else {
+            self.push_system("shell command unavailable".to_string());
+            return;
+        };
+        let command = input
+            .trim_start()
+            .strip_prefix("shell")
+            .and_then(|rest| {
+                rest.chars()
+                    .next()
+                    .is_none_or(char::is_whitespace)
+                    .then_some(rest)
+            })
+            .unwrap_or(input)
+            .trim();
+        self.invoke_capability_command(descriptor, command.to_string())
+            .await;
     }
 
     /// Apply a terminal-side command emitted by a capability. This is the only
@@ -2258,6 +2288,60 @@ mod tests {
         );
         assert!(!app.busy);
         assert!(app.stream_preview.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn bang_input_runs_shell_without_model_turn() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+        app.lines.clear();
+
+        for ch in "!printf shell-ok".chars() {
+            app.handle_key(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::empty()))
+                .await;
+        }
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()))
+            .await;
+
+        assert!(!app.busy, "shell shortcut should not start a model turn");
+        assert!(
+            app.lines
+                .iter()
+                .any(|line| matches!(line.author, Author::System) && line.text == "shell-ok"),
+            "shell output should render inline: {:?}",
+            app.lines
+        );
+        assert!(
+            app.lines
+                .iter()
+                .all(|line| !matches!(line.author, Author::User)),
+            "shell shortcut should not echo as a chat turn: {:?}",
+            app.lines
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn bang_shell_input_accepts_named_form() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+        app.lines.clear();
+
+        for ch in "!shell printf named-ok".chars() {
+            app.handle_key(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::empty()))
+                .await;
+        }
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()))
+            .await;
+
+        assert!(
+            app.lines
+                .iter()
+                .any(|line| matches!(line.author, Author::System) && line.text == "named-ok"),
+            "named shell shortcut should render output: {:?}",
+            app.lines
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -12,8 +12,9 @@ use everruns_core::command::{
     CommandArg, CommandDescriptor, CommandExecutionContext, CommandResult, CommandSource,
     ExecuteCommandRequest,
 };
-use everruns_core::tools::Tool;
+use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_runtime::RuntimeProviderStore;
+use serde_json::json;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Arc, RwLock};
@@ -299,6 +300,7 @@ pub(crate) struct CodingBashCapability {
     pub(crate) workspace: Workspace,
 }
 
+#[async_trait]
 impl Capability for CodingBashCapability {
     fn id(&self) -> &str {
         "yolop_bash"
@@ -323,6 +325,91 @@ impl Capability for CodingBashCapability {
     }
     fn tools(&self) -> Vec<Box<dyn Tool>> {
         vec![Box::new(BashTool::new(self.workspace.clone()))]
+    }
+    fn commands(&self) -> Vec<CommandDescriptor> {
+        vec![CommandDescriptor {
+            name: "shell".to_string(),
+            description: "run a shell command".to_string(),
+            source: CommandSource::System,
+            args: vec![CommandArg {
+                name: "command".to_string(),
+                description: "shell command".to_string(),
+                required: true,
+                suggestions: Vec::new(),
+            }],
+        }]
+    }
+    async fn execute_command(
+        &self,
+        request: &ExecuteCommandRequest,
+        _ctx: &CommandExecutionContext,
+    ) -> everruns_core::Result<CommandResult> {
+        if request.name != "shell" {
+            return Err(everruns_core::AgentLoopError::config(format!(
+                "{} cannot execute /{}",
+                self.id(),
+                request.name
+            )));
+        }
+        let command = request
+            .arguments
+            .as_deref()
+            .map(str::trim)
+            .filter(|command| !command.is_empty())
+            .ok_or_else(|| everruns_core::AgentLoopError::config("/shell requires: command"))?;
+        let result = BashTool::new(self.workspace.clone())
+            .execute(json!({ "command": command, "output": "normal" }))
+            .await;
+        Ok(shell_command_result(result))
+    }
+}
+
+fn shell_command_result(result: ToolExecutionResult) -> CommandResult {
+    match result {
+        ToolExecutionResult::Success(value)
+        | ToolExecutionResult::SuccessWithImages { result: value, .. } => {
+            let success = value["success"].as_bool().unwrap_or(true);
+            CommandResult {
+                success,
+                message: format_shell_output(&value),
+                error_code: None,
+                error_fields: None,
+            }
+        }
+        ToolExecutionResult::ToolError(message) => CommandResult {
+            success: false,
+            message,
+            error_code: None,
+            error_fields: None,
+        },
+        ToolExecutionResult::InternalError(_) => CommandResult {
+            success: false,
+            message: "shell command failed internally".to_string(),
+            error_code: None,
+            error_fields: None,
+        },
+        ToolExecutionResult::ConnectionRequired { provider } => CommandResult {
+            success: false,
+            message: format!("shell command requires connection: {provider}"),
+            error_code: None,
+            error_fields: None,
+        },
+    }
+}
+
+fn format_shell_output(value: &serde_json::Value) -> String {
+    let mut parts = Vec::new();
+    if let Some(stdout) = value["stdout"].as_str().filter(|text| !text.is_empty()) {
+        parts.push(stdout.trim_end().to_string());
+    }
+    if let Some(stderr) = value["stderr"].as_str().filter(|text| !text.is_empty()) {
+        parts.push(stderr.trim_end().to_string());
+    }
+    if parts.is_empty() {
+        let exit_code = value["exit_code"].as_i64().unwrap_or(0);
+        format!("exit {exit_code}")
+    } else {
+        parts.join("\n")
     }
 }
 

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -403,11 +403,19 @@ fn shell_command_result(result: ToolExecutionResult) -> CommandResult {
 
 fn format_shell_output(value: &serde_json::Value) -> String {
     let mut parts = Vec::new();
-    if let Some(stdout) = value["stdout"].as_str().filter(|text| !text.is_empty()) {
-        parts.push(stdout.trim_end().to_string());
+    if let Some(stdout) = value["stdout"]
+        .as_str()
+        .map(str::trim_end)
+        .filter(|text| !text.is_empty())
+    {
+        parts.push(stdout.to_string());
     }
-    if let Some(stderr) = value["stderr"].as_str().filter(|text| !text.is_empty()) {
-        parts.push(stderr.trim_end().to_string());
+    if let Some(stderr) = value["stderr"]
+        .as_str()
+        .map(str::trim_end)
+        .filter(|text| !text.is_empty())
+    {
+        parts.push(stderr.to_string());
     }
     if parts.is_empty() {
         let exit_code = value["exit_code"].as_i64().unwrap_or(0);
@@ -1151,6 +1159,17 @@ mod tests {
             .set_attribution(false)
             .expect("disable attribution");
         assert!(capability.system_prompt_contribution(&ctx).await.is_none());
+    }
+
+    #[test]
+    fn shell_output_format_ignores_whitespace_only_streams() {
+        let value = serde_json::json!({
+            "stdout": "\n",
+            "stderr": "   \n",
+            "exit_code": 0,
+        });
+
+        assert_eq!(format_shell_output(&value), "exit 0");
     }
 
     #[test]

--- a/tests/support/tui_harness.rs
+++ b/tests/support/tui_harness.rs
@@ -57,10 +57,16 @@ impl TuiHarness {
         self.answer_cursor_queries.store(answer, Ordering::SeqCst);
     }
 
-    /// The settings.toml the spawned TUI reads and writes (Linux config
-    /// layout; the harness seeds the macOS path with the same content).
+    /// The settings.toml the spawned TUI reads and writes.
     pub fn settings_path(&self) -> PathBuf {
-        self._home.path().join(".config/yolop/settings.toml")
+        #[cfg(target_os = "macos")]
+        let path = self
+            ._home
+            .path()
+            .join("Library/Application Support/yolop/settings.toml");
+        #[cfg(not(target_os = "macos"))]
+        let path = self._home.path().join(".config/yolop/settings.toml");
+        path
     }
 
     pub fn resize(&mut self, cols: u16, rows: u16) {


### PR DESCRIPTION
## What
Add a direct shell command surface:
- `/shell <command>` as a registered system command.
- `!<command>` and `!shell <command>` shortcuts in the TUI and ACP prompt path.
- README/spec updates for the new command surface.

## Why
Users need a quick way to run shell commands from yolop without asking the model to call `bash`.

## How
The new command reuses the existing bounded `BashTool`, so shell execution keeps the same workspace root, timeout, and output limits as model-driven `bash` calls. TUI and ACP bang-prefix parsing both dispatch through `runtime.execute_command`, preserving command-shaped output and avoiding a model turn.

## Risk
- Low / Medium / High: Medium
- What can break: command parsing for ACP/TUI prompts, command advertisement metadata, or direct shell output rendering.

## Security
- Threat categories reviewed: TM-BASH, TM-TOOL, TM-FS, TM-LLM, TM-DEP
- TM-BASH: `/shell` delegates to the existing `BashTool`; no new executor was added. Existing 120s timeout and per-stream output cap are preserved.
- TM-TOOL: the command is registered through the existing capability command registry and dispatches via `runtime.execute_command`.
- TM-FS: no changes to file write behavior or write blocklist.
- TM-LLM: direct shell commands avoid model turns and do not introduce prompt or API key handling changes.
- TM-DEP: no new dependencies.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo build --release`
- `cargo run -- --provider llmsim -p "hi"`
- ACP stdio smoke: `!printf acp-smoke` returned command output without a model turn.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
