### PR TITLE
Address prompt command review comments

### DIFF
--- a/src/capabilities/client_commands.rs
+++ b/src/capabilities/client_commands.rs
@@ -26,13 +26,14 @@ use std::sync::Arc;
 pub(crate) const CLIENT_COMMANDS_CAPABILITY_ID: &str = "yolop_client_commands";
 
 const CLIENT_COMMANDS_PROMPT: &str = r#"<capability id="yolop_client_commands">
-The interactive terminal has slash commands: `/help`, `/tools`, `/mcp`, `/cwd`,
-`/status [compact|expanded|toggle]`, `/model [id]`, `/effort [level]`,
-`/clear`, and `/quit` (`/exit` is an alias).
-When the user asks in natural language for one of these terminal actions — for
-example "exit", "clear the screen", "show tools", "switch model", or "expand
-the status bar" — call `run_yolop_command`; do not merely tell the user to type
-the slash command.
+For natural-language requests, `run_yolop_command` can perform these TUI client
+commands: `/help`, `/tools`, `/mcp`, `/cwd`, `/status [compact|expanded|toggle]`,
+`/model [id]`, `/effort [level]`, `/clear`, and `/quit` (`/exit` is an alias).
+The TUI may expose other slash commands, but only use `run_yolop_command` for
+this listed client-command set. When the user asks for one of these terminal
+actions — for example "exit", "clear the screen", "show tools", "switch model",
+or "expand the status bar" — call `run_yolop_command`; do not merely tell the
+user to type the slash command.
 </capability>"#;
 
 pub(crate) struct ClientCommandsCapability {
@@ -166,7 +167,7 @@ impl Tool for RunYolopCommandTool {
     fn description(&self) -> &str {
         "Run an interactive yolop slash command on behalf of a natural-language user request. \
          Use this when the user asks to exit, clear the transcript, show help/tools/MCP/cwd, \
-         show or change the status layout, or open/switch model or reasoning effort. Accepts command names without the leading \
+         show or change the status layout, or open/switch model or reasoning effort. Accepts command names with or without the leading \
          slash; `exit` is accepted as an alias for `quit`."
     }
 
@@ -177,7 +178,10 @@ impl Tool for RunYolopCommandTool {
                 "command": {
                     "type": "string",
                     "description": "Slash command name, with or without the leading slash.",
-                    "enum": ["help", "tools", "mcp", "cwd", "status", "model", "effort", "clear", "quit", "exit"]
+                    "enum": [
+                        "help", "tools", "mcp", "cwd", "status", "model", "effort", "clear", "quit", "exit",
+                        "/help", "/tools", "/mcp", "/cwd", "/status", "/model", "/effort", "/clear", "/quit", "/exit"
+                    ]
                 },
                 "arguments": {
                     "type": "string",
@@ -287,8 +291,26 @@ mod tests {
         let prompt = capability.system_prompt_addition().expect("prompt");
 
         assert!(prompt.contains("run_yolop_command"));
+        assert!(prompt.contains("TUI client"));
+        assert!(prompt.contains("only use `run_yolop_command` for this listed"));
         assert!(prompt.contains("/quit"));
         assert!(prompt.contains("/exit"));
+    }
+
+    #[test]
+    fn run_yolop_command_schema_accepts_slashed_aliases() {
+        let tool = RunYolopCommandTool {
+            ui: Arc::new(RecordingUi::default()),
+        };
+        let schema = tool.parameters_schema();
+        let variants = schema["properties"]["command"]["enum"]
+            .as_array()
+            .expect("command enum");
+
+        assert!(variants.contains(&json!("exit")));
+        assert!(variants.contains(&json!("/exit")));
+        assert!(variants.contains(&json!("quit")));
+        assert!(variants.contains(&json!("/quit")));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Clarify the prompt-command system prompt so it describes only the TUI client-command set available through `run_yolop_command`
- Make the `run_yolop_command` JSON schema accept the same slash-prefixed command forms that execution accepts
- Conflict resolution during rebase also incorporated `/status [compact|expanded|toggle]` support added to main in the interim

## Addresses
- https://github.com/everruns/yolop/pull/108#discussion_r3400492740
- https://github.com/everruns/yolop/pull/108#discussion_r3400492761

## Note on third review comment
https://github.com/everruns/yolop/pull/108#discussion_r3400492769 asked to use `DEFAULT_TOOL_SEARCH_THRESHOLD` in the deferral threshold test. That test lived in `src/capabilities/tool_search.rs`, which was deleted in #114 (tool-search moved to the upstream `everruns-runtime` library). The comment is resolved by the deletion.

## Validation
- `cargo fmt --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test -q run_yolop_command --all-features` ✅ (5 passed)
- `cargo test -q prompt_tells_model_to_run_natural_language_commands --all-features` ✅
- `cargo test -q run_yolop_command_schema_accepts_slashed_aliases --all-features` ✅
- `cargo run -- --provider llmsim -p "hi"` ✅

## Security
- **TM-LLM**: System prompt text clarified. No key handling or API changes.
- **TM-FS / TM-BASH / TM-TOOL**: No filesystem access, shell execution, or capability registration changes.
- **TM-DEP**: No dependency changes.

## Follow-ups
No follow-ups.