### PR TITLE
fix(approval): keep approval tools fully loaded

### DIFF
--- a/specs/approval.md
+++ b/specs/approval.md
@@ -56,9 +56,10 @@ effect on the very next turn without a restart.
 Approvals are auditable through the existing per-session event log. The
 `record_approval` tool is called right after the user consents; because every
 tool call already persists a `tool.completed` line to the session's
-`events.jsonl`, the approval — its description, optional detail, and a
-timestamp — lands in that durable, owner-only log for free. No separate audit
-store is introduced.
+`events.jsonl`, the approval lands in that durable, owner-only log for free. It
+records a specific `action` description plus optional detail when provided, and
+uses a conservative fallback instead of failing if a model emits an empty audit
+call after spoken consent. No separate audit store is introduced.
 
 ### Configuration surfaces
 

--- a/src/capabilities/approval.rs
+++ b/src/capabilities/approval.rs
@@ -23,6 +23,7 @@ use crate::config_service::ConfigService;
 use crate::settings::{ApprovalMode, SettingsStore};
 use async_trait::async_trait;
 use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
+use everruns_core::tool_types::{BuiltinTool, DeferrablePolicy, ToolDefinition};
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use serde_json::{Value, json};
 use std::sync::Arc;
@@ -132,8 +133,43 @@ impl Capability for ApprovalCapability {
 /// Records that the user verbally approved a specific critical action. The
 /// tool itself only echoes the record back; the durable audit entry is the
 /// `tool.completed` event this call produces in the per-session `events.jsonl`
-/// log, which captures the arguments (what was approved) and a timestamp.
+/// log, which captures the arguments, output, and timestamp.
 struct RecordApprovalTool;
+
+const FALLBACK_APPROVAL_ACTION: &str = "the pending critical action approved in the conversation";
+
+fn non_deferrable_builtin(tool: &dyn Tool) -> ToolDefinition {
+    ToolDefinition::Builtin(BuiltinTool {
+        name: tool.name().to_string(),
+        display_name: tool.display_name().map(str::to_string),
+        description: tool.description().to_string(),
+        parameters: tool.parameters_schema(),
+        policy: tool.policy(),
+        category: None,
+        deferrable: DeferrablePolicy::Never,
+        hints: tool.hints(),
+        full_parameters: None,
+    })
+}
+
+fn non_empty_str(value: Option<&Value>) -> Option<&str> {
+    value
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+}
+
+fn approval_action(arguments: &Value) -> &str {
+    if let Some(action) = arguments.as_str().map(str::trim).filter(|s| !s.is_empty()) {
+        return action;
+    }
+
+    let Some(object) = arguments.as_object() else {
+        return FALLBACK_APPROVAL_ACTION;
+    };
+
+    non_empty_str(object.get("action")).unwrap_or(FALLBACK_APPROVAL_ACTION)
+}
 
 #[async_trait]
 impl Tool for RecordApprovalTool {
@@ -163,24 +199,17 @@ impl Tool for RecordApprovalTool {
                     "description": "Optional extra context: the command, affected paths, or scope of the approval. Redact any secrets (keys/tokens/passwords) before passing them — this is logged."
                 }
             },
-            "required": ["action"],
             "additionalProperties": false
         })
     }
+
+    fn to_definition(&self) -> ToolDefinition {
+        non_deferrable_builtin(self)
+    }
+
     async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        let action = match arguments.get("action").and_then(Value::as_str) {
-            Some(a) if !a.trim().is_empty() => a.trim(),
-            _ => {
-                return ToolExecutionResult::tool_error(
-                    "'action' is required and must describe what was approved",
-                );
-            }
-        };
-        let detail = arguments
-            .get("detail")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|d| !d.is_empty());
+        let action = approval_action(&arguments);
+        let detail = non_empty_str(arguments.get("detail"));
         ToolExecutionResult::success(json!({
             "ok": true,
             "recorded": true,
@@ -229,6 +258,11 @@ impl Tool for SetApprovalModeTool {
             "additionalProperties": false
         })
     }
+
+    fn to_definition(&self) -> ToolDefinition {
+        non_deferrable_builtin(self)
+    }
+
     async fn execute(&self, arguments: Value) -> ToolExecutionResult {
         let raw = match arguments.get("mode").and_then(Value::as_str) {
             Some(m) => m,
@@ -293,8 +327,14 @@ mod tests {
             config: settings.clone(),
             settings,
         };
-        let names: Vec<String> = cap.tools().iter().map(|t| t.name().to_string()).collect();
+        let tools = cap.tools();
+        let names: Vec<String> = tools.iter().map(|t| t.name().to_string()).collect();
         assert_eq!(names, vec!["record_approval", "set_approval_mode"]);
+        assert!(
+            tools.iter().all(|tool| {
+                matches!(tool.to_definition().deferrable(), DeferrablePolicy::Never)
+            })
+        );
         assert!(cap.commands().is_empty());
     }
 
@@ -319,9 +359,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn record_approval_requires_action_and_echoes_it() {
+    async fn record_approval_echoes_action() {
         let tool = RecordApprovalTool;
-        assert!(tool.execute(json!({ "action": "  " })).await.is_error());
 
         let res = tool
             .execute(json!({ "action": "force-push feature/x", "detail": "git push -f" }))
@@ -329,6 +368,15 @@ mod tests {
         assert!(res.is_success());
         let text = format!("{res:?}");
         assert!(text.contains("force-push feature/x"));
+    }
+
+    #[tokio::test]
+    async fn record_approval_accepts_empty_arguments_after_spoken_consent() {
+        let tool = RecordApprovalTool;
+        let res = tool.execute(json!({})).await;
+        assert!(res.is_success());
+        let text = format!("{res:?}");
+        assert!(text.contains(FALLBACK_APPROVAL_ACTION));
     }
 
     #[tokio::test]

--- a/src/capabilities/approval.rs
+++ b/src/capabilities/approval.rs
@@ -365,18 +365,22 @@ mod tests {
         let res = tool
             .execute(json!({ "action": "force-push feature/x", "detail": "git push -f" }))
             .await;
-        assert!(res.is_success());
-        let text = format!("{res:?}");
-        assert!(text.contains("force-push feature/x"));
+        let ToolExecutionResult::Success(value) = res else {
+            panic!("expected success");
+        };
+        assert_eq!(value["action"], "force-push feature/x");
+        assert_eq!(value["detail"], "git push -f");
     }
 
     #[tokio::test]
     async fn record_approval_accepts_empty_arguments_after_spoken_consent() {
         let tool = RecordApprovalTool;
         let res = tool.execute(json!({})).await;
-        assert!(res.is_success());
-        let text = format!("{res:?}");
-        assert!(text.contains(FALLBACK_APPROVAL_ACTION));
+        let ToolExecutionResult::Success(value) = res else {
+            panic!("expected success");
+        };
+        assert_eq!(value["action"], FALLBACK_APPROVAL_ACTION);
+        assert!(value["detail"].is_null());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What
Fixes soft-approval audit tool calls when `tool_search` deferred schemas are active.

## Why
`record_approval` was treated as a long-tail tool, so `tool_search` could advertise it with hidden parameters. Structured tool callers then emitted `{}`, causing repeated `'action' is required` failures after the user had already approved.

## How
- Marks approval tools as `DeferrablePolicy::Never`, keeping their real schemas loaded.
- Keeps `record_approval` limited to `action` plus optional `detail`.
- Records a conservative fallback if an empty audit call still arrives after spoken consent.
- Updates the approval spec to describe the fallback behavior.

## Risk
- Low
- Approval audit calls now avoid tool-search schema hiding; the main behavior change is that an empty `record_approval` call succeeds with a generic audit action instead of looping on a tool error.

## Security
- TM-LLM: reviewed prompt/tool schema surface. No secrets are added to prompts or logs; existing redaction guidance for approval `detail` remains in the schema.
- TM-TOOL: approval tools only echo audit metadata and update the approval mode setting; no filesystem, shell, network, or new capability side effects were added.
- TM-FS/TM-BASH/TM-DEP: not affected. No file access rules, shell execution, or dependencies changed.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features capabilities::approval`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"`
- `doppler run --project yolop --config ci -- cargo run -- --provider openai -p "Reply with exactly: approval smoke ok"`

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
