### PR TITLE
chore(deps): bump everruns crates to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -203,7 +203,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -468,9 +468,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e20c182deb47b8ce2c8ba724f602cf73bdd6a566971f0f3525b6af60ea2a4c6"
+checksum = "868968c065151d2eec3aaba899f01540723dce112dcb8e23428a0f08aee3d7d6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1156,7 +1156,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1250,7 +1250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1296,9 +1296,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9959d933eb5dfd655016e48a4f04b3110d80d79001734c7e970baeace4fd9264"
+checksum = "1216d19208f5b5b54740373ec401b7d3da3ab5d1eed83c3b2ef06c4ff0201567"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1314,18 +1314,18 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1815c265fcf5fff18ffb10abd543ff2ec14a80e8db69f5f923c5d1ae654c9ba6"
+checksum = "45ce041663aa6201a29bdd07f0afe1133f9d1f4f4f84e4f38fbdcefd25251607"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-core"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276f7367df0b2471e7fb89bb04c94ddfacc2f448e79eafbe4c7eb79b98ae1f8b"
+checksum = "24b8ded51873facc73d12ca6ad1bbcd1ae484c2ffc72e6e95bd6b0b94cd402fa"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -1333,6 +1333,7 @@ dependencies = [
  "async-trait",
  "base64",
  "bashkit",
+ "bytes",
  "chrono",
  "ed25519-dalek",
  "eventsource-stream",
@@ -1365,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f03baebe37835c5abd8a14abd9eb31eb8f7b407235eb90a3a042b0c520810d7"
+checksum = "ef6e6f18171016663f22acfb5c9ce292f65aea5a90665ad563e05f033983a8f6"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1381,9 +1382,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cf93bffba1d5be0f5a62ea0f9e25a67cf43d88137bf804db429edb79ef0488e"
+checksum = "d501fc881fe9cc7d92bc8834f716a42ac03974825f1e81ffb485af0ec15c492d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1396,9 +1397,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066bfedc504e1807483a35656c77d729aedb063e112d9ab446b4fd2d0df4b494"
+checksum = "e625fb0fa8ca24c5667f508aff017302603eeda6deb33886ed6c473c49baf699"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1417,14 +1418,15 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c48703734251977d551b207fd484b8bffe338b769ec512e163e060c500108c"
+checksum = "654bdccce8e1456956dd914416fe4edac9709cd4fd59b0b17a69cbe56c007d39"
 dependencies = [
  "async-trait",
  "chrono",
  "everruns-core",
  "everruns-mcp",
+ "futures",
  "ignore",
  "serde",
  "serde_json",
@@ -1480,21 +1482,22 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fetchkit"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e551cfcd0082a9acbe9be3dc068f368ef6b5ea6546c47fdd76eb3216ddbf686"
+checksum = "82150b89249abf4f7a6bce136567c795803faa601fcb041157b7a43f4c1e856b"
 dependencies = [
  "async-trait",
  "base64",
  "bytes",
  "ed25519-dalek",
  "futures",
- "rand 0.8.6",
+ "libc",
+ "rand 0.10.1",
  "reqwest 0.13.4",
  "schemars 1.2.1",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
  "tower",
@@ -2685,7 +2688,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3418,8 +3421,6 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
- "libc",
- "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -3429,7 +3430,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -3442,16 +3443,6 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3800,7 +3791,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3868,7 +3859,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4328,7 +4319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4459,7 +4450,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5486,7 +5477,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,13 +37,13 @@ tokio-util = { version = "0.7", features = ["compat"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-everruns-anthropic = "0.10.0"
-everruns-core = "0.10.0"
-everruns-openai = "0.10.0"
+everruns-anthropic = "0.11.0"
+everruns-core = "0.11.0"
+everruns-openai = "0.11.0"
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (specs/mcp.md, upstream runtime-mcp.md D2).
-everruns-runtime = { version = "0.10.0", features = ["mcp-stdio"] }
-everruns-integrations-duckduckgo = "0.10.0"
+everruns-runtime = { version = "0.11.0", features = ["mcp-stdio"] }
+everruns-integrations-duckduckgo = "0.11.0"
 futures = "0.3"
 
 [dev-dependencies]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -26,10 +26,10 @@ use everruns_core::capabilities::{
 };
 use everruns_core::command::CommandDescriptor;
 use everruns_core::error::AgentLoopError;
+use everruns_core::in_memory::InMemoryMessageRetriever;
 use everruns_core::llm_driver_registry::DriverRegistry;
 use everruns_core::llm_models::LlmProviderType;
 use everruns_core::llmsim_driver::LlmSimConfig;
-use everruns_core::memory::InMemoryMessageRetriever;
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, InitialFile, SessionFile};
 use everruns_core::typed_id::SessionId;
 use everruns_core::{


### PR DESCRIPTION
## What & why

Bumps all `everruns-*` dependencies from `0.10.0` to `0.11.0` (kept in lockstep per AGENTS.md): `everruns-core`, `everruns-runtime`, `everruns-anthropic`, `everruns-openai`, `everruns-integrations-duckduckgo` (transitively `everruns-mcp`, `everruns-config`).

The `0.11.0` release is mostly server/runtime-side (Capability Editor UI, egress-routed web fetch, session task registry, durable spawn handles, OpenRouter routing) and does not change yolop's consumed surface — **except** that the core `memory` module was repurposed for the new Memory API, relocating `InMemoryMessageRetriever` to `everruns_core::in_memory`. This PR adopts the new path in `src/runtime.rs`. No other API changes affect yolop.

## Changes

- `Cargo.toml` / `Cargo.lock`: `everruns-*` `0.10.0` → `0.11.0`.
- `src/runtime.rs`: import `InMemoryMessageRetriever` from `everruns_core::in_memory` (was `everruns_core::memory`).

## Validation

- `cargo fmt --check` ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓
- `cargo test --all-features` ✓ — 331 + 26 passed, 0 failed, 1 ignored
- `cargo fetch --locked` ✓ — lockfile consistent
- Offline smoke: `cargo run -- --provider llmsim -p "hi"` ✓ — `done success=true`
- Live smoke: `cargo run -- --provider openai -p "..."` ✓ — `openai/gpt-5.5`, `done success=true`, correct reply

This is a dependency bump with a mechanical import-path adoption and no behavior change, so it adds no new feature test (ship outcome 3 exemption). The relocated `InMemoryMessageRetriever` is exercised by the existing runtime/session-resume tests in the suite above.

## Security

- **TM-DEP**: all `everruns-*` crates bumped together to `0.11.0` (no mismatched-version soft break); no new crates introduced.
- **TM-LLM**: verified the live-smoke session JSONL contains no API-key material.
- No changes to the filesystem write blocklist, bash execution bounds, or capability registration (TM-FS / TM-BASH / TM-TOOL untouched).

## Follow-ups

No follow-ups. (The new OpenRouter routing in `everruns 0.11.0` is an optional provider feature; wiring it into yolop is out of scope for this bump.)

https://claude.ai/code/session_011UpvtiheoUueGkRvuvPx35

---
_Generated by [Claude Code](https://claude.ai/code/session_011UpvtiheoUueGkRvuvPx35)_