### PR TITLE
feat(config): add harness capability settings in TOML

### DIFF
--- a/skills/yolop-config/SKILL.md
+++ b/skills/yolop-config/SKILL.md
@@ -53,19 +53,33 @@ command instead.
 ## Harness capabilities
 
 Optional harness capabilities (for example `message_metadata` from everruns-core)
-live under `[capabilities.<id>]` in the same `settings.toml`. Call
-`get_capabilities` to read each capability's `config_schema`, `config_ui_schema`,
-and current effective config. Call `set_capability` to add, remove
-(`enabled=false`), or override config (validated via `validate_config`).
+live in an ordered `[[capabilities]]` list in the same `settings.toml` — matching
+the runtime harness list, so the same ref can appear more than once with different
+configs. Call `get_capabilities` to read each capability's `config_schema`,
+`config_ui_schema`, stored overrides, and effective harness. Call
+`set_capability` to append an override entry (validated via `validate_config`).
 Changes apply on the **next run**.
 
 Examples:
 
+```toml
+[[capabilities]]
+ref = "message_metadata"
+fields = ["timestamp"]
+
+[[capabilities]]
+ref = "duckduckgo"
+enabled = false
+```
+
+Tool equivalents:
+
 - `set_capability id=message_metadata enabled=true config={"fields":["timestamp"]}`
   — annotate messages with UTC timestamps in the LLM view.
-- `set_capability id=duckduckgo enabled=false` — remove web search from the harness.
-- `set_capability id=web_fetch config={"enable_file_download":false}` — override
-  a default capability's config without disabling it.
+- `set_capability id=duckduckgo enabled=false` — append a remove entry for that ref.
+- `set_capability id=web_fetch config={"enable_file_download":false}` — merge config
+  into the first matching harness instance.
+- `set_capability id=some_cap append=true config={...}` — add a duplicate instance.
 
 ## Related surfaces
 

--- a/skills/yolop-config/SKILL.md
+++ b/skills/yolop-config/SKILL.md
@@ -22,9 +22,9 @@ values are validated and persisted atomically.
    tokens) are shown only as `stored` / `unset`, never echoed.
 2. Call `get_config` with a single `key` (e.g. `default_provider`,
    `models.anthropic`, `tokens.openai`) to focus on one entry.
-3. For harness capabilities, use `get_config key=capabilities` (stored overrides
-   + effective harness) or `get_config key=capabilities.<ref>` (per-capability
-   schema metadata from `config_schema` / `config_ui_schema`).
+3. For harness capabilities, use `get_config key=capabilities` (registered catalog,
+   stored overrides, effective harness) or `get_config key=capabilities.<ref>`
+   (per-capability schema metadata from `config_schema` / `config_ui_schema`).
 
 Lead with `get_config` whenever you are unsure of the exact key name or the
 accepted values — the returned schema is the source of truth, so you never have

--- a/skills/yolop-config/SKILL.md
+++ b/skills/yolop-config/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: yolop-config
-description: View and change yolop's own configuration — default provider and model, per-provider API tokens and models, endpoint base URLs, and attribution. Use when the user asks to configure yolop, set a default provider/model, store an API key, point at a custom endpoint, or asks "what is your config / what can you configure".
+description: View and change yolop's own configuration — default provider and model, per-provider API tokens and models, endpoint base URLs, attribution, and harness capabilities. Use when the user asks to configure yolop, set a default provider/model, store an API key, point at a custom endpoint, enable/disable capabilities, or asks "what is your config / what can you configure".
 user-invocable: true
 ---
 
@@ -22,6 +22,9 @@ values are validated and persisted atomically.
    tokens) are shown only as `stored` / `unset`, never echoed.
 2. Call `get_config` with a single `key` (e.g. `default_provider`,
    `models.anthropic`, `tokens.openai`) to focus on one entry.
+3. For harness capabilities, use `get_config key=capabilities` (stored overrides
+   + effective harness) or `get_config key=capabilities.<ref>` (per-capability
+   schema metadata from `config_schema` / `config_ui_schema`).
 
 Lead with `get_config` whenever you are unsure of the exact key name or the
 accepted values — the returned schema is the source of truth, so you never have
@@ -29,7 +32,7 @@ to guess.
 
 ## Change
 
-Call `set_config` with a `key` and a `value`:
+Call `set_config` with a `key` and a `value` for scalar settings:
 
 - `set_config key=default_provider value=anthropic` — the default provider when
   neither `--provider` nor an env credential forces a choice.
@@ -46,21 +49,11 @@ Call `set_config` with a `key` and a `value`:
 Pass `value=clear` to unset an optional or secret key
 (e.g. `set_config key=tokens.openai value=clear`).
 
-Provider and model edits are persisted and take effect on the **next run**. To
-switch the *live* model in the current session, use the interactive `/setup`
-command instead.
+### Harness capabilities
 
-## Harness capabilities
-
-Optional harness capabilities (for example `message_metadata` from everruns-core)
-live in an ordered `[[capabilities]]` list in the same `settings.toml` — matching
-the runtime harness list, so the same ref can appear more than once with different
-configs. Call `get_capabilities` to read each capability's `config_schema`,
-`config_ui_schema`, stored overrides, and effective harness. Call
-`set_capability` to append an override entry (validated via `validate_config`).
-Changes apply on the **next run**.
-
-Examples:
+Overrides are an ordered `[[capabilities]]` list in the same file. Append
+entries with `set_config key=capabilities` and a `json` object (validated via each
+capability's `validate_config`). Pass `value=clear` to drop all stored overrides.
 
 ```toml
 [[capabilities]]
@@ -74,12 +67,15 @@ enabled = false
 
 Tool equivalents:
 
-- `set_capability id=message_metadata enabled=true config={"fields":["timestamp"]}`
-  — annotate messages with UTC timestamps in the LLM view.
-- `set_capability id=duckduckgo enabled=false` — append a remove entry for that ref.
-- `set_capability id=web_fetch config={"enable_file_download":false}` — merge config
-  into the first matching harness instance.
-- `set_capability id=some_cap append=true config={...}` — add a duplicate instance.
+- `set_config key=capabilities json={"ref":"message_metadata","fields":["timestamp"]}`
+- `set_config key=capabilities json={"ref":"duckduckgo","enabled":false}`
+- `set_config key=capabilities json={"ref":"web_fetch","enable_file_download":false}`
+- `set_config key=capabilities json={"ref":"some_cap","append":true,...}` — duplicate instance
+- `set_config key=capabilities value=clear` — remove all stored overrides
+
+Provider and model edits are persisted and take effect on the **next run**. To
+switch the *live* model in the current session, use the interactive `/setup`
+command instead.
 
 ## Related surfaces
 

--- a/skills/yolop-config/SKILL.md
+++ b/skills/yolop-config/SKILL.md
@@ -50,6 +50,23 @@ Provider and model edits are persisted and take effect on the **next run**. To
 switch the *live* model in the current session, use the interactive `/setup`
 command instead.
 
+## Harness capabilities
+
+Optional harness capabilities (for example `message_metadata` from everruns-core)
+live under `[capabilities.<id>]` in the same `settings.toml`. Call
+`get_capabilities` to read each capability's `config_schema`, `config_ui_schema`,
+and current effective config. Call `set_capability` to add, remove
+(`enabled=false`), or override config (validated via `validate_config`).
+Changes apply on the **next run**.
+
+Examples:
+
+- `set_capability id=message_metadata enabled=true config={"fields":["timestamp"]}`
+  — annotate messages with UTC timestamps in the LLM view.
+- `set_capability id=duckduckgo enabled=false` — remove web search from the harness.
+- `set_capability id=web_fetch config={"enable_file_download":false}` — override
+  a default capability's config without disabling it.
+
 ## Related surfaces
 
 - **Durable preferences / memory** ("remember that I prefer terse answers"):

--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -61,6 +61,15 @@ Both honor aliases and validate provider segments against the supported-provider
 list. Provider/model edits take effect on the next run; `/setup` remains the way
 to switch the *live* model mid-session.
 
+- **`get_capabilities`** — with no argument, returns every registered capability
+  with description, JSON config schema, UI schema hints, default harness
+  membership, stored override, and effective config; with an `id`, returns one
+  entry.
+- **`set_capability`** — add, remove (`enabled=false`), or reconfigure a harness
+  capability (`[capabilities.<id>]` in settings.toml). Config is validated
+  through each capability's `config_schema` / `validate_config`. Changes apply
+  on the next run.
+
 ### Configuration as a service
 
 Configuration is exposed to the rest of the agent as a **service** so that
@@ -111,4 +120,4 @@ The schema reaches the agent two ways:
 Configuration is distinct from the neighbouring personalization surfaces:
 durable preferences are `your` **memory**, behavioral rules are **hooks**, and
 interactive live provider/model switching is **`/setup`**. `set_config` is only
-for the typed settings keys above.
+for the typed settings keys above; harness capabilities use `set_capability`.

--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -65,10 +65,11 @@ to switch the *live* model mid-session.
   with description, JSON config schema, UI schema hints, default harness
   membership, stored override, and effective config; with an `id`, returns one
   entry.
-- **`set_capability`** — add, remove (`enabled=false`), or reconfigure a harness
-  capability (`[capabilities.<id>]` in settings.toml). Config is validated
-  through each capability's `config_schema` / `validate_config`. Changes apply
-  on the next run.
+- **`set_capability`** — append an ordered harness override (`[[capabilities]]` in
+  settings.toml). `enabled=false` removes every instance with that `ref`;
+  `append=true` adds a duplicate instance; otherwise config merges into the
+  first matching `ref`. Config is validated through each capability's
+  `config_schema` / `validate_config`. Changes apply on the next run.
 
 ### Configuration as a service
 

--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -53,9 +53,9 @@ by the schema:
 
 - **`get_config`** — with no argument, returns every key with its semantics and
   current value; with a `key`, returns just that entry. Secrets are reported as
-  `stored` / `unset`, never echoed. Use `key=capabilities` or
-  `key=capabilities.<ref>` for harness overrides and per-capability schema
-  metadata (`config_schema`, `config_ui_schema`).
+  `stored` / `unset`, never echoed. Use `key=capabilities` for the registered
+  catalog plus stored overrides and effective harness, or `key=capabilities.<ref>`
+  for one capability's schema metadata (`config_schema`, `config_ui_schema`).
 - **`set_config`** — validates and persists scalar keys via `value` (`clear`
   unsets). Harness overrides: `key=capabilities` with a `json` object appends one
   `[[capabilities]]` entry; `value=clear` drops all stored overrides. Capability

--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -39,6 +39,7 @@ Keys are addressed the way a human would name them:
 | `base_urls.<provider>`    | text   | Endpoint base URL (used by the `custom` provider).             |
 | `approval_mode`           | text   | Soft-approval paranoia level (`protective` / `normal` / `off`). |
 | `attribution`             | bool   | Commit/PR attribution on/off.                                  |
+| `capabilities`            | list   | Ordered `[[capabilities]]` harness overrides; `capabilities.<ref>` for schema metadata. |
 
 `default_provider` is persisted under that name on disk; the legacy `provider`
 key is still read (and accepted as an alias) so pre-rename settings files keep
@@ -52,24 +53,17 @@ by the schema:
 
 - **`get_config`** — with no argument, returns every key with its semantics and
   current value; with a `key`, returns just that entry. Secrets are reported as
-  `stored` / `unset`, never echoed.
-- **`set_config`** — validates a `key`/`value` against the schema and persists
-  through `SettingsStore` (atomic write, owner-only). `value=clear` unsets an
-  optional or secret key.
+  `stored` / `unset`, never echoed. Use `key=capabilities` or
+  `key=capabilities.<ref>` for harness overrides and per-capability schema
+  metadata (`config_schema`, `config_ui_schema`).
+- **`set_config`** — validates and persists scalar keys via `value` (`clear`
+  unsets). Harness overrides: `key=capabilities` with a `json` object appends one
+  `[[capabilities]]` entry; `value=clear` drops all stored overrides. Capability
+  config is validated through each capability's `validate_config`.
 
 Both honor aliases and validate provider segments against the supported-provider
-list. Provider/model edits take effect on the next run; `/setup` remains the way
-to switch the *live* model mid-session.
-
-- **`get_capabilities`** — with no argument, returns every registered capability
-  with description, JSON config schema, UI schema hints, default harness
-  membership, stored override, and effective config; with an `id`, returns one
-  entry.
-- **`set_capability`** — append an ordered harness override (`[[capabilities]]` in
-  settings.toml). `enabled=false` removes every instance with that `ref`;
-  `append=true` adds a duplicate instance; otherwise config merges into the
-  first matching `ref`. Config is validated through each capability's
-  `config_schema` / `validate_config`. Changes apply on the next run.
+list. Provider/model and capability edits take effect on the next run; `/setup`
+remains the way to switch the *live* model mid-session.
 
 ### Configuration as a service
 
@@ -120,5 +114,5 @@ The schema reaches the agent two ways:
 
 Configuration is distinct from the neighbouring personalization surfaces:
 durable preferences are `your` **memory**, behavioral rules are **hooks**, and
-interactive live provider/model switching is **`/setup`**. `set_config` is only
-for the typed settings keys above; harness capabilities use `set_capability`.
+interactive live provider/model switching is **`/setup`**. All settings keys,
+including harness capabilities, go through `get_config` / `set_config`.

--- a/src/agent_scenarios.rs
+++ b/src/agent_scenarios.rs
@@ -99,6 +99,30 @@ async fn run_single_turn(runtime: &BuiltRuntime, user_text: &str) -> everruns_ru
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn scripted_get_config_capabilities_smoke() {
+    let (runtime, _ws) = build_scripted_runtime(LlmSimConfig::scripted(vec![
+        SimTurn::ToolCalls(vec![SimToolCall {
+            name: "get_config".to_string(),
+            arguments: json!({ "key": "capabilities" }),
+            id: None,
+        }]),
+        SimTurn::Assistant("listed capabilities".to_string()),
+    ]))
+    .await;
+
+    let result = run_single_turn(&runtime, "what capabilities can I configure?").await;
+
+    assert!(
+        result.success,
+        "get_config capabilities smoke must succeed: {result:?}"
+    );
+    assert_eq!(
+        result.tool_calls_count, 1,
+        "scripted get_config must run exactly once"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn scripted_assistant_text_returns_success_with_no_tools() {
     let (runtime, _ws) = build_scripted_runtime(LlmSimConfig::scripted(vec![SimTurn::Assistant(
         "hello from scripted llmsim".to_string(),

--- a/src/capabilities/config.rs
+++ b/src/capabilities/config.rs
@@ -14,7 +14,8 @@
 
 use crate::capability_settings::{
     CapabilityCatalog, apply_capability_settings, build_capability_override,
-    capability_catalog_json, effective_harness_json, stored_override_json,
+    capability_catalog_json, effective_harness_json, overrides_to_json, parse_override_from_json,
+    stored_override_json,
 };
 use crate::config_schema::{KeyTarget, ValueKind, known_keys, parse_key, schema};
 use crate::config_service::{ConfigService, current_value, scoped_current};
@@ -55,12 +56,12 @@ impl Capability for ConfigCapability {
         Some(format!(
             "<capability id=\"{}\">\nyolop's settings live at {} and are schema-described \
              (default provider/model, per-provider API tokens and models, endpoint base URLs, \
-             attribution, harness capabilities). To inspect or change settings keys, call \
-             `get_config` and `set_config`. To add, remove, or reconfigure harness capabilities, \
-             call `get_capabilities` and `set_capability` (schemas come from each capability's \
-             `config_schema` / `validate_config`). Or activate the `yolop-config` skill. Unknown \
-             keys in the file are ignored, never fatal. Provider/model and capability edits apply \
-             on the next run; use `/setup` to switch the live model now.\n</capability>",
+             attribution, harness capabilities). To inspect or change any of it, call \
+             `get_config` and `set_config` (use `key=capabilities` / \
+             `key=capabilities.<ref>` for harness overrides; pass a `json` object to append \
+             entries). Or activate the `yolop-config` skill. Unknown keys in the file are \
+             ignored, never fatal. Provider/model and capability edits apply on the next run; \
+             use `/setup` to switch the live model now.\n</capability>",
             self.id(),
             self.settings.path().display()
         ))
@@ -69,8 +70,7 @@ impl Capability for ConfigCapability {
     fn system_prompt_preview(&self) -> Option<String> {
         Some(
             "<capability id=\"yolop_config\">\nyolop's settings and harness capabilities are \
-             schema-described; use `get_config` / `set_config` and `get_capabilities` / \
-             `set_capability`, or the `yolop-config` skill.\n\
+             schema-described; use `get_config` / `set_config` or the `yolop-config` skill.\n\
              </capability>"
                 .to_string(),
         )
@@ -80,15 +80,9 @@ impl Capability for ConfigCapability {
         vec![
             Box::new(GetConfigTool {
                 settings: self.settings.clone(),
-            }),
-            Box::new(SetConfigTool {
-                settings: self.settings.clone(),
-            }),
-            Box::new(GetCapabilitiesTool {
-                settings: self.settings.clone(),
                 catalog: self.catalog.clone(),
             }),
-            Box::new(SetCapabilityTool {
+            Box::new(SetConfigTool {
                 settings: self.settings.clone(),
                 catalog: self.catalog.clone(),
             }),
@@ -104,7 +98,9 @@ impl Capability for ConfigCapability {
 
 /// JSON description of a schema field, optionally with its current value(s).
 fn field_json(settings: &Settings, field: &crate::config_schema::ConfigField) -> Value {
-    let current = if field.provider_scoped {
+    let current = if field.key == "capabilities" {
+        overrides_to_json(&settings.capabilities)
+    } else if field.provider_scoped {
         scoped_current(settings, field.key)
     } else {
         // Scalar fields map 1:1 to a target keyed by `field.key`.
@@ -129,6 +125,7 @@ fn field_json(settings: &Settings, field: &crate::config_schema::ConfigField) ->
 
 struct GetConfigTool {
     settings: Arc<SettingsStore>,
+    catalog: Arc<CapabilityCatalog>,
 }
 
 #[async_trait]
@@ -142,7 +139,8 @@ impl Tool for GetConfigTool {
     fn description(&self) -> &str {
         "Inspect yolop configuration. With no `key`, returns every configuration key with its \
          title, description, type, default, examples, and current value (secrets redacted). \
-         With a `key` (e.g. `default_provider`, `tokens.openai`), returns just that entry."
+         With a `key`, returns just that entry. Use `key=capabilities` or \
+         `key=capabilities.<ref>` for harness capability overrides and schema metadata."
     }
     fn parameters_schema(&self) -> Value {
         json!({
@@ -167,25 +165,71 @@ impl Tool for GetConfigTool {
                     Ok(t) => t,
                     Err(err) => return ToolExecutionResult::tool_error(err),
                 };
-                let field = target.field();
-                let mut entry = field_json(&settings, field);
-                // Read the single value through the config service (the same
-                // path any capability uses), which narrows a provider-scoped
-                // key to the requested provider. For those keys, preserve the
-                // whole-table view that field_json seeded into `current`.
-                let value = self.settings.current(key).unwrap_or(Value::Null);
-                if field.provider_scoped
-                    && let Value::Object(map) = &mut entry
-                {
-                    let table = map.get("current").cloned().unwrap_or(Value::Null);
-                    map.insert("table".to_string(), table);
-                    map.insert("key".to_string(), Value::String(key.to_string()));
-                }
-                entry["current"] = value;
-                return ToolExecutionResult::success(json!({
-                    "settings_path": path,
-                    "field": entry,
-                }));
+                return match &target {
+                    KeyTarget::Capabilities => {
+                        let defaults = coding_harness_defaults(false);
+                        let effective = apply_capability_settings(defaults, &settings.capabilities);
+                        let field = target.field();
+                        ToolExecutionResult::success(json!({
+                            "settings_path": path,
+                            "field": field_json(&settings, field),
+                            "stored_overrides": overrides_to_json(&settings.capabilities),
+                            "effective_harness": effective_harness_json(&effective),
+                            "note": "Append with `set_config key=capabilities json=…`; `value=clear` drops all overrides.",
+                        }))
+                    }
+                    KeyTarget::CapabilityRef(cap_ref) => {
+                        let defaults = coding_harness_defaults(false);
+                        let effective = apply_capability_settings(defaults, &settings.capabilities);
+                        let catalog = match capability_catalog_json(&self.catalog, cap_ref) {
+                            Ok(entry) => entry,
+                            Err(err) => return ToolExecutionResult::tool_error(err),
+                        };
+                        let stored: Vec<Value> = settings
+                            .capability_overrides_for(cap_ref)
+                            .into_iter()
+                            .map(|(index, entry)| stored_override_json(index, entry))
+                            .collect();
+                        let effective_for_id: Vec<Value> = effective
+                            .iter()
+                            .enumerate()
+                            .filter(|(_, cap)| cap.capability_id() == cap_ref)
+                            .map(|(index, cap)| {
+                                json!({
+                                    "index": index,
+                                    "ref": cap.capability_id(),
+                                    "config": cap.config,
+                                })
+                            })
+                            .collect();
+                        let field = target.field();
+                        ToolExecutionResult::success(json!({
+                            "settings_path": path,
+                            "field": field_json(&settings, field),
+                            "capability": catalog,
+                            "stored_overrides": stored,
+                            "effective_instances": effective_for_id,
+                        }))
+                    }
+                    _ => {
+                        let field = target.field();
+                        let mut entry = field_json(&settings, field);
+                        let value = self.settings.current(key).unwrap_or(Value::Null);
+                        if field.provider_scoped
+                            && field.key != "capabilities"
+                            && let Value::Object(map) = &mut entry
+                        {
+                            let table = map.get("current").cloned().unwrap_or(Value::Null);
+                            map.insert("table".to_string(), table);
+                            map.insert("key".to_string(), Value::String(key.to_string()));
+                        }
+                        entry["current"] = value;
+                        ToolExecutionResult::success(json!({
+                            "settings_path": path,
+                            "field": entry,
+                        }))
+                    }
+                };
             }
         }
 
@@ -193,8 +237,8 @@ impl Tool for GetConfigTool {
         ToolExecutionResult::success(json!({
             "settings_path": path,
             "fields": fields,
-            "note": "Set any key with `set_config`. Provider/model edits apply on the next run; \
-                     use /setup to switch the live model now. Unknown keys in the file are ignored.",
+            "note": "Set any key with `set_config`. Harness overrides: `set_config key=capabilities json=…`. \
+                     Provider/model edits apply on the next run; use /setup to switch the live model now.",
         }))
     }
 }
@@ -203,6 +247,7 @@ impl Tool for GetConfigTool {
 
 struct SetConfigTool {
     settings: Arc<SettingsStore>,
+    catalog: Arc<CapabilityCatalog>,
 }
 
 #[async_trait]
@@ -215,9 +260,9 @@ impl Tool for SetConfigTool {
     }
     fn description(&self) -> &str {
         "Set or clear a yolop configuration value, validated against the schema and persisted to \
-         the settings file. `key` is a schema key (e.g. `default_provider`, `default_model`, \
-         `models.openai`, `tokens.anthropic`, `base_urls.custom`, `attribution`). Pass `clear` as \
-         the value to remove an optional/secret key. Run `get_config` first to see valid keys."
+         the settings file. Scalar keys use `value` (pass `clear` to unset). Harness capability \
+         overrides use `key=capabilities` with a `json` override object (or `value=clear` to drop \
+         all overrides). Run `get_config` first to see valid keys."
     }
     fn parameters_schema(&self) -> Value {
         json!({
@@ -225,14 +270,18 @@ impl Tool for SetConfigTool {
             "properties": {
                 "key": {
                     "type": "string",
-                    "description": "Schema key, e.g. `default_provider` or `tokens.openai`."
+                    "description": "Schema key, e.g. `default_provider`, `tokens.openai`, or `capabilities`."
                 },
                 "value": {
                     "type": "string",
-                    "description": "New value, or `clear` to unset an optional/secret key."
+                    "description": "New scalar value, or `clear` to unset."
+                },
+                "json": {
+                    "type": "object",
+                    "description": "For `key=capabilities`: append one `[[capabilities]]` entry with `ref`, optional `enabled`, `append`, and config fields."
                 }
             },
-            "required": ["key", "value"],
+            "required": ["key"],
             "additionalProperties": false
         })
     }
@@ -246,17 +295,83 @@ impl Tool for SetConfigTool {
                 ));
             }
         };
-        let value = match arguments.get("value").and_then(Value::as_str) {
-            Some(v) => v.trim(),
-            None => {
-                return ToolExecutionResult::tool_error(
-                    "'value' is required (use `clear` to unset)",
-                );
-            }
-        };
         let target = match parse_key(key) {
             Ok(t) => t,
             Err(err) => return ToolExecutionResult::tool_error(err),
+        };
+        let json = arguments.get("json");
+        let value = arguments
+            .get("value")
+            .and_then(Value::as_str)
+            .map(str::trim);
+
+        if matches!(target, KeyTarget::CapabilityRef(_)) {
+            return ToolExecutionResult::tool_error(
+                "capabilities.<ref> is read-only; append overrides with `set_config key=capabilities json=…`"
+                    .to_string(),
+            );
+        }
+
+        if matches!(target, KeyTarget::Capabilities) {
+            if let Some(json) = json {
+                let parsed = match parse_override_from_json(json) {
+                    Ok(entry) => entry,
+                    Err(err) => return ToolExecutionResult::tool_error(err),
+                };
+                let entry = match build_capability_override(
+                    &self.catalog,
+                    &parsed.capability_ref,
+                    parsed.enabled,
+                    parsed.append,
+                    Some(&parsed.config),
+                ) {
+                    Ok(entry) => entry,
+                    Err(err) => return ToolExecutionResult::tool_error(err),
+                };
+                let index = match self.settings.append_capability_override(entry.clone()) {
+                    Ok(index) => index,
+                    Err(err) => {
+                        return ToolExecutionResult::tool_error(format!(
+                            "could not save settings: {err}"
+                        ));
+                    }
+                };
+                return ToolExecutionResult::success(json!({
+                    "ok": true,
+                    "key": key,
+                    "index": index,
+                    "message": format!("appended capabilities override at index {index}"),
+                    "settings_path": self.settings.path().display().to_string(),
+                    "stored": entry,
+                    "note": "Restart yolop for harness changes to take effect.",
+                }));
+            }
+            let clearing = value.is_some_and(|v| v.eq_ignore_ascii_case("clear"));
+            if clearing {
+                if let Err(err) = self.settings.clear_capability_overrides() {
+                    return ToolExecutionResult::tool_error(format!(
+                        "could not save settings: {err}"
+                    ));
+                }
+                return ToolExecutionResult::success(json!({
+                    "ok": true,
+                    "key": key,
+                    "message": "cleared all stored capability overrides",
+                    "settings_path": self.settings.path().display().to_string(),
+                }));
+            }
+            return ToolExecutionResult::tool_error(
+                "capabilities expects `json` (append one override) or `value=clear`".to_string(),
+            );
+        }
+
+        let value = match value {
+            Some(v) => v,
+            None => {
+                return ToolExecutionResult::tool_error(
+                    "'value' is required for scalar keys (use `clear` to unset)",
+                );
+            }
         };
         let clearing = value.eq_ignore_ascii_case("clear");
         if value.is_empty() {
@@ -383,6 +498,9 @@ impl SetConfigTool {
                     .map_err(map_err)?;
                 Ok(saved(format!("base_urls.{provider} = {value}")))
             }
+            KeyTarget::Capabilities | KeyTarget::CapabilityRef(_) => {
+                Err("capabilities are configured via set_config with key=capabilities".to_string())
+            }
         }
     }
 }
@@ -397,228 +515,6 @@ fn parse_on_off(raw: &str) -> Option<bool> {
 
 fn on_off(enabled: bool) -> &'static str {
     if enabled { "on" } else { "off" }
-}
-
-// ---------- get_capabilities ----------
-
-struct GetCapabilitiesTool {
-    settings: Arc<SettingsStore>,
-    catalog: Arc<CapabilityCatalog>,
-}
-
-#[async_trait]
-impl Tool for GetCapabilitiesTool {
-    fn name(&self) -> &str {
-        "get_capabilities"
-    }
-    fn display_name(&self) -> Option<&str> {
-        Some("Get capabilities")
-    }
-    fn description(&self) -> &str {
-        "Inspect yolop harness capabilities. With no `id`, returns the registered capability \
-         catalog, stored `[[capabilities]]` overrides, and the effective harness list. With an \
-         `id`, returns catalog metadata plus stored overrides and effective instances for that \
-         capability ref."
-    }
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string",
-                    "description": "Optional capability ref, e.g. `message_metadata` or `web_fetch`."
-                }
-            },
-            "additionalProperties": false
-        })
-    }
-    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        let settings = self.settings.snapshot();
-        let path = self.settings.path().display().to_string();
-        let defaults = coding_harness_defaults(false);
-        let effective = apply_capability_settings(defaults, &settings.capabilities);
-
-        if let Some(id) = arguments.get("id").and_then(Value::as_str) {
-            let id = id.trim();
-            if !id.is_empty() {
-                let catalog = match capability_catalog_json(&self.catalog, id) {
-                    Ok(entry) => entry,
-                    Err(err) => return ToolExecutionResult::tool_error(err),
-                };
-                let stored: Vec<Value> = settings
-                    .capability_overrides_for(id)
-                    .into_iter()
-                    .map(|(index, entry)| stored_override_json(index, entry))
-                    .collect();
-                let effective_for_id: Vec<Value> = effective
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, cap)| cap.capability_id() == id)
-                    .map(|(index, cap)| {
-                        json!({
-                            "index": index,
-                            "ref": cap.capability_id(),
-                            "config": cap.config,
-                        })
-                    })
-                    .collect();
-                return ToolExecutionResult::success(json!({
-                    "settings_path": path,
-                    "capability": catalog,
-                    "stored_overrides": stored,
-                    "effective_instances": effective_for_id,
-                }));
-            }
-        }
-
-        let mut catalog_entries = Vec::new();
-        for cap in self.catalog.list() {
-            match capability_catalog_json(&self.catalog, cap.id()) {
-                Ok(entry) => catalog_entries.push(entry),
-                Err(err) => return ToolExecutionResult::tool_error(err),
-            }
-        }
-        catalog_entries.sort_by(|a, b| {
-            a["id"]
-                .as_str()
-                .unwrap_or_default()
-                .cmp(b["id"].as_str().unwrap_or_default())
-        });
-        let stored: Vec<Value> = settings
-            .capability_overrides()
-            .iter()
-            .enumerate()
-            .map(|(index, entry)| stored_override_json(index, entry))
-            .collect();
-        ToolExecutionResult::success(json!({
-            "settings_path": path,
-            "catalog": catalog_entries,
-            "stored_overrides": stored,
-            "effective_harness": effective_harness_json(&effective),
-            "note": "Overrides are an ordered [[capabilities]] list. Use `set_capability` to append an entry; changes apply on the next run.",
-        }))
-    }
-}
-
-// ---------- set_capability ----------
-
-struct SetCapabilityTool {
-    settings: Arc<SettingsStore>,
-    catalog: Arc<CapabilityCatalog>,
-}
-
-#[async_trait]
-impl Tool for SetCapabilityTool {
-    fn name(&self) -> &str {
-        "set_capability"
-    }
-    fn display_name(&self) -> Option<&str> {
-        Some("Set capability")
-    }
-    fn description(&self) -> &str {
-        "Append a harness capability override to settings.toml. Pass `id` and `enabled=false` to \
-         remove every harness instance with that ref, `append=true` to add a duplicate instance, \
-         and optional `config` (JSON object) for per-instance settings. Config is validated \
-         against the capability's schema via `validate_config`. Run `get_capabilities` first."
-    }
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string",
-                    "description": "Capability ref, e.g. `message_metadata`."
-                },
-                "enabled": {
-                    "type": "boolean",
-                    "description": "When false, appends a remove entry for this ref."
-                },
-                "append": {
-                    "type": "boolean",
-                    "description": "When true, always append a new harness instance instead of merging into the first matching ref."
-                },
-                "remove_index": {
-                    "type": "integer",
-                    "description": "Optional index of a stored [[capabilities]] entry to delete before appending the new override."
-                },
-                "config": {
-                    "type": "object",
-                    "description": "Per-capability JSON config for this override entry."
-                }
-            },
-            "required": ["id"],
-            "additionalProperties": false
-        })
-    }
-    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        let id = match arguments.get("id").and_then(Value::as_str) {
-            Some(id) if !id.trim().is_empty() => id.trim(),
-            _ => return ToolExecutionResult::tool_error("'id' is required".to_string()),
-        };
-        let enabled = arguments.get("enabled").and_then(Value::as_bool);
-        let append = arguments
-            .get("append")
-            .and_then(Value::as_bool)
-            .unwrap_or(false);
-        let config = arguments.get("config");
-        let remove_index = arguments
-            .get("remove_index")
-            .and_then(Value::as_u64)
-            .map(|index| index as usize);
-        if enabled.is_none() && config.is_none() && !append && remove_index.is_none() {
-            return ToolExecutionResult::tool_error(
-                "provide `enabled`, `config`, `remove_index`, and/or `append=true`; call `get_capabilities` to inspect"
-                    .to_string(),
-            );
-        }
-
-        if let Some(index) = remove_index {
-            if let Err(err) = self.settings.remove_capability_override(index) {
-                return ToolExecutionResult::tool_error(format!("could not save settings: {err}"));
-            }
-            if enabled.is_none() && config.is_none() && !append {
-                return ToolExecutionResult::success(json!({
-                    "ok": true,
-                    "removed_index": index,
-                    "message": format!("removed stored override at index {index}"),
-                    "settings_path": self.settings.path().display().to_string(),
-                    "note": "Restart yolop for harness changes to take effect.",
-                }));
-            }
-        }
-
-        let entry = match build_capability_override(&self.catalog, id, enabled, append, config) {
-            Ok(entry) => entry,
-            Err(err) => return ToolExecutionResult::tool_error(err),
-        };
-
-        let index = match self.settings.append_capability_override(entry.clone()) {
-            Ok(index) => index,
-            Err(err) => {
-                return ToolExecutionResult::tool_error(format!("could not save settings: {err}"));
-            }
-        };
-
-        let message = if entry.is_remove() {
-            format!("appended remove entry for `{id}` at index {index}")
-        } else if append {
-            format!("appended new `{id}` harness instance at index {index}")
-        } else if enabled == Some(true) && config.is_none() {
-            format!("appended enable entry for `{id}` at index {index}")
-        } else {
-            format!("appended config override for `{id}` at index {index}")
-        };
-
-        ToolExecutionResult::success(json!({
-            "ok": true,
-            "id": id,
-            "index": index,
-            "message": message,
-            "settings_path": self.settings.path().display().to_string(),
-            "stored": entry,
-            "note": "Restart yolop for harness changes to take effect.",
-        }))
-    }
 }
 
 #[cfg(test)]
@@ -638,12 +534,24 @@ mod tests {
         Arc::new(catalog)
     }
 
+    fn get_config_tool(settings: Arc<SettingsStore>) -> GetConfigTool {
+        GetConfigTool {
+            settings,
+            catalog: catalog(),
+        }
+    }
+
+    fn set_config_tool(settings: Arc<SettingsStore>) -> SetConfigTool {
+        SetConfigTool {
+            settings,
+            catalog: catalog(),
+        }
+    }
+
     #[tokio::test]
     async fn set_config_persists_default_provider_and_model() {
         let (_tmp, settings) = store();
-        let tool = SetConfigTool {
-            settings: settings.clone(),
-        };
+        let tool = set_config_tool(settings.clone());
 
         let r = tool
             .execute(json!({ "key": "default_provider", "value": "anthropic" }))
@@ -663,7 +571,7 @@ mod tests {
     #[tokio::test]
     async fn set_config_rejects_unknown_provider_and_key() {
         let (_tmp, settings) = store();
-        let tool = SetConfigTool { settings };
+        let tool = set_config_tool(settings);
 
         let bad_provider = tool
             .execute(json!({ "key": "default_provider", "value": "nope" }))
@@ -679,9 +587,7 @@ mod tests {
     #[tokio::test]
     async fn set_config_routes_approval_mode() {
         let (_tmp, settings) = store();
-        let tool = SetConfigTool {
-            settings: settings.clone(),
-        };
+        let tool = set_config_tool(settings.clone());
         let ok = tool
             .execute(json!({ "key": "approval_mode", "value": "protective" }))
             .await;
@@ -708,7 +614,7 @@ mod tests {
     #[tokio::test]
     async fn set_config_validates_base_url_scheme() {
         let (_tmp, settings) = store();
-        let tool = SetConfigTool { settings };
+        let tool = set_config_tool(settings);
         let r = tool
             .execute(json!({ "key": "base_urls.custom", "value": "localhost:8000" }))
             .await;
@@ -718,9 +624,7 @@ mod tests {
     #[tokio::test]
     async fn set_and_clear_token_roundtrip() {
         let (_tmp, settings) = store();
-        let tool = SetConfigTool {
-            settings: settings.clone(),
-        };
+        let tool = set_config_tool(settings.clone());
         tool.execute(json!({ "key": "tokens.openai", "value": "sk-secret" }))
             .await;
         assert!(settings.snapshot().has_token("openai"));
@@ -736,9 +640,7 @@ mod tests {
         settings
             .set_token("openai".to_string(), "sk-secret".to_string())
             .unwrap();
-        let tool = GetConfigTool {
-            settings: settings.clone(),
-        };
+        let tool = get_config_tool(settings.clone());
         let r = tool.execute(json!({ "key": "tokens.openai" })).await;
         let ToolExecutionResult::Success(value) = r else {
             panic!("expected success");
@@ -754,7 +656,7 @@ mod tests {
     #[tokio::test]
     async fn get_config_lists_all_fields() {
         let (_tmp, settings) = store();
-        let tool = GetConfigTool { settings };
+        let tool = get_config_tool(settings);
         let ToolExecutionResult::Success(value) = tool.execute(json!({})).await else {
             panic!("expected success");
         };
@@ -765,7 +667,7 @@ mod tests {
     #[tokio::test]
     async fn get_config_renders_attribution_as_bool() {
         let (_tmp, settings) = store();
-        let tool = GetConfigTool { settings };
+        let tool = get_config_tool(settings);
         let ToolExecutionResult::Success(value) =
             tool.execute(json!({ "key": "attribution" })).await
         else {
@@ -785,7 +687,7 @@ mod tests {
         settings
             .set_model("anthropic".to_string(), "claude-opus-4-5".to_string())
             .unwrap();
-        let tool = GetConfigTool { settings };
+        let tool = get_config_tool(settings);
         let ToolExecutionResult::Success(value) =
             tool.execute(json!({ "key": "models.openai" })).await
         else {
@@ -810,7 +712,7 @@ mod tests {
         settings
             .set_model("frobnicate".to_string(), "whatever".to_string())
             .unwrap();
-        let tool = GetConfigTool { settings };
+        let tool = get_config_tool(settings);
         let ToolExecutionResult::Success(value) = tool.execute(json!({})).await else {
             panic!("expected success");
         };
@@ -829,17 +731,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn set_capability_appends_message_metadata_override() {
+    async fn set_config_appends_capabilities_override() {
         let (_tmp, settings) = store();
-        let tool = SetCapabilityTool {
-            settings: settings.clone(),
-            catalog: catalog(),
-        };
+        let tool = set_config_tool(settings.clone());
         let result = tool
             .execute(json!({
-                "id": MESSAGE_METADATA_CAPABILITY_ID,
-                "enabled": true,
-                "config": { "fields": ["timestamp"] }
+                "key": "capabilities",
+                "json": {
+                    "ref": MESSAGE_METADATA_CAPABILITY_ID,
+                    "enabled": true,
+                    "fields": ["timestamp"]
+                }
             }))
             .await;
         assert!(matches!(result, ToolExecutionResult::Success(_)));
@@ -856,31 +758,27 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn set_capability_rejects_invalid_config() {
+    async fn set_config_capabilities_rejects_invalid_config() {
         let (_tmp, settings) = store();
-        let tool = SetCapabilityTool {
-            settings: settings.clone(),
-            catalog: catalog(),
-        };
+        let tool = set_config_tool(settings.clone());
         let result = tool
             .execute(json!({
-                "id": MESSAGE_METADATA_CAPABILITY_ID,
-                "enabled": true,
-                "config": { "fields": ["llm_model"] }
+                "key": "capabilities",
+                "json": {
+                    "ref": MESSAGE_METADATA_CAPABILITY_ID,
+                    "fields": ["llm_model"]
+                }
             }))
             .await;
         assert!(matches!(result, ToolExecutionResult::ToolError(_)));
     }
 
     #[tokio::test]
-    async fn get_capabilities_exposes_schema_for_message_metadata() {
+    async fn get_config_capabilities_ref_exposes_schema() {
         let (_tmp, settings) = store();
-        let tool = GetCapabilitiesTool {
-            settings,
-            catalog: catalog(),
-        };
+        let tool = get_config_tool(settings);
         let ToolExecutionResult::Success(value) = tool
-            .execute(json!({ "id": MESSAGE_METADATA_CAPABILITY_ID }))
+            .execute(json!({ "key": format!("capabilities.{MESSAGE_METADATA_CAPABILITY_ID}") }))
             .await
         else {
             panic!("expected success");
@@ -890,20 +788,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn set_capability_disable_appends_remove_entry() {
+    async fn set_config_capabilities_disable_appends_remove_entry() {
         let (_tmp, settings) = store();
-        let tool = SetCapabilityTool {
-            settings: settings.clone(),
-            catalog: catalog(),
-        };
+        let tool = set_config_tool(settings.clone());
         tool.execute(json!({
-            "id": MESSAGE_METADATA_CAPABILITY_ID,
-            "enabled": true
+            "key": "capabilities",
+            "json": { "ref": MESSAGE_METADATA_CAPABILITY_ID, "enabled": true }
         }))
         .await;
         tool.execute(json!({
-            "id": MESSAGE_METADATA_CAPABILITY_ID,
-            "enabled": false
+            "key": "capabilities",
+            "json": { "ref": MESSAGE_METADATA_CAPABILITY_ID, "enabled": false }
         }))
         .await;
         let snapshot = settings.snapshot();

--- a/src/capabilities/config.rs
+++ b/src/capabilities/config.rs
@@ -14,8 +14,8 @@
 
 use crate::capability_settings::{
     CapabilityCatalog, apply_capability_settings, build_capability_override,
-    capability_catalog_json, effective_harness_json, overrides_to_json, parse_override_from_json,
-    stored_override_json,
+    capability_catalog_json, capability_catalog_list, effective_harness_json, overrides_to_json,
+    parse_override_from_json, stored_override_json,
 };
 use crate::config_schema::{KeyTarget, ValueKind, known_keys, parse_key, schema};
 use crate::config_service::{ConfigService, current_value, scoped_current};
@@ -139,8 +139,9 @@ impl Tool for GetConfigTool {
     fn description(&self) -> &str {
         "Inspect yolop configuration. With no `key`, returns every configuration key with its \
          title, description, type, default, examples, and current value (secrets redacted). \
-         With a `key`, returns just that entry. Use `key=capabilities` or \
-         `key=capabilities.<ref>` for harness capability overrides and schema metadata."
+         With a `key`, returns just that entry. Use `key=capabilities` for the full \
+         registered catalog plus stored overrides, or `key=capabilities.<ref>` for one \
+         capability's schema metadata."
     }
     fn parameters_schema(&self) -> Value {
         json!({
@@ -173,9 +174,12 @@ impl Tool for GetConfigTool {
                         ToolExecutionResult::success(json!({
                             "settings_path": path,
                             "field": field_json(&settings, field),
+                            "catalog": capability_catalog_list(&self.catalog),
                             "stored_overrides": overrides_to_json(&settings.capabilities),
                             "effective_harness": effective_harness_json(&effective),
-                            "note": "Append with `set_config key=capabilities json=…`; `value=clear` drops all overrides.",
+                            "note": "Use `catalog` for registered refs and schema metadata; \
+                                     `capabilities.<ref>` narrows to one entry. Append with \
+                                     `set_config key=capabilities json=…`; `value=clear` drops all overrides.",
                         }))
                     }
                     KeyTarget::CapabilityRef(cap_ref) => {
@@ -771,6 +775,31 @@ mod tests {
             }))
             .await;
         assert!(matches!(result, ToolExecutionResult::ToolError(_)));
+    }
+
+    #[tokio::test]
+    async fn get_config_capabilities_includes_catalog() {
+        let (_tmp, settings) = store();
+        let tool = get_config_tool(settings);
+        let ToolExecutionResult::Success(value) =
+            tool.execute(json!({ "key": "capabilities" })).await
+        else {
+            panic!("expected success");
+        };
+        let catalog = value["catalog"].as_array().expect("catalog array");
+        assert!(
+            catalog
+                .iter()
+                .any(|entry| entry["id"] == MESSAGE_METADATA_CAPABILITY_ID),
+            "catalog must list registered capabilities: {catalog:?}"
+        );
+        let meta = catalog
+            .iter()
+            .find(|entry| entry["id"] == MESSAGE_METADATA_CAPABILITY_ID)
+            .expect("message_metadata entry");
+        assert!(meta["config_schema"].is_object());
+        assert!(value["stored_overrides"].as_array().unwrap().is_empty());
+        assert!(!value["effective_harness"].as_array().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/src/capabilities/config.rs
+++ b/src/capabilities/config.rs
@@ -12,9 +12,12 @@
 // Provider/model edits are persisted here and take effect on the next run; use
 // the interactive `/setup` command to switch the *live* model mid-session.
 
+use crate::capability_settings::{
+    CapabilityCatalog, capability_entry_json, validate_capability_mutation,
+};
 use crate::config_schema::{KeyTarget, ValueKind, known_keys, parse_key, schema};
 use crate::config_service::{ConfigService, current_value, scoped_current};
-use crate::runtime::SUPPORTED_PROVIDERS;
+use crate::runtime::{SUPPORTED_PROVIDERS, coding_harness_defaults};
 use crate::settings::{ApprovalMode, Settings, SettingsStore};
 use async_trait::async_trait;
 use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
@@ -26,6 +29,7 @@ pub(crate) const CONFIG_CAPABILITY_ID: &str = "yolop_config";
 
 pub(crate) struct ConfigCapability {
     pub(crate) settings: Arc<SettingsStore>,
+    pub(crate) catalog: Arc<CapabilityCatalog>,
 }
 
 #[async_trait]
@@ -50,11 +54,12 @@ impl Capability for ConfigCapability {
         Some(format!(
             "<capability id=\"{}\">\nyolop's settings live at {} and are schema-described \
              (default provider/model, per-provider API tokens and models, endpoint base URLs, \
-             attribution). To inspect or change any of it, call `get_config` (lists every key \
-             with its meaning and current value) and `set_config` (validates and persists a \
-             key), or activate the `yolop-config` skill. Unknown keys in the file are ignored, \
-             never fatal. Provider/model edits apply on the next run; use `/setup` to switch the \
-             live model now.\n</capability>",
+             attribution, harness capabilities). To inspect or change settings keys, call \
+             `get_config` and `set_config`. To add, remove, or reconfigure harness capabilities, \
+             call `get_capabilities` and `set_capability` (schemas come from each capability's \
+             `config_schema` / `validate_config`). Or activate the `yolop-config` skill. Unknown \
+             keys in the file are ignored, never fatal. Provider/model and capability edits apply \
+             on the next run; use `/setup` to switch the live model now.\n</capability>",
             self.id(),
             self.settings.path().display()
         ))
@@ -62,8 +67,9 @@ impl Capability for ConfigCapability {
 
     fn system_prompt_preview(&self) -> Option<String> {
         Some(
-            "<capability id=\"yolop_config\">\nyolop's settings are schema-described; use \
-             `get_config` / `set_config` or the `yolop-config` skill to view and edit them.\n\
+            "<capability id=\"yolop_config\">\nyolop's settings and harness capabilities are \
+             schema-described; use `get_config` / `set_config` and `get_capabilities` / \
+             `set_capability`, or the `yolop-config` skill.\n\
              </capability>"
                 .to_string(),
         )
@@ -76,6 +82,14 @@ impl Capability for ConfigCapability {
             }),
             Box::new(SetConfigTool {
                 settings: self.settings.clone(),
+            }),
+            Box::new(GetCapabilitiesTool {
+                settings: self.settings.clone(),
+                catalog: self.catalog.clone(),
+            }),
+            Box::new(SetCapabilityTool {
+                settings: self.settings.clone(),
+                catalog: self.catalog.clone(),
             }),
         ]
     }
@@ -384,14 +398,206 @@ fn on_off(enabled: bool) -> &'static str {
     if enabled { "on" } else { "off" }
 }
 
+// ---------- get_capabilities ----------
+
+struct GetCapabilitiesTool {
+    settings: Arc<SettingsStore>,
+    catalog: Arc<CapabilityCatalog>,
+}
+
+#[async_trait]
+impl Tool for GetCapabilitiesTool {
+    fn name(&self) -> &str {
+        "get_capabilities"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Get capabilities")
+    }
+    fn description(&self) -> &str {
+        "Inspect yolop harness capabilities. With no `id`, returns every registered capability \
+         with its description, JSON config schema, UI schema hints, default harness membership, \
+         stored override, and effective config. With an `id`, returns just that entry."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Optional capability id, e.g. `message_metadata` or `web_fetch`."
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let settings = self.settings.snapshot();
+        let path = self.settings.path().display().to_string();
+        let defaults = coding_harness_defaults(false);
+        let default_by_id = |id: &str| defaults.iter().find(|c| c.capability_id() == id);
+
+        if let Some(id) = arguments.get("id").and_then(Value::as_str) {
+            let id = id.trim();
+            if !id.is_empty() {
+                match capability_entry_json(
+                    &self.catalog,
+                    id,
+                    default_by_id(id),
+                    settings.capability_setting(id),
+                ) {
+                    Ok(entry) => {
+                        return ToolExecutionResult::success(json!({
+                            "settings_path": path,
+                            "capability": entry,
+                        }));
+                    }
+                    Err(err) => return ToolExecutionResult::tool_error(err),
+                }
+            }
+        }
+
+        let mut entries = Vec::new();
+        for cap in self.catalog.list() {
+            let id = cap.id();
+            match capability_entry_json(
+                &self.catalog,
+                id,
+                default_by_id(id),
+                settings.capability_setting(id),
+            ) {
+                Ok(entry) => entries.push(entry),
+                Err(err) => return ToolExecutionResult::tool_error(err),
+            }
+        }
+        entries.sort_by(|a, b| {
+            a["id"]
+                .as_str()
+                .unwrap_or_default()
+                .cmp(b["id"].as_str().unwrap_or_default())
+        });
+        ToolExecutionResult::success(json!({
+            "settings_path": path,
+            "capabilities": entries,
+            "note": "Add, remove, or reconfigure with `set_capability`. Changes apply on the next run.",
+        }))
+    }
+}
+
+// ---------- set_capability ----------
+
+struct SetCapabilityTool {
+    settings: Arc<SettingsStore>,
+    catalog: Arc<CapabilityCatalog>,
+}
+
+#[async_trait]
+impl Tool for SetCapabilityTool {
+    fn name(&self) -> &str {
+        "set_capability"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Set capability")
+    }
+    fn description(&self) -> &str {
+        "Add, remove, or reconfigure a harness capability in settings.toml. Pass `id` and \
+         `enabled=false` to remove/disable, `enabled=true` to add/keep enabled, and optional \
+         `config` (JSON object) to override capability settings. Config is validated against \
+         the capability's schema via `validate_config`. Run `get_capabilities` first."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Capability id, e.g. `message_metadata`."
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "description": "When false, removes the capability from the harness."
+                },
+                "config": {
+                    "type": "object",
+                    "description": "Per-capability JSON config merged over defaults."
+                }
+            },
+            "required": ["id"],
+            "additionalProperties": false
+        })
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let id = match arguments.get("id").and_then(Value::as_str) {
+            Some(id) if !id.trim().is_empty() => id.trim(),
+            _ => return ToolExecutionResult::tool_error("'id' is required".to_string()),
+        };
+        let enabled = arguments.get("enabled").and_then(Value::as_bool);
+        let config = arguments.get("config");
+        if enabled.is_none() && config.is_none() {
+            return ToolExecutionResult::tool_error(
+                "provide `enabled` and/or `config`; call `get_capabilities` to inspect".to_string(),
+            );
+        }
+
+        let snapshot = self.settings.snapshot();
+        let defaults = coding_harness_defaults(false);
+        let setting = match validate_capability_mutation(
+            &self.catalog,
+            id,
+            enabled,
+            config,
+            &defaults,
+            &snapshot.capabilities,
+        ) {
+            Ok(setting) => setting,
+            Err(err) => return ToolExecutionResult::tool_error(err),
+        };
+
+        let clearing = setting.is_explicitly_disabled();
+        let save_result = if clearing {
+            self.settings.clear_capability(id)
+        } else {
+            self.settings
+                .set_capability(id.to_string(), setting.clone())
+                .map(|_| true)
+        };
+        if let Err(err) = save_result {
+            return ToolExecutionResult::tool_error(format!("could not save settings: {err}"));
+        }
+
+        let message = if clearing {
+            format!("removed capability `{id}` from the harness (saved to settings)")
+        } else if enabled == Some(true) && config.is_none() {
+            format!("enabled capability `{id}` with default config")
+        } else {
+            format!("updated capability `{id}` config")
+        };
+
+        ToolExecutionResult::success(json!({
+            "ok": true,
+            "id": id,
+            "message": message,
+            "settings_path": self.settings.path().display().to_string(),
+            "stored": setting,
+            "note": "Restart yolop for harness changes to take effect.",
+        }))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use everruns_core::capabilities::{MESSAGE_METADATA_CAPABILITY_ID, MessageMetadataCapability};
 
     fn store() -> (tempfile::TempDir, Arc<SettingsStore>) {
         let tmp = tempfile::tempdir().expect("tmp");
         let store = Arc::new(SettingsStore::open(tmp.path().join("settings.toml")));
         (tmp, store)
+    }
+
+    fn catalog() -> Arc<CapabilityCatalog> {
+        let mut catalog = CapabilityCatalog::new();
+        catalog.register_arc(Arc::new(MessageMetadataCapability));
+        Arc::new(catalog)
     }
 
     #[tokio::test]
@@ -581,6 +787,87 @@ mod tests {
             models["current"].get("frobnicate").is_none(),
             "unsupported provider must be omitted: {}",
             models["current"]
+        );
+    }
+
+    #[tokio::test]
+    async fn set_capability_adds_message_metadata_to_settings() {
+        let (_tmp, settings) = store();
+        let tool = SetCapabilityTool {
+            settings: settings.clone(),
+            catalog: catalog(),
+        };
+        let result = tool
+            .execute(json!({
+                "id": MESSAGE_METADATA_CAPABILITY_ID,
+                "enabled": true,
+                "config": { "fields": ["timestamp"] }
+            }))
+            .await;
+        assert!(matches!(result, ToolExecutionResult::Success(_)));
+        let snapshot = settings.snapshot();
+        let stored = snapshot
+            .capability_setting(MESSAGE_METADATA_CAPABILITY_ID)
+            .expect("stored");
+        assert_eq!(stored.config["fields"], json!(["timestamp"]));
+    }
+
+    #[tokio::test]
+    async fn set_capability_rejects_invalid_config() {
+        let (_tmp, settings) = store();
+        let tool = SetCapabilityTool {
+            settings: settings.clone(),
+            catalog: catalog(),
+        };
+        let result = tool
+            .execute(json!({
+                "id": MESSAGE_METADATA_CAPABILITY_ID,
+                "enabled": true,
+                "config": { "fields": ["llm_model"] }
+            }))
+            .await;
+        assert!(matches!(result, ToolExecutionResult::ToolError(_)));
+    }
+
+    #[tokio::test]
+    async fn get_capabilities_exposes_schema_for_message_metadata() {
+        let (_tmp, settings) = store();
+        let tool = GetCapabilitiesTool {
+            settings,
+            catalog: catalog(),
+        };
+        let ToolExecutionResult::Success(value) = tool
+            .execute(json!({ "id": MESSAGE_METADATA_CAPABILITY_ID }))
+            .await
+        else {
+            panic!("expected success");
+        };
+        assert!(value["capability"]["config_schema"].is_object());
+        assert_eq!(value["capability"]["default_in_harness"], false);
+    }
+
+    #[tokio::test]
+    async fn set_capability_disable_removes_override() {
+        let (_tmp, settings) = store();
+        let tool = SetCapabilityTool {
+            settings: settings.clone(),
+            catalog: catalog(),
+        };
+        tool.execute(json!({
+            "id": MESSAGE_METADATA_CAPABILITY_ID,
+            "enabled": true
+        }))
+        .await;
+        tool.execute(json!({
+            "id": MESSAGE_METADATA_CAPABILITY_ID,
+            "enabled": false
+        }))
+        .await;
+        assert!(
+            settings
+                .snapshot()
+                .capability_setting(MESSAGE_METADATA_CAPABILITY_ID)
+                .is_none()
         );
     }
 }

--- a/src/capabilities/config.rs
+++ b/src/capabilities/config.rs
@@ -13,7 +13,8 @@
 // the interactive `/setup` command to switch the *live* model mid-session.
 
 use crate::capability_settings::{
-    CapabilityCatalog, capability_entry_json, validate_capability_mutation,
+    CapabilityCatalog, apply_capability_settings, build_capability_override,
+    capability_catalog_json, effective_harness_json, stored_override_json,
 };
 use crate::config_schema::{KeyTarget, ValueKind, known_keys, parse_key, schema};
 use crate::config_service::{ConfigService, current_value, scoped_current};
@@ -414,9 +415,10 @@ impl Tool for GetCapabilitiesTool {
         Some("Get capabilities")
     }
     fn description(&self) -> &str {
-        "Inspect yolop harness capabilities. With no `id`, returns every registered capability \
-         with its description, JSON config schema, UI schema hints, default harness membership, \
-         stored override, and effective config. With an `id`, returns just that entry."
+        "Inspect yolop harness capabilities. With no `id`, returns the registered capability \
+         catalog, stored `[[capabilities]]` overrides, and the effective harness list. With an \
+         `id`, returns catalog metadata plus stored overrides and effective instances for that \
+         capability ref."
     }
     fn parameters_schema(&self) -> Value {
         json!({
@@ -424,7 +426,7 @@ impl Tool for GetCapabilitiesTool {
             "properties": {
                 "id": {
                     "type": "string",
-                    "description": "Optional capability id, e.g. `message_metadata` or `web_fetch`."
+                    "description": "Optional capability ref, e.g. `message_metadata` or `web_fetch`."
                 }
             },
             "additionalProperties": false
@@ -434,51 +436,66 @@ impl Tool for GetCapabilitiesTool {
         let settings = self.settings.snapshot();
         let path = self.settings.path().display().to_string();
         let defaults = coding_harness_defaults(false);
-        let default_by_id = |id: &str| defaults.iter().find(|c| c.capability_id() == id);
+        let effective = apply_capability_settings(defaults, &settings.capabilities);
 
         if let Some(id) = arguments.get("id").and_then(Value::as_str) {
             let id = id.trim();
             if !id.is_empty() {
-                match capability_entry_json(
-                    &self.catalog,
-                    id,
-                    default_by_id(id),
-                    settings.capability_setting(id),
-                ) {
-                    Ok(entry) => {
-                        return ToolExecutionResult::success(json!({
-                            "settings_path": path,
-                            "capability": entry,
-                        }));
-                    }
+                let catalog = match capability_catalog_json(&self.catalog, id) {
+                    Ok(entry) => entry,
                     Err(err) => return ToolExecutionResult::tool_error(err),
-                }
+                };
+                let stored: Vec<Value> = settings
+                    .capability_overrides_for(id)
+                    .into_iter()
+                    .map(|(index, entry)| stored_override_json(index, entry))
+                    .collect();
+                let effective_for_id: Vec<Value> = effective
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, cap)| cap.capability_id() == id)
+                    .map(|(index, cap)| {
+                        json!({
+                            "index": index,
+                            "ref": cap.capability_id(),
+                            "config": cap.config,
+                        })
+                    })
+                    .collect();
+                return ToolExecutionResult::success(json!({
+                    "settings_path": path,
+                    "capability": catalog,
+                    "stored_overrides": stored,
+                    "effective_instances": effective_for_id,
+                }));
             }
         }
 
-        let mut entries = Vec::new();
+        let mut catalog_entries = Vec::new();
         for cap in self.catalog.list() {
-            let id = cap.id();
-            match capability_entry_json(
-                &self.catalog,
-                id,
-                default_by_id(id),
-                settings.capability_setting(id),
-            ) {
-                Ok(entry) => entries.push(entry),
+            match capability_catalog_json(&self.catalog, cap.id()) {
+                Ok(entry) => catalog_entries.push(entry),
                 Err(err) => return ToolExecutionResult::tool_error(err),
             }
         }
-        entries.sort_by(|a, b| {
+        catalog_entries.sort_by(|a, b| {
             a["id"]
                 .as_str()
                 .unwrap_or_default()
                 .cmp(b["id"].as_str().unwrap_or_default())
         });
+        let stored: Vec<Value> = settings
+            .capability_overrides()
+            .iter()
+            .enumerate()
+            .map(|(index, entry)| stored_override_json(index, entry))
+            .collect();
         ToolExecutionResult::success(json!({
             "settings_path": path,
-            "capabilities": entries,
-            "note": "Add, remove, or reconfigure with `set_capability`. Changes apply on the next run.",
+            "catalog": catalog_entries,
+            "stored_overrides": stored,
+            "effective_harness": effective_harness_json(&effective),
+            "note": "Overrides are an ordered [[capabilities]] list. Use `set_capability` to append an entry; changes apply on the next run.",
         }))
     }
 }
@@ -499,10 +516,10 @@ impl Tool for SetCapabilityTool {
         Some("Set capability")
     }
     fn description(&self) -> &str {
-        "Add, remove, or reconfigure a harness capability in settings.toml. Pass `id` and \
-         `enabled=false` to remove/disable, `enabled=true` to add/keep enabled, and optional \
-         `config` (JSON object) to override capability settings. Config is validated against \
-         the capability's schema via `validate_config`. Run `get_capabilities` first."
+        "Append a harness capability override to settings.toml. Pass `id` and `enabled=false` to \
+         remove every harness instance with that ref, `append=true` to add a duplicate instance, \
+         and optional `config` (JSON object) for per-instance settings. Config is validated \
+         against the capability's schema via `validate_config`. Run `get_capabilities` first."
     }
     fn parameters_schema(&self) -> Value {
         json!({
@@ -510,15 +527,23 @@ impl Tool for SetCapabilityTool {
             "properties": {
                 "id": {
                     "type": "string",
-                    "description": "Capability id, e.g. `message_metadata`."
+                    "description": "Capability ref, e.g. `message_metadata`."
                 },
                 "enabled": {
                     "type": "boolean",
-                    "description": "When false, removes the capability from the harness."
+                    "description": "When false, appends a remove entry for this ref."
+                },
+                "append": {
+                    "type": "boolean",
+                    "description": "When true, always append a new harness instance instead of merging into the first matching ref."
+                },
+                "remove_index": {
+                    "type": "integer",
+                    "description": "Optional index of a stored [[capabilities]] entry to delete before appending the new override."
                 },
                 "config": {
                     "type": "object",
-                    "description": "Per-capability JSON config merged over defaults."
+                    "description": "Per-capability JSON config for this override entry."
                 }
             },
             "required": ["id"],
@@ -531,53 +556,66 @@ impl Tool for SetCapabilityTool {
             _ => return ToolExecutionResult::tool_error("'id' is required".to_string()),
         };
         let enabled = arguments.get("enabled").and_then(Value::as_bool);
+        let append = arguments
+            .get("append")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
         let config = arguments.get("config");
-        if enabled.is_none() && config.is_none() {
+        let remove_index = arguments
+            .get("remove_index")
+            .and_then(Value::as_u64)
+            .map(|index| index as usize);
+        if enabled.is_none() && config.is_none() && !append && remove_index.is_none() {
             return ToolExecutionResult::tool_error(
-                "provide `enabled` and/or `config`; call `get_capabilities` to inspect".to_string(),
+                "provide `enabled`, `config`, `remove_index`, and/or `append=true`; call `get_capabilities` to inspect"
+                    .to_string(),
             );
         }
 
-        let snapshot = self.settings.snapshot();
-        let defaults = coding_harness_defaults(false);
-        let setting = match validate_capability_mutation(
-            &self.catalog,
-            id,
-            enabled,
-            config,
-            &defaults,
-            &snapshot.capabilities,
-        ) {
-            Ok(setting) => setting,
+        if let Some(index) = remove_index {
+            if let Err(err) = self.settings.remove_capability_override(index) {
+                return ToolExecutionResult::tool_error(format!("could not save settings: {err}"));
+            }
+            if enabled.is_none() && config.is_none() && !append {
+                return ToolExecutionResult::success(json!({
+                    "ok": true,
+                    "removed_index": index,
+                    "message": format!("removed stored override at index {index}"),
+                    "settings_path": self.settings.path().display().to_string(),
+                    "note": "Restart yolop for harness changes to take effect.",
+                }));
+            }
+        }
+
+        let entry = match build_capability_override(&self.catalog, id, enabled, append, config) {
+            Ok(entry) => entry,
             Err(err) => return ToolExecutionResult::tool_error(err),
         };
 
-        let clearing = setting.is_explicitly_disabled();
-        let save_result = if clearing {
-            self.settings.clear_capability(id)
-        } else {
-            self.settings
-                .set_capability(id.to_string(), setting.clone())
-                .map(|_| true)
+        let index = match self.settings.append_capability_override(entry.clone()) {
+            Ok(index) => index,
+            Err(err) => {
+                return ToolExecutionResult::tool_error(format!("could not save settings: {err}"));
+            }
         };
-        if let Err(err) = save_result {
-            return ToolExecutionResult::tool_error(format!("could not save settings: {err}"));
-        }
 
-        let message = if clearing {
-            format!("removed capability `{id}` from the harness (saved to settings)")
+        let message = if entry.is_remove() {
+            format!("appended remove entry for `{id}` at index {index}")
+        } else if append {
+            format!("appended new `{id}` harness instance at index {index}")
         } else if enabled == Some(true) && config.is_none() {
-            format!("enabled capability `{id}` with default config")
+            format!("appended enable entry for `{id}` at index {index}")
         } else {
-            format!("updated capability `{id}` config")
+            format!("appended config override for `{id}` at index {index}")
         };
 
         ToolExecutionResult::success(json!({
             "ok": true,
             "id": id,
+            "index": index,
             "message": message,
             "settings_path": self.settings.path().display().to_string(),
-            "stored": setting,
+            "stored": entry,
             "note": "Restart yolop for harness changes to take effect.",
         }))
     }
@@ -791,7 +829,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn set_capability_adds_message_metadata_to_settings() {
+    async fn set_capability_appends_message_metadata_override() {
         let (_tmp, settings) = store();
         let tool = SetCapabilityTool {
             settings: settings.clone(),
@@ -806,10 +844,15 @@ mod tests {
             .await;
         assert!(matches!(result, ToolExecutionResult::Success(_)));
         let snapshot = settings.snapshot();
-        let stored = snapshot
-            .capability_setting(MESSAGE_METADATA_CAPABILITY_ID)
-            .expect("stored");
-        assert_eq!(stored.config["fields"], json!(["timestamp"]));
+        assert_eq!(snapshot.capabilities.len(), 1);
+        assert_eq!(
+            snapshot.capabilities[0].capability_ref,
+            MESSAGE_METADATA_CAPABILITY_ID
+        );
+        assert_eq!(
+            snapshot.capabilities[0].config["fields"],
+            json!(["timestamp"])
+        );
     }
 
     #[tokio::test]
@@ -843,11 +886,11 @@ mod tests {
             panic!("expected success");
         };
         assert!(value["capability"]["config_schema"].is_object());
-        assert_eq!(value["capability"]["default_in_harness"], false);
+        assert!(value["stored_overrides"].as_array().unwrap().is_empty());
     }
 
     #[tokio::test]
-    async fn set_capability_disable_removes_override() {
+    async fn set_capability_disable_appends_remove_entry() {
         let (_tmp, settings) = store();
         let tool = SetCapabilityTool {
             settings: settings.clone(),
@@ -863,11 +906,8 @@ mod tests {
             "enabled": false
         }))
         .await;
-        assert!(
-            settings
-                .snapshot()
-                .capability_setting(MESSAGE_METADATA_CAPABILITY_ID)
-                .is_none()
-        );
+        let snapshot = settings.snapshot();
+        assert_eq!(snapshot.capabilities.len(), 2);
+        assert!(snapshot.capabilities[1].is_remove());
     }
 }

--- a/src/capability_settings.rs
+++ b/src/capability_settings.rs
@@ -42,6 +42,13 @@ impl CapabilityCatalog {
         self.capabilities.contains_key(id)
     }
 
+    /// Registered capability ids in stable sorted order.
+    pub fn ids(&self) -> Vec<String> {
+        let mut ids: Vec<_> = self.capabilities.keys().cloned().collect();
+        ids.sort();
+        ids
+    }
+
     pub fn validate(&self, id: &str, config: &Value) -> Result<(), String> {
         let cap = self
             .get(id)
@@ -286,6 +293,15 @@ fn merge_config(default: &Value, override_config: &Value) -> Value {
     }
 }
 
+/// Full catalog entries (`id`, schema metadata) for every registered capability.
+pub fn capability_catalog_list(catalog: &CapabilityCatalog) -> Vec<Value> {
+    catalog
+        .ids()
+        .into_iter()
+        .filter_map(|id| capability_catalog_json(catalog, &id).ok())
+        .collect()
+}
+
 pub fn capability_catalog_json(catalog: &CapabilityCatalog, id: &str) -> Result<Value, String> {
     let cap = catalog
         .get(id)
@@ -334,7 +350,7 @@ pub fn build_capability_override(
 ) -> Result<CapabilityOverride, String> {
     if !catalog.has(capability_ref) {
         return Err(format!(
-            "unknown capability `{capability_ref}`; call `get_capabilities` for registered ids"
+            "unknown capability `{capability_ref}`; call `get_config key=capabilities` for registered ids"
         ));
     }
     if enabled == Some(false) {
@@ -365,6 +381,16 @@ mod tests {
                 json!({ "enable_file_download": true }),
             ),
         ]
+    }
+
+    #[test]
+    fn capability_catalog_list_returns_sorted_entries() {
+        let mut catalog = CapabilityCatalog::new();
+        catalog.register_arc(Arc::new(MessageMetadataCapability));
+        let list = capability_catalog_list(&catalog);
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0]["id"], MESSAGE_METADATA_CAPABILITY_ID);
+        assert!(list[0]["config_schema"].is_object());
     }
 
     #[test]

--- a/src/capability_settings.rs
+++ b/src/capability_settings.rs
@@ -1,0 +1,398 @@
+//! Persisted harness capability overrides in `settings.toml`.
+//!
+//! The default coding harness is fixed at compile time; `[capabilities]` entries
+//! let users add optional capabilities, disable defaults, or override per-capability
+//! JSON config. Overrides are validated through each capability's
+//! `validate_config` before persisting.
+
+use everruns_core::capabilities::Capability;
+use everruns_core::{AgentCapabilityConfig, CapabilityInfo};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+use toml::Table;
+use toml::Value as TomlValue;
+
+/// Read-only view of registered capabilities for schema lookup and validation.
+pub struct CapabilityCatalog {
+    capabilities: HashMap<String, Arc<dyn Capability>>,
+}
+
+impl CapabilityCatalog {
+    pub fn new() -> Self {
+        Self {
+            capabilities: HashMap::new(),
+        }
+    }
+
+    pub fn register_arc(&mut self, capability: Arc<dyn Capability>) {
+        self.capabilities
+            .insert(capability.id().to_string(), capability);
+    }
+
+    pub fn get(&self, id: &str) -> Option<&Arc<dyn Capability>> {
+        self.capabilities.get(id)
+    }
+
+    pub fn list(&self) -> impl Iterator<Item = &Arc<dyn Capability>> {
+        self.capabilities.values()
+    }
+
+    pub fn has(&self, id: &str) -> bool {
+        self.capabilities.contains_key(id)
+    }
+
+    pub fn validate(&self, id: &str, config: &Value) -> Result<(), String> {
+        let cap = self
+            .get(id)
+            .ok_or_else(|| format!("unknown capability `{id}`; not registered in yolop"))?;
+        cap.validate_config(config)
+    }
+}
+
+/// One persisted capability override under `[capabilities.<id>]` in settings.toml.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct CapabilitySetting {
+    /// `Some(false)` removes the capability from the harness. `Some(true)` forces
+    /// it on even when absent from defaults. `None` inherits default presence unless
+    /// `config` is non-empty (which implies an explicit override).
+    pub enabled: Option<bool>,
+    /// Per-capability JSON config merged over the harness default.
+    pub config: Value,
+}
+
+impl CapabilitySetting {
+    pub fn disabled() -> Self {
+        Self {
+            enabled: Some(false),
+            config: Value::Null,
+        }
+    }
+
+    pub fn is_explicitly_disabled(&self) -> bool {
+        self.enabled == Some(false)
+    }
+}
+
+pub fn parse_capabilities_table(table: &Table) -> BTreeMap<String, CapabilitySetting> {
+    let mut capabilities = BTreeMap::new();
+    let Some(caps) = table.get("capabilities").and_then(TomlValue::as_table) else {
+        return capabilities;
+    };
+    for (id, entry) in caps {
+        let Some(entry_table) = entry.as_table() else {
+            continue;
+        };
+        let enabled = entry_table.get("enabled").and_then(TomlValue::as_bool);
+        let mut config_table = entry_table.clone();
+        config_table.remove("enabled");
+        let config = if config_table.is_empty() {
+            Value::Null
+        } else {
+            toml_value_to_json(&TomlValue::Table(config_table))
+        };
+        capabilities.insert(id.clone(), CapabilitySetting { enabled, config });
+    }
+    capabilities
+}
+
+pub fn capabilities_to_table(capabilities: &BTreeMap<String, CapabilitySetting>) -> Table {
+    let mut caps = Table::new();
+    for (id, setting) in capabilities {
+        if setting.enabled.is_none() && setting.config.is_null() {
+            continue;
+        }
+        let mut entry = Table::new();
+        if let Some(enabled) = setting.enabled {
+            entry.insert("enabled".to_string(), TomlValue::Boolean(enabled));
+        }
+        if let TomlValue::Table(config) = json_to_toml(&setting.config) {
+            for (k, v) in config {
+                entry.insert(k, v);
+            }
+        }
+        if !entry.is_empty() {
+            caps.insert(id.clone(), TomlValue::Table(entry));
+        }
+    }
+    caps
+}
+
+fn toml_value_to_json(value: &TomlValue) -> Value {
+    match value {
+        TomlValue::String(s) => Value::String(s.clone()),
+        TomlValue::Integer(i) => json!(*i),
+        TomlValue::Float(f) => json!(*f),
+        TomlValue::Boolean(b) => Value::Bool(*b),
+        TomlValue::Datetime(dt) => Value::String(dt.to_string()),
+        TomlValue::Array(items) => Value::Array(items.iter().map(toml_value_to_json).collect()),
+        TomlValue::Table(table) => {
+            let mut map = serde_json::Map::new();
+            for (k, v) in table {
+                map.insert(k.clone(), toml_value_to_json(v));
+            }
+            Value::Object(map)
+        }
+    }
+}
+
+fn json_to_toml(value: &Value) -> TomlValue {
+    match value {
+        Value::Null => TomlValue::Table(Table::new()),
+        Value::Bool(b) => TomlValue::Boolean(*b),
+        Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                TomlValue::Integer(i)
+            } else if let Some(f) = n.as_f64() {
+                TomlValue::Float(f)
+            } else {
+                TomlValue::String(n.to_string())
+            }
+        }
+        Value::String(s) => TomlValue::String(s.clone()),
+        Value::Array(items) => TomlValue::Array(items.iter().map(json_to_toml).collect()),
+        Value::Object(map) => {
+            let mut table = Table::new();
+            for (k, v) in map {
+                if v.is_null() {
+                    continue;
+                }
+                table.insert(k.clone(), json_to_toml(v));
+            }
+            TomlValue::Table(table)
+        }
+    }
+}
+
+/// Merge user overrides into the compile-time default harness list.
+pub fn apply_capability_settings(
+    defaults: Vec<AgentCapabilityConfig>,
+    settings: &BTreeMap<String, CapabilitySetting>,
+) -> Vec<AgentCapabilityConfig> {
+    let mut by_id: BTreeMap<String, AgentCapabilityConfig> = defaults
+        .into_iter()
+        .map(|cap| (cap.capability_id().to_string(), cap))
+        .collect();
+
+    for (id, setting) in settings {
+        if setting.is_explicitly_disabled() {
+            by_id.remove(id);
+            continue;
+        }
+        match by_id.get_mut(id) {
+            Some(existing) => {
+                existing.config = merge_config(&existing.config, &setting.config);
+            }
+            None => {
+                by_id.insert(
+                    id.clone(),
+                    AgentCapabilityConfig::with_config(id.clone(), setting.config.clone()),
+                );
+            }
+        }
+    }
+
+    by_id.into_values().collect()
+}
+
+fn merge_config(default: &Value, override_config: &Value) -> Value {
+    if override_config.is_null() {
+        return default.clone();
+    }
+    match (default, override_config) {
+        (Value::Object(base), Value::Object(over)) => {
+            let mut merged = base.clone();
+            for (k, v) in over {
+                merged.insert(k.clone(), v.clone());
+            }
+            Value::Object(merged)
+        }
+        (_, over) => over.clone(),
+    }
+}
+
+pub fn effective_config(default: &Value, stored: &CapabilitySetting) -> Value {
+    if stored.is_explicitly_disabled() {
+        return Value::Null;
+    }
+    merge_config(default, &stored.config)
+}
+
+pub fn capability_entry_json(
+    catalog: &CapabilityCatalog,
+    id: &str,
+    default: Option<&AgentCapabilityConfig>,
+    stored: Option<&CapabilitySetting>,
+) -> Result<Value, String> {
+    let cap = catalog
+        .get(id)
+        .ok_or_else(|| format!("unknown capability `{id}`"))?;
+    let info = CapabilityInfo::from_core(cap.as_ref());
+    let default_config = default.map(|d| d.config.clone()).unwrap_or(json!({}));
+    let stored_setting = stored.cloned().unwrap_or_default();
+    let enabled = if stored_setting.is_explicitly_disabled() {
+        false
+    } else {
+        default.is_some()
+            || stored_setting.enabled == Some(true)
+            || !stored_setting.config.is_null()
+    };
+    Ok(json!({
+        "id": id,
+        "name": info.name,
+        "description": info.description,
+        "category": info.category,
+        "default_in_harness": default.is_some(),
+        "enabled": enabled,
+        "config_schema": info.config_schema,
+        "config_ui_schema": info.config_ui_schema,
+        "config_description": cap.describe_schema(None),
+        "default_config": default_config,
+        "stored": stored_setting,
+        "current_config": effective_config(&default_config, &stored_setting),
+        "note": "Changes apply on the next run. Use `set_capability` to add, remove, or reconfigure.",
+    }))
+}
+
+pub fn validate_capability_mutation(
+    catalog: &CapabilityCatalog,
+    id: &str,
+    enabled: Option<bool>,
+    config: Option<&Value>,
+    defaults: &[AgentCapabilityConfig],
+    stored: &BTreeMap<String, CapabilitySetting>,
+) -> Result<CapabilitySetting, String> {
+    if !catalog.has(id) {
+        return Err(format!(
+            "unknown capability `{id}`; call `get_capabilities` for registered ids"
+        ));
+    }
+    if enabled == Some(false) {
+        return Ok(CapabilitySetting::disabled());
+    }
+    let default = defaults.iter().find(|c| c.capability_id() == id);
+    let prior = stored.get(id);
+    let merged_config = match (config, prior) {
+        (Some(new), Some(old)) if !new.is_null() => merge_config(&old.config, new),
+        (Some(new), None) if !new.is_null() => {
+            let base = default.map(|d| d.config.clone()).unwrap_or(json!({}));
+            merge_config(&base, new)
+        }
+        (Some(new), _) if !new.is_null() => new.clone(),
+        (_, Some(old)) => old.config.clone(),
+        _ => default.map(|d| d.config.clone()).unwrap_or(json!({})),
+    };
+    catalog.validate(id, &merged_config)?;
+    let stored_enabled = match enabled {
+        Some(true) => Some(true),
+        Some(false) => Some(false),
+        None if prior.is_some_and(|p| p.enabled == Some(true)) => Some(true),
+        None if config.is_some() => None,
+        None => Some(true),
+    };
+    Ok(CapabilitySetting {
+        enabled: stored_enabled,
+        config: merged_config,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::capabilities::{MESSAGE_METADATA_CAPABILITY_ID, MessageMetadataCapability};
+
+    fn defaults() -> Vec<AgentCapabilityConfig> {
+        vec![AgentCapabilityConfig::with_config(
+            "web_fetch",
+            json!({ "enable_file_download": true }),
+        )]
+    }
+
+    #[test]
+    fn apply_adds_optional_capability() {
+        let mut settings = BTreeMap::new();
+        settings.insert(
+            MESSAGE_METADATA_CAPABILITY_ID.to_string(),
+            CapabilitySetting {
+                enabled: Some(true),
+                config: json!({ "fields": ["timestamp"] }),
+            },
+        );
+        let resolved = apply_capability_settings(defaults(), &settings);
+        assert!(
+            resolved
+                .iter()
+                .any(|c| c.capability_id() == MESSAGE_METADATA_CAPABILITY_ID)
+        );
+    }
+
+    #[test]
+    fn apply_removes_disabled_default() {
+        let mut settings = BTreeMap::new();
+        settings.insert("web_fetch".to_string(), CapabilitySetting::disabled());
+        let resolved = apply_capability_settings(defaults(), &settings);
+        assert!(!resolved.iter().any(|c| c.capability_id() == "web_fetch"));
+    }
+
+    #[test]
+    fn apply_merges_config_over_default() {
+        let mut settings = BTreeMap::new();
+        settings.insert(
+            "web_fetch".to_string(),
+            CapabilitySetting {
+                enabled: None,
+                config: json!({ "enable_file_download": false }),
+            },
+        );
+        let resolved = apply_capability_settings(defaults(), &settings);
+        let cap = resolved
+            .iter()
+            .find(|c| c.capability_id() == "web_fetch")
+            .expect("web_fetch still enabled");
+        assert_eq!(cap.config["enable_file_download"], false);
+    }
+
+    #[test]
+    fn capabilities_table_roundtrip() {
+        let mut capabilities = BTreeMap::new();
+        capabilities.insert(
+            MESSAGE_METADATA_CAPABILITY_ID.to_string(),
+            CapabilitySetting {
+                enabled: Some(true),
+                config: json!({ "fields": ["timestamp"] }),
+            },
+        );
+        capabilities.insert("duckduckgo".to_string(), CapabilitySetting::disabled());
+
+        let mut table = Table::new();
+        let caps = capabilities_to_table(&capabilities);
+        table.insert("capabilities".to_string(), TomlValue::Table(caps));
+
+        let parsed = parse_capabilities_table(&table);
+        assert_eq!(parsed, capabilities);
+    }
+
+    #[test]
+    fn validate_rejects_bad_message_metadata_config() {
+        let mut catalog = CapabilityCatalog::new();
+        catalog.register_arc(Arc::new(MessageMetadataCapability));
+        let err = catalog
+            .validate(
+                MESSAGE_METADATA_CAPABILITY_ID,
+                &json!({ "fields": ["llm_model"] }),
+            )
+            .unwrap_err();
+        assert!(err.contains("invalid message_metadata config"), "{err}");
+    }
+
+    #[test]
+    fn capability_entry_json_includes_schema() {
+        let mut catalog = CapabilityCatalog::new();
+        catalog.register_arc(Arc::new(MessageMetadataCapability));
+        let entry = capability_entry_json(&catalog, MESSAGE_METADATA_CAPABILITY_ID, None, None)
+            .expect("entry");
+        assert!(entry["config_schema"].is_object());
+        assert_eq!(entry["enabled"], false);
+    }
+}

--- a/src/capability_settings.rs
+++ b/src/capability_settings.rs
@@ -38,10 +38,6 @@ impl CapabilityCatalog {
         self.capabilities.get(id)
     }
 
-    pub fn list(&self) -> impl Iterator<Item = &Arc<dyn Capability>> {
-        self.capabilities.values()
-    }
-
     pub fn has(&self, id: &str) -> bool {
         self.capabilities.contains_key(id)
     }
@@ -94,11 +90,6 @@ pub fn parse_capabilities_table(table: &Table) -> Vec<CapabilityOverride> {
 
     match raw {
         TomlValue::Array(items) => items.iter().filter_map(parse_capability_entry).collect(),
-        // Legacy map form `[capabilities.<id>]` — converted to an ordered list.
-        TomlValue::Table(map) => map
-            .iter()
-            .filter_map(|(id, value)| parse_legacy_capability_entry(id, value))
-            .collect(),
         _ => Vec::new(),
     }
 }
@@ -132,20 +123,45 @@ fn parse_capability_entry(value: &TomlValue) -> Option<CapabilityOverride> {
     })
 }
 
-fn parse_legacy_capability_entry(id: &str, value: &TomlValue) -> Option<CapabilityOverride> {
-    let entry = value.as_table()?;
-    let enabled = entry.get("enabled").and_then(TomlValue::as_bool);
-    let mut config_table = entry.clone();
-    config_table.remove("enabled");
-    let config = if config_table.is_empty() {
+pub fn overrides_to_json(overrides: &[CapabilityOverride]) -> Value {
+    Value::Array(
+        overrides
+            .iter()
+            .enumerate()
+            .map(|(index, entry)| stored_override_json(index, entry))
+            .collect(),
+    )
+}
+
+pub fn parse_override_from_json(value: &Value) -> Result<CapabilityOverride, String> {
+    let obj = value
+        .as_object()
+        .ok_or_else(|| "capabilities override must be a JSON object".to_string())?;
+    let capability_ref = obj
+        .get("ref")
+        .or_else(|| obj.get("id"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| "override object requires `ref`".to_string())?
+        .trim()
+        .to_string();
+    if capability_ref.is_empty() {
+        return Err("override `ref` must not be empty".to_string());
+    }
+    let enabled = obj.get("enabled").and_then(Value::as_bool);
+    let append = obj.get("append").and_then(Value::as_bool).unwrap_or(false);
+    let mut config = obj.clone();
+    for key in ["ref", "id", "enabled", "append"] {
+        config.remove(key);
+    }
+    let config = if config.is_empty() {
         Value::Null
     } else {
-        toml_value_to_json(&TomlValue::Table(config_table))
+        Value::Object(config)
     };
-    Some(CapabilityOverride {
-        capability_ref: id.to_string(),
+    Ok(CapabilityOverride {
+        capability_ref,
         enabled,
-        append: false,
+        append,
         config,
     })
 }
@@ -442,35 +458,6 @@ mod tests {
 
         let parsed = parse_capabilities_table(&table);
         assert_eq!(parsed, overrides);
-    }
-
-    #[test]
-    fn legacy_map_form_is_converted_to_list() {
-        let mut legacy = Table::new();
-        let mut message = Table::new();
-        message.insert(
-            "fields".to_string(),
-            TomlValue::Array(vec![TomlValue::String("timestamp".to_string())]),
-        );
-        legacy.insert(
-            MESSAGE_METADATA_CAPABILITY_ID.to_string(),
-            TomlValue::Table(message),
-        );
-        let mut duck = Table::new();
-        duck.insert("enabled".to_string(), TomlValue::Boolean(false));
-        legacy.insert("duckduckgo".to_string(), TomlValue::Table(duck));
-
-        let mut table = Table::new();
-        table.insert("capabilities".to_string(), TomlValue::Table(legacy));
-
-        let parsed = parse_capabilities_table(&table);
-        assert_eq!(parsed.len(), 2);
-        assert!(
-            parsed
-                .iter()
-                .any(|entry| entry.capability_ref == MESSAGE_METADATA_CAPABILITY_ID)
-        );
-        assert!(parsed.iter().any(|entry| entry.is_remove()));
     }
 
     #[test]

--- a/src/capability_settings.rs
+++ b/src/capability_settings.rs
@@ -1,15 +1,18 @@
 //! Persisted harness capability overrides in `settings.toml`.
 //!
-//! The default coding harness is fixed at compile time; `[capabilities]` entries
-//! let users add optional capabilities, disable defaults, or override per-capability
-//! JSON config. Overrides are validated through each capability's
-//! `validate_config` before persisting.
+//! Overrides are stored as an ordered `[[capabilities]]` list — matching the
+//! runtime's `Vec<AgentCapabilityConfig>` — so the same capability can appear
+//! more than once with different configs. Each entry is applied in order:
+//! - `enabled = false` removes every harness instance with that `ref`
+//! - default (`append = false`) merges config into the first matching `ref`, or
+//!   appends when absent
+//! - `append = true` always appends a new harness instance (duplicates allowed)
 
 use everruns_core::capabilities::Capability;
 use everruns_core::{AgentCapabilityConfig, CapabilityInfo};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::sync::Arc;
 use toml::Table;
 use toml::Value as TomlValue;
@@ -51,72 +54,125 @@ impl CapabilityCatalog {
     }
 }
 
-/// One persisted capability override under `[capabilities.<id>]` in settings.toml.
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
-pub struct CapabilitySetting {
-    /// `Some(false)` removes the capability from the harness. `Some(true)` forces
-    /// it on even when absent from defaults. `None` inherits default presence unless
-    /// `config` is non-empty (which implies an explicit override).
+/// One ordered harness override under `[[capabilities]]` in settings.toml.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilityOverride {
+    /// Capability id (`ref` on disk, matching `AgentCapabilityConfig`).
+    #[serde(rename = "ref")]
+    pub capability_ref: String,
+    /// When `false`, removes every harness instance with this `ref`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
-    /// Per-capability JSON config merged over the harness default.
+    /// When `true`, always append a new harness instance instead of merging into
+    /// the first matching `ref`.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub append: bool,
+    /// Per-capability JSON config (inline keys in TOML, or omitted when empty).
+    #[serde(default)]
     pub config: Value,
 }
 
-impl CapabilitySetting {
-    pub fn disabled() -> Self {
+impl CapabilityOverride {
+    pub fn remove(capability_ref: impl Into<String>) -> Self {
         Self {
+            capability_ref: capability_ref.into(),
             enabled: Some(false),
+            append: false,
             config: Value::Null,
         }
     }
 
-    pub fn is_explicitly_disabled(&self) -> bool {
+    pub fn is_remove(&self) -> bool {
         self.enabled == Some(false)
     }
 }
 
-pub fn parse_capabilities_table(table: &Table) -> BTreeMap<String, CapabilitySetting> {
-    let mut capabilities = BTreeMap::new();
-    let Some(caps) = table.get("capabilities").and_then(TomlValue::as_table) else {
-        return capabilities;
+pub fn parse_capabilities_table(table: &Table) -> Vec<CapabilityOverride> {
+    let Some(raw) = table.get("capabilities") else {
+        return Vec::new();
     };
-    for (id, entry) in caps {
-        let Some(entry_table) = entry.as_table() else {
-            continue;
-        };
-        let enabled = entry_table.get("enabled").and_then(TomlValue::as_bool);
-        let mut config_table = entry_table.clone();
-        config_table.remove("enabled");
-        let config = if config_table.is_empty() {
-            Value::Null
-        } else {
-            toml_value_to_json(&TomlValue::Table(config_table))
-        };
-        capabilities.insert(id.clone(), CapabilitySetting { enabled, config });
+
+    match raw {
+        TomlValue::Array(items) => items.iter().filter_map(parse_capability_entry).collect(),
+        // Legacy map form `[capabilities.<id>]` — converted to an ordered list.
+        TomlValue::Table(map) => map
+            .iter()
+            .filter_map(|(id, value)| parse_legacy_capability_entry(id, value))
+            .collect(),
+        _ => Vec::new(),
     }
-    capabilities
 }
 
-pub fn capabilities_to_table(capabilities: &BTreeMap<String, CapabilitySetting>) -> Table {
-    let mut caps = Table::new();
-    for (id, setting) in capabilities {
-        if setting.enabled.is_none() && setting.config.is_null() {
-            continue;
-        }
-        let mut entry = Table::new();
-        if let Some(enabled) = setting.enabled {
-            entry.insert("enabled".to_string(), TomlValue::Boolean(enabled));
-        }
-        if let TomlValue::Table(config) = json_to_toml(&setting.config) {
-            for (k, v) in config {
-                entry.insert(k, v);
-            }
-        }
-        if !entry.is_empty() {
-            caps.insert(id.clone(), TomlValue::Table(entry));
+fn parse_capability_entry(value: &TomlValue) -> Option<CapabilityOverride> {
+    let entry = value.as_table()?;
+    let capability_ref = entry
+        .get("ref")
+        .or_else(|| entry.get("id"))
+        .and_then(TomlValue::as_str)?
+        .to_string();
+    let enabled = entry.get("enabled").and_then(TomlValue::as_bool);
+    let append = entry
+        .get("append")
+        .and_then(TomlValue::as_bool)
+        .unwrap_or(false);
+    let mut config_table = entry.clone();
+    for key in ["ref", "id", "enabled", "append"] {
+        config_table.remove(key);
+    }
+    let config = if config_table.is_empty() {
+        Value::Null
+    } else {
+        toml_value_to_json(&TomlValue::Table(config_table))
+    };
+    Some(CapabilityOverride {
+        capability_ref,
+        enabled,
+        append,
+        config,
+    })
+}
+
+fn parse_legacy_capability_entry(id: &str, value: &TomlValue) -> Option<CapabilityOverride> {
+    let entry = value.as_table()?;
+    let enabled = entry.get("enabled").and_then(TomlValue::as_bool);
+    let mut config_table = entry.clone();
+    config_table.remove("enabled");
+    let config = if config_table.is_empty() {
+        Value::Null
+    } else {
+        toml_value_to_json(&TomlValue::Table(config_table))
+    };
+    Some(CapabilityOverride {
+        capability_ref: id.to_string(),
+        enabled,
+        append: false,
+        config,
+    })
+}
+
+pub fn capabilities_to_toml(overrides: &[CapabilityOverride]) -> TomlValue {
+    let items: Vec<TomlValue> = overrides.iter().map(override_to_toml).collect();
+    TomlValue::Array(items)
+}
+
+fn override_to_toml(entry: &CapabilityOverride) -> TomlValue {
+    let mut table = Table::new();
+    table.insert(
+        "ref".to_string(),
+        TomlValue::String(entry.capability_ref.clone()),
+    );
+    if let Some(enabled) = entry.enabled {
+        table.insert("enabled".to_string(), TomlValue::Boolean(enabled));
+    }
+    if entry.append {
+        table.insert("append".to_string(), TomlValue::Boolean(true));
+    }
+    if let TomlValue::Table(config) = json_to_toml(&entry.config) {
+        for (k, v) in config {
+            table.insert(k, v);
         }
     }
-    caps
+    TomlValue::Table(table)
 }
 
 fn toml_value_to_json(value: &TomlValue) -> Value {
@@ -165,35 +221,37 @@ fn json_to_toml(value: &Value) -> TomlValue {
     }
 }
 
-/// Merge user overrides into the compile-time default harness list.
+/// Apply ordered user overrides to the compile-time default harness list.
 pub fn apply_capability_settings(
     defaults: Vec<AgentCapabilityConfig>,
-    settings: &BTreeMap<String, CapabilitySetting>,
+    overrides: &[CapabilityOverride],
 ) -> Vec<AgentCapabilityConfig> {
-    let mut by_id: BTreeMap<String, AgentCapabilityConfig> = defaults
-        .into_iter()
-        .map(|cap| (cap.capability_id().to_string(), cap))
-        .collect();
-
-    for (id, setting) in settings {
-        if setting.is_explicitly_disabled() {
-            by_id.remove(id);
+    let mut caps = defaults;
+    for entry in overrides {
+        if entry.is_remove() {
+            caps.retain(|cap| cap.capability_id() != entry.capability_ref);
             continue;
         }
-        match by_id.get_mut(id) {
-            Some(existing) => {
-                existing.config = merge_config(&existing.config, &setting.config);
-            }
-            None => {
-                by_id.insert(
-                    id.clone(),
-                    AgentCapabilityConfig::with_config(id.clone(), setting.config.clone()),
-                );
-            }
+        if entry.append {
+            caps.push(AgentCapabilityConfig::with_config(
+                entry.capability_ref.clone(),
+                entry.config.clone(),
+            ));
+            continue;
+        }
+        if let Some(existing) = caps
+            .iter_mut()
+            .find(|cap| cap.capability_id() == entry.capability_ref)
+        {
+            existing.config = merge_config(&existing.config, &entry.config);
+        } else {
+            caps.push(AgentCapabilityConfig::with_config(
+                entry.capability_ref.clone(),
+                entry.config.clone(),
+            ));
         }
     }
-
-    by_id.into_values().collect()
+    caps
 }
 
 fn merge_config(default: &Value, override_config: &Value) -> Value {
@@ -212,88 +270,69 @@ fn merge_config(default: &Value, override_config: &Value) -> Value {
     }
 }
 
-pub fn effective_config(default: &Value, stored: &CapabilitySetting) -> Value {
-    if stored.is_explicitly_disabled() {
-        return Value::Null;
-    }
-    merge_config(default, &stored.config)
-}
-
-pub fn capability_entry_json(
-    catalog: &CapabilityCatalog,
-    id: &str,
-    default: Option<&AgentCapabilityConfig>,
-    stored: Option<&CapabilitySetting>,
-) -> Result<Value, String> {
+pub fn capability_catalog_json(catalog: &CapabilityCatalog, id: &str) -> Result<Value, String> {
     let cap = catalog
         .get(id)
         .ok_or_else(|| format!("unknown capability `{id}`"))?;
     let info = CapabilityInfo::from_core(cap.as_ref());
-    let default_config = default.map(|d| d.config.clone()).unwrap_or(json!({}));
-    let stored_setting = stored.cloned().unwrap_or_default();
-    let enabled = if stored_setting.is_explicitly_disabled() {
-        false
-    } else {
-        default.is_some()
-            || stored_setting.enabled == Some(true)
-            || !stored_setting.config.is_null()
-    };
     Ok(json!({
         "id": id,
         "name": info.name,
         "description": info.description,
         "category": info.category,
-        "default_in_harness": default.is_some(),
-        "enabled": enabled,
         "config_schema": info.config_schema,
         "config_ui_schema": info.config_ui_schema,
         "config_description": cap.describe_schema(None),
-        "default_config": default_config,
-        "stored": stored_setting,
-        "current_config": effective_config(&default_config, &stored_setting),
-        "note": "Changes apply on the next run. Use `set_capability` to add, remove, or reconfigure.",
     }))
 }
 
-pub fn validate_capability_mutation(
+pub fn stored_override_json(index: usize, entry: &CapabilityOverride) -> Value {
+    json!({
+        "index": index,
+        "ref": entry.capability_ref,
+        "enabled": entry.enabled,
+        "append": entry.append,
+        "config": entry.config,
+    })
+}
+
+pub fn effective_harness_json(caps: &[AgentCapabilityConfig]) -> Vec<Value> {
+    caps.iter()
+        .enumerate()
+        .map(|(index, cap)| {
+            json!({
+                "index": index,
+                "ref": cap.capability_id(),
+                "config": cap.config,
+            })
+        })
+        .collect()
+}
+
+pub fn build_capability_override(
     catalog: &CapabilityCatalog,
-    id: &str,
+    capability_ref: &str,
     enabled: Option<bool>,
+    append: bool,
     config: Option<&Value>,
-    defaults: &[AgentCapabilityConfig],
-    stored: &BTreeMap<String, CapabilitySetting>,
-) -> Result<CapabilitySetting, String> {
-    if !catalog.has(id) {
+) -> Result<CapabilityOverride, String> {
+    if !catalog.has(capability_ref) {
         return Err(format!(
-            "unknown capability `{id}`; call `get_capabilities` for registered ids"
+            "unknown capability `{capability_ref}`; call `get_capabilities` for registered ids"
         ));
     }
     if enabled == Some(false) {
-        return Ok(CapabilitySetting::disabled());
+        return Ok(CapabilityOverride::remove(capability_ref));
     }
-    let default = defaults.iter().find(|c| c.capability_id() == id);
-    let prior = stored.get(id);
-    let merged_config = match (config, prior) {
-        (Some(new), Some(old)) if !new.is_null() => merge_config(&old.config, new),
-        (Some(new), None) if !new.is_null() => {
-            let base = default.map(|d| d.config.clone()).unwrap_or(json!({}));
-            merge_config(&base, new)
-        }
-        (Some(new), _) if !new.is_null() => new.clone(),
-        (_, Some(old)) => old.config.clone(),
-        _ => default.map(|d| d.config.clone()).unwrap_or(json!({})),
-    };
-    catalog.validate(id, &merged_config)?;
-    let stored_enabled = match enabled {
-        Some(true) => Some(true),
-        Some(false) => Some(false),
-        None if prior.is_some_and(|p| p.enabled == Some(true)) => Some(true),
-        None if config.is_some() => None,
-        None => Some(true),
-    };
-    Ok(CapabilitySetting {
-        enabled: stored_enabled,
-        config: merged_config,
+    let config = config.cloned().unwrap_or(Value::Null);
+    if !config.is_null() {
+        catalog.validate(capability_ref, &config)?;
+    }
+    Ok(CapabilityOverride {
+        capability_ref: capability_ref.to_string(),
+        enabled,
+        append,
+        config,
     })
 }
 
@@ -303,23 +342,24 @@ mod tests {
     use everruns_core::capabilities::{MESSAGE_METADATA_CAPABILITY_ID, MessageMetadataCapability};
 
     fn defaults() -> Vec<AgentCapabilityConfig> {
-        vec![AgentCapabilityConfig::with_config(
-            "web_fetch",
-            json!({ "enable_file_download": true }),
-        )]
+        vec![
+            AgentCapabilityConfig::new("duckduckgo"),
+            AgentCapabilityConfig::with_config(
+                "web_fetch",
+                json!({ "enable_file_download": true }),
+            ),
+        ]
     }
 
     #[test]
     fn apply_adds_optional_capability() {
-        let mut settings = BTreeMap::new();
-        settings.insert(
-            MESSAGE_METADATA_CAPABILITY_ID.to_string(),
-            CapabilitySetting {
-                enabled: Some(true),
-                config: json!({ "fields": ["timestamp"] }),
-            },
-        );
-        let resolved = apply_capability_settings(defaults(), &settings);
+        let overrides = vec![CapabilityOverride {
+            capability_ref: MESSAGE_METADATA_CAPABILITY_ID.to_string(),
+            enabled: Some(true),
+            append: false,
+            config: json!({ "fields": ["timestamp"] }),
+        }];
+        let resolved = apply_capability_settings(defaults(), &overrides);
         assert!(
             resolved
                 .iter()
@@ -328,24 +368,30 @@ mod tests {
     }
 
     #[test]
-    fn apply_removes_disabled_default() {
-        let mut settings = BTreeMap::new();
-        settings.insert("web_fetch".to_string(), CapabilitySetting::disabled());
-        let resolved = apply_capability_settings(defaults(), &settings);
-        assert!(!resolved.iter().any(|c| c.capability_id() == "web_fetch"));
+    fn apply_removes_all_instances_with_ref() {
+        let mut base = defaults();
+        base.push(AgentCapabilityConfig::new("duckduckgo"));
+        let overrides = vec![CapabilityOverride::remove("duckduckgo")];
+        let resolved = apply_capability_settings(base, &overrides);
+        assert!(!resolved.iter().any(|c| c.capability_id() == "duckduckgo"));
     }
 
     #[test]
-    fn apply_merges_config_over_default() {
-        let mut settings = BTreeMap::new();
-        settings.insert(
-            "web_fetch".to_string(),
-            CapabilitySetting {
-                enabled: None,
-                config: json!({ "enable_file_download": false }),
-            },
+    fn apply_merges_config_into_first_match() {
+        let overrides = vec![CapabilityOverride {
+            capability_ref: "web_fetch".to_string(),
+            enabled: None,
+            append: false,
+            config: json!({ "enable_file_download": false }),
+        }];
+        let resolved = apply_capability_settings(defaults(), &overrides);
+        assert_eq!(
+            resolved
+                .iter()
+                .filter(|c| c.capability_id() == "web_fetch")
+                .count(),
+            1
         );
-        let resolved = apply_capability_settings(defaults(), &settings);
         let cap = resolved
             .iter()
             .find(|c| c.capability_id() == "web_fetch")
@@ -354,23 +400,77 @@ mod tests {
     }
 
     #[test]
-    fn capabilities_table_roundtrip() {
-        let mut capabilities = BTreeMap::new();
-        capabilities.insert(
-            MESSAGE_METADATA_CAPABILITY_ID.to_string(),
-            CapabilitySetting {
+    fn apply_append_allows_duplicate_refs() {
+        let overrides = vec![
+            CapabilityOverride {
+                capability_ref: "duckduckgo".to_string(),
+                enabled: None,
+                append: true,
+                config: json!({}),
+            },
+            CapabilityOverride {
+                capability_ref: "duckduckgo".to_string(),
+                enabled: None,
+                append: true,
+                config: json!({}),
+            },
+        ];
+        let resolved = apply_capability_settings(defaults(), &overrides);
+        assert_eq!(
+            resolved
+                .iter()
+                .filter(|c| c.capability_id() == "duckduckgo")
+                .count(),
+            3
+        );
+    }
+
+    #[test]
+    fn capabilities_array_roundtrip() {
+        let overrides = vec![
+            CapabilityOverride {
+                capability_ref: MESSAGE_METADATA_CAPABILITY_ID.to_string(),
                 enabled: Some(true),
+                append: false,
                 config: json!({ "fields": ["timestamp"] }),
             },
-        );
-        capabilities.insert("duckduckgo".to_string(), CapabilitySetting::disabled());
+            CapabilityOverride::remove("duckduckgo"),
+        ];
 
         let mut table = Table::new();
-        let caps = capabilities_to_table(&capabilities);
-        table.insert("capabilities".to_string(), TomlValue::Table(caps));
+        table.insert("capabilities".to_string(), capabilities_to_toml(&overrides));
 
         let parsed = parse_capabilities_table(&table);
-        assert_eq!(parsed, capabilities);
+        assert_eq!(parsed, overrides);
+    }
+
+    #[test]
+    fn legacy_map_form_is_converted_to_list() {
+        let mut legacy = Table::new();
+        let mut message = Table::new();
+        message.insert(
+            "fields".to_string(),
+            TomlValue::Array(vec![TomlValue::String("timestamp".to_string())]),
+        );
+        legacy.insert(
+            MESSAGE_METADATA_CAPABILITY_ID.to_string(),
+            TomlValue::Table(message),
+        );
+        let mut duck = Table::new();
+        duck.insert("enabled".to_string(), TomlValue::Boolean(false));
+        legacy.insert("duckduckgo".to_string(), TomlValue::Table(duck));
+
+        let mut table = Table::new();
+        table.insert("capabilities".to_string(), TomlValue::Table(legacy));
+
+        let parsed = parse_capabilities_table(&table);
+        assert_eq!(parsed.len(), 2);
+        assert!(
+            parsed
+                .iter()
+                .any(|entry| entry.capability_ref == MESSAGE_METADATA_CAPABILITY_ID)
+        );
+        assert!(parsed.iter().any(|entry| entry.is_remove()));
     }
 
     #[test]
@@ -384,15 +484,5 @@ mod tests {
             )
             .unwrap_err();
         assert!(err.contains("invalid message_metadata config"), "{err}");
-    }
-
-    #[test]
-    fn capability_entry_json_includes_schema() {
-        let mut catalog = CapabilityCatalog::new();
-        catalog.register_arc(Arc::new(MessageMetadataCapability));
-        let entry = capability_entry_json(&catalog, MESSAGE_METADATA_CAPABILITY_ID, None, None)
-            .expect("entry");
-        assert!(entry["config_schema"].is_object());
-        assert_eq!(entry["enabled"], false);
     }
 }

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -27,6 +27,8 @@ pub enum ValueKind {
     /// A secret string (an API token). `get_config` never echoes the value,
     /// only whether one is stored.
     Secret,
+    /// An ordered list (harness capability overrides).
+    List,
 }
 
 impl ValueKind {
@@ -35,6 +37,7 @@ impl ValueKind {
             ValueKind::Text => "text",
             ValueKind::Bool => "bool",
             ValueKind::Secret => "secret",
+            ValueKind::List => "list",
         }
     }
 }
@@ -149,6 +152,26 @@ pub fn schema() -> &'static [ConfigField] {
             examples: &["on", "off"],
             provider_scoped: false,
         },
+        ConfigField {
+            key: "capabilities",
+            aliases: &["capability"],
+            title: "Harness capabilities",
+            description: "Ordered `[[capabilities]]` overrides applied on top of the default \
+                          harness. Each entry has a `ref` (capability id), optional \
+                          `enabled=false` to remove every instance with that ref, optional \
+                          `append=true` to add a duplicate instance, and capability-specific \
+                          config keys validated via `config_schema` / `validate_config`. Use \
+                          `get_config key=capabilities.<ref>` for per-capability schema \
+                          metadata. Append entries with `set_config key=capabilities json=…`; \
+                          pass `value=clear` to drop all stored overrides.",
+            kind: ValueKind::List,
+            default: None,
+            examples: &[
+                "capabilities.message_metadata",
+                "set_config key=capabilities json={\"ref\":\"message_metadata\",\"config\":{\"fields\":[\"timestamp\"]}}",
+            ],
+            provider_scoped: true,
+        },
     ];
     FIELDS
 }
@@ -167,6 +190,10 @@ pub enum KeyTarget {
     Token(String),
     /// Per-provider endpoint base URL.
     BaseUrl(String),
+    /// The ordered `[[capabilities]]` override list.
+    Capabilities,
+    /// Catalog metadata for one harness capability ref (`capabilities.<ref>`).
+    CapabilityRef(String),
 }
 
 impl KeyTarget {
@@ -180,6 +207,7 @@ impl KeyTarget {
             KeyTarget::Model(_) => "models",
             KeyTarget::Token(_) => "tokens",
             KeyTarget::BaseUrl(_) => "base_urls",
+            KeyTarget::Capabilities | KeyTarget::CapabilityRef(_) => "capabilities",
         };
         schema()
             .iter()
@@ -229,6 +257,13 @@ pub fn parse_key(input: &str) -> Result<KeyTarget, String> {
         "models" | "model_for" => scoped(KeyTarget::Model),
         "tokens" | "token" => scoped(KeyTarget::Token),
         "base_urls" | "base_url" | "url" => scoped(KeyTarget::BaseUrl),
+        "capabilities" | "capability" => {
+            if let Some(cap_ref) = sub.filter(|s| !s.is_empty()) {
+                Ok(KeyTarget::CapabilityRef(cap_ref.to_string()))
+            } else {
+                Ok(KeyTarget::Capabilities)
+            }
+        }
         _ => Err(format!(
             "unknown config key `{input}`; known keys: {}",
             known_keys()
@@ -308,6 +343,15 @@ mod tests {
     }
 
     #[test]
+    fn capabilities_keys_parse() {
+        assert_eq!(parse_key("capabilities").unwrap(), KeyTarget::Capabilities);
+        assert_eq!(
+            parse_key("capabilities.message_metadata").unwrap(),
+            KeyTarget::CapabilityRef("message_metadata".to_string())
+        );
+    }
+
+    #[test]
     fn every_target_maps_to_a_field() {
         for target in [
             KeyTarget::DefaultProvider,
@@ -317,6 +361,8 @@ mod tests {
             KeyTarget::Model("openai".into()),
             KeyTarget::Token("openai".into()),
             KeyTarget::BaseUrl("custom".into()),
+            KeyTarget::Capabilities,
+            KeyTarget::CapabilityRef("message_metadata".into()),
         ] {
             let _ = target.field();
         }

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -161,7 +161,8 @@ pub fn schema() -> &'static [ConfigField] {
                           `enabled=false` to remove every instance with that ref, optional \
                           `append=true` to add a duplicate instance, and capability-specific \
                           config keys validated via `config_schema` / `validate_config`. Use \
-                          `get_config key=capabilities.<ref>` for per-capability schema \
+                          `get_config key=capabilities` for the full registered catalog, or \
+                          `get_config key=capabilities.<ref>` for one capability's schema \
                           metadata. Append entries with `set_config key=capabilities json=…`; \
                           pass `value=clear` to drop all stored overrides.",
             kind: ValueKind::List,

--- a/src/config_service.rs
+++ b/src/config_service.rs
@@ -86,6 +86,19 @@ pub(crate) fn current_value(settings: &Settings, target: &KeyTarget) -> Value {
             .base_url_for(p)
             .map(|s| Value::String(s.to_string()))
             .unwrap_or(Value::Null),
+        KeyTarget::Capabilities => {
+            crate::capability_settings::overrides_to_json(&settings.capabilities)
+        }
+        KeyTarget::CapabilityRef(cap_ref) => {
+            let stored: Vec<Value> = settings
+                .capability_overrides_for(cap_ref)
+                .into_iter()
+                .map(|(index, entry)| {
+                    crate::capability_settings::stored_override_json(index, entry)
+                })
+                .collect();
+            Value::Array(stored)
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 mod acp;
 mod app;
 mod capabilities;
+mod capability_settings;
 mod config_schema;
 mod config_service;
 mod hooks_config;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2715,17 +2715,16 @@ mod tests {
 
     #[test]
     fn harness_applies_message_metadata_from_settings() {
-        use crate::capability_settings::CapabilitySetting;
+        use crate::capability_settings::CapabilityOverride;
         use everruns_core::capabilities::MESSAGE_METADATA_CAPABILITY_ID;
 
         let mut settings = Settings::default();
-        settings.capabilities.insert(
-            MESSAGE_METADATA_CAPABILITY_ID.to_string(),
-            CapabilitySetting {
-                enabled: Some(true),
-                config: serde_json::json!({ "fields": ["timestamp"] }),
-            },
-        );
+        settings.capabilities.push(CapabilityOverride {
+            capability_ref: MESSAGE_METADATA_CAPABILITY_ID.to_string(),
+            enabled: Some(true),
+            append: false,
+            config: serde_json::json!({ "fields": ["timestamp"] }),
+        });
         let ids = coding_harness_capabilities(false, None, &settings);
         assert!(
             ids.iter()

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -22,10 +22,9 @@ use everruns_core::capabilities::{
     AGENT_INSTRUCTIONS_CAPABILITY_ID, AgentInstructionsCapability, BTW_CAPABILITY_ID,
     BtwCapability, COMPACTION_CAPABILITY_ID, CompactionCapability, FileSystemCapability,
     INFINITY_CONTEXT_CAPABILITY_ID, InfinityContextCapability, LoopDetectionCapability,
-    MessageMetadataCapability,
-    PROMPT_CACHING_CAPABILITY_ID, PromptCachingCapability, SKILLS_CAPABILITY_ID,
-    StatelessTodoListCapability, TOOL_SEARCH_CAPABILITY_ID, ToolOutputPersistenceCapability,
-    ToolSearchCapability, UserHooksCapability, WebFetchCapability,
+    MessageMetadataCapability, PROMPT_CACHING_CAPABILITY_ID, PromptCachingCapability,
+    SKILLS_CAPABILITY_ID, StatelessTodoListCapability, TOOL_SEARCH_CAPABILITY_ID,
+    ToolOutputPersistenceCapability, ToolSearchCapability, UserHooksCapability, WebFetchCapability,
 };
 use everruns_core::command::CommandDescriptor;
 use everruns_core::error::AgentLoopError;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -12,6 +12,7 @@ use crate::capabilities::{
     CodingBashCapability, CodingCliEnvironmentCapability, ConfigCapability,
     ENVIRONMENT_CONTEXT_CAPABILITY_ID, SETUP_CAPABILITY_ID, SetupCapability,
 };
+use crate::capability_settings::{CapabilityCatalog, apply_capability_settings};
 use crate::host_ui::{HostUi, TuiHandle, UiCommand};
 use crate::settings::{Settings, SettingsStore};
 use crate::tools::Workspace;
@@ -21,6 +22,7 @@ use everruns_core::capabilities::{
     AGENT_INSTRUCTIONS_CAPABILITY_ID, AgentInstructionsCapability, BTW_CAPABILITY_ID,
     BtwCapability, COMPACTION_CAPABILITY_ID, CompactionCapability, FileSystemCapability,
     INFINITY_CONTEXT_CAPABILITY_ID, InfinityContextCapability, LoopDetectionCapability,
+    MessageMetadataCapability,
     PROMPT_CACHING_CAPABILITY_ID, PromptCachingCapability, SKILLS_CAPABILITY_ID,
     StatelessTodoListCapability, TOOL_SEARCH_CAPABILITY_ID, ToolOutputPersistenceCapability,
     ToolSearchCapability, UserHooksCapability, WebFetchCapability,
@@ -997,10 +999,7 @@ pub(crate) fn normalize_reasoning_effort(reasoning_effort: Option<String>) -> Op
         .filter(|effort| !effort.is_empty())
 }
 
-fn coding_harness_capabilities(
-    client_commands: bool,
-    hook_config: Option<serde_json::Value>,
-) -> Vec<AgentCapabilityConfig> {
+fn default_coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabilityConfig> {
     let mut caps = Vec::new();
     // Terminal-side commands lead the registry so the most-typed commands
     // (/help, !shell, /clear, /quit, …) surface first in the palette. Enabled only
@@ -1060,6 +1059,22 @@ fn coding_harness_capabilities(
         AgentCapabilityConfig::new(APPROVAL_CAPABILITY_ID),
         AgentCapabilityConfig::new("yolop_bash"),
     ]);
+    caps
+}
+
+pub(crate) fn coding_harness_defaults(client_commands: bool) -> Vec<AgentCapabilityConfig> {
+    default_coding_harness_capabilities(client_commands)
+}
+
+fn coding_harness_capabilities(
+    client_commands: bool,
+    hook_config: Option<serde_json::Value>,
+    settings: &Settings,
+) -> Vec<AgentCapabilityConfig> {
+    let mut caps = apply_capability_settings(
+        default_coding_harness_capabilities(client_commands),
+        &settings.capabilities,
+    );
     if let Some(config) = hook_config {
         caps.push(AgentCapabilityConfig::with_config("user_hooks", config));
     }
@@ -1367,6 +1382,7 @@ pub async fn build_with_options(
     capabilities.register(UserHooksCapability);
     capabilities.register(DuckDuckGoCapability);
     capabilities.register(WebFetchCapability::from_env());
+    capabilities.register(MessageMetadataCapability);
     capabilities.register(CodingCliEnvironmentCapability::new(canonical_root.clone()));
     // Read-only consumer of the shared config service. `SettingsStore`
     // implements `ConfigService`, so the same handle that backs writes also
@@ -1390,11 +1406,10 @@ pub async fn build_with_options(
         settings: settings.clone(),
     });
     // Schema-described, human-friendly config editing (`get_config` /
-    // `set_config`) plus an always-on pointer into the system prompt. Persists
-    // to the same `settings.toml`; provider/model edits take effect next run.
-    capabilities.register(ConfigCapability {
-        settings: settings.clone(),
-    });
+    // `set_config`, including `key=capabilities`) plus an always-on pointer
+    // into the system prompt. Persists to the same `settings.toml`; provider/
+    // model edits take effect next run. Registered after the catalog is built
+    // (see below).
     // `memory` — global, durable, structured user memory. Its MEMORY.md lives
     // beside settings.toml in the yolop config dir, so a tempdir settings path
     // in tests isolates memory automatically. Only titles are disclosed each
@@ -1427,6 +1442,16 @@ pub async fn build_with_options(
         let ui: Arc<dyn HostUi> = Arc::new(TuiHandle::new(ui_tx));
         capabilities.register(ClientCommandsCapability::new(ui));
     }
+
+    let mut catalog = CapabilityCatalog::new();
+    for cap in capabilities.list() {
+        catalog.register_arc(cap.clone());
+    }
+
+    capabilities.register(ConfigCapability {
+        settings: settings.clone(),
+        catalog: Arc::new(catalog),
+    });
 
     let mut driver_registry = DriverRegistry::new();
     everruns_anthropic::register_driver(&mut driver_registry);
@@ -1465,8 +1490,11 @@ pub async fn build_with_options(
     // runtime owns. `session_id(...)` pins the id so resume can re-attach
     // to the same JSONL log (filename encodes the id).
     let session_title = format!("yolop @ {}", canonical_root.display());
-    let harness_capabilities =
-        coding_harness_capabilities(options.client_commands, hook_capability_config);
+    let harness_capabilities = coding_harness_capabilities(
+        options.client_commands,
+        hook_capability_config,
+        &settings_snapshot,
+    );
     let session_mcp_servers = mcp_servers.clone();
 
     let mut builder = InProcessRuntimeBuilder::new()
@@ -2686,8 +2714,28 @@ mod tests {
     }
 
     #[test]
+    fn harness_applies_message_metadata_from_settings() {
+        use crate::capability_settings::CapabilitySetting;
+        use everruns_core::capabilities::MESSAGE_METADATA_CAPABILITY_ID;
+
+        let mut settings = Settings::default();
+        settings.capabilities.insert(
+            MESSAGE_METADATA_CAPABILITY_ID.to_string(),
+            CapabilitySetting {
+                enabled: Some(true),
+                config: serde_json::json!({ "fields": ["timestamp"] }),
+            },
+        );
+        let ids = coding_harness_capabilities(false, None, &settings);
+        assert!(
+            ids.iter()
+                .any(|cap| cap.capability_id() == MESSAGE_METADATA_CAPABILITY_ID)
+        );
+    }
+
+    #[test]
     fn coding_harness_enables_tool_output_persistence() {
-        let ids = coding_harness_capabilities(false, None);
+        let ids = coding_harness_capabilities(false, None, &Settings::default());
 
         assert!(
             ids.iter()
@@ -2700,7 +2748,7 @@ mod tests {
         // Deferred tool loading must be wired for every host configuration —
         // it works on every provider, so there is no reason to scope it.
         for client_commands in [false, true] {
-            let ids = coding_harness_capabilities(client_commands, None);
+            let ids = coding_harness_capabilities(client_commands, None, &Settings::default());
             assert!(
                 ids.iter()
                     .any(|cap| cap.capability_id() == TOOL_SEARCH_CAPABILITY_ID),
@@ -2744,7 +2792,7 @@ mod tests {
 
     #[test]
     fn coding_harness_enables_loop_detection() {
-        let ids = coding_harness_capabilities(false, None);
+        let ids = coding_harness_capabilities(false, None, &Settings::default());
 
         assert!(
             ids.iter()
@@ -2754,7 +2802,7 @@ mod tests {
 
     #[test]
     fn coding_harness_enables_yolop_attribution() {
-        let ids = coding_harness_capabilities(false, None);
+        let ids = coding_harness_capabilities(false, None, &Settings::default());
 
         assert!(
             ids.iter()
@@ -2764,7 +2812,7 @@ mod tests {
 
     #[test]
     fn coding_harness_gates_client_commands_on_flag() {
-        let without = coding_harness_capabilities(false, None);
+        let without = coding_harness_capabilities(false, None, &Settings::default());
         assert!(
             !without
                 .iter()
@@ -2772,7 +2820,7 @@ mod tests {
             "client commands must stay off for hosts that can't apply them"
         );
 
-        let with = coding_harness_capabilities(true, None);
+        let with = coding_harness_capabilities(true, None, &Settings::default());
         assert!(
             with.iter()
                 .any(|cap| cap.capability_id() == CLIENT_COMMANDS_CAPABILITY_ID),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -13,7 +13,7 @@
 // per-run override is always possible.
 
 use crate::capability_settings::{
-    CapabilitySetting, capabilities_to_table, parse_capabilities_table,
+    CapabilityOverride, capabilities_to_toml, parse_capabilities_table,
 };
 use anyhow::{Context, Result};
 use std::collections::BTreeMap;
@@ -93,10 +93,8 @@ pub struct Settings {
     /// Soft-approval paranoia level, injected into the system prompt each
     /// turn. Central, cross-session, surfaced in the status bar.
     pub approval_mode: ApprovalMode,
-    /// Optional harness capability overrides (`[capabilities.<id>]` in
-    /// settings.toml): add optional capabilities, disable defaults, or override
-    /// per-capability JSON config.
-    pub capabilities: BTreeMap<String, CapabilitySetting>,
+    /// Ordered harness capability overrides (`[[capabilities]]` in settings.toml).
+    pub capabilities: Vec<CapabilityOverride>,
 }
 
 impl Default for Settings {
@@ -109,7 +107,7 @@ impl Default for Settings {
             base_urls: BTreeMap::new(),
             attribution: true,
             approval_mode: ApprovalMode::Normal,
-            capabilities: BTreeMap::new(),
+            capabilities: Vec::new(),
         }
     }
 }
@@ -189,9 +187,11 @@ impl Settings {
         insert_map("tokens", &self.tokens);
         insert_map("models", &self.models);
         insert_map("base_urls", &self.base_urls);
-        let caps = capabilities_to_table(&self.capabilities);
-        if !caps.is_empty() {
-            table.insert("capabilities".to_string(), toml::Value::Table(caps));
+        let caps = capabilities_to_toml(&self.capabilities);
+        if let Value::Array(items) = caps
+            && !items.is_empty()
+        {
+            table.insert("capabilities".to_string(), Value::Array(items));
         }
         table
     }
@@ -224,8 +224,16 @@ impl Settings {
         self.approval_mode
     }
 
-    pub fn capability_setting(&self, id: &str) -> Option<&CapabilitySetting> {
-        self.capabilities.get(id)
+    pub fn capability_overrides(&self) -> &[CapabilityOverride] {
+        &self.capabilities
+    }
+
+    pub fn capability_overrides_for(&self, id: &str) -> Vec<(usize, &CapabilityOverride)> {
+        self.capabilities
+            .iter()
+            .enumerate()
+            .filter(|(_, entry)| entry.capability_ref == id)
+            .collect()
     }
 }
 
@@ -384,22 +392,23 @@ impl SettingsStore {
         Ok(existed)
     }
 
-    /// Persist a harness capability override (add, remove, or reconfigure).
-    pub fn set_capability(&self, id: String, setting: CapabilitySetting) -> Result<()> {
+    /// Append a harness capability override to the ordered settings list.
+    pub fn append_capability_override(&self, entry: CapabilityOverride) -> Result<usize> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
-        if setting.enabled == Some(false) && setting.config.is_null() {
-            guard.capabilities.remove(&id);
-        } else {
-            guard.capabilities.insert(id, setting);
-        }
-        save_to(&self.path, &guard)
+        guard.capabilities.push(entry);
+        let index = guard.capabilities.len() - 1;
+        save_to(&self.path, &guard)?;
+        Ok(index)
     }
 
-    /// Remove any persisted override for a capability id.
-    pub fn clear_capability(&self, id: &str) -> Result<bool> {
+    /// Remove a stored override by its index in `[[capabilities]]`.
+    pub fn remove_capability_override(&self, index: usize) -> Result<bool> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
-        let existed = guard.capabilities.remove(id).is_some();
-        save_to(&self.path, &guard)?;
+        let existed = index < guard.capabilities.len();
+        if existed {
+            guard.capabilities.remove(index);
+            save_to(&self.path, &guard)?;
+        }
         Ok(existed)
     }
 }
@@ -654,6 +663,18 @@ mod tests {
             .expect("save");
         assert!(store.clear_base_url("custom").expect("clear present"));
         assert!(store.snapshot().base_url_for("custom").is_none());
+    }
+
+    #[test]
+    fn remove_capability_override_by_index() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join("settings.toml");
+        let store = SettingsStore::open(path);
+        let index = store
+            .append_capability_override(CapabilityOverride::remove("duckduckgo"))
+            .expect("append");
+        assert!(store.remove_capability_override(index).expect("remove"));
+        assert!(store.snapshot().capabilities.is_empty());
     }
 
     #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -224,10 +224,6 @@ impl Settings {
         self.approval_mode
     }
 
-    pub fn capability_overrides(&self) -> &[CapabilityOverride] {
-        &self.capabilities
-    }
-
     pub fn capability_overrides_for(&self, id: &str) -> Vec<(usize, &CapabilityOverride)> {
         self.capabilities
             .iter()
@@ -401,15 +397,11 @@ impl SettingsStore {
         Ok(index)
     }
 
-    /// Remove a stored override by its index in `[[capabilities]]`.
-    pub fn remove_capability_override(&self, index: usize) -> Result<bool> {
+    /// Drop every stored `[[capabilities]]` override.
+    pub fn clear_capability_overrides(&self) -> Result<()> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
-        let existed = index < guard.capabilities.len();
-        if existed {
-            guard.capabilities.remove(index);
-            save_to(&self.path, &guard)?;
-        }
-        Ok(existed)
+        guard.capabilities.clear();
+        save_to(&self.path, &guard)
     }
 }
 
@@ -663,18 +655,6 @@ mod tests {
             .expect("save");
         assert!(store.clear_base_url("custom").expect("clear present"));
         assert!(store.snapshot().base_url_for("custom").is_none());
-    }
-
-    #[test]
-    fn remove_capability_override_by_index() {
-        let tmp = tempfile::tempdir().expect("tmp");
-        let path = tmp.path().join("settings.toml");
-        let store = SettingsStore::open(path);
-        let index = store
-            .append_capability_override(CapabilityOverride::remove("duckduckgo"))
-            .expect("append");
-        assert!(store.remove_capability_override(index).expect("remove"));
-        assert!(store.snapshot().capabilities.is_empty());
     }
 
     #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -12,6 +12,9 @@
 // (OPENAI_API_KEY, ANTHROPIC_API_KEY, …) continue to take precedence so a
 // per-run override is always possible.
 
+use crate::capability_settings::{
+    CapabilitySetting, capabilities_to_table, parse_capabilities_table,
+};
 use anyhow::{Context, Result};
 use std::collections::BTreeMap;
 use std::io::Write;
@@ -90,6 +93,10 @@ pub struct Settings {
     /// Soft-approval paranoia level, injected into the system prompt each
     /// turn. Central, cross-session, surfaced in the status bar.
     pub approval_mode: ApprovalMode,
+    /// Optional harness capability overrides (`[capabilities.<id>]` in
+    /// settings.toml): add optional capabilities, disable defaults, or override
+    /// per-capability JSON config.
+    pub capabilities: BTreeMap<String, CapabilitySetting>,
 }
 
 impl Default for Settings {
@@ -102,6 +109,7 @@ impl Default for Settings {
             base_urls: BTreeMap::new(),
             attribution: true,
             approval_mode: ApprovalMode::Normal,
+            capabilities: BTreeMap::new(),
         }
     }
 }
@@ -147,6 +155,7 @@ impl Settings {
             base_urls: string_map("base_urls"),
             attribution,
             approval_mode,
+            capabilities: parse_capabilities_table(table),
         }
     }
 
@@ -180,6 +189,10 @@ impl Settings {
         insert_map("tokens", &self.tokens);
         insert_map("models", &self.models);
         insert_map("base_urls", &self.base_urls);
+        let caps = capabilities_to_table(&self.capabilities);
+        if !caps.is_empty() {
+            table.insert("capabilities".to_string(), toml::Value::Table(caps));
+        }
         table
     }
 
@@ -209,6 +222,10 @@ impl Settings {
 
     pub fn approval_mode(&self) -> ApprovalMode {
         self.approval_mode
+    }
+
+    pub fn capability_setting(&self, id: &str) -> Option<&CapabilitySetting> {
+        self.capabilities.get(id)
     }
 }
 
@@ -363,6 +380,25 @@ impl SettingsStore {
     pub fn clear_base_url(&self, provider: &str) -> Result<bool> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
         let existed = guard.base_urls.remove(provider).is_some();
+        save_to(&self.path, &guard)?;
+        Ok(existed)
+    }
+
+    /// Persist a harness capability override (add, remove, or reconfigure).
+    pub fn set_capability(&self, id: String, setting: CapabilitySetting) -> Result<()> {
+        let mut guard = self.inner.lock().expect("settings lock poisoned");
+        if setting.enabled == Some(false) && setting.config.is_null() {
+            guard.capabilities.remove(&id);
+        } else {
+            guard.capabilities.insert(id, setting);
+        }
+        save_to(&self.path, &guard)
+    }
+
+    /// Remove any persisted override for a capability id.
+    pub fn clear_capability(&self, id: &str) -> Result<bool> {
+        let mut guard = self.inner.lock().expect("settings lock poisoned");
+        let existed = guard.capabilities.remove(id).is_some();
         save_to(&self.path, &guard)?;
         Ok(existed)
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds ordered `[[capabilities]]` harness overrides to `settings.toml` and exposes them through the existing `get_config` / `set_config` tools.

- **`get_config key=capabilities`** — registered capability catalog (`config_schema`, `config_ui_schema`, etc.), stored overrides, and effective harness
- **`get_config key=capabilities.<ref>`** — schema metadata and stored/effective instances for one ref
- **`set_config key=capabilities json={...}`** — append a validated override
- **`set_config key=capabilities value=clear`** — drop all stored overrides

Rebased onto latest `main` (GlobalMemoryCapability / `/btw` changes).

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` — 347 unit + 26 integration tests
- `cargo run -- --provider llmsim -p "hi"` — offline smoke (binary starts, turn completes)
- Targeted tests:
  - `get_config_capabilities_includes_catalog`
  - `get_config_capabilities_ref_exposes_schema`
  - `scripted_get_config_capabilities_smoke` (agent loop + llmsim scripted tool call)

## Security

No new shell, filesystem, or network surfaces. Changes are confined to settings persistence and config-tool responses.

- **TM-FS** — no change to write blocklist or read scope
- **TM-BASH** — unchanged
- **TM-LLM** — capability config JSON is validated before persist; API tokens still redacted in `get_config`
- **TM-TOOL** — catalog is read-only metadata from registered capabilities; overrides apply on next run only
- **TM-DEP** — no new dependencies

## Follow-ups

No follow-ups.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-223c0f15-3173-4b7d-a4ce-ff8bfccf845b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-223c0f15-3173-4b7d-a4ce-ff8bfccf845b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

