### PR TITLE
feat(connectors): Daytona sandbox and generic connectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,6 +1365,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns-integrations-daytona"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fefcb04a4a5d5e8370afe6d9cf501f517b49de9f618bd2db100be0ed57b583b0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "everruns-core",
+ "inventory",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "everruns-integrations-duckduckgo"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5872,6 +5889,7 @@ dependencies = [
  "dirs",
  "everruns-anthropic",
  "everruns-core",
+ "everruns-integrations-daytona",
  "everruns-integrations-duckduckgo",
  "everruns-openai",
  "everruns-runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ everruns-openai = "0.11.0"
 # everruns server/worker never enable it (specs/mcp.md, upstream runtime-mcp.md D2).
 everruns-runtime = { version = "0.11.0", features = ["mcp-stdio"] }
 everruns-integrations-duckduckgo = "0.11.0"
+everruns-integrations-daytona = "0.11.0"
 futures = "0.3"
 
 [dev-dependencies]

--- a/specs/connectors.md
+++ b/specs/connectors.md
@@ -1,0 +1,93 @@
+# Connectors and remote sandboxes
+
+Status: v1 implemented (Daytona).
+
+## Why
+
+Yolop runs unsandboxed on the user's host by default. Some tasks — untrusted
+code, heavy builds, network experiments — should run in an isolated remote
+environment instead. [Daytona](https://www.daytona.io/) provides cloud Linux
+sandboxes; upstream ships the integration as `everruns-integrations-daytona`.
+
+Connectors are yolop's generic credential layer for those backends. The same
+interface can register additional sandbox providers (E2B, etc.) without
+rewriting host wiring.
+
+## What
+
+### Connector storage
+
+Credentials persist in `<config_dir>/yolop/connections.toml`, beside
+`settings.toml`. Values are owner-only on Unix. Environment variables remain
+supported as overrides (`DAYTONA_API_KEY` for Daytona).
+
+### Connector catalog
+
+`src/connectors/catalog.rs` registers upstream [`ConnectionProvider`]
+implementations. Daytona is registered by default; new providers add a
+`.register(...)` call there.
+
+### Runtime wiring
+
+- **`yolop_connectors`** is enabled on the default harness — always available
+  for listing providers and saving credentials.
+- **`daytona`** and **`session_storage`** are registered but **not** on the
+  default harness. Opt in through the generic capability config in
+  `settings.toml` (see [`configuration.md`](./configuration.md)).
+- `YolopConnectionResolver` implements `UserConnectionResolver` and is injected
+  through `RuntimeBackends::with_connection_resolver`.
+- `DaytonaConnectionProvider` is registered on `PlatformDefinition` for form
+  schema and validation.
+
+When `daytona` is enabled via `[[capabilities]]`, yolop automatically adds
+`session_storage` to the harness (Daytona's upstream dependency).
+
+### Enabling Daytona
+
+```toml
+[[capabilities]]
+ref = "daytona"
+enabled = true
+```
+
+Optional direct API calling:
+
+```toml
+[[capabilities]]
+ref = "daytona"
+enabled = true
+enable_api_calling = true
+```
+
+Inspect the registered catalog with `get_config key=capabilities` or
+`get_config key=capabilities.daytona`.
+
+### Tools (`yolop_connectors` capability, default on)
+
+| Tool | Purpose |
+|------|---------|
+| `list_connectors` | Available providers + connected status |
+| `get_connector` | One provider's instructions and form schema |
+| `connect` | Validate and save credentials |
+| `disconnect` | Remove stored credentials |
+
+### Daytona tools (upstream `daytona` capability, opt-in)
+
+When enabled and connected, the agent can create sandboxes and outsource work
+remotely: `daytona_create_sandbox`, `daytona_exec`, file tools, git helpers,
+and lifecycle management. See upstream `everruns-integrations-daytona` / Everruns
+docs for the full tool reference.
+
+## Boundaries
+
+- Connectors store integration credentials, not LLM provider tokens (those stay
+  in `settings.toml` / `/setup token`).
+- Host `bash` and file tools still target the local workspace; Daytona is opt-in
+  per task via `daytona_*` tools after enabling the capability.
+- OAuth connectors are listed but not yet configurable through `connect`.
+
+## See also
+
+- [`specs/configuration.md`](./configuration.md) — `[[capabilities]]` harness overrides
+- [`specs/maintenance.md`](./maintenance.md) — host threat surface
+- [Everruns Daytona integration](https://docs.everruns.com/integrations/daytona/)

--- a/specs/connectors.md
+++ b/specs/connectors.md
@@ -29,7 +29,7 @@ implementations. Daytona is registered by default; new providers add a
 
 ### Runtime wiring
 
-- **`yolop_connectors`** is enabled on the default harness — always available
+- **`connectors`** is enabled on the default harness — always available
   for listing providers and saving credentials.
 - **`daytona`** and **`session_storage`** are registered but **not** on the
   default harness. Opt in through the generic capability config in
@@ -62,7 +62,7 @@ enable_api_calling = true
 Inspect the registered catalog with `get_config key=capabilities` or
 `get_config key=capabilities.daytona`.
 
-### Tools (`yolop_connectors` capability, default on)
+### Tools (`connectors` capability, default on)
 
 | Tool | Purpose |
 |------|---------|

--- a/src/connectors/capability.rs
+++ b/src/connectors/capability.rs
@@ -1,0 +1,364 @@
+//! The `yolop_connectors` capability — discover, connect, and disconnect sandbox
+//! and integration backends through a uniform tool surface.
+
+use crate::connectors::catalog::{ConnectionCatalog, ConnectorInfo};
+use crate::connectors::store::ConnectionStore;
+use async_trait::async_trait;
+use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
+use everruns_core::connection_provider::ConnectionType;
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+pub(crate) const CONNECTORS_CAPABILITY_ID: &str = "yolop_connectors";
+
+pub(crate) struct ConnectorsCapability {
+    pub(crate) catalog: Arc<ConnectionCatalog>,
+    pub(crate) store: Arc<ConnectionStore>,
+}
+
+#[async_trait]
+impl Capability for ConnectorsCapability {
+    fn id(&self) -> &str {
+        CONNECTORS_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Connectors"
+    }
+
+    fn description(&self) -> &str {
+        "Connect external sandbox and integration backends (Daytona, …) with a uniform interface."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Integrations")
+    }
+
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        Some(format!(
+            "<capability id=\"{id}\">\n\
+             Connectors link yolop to remote sandbox backends. Use `list_connectors` to see \
+             available providers and connection status, `get_connector` for setup instructions, \
+             and `connect` / `disconnect` to manage credentials stored in {path}. \
+             When Daytona is connected, use the `daytona_*` tools to create isolated sandboxes \
+             and outsource risky or heavy work away from the host workspace. Host `bash` and file \
+             tools still operate on the local workspace.\n\
+             </capability>",
+            id = self.id(),
+            path = self.store.path().display()
+        ))
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        let shared = ConnectorTools {
+            catalog: self.catalog.clone(),
+            store: self.store.clone(),
+        };
+        vec![
+            Box::new(ListConnectorsTool {
+                catalog: self.catalog.clone(),
+                store: self.store.clone(),
+            }),
+            Box::new(GetConnectorTool {
+                catalog: self.catalog.clone(),
+                store: self.store.clone(),
+            }),
+            Box::new(ConnectTool {
+                inner: shared.clone(),
+            }),
+            Box::new(DisconnectTool {
+                catalog: self.catalog.clone(),
+                store: self.store.clone(),
+            }),
+        ]
+    }
+}
+
+#[derive(Clone)]
+struct ConnectorTools {
+    catalog: Arc<ConnectionCatalog>,
+    store: Arc<ConnectionStore>,
+}
+
+fn connector_json(info: &ConnectorInfo) -> Value {
+    json!({
+        "provider": info.provider_id,
+        "display_name": info.display_name,
+        "description": info.description,
+        "icon": info.icon,
+        "connection_type": info.connection_type,
+        "connected": info.connected,
+        "form_schema": info.form_schema,
+        "storage_path": null,
+    })
+}
+
+fn connector_json_with_path(info: &ConnectorInfo, path: &str) -> Value {
+    let mut value = connector_json(info);
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert("storage_path".to_string(), json!(path));
+    }
+    value
+}
+
+struct ListConnectorsTool {
+    catalog: Arc<ConnectionCatalog>,
+    store: Arc<ConnectionStore>,
+}
+
+#[async_trait]
+impl Tool for ListConnectorsTool {
+    fn name(&self) -> &str {
+        "list_connectors"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("List connectors")
+    }
+    fn description(&self) -> &str {
+        "List available connector providers (Daytona, …) with connection status and form hints."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({ "type": "object", "additionalProperties": false })
+    }
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        let path = self.store.path().display().to_string();
+        let connectors: Vec<Value> = self
+            .catalog
+            .list_connectors(&self.store)
+            .iter()
+            .map(|info| connector_json_with_path(info, &path))
+            .collect();
+        ToolExecutionResult::success(json!({
+            "connectors": connectors,
+            "count": connectors.len(),
+            "storage_path": path,
+        }))
+    }
+}
+
+struct GetConnectorTool {
+    catalog: Arc<ConnectionCatalog>,
+    store: Arc<ConnectionStore>,
+}
+
+#[async_trait]
+impl Tool for GetConnectorTool {
+    fn name(&self) -> &str {
+        "get_connector"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Get connector")
+    }
+    fn description(&self) -> &str {
+        "Describe one connector provider: setup instructions, form fields, and whether it is connected."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "provider": {
+                    "type": "string",
+                    "description": "Connector provider id, e.g. `daytona`."
+                }
+            },
+            "required": ["provider"],
+            "additionalProperties": false
+        })
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let provider = match arguments.get("provider").and_then(Value::as_str) {
+            Some(p) if !p.trim().is_empty() => p.trim(),
+            _ => {
+                return ToolExecutionResult::tool_error("Missing required parameter: provider");
+            }
+        };
+        let Some(entry) = self.catalog.get(provider) else {
+            return ToolExecutionResult::tool_error(format!("Unknown connector `{provider}`"));
+        };
+        let info = self.catalog.connector_info(entry, &self.store);
+        ToolExecutionResult::success(connector_json_with_path(
+            &info,
+            &self.store.path().display().to_string(),
+        ))
+    }
+}
+
+struct ConnectTool {
+    inner: ConnectorTools,
+}
+
+#[async_trait]
+impl Tool for ConnectTool {
+    fn name(&self) -> &str {
+        "connect"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Connect")
+    }
+    fn description(&self) -> &str {
+        "Validate and save connector credentials. For API-key providers pass `fields.api_key`. \
+         Credentials are stored locally and never echoed back."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "provider": {
+                    "type": "string",
+                    "description": "Connector provider id, e.g. `daytona`."
+                },
+                "fields": {
+                    "type": "object",
+                    "description": "Provider form fields (typically `{ \"api_key\": \"...\" }`).",
+                    "additionalProperties": { "type": "string" }
+                }
+            },
+            "required": ["provider", "fields"],
+            "additionalProperties": false
+        })
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let provider = match arguments.get("provider").and_then(Value::as_str) {
+            Some(p) if !p.trim().is_empty() => p.trim().to_string(),
+            _ => {
+                return ToolExecutionResult::tool_error("Missing required parameter: provider");
+            }
+        };
+        let fields_value = match arguments.get("fields") {
+            Some(v) if v.is_object() => v,
+            _ => {
+                return ToolExecutionResult::tool_error(
+                    "Missing required parameter: fields (object of form field names to values)",
+                );
+            }
+        };
+        let mut fields = HashMap::new();
+        if let Some(obj) = fields_value.as_object() {
+            for (key, value) in obj {
+                let Some(text) = value.as_str() else {
+                    return ToolExecutionResult::tool_error(format!(
+                        "Field `{key}` must be a string"
+                    ));
+                };
+                if text.trim().is_empty() {
+                    continue;
+                }
+                fields.insert(key.clone(), text.to_string());
+            }
+        }
+        if fields.is_empty() {
+            return ToolExecutionResult::tool_error(
+                "fields must include at least one non-empty value",
+            );
+        }
+
+        let Some(entry) = self.inner.catalog.get(&provider) else {
+            return ToolExecutionResult::tool_error(format!("Unknown connector `{provider}`"));
+        };
+        if entry.connection_type() == ConnectionType::OAuth {
+            return ToolExecutionResult::tool_error(format!(
+                "Connector `{provider}` uses OAuth and cannot be configured through this tool yet"
+            ));
+        }
+
+        match self
+            .inner
+            .catalog
+            .validate_and_store(&self.inner.store, &provider, fields)
+            .await
+        {
+            Ok(validation) => ToolExecutionResult::success(json!({
+                "provider": provider,
+                "connected": true,
+                "provider_username": validation.provider_username,
+                "storage_path": self.inner.store.path().display().to_string(),
+            })),
+            Err(message) => ToolExecutionResult::tool_error(message),
+        }
+    }
+}
+
+struct DisconnectTool {
+    catalog: Arc<ConnectionCatalog>,
+    store: Arc<ConnectionStore>,
+}
+
+#[async_trait]
+impl Tool for DisconnectTool {
+    fn name(&self) -> &str {
+        "disconnect"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Disconnect")
+    }
+    fn description(&self) -> &str {
+        "Remove stored credentials for a connector provider. Does not delete remote resources."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "provider": {
+                    "type": "string",
+                    "description": "Connector provider id, e.g. `daytona`."
+                }
+            },
+            "required": ["provider"],
+            "additionalProperties": false
+        })
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let provider = match arguments.get("provider").and_then(Value::as_str) {
+            Some(p) if !p.trim().is_empty() => p.trim(),
+            _ => {
+                return ToolExecutionResult::tool_error("Missing required parameter: provider");
+            }
+        };
+        if self.catalog.get(provider).is_none() {
+            return ToolExecutionResult::tool_error(format!("Unknown connector `{provider}`"));
+        }
+        match self.store.clear(provider) {
+            Ok(existed) => ToolExecutionResult::success(json!({
+                "provider": provider,
+                "connected": false,
+                "cleared": existed,
+            })),
+            Err(err) => {
+                ToolExecutionResult::internal_error_msg(format!("disconnect failed: {err}"))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn list_connectors_includes_daytona() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let store = Arc::new(ConnectionStore::open(tmp.path().join("connections.toml")));
+        let catalog = Arc::new(ConnectionCatalog::with_defaults());
+        let tool = ListConnectorsTool { catalog, store };
+        let result = tool.execute(json!({})).await;
+        assert!(result.is_success(), "{result:?}");
+        match result {
+            everruns_core::tools::ToolExecutionResult::Success(value) => {
+                let names: Vec<&str> = value["connectors"]
+                    .as_array()
+                    .expect("array")
+                    .iter()
+                    .filter_map(|c| c["provider"].as_str())
+                    .collect();
+                assert!(names.contains(&"daytona"));
+            }
+            other => panic!("expected success, got {other:?}"),
+        }
+    }
+}

--- a/src/connectors/capability.rs
+++ b/src/connectors/capability.rs
@@ -1,4 +1,4 @@
-//! The `yolop_connectors` capability — discover, connect, and disconnect sandbox
+//! The `connectors` capability — discover, connect, and disconnect sandbox
 //! and integration backends through a uniform tool surface.
 
 use crate::connectors::catalog::{ConnectionCatalog, ConnectorInfo};
@@ -11,7 +11,7 @@ use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-pub(crate) const CONNECTORS_CAPABILITY_ID: &str = "yolop_connectors";
+pub(crate) const CONNECTORS_CAPABILITY_ID: &str = "connectors";
 
 pub(crate) struct ConnectorsCapability {
     pub(crate) catalog: Arc<ConnectionCatalog>,

--- a/src/connectors/catalog.rs
+++ b/src/connectors/catalog.rs
@@ -1,0 +1,173 @@
+//! Registry of available connector providers.
+//!
+//! Yolop registers upstream [`ConnectionProvider`] implementations here. The
+//! catalog is the single place new sandbox backends (E2B, etc.) plug in.
+
+use everruns_core::connection_provider::{
+    ConnectionProvider, ConnectionProviderRegistry, ConnectionValidation,
+};
+use everruns_integrations_daytona::connection::DaytonaConnectionProvider;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::connectors::store::{ConnectionStore, StoredConnection};
+
+/// Describes one connector for model-facing tools and setup UI.
+#[derive(Debug, Clone)]
+pub struct ConnectorInfo {
+    pub provider_id: String,
+    pub display_name: String,
+    pub description: String,
+    pub icon: String,
+    pub connection_type: everruns_core::connection_provider::ConnectionType,
+    pub form_schema: Option<everruns_core::connection_provider::ConnectionFormSchema>,
+    pub connected: bool,
+}
+
+pub struct ConnectionCatalog {
+    providers: ConnectionProviderRegistry,
+}
+
+impl ConnectionCatalog {
+    pub fn with_defaults() -> Self {
+        Self::builder().build()
+    }
+
+    /// Register an additional connector provider (e.g. future E2B integration).
+    pub fn builder() -> ConnectionCatalogBuilder {
+        ConnectionCatalogBuilder {
+            providers: ConnectionProviderRegistry::new(),
+        }
+    }
+}
+
+pub struct ConnectionCatalogBuilder {
+    providers: ConnectionProviderRegistry,
+}
+
+impl ConnectionCatalogBuilder {
+    #[allow(dead_code)] // used by tests and future sandbox provider wiring
+    pub fn register(mut self, provider: impl ConnectionProvider + 'static) -> Self {
+        self.providers.register(provider);
+        self
+    }
+
+    pub fn build(mut self) -> ConnectionCatalog {
+        if !self.providers.has("daytona") {
+            self.providers.register(DaytonaConnectionProvider);
+        }
+        ConnectionCatalog {
+            providers: self.providers,
+        }
+    }
+}
+
+impl ConnectionCatalog {
+    #[allow(dead_code)]
+    pub fn register(&mut self, provider: impl ConnectionProvider + 'static) {
+        self.providers.register(provider);
+    }
+
+    pub fn get(&self, provider_id: &str) -> Option<&Arc<dyn ConnectionProvider>> {
+        self.providers.get(provider_id)
+    }
+
+    pub fn list(&self) -> Vec<&Arc<dyn ConnectionProvider>> {
+        self.providers.list()
+    }
+
+    pub fn connector_info(
+        &self,
+        provider: &Arc<dyn ConnectionProvider>,
+        store: &ConnectionStore,
+    ) -> ConnectorInfo {
+        let provider_id = provider.provider_id().to_string();
+        ConnectorInfo {
+            provider_id: provider_id.clone(),
+            display_name: provider.display_name().to_string(),
+            description: provider.description().to_string(),
+            icon: provider.icon().to_string(),
+            connection_type: provider.connection_type(),
+            form_schema: provider.form_schema(),
+            connected: store.is_connected(&provider_id)
+                || crate::connectors::resolver::env_credential(&provider_id).is_some(),
+        }
+    }
+
+    pub fn list_connectors(&self, store: &ConnectionStore) -> Vec<ConnectorInfo> {
+        let mut infos: Vec<_> = self
+            .list()
+            .into_iter()
+            .map(|p| self.connector_info(p, store))
+            .collect();
+        infos.sort_by(|a, b| a.provider_id.cmp(&b.provider_id));
+        infos
+    }
+
+    pub async fn validate_and_store(
+        &self,
+        store: &ConnectionStore,
+        provider_id: &str,
+        fields: HashMap<String, String>,
+    ) -> Result<ConnectionValidation, String> {
+        let provider = self
+            .get(provider_id)
+            .ok_or_else(|| format!("unknown connector `{provider_id}`"))?;
+        let validation = provider.validate_fields(&fields).await?;
+        let stored_fields: std::collections::BTreeMap<String, String> =
+            fields.into_iter().collect();
+        store
+            .save(
+                provider_id,
+                StoredConnection {
+                    fields: stored_fields,
+                    metadata: validation.provider_metadata.clone(),
+                },
+            )
+            .map_err(|e| format!("failed to save connection: {e}"))?;
+        Ok(validation)
+    }
+}
+
+#[cfg(test)]
+mod catalog_tests {
+    use super::*;
+    use everruns_core::connection_provider::ConnectionType;
+
+    struct StubProvider;
+
+    #[async_trait::async_trait]
+    impl ConnectionProvider for StubProvider {
+        fn provider_id(&self) -> &str {
+            "stub"
+        }
+        fn display_name(&self) -> &str {
+            "Stub"
+        }
+        fn description(&self) -> &str {
+            "test"
+        }
+        fn icon(&self) -> &str {
+            "box"
+        }
+        fn connection_type(&self) -> ConnectionType {
+            ConnectionType::ApiKey
+        }
+        fn form_schema(&self) -> Option<everruns_core::connection_provider::ConnectionFormSchema> {
+            None
+        }
+        async fn validate(&self, _credential: &str) -> Result<ConnectionValidation, String> {
+            Ok(ConnectionValidation {
+                provider_username: None,
+                provider_metadata: None,
+            })
+        }
+    }
+
+    #[test]
+    fn builder_registers_extra_providers() {
+        let catalog = ConnectionCatalog::builder().register(StubProvider).build();
+        assert!(catalog.get("stub").is_some());
+        assert!(catalog.get("daytona").is_some());
+    }
+}

--- a/src/connectors/mod.rs
+++ b/src/connectors/mod.rs
@@ -1,0 +1,15 @@
+//! Generic connector (user connection) support for yolop.
+//!
+//! Connectors wrap upstream [`ConnectionProvider`] implementations so sandbox and
+//! integration capabilities (Daytona today; E2B and others later) can resolve
+//! credentials lazily at tool time through [`YolopConnectionResolver`].
+
+mod capability;
+mod catalog;
+mod resolver;
+mod store;
+
+pub(crate) use capability::{CONNECTORS_CAPABILITY_ID, ConnectorsCapability};
+pub(crate) use catalog::ConnectionCatalog;
+pub(crate) use resolver::YolopConnectionResolver;
+pub(crate) use store::{ConnectionStore, default_connections_path};

--- a/src/connectors/resolver.rs
+++ b/src/connectors/resolver.rs
@@ -1,0 +1,113 @@
+//! Resolves connector credentials for sandbox capabilities at tool time.
+
+use async_trait::async_trait;
+use everruns_core::Result;
+use everruns_core::traits::UserConnectionResolver;
+use everruns_core::typed_id::SessionId;
+use std::sync::Arc;
+
+use crate::connectors::store::ConnectionStore;
+
+/// Environment-variable fallbacks keyed by connector provider id.
+pub(crate) fn env_credential(provider: &str) -> Option<String> {
+    let var = match provider {
+        "daytona" => "DAYTONA_API_KEY",
+        _ => return None,
+    };
+    std::env::var(var)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+/// Resolves stored connector credentials for upstream sandbox capabilities.
+pub struct YolopConnectionResolver {
+    store: Arc<ConnectionStore>,
+}
+
+impl YolopConnectionResolver {
+    pub fn new(store: Arc<ConnectionStore>) -> Self {
+        Self { store }
+    }
+
+    fn stored_token(&self, provider: &str) -> Option<String> {
+        let conn = self.store.get(provider)?;
+        conn.fields
+            .get("api_key")
+            .cloned()
+            .or_else(|| conn.fields.values().next().cloned())
+            .filter(|v| !v.trim().is_empty())
+    }
+
+    fn resolve_token(&self, provider: &str) -> Option<String> {
+        self.stored_token(provider)
+            .or_else(|| env_credential(provider))
+    }
+}
+
+#[async_trait]
+impl UserConnectionResolver for YolopConnectionResolver {
+    async fn get_connection_token(
+        &self,
+        _session_id: SessionId,
+        provider: &str,
+    ) -> Result<Option<String>> {
+        Ok(self.resolve_token(provider))
+    }
+
+    async fn get_connection_metadata(
+        &self,
+        _session_id: SessionId,
+        provider: &str,
+    ) -> Result<Option<serde_json::Value>> {
+        Ok(self.store.get(provider).and_then(|c| c.metadata.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    #[tokio::test]
+    async fn prefers_stored_credential_over_env() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let store = Arc::new(ConnectionStore::open(tmp.path().join("connections.toml")));
+        store
+            .save(
+                "daytona",
+                crate::connectors::store::StoredConnection {
+                    fields: BTreeMap::from([("api_key".to_string(), "stored-key".to_string())]),
+                    metadata: None,
+                },
+            )
+            .expect("save");
+        let resolver = YolopConnectionResolver::new(store);
+        let session_id = SessionId::new();
+        let token = resolver
+            .get_connection_token(session_id, "daytona")
+            .await
+            .expect("resolve");
+        assert_eq!(token.as_deref(), Some("stored-key"));
+    }
+
+    #[tokio::test]
+    async fn env_fallback_when_not_stored() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let store = Arc::new(ConnectionStore::open(tmp.path().join("connections.toml")));
+        let resolver = YolopConnectionResolver::new(store);
+        let session_id = SessionId::new();
+        // SAFETY: test is single-threaded; env var is restored before return.
+        unsafe {
+            std::env::set_var("DAYTONA_API_KEY", "env-key");
+        }
+        let token = resolver
+            .get_connection_token(session_id, "daytona")
+            .await
+            .expect("resolve");
+        unsafe {
+            std::env::remove_var("DAYTONA_API_KEY");
+        }
+        assert_eq!(token.as_deref(), Some("env-key"));
+    }
+}

--- a/src/connectors/store.rs
+++ b/src/connectors/store.rs
@@ -1,0 +1,238 @@
+//! Persistent storage for connector credentials.
+//!
+//! Credentials live in `<config_dir>/yolop/connections.toml`, beside
+//! `settings.toml`. Values are written owner-only on Unix, matching the
+//! settings token policy.
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use toml::Table;
+use toml::Value as TomlValue;
+
+/// One saved connector credential bundle.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StoredConnection {
+    /// Form fields submitted by the user (e.g. `api_key`).
+    pub fields: BTreeMap<String, String>,
+    /// Optional provider metadata returned from validation.
+    pub metadata: Option<Value>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct ConnectionsFile {
+    connections: BTreeMap<String, StoredConnection>,
+}
+
+impl ConnectionsFile {
+    fn from_table(table: &Table) -> Self {
+        let mut connections = BTreeMap::new();
+        for (provider, value) in table {
+            let Some(entry) = value.as_table() else {
+                continue;
+            };
+            let mut fields = BTreeMap::new();
+            let mut metadata = None;
+            for (key, val) in entry {
+                if key == "metadata" {
+                    metadata = val
+                        .as_str()
+                        .map(|s| Value::String(s.to_string()))
+                        .or_else(|| serde_json::to_value(val).ok());
+                    continue;
+                }
+                if let Some(text) = val.as_str() {
+                    fields.insert(key.clone(), text.to_string());
+                }
+            }
+            if !fields.is_empty() {
+                connections.insert(provider.clone(), StoredConnection { fields, metadata });
+            }
+        }
+        Self { connections }
+    }
+
+    fn to_table(&self) -> Table {
+        let mut root = Table::new();
+        for (provider, conn) in &self.connections {
+            let mut entry = Table::new();
+            for (key, value) in &conn.fields {
+                entry.insert(key.clone(), TomlValue::String(value.clone()));
+            }
+            if let Some(metadata) = &conn.metadata
+                && let Ok(val) = toml::Value::try_from(metadata.clone())
+            {
+                entry.insert("metadata".to_string(), val);
+            }
+            root.insert(provider.clone(), TomlValue::Table(entry));
+        }
+        root
+    }
+}
+
+pub fn default_connections_path() -> Option<PathBuf> {
+    crate::settings::default_settings_path().map(|p| {
+        p.parent()
+            .map(|dir| dir.join("connections.toml"))
+            .unwrap_or_else(|| PathBuf::from("connections.toml"))
+    })
+}
+
+fn load_from(path: &Path) -> ConnectionsFile {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return ConnectionsFile::default();
+    };
+    let table: Table = toml::from_str(&text).unwrap_or_default();
+    ConnectionsFile::from_table(&table)
+}
+
+fn save_to(path: &Path, file: &ConnectionsFile) -> Result<()> {
+    let parent = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+    std::fs::create_dir_all(&parent)
+        .with_context(|| format!("create connections dir {}", parent.display()))?;
+    let toml_text = toml::to_string(&file.to_table()).context("serialize connections")?;
+
+    let file_name = path
+        .file_name()
+        .with_context(|| format!("connections path has no file name: {}", path.display()))?;
+    let mut tmp_name = std::ffi::OsString::from(".");
+    tmp_name.push(file_name);
+    tmp_name.push(format!(".tmp.{}", std::process::id()));
+    let tmp_path = parent.join(tmp_name);
+
+    let write_result = (|| -> Result<()> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            let file = std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .mode(0o600)
+                .open(&tmp_path)
+                .with_context(|| format!("open temp connections {}", tmp_path.display()))?;
+            let mut file = file;
+            file.write_all(toml_text.as_bytes())
+                .with_context(|| format!("write temp connections {}", tmp_path.display()))?;
+            file.sync_all()
+                .with_context(|| format!("sync temp connections {}", tmp_path.display()))?;
+            Ok(())
+        }
+        #[cfg(not(unix))]
+        {
+            std::fs::write(&tmp_path, toml_text.as_bytes())
+                .with_context(|| format!("write temp connections {}", tmp_path.display()))?;
+            Ok(())
+        }
+    })();
+    if let Err(e) = write_result {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(e);
+    }
+    std::fs::rename(&tmp_path, path)
+        .with_context(|| format!("rename {} -> {}", tmp_path.display(), path.display()))?;
+    Ok(())
+}
+
+/// Thread-safe handle to persisted connector credentials.
+pub struct ConnectionStore {
+    path: PathBuf,
+    inner: Mutex<ConnectionsFile>,
+}
+
+impl ConnectionStore {
+    pub fn open(path: PathBuf) -> Self {
+        let file = load_from(&path);
+        Self {
+            path,
+            inner: Mutex::new(file),
+        }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn get(&self, provider: &str) -> Option<StoredConnection> {
+        self.inner
+            .lock()
+            .expect("connections lock poisoned")
+            .connections
+            .get(provider)
+            .cloned()
+    }
+
+    pub fn is_connected(&self, provider: &str) -> bool {
+        self.get(provider)
+            .map(|c| c.fields.values().any(|v| !v.trim().is_empty()))
+            .unwrap_or(false)
+    }
+
+    pub fn save(&self, provider: &str, connection: StoredConnection) -> Result<()> {
+        let mut guard = self.inner.lock().expect("connections lock poisoned");
+        guard.connections.insert(provider.to_string(), connection);
+        save_to(&self.path, &guard)
+    }
+
+    pub fn clear(&self, provider: &str) -> Result<bool> {
+        let mut guard = self.inner.lock().expect("connections lock poisoned");
+        let existed = guard.connections.remove(provider).is_some();
+        save_to(&self.path, &guard)?;
+        Ok(existed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_via_disk() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join("connections.toml");
+        let store = ConnectionStore::open(path.clone());
+
+        let mut fields = BTreeMap::new();
+        fields.insert("api_key".to_string(), "daytona-secret".to_string());
+        store
+            .save(
+                "daytona",
+                StoredConnection {
+                    fields,
+                    metadata: None,
+                },
+            )
+            .expect("save");
+
+        let reloaded = ConnectionStore::open(path);
+        let conn = reloaded.get("daytona").expect("daytona");
+        assert_eq!(
+            conn.fields.get("api_key").map(String::as_str),
+            Some("daytona-secret")
+        );
+    }
+
+    #[test]
+    fn clear_removes_provider() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let store = ConnectionStore::open(tmp.path().join("connections.toml"));
+        store
+            .save(
+                "daytona",
+                StoredConnection {
+                    fields: BTreeMap::from([("api_key".to_string(), "x".to_string())]),
+                    metadata: None,
+                },
+            )
+            .expect("save");
+        assert!(store.clear("daytona").expect("clear"));
+        assert!(!store.is_connected("daytona"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod capabilities;
 mod capability_settings;
 mod config_schema;
 mod config_service;
+mod connectors;
 mod hooks_config;
 mod host_ui;
 mod into;
@@ -30,6 +31,10 @@ mod mcp_e2e_tests;
 mod agent_scenarios;
 
 use anyhow::Result;
+
+// Force-link integration crates whose inventory registrations must survive
+// LTO/dead-code elimination when we register capabilities explicitly.
+extern crate everruns_integrations_daytona;
 use app::{App, COMPOSER_VIEWPORT_HEIGHT};
 use clap::{Args, Parser, Subcommand};
 use crossterm::event::{

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -13,6 +13,10 @@ use crate::capabilities::{
     ENVIRONMENT_CONTEXT_CAPABILITY_ID, SETUP_CAPABILITY_ID, SetupCapability,
 };
 use crate::capability_settings::{CapabilityCatalog, apply_capability_settings};
+use crate::connectors::{
+    CONNECTORS_CAPABILITY_ID, ConnectionCatalog, ConnectionStore, ConnectorsCapability,
+    YolopConnectionResolver, default_connections_path,
+};
 use crate::host_ui::{HostUi, TuiHandle, UiCommand};
 use crate::settings::{Settings, SettingsStore};
 use crate::tools::Workspace;
@@ -23,8 +27,9 @@ use everruns_core::capabilities::{
     BtwCapability, COMPACTION_CAPABILITY_ID, CompactionCapability, FileSystemCapability,
     INFINITY_CONTEXT_CAPABILITY_ID, InfinityContextCapability, LoopDetectionCapability,
     MessageMetadataCapability, PROMPT_CACHING_CAPABILITY_ID, PromptCachingCapability,
-    SKILLS_CAPABILITY_ID, StatelessTodoListCapability, TOOL_SEARCH_CAPABILITY_ID,
-    ToolOutputPersistenceCapability, ToolSearchCapability, UserHooksCapability, WebFetchCapability,
+    SKILLS_CAPABILITY_ID, SessionStorageCapability, StatelessTodoListCapability,
+    TOOL_SEARCH_CAPABILITY_ID, ToolOutputPersistenceCapability, ToolSearchCapability,
+    UserHooksCapability, WebFetchCapability,
 };
 use everruns_core::command::CommandDescriptor;
 use everruns_core::error::AgentLoopError;
@@ -39,6 +44,7 @@ use everruns_core::{
     PlatformDefinition, ReasoningConfig, ScopedMcpServers, SessionFileSystem,
     SessionFileSystemFactory, SessionFileSystemFactoryContext,
 };
+use everruns_integrations_daytona::DaytonaCapability;
 use everruns_integrations_duckduckgo::DuckDuckGoCapability;
 use everruns_runtime::{
     InProcessRuntime, InProcessRuntimeBuilder, RealDiskFileStore, RuntimeBackends,
@@ -1048,6 +1054,7 @@ fn default_coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabi
         ),
         AgentCapabilityConfig::new(SETUP_CAPABILITY_ID),
         AgentCapabilityConfig::new(CONFIG_CAPABILITY_ID),
+        AgentCapabilityConfig::new(CONNECTORS_CAPABILITY_ID),
         AgentCapabilityConfig::new(MEMORY_CAPABILITY_ID),
         AgentCapabilityConfig::new(YOUR_CAPABILITY_ID),
         // `/btw` — ephemeral side question, answered out-of-band with the
@@ -1065,6 +1072,16 @@ pub(crate) fn coding_harness_defaults(client_commands: bool) -> Vec<AgentCapabil
     default_coding_harness_capabilities(client_commands)
 }
 
+/// Daytona depends on `session_storage`. When enabled via `[[capabilities]]`,
+/// ensure that dependency is present on the harness.
+fn ensure_harness_capability_dependencies(caps: &mut Vec<AgentCapabilityConfig>) {
+    let daytona = caps.iter().any(|c| c.capability_id() == "daytona");
+    let storage = caps.iter().any(|c| c.capability_id() == "session_storage");
+    if daytona && !storage {
+        caps.push(AgentCapabilityConfig::new("session_storage"));
+    }
+}
+
 fn coding_harness_capabilities(
     client_commands: bool,
     hook_config: Option<serde_json::Value>,
@@ -1074,6 +1091,7 @@ fn coding_harness_capabilities(
         default_coding_harness_capabilities(client_commands),
         &settings.capabilities,
     );
+    ensure_harness_capability_dependencies(&mut caps);
     if let Some(config) = hook_config {
         caps.push(AgentCapabilityConfig::with_config("user_hooks", config));
     }
@@ -1277,6 +1295,11 @@ pub async fn build_with_options(
     let disabled_hook_contribution_count = effective_hooks.disabled_contributions.len();
     let hook_configured = !effective_hooks.is_empty();
     let hook_capability_config = hook_configured.then(|| effective_hooks.capability_config());
+    let connections_path =
+        default_connections_path().unwrap_or_else(|| PathBuf::from("connections.toml"));
+    let connections = Arc::new(ConnectionStore::open(connections_path));
+    let connection_catalog = Arc::new(ConnectionCatalog::with_defaults());
+    let connection_resolver = Arc::new(YolopConnectionResolver::new(connections.clone()));
 
     // Pin the SessionId so resume can re-attach to the same session folder
     // (directory name is the session id).
@@ -1318,7 +1341,8 @@ pub async fn build_with_options(
     // pre-seeded message store (so replayed history is available).
     let backends = RuntimeBackends::in_memory()
         .with_event_bus(event_bus)
-        .with_message_store(message_store);
+        .with_message_store(message_store)
+        .with_connection_resolver(connection_resolver);
     // Shared between `ModelState` (for banner labels) and
     // `SetupCapability` (which mutates it on a successful `/setup`).
     let provider_state = Arc::new(RwLock::new(provider.clone()));
@@ -1344,6 +1368,9 @@ pub async fn build_with_options(
     //   * loop_detection       — safety net against repeated identical tool calls
     //   * prompt_caching       — Anthropic prompt caching; free token savings
     //   * duckduckgo           — free web search (`duckduckgo_search`); no API key
+    //   * session_storage      — session kv/secret store (Daytona dependency)
+    //   * daytona              — remote cloud sandboxes (`daytona_*` tools)
+    //   * yolop_connectors     — connect/disconnect sandbox backends
     //   * user_hooks           — executes user-authored hook specs loaded from
     //                            global/workspace hook config
     let mut capabilities = CapabilityRegistry::new();
@@ -1378,6 +1405,8 @@ pub async fn build_with_options(
         "run_yolop_command",
     ]));
     capabilities.register(ToolOutputPersistenceCapability);
+    capabilities.register(SessionStorageCapability);
+    capabilities.register(DaytonaCapability);
     capabilities.register(UserHooksCapability);
     capabilities.register(DuckDuckGoCapability);
     capabilities.register(WebFetchCapability::from_env());
@@ -1409,6 +1438,10 @@ pub async fn build_with_options(
     // into the system prompt. Persists to the same `settings.toml`; provider/
     // model edits take effect next run. Registered after the catalog is built
     // (see below).
+    capabilities.register(ConnectorsCapability {
+        catalog: connection_catalog,
+        store: connections,
+    });
     // `memory` — global, durable, structured user memory. Its MEMORY.md lives
     // beside settings.toml in the yolop config dir, so a tempdir settings path
     // in tests isolates memory automatically. Only titles are disclosed each
@@ -1479,6 +1512,11 @@ pub async fn build_with_options(
     let platform = PlatformDefinition::builder()
         .capability_registry(capabilities)
         .driver_registry(driver_registry)
+        .connection_providers(
+            everruns_core::ConnectionProviderRegistry::builder()
+                .provider(everruns_integrations_daytona::connection::DaytonaConnectionProvider)
+                .build(),
+        )
         .session_file_system_factory(Arc::new(CodingCliSessionFileSystemFactory {
             workspace_root: canonical_root.clone(),
             session_dir: session_dir.clone(),
@@ -1579,6 +1617,86 @@ mod tests {
             err.to_string()
                 .contains("offline llmsim only supports llmsim-yolop")
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn build_exposes_connector_tools_by_default() {
+        use everruns_runtime::RuntimeHostAdapter;
+
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+
+        let built = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Sim,
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            BuildOptions::default(),
+        )
+        .await
+        .expect("build runtime");
+
+        assert!(
+            !built
+                .startup
+                .tool_names
+                .contains(&"daytona_create_sandbox".to_string()),
+            "daytona is opt-in via [[capabilities]]: {:?}",
+            built.startup.tool_names
+        );
+        for connector_tool in ["list_connectors", "connect", "disconnect", "get_connector"] {
+            assert!(
+                built
+                    .startup
+                    .tool_names
+                    .contains(&connector_tool.to_string()),
+                "connector tools: {:?}",
+                built.startup.tool_names
+            );
+        }
+        assert!(
+            built
+                .handles
+                .runtime
+                .connection_resolver()
+                .expect("connection resolver")
+                .get_connection_token(built.handles.session_id, "daytona")
+                .await
+                .expect("resolve")
+                .is_none(),
+            "no credential configured yet"
+        );
+    }
+
+    #[test]
+    fn harness_applies_daytona_from_settings() {
+        use crate::capability_settings::CapabilityOverride;
+
+        let mut settings = Settings::default();
+        settings.capabilities.push(CapabilityOverride {
+            capability_ref: "daytona".to_string(),
+            enabled: Some(true),
+            append: false,
+            config: serde_json::json!({}),
+        });
+        let ids = coding_harness_capabilities(false, None, &settings);
+        assert!(ids.iter().any(|cap| cap.capability_id() == "daytona"));
+        assert!(
+            ids.iter()
+                .any(|cap| cap.capability_id() == "session_storage")
+        );
+    }
+
+    #[test]
+    fn coding_harness_enables_connectors_by_default() {
+        let ids = coding_harness_capabilities(false, None, &Settings::default());
+        assert!(
+            ids.iter()
+                .any(|cap| cap.capability_id() == CONNECTORS_CAPABILITY_ID)
+        );
+        assert!(!ids.iter().any(|cap| cap.capability_id() == "daytona"));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1370,7 +1370,7 @@ pub async fn build_with_options(
     //   * duckduckgo           — free web search (`duckduckgo_search`); no API key
     //   * session_storage      — session kv/secret store (Daytona dependency)
     //   * daytona              — remote cloud sandboxes (`daytona_*` tools)
-    //   * yolop_connectors     — connect/disconnect sandbox backends
+    //   * connectors           — connect/disconnect sandbox backends
     //   * user_hooks           — executes user-authored hook specs loaded from
     //                            global/workspace hook config
     let mut capabilities = CapabilityRegistry::new();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds remote Daytona sandbox execution with a generic connector layer for future sandbox backends.

- **`connectors`** capability (default on) — `list_connectors`, `get_connector`, `connect`, `disconnect`; credentials in `connections.toml`
- **`daytona`** capability (opt-in via `[[capabilities]]`) — upstream `everruns-integrations-daytona` tools; auto-pulls in `session_storage`
- **`YolopConnectionResolver`** — wires stored/env credentials into sandbox tools at runtime

## Enabling Daytona

```toml
[[capabilities]]
ref = "daytona"
enabled = true
```

Then connect via `connect` or set `DAYTONA_API_KEY`.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (356 tests)
- Offline smoke: `cargo run -- --provider llmsim -p "list available connectors"` — connector tools present in tool list

## Security

- **TM-FS**: No change to host filesystem policy; Daytona runs in remote sandboxes only.
- **TM-BASH**: Host bash unchanged; remote exec is Daytona API scoped.
- **TM-LLM**: Connector credentials stored owner-only in `connections.toml`; never echoed by tools; env fallback `DAYTONA_API_KEY` only.
- **TM-TOOL**: `daytona` opt-in; `connectors` validates API keys via upstream provider before save.
- **TM-DEP**: Added `everruns-integrations-daytona` at 0.11.0 (lockstep with other `everruns-*` crates).

## Follow-ups

No follow-ups.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e01be186-1cf9-487f-9e33-033cef3ea754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e01be186-1cf9-487f-9e33-033cef3ea754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

