### PR TITLE
feat(memory): structured global memory with progressive disclosure

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   language ("remember that I prefer terse answers") via the `remember` /
   `recall` / `forget` tools. Only memory *titles* are injected each turn
   (progressive disclosure); bodies are recalled on demand, so the prompt stays
-  small however much you remember. Tunable via the `[memory]` table in
-  `settings.toml`. See [`specs/memory.md`](./specs/memory.md).
+  small however much you remember. Tunable through the generic capability-config
+  system (`disclosed_titles`, `recall_limit`, `soft_cap`). See
+  [`specs/memory.md`](./specs/memory.md).
 - **Skills** — `SKILL.md` files discovered from workspace
   (`.agents/skills/`), global (`<config_dir>/yolop/skills/`), and system
   (bundled) scopes, exposed via `list_skills`, `read_skill`, `write_skill`,

--- a/README.md
+++ b/README.md
@@ -82,10 +82,13 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
 - **`AGENTS.md`** — project instructions re-read every turn.
 - **Workspace context** — root, shell, local date/timezone, Git identity and
   branch injected automatically.
-- **Memory** — a central `MEMORY.md` of durable, cross-session user
-  preferences, edited in natural language ("remember that I prefer terse
-  answers") and injected every turn under a managed size budget. See
-  [`specs/your.md`](./specs/your.md).
+- **Memory** — a central, structured `MEMORY.md` of durable, cross-session
+  user memories, each with a title, timestamp, and body. Managed in natural
+  language ("remember that I prefer terse answers") via the `remember` /
+  `recall` / `forget` tools. Only memory *titles* are injected each turn
+  (progressive disclosure); bodies are recalled on demand, so the prompt stays
+  small however much you remember. Tunable via the `[memory]` table in
+  `settings.toml`. See [`specs/memory.md`](./specs/memory.md).
 - **Skills** — `SKILL.md` files discovered from workspace
   (`.agents/skills/`), global (`<config_dir>/yolop/skills/`), and system
   (bundled) scopes, exposed via `list_skills`, `read_skill`, `write_skill`,

--- a/skills/yolop-config/SKILL.md
+++ b/skills/yolop-config/SKILL.md
@@ -53,9 +53,10 @@ command instead.
 ## Related surfaces
 
 - **Durable preferences / memory** ("remember that I prefer terse answers"):
-  these are not config keys. Use the `remember_your_memory` /
-  `write_your_memory` tools (the `your` personalization layer), not
-  `set_config`.
+  these are not config keys. Use the `remember` / `recall` / `forget` tools
+  (the global `memory` capability), not `set_config`. Memory tuning lives in a
+  `[memory]` table in `settings.toml` (`disclosed_titles`, `recall_limit`,
+  `soft_cap`).
 - **Behavioral hooks** (block/allow/audit tool calls): use the `yolop-hooks`
   skill and the `*_your_hook` tools.
 - **Interactive provider/model setup**: the `/setup` command runs a guided

--- a/skills/yolop-config/SKILL.md
+++ b/skills/yolop-config/SKILL.md
@@ -54,9 +54,9 @@ command instead.
 
 - **Durable preferences / memory** ("remember that I prefer terse answers"):
   these are not config keys. Use the `remember` / `recall` / `forget` tools
-  (the global `memory` capability), not `set_config`. Memory tuning lives in a
-  `[memory]` table in `settings.toml` (`disclosed_titles`, `recall_limit`,
-  `soft_cap`).
+  (the global `memory` capability), not `set_config`. Memory tuning
+  (`disclosed_titles`, `recall_limit`, `soft_cap`) is per-capability config
+  exposed via the capability's `config_schema`, not a `settings.toml` key.
 - **Behavioral hooks** (block/allow/audit tool calls): use the `yolop-hooks`
   skill and the `*_your_hook` tools.
 - **Interactive provider/model setup**: the `/setup` command runs a guided

--- a/specs/memory.md
+++ b/specs/memory.md
@@ -76,15 +76,22 @@ to most-recent order.
 
 ## Configuration
 
-Tuning lives in an optional `[memory]` table in `settings.toml`. All keys are
-optional; defaults apply otherwise.
+Tuning flows through the **generic capability-config system**, not a bespoke
+settings key: the capability publishes a `config_schema()` and reads its values
+from the per-agent `AgentCapabilityConfig.config` (consumed via
+`tools_with_config` / `system_prompt_contribution_with_config`). This is the
+same mechanism `agent_instructions` and `user_hooks` use, so a generic settings
+editor can drive it without hard-coding `memory`.
 
-```toml
-[memory]
-disclosed_titles = 15   # memory titles injected into the prompt each turn
-recall_limit = 5        # default number of memories `recall` returns
-soft_cap = 200          # warn (never delete) once this many memories exist
-```
+| Key                | Default | Meaning                                                  |
+|--------------------|---------|----------------------------------------------------------|
+| `disclosed_titles` | 15      | Memory titles injected into the prompt each turn.        |
+| `recall_limit`     | 5       | Default number of memories `recall` returns.             |
+| `soft_cap`         | 200     | Warn (never delete) once more than this many exist.      |
+
+Missing or null config falls back to defaults; `validate_config` rejects wrong
+types on the write path, while the per-turn read paths fall back to defaults and
+log on bad input rather than dropping the capability.
 
 `soft_cap` is a **soft** limit: once memory grows past it, `remember`/`recall`
 nudge the model to `forget` stale memories or promote stable guidance to a

--- a/specs/memory.md
+++ b/specs/memory.md
@@ -1,0 +1,98 @@
+# `memory` — global, durable user memory
+
+Status: implemented.
+
+## Why
+
+Yolop needs to remember durable, cross-session facts about the user — "prefer
+terse answers", "my name is Mike", "always run `cargo fmt` before committing" —
+so the model honors them without being reminded each session.
+
+The first cut lived inside the `your` personalization capability as a single
+flat `MEMORY.md` bullet list, injected **in full every turn** under a byte
+budget. That has two problems: the whole file competes for prompt space no
+matter how little of it is relevant, and a flat bullet list has no structure to
+search, timestamp, or address individual notes.
+
+`memory` is its own capability. It owns structured, durable memory and the
+tools to manage it; `your` keeps the personalization *framing* and hook
+self-configuration (see [`your.md`](./your.md)).
+
+## What
+
+`MEMORY.md` lives in the central config dir beside `settings.toml`
+(`~/.config/yolop/MEMORY.md` on Linux) and is never committed to a repo —
+distinct from `AGENTS.md`, which is per-project guidance.
+
+It is **structured**: each memory is a `## ` section with
+
+- a **title** — a short description of the memory; doubles as the search key
+  and the disclosed label,
+- a generated **id** (`m-1a2b3c`) plus **created**/**updated** timestamps,
+  carried in an HTML comment, and
+- a **body** — the memory text itself.
+
+```markdown
+## Prefer terse answers
+<!-- id: m-1a2b3c · created: 2026-06-13T03:54:00Z · updated: 2026-06-13T03:54:00Z -->
+
+The user prefers terse, factual answers without preamble.
+```
+
+The file is the durable store; an in-memory `Vec<Memory>`, kept newest-first by
+`updated`, is the source of truth at runtime. Writes are atomic (temp file +
+`fsync` + `rename`, `0o600` on Unix) so readers and crashes never see a
+half-written file. A legacy flat-bullet file is imported wholesale as a single
+"Imported notes" memory on first open, so an upgrade never loses notes.
+
+## Progressive disclosure
+
+Only memory **titles** are injected into the system prompt each turn (the most
+recent `disclosed_titles`, newest first), with the id and date. Bodies are
+**not** injected. The block tells the model how many memories exist in total and
+to use `recall` to read full text or find the rest. This keeps prompt cost flat
+no matter how much the user has stored — the opposite of injecting the whole
+file.
+
+## Tools
+
+- `remember(title, memory, id?)` — store a memory. The timestamp is set
+  automatically. Passing an existing `id` — or reusing an existing title
+  (case-insensitive) — updates in place instead of duplicating.
+- `recall(query?, id?, limit?)` — read memory. An `id` fetches one memory's
+  full text; a `query` searches; with neither, the most recent memories are
+  returned. Results are **capped** at `limit` (default `recall_limit`), and when
+  more match, the response says so — the model is told to narrow the query
+  rather than try to read everything. There is deliberately no "dump the whole
+  file" tool.
+- `forget(id)` — delete one memory by id (preferred) or exact title.
+
+### Search ranking
+
+Query tokens are matched case-insensitively. A token in a memory's **title**
+scores 3; in its **body**, 1; summed across tokens. Ties break toward the most
+recently updated memory, so search "prefers latest". An empty query falls back
+to most-recent order.
+
+## Configuration
+
+Tuning lives in an optional `[memory]` table in `settings.toml`. All keys are
+optional; defaults apply otherwise.
+
+```toml
+[memory]
+disclosed_titles = 15   # memory titles injected into the prompt each turn
+recall_limit = 5        # default number of memories `recall` returns
+soft_cap = 200          # warn (never delete) once this many memories exist
+```
+
+`soft_cap` is a **soft** limit: once memory grows past it, `remember`/`recall`
+nudge the model to `forget` stale memories or promote stable guidance to a
+skill. Yolop never silently drops a user's memory. Setting it to `0` disables
+the warning.
+
+## Non-goals
+
+- Not a secret store — tokens stay in `settings.toml`.
+- Not project memory — repo-scoped guidance stays in `AGENTS.md`.
+- No automatic retention/rotation; `MEMORY.md` is a plain file the user owns.

--- a/specs/your.md
+++ b/specs/your.md
@@ -1,6 +1,7 @@
 # `your` — personalization
 
-Status: v1 implemented (memory core). Roadmap sections below are not yet built.
+Status: implemented (framing + hooks). Durable memory now lives in the `memory`
+capability ([`memory.md`](./memory.md)); roadmap sections below are not yet built.
 
 ## Why
 
@@ -33,7 +34,7 @@ existing `settings.toml`:
 ```
 <config_dir>/yolop/
   settings.toml      # provider + tokens (pre-existing)
-  MEMORY.md          # v1: durable cross-session user memory
+  MEMORY.md          # durable cross-session user memory (owned by the `memory` capability)
   skills/            # global, always-available skills
 ```
 
@@ -42,38 +43,14 @@ its state lives, and what it can currently do — to the model through the syste
 prompt and tools, and to the user through natural-language questions such as
 "what is your config?"
 
-## v1 — central memory
+## Memory
 
-`MEMORY.md` is a single markdown file of durable, global user preferences and
-facts ("I prefer terse answers", "always run `cargo fmt` before committing",
-"my name is Mike"). It is **injected into every turn** so the model honors
-preferences without being reminded.
-
-Distinct from `AGENTS.md`: `AGENTS.md` is per-project guidance committed to a
-repo; `MEMORY.md` is per-user, global, and never committed.
-
-### Managed size
-
-Unbounded memory would bloat every prompt. So:
-
-- A **byte budget** caps how much is injected. Beyond it, injection is
-  truncated at a char boundary with a visible notice — the model is told the
-  memory was clipped and to use `read_your_memory` for the full text.
-- A **soft limit** (below the hard budget) triggers a standing suggestion, in
-  both the injected block and tool results, to extract stable, topic-specific
-  guidance into a **skill** rather than letting memory grow without bound.
-  Skills are the pressure-release valve for memory that has outgrown a few
-  bullet points.
-
-### Natural-language configuration
-
-The model configures memory through tools, driven by ordinary chat — no slash
-syntax required:
-
-- `remember_your_memory` — append a durable preference/fact.
-- `read_your_memory` — read the full file (needed when injection was truncated,
-  or to edit precisely).
-- `write_your_memory` — replace the whole file, for reorganizing or removing.
+Durable, cross-session user memory has moved into its own `memory` capability —
+structured `MEMORY.md`, progressive disclosure, and the `remember` / `recall` /
+`forget` tools. See [`memory.md`](./memory.md). `your` keeps only the
+personalization *framing*: it decides when a request is global personalization
+and routes "remember that I prefer X" to the `remember` tool, rather than owning
+the store itself.
 
 ## Self-Configuration Pattern
 
@@ -117,4 +94,5 @@ yolop-specific formats.
 
 - Not a secret store — tokens stay in `settings.toml` under `/token`.
 - Not project memory — repo-scoped guidance stays in `AGENTS.md`.
-- No retention/rotation policy; `MEMORY.md` is a plain file the user owns.
+- Not the memory store itself — durable memory is the `memory` capability's
+  job ([`memory.md`](./memory.md)).

--- a/src/capabilities/memory.rs
+++ b/src/capabilities/memory.rs
@@ -69,40 +69,67 @@ impl Default for MemoryConfig {
 }
 
 impl MemoryConfig {
-    /// Derive config from the `[memory]` table of the settings file backing
-    /// `settings`. Missing file / table / keys fall back to defaults, so this
-    /// never fails — the worst case is the default tuning.
-    pub(crate) fn from_settings(settings: &SettingsStore) -> Self {
-        Self::from_settings_file(settings.path())
+    /// Parse config from a capability config `Value` (from
+    /// `AgentCapabilityConfig.config`, the generic capability-config system).
+    /// `Null` / missing keys fall back to defaults. Strict on types so the same
+    /// parse backs `validate_config`: a present key must be a non-negative
+    /// integer or it is rejected.
+    pub(crate) fn from_value(config: &Value) -> Result<Self, String> {
+        let mut cfg = Self::default();
+        if config.is_null() {
+            return Ok(cfg);
+        }
+        let obj = config
+            .as_object()
+            .ok_or_else(|| "memory config must be an object".to_string())?;
+        let read = |key: &str, slot: &mut usize| -> Result<(), String> {
+            match obj.get(key) {
+                None | Some(Value::Null) => Ok(()),
+                Some(v) => {
+                    let n = v
+                        .as_u64()
+                        .ok_or_else(|| format!("`{key}` must be a non-negative integer"))?;
+                    *slot = n as usize;
+                    Ok(())
+                }
+            }
+        };
+        read("disclosed_titles", &mut cfg.disclosed_titles)?;
+        read("recall_limit", &mut cfg.recall_limit)?;
+        read("soft_cap", &mut cfg.soft_cap)?;
+        Ok(cfg)
     }
 
-    fn from_settings_file(path: &Path) -> Self {
-        let mut cfg = Self::default();
-        let Ok(text) = std::fs::read_to_string(path) else {
-            return cfg;
-        };
-        let Ok(table) = toml::from_str::<toml::Table>(&text) else {
-            return cfg;
-        };
-        let Some(mem) = table.get("memory").and_then(toml::Value::as_table) else {
-            return cfg;
-        };
-        let read = |key: &str| {
-            mem.get(key)
-                .and_then(toml::Value::as_integer)
-                .filter(|v| *v >= 0)
-                .map(|v| v as usize)
-        };
-        if let Some(v) = read("disclosed_titles") {
-            cfg.disclosed_titles = v;
-        }
-        if let Some(v) = read("recall_limit") {
-            cfg.recall_limit = v;
-        }
-        if let Some(v) = read("soft_cap") {
-            cfg.soft_cap = v;
-        }
-        cfg
+    /// JSON Schema for the generic capability-config editor.
+    fn schema() -> Value {
+        let default = Self::default();
+        json!({
+            "type": "object",
+            "properties": {
+                "disclosed_titles": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "title": "Disclosed titles",
+                    "description": "How many memory titles to inject into the system prompt each turn (newest first).",
+                    "default": default.disclosed_titles,
+                },
+                "recall_limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "title": "Recall limit",
+                    "description": "Default number of memories `recall` returns for a search or recent query.",
+                    "default": default.recall_limit,
+                },
+                "soft_cap": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "title": "Soft cap",
+                    "description": "Warn (never delete) once more than this many memories exist. 0 disables the warning.",
+                    "default": default.soft_cap,
+                }
+            },
+            "additionalProperties": false
+        })
     }
 }
 
@@ -602,7 +629,34 @@ fn render_memory_block(
 
 pub(crate) struct GlobalMemoryCapability {
     pub(crate) memory: Arc<MemoryStore>,
-    pub(crate) config: MemoryConfig,
+}
+
+impl GlobalMemoryCapability {
+    /// Resolve config leniently for the per-turn read paths: invalid config
+    /// falls back to defaults (and is logged) rather than dropping the whole
+    /// capability. `validate_config` is the strict guardrail on the write path.
+    fn resolved_config(config: &Value) -> MemoryConfig {
+        MemoryConfig::from_value(config).unwrap_or_else(|error| {
+            tracing::warn!(error = %error, "invalid memory config, using defaults");
+            MemoryConfig::default()
+        })
+    }
+
+    fn build_tools(&self, config: MemoryConfig) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(RememberTool {
+                memory: self.memory.clone(),
+                config,
+            }),
+            Box::new(RecallTool {
+                memory: self.memory.clone(),
+                config,
+            }),
+            Box::new(ForgetTool {
+                memory: self.memory.clone(),
+            }),
+        ]
+    }
 }
 
 #[async_trait]
@@ -624,8 +678,26 @@ impl Capability for GlobalMemoryCapability {
         Some("Personalization")
     }
 
-    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
-        let (titles, total) = self.memory.titles(self.config.disclosed_titles);
+    fn config_schema(&self) -> Option<Value> {
+        Some(MemoryConfig::schema())
+    }
+
+    fn validate_config(&self, config: &Value) -> Result<(), String> {
+        MemoryConfig::from_value(config).map(|_| ())
+    }
+
+    async fn system_prompt_contribution(&self, ctx: &SystemPromptContext) -> Option<String> {
+        self.system_prompt_contribution_with_config(ctx, &Value::Null)
+            .await
+    }
+
+    async fn system_prompt_contribution_with_config(
+        &self,
+        _ctx: &SystemPromptContext,
+        config: &Value,
+    ) -> Option<String> {
+        let cfg = Self::resolved_config(config);
+        let (titles, total) = self.memory.titles(cfg.disclosed_titles);
         Some(render_memory_block(self.memory.path(), &titles, total))
     }
 
@@ -643,19 +715,11 @@ known memories (most recent first, 1 of 1):
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
-        vec![
-            Box::new(RememberTool {
-                memory: self.memory.clone(),
-                config: self.config,
-            }),
-            Box::new(RecallTool {
-                memory: self.memory.clone(),
-                config: self.config,
-            }),
-            Box::new(ForgetTool {
-                memory: self.memory.clone(),
-            }),
-        ]
+        self.build_tools(MemoryConfig::default())
+    }
+
+    fn tools_with_config(&self, config: &Value) -> Vec<Box<dyn Tool>> {
+        self.build_tools(Self::resolved_config(config))
     }
 }
 
@@ -1064,22 +1128,43 @@ mod tests {
     }
 
     #[test]
-    fn config_reads_memory_table_with_defaults() {
-        let tmp = tempfile::tempdir().expect("tmp");
-        let path = tmp.path().join("settings.toml");
-
-        // Missing file → defaults.
+    fn config_parses_from_capability_config_value() {
+        // Null / empty → defaults.
         assert_eq!(
-            MemoryConfig::from_settings_file(&path),
+            MemoryConfig::from_value(&Value::Null).unwrap(),
+            MemoryConfig::default()
+        );
+        assert_eq!(
+            MemoryConfig::from_value(&json!({})).unwrap(),
             MemoryConfig::default()
         );
 
-        std::fs::write(&path, "[memory]\ndisclosed_titles = 5\nrecall_limit = 3\n").expect("seed");
-        let cfg = MemoryConfig::from_settings_file(&path);
+        // Present keys override; unset keys keep defaults.
+        let cfg = MemoryConfig::from_value(&json!({ "disclosed_titles": 5, "recall_limit": 3 }))
+            .expect("valid");
         assert_eq!(cfg.disclosed_titles, 5);
         assert_eq!(cfg.recall_limit, 3);
-        // Unset key keeps its default.
         assert_eq!(cfg.soft_cap, MemoryConfig::default().soft_cap);
+
+        // Wrong types are rejected — this is the `validate_config` guardrail.
+        assert!(MemoryConfig::from_value(&json!({ "soft_cap": -1 })).is_err());
+        assert!(MemoryConfig::from_value(&json!({ "recall_limit": "lots" })).is_err());
+        assert!(MemoryConfig::from_value(&json!([1, 2, 3])).is_err());
+    }
+
+    #[test]
+    fn capability_config_schema_validates_and_tools_read_config() {
+        let (_tmp, store) = store_in_tmp();
+        let cap = GlobalMemoryCapability {
+            memory: Arc::new(store),
+        };
+        assert!(cap.config_schema().is_some());
+        assert!(cap.validate_config(&json!({ "recall_limit": 2 })).is_ok());
+        assert!(cap.validate_config(&json!({ "recall_limit": -2 })).is_err());
+
+        // Config drives the tools built via the capability-config path.
+        let tools = cap.tools_with_config(&json!({ "recall_limit": 2 }));
+        assert_eq!(tools.len(), 3);
     }
 
     #[test]
@@ -1174,7 +1259,6 @@ mod tests {
         let (_tmp, store) = store_in_tmp();
         let capability = GlobalMemoryCapability {
             memory: Arc::new(store),
-            config: MemoryConfig::default(),
         };
         let names: Vec<String> = capability
             .tools()

--- a/src/capabilities/memory.rs
+++ b/src/capabilities/memory.rs
@@ -1,0 +1,1187 @@
+// The `memory` capability — yolop's global, durable memory.
+//
+// Extracted from the `your` capability so personalization (hooks, framing) and
+// durable cross-session memory evolve independently. Memory is now *structured*:
+// a `MEMORY.md` where each `## ` section is one memory with a title (its
+// description), an id, created/updated timestamps, and a body (the memory text).
+//
+// Progressive disclosure: only memory TITLES are injected every turn (newest
+// first, capped). The model reads a memory's full body on demand with `recall`,
+// adds/updates with `remember`, and deletes with `forget`. This keeps the prompt
+// small no matter how much the user remembers — the opposite of the old model,
+// which injected the whole file every turn.
+//
+// See specs/memory.md for the design and configuration knobs.
+
+use crate::settings::SettingsStore;
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use serde_json::{Value, json};
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+pub(crate) const MEMORY_CAPABILITY_ID: &str = "memory";
+
+/// Structured memory file name, co-located with `settings.toml` in the yolop
+/// config dir.
+pub(crate) const MEMORY_FILE_NAME: &str = "MEMORY.md";
+
+const MEMORY_HEADER: &str = "# yolop memory\n\n\
+<!-- Global, durable user memory. One `## ` section per memory: the heading is its\n\
+title, the HTML comment carries its id and timestamps, and the body is the memory\n\
+text. Managed by the `remember` / `recall` / `forget` tools — edit through those,\n\
+not by hand. -->\n";
+
+// ---------- configuration ----------
+
+/// Tunables for the memory capability, read from a `[memory]` table in
+/// `settings.toml` (all keys optional; sensible defaults otherwise).
+///
+/// ```toml
+/// [memory]
+/// disclosed_titles = 15   # memory titles injected into the prompt each turn
+/// recall_limit = 5        # default number of memories `recall` returns
+/// soft_cap = 200          # warn (never delete) once this many memories exist
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct MemoryConfig {
+    /// How many memory titles to inject into the system prompt each turn.
+    pub disclosed_titles: usize,
+    /// Default number of memories `recall` returns for a search/recent query.
+    pub recall_limit: usize,
+    /// Once memory holds more than this, `remember`/`recall` nudge the model to
+    /// prune. A soft limit only — yolop never silently drops a user's memory.
+    pub soft_cap: usize,
+}
+
+impl Default for MemoryConfig {
+    fn default() -> Self {
+        Self {
+            disclosed_titles: 15,
+            recall_limit: 5,
+            soft_cap: 200,
+        }
+    }
+}
+
+impl MemoryConfig {
+    /// Derive config from the `[memory]` table of the settings file backing
+    /// `settings`. Missing file / table / keys fall back to defaults, so this
+    /// never fails — the worst case is the default tuning.
+    pub(crate) fn from_settings(settings: &SettingsStore) -> Self {
+        Self::from_settings_file(settings.path())
+    }
+
+    fn from_settings_file(path: &Path) -> Self {
+        let mut cfg = Self::default();
+        let Ok(text) = std::fs::read_to_string(path) else {
+            return cfg;
+        };
+        let Ok(table) = toml::from_str::<toml::Table>(&text) else {
+            return cfg;
+        };
+        let Some(mem) = table.get("memory").and_then(toml::Value::as_table) else {
+            return cfg;
+        };
+        let read = |key: &str| {
+            mem.get(key)
+                .and_then(toml::Value::as_integer)
+                .filter(|v| *v >= 0)
+                .map(|v| v as usize)
+        };
+        if let Some(v) = read("disclosed_titles") {
+            cfg.disclosed_titles = v;
+        }
+        if let Some(v) = read("recall_limit") {
+            cfg.recall_limit = v;
+        }
+        if let Some(v) = read("soft_cap") {
+            cfg.soft_cap = v;
+        }
+        cfg
+    }
+}
+
+// ---------- data model ----------
+
+/// One durable memory: a titled, timestamped note. `title` doubles as the
+/// memory's human description and is what search boosts and disclosure shows.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct Memory {
+    pub id: String,
+    pub title: String,
+    pub created: DateTime<Utc>,
+    pub updated: DateTime<Utc>,
+    pub body: String,
+}
+
+impl Memory {
+    fn to_json(&self) -> Value {
+        json!({
+            "id": self.id,
+            "title": self.title,
+            "created": self.created.to_rfc3339(),
+            "updated": self.updated.to_rfc3339(),
+            "memory": self.body,
+        })
+    }
+
+    /// Render one `## ` section for the on-disk file.
+    fn render(&self) -> String {
+        format!(
+            "## {title}\n<!-- id: {id} · created: {created} · updated: {updated} -->\n\n{body}\n",
+            title = self.title.trim(),
+            id = self.id,
+            created = self.created.to_rfc3339(),
+            updated = self.updated.to_rfc3339(),
+            body = self.body.trim(),
+        )
+    }
+}
+
+/// Outcome of a `remember` call: the resulting memory, whether it was newly
+/// created (vs. an update), and the new total count.
+pub(crate) struct RememberOutcome {
+    pub memory: Memory,
+    pub created: bool,
+    pub total: usize,
+}
+
+/// Result of a `recall` search: the capped slice plus the total number of
+/// matches, so callers can tell the model "showing N of T — narrow your query".
+pub(crate) struct SearchResult {
+    pub matches: Vec<Memory>,
+    pub total_matched: usize,
+}
+
+// ---------- store ----------
+
+/// Thread-safe handle to the structured `MEMORY.md`. The in-memory `Vec` is the
+/// source of truth (kept newest-first by `updated`); mutations flush to disk via
+/// an atomic temp-file + rename so readers and crashes never see a half-written
+/// file. Mirrors `SettingsStore`.
+pub(crate) struct MemoryStore {
+    path: PathBuf,
+    inner: Mutex<Vec<Memory>>,
+}
+
+impl MemoryStore {
+    pub(crate) fn open(path: PathBuf) -> Self {
+        let content = std::fs::read_to_string(&path).unwrap_or_default();
+        let mut memories = parse(&content);
+        sort_newest_first(&mut memories);
+        Self {
+            path,
+            inner: Mutex::new(memories),
+        }
+    }
+
+    /// Derive the memory path from the settings file's directory so memory
+    /// lives next to `settings.toml` and tests pointing settings at a tempdir
+    /// get an isolated memory file for free.
+    pub(crate) fn beside_settings(settings: &SettingsStore) -> Self {
+        let path = settings
+            .path()
+            .parent()
+            .map(|p| p.join(MEMORY_FILE_NAME))
+            .unwrap_or_else(|| PathBuf::from(MEMORY_FILE_NAME));
+        Self::open(path)
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.inner.lock().expect("memory lock poisoned").len()
+    }
+
+    /// Add a new memory, or update an existing one. A memory is updated when an
+    /// `id` is given and matches, or (when no id is given) when an existing
+    /// title matches case-insensitively — so re-remembering the same thing
+    /// edits in place instead of duplicating. Always stamps `updated = now`.
+    pub(crate) fn remember(
+        &self,
+        title: &str,
+        body: &str,
+        id: Option<&str>,
+    ) -> Result<RememberOutcome> {
+        let now = Utc::now();
+        let title = title.trim();
+        let mut guard = self.inner.lock().expect("memory lock poisoned");
+
+        let existing = match id {
+            Some(id) => guard.iter().position(|m| m.id == id),
+            None => guard
+                .iter()
+                .position(|m| m.title.eq_ignore_ascii_case(title)),
+        };
+
+        let (memory, created) = match existing {
+            Some(idx) => {
+                let m = &mut guard[idx];
+                m.title = title.to_string();
+                m.body = body.trim().to_string();
+                m.updated = now;
+                (m.clone(), false)
+            }
+            None => {
+                let new_id = id
+                    .map(str::to_string)
+                    .unwrap_or_else(|| generate_id(&guard, title, now));
+                let m = Memory {
+                    id: new_id,
+                    title: title.to_string(),
+                    created: now,
+                    updated: now,
+                    body: body.trim().to_string(),
+                };
+                guard.push(m.clone());
+                (m, true)
+            }
+        };
+
+        sort_newest_first(&mut guard);
+        let total = guard.len();
+        save_to(&self.path, &guard)?;
+        Ok(RememberOutcome {
+            memory,
+            created,
+            total,
+        })
+    }
+
+    /// Remove a memory by id, or by exact (case-insensitive) title. Returns the
+    /// removed memory, or `None` if nothing matched.
+    pub(crate) fn forget(&self, key: &str) -> Result<Option<Memory>> {
+        let key = key.trim();
+        let mut guard = self.inner.lock().expect("memory lock poisoned");
+        let idx = guard
+            .iter()
+            .position(|m| m.id == key)
+            .or_else(|| guard.iter().position(|m| m.title.eq_ignore_ascii_case(key)));
+        let removed = idx.map(|i| guard.remove(i));
+        if removed.is_some() {
+            save_to(&self.path, &guard)?;
+        }
+        Ok(removed)
+    }
+
+    /// Fetch a single memory by id.
+    pub(crate) fn get(&self, id: &str) -> Option<Memory> {
+        let guard = self.inner.lock().expect("memory lock poisoned");
+        guard.iter().find(|m| m.id == id).cloned()
+    }
+
+    /// The `limit` most recently updated memories, plus the total count.
+    pub(crate) fn recent(&self, limit: usize) -> SearchResult {
+        let guard = self.inner.lock().expect("memory lock poisoned");
+        SearchResult {
+            matches: guard.iter().take(limit).cloned().collect(),
+            total_matched: guard.len(),
+        }
+    }
+
+    /// Rank memories against `query`, returning the top `limit` plus the total
+    /// number that matched. Title hits are weighted more than body hits, and
+    /// ties break toward the most recently updated memory ("prefer latest").
+    pub(crate) fn search(&self, query: &str, limit: usize) -> SearchResult {
+        let tokens = tokenize(query);
+        if tokens.is_empty() {
+            return self.recent(limit);
+        }
+        let guard = self.inner.lock().expect("memory lock poisoned");
+        let mut scored: Vec<(i64, &Memory)> = guard
+            .iter()
+            .filter_map(|m| {
+                let score = relevance(m, &tokens);
+                (score > 0).then_some((score, m))
+            })
+            .collect();
+        // Primary: score desc. Secondary: updated desc (guard is already sorted
+        // newest-first, so a stable sort by score keeps recency as the tiebreak).
+        scored.sort_by(|a, b| b.0.cmp(&a.0));
+        let total_matched = scored.len();
+        let matches = scored
+            .into_iter()
+            .take(limit)
+            .map(|(_, m)| m.clone())
+            .collect();
+        SearchResult {
+            matches,
+            total_matched,
+        }
+    }
+
+    /// Titles of the `limit` most recent memories, plus the total count, for
+    /// progressive disclosure in the system prompt.
+    pub(crate) fn titles(&self, limit: usize) -> (Vec<(String, String, DateTime<Utc>)>, usize) {
+        let guard = self.inner.lock().expect("memory lock poisoned");
+        let titles = guard
+            .iter()
+            .take(limit)
+            .map(|m| (m.id.clone(), m.title.clone(), m.updated))
+            .collect();
+        (titles, guard.len())
+    }
+}
+
+// ---------- parsing / serialization ----------
+
+fn sort_newest_first(memories: &mut [Memory]) {
+    memories.sort_by(|a, b| b.updated.cmp(&a.updated));
+}
+
+/// Split case-insensitive query into deduped non-empty word tokens.
+fn tokenize(query: &str) -> Vec<String> {
+    let mut tokens: Vec<String> = Vec::new();
+    for raw in query.split_whitespace() {
+        let t = raw.trim().to_lowercase();
+        if !t.is_empty() && !tokens.contains(&t) {
+            tokens.push(t);
+        }
+    }
+    tokens
+}
+
+/// Relevance of one memory to the query tokens. Each token present in the title
+/// scores 3, in the body scores 1; summed across tokens.
+fn relevance(memory: &Memory, tokens: &[String]) -> i64 {
+    let title = memory.title.to_lowercase();
+    let body = memory.body.to_lowercase();
+    tokens
+        .iter()
+        .map(|t| {
+            let mut s = 0;
+            if title.contains(t.as_str()) {
+                s += 3;
+            }
+            if body.contains(t.as_str()) {
+                s += 1;
+            }
+            s
+        })
+        .sum()
+}
+
+/// Generate a short, unique-within-store id like `m-1a2b3c`.
+fn generate_id(existing: &[Memory], seed: &str, now: DateTime<Utc>) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut counter: u64 = 0;
+    loop {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        seed.hash(&mut hasher);
+        now.timestamp_nanos_opt().unwrap_or(0).hash(&mut hasher);
+        counter.hash(&mut hasher);
+        let id = format!("m-{:06x}", hasher.finish() & 0xFFFFFF);
+        if !existing.iter().any(|m| m.id == id) {
+            return id;
+        }
+        counter += 1;
+    }
+}
+
+/// Parse the structured `MEMORY.md` into memories. Robust by design: a missing
+/// metadata comment gets a generated id and `now` timestamps, and a legacy
+/// flat-bullet file (no `## ` sections) is imported wholesale as a single
+/// "Imported notes" memory so an upgrade never loses a user's notes.
+fn parse(content: &str) -> Vec<Memory> {
+    let lines: Vec<&str> = content.lines().collect();
+    // Indices of section heading lines ("## ...").
+    let heads: Vec<usize> = lines
+        .iter()
+        .enumerate()
+        .filter(|(_, l)| l.starts_with("## "))
+        .map(|(i, _)| i)
+        .collect();
+
+    if heads.is_empty() {
+        return import_legacy(&lines);
+    }
+
+    let mut memories = Vec::new();
+    for (n, &start) in heads.iter().enumerate() {
+        let end = heads.get(n + 1).copied().unwrap_or(lines.len());
+        let title = lines[start].trim_start_matches("## ").trim().to_string();
+        let mut id = None;
+        let mut created = None;
+        let mut updated = None;
+        let mut body_lines: Vec<&str> = Vec::new();
+        for &line in &lines[start + 1..end] {
+            let trimmed = line.trim();
+            if id.is_none() && trimmed.starts_with("<!--") && trimmed.ends_with("-->") {
+                let (i, c, u) = parse_meta(trimmed);
+                id = i;
+                created = c;
+                updated = u;
+                continue;
+            }
+            body_lines.push(line);
+        }
+        let body = body_lines.join("\n").trim().to_string();
+        let now = Utc::now();
+        let created = created.unwrap_or_else(|| updated.unwrap_or(now));
+        let updated = updated.unwrap_or(created);
+        let id = id.unwrap_or_else(|| generate_id(&memories, &title, created));
+        memories.push(Memory {
+            id,
+            title,
+            created,
+            updated,
+            body,
+        });
+    }
+    memories
+}
+
+/// Parse a `<!-- id: … · created: … · updated: … -->` metadata line. Each field
+/// is optional and order-independent.
+fn parse_meta(comment: &str) -> (Option<String>, Option<DateTime<Utc>>, Option<DateTime<Utc>>) {
+    let inner = comment
+        .trim_start_matches("<!--")
+        .trim_end_matches("-->")
+        .trim();
+    let mut id = None;
+    let mut created = None;
+    let mut updated = None;
+    for part in inner.split('·') {
+        let Some((key, value)) = part.split_once(':') else {
+            continue;
+        };
+        let key = key.trim();
+        let value = value.trim();
+        match key {
+            "id" => id = (!value.is_empty()).then(|| value.to_string()),
+            "created" => created = parse_ts(value),
+            "updated" => updated = parse_ts(value),
+            _ => {}
+        }
+    }
+    (id, created, updated)
+}
+
+fn parse_ts(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+/// Import a pre-structure file (flat bullets, free text) as one memory so an
+/// upgrade is lossless. Returns empty when there's nothing but a header.
+fn import_legacy(lines: &[&str]) -> Vec<Memory> {
+    let body: String = lines
+        .iter()
+        .filter(|l| {
+            let t = l.trim();
+            !t.is_empty() && !t.starts_with('#') && !t.starts_with("<!--")
+        })
+        .copied()
+        .collect::<Vec<_>>()
+        .join("\n");
+    if body.trim().is_empty() {
+        return Vec::new();
+    }
+    let now = Utc::now();
+    vec![Memory {
+        id: generate_id(&[], "imported notes", now),
+        title: "Imported notes".to_string(),
+        created: now,
+        updated: now,
+        body: body.trim().to_string(),
+    }]
+}
+
+/// Serialize all memories back to `MEMORY.md` text (header + sections).
+fn serialize(memories: &[Memory]) -> String {
+    let mut out = String::from(MEMORY_HEADER);
+    for m in memories {
+        out.push('\n');
+        out.push_str(&m.render());
+    }
+    out
+}
+
+/// Atomic write: stage into a sibling temp file, `fsync`, then `rename` over the
+/// target. The temp file is created 0o600 on Unix so memory — which may hold
+/// personal facts — stays owner-only. Mirrors `settings::save_to`.
+fn save_to(path: &Path, memories: &[Memory]) -> Result<()> {
+    let content = serialize(memories);
+    let parent = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+    std::fs::create_dir_all(&parent)
+        .with_context(|| format!("create memory dir {}", parent.display()))?;
+
+    let file_name = path
+        .file_name()
+        .with_context(|| format!("memory path has no file name: {}", path.display()))?;
+    let mut tmp_name = std::ffi::OsString::from(".");
+    tmp_name.push(file_name);
+    tmp_name.push(format!(".tmp.{}", std::process::id()));
+    let tmp_path = parent.join(tmp_name);
+
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    let write_result = (|| -> Result<()> {
+        let mut file = opts
+            .open(&tmp_path)
+            .with_context(|| format!("open temp memory {}", tmp_path.display()))?;
+        file.write_all(content.as_bytes())
+            .with_context(|| format!("write temp memory {}", tmp_path.display()))?;
+        file.sync_all()
+            .with_context(|| format!("sync temp memory {}", tmp_path.display()))?;
+        Ok(())
+    })();
+    if let Err(e) = write_result {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(e);
+    }
+    std::fs::rename(&tmp_path, path)
+        .with_context(|| format!("rename {} -> {}", tmp_path.display(), path.display()))?;
+    Ok(())
+}
+
+// ---------- system prompt ----------
+
+/// Render the `<memory>` block: framing plus the disclosed titles (newest
+/// first). Bodies are never injected — they are fetched on demand via `recall`.
+/// Pure so the branch logic is unit-testable.
+fn render_memory_block(
+    memory_path: &Path,
+    titles: &[(String, String, DateTime<Utc>)],
+    total: usize,
+) -> String {
+    let mut out = String::new();
+    out.push_str("<memory>\n");
+    out.push_str(
+        "Global, durable user memory across all yolop sessions — preferences, facts, and \
+         conventions about the user (\"prefer terse answers\", \"my name is Mike\"). Only memory \
+         TITLES are shown here: call `recall` with an id or a search query to read a memory's full \
+         text, `remember` to add or update one, and `forget` to delete one. This is GLOBAL \
+         personalization about the user, NOT project guidance (that belongs in the repo's \
+         AGENTS.md).\n",
+    );
+    out.push_str(&format!("memory file: {}\n", memory_path.display()));
+
+    if total == 0 {
+        out.push_str("memory is empty — use `remember` to store a durable preference or fact.\n");
+    } else {
+        out.push_str(&format!(
+            "known memories (most recent first, {} of {}):\n",
+            titles.len(),
+            total
+        ));
+        for (id, title, updated) in titles {
+            out.push_str(&format!(
+                "- [{id}] {title} ({date})\n",
+                date = updated.format("%Y-%m-%d")
+            ));
+        }
+        if titles.len() < total {
+            out.push_str(
+                "(more memories exist than shown — use `recall` with a search query to find them.)\n",
+            );
+        }
+    }
+    out.push_str("</memory>");
+    out
+}
+
+// ---------- capability ----------
+
+pub(crate) struct GlobalMemoryCapability {
+    pub(crate) memory: Arc<MemoryStore>,
+    pub(crate) config: MemoryConfig,
+}
+
+#[async_trait]
+impl Capability for GlobalMemoryCapability {
+    fn id(&self) -> &str {
+        MEMORY_CAPABILITY_ID
+    }
+    fn name(&self) -> &str {
+        "Global memory"
+    }
+    fn description(&self) -> &str {
+        "Global, durable, structured user memory. Titles are disclosed every turn; bodies are \
+         recalled on demand via `remember` / `recall` / `forget`."
+    }
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+    fn category(&self) -> Option<&str> {
+        Some("Personalization")
+    }
+
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        let (titles, total) = self.memory.titles(self.config.disclosed_titles);
+        Some(render_memory_block(self.memory.path(), &titles, total))
+    }
+
+    fn system_prompt_preview(&self) -> Option<String> {
+        Some(
+            "\
+<memory>
+Global, durable user memory. Titles disclosed here; read full text with `recall`,
+add/update with `remember`, delete with `forget`.
+known memories (most recent first, 1 of 1):
+- [m-1a2b3c] Prefer terse answers (2026-06-13)
+</memory>"
+                .to_string(),
+        )
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(RememberTool {
+                memory: self.memory.clone(),
+                config: self.config,
+            }),
+            Box::new(RecallTool {
+                memory: self.memory.clone(),
+                config: self.config,
+            }),
+            Box::new(ForgetTool {
+                memory: self.memory.clone(),
+            }),
+        ]
+    }
+}
+
+/// One-line nudge once memory has outgrown the soft cap.
+fn soft_cap_warning(total: usize, soft_cap: usize) -> Option<String> {
+    (soft_cap > 0 && total > soft_cap).then(|| {
+        format!(
+            "memory is large ({total} memories, soft cap {soft_cap}) — consider `forget`ting stale \
+             memories or moving stable, topic-specific guidance into a skill."
+        )
+    })
+}
+
+// ---------- tools ----------
+
+struct RememberTool {
+    memory: Arc<MemoryStore>,
+    config: MemoryConfig,
+}
+
+#[async_trait]
+impl Tool for RememberTool {
+    fn name(&self) -> &str {
+        "remember"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Remember")
+    }
+    fn description(&self) -> &str {
+        "Store a durable, GLOBAL memory about the user or how yolop should behave across all \
+         projects (e.g. \"prefer terse answers\"). `title` is a short description; `memory` is the \
+         full text. A timestamp is set automatically. Pass an existing `id` (or reuse an existing \
+         title) to update in place instead of adding a duplicate. Use for personalization about \
+         the user — NOT project-specific guidance (that belongs in AGENTS.md)."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "Short description of the memory; also what search boosts and disclosure shows."
+                },
+                "memory": {
+                    "type": "string",
+                    "description": "The full memory text, phrased to stand alone on later turns."
+                },
+                "id": {
+                    "type": "string",
+                    "description": "Optional id of an existing memory to update in place (from `recall`)."
+                }
+            },
+            "required": ["title", "memory"],
+            "additionalProperties": false
+        })
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let title = match arguments.get("title").and_then(Value::as_str) {
+            Some(t) if !t.trim().is_empty() => t,
+            _ => {
+                return ToolExecutionResult::tool_error(
+                    "'title' is required and must be non-empty",
+                );
+            }
+        };
+        let body = match arguments.get("memory").and_then(Value::as_str) {
+            Some(b) if !b.trim().is_empty() => b,
+            _ => {
+                return ToolExecutionResult::tool_error(
+                    "'memory' is required and must be non-empty",
+                );
+            }
+        };
+        let id = arguments
+            .get("id")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+
+        match self.memory.remember(title, body, id) {
+            Ok(outcome) => {
+                let verb = if outcome.created {
+                    "remembered"
+                } else {
+                    "updated"
+                };
+                let mut message = format!(
+                    "{verb} [{}] ({} memories total)",
+                    outcome.memory.id, outcome.total
+                );
+                if let Some(note) = soft_cap_warning(outcome.total, self.config.soft_cap) {
+                    message.push_str(". ");
+                    message.push_str(&note);
+                }
+                ToolExecutionResult::success(json!({
+                    "ok": true,
+                    "created": outcome.created,
+                    "id": outcome.memory.id,
+                    "total": outcome.total,
+                    "message": message,
+                }))
+            }
+            Err(e) => ToolExecutionResult::tool_error(format!("could not save memory: {e}")),
+        }
+    }
+}
+
+struct RecallTool {
+    memory: Arc<MemoryStore>,
+    config: MemoryConfig,
+}
+
+#[async_trait]
+impl Tool for RecallTool {
+    fn name(&self) -> &str {
+        "recall"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Recall")
+    }
+    fn description(&self) -> &str {
+        "Read durable memory. Pass an `id` to fetch one memory's full text, or a `query` to search \
+         (title matches rank above body matches, and newer memories win ties). With neither, \
+         returns the most recent memories. Results are capped (`limit`); when more match, the \
+         response says so — narrow the query rather than trying to read everything."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Search text. Omit to list the most recent memories."
+                },
+                "id": {
+                    "type": "string",
+                    "description": "Fetch exactly this memory by id (from disclosure or an earlier recall)."
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Max memories to return (defaults to the configured recall limit)."
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        // By-id retrieval is exact and ignores limit.
+        if let Some(id) = arguments
+            .get("id")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            return match self.memory.get(id) {
+                Some(m) => ToolExecutionResult::success(json!({
+                    "ok": true,
+                    "memory": m.to_json(),
+                })),
+                None => ToolExecutionResult::success(json!({
+                    "ok": true,
+                    "memory": Value::Null,
+                    "message": format!("no memory with id '{id}'"),
+                })),
+            };
+        }
+
+        let limit = arguments
+            .get("limit")
+            .and_then(Value::as_u64)
+            .map(|v| v as usize)
+            .filter(|v| *v > 0)
+            .unwrap_or(self.config.recall_limit)
+            .max(1);
+        let query = arguments
+            .get("query")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .trim();
+
+        let result = self.memory.search(query, limit);
+        let shown = result.matches.len();
+        let mut message = if query.is_empty() {
+            format!("{shown} most recent of {} memories", result.total_matched)
+        } else {
+            format!("{shown} of {} matching memories", result.total_matched)
+        };
+        if result.total_matched > shown {
+            message.push_str("; more exist — narrow the query or raise `limit` to see them.");
+        }
+        ToolExecutionResult::success(json!({
+            "ok": true,
+            "query": query,
+            "shown": shown,
+            "total_matched": result.total_matched,
+            "truncated": result.total_matched > shown,
+            "matches": result.matches.iter().map(Memory::to_json).collect::<Vec<_>>(),
+            "message": message,
+        }))
+    }
+}
+
+struct ForgetTool {
+    memory: Arc<MemoryStore>,
+}
+
+#[async_trait]
+impl Tool for ForgetTool {
+    fn name(&self) -> &str {
+        "forget"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Forget")
+    }
+    fn description(&self) -> &str {
+        "Delete one durable memory by `id` (preferred) or by its exact title. Use when a stored \
+         preference or fact is no longer true."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "The memory id (from `recall`/disclosure), or the exact memory title."
+                }
+            },
+            "required": ["id"],
+            "additionalProperties": false
+        })
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let key = match arguments.get("id").and_then(Value::as_str) {
+            Some(k) if !k.trim().is_empty() => k,
+            _ => return ToolExecutionResult::tool_error("'id' is required and must be non-empty"),
+        };
+        match self.memory.forget(key) {
+            Ok(Some(removed)) => ToolExecutionResult::success(json!({
+                "ok": true,
+                "removed": true,
+                "id": removed.id,
+                "title": removed.title,
+                "total": self.memory.len(),
+            })),
+            Ok(None) => ToolExecutionResult::success(json!({
+                "ok": true,
+                "removed": false,
+                "message": format!("no memory matched '{}'", key.trim()),
+            })),
+            Err(e) => ToolExecutionResult::tool_error(format!("could not update memory: {e}")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store_in_tmp() -> (tempfile::TempDir, MemoryStore) {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let store = MemoryStore::open(tmp.path().join(MEMORY_FILE_NAME));
+        (tmp, store)
+    }
+
+    #[test]
+    fn remember_creates_then_updates_in_place_by_title() {
+        let (_tmp, store) = store_in_tmp();
+        let first = store
+            .remember("Prefer terse", "Keep answers short.", None)
+            .expect("remember");
+        assert!(first.created);
+        assert_eq!(first.total, 1);
+
+        // Same title (case-insensitive) updates rather than duplicating.
+        let second = store
+            .remember("prefer TERSE", "Keep answers very short.", None)
+            .expect("remember");
+        assert!(!second.created);
+        assert_eq!(second.total, 1);
+        assert_eq!(second.memory.id, first.memory.id);
+        assert_eq!(
+            store.get(&first.memory.id).unwrap().body,
+            "Keep answers very short."
+        );
+    }
+
+    #[test]
+    fn remember_update_by_id_changes_title_and_body() {
+        let (_tmp, store) = store_in_tmp();
+        let m = store.remember("Old title", "old", None).expect("remember");
+        let updated = store
+            .remember("New title", "new", Some(&m.memory.id))
+            .expect("update");
+        assert!(!updated.created);
+        let got = store.get(&m.memory.id).expect("present");
+        assert_eq!(got.title, "New title");
+        assert_eq!(got.body, "new");
+    }
+
+    #[test]
+    fn forget_removes_by_id_and_by_title() {
+        let (_tmp, store) = store_in_tmp();
+        let a = store.remember("Alpha", "a", None).expect("a");
+        let _b = store.remember("Beta", "b", None).expect("b");
+        assert_eq!(store.len(), 2);
+
+        assert!(store.forget(&a.memory.id).expect("forget").is_some());
+        assert_eq!(store.len(), 1);
+        assert!(store.forget("beta").expect("forget by title").is_some());
+        assert_eq!(store.len(), 0);
+        assert!(store.forget("nope").expect("forget missing").is_none());
+    }
+
+    #[test]
+    fn search_boosts_title_over_body_and_caps_with_total() {
+        let (_tmp, store) = store_in_tmp();
+        // "rust" only in body.
+        store
+            .remember("Editor", "Uses rust-analyzer in the editor.", None)
+            .expect("m1");
+        // "rust" in the title — should rank first.
+        store
+            .remember("Rust style", "Prefers explicit error handling.", None)
+            .expect("m2");
+        store
+            .remember("Unrelated", "nothing here", None)
+            .expect("m3");
+
+        let result = store.search("rust", 1);
+        assert_eq!(result.total_matched, 2);
+        assert_eq!(result.matches.len(), 1);
+        assert_eq!(result.matches[0].title, "Rust style");
+    }
+
+    #[test]
+    fn empty_query_returns_recent() {
+        let (_tmp, store) = store_in_tmp();
+        store.remember("One", "1", None).expect("m1");
+        store.remember("Two", "2", None).expect("m2");
+        let result = store.search("   ", 5);
+        assert_eq!(result.total_matched, 2);
+        // Most recently remembered comes first.
+        assert_eq!(result.matches[0].title, "Two");
+    }
+
+    #[test]
+    fn persists_and_reparses_across_reopen() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join("nested").join(MEMORY_FILE_NAME);
+        let store = MemoryStore::open(path.clone());
+        let m = store
+            .remember("Likes blue", "The user likes the color blue.", None)
+            .expect("remember");
+
+        let reopened = MemoryStore::open(path);
+        let got = reopened.get(&m.memory.id).expect("survives reopen");
+        assert_eq!(got.title, "Likes blue");
+        assert_eq!(got.body, "The user likes the color blue.");
+        assert_eq!(got.created, m.memory.created);
+    }
+
+    #[test]
+    fn legacy_bullet_file_is_imported_losslessly() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join(MEMORY_FILE_NAME);
+        std::fs::write(
+            &path,
+            "# yolop memory\n\n- prefer terse answers\n- name is Mike\n",
+        )
+        .expect("seed legacy");
+        let store = MemoryStore::open(path);
+        assert_eq!(store.len(), 1);
+        let imported = &store.recent(1).matches[0];
+        assert_eq!(imported.title, "Imported notes");
+        assert!(imported.body.contains("prefer terse answers"));
+        assert!(imported.body.contains("name is Mike"));
+    }
+
+    #[test]
+    fn titles_disclosure_caps_and_reports_total() {
+        let (_tmp, store) = store_in_tmp();
+        for i in 0..20 {
+            store
+                .remember(&format!("Memory {i}"), "body", None)
+                .expect("remember");
+        }
+        let (titles, total) = store.titles(15);
+        assert_eq!(total, 20);
+        assert_eq!(titles.len(), 15);
+    }
+
+    #[test]
+    fn render_block_handles_empty_and_overflow() {
+        let empty = render_memory_block(Path::new("/cfg/MEMORY.md"), &[], 0);
+        assert!(empty.starts_with("<memory>\n"));
+        assert!(empty.contains("memory is empty"));
+        assert!(empty.ends_with("</memory>"));
+
+        let now = Utc::now();
+        let titles = vec![("m-1".to_string(), "Prefer terse".to_string(), now)];
+        let block = render_memory_block(Path::new("/cfg/MEMORY.md"), &titles, 9);
+        assert!(block.contains("known memories (most recent first, 1 of 9)"));
+        assert!(block.contains("- [m-1] Prefer terse"));
+        assert!(block.contains("more memories exist than shown"));
+    }
+
+    #[test]
+    fn config_reads_memory_table_with_defaults() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join("settings.toml");
+
+        // Missing file → defaults.
+        assert_eq!(
+            MemoryConfig::from_settings_file(&path),
+            MemoryConfig::default()
+        );
+
+        std::fs::write(&path, "[memory]\ndisclosed_titles = 5\nrecall_limit = 3\n").expect("seed");
+        let cfg = MemoryConfig::from_settings_file(&path);
+        assert_eq!(cfg.disclosed_titles, 5);
+        assert_eq!(cfg.recall_limit, 3);
+        // Unset key keeps its default.
+        assert_eq!(cfg.soft_cap, MemoryConfig::default().soft_cap);
+    }
+
+    #[test]
+    fn soft_cap_warning_only_past_limit() {
+        assert!(soft_cap_warning(5, 200).is_none());
+        assert!(soft_cap_warning(201, 200).is_some());
+        // A zero cap disables the warning entirely.
+        assert!(soft_cap_warning(10_000, 0).is_none());
+    }
+
+    #[tokio::test]
+    async fn remember_tool_then_recall_by_query_and_id() {
+        let (_tmp, store) = store_in_tmp();
+        let store = Arc::new(store);
+        let remember = RememberTool {
+            memory: store.clone(),
+            config: MemoryConfig::default(),
+        };
+        let res = remember
+            .execute(json!({ "title": "Prefer spaces", "memory": "Use spaces, not tabs." }))
+            .await;
+        assert!(res.is_success());
+
+        let recall = RecallTool {
+            memory: store.clone(),
+            config: MemoryConfig::default(),
+        };
+        let by_query = recall.execute(json!({ "query": "spaces" })).await;
+        assert!(by_query.is_success());
+        let text = format!("{by_query:?}");
+        assert!(text.contains("Use spaces, not tabs."), "got: {text}");
+    }
+
+    #[tokio::test]
+    async fn recall_reports_more_when_truncated() {
+        let (_tmp, store) = store_in_tmp();
+        let store = Arc::new(store);
+        for i in 0..4 {
+            store
+                .remember(&format!("Note {i}"), "shared keyword body", None)
+                .expect("seed");
+        }
+        let recall = RecallTool {
+            memory: store.clone(),
+            config: MemoryConfig::default(),
+        };
+        let res = recall
+            .execute(json!({ "query": "keyword", "limit": 2 }))
+            .await;
+        assert!(res.is_success());
+        let text = format!("{res:?}");
+        assert!(text.contains("more exist"), "got: {text}");
+    }
+
+    #[tokio::test]
+    async fn remember_tool_rejects_empty_fields() {
+        let (_tmp, store) = store_in_tmp();
+        let tool = RememberTool {
+            memory: Arc::new(store),
+            config: MemoryConfig::default(),
+        };
+        assert!(
+            tool.execute(json!({ "title": " ", "memory": "x" }))
+                .await
+                .is_error()
+        );
+        assert!(
+            tool.execute(json!({ "title": "x", "memory": " " }))
+                .await
+                .is_error()
+        );
+    }
+
+    #[tokio::test]
+    async fn forget_tool_reports_removal() {
+        let (_tmp, store) = store_in_tmp();
+        let store = Arc::new(store);
+        store.remember("Throwaway", "temp", None).expect("seed");
+        let tool = ForgetTool {
+            memory: store.clone(),
+        };
+        let hit = tool.execute(json!({ "id": "Throwaway" })).await;
+        assert!(hit.is_success());
+        assert!(format!("{hit:?}").contains("\"removed\": true") || store.len() == 0);
+
+        let miss = tool.execute(json!({ "id": "ghost" })).await;
+        assert!(miss.is_success());
+    }
+
+    #[test]
+    fn capability_exposes_memory_tools_without_slash_command() {
+        let (_tmp, store) = store_in_tmp();
+        let capability = GlobalMemoryCapability {
+            memory: Arc::new(store),
+            config: MemoryConfig::default(),
+        };
+        let names: Vec<String> = capability
+            .tools()
+            .iter()
+            .map(|t| t.name().to_string())
+            .collect();
+        assert_eq!(names, vec!["remember", "recall", "forget"]);
+        assert!(capability.commands().is_empty());
+    }
+}

--- a/src/capabilities/memory.rs
+++ b/src/capabilities/memory.rs
@@ -325,7 +325,7 @@ impl MemoryStore {
             .collect();
         // Primary: score desc. Secondary: updated desc (guard is already sorted
         // newest-first, so a stable sort by score keeps recency as the tiebreak).
-        scored.sort_by(|a, b| b.0.cmp(&a.0));
+        scored.sort_by_key(|(score, _)| std::cmp::Reverse(*score));
         let total_matched = scored.len();
         let matches = scored
             .into_iter()
@@ -354,7 +354,7 @@ impl MemoryStore {
 // ---------- parsing / serialization ----------
 
 fn sort_newest_first(memories: &mut [Memory]) {
-    memories.sort_by(|a, b| b.updated.cmp(&a.updated));
+    memories.sort_by_key(|m| std::cmp::Reverse(m.updated));
 }
 
 /// Split case-insensitive query into deduped non-empty word tokens.

--- a/src/capabilities/memory.rs
+++ b/src/capabilities/memory.rs
@@ -38,15 +38,9 @@ not by hand. -->\n";
 
 // ---------- configuration ----------
 
-/// Tunables for the memory capability, read from a `[memory]` table in
-/// `settings.toml` (all keys optional; sensible defaults otherwise).
-///
-/// ```toml
-/// [memory]
-/// disclosed_titles = 15   # memory titles injected into the prompt each turn
-/// recall_limit = 5        # default number of memories `recall` returns
-/// soft_cap = 200          # warn (never delete) once this many memories exist
-/// ```
+/// Tunables for the memory capability, supplied through the generic
+/// capability-config system (`AgentCapabilityConfig.config`) and described by
+/// [`MemoryConfig::schema`]. All keys are optional; defaults apply otherwise.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct MemoryConfig {
     /// How many memory titles to inject into the system prompt each turn.
@@ -412,19 +406,40 @@ fn generate_id(existing: &[Memory], seed: &str, now: DateTime<Utc>) -> String {
     }
 }
 
-/// Parse the structured `MEMORY.md` into memories. Robust by design: a missing
-/// metadata comment gets a generated id and `now` timestamps, and a legacy
-/// flat-bullet file (no `## ` sections) is imported wholesale as a single
-/// "Imported notes" memory so an upgrade never loses a user's notes.
+/// Parse the structured `MEMORY.md` into memories. Robust by design:
+/// - Section boundaries are `## ` headings *anchored* by the `<!-- id: … -->`
+///   metadata line we always write directly beneath them. This keeps round-trips
+///   lossless even when a memory body itself contains a `## ` markdown heading —
+///   such a body line is not metadata-anchored, so it stays in the body.
+/// - If no heading is anchored (a hand-authored file), every `## ` is treated as
+///   a boundary, and a missing metadata comment gets a generated id / `now`.
+/// - A legacy flat-bullet file (no `## ` sections) is imported wholesale as a
+///   single "Imported notes" memory so an upgrade never loses a user's notes.
 fn parse(content: &str) -> Vec<Memory> {
     let lines: Vec<&str> = content.lines().collect();
-    // Indices of section heading lines ("## ...").
-    let heads: Vec<usize> = lines
+    let is_heading = |l: &str| l.starts_with("## ");
+    let is_meta = |l: &str| {
+        let t = l.trim();
+        t.starts_with("<!--") && t.contains("id:")
+    };
+    // Prefer metadata-anchored headings so a `## ` line inside a body never
+    // splits a memory. Fall back to every heading only when nothing is anchored.
+    let anchored: Vec<usize> = lines
         .iter()
         .enumerate()
-        .filter(|(_, l)| l.starts_with("## "))
+        .filter(|(i, l)| is_heading(l) && lines.get(i + 1).map(|n| is_meta(n)).unwrap_or(false))
         .map(|(i, _)| i)
         .collect();
+    let heads: Vec<usize> = if anchored.is_empty() {
+        lines
+            .iter()
+            .enumerate()
+            .filter(|(_, l)| is_heading(l))
+            .map(|(i, _)| i)
+            .collect()
+    } else {
+        anchored
+    };
 
     if heads.is_empty() {
         return import_legacy(&lines);
@@ -1097,6 +1112,26 @@ mod tests {
         assert_eq!(imported.title, "Imported notes");
         assert!(imported.body.contains("prefer terse answers"));
         assert!(imported.body.contains("name is Mike"));
+    }
+
+    #[test]
+    fn body_with_markdown_heading_survives_round_trip() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join(MEMORY_FILE_NAME);
+        let store = MemoryStore::open(path.clone());
+        // A body that itself contains a `## ` heading line must not be re-parsed
+        // into a second spurious memory on reload.
+        let body = "Commit style:\n\n## Heading rules\nUse `## ` for sections.";
+        let m = store
+            .remember("Markdown habits", body, None)
+            .expect("remember");
+
+        let reopened = MemoryStore::open(path);
+        assert_eq!(reopened.len(), 1);
+        let got = reopened.get(&m.memory.id).expect("single memory survives");
+        assert_eq!(got.title, "Markdown habits");
+        assert!(got.body.contains("## Heading rules"));
+        assert!(got.body.contains("Use `## ` for sections."));
     }
 
     #[test]

--- a/src/capabilities/memory.rs
+++ b/src/capabilities/memory.rs
@@ -76,21 +76,29 @@ impl MemoryConfig {
         let obj = config
             .as_object()
             .ok_or_else(|| "memory config must be an object".to_string())?;
-        let read = |key: &str, slot: &mut usize| -> Result<(), String> {
+        // `min` mirrors the JSON schema's per-key minimum so `validate_config`
+        // rejects exactly what the schema forbids. `try_from` avoids silently
+        // truncating an out-of-range value into `usize` on 32-bit targets.
+        let read = |key: &str, slot: &mut usize, min: usize| -> Result<(), String> {
             match obj.get(key) {
                 None | Some(Value::Null) => Ok(()),
                 Some(v) => {
                     let n = v
                         .as_u64()
                         .ok_or_else(|| format!("`{key}` must be a non-negative integer"))?;
-                    *slot = n as usize;
+                    let n = usize::try_from(n)
+                        .map_err(|_| format!("`{key}` is too large for this platform"))?;
+                    if n < min {
+                        return Err(format!("`{key}` must be at least {min}"));
+                    }
+                    *slot = n;
                     Ok(())
                 }
             }
         };
-        read("disclosed_titles", &mut cfg.disclosed_titles)?;
-        read("recall_limit", &mut cfg.recall_limit)?;
-        read("soft_cap", &mut cfg.soft_cap)?;
+        read("disclosed_titles", &mut cfg.disclosed_titles, 0)?;
+        read("recall_limit", &mut cfg.recall_limit, 1)?;
+        read("soft_cap", &mut cfg.soft_cap, 0)?;
         Ok(cfg)
     }
 
@@ -418,16 +426,18 @@ fn generate_id(existing: &[Memory], seed: &str, now: DateTime<Utc>) -> String {
 fn parse(content: &str) -> Vec<Memory> {
     let lines: Vec<&str> = content.lines().collect();
     let is_heading = |l: &str| l.starts_with("## ");
-    let is_meta = |l: &str| {
-        let t = l.trim();
-        t.starts_with("<!--") && t.contains("id:")
-    };
     // Prefer metadata-anchored headings so a `## ` line inside a body never
     // splits a memory. Fall back to every heading only when nothing is anchored.
     let anchored: Vec<usize> = lines
         .iter()
         .enumerate()
-        .filter(|(i, l)| is_heading(l) && lines.get(i + 1).map(|n| is_meta(n)).unwrap_or(false))
+        .filter(|(i, l)| {
+            is_heading(l)
+                && lines
+                    .get(i + 1)
+                    .map(|n| looks_like_metadata(n))
+                    .unwrap_or(false)
+        })
         .map(|(i, _)| i)
         .collect();
     let heads: Vec<usize> = if anchored.is_empty() {
@@ -454,9 +464,11 @@ fn parse(content: &str) -> Vec<Memory> {
         let mut updated = None;
         let mut body_lines: Vec<&str> = Vec::new();
         for &line in &lines[start + 1..end] {
-            let trimmed = line.trim();
-            if id.is_none() && trimmed.starts_with("<!--") && trimmed.ends_with("-->") {
-                let (i, c, u) = parse_meta(trimmed);
+            // Only consume a comment as metadata when it actually looks like our
+            // metadata line; a hand-authored body that opens with an unrelated
+            // HTML comment is kept verbatim rather than silently dropped.
+            if id.is_none() && created.is_none() && updated.is_none() && looks_like_metadata(line) {
+                let (i, c, u) = parse_meta(line.trim());
                 id = i;
                 created = c;
                 updated = u;
@@ -512,19 +524,50 @@ fn parse_ts(value: &str) -> Option<DateTime<Utc>> {
         .map(|dt| dt.with_timezone(&Utc))
 }
 
+/// Whether a line is one of our memory metadata comments — an HTML comment that
+/// actually carries id/created/updated, not just any `<!-- … -->`.
+fn looks_like_metadata(line: &str) -> bool {
+    let t = line.trim();
+    t.starts_with("<!--")
+        && t.ends_with("-->")
+        && (t.contains("id:") || t.contains("created:") || t.contains("updated:"))
+}
+
 /// Import a pre-structure file (flat bullets, free text) as one memory so an
-/// upgrade is lossless. Returns empty when there's nothing but a header.
+/// upgrade is lossless. Only the generated file header is dropped — a leading
+/// `# yolop memory` title and a leading HTML comment block (e.g. the header
+/// comment). Everything after the header, including any user headings, is kept
+/// verbatim. Returns empty when nothing but a header remains.
 fn import_legacy(lines: &[&str]) -> Vec<Memory> {
-    let body: String = lines
-        .iter()
-        .filter(|l| {
-            let t = l.trim();
-            !t.is_empty() && !t.starts_with('#') && !t.starts_with("<!--")
-        })
-        .copied()
-        .collect::<Vec<_>>()
-        .join("\n");
-    if body.trim().is_empty() {
+    let mut i = 0;
+    loop {
+        while i < lines.len() && lines[i].trim().is_empty() {
+            i += 1;
+        }
+        // Drop only the known generated H1 title, never an arbitrary `#` line.
+        if lines
+            .get(i)
+            .map(|l| l.trim().eq_ignore_ascii_case("# yolop memory"))
+            .unwrap_or(false)
+        {
+            i += 1;
+            continue;
+        }
+        // Drop a leading HTML comment block (single- or multi-line).
+        if lines.get(i).map(|l| l.trim_start().starts_with("<!--")) == Some(true) {
+            while i < lines.len() {
+                let closes = lines[i].contains("-->");
+                i += 1;
+                if closes {
+                    break;
+                }
+            }
+            continue;
+        }
+        break;
+    }
+    let body = lines[i..].join("\n").trim().to_string();
+    if body.is_empty() {
         return Vec::new();
     }
     let now = Utc::now();
@@ -533,7 +576,7 @@ fn import_legacy(lines: &[&str]) -> Vec<Memory> {
         title: "Imported notes".to_string(),
         created: now,
         updated: now,
-        body: body.trim().to_string(),
+        body,
     }]
 }
 
@@ -1135,6 +1178,50 @@ mod tests {
     }
 
     #[test]
+    fn hand_authored_body_keeps_non_metadata_html_comment() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join(MEMORY_FILE_NAME);
+        // A hand-authored section whose body opens with an unrelated HTML
+        // comment (no id/created/updated) must keep that comment in the body.
+        std::fs::write(
+            &path,
+            "# yolop memory\n\n## Note\n<!-- TODO: revisit this -->\nThe actual memory text.\n",
+        )
+        .expect("seed");
+        let store = MemoryStore::open(path);
+        assert_eq!(store.len(), 1);
+        let m = &store.recent(1).matches[0];
+        assert_eq!(m.title, "Note");
+        assert!(
+            m.body.contains("<!-- TODO: revisit this -->"),
+            "got: {}",
+            m.body
+        );
+        assert!(m.body.contains("The actual memory text."));
+    }
+
+    #[test]
+    fn legacy_import_preserves_user_headings() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join(MEMORY_FILE_NAME);
+        // Legacy free-text file (no `## ` sections) with a user heading: the
+        // generated `# yolop memory` title is dropped but the user's `#`
+        // heading and content are preserved.
+        std::fs::write(
+            &path,
+            "# yolop memory\n\n# My important note\n- detail one\n- detail two\n",
+        )
+        .expect("seed");
+        let store = MemoryStore::open(path);
+        assert_eq!(store.len(), 1);
+        let m = &store.recent(1).matches[0];
+        assert_eq!(m.title, "Imported notes");
+        assert!(m.body.contains("# My important note"), "got: {}", m.body);
+        assert!(m.body.contains("- detail one"));
+        assert!(!m.body.contains("# yolop memory"));
+    }
+
+    #[test]
     fn titles_disclosure_caps_and_reports_total() {
         let (_tmp, store) = store_in_tmp();
         for i in 0..20 {
@@ -1185,6 +1272,12 @@ mod tests {
         assert!(MemoryConfig::from_value(&json!({ "soft_cap": -1 })).is_err());
         assert!(MemoryConfig::from_value(&json!({ "recall_limit": "lots" })).is_err());
         assert!(MemoryConfig::from_value(&json!([1, 2, 3])).is_err());
+
+        // Per-key minimums match the schema: recall_limit must be >= 1, while
+        // disclosed_titles / soft_cap may be 0.
+        assert!(MemoryConfig::from_value(&json!({ "recall_limit": 0 })).is_err());
+        assert!(MemoryConfig::from_value(&json!({ "disclosed_titles": 0 })).is_ok());
+        assert!(MemoryConfig::from_value(&json!({ "soft_cap": 0 })).is_ok());
     }
 
     #[test]

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod approval;
 pub(crate) mod client_commands;
 pub(crate) mod config;
 mod host;
+pub(crate) mod memory;
 pub(crate) mod model_discovery;
 pub mod skills;
 pub(crate) mod your;

--- a/src/capabilities/your.rs
+++ b/src/capabilities/your.rs
@@ -1,222 +1,44 @@
-// The `your` capability — yolop's personalization layer.
+// The `your` capability — yolop's personalization framing + self-configuration.
 //
-// "your" is how a user addresses yolop itself: "what is your config?",
-// "update your memory", "set yolop blue", "remember that I prefer terse
-// answers". These are GLOBAL personalization requests about yolop the tool,
-// distinct from changes to the current project (which belong in the repo's
-// AGENTS.md, source, and tests).
+// "your" is how a user addresses yolop itself: "what is your config?", "set
+// yolop blue", "remember that I prefer terse answers". These are GLOBAL
+// personalization requests about yolop the tool, distinct from changes to the
+// current project (which belong in the repo's AGENTS.md, source, and tests).
 //
-// v1 owns a single piece of state: a central MEMORY.md of durable, cross-
-// session user preferences. It is injected into every turn under a managed
-// byte budget, with a soft limit that nudges bulky guidance toward skills.
-// The model edits it through natural-language tools (`remember_your_memory`,
-// `read_your_memory`, `write_your_memory`).
+// Durable, cross-session user memory now lives in its own `memory` capability
+// (`remember` / `recall` / `forget` — see capabilities::memory). `your` keeps
+// the personalization framing — pointing the model at those memory tools — and
+// owns hook self-configuration: translating requests like "yolop setup a hook
+// to prevent calls to git" into validated hook specs.
 //
 // See specs/your.md for the full vision (global skills, hooks, user-defined
 // capabilities) — all of which hang off the same central config dir.
 
 use crate::hooks_config::{HookScope, HooksStore};
-use crate::settings::SettingsStore;
-use anyhow::{Context, Result};
 use async_trait::async_trait;
 use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use serde_json::{Value, json};
-use std::io::Write;
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 pub(crate) const YOUR_CAPABILITY_ID: &str = "your";
 
-/// Central memory file name, co-located with `settings.toml` in the yolop
-/// config dir.
-pub(crate) const MEMORY_FILE_NAME: &str = "MEMORY.md";
-
-/// Hard cap on how many bytes of memory are injected into a turn. Beyond
-/// this the injection is truncated (at a char boundary) with a notice; the
-/// full file is still reachable via `read_your_memory`.
-const MEMORY_INJECT_BUDGET_BYTES: usize = 8 * 1024;
-
-/// Soft limit: once memory exceeds this, both the injected block and tool
-/// results suggest extracting stable, topic-specific guidance into a skill
-/// rather than letting memory grow unbounded.
-const MEMORY_SUGGEST_SKILL_BYTES: usize = 4 * 1024;
-
-const MEMORY_HEADER: &str = "# yolop memory\n\nDurable, global user preferences. Edit via the `remember_your_memory` / `write_your_memory` tools or by chatting with yolop (\"remember that …\", \"what is your config?\").\n";
-
-/// Thread-safe handle to the central `MEMORY.md`. Mirrors `SettingsStore`:
-/// the cached string is the in-memory source of truth and mutations flush to
-/// disk via an atomic temp-file + rename, so readers and crashes never see a
-/// half-written file.
-pub(crate) struct YourStore {
-    path: PathBuf,
-    inner: Mutex<String>,
-}
-
-impl YourStore {
-    pub(crate) fn open(path: PathBuf) -> Self {
-        let content = std::fs::read_to_string(&path).unwrap_or_default();
-        Self {
-            path,
-            inner: Mutex::new(content),
-        }
-    }
-
-    /// Derive the memory path from the settings file's directory so memory
-    /// lives next to `settings.toml` and tests that point settings at a
-    /// tempdir get an isolated memory file for free.
-    pub(crate) fn beside_settings(settings: &SettingsStore) -> Self {
-        let path = settings
-            .path()
-            .parent()
-            .map(|p| p.join(MEMORY_FILE_NAME))
-            .unwrap_or_else(|| PathBuf::from(MEMORY_FILE_NAME));
-        Self::open(path)
-    }
-
-    pub(crate) fn path(&self) -> &Path {
-        &self.path
-    }
-
-    pub(crate) fn snapshot(&self) -> String {
-        self.inner.lock().expect("memory lock poisoned").clone()
-    }
-
-    /// Append a single durable note as a markdown bullet, seeding the header
-    /// on first write. Returns the new byte length.
-    pub(crate) fn append_note(&self, note: &str) -> Result<usize> {
-        let note = note.trim();
-        let mut guard = self.inner.lock().expect("memory lock poisoned");
-        if guard.trim().is_empty() {
-            *guard = MEMORY_HEADER.to_string();
-        }
-        if !guard.ends_with('\n') {
-            guard.push('\n');
-        }
-        guard.push_str("- ");
-        guard.push_str(note);
-        guard.push('\n');
-        save_to(&self.path, &guard)?;
-        Ok(guard.len())
-    }
-
-    /// Replace the entire memory file. Returns the new byte length.
-    pub(crate) fn write(&self, content: &str) -> Result<usize> {
-        let mut guard = self.inner.lock().expect("memory lock poisoned");
-        *guard = content.to_string();
-        save_to(&self.path, &guard)?;
-        Ok(guard.len())
-    }
-}
-
-/// Atomic write: stage into a sibling temp file, `fsync`, then `rename` over
-/// the target (POSIX rename is atomic). The temp file is created 0o600 on
-/// Unix so memory — which may hold personal facts — stays owner-only. Mirrors
-/// `settings::save_to`.
-fn save_to(path: &Path, content: &str) -> Result<()> {
-    let parent = path
-        .parent()
-        .filter(|p| !p.as_os_str().is_empty())
-        .map(Path::to_path_buf)
-        .unwrap_or_else(|| PathBuf::from("."));
-    std::fs::create_dir_all(&parent)
-        .with_context(|| format!("create memory dir {}", parent.display()))?;
-
-    let file_name = path
-        .file_name()
-        .with_context(|| format!("memory path has no file name: {}", path.display()))?;
-    let mut tmp_name = std::ffi::OsString::from(".");
-    tmp_name.push(file_name);
-    tmp_name.push(format!(".tmp.{}", std::process::id()));
-    let tmp_path = parent.join(tmp_name);
-
-    let mut opts = std::fs::OpenOptions::new();
-    opts.write(true).create(true).truncate(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        opts.mode(0o600);
-    }
-    let write_result = (|| -> Result<()> {
-        let mut file = opts
-            .open(&tmp_path)
-            .with_context(|| format!("open temp memory {}", tmp_path.display()))?;
-        file.write_all(content.as_bytes())
-            .with_context(|| format!("write temp memory {}", tmp_path.display()))?;
-        file.sync_all()
-            .with_context(|| format!("sync temp memory {}", tmp_path.display()))?;
-        Ok(())
-    })();
-    if let Err(e) = write_result {
-        let _ = std::fs::remove_file(&tmp_path);
-        return Err(e);
-    }
-    std::fs::rename(&tmp_path, path)
-        .with_context(|| format!("rename {} -> {}", tmp_path.display(), path.display()))?;
-    Ok(())
-}
-
-/// Truncate to at most `budget` bytes, snapping back to a char boundary so we
-/// never split a UTF-8 sequence. Returns the slice and whether it was clipped.
-fn clip_to_budget(content: &str, budget: usize) -> (&str, bool) {
-    if content.len() <= budget {
-        return (content, false);
-    }
-    let mut end = budget;
-    while end > 0 && !content.is_char_boundary(end) {
-        end -= 1;
-    }
-    (&content[..end], true)
-}
-
-/// One-line nudge appended to tool results / status once memory is large.
-fn skill_suggestion(byte_len: usize) -> Option<&'static str> {
-    (byte_len > MEMORY_SUGGEST_SKILL_BYTES).then_some(
-        "Memory is getting large — consider moving stable, topic-specific \
-         guidance into a skill so it loads on demand instead of every turn.",
-    )
-}
-
-/// Render the `<your>` system-prompt block: the framing, the memory file
-/// path, and the (budget-clipped) memory contents with truncation /
-/// skill-suggestion notices. Pure so the branch logic is unit-testable
-/// without constructing a `SystemPromptContext`.
-fn render_memory_block(memory_path: &Path, content: &str) -> String {
+/// Render the `<your>` system-prompt block: personalization framing that routes
+/// "remember that…" to the `memory` capability and hook requests to the hook
+/// tools. Pure so it is unit-testable without a `SystemPromptContext`.
+fn render_your_block() -> String {
     let mut out = String::new();
     out.push_str("<your>\n");
     out.push_str(
         "yolop's personalization layer. When the user addresses \"you\" or \"yolop\" itself \
          — e.g. \"what is your config?\", \"update your settings\", \"set yolop blue\", \
          \"remember that I prefer X\" — treat it as a GLOBAL personalization request about \
-         yolop, NOT a change to the current project. Persist durable user preferences with \
-         the `remember_your_memory` tool, reorganize with `write_your_memory`, and read the \
-         full set with `read_your_memory`. Configure hook requests such as \"yolop setup a \
-         hook to prevent calls to git\" with `validate_your_hook` and `upsert_your_hook`, not \
-         by adding a memory note. Project-specific guidance belongs in the repo's AGENTS.md, \
-         not here.\n",
+         yolop, NOT a change to the current project. Persist durable user preferences and facts \
+         with the `remember` tool and read them back with `recall` (the global `memory` \
+         capability); project-specific guidance belongs in the repo's AGENTS.md instead. \
+         Configure hook requests such as \"yolop setup a hook to prevent calls to git\" with \
+         `validate_your_hook` and `upsert_your_hook`, not by storing a memory note.\n",
     );
-    out.push_str(&format!("memory file: {}\n", memory_path.display()));
-
-    if content.trim().is_empty() {
-        out.push_str("memory is empty.\n");
-    } else {
-        let (shown, clipped) = clip_to_budget(content, MEMORY_INJECT_BUDGET_BYTES);
-        out.push_str("<your_memory>\n");
-        out.push_str(shown);
-        if !shown.ends_with('\n') {
-            out.push('\n');
-        }
-        out.push_str("</your_memory>\n");
-        if clipped {
-            out.push_str(
-                "(memory truncated to fit the prompt budget — call `read_your_memory` for the full text.)\n",
-            );
-        }
-        if let Some(note) = skill_suggestion(content.len()) {
-            out.push_str(note);
-            out.push('\n');
-        }
-    }
     out.push_str("</your>");
     out
 }
@@ -224,7 +46,6 @@ fn render_memory_block(memory_path: &Path, content: &str) -> String {
 // ---------- capability ----------
 
 pub(crate) struct YourCapability {
-    pub(crate) memory: Arc<YourStore>,
     pub(crate) hooks: Arc<HooksStore>,
 }
 
@@ -237,7 +58,8 @@ impl Capability for YourCapability {
         "Your (personalization)"
     }
     fn description(&self) -> &str {
-        "Global yolop personalization: durable user memory, injected every turn, edited in natural language."
+        "Global yolop personalization framing and hook self-configuration. Routes durable user \
+         memory to the `memory` capability and translates hook requests into validated hook specs."
     }
     fn status(&self) -> CapabilityStatus {
         CapabilityStatus::Available
@@ -247,21 +69,15 @@ impl Capability for YourCapability {
     }
 
     async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
-        Some(render_memory_block(
-            self.memory.path(),
-            &self.memory.snapshot(),
-        ))
+        Some(render_your_block())
     }
 
     fn system_prompt_preview(&self) -> Option<String> {
         Some(
             "\
 <your>
-yolop's personalization layer (global). Use `remember_your_memory` / `read_your_memory` /
-`write_your_memory` for durable user preferences.
-<your_memory>
-- example: prefer terse answers
-</your_memory>
+yolop's personalization layer (global). Persist durable user preferences with `remember` /
+`recall` (the memory capability); configure hooks with the `*_your_hook` tools.
 </your>"
                 .to_string(),
         )
@@ -269,15 +85,6 @@ yolop's personalization layer (global). Use `remember_your_memory` / `read_your_
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
         vec![
-            Box::new(RememberTool {
-                memory: self.memory.clone(),
-            }),
-            Box::new(ReadMemoryTool {
-                memory: self.memory.clone(),
-            }),
-            Box::new(WriteMemoryTool {
-                memory: self.memory.clone(),
-            }),
             Box::new(ListHooksTool {
                 hooks: self.hooks.clone(),
             }),
@@ -295,137 +102,6 @@ yolop's personalization layer (global). Use `remember_your_memory` / `read_your_
 }
 
 // ---------- tools ----------
-
-struct RememberTool {
-    memory: Arc<YourStore>,
-}
-
-#[async_trait]
-impl Tool for RememberTool {
-    fn name(&self) -> &str {
-        "remember_your_memory"
-    }
-    fn display_name(&self) -> Option<&str> {
-        Some("Remember")
-    }
-    fn description(&self) -> &str {
-        "Persist a durable, GLOBAL user preference or fact about how yolop should behave across \
-         all projects (e.g. \"prefer terse answers\"). Appends one note to yolop's central \
-         memory, which is injected every turn. Use for personalization requests about yolop \
-         itself — NOT for project-specific guidance (that belongs in AGENTS.md)."
-    }
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "note": {
-                    "type": "string",
-                    "description": "A single durable preference or fact, phrased so it stands alone on later turns."
-                }
-            },
-            "required": ["note"],
-            "additionalProperties": false
-        })
-    }
-    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        let note = match arguments.get("note").and_then(Value::as_str) {
-            Some(n) if !n.trim().is_empty() => n,
-            _ => {
-                return ToolExecutionResult::tool_error("'note' is required and must be non-empty");
-            }
-        };
-        match self.memory.append_note(note) {
-            Ok(len) => {
-                let mut msg = format!("remembered ({len} bytes total)");
-                if let Some(note) = skill_suggestion(len) {
-                    msg.push_str(". ");
-                    msg.push_str(note);
-                }
-                ToolExecutionResult::success(json!({ "ok": true, "message": msg }))
-            }
-            Err(e) => ToolExecutionResult::tool_error(format!("could not save memory: {e}")),
-        }
-    }
-}
-
-struct ReadMemoryTool {
-    memory: Arc<YourStore>,
-}
-
-#[async_trait]
-impl Tool for ReadMemoryTool {
-    fn name(&self) -> &str {
-        "read_your_memory"
-    }
-    fn display_name(&self) -> Option<&str> {
-        Some("Read memory")
-    }
-    fn description(&self) -> &str {
-        "Read the full contents of yolop's central personalization memory. Use this to answer \
-         \"what is your config?\"-style questions, or before `write_your_memory` when the injected \
-         copy may have been truncated."
-    }
-    fn parameters_schema(&self) -> Value {
-        json!({ "type": "object", "properties": {}, "additionalProperties": false })
-    }
-    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
-        let content = self.memory.snapshot();
-        ToolExecutionResult::success(json!({
-            "path": self.memory.path().display().to_string(),
-            "bytes": content.len(),
-            "content": content,
-        }))
-    }
-}
-
-struct WriteMemoryTool {
-    memory: Arc<YourStore>,
-}
-
-#[async_trait]
-impl Tool for WriteMemoryTool {
-    fn name(&self) -> &str {
-        "write_your_memory"
-    }
-    fn display_name(&self) -> Option<&str> {
-        Some("Write memory")
-    }
-    fn description(&self) -> &str {
-        "Replace yolop's entire central personalization memory with new markdown. Use to edit, \
-         remove, or reorganize preferences — read the current contents first with `read_your_memory`. \
-         Appending a single new preference is better done with `remember_your_memory`."
-    }
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "content": {
-                    "type": "string",
-                    "description": "The full new memory file contents (markdown)."
-                }
-            },
-            "required": ["content"],
-            "additionalProperties": false
-        })
-    }
-    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        let content = match arguments.get("content").and_then(Value::as_str) {
-            Some(c) => c,
-            None => return ToolExecutionResult::tool_error("'content' is required"),
-        };
-        match self.memory.write(content) {
-            Ok(len) => {
-                let mut msg = format!("memory updated ({len} bytes)");
-                if let Some(note) = skill_suggestion(len) {
-                    msg.push_str(". ");
-                    msg.push_str(note);
-                }
-                ToolExecutionResult::success(json!({ "ok": true, "message": msg }))
-            }
-            Err(e) => ToolExecutionResult::tool_error(format!("could not save memory: {e}")),
-        }
-    }
-}
 
 struct ListHooksTool {
     hooks: Arc<HooksStore>,
@@ -631,13 +307,6 @@ fn hook_value_schema() -> Value {
 mod tests {
     use super::*;
 
-    fn store_in_tmp() -> (tempfile::TempDir, YourStore) {
-        let tmp = tempfile::tempdir().expect("tmp");
-        let path = tmp.path().join("MEMORY.md");
-        let store = YourStore::open(path);
-        (tmp, store)
-    }
-
     fn hooks_in_tmp() -> (tempfile::TempDir, HooksStore) {
         let tmp = tempfile::tempdir().expect("hooks tmp");
         let store = HooksStore::new(tmp.path().join("hooks.json"), tmp.path().join("workspace"));
@@ -645,67 +314,9 @@ mod tests {
     }
 
     #[test]
-    fn append_seeds_header_then_bullets() {
-        let (_tmp, store) = store_in_tmp();
-        assert!(store.snapshot().trim().is_empty());
-        store.append_note("prefer terse answers").expect("append");
-        store.append_note("name is Mike").expect("append");
-
-        let content = store.snapshot();
-        assert!(content.starts_with("# yolop memory"));
-        assert!(content.contains("- prefer terse answers\n"));
-        assert!(content.contains("- name is Mike\n"));
-        assert!(!store.snapshot().trim().is_empty());
-    }
-
-    #[test]
-    fn append_persists_across_reopen() {
-        let tmp = tempfile::tempdir().expect("tmp");
-        let path = tmp.path().join("nested").join("MEMORY.md");
-        let store = YourStore::open(path.clone());
-        store.append_note("likes blue").expect("append");
-
-        let reopened = YourStore::open(path);
-        assert!(reopened.snapshot().contains("- likes blue\n"));
-    }
-
-    #[test]
-    fn write_replaces_whole_file() {
-        let (_tmp, store) = store_in_tmp();
-        store.append_note("old fact").expect("append");
-        store.write("# fresh\n\n- only this\n").expect("write");
-        let content = store.snapshot();
-        assert!(!content.contains("old fact"));
-        assert!(content.contains("- only this"));
-    }
-
-    #[test]
-    fn clip_respects_budget_and_char_boundaries() {
-        let (short, clipped) = clip_to_budget("hello", 100);
-        assert_eq!(short, "hello");
-        assert!(!clipped);
-
-        // Multi-byte chars: budget falls mid-sequence, must snap back.
-        let s = "héllo wörld"; // é and ö are 2 bytes each
-        let (slice, clipped) = clip_to_budget(s, 2);
-        assert!(clipped);
-        assert!(s.starts_with(slice));
-        // Did not panic and produced valid UTF-8 (guaranteed by &str type).
-        assert!(slice.len() <= 2);
-    }
-
-    #[test]
-    fn skill_suggestion_only_past_soft_limit() {
-        assert!(skill_suggestion(10).is_none());
-        assert!(skill_suggestion(MEMORY_SUGGEST_SKILL_BYTES + 1).is_some());
-    }
-
-    #[test]
-    fn capability_exposes_your_named_tools_without_slash_command() {
-        let (_tmp, store) = store_in_tmp();
+    fn capability_exposes_hook_tools_without_slash_command() {
         let (_hooks_tmp, hooks) = hooks_in_tmp();
         let capability = YourCapability {
-            memory: Arc::new(store),
             hooks: Arc::new(hooks),
         };
 
@@ -718,9 +329,6 @@ mod tests {
         assert_eq!(
             names,
             vec![
-                "remember_your_memory",
-                "read_your_memory",
-                "write_your_memory",
                 "list_your_hooks",
                 "validate_your_hook",
                 "upsert_your_hook",
@@ -747,75 +355,6 @@ mod tests {
             "on_error": "block",
             "description": "Block git"
         })
-    }
-
-    #[tokio::test]
-    async fn remember_tool_appends_and_reports() {
-        let (_tmp, store) = store_in_tmp();
-        let tool = RememberTool {
-            memory: Arc::new(store),
-        };
-        let res = tool.execute(json!({ "note": "use spaces not tabs" })).await;
-        assert!(res.is_success());
-        assert!(tool.memory.snapshot().contains("- use spaces not tabs"));
-    }
-
-    #[tokio::test]
-    async fn remember_tool_rejects_empty_note() {
-        let (_tmp, store) = store_in_tmp();
-        let tool = RememberTool {
-            memory: Arc::new(store),
-        };
-        let res = tool.execute(json!({ "note": "   " })).await;
-        assert!(res.is_error());
-    }
-
-    #[tokio::test]
-    async fn read_memory_tool_returns_content() {
-        let (_tmp, store) = store_in_tmp();
-        store.append_note("fact one").expect("append");
-        let tool = ReadMemoryTool {
-            memory: Arc::new(store),
-        };
-        let res = tool.execute(json!({})).await;
-        assert!(res.is_success());
-    }
-
-    #[tokio::test]
-    async fn write_memory_tool_replaces_and_reports() {
-        let (_tmp, store) = store_in_tmp();
-        let tool = WriteMemoryTool {
-            memory: Arc::new(store),
-        };
-        let res = tool.execute(json!({ "content": "# x\n- one\n" })).await;
-        assert!(res.is_success());
-        assert_eq!(tool.memory.snapshot(), "# x\n- one\n");
-    }
-
-    #[tokio::test]
-    async fn write_memory_tool_requires_content() {
-        let (_tmp, store) = store_in_tmp();
-        let tool = WriteMemoryTool {
-            memory: Arc::new(store),
-        };
-        let res = tool.execute(json!({})).await;
-        assert!(res.is_error());
-    }
-
-    #[tokio::test]
-    async fn remember_tool_suggests_skill_when_large() {
-        let (_tmp, store) = store_in_tmp();
-        // Seed past the soft limit so the next append crosses it.
-        store
-            .write(&format!("# m\n{}", "- x\n".repeat(1200)))
-            .expect("seed");
-        let tool = RememberTool {
-            memory: Arc::new(store),
-        };
-        let res = tool.execute(json!({ "note": "one more" })).await;
-        assert!(res.is_success());
-        let text = format!("{res:?}");
-        assert!(text.contains("Memory is getting large"), "got: {text}");
     }
 
     #[tokio::test]
@@ -853,31 +392,14 @@ mod tests {
     }
 
     #[test]
-    fn render_block_reports_empty_memory() {
-        let block = render_memory_block(Path::new("/cfg/MEMORY.md"), "   \n");
+    fn your_block_frames_personalization_and_routes_memory_and_hooks() {
+        let block = render_your_block();
         assert!(block.starts_with("<your>\n"));
-        assert!(block.contains("memory file: /cfg/MEMORY.md"));
-        assert!(block.contains("memory is empty."));
-        assert!(!block.contains("<your_memory>"));
         assert!(block.ends_with("</your>"));
-    }
-
-    #[test]
-    fn render_block_wraps_small_memory_without_notices() {
-        let block = render_memory_block(Path::new("/cfg/MEMORY.md"), "- prefer terse\n");
-        assert!(block.contains("<your_memory>\n- prefer terse\n</your_memory>\n"));
-        assert!(!block.contains("truncated"));
-        assert!(!block.contains("Memory is getting large"));
-    }
-
-    #[test]
-    fn render_block_truncates_and_suggests_when_oversized() {
-        let big = "a".repeat(MEMORY_INJECT_BUDGET_BYTES + 100);
-        let block = render_memory_block(Path::new("/cfg/MEMORY.md"), &big);
-        assert!(block.contains("truncated to fit the prompt budget"));
-        // Over the inject budget is also over the soft limit, so both fire.
-        assert!(block.contains("Memory is getting large"));
-        // The injected slice itself is capped at the budget.
-        assert!(!block.contains(&"a".repeat(MEMORY_INJECT_BUDGET_BYTES + 1)));
+        // Routes durable memory to the memory capability tools, not a local note.
+        assert!(block.contains("`remember`"));
+        assert!(block.contains("`recall`"));
+        // Still owns hook self-configuration framing.
+        assert!(block.contains("upsert_your_hook"));
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4,9 +4,7 @@
 // actual workspace. Only the `bash` tool is custom — it shells out to the host
 // instead of running against the VFS.
 
-use crate::capabilities::memory::{
-    GlobalMemoryCapability, MEMORY_CAPABILITY_ID, MemoryConfig, MemoryStore,
-};
+use crate::capabilities::memory::{GlobalMemoryCapability, MEMORY_CAPABILITY_ID, MemoryStore};
 use crate::capabilities::your::{YOUR_CAPABILITY_ID, YourCapability};
 use crate::capabilities::{
     APPROVAL_CAPABILITY_ID, ATTRIBUTION_CAPABILITY_ID, ApprovalCapability, AttributionCapability,
@@ -1395,11 +1393,12 @@ pub async fn build_with_options(
     // `memory` — global, durable, structured user memory. Its MEMORY.md lives
     // beside settings.toml in the yolop config dir, so a tempdir settings path
     // in tests isolates memory automatically. Only titles are disclosed each
-    // turn; bodies are recalled on demand. Tuning comes from the optional
-    // `[memory]` table in settings.toml.
+    // turn; bodies are recalled on demand. Tuning (disclosed_titles,
+    // recall_limit, soft_cap) flows through the generic capability-config
+    // system — see its `config_schema()` and the `AgentCapabilityConfig` for
+    // MEMORY_CAPABILITY_ID below.
     capabilities.register(GlobalMemoryCapability {
         memory: Arc::new(MemoryStore::beside_settings(&settings)),
-        config: MemoryConfig::from_settings(&settings),
     });
     // `your` — global personalization framing + hook self-configuration.
     // Durable memory now lives in the `memory` capability above.

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4,7 +4,10 @@
 // actual workspace. Only the `bash` tool is custom — it shells out to the host
 // instead of running against the VFS.
 
-use crate::capabilities::your::{YOUR_CAPABILITY_ID, YourCapability, YourStore};
+use crate::capabilities::memory::{
+    GlobalMemoryCapability, MEMORY_CAPABILITY_ID, MemoryConfig, MemoryStore,
+};
+use crate::capabilities::your::{YOUR_CAPABILITY_ID, YourCapability};
 use crate::capabilities::{
     APPROVAL_CAPABILITY_ID, ATTRIBUTION_CAPABILITY_ID, ApprovalCapability, AttributionCapability,
     CLIENT_COMMANDS_CAPABILITY_ID, CONFIG_CAPABILITY_ID, ClientCommandsCapability,
@@ -1049,6 +1052,7 @@ fn coding_harness_capabilities(
         ),
         AgentCapabilityConfig::new(SETUP_CAPABILITY_ID),
         AgentCapabilityConfig::new(CONFIG_CAPABILITY_ID),
+        AgentCapabilityConfig::new(MEMORY_CAPABILITY_ID),
         AgentCapabilityConfig::new(YOUR_CAPABILITY_ID),
         // Soft approval: injects spoken-consent guidance for critical actions,
         // tuned by the central `approval_mode` setting (off contributes nothing).
@@ -1388,13 +1392,18 @@ pub async fn build_with_options(
     capabilities.register(ConfigCapability {
         settings: settings.clone(),
     });
-    // `your` — global personalization. Its MEMORY.md lives beside
-    // settings.toml in the yolop config dir, so a tempdir settings path in
-    // tests isolates memory automatically.
-    capabilities.register(YourCapability {
-        memory: Arc::new(YourStore::beside_settings(&settings)),
-        hooks: hooks_store,
+    // `memory` — global, durable, structured user memory. Its MEMORY.md lives
+    // beside settings.toml in the yolop config dir, so a tempdir settings path
+    // in tests isolates memory automatically. Only titles are disclosed each
+    // turn; bodies are recalled on demand. Tuning comes from the optional
+    // `[memory]` table in settings.toml.
+    capabilities.register(GlobalMemoryCapability {
+        memory: Arc::new(MemoryStore::beside_settings(&settings)),
+        config: MemoryConfig::from_settings(&settings),
     });
+    // `your` — global personalization framing + hook self-configuration.
+    // Durable memory now lives in the `memory` capability above.
+    capabilities.register(YourCapability { hooks: hooks_store });
     // Soft approval — spoken-consent guidance + audit tool, gated by the
     // central `approval_mode` setting (read live each turn).
     capabilities.register(ApprovalCapability {


### PR DESCRIPTION
## What

Rebuilds yolop's memory system as its own **`memory`** capability (enabled by default), extracted out of the `your` personalization capability.

- **Structured store.** `MEMORY.md` is now sections, not a flat bullet list. Each memory is a `## ` heading (its title/description) plus an `<!-- id · created · updated -->` metadata comment and a body. The id is generated (`m-1a2b3c`); timestamps are set automatically.
- **Tools:** `remember(title, memory, id?)` (auto-timestamps; updates in place by id or matching title instead of duplicating), `recall(query?, id?, limit?)` (fetch by id, or search — title hits outrank body hits, newer wins ties — capped, and **says when more match so the model narrows instead of dumping the whole file**), and `forget(id)` (by id or exact title).
- **Progressive disclosure.** Only the most recent memory *titles* are injected into the system prompt each turn; bodies are recalled on demand. Prompt cost stays flat however much is stored — the opposite of the old "inject the whole file every turn" model.
- **Configurable via the generic capability-config system.** The capability publishes `config_schema()` and reads `disclosed_titles` / `recall_limit` / `soft_cap` from `AgentCapabilityConfig.config` (via `tools_with_config` / `system_prompt_contribution_with_config`), the same pattern `agent_instructions` and `user_hooks` use — ready for the generic config editor. `soft_cap` only *warns*, never deletes.
- **`your`** keeps personalization framing + hook self-configuration and routes "remember that…" to the new tools.
- Legacy flat-bullet `MEMORY.md` is imported losslessly on first open.

## Why

The old memory lived inside `your` as a single flat file injected **in full every turn** under a byte budget: the whole file competed for prompt space regardless of relevance, and a flat list had no structure to title, timestamp, search, or address individual notes. Structure + progressive disclosure fixes both.

## How validated

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings` — clean.
- `cargo test --all-features` — **329 bin/unit + 26 integration** pass. New tests drive the real entry points: remember create/update-by-title/update-by-id, forget by id and title, search title-boost + cap/total, empty-query recency, recall "more exist" truncation note, disclosure cap/total, parse/reparse persistence, legacy import, **body-with-`## `-heading round-trip**, config parse/validate from `Value`, and `tools_with_config` reading config.
- **Live end-to-end smoke** (`cargo run --provider openai`): the agent discovered the tools, ran Remember then Recall, and returned id `m-71ef69`; verified the on-disk `MEMORY.md` was written in the structured format.
- Offline `--provider llmsim` smoke confirms the binary starts and the tool surface is `remember, recall, forget` (old `*_your_memory` tools gone, hook tools preserved).

## Security

Reviewed against the threat-model categories:

- **TM-FS** — memory writes only to `MEMORY.md` in the central config dir (beside `settings.toml`), via atomic temp-file + `fsync` + `rename`, `0o600` on Unix. The path is derived from the settings dir + a fixed filename; the model never supplies a path, so no traversal. No new workspace write paths; the write blocklist in `tools.rs` is untouched.
- **TM-LLM** — only memory *titles* reach the prompt (less exposure than the old full-file injection); memory is its own file, never written to session JSONL; no API keys involved.
- **TM-TOOL** — new capability touches only the config dir; tool inputs validated (non-empty title/memory; `validate_config` rejects non-integer/negative config).
- **TM-DEP** — no new dependencies (`chrono` already present), no version bumps.
- Resource exhaustion: parse/search are linear; id generation loops only on hash collision within existing memories; disclosure and recall are capped so prompt cost stays bounded even though the file itself is intentionally uncapped (user owns it; `soft_cap` nudges pruning).

A round-trip risk found during review — a body line starting with `## ` re-parsing into a spurious second memory — is fixed by anchoring section detection on the metadata line, with a regression test.

## Docs

`specs/memory.md` added; `specs/your.md` trimmed and cross-linked; `README.md` and the `yolop-config` skill updated.

## Follow-ups

No follow-ups.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HLYCLv8tqzSA3FJET7HvDf)_