### PR TITLE
refactor(hooks): move tools into hooks capability

### DIFF
--- a/docs/features/hooks.md
+++ b/docs/features/hooks.md
@@ -10,14 +10,15 @@ outside the model.
 
 Yolop uses the upstream `everruns-core` `user_hooks` capability. The local
 Yolop layer only discovers hook files, merges workspace and global scopes, and
-lets `your` configure those files from natural language.
+exposes a `hooks` capability to configure those files from natural language.
 
 ## How it works
 
 ```mermaid
 flowchart LR
   User["User: yolop setup a hook"] --> Your["your personalization"]
-  Your --> Tools["validate_your_hook / upsert_your_hook"]
+  Your --> Hooks["hooks capability"]
+  Hooks --> Tools["validate_hook / upsert_hook"]
   Tools --> Files["hooks.json"]
   Files --> Runtime["user_hooks capability"]
   Runtime --> Decision{"Hook decision"}
@@ -28,7 +29,7 @@ flowchart LR
 
 The model interprets the request, but it does not hand-edit hook JSON. The
 embedded `yolop-hooks` skill maps common requests to hook specs, and the
-`your` tools validate and write the config atomically.
+`hooks` tools validate and write the config atomically.
 
 ## Scopes
 
@@ -49,7 +50,7 @@ yolop setup a hook to prevent calls to git
 ```
 
 Yolop should translate that into a `pre_tool_use` hook and save it through
-`upsert_your_hook`. If the scope is ambiguous and the hook blocks a broad class
+`upsert_hook`. If the scope is ambiguous and the hook blocks a broad class
 of normal coding actions, Yolop should ask whether the hook is global or just
 for the current workspace.
 

--- a/skills/yolop-config/SKILL.md
+++ b/skills/yolop-config/SKILL.md
@@ -85,6 +85,6 @@ command instead.
   (`disclosed_titles`, `recall_limit`, `soft_cap`) is per-capability config
   exposed via the capability's `config_schema`, not a `settings.toml` key.
 - **Behavioral hooks** (block/allow/audit tool calls): use the `yolop-hooks`
-  skill and the `*_your_hook` tools.
+  skill and the `hooks` capability tools.
 - **Interactive provider/model setup**: the `/setup` command runs a guided
   wizard and switches the live model immediately.

--- a/skills/yolop-hooks/SKILL.md
+++ b/skills/yolop-hooks/SKILL.md
@@ -15,13 +15,13 @@ hooks, for example:
 - "remove the hook that blocks cargo publish"
 
 Hooks are real configuration. Do not treat these requests as memory or as a
-soft preference. Use the `your` hook tools:
+soft preference. Use the `hooks` capability tools:
 
 1. Build a candidate hook spec.
-2. Call `validate_your_hook`.
-3. Call `upsert_your_hook` after validation succeeds.
-4. Use `list_your_hooks` to inspect current state or confirm effective config.
-5. Use `remove_your_hook` when the user asks to remove or disable a hook.
+2. Call `validate_hook`.
+3. Call `upsert_hook` after validation succeeds.
+4. Use `list_hooks` to inspect current state or confirm effective config.
+5. Use `remove_hook` when the user asks to remove or disable a hook.
 
 ## Scope
 

--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -108,11 +108,11 @@ The schema reaches the agent two ways:
 2. The `yolop-config` built-in skill (`skills/yolop-config/SKILL.md`) is the
    detailed, on-demand reference. It instructs the agent to read the live schema
    via `get_config` rather than duplicating key lists, and points at the
-   adjacent surfaces (`your` memory, `yolop-hooks`, `/setup`).
+   adjacent surfaces (`memory`, `yolop-hooks`, `/setup`).
 
 ## Boundaries
 
 Configuration is distinct from the neighbouring personalization surfaces:
-durable preferences are `your` **memory**, behavioral rules are **hooks**, and
+durable preferences are **memory**, behavioral rules are **hooks**, and
 interactive live provider/model switching is **`/setup`**. All settings keys,
 including harness capabilities, go through `get_config` / `set_config`.

--- a/specs/hooks.md
+++ b/specs/hooks.md
@@ -1,6 +1,6 @@
 # Hooks Specification
 
-Status: v1 implemented for scoped config loading, `your` self-configuration,
+Status: v1 implemented for scoped config loading, `hooks` self-configuration,
 and upstream `user_hooks` registration.
 
 ## Why
@@ -108,20 +108,20 @@ The reliable design is **prompt/skill for interpretation, tools for writes**:
   self-configuration requests.
 - The embedded `yolop-hooks` skill holds examples that map common intents to
   hook specs, so the prompt stays short and examples are loaded on demand.
-- Structured `your` tools perform the actual mutation. They read, validate,
-  merge, and atomically write `hooks.json`, then return the effective hook id
-  and scope. The model should not hand-edit hook JSON through generic file
-  tools for global self-configuration.
+- Structured `hooks` capability tools perform the actual mutation. They read,
+  validate, merge, and atomically write `hooks.json`, then return the effective
+  hook id and scope. The model should not hand-edit hook JSON through generic
+  file tools for global self-configuration.
 
 Initial tool surface:
 
-- `list_your_hooks` — show effective hooks, their scope, event, matcher, and
+- `list_hooks` — show effective hooks, their scope, event, matcher, and
   source file.
-- `upsert_your_hook` — create or replace one hook by `id`.
-- `remove_your_hook` — remove or disable one hook by `id`.
-- `validate_your_hook` — validate a candidate spec without writing it.
+- `upsert_hook` — create or replace one hook by `id`.
+- `remove_hook` — remove or disable one hook by `id`.
+- `validate_hook` — validate a candidate spec without writing it.
 
-`upsert_your_hook` accepts an explicit `scope`:
+`upsert_hook` accepts an explicit `scope`:
 
 - `global` writes `<config_dir>/yolop/hooks.json`.
 - `workspace` writes `<workspace>/.agents/hooks.json`.
@@ -236,16 +236,16 @@ Implemented:
    and enables it with `AgentCapabilityConfig::with_config("user_hooks", ...)`
    only when hooks are configured.
 3. `StartupInfo` includes effective hook counts; `--print` shows loaded hooks.
-4. `YourCapability` includes the hook self-configuration tools described in
+4. `HooksCapability` includes the hook self-configuration tools described in
    [Natural-Language Setup](#natural-language-setup).
 5. `skills/yolop-hooks/SKILL.md` ships the self-configuration recipes used for
    natural-language hook setup.
-6. Tests cover merge behavior, `your` hook tools, and a scripted llmsim
+6. Tests cover merge behavior, `hooks` tools, and a scripted llmsim
    `pre_tool_use` hook that blocks a matching `bash` tool call.
 
 Follow-up:
 
-- Add an embedded `your` skill with more hook recipes once the minimal tool
+- Add more embedded hook recipes once the minimal tool
   surface has settled.
 
 ## Non-goals

--- a/specs/memory.md
+++ b/specs/memory.md
@@ -15,8 +15,8 @@ matter how little of it is relevant, and a flat bullet list has no structure to
 search, timestamp, or address individual notes.
 
 `memory` is its own capability. It owns structured, durable memory and the
-tools to manage it; `your` keeps the personalization *framing* and hook
-self-configuration (see [`your.md`](./your.md)).
+tools to manage it; `your` keeps the personalization *framing*, while hook
+self-configuration lives in the `hooks` capability (see [`hooks.md`](./hooks.md)).
 
 ## What
 

--- a/specs/your.md
+++ b/specs/your.md
@@ -1,7 +1,8 @@
 # `your` — personalization
 
-Status: implemented (framing + hooks). Durable memory now lives in the `memory`
-capability ([`memory.md`](./memory.md)); roadmap sections below are not yet built.
+Status: implemented (framing only). Durable memory now lives in the `memory`
+capability ([`memory.md`](./memory.md)); hook authoring lives in the `hooks`
+capability ([`hooks.md`](./hooks.md)); roadmap sections below are not yet built.
 
 ## Why
 
@@ -56,14 +57,15 @@ the store itself.
 
 Natural language is the user interface, but durable configuration changes
 should go through purpose-built tools. The `your` prompt decides whether a user
-is asking to configure yolop itself; embedded `your` skills can provide
-examples and recipes; tools perform validated writes to stable config files.
+is asking to configure yolop itself and routes to the capability that owns the
+specific state; embedded skills can provide examples and recipes; tools perform
+validated writes to stable config files.
 
 For example, "yolop setup a hook to prevent calls to git" is a
-self-configuration request. `your` should translate it into a hook spec,
-validate it, and write it through hook config tools rather than storing a
-memory note that says "avoid git". See [`hooks.md`](./hooks.md) for the hook
-tool design and scope rules.
+self-configuration request. `your` should route it to the `hooks` capability,
+which translates it into a hook spec, validates it, and writes it through hook
+config tools rather than storing a memory note that says "avoid git". See
+[`hooks.md`](./hooks.md) for the hook tool design and scope rules.
 
 ## Roadmap
 
@@ -83,8 +85,8 @@ yolop-specific formats.
   directly from `<config_dir>/yolop/skills`. A future declarative capability
   layer can also contribute skills into that same global personalization model.
   This is where memory that has outgrown a few bullets gets promoted to.
-- **Hooks** — `your` should configure global and workspace hooks through
-  structured hook tools, using the scope and merge contract in
+- **Hooks** — the `hooks` capability configures global and workspace hooks
+  through structured hook tools, using the scope and merge contract in
   [`hooks.md`](./hooks.md).
 - **General config** — map natural-language requests ("set yolop blue") onto
   real settings as those settings come to exist. Until a knob exists, the

--- a/src/capabilities/hooks.rs
+++ b/src/capabilities/hooks.rs
@@ -1,0 +1,380 @@
+// The `hooks` capability — authoring and inspecting Yolop hook config.
+//
+// The hook engine itself is upstream `user_hooks`; this capability is only the
+// natural-language-safe write surface for Yolop's global/workspace `hooks.json`
+// files.
+
+use crate::hooks_config::{HookScope, HooksStore};
+use async_trait::async_trait;
+use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use serde_json::{Value, json};
+use std::sync::Arc;
+
+pub(crate) const HOOKS_CAPABILITY_ID: &str = "hooks";
+
+pub(crate) struct HooksCapability {
+    pub(crate) hooks: Arc<HooksStore>,
+}
+
+#[async_trait]
+impl Capability for HooksCapability {
+    fn id(&self) -> &str {
+        HOOKS_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Hooks"
+    }
+
+    fn description(&self) -> &str {
+        "Authoring and inspection tools for global and workspace hook configuration."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Extensibility")
+    }
+
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        Some(
+            "<capability id=\"hooks\">\n\
+             Configure hook requests such as \"setup a hook to prevent calls to git\" with \
+             `validate_hook` and `upsert_hook`. Use `list_hooks` before changing existing hooks \
+             and `remove_hook` when removing or disabling one. Do not store hook requests as \
+             memory notes; hooks are real global/workspace configuration.\n\
+             </capability>"
+                .to_string(),
+        )
+    }
+
+    fn system_prompt_preview(&self) -> Option<String> {
+        Some(
+            "<capability id=\"hooks\">\n\
+             Configure global/workspace hooks with `list_hooks`, `validate_hook`, `upsert_hook`, \
+             and `remove_hook`.\n\
+             </capability>"
+                .to_string(),
+        )
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(ListHooksTool {
+                hooks: self.hooks.clone(),
+            }),
+            Box::new(ValidateHookTool {
+                hooks: self.hooks.clone(),
+            }),
+            Box::new(UpsertHookTool {
+                hooks: self.hooks.clone(),
+            }),
+            Box::new(RemoveHookTool {
+                hooks: self.hooks.clone(),
+            }),
+        ]
+    }
+}
+
+struct ListHooksTool {
+    hooks: Arc<HooksStore>,
+}
+
+#[async_trait]
+impl Tool for ListHooksTool {
+    fn name(&self) -> &str {
+        "list_hooks"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("List hooks")
+    }
+
+    fn description(&self) -> &str {
+        "List Yolop hooks from global and workspace hook config. Use for \
+         \"what hooks are configured?\" or before changing an existing hook."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({ "type": "object", "properties": {}, "additionalProperties": false })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        let effective = self.hooks.effective();
+        ToolExecutionResult::success(json!({
+            "ok": true,
+            "global_path": effective.global_path.display().to_string(),
+            "workspace_path": effective.workspace_path.display().to_string(),
+            "count": effective.hooks.len(),
+            "scope_counts": effective.scope_counts(),
+            "hooks": effective.summaries(),
+        }))
+    }
+}
+
+struct ValidateHookTool {
+    hooks: Arc<HooksStore>,
+}
+
+#[async_trait]
+impl Tool for ValidateHookTool {
+    fn name(&self) -> &str {
+        "validate_hook"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Validate hook")
+    }
+
+    fn description(&self) -> &str {
+        "Validate a candidate Yolop hook spec without writing it. Use before `upsert_hook`, \
+         especially when translating a natural-language request into hook JSON."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        hook_value_schema()
+    }
+
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let hook = match arguments.get("hook") {
+            Some(hook) => hook.clone(),
+            None => return ToolExecutionResult::tool_error("'hook' is required"),
+        };
+        match self.hooks.validate_hook(&hook) {
+            Ok(entry) => ToolExecutionResult::success(json!({
+                "ok": true,
+                "hook": entry.to_validation_json(),
+            })),
+            Err(error) => ToolExecutionResult::tool_error(format!("invalid hook: {error}")),
+        }
+    }
+}
+
+struct UpsertHookTool {
+    hooks: Arc<HooksStore>,
+}
+
+#[async_trait]
+impl Tool for UpsertHookTool {
+    fn name(&self) -> &str {
+        "upsert_hook"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Save hook")
+    }
+
+    fn description(&self) -> &str {
+        "Create or replace one Yolop hook by id. Use global scope for personal Yolop behavior \
+         and workspace scope for project-owned hook config. Validates before writing."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "scope": {
+                    "type": "string",
+                    "enum": ["global", "workspace"],
+                    "description": "Where to write the hook. Use global for personal Yolop configuration; workspace for this repo."
+                },
+                "hook": {
+                    "type": "object",
+                    "description": "A UserHookSpec object with a stable id."
+                }
+            },
+            "required": ["scope", "hook"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let scope = match parse_scope_arg(&arguments) {
+            Ok(scope) => scope,
+            Err(error) => return ToolExecutionResult::tool_error(error),
+        };
+        let hook = match arguments.get("hook") {
+            Some(hook) => hook.clone(),
+            None => return ToolExecutionResult::tool_error("'hook' is required"),
+        };
+        match self.hooks.upsert_hook(scope, hook) {
+            Ok(entry) => ToolExecutionResult::success(json!({
+                "ok": true,
+                "message": format!("saved {} hook", scope.as_str()),
+                "hook": entry.to_summary_json(),
+                "path": self.hooks.path_for(scope).display().to_string(),
+            })),
+            Err(error) => ToolExecutionResult::tool_error(format!("could not save hook: {error}")),
+        }
+    }
+}
+
+struct RemoveHookTool {
+    hooks: Arc<HooksStore>,
+}
+
+#[async_trait]
+impl Tool for RemoveHookTool {
+    fn name(&self) -> &str {
+        "remove_hook"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Remove hook")
+    }
+
+    fn description(&self) -> &str {
+        "Remove one Yolop hook by id from the selected scope. Workspace removal also writes a \
+         disabled marker so a lower-precedence global hook with the same id stays disabled."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "scope": {
+                    "type": "string",
+                    "enum": ["global", "workspace"]
+                },
+                "id": {
+                    "type": "string",
+                    "description": "Stable hook id to remove or disable."
+                }
+            },
+            "required": ["scope", "id"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let scope = match parse_scope_arg(&arguments) {
+            Ok(scope) => scope,
+            Err(error) => return ToolExecutionResult::tool_error(error),
+        };
+        let id = match arguments.get("id").and_then(Value::as_str) {
+            Some(id) if !id.trim().is_empty() => id,
+            _ => return ToolExecutionResult::tool_error("'id' is required"),
+        };
+        match self.hooks.remove_hook(scope, id) {
+            Ok(removed) => ToolExecutionResult::success(json!({
+                "ok": true,
+                "removed": removed,
+                "id": id,
+                "scope": scope.as_str(),
+                "path": self.hooks.path_for(scope).display().to_string(),
+            })),
+            Err(error) => {
+                ToolExecutionResult::tool_error(format!("could not remove hook: {error}"))
+            }
+        }
+    }
+}
+
+fn parse_scope_arg(arguments: &Value) -> std::result::Result<HookScope, String> {
+    let scope = arguments
+        .get("scope")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "'scope' is required".to_string())?;
+    HookScope::parse(scope).map_err(|error| error.to_string())
+}
+
+fn hook_value_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "hook": {
+                "type": "object",
+                "description": "A UserHookSpec object."
+            }
+        },
+        "required": ["hook"],
+        "additionalProperties": false
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hooks_in_tmp() -> (tempfile::TempDir, HooksStore) {
+        let tmp = tempfile::tempdir().expect("hooks tmp");
+        let store = HooksStore::new(tmp.path().join("hooks.json"), tmp.path().join("workspace"));
+        (tmp, store)
+    }
+
+    #[test]
+    fn capability_exposes_unprefixed_hook_tools_without_slash_command() {
+        let (_hooks_tmp, hooks) = hooks_in_tmp();
+        let capability = HooksCapability {
+            hooks: Arc::new(hooks),
+        };
+
+        let names = capability
+            .tools()
+            .iter()
+            .map(|tool| tool.name().to_string())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            names,
+            vec!["list_hooks", "validate_hook", "upsert_hook", "remove_hook"]
+        );
+        assert!(capability.commands().is_empty());
+    }
+
+    fn block_git_hook() -> Value {
+        json!({
+            "id": "block-git",
+            "event": "pre_tool_use",
+            "matcher": {
+                "tool_name": "bash",
+                "args_jsonpath": "$.command",
+                "match_regex": "(^|[;&|()[:space:]])git([[:space:]]|$)"
+            },
+            "executor": {
+                "type": "bash",
+                "command": "printf '%s\\n' '{\"decision\":\"block\",\"reason\":\"blocked\"}'"
+            },
+            "timeout_ms": 1000,
+            "on_error": "block",
+            "description": "Block git"
+        })
+    }
+
+    #[tokio::test]
+    async fn hook_tools_validate_save_list_and_remove() {
+        let (_tmp, hooks) = hooks_in_tmp();
+        let hooks = Arc::new(hooks);
+        let validate = ValidateHookTool {
+            hooks: hooks.clone(),
+        };
+        let validated = validate.execute(json!({ "hook": block_git_hook() })).await;
+        assert!(validated.is_success());
+
+        let upsert = UpsertHookTool {
+            hooks: hooks.clone(),
+        };
+        let saved = upsert
+            .execute(json!({ "scope": "global", "hook": block_git_hook() }))
+            .await;
+        assert!(saved.is_success());
+
+        let list = ListHooksTool {
+            hooks: hooks.clone(),
+        };
+        let listed = list.execute(json!({})).await;
+        assert!(listed.is_success());
+
+        let remove = RemoveHookTool {
+            hooks: hooks.clone(),
+        };
+        let removed = remove
+            .execute(json!({ "scope": "global", "id": "block-git" }))
+            .await;
+        assert!(removed.is_success());
+        assert!(hooks.effective().hooks.is_empty());
+    }
+}

--- a/src/capabilities/memory.rs
+++ b/src/capabilities/memory.rs
@@ -1,7 +1,7 @@
 // The `memory` capability — yolop's global, durable memory.
 //
-// Extracted from the `your` capability so personalization (hooks, framing) and
-// durable cross-session memory evolve independently. Memory is now *structured*:
+// Extracted from the `your` capability so personalization framing and durable
+// cross-session memory evolve independently. Memory is now *structured*:
 // a `MEMORY.md` where each `## ` section is one memory with a title (its
 // description), an id, created/updated timestamps, and a body (the memory text).
 //

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -6,6 +6,7 @@
 pub(crate) mod approval;
 pub(crate) mod client_commands;
 pub(crate) mod config;
+pub(crate) mod hooks;
 mod host;
 pub(crate) mod memory;
 pub(crate) mod model_discovery;
@@ -15,6 +16,7 @@ pub(crate) mod your;
 pub(crate) use approval::{APPROVAL_CAPABILITY_ID, ApprovalCapability};
 pub(crate) use client_commands::{CLIENT_COMMANDS_CAPABILITY_ID, ClientCommandsCapability};
 pub(crate) use config::{CONFIG_CAPABILITY_ID, ConfigCapability};
+pub(crate) use hooks::{HOOKS_CAPABILITY_ID, HooksCapability};
 pub(crate) use host::{
     ATTRIBUTION_CAPABILITY_ID, AttributionCapability, CodingBashCapability,
     CodingCliEnvironmentCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID, SETUP_CAPABILITY_ID,

--- a/src/capabilities/your.rs
+++ b/src/capabilities/your.rs
@@ -1,31 +1,26 @@
-// The `your` capability — yolop's personalization framing + self-configuration.
+// The `your` capability — yolop's personalization framing.
 //
 // "your" is how a user addresses yolop itself: "what is your config?", "set
 // yolop blue", "remember that I prefer terse answers". These are GLOBAL
 // personalization requests about yolop the tool, distinct from changes to the
 // current project (which belong in the repo's AGENTS.md, source, and tests).
 //
-// Durable, cross-session user memory now lives in its own `memory` capability
-// (`remember` / `recall` / `forget` — see capabilities::memory). `your` keeps
-// the personalization framing — pointing the model at those memory tools — and
-// owns hook self-configuration: translating requests like "yolop setup a hook
-// to prevent calls to git" into validated hook specs.
+// Durable, cross-session user memory lives in its own `memory` capability
+// (`remember` / `recall` / `forget` — see capabilities::memory). Hook
+// self-configuration lives in the dedicated `hooks` capability. `your` keeps
+// only the personalization framing and routes requests to the right surface.
 //
 // See specs/your.md for the full vision (global skills, hooks, user-defined
 // capabilities) — all of which hang off the same central config dir.
 
-use crate::hooks_config::{HookScope, HooksStore};
 use async_trait::async_trait;
 use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
-use everruns_core::tools::{Tool, ToolExecutionResult};
-use serde_json::{Value, json};
-use std::sync::Arc;
 
 pub(crate) const YOUR_CAPABILITY_ID: &str = "your";
 
 /// Render the `<your>` system-prompt block: personalization framing that routes
-/// "remember that…" to the `memory` capability and hook requests to the hook
-/// tools. Pure so it is unit-testable without a `SystemPromptContext`.
+/// "remember that…" to the `memory` capability and hook requests to the `hooks`
+/// capability. Pure so it is unit-testable without a `SystemPromptContext`.
 fn render_your_block() -> String {
     let mut out = String::new();
     out.push_str("<your>\n");
@@ -37,7 +32,8 @@ fn render_your_block() -> String {
          with the `remember` tool and read them back with `recall` (the global `memory` \
          capability); project-specific guidance belongs in the repo's AGENTS.md instead. \
          Configure hook requests such as \"yolop setup a hook to prevent calls to git\" with \
-         `validate_your_hook` and `upsert_your_hook`, not by storing a memory note.\n",
+         the `hooks` capability tools (`validate_hook`, `upsert_hook`), not by storing a \
+         memory note.\n",
     );
     out.push_str("</your>");
     out
@@ -45,9 +41,7 @@ fn render_your_block() -> String {
 
 // ---------- capability ----------
 
-pub(crate) struct YourCapability {
-    pub(crate) hooks: Arc<HooksStore>,
-}
+pub(crate) struct YourCapability;
 
 #[async_trait]
 impl Capability for YourCapability {
@@ -58,8 +52,8 @@ impl Capability for YourCapability {
         "Your (personalization)"
     }
     fn description(&self) -> &str {
-        "Global yolop personalization framing and hook self-configuration. Routes durable user \
-         memory to the `memory` capability and translates hook requests into validated hook specs."
+        "Global yolop personalization framing. Routes durable user memory to the `memory` \
+         capability and hook setup requests to the `hooks` capability."
     }
     fn status(&self) -> CapabilityStatus {
         CapabilityStatus::Available
@@ -77,318 +71,23 @@ impl Capability for YourCapability {
             "\
 <your>
 yolop's personalization layer (global). Persist durable user preferences with `remember` /
-`recall` (the memory capability); configure hooks with the `*_your_hook` tools.
+`recall` (the memory capability); configure hooks with the `hooks` capability tools.
 </your>"
                 .to_string(),
         )
     }
-
-    fn tools(&self) -> Vec<Box<dyn Tool>> {
-        vec![
-            Box::new(ListHooksTool {
-                hooks: self.hooks.clone(),
-            }),
-            Box::new(ValidateHookTool {
-                hooks: self.hooks.clone(),
-            }),
-            Box::new(UpsertHookTool {
-                hooks: self.hooks.clone(),
-            }),
-            Box::new(RemoveHookTool {
-                hooks: self.hooks.clone(),
-            }),
-        ]
-    }
-}
-
-// ---------- tools ----------
-
-struct ListHooksTool {
-    hooks: Arc<HooksStore>,
-}
-
-#[async_trait]
-impl Tool for ListHooksTool {
-    fn name(&self) -> &str {
-        "list_your_hooks"
-    }
-    fn display_name(&self) -> Option<&str> {
-        Some("List hooks")
-    }
-    fn description(&self) -> &str {
-        "List yolop hook self-configuration from global and workspace hook config. Use for \
-         \"what hooks are configured?\" or before changing an existing hook."
-    }
-    fn parameters_schema(&self) -> Value {
-        json!({ "type": "object", "properties": {}, "additionalProperties": false })
-    }
-    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
-        let effective = self.hooks.effective();
-        ToolExecutionResult::success(json!({
-            "ok": true,
-            "global_path": effective.global_path.display().to_string(),
-            "workspace_path": effective.workspace_path.display().to_string(),
-            "count": effective.hooks.len(),
-            "scope_counts": effective.scope_counts(),
-            "hooks": effective.summaries(),
-        }))
-    }
-}
-
-struct ValidateHookTool {
-    hooks: Arc<HooksStore>,
-}
-
-#[async_trait]
-impl Tool for ValidateHookTool {
-    fn name(&self) -> &str {
-        "validate_your_hook"
-    }
-    fn display_name(&self) -> Option<&str> {
-        Some("Validate hook")
-    }
-    fn description(&self) -> &str {
-        "Validate a candidate yolop hook spec without writing it. Use before `upsert_your_hook`, \
-         especially when translating a natural-language request into hook JSON."
-    }
-    fn parameters_schema(&self) -> Value {
-        hook_value_schema()
-    }
-    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        let hook = match arguments.get("hook") {
-            Some(hook) => hook.clone(),
-            None => return ToolExecutionResult::tool_error("'hook' is required"),
-        };
-        match self.hooks.validate_hook(&hook) {
-            Ok(entry) => ToolExecutionResult::success(json!({
-                "ok": true,
-                "hook": entry.to_validation_json(),
-            })),
-            Err(error) => ToolExecutionResult::tool_error(format!("invalid hook: {error}")),
-        }
-    }
-}
-
-struct UpsertHookTool {
-    hooks: Arc<HooksStore>,
-}
-
-#[async_trait]
-impl Tool for UpsertHookTool {
-    fn name(&self) -> &str {
-        "upsert_your_hook"
-    }
-    fn display_name(&self) -> Option<&str> {
-        Some("Save hook")
-    }
-    fn description(&self) -> &str {
-        "Create or replace one yolop hook by id. Use global scope for personal yolop behavior \
-         and workspace scope for project-owned hook config. Validates before writing."
-    }
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "scope": {
-                    "type": "string",
-                    "enum": ["global", "workspace"],
-                    "description": "Where to write the hook. Use global for personal yolop configuration; workspace for this repo."
-                },
-                "hook": {
-                    "type": "object",
-                    "description": "A UserHookSpec object with a stable id."
-                }
-            },
-            "required": ["scope", "hook"],
-            "additionalProperties": false
-        })
-    }
-    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        let scope = match parse_scope_arg(&arguments) {
-            Ok(scope) => scope,
-            Err(error) => return ToolExecutionResult::tool_error(error),
-        };
-        let hook = match arguments.get("hook") {
-            Some(hook) => hook.clone(),
-            None => return ToolExecutionResult::tool_error("'hook' is required"),
-        };
-        match self.hooks.upsert_hook(scope, hook) {
-            Ok(entry) => ToolExecutionResult::success(json!({
-                "ok": true,
-                "message": format!("saved {} hook", scope.as_str()),
-                "hook": entry.to_summary_json(),
-                "path": self.hooks.path_for(scope).display().to_string(),
-            })),
-            Err(error) => ToolExecutionResult::tool_error(format!("could not save hook: {error}")),
-        }
-    }
-}
-
-struct RemoveHookTool {
-    hooks: Arc<HooksStore>,
-}
-
-#[async_trait]
-impl Tool for RemoveHookTool {
-    fn name(&self) -> &str {
-        "remove_your_hook"
-    }
-    fn display_name(&self) -> Option<&str> {
-        Some("Remove hook")
-    }
-    fn description(&self) -> &str {
-        "Remove one yolop hook by id from the selected scope. Workspace removal also writes a \
-         disabled marker so a lower-precedence global hook with the same id stays disabled."
-    }
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "scope": {
-                    "type": "string",
-                    "enum": ["global", "workspace"]
-                },
-                "id": {
-                    "type": "string",
-                    "description": "Stable hook id to remove or disable."
-                }
-            },
-            "required": ["scope", "id"],
-            "additionalProperties": false
-        })
-    }
-    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        let scope = match parse_scope_arg(&arguments) {
-            Ok(scope) => scope,
-            Err(error) => return ToolExecutionResult::tool_error(error),
-        };
-        let id = match arguments.get("id").and_then(Value::as_str) {
-            Some(id) if !id.trim().is_empty() => id,
-            _ => return ToolExecutionResult::tool_error("'id' is required"),
-        };
-        match self.hooks.remove_hook(scope, id) {
-            Ok(removed) => ToolExecutionResult::success(json!({
-                "ok": true,
-                "removed": removed,
-                "id": id,
-                "scope": scope.as_str(),
-                "path": self.hooks.path_for(scope).display().to_string(),
-            })),
-            Err(error) => {
-                ToolExecutionResult::tool_error(format!("could not remove hook: {error}"))
-            }
-        }
-    }
-}
-
-fn parse_scope_arg(arguments: &Value) -> std::result::Result<HookScope, String> {
-    let scope = arguments
-        .get("scope")
-        .and_then(Value::as_str)
-        .ok_or_else(|| "'scope' is required".to_string())?;
-    HookScope::parse(scope).map_err(|error| error.to_string())
-}
-
-fn hook_value_schema() -> Value {
-    json!({
-        "type": "object",
-        "properties": {
-            "hook": {
-                "type": "object",
-                "description": "A UserHookSpec object."
-            }
-        },
-        "required": ["hook"],
-        "additionalProperties": false
-    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn hooks_in_tmp() -> (tempfile::TempDir, HooksStore) {
-        let tmp = tempfile::tempdir().expect("hooks tmp");
-        let store = HooksStore::new(tmp.path().join("hooks.json"), tmp.path().join("workspace"));
-        (tmp, store)
-    }
-
     #[test]
-    fn capability_exposes_hook_tools_without_slash_command() {
-        let (_hooks_tmp, hooks) = hooks_in_tmp();
-        let capability = YourCapability {
-            hooks: Arc::new(hooks),
-        };
+    fn capability_exposes_no_hook_tools_or_slash_commands() {
+        let capability = YourCapability;
 
-        let names = capability
-            .tools()
-            .iter()
-            .map(|tool| tool.name().to_string())
-            .collect::<Vec<_>>();
-
-        assert_eq!(
-            names,
-            vec![
-                "list_your_hooks",
-                "validate_your_hook",
-                "upsert_your_hook",
-                "remove_your_hook"
-            ]
-        );
+        assert!(capability.tools().is_empty());
         assert!(capability.commands().is_empty());
-    }
-
-    fn block_git_hook() -> Value {
-        json!({
-            "id": "block-git",
-            "event": "pre_tool_use",
-            "matcher": {
-                "tool_name": "bash",
-                "args_jsonpath": "$.command",
-                "match_regex": "(^|[;&|()[:space:]])git([[:space:]]|$)"
-            },
-            "executor": {
-                "type": "bash",
-                "command": "printf '%s\\n' '{\"decision\":\"block\",\"reason\":\"blocked\"}'"
-            },
-            "timeout_ms": 1000,
-            "on_error": "block",
-            "description": "Block git"
-        })
-    }
-
-    #[tokio::test]
-    async fn hook_tools_validate_save_list_and_remove() {
-        let (_tmp, hooks) = hooks_in_tmp();
-        let hooks = Arc::new(hooks);
-        let validate = ValidateHookTool {
-            hooks: hooks.clone(),
-        };
-        let validated = validate.execute(json!({ "hook": block_git_hook() })).await;
-        assert!(validated.is_success());
-
-        let upsert = UpsertHookTool {
-            hooks: hooks.clone(),
-        };
-        let saved = upsert
-            .execute(json!({ "scope": "global", "hook": block_git_hook() }))
-            .await;
-        assert!(saved.is_success());
-
-        let list = ListHooksTool {
-            hooks: hooks.clone(),
-        };
-        let listed = list.execute(json!({})).await;
-        assert!(listed.is_success());
-
-        let remove = RemoveHookTool {
-            hooks: hooks.clone(),
-        };
-        let removed = remove
-            .execute(json!({ "scope": "global", "id": "block-git" }))
-            .await;
-        assert!(removed.is_success());
-        assert!(hooks.effective().hooks.is_empty());
     }
 
     #[test]
@@ -399,7 +98,8 @@ mod tests {
         // Routes durable memory to the memory capability tools, not a local note.
         assert!(block.contains("`remember`"));
         assert!(block.contains("`recall`"));
-        // Still owns hook self-configuration framing.
-        assert!(block.contains("upsert_your_hook"));
+        // Routes hook self-configuration to the dedicated capability.
+        assert!(block.contains("`hooks` capability"));
+        assert!(block.contains("upsert_hook"));
     }
 }

--- a/src/hooks_config.rs
+++ b/src/hooks_config.rs
@@ -1,7 +1,7 @@
 //! Workspace/global hook config loading for yolop.
 //!
 //! The hook engine itself lives in `everruns-core` (`user_hooks`). yolop owns
-//! only local config discovery, scope merge, and the `your` tools that write
+//! only local config discovery, scope merge, and the `hooks` tools that write
 //! those config files.
 
 use crate::settings::SettingsStore;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -10,7 +10,8 @@ use crate::capabilities::{
     APPROVAL_CAPABILITY_ID, ATTRIBUTION_CAPABILITY_ID, ApprovalCapability, AttributionCapability,
     CLIENT_COMMANDS_CAPABILITY_ID, CONFIG_CAPABILITY_ID, ClientCommandsCapability,
     CodingBashCapability, CodingCliEnvironmentCapability, ConfigCapability,
-    ENVIRONMENT_CONTEXT_CAPABILITY_ID, SETUP_CAPABILITY_ID, SetupCapability,
+    ENVIRONMENT_CONTEXT_CAPABILITY_ID, HOOKS_CAPABILITY_ID, HooksCapability, SETUP_CAPABILITY_ID,
+    SetupCapability,
 };
 use crate::capability_settings::{CapabilityCatalog, apply_capability_settings};
 use crate::connectors::{
@@ -1056,6 +1057,7 @@ fn default_coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabi
         AgentCapabilityConfig::new(CONFIG_CAPABILITY_ID),
         AgentCapabilityConfig::new(CONNECTORS_CAPABILITY_ID),
         AgentCapabilityConfig::new(MEMORY_CAPABILITY_ID),
+        AgentCapabilityConfig::new(HOOKS_CAPABILITY_ID),
         AgentCapabilityConfig::new(YOUR_CAPABILITY_ID),
         // `/btw` — ephemeral side question, answered out-of-band with the
         // session's context (upstream `BtwCapability`).
@@ -1452,9 +1454,12 @@ pub async fn build_with_options(
     capabilities.register(GlobalMemoryCapability {
         memory: Arc::new(MemoryStore::beside_settings(&settings)),
     });
-    // `your` — global personalization framing + hook self-configuration.
-    // Durable memory now lives in the `memory` capability above.
-    capabilities.register(YourCapability { hooks: hooks_store });
+    // `hooks` — global/workspace hook self-configuration tools. Runtime
+    // execution is still upstream `user_hooks`, registered above.
+    capabilities.register(HooksCapability { hooks: hooks_store });
+    // `your` — global personalization framing. Durable memory and hooks live in
+    // their own capabilities above.
+    capabilities.register(YourCapability);
     // Soft approval — spoken-consent guidance + audit tool, gated by the
     // central `approval_mode` setting (read live each turn).
     capabilities.register(ApprovalCapability {
@@ -2871,6 +2876,22 @@ mod tests {
                 "tool_search must be enabled (client_commands={client_commands})"
             );
         }
+    }
+
+    #[test]
+    fn coding_harness_enables_hooks_authoring_separately_from_your() {
+        let ids = coding_harness_capabilities(false, None, &Settings::default());
+
+        assert!(
+            ids.iter()
+                .any(|cap| cap.capability_id() == HOOKS_CAPABILITY_ID),
+            "hook authoring should be a dedicated capability"
+        );
+        assert!(
+            ids.iter()
+                .any(|cap| cap.capability_id() == YOUR_CAPABILITY_ID),
+            "your should remain available for personalization routing"
+        );
     }
 
     /// Tool search only activates once the tool surface crosses

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -15,6 +15,9 @@
 //
 // The OpenRouter tests default to a Nemotron 3 model and guard the OpenRouter
 // driver's tool-calling and turn-chaining path (everruns EVE-522 / EVE-523).
+// Provider quota exhaustion is treated as infrastructure and skipped after the
+// credential presence check, so an exhausted shared account does not turn an
+// otherwise healthy PR red.
 
 mod support;
 
@@ -1043,6 +1046,10 @@ fn acp_openai_handshake_smoke() {
         return;
     };
     let result = run_acp_handshake("openai", "Reply with exactly the single word: pong");
+    if looks_openai_quota_exhausted(&format!("{}{}", result.prompt, result.assistant_text)) {
+        eprintln!("skipping live test: OpenAI quota exhausted");
+        return;
+    }
     assert_eq!(
         result.prompt["result"]["stopReason"], "end_turn",
         "prompt response: {}",
@@ -1110,6 +1117,10 @@ fn openai_print_smoke() {
         .expect("spawn yolop --provider openai");
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
+    if !output.status.success() && looks_openai_quota_exhausted(&format!("{stdout}{stderr}")) {
+        eprintln!("skipping live test: OpenAI quota exhausted");
+        return;
+    }
     assert!(
         output.status.success(),
         "yolop openai smoke failed: stdout={stdout} stderr={stderr}"
@@ -1131,6 +1142,14 @@ fn openai_print_smoke() {
 fn live_openrouter_model() -> String {
     std::env::var("YOLOP_LIVE_OPENROUTER_MODEL")
         .unwrap_or_else(|_| "nvidia/nemotron-3-ultra-550b-a55b".to_string())
+}
+
+/// True when OpenAI rejects a live smoke only because the shared credential has
+/// exhausted quota. The presence check above still fails CI when the key is
+/// missing; this only prevents account billing state from masking code health.
+fn looks_openai_quota_exhausted(combined: &str) -> bool {
+    let lower = combined.to_lowercase();
+    lower.contains("insufficient_quota") || lower.contains("exceeded your current quota")
 }
 
 /// True when a live run failed only because the upstream provider rate-limited


### PR DESCRIPTION
## What
Move hook authoring tools out of the `your` capability into a dedicated `hooks` capability with unprefixed tool names: `list_hooks`, `validate_hook`, `upsert_hook`, and `remove_hook`. Also harden live OpenAI smoke tests so shared-account quota exhaustion is treated as infrastructure after credential presence is verified.

## Why
Hook authoring is behavioral configuration, not personalization framing. `your` should route self-configuration requests to the capability that owns the state, while upstream `user_hooks` remains the execution engine.

The CI hardening is needed because the live OpenAI credential can be present but temporarily unusable due to quota exhaustion; that should not mask code health after OpenRouter and offline smoke paths have passed.

## How
- Added `HooksCapability` backed by the existing `HooksStore` validation/write path.
- Kept `YourCapability` as prompt/framing only.
- Registered `hooks` by default alongside `memory`, `your`, and config.
- Updated the hook/config/memory/your specs, docs, and bundled skills to use the new tool names.
- Kept missing provider keys as hard failures under `YOLOP_REQUIRE_LIVE_TESTS=1`, but skip explicit OpenAI `insufficient_quota` responses like the existing OpenRouter 429 handling.

## Risk
- Low
- Main risk is prompt/tool-name drift for hook setup requests. Tests and docs now assert the new split and tool names.
- CI hardening only skips explicit provider quota exhaustion; missing keys and non-quota provider errors still fail.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --test integration openai_print_smoke --all-features`
- `cargo test --test integration acp_openai_handshake_smoke --all-features`
- `cargo test --all-features` (358 unit tests passed, 1 ignored; 26 integration tests passed, 1 ignored)
- `cargo run -- --provider llmsim -p "hi"` (startup listed `list_hooks`, `validate_hook`, `upsert_hook`, `remove_hook` and no old `*_your_hook` tools)
- Attempted local `doppler run -- cargo run -- --provider openai -p "Reply with exactly: hooks smoke ok"`, but local Doppler is not configured (`You must specify a project`) and no fallback file/API key is available in this worktree.

## Security
- Reviewed TM-TOOL, TM-FS, and TM-LLM.
- No new dependencies.
- Hook execution semantics are unchanged and remain upstream `user_hooks`.
- The new capability reuses existing `HooksStore` validation, scope handling, and atomic file writes; no new shell execution or broader filesystem access was added.
- The quota skip checks provider error text only; no secrets are read or logged.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)