### PR TITLE
chore(deps): bump everruns family to 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,9 +1296,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1216d19208f5b5b54740373ec401b7d3da3ab5d1eed83c3b2ef06c4ff0201567"
+checksum = "9295c9c718fae3026f780d36ce0256e9e9118994b20f8aa2055a9c9271e1eb0e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1314,18 +1314,18 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ce041663aa6201a29bdd07f0afe1133f9d1f4f4f84e4f38fbdcefd25251607"
+checksum = "abe88657a085bfe7ea8f73443cc84ae1e9abdcae74ad96769235f1a5b30be0e2"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-core"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b8ded51873facc73d12ca6ad1bbcd1ae484c2ffc72e6e95bd6b0b94cd402fa"
+checksum = "211cf9292e24ff50ae36c4115b93b5d96e805092922c1337bd339633eeeab416"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -1366,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fefcb04a4a5d5e8370afe6d9cf501f517b49de9f618bd2db100be0ed57b583b0"
+checksum = "9088141f4275c4a04f7cac0ee94a17592fd18e2e5efd85ee43ada24c96fd8915"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1383,9 +1383,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef6e6f18171016663f22acfb5c9ce292f65aea5a90665ad563e05f033983a8f6"
+checksum = "87ed62241cccb1ffde62996e6b5e10e9a4c83ff342cc8e7d6d1261889990865f"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1399,9 +1399,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d501fc881fe9cc7d92bc8834f716a42ac03974825f1e81ffb485af0ec15c492d"
+checksum = "51c5d45ac64386491ed47f1c2aa65aacd01c2ba6daf8ff9bc045d7f5dfbecb58"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1414,9 +1414,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e625fb0fa8ca24c5667f508aff017302603eeda6deb33886ed6c473c49baf699"
+checksum = "4d1e8876a0eac394be1033ef6f2925c9757867a1497bef83a9b36783de41b650"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1435,9 +1435,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654bdccce8e1456956dd914416fe4edac9709cd4fd59b0b17a69cbe56c007d39"
+checksum = "d6ad18a40d38fb9ceeb0416044cae40d7368b816eccadd1ed8763230d877d6b6"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,14 +37,14 @@ tokio-util = { version = "0.7", features = ["compat"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-everruns-anthropic = "0.11.0"
-everruns-core = "0.11.0"
-everruns-openai = "0.11.0"
+everruns-anthropic = "0.12.0"
+everruns-core = "0.12.0"
+everruns-openai = "0.12.0"
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (specs/mcp.md, upstream runtime-mcp.md D2).
-everruns-runtime = { version = "0.11.0", features = ["mcp-stdio"] }
-everruns-integrations-duckduckgo = "0.11.0"
-everruns-integrations-daytona = "0.11.0"
+everruns-runtime = { version = "0.12.0", features = ["mcp-stdio"] }
+everruns-integrations-duckduckgo = "0.12.0"
+everruns-integrations-daytona = "0.12.0"
 futures = "0.3"
 
 [dev-dependencies]

--- a/specs/connectors.md
+++ b/specs/connectors.md
@@ -23,7 +23,7 @@ supported as overrides (`DAYTONA_API_KEY` for Daytona).
 
 ### Connector catalog
 
-`src/connectors/catalog.rs` registers upstream [`ConnectionProvider`]
+`src/connectors/catalog.rs` registers upstream [`Connector`]
 implementations. Daytona is registered by default; new providers add a
 `.register(...)` call there.
 
@@ -36,7 +36,7 @@ implementations. Daytona is registered by default; new providers add a
   `settings.toml` (see [`configuration.md`](./configuration.md)).
 - `YolopConnectionResolver` implements `UserConnectionResolver` and is injected
   through `RuntimeBackends::with_connection_resolver`.
-- `DaytonaConnectionProvider` is registered on `PlatformDefinition` for form
+- `DaytonaConnector` is registered on `PlatformDefinition` for form
   schema and validation.
 
 When `daytona` is enabled via `[[capabilities]]`, yolop automatically adds

--- a/specs/connectors.md
+++ b/specs/connectors.md
@@ -23,7 +23,7 @@ supported as overrides (`DAYTONA_API_KEY` for Daytona).
 
 ### Connector catalog
 
-`src/connectors/catalog.rs` registers upstream [`Connector`]
+`src/connectors/catalog.rs` registers upstream `Connector`
 implementations. Daytona is registered by default; new providers add a
 `.register(...)` call there.
 

--- a/src/acp/bridge.rs
+++ b/src/acp/bridge.rs
@@ -283,6 +283,7 @@ mod tests {
                 usage: None,
                 error_code: None,
                 error_fields: None,
+                error_disclosure: None,
             },
         )));
         assert!(
@@ -301,6 +302,7 @@ mod tests {
                 usage: None,
                 error_code: None,
                 error_fields: None,
+                error_disclosure: None,
             },
         )));
         assert_eq!(

--- a/src/capabilities/model_discovery.rs
+++ b/src/capabilities/model_discovery.rs
@@ -10,11 +10,9 @@
 use crate::runtime::ProviderChoice;
 use crate::settings::Settings;
 use anyhow::{Context, Result, anyhow};
+use everruns_core::DriverId;
 use everruns_core::get_model_profile;
-use everruns_core::llm_driver_registry::{
-    DiscoveredModel, DriverRegistry, ProviderConfig, ProviderType,
-};
-use everruns_core::llm_models::LlmProviderType;
+use everruns_core::llm_driver_registry::{DiscoveredModel, DriverRegistry, ProviderConfig};
 
 /// One model offered by a provider, ready for display: bare id plus
 /// human-readable metadata merged from the provider's API response and the
@@ -37,18 +35,12 @@ pub(crate) async fn discover_provider_models(
         return Ok(None);
     }
     let target = choice.model_with_provider(settings)?;
-    let provider_type = match target.provider_type {
-        LlmProviderType::Openai => ProviderType::OpenAI,
-        LlmProviderType::AzureOpenai => ProviderType::AzureOpenAI,
-        LlmProviderType::OpenaiCompletions => ProviderType::OpenAICompletions,
-        LlmProviderType::Anthropic => ProviderType::Anthropic,
-        LlmProviderType::Gemini => ProviderType::Gemini,
-        LlmProviderType::Openrouter => ProviderType::OpenRouter,
-        // Yolop never constructs Bedrock (no Bedrock driver is registered
-        // below); treat discovery as unsupported rather than erroring.
-        LlmProviderType::Bedrock | LlmProviderType::LlmSim => return Ok(None),
-    };
-    let mut config = ProviderConfig::new(provider_type);
+    // Yolop never registers Bedrock (no Bedrock driver below) or the llmsim
+    // discovery driver; treat discovery as unsupported rather than erroring.
+    if matches!(target.provider_type, DriverId::Bedrock | DriverId::LlmSim) {
+        return Ok(None);
+    }
+    let mut config = ProviderConfig::new(target.provider_type.clone());
     if let Some(key) = &target.api_key {
         config = config.with_api_key(key);
     }
@@ -59,7 +51,7 @@ pub(crate) async fn discover_provider_models(
     let mut registry = DriverRegistry::new();
     everruns_anthropic::register_driver(&mut registry);
     everruns_openai::register_driver(&mut registry);
-    let driver = registry.create_driver(&config)?;
+    let driver = registry.create_chat_driver(&config)?;
 
     let models = match driver.list_models().await? {
         Some(models) => Some(models),
@@ -99,7 +91,7 @@ pub(crate) async fn discover_provider_models(
 /// catalog best — e.g. OpenRouter's `name` field), with the core profile
 /// filling the gap for APIs that return bare ids (e.g. OpenAI).
 fn enrich_with_profiles(
-    provider_type: &LlmProviderType,
+    provider_type: &DriverId,
     models: Vec<DiscoveredModel>,
 ) -> Vec<DiscoveredProviderModel> {
     models
@@ -211,8 +203,7 @@ mod tests {
     fn enrichment_fills_names_and_descriptions_from_core_profiles() {
         // OpenAI's models API returns bare ids; the core profile registry
         // supplies the human-readable name and description.
-        let enriched =
-            enrich_with_profiles(&LlmProviderType::Openai, vec![bare_discovered("gpt-5.5")]);
+        let enriched = enrich_with_profiles(&DriverId::OpenAI, vec![bare_discovered("gpt-5.5")]);
 
         assert_eq!(enriched.len(), 1);
         assert_eq!(enriched[0].model_id, "gpt-5.5");
@@ -232,7 +223,7 @@ mod tests {
         let mut model = bare_discovered("gpt-5.5");
         model.display_name = Some("GPT-5.5 (via gateway)".to_string());
 
-        let enriched = enrich_with_profiles(&LlmProviderType::Openai, vec![model]);
+        let enriched = enrich_with_profiles(&DriverId::OpenAI, vec![model]);
 
         assert_eq!(
             enriched[0].display_name.as_deref(),
@@ -243,7 +234,7 @@ mod tests {
     #[test]
     fn enrichment_keeps_unknown_models_with_bare_ids() {
         let enriched = enrich_with_profiles(
-            &LlmProviderType::Openai,
+            &DriverId::OpenAI,
             vec![bare_discovered("totally-new-model")],
         );
 

--- a/src/connectors/capability.rs
+++ b/src/connectors/capability.rs
@@ -5,7 +5,7 @@ use crate::connectors::catalog::{ConnectionCatalog, ConnectorInfo};
 use crate::connectors::store::ConnectionStore;
 use async_trait::async_trait;
 use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
-use everruns_core::connection_provider::ConnectionType;
+use everruns_core::connector::ConnectorType;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use serde_json::{Value, json};
 use std::collections::HashMap;
@@ -261,7 +261,7 @@ impl Tool for ConnectTool {
         let Some(entry) = self.inner.catalog.get(&provider) else {
             return ToolExecutionResult::tool_error(format!("Unknown connector `{provider}`"));
         };
-        if entry.connection_type() == ConnectionType::OAuth {
+        if entry.connection_type() == ConnectorType::OAuth {
             return ToolExecutionResult::tool_error(format!(
                 "Connector `{provider}` uses OAuth and cannot be configured through this tool yet"
             ));

--- a/src/connectors/catalog.rs
+++ b/src/connectors/catalog.rs
@@ -1,12 +1,10 @@
 //! Registry of available connector providers.
 //!
-//! Yolop registers upstream [`ConnectionProvider`] implementations here. The
+//! Yolop registers upstream [`Connector`] implementations here. The
 //! catalog is the single place new sandbox backends (E2B, etc.) plug in.
 
-use everruns_core::connection_provider::{
-    ConnectionProvider, ConnectionProviderRegistry, ConnectionValidation,
-};
-use everruns_integrations_daytona::connection::DaytonaConnectionProvider;
+use everruns_core::connector::{Connector, ConnectorRegistry, ConnectorValidation};
+use everruns_integrations_daytona::connection::DaytonaConnector;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -19,13 +17,13 @@ pub struct ConnectorInfo {
     pub display_name: String,
     pub description: String,
     pub icon: String,
-    pub connection_type: everruns_core::connection_provider::ConnectionType,
-    pub form_schema: Option<everruns_core::connection_provider::ConnectionFormSchema>,
+    pub connection_type: everruns_core::connector::ConnectorType,
+    pub form_schema: Option<everruns_core::connector::ConnectorFormSchema>,
     pub connected: bool,
 }
 
 pub struct ConnectionCatalog {
-    providers: ConnectionProviderRegistry,
+    providers: ConnectorRegistry,
 }
 
 impl ConnectionCatalog {
@@ -36,25 +34,25 @@ impl ConnectionCatalog {
     /// Register an additional connector provider (e.g. future E2B integration).
     pub fn builder() -> ConnectionCatalogBuilder {
         ConnectionCatalogBuilder {
-            providers: ConnectionProviderRegistry::new(),
+            providers: ConnectorRegistry::new(),
         }
     }
 }
 
 pub struct ConnectionCatalogBuilder {
-    providers: ConnectionProviderRegistry,
+    providers: ConnectorRegistry,
 }
 
 impl ConnectionCatalogBuilder {
     #[allow(dead_code)] // used by tests and future sandbox provider wiring
-    pub fn register(mut self, provider: impl ConnectionProvider + 'static) -> Self {
+    pub fn register(mut self, provider: impl Connector + 'static) -> Self {
         self.providers.register(provider);
         self
     }
 
     pub fn build(mut self) -> ConnectionCatalog {
         if !self.providers.has("daytona") {
-            self.providers.register(DaytonaConnectionProvider);
+            self.providers.register(DaytonaConnector);
         }
         ConnectionCatalog {
             providers: self.providers,
@@ -64,21 +62,21 @@ impl ConnectionCatalogBuilder {
 
 impl ConnectionCatalog {
     #[allow(dead_code)]
-    pub fn register(&mut self, provider: impl ConnectionProvider + 'static) {
+    pub fn register(&mut self, provider: impl Connector + 'static) {
         self.providers.register(provider);
     }
 
-    pub fn get(&self, provider_id: &str) -> Option<&Arc<dyn ConnectionProvider>> {
+    pub fn get(&self, provider_id: &str) -> Option<&Arc<dyn Connector>> {
         self.providers.get(provider_id)
     }
 
-    pub fn list(&self) -> Vec<&Arc<dyn ConnectionProvider>> {
+    pub fn list(&self) -> Vec<&Arc<dyn Connector>> {
         self.providers.list()
     }
 
     pub fn connector_info(
         &self,
-        provider: &Arc<dyn ConnectionProvider>,
+        provider: &Arc<dyn Connector>,
         store: &ConnectionStore,
     ) -> ConnectorInfo {
         let provider_id = provider.provider_id().to_string();
@@ -109,7 +107,7 @@ impl ConnectionCatalog {
         store: &ConnectionStore,
         provider_id: &str,
         fields: HashMap<String, String>,
-    ) -> Result<ConnectionValidation, String> {
+    ) -> Result<ConnectorValidation, String> {
         let provider = self
             .get(provider_id)
             .ok_or_else(|| format!("unknown connector `{provider_id}`"))?;
@@ -132,12 +130,12 @@ impl ConnectionCatalog {
 #[cfg(test)]
 mod catalog_tests {
     use super::*;
-    use everruns_core::connection_provider::ConnectionType;
+    use everruns_core::connector::ConnectorType;
 
     struct StubProvider;
 
     #[async_trait::async_trait]
-    impl ConnectionProvider for StubProvider {
+    impl Connector for StubProvider {
         fn provider_id(&self) -> &str {
             "stub"
         }
@@ -150,14 +148,14 @@ mod catalog_tests {
         fn icon(&self) -> &str {
             "box"
         }
-        fn connection_type(&self) -> ConnectionType {
-            ConnectionType::ApiKey
+        fn connection_type(&self) -> ConnectorType {
+            ConnectorType::ApiKey
         }
-        fn form_schema(&self) -> Option<everruns_core::connection_provider::ConnectionFormSchema> {
+        fn form_schema(&self) -> Option<everruns_core::connector::ConnectorFormSchema> {
             None
         }
-        async fn validate(&self, _credential: &str) -> Result<ConnectionValidation, String> {
-            Ok(ConnectionValidation {
+        async fn validate(&self, _credential: &str) -> Result<ConnectorValidation, String> {
+            Ok(ConnectorValidation {
                 provider_username: None,
                 provider_metadata: None,
             })

--- a/src/connectors/mod.rs
+++ b/src/connectors/mod.rs
@@ -1,6 +1,6 @@
 //! Generic connector (user connection) support for yolop.
 //!
-//! Connectors wrap upstream [`ConnectionProvider`] implementations so sandbox and
+//! Connectors wrap upstream [`Connector`] implementations so sandbox and
 //! integration capabilities (Daytona today; E2B and others later) can resolve
 //! credentials lazily at tool time through [`YolopConnectionResolver`].
 

--- a/src/connectors/mod.rs
+++ b/src/connectors/mod.rs
@@ -1,8 +1,9 @@
 //! Generic connector (user connection) support for yolop.
 //!
-//! Connectors wrap upstream [`Connector`] implementations so sandbox and
-//! integration capabilities (Daytona today; E2B and others later) can resolve
-//! credentials lazily at tool time through [`YolopConnectionResolver`].
+//! Connectors wrap upstream [`everruns_core::connector::Connector`]
+//! implementations so sandbox and integration capabilities (Daytona today;
+//! E2B and others later) can resolve credentials lazily at tool time through
+//! [`YolopConnectionResolver`].
 
 mod capability;
 mod catalog;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -23,6 +23,7 @@ use crate::settings::{Settings, SettingsStore};
 use crate::tools::Workspace;
 use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
+use everruns_core::DriverId;
 use everruns_core::capabilities::{
     AGENT_INSTRUCTIONS_CAPABILITY_ID, AgentInstructionsCapability, BTW_CAPABILITY_ID,
     BtwCapability, COMPACTION_CAPABILITY_ID, CompactionCapability, FileSystemCapability,
@@ -36,14 +37,13 @@ use everruns_core::command::CommandDescriptor;
 use everruns_core::error::AgentLoopError;
 use everruns_core::in_memory::InMemoryMessageRetriever;
 use everruns_core::llm_driver_registry::DriverRegistry;
-use everruns_core::llm_models::LlmProviderType;
 use everruns_core::llmsim_driver::LlmSimConfig;
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, InitialFile, SessionFile};
 use everruns_core::typed_id::SessionId;
 use everruns_core::{
-    AgentCapabilityConfig, CapabilityRegistry, Controls, InputMessage, ModelWithProvider,
-    PlatformDefinition, ReasoningConfig, ScopedMcpServers, SessionFileSystem,
-    SessionFileSystemFactory, SessionFileSystemFactoryContext,
+    AgentCapabilityConfig, CapabilityRegistry, Controls, InputMessage, PlatformDefinition,
+    ReasoningConfig, ResolvedModel, ScopedMcpServers, SessionFileSystem, SessionFileSystemFactory,
+    SessionFileSystemFactoryContext,
 };
 use everruns_integrations_daytona::DaytonaCapability;
 use everruns_integrations_duckduckgo::DuckDuckGoCapability;
@@ -789,14 +789,15 @@ impl ProviderChoice {
         REASONING_EFFORT_SUGGESTIONS
     }
 
-    pub(crate) fn model_with_provider(&self, settings: &Settings) -> Result<ModelWithProvider> {
+    pub(crate) fn model_with_provider(&self, settings: &Settings) -> Result<ResolvedModel> {
         match self {
             ProviderChoice::Anthropic { model } => {
                 let key = resolve_token(settings, "anthropic", &["ANTHROPIC_API_KEY"])
                     .ok_or_else(|| anyhow!("ANTHROPIC_API_KEY not set (and no token stored)"))?;
-                Ok(ModelWithProvider {
+                Ok(ResolvedModel {
                     model: model.clone(),
-                    provider_type: LlmProviderType::Anthropic,
+                    provider_type: DriverId::Anthropic,
+                    provider_metadata: None,
                     api_key: Some(key),
                     base_url: None,
                 })
@@ -804,9 +805,10 @@ impl ProviderChoice {
             ProviderChoice::OpenAi { model, .. } => {
                 let key = resolve_token(settings, "openai", &["OPENAI_API_KEY"])
                     .ok_or_else(|| anyhow!("OPENAI_API_KEY not set (and no token stored)"))?;
-                Ok(ModelWithProvider {
+                Ok(ResolvedModel {
                     model: model.clone(),
-                    provider_type: LlmProviderType::Openai,
+                    provider_type: DriverId::OpenAI,
+                    provider_metadata: None,
                     api_key: Some(key),
                     base_url: None,
                 })
@@ -816,9 +818,10 @@ impl ProviderChoice {
                     .ok_or_else(|| {
                         anyhow!("GEMINI_API_KEY (or GOOGLE_API_KEY) not set (and no token stored)")
                     })?;
-                Ok(ModelWithProvider {
+                Ok(ResolvedModel {
                     model: model.clone(),
-                    provider_type: LlmProviderType::Openai,
+                    provider_type: DriverId::OpenAI,
+                    provider_metadata: None,
                     api_key: Some(key),
                     base_url: Some(base_url.clone()),
                 })
@@ -828,7 +831,7 @@ impl ProviderChoice {
             } => {
                 let key = resolve_token(settings, "openrouter", &["OPENROUTER_API_KEY"])
                     .ok_or_else(|| anyhow!("OPENROUTER_API_KEY not set (and no token stored)"))?;
-                Ok(ModelWithProvider {
+                Ok(ResolvedModel {
                     model: model.clone(),
                     // First-class OpenRouter driver (everruns 0.10+). It speaks
                     // OpenRouter's OpenAI-compatible Responses API but knows the
@@ -839,7 +842,8 @@ impl ProviderChoice {
                     // extensions (native phases, hosted tool_search) are never
                     // sent to the gateway. This replaces the earlier Chat
                     // Completions workaround for the stateless endpoint.
-                    provider_type: LlmProviderType::Openrouter,
+                    provider_type: DriverId::OpenRouter,
+                    provider_metadata: None,
                     api_key: Some(key),
                     base_url: Some(base_url.clone()),
                 })
@@ -847,9 +851,10 @@ impl ProviderChoice {
             ProviderChoice::Ollama { model, base_url } => {
                 let key = resolve_token(settings, "ollama", &["OLLAMA_API_KEY"])
                     .unwrap_or_else(|| DEFAULT_OLLAMA_API_KEY.to_string());
-                Ok(ModelWithProvider {
+                Ok(ResolvedModel {
                     model: model.clone(),
-                    provider_type: LlmProviderType::Openai,
+                    provider_type: DriverId::OpenAI,
+                    provider_metadata: None,
                     api_key: Some(key),
                     base_url: Some(base_url.clone()),
                 })
@@ -866,39 +871,44 @@ impl ProviderChoice {
                 // Responses driver would break on most of them.
                 let key = resolve_token(settings, "custom", &["CUSTOM_API_KEY"])
                     .unwrap_or_else(|| DEFAULT_CUSTOM_API_KEY.to_string());
-                Ok(ModelWithProvider {
+                Ok(ResolvedModel {
                     model: model.clone(),
-                    provider_type: LlmProviderType::OpenaiCompletions,
+                    provider_type: DriverId::OpenAICompletions,
+                    provider_metadata: None,
                     api_key: Some(key),
                     base_url: Some(base_url),
                 })
             }
-            ProviderChoice::Sim => Ok(ModelWithProvider {
+            ProviderChoice::Sim => Ok(ResolvedModel {
                 model: "llmsim-yolop".into(),
-                provider_type: LlmProviderType::LlmSim,
+                provider_type: DriverId::LlmSim,
+                provider_metadata: None,
                 api_key: Some("fake-key".into()),
                 base_url: None,
             }),
         }
     }
 
-    fn model_without_stored_key(&self) -> ModelWithProvider {
+    fn model_without_stored_key(&self) -> ResolvedModel {
         match self {
-            ProviderChoice::Anthropic { model } => ModelWithProvider {
+            ProviderChoice::Anthropic { model } => ResolvedModel {
                 model: model.clone(),
-                provider_type: LlmProviderType::Anthropic,
+                provider_type: DriverId::Anthropic,
+                provider_metadata: None,
                 api_key: None,
                 base_url: None,
             },
-            ProviderChoice::OpenAi { model, .. } => ModelWithProvider {
+            ProviderChoice::OpenAi { model, .. } => ResolvedModel {
                 model: model.clone(),
-                provider_type: LlmProviderType::Openai,
+                provider_type: DriverId::OpenAI,
+                provider_metadata: None,
                 api_key: None,
                 base_url: None,
             },
-            ProviderChoice::Google { model, base_url } => ModelWithProvider {
+            ProviderChoice::Google { model, base_url } => ResolvedModel {
                 model: model.clone(),
-                provider_type: LlmProviderType::Openai,
+                provider_type: DriverId::OpenAI,
+                provider_metadata: None,
                 api_key: None,
                 base_url: Some(base_url.clone()),
             },
@@ -906,27 +916,31 @@ impl ProviderChoice {
             // `model_with_provider` for the full rationale.
             ProviderChoice::OpenRouter {
                 model, base_url, ..
-            } => ModelWithProvider {
+            } => ResolvedModel {
                 model: model.clone(),
-                provider_type: LlmProviderType::Openrouter,
+                provider_type: DriverId::OpenRouter,
+                provider_metadata: None,
                 api_key: None,
                 base_url: Some(base_url.clone()),
             },
-            ProviderChoice::Ollama { model, base_url } => ModelWithProvider {
+            ProviderChoice::Ollama { model, base_url } => ResolvedModel {
                 model: model.clone(),
-                provider_type: LlmProviderType::Openai,
+                provider_type: DriverId::OpenAI,
+                provider_metadata: None,
                 api_key: Some(DEFAULT_OLLAMA_API_KEY.to_string()),
                 base_url: Some(base_url.clone()),
             },
-            ProviderChoice::Custom { model, .. } => ModelWithProvider {
+            ProviderChoice::Custom { model, .. } => ResolvedModel {
                 model: model.clone(),
-                provider_type: LlmProviderType::OpenaiCompletions,
+                provider_type: DriverId::OpenAICompletions,
+                provider_metadata: None,
                 api_key: None,
                 base_url: env_non_empty("CUSTOM_BASE_URL"),
             },
-            ProviderChoice::Sim => ModelWithProvider {
+            ProviderChoice::Sim => ResolvedModel {
                 model: "llmsim-yolop".into(),
-                provider_type: LlmProviderType::LlmSim,
+                provider_type: DriverId::LlmSim,
+                provider_metadata: None,
                 api_key: Some("fake-key".into()),
                 base_url: None,
             },
@@ -1506,9 +1520,10 @@ pub async fn build_with_options(
             Err(_) if setup_recommended => provider.model_without_stored_key(),
             Err(err) => return Err(err),
         },
-        ProviderChoice::Sim => ModelWithProvider {
+        ProviderChoice::Sim => ResolvedModel {
             model: "llmsim-yolop".into(),
-            provider_type: LlmProviderType::LlmSim,
+            provider_type: DriverId::LlmSim,
+            provider_metadata: None,
             api_key: Some("fake-key".into()),
             base_url: None,
         },
@@ -1517,11 +1532,7 @@ pub async fn build_with_options(
     let platform = PlatformDefinition::builder()
         .capability_registry(capabilities)
         .driver_registry(driver_registry)
-        .connection_providers(
-            everruns_core::ConnectionProviderRegistry::builder()
-                .provider(everruns_integrations_daytona::connection::DaytonaConnectionProvider)
-                .build(),
-        )
+        .connector(everruns_integrations_daytona::connection::DaytonaConnector)
         .session_file_system_factory(Arc::new(CodingCliSessionFileSystemFactory {
             workspace_root: canonical_root.clone(),
             session_dir: session_dir.clone(),
@@ -2553,7 +2564,7 @@ mod tests {
             std::env::remove_var("OPENROUTER_API_KEY");
         }
 
-        assert_eq!(model.provider_type, LlmProviderType::Openrouter);
+        assert_eq!(model.provider_type, DriverId::OpenRouter);
         assert_eq!(model.api_key, Some("test-or-key".to_string()));
         assert_eq!(
             model.base_url,
@@ -2564,7 +2575,7 @@ mod tests {
         // silently fall back to a different driver.
         assert_eq!(
             provider.model_without_stored_key().provider_type,
-            LlmProviderType::Openrouter
+            DriverId::OpenRouter
         );
     }
 
@@ -2581,7 +2592,7 @@ mod tests {
 
         let model = provider.model_with_provider(&Settings::default()).unwrap();
 
-        assert_eq!(model.provider_type, LlmProviderType::Openai);
+        assert_eq!(model.provider_type, DriverId::OpenAI);
         assert_eq!(model.api_key, Some(DEFAULT_OLLAMA_API_KEY.to_string()));
         assert_eq!(model.base_url, Some(DEFAULT_OLLAMA_BASE_URL.to_string()));
     }


### PR DESCRIPTION
## What

Bumps the `everruns-*` crate family from `0.11.0` to `0.12.0` (all bumped
together, per the dependency-discipline rule that mixing minor versions is a
soft API break) and reconciles the renamed/changed runtime API.

### API changes reconciled

- **Connector module rename** (`connection_provider` → `connector`):
  `ConnectionProvider` → `Connector`, `ConnectionProviderRegistry` →
  `ConnectorRegistry`, `ConnectionType` → `ConnectorType`,
  `ConnectionFormSchema` → `ConnectorFormSchema`, `ConnectionValidation` →
  `ConnectorValidation`, and `DaytonaConnectionProvider` → `DaytonaConnector`.
  The trait method names and validation field names are unchanged. Platform
  wiring switched from building a registry + `.connection_providers(...)` to the
  simpler `.connector(DaytonaConnector)`.
- **Model resolution**: `ModelWithProvider` → `ResolvedModel`, which gained a
  `provider_metadata` field (set to `None` at every construction site).
  `everruns_core::llm_models::LlmProviderType` is gone; the equivalent is now
  `DriverId` (note the casing: `OpenAI`, `OpenRouter`, `OpenAICompletions`).
  `ProviderConfig::new` now takes a `DriverId` directly, so the old
  `LlmProviderType → ProviderType` bridge in model discovery was removed in
  favor of a small guard that skips discovery for `Bedrock`/`LlmSim`.
- **Driver registry**: `DriverRegistry::create_driver` → `create_chat_driver`.
- **Events**: `OutputMessageCompletedData` gained an `error_disclosure` field
  (set to `None` in the two exhaustive test literals; production code uses the
  `::new()` constructor).

## Why

Keep yolop's most consequential dependency vector current and in lockstep with
the latest published everruns runtime, as required by `AGENTS.md` and
`specs/maintenance.md`.

## Validation

- `cargo build --all-features` — green
- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all-features` — **384 pass, 0 fail** (358 lib + 26 integration; 2 ignored)
- Offline smoke `--provider llmsim -p "hi"` — binary starts, agent loop runs,
  connectors capability wired (`list_connectors`/`connect`/…), session log created
- Live smoke `--provider anthropic` — full successful turn (`success=true`)
- Live smoke `--provider openai` — reaches the API and returns a server-side
  `insufficient_quota` (account billing, not a code error), confirming the
  `DriverId::OpenAI` → driver factory → HTTP path resolves correctly

This change is a dependency bump + mechanical API migration with no behavior
change, so it is covered by the existing test suite (which exercises
`model_with_provider`/`ResolvedModel`, the connector catalog, and the ACP
bridge events) rather than a new test.

## Security

`everruns-*` bumped together (no mixed minor versions); no new crates added.
No changes to the filesystem write blocklist, the bash timeout/output caps, or
API-key handling — keys are still read from process env only and never logged.
The additive `provider_metadata`/`error_disclosure` fields are set to `None`
and introduce no new data-exposure surface. Risk: **low** (TM-DEP only).

## Follow-ups

No follow-ups.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HP2WJcMnkhhs6QCYQdQE4s)_