### PR TITLE
fix(app): render compact write_todos transcript

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1086,6 +1086,7 @@ impl App {
                                 &handles,
                                 events_before,
                                 &mut emitted_events,
+                                &mut delta_router,
                                 &tx,
                             )
                             .await;
@@ -1102,7 +1103,14 @@ impl App {
 
             // Drain any tail events emitted between the last broadcast
             // poll and the turn's actual completion.
-            catch_up_events(&handles, events_before, &mut emitted_events, &tx).await;
+            catch_up_events(
+                &handles,
+                events_before,
+                &mut emitted_events,
+                &mut delta_router,
+                &tx,
+            )
+            .await;
             // Clear any in-flight streaming preview before we finalize.
             let _ = tx.send(TurnEvent::Stream(None));
 
@@ -1173,6 +1181,7 @@ pub(crate) struct DeltaRouter {
     last_assistant_turn: Option<everruns_core::typed_id::TurnId>,
     last_thinking_turn: Option<everruns_core::typed_id::TurnId>,
     last_tool_call: Option<String>,
+    write_todos_args: HashMap<String, Value>,
 }
 
 fn parse_bang_shell_command(input: &str) -> Option<&str> {
@@ -1885,6 +1894,87 @@ mod tests {
             "1 of 3 todos completed  ✓ Read current CLI renderer  › Rendering todos in transcript  ○ Run focused tests"
         );
         assert_eq!(lines.len(), 1);
+    }
+
+    #[test]
+    fn handle_live_event_renders_write_todos_from_started_args_when_result_is_compact() {
+        use everruns_core::events::ToolStartedData;
+        use everruns_core::tool_types::ToolCall;
+
+        let (tx, mut rx) = mpsc::unbounded_channel::<TurnEvent>();
+        let mut emitted = HashSet::new();
+        let mut router = DeltaRouter::default();
+        let session_id = SessionId::new();
+
+        let started = RuntimeEvent::new(
+            session_id,
+            EventContext::empty(),
+            ToolStartedData {
+                tool_call: ToolCall {
+                    id: "call_todos".to_string(),
+                    name: "write_todos".to_string(),
+                    arguments: serde_json::json!({
+                        "todos": [
+                            {
+                                "content": "Read current CLI renderer",
+                                "activeForm": "Reading current CLI renderer",
+                                "status": "completed"
+                            },
+                            {
+                                "content": "Render todos in transcript",
+                                "activeForm": "Rendering todos in transcript",
+                                "status": "in_progress"
+                            },
+                            {
+                                "content": "Run focused tests",
+                                "activeForm": "Running focused tests",
+                                "status": "pending"
+                            }
+                        ]
+                    }),
+                },
+                tool_call_fingerprint: None,
+                display_name: Some("Write Todos".to_string()),
+                narration: None,
+            },
+        );
+        let completed = RuntimeEvent::new(
+            session_id,
+            EventContext::empty(),
+            ToolCompletedData {
+                tool_call_id: "call_todos".to_string(),
+                tool_name: "write_todos".to_string(),
+                tool_call_fingerprint: None,
+                tool_result_fingerprint: None,
+                display_name: Some("Write Todos".to_string()),
+                success: true,
+                status: "success".to_string(),
+                result: None,
+                error: None,
+                duration_ms: None,
+                capability_id: None,
+                capability_name: None,
+                narration: None,
+            },
+        );
+
+        handle_live_event(&started, &mut emitted, &mut router, &tx);
+        handle_live_event(&completed, &mut emitted, &mut router, &tx);
+
+        let mut lines = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            if let TurnEvent::Lines(batch) = event {
+                lines.extend(batch.into_iter().map(|line| line.text));
+            }
+        }
+
+        assert!(lines.iter().all(|line| line != "✓ Write Todos"));
+        assert_eq!(
+            lines,
+            vec![
+                "1 of 3 todos completed  ✓ Read current CLI renderer  › Rendering todos in transcript  ○ Run focused tests"
+            ]
+        );
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1897,7 +1897,7 @@ mod tests {
     }
 
     #[test]
-    fn handle_live_event_renders_write_todos_from_started_args_when_result_is_compact() {
+    fn handle_live_event_renders_write_todos_from_started_args_when_result_is_counts_only() {
         use everruns_core::events::ToolStartedData;
         use everruns_core::tool_types::ToolCall;
 
@@ -1941,21 +1941,21 @@ mod tests {
         let completed = RuntimeEvent::new(
             session_id,
             EventContext::empty(),
-            ToolCompletedData {
-                tool_call_id: "call_todos".to_string(),
-                tool_name: "write_todos".to_string(),
-                tool_call_fingerprint: None,
-                tool_result_fingerprint: None,
-                display_name: Some("Write Todos".to_string()),
-                success: true,
-                status: "success".to_string(),
-                result: None,
-                error: None,
-                duration_ms: None,
-                capability_id: None,
-                capability_name: None,
-                narration: None,
-            },
+            ToolCompletedData::success(
+                "call_todos".to_string(),
+                "write_todos".to_string(),
+                vec![ContentPart::text(
+                    serde_json::json!({
+                        "success": true,
+                        "total_tasks": 3,
+                        "pending": 1,
+                        "in_progress": 1,
+                        "completed": 1
+                    })
+                    .to_string(),
+                )],
+                None,
+            ),
         );
 
         handle_live_event(&started, &mut emitted, &mut router, &tx);

--- a/src/app/transcript.rs
+++ b/src/app/transcript.rs
@@ -65,10 +65,11 @@ pub(crate) fn handle_live_event(
         _ => {}
     }
 
+    remember_write_todos_args(event, router);
     if let Some(activity) = status_for_event(event) {
         let _ = tx.send(TurnEvent::Activity(activity));
     }
-    let lines = lines_for_event(event);
+    let lines = lines_for_event_with_router(event, router);
     if !lines.is_empty() {
         let _ = tx.send(TurnEvent::Lines(lines));
     }
@@ -82,6 +83,7 @@ pub(crate) async fn catch_up_events(
     handles: &RuntimeHandles,
     events_before: usize,
     emitted_events: &mut HashSet<String>,
+    router: &mut DeltaRouter,
     tx: &mpsc::UnboundedSender<TurnEvent>,
 ) {
     let events = handles.runtime.events().await.unwrap_or_default();
@@ -91,13 +93,33 @@ pub(crate) async fn catch_up_events(
         if !emitted_events.insert(event_id) {
             continue;
         }
+        remember_write_todos_args(event, router);
         if let Some(activity) = status_for_event(event) {
             let _ = tx.send(TurnEvent::Activity(activity));
         }
-        lines.extend(lines_for_event(event));
+        lines.extend(lines_for_event_with_router(event, router));
     }
     if !lines.is_empty() {
         let _ = tx.send(TurnEvent::Lines(lines));
+    }
+}
+
+fn remember_write_todos_args(event: &RuntimeEvent, router: &mut DeltaRouter) {
+    if let EventData::ToolStarted(data) = &event.data
+        && data.tool_call.name == "write_todos"
+    {
+        router
+            .write_todos_args
+            .insert(data.tool_call.id.clone(), data.tool_call.arguments.clone());
+    }
+}
+
+fn lines_for_event_with_router(event: &RuntimeEvent, router: &mut DeltaRouter) -> Vec<ChatLine> {
+    match &event.data {
+        EventData::ToolCompleted(data) if data.tool_name == "write_todos" => {
+            todo_lines_for_result_or_args(data, &mut router.write_todos_args)
+        }
+        _ => lines_for_event(event),
     }
 }
 
@@ -311,7 +333,16 @@ pub(crate) fn truncate_chars(value: &str, max_chars: usize) -> String {
 }
 
 pub(crate) fn todo_lines_for_result(data: &ToolCompletedData) -> Vec<ChatLine> {
-    let Some(v) = result_value(data) else {
+    todo_lines_for_result_or_args(data, &mut HashMap::new())
+}
+
+fn todo_lines_for_result_or_args(
+    data: &ToolCompletedData,
+    write_todos_args: &mut HashMap<String, Value>,
+) -> Vec<ChatLine> {
+    let cached_args = write_todos_args.remove(&data.tool_call_id);
+    let result = result_value(data);
+    let Some(v) = result.as_ref().or(cached_args.as_ref()) else {
         return vec![ChatLine {
             author: Author::Tool,
             text: format!(

--- a/src/app/transcript.rs
+++ b/src/app/transcript.rs
@@ -342,11 +342,19 @@ fn todo_lines_for_result_or_args(
 ) -> Vec<ChatLine> {
     let cached_args = write_todos_args.remove(&data.tool_call_id);
     let result = result_value(data);
-    let Some(v) = result.as_ref().or(cached_args.as_ref()) else {
+    let has_todos = |value: &&Value| value.get("todos").and_then(Value::as_array).is_some();
+    let Some(v) = result
+        .as_ref()
+        .filter(has_todos)
+        .or_else(|| cached_args.as_ref().filter(has_todos))
+        .or(result.as_ref())
+        .or(cached_args.as_ref())
+    else {
+        let marker = if data.success { "✓" } else { "✗" };
         return vec![ChatLine {
             author: Author::Tool,
             text: format!(
-                "✓ {}",
+                "{marker} {}",
                 data.display_name.as_deref().unwrap_or("Write Todos")
             ),
         }];


### PR DESCRIPTION
## What
Render `write_todos` transcript lines from cached `tool.started` arguments when the completed tool event has no full JSON todo result.

## Why
The terminal transcript could show only `✓ Write Todos` when the todo list was available on the start event but absent or compacted on completion. That hid the actual plan contents from users.

## How
- Track `write_todos` arguments in the per-turn transcript router by tool-call id.
- Prefer the completed result when it includes todos, and fall back to the cached start arguments otherwise.
- Cover the compact-completion path through `handle_live_event`, the same entry point used by the live transcript.

## Risk
- Low
- Touches transcript rendering state only; incorrect routing could affect how completed todo writes are displayed, not tool execution.

## Security
- TM-FS: Not affected; no filesystem read/write behavior changed.
- TM-BASH: Not affected; no shell execution behavior changed.
- TM-LLM: Not affected; no prompt construction, provider config, or secret handling changed.
- TM-TOOL: Not affected; no capability registration or tool execution changed.
- TM-DEP: Not affected; no dependency changes.

## Validation
- `cargo fmt --check`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- --provider llmsim -p "hi"`
- `doppler run --project yolop --config ci -- cargo run -- --provider anthropic -p "Use write_todos to create a two-step plan for this smoke test, then reply exactly: smoke done"`
- Attempted required OpenAI smoke with `doppler run --project yolop --config ci -- cargo run -- --provider openai ...`; it reached OpenAI but failed before the turn with `insufficient_quota`, so Anthropic was used as secondary live-provider smoke.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
