### PR TITLE
feat(runtime): send yolop metadata to everruns

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -332,7 +332,6 @@ pub struct StreamPreview {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum StreamKind {
     Assistant,
-    Thinking,
     Tool,
 }
 
@@ -340,7 +339,6 @@ impl StreamKind {
     fn label(self) -> &'static str {
         match self {
             StreamKind::Assistant => "agent",
-            StreamKind::Thinking => "thinking",
             StreamKind::Tool => "tool",
         }
     }
@@ -348,7 +346,6 @@ impl StreamKind {
     fn color(self) -> Color {
         match self {
             StreamKind::Assistant => ACCENT_GOLD,
-            StreamKind::Thinking => TEXT_MUTED,
             StreamKind::Tool => TEXT_MUTED,
         }
     }
@@ -1241,7 +1238,6 @@ impl App {
 #[derive(Default)]
 pub(crate) struct DeltaRouter {
     last_assistant_turn: Option<everruns_core::typed_id::TurnId>,
-    last_thinking_turn: Option<everruns_core::typed_id::TurnId>,
     last_tool_call: Option<String>,
     write_todos_args: HashMap<String, Value>,
 }
@@ -2261,6 +2257,34 @@ mod tests {
                 );
             }
             None => panic!("expected tool delta to surface preview"),
+        }
+    }
+
+    #[test]
+    fn handle_live_event_hides_thinking_delta_from_stream_preview() {
+        use everruns_core::events::ReasonThinkingDeltaData;
+        use everruns_core::typed_id::TurnId;
+
+        let (tx, mut rx) = mpsc::unbounded_channel::<TurnEvent>();
+        let mut emitted = HashSet::new();
+        let mut router = DeltaRouter::default();
+
+        let event = RuntimeEvent::new(
+            SessionId::new(),
+            EventContext::empty(),
+            ReasonThinkingDeltaData {
+                turn_id: TurnId::new(),
+                delta: "private chain".to_string(),
+                accumulated: "private chain".to_string(),
+            },
+        );
+        handle_live_event(&event, &mut emitted, &mut router, &tx);
+
+        while let Ok(event) = rx.try_recv() {
+            assert!(
+                !matches!(event, TurnEvent::Stream(_)),
+                "private thinking must not create a stream preview: {event:?}"
+            );
         }
     }
 
@@ -4348,23 +4372,6 @@ mod tests {
         assert!(
             !rows[0].contains("first line"),
             "stream preview should not show earlier lines: {}",
-            rows[0]
-        );
-    }
-
-    #[test]
-    fn chrome_stream_preview_thinking_uses_thinking_label() {
-        let state = ViewState {
-            stream_preview: Some(StreamPreview {
-                kind: StreamKind::Thinking,
-                text: "weighing options".to_string(),
-            }),
-            ..view_state_idle()
-        };
-        let rows = render_chrome_lines(&state, 80, 5);
-        assert!(
-            rows[0].contains("thinking"),
-            "thinking-kind preview should use 'thinking' label: {}",
             rows[0]
         );
     }

--- a/src/app/transcript.rs
+++ b/src/app/transcript.rs
@@ -30,18 +30,6 @@ pub(crate) fn handle_live_event(
             router.last_assistant_turn = None;
             let _ = tx.send(TurnEvent::Stream(None));
         }
-        EventData::ReasonThinkingDelta(data) => {
-            router.last_thinking_turn = Some(data.turn_id);
-            let _ = tx.send(TurnEvent::Stream(Some(StreamPreview {
-                kind: StreamKind::Thinking,
-                text: data.accumulated.clone(),
-            })));
-            return;
-        }
-        EventData::ReasonThinkingCompleted(_) if router.last_thinking_turn.is_some() => {
-            router.last_thinking_turn = None;
-            let _ = tx.send(TurnEvent::Stream(None));
-        }
         EventData::ToolOutputDelta(data) => {
             router.last_tool_call = Some(data.tool_call_id.clone());
             let text = format!(

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -48,8 +48,8 @@ use everruns_core::{
 use everruns_integrations_daytona::DaytonaCapability;
 use everruns_integrations_duckduckgo::DuckDuckGoCapability;
 use everruns_runtime::{
-    InProcessRuntime, InProcessRuntimeBuilder, RealDiskFileStore, RuntimeBackends,
-    WriteBlocklistFileStore,
+    AgentBuilder, HarnessBuilder, InProcessRuntime, InProcessRuntimeBuilder, RealDiskFileStore,
+    RuntimeBackends, SessionBuilder, WriteBlocklistFileStore,
 };
 
 use crate::session_log::{
@@ -1542,9 +1542,8 @@ pub async fn build_with_options(
         }))
         .build();
 
-    // SingleSessionBuilder bundles harness/agent/session with defaults the
-    // runtime owns. `session_id(...)` pins the id so resume can re-attach
-    // to the same JSONL log (filename encodes the id).
+    // Seed harness/agent/session explicitly so Yolop can attach harness
+    // metadata that Everruns forwards to LLM calls and observability.
     let session_title = format!("yolop @ {}", canonical_root.display());
     let harness_capabilities = coding_harness_capabilities(
         options.client_commands,
@@ -1553,28 +1552,44 @@ pub async fn build_with_options(
     );
     let session_mcp_servers = mcp_servers.clone();
 
+    let mut harness_builder = HarnessBuilder::new("yolop", HARNESS_PROMPT)
+        .metadata_entry("app", "yolop")
+        .metadata_entry("yolop_version", env!("CARGO_PKG_VERSION"))
+        .metadata_entry(
+            "everruns_runtime_version",
+            env!("YOLOP_EVERRUNS_RUNTIME_VERSION"),
+        )
+        .display_name("Coding CLI")
+        .description("Embedded terminal coding agent.")
+        .tag("example")
+        .tag("coding");
+    for cap in harness_capabilities {
+        harness_builder = harness_builder.capability(cap);
+    }
+    let harness_id = harness_builder.harness_id();
+
+    let agent_builder = AgentBuilder::new("coding-agent", AGENT_PROMPT)
+        .display_name("Coding Agent")
+        .description("Reads, edits, and runs commands inside a project workspace.")
+        .tag("example")
+        .tag("coding");
+    let agent_id = agent_builder.agent_id();
+
+    let session_builder = SessionBuilder::new(harness_id)
+        .agent(agent_id)
+        .id(session_id)
+        .title(session_title)
+        .mcp_servers(session_mcp_servers)
+        .tag("example")
+        .tag("coding");
+
     let mut builder = InProcessRuntimeBuilder::new()
         .platform_definition(platform)
         .default_model(default_model)
         .backends(backends)
-        .single_session(move |s| {
-            let mut s = s
-                .harness("yolop", HARNESS_PROMPT)
-                .harness_display_name("Coding CLI")
-                .harness_description("Embedded terminal coding agent.")
-                .agent("coding-agent", AGENT_PROMPT)
-                .agent_display_name("Coding Agent")
-                .agent_description("Reads, edits, and runs commands inside a project workspace.")
-                .session_id(session_id)
-                .session_title(session_title.clone())
-                .session_mcp_servers(session_mcp_servers.clone())
-                .tag("example")
-                .tag("coding");
-            for cap in harness_capabilities {
-                s = s.harness_capability(cap);
-            }
-            s
-        });
+        .harness(harness_builder.build())
+        .agent(agent_builder.build())
+        .session(session_builder.build());
     // Always register the llmsim driver so `/setup` can switch to offline mode.
     // mid-session, even if the user started with anthropic or openai.
     let llmsim_config = options.llmsim_override.unwrap_or_else(|| {
@@ -1686,6 +1701,49 @@ mod tests {
                 .expect("resolve")
                 .is_none(),
             "no credential configured yet"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn build_attaches_yolop_embedder_metadata() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+
+        let built = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Sim,
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            BuildOptions::default(),
+        )
+        .await
+        .expect("build runtime");
+
+        let context = built
+            .handles
+            .runtime
+            .load_context(built.handles.session_id)
+            .await
+            .expect("load context");
+        assert_eq!(
+            context.embedder_metadata.get("app").map(String::as_str),
+            Some("yolop")
+        );
+        assert_eq!(
+            context
+                .embedder_metadata
+                .get("yolop_version")
+                .map(String::as_str),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
+        assert_eq!(
+            context
+                .embedder_metadata
+                .get("everruns_runtime_version")
+                .map(String::as_str),
+            Some(env!("YOLOP_EVERRUNS_RUNTIME_VERSION"))
         );
     }
 


### PR DESCRIPTION
## What
Attach Yolop embedder metadata to the seeded Everruns harness:

- `app = yolop`
- `yolop_version = <Cargo package version>`
- `everruns_runtime_version = <embedded everruns-runtime version>`

This uses the harness metadata API now available through the published `everruns-runtime 0.13.0` family on `main`.

Also stop rendering private `ReasonThinkingDelta` text in Yolop's terminal stream-preview row. Public assistant and tool output previews still render; private thinking remains hidden from the TUI transcript/chrome.

## Why
Yolop should identify itself in metadata that Everruns forwards to LLM calls and observability. This lets provider and telemetry records distinguish Yolop traffic and correlate it with the embedded runtime version.

For the OpenRouter/Nemotron narration issue, Everruns PR #2228 keeps provider reasoning private by default. Yolop should match that privacy boundary locally by not surfacing private thinking deltas as visible bottom-row narration.

## How
Use `HarnessBuilder::metadata_entry(...)` and add a runtime test that builds the offline llmsim runtime, loads the assembled context, and asserts the metadata values are present.

Remove the TUI `StreamKind::Thinking` path for `ReasonThinkingDelta`; add a test asserting thinking deltas do not create stream previews.

## Risk
- Low
- Metadata values are compile-time constants and do not include user input, workspace paths, prompts, or secrets.
- Runtime construction is equivalent to the previous `single_session` seed path, but explicit so harness metadata can be attached.
- Users will still see public assistant/tool stream previews and status text, but not private thinking text.

## Security
- TM-LLM: metadata values are fixed compile-time constants; no API keys, user prompts, paths, or workspace data are added.
- TM-LLM/data exposure: private reasoning/thinking deltas are no longer rendered in the terminal stream preview.
- TM-DEP: no dependency pinning in this PR; `main` already carries the Everruns `0.13.0` family bump that includes the metadata API and OpenRouter private-reasoning fix.
- TM-FS, TM-BASH, TM-TOOL: no filesystem access, shell execution, write blocklist, or capability registration behavior changed.

## Validation
- `cargo check`
- `cargo fmt --check`
- `cargo test stream_preview`
- `cargo test build_attaches_yolop_embedder_metadata`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"`

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered