### PR TITLE
fix(session): restore workspace root on resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,17 +349,23 @@ data directory:
 | macOS   | `~/Library/Application Support/yolop/sessions/<session_id>/` |
 | Windows | `%APPDATA%\yolop\sessions\<session_id>\`                   |
 
-The event log lives at `<session_folder>/events.jsonl`; large tool output is
-spilled under `<session_folder>/outputs/`. On Unix the session folder is
-`0o700` and the log `0o600` (owner-only). The log keeps everything needed to
-restore the transcript and provider continuation state on resume — including
-prompts, tool arguments and output, and reasoning artifacts.
+The event log lives at `<session_folder>/events.jsonl`; the workspace root is
+stored in `<session_folder>/workspace.json`; large tool output is spilled under
+`<session_folder>/outputs/`. On Unix the session folder is `0o700` and the log
+and workspace metadata are `0o600` (owner-only). The log keeps everything
+needed to restore the transcript and provider continuation state on resume —
+including prompts, tool arguments and output, and reasoning artifacts.
 
 To continue a previous conversation:
 
 ```bash
 yolop --session session_019e3db018a17450aba5407af5777237
 ```
+
+When no `-C/--cwd` is supplied, resume uses the workspace root saved for that
+session instead of the shell's current directory. Pass `-C <PATH>` with
+`--session` to intentionally move the resumed session to a different
+workspace.
 
 `--session-dir <PATH>` overrides the parent storage location (useful for
 keeping per-workspace session histories in `<workspace>/.yolop/sessions/`).

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,12 +43,13 @@ use crossterm::event::{
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 use crossterm::{execute, queue};
 use everruns_core::message::MessageRole;
+use everruns_core::typed_id::SessionId;
 use ratatui::backend::CrosstermBackend;
 use ratatui::{Terminal, TerminalOptions, Viewport};
 use runtime::{BuiltRuntime, ProviderChoice};
 use settings::SettingsStore;
 use std::io::{self, IsTerminal, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 #[derive(Parser, Debug)]
@@ -283,10 +284,6 @@ async fn main() -> Result<()> {
         return run_command(command);
     }
 
-    let cwd = cli
-        .cwd
-        .clone()
-        .unwrap_or_else(|| std::env::current_dir().expect("cwd"));
     // Fall back to an unwritable scratch path when no platform config dir
     // is resolvable (minimal containers, CI without HOME). `SettingsStore`
     // loads to defaults when the file does not exist, and writes will
@@ -312,6 +309,7 @@ async fn main() -> Result<()> {
         Some(p) => p,
         None => session_log::default_sessions_dir()?,
     };
+    let cwd = resolve_workspace_root(cli.cwd.clone(), resume_session_id, &sessions_dir)?;
 
     // ACP mode builds runtimes per session (cwd arrives via `session/new`), so
     // it bypasses the up-front runtime build and the TUI.
@@ -340,6 +338,23 @@ async fn main() -> Result<()> {
         return run_print_mode(runtime, prompt).await;
     }
     run_tui(runtime).await
+}
+
+fn resolve_workspace_root(
+    cli_cwd: Option<PathBuf>,
+    resume_session_id: Option<SessionId>,
+    sessions_dir: &Path,
+) -> Result<PathBuf> {
+    if let Some(cwd) = cli_cwd {
+        return Ok(cwd);
+    }
+    if let Some(session_id) = resume_session_id {
+        let session_dir = session_log::session_dir_path(sessions_dir, session_id);
+        if let Some(saved) = session_log::read_session_workspace(&session_dir)? {
+            return Ok(saved);
+        }
+    }
+    Ok(std::env::current_dir().expect("cwd"))
 }
 
 fn run_command(command: Commands) -> Result<()> {
@@ -773,6 +788,41 @@ mod tests {
         let provider = pick_provider(&cli, &settings);
 
         assert_eq!(provider.label(), "openai/gpt-5.4 high");
+    }
+
+    #[test]
+    fn resolve_workspace_root_uses_saved_session_workspace() {
+        let sessions = tempfile::tempdir().expect("sessions tempdir");
+        let workspace = tempfile::tempdir().expect("workspace tempdir");
+        let session_id = SessionId::from_seed(42);
+        let session_dir = session_log::session_dir_path(sessions.path(), session_id);
+        session_log::write_session_workspace(&session_dir, workspace.path())
+            .expect("write workspace metadata");
+
+        let resolved =
+            resolve_workspace_root(None, Some(session_id), sessions.path()).expect("resolve");
+
+        assert_eq!(resolved, workspace.path());
+    }
+
+    #[test]
+    fn resolve_workspace_root_prefers_explicit_cwd() {
+        let sessions = tempfile::tempdir().expect("sessions tempdir");
+        let saved = tempfile::tempdir().expect("saved workspace tempdir");
+        let explicit = tempfile::tempdir().expect("explicit workspace tempdir");
+        let session_id = SessionId::from_seed(43);
+        let session_dir = session_log::session_dir_path(sessions.path(), session_id);
+        session_log::write_session_workspace(&session_dir, saved.path())
+            .expect("write workspace metadata");
+
+        let resolved = resolve_workspace_root(
+            Some(explicit.path().to_path_buf()),
+            Some(session_id),
+            sessions.path(),
+        )
+        .expect("resolve");
+
+        assert_eq!(resolved, explicit.path());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ mod mcp_e2e_tests;
 #[cfg(test)]
 mod agent_scenarios;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 // Force-link integration crates whose inventory registrations must survive
 // LTO/dead-code elimination when we register capabilities explicitly.
@@ -354,7 +354,7 @@ fn resolve_workspace_root(
             return Ok(saved);
         }
     }
-    Ok(std::env::current_dir().expect("cwd"))
+    std::env::current_dir().context("resolve current workspace directory")
 }
 
 fn run_command(command: Commands) -> Result<()> {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -54,6 +54,7 @@ use everruns_runtime::{
 
 use crate::session_log::{
     JsonlEventEmitter, migrate_legacy_session_log, replay, session_dir_path, session_log_path,
+    write_session_workspace,
 };
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
@@ -235,28 +236,19 @@ impl CodingCliSessionFileStore {
     fn secure_session_artifact_path(&self, _path: &str) -> everruns_core::Result<()> {
         Ok(())
     }
-
-    fn grep_filter_path(path: &str) -> Option<String> {
-        let normalized = if path.is_empty() {
-            String::new()
-        } else if let Some(stripped) = path.strip_prefix("/workspace/") {
-            stripped.to_string()
-        } else if path == "/workspace" {
-            String::new()
-        } else {
-            path.trim_start_matches('/').to_string()
-        };
-
-        if normalized.is_empty() {
-            None
-        } else {
-            Some(normalized)
-        }
-    }
 }
 
 #[async_trait]
 impl SessionFileSystem for CodingCliSessionFileStore {
+    fn display_root(&self) -> String {
+        self.workspace.display_root()
+    }
+
+    fn display_path(&self, path: &str) -> String {
+        let (store, path) = self.store_for_path(path);
+        store.display_path(&path)
+    }
+
     async fn read_file(
         &self,
         session_id: SessionId,
@@ -348,9 +340,8 @@ impl SessionFileSystem for CodingCliSessionFileStore {
                     .await
             }
             None => {
-                let normalized_filter = path_pattern.and_then(Self::grep_filter_path);
                 self.workspace
-                    .grep_files(session_id, pattern, normalized_filter.as_deref())
+                    .grep_files(session_id, pattern, path_pattern)
                     .await
             }
         }
@@ -1323,6 +1314,7 @@ pub async fn build_with_options(
     let session_dir = session_dir_path(&sessions_dir, session_id);
     let log_path = session_log_path(&session_dir);
     let _legacy_log = migrate_legacy_session_log(&sessions_dir, &session_dir, session_id)?;
+    write_session_workspace(&session_dir, &canonical_root)?;
 
     // Replay anything already on disk for this id. Missing file → empty.
     // Pass `session_id` so events for any other session get skipped
@@ -1745,6 +1737,29 @@ mod tests {
                 .map(String::as_str),
             Some(env!("YOLOP_EVERRUNS_RUNTIME_VERSION"))
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn build_persists_workspace_root_for_session_resume() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+
+        let built = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Sim,
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            BuildOptions::default(),
+        )
+        .await
+        .expect("build runtime");
+
+        let saved = crate::session_log::read_session_workspace(&built.startup.session_dir)
+            .expect("read workspace metadata")
+            .expect("workspace metadata");
+        assert_eq!(saved, built.startup.workspace_root);
     }
 
     #[test]
@@ -2798,6 +2813,37 @@ mod tests {
             .expect("grep workspace");
         assert_eq!(workspace_grep.len(), 1);
         assert_eq!(workspace_grep[0].path, "/src/lib.rs");
+
+        let host_filter = store.display_path("/src");
+        let host_path_grep = store
+            .grep_files(session_id, "grep target", Some(&host_filter))
+            .await
+            .expect("grep workspace via host display path");
+        assert_eq!(host_path_grep.len(), 1);
+        assert_eq!(host_path_grep[0].path, "/src/lib.rs");
+    }
+
+    #[test]
+    fn yolop_file_store_displays_workspace_and_session_paths() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let session = tempfile::tempdir().expect("session");
+        let store = CodingCliSessionFileStore::new(workspace.path().into(), session.path().into())
+            .expect("store");
+        let workspace_root = std::fs::canonicalize(workspace.path()).expect("canonical workspace");
+        let session_root = std::fs::canonicalize(session.path()).expect("canonical session");
+
+        assert_eq!(store.display_root(), workspace_root.display().to_string());
+        assert_eq!(
+            store.display_path("/src/lib.rs"),
+            workspace_root.join("src/lib.rs").display().to_string()
+        );
+        assert_eq!(
+            store.display_path("/outputs/call.stdout"),
+            session_root
+                .join("outputs/call.stdout")
+                .display()
+                .to_string()
+        );
     }
 
     #[cfg(unix)]

--- a/src/session_log.rs
+++ b/src/session_log.rs
@@ -65,6 +65,7 @@ use everruns_core::traits::EventEmitter;
 use everruns_core::typed_id::EventId;
 use everruns_core::typed_id::SessionId;
 use everruns_runtime::EventBus;
+use serde::{Deserialize, Serialize};
 use std::fs::{File, OpenOptions, TryLockError};
 use std::io::{BufRead, BufReader, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
@@ -106,8 +107,89 @@ pub fn session_log_path(session_dir: &Path) -> PathBuf {
     session_dir.join("events.jsonl")
 }
 
+fn session_workspace_path(session_dir: &Path) -> PathBuf {
+    session_dir.join("workspace.json")
+}
+
 pub fn legacy_session_log_path(sessions_dir: &Path, session_id: SessionId) -> PathBuf {
     sessions_dir.join(format!("{session_id}.jsonl"))
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct SessionWorkspaceMetadata {
+    workspace_root: PathBuf,
+}
+
+pub fn read_session_workspace(session_dir: &Path) -> Result<Option<PathBuf>> {
+    let path = session_workspace_path(session_dir);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let bytes = std::fs::read(&path).map_err(|e| {
+        AgentLoopError::config(format!("read session workspace {}: {e}", path.display()))
+    })?;
+    let metadata: SessionWorkspaceMetadata = serde_json::from_slice(&bytes).map_err(|e| {
+        AgentLoopError::config(format!("parse session workspace {}: {e}", path.display()))
+    })?;
+    Ok(Some(metadata.workspace_root))
+}
+
+pub fn write_session_workspace(session_dir: &Path, workspace_root: &Path) -> Result<()> {
+    std::fs::create_dir_all(session_dir).map_err(|e| {
+        AgentLoopError::config(format!("create session dir {}: {e}", session_dir.display()))
+    })?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(session_dir, std::fs::Permissions::from_mode(0o700)).map_err(
+            |e| {
+                AgentLoopError::config(format!(
+                    "tighten session dir permissions on {}: {e}",
+                    session_dir.display()
+                ))
+            },
+        )?;
+    }
+    let path = session_workspace_path(session_dir);
+    let metadata = SessionWorkspaceMetadata {
+        workspace_root: workspace_root.to_path_buf(),
+    };
+    let bytes = serde_json::to_vec_pretty(&metadata)
+        .map_err(|e| AgentLoopError::config(format!("serialize session workspace: {e}")))?;
+    write_private_file(&path, &bytes)
+}
+
+fn write_private_file(path: &Path, bytes: &[u8]) -> Result<()> {
+    let mut opts = OpenOptions::new();
+    opts.create(true).write(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    let mut file = opts.open(path).map_err(|e| {
+        AgentLoopError::config(format!("open private file {}: {e}", path.display()))
+    })?;
+    file.write_all(bytes).map_err(|e| {
+        AgentLoopError::config(format!("write private file {}: {e}", path.display()))
+    })?;
+    file.write_all(b"\n").map_err(|e| {
+        AgentLoopError::config(format!("write private file {}: {e}", path.display()))
+    })?;
+    file.flush().map_err(|e| {
+        AgentLoopError::config(format!("flush private file {}: {e}", path.display()))
+    })?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(|e| {
+            AgentLoopError::config(format!(
+                "tighten private file permissions on {}: {e}",
+                path.display()
+            ))
+        })?;
+    }
+    Ok(())
 }
 
 /// Copy a pre-folder-layout session log into the current session folder.

--- a/src/session_log.rs
+++ b/src/session_log.rs
@@ -125,12 +125,28 @@ pub fn read_session_workspace(session_dir: &Path) -> Result<Option<PathBuf>> {
     if !path.exists() {
         return Ok(None);
     }
-    let bytes = std::fs::read(&path).map_err(|e| {
-        AgentLoopError::config(format!("read session workspace {}: {e}", path.display()))
-    })?;
-    let metadata: SessionWorkspaceMetadata = serde_json::from_slice(&bytes).map_err(|e| {
-        AgentLoopError::config(format!("parse session workspace {}: {e}", path.display()))
-    })?;
+    let bytes = match std::fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "ignoring unreadable session workspace metadata"
+            );
+            return Ok(None);
+        }
+    };
+    let metadata: SessionWorkspaceMetadata = match serde_json::from_slice(&bytes) {
+        Ok(metadata) => metadata,
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "ignoring malformed session workspace metadata"
+            );
+            return Ok(None);
+        }
+    };
     Ok(Some(metadata.workspace_root))
 }
 
@@ -689,6 +705,20 @@ mod tests {
             std::fs::read_to_string(&current_path).expect("read current"),
             "current event\n"
         );
+    }
+
+    #[test]
+    fn read_session_workspace_ignores_malformed_metadata() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionId::from_seed(48202);
+        let session_dir = session_dir_path(dir.path(), session_id);
+        std::fs::create_dir_all(&session_dir).expect("create session dir");
+        std::fs::write(session_workspace_path(&session_dir), "{not json")
+            .expect("write malformed metadata");
+
+        let workspace = read_session_workspace(&session_dir).expect("read workspace metadata");
+
+        assert!(workspace.is_none());
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## What
- Persist each session's canonical workspace root in `<session_folder>/workspace.json`.
- Use the saved workspace root when resuming a session without `-C/--cwd`.
- Delegate Yolop file-store display paths and grep path normalization to the underlying Everruns `RealDiskFileStore` so host-display paths work centrally while `/outputs` still routes to the session folder.
- Document the new resume behavior and override semantics.

## Why
Yolop sessions could still present and route workspace paths as `/workspace` or fall back to the shell cwd on resume, which breaks worktree expectations. The session needs to remember the real workspace root and lean on Everruns' central file-store display-path behavior instead of carrying Yolop-specific path aliases.

## How
- Added private `workspace.json` session metadata with owner-only permissions on Unix.
- Resolved startup cwd from `--cwd`, then saved session metadata, then the process cwd.
- Tolerate malformed/unreadable workspace metadata as absent so resume still works.
- Wrote runtime tests for workspace metadata persistence, resume root selection, display path routing, host-display grep filters, and malformed metadata fallback.

## Risk
- Low
- Resume now prefers saved session metadata when no `-C/--cwd` is supplied. Users can still intentionally move a session by passing `-C <PATH>` with `--session`.
- Existing sessions without `workspace.json` continue to fall back to the shell cwd. Existing sessions with malformed `workspace.json` fall back to the shell cwd and log a warning.

## Security
- Reviewed: TM-FS, TM-LLM, TM-BASH, TM-DEP.
- TM-FS: `workspace.json` is written only under the private session directory; Unix permissions are tightened to `0o700` for the session dir and `0o600` for metadata. No new workspace write paths or blocklist changes.
- TM-LLM: The model sees host display paths through the existing file-system capability; no credentials or secret material are added.
- TM-BASH: No shell execution behavior changed.
- TM-DEP: No dependency changes.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `git diff --check`
- `cargo run -- --provider llmsim -p "hi"`
- GitHub CI: Format + Clippy, Build + Tests + Offline Smoke, CodeQL, and Live Provider Smoke (Doppler) passed on the updated branch.
- Local `doppler run -- cargo run -- --provider openai -p "hi"` was blocked because this checkout has no Doppler project/fallback file; CI Doppler smoke passed with repository secrets.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
