### PR TITLE
fix(app): revert unintended preview changes

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -332,6 +332,7 @@ pub struct StreamPreview {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum StreamKind {
     Assistant,
+    Thinking,
     Tool,
 }
 
@@ -339,6 +340,7 @@ impl StreamKind {
     fn label(self) -> &'static str {
         match self {
             StreamKind::Assistant => "agent",
+            StreamKind::Thinking => "thinking",
             StreamKind::Tool => "tool",
         }
     }
@@ -346,6 +348,7 @@ impl StreamKind {
     fn color(self) -> Color {
         match self {
             StreamKind::Assistant => ACCENT_GOLD,
+            StreamKind::Thinking => TEXT_MUTED,
             StreamKind::Tool => TEXT_MUTED,
         }
     }
@@ -1238,6 +1241,7 @@ impl App {
 #[derive(Default)]
 pub(crate) struct DeltaRouter {
     last_assistant_turn: Option<everruns_core::typed_id::TurnId>,
+    last_thinking_turn: Option<everruns_core::typed_id::TurnId>,
     last_tool_call: Option<String>,
     write_todos_args: HashMap<String, Value>,
 }
@@ -2257,34 +2261,6 @@ mod tests {
                 );
             }
             None => panic!("expected tool delta to surface preview"),
-        }
-    }
-
-    #[test]
-    fn handle_live_event_hides_thinking_delta_from_stream_preview() {
-        use everruns_core::events::ReasonThinkingDeltaData;
-        use everruns_core::typed_id::TurnId;
-
-        let (tx, mut rx) = mpsc::unbounded_channel::<TurnEvent>();
-        let mut emitted = HashSet::new();
-        let mut router = DeltaRouter::default();
-
-        let event = RuntimeEvent::new(
-            SessionId::new(),
-            EventContext::empty(),
-            ReasonThinkingDeltaData {
-                turn_id: TurnId::new(),
-                delta: "private chain".to_string(),
-                accumulated: "private chain".to_string(),
-            },
-        );
-        handle_live_event(&event, &mut emitted, &mut router, &tx);
-
-        while let Ok(event) = rx.try_recv() {
-            assert!(
-                !matches!(event, TurnEvent::Stream(_)),
-                "private thinking must not create a stream preview: {event:?}"
-            );
         }
     }
 
@@ -4372,6 +4348,23 @@ mod tests {
         assert!(
             !rows[0].contains("first line"),
             "stream preview should not show earlier lines: {}",
+            rows[0]
+        );
+    }
+
+    #[test]
+    fn chrome_stream_preview_thinking_uses_thinking_label() {
+        let state = ViewState {
+            stream_preview: Some(StreamPreview {
+                kind: StreamKind::Thinking,
+                text: "weighing options".to_string(),
+            }),
+            ..view_state_idle()
+        };
+        let rows = render_chrome_lines(&state, 80, 5);
+        assert!(
+            rows[0].contains("thinking"),
+            "thinking-kind preview should use 'thinking' label: {}",
             rows[0]
         );
     }

--- a/src/app/transcript.rs
+++ b/src/app/transcript.rs
@@ -30,6 +30,18 @@ pub(crate) fn handle_live_event(
             router.last_assistant_turn = None;
             let _ = tx.send(TurnEvent::Stream(None));
         }
+        EventData::ReasonThinkingDelta(data) => {
+            router.last_thinking_turn = Some(data.turn_id);
+            let _ = tx.send(TurnEvent::Stream(Some(StreamPreview {
+                kind: StreamKind::Thinking,
+                text: data.accumulated.clone(),
+            })));
+            return;
+        }
+        EventData::ReasonThinkingCompleted(_) if router.last_thinking_turn.is_some() => {
+            router.last_thinking_turn = None;
+            let _ = tx.send(TurnEvent::Stream(None));
+        }
         EventData::ToolOutputDelta(data) => {
             router.last_tool_call = Some(data.tool_call_id.clone());
             let text = format!(


### PR DESCRIPTION
## What
Reverts the unintended app preview changes that were accidentally included in the metadata squash merge.

## Why
PR #123 was meant to ship only the runtime metadata wiring. The squash merge also picked up `src/app/mod.rs` and `src/app/transcript.rs` changes from a separate local commit, so this restores those files to the prior `main` behavior while keeping the metadata change.

## How
Applies the reverse patch for the accidental app commit only. `src/runtime.rs` and the metadata behavior remain untouched.

## Risk
- Low
- Restores previously-tested app rendering behavior; risk is limited to the stream preview/transcript rendering paths touched by the accidental commit.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

Validation:
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`