### PR TITLE
feat(openrouter): rank model picker with recommended section

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
 | ---------- | ------------------------------------- | ----------------- |
 | OpenAI     | `OPENAI_API_KEY`                      | `gpt-5.5`         |
 | Anthropic  | `ANTHROPIC_API_KEY`                   | `claude-sonnet-4-5` |
-| OpenRouter | `OPENROUTER_API_KEY`                  | `openai/gpt-5.2`  |
+| OpenRouter | `OPENROUTER_API_KEY`                  | `openai/gpt-5.5`  |
 | Google     | `GEMINI_API_KEY` / `GOOGLE_API_KEY`   | `gemini-2.5-flash` |
 | Ollama     | `OLLAMA_BASE_URL` / `OLLAMA_API_KEY`  | `llama3.2`        |
 | Custom     | `CUSTOM_BASE_URL` (+ optional `CUSTOM_API_KEY`) | — (set via `/setup`) |

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3780,8 +3780,8 @@ mod tests {
 
     #[test]
     fn discovered_models_convert_to_options_with_custom_escape_hatch() {
-        let mut described = discovered("openai/gpt-5.2", Some("OpenAI: GPT-5.2"));
-        described.description = Some("optimized for long-running agents".to_string());
+        let mut described = discovered("openai/gpt-5.5", Some("OpenAI: GPT-5.5"));
+        described.description = Some("frontier model for complex coding".to_string());
         let catalog = model_options_from_discovered(
             "openrouter",
             vec![
@@ -3793,11 +3793,11 @@ mod tests {
 
         assert_eq!(catalog.options.len(), 3);
         assert_eq!(catalog.recommended_count, 2);
-        assert_eq!(catalog.options[0].spec.as_deref(), Some("openai/gpt-5.2"));
-        assert_eq!(catalog.options[0].label, "openai/gpt-5.2");
+        assert_eq!(catalog.options[0].spec.as_deref(), Some("openai/gpt-5.5"));
+        assert_eq!(catalog.options[0].label, "openai/gpt-5.5");
         assert_eq!(
             catalog.options[0].hint,
-            "OpenAI: GPT-5.2 · optimized for long-running agents"
+            "OpenAI: GPT-5.5 · frontier model for complex coding"
         );
         assert_eq!(
             catalog.options[1].spec.as_deref(),
@@ -3839,8 +3839,8 @@ mod tests {
             "openrouter",
             vec![
                 discovered("zai/glm-5", None),
-                discovered("openai/gpt-5.2", None),
-                discovered("anthropic/claude-sonnet-4-5", None),
+                discovered("openai/gpt-5.5", None),
+                discovered("anthropic/claude-opus-4-8", None),
             ],
             None,
         );
@@ -3854,10 +3854,10 @@ mod tests {
         });
 
         let options = app.model_options("openrouter");
-        assert_eq!(options[0].spec.as_deref(), Some("openai/gpt-5.2"));
+        assert_eq!(options[0].spec.as_deref(), Some("openai/gpt-5.5"));
         assert_eq!(
             options[1].spec.as_deref(),
-            Some("anthropic/claude-sonnet-4-5")
+            Some("anthropic/claude-opus-4-8")
         );
         assert_eq!(options[2].spec.as_deref(), Some("zai/glm-5"));
         assert_eq!(app.model_recommended_count("openrouter"), 2);
@@ -3877,8 +3877,8 @@ mod tests {
             "openrouter",
             vec![
                 discovered("zai/glm-5", None),
-                discovered("openai/gpt-5.2", None),
-                discovered("anthropic/claude-sonnet-4-5", None),
+                discovered("openai/gpt-5.5", None),
+                discovered("anthropic/claude-opus-4-8", None),
                 discovered("moon/kimi-k3", None),
             ],
             None,
@@ -3893,8 +3893,8 @@ mod tests {
         assert_eq!(
             ids,
             &[
-                "openai/gpt-5.2",
-                "anthropic/claude-sonnet-4-5",
+                "openai/gpt-5.5",
+                "anthropic/claude-opus-4-8",
                 "moon/kimi-k3",
                 "zai/glm-5",
             ]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -146,7 +146,7 @@ pub struct App {
     /// Models discovered from each provider's models API, keyed by provider
     /// name. Once populated, replaces the curated fallback list in the
     /// model picker.
-    model_catalog: HashMap<String, Vec<ModelOption>>,
+    model_catalog: HashMap<String, ModelPickerCatalog>,
     /// Providers with an in-flight models API fetch.
     model_fetches_in_flight: HashSet<String>,
     /// Disabled in unit tests so opening the picker never spawns real
@@ -160,7 +160,15 @@ pub struct App {
 /// does not support listing; the picker keeps the curated fallback list.
 pub(crate) struct ModelDiscovery {
     provider: String,
-    result: Result<Option<Vec<ModelOption>>, String>,
+    result: Result<Option<ModelPickerCatalog>, String>,
+}
+
+/// One provider's model picker list: selectable rows plus how many leading
+/// rows belong in the recommended section (before the "more models" divider).
+#[derive(Clone, Debug)]
+pub(crate) struct ModelPickerCatalog {
+    pub options: Vec<ModelOption>,
+    pub recommended_count: usize,
 }
 
 /// State of the first-run / `/setup` overlay. This enum *is* the overlay's
@@ -3774,23 +3782,31 @@ mod tests {
     fn discovered_models_convert_to_options_with_custom_escape_hatch() {
         let mut described = discovered("openai/gpt-5.2", Some("OpenAI: GPT-5.2"));
         described.description = Some("optimized for long-running agents".to_string());
-        let options = model_options_from_discovered(vec![
-            described,
-            discovered("nvidia/nemotron-3-super-120b-a12b", None),
-        ]);
+        let catalog = model_options_from_discovered(
+            "openrouter",
+            vec![
+                described,
+                discovered("nvidia/nemotron-3-super-120b-a12b", None),
+            ],
+            2,
+        );
 
-        assert_eq!(options.len(), 3);
-        assert_eq!(options[0].spec.as_deref(), Some("openai/gpt-5.2"));
-        assert_eq!(options[0].label, "openai/gpt-5.2");
+        assert_eq!(catalog.options.len(), 3);
+        assert_eq!(catalog.recommended_count, 2);
+        assert_eq!(catalog.options[0].spec.as_deref(), Some("openai/gpt-5.2"));
+        assert_eq!(catalog.options[0].label, "openai/gpt-5.2");
         assert_eq!(
-            options[0].hint,
+            catalog.options[0].hint,
             "OpenAI: GPT-5.2 · optimized for long-running agents"
         );
         assert_eq!(
-            options[1].spec.as_deref(),
+            catalog.options[1].spec.as_deref(),
             Some("nvidia/nemotron-3-super-120b-a12b")
         );
-        assert!(options[2].spec.is_none(), "last option must stay Custom...");
+        assert!(
+            catalog.options[2].spec.is_none(),
+            "last option must stay Custom..."
+        );
     }
 
     #[test]
@@ -3798,14 +3814,91 @@ mod tests {
         let mut model = discovered("verbose/model", None);
         model.description = Some("x".repeat(200));
 
-        let options = model_options_from_discovered(vec![model]);
+        let catalog = model_options_from_discovered("openrouter", vec![model], 1);
 
         assert!(
-            options[0].hint.chars().count() <= 72,
+            catalog.options[0].hint.chars().count() <= 72,
             "hint must fit one picker row: {} chars",
-            options[0].hint.chars().count()
+            catalog.options[0].hint.chars().count()
         );
-        assert!(options[0].hint.ends_with('…'));
+        assert!(catalog.options[0].hint.ends_with('…'));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn openrouter_model_picker_shows_recommended_divider() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = Some(SetupStep::PickModel {
+            provider: "openrouter".to_string(),
+            selected: 0,
+            custom: None,
+            error: None,
+        });
+
+        let ranked = crate::capabilities::model_ranking::rank_discovered_models(
+            "openrouter",
+            vec![
+                discovered("zai/glm-5", None),
+                discovered("openai/gpt-5.2", None),
+                discovered("anthropic/claude-sonnet-4-5", None),
+            ],
+            None,
+        );
+        app.apply_model_discovery(ModelDiscovery {
+            provider: "openrouter".to_string(),
+            result: Ok(Some(model_options_from_discovered(
+                "openrouter",
+                ranked.models,
+                ranked.recommended_count,
+            ))),
+        });
+
+        let options = app.model_options("openrouter");
+        assert_eq!(options[0].spec.as_deref(), Some("openai/gpt-5.2"));
+        assert_eq!(
+            options[1].spec.as_deref(),
+            Some("anthropic/claude-sonnet-4-5")
+        );
+        assert_eq!(options[2].spec.as_deref(), Some("zai/glm-5"));
+        assert_eq!(app.model_recommended_count("openrouter"), 2);
+
+        let rendered = setup_overlay_text(app);
+        assert!(
+            rendered.iter().any(|line| line.contains("more models")),
+            "recommended section should be separated from the full catalog: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn openrouter_ranking_applies_curated_order_and_alphabetical_rest() {
+        use crate::capabilities::model_ranking::rank_discovered_models;
+
+        let ranked = rank_discovered_models(
+            "openrouter",
+            vec![
+                discovered("zai/glm-5", None),
+                discovered("openai/gpt-5.2", None),
+                discovered("anthropic/claude-sonnet-4-5", None),
+                discovered("moon/kimi-k3", None),
+            ],
+            None,
+        );
+
+        assert_eq!(ranked.recommended_count, 2);
+        let ids: Vec<&str> = ranked
+            .models
+            .iter()
+            .map(|model| model.model_id.as_str())
+            .collect();
+        assert_eq!(
+            ids,
+            &[
+                "openai/gpt-5.2",
+                "anthropic/claude-sonnet-4-5",
+                "moon/kimi-k3",
+                "zai/glm-5",
+            ]
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -3821,10 +3914,14 @@ mod tests {
 
         app.apply_model_discovery(ModelDiscovery {
             provider: "openrouter".to_string(),
-            result: Ok(Some(model_options_from_discovered(vec![
-                discovered("zai/glm-5", None),
-                discovered("moon/kimi-k3", None),
-            ]))),
+            result: Ok(Some(model_options_from_discovered(
+                "openrouter",
+                vec![
+                    discovered("zai/glm-5", None),
+                    discovered("moon/kimi-k3", None),
+                ],
+                0,
+            ))),
         });
 
         let options = app.model_options("openrouter");

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -358,6 +358,7 @@ pub(crate) fn setup_overlay_content(app: &App) -> (Vec<Line<'static>>, Option<(u
                     lines.push(setup_hint("fetching models from the provider API…"));
                 }
                 let total = options.len();
+                let recommended_count = app.model_recommended_count(provider);
                 let (start, end) = model_window(*selected, total, MAX_VISIBLE_MODEL_ROWS);
                 if start > 0 {
                     lines.push(setup_hint(&format!("↑ {start} more")));
@@ -366,6 +367,12 @@ pub(crate) fn setup_overlay_content(app: &App) -> (Vec<Line<'static>>, Option<(u
                 // id (the same anchor `model_index_for_label` uses).
                 let current = app.model.model_id();
                 for (idx, option) in options.iter().enumerate().take(end).skip(start) {
+                    if recommended_count > 0
+                        && idx == recommended_count
+                        && recommended_count < total.saturating_sub(1)
+                    {
+                        lines.push(setup_divider("─── more models ───"));
+                    }
                     let mut hint = option.hint.to_string();
                     if option.spec.as_deref() == Some(current.as_str()) {
                         hint.push_str(" · current");
@@ -430,6 +437,13 @@ pub(crate) fn setup_hint(text: &str) -> Line<'static> {
     Line::from(Span::styled(
         text.to_string(),
         Style::default().fg(TEXT_MUTED).bg(PANEL_BG),
+    ))
+}
+
+pub(crate) fn setup_divider(text: &str) -> Line<'static> {
+    Line::from(Span::styled(
+        text.to_string(),
+        Style::default().fg(ACCENT_BLUE).bg(PANEL_BG),
     ))
 }
 
@@ -1055,8 +1069,10 @@ pub(crate) fn custom_model_option() -> ModelOption {
 /// with core profile names/descriptions) into picker options, keeping the
 /// trailing "Custom..." escape hatch.
 pub(crate) fn model_options_from_discovered(
+    _provider: &str,
     models: Vec<crate::capabilities::model_discovery::DiscoveredProviderModel>,
-) -> Vec<ModelOption> {
+    recommended_count: usize,
+) -> ModelPickerCatalog {
     /// OpenRouter descriptions run to paragraphs; the hint shares one row
     /// with the model id, so keep it short.
     const MAX_HINT_CHARS: usize = 72;
@@ -1081,7 +1097,10 @@ pub(crate) fn model_options_from_discovered(
         })
         .collect();
     options.push(custom_model_option());
-    options
+    ModelPickerCatalog {
+        recommended_count,
+        options,
+    }
 }
 
 /// Discovered model lists can be hundreds of entries (OpenRouter), far more

--- a/src/app/setup.rs
+++ b/src/app/setup.rs
@@ -210,9 +210,16 @@ impl App {
     /// fallback list.
     pub(crate) fn model_options(&self, provider: &str) -> Vec<ModelOption> {
         match self.model_catalog.get(provider) {
-            Some(options) => options.clone(),
+            Some(catalog) => catalog.options.clone(),
             None => Self::fallback_model_options(provider),
         }
+    }
+
+    pub(crate) fn model_recommended_count(&self, provider: &str) -> usize {
+        self.model_catalog
+            .get(provider)
+            .map(|catalog| catalog.recommended_count)
+            .unwrap_or(0)
     }
 
     /// Curated static list, used until (or instead of) live discovery —
@@ -351,6 +358,11 @@ impl App {
         let tx = self.models_tx.clone();
         let settings = self.settings.clone();
         let provider_name = provider.to_string();
+        let current_model = if self.current_provider_name() == provider {
+            Some(self.model.model_id())
+        } else {
+            None
+        };
         tokio::spawn(async move {
             let result = match tokio::time::timeout(
                 Duration::from_secs(10),
@@ -361,7 +373,18 @@ impl App {
             )
             .await
             {
-                Ok(Ok(Some(models))) => Ok(Some(model_options_from_discovered(models))),
+                Ok(Ok(Some(models))) => {
+                    let ranked = crate::capabilities::model_ranking::rank_discovered_models(
+                        &provider_name,
+                        models,
+                        current_model.as_deref(),
+                    );
+                    Ok(Some(model_options_from_discovered(
+                        &provider_name,
+                        ranked.models,
+                        ranked.recommended_count,
+                    )))
+                }
                 Ok(Ok(None)) => Ok(None),
                 Ok(Err(err)) => Err(err.to_string()),
                 Err(_) => Err("models API request timed out".to_string()),
@@ -379,9 +402,9 @@ impl App {
         self.model_fetches_in_flight.remove(&discovery.provider);
         match discovery.result {
             // > 1 because the list always ends with the "Custom..." entry.
-            Ok(Some(options)) if options.len() > 1 => {
+            Ok(Some(catalog)) if catalog.options.len() > 1 => {
                 self.model_catalog
-                    .insert(discovery.provider.clone(), options);
+                    .insert(discovery.provider.clone(), catalog);
                 if let Some(SetupStep::PickModel {
                     provider,
                     custom,
@@ -409,7 +432,10 @@ impl App {
             Ok(_) => {
                 self.model_catalog.insert(
                     discovery.provider.clone(),
-                    Self::fallback_model_options(&discovery.provider),
+                    ModelPickerCatalog {
+                        options: Self::fallback_model_options(&discovery.provider),
+                        recommended_count: 0,
+                    },
                 );
             }
             Err(mut err) => {

--- a/src/app/setup.rs
+++ b/src/app/setup.rs
@@ -295,19 +295,19 @@ impl App {
             ],
             "openrouter" => vec![
                 ModelOption {
-                    spec: Some("openai/gpt-5.2".to_string()),
-                    label: "openai/gpt-5.2".to_string(),
-                    hint: "default OpenRouter model".to_string(),
+                    spec: Some("openai/gpt-5.5".to_string()),
+                    label: "openai/gpt-5.5".to_string(),
+                    hint: "frontier OpenAI model through OpenRouter".to_string(),
+                },
+                ModelOption {
+                    spec: Some("anthropic/claude-opus-4-8".to_string()),
+                    label: "anthropic/claude-opus-4-8".to_string(),
+                    hint: "most capable Claude through OpenRouter".to_string(),
                 },
                 ModelOption {
                     spec: Some("nvidia/nemotron-3-super-120b-a12b high".to_string()),
                     label: "nvidia/nemotron-3-super-120b-a12b".to_string(),
                     hint: "reasoning model through OpenRouter".to_string(),
-                },
-                ModelOption {
-                    spec: Some("anthropic/claude-sonnet-4-5".to_string()),
-                    label: "anthropic/claude-sonnet-4-5".to_string(),
-                    hint: "Claude through OpenRouter".to_string(),
                 },
             ],
             "ollama" => vec![ModelOption {

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -755,13 +755,22 @@ impl SetupCapability {
             && !models.is_empty()
         {
             let provider = current.provider_name();
-            let shown: Vec<&str> = models
+            let ranked = super::model_ranking::rank_discovered_models(
+                provider,
+                models,
+                Some(current.model_id()),
+            );
+            let shown: Vec<&str> = ranked
+                .models
                 .iter()
                 .take(MODEL_SUGGESTION_LIMIT)
                 .map(|model| model.model_id.as_str())
                 .collect();
-            let suffix = if models.len() > MODEL_SUGGESTION_LIMIT {
-                format!(" … and {} more", models.len() - MODEL_SUGGESTION_LIMIT)
+            let suffix = if ranked.models.len() > MODEL_SUGGESTION_LIMIT {
+                format!(
+                    " … and {} more",
+                    ranked.models.len() - MODEL_SUGGESTION_LIMIT
+                )
             } else {
                 String::new()
             };

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod hooks;
 mod host;
 pub(crate) mod memory;
 pub(crate) mod model_discovery;
+pub(crate) mod model_ranking;
 pub mod skills;
 pub(crate) mod your;
 

--- a/src/capabilities/model_discovery.rs
+++ b/src/capabilities/model_discovery.rs
@@ -17,7 +17,7 @@ use everruns_core::llm_driver_registry::{DiscoveredModel, DriverRegistry, Provid
 /// One model offered by a provider, ready for display: bare id plus
 /// human-readable metadata merged from the provider's API response and the
 /// everruns-core profile registry.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct DiscoveredProviderModel {
     pub model_id: String,
     pub display_name: Option<String>,
@@ -51,6 +51,7 @@ pub(crate) async fn discover_provider_models(
     let mut registry = DriverRegistry::new();
     everruns_anthropic::register_driver(&mut registry);
     everruns_openai::register_driver(&mut registry);
+    everruns_openrouter::register_driver(&mut registry);
     let driver = registry.create_chat_driver(&config)?;
 
     let models = match driver.list_models().await? {

--- a/src/capabilities/model_ranking.rs
+++ b/src/capabilities/model_ranking.rs
@@ -1,0 +1,171 @@
+// Heuristics for ordering provider model lists in the setup picker.
+//
+// OpenRouter exposes hundreds of models; the picker surfaces a short
+// "recommended" block (curated ids, the active model, profile-known
+// flagship ids) before an alphabetical catalog of everything else.
+
+use crate::capabilities::model_discovery::DiscoveredProviderModel;
+use crate::runtime::ProviderChoice;
+use everruns_core::DriverId;
+use everruns_core::get_model_profile;
+
+/// Models reordered for display plus how many leading rows belong in the
+/// recommended section (excluding the trailing "Custom..." picker entry).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RankedDiscoveredModels {
+    pub models: Vec<DiscoveredProviderModel>,
+    pub recommended_count: usize,
+}
+
+/// Reorder discovered models for the picker. OpenRouter gets a recommended
+/// block; other providers keep discovery order (newest-first from the API).
+pub(crate) fn rank_discovered_models(
+    provider: &str,
+    models: Vec<DiscoveredProviderModel>,
+    current_model: Option<&str>,
+) -> RankedDiscoveredModels {
+    if provider == "openrouter" {
+        rank_openrouter_models(models, current_model)
+    } else {
+        RankedDiscoveredModels {
+            recommended_count: 0,
+            models,
+        }
+    }
+}
+
+fn rank_openrouter_models(
+    models: Vec<DiscoveredProviderModel>,
+    current_model: Option<&str>,
+) -> RankedDiscoveredModels {
+    let mut recommended_ids: Vec<String> = Vec::new();
+
+    for suggestion in ProviderChoice::model_suggestions_for_provider("openrouter") {
+        let bare = bare_model_id(suggestion);
+        if models.iter().any(|model| model.model_id == bare) {
+            push_unique(&mut recommended_ids, bare);
+        }
+    }
+
+    if let Some(current) = current_model.map(bare_model_id)
+        && models.iter().any(|model| model.model_id == current)
+    {
+        push_unique(&mut recommended_ids, current);
+    }
+
+    // Profile-known flagship models from major providers — capped so the
+    // recommended block stays a short shortlist, not a second full catalog.
+    const RECOMMENDED_CAP: usize = 20;
+    let mut profile_candidates: Vec<String> = models
+        .iter()
+        .filter(|model| {
+            !recommended_ids.contains(&model.model_id)
+                && is_major_openrouter_model(&model.model_id)
+                && get_model_profile(&DriverId::OpenRouter, &model.model_id).is_some()
+        })
+        .map(|model| model.model_id.clone())
+        .collect();
+    profile_candidates.sort();
+    for model_id in profile_candidates {
+        if recommended_ids.len() >= RECOMMENDED_CAP {
+            break;
+        }
+        push_unique(&mut recommended_ids, model_id);
+    }
+
+    let recommended_count = recommended_ids.len();
+    let mut ranked = Vec::with_capacity(models.len());
+    for model_id in &recommended_ids {
+        if let Some(index) = models.iter().position(|model| &model.model_id == model_id) {
+            ranked.push(models[index].clone());
+        }
+    }
+
+    let mut rest: Vec<DiscoveredProviderModel> = models
+        .into_iter()
+        .filter(|model| !recommended_ids.contains(&model.model_id))
+        .collect();
+    rest.sort_by(|a, b| a.model_id.cmp(&b.model_id));
+    ranked.extend(rest);
+
+    RankedDiscoveredModels {
+        models: ranked,
+        recommended_count,
+    }
+}
+
+fn bare_model_id(spec: &str) -> String {
+    spec.split_whitespace().next().unwrap_or(spec).to_string()
+}
+
+fn push_unique(ids: &mut Vec<String>, id: String) {
+    if !ids.contains(&id) {
+        ids.push(id);
+    }
+}
+
+fn is_major_openrouter_model(model_id: &str) -> bool {
+    model_id.starts_with("openai/")
+        || model_id.starts_with("anthropic/")
+        || model_id.starts_with("google/")
+        || model_id.starts_with("nvidia/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn model(id: &str) -> DiscoveredProviderModel {
+        DiscoveredProviderModel {
+            model_id: id.to_string(),
+            display_name: None,
+            description: None,
+        }
+    }
+
+    #[test]
+    fn openrouter_ranking_puts_curated_and_current_first_then_sorts_rest() {
+        let ranked = rank_openrouter_models(
+            vec![
+                model("zai/glm-5"),
+                model("openai/gpt-5.2"),
+                model("anthropic/claude-sonnet-4-5"),
+                model("moon/kimi-k3"),
+            ],
+            Some("moon/kimi-k3"),
+        );
+
+        assert_eq!(ranked.recommended_count, 3);
+        let ids: Vec<&str> = ranked.models.iter().map(|m| m.model_id.as_str()).collect();
+        assert_eq!(
+            ids,
+            &[
+                "openai/gpt-5.2",
+                "anthropic/claude-sonnet-4-5",
+                "moon/kimi-k3",
+                "zai/glm-5",
+            ]
+        );
+    }
+
+    #[test]
+    fn non_openrouter_providers_skip_ranking() {
+        let input = vec![model("gpt-5.5"), model("gpt-5.2")];
+        let ranked = rank_discovered_models("openai", input.clone(), None);
+        assert_eq!(ranked.recommended_count, 0);
+        let ids: Vec<&str> = ranked
+            .models
+            .iter()
+            .map(|model| model.model_id.as_str())
+            .collect();
+        assert_eq!(ids, &["gpt-5.5", "gpt-5.2"]);
+    }
+
+    #[test]
+    fn bare_model_id_strips_reasoning_effort_suffix() {
+        assert_eq!(
+            bare_model_id("nvidia/nemotron-3-super-120b-a12b high"),
+            "nvidia/nemotron-3-super-120b-a12b"
+        );
+    }
+}

--- a/src/capabilities/model_ranking.rs
+++ b/src/capabilities/model_ranking.rs
@@ -128,8 +128,8 @@ mod tests {
         let ranked = rank_openrouter_models(
             vec![
                 model("zai/glm-5"),
-                model("openai/gpt-5.2"),
-                model("anthropic/claude-sonnet-4-5"),
+                model("openai/gpt-5.5"),
+                model("anthropic/claude-opus-4-8"),
                 model("moon/kimi-k3"),
             ],
             Some("moon/kimi-k3"),
@@ -140,8 +140,8 @@ mod tests {
         assert_eq!(
             ids,
             &[
-                "openai/gpt-5.2",
-                "anthropic/claude-sonnet-4-5",
+                "openai/gpt-5.5",
+                "anthropic/claude-opus-4-8",
                 "moon/kimi-k3",
                 "zai/glm-5",
             ]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -379,7 +379,7 @@ const DEFAULT_GOOGLE_MODEL: &str = "gemini-2.5-flash";
 // `everruns_openai`. (OpenRouter has its own first-class driver since
 // everruns 0.10 — see `model_with_provider`.)
 const DEFAULT_GOOGLE_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta/openai";
-const DEFAULT_OPENROUTER_MODEL: &str = "openai/gpt-5.2";
+const DEFAULT_OPENROUTER_MODEL: &str = "openai/gpt-5.5";
 const DEFAULT_OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
 const DEFAULT_OLLAMA_MODEL: &str = "llama3.2";
 const DEFAULT_OLLAMA_BASE_URL: &str = "http://localhost:11434/v1";
@@ -658,9 +658,9 @@ impl ProviderChoice {
             ],
             "google" => &["gemini-2.5-flash", "gemini-2.5-pro"],
             "openrouter" => &[
-                "openai/gpt-5.2",
+                "openai/gpt-5.5",
+                "anthropic/claude-opus-4-8",
                 "nvidia/nemotron-3-super-120b-a12b high",
-                "anthropic/claude-sonnet-4-5",
             ],
             "ollama" => &["llama3.2"],
             "llmsim" => &["llmsim-yolop"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

OpenRouter's model picker can list hundreds of entries. This adds a short **recommended** block at the top, a visual divider, and the full catalog sorted alphabetically below.

## Recommended section (OpenRouter only)

Models are promoted to the top in this order:

1. Curated defaults: `openai/gpt-5.5`, `anthropic/claude-opus-4-8`, `nvidia/nemotron-3-super-120b-a12b`
2. The currently active model (if present in the catalog)
3. Profile-known flagship models from major providers (`openai/`, `anthropic/`, `google/`, `nvidia/`), capped at 20 total recommended rows

Everything else appears below a `─── more models ───` divider, sorted A→Z by model id.

The OpenRouter default model is now `openai/gpt-5.5`.

## Other changes

- Register the OpenRouter driver during model discovery (more reliable `list_models()`)
- Apply the same ranking heuristics to `/setup model` text suggestions in the host
- Other providers keep their existing discovery order (no divider)

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (371 unit + 26 integration)
- Offline smoke: `cargo run -- --provider llmsim -p "hi"`
- CI green after rebase onto latest `main` (Format + Clippy, Build + Tests + Offline Smoke, Live Provider Smoke, CodeQL)

## Tests

- `openrouter_ranking_puts_curated_and_current_first_then_sorts_rest`
- `openrouter_ranking_applies_curated_order_and_alphabetical_rest`
- `openrouter_model_picker_shows_recommended_divider` (exercises ranking + render path via `apply_model_discovery`)

## Security

No security-relevant behavior changes. Model discovery still uses existing provider credentials and bounded 10s timeout. Ranking only reorders in-memory model metadata for display; no new shell, filesystem, or network surfaces.

## Follow-ups

No follow-ups.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-654302e3-260a-4c2a-aa89-19f994f3a090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-654302e3-260a-4c2a-aa89-19f994f3a090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

