### PR TITLE
fix(config): safe provider/model resolution on switch

### DIFF
--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -33,7 +33,7 @@ Keys are addressed the way a human would name them:
 | Key                       | Type   | Meaning                                                        |
 |---------------------------|--------|----------------------------------------------------------------|
 | `default_provider`        | text   | Provider used when no `--provider` flag is given; takes precedence over env auto-detection. |
-| `default_model`           | text   | Global fallback model spec for the active provider; a per-provider pick wins over it. |
+| `default_model`           | text   | Global fallback model spec for the active provider when no per-provider pick exists; only applied when the id is recognized for that provider. |
 | `models.<provider>`       | text   | Per-provider model spec, survives provider switches.           |
 | `tokens.<provider>`       | secret | Provider API token (owner-only on disk; env vars override).    |
 | `base_urls.<provider>`    | text   | Endpoint base URL (used by the `custom` provider).             |
@@ -44,7 +44,11 @@ Keys are addressed the way a human would name them:
 `default_provider` is persisted under that name on disk; the legacy `provider`
 key is still read (and accepted as an alias) so pre-rename settings files keep
 working. `default_model` is applied as a cross-provider fallback in
-`ProviderChoice::with_saved_model`.
+`ProviderChoice::resolve_for_settings`, but only when the model id is
+recognized for the active provider. At startup and on `/setup provider`
+switches, yolop may also query the provider's models API (when credentials
+exist) and fall back with a warning if the resolved model is no longer offered.
+Per-provider `models.<provider>` picks are always trusted.
 
 ### Tools
 

--- a/src/capabilities/config.rs
+++ b/src/capabilities/config.rs
@@ -19,7 +19,9 @@ use crate::capability_settings::{
 };
 use crate::config_schema::{KeyTarget, ValueKind, known_keys, parse_key, schema};
 use crate::config_service::{ConfigService, current_value, scoped_current};
-use crate::runtime::{SUPPORTED_PROVIDERS, coding_harness_defaults};
+use crate::runtime::{
+    ProviderChoice, SUPPORTED_PROVIDERS, coding_harness_defaults, resolve_for_settings,
+};
 use crate::settings::{ApprovalMode, Settings, SettingsStore};
 use async_trait::async_trait;
 use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
@@ -422,8 +424,11 @@ impl SetConfigTool {
                 self.settings
                     .set_default_provider(Some(provider.clone()))
                     .map_err(map_err)?;
+                let preview = resolve_for_settings(&provider, &self.settings.snapshot())
+                    .map(|resolved| resolved.next_run_preview())
+                    .unwrap_or_else(|err| format!("→ next run: could not resolve model: {err}"));
                 Ok(saved(format!(
-                    "default_provider = {provider}; applies on the next run (use /setup to switch now)"
+                    "default_provider = {provider}; applies on the next run (use /setup to switch now)\n{preview}"
                 )))
             }
             KeyTarget::DefaultModel => {
@@ -434,8 +439,13 @@ impl SetConfigTool {
                 self.settings
                     .set_default_model(Some(value.to_string()))
                     .map_err(map_err)?;
+                let preview_provider =
+                    ProviderChoice::preview_provider_name(&self.settings.snapshot());
+                let preview = resolve_for_settings(&preview_provider, &self.settings.snapshot())
+                    .map(|resolved| resolved.next_run_preview())
+                    .unwrap_or_else(|err| format!("→ next run: could not resolve model: {err}"));
                 Ok(saved(format!(
-                    "default_model = {value}; applies on the next run (use /setup to switch now)"
+                    "default_model = {value}; applies on the next run (use /setup to switch now)\n{preview}"
                 )))
             }
             KeyTarget::Attribution => {
@@ -560,7 +570,14 @@ mod tests {
         let r = tool
             .execute(json!({ "key": "default_provider", "value": "anthropic" }))
             .await;
-        assert!(matches!(r, ToolExecutionResult::Success(_)));
+        match &r {
+            ToolExecutionResult::Success(msg) => {
+                let text = msg.to_string();
+                assert!(text.contains("→ next run:"), "{text}");
+                assert!(text.contains("anthropic/"), "{text}");
+            }
+            other => panic!("expected success, got {other:?}"),
+        }
         assert_eq!(
             settings.snapshot().default_provider.as_deref(),
             Some("anthropic")
@@ -570,6 +587,29 @@ mod tests {
         tool.execute(json!({ "key": "model", "value": "claude-opus-4-5" }))
             .await;
         assert_eq!(settings.snapshot().default_model(), Some("claude-opus-4-5"));
+    }
+
+    #[tokio::test]
+    async fn set_config_warns_when_default_model_mismatches_provider() {
+        let (_tmp, settings) = store();
+        settings
+            .set_default_model(Some("gpt-5.5".to_string()))
+            .expect("seed default_model");
+        let tool = set_config_tool(settings.clone());
+
+        let r = tool
+            .execute(json!({ "key": "default_provider", "value": "anthropic" }))
+            .await;
+        match &r {
+            ToolExecutionResult::Success(msg) => {
+                let text = msg.to_string();
+                assert!(
+                    text.contains("default_model") && text.contains("ignored"),
+                    "{text}"
+                );
+            }
+            other => panic!("expected success, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -2,7 +2,7 @@
 // TUI-facing slash commands that mutate this process's provider selection.
 
 use crate::config_service::ConfigService;
-use crate::runtime::{ProviderChoice, SUPPORTED_PROVIDERS};
+use crate::runtime::{ProviderChoice, SUPPORTED_PROVIDERS, resolve_for_settings};
 use crate::settings::{ApprovalMode, SettingsStore};
 use crate::tools::{BashTool, Workspace};
 use async_trait::async_trait;
@@ -630,18 +630,22 @@ impl SetupCapability {
         // One snapshot reused across both reads in this command: consistent and
         // avoids cloning the full Settings (token strings included) twice.
         let snapshot = self.config.snapshot();
-        let next = match ProviderChoice::default_for_provider_name(name) {
-            Ok(n) => n.with_saved_model(&snapshot),
+        let resolved = match resolve_for_settings(name, &snapshot) {
+            Ok(resolved) => resolved,
             Err(err) => return Ok(failed_result(format!("setup provider failed: {err}"))),
         };
+        let mut notes = resolved.notes;
         let next = if model_spec.is_empty() {
-            next
+            resolved.choice
         } else {
-            match next.resolve_model_spec(model_spec) {
+            match resolved.choice.resolve_model_spec(model_spec) {
                 Ok(n) => n,
                 Err(err) => return Ok(failed_result(format!("setup provider failed: {err}"))),
             }
         };
+        let (next, reconcile_notes) =
+            super::model_discovery::reconcile_provider_with_catalog(next, &snapshot).await;
+        notes.extend(reconcile_notes);
         if next.model_id().trim().is_empty() {
             return Ok(failed_result(format!(
                 "setup provider failed: no model configured for {name}; pick one with /setup"
@@ -674,7 +678,14 @@ impl SetupCapability {
         };
         Ok(CommandResult {
             success: true,
-            message: format!("setup provider changed: {label} ({persist_note})"),
+            message: format!(
+                "setup provider changed: {label} ({persist_note}){}",
+                if notes.is_empty() {
+                    String::new()
+                } else {
+                    format!("; {}", notes.join("; "))
+                }
+            ),
             error_code: None,
             error_fields: None,
         })

--- a/src/capabilities/model_discovery.rs
+++ b/src/capabilities/model_discovery.rs
@@ -13,6 +13,7 @@ use anyhow::{Context, Result, anyhow};
 use everruns_core::DriverId;
 use everruns_core::get_model_profile;
 use everruns_core::llm_driver_registry::{DiscoveredModel, DriverRegistry, ProviderConfig};
+use std::collections::HashSet;
 
 /// One model offered by a provider, ready for display: bare id plus
 /// human-readable metadata merged from the provider's API response and the
@@ -84,6 +85,78 @@ pub(crate) async fn discover_provider_models(
             .then_with(|| a.model_id.cmp(&b.model_id))
     });
     Ok(Some(enrich_with_profiles(&target.provider_type, models)))
+}
+
+const DISCOVERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+fn bare_model_id_from_spec(spec: &str) -> &str {
+    spec.split_whitespace().next().unwrap_or(spec)
+}
+
+/// When the provider exposes a models catalog, verify the resolved model id
+/// is still offered. Falls back to the provider default, a curated pick, or
+/// the newest discovered model, and returns a human-readable note.
+pub(crate) async fn reconcile_provider_with_catalog(
+    choice: ProviderChoice,
+    settings: &Settings,
+) -> (ProviderChoice, Vec<String>) {
+    let discovered = tokio::time::timeout(
+        DISCOVERY_TIMEOUT,
+        discover_provider_models(&choice, settings),
+    )
+    .await;
+
+    let Ok(Ok(Some(models))) = discovered else {
+        return (choice, vec![]);
+    };
+    if models.is_empty() {
+        return (choice, vec![]);
+    }
+
+    let ids: HashSet<String> = models.iter().map(|m| m.model_id.clone()).collect();
+    let model_id = choice.model_id().to_string();
+    if ids.contains(&model_id) {
+        return (choice, vec![]);
+    }
+
+    let fallback = pick_catalog_fallback(&choice, &ids, &models);
+    let note = format!(
+        "model \"{model_id}\" not available on {}; using {} instead",
+        choice.provider_name(),
+        fallback.label()
+    );
+    (fallback, vec![note])
+}
+
+fn pick_catalog_fallback(
+    choice: &ProviderChoice,
+    ids: &HashSet<String>,
+    models: &[DiscoveredProviderModel],
+) -> ProviderChoice {
+    let provider = choice.provider_name();
+    let default =
+        ProviderChoice::default_for_provider_name(provider).unwrap_or_else(|_| choice.clone());
+
+    if ids.contains(default.model_id()) {
+        return default;
+    }
+
+    for suggestion in ProviderChoice::model_suggestions_for_provider(provider) {
+        let bare = bare_model_id_from_spec(suggestion);
+        if ids.contains(bare)
+            && let Ok(resolved) = default.resolve_model_spec(suggestion)
+        {
+            return resolved;
+        }
+    }
+
+    if let Some(first) = models.first()
+        && let Ok(resolved) = default.resolve_model_spec(&first.model_id)
+    {
+        return resolved;
+    }
+
+    default
 }
 
 /// Merge each discovered model with metadata from the everruns-core model
@@ -230,6 +303,37 @@ mod tests {
             enriched[0].display_name.as_deref(),
             Some("GPT-5.5 (via gateway)")
         );
+    }
+
+    #[test]
+    fn pick_catalog_fallback_prefers_provider_default_when_available() {
+        use super::pick_catalog_fallback;
+        use std::collections::HashSet;
+
+        let choice = ProviderChoice::default_for_provider_name("openai").unwrap();
+        let ids: HashSet<String> = ["gpt-5.5", "gpt-4o"]
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        let models = vec![
+            DiscoveredProviderModel {
+                model_id: "gpt-4o".to_string(),
+                display_name: None,
+                description: None,
+            },
+            DiscoveredProviderModel {
+                model_id: "gpt-5.5".to_string(),
+                display_name: None,
+                description: None,
+            },
+        ];
+
+        let unavailable = ProviderChoice::OpenAi {
+            model: "gpt-4o-mini".to_string(),
+            reasoning_effort: Some("medium".to_string()),
+        };
+        let fallback = pick_catalog_fallback(&unavailable, &ids, &models);
+        assert_eq!(fallback.label(), choice.label());
     }
 
     #[test]

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -91,7 +91,8 @@ pub fn schema() -> &'static [ConfigField] {
             description: "Global fallback model spec applied to the active provider when that \
                           provider has no per-provider entry under `models`. Provider-relative, \
                           same `model [reasoning-effort]` form `/setup model` accepts. A \
-                          per-provider `models.<provider>` pick always wins over this.",
+                          per-provider `models.<provider>` pick always wins over this. Applied \
+                          only when the model id is recognized for the active provider.",
             kind: ValueKind::Text,
             default: Some("the active provider's built-in default model"),
             examples: &["claude-sonnet-4-5", "gpt-5.5 high", "gemini-2.5-pro"],

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ use everruns_core::message::MessageRole;
 use everruns_core::typed_id::SessionId;
 use ratatui::backend::CrosstermBackend;
 use ratatui::{Terminal, TerminalOptions, Viewport};
-use runtime::{BuiltRuntime, ProviderChoice};
+use runtime::{BuiltRuntime, ProviderChoice, ResolvedProviderChoice, resolve_for_settings};
 use settings::SettingsStore;
 use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
@@ -177,26 +177,40 @@ fn provider_name_for_arg(arg: ProviderArg) -> &'static str {
 /// Resolution order: explicit `--provider` flag > persisted settings >
 /// env-var auto-detection. Model and reasoning-effort flags layer on top
 /// of whichever base was chosen.
-fn pick_provider(cli: &Cli, settings: &SettingsStore) -> ProviderChoice {
+fn pick_provider(cli: &Cli, settings: &SettingsStore) -> (ProviderChoice, Vec<String>) {
     let snapshot = settings.snapshot();
     let cli_reasoning_effort = runtime::normalize_reasoning_effort(cli.reasoning_effort.clone());
-    let base = if let Some(arg) = cli.provider {
-        ProviderChoice::default_for_provider_name(provider_name_for_arg(arg))
+    let mut notes = Vec::new();
+
+    let resolved = if let Some(arg) = cli.provider {
+        resolve_for_settings(provider_name_for_arg(arg), &snapshot)
             .expect("ProviderArg names are always valid")
     } else if let Some(saved) = snapshot.default_provider.as_deref() {
-        match ProviderChoice::default_for_provider_name(saved) {
-            Ok(choice) => choice,
+        match resolve_for_settings(saved, &snapshot) {
+            Ok(resolved) => resolved,
             Err(err) => {
                 eprintln!("yolop: ignoring saved provider `{saved}`: {err}");
-                ProviderChoice::from_env_or_settings(&snapshot)
+                let auto = ProviderChoice::from_env_or_settings(&snapshot);
+                resolve_for_settings(auto.provider_name(), &snapshot).unwrap_or(
+                    ResolvedProviderChoice {
+                        choice: auto,
+                        source: runtime::ModelResolutionSource::ProviderDefault,
+                        notes: vec![],
+                    },
+                )
             }
         }
     } else {
-        ProviderChoice::from_env_or_settings(&snapshot)
+        let auto = ProviderChoice::from_env_or_settings(&snapshot);
+        resolve_for_settings(auto.provider_name(), &snapshot).unwrap_or(ResolvedProviderChoice {
+            choice: auto,
+            source: runtime::ModelResolutionSource::ProviderDefault,
+            notes: vec![],
+        })
     };
-    // A model persisted by `/setup model` for the chosen provider wins over
-    // the provider default; CLI flags still override it below.
-    let base = base.with_saved_model(&snapshot);
+
+    notes.extend(resolved.notes);
+    let base = resolved.choice;
     let selected = match (base, cli.model.clone()) {
         (ProviderChoice::Anthropic { .. }, Some(m)) => ProviderChoice::Anthropic { model: m },
         (
@@ -246,7 +260,7 @@ fn pick_provider(cli: &Cli, settings: &SettingsStore) -> ProviderChoice {
         },
         (other, _) => other,
     };
-    match (selected, cli_reasoning_effort) {
+    let selected = match (selected, cli_reasoning_effort) {
         (
             ProviderChoice::OpenAi {
                 model,
@@ -290,7 +304,8 @@ fn pick_provider(cli: &Cli, settings: &SettingsStore) -> ProviderChoice {
             reasoning_effort: effort.or(reasoning_effort),
         },
         (other, _) => other,
-    }
+    };
+    (selected, notes)
 }
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 4)]
@@ -320,7 +335,15 @@ async fn main() -> Result<()> {
         std::path::PathBuf::from("/dev/null/yolop/settings.toml")
     });
     let settings = Arc::new(SettingsStore::open(settings_path));
-    let provider = pick_provider(&cli, &settings);
+    let (mut provider, mut notes) = pick_provider(&cli, &settings);
+    let snapshot = settings.snapshot();
+    let (reconciled, catalog_notes) =
+        capabilities::model_discovery::reconcile_provider_with_catalog(provider, &snapshot).await;
+    provider = reconciled;
+    notes.extend(catalog_notes);
+    for note in notes {
+        eprintln!("yolop: {note}");
+    }
 
     let resume_session_id = match cli.session.as_deref() {
         Some(raw) => Some(
@@ -791,7 +814,8 @@ mod tests {
         let tmp = tempfile::tempdir().expect("settings tempdir");
         let settings = SettingsStore::open(tmp.path().join("settings.toml"));
 
-        let provider = pick_provider(&cli_with_reasoning_effort(Some(" HIGH ")), &settings);
+        let (provider, _notes) =
+            pick_provider(&cli_with_reasoning_effort(Some(" HIGH ")), &settings);
 
         assert_eq!(
             provider.label(),
@@ -804,7 +828,7 @@ mod tests {
         let tmp = tempfile::tempdir().expect("settings tempdir");
         let settings = SettingsStore::open(tmp.path().join("settings.toml"));
 
-        let provider = pick_provider(&cli_with_reasoning_effort(Some("  ")), &settings);
+        let (provider, _notes) = pick_provider(&cli_with_reasoning_effort(Some("  ")), &settings);
 
         assert_eq!(
             provider.label(),
@@ -838,7 +862,7 @@ mod tests {
             session_dir: None,
         };
 
-        let provider = pick_provider(&cli, &settings);
+        let (provider, _notes) = pick_provider(&cli, &settings);
 
         assert_eq!(provider.label(), "openai/gpt-5.4 high");
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -35,6 +35,7 @@ use everruns_core::capabilities::{
 };
 use everruns_core::command::CommandDescriptor;
 use everruns_core::error::AgentLoopError;
+use everruns_core::get_model_profile;
 use everruns_core::in_memory::InMemoryMessageRetriever;
 use everruns_core::llm_driver_registry::{DriverRegistry, ProviderMetadata};
 use everruns_core::llmsim_driver::LlmSimConfig;
@@ -485,7 +486,7 @@ impl ProviderChoice {
         // The custom endpoint has no default model, so it is auto-selected
         // only when a model is also known (env override or a persisted
         // `[models].custom` pick — applied by the caller's
-        // `with_saved_model`). Otherwise a non-interactive run would send a
+        // `resolve_for_settings`). Otherwise a non-interactive run would send a
         // Chat Completions request with an empty model id.
         if (env_non_empty("CUSTOM_BASE_URL").is_some() || settings.base_url_for("custom").is_some())
             && (env_non_empty("EVERRUNS_CLI_MODEL").is_some()
@@ -615,29 +616,180 @@ impl ProviderChoice {
         }
     }
 
-    /// Overlay the model spec persisted for this provider in settings, if
-    /// any. `EVERRUNS_CLI_MODEL` keeps precedence (env beats settings,
-    /// matching token resolution); a stored spec that fails to parse is
-    /// ignored rather than fatal. Specs are provider-relative
-    /// (`gpt-5.5 medium`), matching `/setup model`.
-    pub fn with_saved_model(self, settings: &Settings) -> Self {
-        if env_non_empty("EVERRUNS_CLI_MODEL").is_some() {
-            return self;
-        }
-        // A per-provider pick wins; the global `default_model` is the
-        // cross-provider fallback when this provider has no saved model.
-        let Some(spec) = settings
-            .model_for(self.provider_name())
-            .or_else(|| settings.default_model())
-        else {
-            return self;
+    /// Provider name used when previewing config changes before the next run.
+    pub fn preview_provider_name(settings: &Settings) -> String {
+        settings.default_provider.clone().unwrap_or_else(|| {
+            Self::from_env_or_settings(settings)
+                .provider_name()
+                .to_string()
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ModelResolutionSource {
+    ProviderDefault,
+    PerProviderModel,
+    DefaultModel,
+    EnvOverride,
+}
+
+#[derive(Clone, Debug)]
+pub struct ResolvedProviderChoice {
+    pub choice: ProviderChoice,
+    pub source: ModelResolutionSource,
+    pub notes: Vec<String>,
+}
+
+impl ResolvedProviderChoice {
+    pub fn next_run_preview(&self) -> String {
+        let label = self.choice.label();
+        let mut preview = match self.source {
+            ModelResolutionSource::PerProviderModel => {
+                let provider = self.choice.provider_name();
+                format!("→ next run: {label} (from models.{provider})")
+            }
+            ModelResolutionSource::DefaultModel => {
+                format!("→ next run: {label} (from default_model)")
+            }
+            ModelResolutionSource::EnvOverride => {
+                format!("→ next run: {label} (EVERRUNS_CLI_MODEL env)")
+            }
+            ModelResolutionSource::ProviderDefault => {
+                format!("→ next run: {label} (provider default)")
+            }
         };
-        match self.resolve_model_spec(spec) {
-            Ok(saved) => saved,
-            Err(_) => self,
+        for note in &self.notes {
+            preview.push('\n');
+            preview.push_str("→ ");
+            preview.push_str(note);
         }
+        preview
+    }
+}
+
+fn bare_model_id_from_spec(spec: &str) -> &str {
+    spec.split_whitespace().next().unwrap_or(spec)
+}
+
+fn driver_id_for_provider_name(provider: &str) -> Option<DriverId> {
+    match provider {
+        "anthropic" => Some(DriverId::Anthropic),
+        "openai" => Some(DriverId::OpenAI),
+        "google" => Some(DriverId::OpenAI),
+        "openrouter" => Some(DriverId::OpenRouter),
+        _ => None,
+    }
+}
+
+/// Whether a bare model id plausibly belongs to the given provider. Used to
+/// gate the cross-provider `default_model` fallback so an OpenAI pick is not
+/// silently applied after switching to Anthropic.
+pub fn model_compatible_with_provider(model_id: &str, provider: &str) -> bool {
+    match provider {
+        "openrouter" | "ollama" | "custom" => true,
+        "llmsim" => model_id == "llmsim-yolop",
+        "anthropic" | "openai" | "google" => {
+            let bare = model_id.strip_suffix("[1m]").unwrap_or(model_id);
+            if ProviderChoice::model_suggestions_for_provider(provider)
+                .iter()
+                .any(|s| bare_model_id_from_spec(s) == bare)
+            {
+                return true;
+            }
+            if let Some(driver) = driver_id_for_provider_name(provider)
+                && get_model_profile(&driver, bare).is_some()
+            {
+                return true;
+            }
+            match provider {
+                "anthropic" => bare.starts_with("claude-"),
+                "openai" => {
+                    bare.starts_with("gpt-")
+                        || bare.starts_with("o1")
+                        || bare.starts_with("o3")
+                        || bare.starts_with("o4")
+                        || bare.starts_with("codex")
+                }
+                "google" => bare.starts_with("gemini-"),
+                _ => false,
+            }
+        }
+        _ => false,
+    }
+}
+
+/// Resolve a provider plus its model from persisted settings.
+///
+/// Priority: `EVERRUNS_CLI_MODEL` env → `models.<provider>` → compatible
+/// `default_model` → the provider's built-in default.
+pub fn resolve_for_settings(provider: &str, settings: &Settings) -> Result<ResolvedProviderChoice> {
+    let base = ProviderChoice::default_for_provider_name(provider)?;
+    let base_label = base.label();
+    if env_non_empty("EVERRUNS_CLI_MODEL").is_some() {
+        return Ok(ResolvedProviderChoice {
+            choice: base,
+            source: ModelResolutionSource::EnvOverride,
+            notes: vec![],
+        });
     }
 
+    let provider_name = base.provider_name();
+
+    if let Some(spec) = settings.model_for(provider_name) {
+        return match base.resolve_model_spec(spec) {
+            Ok(choice) => Ok(ResolvedProviderChoice {
+                choice,
+                source: ModelResolutionSource::PerProviderModel,
+                notes: vec![],
+            }),
+            Err(err) => Ok(ResolvedProviderChoice {
+                choice: base,
+                source: ModelResolutionSource::ProviderDefault,
+                notes: vec![format!(
+                    "ignored models.{provider_name} \"{spec}\": {err}; using {base_label}"
+                )],
+            }),
+        };
+    }
+
+    if let Some(spec) = settings.default_model() {
+        let model_id = bare_model_id_from_spec(spec);
+        if !model_compatible_with_provider(model_id, provider_name) {
+            return Ok(ResolvedProviderChoice {
+                choice: base,
+                source: ModelResolutionSource::ProviderDefault,
+                notes: vec![format!(
+                    "default_model \"{spec}\" ignored for {provider_name} (not a recognized \
+                     {provider_name} model); using {base_label}"
+                )],
+            });
+        }
+        return match base.resolve_model_spec(spec) {
+            Ok(choice) => Ok(ResolvedProviderChoice {
+                choice,
+                source: ModelResolutionSource::DefaultModel,
+                notes: vec![],
+            }),
+            Err(err) => Ok(ResolvedProviderChoice {
+                choice: base,
+                source: ModelResolutionSource::ProviderDefault,
+                notes: vec![format!(
+                    "default_model \"{spec}\" ignored for {provider_name}: {err}; using \
+                     {base_label}"
+                )],
+            }),
+        };
+    }
+
+    Ok(ResolvedProviderChoice {
+        choice: base,
+        source: ModelResolutionSource::ProviderDefault,
+        notes: vec![],
+    })
+}
+
+impl ProviderChoice {
     pub fn model_id(&self) -> &str {
         match self {
             Self::Anthropic { model }
@@ -2540,14 +2692,17 @@ mod tests {
         assert_eq!(provider.provider_name(), "openai");
 
         // With a persisted model the custom endpoint is auto-selected (the
-        // caller's `with_saved_model` fills the model in).
+        // caller's `resolve_for_settings` fills the model in).
         settings
             .models
             .insert("custom".to_string(), "qwen3-coder".to_string());
         let provider = ProviderChoice::from_env_or_settings(&settings);
         assert_eq!(provider.provider_name(), "custom");
         assert_eq!(
-            provider.with_saved_model(&settings).label(),
+            resolve_for_settings(provider.provider_name(), &settings)
+                .expect("resolve")
+                .choice
+                .label(),
             "custom/qwen3-coder"
         );
     }
@@ -2618,7 +2773,7 @@ mod tests {
     }
 
     #[test]
-    fn with_saved_model_overlays_persisted_spec_for_same_provider() {
+    fn resolve_for_settings_overlays_persisted_spec_for_same_provider() {
         let _guard = crate::test_env::lock();
         unsafe {
             std::env::remove_var("EVERRUNS_CLI_MODEL");
@@ -2633,19 +2788,19 @@ mod tests {
             .models
             .insert("anthropic".to_string(), "claude-opus-4-5 high".to_string());
 
-        let openai = ProviderChoice::default_for_provider_name("openai")
-            .unwrap()
-            .with_saved_model(&settings);
+        let openai = resolve_for_settings("openai", &settings)
+            .expect("resolve")
+            .choice;
         assert_eq!(openai.label(), "openai/gpt-5.4 high");
 
-        let anthropic = ProviderChoice::default_for_provider_name("anthropic")
-            .unwrap()
-            .with_saved_model(&settings);
+        let anthropic = resolve_for_settings("anthropic", &settings)
+            .expect("resolve")
+            .choice;
         assert_eq!(anthropic.label(), "anthropic/claude-sonnet-4-5");
     }
 
     #[test]
-    fn with_saved_model_falls_back_to_global_default_model() {
+    fn resolve_for_settings_falls_back_to_global_default_model() {
         let _guard = crate::test_env::lock();
         unsafe {
             std::env::remove_var("EVERRUNS_CLI_MODEL");
@@ -2656,19 +2811,83 @@ mod tests {
         };
 
         // No per-provider entry, so the global default_model is applied.
-        let anthropic = ProviderChoice::default_for_provider_name("anthropic")
-            .unwrap()
-            .with_saved_model(&settings);
+        let anthropic = resolve_for_settings("anthropic", &settings)
+            .expect("resolve")
+            .choice;
         assert_eq!(anthropic.label(), "anthropic/claude-opus-4-5");
 
         // A per-provider pick still wins over the global default.
         settings
             .models
             .insert("anthropic".to_string(), "claude-haiku-4-5".to_string());
-        let anthropic = ProviderChoice::default_for_provider_name("anthropic")
-            .unwrap()
-            .with_saved_model(&settings);
+        let anthropic = resolve_for_settings("anthropic", &settings)
+            .expect("resolve")
+            .choice;
         assert_eq!(anthropic.label(), "anthropic/claude-haiku-4-5");
+    }
+
+    #[test]
+    fn resolve_for_settings_ignores_cross_provider_default_model() {
+        let _guard = crate::test_env::lock();
+        unsafe {
+            std::env::remove_var("EVERRUNS_CLI_MODEL");
+        }
+        let settings = Settings {
+            default_provider: Some("anthropic".to_string()),
+            default_model: Some("gpt-5.5".to_string()),
+            ..Default::default()
+        };
+
+        let resolved = resolve_for_settings("anthropic", &settings).expect("resolve");
+        assert_eq!(resolved.choice.label(), "anthropic/claude-sonnet-4-5");
+        assert_eq!(resolved.source, ModelResolutionSource::ProviderDefault);
+        assert!(
+            resolved.notes.iter().any(|n| n.contains("default_model")),
+            "expected warning about ignored default_model, got {:?}",
+            resolved.notes
+        );
+    }
+
+    #[test]
+    fn resolve_for_settings_uses_per_provider_model() {
+        let _guard = crate::test_env::lock();
+        unsafe {
+            std::env::remove_var("EVERRUNS_CLI_MODEL");
+        }
+        let mut settings = Settings::default();
+        settings
+            .models
+            .insert("openai".to_string(), "gpt-5.4 high".to_string());
+
+        let resolved = resolve_for_settings("openai", &settings).expect("resolve");
+        assert_eq!(resolved.choice.label(), "openai/gpt-5.4 high");
+        assert_eq!(resolved.source, ModelResolutionSource::PerProviderModel);
+    }
+
+    #[test]
+    fn model_compatible_with_provider_rejects_obvious_mismatches() {
+        assert!(model_compatible_with_provider(
+            "claude-opus-4-5",
+            "anthropic"
+        ));
+        assert!(model_compatible_with_provider("gpt-5.5", "openai"));
+        assert!(!model_compatible_with_provider("gpt-5.5", "anthropic"));
+        assert!(model_compatible_with_provider(
+            "anthropic/claude-sonnet-4-5",
+            "openrouter"
+        ));
+    }
+
+    #[test]
+    fn next_run_preview_includes_resolution_notes() {
+        let resolved = ResolvedProviderChoice {
+            choice: ProviderChoice::default_for_provider_name("anthropic").unwrap(),
+            source: ModelResolutionSource::ProviderDefault,
+            notes: vec!["default_model \"gpt-5.5\" ignored for anthropic".to_string()],
+        };
+        let preview = resolved.next_run_preview();
+        assert!(preview.contains("provider default"));
+        assert!(preview.contains("default_model"));
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements safer provider/model resolution when the user changes `default_provider` without updating the model, or when a saved model is no longer offered by the provider.

- **`resolve_for_settings`** centralizes resolution: `models.<provider>` → compatible `default_model` → provider built-in default, with explicit warnings when `default_model` is ignored for the active provider.
- **Catalog reconciliation** at startup and on `/setup provider` queries the provider models API (when credentials exist) and falls back with a stderr warning if the resolved model is missing.
- **`set_config` previews** show the effective next-run provider/model when changing `default_provider` or `default_model`.

## Behavior examples

| Settings | Result |
|----------|--------|
| `default_provider=anthropic`, `default_model=gpt-5.5` | Uses `anthropic/claude-sonnet-4-5` + warning |
| `default_provider=anthropic`, `models.anthropic=claude-opus-4-5` | Uses saved per-provider model |
| Saved model deprecated but still in API catalog | Unchanged |
| Saved model not in provider catalog | Falls back to provider default / curated pick |

## Tests

- `resolve_for_settings_ignores_cross_provider_default_model`
- `resolve_for_settings_uses_per_provider_model`
- `pick_catalog_fallback_prefers_provider_default_when_available`
- `set_config_warns_when_default_model_mismatches_provider`
- Updated `pick_provider_*` and existing resolution tests

## Validation

```bash
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all-features   # 395 unit + 26 integration
cargo run -- --provider llmsim -p "hi"
```

Rebased onto latest `origin/main` (includes codex provider + status bar changes).

## Security

No security-relevant code changes beyond existing config resolution paths. API tokens are not logged; catalog discovery uses the same credential resolution as normal LLM calls. No new shell/filesystem surfaces.

## Follow-ups

Runtime auto-retry on `AgentLoopError::ModelNotAvailable` (deferred — yolop-only orchestration; everruns already classifies the error).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26a74505-4e49-4f8b-866b-006e5095c79e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26a74505-4e49-4f8b-866b-006e5095c79e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

