### PR TITLE
feat(app): expand session status bar

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -8,7 +8,8 @@ use crate::runtime::{BuiltRuntime, ModelState, RuntimeHandles, StartupInfo};
 use crate::tools::{BashTool, Workspace};
 use anyhow::Result;
 use crossterm::event::{
-    self, Event as CrosstermEvent, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
+    self, Event as CrosstermEvent, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton,
+    MouseEvent, MouseEventKind,
 };
 use everruns_core::command::{CommandDescriptor, CommandSource};
 use everruns_core::events::{Event as RuntimeEvent, EventData, ToolCompletedData};
@@ -96,6 +97,7 @@ pub const COMPOSER_VIEWPORT_HEIGHT: u16 = 18;
 const MAX_TERMINAL_IO_FAILURES: usize = 5;
 const COMPACT_CHROME_HEIGHT: u16 = 5;
 const MAX_INPUT_HEIGHT: u16 = 12;
+const EXPANDED_STATUS_ROWS: u16 = 3;
 const RECENT_TRANSCRIPT_SOURCE_LINES: usize = 80;
 const RECENT_TRANSCRIPT_MAX_TEXT_BYTES: usize = 4_000;
 const ACCENT_BLUE: Color = Color::Rgb(45, 91, 158);
@@ -134,6 +136,8 @@ pub struct App {
     /// handling so provider, token, and model setup never echo through the
     /// normal chat composer.
     setup: Option<SetupStep>,
+    status_layout: StatusLayout,
+    session_tokens: Option<u64>,
     /// Terminal-side commands emitted by `ClientCommandsCapability` (via
     /// `runtime.execute_command`). Drained in the event loop; see
     /// [`App::apply_ui_command`].
@@ -319,10 +323,14 @@ pub(crate) struct ViewState {
     pub busy: bool,
     pub busy_frame: u64,
     pub turn_activity: Option<String>,
-    pub model_label: String,
-    pub workspace_root: std::path::PathBuf,
+    pub model_id: String,
+    pub provider_name: String,
+    pub reasoning_effort: Option<String>,
     pub session_id: SessionId,
     pub lines_count: usize,
+    pub session_tokens: Option<u64>,
+    pub status_layout: StatusLayout,
+    pub hooks_summary: String,
     /// Current soft-approval level (`protective` / `normal` / `off`), shown
     /// in the session status bar so the paranoia level is always visible.
     pub approval_mode: String,
@@ -365,6 +373,21 @@ pub struct ActivityStatus {
     fallback: bool,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum StatusLayout {
+    Compact,
+    Expanded,
+}
+
+impl StatusLayout {
+    pub(crate) fn row_count(self) -> u16 {
+        match self {
+            Self::Compact => 1,
+            Self::Expanded => EXPANDED_STATUS_ROWS,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub(crate) enum TurnEvent {
     Lines(Vec<ChatLine>),
@@ -372,6 +395,7 @@ pub(crate) enum TurnEvent {
     /// Replace the live streaming preview shown above the input.
     /// `None` clears the preview.
     Stream(Option<StreamPreview>),
+    Tokens(u64),
     Done,
     Failed(String),
 }
@@ -398,6 +422,8 @@ impl App {
             rx: None,
             turn_cancel: None,
             setup: None,
+            status_layout: StatusLayout::Compact,
+            session_tokens: None,
             ui_rx: runtime.ui_rx,
             settings: runtime.settings,
             model_catalog: HashMap::new(),
@@ -434,10 +460,14 @@ impl App {
             busy: self.busy,
             busy_frame: self.busy_frame,
             turn_activity: self.turn_activity.clone(),
-            model_label: self.model.provider_label(),
-            workspace_root: self.startup.workspace_root.clone(),
+            model_id: self.model.model_id(),
+            provider_name: self.model.provider_name(),
+            reasoning_effort: self.model.reasoning_effort(),
             session_id: self.handles.session_id,
             lines_count: self.lines.len(),
+            session_tokens: self.session_tokens,
+            status_layout: self.status_layout,
+            hooks_summary: self.startup.hook_summary(),
             approval_mode: self
                 .settings
                 .snapshot()
@@ -559,6 +589,11 @@ impl App {
                     self.stream_preview = preview;
                     return Ok(());
                 }
+                Ok(TurnEvent::Tokens(tokens)) => {
+                    self.session_tokens =
+                        Some(self.session_tokens.unwrap_or(0).saturating_add(tokens));
+                    return Ok(());
+                }
                 Ok(TurnEvent::Done) => {
                     self.finish_busy();
                     return Ok(());
@@ -598,19 +633,27 @@ impl App {
             return Ok(());
         }
 
-        // 4) keystrokes. Mouse wheel/drag stays native terminal behavior
-        // because the transcript lives in scrollback, not in this viewport.
+        // 4) direct terminal input.
         let mut poll_timeout = Duration::from_millis(80);
         while event::poll(poll_timeout)? {
             poll_timeout = Duration::ZERO;
-            if let CrosstermEvent::Key(key) = event::read()? {
-                if key.kind == KeyEventKind::Release {
-                    continue;
+            match event::read()? {
+                CrosstermEvent::Key(key) => {
+                    if key.kind == KeyEventKind::Release {
+                        continue;
+                    }
+                    if key.code == KeyCode::Esc && self.handle_escape_prefixed_enter().await? {
+                        continue;
+                    }
+                    self.handle_key(key).await;
                 }
-                if key.code == KeyCode::Esc && self.handle_escape_prefixed_enter().await? {
-                    continue;
+                CrosstermEvent::Mouse(mouse) => {
+                    let area = terminal.get_frame().area();
+                    if self.handle_mouse(mouse, area) {
+                        return Ok(());
+                    }
                 }
-                self.handle_key(key).await;
+                _ => {}
             }
             if self.should_quit {
                 break;
@@ -881,6 +924,7 @@ impl App {
                     self.startup.workspace_root.display()
                 ));
             }
+            UiCommand::SetStatusLayout { arg } => self.set_status_layout(arg.as_deref()),
             UiCommand::ClearTranscript => {
                 self.lines.clear();
                 self.printed_lines = 0;
@@ -914,6 +958,57 @@ impl App {
             newline_shortcut_hint()
         ));
         self.push_system("exit: Ctrl-C twice / Ctrl-D".into());
+    }
+
+    fn set_status_layout(&mut self, raw: Option<&str>) {
+        let layout = match raw.map(str::trim).filter(|s| !s.is_empty()) {
+            None | Some("toggle") => match self.status_layout {
+                StatusLayout::Compact => StatusLayout::Expanded,
+                StatusLayout::Expanded => StatusLayout::Compact,
+            },
+            Some("compact") => StatusLayout::Compact,
+            Some("expanded") => StatusLayout::Expanded,
+            Some(other) => {
+                self.push_system(format!(
+                    "usage: /status [compact|expanded|toggle] (unknown layout: {other})"
+                ));
+                return;
+            }
+        };
+        self.status_layout = layout;
+    }
+
+    fn toggle_status_layout(&mut self) {
+        self.status_layout = match self.status_layout {
+            StatusLayout::Compact => StatusLayout::Expanded,
+            StatusLayout::Expanded => StatusLayout::Compact,
+        };
+    }
+
+    fn handle_mouse(&mut self, mouse: MouseEvent, terminal_area: Rect) -> bool {
+        if !matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
+            return false;
+        }
+        if self.mouse_is_on_status(mouse, terminal_area) {
+            self.toggle_status_layout();
+            return true;
+        }
+        false
+    }
+
+    fn mouse_is_on_status(&self, mouse: MouseEvent, terminal_area: Rect) -> bool {
+        let input_width = terminal_area.width.saturating_sub(2);
+        let input_height = self.input_height(input_width);
+        let chrome = bottom_rect(
+            terminal_area,
+            chrome_height(input_height, self.status_layout),
+        );
+        let status_rows = self.status_layout.row_count();
+        if status_rows == 0 || chrome.height < status_rows {
+            return false;
+        }
+        let status_y = chrome.y + chrome.height.saturating_sub(status_rows);
+        mouse.row >= status_y && mouse.row < status_y.saturating_add(status_rows)
     }
 
     fn handle_ctrl_c(&mut self) {
@@ -1398,7 +1493,7 @@ fn command_suggestions(
     }
 
     // Keep the dropdown bounded but large enough to show every built-in
-    // command (9 client commands + capability commands like /setup) for a
+    // command (10 client commands + capability commands like /setup) for a
     // bare `/`, so none is hidden behind the cap.
     out.truncate(12);
     out
@@ -1769,6 +1864,16 @@ mod tests {
     #[test]
     fn newline_shortcut_hint_uses_shift_enter_only() {
         assert_eq!(newline_shortcut_hint(), "Shift-Enter");
+    }
+
+    #[test]
+    fn chrome_height_reserves_three_expanded_status_rows() {
+        assert_eq!(chrome_height(1, StatusLayout::Compact), 5);
+        assert_eq!(chrome_height(1, StatusLayout::Expanded), 7);
+        assert_eq!(chrome_height(3, StatusLayout::Compact), 5);
+        assert_eq!(chrome_height(3, StatusLayout::Expanded), 7);
+        assert_eq!(chrome_height(4, StatusLayout::Compact), 6);
+        assert_eq!(chrome_height(4, StatusLayout::Expanded), 8);
     }
 
     #[test]
@@ -2321,6 +2426,38 @@ mod tests {
     }
 
     #[test]
+    fn handle_live_event_emits_known_token_counts() {
+        use everruns_core::events::ReasonItemData;
+
+        let (tx, mut rx) = mpsc::unbounded_channel::<TurnEvent>();
+        let mut emitted = HashSet::new();
+        let mut router = DeltaRouter::default();
+
+        let event = RuntimeEvent::new(
+            SessionId::new(),
+            EventContext::empty(),
+            ReasonItemData {
+                turn_id: TurnId::new(),
+                provider: "openai".to_string(),
+                model: Some("gpt-5".to_string()),
+                item_id: "rs_tokens".to_string(),
+                encrypted_content: None,
+                summary: Vec::new(),
+                token_count: Some(120),
+            },
+        );
+        handle_live_event(&event, &mut emitted, &mut router, &tx);
+
+        let mut tokens = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            if let TurnEvent::Tokens(count) = event {
+                tokens.push(count);
+            }
+        }
+        assert_eq!(tokens, vec![120]);
+    }
+
+    #[test]
     fn truncate_tail_keeps_visible_cursor() {
         assert_eq!(truncate_tail_chars("hello", 10), "hello");
         let out = truncate_tail_chars("0123456789abcdef", 8);
@@ -2441,10 +2578,14 @@ mod tests {
             busy: false,
             busy_frame: 0,
             turn_activity: None,
-            model_label: "openai/gpt-5.5".to_string(),
-            workspace_root: std::path::PathBuf::from("/tmp/ws"),
+            model_id: "gpt-5.5".to_string(),
+            provider_name: "openai".to_string(),
+            reasoning_effort: Some("medium".to_string()),
             session_id: SessionId::from_seed(770001),
             lines_count: 3,
+            session_tokens: None,
+            status_layout: StatusLayout::Compact,
+            hooks_summary: "none".to_string(),
             approval_mode: "normal".to_string(),
         }
     }
@@ -2454,14 +2595,20 @@ mod tests {
     /// height are minimums; if the chrome layout would need more space
     /// it will be silently clipped, which is fine for substring asserts.
     fn render_chrome_lines(state: &ViewState, width: u16, height: u16) -> Vec<String> {
+        render_chrome_lines_with_input_height(state, width, height, 1)
+    }
+
+    fn render_chrome_lines_with_input_height(
+        state: &ViewState,
+        width: u16,
+        height: u16,
+        input_height: u16,
+    ) -> Vec<String> {
         let backend = TestBackend::new(width, height);
         let mut terminal = Terminal::new(backend).expect("terminal");
         terminal
             .draw(|f| {
-                // Production input slot height is 1; tests don't
-                // exercise the input row so the value only matters
-                // because it shifts the status rows by that amount.
-                let _input_rect = draw_chrome(f, f.area(), 1, state);
+                let _input_rect = draw_chrome(f, f.area(), input_height, state);
             })
             .expect("draw");
         let buffer = terminal.backend().buffer();
@@ -2576,6 +2723,10 @@ mod tests {
                             }
                         }
                         Ok(TurnEvent::Stream(preview)) => self.stream_preview = preview,
+                        Ok(TurnEvent::Tokens(tokens)) => {
+                            self.session_tokens =
+                                Some(self.session_tokens.unwrap_or(0).saturating_add(tokens));
+                        }
                         Ok(TurnEvent::Done) => {
                             self.finish_busy();
                         }
@@ -3273,6 +3424,67 @@ mod tests {
             "cwd should print the workspace root: {:?}",
             app.lines
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn status_command_switches_between_compact_and_expanded_layouts() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.lines.clear();
+
+        assert_eq!(app.status_layout, StatusLayout::Compact);
+        app.dispatch_command_for_test("status expanded").await;
+        assert_eq!(app.status_layout, StatusLayout::Expanded);
+
+        app.dispatch_command_for_test("status compact").await;
+        assert_eq!(app.status_layout, StatusLayout::Compact);
+
+        app.dispatch_command_for_test("status nonsense").await;
+        assert_eq!(app.status_layout, StatusLayout::Compact);
+        assert!(
+            app.lines
+                .iter()
+                .any(|line| line.text.contains("usage: /status")),
+            "invalid status layout should render usage: {:?}",
+            app.lines
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn clicking_status_rows_toggles_layout() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+
+        let area = Rect {
+            x: 0,
+            y: 10,
+            width: 120,
+            height: 24,
+        };
+
+        assert_eq!(app.status_layout, StatusLayout::Compact);
+        assert!(app.handle_mouse(
+            MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: 3,
+                row: 33,
+                modifiers: KeyModifiers::empty(),
+            },
+            area,
+        ));
+        assert_eq!(app.status_layout, StatusLayout::Expanded);
+
+        assert!(app.handle_mouse(
+            MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: 3,
+                row: 31,
+                modifiers: KeyModifiers::empty(),
+            },
+            area,
+        ));
+        assert_eq!(app.status_layout, StatusLayout::Compact);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -4474,76 +4686,109 @@ mod tests {
     }
 
     #[test]
-    fn chrome_session_status_shows_model_workspace_msgs_and_session() {
+    fn chrome_session_status_compact_shows_model_effort_approval_and_messages() {
         let state = ViewState {
-            model_label: "anthropic/claude-sonnet-4-5".to_string(),
-            workspace_root: std::path::PathBuf::from("/tmp/some-workspace"),
-            session_id: SessionId::from_seed(99887766),
             lines_count: 42,
-            ..view_state_idle()
-        };
-        // Wide enough for the full status line (model · workspace · msgs ·
-        // approval · session <id>) without truncating the long session id.
-        let rows = render_chrome_lines(&state, 160, 5);
-        let status = &rows[4];
-        assert!(
-            status.contains("anthropic/claude-sonnet-4-5"),
-            "status should include model label: {status}"
-        );
-        assert!(
-            status.contains("/tmp/some-workspace"),
-            "status should include workspace path: {status}"
-        );
-        assert!(
-            status.contains("42 msgs"),
-            "status should include message count: {status}"
-        );
-        assert!(
-            status.contains("approval normal"),
-            "status should include the soft-approval level: {status}"
-        );
-        assert!(
-            status.contains("session "),
-            "status should include 'session' label: {status}"
-        );
-        let session_id_str = state.session_id.to_string();
-        assert!(
-            status.contains(&session_id_str),
-            "status should include the session id ({session_id_str}): {status}"
-        );
-    }
-
-    #[test]
-    fn chrome_session_status_collapses_home_prefix_with_tilde() {
-        // `display_path` rewrites $HOME-prefixed paths to start with '~'.
-        // Save / restore the env var so this test doesn't leak.
-        // SAFETY: env mutation in tests is racy across threads. cargo
-        // test by default runs tests in parallel; we accept the tiny
-        // window of cross-test contamination here because the assertion
-        // is on the rendered output of THIS state alone, and a parallel
-        // mutation can only widen the substring we check for, not narrow
-        // it. (`display_path` returns plain `path.display()` if $HOME
-        // doesn't prefix; tilde replacement is opt-in per path.)
-        let prior = std::env::var("HOME").ok();
-        unsafe {
-            std::env::set_var("HOME", "/tmp/fake-home");
-        }
-        let state = ViewState {
-            workspace_root: std::path::PathBuf::from("/tmp/fake-home/projects/yolop"),
             ..view_state_idle()
         };
         let rows = render_chrome_lines(&state, 120, 5);
         let status = &rows[4];
         assert!(
-            status.contains("~/projects/yolop"),
-            "status should collapse $HOME to ~: {status}"
+            status.contains("[expand ↓]"),
+            "compact status should include expand affordance: {status}"
         );
-        unsafe {
-            match prior {
-                Some(v) => std::env::set_var("HOME", v),
-                None => std::env::remove_var("HOME"),
-            }
-        }
+        assert!(
+            status.contains("gpt-5.5"),
+            "compact status should include model id: {status}"
+        );
+        assert!(
+            status.contains("effort medium"),
+            "compact status should include effort: {status}"
+        );
+        assert!(
+            status.contains("approval normal"),
+            "compact status should include approval: {status}"
+        );
+        assert!(
+            status.contains("42 msgs"),
+            "compact status should include message count: {status}"
+        );
+        assert!(
+            !status.contains("session "),
+            "compact status should keep session id for expanded layout: {status}"
+        );
+    }
+
+    #[test]
+    fn chrome_session_status_expanded_groups_details_across_three_lines() {
+        let state = ViewState {
+            model_id: "nvidia/nemotron-3-super-120b-a12b".to_string(),
+            provider_name: "openrouter".to_string(),
+            reasoning_effort: Some("high".to_string()),
+            session_id: SessionId::from_seed(99887766),
+            lines_count: 42,
+            session_tokens: Some(1234),
+            status_layout: StatusLayout::Expanded,
+            ..view_state_idle()
+        };
+        let rows = render_chrome_lines(&state, 180, 7);
+        assert!(
+            rows[4].contains("[collapse ↑]")
+                && rows[4].contains("nvidia/nemotron-3-super-120b-a12b")
+                && rows[4].contains("provider openrouter"),
+            "expanded model row should include selected model and provider: {:?}",
+            rows[4]
+        );
+        assert!(
+            !rows[4].contains("full "),
+            "expanded model row should not duplicate model/provider as a full label: {:?}",
+            rows[4]
+        );
+        assert!(
+            rows[5].contains("effort high")
+                && rows[5].contains("approval normal")
+                && rows[5].contains("hooks none"),
+            "expanded controls row should include effort, approval, and hooks: {:?}",
+            rows[5]
+        );
+        let session_id_str = state.session_id.to_string();
+        assert!(
+            rows[6].contains("42 msgs")
+                && rows[6].contains("tokens 1234")
+                && rows[6].contains("session ")
+                && rows[6].contains('…'),
+            "expanded counts row should include messages, tokens, and shortened session: {:?}",
+            rows[6]
+        );
+        assert!(
+            !rows[6].contains(&session_id_str),
+            "expanded counts row should not show the full session id: {:?}",
+            rows[6]
+        );
+    }
+
+    #[test]
+    fn chrome_session_status_stays_visible_with_multiline_input() {
+        let state = ViewState {
+            status_layout: StatusLayout::Expanded,
+            ..view_state_idle()
+        };
+        let rows = render_chrome_lines_with_input_height(&state, 120, 7, 3);
+        assert!(
+            rows[4].contains("[collapse ↑]") && rows[4].contains("provider openai"),
+            "expanded model row should remain visible with multiline input: {:?}",
+            rows
+        );
+        assert!(
+            rows[5].contains("effort medium") && rows[5].contains("hooks none"),
+            "expanded controls row should remain visible with multiline input: {:?}",
+            rows
+        );
+        assert!(
+            rows[6].contains("3 msgs") && rows[6].contains("tokens n/a"),
+            "expanded counts row should remain visible with multiline input: {:?}",
+            rows
+        );
     }
 
     #[test]

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -11,7 +11,7 @@ pub(crate) fn draw(f: &mut ratatui::Frame, app: &mut App) {
     let input_width = area.width.saturating_sub(2);
     let input_height = app.input_height(input_width);
     let state = app.view_state();
-    let chrome_area = bottom_rect(area, chrome_height(input_height));
+    let chrome_area = bottom_rect(area, chrome_height(input_height, state.status_layout));
     let transcript_area = Rect {
         height: area.height.saturating_sub(chrome_area.height),
         ..area
@@ -35,8 +35,14 @@ pub(crate) fn bottom_rect(area: Rect, height: u16) -> Rect {
     }
 }
 
-pub(crate) fn chrome_height(input_height: u16) -> u16 {
-    COMPACT_CHROME_HEIGHT.max(input_height.saturating_add(2))
+pub(crate) fn chrome_height(input_height: u16, status_layout: StatusLayout) -> u16 {
+    let preview_height = u16::from(input_height == 1);
+    let status_separator_height = u16::from(input_height < 3);
+    let fixed_rows = preview_height
+        .saturating_add(1)
+        .saturating_add(status_separator_height)
+        .saturating_add(status_layout.row_count());
+    COMPACT_CHROME_HEIGHT.max(input_height.saturating_add(fixed_rows))
 }
 
 pub(crate) fn clear_transcript_viewport(f: &mut ratatui::Frame, area: Rect) {
@@ -143,6 +149,7 @@ pub(crate) fn draw_chrome(
 ) -> Rect {
     let preview_height = u16::from(input_height == 1);
     let status_height = u16::from(input_height < 3);
+    let status_rows = state.status_layout.row_count();
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -150,7 +157,7 @@ pub(crate) fn draw_chrome(
             Constraint::Length(1),              // message separator
             Constraint::Length(input_height),   // input (left to the caller)
             Constraint::Length(status_height),  // status separator
-            Constraint::Length(1),              // session status
+            Constraint::Length(status_rows),    // session status
         ])
         .split(area);
 
@@ -1259,42 +1266,150 @@ pub(crate) fn draw_status_separator(f: &mut ratatui::Frame, area: Rect) {
 }
 
 pub(crate) fn draw_session_status(f: &mut ratatui::Frame, area: Rect, state: &ViewState) {
-    f.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled(" ", Style::default().fg(TEXT_MUTED)),
-            Span::styled(state.model_label.clone(), Style::default().fg(TEXT_MUTED)),
-            Span::styled("  ·  ", Style::default().fg(TEXT_DIM)),
-            Span::styled(
-                display_path(&state.workspace_root),
-                Style::default().fg(TEXT_MUTED),
-            ),
-            Span::styled("  ·  ", Style::default().fg(TEXT_DIM)),
-            Span::styled(
-                format!("{} msgs", state.lines_count),
-                Style::default().fg(TEXT_MUTED),
-            ),
-            Span::styled("  ·  approval ", Style::default().fg(TEXT_DIM)),
-            Span::styled(state.approval_mode.clone(), Style::default().fg(TEXT_MUTED)),
-            Span::styled("  ·  session ", Style::default().fg(TEXT_DIM)),
-            Span::styled(
-                state.session_id.to_string(),
-                Style::default().fg(TEXT_MUTED),
-            ),
-            Span::styled(" ", Style::default().fg(TEXT_MUTED)),
-        ])),
-        area,
-    );
+    let lines = match state.status_layout {
+        StatusLayout::Compact => compact_status_lines(state),
+        StatusLayout::Expanded => expanded_status_lines(state),
+    };
+    f.render_widget(Paragraph::new(lines), area);
 }
 
-pub(crate) fn display_path(path: &std::path::Path) -> String {
-    if let Ok(home) = std::env::var("HOME") {
-        let home = std::path::Path::new(&home);
-        if let Ok(rest) = path.strip_prefix(home) {
-            if rest.as_os_str().is_empty() {
-                return "~".to_string();
-            }
-            return format!("~/{}", rest.display());
-        }
+#[derive(Clone, Debug)]
+pub(crate) struct StatusContribution {
+    compact: Vec<StatusField>,
+    expanded: Vec<StatusField>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct StatusField {
+    label: Option<&'static str>,
+    value: String,
+}
+
+impl StatusContribution {
+    pub(crate) fn new(compact: Vec<StatusField>, expanded: Vec<StatusField>) -> Self {
+        Self { compact, expanded }
     }
-    path.display().to_string()
+}
+
+fn compact_status_lines(state: &ViewState) -> Vec<Line<'static>> {
+    vec![status_line(
+        status_contributions(state)
+            .iter()
+            .flat_map(|section| section.compact.iter()),
+    )]
+}
+
+fn expanded_status_lines(state: &ViewState) -> Vec<Line<'static>> {
+    status_contributions(state)
+        .iter()
+        .map(|section| status_line(section.expanded.iter()))
+        .collect()
+}
+
+fn status_contributions(state: &ViewState) -> Vec<StatusContribution> {
+    let toggle_label = match state.status_layout {
+        StatusLayout::Compact => "[expand ↓]",
+        StatusLayout::Expanded => "[collapse ↑]",
+    };
+    vec![
+        StatusContribution::new(
+            vec![
+                status_value(toggle_label),
+                status_value(state.model_id.clone()),
+            ],
+            vec![
+                status_value(toggle_label),
+                status_value(state.model_id.clone()),
+                status_field("provider", state.provider_name.clone()),
+            ],
+        ),
+        StatusContribution::new(
+            vec![
+                status_field("effort", effort_label(state)),
+                status_field("approval", state.approval_mode.clone()),
+            ],
+            vec![
+                status_field("effort", effort_label(state)),
+                status_field("approval", state.approval_mode.clone()),
+                status_field("hooks", state.hooks_summary.clone()),
+            ],
+        ),
+        StatusContribution::new(
+            vec![status_value(message_count_label(state.lines_count))],
+            vec![
+                status_value(message_count_label(state.lines_count)),
+                status_field("tokens", token_label(state.session_tokens)),
+                status_field("session", short_session_id(&state.session_id)),
+            ],
+        ),
+    ]
+}
+
+pub(crate) fn status_value(value: impl Into<String>) -> StatusField {
+    StatusField {
+        label: None,
+        value: value.into(),
+    }
+}
+
+pub(crate) fn status_field(label: &'static str, value: impl Into<String>) -> StatusField {
+    StatusField {
+        label: Some(label),
+        value: value.into(),
+    }
+}
+
+fn status_line<'a>(fields: impl IntoIterator<Item = &'a StatusField>) -> Line<'static> {
+    let mut spans = vec![Span::styled(" ", Style::default().fg(TEXT_MUTED))];
+    let mut first = true;
+    for field in fields {
+        if !first {
+            spans.push(Span::styled("  ·  ", Style::default().fg(TEXT_DIM)));
+        }
+        first = false;
+        if let Some(label) = field.label {
+            spans.push(Span::styled(
+                format!("{label} "),
+                Style::default().fg(TEXT_DIM),
+            ));
+        }
+        spans.push(Span::styled(
+            field.value.clone(),
+            Style::default().fg(TEXT_MUTED),
+        ));
+    }
+    spans.push(Span::styled(" ", Style::default().fg(TEXT_MUTED)));
+    Line::from(spans)
+}
+
+fn effort_label(state: &ViewState) -> String {
+    state
+        .reasoning_effort
+        .clone()
+        .unwrap_or_else(|| "n/a".to_string())
+}
+
+fn token_label(tokens: Option<u64>) -> String {
+    tokens
+        .map(|tokens| tokens.to_string())
+        .unwrap_or_else(|| "n/a".to_string())
+}
+
+fn message_count_label(count: usize) -> String {
+    format!("{count} msgs")
+}
+
+fn short_session_id(session_id: &SessionId) -> String {
+    let raw = session_id.to_string();
+    let id = raw.strip_prefix("session_").unwrap_or(&raw);
+    let chars = id.chars().collect::<Vec<_>>();
+    if chars.len() <= 16 {
+        return id.to_string();
+    }
+    let head = chars.iter().take(8).collect::<String>();
+    let tail = chars
+        .iter()
+        .skip(chars.len().saturating_sub(4))
+        .collect::<String>();
+    format!("{head}…{tail}")
 }

--- a/src/app/transcript.rs
+++ b/src/app/transcript.rs
@@ -53,6 +53,9 @@ pub(crate) fn handle_live_event(
         _ => {}
     }
 
+    if let Some(tokens) = tokens_for_event(event) {
+        let _ = tx.send(TurnEvent::Tokens(tokens));
+    }
     remember_write_todos_args(event, router);
     if let Some(activity) = status_for_event(event) {
         let _ = tx.send(TurnEvent::Activity(activity));
@@ -81,6 +84,9 @@ pub(crate) async fn catch_up_events(
         if !emitted_events.insert(event_id) {
             continue;
         }
+        if let Some(tokens) = tokens_for_event(event) {
+            let _ = tx.send(TurnEvent::Tokens(tokens));
+        }
         remember_write_todos_args(event, router);
         if let Some(activity) = status_for_event(event) {
             let _ = tx.send(TurnEvent::Activity(activity));
@@ -99,6 +105,13 @@ fn remember_write_todos_args(event: &RuntimeEvent, router: &mut DeltaRouter) {
         router
             .write_todos_args
             .insert(data.tool_call.id.clone(), data.tool_call.arguments.clone());
+    }
+}
+
+pub(crate) fn tokens_for_event(event: &RuntimeEvent) -> Option<u64> {
+    match &event.data {
+        EventData::ReasonItem(data) => data.token_count.map(u64::from),
+        _ => None,
     }
 }
 

--- a/src/capabilities/client_commands.rs
+++ b/src/capabilities/client_commands.rs
@@ -1,6 +1,6 @@
 //! Client-executed slash commands for the TUI host.
 //!
-//! `help`, `tools`, `mcp`, `cwd`, `model`, `effort`, `clear`, `/shell`, and
+//! `help`, `tools`, `mcp`, `cwd`, `status`, `model`, `effort`, `clear`, `/shell`, and
 //! `quit` act on the terminal, not the agent runtime. They are declared here as ordinary
 //! capability commands so they share the single command registry — palette,
 //! `/help`, and completion all read `runtime.list_commands` — and dispatched
@@ -27,10 +27,12 @@ pub(crate) const CLIENT_COMMANDS_CAPABILITY_ID: &str = "yolop_client_commands";
 
 const CLIENT_COMMANDS_PROMPT: &str = r#"<capability id="yolop_client_commands">
 The interactive terminal has slash commands: `/help`, `/tools`, `/mcp`, `/cwd`,
-`/model [id]`, `/effort [level]`, `/clear`, and `/quit` (`/exit` is an alias).
+`/status [compact|expanded|toggle]`, `/model [id]`, `/effort [level]`,
+`/clear`, and `/quit` (`/exit` is an alias).
 When the user asks in natural language for one of these terminal actions — for
-example "exit", "clear the screen", "show tools", or "switch model" — call
-`run_yolop_command`; do not merely tell the user to type the slash command.
+example "exit", "clear the screen", "show tools", "switch model", or "expand
+the status bar" — call `run_yolop_command`; do not merely tell the user to type
+the slash command.
 </capability>"#;
 
 pub(crate) struct ClientCommandsCapability {
@@ -52,7 +54,7 @@ impl Capability for ClientCommandsCapability {
         "Client Commands"
     }
     fn description(&self) -> &str {
-        "Terminal-side commands (help, tools, mcp, cwd, model, effort, clear, shell, quit)."
+        "Terminal-side commands (help, tools, mcp, cwd, status, model, effort, clear, shell, quit)."
     }
     fn status(&self) -> CapabilityStatus {
         CapabilityStatus::Available
@@ -109,6 +111,14 @@ fn command_descriptors() -> Vec<CommandDescriptor> {
         cmd("tools", "list available tools", &[]),
         cmd("mcp", "list configured MCP servers", &[]),
         cmd("cwd", "show workspace root", &[]),
+        cmd(
+            "status",
+            "toggle compact or expanded session status",
+            &[opt_with_suggestions(
+                "layout",
+                &["compact", "expanded", "toggle"],
+            )],
+        ),
         cmd("model", "show or switch model", &[opt("id")]),
         cmd("effort", "show or set reasoning effort", &[opt("level")]),
         cmd("clear", "clear transcript", &[]),
@@ -127,6 +137,7 @@ fn ui_command_for(name: &str, arg: Option<String>) -> Option<UiCommand> {
         "tools" => Some(UiCommand::ShowTools),
         "mcp" => Some(UiCommand::ShowMcp),
         "cwd" => Some(UiCommand::ShowCwd),
+        "status" => Some(UiCommand::SetStatusLayout { arg }),
         "clear" => Some(UiCommand::ClearTranscript),
         "shell" => Some(UiCommand::RunShell {
             command: arg.unwrap_or_default(),
@@ -155,7 +166,7 @@ impl Tool for RunYolopCommandTool {
     fn description(&self) -> &str {
         "Run an interactive yolop slash command on behalf of a natural-language user request. \
          Use this when the user asks to exit, clear the transcript, show help/tools/MCP/cwd, \
-         or open/switch model or reasoning effort. Accepts command names without the leading \
+         show or change the status layout, or open/switch model or reasoning effort. Accepts command names without the leading \
          slash; `exit` is accepted as an alias for `quit`."
     }
 
@@ -166,7 +177,7 @@ impl Tool for RunYolopCommandTool {
                 "command": {
                     "type": "string",
                     "description": "Slash command name, with or without the leading slash.",
-                    "enum": ["help", "tools", "mcp", "cwd", "model", "effort", "clear", "quit", "exit"]
+                    "enum": ["help", "tools", "mcp", "cwd", "status", "model", "effort", "clear", "quit", "exit"]
                 },
                 "arguments": {
                     "type": "string",
@@ -225,6 +236,13 @@ fn cmd(name: &str, description: &str, args: &[CommandArg]) -> CommandDescriptor 
 
 fn opt(name: &str) -> CommandArg {
     arg(name, false)
+}
+
+fn opt_with_suggestions(name: &str, suggestions: &[&str]) -> CommandArg {
+    CommandArg {
+        suggestions: suggestions.iter().map(|s| (*s).to_string()).collect(),
+        ..arg(name, false)
+    }
 }
 
 fn required(name: &str) -> CommandArg {
@@ -317,6 +335,27 @@ mod tests {
             ui.take(),
             vec![UiCommand::OpenModelOverlay {
                 arg: Some("openai/gpt-5.4".to_string())
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn run_yolop_command_preserves_status_layout_argument() {
+        let ui = Arc::new(RecordingUi::default());
+        let tool = RunYolopCommandTool { ui: ui.clone() };
+
+        let result = tool
+            .execute(json!({
+                "command": "status",
+                "arguments": "expanded"
+            }))
+            .await;
+
+        assert!(result.is_success(), "tool result: {result:?}");
+        assert_eq!(
+            ui.take(),
+            vec![UiCommand::SetStatusLayout {
+                arg: Some("expanded".to_string())
             }]
         );
     }

--- a/src/host_ui.rs
+++ b/src/host_ui.rs
@@ -24,6 +24,8 @@ pub enum UiCommand {
     ShowMcp,
     /// Print the workspace root.
     ShowCwd,
+    /// Change the inline session status layout.
+    SetStatusLayout { arg: Option<String> },
     /// Clear the transcript buffer.
     ClearTranscript,
     /// Run a shell command from the workspace root.

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,8 @@ extern crate everruns_integrations_daytona;
 use app::{App, COMPOSER_VIEWPORT_HEIGHT};
 use clap::{Args, Parser, Subcommand};
 use crossterm::event::{
-    KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+    DisableMouseCapture, EnableMouseCapture, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags,
+    PushKeyboardEnhancementFlags,
 };
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 use crossterm::{execute, queue};
@@ -408,6 +409,7 @@ fn run_command(command: Commands) -> Result<()> {
 async fn run_tui(runtime: BuiltRuntime) -> Result<()> {
     let mut raw_mode = RawModeGuard::new()?;
     let mut keyboard_enhancements = KeyboardEnhancementGuard::new();
+    let mut mouse_capture = MouseCaptureGuard::new();
     let stdout = io::stdout();
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::with_options(
@@ -442,6 +444,7 @@ async fn run_tui(runtime: BuiltRuntime) -> Result<()> {
         tracing::warn!("cursor restore failed: {err:#}");
     }
     drop(terminal);
+    mouse_capture.disable();
     keyboard_enhancements.disable();
     raw_mode.disable()?;
 
@@ -509,6 +512,33 @@ impl Drop for RawModeGuard {
 
 struct KeyboardEnhancementGuard {
     active: bool,
+}
+
+struct MouseCaptureGuard {
+    active: bool,
+}
+
+impl MouseCaptureGuard {
+    fn new() -> Self {
+        let mut stdout = io::stdout();
+        let active = execute!(stdout, EnableMouseCapture).is_ok();
+        Self { active }
+    }
+
+    fn disable(&mut self) {
+        if self.active {
+            let mut stdout = io::stdout();
+            let _ = queue!(stdout, DisableMouseCapture);
+            let _ = stdout.flush();
+            self.active = false;
+        }
+    }
+}
+
+impl Drop for MouseCaptureGuard {
+    fn drop(&mut self) {
+        self.disable();
+    }
 }
 
 impl KeyboardEnhancementGuard {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -622,6 +622,21 @@ impl ProviderChoice {
         }
     }
 
+    pub fn reasoning_effort(&self) -> Option<&str> {
+        match self {
+            Self::OpenAi {
+                reasoning_effort, ..
+            }
+            | Self::OpenRouter {
+                reasoning_effort, ..
+            }
+            | Self::Custom {
+                reasoning_effort, ..
+            } => reasoning_effort.as_deref(),
+            _ => None,
+        }
+    }
+
     /// Provider-relative model spec (`<model> [effort]`) — the label without
     /// the `provider/` prefix. This is the form `/setup model` accepts and
     /// the form persisted under `[models]` in settings.
@@ -1214,12 +1229,28 @@ impl ModelState {
             .label()
     }
 
+    pub fn provider_name(&self) -> String {
+        self.provider
+            .read()
+            .expect("provider lock poisoned")
+            .provider_name()
+            .to_string()
+    }
+
     pub fn model_id(&self) -> String {
         self.provider
             .read()
             .expect("provider lock poisoned")
             .model_id()
             .to_string()
+    }
+
+    pub fn reasoning_effort(&self) -> Option<String> {
+        self.provider
+            .read()
+            .expect("provider lock poisoned")
+            .reasoning_effort()
+            .map(str::to_string)
     }
 
     /// Snapshot of the current provider choice (including any custom base


### PR DESCRIPTION
## What
Add compact and expanded session status layouts in the TUI.

Compact status now shows the expand affordance, selected model, reasoning effort, approval mode, and message count. Expanded status uses three grouped rows for model/provider, effort/approval/hooks, and messages/tokens/session.

## Why
The prior single-row status bar could not expose useful session details without becoming crowded, and there was no direct TUI interaction for expanding it.

## How
- Add `StatusLayout` state with `/status [compact|expanded|toggle]` routing through `ClientCommandsCapability`.
- Enable terminal mouse capture and toggle the layout on left-clicks within the status rows.
- Structure rendering with `StatusContribution` / `StatusField` so status sections are easier to extend.
- Surface provider, reasoning effort, hook summary, token count, and shortened session id in expanded mode.

## Validation
- `cargo fmt --check`
- `cargo test --all-features status`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"`

## Security
- TM-FS: no filesystem read/write behavior changed.
- TM-BASH: no shell execution behavior changed.
- TM-LLM: no prompt secret handling or provider key handling changed; only model/provider/effort display accessors were added.
- TM-TOOL: `/status` is routed through the existing client-command capability and only mutates local TUI layout state.
- TM-DEP: no new dependencies.

## Risk
- Low.
- Main risk is terminal mouse-capture compatibility or status-row layout regressions; covered by focused TUI/render tests and existing PTY tests.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
