### PR TITLE
feat(tui): show provider in compact status

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4693,8 +4693,9 @@ mod tests {
     }
 
     #[test]
-    fn chrome_session_status_compact_shows_model_effort_approval_and_messages() {
+    fn chrome_session_status_compact_shows_provider_model_effort_approval_and_messages() {
         let state = ViewState {
+            provider_name: "openrouter".to_string(),
             lines_count: 42,
             ..view_state_idle()
         };
@@ -4703,6 +4704,10 @@ mod tests {
         assert!(
             status.contains("[expand ↓]"),
             "compact status should include expand affordance: {status}"
+        );
+        assert!(
+            status.contains("openrouter"),
+            "compact status should include provider: {status}"
         );
         assert!(
             status.contains("gpt-5.5"),

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1320,6 +1320,7 @@ fn status_contributions(state: &ViewState) -> Vec<StatusContribution> {
         StatusContribution::new(
             vec![
                 status_value(toggle_label),
+                status_value(state.provider_name.clone()),
                 status_value(state.model_id.clone()),
             ],
             vec![


### PR DESCRIPTION
## What
Show the active provider in the compact TUI status bar before the model id.

## Why
Compact status currently shows the model, effort, approval level, and message count, but not which provider owns the model. For OpenRouter-style model ids this makes the compact bar less clear than expanded status.

## How
- Include `provider_name` in the compact status contribution before `model_id`.
- Update the chrome rendering unit test to assert compact status includes the provider.

## Risk
- Low
- Can affect compact status row width/truncation on narrow terminals; expanded status behavior is unchanged.

## Security
- Reviewed TM-FS, TM-BASH, TM-LLM, TM-TOOL, TM-DEP, and resource exhaustion categories.
- No security-relevant code paths changed: this only renders an existing provider string already present in `ViewState` and updates a unit test.
- No dependency changes.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo test chrome_session_status_compact_shows_provider_model_effort_approval_and_messages`
- `cargo run -- --provider llmsim -p "hi"`

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered