### PR TITLE
feat(cli): attach images to prompts via --image/-i

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -166,6 +166,8 @@ pub struct App {
     /// `None` when closed. Toggled with Ctrl+B; read-only view of the registry.
     background_panel: Option<usize>,
     goal_store: Arc<GoalStore>,
+    /// Images from `--image` / `-i` on the CLI, consumed on the first turn.
+    pending_images: Vec<ContentPart>,
 }
 
 /// Result of one background models API fetch. `Ok(None)` means the provider
@@ -421,7 +423,7 @@ pub(crate) enum TurnEvent {
 }
 
 impl App {
-    pub fn new(runtime: BuiltRuntime) -> Self {
+    pub fn new(runtime: BuiltRuntime, pending_images: Vec<ContentPart>) -> Self {
         let should_setup = runtime.startup.setup_recommended;
         let goal_store = runtime.goal_store.clone();
         let session_id = runtime.handles.session_id;
@@ -456,6 +458,7 @@ impl App {
             background: runtime.background,
             background_panel: None,
             goal_store,
+            pending_images,
         };
         app.emit_system_banner();
         if should_setup {
@@ -911,10 +914,12 @@ impl App {
             self.handle_command(rest).await;
             return;
         }
-        if text.is_empty() {
+        if text.is_empty() && self.pending_images.is_empty() {
             return;
         }
-        self.push_user(text.clone());
+        let image_count = self.pending_images.len();
+        let display = crate::image_input::user_display_text(&text, image_count);
+        self.push_user(display);
         self.start_turn(text);
     }
 
@@ -1382,6 +1387,7 @@ impl App {
     fn start_turn(&mut self, prompt: String) {
         let handles = self.handles.clone();
         let model = self.model.clone();
+        let images = std::mem::take(&mut self.pending_images);
         let (tx, rx) = mpsc::unbounded_channel::<TurnEvent>();
         let (cancel_tx, mut cancel_rx) = oneshot::channel::<()>();
         self.rx = Some(rx);
@@ -1411,7 +1417,7 @@ impl App {
                 Err(_) => 0,
             };
 
-            let input = model.input_message(prompt);
+            let input = model.input_message_with_images(prompt, images);
             let runtime = handles.runtime.clone();
             let turn = tokio::spawn(async move { runtime.run_turn(session_id, input).await });
 
@@ -3091,7 +3097,7 @@ mod tests {
         )
         .await
         .expect("build llmsim runtime");
-        let mut app = App::new(runtime);
+        let mut app = App::new(runtime, vec![]);
         // Never let unit tests hit real provider models APIs.
         app.model_discovery_enabled = false;
         TestApp {
@@ -3525,7 +3531,7 @@ mod tests {
             "resume should report replayed events"
         );
 
-        let mut app = App::new(resumed);
+        let mut app = App::new(resumed, vec![]);
         app.setup = None;
         app.lines.clear();
         app.replay_transcript_for_test().await;
@@ -3743,7 +3749,7 @@ mod tests {
         )
         .await
         .expect("build resumed runtime");
-        let mut app = App::new(runtime);
+        let mut app = App::new(runtime, vec![]);
         app.setup = None;
 
         app.emit_replayed_transcript().await;

--- a/src/app/transcript.rs
+++ b/src/app/transcript.rs
@@ -215,7 +215,13 @@ pub(crate) fn lines_for_replayed_event(event: &RuntimeEvent) -> Vec<ChatLine> {
 }
 
 pub(crate) fn message_line(author: Author, message: &Message) -> Option<ChatLine> {
-    let text = message.text()?;
+    let image_count = message
+        .content
+        .iter()
+        .filter(|part| matches!(part, ContentPart::Image(_)))
+        .count();
+    let text = message.text().unwrap_or_default();
+    let text = crate::image_input::user_display_text(text, image_count);
     let text = text.trim();
     if text.is_empty() {
         return None;

--- a/src/image_input.rs
+++ b/src/image_input.rs
@@ -1,0 +1,126 @@
+// Load local image files into multimodal user-message content parts.
+//
+// Mirrors Codex CLI's `--image` / `-i` flow: read supported formats from
+// disk, base64-encode, and attach as `ContentPart::Image` before the text
+// prompt (models tend to prefer definitions before references).
+
+use anyhow::{Context, Result, bail};
+use base64::Engine;
+use everruns_core::message::{ContentPart, ImageContentPart};
+use std::path::{Path, PathBuf};
+
+/// Conservative per-file cap — large enough for screenshots, small enough
+/// to avoid accidentally loading multi-hundred-MB assets into context.
+pub const MAX_IMAGE_BYTES: usize = 20 * 1024 * 1024;
+
+/// Load one or more local image paths into content parts (images only).
+pub fn load_image_parts(paths: &[PathBuf]) -> Result<Vec<ContentPart>> {
+    paths
+        .iter()
+        .map(|path| load_image_part(path))
+        .collect::<Result<Vec<_>>>()
+}
+
+/// Read a single image file and return a base64 `ContentPart::Image`.
+pub fn load_image_part(path: &Path) -> Result<ContentPart> {
+    let bytes = std::fs::read(path).with_context(|| format!("read image {}", path.display()))?;
+    if bytes.is_empty() {
+        bail!("image {} is empty", path.display());
+    }
+    if bytes.len() > MAX_IMAGE_BYTES {
+        bail!(
+            "image {} is {} bytes (max {})",
+            path.display(),
+            bytes.len(),
+            MAX_IMAGE_BYTES
+        );
+    }
+    let media_type = detect_media_type(path, &bytes)?;
+    let base64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+    Ok(ContentPart::Image(ImageContentPart::from_base64(
+        base64, media_type,
+    )))
+}
+
+/// Build user-facing transcript text that mentions attached images.
+pub fn user_display_text(text: &str, image_count: usize) -> String {
+    if image_count == 0 {
+        return text.to_string();
+    }
+    let labels: Vec<String> = (1..=image_count)
+        .map(|index| format!("[Image #{index}]"))
+        .collect();
+    let prefix = labels.join(" ");
+    if text.trim().is_empty() {
+        prefix
+    } else {
+        format!("{prefix} {text}")
+    }
+}
+
+fn detect_media_type(path: &Path, bytes: &[u8]) -> Result<String> {
+    if let Some(mime) = sniff_media_type(bytes) {
+        return Ok(mime);
+    }
+    match path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("png") => Ok("image/png".into()),
+        Some("jpg") | Some("jpeg") => Ok("image/jpeg".into()),
+        Some("gif") => Ok("image/gif".into()),
+        Some("webp") => Ok("image/webp".into()),
+        _ => bail!(
+            "unsupported image format for {} (supported: png, jpeg, gif, webp)",
+            path.display()
+        ),
+    }
+}
+
+fn sniff_media_type(bytes: &[u8]) -> Option<String> {
+    if bytes.starts_with(b"\x89PNG\r\n\x1a\n") {
+        return Some("image/png".into());
+    }
+    if bytes.starts_with(b"\xff\xd8\xff") {
+        return Some("image/jpeg".into());
+    }
+    if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
+        return Some("image/gif".into());
+    }
+    if bytes.len() >= 12 && bytes.starts_with(b"RIFF") && &bytes[8..12] == b"WEBP" {
+        return Some("image/webp".into());
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sniff_png_magic_bytes() {
+        let png = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR";
+        assert_eq!(sniff_media_type(png).as_deref(), Some("image/png"));
+    }
+
+    #[test]
+    fn user_display_text_labels_images() {
+        assert_eq!(
+            user_display_text("describe this", 2),
+            "[Image #1] [Image #2] describe this"
+        );
+        assert_eq!(user_display_text("", 1), "[Image #1]");
+        assert_eq!(user_display_text("plain", 0), "plain");
+    }
+
+    #[test]
+    fn load_image_part_rejects_empty_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("empty.png");
+        std::fs::write(&path, b"").expect("write empty");
+        let err = load_image_part(&path).expect_err("empty image should fail");
+        assert!(err.to_string().contains("empty"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod connectors;
 mod goal;
 mod hooks_config;
 mod host_ui;
+mod image_input;
 mod into;
 mod mcp_config;
 mod runtime;
@@ -46,7 +47,7 @@ use crossterm::event::{
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 use crossterm::{execute, queue};
 use everruns_core::command::ExecuteCommandRequest;
-use everruns_core::message::MessageRole;
+use everruns_core::message::{ContentPart, MessageRole};
 use everruns_core::typed_id::SessionId;
 use ratatui::backend::CrosstermBackend;
 use ratatui::{Terminal, TerminalOptions, Viewport};
@@ -85,6 +86,17 @@ struct Cli {
     /// Run a single prompt non-interactively and print the result. Useful for CI smoke tests.
     #[arg(short = 'p', long)]
     print: Option<String>,
+
+    /// Attach one or more image files to the prompt. Separate multiple paths
+    /// with commas or repeat the flag. Supported formats: png, jpeg, gif, webp.
+    #[arg(
+        long = "image",
+        short = 'i',
+        value_name = "FILE",
+        value_delimiter = ',',
+        num_args = 1..
+    )]
+    images: Vec<PathBuf>,
 
     /// Speak the Agent Client Protocol (ACP) over stdio instead of launching
     /// the TUI. Editors such as Zed spawn `yolop --acp` and drive it as an
@@ -383,9 +395,11 @@ async fn main() -> Result<()> {
     .await?;
 
     if let Some(prompt) = cli.print {
-        return run_print_mode(runtime, prompt).await;
+        let image_parts = image_input::load_image_parts(&cli.images)?;
+        return run_print_mode(runtime, prompt, image_parts).await;
     }
-    run_tui(runtime).await
+    let pending_images = image_input::load_image_parts(&cli.images)?;
+    run_tui(runtime, pending_images).await
 }
 
 fn resolve_workspace_root(
@@ -453,7 +467,7 @@ fn run_command(command: Commands) -> Result<()> {
     }
 }
 
-async fn run_tui(runtime: BuiltRuntime) -> Result<()> {
+async fn run_tui(runtime: BuiltRuntime, pending_images: Vec<ContentPart>) -> Result<()> {
     let mut raw_mode = RawModeGuard::new()?;
     let mut keyboard_enhancements = KeyboardEnhancementGuard::new();
     let stdout = io::stdout();
@@ -472,7 +486,7 @@ async fn run_tui(runtime: BuiltRuntime) -> Result<()> {
         tracing::warn!("inline viewport anchoring failed, starting unanchored: {err:#}");
     }
 
-    let mut app = App::new(runtime);
+    let mut app = App::new(runtime, pending_images);
     let result = app.run(&mut terminal).await;
     let show_resume_hint = app.should_show_resume_hint();
     let session_id = app.session_id();
@@ -604,7 +618,11 @@ fn print_centered_ukraine_banner() {
     );
 }
 
-async fn run_print_mode(runtime: BuiltRuntime, prompt: String) -> Result<()> {
+async fn run_print_mode(
+    runtime: BuiltRuntime,
+    prompt: String,
+    images: Vec<ContentPart>,
+) -> Result<()> {
     let BuiltRuntime {
         handles,
         startup,
@@ -613,7 +631,8 @@ async fn run_print_mode(runtime: BuiltRuntime, prompt: String) -> Result<()> {
         ..
     } = runtime;
     let color = io::stdout().is_terminal();
-    println!("{}", paint(color, "90", &format!("› {prompt}")));
+    let display_prompt = image_input::user_display_text(&prompt, images.len());
+    println!("{}", paint(color, "90", &format!("› {display_prompt}")));
     println!();
     println!(
         "{} {}",
@@ -660,7 +679,7 @@ async fn run_print_mode(runtime: BuiltRuntime, prompt: String) -> Result<()> {
         return run_print_goal(&handles, &model, &goal_store, goal_args.trim(), color).await;
     }
 
-    let result = run_print_turn(&handles, &model, trimmed, color).await?;
+    let result = run_print_turn(&handles, &model, trimmed, images, color).await?;
     if !result.success {
         std::process::exit(1);
     }
@@ -704,7 +723,7 @@ async fn run_print_goal(
     loop {
         println!();
         println!("{}", paint(color, "90", &format!("› {turn_prompt}")));
-        let turn = run_print_turn(handles, model, &turn_prompt, color).await?;
+        let turn = run_print_turn(handles, model, &turn_prompt, vec![], color).await?;
         if !turn.success {
             std::process::exit(1);
         }
@@ -749,6 +768,7 @@ async fn run_print_turn(
     handles: &runtime::RuntimeHandles,
     model: &runtime::ModelState,
     prompt: &str,
+    images: Vec<ContentPart>,
     color: bool,
 ) -> Result<everruns_runtime::TurnResult> {
     let before_events = handles.runtime.events().await.map(|e| e.len()).unwrap_or(0);
@@ -759,7 +779,7 @@ async fn run_print_turn(
         .map(|m| m.len())
         .unwrap_or(0);
 
-    let input = model.input_message(prompt.to_string());
+    let input = model.input_message_with_images(prompt, images);
     let result = handles.runtime.run_turn(handles.session_id, input).await?;
     let events = handles.runtime.events().await.unwrap_or_default();
     let messages = handles
@@ -871,6 +891,7 @@ mod tests {
             model: Some("nvidia/nemotron-3-super-120b-a12b".to_string()),
             reasoning_effort: reasoning_effort.map(str::to_string),
             print: None,
+            images: vec![],
             acp: false,
             session: None,
             session_dir: None,
@@ -925,6 +946,7 @@ mod tests {
             model: None,
             reasoning_effort: None,
             print: None,
+            images: vec![],
             acp: false,
             session: None,
             session_dir: None,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -43,6 +43,7 @@ use everruns_core::get_model_profile;
 use everruns_core::in_memory::InMemoryMessageRetriever;
 use everruns_core::llm_driver_registry::{DriverRegistry, ProviderMetadata};
 use everruns_core::llmsim_driver::LlmSimConfig;
+use everruns_core::message::{ContentPart, MessageRole};
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, InitialFile, SessionFile};
 use everruns_core::typed_id::SessionId;
 use everruns_core::{
@@ -1187,8 +1188,22 @@ impl ProviderChoice {
     }
 
     fn input_message(&self, text: impl Into<String>) -> InputMessage {
-        let mut input = InputMessage::user(text);
-        let reasoning_effort = match self {
+        self.input_message_with_parts(vec![ContentPart::text(text)])
+    }
+
+    fn input_message_with_parts(&self, mut parts: Vec<ContentPart>) -> InputMessage {
+        parts.retain(|part| match part {
+            ContentPart::Text(text) => !text.text.trim().is_empty(),
+            _ => true,
+        });
+        let mut input = InputMessage {
+            role: MessageRole::User,
+            content: parts,
+            controls: None,
+            metadata: None,
+            tags: vec![],
+        };
+        if let Some(effort) = match self {
             Self::OpenAi {
                 reasoning_effort, ..
             }
@@ -1200,18 +1215,30 @@ impl ProviderChoice {
             }
             | Self::Custom {
                 reasoning_effort, ..
-            } => reasoning_effort.as_ref(),
+            } => reasoning_effort.as_deref(),
             _ => None,
-        };
-        if let Some(effort) = reasoning_effort {
+        } {
             input.controls = Some(Controls {
                 reasoning: Some(ReasoningConfig {
-                    effort: Some(effort.clone()),
+                    effort: Some(effort.to_string()),
                 }),
                 ..Default::default()
             });
         }
         input
+    }
+
+    fn input_message_with_images(
+        &self,
+        text: impl Into<String>,
+        images: Vec<ContentPart>,
+    ) -> InputMessage {
+        let mut parts = images;
+        let text = text.into();
+        if !text.trim().is_empty() {
+            parts.push(ContentPart::text(text));
+        }
+        self.input_message_with_parts(parts)
     }
 }
 
@@ -1513,6 +1540,17 @@ impl ModelState {
             .read()
             .expect("provider lock poisoned")
             .input_message(text)
+    }
+
+    pub fn input_message_with_images(
+        &self,
+        text: impl Into<String>,
+        images: Vec<ContentPart>,
+    ) -> InputMessage {
+        self.provider
+            .read()
+            .expect("provider lock poisoned")
+            .input_message_with_images(text, images)
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -58,6 +58,7 @@ fn help_flag_succeeds() {
         "help output missing --provider"
     );
     assert!(stdout.contains("--print"), "help output missing --print");
+    assert!(stdout.contains("--image"), "help output missing --image");
 }
 
 #[test]
@@ -754,6 +755,95 @@ fn print_mode_sends_saved_model_selection_to_endpoint() {
     assert_eq!(
         request["model"], "picked-model-x",
         "request must carry the saved model id: {request}"
+    );
+}
+
+/// `--image` should base64-encode local files and send them as multimodal
+/// user content to OpenAI-compatible chat/completions endpoints.
+#[test]
+fn print_mode_attaches_images_to_provider_request() {
+    let mock = MockOpenAiServer::spawn("saw the image");
+    let home = tempfile::tempdir().expect("home tempdir");
+    let sessions = tempfile::tempdir().expect("sessions tempdir");
+    let image_dir = tempfile::tempdir().expect("image tempdir");
+    let image_path = image_dir.path().join("pixel.png");
+    // 1x1 PNG (68 bytes)
+    let png: [u8; 67] = [
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f,
+        0x15, 0xc4, 0x89, 0x00, 0x00, 0x00, 0x0a, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x00,
+        0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49,
+        0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+    ];
+    std::fs::write(&image_path, png).expect("write png");
+
+    let settings_toml = format!(
+        "provider = \"custom\"\n\n[base_urls]\ncustom = \"{}\"\n\n[models]\ncustom = \"vision-model\"\n",
+        mock.base_url
+    );
+    for settings_dir in [
+        home.path().join(".config/yolop"),
+        home.path().join("Library/Application Support/yolop"),
+    ] {
+        std::fs::create_dir_all(&settings_dir).expect("create settings dir");
+        std::fs::write(settings_dir.join("settings.toml"), &settings_toml).expect("write settings");
+    }
+
+    let output = Command::new(yolop_binary())
+        .args([
+            "--session-dir",
+            sessions.path().to_str().unwrap(),
+            "-p",
+            "describe the image",
+            "--image",
+            image_path.to_str().unwrap(),
+        ])
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join(".config"))
+        .env("XDG_DATA_HOME", home.path().join(".local/share"))
+        .env_remove("OPENAI_API_KEY")
+        .env_remove("ANTHROPIC_API_KEY")
+        .env_remove("OPENROUTER_API_KEY")
+        .env_remove("GEMINI_API_KEY")
+        .env_remove("GOOGLE_API_KEY")
+        .env_remove("OLLAMA_BASE_URL")
+        .env_remove("OLLAMA_API_KEY")
+        .env_remove("CUSTOM_BASE_URL")
+        .env_remove("CUSTOM_API_KEY")
+        .env_remove("EVERRUNS_CLI_MODEL")
+        .env_remove("EVERRUNS_CLI_REASONING_EFFORT")
+        .output()
+        .expect("spawn yolop with --image");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "image attach run failed: stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        stdout.contains("[Image #1]"),
+        "prompt banner should mention attached image: {stdout}"
+    );
+
+    let request = mock.next_request(Duration::from_secs(5));
+    let messages = request["messages"]
+        .as_array()
+        .expect("messages array in request");
+    let user = messages
+        .iter()
+        .find(|msg| msg["role"] == "user")
+        .expect("user message in request");
+    let content = user["content"].as_array().expect("multimodal user content");
+    let image_part = content
+        .iter()
+        .find(|part| part["type"] == "image_url")
+        .expect("image_url content part");
+    let url = image_part["image_url"]["url"]
+        .as_str()
+        .expect("image data url");
+    assert!(
+        url.starts_with("data:image/png;base64,"),
+        "expected png data url, got {url}"
     );
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Codex CLI-style image attachment for user prompts. Local image files can be attached with `--image` / `-i` and are sent as multimodal user messages through the existing everruns provider drivers.

## Codex CLI reference

Codex exposes shared `--image` / `-i` flags (`value_delimiter = ','`, repeatable) on interactive and non-interactive entry points. Local paths are base64-encoded at request time and ordered **before** the text prompt.

## Changes

- **`src/image_input.rs`**: load png/jpeg/gif/webp from disk, sniff magic bytes, base64-encode into `ContentPart::Image`, format `[Image #N]` labels for transcript display.
- **`src/runtime.rs`**: `input_message_with_images()` builds multipart `InputMessage` (images first, then text) with reasoning controls preserved.
- **`src/main.rs`**: new `--image` / `-i` CLI flags; wired into `--print` and interactive startup.
- **`src/app/mod.rs`**: CLI images attach to the first TUI turn via `pending_images`.
- **`src/app/transcript.rs`**: replayed user lines show image labels when messages contain image parts.
- **`tests/integration.rs`**: asserts mock OpenAI-compatible endpoint receives `image_url` data URLs.

## Usage

```bash
yolop -p "describe this UI" --image screenshot.png
yolop -p "compare layouts" -i mockup-a.png -i mockup-b.png
yolop --image diagram.png   # attaches to first TUI message
```

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (includes `print_mode_attaches_images_to_provider_request`)
- `cargo run -- --provider llmsim -p "hi"` smoke test

## Security

- **TM-FS**: reads only user-supplied image paths; no traversal beyond explicit CLI args. 20MB per-file cap limits resource exhaustion.
- **TM-LLM**: images become base64 in session JSONL like existing tool-result images; no new secret handling.
- **TM-DEP**: no new crates.

## Follow-ups

- Clipboard image paste in the TUI (tracked separately; user requested after merge).
- ACP `PromptCapabilities::image(true)` for editor-driven image blocks.
- Image resize/re-encode (Codex uses `codex-utils-image`; yolop passes originals up to 20MB).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c71d9a3-7113-4bf9-ac80-297f46be2e10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c71d9a3-7113-4bf9-ac80-297f46be2e10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

