### PR TITLE
feat(goal): add autonomous /goal completion loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,17 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   or less careful). See [Soft approval](#soft-approval) below.
 - **TUI chat** (ratatui): scrolling transcript, multiline composer, status
   bar (with a `bg` count whenever the session has background tasks), slash commands
-  (`/help`, `/tools`, `/mcp`, `/cwd`, `/setup`, `/model`, `/effort`, `/shell`,
-  `/background`, `/clear`, `/quit`), a read-only background-tasks panel toggled
-  with `Ctrl+B`, `!<command>` as a direct shell shortcut, and natural-language
-  requests for terminal actions such as "exit" or "clear the screen".
+  (`/help`, `/tools`, `/mcp`, `/cwd`, `/setup`, `/model`, `/effort`, `/goal`,
+  `/shell`, `/background`, `/clear`, `/quit`), a read-only background-tasks panel
+  toggled with `Ctrl+B`, `!<command>` as a direct shell shortcut, and
+  natural-language requests for terminal actions such as "exit" or "clear the screen".
 - **Side questions** — `/btw <question>` answers a question about the current
   session out-of-band: same context as the main task, no tools, and nothing
   added to the conversation history.
+- **Goal loops** — `/goal <condition>` keeps working across turns until a
+  separate evaluator model confirms the condition from the transcript; use
+  `/goal` for status and `/goal clear` to stop early. Works in `--print` mode
+  (`yolop -p "/goal …"`). See [`specs/goal.md`](./specs/goal.md).
 - **Planning** — `write_todos` keeps multi-step tasks on track, and
   loop detection stops the model from retrying the same failing tool call.
 - **One-shot mode** — `--print` runs a single prompt non-interactively, for

--- a/specs/commands.md
+++ b/specs/commands.md
@@ -27,7 +27,8 @@ top of the runtime's two, not a separate `CommandSource` variant.
 1. **System** — the **runtime** executes it via `runtime.execute_command`,
    returning a `CommandResult { success, message }` the host renders inline.
    Example: `/setup` and its subcommands mutate provider/model/token settings;
-   `/shell <command>` runs the existing bounded bash tool.
+   `/shell <command>` runs the existing bounded bash tool; `/goal <condition>`
+   starts an autonomous completion loop (see [`goal.md`](./goal.md)).
 
 2. **Skill** — the **LLM** executes it. The literal `/name args` text is
    forwarded as a chat turn so the model activates the skill. Skill commands are

--- a/specs/goal.md
+++ b/specs/goal.md
@@ -1,0 +1,66 @@
+# `/goal` — autonomous completion loops
+
+Status: implemented in yolop (`yolop_goal` capability).
+
+## Why
+
+Multi-step coding work often has a verifiable end state — all tests pass, a
+refactor is complete, a checklist is satisfied — but the agent stops after each
+turn and waits for another prompt. Claude Code's `/goal` command (v2.1.139+)
+showed that a session-scoped completion condition plus a lightweight evaluator
+after every turn removes that bottleneck without giving the working model
+authority to judge its own completion.
+
+yolop mirrors that pattern: one active condition per session, automatic
+continuation until a separate tool-less evaluator confirms the condition from
+the transcript.
+
+## Behavior
+
+| Invocation | Effect |
+| --- | --- |
+| `/goal <condition>` | Replace any active goal, persist it, and start a turn immediately with the condition as the directive. |
+| `/goal` | Show status: condition, elapsed time, evaluated turns, session tokens, last evaluator reason. |
+| `/goal clear` | Clear the active goal (`stop`, `off`, `reset`, `none`, `cancel` are aliases). |
+| `/clear` | Also clears an active goal (new conversation). |
+
+After each agent turn while a goal is active:
+
+1. The host calls an internal evaluator through the same `CommandHost`
+   completion path as `/btw` — no tools, nothing extra persisted.
+2. The evaluator returns JSON `{"met": bool, "reason": "..."}` judged only from
+   the conversation transcript.
+3. If `met` is true, the goal clears and the host prints `goal achieved`.
+4. If `met` is false, the host starts another turn with the evaluator reason
+   as guidance.
+
+Conditions may be up to 4,000 characters. Users can bound runs in the condition
+itself (for example `or stop after 20 turns`); the evaluator judges that clause
+from the transcript, matching the Claude Code contract.
+
+## Hosts
+
+| Host | Support |
+| --- | --- |
+| Interactive TUI | Full loop, `◎ goal (N)` indicator in the status bar. |
+| `--print` | `yolop -p "/goal <condition>"` runs the loop to completion. |
+| ACP | Command is listed; loop continuation requires the TUI/print host today. |
+
+## Persistence
+
+Active goals are stored in `<session_dir>/goal.json` so a resumed session
+(`--session`) restores the condition. Timer and evaluated-turn counters reset
+on resume; an already-achieved goal is not restored as active.
+
+## Ownership
+
+- `GoalCapability` and `GoalStore` live in yolop (`src/capabilities/goal.rs`,
+  `src/goal.rs`).
+- Evaluator calls use upstream `CommandHost::completion` (everruns-core); no
+  `everruns-core` API changes are required.
+
+## Related
+
+- [`commands.md`](./commands.md) — single command registry and dispatch.
+- [Claude Code `/goal` docs](https://code.claude.com/docs/en/goal) — upstream
+  UX reference.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3,6 +3,7 @@
 // native terminal scrollback; ratatui owns only a short inline composer at the
 // bottom.
 
+use crate::goal::{GOAL_EVALUATE_ARG, GoalStore, parse_evaluation_response};
 use crate::host_ui::UiCommand;
 use crate::runtime::{BuiltRuntime, ModelState, RuntimeHandles, StartupInfo};
 use crate::tools::{BashTool, Workspace};
@@ -11,7 +12,7 @@ use crossterm::event::{
     self, Event as CrosstermEvent, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton,
     MouseEvent, MouseEventKind,
 };
-use everruns_core::command::{CommandDescriptor, CommandSource};
+use everruns_core::command::{CommandDescriptor, CommandSource, ExecuteCommandRequest};
 use everruns_core::events::{Event as RuntimeEvent, EventData, ToolCompletedData};
 use everruns_core::message::{ContentPart, Message, MessageRole};
 use everruns_core::tools::{Tool, ToolExecutionResult};
@@ -97,7 +98,7 @@ pub const COMPOSER_VIEWPORT_HEIGHT: u16 = 18;
 const MAX_TERMINAL_IO_FAILURES: usize = 5;
 const COMPACT_CHROME_HEIGHT: u16 = 5;
 const MAX_INPUT_HEIGHT: u16 = 12;
-const EXPANDED_STATUS_ROWS: u16 = 3;
+const EXPANDED_STATUS_ROWS: u16 = 4;
 const RECENT_TRANSCRIPT_SOURCE_LINES: usize = 80;
 const RECENT_TRANSCRIPT_MAX_TEXT_BYTES: usize = 4_000;
 const ACCENT_BLUE: Color = Color::Rgb(45, 91, 158);
@@ -164,6 +165,7 @@ pub struct App {
     /// Open background-tasks panel overlay, holding its scroll offset (in lines).
     /// `None` when closed. Toggled with Ctrl+B; read-only view of the registry.
     background_panel: Option<usize>,
+    goal_store: Arc<GoalStore>,
 }
 
 /// Result of one background models API fetch. `Ok(None)` means the provider
@@ -350,6 +352,8 @@ pub(crate) struct ViewState {
     /// `(running, total)` background task counts, shown in the status bar only
     /// when there is at least one task this session. `None` hides the segment.
     pub background: Option<(usize, usize)>,
+    /// Short label when a `/goal` loop is active (for example `◎ goal`).
+    pub goal_indicator: Option<String>,
 }
 
 /// What kind of delta is currently being streamed. Only the assistant
@@ -419,6 +423,8 @@ pub(crate) enum TurnEvent {
 impl App {
     pub fn new(runtime: BuiltRuntime) -> Self {
         let should_setup = runtime.startup.setup_recommended;
+        let goal_store = runtime.goal_store.clone();
+        let session_id = runtime.handles.session_id;
         let (models_tx, models_rx) = mpsc::unbounded_channel::<ModelDiscovery>();
         let mut app = Self {
             handles: runtime.handles,
@@ -449,10 +455,17 @@ impl App {
             models_rx,
             background: runtime.background,
             background_panel: None,
+            goal_store,
         };
         app.emit_system_banner();
         if should_setup {
             app.start_first_run_setup();
+        } else if app.goal_store.take_pending_turn(session_id)
+            && let Some(condition) = app.goal_store.active_condition(session_id)
+        {
+            app.push_system(format!("restored active goal: {condition}"));
+            app.push_user(condition.clone());
+            app.start_turn(condition);
         }
         app
     }
@@ -496,7 +509,21 @@ impl App {
                 (_, 0) => None,
                 counts => Some(counts),
             },
+            goal_indicator: self.goal_indicator(),
         }
+    }
+
+    fn goal_indicator(&self) -> Option<String> {
+        if !self.goal_store.is_active(self.handles.session_id) {
+            return None;
+        }
+        let turns = self
+            .goal_store
+            .status(self.handles.session_id, self.session_tokens)
+            .active
+            .map(|active| active.evaluated_turns)
+            .unwrap_or(0);
+        Some(format!("◎ goal ({turns})"))
     }
 
     fn emit_system_banner(&mut self) {
@@ -618,6 +645,7 @@ impl App {
                 }
                 Ok(TurnEvent::Done) => {
                     self.finish_busy();
+                    self.after_turn_goal_check().await;
                     return Ok(());
                 }
                 Ok(TurnEvent::Failed(err)) => {
@@ -1044,6 +1072,7 @@ impl App {
             UiCommand::ClearTranscript => {
                 self.lines.clear();
                 self.printed_lines = 0;
+                self.goal_store.clear_active(self.handles.session_id);
                 self.emit_system_banner();
             }
             UiCommand::RunShell { command } => self.start_shell_command(command),
@@ -1180,6 +1209,63 @@ impl App {
         self.esc_pending_cancel = false;
     }
 
+    fn maybe_start_goal_turn(&mut self) {
+        let session_id = self.handles.session_id;
+        if !self.goal_store.take_pending_turn(session_id) {
+            return;
+        }
+        let Some(condition) = self.goal_store.active_condition(session_id) else {
+            return;
+        };
+        self.push_user(condition.clone());
+        self.start_turn(condition);
+    }
+
+    async fn after_turn_goal_check(&mut self) {
+        let session_id = self.handles.session_id;
+        if !self.goal_store.is_active(session_id) {
+            return;
+        }
+        let request = ExecuteCommandRequest {
+            name: "goal".to_string(),
+            arguments: Some(GOAL_EVALUATE_ARG.to_string()),
+            controls: None,
+        };
+        let result = match self
+            .handles
+            .runtime
+            .execute_command(session_id, request)
+            .await
+        {
+            Ok(result) => result,
+            Err(err) => {
+                self.push_system(format!("goal evaluation failed: {err}"));
+                return;
+            }
+        };
+        if !result.success {
+            self.push_system(format!("goal evaluation failed: {}", result.message));
+            return;
+        }
+        let evaluation = match parse_evaluation_response(&result.message) {
+            Ok(evaluation) => evaluation,
+            Err(err) => {
+                self.push_system(format!("goal evaluation failed: {err}"));
+                return;
+            }
+        };
+        if evaluation.met {
+            self.push_system(format!("goal achieved: {}", evaluation.reason));
+            return;
+        }
+        self.push_system(format!("goal: {}", evaluation.reason));
+        let Some(prompt) = self.goal_store.continuation_prompt(session_id) else {
+            return;
+        };
+        self.push_user(prompt.clone());
+        self.start_turn(prompt);
+    }
+
     /// Dispatch a capability-provided slash command.
     ///
     /// `System` commands execute through `runtime.execute_command` — the
@@ -1237,6 +1323,9 @@ impl App {
                         if !result.message.is_empty() {
                             let prefix = if result.success { "" } else { "error: " };
                             self.push_system(format!("{prefix}{}", result.message));
+                        }
+                        if descriptor.name == "goal" && result.success {
+                            self.maybe_start_goal_turn();
                         }
                     }
                     Err(err) => self.push_system(format!("/{} failed: {err}", descriptor.name)),
@@ -1987,20 +2076,20 @@ mod tests {
     }
 
     #[test]
-    fn chrome_height_reserves_three_expanded_status_rows() {
+    fn chrome_height_reserves_four_expanded_status_rows() {
         assert_eq!(chrome_height(1, StatusLayout::Compact), 5);
-        assert_eq!(chrome_height(1, StatusLayout::Expanded), 7);
+        assert_eq!(chrome_height(1, StatusLayout::Expanded), 8);
         assert_eq!(chrome_height(3, StatusLayout::Compact), 5);
-        assert_eq!(chrome_height(3, StatusLayout::Expanded), 7);
+        assert_eq!(chrome_height(3, StatusLayout::Expanded), 8);
         assert_eq!(chrome_height(4, StatusLayout::Compact), 6);
-        assert_eq!(chrome_height(4, StatusLayout::Expanded), 8);
+        assert_eq!(chrome_height(4, StatusLayout::Expanded), 9);
     }
 
     #[test]
     fn chrome_dimensions_clamp_input_to_visible_frame() {
         assert_eq!(
             chrome_dimensions(7, MAX_INPUT_HEIGHT, StatusLayout::Expanded),
-            (7, 3)
+            (7, 1)
         );
         assert_eq!(
             chrome_dimensions(5, MAX_INPUT_HEIGHT, StatusLayout::Compact),
@@ -2882,6 +2971,7 @@ mod tests {
             hooks_summary: "none".to_string(),
             approval_mode: "normal".to_string(),
             background: None,
+            goal_indicator: None,
         }
     }
 
@@ -5231,7 +5321,7 @@ mod tests {
             status_layout: StatusLayout::Expanded,
             ..view_state_idle()
         };
-        let rows = render_chrome_lines(&state, 180, 7);
+        let rows = render_chrome_lines(&state, 180, 8);
         assert!(
             rows[4].contains("[collapse ↑]")
                 && rows[4].contains("nvidia/nemotron-3-super-120b-a12b")
@@ -5251,19 +5341,24 @@ mod tests {
             "expanded controls row should include effort, approval, and hooks: {:?}",
             rows[5]
         );
-        let session_id_str = state.session_id.to_string();
         assert!(
-            rows[6].contains("42 msgs")
-                && rows[6].contains("tokens 1234")
-                && rows[6].contains("session ")
-                && rows[6].contains('…'),
-            "expanded counts row should include messages, tokens, and shortened session: {:?}",
+            rows[6].contains("goal"),
+            "expanded goal row should be present: {:?}",
             rows[6]
         );
+        let session_id_str = state.session_id.to_string();
         assert!(
-            !rows[6].contains(&session_id_str),
+            rows[7].contains("42 msgs")
+                && rows[7].contains("tokens 1234")
+                && rows[7].contains("session ")
+                && rows[7].contains('…'),
+            "expanded counts row should include messages, tokens, and shortened session: {:?}",
+            rows[7]
+        );
+        assert!(
+            !rows[7].contains(&session_id_str),
             "expanded counts row should not show the full session id: {:?}",
-            rows[6]
+            rows[7]
         );
     }
 
@@ -5273,7 +5368,7 @@ mod tests {
             status_layout: StatusLayout::Expanded,
             ..view_state_idle()
         };
-        let rows = render_chrome_lines_with_input_height(&state, 120, 7, 3);
+        let rows = render_chrome_lines_with_input_height(&state, 120, 8, 3);
         assert!(
             rows[4].contains("[collapse ↑]") && rows[4].contains("provider openai"),
             "expanded model row should remain visible with multiline input: {:?}",
@@ -5285,7 +5380,12 @@ mod tests {
             rows
         );
         assert!(
-            rows[6].contains("3 msgs") && rows[6].contains("tokens n/a"),
+            rows[6].contains("goal"),
+            "expanded goal row should remain visible with multiline input: {:?}",
+            rows
+        );
+        assert!(
+            rows[7].contains("3 msgs") && rows[7].contains("tokens n/a"),
             "expanded counts row should remain visible with multiline input: {:?}",
             rows
         );

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1548,6 +1548,16 @@ fn status_contributions(state: &ViewState) -> Vec<StatusContribution> {
             ],
         ),
         StatusContribution::new(
+            vec![status_field(
+                "goal",
+                state.goal_indicator.clone().unwrap_or_else(|| "—".into()),
+            )],
+            vec![status_field(
+                "goal",
+                state.goal_indicator.clone().unwrap_or_else(|| "—".into()),
+            )],
+        ),
+        StatusContribution::new(
             {
                 let mut compact = vec![status_value(message_count_label(state.lines_count))];
                 if let Some(bg) = background_label(state.background) {

--- a/src/capabilities/goal.rs
+++ b/src/capabilities/goal.rs
@@ -1,0 +1,236 @@
+//! `/goal` — autonomous multi-turn work toward a verifiable completion condition.
+//!
+//! After each agent turn, a separate tool-less evaluator model reads the
+//! transcript and decides whether the condition holds. If not, the host starts
+//! another turn automatically.
+
+use crate::goal::{
+    GOAL_CAPABILITY_ID, GOAL_COMMAND_NAME, GoalCommandOutcome, GoalStore, evaluate_active_goal,
+    evaluation_result_message, format_status, is_goal_evaluate_request,
+};
+use async_trait::async_trait;
+use everruns_core::capabilities::{Capability, CapabilityStatus};
+use everruns_core::command::{
+    CommandArg, CommandDescriptor, CommandExecutionContext, CommandResult, CommandSource,
+    ExecuteCommandRequest,
+};
+use std::sync::Arc;
+
+pub(crate) struct GoalCapability {
+    pub(crate) store: Arc<GoalStore>,
+}
+
+#[async_trait]
+impl Capability for GoalCapability {
+    fn id(&self) -> &str {
+        GOAL_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Goal"
+    }
+
+    fn description(&self) -> &str {
+        "Keep working across turns until a completion condition is met."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("target")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("System")
+    }
+
+    fn commands(&self) -> Vec<CommandDescriptor> {
+        vec![CommandDescriptor {
+            name: GOAL_COMMAND_NAME.to_string(),
+            description: "Set a completion condition and keep working until it is met.".to_string(),
+            source: CommandSource::System,
+            args: vec![CommandArg {
+                name: "condition".to_string(),
+                description: "Verifiable end state, `clear` to stop, or omit for status."
+                    .to_string(),
+                required: false,
+                suggestions: vec![],
+            }],
+        }]
+    }
+
+    async fn execute_command(
+        &self,
+        request: &ExecuteCommandRequest,
+        ctx: &CommandExecutionContext,
+    ) -> everruns_core::Result<CommandResult> {
+        if request.name != GOAL_COMMAND_NAME {
+            return Err(everruns_core::AgentLoopError::config(format!(
+                "{} cannot execute /{}",
+                self.id(),
+                request.name
+            )));
+        }
+
+        if is_goal_evaluate_request(request) {
+            let condition = self.store.active_condition(ctx.session_id).ok_or_else(|| {
+                everruns_core::AgentLoopError::config("no active goal to evaluate")
+            })?;
+            let evaluation = evaluate_active_goal(ctx, &condition).await?;
+            self.store
+                .record_evaluation(ctx.session_id, &evaluation)
+                .map_err(|err| everruns_core::AgentLoopError::config(err.to_string()))?;
+            return Ok(CommandResult {
+                success: true,
+                message: evaluation_result_message(&evaluation),
+                error_code: None,
+                error_fields: None,
+            });
+        }
+
+        let outcome = GoalStore::parse_user_args(request.arguments.as_deref())
+            .map_err(|err| everruns_core::AgentLoopError::config(err.to_string()))?;
+
+        if let GoalCommandOutcome::Status(_) = &outcome {
+            let status = self.store.status(ctx.session_id, None);
+            return Ok(CommandResult {
+                success: true,
+                message: format_status(&status),
+                error_code: None,
+                error_fields: None,
+            });
+        }
+
+        let message = self
+            .store
+            .apply_outcome(ctx.session_id, outcome)
+            .map_err(|err| everruns_core::AgentLoopError::config(err.to_string()))?;
+        Ok(CommandResult {
+            success: true,
+            message,
+            error_code: None,
+            error_fields: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::goal::GOAL_EVALUATE_ARG;
+    use everruns_core::command_host::{
+        CommandHost, CommandTurnContext, SessionCompletion, SessionCompletionError,
+    };
+    use everruns_core::session::{Session, SessionStatus};
+    use everruns_core::typed_id::{HarnessId, SessionId};
+    use std::sync::Mutex;
+
+    fn test_session(session_id: SessionId) -> Session {
+        Session {
+            id: session_id,
+            workspace_id: everruns_core::WorkspaceId::from_uuid(session_id.uuid()),
+            organization_id: everruns_core::DEFAULT_ORG_PUBLIC_ID.to_string(),
+            harness_id: HarnessId::new(),
+            agent_id: None,
+            agent_version_id: None,
+            agent_identity_id: None,
+            owner_principal_id: everruns_core::PrincipalId::from_seed(1),
+            resolved_owner_user_id: None,
+            owner: None,
+            effective_owner: None,
+            title: None,
+            locale: None,
+            preview: None,
+            output_preview: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: vec![],
+            tools: vec![],
+            mcp_servers: Default::default(),
+            system_prompt: None,
+            initial_files: vec![],
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            status: SessionStatus::Started,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            started_at: None,
+            finished_at: None,
+            usage: None,
+            is_pinned: None,
+            active_schedule_count: None,
+            features: vec![],
+            parent_session_id: None,
+            blueprint_id: None,
+            blueprint_config: None,
+        }
+    }
+
+    struct FakeHost {
+        completion: Mutex<String>,
+    }
+
+    #[async_trait]
+    impl CommandHost for FakeHost {
+        async fn turn_context(&self) -> everruns_core::Result<CommandTurnContext> {
+            let session_id = SessionId::new();
+            Ok(CommandTurnContext {
+                session: test_session(session_id),
+                messages: vec![everruns_core::message::Message::user(
+                    "ran cargo test and all tests passed",
+                )],
+                system_prompt: "system".into(),
+                model: "test-model".into(),
+                provider_type: "llmsim".into(),
+                resolved_locale: None,
+            })
+        }
+
+        async fn completion(
+            &self,
+            _request: everruns_core::command_host::SessionCompletionRequest,
+        ) -> std::result::Result<SessionCompletion, SessionCompletionError> {
+            Ok(SessionCompletion {
+                text: self.completion.lock().expect("lock").clone(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn goal_evaluate_marks_goal_achieved() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(GoalStore::open(dir.path().to_path_buf()));
+        let session_id = SessionId::new();
+        store
+            .set_active(session_id, "all tests pass".into())
+            .expect("set");
+
+        let capability = GoalCapability {
+            store: store.clone(),
+        };
+        let host = Arc::new(FakeHost {
+            completion: Mutex::new(
+                r#"{"met": true, "reason": "tests passed in transcript"}"#.into(),
+            ),
+        });
+        let ctx = CommandExecutionContext::new(session_id, host);
+        let result = capability
+            .execute_command(
+                &ExecuteCommandRequest {
+                    name: GOAL_COMMAND_NAME.to_string(),
+                    arguments: Some(GOAL_EVALUATE_ARG.to_string()),
+                    controls: None,
+                },
+                &ctx,
+            )
+            .await
+            .expect("evaluate");
+        assert!(result.success);
+        let evaluation = crate::goal::parse_evaluation_response(&result.message).expect("parse");
+        assert!(evaluation.met);
+        assert!(!store.is_active(session_id));
+    }
+}

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod ast_grep;
 pub(crate) mod background;
 pub(crate) mod client_commands;
 pub(crate) mod config;
+pub(crate) mod goal;
 pub(crate) mod hooks;
 mod host;
 pub(crate) mod memory;
@@ -17,6 +18,7 @@ pub(crate) mod repo_map;
 pub mod skills;
 pub(crate) mod your;
 
+pub(crate) use crate::goal::GOAL_CAPABILITY_ID;
 pub(crate) use approval::{APPROVAL_CAPABILITY_ID, ApprovalCapability};
 pub(crate) use ast_grep::{AST_GREP_CAPABILITY_ID, AstGrepCapability};
 pub(crate) use background::{
@@ -25,6 +27,7 @@ pub(crate) use background::{
 };
 pub(crate) use client_commands::{CLIENT_COMMANDS_CAPABILITY_ID, ClientCommandsCapability};
 pub(crate) use config::{CONFIG_CAPABILITY_ID, ConfigCapability};
+pub(crate) use goal::GoalCapability;
 pub(crate) use hooks::{HOOKS_CAPABILITY_ID, HooksCapability};
 pub(crate) use host::{
     ATTRIBUTION_CAPABILITY_ID, AttributionCapability, CodingBashCapability,

--- a/src/goal.rs
+++ b/src/goal.rs
@@ -1,0 +1,546 @@
+//! Session-scoped `/goal` state and evaluator helpers.
+//!
+//! `/goal` keeps the agent working across turns until a model-evaluated
+//! completion condition holds. The evaluator reads the conversation transcript
+//! (no tools) after each turn, matching the Claude Code pattern.
+
+use anyhow::{Context, Result, bail};
+use everruns_core::command::{CommandExecutionContext, ExecuteCommandRequest};
+use everruns_core::command_host::SessionCompletionRequest;
+use everruns_core::message::Message;
+use everruns_core::typed_id::SessionId;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::RwLock;
+use std::time::{Duration, Instant};
+
+pub(crate) const GOAL_CAPABILITY_ID: &str = "yolop_goal";
+pub(crate) const GOAL_COMMAND_NAME: &str = "goal";
+/// Internal `execute_command` argument — not user-facing.
+pub(crate) const GOAL_EVALUATE_ARG: &str = "\x00evaluate";
+
+pub(crate) const MAX_GOAL_CONDITION_LEN: usize = 4_000;
+
+const GOAL_FILE: &str = "goal.json";
+
+const EVALUATOR_SYSTEM_PROMPT: &str = "\
+You evaluate whether a completion condition is met using only the conversation \
+transcript below. You cannot run commands or read files independently — judge \
+only what the agent has already surfaced in the conversation.\n\
+\n\
+Respond with exactly one JSON object and no other text:\n\
+{\"met\": true|false, \"reason\": \"short explanation\"}\n\
+\n\
+Set `met` to true only when the condition is clearly satisfied from the \
+transcript. Otherwise set `met` to false and explain what is still missing or \
+what the agent should do next.";
+
+const CLEAR_ALIASES: &[&str] = &["clear", "stop", "off", "reset", "none", "cancel"];
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct GoalAchieved {
+    pub condition: String,
+    pub evaluated_turns: u32,
+    pub reason: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct PersistedGoal {
+    pub condition: String,
+    pub active: bool,
+    pub evaluated_turns: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub achieved: Option<GoalAchieved>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct GoalStatus {
+    pub active: Option<PersistedGoal>,
+    pub achieved: Option<GoalAchieved>,
+    pub elapsed: Option<Duration>,
+    pub session_tokens: Option<u64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum GoalCommandOutcome {
+    Set { condition: String },
+    Cleared,
+    Status(GoalStatus),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct GoalEvaluation {
+    pub met: bool,
+    pub reason: String,
+}
+
+struct SessionGoalRuntime {
+    persisted: PersistedGoal,
+    started_at: Instant,
+    pending_turn: bool,
+}
+
+pub(crate) struct GoalStore {
+    session_dir: PathBuf,
+    sessions: RwLock<HashMap<SessionId, SessionGoalRuntime>>,
+}
+
+impl GoalStore {
+    pub(crate) fn open(session_dir: PathBuf) -> Self {
+        Self {
+            session_dir,
+            sessions: RwLock::new(HashMap::new()),
+        }
+    }
+
+    pub(crate) fn load_session(&self, session_id: SessionId) -> Result<()> {
+        let path = self.goal_path(session_id);
+        if !path.is_file() {
+            return Ok(());
+        }
+        let raw = std::fs::read_to_string(&path)
+            .with_context(|| format!("read goal state: {}", path.display()))?;
+        let persisted: PersistedGoal = serde_json::from_str(&raw)
+            .with_context(|| format!("parse goal state: {}", path.display()))?;
+        if persisted.active {
+            let mut sessions = self.sessions.write().expect("goal store lock poisoned");
+            sessions.insert(
+                session_id,
+                SessionGoalRuntime {
+                    persisted,
+                    started_at: Instant::now(),
+                    pending_turn: true,
+                },
+            );
+        }
+        Ok(())
+    }
+
+    pub(crate) fn parse_user_args(arguments: Option<&str>) -> Result<GoalCommandOutcome> {
+        let trimmed = arguments.map(str::trim).unwrap_or_default();
+        if trimmed.is_empty() {
+            return Ok(GoalCommandOutcome::Status(GoalStatus {
+                active: None,
+                achieved: None,
+                elapsed: None,
+                session_tokens: None,
+            }));
+        }
+        if CLEAR_ALIASES
+            .iter()
+            .any(|alias| trimmed.eq_ignore_ascii_case(alias))
+        {
+            return Ok(GoalCommandOutcome::Cleared);
+        }
+        if trimmed.len() > MAX_GOAL_CONDITION_LEN {
+            bail!("goal condition is too long (max {MAX_GOAL_CONDITION_LEN} characters)");
+        }
+        Ok(GoalCommandOutcome::Set {
+            condition: trimmed.to_string(),
+        })
+    }
+
+    pub(crate) fn apply_outcome(
+        &self,
+        session_id: SessionId,
+        outcome: GoalCommandOutcome,
+    ) -> Result<String> {
+        match outcome {
+            GoalCommandOutcome::Set { condition } => {
+                self.set_active(session_id, condition.clone())?;
+                Ok(format!("goal active: {condition}"))
+            }
+            GoalCommandOutcome::Cleared => {
+                self.clear_active(session_id);
+                Ok("goal cleared".into())
+            }
+            GoalCommandOutcome::Status(_) => Ok(String::new()),
+        }
+    }
+
+    pub(crate) fn status(&self, session_id: SessionId, session_tokens: Option<u64>) -> GoalStatus {
+        let sessions = self.sessions.read().expect("goal store lock poisoned");
+        if let Some(runtime) = sessions.get(&session_id) {
+            if runtime.persisted.active {
+                return GoalStatus {
+                    active: Some(runtime.persisted.clone()),
+                    achieved: None,
+                    elapsed: Some(runtime.started_at.elapsed()),
+                    session_tokens,
+                };
+            }
+            if let Some(achieved) = runtime.persisted.achieved.clone() {
+                return GoalStatus {
+                    active: None,
+                    achieved: Some(achieved),
+                    elapsed: None,
+                    session_tokens,
+                };
+            }
+        }
+        GoalStatus {
+            active: None,
+            achieved: None,
+            elapsed: None,
+            session_tokens,
+        }
+    }
+
+    pub(crate) fn set_active(&self, session_id: SessionId, condition: String) -> Result<()> {
+        let mut sessions = self.sessions.write().expect("goal store lock poisoned");
+        sessions.insert(
+            session_id,
+            SessionGoalRuntime {
+                persisted: PersistedGoal {
+                    condition: condition.clone(),
+                    active: true,
+                    evaluated_turns: 0,
+                    last_reason: None,
+                    achieved: None,
+                },
+                started_at: Instant::now(),
+                pending_turn: true,
+            },
+        );
+        drop(sessions);
+        self.persist(session_id)
+    }
+
+    pub(crate) fn clear_active(&self, session_id: SessionId) {
+        let mut sessions = self.sessions.write().expect("goal store lock poisoned");
+        if let Some(runtime) = sessions.get_mut(&session_id) {
+            runtime.persisted.active = false;
+            runtime.pending_turn = false;
+        } else {
+            sessions.remove(&session_id);
+        }
+        drop(sessions);
+        let _ = self.persist(session_id);
+        let path = self.goal_path(session_id);
+        if path.is_file() {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+
+    pub(crate) fn is_active(&self, session_id: SessionId) -> bool {
+        self.sessions
+            .read()
+            .expect("goal store lock poisoned")
+            .get(&session_id)
+            .is_some_and(|runtime| runtime.persisted.active)
+    }
+
+    pub(crate) fn active_condition(&self, session_id: SessionId) -> Option<String> {
+        self.sessions
+            .read()
+            .expect("goal store lock poisoned")
+            .get(&session_id)
+            .filter(|runtime| runtime.persisted.active)
+            .map(|runtime| runtime.persisted.condition.clone())
+    }
+
+    pub(crate) fn take_pending_turn(&self, session_id: SessionId) -> bool {
+        self.sessions
+            .write()
+            .expect("goal store lock poisoned")
+            .get_mut(&session_id)
+            .is_some_and(|runtime| std::mem::take(&mut runtime.pending_turn))
+    }
+
+    pub(crate) fn record_evaluation(
+        &self,
+        session_id: SessionId,
+        evaluation: &GoalEvaluation,
+    ) -> Result<()> {
+        let mut sessions = self.sessions.write().expect("goal store lock poisoned");
+        let Some(runtime) = sessions.get_mut(&session_id) else {
+            return Ok(());
+        };
+        runtime.persisted.evaluated_turns = runtime.persisted.evaluated_turns.saturating_add(1);
+        runtime.persisted.last_reason = Some(evaluation.reason.clone());
+        if evaluation.met {
+            let achieved = GoalAchieved {
+                condition: runtime.persisted.condition.clone(),
+                evaluated_turns: runtime.persisted.evaluated_turns,
+                reason: evaluation.reason.clone(),
+            };
+            runtime.persisted.active = false;
+            runtime.persisted.achieved = Some(achieved);
+            runtime.pending_turn = false;
+        } else {
+            runtime.pending_turn = true;
+        }
+        drop(sessions);
+        self.persist(session_id)
+    }
+
+    pub(crate) fn continuation_prompt(&self, session_id: SessionId) -> Option<String> {
+        let sessions = self.sessions.read().expect("goal store lock poisoned");
+        let runtime = sessions.get(&session_id)?;
+        if !runtime.persisted.active {
+            return None;
+        }
+        let reason = runtime
+            .persisted
+            .last_reason
+            .as_deref()
+            .filter(|value| !value.is_empty())
+            .unwrap_or("keep working toward the goal");
+        Some(format!(
+            "Continue working toward the active goal:\n{}\n\nEvaluator: {}",
+            runtime.persisted.condition, reason
+        ))
+    }
+
+    fn goal_path(&self, _session_id: SessionId) -> PathBuf {
+        self.session_dir.join(GOAL_FILE)
+    }
+
+    fn persist(&self, session_id: SessionId) -> Result<()> {
+        let sessions = self.sessions.read().expect("goal store lock poisoned");
+        let Some(runtime) = sessions.get(&session_id) else {
+            return Ok(());
+        };
+        if !runtime.persisted.active && runtime.persisted.achieved.is_none() {
+            return Ok(());
+        }
+        let path = self.goal_path(session_id);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create goal parent dir: {}", parent.display()))?;
+        }
+        let encoded = serde_json::to_string_pretty(&runtime.persisted)?;
+        std::fs::write(&path, encoded)
+            .with_context(|| format!("write goal state: {}", path.display()))?;
+        Ok(())
+    }
+}
+
+pub(crate) fn format_status(status: &GoalStatus) -> String {
+    if let Some(active) = &status.active {
+        let elapsed = status
+            .elapsed
+            .map(format_duration)
+            .unwrap_or_else(|| "0s".into());
+        let tokens = status
+            .session_tokens
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "—".into());
+        let reason = active
+            .last_reason
+            .as_deref()
+            .filter(|value| !value.is_empty())
+            .map(|value| format!("\nlast evaluation: {value}"))
+            .unwrap_or_default();
+        return format!(
+            "goal active\ncondition: {}\nrunning: {elapsed}\nevaluated turns: {}\nsession tokens: {tokens}{reason}",
+            active.condition, active.evaluated_turns
+        );
+    }
+    if let Some(achieved) = &status.achieved {
+        return format!(
+            "goal achieved\ncondition: {}\nevaluated turns: {}\nreason: {}",
+            achieved.condition, achieved.evaluated_turns, achieved.reason
+        );
+    }
+    "no active goal".into()
+}
+
+fn format_duration(duration: Duration) -> String {
+    let secs = duration.as_secs();
+    if secs < 60 {
+        return format!("{secs}s");
+    }
+    let mins = secs / 60;
+    let rem = secs % 60;
+    if mins < 60 {
+        return format!("{mins}m {rem}s");
+    }
+    let hours = mins / 60;
+    let rem_mins = mins % 60;
+    format!("{hours}h {rem_mins}m")
+}
+
+pub(crate) async fn evaluate_active_goal(
+    ctx: &CommandExecutionContext,
+    condition: &str,
+) -> everruns_core::Result<GoalEvaluation> {
+    let turn = ctx.host.turn_context().await?;
+    let transcript = format_transcript(&turn.messages);
+    let user_prompt =
+        format!("Completion condition:\n{condition}\n\nConversation transcript:\n{transcript}");
+    let completion_request = SessionCompletionRequest {
+        system_prompts: vec![EVALUATOR_SYSTEM_PROMPT.to_string()],
+        messages: vec![Message::user(user_prompt)],
+        controls: None,
+        metadata: std::collections::HashMap::from([(
+            "command".to_string(),
+            "goal_evaluate".to_string(),
+        )]),
+    };
+    let completion = ctx
+        .host
+        .completion(completion_request)
+        .await
+        .map_err(map_completion_error)?;
+    parse_evaluation_response(&completion.text)
+}
+
+fn map_completion_error(
+    error: everruns_core::command_host::SessionCompletionError,
+) -> everruns_core::AgentLoopError {
+    match error {
+        everruns_core::command_host::SessionCompletionError::InvalidRequest(err) => err,
+        everruns_core::command_host::SessionCompletionError::StreamingUnsupported => {
+            everruns_core::AgentLoopError::config("goal evaluator does not support streaming")
+        }
+        everruns_core::command_host::SessionCompletionError::Completion { error, .. } => {
+            everruns_core::AgentLoopError::config(error)
+        }
+    }
+}
+
+fn format_transcript(messages: &[Message]) -> String {
+    if messages.is_empty() {
+        return "(empty)".into();
+    }
+    messages
+        .iter()
+        .filter_map(|message| {
+            let role = match message.role {
+                everruns_core::message::MessageRole::User => "user",
+                everruns_core::message::MessageRole::Agent => "assistant",
+                everruns_core::message::MessageRole::System => "system",
+                everruns_core::message::MessageRole::ToolResult => "tool",
+            };
+            message
+                .text()
+                .map(|text| format!("{role}: {}", text.trim()))
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+pub(crate) fn parse_evaluation_response(text: &str) -> everruns_core::Result<GoalEvaluation> {
+    let trimmed = text.trim();
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) {
+        return parse_evaluation_value(&value);
+    }
+    if let Some(start) = trimmed.find('{')
+        && let Some(end) = trimmed.rfind('}')
+    {
+        let slice = &trimmed[start..=end];
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(slice) {
+            return parse_evaluation_value(&value);
+        }
+    }
+    let met = trimmed.eq_ignore_ascii_case("yes")
+        || trimmed.starts_with("YES")
+        || trimmed.contains("\"met\": true")
+        || trimmed.contains("\"met\":true");
+    Ok(GoalEvaluation {
+        met,
+        reason: trimmed.to_string(),
+    })
+}
+
+fn parse_evaluation_value(value: &serde_json::Value) -> everruns_core::Result<GoalEvaluation> {
+    let met = value
+        .get("met")
+        .and_then(serde_json::Value::as_bool)
+        .ok_or_else(|| {
+            everruns_core::AgentLoopError::config("goal evaluator returned JSON without `met`")
+        })?;
+    let reason = value
+        .get("reason")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    Ok(GoalEvaluation { met, reason })
+}
+
+pub(crate) fn evaluation_result_message(evaluation: &GoalEvaluation) -> String {
+    serde_json::json!({
+        "met": evaluation.met,
+        "reason": evaluation.reason,
+    })
+    .to_string()
+}
+
+pub(crate) fn is_goal_evaluate_request(request: &ExecuteCommandRequest) -> bool {
+    request.name == GOAL_COMMAND_NAME
+        && request
+            .arguments
+            .as_deref()
+            .is_some_and(|args| args == GOAL_EVALUATE_ARG)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_clear_aliases() {
+        for alias in CLEAR_ALIASES {
+            let outcome = GoalStore::parse_user_args(Some(alias)).expect("parse");
+            assert_eq!(outcome, GoalCommandOutcome::Cleared);
+        }
+    }
+
+    #[test]
+    fn parse_set_condition() {
+        let outcome = GoalStore::parse_user_args(Some("all tests pass")).expect("parse");
+        assert_eq!(
+            outcome,
+            GoalCommandOutcome::Set {
+                condition: "all tests pass".into()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_evaluation_json() {
+        let evaluation = parse_evaluation_response(
+            r#"{"met": true, "reason": "cargo test exits 0 in the transcript"}"#,
+        )
+        .expect("parse");
+        assert!(evaluation.met);
+        assert!(evaluation.reason.contains("cargo test"));
+    }
+
+    #[test]
+    fn format_status_active_and_achieved() {
+        let active = format_status(&GoalStatus {
+            active: Some(PersistedGoal {
+                condition: "tests pass".into(),
+                active: true,
+                evaluated_turns: 2,
+                last_reason: Some("still failing".into()),
+                achieved: None,
+            }),
+            achieved: None,
+            elapsed: Some(Duration::from_secs(95)),
+            session_tokens: Some(42),
+        });
+        assert!(active.contains("goal active"));
+        assert!(active.contains("tests pass"));
+        assert!(active.contains("1m 35s"));
+
+        let achieved = format_status(&GoalStatus {
+            active: None,
+            achieved: Some(GoalAchieved {
+                condition: "tests pass".into(),
+                evaluated_turns: 3,
+                reason: "all green".into(),
+            }),
+            elapsed: None,
+            session_tokens: None,
+        });
+        assert!(achieved.contains("goal achieved"));
+        assert!(achieved.contains("all green"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod codex_driver;
 mod config_schema;
 mod config_service;
 mod connectors;
+mod goal;
 mod hooks_config;
 mod host_ui;
 mod into;
@@ -44,6 +45,7 @@ use crossterm::event::{
 };
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 use crossterm::{execute, queue};
+use everruns_core::command::ExecuteCommandRequest;
 use everruns_core::message::MessageRole;
 use everruns_core::typed_id::SessionId;
 use ratatui::backend::CrosstermBackend;
@@ -607,6 +609,7 @@ async fn run_print_mode(runtime: BuiltRuntime, prompt: String) -> Result<()> {
         handles,
         startup,
         model,
+        goal_store,
         ..
     } = runtime;
     let color = io::stdout().is_terminal();
@@ -652,6 +655,102 @@ async fn run_print_mode(runtime: BuiltRuntime, prompt: String) -> Result<()> {
     }
     println!();
 
+    let trimmed = prompt.trim();
+    if let Some(goal_args) = trimmed.strip_prefix("/goal") {
+        return run_print_goal(&handles, &model, &goal_store, goal_args.trim(), color).await;
+    }
+
+    let result = run_print_turn(&handles, &model, trimmed, color).await?;
+    if !result.success {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+async fn run_print_goal(
+    handles: &runtime::RuntimeHandles,
+    model: &runtime::ModelState,
+    goal_store: &goal::GoalStore,
+    arguments: &str,
+    color: bool,
+) -> Result<()> {
+    let session_id = handles.session_id;
+    let request = ExecuteCommandRequest {
+        name: "goal".to_string(),
+        arguments: if arguments.is_empty() {
+            None
+        } else {
+            Some(arguments.to_string())
+        },
+        controls: None,
+    };
+    let result = handles.runtime.execute_command(session_id, request).await?;
+    if !result.message.is_empty() {
+        println!("{}", paint(color, "90", &result.message));
+    }
+    if !result.success {
+        eprintln!("goal command failed: {}", result.message);
+        std::process::exit(1);
+    }
+
+    if !goal_store.take_pending_turn(session_id) {
+        return Ok(());
+    }
+
+    let Some(mut turn_prompt) = goal_store.active_condition(session_id) else {
+        return Ok(());
+    };
+
+    loop {
+        println!();
+        println!("{}", paint(color, "90", &format!("› {turn_prompt}")));
+        let turn = run_print_turn(handles, model, &turn_prompt, color).await?;
+        if !turn.success {
+            std::process::exit(1);
+        }
+        if !goal_store.is_active(session_id) {
+            return Ok(());
+        }
+
+        let evaluation = handles
+            .runtime
+            .execute_command(
+                session_id,
+                ExecuteCommandRequest {
+                    name: "goal".to_string(),
+                    arguments: Some(goal::GOAL_EVALUATE_ARG.to_string()),
+                    controls: None,
+                },
+            )
+            .await?;
+        if !evaluation.success {
+            eprintln!("goal evaluation failed: {}", evaluation.message);
+            std::process::exit(1);
+        }
+        let parsed = goal::parse_evaluation_response(&evaluation.message)?;
+        if parsed.met {
+            println!(
+                "{}",
+                paint(color, "92", &format!("goal achieved: {}", parsed.reason))
+            );
+            return Ok(());
+        }
+        println!(
+            "{}",
+            paint(color, "94", &format!("goal: {}", parsed.reason))
+        );
+        turn_prompt = goal_store
+            .continuation_prompt(session_id)
+            .unwrap_or_else(|| turn_prompt.clone());
+    }
+}
+
+async fn run_print_turn(
+    handles: &runtime::RuntimeHandles,
+    model: &runtime::ModelState,
+    prompt: &str,
+    color: bool,
+) -> Result<everruns_runtime::TurnResult> {
     let before_events = handles.runtime.events().await.map(|e| e.len()).unwrap_or(0);
     let before_msgs = handles
         .runtime
@@ -660,7 +759,7 @@ async fn run_print_mode(runtime: BuiltRuntime, prompt: String) -> Result<()> {
         .map(|m| m.len())
         .unwrap_or(0);
 
-    let input = model.input_message(prompt);
+    let input = model.input_message(prompt.to_string());
     let result = handles.runtime.run_turn(handles.session_id, input).await?;
     let events = handles.runtime.events().await.unwrap_or_default();
     let messages = handles
@@ -703,12 +802,11 @@ async fn run_print_mode(runtime: BuiltRuntime, prompt: String) -> Result<()> {
         result.tool_calls_count
     );
     if !result.success
-        && let Some(err) = result.error
+        && let Some(err) = &result.error
     {
         eprintln!("turn error: {err}");
-        std::process::exit(1);
     }
-    Ok(())
+    Ok(result)
 }
 
 fn print_transcript_line(line: &app::ChatLine, color: bool) {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -12,14 +12,16 @@ use crate::capabilities::{
     BACKGROUND_CAPABILITY_ID, BackgroundCapability, BackgroundRegistry,
     CLIENT_COMMANDS_CAPABILITY_ID, CONFIG_CAPABILITY_ID, ClientCommandsCapability,
     CodingBashCapability, CodingCliEnvironmentCapability, ConfigCapability,
-    ENVIRONMENT_CONTEXT_CAPABILITY_ID, HOOKS_CAPABILITY_ID, HooksCapability,
-    REPO_MAP_CAPABILITY_ID, RepoMapCapability, SETUP_CAPABILITY_ID, SetupCapability,
+    ENVIRONMENT_CONTEXT_CAPABILITY_ID, GOAL_CAPABILITY_ID, GoalCapability, HOOKS_CAPABILITY_ID,
+    HooksCapability, REPO_MAP_CAPABILITY_ID, RepoMapCapability, SETUP_CAPABILITY_ID,
+    SetupCapability,
 };
 use crate::capability_settings::{CapabilityCatalog, apply_capability_settings};
 use crate::connectors::{
     CONNECTORS_CAPABILITY_ID, ConnectionCatalog, ConnectionStore, ConnectorsCapability,
     YolopConnectionResolver, default_connections_path,
 };
+use crate::goal::GoalStore;
 use crate::host_ui::{HostUi, TuiHandle, UiCommand};
 use crate::settings::{Settings, SettingsStore};
 use crate::tools::Workspace;
@@ -1318,6 +1320,8 @@ fn default_coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabi
         // `/btw` — ephemeral side question, answered out-of-band with the
         // session's context (upstream `BtwCapability`).
         AgentCapabilityConfig::new(BTW_CAPABILITY_ID),
+        // `/goal` — keep working across turns until a model-evaluated condition holds.
+        AgentCapabilityConfig::new(GOAL_CAPABILITY_ID),
         // Soft approval: injects spoken-consent guidance for critical actions,
         // tuned by the central `approval_mode` setting (off contributes nothing).
         AgentCapabilityConfig::new(APPROVAL_CAPABILITY_ID),
@@ -1363,6 +1367,7 @@ pub struct BuiltRuntime {
     pub handles: RuntimeHandles,
     pub startup: StartupInfo,
     pub model: ModelState,
+    pub goal_store: Arc<GoalStore>,
     /// Settings store shared with the runtime capabilities. The TUI uses it
     /// to resolve credentials when querying provider models APIs and to show
     /// per-provider connection status in the setup overlay.
@@ -1782,6 +1787,11 @@ pub async fn build_with_options(
     // dispatches it like any other capability command — no bespoke executor
     // needed. yolop owns no `/btw` logic; it only registers and enables it.
     capabilities.register(BtwCapability);
+    let goal_store = Arc::new(GoalStore::open(session_dir.clone()));
+    goal_store.load_session(session_id)?;
+    capabilities.register(GoalCapability {
+        store: goal_store.clone(),
+    });
     // `/setup` (below) is the capability-sourced slash command. It implements
     // `Capability::execute_command` end to end.
     capabilities.register(SetupCapability {
@@ -2000,6 +2010,7 @@ pub async fn build_with_options(
         settings,
         ui_rx,
         background: background_registry,
+        goal_store,
     })
 }
 
@@ -2358,6 +2369,63 @@ mod tests {
             )
             .await
             .expect_err("missing question is rejected");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn goal_command_is_registered_and_sets_active_condition() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+        let built = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Sim,
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            BuildOptions::default(),
+        )
+        .await
+        .expect("build runtime");
+
+        let commands = built
+            .handles
+            .runtime
+            .list_commands(built.handles.session_id)
+            .await
+            .expect("commands");
+        let goal = commands
+            .iter()
+            .find(|c| c.name == "goal")
+            .expect("/goal surfaced in the command registry");
+
+        let result = built
+            .handles
+            .runtime
+            .execute_command(
+                built.handles.session_id,
+                ExecuteCommandRequest {
+                    name: "goal".to_string(),
+                    arguments: Some("cargo test exits 0".to_string()),
+                    controls: None,
+                },
+            )
+            .await
+            .expect("execute /goal");
+        assert!(result.success, "result: {}", result.message);
+        assert!(built.goal_store.is_active(built.handles.session_id));
+        assert!(built.goal_store.take_pending_turn(built.handles.session_id));
+        assert_eq!(
+            built
+                .goal_store
+                .active_condition(built.handles.session_id)
+                .as_deref(),
+            Some("cargo test exits 0")
+        );
+        assert!(
+            goal.description.contains("completion"),
+            "descriptor: {}",
+            goal.description
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `/goal`, modeled on Claude Code's completion-loop command: set a verifiable end condition, and yolop keeps working across turns until a separate tool-less evaluator confirms it from the transcript.

- **`/goal <condition>`** — activate a goal and start a turn immediately
- **`/goal`** — show status (condition, elapsed time, evaluated turns, last reason)
- **`/goal clear`** — stop early (`stop`, `off`, `reset`, `none`, `cancel` aliases)
- **`/clear`** — also clears an active goal
- **TUI** — auto-continues after each turn; shows `◎ goal (N)` in the status bar
- **`--print`** — `yolop -p "/goal <condition>"` runs the loop to completion
- **Resume** — active goals persist in `<session_dir>/goal.json`

Rebased onto latest `main` (includes background-tasks work); status bar shows both `bg` counts and goal indicator.

## SOTA reference

Claude Code `/goal` (v2.1.139+): session-scoped condition, evaluator on a fast model after every turn, transcript-only verification, turn/time bounds expressed in the condition text. See [Claude Code goal docs](https://code.claude.com/docs/en/goal) and [`specs/goal.md`](specs/goal.md).

## Security

- **TM-LLM**: Evaluator uses `CommandHost::completion` (same credential path as `/btw`). Condition capped at 4,000 chars. Evaluator prompt is fixed; user condition is passed as user message content only.
- **TM-FS**: Goal state writes only to `<session_dir>/goal.json` under the existing session folder. No change to write blocklist.
- **TM-BASH / TM-TOOL**: No changes to shell or tool execution paths.
- **Resource exhaustion**: Loop continues only while goal is active; user can `/goal clear` or cancel turns. Turn bounds are evaluator-judged from condition text (Claude Code pattern).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` (454 unit + integration tests)
- [x] `goal_command_is_registered_and_sets_active_condition` runtime test
- [x] `goal_evaluate_marks_goal_achieved` capability unit test
- [x] Offline smoke: `cargo run -- --provider llmsim -p "/goal"` → `no active goal`

## Follow-ups

No follow-ups.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d5a7a1fe-a77b-436e-a657-3f02d1173b76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d5a7a1fe-a77b-436e-a657-3f02d1173b76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

