### PR TITLE
fix(tui): harden layout and text selection

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1005,17 +1005,21 @@ impl App {
 
     fn mouse_is_on_status(&self, mouse: MouseEvent, terminal_area: Rect) -> bool {
         let input_width = terminal_area.width.saturating_sub(2);
-        let input_height = self.input_height(input_width);
-        let chrome = bottom_rect(
+        let layout = app_layout_for_frame(
             terminal_area,
-            chrome_height(input_height, self.status_layout),
+            self.input_height(input_width),
+            self.status_layout,
         );
-        let status_rows = self.status_layout.row_count();
-        if status_rows == 0 || chrome.height < status_rows {
+        if layout.chrome.session_status.height == 0 {
             return false;
         }
-        let status_y = chrome.y + chrome.height.saturating_sub(status_rows);
-        mouse.row >= status_y && mouse.row < status_y.saturating_add(status_rows)
+        mouse.row >= layout.chrome.session_status.y
+            && mouse.row
+                < layout
+                    .chrome
+                    .session_status
+                    .y
+                    .saturating_add(layout.chrome.session_status.height)
     }
 
     fn handle_ctrl_c(&mut self) {
@@ -1884,6 +1888,92 @@ mod tests {
     }
 
     #[test]
+    fn chrome_dimensions_clamp_input_to_visible_frame() {
+        assert_eq!(
+            chrome_dimensions(7, MAX_INPUT_HEIGHT, StatusLayout::Expanded),
+            (7, 3)
+        );
+        assert_eq!(
+            chrome_dimensions(5, MAX_INPUT_HEIGHT, StatusLayout::Compact),
+            (5, 3)
+        );
+        assert_eq!(
+            chrome_dimensions(0, MAX_INPUT_HEIGHT, StatusLayout::Compact),
+            (0, 0)
+        );
+    }
+
+    fn rect_inside(parent: Rect, child: Rect) -> bool {
+        let parent_right = parent.x as u32 + parent.width as u32;
+        let parent_bottom = parent.y as u32 + parent.height as u32;
+        let child_right = child.x as u32 + child.width as u32;
+        let child_bottom = child.y as u32 + child.height as u32;
+        child.x >= parent.x
+            && child.y >= parent.y
+            && child_right <= parent_right
+            && child_bottom <= parent_bottom
+    }
+
+    #[test]
+    fn app_layout_rectangles_stay_inside_frame_across_sizes() {
+        let widths = [0, 1, 2, 4, 8, 16, 40, 120];
+        let heights = [0, 1, 2, 3, 4, 5, 7, 12, 24, 60];
+        let desired_inputs = [0, 1, 2, 3, MAX_INPUT_HEIGHT, MAX_INPUT_HEIGHT + 8];
+        for status_layout in [StatusLayout::Compact, StatusLayout::Expanded] {
+            for width in widths {
+                for height in heights {
+                    for desired_input in desired_inputs {
+                        let frame = Rect {
+                            x: 2,
+                            y: 3,
+                            width,
+                            height,
+                        };
+                        let layout = app_layout_for_frame(frame, desired_input, status_layout);
+                        assert_eq!(layout.frame, frame);
+                        assert!(
+                            rect_inside(frame, layout.transcript),
+                            "transcript escaped frame: {layout:?}"
+                        );
+                        assert!(
+                            rect_inside(frame, layout.chrome.area),
+                            "chrome escaped frame: {layout:?}"
+                        );
+                        assert!(
+                            rect_inside(layout.chrome.area, layout.chrome.preview),
+                            "preview escaped chrome: {layout:?}"
+                        );
+                        assert!(
+                            rect_inside(layout.chrome.area, layout.chrome.message_separator),
+                            "message separator escaped chrome: {layout:?}"
+                        );
+                        assert!(
+                            rect_inside(layout.chrome.area, layout.chrome.input),
+                            "input escaped chrome: {layout:?}"
+                        );
+                        assert!(
+                            rect_inside(layout.chrome.area, layout.chrome.status_separator),
+                            "status separator escaped chrome: {layout:?}"
+                        );
+                        assert!(
+                            rect_inside(layout.chrome.area, layout.chrome.session_status),
+                            "session status escaped chrome: {layout:?}"
+                        );
+                        assert!(
+                            layout.chrome.area.height <= frame.height,
+                            "chrome taller than frame: {layout:?}"
+                        );
+                        assert!(
+                            layout.chrome.input_height <= MAX_INPUT_HEIGHT,
+                            "input height exceeded cap: {layout:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
     fn replayed_events_render_user_assistant_and_tool_lines() {
         let session_id = SessionId::new();
         let user_event = RuntimeEvent::new(
@@ -2541,6 +2631,94 @@ mod tests {
         );
         assert_eq!(lines[0].spans[0].style.fg, Some(TEXT_MUTED));
         assert_eq!(line_content_color(&lines[0]), Some(TEXT_MUTED));
+    }
+
+    #[test]
+    fn markdown_lines_wrap_styled_content_to_available_width() {
+        let width = 32;
+        let mut lines = Vec::new();
+        append_chat_lines(
+            &mut lines,
+            &ChatLine {
+                author: Author::Assistant,
+                text: "Use `very-long-command-name` before continuing with the next operation."
+                    .to_string(),
+            },
+            width,
+        );
+
+        assert!(
+            lines.len() > 1,
+            "styled markdown should wrap into multiple rows: {lines:?}"
+        );
+        assert!(
+            lines.iter().all(|line| line_width(line) <= width),
+            "all rendered rows should fit width {width}: {lines:?}"
+        );
+        assert!(
+            lines
+                .iter()
+                .flat_map(|line| line.spans.iter())
+                .any(|span| span.style.bg == Some(CODE_BG)),
+            "wrapped inline-code spans should keep code styling: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn wrapped_plain_lines_do_not_use_wider_than_view_floor() {
+        let width = 14;
+        let mut lines = Vec::new();
+        append_chat_lines(
+            &mut lines,
+            &ChatLine {
+                author: Author::User,
+                text: "supercalifragilistic".to_string(),
+            },
+            width,
+        );
+
+        assert!(
+            lines.iter().all(|line| line_width(line) <= width),
+            "hard-wrapped rows should fit narrow width {width}: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn rendered_chat_lines_fit_available_width_across_authors() {
+        let chats = [
+            ChatLine {
+                author: Author::User,
+                text: "this is a deliberately long user prompt with one-super-long-token".into(),
+            },
+            ChatLine {
+                author: Author::Assistant,
+                text: "Use `cargo test --all-features` before resizing the terminal again.".into(),
+            },
+            ChatLine {
+                author: Author::Narration,
+                text: "reviewing layout constraints before drawing bottom chrome".into(),
+            },
+            ChatLine {
+                author: Author::Diff,
+                text: "+changed line with a very long path /workspace/src/app/render.rs".into(),
+            },
+            ChatLine {
+                author: Author::ToolDetail,
+                text: "stdout: output with a long uninterrupted token abcdefghijklmnopqrstuvwxyz"
+                    .into(),
+            },
+        ];
+
+        for width in [12, 16, 24, 40, 80] {
+            for chat in &chats {
+                let mut lines = Vec::new();
+                append_chat_lines(&mut lines, chat, width);
+                assert!(
+                    lines.iter().all(|line| line_width(line) <= width),
+                    "rendered line escaped width {width} for {chat:?}: {lines:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -9,21 +9,79 @@ pub(crate) fn draw(f: &mut ratatui::Frame, app: &mut App) {
     let area = f.area();
     // Match `draw_input`: the `> ` prompt consumes two columns.
     let input_width = area.width.saturating_sub(2);
-    let input_height = app.input_height(input_width);
+    let desired_input_height = app.input_height(input_width);
     let state = app.view_state();
-    let chrome_area = bottom_rect(area, chrome_height(input_height, state.status_layout));
-    let transcript_area = Rect {
-        height: area.height.saturating_sub(chrome_area.height),
-        ..area
-    };
+    let layout = TuiLayout::new(area, desired_input_height, state.status_layout);
 
     // Chrome renders the non-input rows; we then layer the input field
     // on top into the chrome-reserved input slot.
-    clear_transcript_viewport(f, transcript_area);
-    draw_recent_transcript(f, transcript_area, app);
-    let input_rect = draw_chrome(f, chrome_area, input_height, &state);
-    draw_input(f, input_rect, app);
+    clear_transcript_viewport(f, layout.transcript);
+    draw_recent_transcript(f, layout.transcript, app);
+    draw_chrome_layout(f, layout.chrome, &state);
+    draw_input(f, layout.chrome.input, app);
     draw_setup_overlay(f, area, app);
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TuiLayout {
+    pub frame: Rect,
+    pub transcript: Rect,
+    pub chrome: ChromeLayout,
+}
+
+impl TuiLayout {
+    pub(crate) fn new(frame: Rect, desired_input_height: u16, status_layout: StatusLayout) -> Self {
+        let (chrome_height, input_height) =
+            chrome_dimensions(frame.height, desired_input_height, status_layout);
+        let chrome_area = bottom_rect(frame, chrome_height);
+        let transcript = Rect {
+            height: frame.height.saturating_sub(chrome_area.height),
+            ..frame
+        };
+        Self {
+            frame,
+            transcript,
+            chrome: ChromeLayout::new(chrome_area, input_height, status_layout),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ChromeLayout {
+    pub area: Rect,
+    pub preview: Rect,
+    pub message_separator: Rect,
+    pub input: Rect,
+    pub status_separator: Rect,
+    pub session_status: Rect,
+    pub input_height: u16,
+}
+
+impl ChromeLayout {
+    pub(crate) fn new(area: Rect, input_height: u16, status_layout: StatusLayout) -> Self {
+        let preview_height = u16::from(input_height == 1);
+        let status_height = u16::from(input_height < 3);
+        let status_rows = status_layout.row_count();
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(preview_height),
+                Constraint::Length(1),
+                Constraint::Length(input_height),
+                Constraint::Length(status_height),
+                Constraint::Length(status_rows),
+            ])
+            .split(area);
+        Self {
+            area,
+            preview: chunks[0],
+            message_separator: chunks[1],
+            input: chunks[2],
+            status_separator: chunks[3],
+            session_status: chunks[4],
+            input_height,
+        }
+    }
 }
 
 pub(crate) fn bottom_rect(area: Rect, height: u16) -> Rect {
@@ -43,6 +101,42 @@ pub(crate) fn chrome_height(input_height: u16, status_layout: StatusLayout) -> u
         .saturating_add(status_separator_height)
         .saturating_add(status_layout.row_count());
     COMPACT_CHROME_HEIGHT.max(input_height.saturating_add(fixed_rows))
+}
+
+pub(crate) fn chrome_dimensions(
+    frame_height: u16,
+    desired_input_height: u16,
+    status_layout: StatusLayout,
+) -> (u16, u16) {
+    if frame_height == 0 {
+        return (0, 0);
+    }
+
+    let desired_input_height = desired_input_height.clamp(1, MAX_INPUT_HEIGHT);
+    let chrome_height = chrome_height(desired_input_height, status_layout).min(frame_height);
+    let mut input_height = desired_input_height.min(chrome_height);
+    while input_height > 1
+        && input_height.saturating_add(chrome_fixed_rows(input_height, status_layout))
+            > chrome_height
+    {
+        input_height -= 1;
+    }
+    (chrome_height, input_height)
+}
+
+pub(crate) fn app_layout_for_frame(
+    frame: Rect,
+    desired_input_height: u16,
+    status_layout: StatusLayout,
+) -> TuiLayout {
+    TuiLayout::new(frame, desired_input_height, status_layout)
+}
+
+fn chrome_fixed_rows(input_height: u16, status_layout: StatusLayout) -> u16 {
+    u16::from(input_height == 1)
+        .saturating_add(1)
+        .saturating_add(u16::from(input_height < 3))
+        .saturating_add(status_layout.row_count())
 }
 
 pub(crate) fn clear_transcript_viewport(f: &mut ratatui::Frame, area: Rect) {
@@ -141,36 +235,27 @@ pub(crate) fn bounded_recent_chat_line(chat: &ChatLine) -> ChatLine {
 /// Snapshot tests call this against a `TestBackend` and ignore the
 /// returned input rect — the buffer's other rows are what they assert
 /// against.
+#[cfg(test)]
 pub(crate) fn draw_chrome(
     f: &mut ratatui::Frame,
     area: Rect,
     input_height: u16,
     state: &ViewState,
 ) -> Rect {
-    let preview_height = u16::from(input_height == 1);
-    let status_height = u16::from(input_height < 3);
-    let status_rows = state.status_layout.row_count();
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(preview_height), // suggestions / stream preview
-            Constraint::Length(1),              // message separator
-            Constraint::Length(input_height),   // input (left to the caller)
-            Constraint::Length(status_height),  // status separator
-            Constraint::Length(status_rows),    // session status
-        ])
-        .split(area);
+    let layout = ChromeLayout::new(area, input_height, state.status_layout);
+    draw_chrome_layout(f, layout, state);
+    layout.input
+}
 
+pub(crate) fn draw_chrome_layout(f: &mut ratatui::Frame, layout: ChromeLayout, state: &ViewState) {
     if state.command_suggestions.is_empty() {
-        draw_stream_preview(f, chunks[0], state);
+        draw_stream_preview(f, layout.preview, state);
     } else {
-        draw_suggestions(f, chunks[0], &state.command_suggestions);
+        draw_suggestions(f, layout.preview, &state.command_suggestions);
     }
-    draw_message_separator(f, chunks[1], state);
-    draw_status_separator(f, chunks[3]);
-    draw_session_status(f, chunks[4], state);
-
-    chunks[2]
+    draw_message_separator(f, layout.message_separator, state);
+    draw_status_separator(f, layout.status_separator);
+    draw_session_status(f, layout.session_status, state);
 }
 
 pub(crate) fn draw_setup_overlay(f: &mut ratatui::Frame, area: Rect, app: &App) {
@@ -728,10 +813,15 @@ pub(crate) fn append_wrapped_styled<'a>(
     let continuation = " ".repeat(first_prefix.chars().count());
     let wrap_width = inner_width
         .saturating_sub(first_prefix.chars().count())
-        .max(20);
+        .max(1);
     let mut emitted = false;
     for raw in text.lines() {
-        let wrapped = textwrap::wrap(raw, wrap_width);
+        let wrapped = textwrap::wrap(
+            raw,
+            textwrap::Options::new(wrap_width)
+                .break_words(true)
+                .word_separator(textwrap::WordSeparator::AsciiSpace),
+        );
         if wrapped.is_empty() {
             let prefix = if emitted {
                 continuation.as_str()
@@ -776,11 +866,16 @@ pub(crate) fn append_wrapped_diff<'a>(
     let continuation = " ".repeat(first_prefix.chars().count());
     let wrap_width = inner_width
         .saturating_sub(first_prefix.chars().count())
-        .max(20);
+        .max(1);
     let mut emitted = false;
     for raw in text.lines() {
         let content_style = diff_line_style(raw);
-        let wrapped = textwrap::wrap(raw, wrap_width);
+        let wrapped = textwrap::wrap(
+            raw,
+            textwrap::Options::new(wrap_width)
+                .break_words(true)
+                .word_separator(textwrap::WordSeparator::AsciiSpace),
+        );
         if wrapped.is_empty() {
             let prefix = if emitted {
                 continuation.as_str()
@@ -838,7 +933,7 @@ pub(crate) fn append_markdown_lines<'a>(
     let continuation = " ".repeat(first_prefix.chars().count());
     let wrap_width = inner_width
         .saturating_sub(first_prefix.chars().count())
-        .max(20);
+        .max(1);
     let mut first = true;
     let mut in_code = false;
 
@@ -876,7 +971,12 @@ pub(crate) fn append_markdown_lines<'a>(
             markdown_text_spans(trimmed)
         };
         let plain = spans_plain_text(&content_spans);
-        let wrapped = textwrap::wrap(&plain, wrap_width);
+        let wrapped = textwrap::wrap(
+            &plain,
+            textwrap::Options::new(wrap_width)
+                .break_words(true)
+                .word_separator(textwrap::WordSeparator::AsciiSpace),
+        );
         if wrapped.is_empty() {
             push_markdown_line(
                 lines,
@@ -888,26 +988,19 @@ pub(crate) fn append_markdown_lines<'a>(
             );
             continue;
         }
-        if content_spans.len() == 1 {
-            let style = content_spans[0].style;
-            for piece in wrapped {
-                push_markdown_line(
-                    lines,
-                    first_prefix,
-                    &continuation,
-                    prefix_style,
-                    &mut first,
-                    vec![Span::styled(piece.into_owned(), style)],
-                );
-            }
-        } else {
+        let mut search_from = 0;
+        for piece in wrapped {
+            let piece = piece.into_owned();
+            let piece_spans =
+                styled_piece_for_wrapped_text(&plain, &content_spans, &piece, &mut search_from)
+                    .unwrap_or_else(|| vec![Span::raw(piece)]);
             push_markdown_line(
                 lines,
                 first_prefix,
                 &continuation,
                 prefix_style,
                 &mut first,
-                content_spans,
+                piece_spans,
             );
         }
     }
@@ -1051,6 +1144,61 @@ pub(crate) fn numbered_marker(text: &str) -> Option<(String, &str)> {
 
 pub(crate) fn spans_plain_text(spans: &[Span]) -> String {
     spans.iter().map(|span| span.content.as_ref()).collect()
+}
+
+pub(crate) fn styled_piece_for_wrapped_text(
+    plain: &str,
+    spans: &[Span],
+    piece: &str,
+    search_from: &mut usize,
+) -> Option<Vec<Span<'static>>> {
+    let offset = plain.get(*search_from..)?.find(piece)?;
+    let start_byte = search_from.saturating_add(offset);
+    let start_char = plain.get(..start_byte)?.chars().count();
+    *search_from = start_byte.saturating_add(piece.len());
+    Some(spans_for_char_range(
+        spans,
+        start_char,
+        piece.chars().count(),
+    ))
+}
+
+pub(crate) fn spans_for_char_range(
+    spans: &[Span],
+    start_char: usize,
+    len_chars: usize,
+) -> Vec<Span<'static>> {
+    if len_chars == 0 {
+        return Vec::new();
+    }
+
+    let end_char = start_char.saturating_add(len_chars);
+    let mut span_start = 0usize;
+    let mut out = Vec::new();
+    for span in spans {
+        let content = span.content.as_ref();
+        let span_len = content.chars().count();
+        let span_end = span_start.saturating_add(span_len);
+        let overlap_start = start_char.max(span_start);
+        let overlap_end = end_char.min(span_end);
+        if overlap_start < overlap_end {
+            let local_start = overlap_start.saturating_sub(span_start);
+            let local_len = overlap_end.saturating_sub(overlap_start);
+            out.push(Span::styled(
+                content
+                    .chars()
+                    .skip(local_start)
+                    .take(local_len)
+                    .collect::<String>(),
+                span.style,
+            ));
+        }
+        span_start = span_end;
+        if span_start >= end_char {
+            break;
+        }
+    }
+    out
 }
 
 pub(crate) fn digit_index(ch: char, len: usize) -> Option<usize> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,8 +40,7 @@ extern crate everruns_integrations_daytona;
 use app::{App, COMPOSER_VIEWPORT_HEIGHT};
 use clap::{Args, Parser, Subcommand};
 use crossterm::event::{
-    DisableMouseCapture, EnableMouseCapture, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags,
-    PushKeyboardEnhancementFlags,
+    KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
 };
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 use crossterm::{execute, queue};
@@ -455,7 +454,6 @@ fn run_command(command: Commands) -> Result<()> {
 async fn run_tui(runtime: BuiltRuntime) -> Result<()> {
     let mut raw_mode = RawModeGuard::new()?;
     let mut keyboard_enhancements = KeyboardEnhancementGuard::new();
-    let mut mouse_capture = MouseCaptureGuard::new();
     let stdout = io::stdout();
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::with_options(
@@ -490,7 +488,6 @@ async fn run_tui(runtime: BuiltRuntime) -> Result<()> {
         tracing::warn!("cursor restore failed: {err:#}");
     }
     drop(terminal);
-    mouse_capture.disable();
     keyboard_enhancements.disable();
     raw_mode.disable()?;
 
@@ -558,33 +555,6 @@ impl Drop for RawModeGuard {
 
 struct KeyboardEnhancementGuard {
     active: bool,
-}
-
-struct MouseCaptureGuard {
-    active: bool,
-}
-
-impl MouseCaptureGuard {
-    fn new() -> Self {
-        let mut stdout = io::stdout();
-        let active = execute!(stdout, EnableMouseCapture).is_ok();
-        Self { active }
-    }
-
-    fn disable(&mut self) {
-        if self.active {
-            let mut stdout = io::stdout();
-            let _ = queue!(stdout, DisableMouseCapture);
-            let _ = stdout.flush();
-            self.active = false;
-        }
-    }
-}
-
-impl Drop for MouseCaptureGuard {
-    fn drop(&mut self) {
-        self.disable();
-    }
 }
 
 impl KeyboardEnhancementGuard {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -31,8 +31,8 @@ use std::time::{Duration, Instant};
 use support::mock_openai::MockOpenAiServer;
 use support::strip_ansi;
 use support::tui_harness::{
-    TuiSpawnOptions, assert_cursor_near_bottom, spawn_tui_llmsim, spawn_tui_llmsim_with,
-    spawn_tui_llmsim_with_settings, wait_for_exit,
+    TuiSpawnOptions, assert_cursor_near_bottom, max_absolute_cursor_position, spawn_tui_llmsim,
+    spawn_tui_llmsim_with, spawn_tui_llmsim_with_settings, wait_for_exit,
 };
 
 fn yolop_binary() -> PathBuf {
@@ -422,6 +422,50 @@ fn tui_survives_slow_cursor_position_reply_after_resize() {
     );
 }
 
+#[test]
+fn tui_resize_with_wrapped_input_keeps_cursor_inside_new_frame() {
+    let mut tui = spawn_tui_llmsim(&yolop_binary());
+    assert!(
+        tui.wait_for_output("type /help", Duration::from_secs(3)),
+        "TUI did not render startup banner: {}",
+        tui.output_text()
+    );
+
+    tui.write_input(
+        b"alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron",
+    );
+    assert!(
+        tui.wait_for_output("omicron", Duration::from_secs(3)),
+        "long draft did not render before resize: {}",
+        tui.output_text()
+    );
+
+    tui.clear_output();
+    tui.resize(32, 10);
+    tui.write_input(b" ");
+    assert!(
+        tui.wait_for_output("[expand", Duration::from_secs(3)),
+        "TUI did not redraw after resize: {}",
+        tui.output_text()
+    );
+
+    let output = tui.output_text();
+    let (max_row, max_col) = max_absolute_cursor_position(output.as_bytes())
+        .unwrap_or_else(|| panic!("missing absolute cursor move after resize: {output:?}"));
+    assert!(
+        max_row <= 10 && max_col <= 32,
+        "cursor moved outside resized frame ({max_row}, {max_col}) for 32x10 output: {output:?}"
+    );
+
+    tui.write_input(b"\x03\x03\x03");
+    let status = tui.wait_or_kill(Duration::from_secs(3));
+    assert!(
+        status.success(),
+        "Ctrl-C should clear the draft and then exit cleanly after resize, got {status:?}: {}",
+        tui.output_text()
+    );
+}
+
 // ratatui 0.30.1 `Terminal::clear` snapshots the cursor with a blocking
 // `CSI 6n` query, and the inline viewport calls `clear` inside
 // `insert_before` — so viewport anchoring, every transcript flush, and exit
@@ -792,6 +836,32 @@ fn tui_double_ctrl_c_exits() {
         "TUI did not render startup banner: {}",
         tui.output_text()
     );
+
+    tui.write_input(b"\x03\x03");
+    let status = tui.wait_or_kill(Duration::from_secs(3));
+    assert!(
+        status.success(),
+        "double Ctrl-C should exit cleanly, got {status:?}: {}",
+        tui.output_text()
+    );
+}
+
+#[test]
+fn tui_startup_does_not_enable_mouse_capture() {
+    let mut tui = spawn_tui_llmsim(&yolop_binary());
+    assert!(
+        tui.wait_for_output("type /help", Duration::from_secs(3)),
+        "TUI did not render startup banner: {}",
+        tui.output_text()
+    );
+
+    let output = tui.output_text();
+    for sequence in ["\x1b[?1000h", "\x1b[?1002h", "\x1b[?1003h", "\x1b[?1006h"] {
+        assert!(
+            !output.contains(sequence),
+            "TUI should leave terminal text selection to the emulator; found mouse capture sequence {sequence:?}: {output:?}"
+        );
+    }
 
     tui.write_input(b"\x03\x03");
     let status = tui.wait_or_kill(Duration::from_secs(3));

--- a/tests/support/tui_harness.rs
+++ b/tests/support/tui_harness.rs
@@ -111,6 +111,11 @@ impl TuiHarness {
         String::from_utf8_lossy(&self.output).into_owned()
     }
 
+    pub fn clear_output(&mut self) {
+        while self.output_rx.try_recv().is_ok() {}
+        self.output.clear();
+    }
+
     fn drain_output(&mut self) {
         while let Ok(chunk) = self.output_rx.try_recv() {
             self.output.extend_from_slice(&chunk);
@@ -278,7 +283,11 @@ pub fn assert_cursor_near_bottom(tui: &mut TuiHarness, rows: u16) {
 }
 
 pub fn max_absolute_cursor_row(output: &[u8]) -> Option<u16> {
-    let mut row = None;
+    max_absolute_cursor_position(output).map(|(row, _)| row)
+}
+
+pub fn max_absolute_cursor_position(output: &[u8]) -> Option<(u16, u16)> {
+    let mut position = None;
     let mut i = 0;
     while i + 2 < output.len() {
         if output[i] != 0x1b || output[i + 1] != b'[' {
@@ -297,19 +306,29 @@ pub fn max_absolute_cursor_row(output: &[u8]) -> Option<u16> {
         if matches!(final_byte, b'H' | b'f') {
             let params = std::str::from_utf8(&output[start..end]).ok()?;
             if !params.starts_with('?') {
-                let parsed = params
-                    .split(';')
+                let mut parts = params.split(';');
+                let row = parts
                     .next()
                     .filter(|value| !value.is_empty())
                     .unwrap_or("1")
                     .parse::<u16>()
                     .ok();
-                if let Some(parsed) = parsed {
-                    row = Some(row.map_or(parsed, |current: u16| current.max(parsed)));
+                let col = parts
+                    .next()
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or("1")
+                    .parse::<u16>()
+                    .ok();
+                if let (Some(row), Some(col)) = (row, col) {
+                    position = Some(
+                        position.map_or((row, col), |(max_row, max_col): (u16, u16)| {
+                            (max_row.max(row), max_col.max(col))
+                        }),
+                    );
                 }
             }
         }
         i = end + 1;
     }
-    row
+    position
 }


### PR DESCRIPTION
## What
- Centralize TUI frame/chrome/input rectangle calculation in a shared layout snapshot.
- Clamp bottom chrome and composer height to the current terminal frame on every draw.
- Wrap styled transcript lines, long words, diffs, and tool-detail rows to the available width while preserving inline styling.
- Stop enabling global terminal mouse capture so native text selection works in message history.
- Add renderer invariant tests and PTY regressions for resize and mouse-capture behavior.

## Why
The TUI had repeated layout regressions under long text and terminal resize: content could overflow horizontally, bottom chrome could be allocated from stale/oversized dimensions, and global mouse capture prevented normal selection/copy of agent history. These are expensive to catch manually after every PR, so the fix adds automated guardrails around the failure modes.

## How
- Introduced `TuiLayout` and `ChromeLayout` so draw and hit-testing share one frame-derived rectangle calculation.
- Reworked markdown/plain/diff wrapping to use the actual available width instead of a 20-column floor that could exceed narrow terminals.
- Added span slicing for wrapped markdown so inline code styles survive wrapping.
- Removed the `MouseCaptureGuard`; `/status toggle` remains the non-mouse path for changing status layout.
- Extended the PTY harness to clear output and inspect absolute cursor positions after resize.

## Risk
- Medium: this changes terminal rendering and terminal mode setup.
- What can break: narrow terminal rendering, status/chrome placement, and mouse-based status-row toggling. The global mouse-capture removal intentionally prioritizes terminal-native text selection; status layout remains controllable through `/status toggle`.

## Security
Reviewed TM-FS, TM-BASH, TM-LLM, TM-TOOL, and TM-DEP.
- No filesystem, shell execution, prompt/API-key handling, capability registration, or dependency changes.
- No new crates or secret-handling paths.
- The change is limited to TUI layout/rendering and PTY tests.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"`
- `doppler run --project yolop --config ci -- cargo run -- --provider openai -p "Reply with one short sentence."`

## Follow-ups
- Optional: add an explicit mouse mode if status-row clicking is still desired without sacrificing native terminal selection.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
