### PR TITLE
chore: add keywords, categories, authors to crate metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,14 @@
 name = "yolop"
 version = "0.3.0"
 edition = "2024"
+authors = ["Everruns <support@everruns.com>"]
 license = "MIT"
 description = "Yolop — a terminal coding agent built on everruns-runtime"
 homepage = "https://github.com/everruns/yolop"
 repository = "https://github.com/everruns/yolop"
 readme = "README.md"
+keywords = ["cli", "agent", "coding", "terminal", "llm"]
+categories = ["command-line-utilities", "development-tools"]
 # Demo media is for the GitHub README only; keep it out of the crate package.
 exclude = ["/docs"]
 


### PR DESCRIPTION
## What

Add `keywords`, `categories`, and `authors` to the `yolop` crate metadata (`Cargo.toml`).

## Why

Metadata audit across all publishable targets found `yolop` was missing all three discoverability fields. Since the crate is published to crates.io, these matter for search and attribution.

## How

- `keywords = ["cli", "agent", "coding", "terminal", "llm"]`
- `categories = ["command-line-utilities", "development-tools"]` (valid crates.io slugs)
- `authors = ["Everruns <support@everruns.com>"]`

## Tests

- `cargo fmt --check` — clean
- `cargo test --all-features` — 28 pass, 1 ignored
- `cargo verify-project` — manifest valid


---
_Generated by [Claude Code](https://claude.ai/code/session_015TgRkfFz6qEhaiEH2WmbSP)_