### PR TITLE
feat(repo-map): add multi-language symbol map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4065,6 +4065,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -4373,6 +4374,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "strsim"
@@ -5044,6 +5051,136 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.26.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dab76d0b724ba557954125188cf0633a1ca43199ced82d95c7b9c32cc3de1f3"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-bash"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5ec769279cc91b561d3df0d8a5deb26b0ad40d183127f409494d6d8fc53062"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-c-sharp"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1aac67f1ad71de1d6d39708d34811081c26dfa495658de6c14c34200849357c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-css"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5cbc5e18f29a2c6d6435891f42569525cf95435a3e01c2f1947abcde178686f"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-go"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-html"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261b708e5d92061ede329babaaa427b819329a9d427a1d710abb0f67bbef63ee"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-javascript"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-sequel"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d198ad3c319c02e43c21efa1ec796b837afcb96ffaef1a40c1978fbdcec7d17"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-zig"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab11fc124851b0db4dd5e55983bbd9631192e93238389dcd44521715e5d53e28"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]
@@ -5925,6 +6062,18 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
+ "tree-sitter",
+ "tree-sitter-bash",
+ "tree-sitter-c-sharp",
+ "tree-sitter-css",
+ "tree-sitter-go",
+ "tree-sitter-html",
+ "tree-sitter-javascript",
+ "tree-sitter-python",
+ "tree-sitter-rust",
+ "tree-sitter-sequel",
+ "tree-sitter-typescript",
+ "tree-sitter-zig",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,18 @@ toml = "1"
 textwrap = "0.16"
 tokio = { version = "1.50", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
+tree-sitter = "0.26"
+tree-sitter-bash = "0.25"
+tree-sitter-c-sharp = "0.23"
+tree-sitter-css = "0.25"
+tree-sitter-go = "0.25"
+tree-sitter-html = "0.23"
+tree-sitter-javascript = "0.25"
+tree-sitter-python = "0.25"
+tree-sitter-rust = "0.24"
+tree-sitter-sequel = "0.3"
+tree-sitter-typescript = "0.23"
+tree-sitter-zig = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
 
 - **Filesystem** — `read_file`, `write_file`, `edit_file`, `list_directory`,
   `grep_files`, `delete_file`, `stat_file`, backed by the real workspace disk.
+- **Repo map** — `repo_map` and `repo_symbols` build an on-demand
+  multi-language symbol overview for broad codebase orientation before
+  targeted grep/read.
 - **Shell** — `bash -lc` from the workspace root, with a 120 s wall-clock
   timeout and per-stream 1 MiB output cap; large output is spilled to disk
   under the session folder and stays readable for model tool calls. Use

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -11,6 +11,7 @@ mod host;
 pub(crate) mod memory;
 pub(crate) mod model_discovery;
 pub(crate) mod model_ranking;
+pub(crate) mod repo_map;
 pub mod skills;
 pub(crate) mod your;
 
@@ -23,3 +24,4 @@ pub(crate) use host::{
     CodingCliEnvironmentCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID, SETUP_CAPABILITY_ID,
     SetupCapability,
 };
+pub(crate) use repo_map::{REPO_MAP_CAPABILITY_ID, RepoMapCapability};

--- a/src/capabilities/repo_map.rs
+++ b/src/capabilities/repo_map.rs
@@ -1,0 +1,1293 @@
+//! On-demand symbol maps for broad repository orientation.
+//!
+//! This capability is intentionally read-only and scan-on-demand. Grep/read
+//! remain the hot path; repo-map gives the model a compact structural view when
+//! lexical search is too narrow.
+
+use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
+use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use serde::Serialize;
+use serde_json::{Value, json};
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+use tree_sitter::{Language, Node, Parser};
+
+pub(crate) const REPO_MAP_CAPABILITY_ID: &str = "repo_map";
+
+const DEFAULT_LIMIT: usize = 200;
+const MAX_LIMIT: usize = 1000;
+const DEFAULT_MAX_FILE_BYTES: usize = 512 * 1024;
+const MAX_FILE_BYTES: usize = 2 * 1024 * 1024;
+const MAX_SIGNATURE_CHARS: usize = 180;
+const SKIP_DIRS: &[&str] = &[
+    ".git",
+    ".hg",
+    ".svn",
+    "target",
+    "node_modules",
+    ".next",
+    "dist",
+    "build",
+    ".direnv",
+    ".venv",
+    "venv",
+];
+
+#[derive(Clone)]
+pub(crate) struct RepoMapCapability {
+    workspace_root: PathBuf,
+}
+
+impl RepoMapCapability {
+    pub(crate) fn new(workspace_root: PathBuf) -> Self {
+        Self { workspace_root }
+    }
+}
+
+#[async_trait]
+impl Capability for RepoMapCapability {
+    fn id(&self) -> &str {
+        REPO_MAP_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Repo Map"
+    }
+
+    fn description(&self) -> &str {
+        "Read-only, on-demand multi-language symbol map for broad codebase orientation."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Code Navigation")
+    }
+
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        Some(
+            "<capability id=\"repo_map\">\n\
+             For broad codebase orientation, call `repo_map` or `repo_symbols` to get an \
+             on-demand symbol overview. Use grep/read for exact text and implementation \
+             details; the map is structural context, not a replacement for reading code.\n\
+             </capability>"
+                .to_string(),
+        )
+    }
+
+    fn system_prompt_preview(&self) -> Option<String> {
+        Some(
+            "<capability id=\"repo_map\">\n\
+             Use `repo_map` / `repo_symbols` for on-demand multi-language symbol overviews.\n\
+             </capability>"
+                .to_string(),
+        )
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(RepoMapTool {
+                workspace_root: self.workspace_root.clone(),
+            }),
+            Box::new(RepoSymbolsTool {
+                workspace_root: self.workspace_root.clone(),
+            }),
+        ]
+    }
+}
+
+struct RepoMapTool {
+    workspace_root: PathBuf,
+}
+
+#[async_trait]
+impl Tool for RepoMapTool {
+    fn name(&self) -> &str {
+        "repo_map"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Repo map")
+    }
+
+    fn description(&self) -> &str {
+        "Build a compact, grouped multi-language symbol map for the workspace or a subpath. \
+         Use this for broad orientation before targeted grep/read."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        scan_schema(
+            "Optional case-insensitive filter matched against path, name, kind, parent, and signature.",
+        )
+    }
+
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        match scan_from_arguments(&self.workspace_root, &arguments) {
+            Ok(report) => ToolExecutionResult::success(json!({
+                "ok": true,
+                "workspace_root": self.workspace_root.display().to_string(),
+                "path": report.path,
+                "query": report.query,
+                "languages": report.languages,
+                "count": report.symbols.len(),
+                "scanned_files": report.scanned_files,
+                "skipped_unsupported_files": report.skipped_unsupported_files,
+                "skipped_files": report.skipped_files,
+                "skipped_large_files": report.skipped_large_files,
+                "parse_error_files": report.parse_error_files,
+                "truncated": report.truncated,
+                "files": grouped_symbols(&report.symbols),
+            })),
+            Err(err) => ToolExecutionResult::tool_error(err.to_string()),
+        }
+    }
+}
+
+struct RepoSymbolsTool {
+    workspace_root: PathBuf,
+}
+
+#[async_trait]
+impl Tool for RepoSymbolsTool {
+    fn name(&self) -> &str {
+        "repo_symbols"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Repo symbols")
+    }
+
+    fn description(&self) -> &str {
+        "Return a flat list of symbols from the workspace or a subpath, optionally \
+         filtered by query. Use when you need specific symbol candidates."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        scan_schema(
+            "Optional case-insensitive filter matched against path, name, kind, parent, and signature.",
+        )
+    }
+
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        match scan_from_arguments(&self.workspace_root, &arguments) {
+            Ok(report) => ToolExecutionResult::success(json!({
+                "ok": true,
+                "workspace_root": self.workspace_root.display().to_string(),
+                "path": report.path,
+                "query": report.query,
+                "languages": report.languages,
+                "count": report.symbols.len(),
+                "scanned_files": report.scanned_files,
+                "skipped_unsupported_files": report.skipped_unsupported_files,
+                "skipped_files": report.skipped_files,
+                "skipped_large_files": report.skipped_large_files,
+                "parse_error_files": report.parse_error_files,
+                "truncated": report.truncated,
+                "symbols": report.symbols,
+            })),
+            Err(err) => ToolExecutionResult::tool_error(err.to_string()),
+        }
+    }
+}
+
+fn scan_schema(query_description: &str) -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": "Optional workspace-relative file or directory to scan. Defaults to the workspace root."
+            },
+            "query": {
+                "type": "string",
+                "description": query_description
+            },
+            "language": {
+                "type": "string",
+                "description": "Optional language filter. Supported values include rust, python, typescript, tsx, javascript, csharp, go, zig, css, html, bash, and sql."
+            },
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": MAX_LIMIT,
+                "description": "Maximum number of matching symbols to return. Defaults to 200."
+            },
+            "max_file_bytes": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": MAX_FILE_BYTES,
+                "description": "Skip Rust files larger than this many bytes. Defaults to 524288."
+            }
+        },
+        "additionalProperties": false
+    })
+}
+
+fn scan_from_arguments(workspace_root: &Path, arguments: &Value) -> Result<SymbolScanReport> {
+    let path = arguments
+        .get("path")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .map(str::to_string);
+    let query = arguments
+        .get("query")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|query| !query.is_empty())
+        .map(str::to_string);
+    let language = arguments
+        .get("language")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|language| !language.is_empty())
+        .map(str::to_string);
+    let limit = bounded_usize(arguments, "limit", DEFAULT_LIMIT, MAX_LIMIT)?;
+    let max_file_bytes = bounded_usize(
+        arguments,
+        "max_file_bytes",
+        DEFAULT_MAX_FILE_BYTES,
+        MAX_FILE_BYTES,
+    )?;
+
+    collect_repo_symbols(
+        workspace_root,
+        SymbolScanOptions {
+            path,
+            query,
+            language,
+            limit,
+            max_file_bytes,
+        },
+    )
+}
+
+fn bounded_usize(arguments: &Value, key: &str, default: usize, max: usize) -> Result<usize> {
+    let Some(raw) = arguments.get(key) else {
+        return Ok(default);
+    };
+    let Some(value) = raw.as_u64() else {
+        bail!("`{key}` must be a positive integer");
+    };
+    if value == 0 || value as usize > max {
+        bail!("`{key}` must be between 1 and {max}");
+    }
+    Ok(value as usize)
+}
+
+#[derive(Clone, Debug)]
+struct SymbolScanOptions {
+    path: Option<String>,
+    query: Option<String>,
+    language: Option<String>,
+    limit: usize,
+    max_file_bytes: usize,
+}
+
+#[derive(Clone, Debug)]
+struct SymbolScanReport {
+    path: String,
+    query: Option<String>,
+    languages: Vec<String>,
+    scanned_files: usize,
+    skipped_unsupported_files: usize,
+    skipped_files: usize,
+    skipped_large_files: usize,
+    parse_error_files: usize,
+    truncated: bool,
+    symbols: Vec<RepoSymbol>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+struct RepoSymbol {
+    path: String,
+    language: String,
+    kind: String,
+    name: String,
+    parent: Option<String>,
+    visibility: Option<String>,
+    signature: String,
+    line: usize,
+    column: usize,
+}
+
+#[derive(Serialize)]
+struct SymbolFileGroup<'a> {
+    path: &'a str,
+    symbols: Vec<&'a RepoSymbol>,
+}
+
+fn collect_repo_symbols(
+    workspace_root: &Path,
+    options: SymbolScanOptions,
+) -> Result<SymbolScanReport> {
+    let root = workspace_root
+        .canonicalize()
+        .with_context(|| format!("canonicalize workspace root {}", workspace_root.display()))?;
+    let scope = resolve_scope(&root, options.path.as_deref())?;
+    let language_filter = options.language.as_deref().map(normalize_language_filter);
+    if let Some(filter) = language_filter.as_deref()
+        && !LANGUAGES
+            .iter()
+            .any(|language| language.matches_filter(filter))
+    {
+        bail!("unsupported language `{filter}`");
+    }
+    let mut files = Vec::new();
+    let mut skipped_unsupported_files = 0;
+    collect_supported_files(
+        &scope,
+        language_filter.as_deref(),
+        &mut files,
+        &mut skipped_unsupported_files,
+    )?;
+    files.sort_by(|a, b| a.path.cmp(&b.path));
+
+    let query = options.query.as_ref().map(|query| query.to_lowercase());
+    let mut report = SymbolScanReport {
+        path: relative_path(&root, &scope),
+        query: options.query,
+        languages: Vec::new(),
+        scanned_files: 0,
+        skipped_unsupported_files,
+        skipped_files: 0,
+        skipped_large_files: 0,
+        parse_error_files: 0,
+        truncated: false,
+        symbols: Vec::new(),
+    };
+
+    let mut parser = Parser::new();
+
+    for file in files {
+        if report.truncated {
+            break;
+        }
+        let metadata = match fs::metadata(&file.path) {
+            Ok(metadata) => metadata,
+            Err(_) => {
+                report.skipped_files += 1;
+                continue;
+            }
+        };
+        if metadata.len() as usize > options.max_file_bytes {
+            report.skipped_large_files += 1;
+            continue;
+        }
+        let source = match fs::read_to_string(&file.path) {
+            Ok(source) => source,
+            Err(_) => {
+                report.skipped_files += 1;
+                continue;
+            }
+        };
+        parser
+            .set_language(&file.language.language())
+            .with_context(|| format!("load {} tree-sitter grammar", file.language.name))?;
+        report.scanned_files += 1;
+        let Some(tree) = parser.parse(&source, None) else {
+            report.parse_error_files += 1;
+            continue;
+        };
+        if tree.root_node().has_error() {
+            report.parse_error_files += 1;
+        }
+        if !report
+            .languages
+            .iter()
+            .any(|language| language == file.language.name)
+        {
+            report.languages.push(file.language.name.to_string());
+        }
+        let path = relative_path(&root, &file.path);
+        let mut parents = Vec::new();
+        let context = SymbolCollectContext {
+            source: &source,
+            path: &path,
+            language: file.language,
+            query: query.as_deref(),
+            limit: options.limit,
+        };
+        collect_symbols_from_node(tree.root_node(), &context, &mut parents, &mut report);
+    }
+
+    Ok(report)
+}
+
+#[derive(Clone)]
+struct SourceFile {
+    path: PathBuf,
+    language: &'static LanguageSpec,
+}
+
+struct LanguageSpec {
+    name: &'static str,
+    aliases: &'static [&'static str],
+    extensions: &'static [&'static str],
+    filenames: &'static [&'static str],
+    grammar: fn() -> Language,
+    symbol_kinds: &'static [KindMap],
+    parent_kinds: &'static [&'static str],
+}
+
+impl LanguageSpec {
+    fn language(&self) -> Language {
+        (self.grammar)()
+    }
+
+    fn matches_filter(&self, filter: &str) -> bool {
+        self.name == filter || self.aliases.contains(&filter)
+    }
+
+    fn symbol_kind(&self, node_kind: &str) -> Option<&'static str> {
+        self.symbol_kinds
+            .iter()
+            .find(|kind| kind.node == node_kind)
+            .map(|kind| kind.kind)
+    }
+
+    fn is_parent_kind(&self, node_kind: &str) -> bool {
+        self.parent_kinds.contains(&node_kind)
+    }
+}
+
+struct KindMap {
+    node: &'static str,
+    kind: &'static str,
+}
+
+const fn kind(node: &'static str, kind: &'static str) -> KindMap {
+    KindMap { node, kind }
+}
+
+fn rust_language() -> Language {
+    tree_sitter_rust::LANGUAGE.into()
+}
+
+fn python_language() -> Language {
+    tree_sitter_python::LANGUAGE.into()
+}
+
+fn javascript_language() -> Language {
+    tree_sitter_javascript::LANGUAGE.into()
+}
+
+fn typescript_language() -> Language {
+    tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()
+}
+
+fn tsx_language() -> Language {
+    tree_sitter_typescript::LANGUAGE_TSX.into()
+}
+
+fn csharp_language() -> Language {
+    tree_sitter_c_sharp::LANGUAGE.into()
+}
+
+fn go_language() -> Language {
+    tree_sitter_go::LANGUAGE.into()
+}
+
+fn zig_language() -> Language {
+    tree_sitter_zig::LANGUAGE.into()
+}
+
+fn css_language() -> Language {
+    tree_sitter_css::LANGUAGE.into()
+}
+
+fn html_language() -> Language {
+    tree_sitter_html::LANGUAGE.into()
+}
+
+fn bash_language() -> Language {
+    tree_sitter_bash::LANGUAGE.into()
+}
+
+fn sql_language() -> Language {
+    tree_sitter_sequel::LANGUAGE.into()
+}
+
+const RUST_KINDS: &[KindMap] = &[
+    kind("const_item", "const"),
+    kind("enum_item", "enum"),
+    kind("function_item", "function"),
+    kind("function_signature_item", "function_signature"),
+    kind("impl_item", "impl"),
+    kind("macro_definition", "macro"),
+    kind("mod_item", "module"),
+    kind("static_item", "static"),
+    kind("struct_item", "struct"),
+    kind("trait_item", "trait"),
+    kind("type_item", "type"),
+];
+
+const PYTHON_KINDS: &[KindMap] = &[
+    kind("class_definition", "class"),
+    kind("function_definition", "function"),
+];
+
+const JS_KINDS: &[KindMap] = &[
+    kind("class_declaration", "class"),
+    kind("function_declaration", "function"),
+    kind("generator_function_declaration", "function"),
+    kind("method_definition", "method"),
+];
+
+const TS_KINDS: &[KindMap] = &[
+    kind("abstract_class_declaration", "class"),
+    kind("class_declaration", "class"),
+    kind("enum_declaration", "enum"),
+    kind("function_declaration", "function"),
+    kind("generator_function_declaration", "function"),
+    kind("interface_declaration", "interface"),
+    kind("internal_module", "module"),
+    kind("method_definition", "method"),
+    kind("type_alias_declaration", "type"),
+];
+
+const CSHARP_KINDS: &[KindMap] = &[
+    kind("class_declaration", "class"),
+    kind("constructor_declaration", "constructor"),
+    kind("delegate_declaration", "delegate"),
+    kind("enum_declaration", "enum"),
+    kind("interface_declaration", "interface"),
+    kind("method_declaration", "method"),
+    kind("namespace_declaration", "namespace"),
+    kind("property_declaration", "property"),
+    kind("record_declaration", "record"),
+    kind("struct_declaration", "struct"),
+];
+
+const GO_KINDS: &[KindMap] = &[
+    kind("function_declaration", "function"),
+    kind("method_declaration", "method"),
+    kind("type_declaration", "type"),
+];
+
+const ZIG_KINDS: &[KindMap] = &[
+    kind("enum_declaration", "enum"),
+    kind("function_declaration", "function"),
+    kind("struct_declaration", "struct"),
+    kind("variable_declaration", "variable"),
+];
+
+const CSS_KINDS: &[KindMap] = &[
+    kind("import_statement", "import"),
+    kind("keyframes_statement", "keyframes"),
+    kind("rule_set", "selector"),
+];
+
+const HTML_KINDS: &[KindMap] = &[kind("element", "element"), kind("script_element", "script")];
+
+const BASH_KINDS: &[KindMap] = &[kind("function_definition", "function")];
+
+const SQL_KINDS: &[KindMap] = &[
+    kind("create_database", "database"),
+    kind("create_extension", "extension"),
+    kind("create_function", "function"),
+    kind("create_index", "index"),
+    kind("create_materialized_view", "view"),
+    kind("create_schema", "schema"),
+    kind("create_sequence", "sequence"),
+    kind("create_table", "table"),
+    kind("create_trigger", "trigger"),
+    kind("create_type", "type"),
+    kind("create_view", "view"),
+    kind("function_declaration", "function"),
+];
+
+static LANGUAGES: &[LanguageSpec] = &[
+    LanguageSpec {
+        name: "rust",
+        aliases: &["rs"],
+        extensions: &["rs"],
+        filenames: &[],
+        grammar: rust_language,
+        symbol_kinds: RUST_KINDS,
+        parent_kinds: &["impl_item", "mod_item", "trait_item"],
+    },
+    LanguageSpec {
+        name: "python",
+        aliases: &["py"],
+        extensions: &["py", "pyi"],
+        filenames: &[],
+        grammar: python_language,
+        symbol_kinds: PYTHON_KINDS,
+        parent_kinds: &["class_definition"],
+    },
+    LanguageSpec {
+        name: "typescript",
+        aliases: &["ts"],
+        extensions: &["ts", "mts", "cts"],
+        filenames: &[],
+        grammar: typescript_language,
+        symbol_kinds: TS_KINDS,
+        parent_kinds: &[
+            "abstract_class_declaration",
+            "class_declaration",
+            "interface_declaration",
+            "internal_module",
+        ],
+    },
+    LanguageSpec {
+        name: "tsx",
+        aliases: &[],
+        extensions: &["tsx"],
+        filenames: &[],
+        grammar: tsx_language,
+        symbol_kinds: TS_KINDS,
+        parent_kinds: &[
+            "abstract_class_declaration",
+            "class_declaration",
+            "interface_declaration",
+            "internal_module",
+        ],
+    },
+    LanguageSpec {
+        name: "javascript",
+        aliases: &["js", "jsx"],
+        extensions: &["js", "jsx", "mjs", "cjs"],
+        filenames: &[],
+        grammar: javascript_language,
+        symbol_kinds: JS_KINDS,
+        parent_kinds: &["class_declaration"],
+    },
+    LanguageSpec {
+        name: "csharp",
+        aliases: &["c#", "cs"],
+        extensions: &["cs"],
+        filenames: &[],
+        grammar: csharp_language,
+        symbol_kinds: CSHARP_KINDS,
+        parent_kinds: &[
+            "class_declaration",
+            "interface_declaration",
+            "namespace_declaration",
+            "record_declaration",
+            "struct_declaration",
+        ],
+    },
+    LanguageSpec {
+        name: "go",
+        aliases: &["golang"],
+        extensions: &["go"],
+        filenames: &[],
+        grammar: go_language,
+        symbol_kinds: GO_KINDS,
+        parent_kinds: &[],
+    },
+    LanguageSpec {
+        name: "zig",
+        aliases: &["zed"],
+        extensions: &["zig", "zon"],
+        filenames: &[],
+        grammar: zig_language,
+        symbol_kinds: ZIG_KINDS,
+        parent_kinds: &["struct_declaration", "enum_declaration"],
+    },
+    LanguageSpec {
+        name: "css",
+        aliases: &[],
+        extensions: &["css"],
+        filenames: &[],
+        grammar: css_language,
+        symbol_kinds: CSS_KINDS,
+        parent_kinds: &[],
+    },
+    LanguageSpec {
+        name: "html",
+        aliases: &["htm"],
+        extensions: &["html", "htm"],
+        filenames: &[],
+        grammar: html_language,
+        symbol_kinds: HTML_KINDS,
+        parent_kinds: &["element"],
+    },
+    LanguageSpec {
+        name: "bash",
+        aliases: &["sh", "shell"],
+        extensions: &["bash", "sh", "zsh"],
+        filenames: &[".bashrc", ".bash_profile", ".zshrc", "bashrc", "zshrc"],
+        grammar: bash_language,
+        symbol_kinds: BASH_KINDS,
+        parent_kinds: &[],
+    },
+    LanguageSpec {
+        name: "sql",
+        aliases: &[],
+        extensions: &["sql"],
+        filenames: &[],
+        grammar: sql_language,
+        symbol_kinds: SQL_KINDS,
+        parent_kinds: &[],
+    },
+];
+
+fn normalize_language_filter(language: &str) -> String {
+    language.trim().to_ascii_lowercase()
+}
+
+fn resolve_scope(root: &Path, path: Option<&str>) -> Result<PathBuf> {
+    let Some(path) = path else {
+        return Ok(root.to_path_buf());
+    };
+    let relative = path.trim_start_matches('/');
+    let candidate = Path::new(relative);
+    if candidate.components().any(|component| {
+        matches!(
+            component,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        )
+    }) {
+        bail!("`path` must stay inside the workspace");
+    }
+    let scope = root.join(candidate);
+    let canonical = scope
+        .canonicalize()
+        .with_context(|| format!("path not found: {path}"))?;
+    if !canonical.starts_with(root) {
+        bail!("`path` must stay inside the workspace");
+    }
+    Ok(canonical)
+}
+
+fn collect_supported_files(
+    path: &Path,
+    language_filter: Option<&str>,
+    files: &mut Vec<SourceFile>,
+    skipped_unsupported_files: &mut usize,
+) -> Result<()> {
+    if path.is_file() {
+        match language_for_path(path, language_filter) {
+            Some(language) => files.push(SourceFile {
+                path: path.to_path_buf(),
+                language,
+            }),
+            None => *skipped_unsupported_files += 1,
+        }
+        return Ok(());
+    }
+    if !path.is_dir() {
+        return Ok(());
+    }
+
+    let mut entries = fs::read_dir(path)
+        .with_context(|| format!("read directory {}", path.display()))?
+        .collect::<std::io::Result<Vec<_>>>()
+        .with_context(|| format!("read directory entries for {}", path.display()))?;
+    entries.sort_by_key(|entry| entry.path());
+
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            if path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| SKIP_DIRS.contains(&name))
+            {
+                continue;
+            }
+            collect_supported_files(&path, language_filter, files, skipped_unsupported_files)?;
+        } else {
+            match language_for_path(&path, language_filter) {
+                Some(language) => files.push(SourceFile { path, language }),
+                None => *skipped_unsupported_files += 1,
+            }
+        }
+    }
+    Ok(())
+}
+
+fn language_for_path(path: &Path, language_filter: Option<&str>) -> Option<&'static LanguageSpec> {
+    let file_name = path.file_name().and_then(|name| name.to_str())?;
+    let extension = path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(str::to_ascii_lowercase);
+    LANGUAGES.iter().find(|language| {
+        language_filter.is_none_or(|filter| language.matches_filter(filter))
+            && (language.filenames.contains(&file_name)
+                || extension
+                    .as_deref()
+                    .is_some_and(|extension| language.extensions.contains(&extension)))
+    })
+}
+
+struct SymbolCollectContext<'a> {
+    source: &'a str,
+    path: &'a str,
+    language: &'static LanguageSpec,
+    query: Option<&'a str>,
+    limit: usize,
+}
+
+fn collect_symbols_from_node(
+    node: Node<'_>,
+    context: &SymbolCollectContext<'_>,
+    parents: &mut Vec<String>,
+    report: &mut SymbolScanReport,
+) {
+    if report.truncated {
+        return;
+    }
+
+    let symbol = symbol_for_node(
+        node,
+        context.source,
+        context.path,
+        context.language,
+        parents.last().cloned(),
+    );
+    let parent_label = symbol
+        .as_ref()
+        .and_then(|symbol| parent_context_label(symbol, context.language, node.kind()));
+    if let Some(symbol) = symbol
+        && matches_query(&symbol, context.query)
+    {
+        if report.symbols.len() >= context.limit {
+            report.truncated = true;
+            return;
+        }
+        report.symbols.push(symbol);
+    }
+
+    if let Some(label) = parent_label.as_ref() {
+        parents.push(label.clone());
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_symbols_from_node(child, context, parents, report);
+        if report.truncated {
+            break;
+        }
+    }
+    if parent_label.is_some() {
+        parents.pop();
+    }
+}
+
+fn symbol_for_node(
+    node: Node<'_>,
+    source: &str,
+    path: &str,
+    language: &LanguageSpec,
+    parent: Option<String>,
+) -> Option<RepoSymbol> {
+    let kind = language.symbol_kind(node.kind())?;
+    let name = symbol_name(node, source, language, kind)?;
+    let position = node.start_position();
+    Some(RepoSymbol {
+        path: path.to_string(),
+        language: language.name.to_string(),
+        kind: kind.to_string(),
+        name,
+        parent,
+        visibility: visibility(node, source),
+        signature: signature(node, source),
+        line: position.row + 1,
+        column: position.column + 1,
+    })
+}
+
+fn symbol_name(
+    node: Node<'_>,
+    source: &str,
+    language: &LanguageSpec,
+    kind: &str,
+) -> Option<String> {
+    if kind == "impl" {
+        return Some(impl_name(node, source));
+    }
+    if matches!(kind, "selector" | "import") {
+        return Some(signature_name(node, source));
+    }
+    if language.name == "html" {
+        return descendant_text(node, source, &["tag_name"]).map(str::to_string);
+    }
+    if language.name == "sql" {
+        return descendant_text(
+            node,
+            source,
+            &[
+                "identifier",
+                "object_reference",
+                "function_reference",
+                "table_reference",
+            ],
+        )
+        .map(str::to_string)
+        .or_else(|| Some(signature_name(node, source)));
+    }
+    node.child_by_field_name("name")
+        .and_then(|name| node_text(name, source))
+        .map(str::to_string)
+        .or_else(|| {
+            descendant_text(
+                node,
+                source,
+                &[
+                    "identifier",
+                    "property_identifier",
+                    "type_identifier",
+                    "field_identifier",
+                    "word",
+                ],
+            )
+            .map(str::to_string)
+        })
+}
+
+fn impl_name(node: Node<'_>, source: &str) -> String {
+    let sig = signature(node, source);
+    let without_brace = sig.split('{').next().unwrap_or(&sig).trim();
+    if without_brace.is_empty() {
+        "impl".to_string()
+    } else {
+        without_brace.to_string()
+    }
+}
+
+fn visibility(node: Node<'_>, source: &str) -> Option<String> {
+    let mut cursor = node.walk();
+    node.children(&mut cursor)
+        .find(|child| child.kind() == "visibility_modifier")
+        .and_then(|child| node_text(child, source))
+        .map(str::to_string)
+}
+
+fn signature(node: Node<'_>, source: &str) -> String {
+    let raw = node_text(node, source).unwrap_or_default();
+    let line = raw.lines().next().unwrap_or_default().trim();
+    truncate_chars(line, MAX_SIGNATURE_CHARS)
+}
+
+fn node_text<'a>(node: Node<'_>, source: &'a str) -> Option<&'a str> {
+    source.get(node.byte_range())
+}
+
+fn descendant_text<'a>(node: Node<'_>, source: &'a str, kinds: &[&str]) -> Option<&'a str> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if kinds.contains(&child.kind()) {
+            return node_text(child, source);
+        }
+        if let Some(text) = descendant_text(child, source, kinds) {
+            return Some(text);
+        }
+    }
+    None
+}
+
+fn signature_name(node: Node<'_>, source: &str) -> String {
+    signature(node, source)
+        .split('{')
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .to_string()
+}
+
+fn parent_context_label(
+    symbol: &RepoSymbol,
+    language: &LanguageSpec,
+    node_kind: &str,
+) -> Option<String> {
+    if language.is_parent_kind(node_kind) {
+        if symbol.kind == "impl" {
+            Some(symbol.name.clone())
+        } else {
+            Some(format!("{} {}", symbol.kind, symbol.name))
+        }
+    } else {
+        None
+    }
+}
+
+fn matches_query(symbol: &RepoSymbol, query: Option<&str>) -> bool {
+    let Some(query) = query else {
+        return true;
+    };
+    symbol.path.to_lowercase().contains(query)
+        || symbol.kind.to_lowercase().contains(query)
+        || symbol.name.to_lowercase().contains(query)
+        || symbol.signature.to_lowercase().contains(query)
+        || symbol
+            .parent
+            .as_ref()
+            .is_some_and(|parent| parent.to_lowercase().contains(query))
+}
+
+fn grouped_symbols(symbols: &[RepoSymbol]) -> Vec<SymbolFileGroup<'_>> {
+    let mut groups = Vec::new();
+    let mut index = 0;
+    while index < symbols.len() {
+        let path = symbols[index].path.as_str();
+        let mut group = SymbolFileGroup {
+            path,
+            symbols: Vec::new(),
+        };
+        while index < symbols.len() && symbols[index].path == path {
+            group.symbols.push(&symbols[index]);
+            index += 1;
+        }
+        groups.push(group);
+    }
+    groups
+}
+
+fn relative_path(root: &Path, path: &Path) -> String {
+    let relative = path.strip_prefix(root).unwrap_or(path);
+    let rendered = relative.to_string_lossy().replace('\\', "/");
+    if rendered.is_empty() {
+        ".".to_string()
+    } else {
+        rendered
+    }
+}
+
+fn truncate_chars(value: &str, max: usize) -> String {
+    if value.chars().count() <= max {
+        return value.to_string();
+    }
+    let suffix = "...";
+    let mut truncated: String = value
+        .chars()
+        .take(max.saturating_sub(suffix.len()))
+        .collect();
+    truncated.push_str(suffix);
+    truncated
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent");
+        }
+        fs::write(path, content).expect("write file");
+    }
+
+    #[test]
+    fn collects_rust_symbols_with_parent_context() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            &dir.path().join("src/lib.rs"),
+            r#"
+pub struct Widget {
+    id: String,
+}
+
+impl Widget {
+    pub fn new(id: String) -> Self {
+        Self { id }
+    }
+
+    fn id(&self) -> &str {
+        &self.id
+    }
+}
+
+trait Named {
+    fn name(&self) -> &str;
+}
+"#,
+        );
+
+        let report = collect_repo_symbols(
+            dir.path(),
+            SymbolScanOptions {
+                path: None,
+                query: None,
+                language: None,
+                limit: 20,
+                max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+            },
+        )
+        .expect("scan");
+
+        assert_eq!(report.scanned_files, 1);
+        assert!(report.symbols.iter().any(|symbol| symbol.language == "rust"
+            && symbol.kind == "struct"
+            && symbol.name == "Widget"));
+        let new_fn = report
+            .symbols
+            .iter()
+            .find(|symbol| symbol.kind == "function" && symbol.name == "new")
+            .expect("new function");
+        assert_eq!(new_fn.parent.as_deref(), Some("impl Widget"));
+        assert_eq!(new_fn.visibility.as_deref(), Some("pub"));
+        assert!(
+            report
+                .symbols
+                .iter()
+                .any(|symbol| symbol.kind == "function_signature" && symbol.name == "name")
+        );
+    }
+
+    #[test]
+    fn filters_by_query_and_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(&dir.path().join("src/lib.rs"), "pub fn keep_me() {}\n");
+        write(&dir.path().join("tests/demo.rs"), "fn skip_me() {}\n");
+
+        let report = collect_repo_symbols(
+            dir.path(),
+            SymbolScanOptions {
+                path: Some("src".to_string()),
+                query: Some("keep".to_string()),
+                language: None,
+                limit: 20,
+                max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+            },
+        )
+        .expect("scan");
+
+        assert_eq!(report.symbols.len(), 1);
+        assert_eq!(report.symbols[0].path, "src/lib.rs");
+        assert_eq!(report.symbols[0].name, "keep_me");
+    }
+
+    #[test]
+    fn collects_symbols_across_supported_languages() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            &dir.path().join("app.py"),
+            "class Service:\n    def run(self):\n        pass\n",
+        );
+        write(
+            &dir.path().join("widget.ts"),
+            "export interface Widget {}\nexport function render() {}\n",
+        );
+        write(&dir.path().join("style.css"), ".button { color: red; }\n");
+        write(
+            &dir.path().join("index.html"),
+            "<main><section></section></main>\n",
+        );
+        write(&dir.path().join("script.sh"), "deploy() { echo ok; }\n");
+        write(
+            &dir.path().join("schema.sql"),
+            "CREATE TABLE users (id int);\n",
+        );
+
+        let report = collect_repo_symbols(
+            dir.path(),
+            SymbolScanOptions {
+                path: None,
+                query: None,
+                language: None,
+                limit: 100,
+                max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+            },
+        )
+        .expect("scan");
+
+        for language in ["python", "typescript", "css", "html", "bash", "sql"] {
+            assert!(
+                report.languages.iter().any(|seen| seen == language),
+                "expected {language} in {:?}",
+                report.languages
+            );
+        }
+        assert!(
+            report
+                .symbols
+                .iter()
+                .any(|symbol| symbol.language == "python"
+                    && symbol.kind == "class"
+                    && symbol.name == "Service")
+        );
+        assert!(
+            report
+                .symbols
+                .iter()
+                .any(|symbol| symbol.language == "typescript"
+                    && symbol.kind == "function"
+                    && symbol.name == "render")
+        );
+        assert!(
+            report
+                .symbols
+                .iter()
+                .any(|symbol| symbol.language == "css" && symbol.name.contains(".button"))
+        );
+        assert!(report.symbols.iter().any(|symbol| symbol.language == "bash"
+            && symbol.kind == "function"
+            && symbol.name == "deploy"));
+    }
+
+    #[test]
+    fn filters_by_language() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(&dir.path().join("src/lib.rs"), "pub fn rust_fn() {}\n");
+        write(&dir.path().join("app.py"), "def py_fn():\n    pass\n");
+
+        let report = collect_repo_symbols(
+            dir.path(),
+            SymbolScanOptions {
+                path: None,
+                query: None,
+                language: Some("python".to_string()),
+                limit: 20,
+                max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+            },
+        )
+        .expect("scan");
+
+        assert_eq!(report.languages, vec!["python"]);
+        assert!(report.symbols.iter().any(|symbol| symbol.name == "py_fn"));
+        assert!(!report.symbols.iter().any(|symbol| symbol.name == "rust_fn"));
+    }
+
+    #[tokio::test]
+    async fn repo_symbols_tool_executes_multilanguage_scan() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(&dir.path().join("app.py"), "def py_fn():\n    pass\n");
+
+        let capability = RepoMapCapability::new(dir.path().to_path_buf());
+        let tools = capability.tools();
+        let tool = tools
+            .iter()
+            .find(|tool| tool.name() == "repo_symbols")
+            .expect("repo_symbols tool");
+        let result = tool
+            .execute(json!({
+                "language": "python",
+                "query": "py_fn",
+                "limit": 10
+            }))
+            .await;
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("expected success, got {result:?}");
+        };
+
+        assert_eq!(value["languages"], json!(["python"]));
+        assert_eq!(value["count"], json!(1));
+        assert_eq!(value["symbols"][0]["language"], json!("python"));
+        assert_eq!(value["symbols"][0]["name"], json!("py_fn"));
+    }
+
+    #[test]
+    fn rejects_paths_outside_workspace() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let err = collect_repo_symbols(
+            dir.path(),
+            SymbolScanOptions {
+                path: Some("../outside".to_string()),
+                query: None,
+                language: None,
+                limit: 20,
+                max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+            },
+        )
+        .expect_err("outside path should fail");
+
+        assert!(err.to_string().contains("inside the workspace"));
+    }
+}

--- a/src/capabilities/repo_map.rs
+++ b/src/capabilities/repo_map.rs
@@ -220,7 +220,7 @@ fn scan_schema(query_description: &str) -> Value {
                 "type": "integer",
                 "minimum": 1,
                 "maximum": MAX_FILE_BYTES,
-                "description": "Skip Rust files larger than this many bytes. Defaults to 524288."
+                "description": "Skip supported source files larger than this many bytes. Defaults to 524288."
             }
         },
         "additionalProperties": false
@@ -778,13 +778,16 @@ fn collect_supported_files(
 
     let mut entries = fs::read_dir(path)
         .with_context(|| format!("read directory {}", path.display()))?
-        .collect::<std::io::Result<Vec<_>>>()
-        .with_context(|| format!("read directory entries for {}", path.display()))?;
+        .filter_map(std::result::Result::ok)
+        .collect::<Vec<_>>();
     entries.sort_by_key(|entry| entry.path());
 
     for entry in entries {
         let path = entry.path();
-        if path.is_dir() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_dir() {
             if path
                 .file_name()
                 .and_then(|name| name.to_str())
@@ -793,7 +796,7 @@ fn collect_supported_files(
                 continue;
             }
             collect_supported_files(&path, language_filter, files, skipped_unsupported_files)?;
-        } else {
+        } else if file_type.is_file() {
             match language_for_path(&path, language_filter) {
                 Some(language) => files.push(SourceFile { path, language }),
                 None => *skipped_unsupported_files += 1,
@@ -1271,6 +1274,45 @@ trait Named {
         assert_eq!(value["count"], json!(1));
         assert_eq!(value["symbols"][0]["language"], json!("python"));
         assert_eq!(value["symbols"][0]["name"], json!("py_fn"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn skips_symlinked_directories_during_recursive_scan() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let outside = tempfile::tempdir().expect("outside tempdir");
+        write(&dir.path().join("src/lib.rs"), "pub fn inside_fn() {}\n");
+        write(
+            &outside.path().join("outside.rs"),
+            "pub fn outside_fn() {}\n",
+        );
+        std::os::unix::fs::symlink(outside.path(), dir.path().join("linked_outside"))
+            .expect("symlink outside dir");
+
+        let report = collect_repo_symbols(
+            dir.path(),
+            SymbolScanOptions {
+                path: None,
+                query: None,
+                language: Some("rust".to_string()),
+                limit: 20,
+                max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+            },
+        )
+        .expect("scan");
+
+        assert!(
+            report
+                .symbols
+                .iter()
+                .any(|symbol| symbol.name == "inside_fn")
+        );
+        assert!(
+            !report
+                .symbols
+                .iter()
+                .any(|symbol| symbol.name == "outside_fn")
+        );
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -10,8 +10,8 @@ use crate::capabilities::{
     APPROVAL_CAPABILITY_ID, ATTRIBUTION_CAPABILITY_ID, ApprovalCapability, AttributionCapability,
     CLIENT_COMMANDS_CAPABILITY_ID, CONFIG_CAPABILITY_ID, ClientCommandsCapability,
     CodingBashCapability, CodingCliEnvironmentCapability, ConfigCapability,
-    ENVIRONMENT_CONTEXT_CAPABILITY_ID, HOOKS_CAPABILITY_ID, HooksCapability, SETUP_CAPABILITY_ID,
-    SetupCapability,
+    ENVIRONMENT_CONTEXT_CAPABILITY_ID, HOOKS_CAPABILITY_ID, HooksCapability,
+    REPO_MAP_CAPABILITY_ID, RepoMapCapability, SETUP_CAPABILITY_ID, SetupCapability,
 };
 use crate::capability_settings::{CapabilityCatalog, apply_capability_settings};
 use crate::connectors::{
@@ -1275,6 +1275,7 @@ fn default_coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabi
         ),
         AgentCapabilityConfig::new("session_file_system"),
         AgentCapabilityConfig::new(SKILLS_CAPABILITY_ID),
+        AgentCapabilityConfig::new(REPO_MAP_CAPABILITY_ID),
         AgentCapabilityConfig::new(INFINITY_CONTEXT_CAPABILITY_ID),
         AgentCapabilityConfig::with_config(
             COMPACTION_CAPABILITY_ID,
@@ -1633,6 +1634,7 @@ pub async fn build_with_options(
     //                            system scopes; list_skills + activate_skill
     //
     // Non-filesystem, but useful for a coding agent:
+    //   * repo_map            - on-demand multi-language symbol map for broad codebase orientation
     //   * infinity_context     — keeps long sessions usable; adds query_history
     //   * compaction           — proactively masks older large tool outputs
     //   * stateless_todo_list  — write_todos tool for multi-step tasks
@@ -1652,6 +1654,7 @@ pub async fn build_with_options(
     capabilities.register(crate::capabilities::skills::YolopSkillsCapability::new(
         crate::capabilities::skills::SkillSources::resolve(&canonical_root),
     ));
+    capabilities.register(RepoMapCapability::new(canonical_root.clone()));
     capabilities.register(InfinityContextCapability);
     capabilities.register(CompactionCapability);
     capabilities.register(StatelessTodoListCapability);
@@ -1897,6 +1900,7 @@ pub async fn build_with_options(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::capabilities::REPO_MAP_CAPABILITY_ID;
     use everruns_core::command::ExecuteCommandRequest;
 
     #[test]
@@ -3369,6 +3373,17 @@ mod tests {
                 "tool_search must be enabled (client_commands={client_commands})"
             );
         }
+    }
+
+    #[test]
+    fn coding_harness_enables_repo_map() {
+        let ids = coding_harness_capabilities(false, None, &Settings::default());
+
+        assert!(
+            ids.iter()
+                .any(|cap| cap.capability_id() == REPO_MAP_CAPABILITY_ID),
+            "repo_map should be available for on-demand codebase orientation"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What
Add a read-only `repo_map` capability with `repo_map` and `repo_symbols` tools for on-demand symbol overviews.

Supported languages: Rust, Python, TypeScript, TSX, JavaScript, C#, Go, Zig, CSS, HTML, Bash, and SQL.

## Why
Agents need a structural orientation layer before targeted grep/read when working across larger or unfamiliar codebases.

## How
- Add tree-sitter grammar dependencies and a table-driven language scanner.
- Keep scanning on demand, workspace-bounded, and capped by result/file-size limits.
- Register `repo_map` in the default harness and runtime capability registry.
- Add direct tool-entry tests plus scanner coverage for language filtering and multi-language discovery.
- Document the tool in `README.md`.

## Risk
- Medium: adds parser dependencies and a new read-only model-facing tool.
- What can break: dependency build compatibility, noisy symbol extraction for some language grammars, or larger scans taking too long on very large repos.

## Security
- TM-FS: read-only scanner resolves paths under the canonical workspace root and rejects traversal; it does not write files.
- TM-TOOL: capability exposes read-only tools only; no shell execution or mutation path is added.
- TM-DEP: adds official tree-sitter grammar crates for supported languages; parser work is bounded by `limit`, `max_file_bytes`, and generated-directory skips.
- Resource exhaustion reviewed: per-file byte cap, result cap, skipped generated dirs, and no persistent index.

## Validation
- `cargo fetch --locked`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"`
- Attempted `doppler run -- cargo run -- --provider openai -p "Use repo_symbols to find symbols matching RepoMapCapability, then reply with the symbol names only."`; local Doppler is not configured for a project in this checkout, so the live-provider smoke is deferred to CI's Doppler-backed job.

## Follow-ups
- Add ast-grep structural search as a separate PR; it is intentionally out of scope for this repo-map PR.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
