### PR TITLE
feat(background): background execution core with scripted tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   under the session folder and stays readable for model tool calls. Use
   `/shell <command>` or `!<command>` in interactive sessions to run a command
   directly with bounded inline output.
+- **Background tasks** — `background_run` starts a shell command that runs
+  detached from the current turn (e.g. `gh pr checks <pr> --watch` waiting on
+  CI); `background_list`, `background_output`, and `background_cancel` track and
+  read it. Output streams to the session folder and a task's *result* survives a
+  restart (a task still running when yolop exits is restored as `interrupted`).
+  See [`specs/background.md`](./specs/background.md).
 - **Web** — `web_fetch` (HTTP GET/HEAD with markdown/text conversion, DNS-pinned
   SSRF protection) and `duckduckgo_search` (free, no API key). Setting
   `EVERRUNS_SYSTEM_ALLOWLIST_ENABLED=true` restricts `web_fetch` to the

--- a/specs/background.md
+++ b/specs/background.md
@@ -1,0 +1,129 @@
+# Background execution — background tasks and background agents
+
+Status: v1 (scripted background tasks) implemented. Background sub-agents and a
+live TUI panel are specified here as follow-up phases.
+
+## Why
+
+A coding session often spawns work that should not block the foreground turn:
+
+- **Scripted waits** — kick off a long command and react when it finishes. The
+  canonical case is *waiting for CI*: `gh pr checks <pr> --watch` (or a poll
+  loop) runs for minutes, then the agent reads the result and continues.
+- **Background sub-agents** — when a request fans out (analyse this subtree,
+  draft an integration, review a diff) it is cheaper and faster to spin off
+  focused sub-agents than to do everything inline in one context window.
+
+Today yolop has exactly one agent loop per session and every unit of work is
+*turn-scoped*: a turn is `runtime.run_turn`, and cancellation is a hard
+`JoinHandle::abort()`. Nothing survives the end of a turn, and nothing survives
+a process restart except the conversation itself (replayed from
+`events.jsonl`). Background execution is the missing primitive.
+
+The design goal is a **single generic background-execution core** that both
+scripted tasks and background agents are *kinds* of — not two parallel
+mechanisms. yolop already has the right substrate for durability: every session
+owns a private folder under `<data_dir>/yolop/sessions/<session_id>/` (see
+`specs/` neighbours and `src/session_log.rs`). Background state lives there, so
+it is naturally per-session, owner-only, and restorable on `--session` resume.
+
+## Core abstraction
+
+A **background task** is a unit of work that runs detached from the foreground
+turn. It has an id, a kind, a lifecycle status, captured output, and is
+cancellable and observable. The registry owns them:
+
+- `BackgroundRegistry` — an `Arc`-shared handle holding the live task table and
+  persisting an index to `<session_dir>/background/index.json`. One registry per
+  session, constructed during `runtime::build` and shared with the capability.
+- `BackgroundRecord` — the serialized, restart-survivable description of a task:
+  `id`, `kind`, `label`, optional `command`, `status`, `created`/`updated`,
+  optional `exit_code`, `summary`, and the `log_file` holding full output.
+- `BackgroundKind` — `script` in v1; `agent` is the Phase 2 extension and reuses
+  the same record, index, status model, and surfaces.
+
+### Status lifecycle
+
+`running → {completed | failed | cancelled | timed_out}`, plus `interrupted`
+which is assigned on restore (below). `completed`/`failed`/`cancelled`/
+`timed_out`/`interrupted` are terminal.
+
+### Surviving a restart
+
+The index is the durable record. On `BackgroundRegistry::load`:
+
+- terminal tasks are restored verbatim — a `completed`/`failed` task's
+  `exit_code`, `summary`, and full `log_file` are still readable after a
+  restart, so the agent can act on a result produced before the crash;
+- any task still marked `running` is re-labelled **`interrupted`**. Its OS
+  process was a child of the previous yolop and did not survive — yolop does not
+  pretend otherwise (this mirrors Claude Code, where background bash is not
+  resurrected on resume). The model sees the interrupted task and can re-launch
+  it. The corrected index is re-persisted immediately.
+
+This is the honest contract: *results* survive a restart; *in-flight OS
+processes* do not. Background **agents** (Phase 2) are different — an agent is
+itself a `session_id` with its own `events.jsonl`, so an interrupted agent can
+be genuinely resumed by rebuilding its session (Phase 2 detail).
+
+## Surfaces
+
+### Tools (v1)
+
+The `background` capability contributes four tools:
+
+- `background_run` — start a scripted task. `command` (required), `label`
+  (optional human tag). Returns the new task id and status. Non-blocking.
+- `background_list` — list every task with its status and one-line summary.
+- `background_output` — read a task's captured output by `id` (tail-capped),
+  with its status and exit code.
+- `background_cancel` — cancel a running task by `id`.
+
+### System-prompt disclosure
+
+Like `memory`, the capability injects a compact `<background_tasks>` block each
+turn listing current tasks (most-recent first, capped) with status and summary.
+This is how a turn-based agent *learns a task finished*: it started the task,
+ended (or continued) its turn, and on a later turn the disclosure shows
+`completed`/`failed` with a pointer to `background_output`. Restart-survivable
+because it is rebuilt from the persisted index. When there are no tasks the
+block is omitted entirely.
+
+### Output and limits
+
+Each task streams stdout+stderr into `<session_dir>/background/<id>.log`
+(owner-only) as it runs, so `background_output` can show partial progress while
+the task is still running. A per-task output cap (256 KiB) and a wall-clock
+safety ceiling (30 min, → `timed_out`) keep a runaway background command from
+filling the disk or living forever; both are generous for the CI-wait case.
+
+## Phased plan
+
+1. **v1 — scripted background tasks (this spec, implemented).** The core
+   registry, persistence + restore, the four tools, and system-prompt
+   disclosure. Delivers the CI-wait use case end to end.
+2. **Phase 2 — background sub-agents.** A `background_agent` tool that builds a
+   child session (`runtime::build(cwd, fresh_session_id)`, the pattern the ACP
+   server already uses for N concurrent runtimes) and drives its turns on a
+   detached task. The parent reads the child's summary via `background_output`;
+   because each agent is a real session folder, an interrupted agent is
+   resumable, not just re-launchable.
+3. **Phase 3 — live TUI panel.** A background-tasks region in the TUI, fed by a
+   status channel drained in the existing `App` event loop (alongside
+   `TurnEvent`/`UiCommand`), plus a `/background` command. Today v1 surfaces
+   through the agent and tool results; Phase 3 makes it a first-class user view
+   (status, peek, cancel) the way Claude Code's agent view does.
+4. **Phase 4 — proactive wake.** Optionally inject a turn when a watched task
+   finishes, instead of waiting for the user's next prompt, for true
+   fire-and-forget CI monitoring.
+
+## Non-goals (v1)
+
+- No resurrection of an interrupted OS process — only its captured output and
+  final state survive a restart.
+- No cross-session background work — tasks belong to the session that spawned
+  them and live in that session's folder.
+- No second persistence engine — the per-session folder and atomic-write
+  pattern already used by `session_log.rs` / `memory` are reused as-is.
+- No new approval gate — `background_run` runs the same unsandboxed shell as the
+  `bash` tool and inherits the same standing guardrails.

--- a/src/capabilities/background.rs
+++ b/src/capabilities/background.rs
@@ -1,0 +1,1031 @@
+// The `background` capability — generic background execution for yolop.
+//
+// A *background task* is a unit of work that runs detached from the foreground
+// turn: it has an id, a kind, a lifecycle status, captured output, and is
+// cancellable and observable. v1 ships one kind — `script` (a shell command
+// that outlives the turn, e.g. `gh pr checks --watch` waiting on CI). Background
+// sub-agents are a planned second kind that reuses this same registry, record,
+// and surfaces (see specs/background.md).
+//
+// Durability reuses the per-session folder that `session_log.rs` already owns:
+// the registry persists an index to `<session_dir>/background/index.json` and
+// each task streams its output to `<session_dir>/background/<id>.log`. On a
+// restart the index is restored verbatim, except tasks still marked `running`
+// (whose OS process died with the previous yolop) are re-labelled `interrupted`.
+// Results survive a restart; in-flight processes do not. See specs/background.md.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::{Arc, Mutex};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::process::Command;
+use tokio::task::JoinHandle;
+
+pub(crate) const BACKGROUND_CAPABILITY_ID: &str = "background";
+
+const BACKGROUND_SUBDIR: &str = "background";
+const INDEX_FILE: &str = "index.json";
+/// Per-task output log cap. Generous for a CI watch; protects the session
+/// folder from a runaway command. Past the cap we keep draining the pipes
+/// (so the exit code is still captured) but stop writing.
+const MAX_OUTPUT_BYTES: usize = 256 * 1024;
+/// Wall-clock safety ceiling for a single background task. A task that exceeds
+/// it is killed and marked `timed_out`. Long enough for typical CI.
+const DEFAULT_MAX_RUNTIME_SECS: u64 = 30 * 60;
+/// How many tasks to surface in the per-turn system-prompt block.
+const DISCLOSED_TASKS: usize = 10;
+/// Default tail size returned by `background_output` when the caller does not
+/// ask for a specific window.
+const DEFAULT_OUTPUT_TAIL_BYTES: usize = 16 * 1024;
+
+// ---------- data model ----------
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BackgroundKind {
+    /// A shell command run via `bash -lc` from the workspace root.
+    Script,
+}
+
+impl BackgroundKind {
+    fn label(self) -> &'static str {
+        match self {
+            BackgroundKind::Script => "script",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BackgroundStatus {
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+    TimedOut,
+    /// Assigned on restore: the task was `running` when a previous yolop exited,
+    /// so its OS process did not survive. Not resumable as a process.
+    Interrupted,
+}
+
+impl BackgroundStatus {
+    /// Terminal statuses never transition again.
+    #[cfg(test)]
+    fn is_terminal(self) -> bool {
+        !matches!(self, BackgroundStatus::Running)
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            BackgroundStatus::Running => "running",
+            BackgroundStatus::Completed => "completed",
+            BackgroundStatus::Failed => "failed",
+            BackgroundStatus::Cancelled => "cancelled",
+            BackgroundStatus::TimedOut => "timed_out",
+            BackgroundStatus::Interrupted => "interrupted",
+        }
+    }
+}
+
+/// Serialized, restart-survivable description of one background task.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BackgroundRecord {
+    pub id: String,
+    pub kind: BackgroundKind,
+    pub label: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub command: Option<String>,
+    pub status: BackgroundStatus,
+    pub created: DateTime<Utc>,
+    pub updated: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub exit_code: Option<i32>,
+    /// One-line summary — the last non-empty output line, or a terminal note.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub summary: Option<String>,
+    /// File name (relative to the background dir) holding full output.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub log_file: Option<String>,
+}
+
+impl BackgroundRecord {
+    fn to_json(&self) -> Value {
+        json!({
+            "id": self.id,
+            "kind": self.kind.label(),
+            "label": self.label,
+            "status": self.status.as_str(),
+            "created": self.created.to_rfc3339(),
+            "updated": self.updated.to_rfc3339(),
+            "exit_code": self.exit_code,
+            "summary": self.summary,
+        })
+    }
+}
+
+/// On-disk index envelope.
+#[derive(Default, Serialize, Deserialize)]
+struct IndexFile {
+    tasks: Vec<BackgroundRecord>,
+}
+
+// ---------- registry ----------
+
+struct Inner {
+    records: Vec<BackgroundRecord>,
+    /// Live task handles, keyed by id. Only present while a task is in-process;
+    /// a finished handle is harmless to keep but `cancel` removes it. Not
+    /// persisted — handles cannot outlive the process.
+    handles: HashMap<String, JoinHandle<()>>,
+}
+
+/// Per-session owner of background tasks. Cheap to clone via the inner `Arc`.
+pub struct BackgroundRegistry {
+    inner: Arc<Mutex<Inner>>,
+    dir: PathBuf,
+    index_path: PathBuf,
+    workspace_root: PathBuf,
+    max_runtime_secs: u64,
+}
+
+impl BackgroundRegistry {
+    /// Open (or restore) the registry for a session. Reads the index if present;
+    /// any task still marked `running` is re-labelled `interrupted` (its process
+    /// died with the previous yolop) and the corrected index is re-persisted.
+    pub fn load(session_dir: &Path, workspace_root: PathBuf) -> Self {
+        let dir = session_dir.join(BACKGROUND_SUBDIR);
+        let index_path = dir.join(INDEX_FILE);
+        let mut records = read_index(&index_path);
+
+        let mut corrected = false;
+        let now = Utc::now();
+        for record in &mut records {
+            if record.status == BackgroundStatus::Running {
+                record.status = BackgroundStatus::Interrupted;
+                record.updated = now;
+                if record.summary.is_none() {
+                    record.summary =
+                        Some("interrupted: yolop exited while this task was running".into());
+                }
+                corrected = true;
+            }
+        }
+
+        let registry = Self {
+            inner: Arc::new(Mutex::new(Inner {
+                records,
+                handles: HashMap::new(),
+            })),
+            dir,
+            index_path,
+            workspace_root,
+            max_runtime_secs: DEFAULT_MAX_RUNTIME_SECS,
+        };
+        if corrected {
+            registry.persist();
+        }
+        registry
+    }
+
+    #[cfg(test)]
+    fn with_max_runtime(mut self, secs: u64) -> Self {
+        self.max_runtime_secs = secs;
+        self
+    }
+
+    /// Snapshot of all tasks, most-recently-updated first.
+    pub fn list(&self) -> Vec<BackgroundRecord> {
+        let guard = self.inner.lock().expect("background lock poisoned");
+        let mut records = guard.records.clone();
+        records.sort_by(|a, b| b.updated.cmp(&a.updated));
+        records
+    }
+
+    /// Fetch one task by id.
+    pub fn get(&self, id: &str) -> Option<BackgroundRecord> {
+        let guard = self.inner.lock().expect("background lock poisoned");
+        guard.records.iter().find(|r| r.id == id).cloned()
+    }
+
+    /// Start a scripted background task. Returns the new record immediately; the
+    /// command runs on a detached task and updates its record as it progresses.
+    pub fn spawn_script(&self, label: Option<String>, command: String) -> BackgroundRecord {
+        let now = Utc::now();
+        let id = self.next_id();
+        let log_file = format!("{id}.log");
+        let label = label
+            .map(|l| l.trim().to_string())
+            .filter(|l| !l.is_empty())
+            .unwrap_or_else(|| first_line(&command, 60));
+        let record = BackgroundRecord {
+            id: id.clone(),
+            kind: BackgroundKind::Script,
+            label,
+            command: Some(command.clone()),
+            status: BackgroundStatus::Running,
+            created: now,
+            updated: now,
+            exit_code: None,
+            summary: None,
+            log_file: Some(log_file.clone()),
+        };
+
+        {
+            let mut guard = self.inner.lock().expect("background lock poisoned");
+            guard.records.push(record.clone());
+        }
+        self.persist();
+
+        let inner = self.inner.clone();
+        let index_path = self.index_path.clone();
+        let dir = self.dir.clone();
+        let workspace_root = self.workspace_root.clone();
+        let max_runtime = self.max_runtime_secs;
+        let task_id = id.clone();
+        let handle = tokio::spawn(async move {
+            let outcome = run_script(&dir, &log_file, &workspace_root, &command, max_runtime).await;
+            update_record(&inner, &index_path, &task_id, |r| {
+                r.status = outcome.status;
+                r.exit_code = outcome.exit_code;
+                r.summary = Some(outcome.summary.clone());
+            });
+        });
+
+        let mut guard = self.inner.lock().expect("background lock poisoned");
+        guard.handles.insert(id, handle);
+        record
+    }
+
+    /// Read a task's captured output (the tail of its log), capped at `max_bytes`.
+    pub fn read_output(
+        &self,
+        id: &str,
+        max_bytes: usize,
+    ) -> Option<(BackgroundRecord, String, bool)> {
+        let record = self.get(id)?;
+        let log = record.log_file.as_ref()?;
+        let path = self.dir.join(log);
+        let bytes = std::fs::read(&path).unwrap_or_default();
+        let truncated = bytes.len() > max_bytes;
+        let slice = if truncated {
+            &bytes[bytes.len() - max_bytes..]
+        } else {
+            &bytes[..]
+        };
+        let text = String::from_utf8_lossy(slice).to_string();
+        Some((record, text, truncated))
+    }
+
+    /// Cancel a running task. Aborts its detached task (whose child is reaped via
+    /// `kill_on_drop`) and marks it `cancelled`. Returns true if it was running.
+    pub fn cancel(&self, id: &str) -> bool {
+        let mut guard = self.inner.lock().expect("background lock poisoned");
+        if let Some(handle) = guard.handles.remove(id) {
+            handle.abort();
+        }
+        let now = Utc::now();
+        let mut changed = false;
+        if let Some(record) = guard.records.iter_mut().find(|r| r.id == id)
+            && record.status == BackgroundStatus::Running
+        {
+            record.status = BackgroundStatus::Cancelled;
+            record.updated = now;
+            record.summary = Some("cancelled".into());
+            changed = true;
+        }
+        drop(guard);
+        if changed {
+            self.persist();
+        }
+        changed
+    }
+
+    /// Render the per-turn `<background_tasks>` block, or `None` when there are
+    /// no tasks. Disclosed newest-first and capped at [`DISCLOSED_TASKS`].
+    fn system_prompt_block(&self) -> Option<String> {
+        let records = self.list();
+        if records.is_empty() {
+            return None;
+        }
+        let total = records.len();
+        let running = records
+            .iter()
+            .filter(|r| r.status == BackgroundStatus::Running)
+            .count();
+
+        let mut out = String::from("<background_tasks>\n");
+        out.push_str(
+            "Background tasks run detached from this turn. Start one with `background_run`, \
+             list with `background_list`, read full output with `background_output`, cancel with \
+             `background_cancel`. A `completed`/`failed` task's result is ready to read NOW.\n",
+        );
+        out.push_str(&format!(
+            "{total} task(s), {running} running (most recent first):\n"
+        ));
+        for r in records.iter().take(DISCLOSED_TASKS) {
+            let summary = r
+                .summary
+                .as_deref()
+                .map(|s| format!(" — {s}"))
+                .unwrap_or_default();
+            let exit = r
+                .exit_code
+                .map(|c| format!(" exit={c}"))
+                .unwrap_or_default();
+            out.push_str(&format!(
+                "- [{id}] {status}{exit}: {label}{summary}\n",
+                id = r.id,
+                status = r.status.as_str(),
+                label = r.label,
+            ));
+        }
+        if total > DISCLOSED_TASKS {
+            out.push_str("(more tasks exist — use `background_list` to see them.)\n");
+        }
+        out.push_str("</background_tasks>");
+        Some(out)
+    }
+
+    /// Generate a short id unique within the current task set.
+    fn next_id(&self) -> String {
+        let guard = self.inner.lock().expect("background lock poisoned");
+        loop {
+            let id = format!("bg-{:06x}", rand::random::<u32>() & 0xFF_FFFF);
+            if !guard.records.iter().any(|r| r.id == id) {
+                return id;
+            }
+        }
+    }
+
+    /// Atomically write the index. Best-effort: a persistence failure is logged
+    /// but never sinks a running task.
+    fn persist(&self) {
+        let records = {
+            let guard = self.inner.lock().expect("background lock poisoned");
+            guard.records.clone()
+        };
+        if let Err(e) = write_index(&self.index_path, &records) {
+            tracing::warn!(path = %self.index_path.display(), error = %e, "failed to persist background index");
+        }
+    }
+}
+
+/// Mutate one record under the lock, stamp `updated`, and persist.
+fn update_record(
+    inner: &Arc<Mutex<Inner>>,
+    index_path: &Path,
+    id: &str,
+    f: impl FnOnce(&mut BackgroundRecord),
+) {
+    let records = {
+        let mut guard = inner.lock().expect("background lock poisoned");
+        if let Some(record) = guard.records.iter_mut().find(|r| r.id == id) {
+            f(record);
+            record.updated = Utc::now();
+        }
+        guard.records.clone()
+    };
+    if let Err(e) = write_index(index_path, &records) {
+        tracing::warn!(path = %index_path.display(), error = %e, "failed to persist background index");
+    }
+}
+
+/// Outcome of a finished scripted task.
+struct ScriptOutcome {
+    status: BackgroundStatus,
+    exit_code: Option<i32>,
+    summary: String,
+}
+
+/// Run a shell command in the background, streaming output to `<dir>/<log_file>`
+/// as it arrives. Returns the terminal status, exit code, and a one-line summary.
+async fn run_script(
+    dir: &Path,
+    log_file: &str,
+    workspace_root: &Path,
+    command: &str,
+    max_runtime_secs: u64,
+) -> ScriptOutcome {
+    if let Err(e) = tokio::fs::create_dir_all(dir).await {
+        return ScriptOutcome {
+            status: BackgroundStatus::Failed,
+            exit_code: None,
+            summary: format!("could not create background dir: {e}"),
+        };
+    }
+    let log_path = dir.join(log_file);
+    let mut log = match tokio::fs::File::create(&log_path).await {
+        Ok(f) => f,
+        Err(e) => {
+            return ScriptOutcome {
+                status: BackgroundStatus::Failed,
+                exit_code: None,
+                summary: format!("could not open log file: {e}"),
+            };
+        }
+    };
+
+    let mut child = match Command::new("bash")
+        .arg("-lc")
+        .arg(command)
+        .current_dir(workspace_root)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            return ScriptOutcome {
+                status: BackgroundStatus::Failed,
+                exit_code: None,
+                summary: format!("spawn failed: {e}"),
+            };
+        }
+    };
+    let mut stdout = child.stdout.take().expect("piped stdout");
+    let mut stderr = child.stderr.take().expect("piped stderr");
+
+    let drive = async {
+        // `current` is the line being accumulated; `last_complete` is the most
+        // recent finished non-empty line. The summary is whichever holds the
+        // last non-empty content when the streams close.
+        let mut current = String::new();
+        let mut last_complete = String::new();
+        let mut written = 0usize;
+        let mut o = vec![0u8; 8192];
+        let mut e = vec![0u8; 8192];
+        let mut out_done = false;
+        let mut err_done = false;
+        while !(out_done && err_done) {
+            let chunk = tokio::select! {
+                biased;
+                n = stdout.read(&mut o), if !out_done => match n {
+                    Ok(0) | Err(_) => { out_done = true; None }
+                    Ok(n) => Some(o[..n].to_vec()),
+                },
+                n = stderr.read(&mut e), if !err_done => match n {
+                    Ok(0) | Err(_) => { err_done = true; None }
+                    Ok(n) => Some(e[..n].to_vec()),
+                },
+            };
+            if let Some(chunk) = chunk {
+                for ch in String::from_utf8_lossy(&chunk).chars() {
+                    match ch {
+                        '\n' => {
+                            if !current.trim().is_empty() {
+                                last_complete = std::mem::take(&mut current);
+                            } else {
+                                current.clear();
+                            }
+                        }
+                        '\r' => {}
+                        _ => current.push(ch),
+                    }
+                }
+                if written < MAX_OUTPUT_BYTES {
+                    let room = MAX_OUTPUT_BYTES - written;
+                    let slice = &chunk[..chunk.len().min(room)];
+                    let _ = log.write_all(slice).await;
+                    written += slice.len();
+                    if written >= MAX_OUTPUT_BYTES {
+                        let _ = log
+                            .write_all(b"\n[background: output truncated at 256 KiB]\n")
+                            .await;
+                    }
+                }
+            }
+        }
+        let _ = log.flush().await;
+        let status = child.wait().await;
+        let last_line = if current.trim().is_empty() {
+            last_complete
+        } else {
+            current
+        };
+        (status, last_line)
+    };
+
+    let timeout = std::time::Duration::from_secs(max_runtime_secs);
+    match tokio::time::timeout(timeout, drive).await {
+        Ok((status, last_line)) => {
+            let exit_code = status.as_ref().ok().and_then(|s| s.code());
+            let success = matches!(&status, Ok(s) if s.success());
+            let summary = summarize(&last_line, exit_code, success);
+            ScriptOutcome {
+                status: if success {
+                    BackgroundStatus::Completed
+                } else {
+                    BackgroundStatus::Failed
+                },
+                exit_code,
+                summary,
+            }
+        }
+        Err(_) => {
+            // `drive` is dropped here; the owned child is dropped with it and
+            // `kill_on_drop` reaps the OS process.
+            ScriptOutcome {
+                status: BackgroundStatus::TimedOut,
+                exit_code: None,
+                summary: format!("timed out after {max_runtime_secs}s"),
+            }
+        }
+    }
+}
+
+fn summarize(last_line: &str, exit_code: Option<i32>, success: bool) -> String {
+    let tail = last_line.trim();
+    if !tail.is_empty() {
+        return truncate(tail, 200);
+    }
+    match exit_code {
+        Some(code) if success => format!("completed (exit {code})"),
+        Some(code) => format!("failed (exit {code})"),
+        None => "finished".to_string(),
+    }
+}
+
+fn first_line(s: &str, max: usize) -> String {
+    let line = s.lines().next().unwrap_or("").trim();
+    truncate(line, max)
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+    out.push('…');
+    out
+}
+
+// ---------- persistence ----------
+
+fn read_index(path: &Path) -> Vec<BackgroundRecord> {
+    let Ok(bytes) = std::fs::read(path) else {
+        return Vec::new();
+    };
+    match serde_json::from_slice::<IndexFile>(&bytes) {
+        Ok(index) => index.tasks,
+        Err(e) => {
+            tracing::warn!(path = %path.display(), error = %e, "ignoring malformed background index");
+            Vec::new()
+        }
+    }
+}
+
+/// Atomic write (temp file + rename), owner-only on Unix — background output can
+/// echo workspace contents, so the index stays private like the session log.
+fn write_index(path: &Path, records: &[BackgroundRecord]) -> std::io::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(parent)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700));
+    }
+    let index = IndexFile {
+        tasks: records.to_vec(),
+    };
+    let bytes = serde_json::to_vec_pretty(&index)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+    let tmp = parent.join(format!(".{INDEX_FILE}.tmp.{}", std::process::id()));
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    let mut file = opts.open(&tmp)?;
+    file.write_all(&bytes)?;
+    file.sync_all()?;
+    std::fs::rename(&tmp, path)
+}
+
+// ---------- capability ----------
+
+pub(crate) struct BackgroundCapability {
+    pub(crate) registry: Arc<BackgroundRegistry>,
+}
+
+#[async_trait]
+impl Capability for BackgroundCapability {
+    fn id(&self) -> &str {
+        BACKGROUND_CAPABILITY_ID
+    }
+    fn name(&self) -> &str {
+        "Background execution"
+    }
+    fn description(&self) -> &str {
+        "Run shell commands detached from the current turn (e.g. waiting for CI), then read their \
+         results on a later turn. Tasks survive a restart's results via the per-session folder."
+    }
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+    fn category(&self) -> Option<&str> {
+        Some("Execution")
+    }
+
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        self.registry.system_prompt_block()
+    }
+
+    fn system_prompt_preview(&self) -> Option<String> {
+        Some(
+            "\
+<background_tasks>
+Background tasks run detached from this turn (background_run / background_list /
+background_output / background_cancel).
+1 task(s), 1 running (most recent first):
+- [bg-1a2b3c] running: wait for CI — Run #42 in progress
+</background_tasks>"
+                .to_string(),
+        )
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(BackgroundRunTool {
+                registry: self.registry.clone(),
+            }),
+            Box::new(BackgroundListTool {
+                registry: self.registry.clone(),
+            }),
+            Box::new(BackgroundOutputTool {
+                registry: self.registry.clone(),
+            }),
+            Box::new(BackgroundCancelTool {
+                registry: self.registry.clone(),
+            }),
+        ]
+    }
+}
+
+// ---------- tools ----------
+
+struct BackgroundRunTool {
+    registry: Arc<BackgroundRegistry>,
+}
+
+#[async_trait]
+impl Tool for BackgroundRunTool {
+    fn name(&self) -> &str {
+        "background_run"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Run in background")
+    }
+    fn description(&self) -> &str {
+        "Start a shell command that runs DETACHED from this turn and returns immediately. Use for \
+         long waits that should not block you — most commonly waiting for CI (e.g. \
+         `gh pr checks <pr> --watch`). Returns a task id; read its result later with \
+         `background_output` (its status also shows up at the top of later turns). Do NOT use this \
+         for quick commands — use `bash` for those."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "Shell command to run via `bash -lc` from the workspace root."
+                },
+                "label": {
+                    "type": "string",
+                    "description": "Optional short human label (e.g. \"wait for CI on PR 42\"). Defaults to the command."
+                }
+            },
+            "required": ["command"],
+            "additionalProperties": false
+        })
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let command = match arguments.get("command").and_then(Value::as_str) {
+            Some(c) if !c.trim().is_empty() => c.to_string(),
+            _ => {
+                return ToolExecutionResult::tool_error(
+                    "'command' is required and must be non-empty",
+                );
+            }
+        };
+        let label = arguments
+            .get("label")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let record = self.registry.spawn_script(label, command);
+        ToolExecutionResult::success(json!({
+            "ok": true,
+            "id": record.id,
+            "status": record.status.as_str(),
+            "label": record.label,
+            "message": format!(
+                "started background task {} — check `background_output` later or watch later turns.",
+                record.id
+            ),
+        }))
+    }
+}
+
+struct BackgroundListTool {
+    registry: Arc<BackgroundRegistry>,
+}
+
+#[async_trait]
+impl Tool for BackgroundListTool {
+    fn name(&self) -> &str {
+        "background_list"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("List background tasks")
+    }
+    fn description(&self) -> &str {
+        "List background tasks for this session with their status and one-line summary."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({ "type": "object", "properties": {}, "additionalProperties": false })
+    }
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        let records = self.registry.list();
+        ToolExecutionResult::success(json!({
+            "ok": true,
+            "count": records.len(),
+            "tasks": records.iter().map(BackgroundRecord::to_json).collect::<Vec<_>>(),
+        }))
+    }
+}
+
+struct BackgroundOutputTool {
+    registry: Arc<BackgroundRegistry>,
+}
+
+#[async_trait]
+impl Tool for BackgroundOutputTool {
+    fn name(&self) -> &str {
+        "background_output"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Read background output")
+    }
+    fn description(&self) -> &str {
+        "Read a background task's captured output (the tail of its log) by id, along with its \
+         status and exit code. Works while the task is still running (partial output) or after it \
+         finished."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "id": { "type": "string", "description": "The background task id (from `background_run`/`background_list`)." },
+                "max_bytes": { "type": "integer", "minimum": 1, "description": "Max bytes of output tail to return (default 16384)." }
+            },
+            "required": ["id"],
+            "additionalProperties": false
+        })
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let id = match arguments.get("id").and_then(Value::as_str) {
+            Some(id) if !id.trim().is_empty() => id.trim(),
+            _ => return ToolExecutionResult::tool_error("'id' is required and must be non-empty"),
+        };
+        let max_bytes = arguments
+            .get("max_bytes")
+            .and_then(Value::as_u64)
+            .map(|v| v as usize)
+            .filter(|v| *v > 0)
+            .unwrap_or(DEFAULT_OUTPUT_TAIL_BYTES);
+        match self.registry.read_output(id, max_bytes) {
+            Some((record, output, truncated)) => ToolExecutionResult::success(json!({
+                "ok": true,
+                "id": record.id,
+                "status": record.status.as_str(),
+                "exit_code": record.exit_code,
+                "summary": record.summary,
+                "output": output,
+                "truncated": truncated,
+            })),
+            None => ToolExecutionResult::success(json!({
+                "ok": true,
+                "id": id,
+                "found": false,
+                "message": format!("no background task with id '{id}'"),
+            })),
+        }
+    }
+}
+
+struct BackgroundCancelTool {
+    registry: Arc<BackgroundRegistry>,
+}
+
+#[async_trait]
+impl Tool for BackgroundCancelTool {
+    fn name(&self) -> &str {
+        "background_cancel"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Cancel background task")
+    }
+    fn description(&self) -> &str {
+        "Cancel a running background task by id. Already-finished tasks are left as-is."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "id": { "type": "string", "description": "The background task id to cancel." }
+            },
+            "required": ["id"],
+            "additionalProperties": false
+        })
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let id = match arguments.get("id").and_then(Value::as_str) {
+            Some(id) if !id.trim().is_empty() => id.trim(),
+            _ => return ToolExecutionResult::tool_error("'id' is required and must be non-empty"),
+        };
+        let cancelled = self.registry.cancel(id);
+        let status = self.registry.get(id).map(|r| r.status.as_str().to_string());
+        ToolExecutionResult::success(json!({
+            "ok": true,
+            "id": id,
+            "cancelled": cancelled,
+            "status": status,
+            "message": if cancelled {
+                format!("cancelled background task {id}")
+            } else {
+                format!("background task {id} was not running (already finished or unknown)")
+            },
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn registry_in(dir: &Path) -> BackgroundRegistry {
+        BackgroundRegistry::load(dir, dir.to_path_buf())
+    }
+
+    /// Poll until a task reaches a terminal status, or panic after `tries`.
+    async fn wait_terminal(reg: &BackgroundRegistry, id: &str, tries: u32) -> BackgroundRecord {
+        for _ in 0..tries {
+            if let Some(r) = reg.get(id)
+                && r.status.is_terminal()
+            {
+                return r;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        panic!("task {id} did not reach a terminal status in time");
+    }
+
+    #[tokio::test]
+    async fn script_completes_and_captures_output() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = registry_in(tmp.path());
+        let record = reg.spawn_script(Some("hello task".into()), "echo hello-bg".into());
+        assert_eq!(record.status, BackgroundStatus::Running);
+
+        let done = wait_terminal(&reg, &record.id, 100).await;
+        assert_eq!(done.status, BackgroundStatus::Completed);
+        assert_eq!(done.exit_code, Some(0));
+
+        let (_, output, _) = reg.read_output(&record.id, 64 * 1024).unwrap();
+        assert!(output.contains("hello-bg"), "got: {output}");
+    }
+
+    #[tokio::test]
+    async fn nonzero_exit_is_failed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = registry_in(tmp.path());
+        let record = reg.spawn_script(None, "echo boom 1>&2; exit 3".into());
+        let done = wait_terminal(&reg, &record.id, 100).await;
+        assert_eq!(done.status, BackgroundStatus::Failed);
+        assert_eq!(done.exit_code, Some(3));
+        let (_, output, _) = reg.read_output(&record.id, 64 * 1024).unwrap();
+        assert!(output.contains("boom"), "got: {output}");
+    }
+
+    #[tokio::test]
+    async fn cancel_marks_cancelled() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = registry_in(tmp.path());
+        let record = reg.spawn_script(None, "sleep 30".into());
+        // Give the child a moment to actually start.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(reg.cancel(&record.id));
+        let got = reg.get(&record.id).unwrap();
+        assert_eq!(got.status, BackgroundStatus::Cancelled);
+        // Cancelling again is a no-op (already terminal).
+        assert!(!reg.cancel(&record.id));
+    }
+
+    #[tokio::test]
+    async fn timeout_marks_timed_out() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = registry_in(tmp.path()).with_max_runtime(1);
+        let record = reg.spawn_script(None, "sleep 30".into());
+        let done = wait_terminal(&reg, &record.id, 100).await;
+        assert_eq!(done.status, BackgroundStatus::TimedOut);
+    }
+
+    #[tokio::test]
+    async fn results_survive_restart_and_running_becomes_interrupted() {
+        let tmp = tempfile::tempdir().unwrap();
+        // First "process": run a task to completion.
+        let first_id = {
+            let reg = registry_in(tmp.path());
+            let record = reg.spawn_script(Some("done task".into()), "echo persisted".into());
+            wait_terminal(&reg, &record.id, 100).await;
+            record.id
+        };
+
+        // Inject a stale `running` record straight into the index to simulate a
+        // task that was mid-flight when the previous process died.
+        let index_path = tmp.path().join(BACKGROUND_SUBDIR).join(INDEX_FILE);
+        let mut tasks = read_index(&index_path);
+        let now = Utc::now();
+        tasks.push(BackgroundRecord {
+            id: "bg-stale1".into(),
+            kind: BackgroundKind::Script,
+            label: "stuck".into(),
+            command: Some("sleep 999".into()),
+            status: BackgroundStatus::Running,
+            created: now,
+            updated: now,
+            exit_code: None,
+            summary: None,
+            log_file: None,
+        });
+        write_index(&index_path, &tasks).unwrap();
+
+        // Second "process": restore.
+        let reg = registry_in(tmp.path());
+        let completed = reg.get(&first_id).expect("completed task survives restart");
+        assert_eq!(completed.status, BackgroundStatus::Completed);
+        let stale = reg.get("bg-stale1").expect("stale task restored");
+        assert_eq!(stale.status, BackgroundStatus::Interrupted);
+        assert!(
+            stale
+                .summary
+                .as_deref()
+                .unwrap_or("")
+                .contains("interrupted")
+        );
+    }
+
+    #[tokio::test]
+    async fn capability_exposes_four_tools_and_discloses_tasks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = Arc::new(registry_in(tmp.path()));
+        let record = reg.spawn_script(Some("ci".into()), "echo hi".into());
+        wait_terminal(&reg, &record.id, 100).await;
+
+        let cap = BackgroundCapability {
+            registry: reg.clone(),
+        };
+        let names: Vec<String> = cap.tools().iter().map(|t| t.name().to_string()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "background_run",
+                "background_list",
+                "background_output",
+                "background_cancel"
+            ]
+        );
+
+        let block = reg.system_prompt_block().expect("block present with tasks");
+        assert!(block.contains("<background_tasks>"));
+        assert!(block.contains(&record.id));
+    }
+
+    #[test]
+    fn no_tasks_means_no_prompt_block() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = registry_in(tmp.path());
+        assert!(reg.system_prompt_block().is_none());
+    }
+
+    #[tokio::test]
+    async fn run_tool_requires_command() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = Arc::new(registry_in(tmp.path()));
+        let tool = BackgroundRunTool { registry: reg };
+        assert!(tool.execute(json!({})).await.is_error());
+        assert!(tool.execute(json!({ "command": "  " })).await.is_error());
+    }
+}

--- a/src/capabilities/background.rs
+++ b/src/capabilities/background.rs
@@ -141,9 +141,10 @@ struct IndexFile {
 
 struct Inner {
     records: Vec<BackgroundRecord>,
-    /// Live task handles, keyed by id. Only present while a task is in-process;
-    /// a finished handle is harmless to keep but `cancel` removes it. Not
-    /// persisted — handles cannot outlive the process.
+    /// Live task handles, keyed by id, used to cancel a running task. Finished
+    /// handles are pruned in [`BackgroundRegistry::list`] (and removed by
+    /// `cancel`), so this stays bounded by the live task count. Not persisted —
+    /// handles cannot outlive the process.
     handles: HashMap<String, JoinHandle<()>>,
 }
 
@@ -201,11 +202,14 @@ impl BackgroundRegistry {
         self
     }
 
-    /// Snapshot of all tasks, most-recently-updated first.
+    /// Snapshot of all tasks, most-recently-updated first. Opportunistically
+    /// prunes finished task handles (this is called every turn) so completed
+    /// `JoinHandle`s don't accumulate over a long session.
     pub fn list(&self) -> Vec<BackgroundRecord> {
-        let guard = self.inner.lock().expect("background lock poisoned");
+        let mut guard = self.inner.lock().expect("background lock poisoned");
+        guard.handles.retain(|_, handle| !handle.is_finished());
         let mut records = guard.records.clone();
-        records.sort_by(|a, b| b.updated.cmp(&a.updated));
+        records.sort_by_key(|r| std::cmp::Reverse(r.updated));
         records
     }
 
@@ -253,9 +257,17 @@ impl BackgroundRegistry {
         let handle = tokio::spawn(async move {
             let outcome = run_script(&dir, &log_file, &workspace_root, &command, max_runtime).await;
             update_record(&inner, &index_path, &task_id, |r| {
+                // Only apply the outcome if the task is still running. A
+                // concurrent `cancel` may have already marked it `cancelled`
+                // after the child exited but before this update ran; do not
+                // clobber that terminal status.
+                if r.status != BackgroundStatus::Running {
+                    return false;
+                }
                 r.status = outcome.status;
                 r.exit_code = outcome.exit_code;
                 r.summary = Some(outcome.summary.clone());
+                true
             });
         });
 
@@ -324,8 +336,9 @@ impl BackgroundRegistry {
         let mut out = String::from("<background_tasks>\n");
         out.push_str(
             "Background tasks run detached from this turn. Start one with `background_run`, \
-             list with `background_list`, read full output with `background_output`, cancel with \
-             `background_cancel`. A `completed`/`failed` task's result is ready to read NOW.\n",
+             list with `background_list`, read a task's output (most recent tail) with \
+             `background_output`, cancel with `background_cancel`. A `completed`/`failed` task's \
+             result is ready to read NOW.\n",
         );
         out.push_str(&format!(
             "{total} task(s), {running} running (most recent first):\n"
@@ -378,18 +391,31 @@ impl BackgroundRegistry {
     }
 }
 
-/// Mutate one record under the lock, stamp `updated`, and persist.
+/// Mutate one record under the lock and, only when the mutator reports a change
+/// (returns `true`), stamp `updated` and persist. The bool guard lets a caller
+/// no-op when the record is no longer in the expected state (e.g. it was
+/// cancelled out from under a finishing task) without a redundant write.
 fn update_record(
     inner: &Arc<Mutex<Inner>>,
     index_path: &Path,
     id: &str,
-    f: impl FnOnce(&mut BackgroundRecord),
+    f: impl FnOnce(&mut BackgroundRecord) -> bool,
 ) {
     let records = {
         let mut guard = inner.lock().expect("background lock poisoned");
-        if let Some(record) = guard.records.iter_mut().find(|r| r.id == id) {
-            f(record);
-            record.updated = Utc::now();
+        let changed = match guard.records.iter_mut().find(|r| r.id == id) {
+            Some(record) => {
+                let changed = f(record);
+                if changed {
+                    record.updated = Utc::now();
+                }
+                changed
+            }
+            None => false,
+        };
+        // Record missing, or the mutator made no change — nothing to persist.
+        if !changed {
+            return;
         }
         guard.records.clone()
     };
@@ -432,6 +458,14 @@ async fn run_script(
             };
         }
     };
+    // Owner-only: the log can echo workspace contents, so keep it as private as
+    // the session JSONL and the background index. `File::create` would leave the
+    // OS default (often 0o644).
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = tokio::fs::set_permissions(&log_path, std::fs::Permissions::from_mode(0o600)).await;
+    }
 
     let mut child = match Command::new("bash")
         .arg("-lc")
@@ -570,6 +604,9 @@ fn truncate(s: &str, max: usize) -> String {
 
 // ---------- persistence ----------
 
+/// Process-wide counter for unique index staging-file names. See `write_index`.
+static WRITE_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 fn read_index(path: &Path) -> Vec<BackgroundRecord> {
     let Ok(bytes) = std::fs::read(path) else {
         return Vec::new();
@@ -599,7 +636,12 @@ fn write_index(path: &Path, records: &[BackgroundRecord]) -> std::io::Result<()>
     let bytes = serde_json::to_vec_pretty(&index)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
 
-    let tmp = parent.join(format!(".{INDEX_FILE}.tmp.{}", std::process::id()));
+    // Per-write unique temp name: tasks finish concurrently and each persists
+    // outside the lock, so a pid-only temp path would let two writes collide on
+    // the same file. A process-wide counter keeps each staging file distinct;
+    // the atomic rename then makes the last consistent snapshot win.
+    let seq = WRITE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = parent.join(format!(".{INDEX_FILE}.tmp.{}.{seq}", std::process::id()));
     let mut opts = std::fs::OpenOptions::new();
     opts.write(true).create(true).truncate(true);
     #[cfg(unix)]
@@ -607,9 +649,17 @@ fn write_index(path: &Path, records: &[BackgroundRecord]) -> std::io::Result<()>
         use std::os::unix::fs::OpenOptionsExt;
         opts.mode(0o600);
     }
-    let mut file = opts.open(&tmp)?;
-    file.write_all(&bytes)?;
-    file.sync_all()?;
+    // Clean up the staging file if any step fails, so a write error never leaves
+    // a stray temp behind.
+    let staged = (|| -> std::io::Result<()> {
+        let mut file = opts.open(&tmp)?;
+        file.write_all(&bytes)?;
+        file.sync_all()
+    })();
+    if let Err(e) = staged {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
     std::fs::rename(&tmp, path)
 }
 
@@ -931,6 +981,13 @@ mod tests {
         assert_eq!(got.status, BackgroundStatus::Cancelled);
         // Cancelling again is a no-op (already terminal).
         assert!(!reg.cancel(&record.id));
+        // The aborted task must not race back and clobber `cancelled` with a
+        // terminal script outcome — give it time to (not) do so.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        assert_eq!(
+            reg.get(&record.id).unwrap().status,
+            BackgroundStatus::Cancelled
+        );
     }
 
     #[tokio::test]

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -5,6 +5,7 @@
 
 pub(crate) mod approval;
 pub(crate) mod ast_grep;
+pub(crate) mod background;
 pub(crate) mod client_commands;
 pub(crate) mod config;
 pub(crate) mod hooks;
@@ -18,6 +19,7 @@ pub(crate) mod your;
 
 pub(crate) use approval::{APPROVAL_CAPABILITY_ID, ApprovalCapability};
 pub(crate) use ast_grep::{AST_GREP_CAPABILITY_ID, AstGrepCapability};
+pub(crate) use background::{BACKGROUND_CAPABILITY_ID, BackgroundCapability, BackgroundRegistry};
 pub(crate) use client_commands::{CLIENT_COMMANDS_CAPABILITY_ID, ClientCommandsCapability};
 pub(crate) use config::{CONFIG_CAPABILITY_ID, ConfigCapability};
 pub(crate) use hooks::{HOOKS_CAPABILITY_ID, HooksCapability};

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -8,7 +8,8 @@ use crate::capabilities::memory::{GlobalMemoryCapability, MEMORY_CAPABILITY_ID, 
 use crate::capabilities::your::{YOUR_CAPABILITY_ID, YourCapability};
 use crate::capabilities::{
     APPROVAL_CAPABILITY_ID, AST_GREP_CAPABILITY_ID, ATTRIBUTION_CAPABILITY_ID, ApprovalCapability,
-    AstGrepCapability, AttributionCapability, CLIENT_COMMANDS_CAPABILITY_ID, CONFIG_CAPABILITY_ID,
+    AstGrepCapability, AttributionCapability, BACKGROUND_CAPABILITY_ID, BackgroundCapability,
+    BackgroundRegistry, CLIENT_COMMANDS_CAPABILITY_ID, CONFIG_CAPABILITY_ID,
     ClientCommandsCapability, CodingBashCapability, CodingCliEnvironmentCapability,
     ConfigCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID, HOOKS_CAPABILITY_ID, HooksCapability,
     REPO_MAP_CAPABILITY_ID, RepoMapCapability, SETUP_CAPABILITY_ID, SetupCapability,
@@ -1320,6 +1321,7 @@ fn default_coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabi
         // tuned by the central `approval_mode` setting (off contributes nothing).
         AgentCapabilityConfig::new(APPROVAL_CAPABILITY_ID),
         AgentCapabilityConfig::new("yolop_bash"),
+        AgentCapabilityConfig::new(BACKGROUND_CAPABILITY_ID),
     ]);
     caps
 }
@@ -1744,6 +1746,17 @@ pub async fn build_with_options(
     capabilities.register(CodingBashCapability {
         workspace: workspace.clone(),
         expose_command: !options.client_commands,
+    });
+    // `background` — generic background execution. Tasks (v1: scripted shell
+    // commands, e.g. waiting for CI) run detached from the turn and persist
+    // their state to `<session_dir>/background/` so results survive a restart.
+    // Reuses this session's folder, the same durability substrate as the JSONL
+    // event log. See specs/background.md.
+    capabilities.register(BackgroundCapability {
+        registry: Arc::new(BackgroundRegistry::load(
+            &session_dir,
+            canonical_root.clone(),
+        )),
     });
     // Terminal-side commands. Registered only when the host can apply
     // their effects (the TUI). The capability declares help/tools/mcp/cwd/model/


### PR DESCRIPTION
## What

Adds a generic, per-session **background-execution** core and a `background`
capability. This is **Phase 1** of background agents/execution: scripted
background tasks — shell commands that run **detached from the current turn**
(canonical case: waiting for CI, e.g. `gh pr checks <pr> --watch`) and report
their result on a later turn.

- `BackgroundRegistry` — spawn / list / read-output / cancel. Each task streams
  stdout+stderr to `<session_dir>/background/<id>.log` and the registry persists
  an `index.json` atomically (temp-file + rename, owner-only on Unix).
- **Restart-aware** (the explicit "survive restart" requirement): results
  survive `--session` resume; a task still marked `running` when yolop exited is
  restored as `interrupted` (its OS process was a child of the previous process
  and did not survive — mirrors Claude Code's background-bash behaviour).
- Tools: `background_run`, `background_list`, `background_output`,
  `background_cancel`, plus a per-turn `<background_tasks>` system-prompt
  disclosure (progressive, like `memory`) — that is how a turn-based agent
  *learns a task finished*.
- Wired into the runtime capability registry and the coding-harness defaults.
- `specs/background.md` documents the design and the phased plan.

## Why

yolop had exactly one turn-scoped agent loop; nothing survived a turn or a
restart except the replayed conversation. Background execution is the missing
primitive, and a single generic core lets the planned background **sub-agents**
reuse the same registry, record, status model, and surfaces rather than adding a
parallel mechanism. Durability reuses the per-session folder
(`src/session_log.rs`) — no second persistence engine.

## How validated

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo test --all-features` — full suite green; **8 new unit tests** drive the
  feature's real entry points: script completion + output capture, non-zero
  exit → `failed`, cancel → `cancelled`, wall-clock timeout → `timed_out`,
  restart restore (results persist; stale `running` → `interrupted`), the
  capability's four tools + prompt disclosure, and `background_run` input
  validation.
- **Live end-to-end smoke** (`cargo run -- --provider openai`): the model loaded
  `background_run` via tool-search, started a task, called `background_list`, and
  correctly reported `bg-…` → `completed`. Confirms the full wiring through the
  real agent loop (including deferred-tool loading).

## Security

Reviewed against the ship categories:

- **TM-BASH** — bounded execution preserved: per-task 256 KiB output cap (drains
  but stops writing past it so the exit code is still captured) and a 30-minute
  wall-clock ceiling (→ `timed_out`); `kill_on_drop(true)` reaps the child on
  cancel/timeout. Bounds differ from `bash` (120 s/1 MiB) because background
  tasks are long-running by nature; documented in the spec.
- **TM-FS** — no change to the filesystem write blocklist. `background_run` is
  the same unsandboxed `bash -lc` as the existing `bash` tool and inherits the
  same standing guardrails; it adds no new blocklist-bypassing write path. Task
  output/index are written to the owner-only session folder (`0o600`/`0o700`),
  the same sensitivity class as the session JSONL.
- **TM-LLM** — no API keys touched, logged, or written; the index/logs hold only
  the command and its output.
- **TM-TOOL** — new capability does not touch the platform file store.
- **TM-DEP** — no new dependencies (reuses tokio, chrono, serde, rand).

## Follow-ups

Each shipped as its own sequential PR (see `specs/background.md`):

- **Phase 2 — background sub-agents** (`background_agent` tool building a child
  session and driving its turns detached; reuses this registry).
- **Phase 3 — live TUI status panel** + `/background` command. Today v1 surfaces
  through the agent and tool results, not a dedicated user view.
- **Phase 4 — proactive wake** (inject a turn when a watched task finishes).
- Add a cap on concurrent background tasks (currently unbounded; each is
  output- and time-bounded individually).


---
_Generated by [Claude Code](https://claude.ai/code/session_01AmVPP3mHu1ALBThQ9ySuxQ)_