### PR TITLE
feat(background): add background sub-agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,12 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   directly with bounded inline output.
 - **Background tasks** — `background_run` starts a shell command that runs
   detached from the current turn (e.g. `gh pr checks <pr> --watch` waiting on
-  CI); `background_list`, `background_output`, and `background_cancel` track and
-  read it. Output streams to the session folder and a task's *result* survives a
-  restart (a task still running when yolop exits is restored as `interrupted`).
+  CI), and `background_agent` spins off a focused sub-agent (its own child
+  session, same tools and workspace) for a self-contained piece of work;
+  `background_list`, `background_output`, and `background_cancel` track and read
+  them. Output streams to the session folder and a task's *result* survives a
+  restart (a task still running when yolop exits is restored as `interrupted`; a
+  sub-agent's child session is resumable with `--session`).
   See [`specs/background.md`](./specs/background.md).
 - **Web** — `web_fetch` (HTTP GET/HEAD with markdown/text conversion, DNS-pinned
   SSRF protection) and `duckduckgo_search` (free, no API key). Setting

--- a/specs/background.md
+++ b/specs/background.md
@@ -1,7 +1,7 @@
 # Background execution — background tasks and background agents
 
-Status: v1 (scripted background tasks) implemented. Background sub-agents and a
-live TUI panel are specified here as follow-up phases.
+Status: scripted background tasks and background sub-agents implemented. A live
+TUI panel and proactive wake remain follow-up phases.
 
 ## Why
 
@@ -62,22 +62,40 @@ The index is the durable record. On `BackgroundRegistry::load`:
   it. The corrected index is re-persisted immediately.
 
 This is the honest contract: *results* survive a restart; *in-flight OS
-processes* do not. Background **agents** (Phase 2) are different — an agent is
-itself a `session_id` with its own `events.jsonl`, so an interrupted agent can
-be genuinely resumed by rebuilding its session (Phase 2 detail).
+processes* do not. Background **agents** are different — an agent is itself a
+`session_id` with its own `events.jsonl`, so even an interrupted agent's
+transcript is durable and its child session id is recorded for resume.
 
 ## Surfaces
 
-### Tools (v1)
+### Tools
 
-The `background` capability contributes four tools:
+The `background` capability contributes:
 
 - `background_run` — start a scripted task. `command` (required), `label`
   (optional human tag). Returns the new task id and status. Non-blocking.
+- `background_agent` — spin off a sub-agent. `task` (required, a complete
+  standalone instruction — the sub-agent does not see the parent conversation),
+  `label` (optional). Returns the new task id. Offered only when the session can
+  spawn agents (see [Sub-agents](#sub-agents)).
 - `background_list` — list every task with its status and one-line summary.
 - `background_output` — read a task's captured output by `id` (tail-capped),
   with its status and exit code.
 - `background_cancel` — cancel a running task by `id`.
+
+### Sub-agents
+
+A sub-agent (`background_agent`) is a real child yolop session built with
+`runtime::build` (the pattern the ACP server already uses to run N concurrent
+runtimes), reusing the parent's workspace, live provider, and settings. The
+registry runs one turn on a detached task and records the final assistant
+message as the result; the child's full transcript lives in its own session
+folder (`background_output` reports the child session id for `--session` resume).
+
+The capability holds an injected `AgentSpawner` only in top-level sessions;
+child sessions are built with sub-agent spawning disabled, so the
+`background_agent` tool is absent there. That bounds sub-agent depth at one
+level — a sub-agent cannot recursively spawn its own sub-agents.
 
 ### System-prompt disclosure
 
@@ -99,25 +117,23 @@ filling the disk or living forever; both are generous for the CI-wait case.
 
 ## Phased plan
 
-1. **v1 — scripted background tasks (this spec, implemented).** The core
-   registry, persistence + restore, the four tools, and system-prompt
-   disclosure. Delivers the CI-wait use case end to end.
-2. **Phase 2 — background sub-agents.** A `background_agent` tool that builds a
-   child session (`runtime::build(cwd, fresh_session_id)`, the pattern the ACP
-   server already uses for N concurrent runtimes) and drives its turns on a
-   detached task. The parent reads the child's summary via `background_output`;
-   because each agent is a real session folder, an interrupted agent is
-   resumable, not just re-launchable.
+1. **Scripted background tasks (implemented).** The core registry, persistence +
+   restore, the script tools, and system-prompt disclosure. Delivers the CI-wait
+   use case end to end.
+2. **Background sub-agents (implemented).** The `background_agent` tool builds a
+   child session and drives one turn on a detached task; the parent reads the
+   child's result via `background_output`. Each sub-agent is a real session
+   folder, so its transcript is resumable. Depth is bounded at one level.
 3. **Phase 3 — live TUI panel.** A background-tasks region in the TUI, fed by a
    status channel drained in the existing `App` event loop (alongside
-   `TurnEvent`/`UiCommand`), plus a `/background` command. Today v1 surfaces
-   through the agent and tool results; Phase 3 makes it a first-class user view
-   (status, peek, cancel) the way Claude Code's agent view does.
+   `TurnEvent`/`UiCommand`), plus a `/background` command. Today background work
+   surfaces through the agent and tool results; this makes it a first-class user
+   view (status, peek, cancel) the way Claude Code's agent view does.
 4. **Phase 4 — proactive wake.** Optionally inject a turn when a watched task
    finishes, instead of waiting for the user's next prompt, for true
    fire-and-forget CI monitoring.
 
-## Non-goals (v1)
+## Non-goals (for now)
 
 - No resurrection of an interrupted OS process — only its captured output and
   final state survive a restart.

--- a/src/capabilities/background.rs
+++ b/src/capabilities/background.rs
@@ -2,10 +2,11 @@
 //
 // A *background task* is a unit of work that runs detached from the foreground
 // turn: it has an id, a kind, a lifecycle status, captured output, and is
-// cancellable and observable. v1 ships one kind — `script` (a shell command
-// that outlives the turn, e.g. `gh pr checks --watch` waiting on CI). Background
-// sub-agents are a planned second kind that reuses this same registry, record,
-// and surfaces (see specs/background.md).
+// cancellable and observable. Two kinds share this one registry, record, status
+// model, persistence, and surfaces: `script` (a shell command that outlives the
+// turn, e.g. `gh pr checks --watch` waiting on CI) and `agent` (a child session
+// that runs one focused turn and returns its final message). See
+// specs/background.md.
 //
 // Durability reuses the per-session folder that `session_log.rs` already owns:
 // the registry persists an index to `<session_dir>/background/index.json` and
@@ -368,9 +369,10 @@ impl BackgroundRegistry {
         let inner = self.inner.clone();
         let index_path = self.index_path.clone();
         let dir = self.dir.clone();
+        let max_runtime = self.max_runtime_secs;
         let task_id = id.clone();
         let handle = tokio::spawn(async move {
-            let outcome = run_agent(spawner, &dir, &log_file, task).await;
+            let outcome = run_agent(spawner, &dir, &log_file, task, max_runtime).await;
             update_record(&inner, &index_path, &task_id, |r| {
                 // Don't clobber a status a concurrent `cancel` already set.
                 if r.status != BackgroundStatus::Running {
@@ -702,26 +704,46 @@ struct AgentOutcome {
 }
 
 /// Drive a background sub-agent to completion: run the child turn via the
-/// spawner, write its final message (and child session id) to the task log, and
-/// return the terminal state.
+/// spawner under a wall-clock ceiling, write its final message to the task log,
+/// and return the terminal state. Mirrors `run_script`'s timeout/cap discipline.
 async fn run_agent(
     spawner: Arc<dyn AgentSpawner>,
     dir: &Path,
     log_file: &str,
     task: String,
+    max_runtime_secs: u64,
 ) -> AgentOutcome {
-    match spawner.run(task).await {
-        Ok(run) => {
+    let timeout = std::time::Duration::from_secs(max_runtime_secs);
+    match tokio::time::timeout(timeout, spawner.run(task)).await {
+        // Timed out: the spawner future (and the child turn it owns) is dropped,
+        // abandoning the run. Match `run_script`'s `timed_out` semantics.
+        Err(_) => {
+            write_log(
+                dir,
+                log_file,
+                &format!("sub-agent timed out after {max_runtime_secs}s\n"),
+            )
+            .await;
+            AgentOutcome {
+                status: BackgroundStatus::TimedOut,
+                summary: format!("timed out after {max_runtime_secs}s"),
+                child_session_id: None,
+            }
+        }
+        Ok(Ok(run)) => {
             let final_text = run.final_text.unwrap_or_default();
+            let shown = if final_text.trim().is_empty() {
+                "(sub-agent produced no final message)"
+            } else {
+                &final_text
+            };
+            // Header AND footer carry the child session id, so it stays visible
+            // even when `background_output` returns only the tail of a long log.
             let body = format!(
-                "background sub-agent\nchild session: {sid}\nsuccess: {ok}\n\n{text}\n",
+                "background sub-agent\nchild session: {sid}\nsuccess: {ok}\n\n{shown}\n\n\
+                 [child session: {sid}]\n",
                 sid = run.session_id,
                 ok = run.success,
-                text = if final_text.trim().is_empty() {
-                    "(sub-agent produced no final message)"
-                } else {
-                    &final_text
-                },
             );
             write_log(dir, log_file, &body).await;
             let summary = if final_text.trim().is_empty() {
@@ -743,7 +765,7 @@ async fn run_agent(
                 child_session_id: Some(run.session_id),
             }
         }
-        Err(e) => {
+        Ok(Err(e)) => {
             write_log(dir, log_file, &format!("sub-agent failed to run: {e}\n")).await;
             AgentOutcome {
                 status: BackgroundStatus::Failed,
@@ -755,13 +777,15 @@ async fn run_agent(
 }
 
 /// Write a complete log file for a task (used by sub-agents, which produce their
-/// output all at once). Owner-only on Unix, like the script log.
+/// output all at once). Capped at [`MAX_OUTPUT_BYTES`] like the script log so a
+/// verbose sub-agent can't bloat the session folder; owner-only on Unix.
 async fn write_log(dir: &Path, log_file: &str, body: &str) {
     if tokio::fs::create_dir_all(dir).await.is_err() {
         return;
     }
+    let capped = cap_bytes(body, MAX_OUTPUT_BYTES);
     let path = dir.join(log_file);
-    if tokio::fs::write(&path, body).await.is_err() {
+    if tokio::fs::write(&path, capped.as_ref()).await.is_err() {
         return;
     }
     #[cfg(unix)]
@@ -769,6 +793,23 @@ async fn write_log(dir: &Path, log_file: &str, body: &str) {
         use std::os::unix::fs::PermissionsExt;
         let _ = tokio::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).await;
     }
+}
+
+/// Truncate `s` to at most `max` bytes on a char boundary, appending a note when
+/// truncation happens. Borrows when no truncation is needed.
+fn cap_bytes(s: &str, max: usize) -> std::borrow::Cow<'_, str> {
+    if s.len() <= max {
+        return std::borrow::Cow::Borrowed(s);
+    }
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    std::borrow::Cow::Owned(format!(
+        "{}\n[background: output truncated at {} KiB]\n",
+        &s[..end],
+        max / 1024
+    ))
 }
 
 fn summarize(last_line: &str, exit_code: Option<i32>, success: bool) -> String {
@@ -1130,6 +1171,9 @@ impl Tool for BackgroundOutputTool {
                 "status": record.status.as_str(),
                 "exit_code": record.exit_code,
                 "summary": record.summary,
+                // Reported structurally so a sub-agent's child session id is
+                // always available even if the log tail truncated the header.
+                "child_session_id": record.child_session_id,
                 "output": output,
                 "truncated": truncated,
             })),
@@ -1212,6 +1256,17 @@ mod tests {
                 final_text: self.final_text.clone(),
                 success: self.success,
             })
+        }
+    }
+
+    /// Spawner that never finishes in time, to exercise the agent timeout path.
+    struct SlowSpawner;
+
+    #[async_trait]
+    impl AgentSpawner for SlowSpawner {
+        async fn run(&self, _prompt: String) -> Result<AgentRunResult, String> {
+            tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+            unreachable!("should be cancelled by the timeout")
         }
     }
 
@@ -1397,6 +1452,21 @@ mod tests {
         let (_, output, _) = reg.read_output(&record.id, 64 * 1024).unwrap();
         assert!(output.contains("found 3 risks"), "got: {output}");
         assert!(output.contains("session_child_test"), "got: {output}");
+    }
+
+    #[tokio::test]
+    async fn agent_times_out() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = registry_in(tmp.path())
+            .with_max_runtime(1)
+            .with_spawner(Arc::new(SlowSpawner));
+        let record = reg
+            .spawn_agent(None, "slow task".into())
+            .expect("spawner present");
+        let done = wait_terminal(&reg, &record.id, 100).await;
+        assert_eq!(done.status, BackgroundStatus::TimedOut);
+        let (_, output, _) = reg.read_output(&record.id, 64 * 1024).unwrap();
+        assert!(output.contains("timed out"), "got: {output}");
     }
 
     #[tokio::test]

--- a/src/capabilities/background.rs
+++ b/src/capabilities/background.rs
@@ -53,14 +53,40 @@ const DEFAULT_OUTPUT_TAIL_BYTES: usize = 16 * 1024;
 pub enum BackgroundKind {
     /// A shell command run via `bash -lc` from the workspace root.
     Script,
+    /// A sub-agent: a child session that runs one focused turn detached from
+    /// the parent turn and returns its final message as the result.
+    Agent,
 }
 
 impl BackgroundKind {
     fn label(self) -> &'static str {
         match self {
             BackgroundKind::Script => "script",
+            BackgroundKind::Agent => "agent",
         }
     }
+}
+
+/// Result of running a background sub-agent to completion.
+#[derive(Debug)]
+pub struct AgentRunResult {
+    /// The child session's id — resume its full transcript with `--session <id>`.
+    pub session_id: String,
+    /// The sub-agent's final assistant message, if any.
+    pub final_text: Option<String>,
+    /// Whether the child turn completed successfully.
+    pub success: bool,
+}
+
+/// Builds and drives a child sub-agent session. Implemented in `runtime.rs`
+/// (where `build` and the provider live) and injected into the registry, so the
+/// background module stays free of runtime-construction details. Absent in
+/// child sessions, which is what prevents a sub-agent from spawning its own
+/// sub-agents (bounded depth).
+#[async_trait]
+pub trait AgentSpawner: Send + Sync {
+    /// Run a one-shot sub-agent with `prompt` and return its outcome.
+    async fn run(&self, prompt: String) -> Result<AgentRunResult, String>;
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -114,6 +140,9 @@ pub struct BackgroundRecord {
     /// File name (relative to the background dir) holding full output.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub log_file: Option<String>,
+    /// For `agent` tasks: the child session id, resumable with `--session <id>`.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub child_session_id: Option<String>,
 }
 
 impl BackgroundRecord {
@@ -127,6 +156,7 @@ impl BackgroundRecord {
             "updated": self.updated.to_rfc3339(),
             "exit_code": self.exit_code,
             "summary": self.summary,
+            "child_session_id": self.child_session_id,
         })
     }
 }
@@ -155,6 +185,9 @@ pub struct BackgroundRegistry {
     index_path: PathBuf,
     workspace_root: PathBuf,
     max_runtime_secs: u64,
+    /// Present only when this session may spawn sub-agents (absent in child
+    /// sessions — see [`AgentSpawner`]).
+    spawner: Option<Arc<dyn AgentSpawner>>,
 }
 
 impl BackgroundRegistry {
@@ -189,11 +222,25 @@ impl BackgroundRegistry {
             index_path,
             workspace_root,
             max_runtime_secs: DEFAULT_MAX_RUNTIME_SECS,
+            spawner: None,
         };
         if corrected {
             registry.persist();
         }
         registry
+    }
+
+    /// Enable sub-agent spawning by attaching the spawner. Top-level sessions
+    /// set this; child sessions do not, which bounds sub-agent depth.
+    pub fn with_spawner(mut self, spawner: Arc<dyn AgentSpawner>) -> Self {
+        self.spawner = Some(spawner);
+        self
+    }
+
+    /// Whether this session can spawn sub-agents (the `background_agent` tool is
+    /// only offered when true).
+    pub fn can_spawn_agents(&self) -> bool {
+        self.spawner.is_some()
     }
 
     #[cfg(test)]
@@ -240,6 +287,7 @@ impl BackgroundRegistry {
             exit_code: None,
             summary: None,
             log_file: Some(log_file.clone()),
+            child_session_id: None,
         };
 
         {
@@ -274,6 +322,70 @@ impl BackgroundRegistry {
         let mut guard = self.inner.lock().expect("background lock poisoned");
         guard.handles.insert(id, handle);
         record
+    }
+
+    /// Start a background sub-agent: a child session that runs one focused turn
+    /// with `task` and returns its final message. Returns the new record
+    /// immediately; the agent runs detached. Errors if this session can't spawn
+    /// sub-agents (no spawner — e.g. inside another sub-agent).
+    pub fn spawn_agent(
+        &self,
+        label: Option<String>,
+        task: String,
+    ) -> Result<BackgroundRecord, String> {
+        let spawner = self
+            .spawner
+            .clone()
+            .ok_or_else(|| "background sub-agents are not available in this session".to_string())?;
+
+        let now = Utc::now();
+        let id = self.next_id();
+        let log_file = format!("{id}.log");
+        let label = label
+            .map(|l| l.trim().to_string())
+            .filter(|l| !l.is_empty())
+            .unwrap_or_else(|| first_line(&task, 60));
+        let record = BackgroundRecord {
+            id: id.clone(),
+            kind: BackgroundKind::Agent,
+            label,
+            command: Some(task.clone()),
+            status: BackgroundStatus::Running,
+            created: now,
+            updated: now,
+            exit_code: None,
+            summary: None,
+            log_file: Some(log_file.clone()),
+            child_session_id: None,
+        };
+
+        {
+            let mut guard = self.inner.lock().expect("background lock poisoned");
+            guard.records.push(record.clone());
+        }
+        self.persist();
+
+        let inner = self.inner.clone();
+        let index_path = self.index_path.clone();
+        let dir = self.dir.clone();
+        let task_id = id.clone();
+        let handle = tokio::spawn(async move {
+            let outcome = run_agent(spawner, &dir, &log_file, task).await;
+            update_record(&inner, &index_path, &task_id, |r| {
+                // Don't clobber a status a concurrent `cancel` already set.
+                if r.status != BackgroundStatus::Running {
+                    return false;
+                }
+                r.status = outcome.status;
+                r.summary = Some(outcome.summary.clone());
+                r.child_session_id = outcome.child_session_id.clone();
+                true
+            });
+        });
+
+        let mut guard = self.inner.lock().expect("background lock poisoned");
+        guard.handles.insert(id, handle);
+        Ok(record)
     }
 
     /// Read a task's captured output (the tail of its log), capped at `max_bytes`.
@@ -340,6 +452,12 @@ impl BackgroundRegistry {
              `background_output`, cancel with `background_cancel`. A `completed`/`failed` task's \
              result is ready to read NOW.\n",
         );
+        if self.can_spawn_agents() {
+            out.push_str(
+                "Spin off a focused sub-agent with `background_agent` for a self-contained piece \
+                 of work (analysis, drafting); read its result the same way.\n",
+            );
+        }
         out.push_str(&format!(
             "{total} task(s), {running} running (most recent first):\n"
         ));
@@ -576,6 +694,83 @@ async fn run_script(
     }
 }
 
+/// Terminal state of a finished sub-agent task.
+struct AgentOutcome {
+    status: BackgroundStatus,
+    summary: String,
+    child_session_id: Option<String>,
+}
+
+/// Drive a background sub-agent to completion: run the child turn via the
+/// spawner, write its final message (and child session id) to the task log, and
+/// return the terminal state.
+async fn run_agent(
+    spawner: Arc<dyn AgentSpawner>,
+    dir: &Path,
+    log_file: &str,
+    task: String,
+) -> AgentOutcome {
+    match spawner.run(task).await {
+        Ok(run) => {
+            let final_text = run.final_text.unwrap_or_default();
+            let body = format!(
+                "background sub-agent\nchild session: {sid}\nsuccess: {ok}\n\n{text}\n",
+                sid = run.session_id,
+                ok = run.success,
+                text = if final_text.trim().is_empty() {
+                    "(sub-agent produced no final message)"
+                } else {
+                    &final_text
+                },
+            );
+            write_log(dir, log_file, &body).await;
+            let summary = if final_text.trim().is_empty() {
+                if run.success {
+                    "sub-agent finished".to_string()
+                } else {
+                    "sub-agent failed".to_string()
+                }
+            } else {
+                first_line(&final_text, 200)
+            };
+            AgentOutcome {
+                status: if run.success {
+                    BackgroundStatus::Completed
+                } else {
+                    BackgroundStatus::Failed
+                },
+                summary,
+                child_session_id: Some(run.session_id),
+            }
+        }
+        Err(e) => {
+            write_log(dir, log_file, &format!("sub-agent failed to run: {e}\n")).await;
+            AgentOutcome {
+                status: BackgroundStatus::Failed,
+                summary: truncate(&format!("error: {e}"), 200),
+                child_session_id: None,
+            }
+        }
+    }
+}
+
+/// Write a complete log file for a task (used by sub-agents, which produce their
+/// output all at once). Owner-only on Unix, like the script log.
+async fn write_log(dir: &Path, log_file: &str, body: &str) {
+    if tokio::fs::create_dir_all(dir).await.is_err() {
+        return;
+    }
+    let path = dir.join(log_file);
+    if tokio::fs::write(&path, body).await.is_err() {
+        return;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = tokio::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).await;
+    }
+}
+
 fn summarize(last_line: &str, exit_code: Option<i32>, success: bool) -> String {
     let tail = last_line.trim();
     if !tail.is_empty() {
@@ -706,7 +901,7 @@ background_output / background_cancel).
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
-        vec![
+        let mut tools: Vec<Box<dyn Tool>> = vec![
             Box::new(BackgroundRunTool {
                 registry: self.registry.clone(),
             }),
@@ -719,7 +914,15 @@ background_output / background_cancel).
             Box::new(BackgroundCancelTool {
                 registry: self.registry.clone(),
             }),
-        ]
+        ];
+        // The sub-agent tool is only offered when this session can spawn agents
+        // (i.e. it is not itself a sub-agent) — this bounds sub-agent depth.
+        if self.registry.can_spawn_agents() {
+            tools.push(Box::new(BackgroundAgentTool {
+                registry: self.registry.clone(),
+            }));
+        }
+        tools
     }
 }
 
@@ -785,6 +988,71 @@ impl Tool for BackgroundRunTool {
                 record.id
             ),
         }))
+    }
+}
+
+struct BackgroundAgentTool {
+    registry: Arc<BackgroundRegistry>,
+}
+
+#[async_trait]
+impl Tool for BackgroundAgentTool {
+    fn name(&self) -> &str {
+        "background_agent"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Run sub-agent in background")
+    }
+    fn description(&self) -> &str {
+        "Spin off a focused sub-agent that runs DETACHED from this turn in its own session, with \
+         the same tools and workspace, and returns its final message. Use to parallelize a \
+         self-contained piece of work whose intermediate output would otherwise flood your context \
+         (e.g. \"analyze the auth module and summarize the risks\", \"draft an integration test for \
+         X\"). Give it a complete, standalone instruction — it does not see this conversation. \
+         Returns a task id; read its result later with `background_output` (status also shows at \
+         the top of later turns). The sub-agent cannot spawn further sub-agents."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "task": {
+                    "type": "string",
+                    "description": "Complete, standalone instruction for the sub-agent. It does not see this conversation, so include all needed context."
+                },
+                "label": {
+                    "type": "string",
+                    "description": "Optional short human label (e.g. \"analyze auth module\"). Defaults to the task."
+                }
+            },
+            "required": ["task"],
+            "additionalProperties": false
+        })
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let task = match arguments.get("task").and_then(Value::as_str) {
+            Some(t) if !t.trim().is_empty() => t.to_string(),
+            _ => {
+                return ToolExecutionResult::tool_error("'task' is required and must be non-empty");
+            }
+        };
+        let label = arguments
+            .get("label")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        match self.registry.spawn_agent(label, task) {
+            Ok(record) => ToolExecutionResult::success(json!({
+                "ok": true,
+                "id": record.id,
+                "status": record.status.as_str(),
+                "label": record.label,
+                "message": format!(
+                    "started background sub-agent {} — read its result with `background_output` or watch later turns.",
+                    record.id
+                ),
+            })),
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
     }
 }
 
@@ -929,6 +1197,24 @@ mod tests {
         BackgroundRegistry::load(dir, dir.to_path_buf())
     }
 
+    /// Test spawner that returns a canned outcome, so the registry's sub-agent
+    /// bookkeeping can be tested without building a real child runtime.
+    struct MockSpawner {
+        final_text: Option<String>,
+        success: bool,
+    }
+
+    #[async_trait]
+    impl AgentSpawner for MockSpawner {
+        async fn run(&self, _prompt: String) -> Result<AgentRunResult, String> {
+            Ok(AgentRunResult {
+                session_id: "session_child_test".to_string(),
+                final_text: self.final_text.clone(),
+                success: self.success,
+            })
+        }
+    }
+
     /// Poll until a task reaches a terminal status, or panic after `tries`.
     async fn wait_terminal(reg: &BackgroundRegistry, id: &str, tries: u32) -> BackgroundRecord {
         for _ in 0..tries {
@@ -1026,6 +1312,7 @@ mod tests {
             exit_code: None,
             summary: None,
             log_file: None,
+            child_session_id: None,
         });
         write_index(&index_path, &tasks).unwrap();
 
@@ -1084,5 +1371,76 @@ mod tests {
         let tool = BackgroundRunTool { registry: reg };
         assert!(tool.execute(json!({})).await.is_error());
         assert!(tool.execute(json!({ "command": "  " })).await.is_error());
+    }
+
+    #[tokio::test]
+    async fn agent_task_records_result_and_child_session() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = registry_in(tmp.path()).with_spawner(Arc::new(MockSpawner {
+            final_text: Some("found 3 risks in the auth module".into()),
+            success: true,
+        }));
+        let record = reg
+            .spawn_agent(
+                Some("analyze auth".into()),
+                "analyze the auth module".into(),
+            )
+            .expect("spawner present");
+        assert_eq!(record.kind, BackgroundKind::Agent);
+
+        let done = wait_terminal(&reg, &record.id, 100).await;
+        assert_eq!(done.status, BackgroundStatus::Completed);
+        assert_eq!(done.child_session_id.as_deref(), Some("session_child_test"));
+        assert!(done.summary.as_deref().unwrap_or("").contains("3 risks"));
+
+        // The sub-agent's final message and child session id are in the log.
+        let (_, output, _) = reg.read_output(&record.id, 64 * 1024).unwrap();
+        assert!(output.contains("found 3 risks"), "got: {output}");
+        assert!(output.contains("session_child_test"), "got: {output}");
+    }
+
+    #[tokio::test]
+    async fn agent_failure_marks_failed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = registry_in(tmp.path()).with_spawner(Arc::new(MockSpawner {
+            final_text: None,
+            success: false,
+        }));
+        let record = reg
+            .spawn_agent(None, "do a thing".into())
+            .expect("spawner present");
+        let done = wait_terminal(&reg, &record.id, 100).await;
+        assert_eq!(done.status, BackgroundStatus::Failed);
+    }
+
+    #[tokio::test]
+    async fn agent_unavailable_without_spawner() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = registry_in(tmp.path());
+        // No spawner attached → spawning a sub-agent errors and the tool is hidden.
+        assert!(!reg.can_spawn_agents());
+        assert!(reg.spawn_agent(None, "x".into()).is_err());
+
+        let cap = BackgroundCapability {
+            registry: Arc::new(reg),
+        };
+        let names: Vec<String> = cap.tools().iter().map(|t| t.name().to_string()).collect();
+        assert!(!names.contains(&"background_agent".to_string()));
+        assert_eq!(names.len(), 4);
+    }
+
+    #[tokio::test]
+    async fn agent_tool_offered_when_spawner_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = registry_in(tmp.path()).with_spawner(Arc::new(MockSpawner {
+            final_text: None,
+            success: true,
+        }));
+        let cap = BackgroundCapability {
+            registry: Arc::new(reg),
+        };
+        let names: Vec<String> = cap.tools().iter().map(|t| t.name().to_string()).collect();
+        assert!(names.contains(&"background_agent".to_string()));
+        assert_eq!(names.len(), 5);
     }
 }

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -19,7 +19,10 @@ pub(crate) mod your;
 
 pub(crate) use approval::{APPROVAL_CAPABILITY_ID, ApprovalCapability};
 pub(crate) use ast_grep::{AST_GREP_CAPABILITY_ID, AstGrepCapability};
-pub(crate) use background::{BACKGROUND_CAPABILITY_ID, BackgroundCapability, BackgroundRegistry};
+pub(crate) use background::{
+    AgentRunResult, AgentSpawner, BACKGROUND_CAPABILITY_ID, BackgroundCapability,
+    BackgroundRegistry,
+};
 pub(crate) use client_commands::{CLIENT_COMMANDS_CAPABILITY_ID, ClientCommandsCapability};
 pub(crate) use config::{CONFIG_CAPABILITY_ID, ConfigCapability};
 pub(crate) use hooks::{HOOKS_CAPABILITY_ID, HooksCapability};

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -7,11 +7,12 @@
 use crate::capabilities::memory::{GlobalMemoryCapability, MEMORY_CAPABILITY_ID, MemoryStore};
 use crate::capabilities::your::{YOUR_CAPABILITY_ID, YourCapability};
 use crate::capabilities::{
-    APPROVAL_CAPABILITY_ID, AST_GREP_CAPABILITY_ID, ATTRIBUTION_CAPABILITY_ID, ApprovalCapability,
-    AstGrepCapability, AttributionCapability, BACKGROUND_CAPABILITY_ID, BackgroundCapability,
-    BackgroundRegistry, CLIENT_COMMANDS_CAPABILITY_ID, CONFIG_CAPABILITY_ID,
-    ClientCommandsCapability, CodingBashCapability, CodingCliEnvironmentCapability,
-    ConfigCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID, HOOKS_CAPABILITY_ID, HooksCapability,
+    APPROVAL_CAPABILITY_ID, AST_GREP_CAPABILITY_ID, ATTRIBUTION_CAPABILITY_ID, AgentRunResult,
+    AgentSpawner, ApprovalCapability, AstGrepCapability, AttributionCapability,
+    BACKGROUND_CAPABILITY_ID, BackgroundCapability, BackgroundRegistry,
+    CLIENT_COMMANDS_CAPABILITY_ID, CONFIG_CAPABILITY_ID, ClientCommandsCapability,
+    CodingBashCapability, CodingCliEnvironmentCapability, ConfigCapability,
+    ENVIRONMENT_CONTEXT_CAPABILITY_ID, HOOKS_CAPABILITY_ID, HooksCapability,
     REPO_MAP_CAPABILITY_ID, RepoMapCapability, SETUP_CAPABILITY_ID, SetupCapability,
 };
 use crate::capability_settings::{CapabilityCatalog, apply_capability_settings};
@@ -1521,6 +1522,79 @@ pub struct BuildOptions {
     /// the effects sets this: the interactive TUI (and the `app` unit tests
     /// that exercise it). ACP and `--print` leave it `false`.
     pub client_commands: bool,
+    /// Disable background sub-agent spawning for this session. Set when building
+    /// a child sub-agent session so it cannot recursively spawn its own
+    /// sub-agents — this bounds depth at one level. Top-level sessions leave it
+    /// `false`, so the `background_agent` tool is available.
+    pub disable_background_agents: bool,
+}
+
+/// Spawns background sub-agents by building a fresh child session and driving
+/// one turn. Each sub-agent is a real yolop session with its own JSONL folder,
+/// so its transcript is durable and resumable with `--session <id>`. The child
+/// is built with `disable_background_agents: true`, so it cannot spawn further
+/// sub-agents (depth is bounded at one level).
+struct YolopAgentSpawner {
+    workspace_root: PathBuf,
+    /// The live provider/model handle, shared with `SetupCapability`, so a
+    /// sub-agent uses whatever provider the session is currently on.
+    provider: Arc<RwLock<ProviderChoice>>,
+    sessions_dir: PathBuf,
+    settings: Arc<SettingsStore>,
+}
+
+#[async_trait]
+impl AgentSpawner for YolopAgentSpawner {
+    async fn run(&self, prompt: String) -> std::result::Result<AgentRunResult, String> {
+        let provider = self
+            .provider
+            .read()
+            .map_err(|_| "provider lock poisoned".to_string())?
+            .clone();
+        let built = build_with_options(
+            self.workspace_root.clone(),
+            provider,
+            None,
+            self.sessions_dir.clone(),
+            self.settings.clone(),
+            BuildOptions {
+                disable_background_agents: true,
+                ..BuildOptions::default()
+            },
+        )
+        .await
+        .map_err(|e| format!("failed to build sub-agent session: {e}"))?;
+
+        let session_id = built.handles.session_id;
+        let input = built.model.input_message(prompt);
+        let result = built
+            .handles
+            .runtime
+            .run_turn(session_id, input)
+            .await
+            .map_err(|e| format!("sub-agent turn failed: {e}"))?;
+
+        // The sub-agent's answer is its last assistant message with no pending
+        // tool calls. Its full transcript lives in the child session folder.
+        let messages = built
+            .handles
+            .runtime
+            .messages(session_id)
+            .await
+            .unwrap_or_default();
+        let final_text = messages
+            .iter()
+            .rev()
+            .find(|m| m.role == everruns_core::message::MessageRole::Agent && !m.has_tool_calls())
+            .and_then(|m| m.text().map(|t| t.trim().to_string()))
+            .filter(|t| !t.is_empty());
+
+        Ok(AgentRunResult {
+            session_id: session_id.to_string(),
+            final_text,
+            success: result.success,
+        })
+    }
 }
 
 pub async fn build(
@@ -1747,16 +1821,26 @@ pub async fn build_with_options(
         workspace: workspace.clone(),
         expose_command: !options.client_commands,
     });
-    // `background` — generic background execution. Tasks (v1: scripted shell
-    // commands, e.g. waiting for CI) run detached from the turn and persist
-    // their state to `<session_dir>/background/` so results survive a restart.
-    // Reuses this session's folder, the same durability substrate as the JSONL
-    // event log. See specs/background.md.
+    // `background` — generic background execution. Scripted tasks (e.g. waiting
+    // for CI) and sub-agents run detached from the turn and persist their state
+    // to `<session_dir>/background/` so results survive a restart. Reuses this
+    // session's folder, the same durability substrate as the JSONL event log.
+    // See specs/background.md.
+    let mut background_registry = BackgroundRegistry::load(&session_dir, canonical_root.clone());
+    // Top-level sessions can spawn sub-agents; child sub-agent sessions cannot
+    // (depth bound). The spawner builds a fresh child session per sub-agent,
+    // reusing the live provider, this session's sessions dir, and settings.
+    if !options.disable_background_agents {
+        let spawner: Arc<dyn AgentSpawner> = Arc::new(YolopAgentSpawner {
+            workspace_root: canonical_root.clone(),
+            provider: provider_state.clone(),
+            sessions_dir: sessions_dir.clone(),
+            settings: settings.clone(),
+        });
+        background_registry = background_registry.with_spawner(spawner);
+    }
     capabilities.register(BackgroundCapability {
-        registry: Arc::new(BackgroundRegistry::load(
-            &session_dir,
-            canonical_root.clone(),
-        )),
+        registry: Arc::new(background_registry),
     });
     // Terminal-side commands. Registered only when the host can apply
     // their effects (the TUI). The capability declares help/tools/mcp/cwd/model/
@@ -1927,6 +2011,86 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("offline llmsim only supports llmsim-yolop")
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn background_agent_spawner_runs_child_session_offline() {
+        // Exercises the real sub-agent path end to end offline: build a child
+        // session, run one turn (bundled llmsim), and extract its result.
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+
+        let spawner = YolopAgentSpawner {
+            workspace_root: workspace.path().to_path_buf(),
+            provider: Arc::new(RwLock::new(ProviderChoice::Sim)),
+            sessions_dir: sessions.path().to_path_buf(),
+            settings,
+        };
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(20),
+            spawner.run("say hello".to_string()),
+        )
+        .await
+        .expect("sub-agent timed out")
+        .expect("sub-agent run failed");
+
+        assert!(result.success, "child turn should succeed: {result:?}");
+        assert!(
+            !result.session_id.is_empty(),
+            "child session id must be reported for resume"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn background_agent_tool_present_at_top_level_absent_in_children() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+
+        // Top-level build: background_agent is offered.
+        let top = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Sim,
+            None,
+            sessions.path().to_path_buf(),
+            settings.clone(),
+            BuildOptions::default(),
+        )
+        .await
+        .expect("build top-level");
+        assert!(
+            top.startup
+                .tool_names
+                .contains(&"background_agent".to_string()),
+            "top-level session should offer background_agent: {:?}",
+            top.startup.tool_names
+        );
+
+        // Child build (as a sub-agent would be built): no background_agent, so a
+        // sub-agent cannot spawn its own sub-agents.
+        let child = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Sim,
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            BuildOptions {
+                disable_background_agents: true,
+                ..BuildOptions::default()
+            },
+        )
+        .await
+        .expect("build child");
+        assert!(
+            !child
+                .startup
+                .tool_names
+                .contains(&"background_agent".to_string()),
+            "child sub-agent session must NOT offer background_agent: {:?}",
+            child.startup.tool_names
         );
     }
 


### PR DESCRIPTION
## What

**Phase 2** of background execution (Phase 1 = scripted tasks, #139). Adds a
`background_agent` tool that spins off a focused **sub-agent** detached from the
current turn, reusing the existing background registry, record, status model,
persistence, and surfaces — one generic core, two kinds of task.

- `AgentSpawner` trait (background module) with `YolopAgentSpawner` impl in
  `runtime.rs`: builds a fresh child session via `runtime::build`, runs one
  turn, and returns the sub-agent's final assistant message. Each sub-agent is a
  real yolop session with its own JSONL folder, so its transcript is durable and
  resumable with `--session <id>` (the child session id is recorded on the task
  and reported by `background_output`).
- **Depth bounded at one level:** children are built with
  `disable_background_agents = true`, so the `background_agent` tool is absent in
  a sub-agent and it cannot recursively spawn its own sub-agents.
- `BackgroundKind::Agent` + `child_session_id` on the record; `spawn_agent` on
  the registry; the tool is offered only when an `AgentSpawner` is attached
  (top-level sessions).
- Reuses the Phase 1 detached-task machinery: result written to the per-session
  background log (owner-only), status surfaced in the per-turn
  `<background_tasks>` block and via `background_output`.

## Why

When a request fans out (analyze a subtree, draft a test, review a diff), a
sub-agent does the work in an isolated context and returns a summary, instead of
flooding the parent's context window. Building it as a second `BackgroundKind`
keeps a single mechanism rather than a parallel one.

## How validated

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` — clean (Rust 1.96 stable, matching CI).
- `cargo test --all-features` — full suite green. New tests drive the real entry points:
  - registry sub-agent path via a mock spawner (records completion, `child_session_id`, summary, and writes the log);
  - `agent_failure_marks_failed`; `agent_unavailable_without_spawner` (tool hidden + `spawn_agent` errors);
  - `background_agent_spawner_runs_child_session_offline` — the **real** `YolopAgentSpawner` builds a child session and runs a turn end to end via bundled `llmsim` (offline), asserting success + a reported child session id;
  - `background_agent_tool_present_at_top_level_absent_in_children` — proves the depth bound through `build_with_options`.
- **Live end-to-end smoke** (`cargo run -- --provider openai`): the model loaded `background_agent` via tool-search and spawned sub-agent `bg-…` (kind `agent`) through the real agent loop.

## Security

Reviewed against the ship categories:

- **TM-TOOL / TM-FS / TM-BASH** — a sub-agent is built through the same
  `runtime::build` path as any session, so it inherits the identical capability
  set, filesystem **write blocklist**, and bounded `bash` execution. No new
  privilege or blocklist bypass. The child session folder is owner-only (the
  session log tightens it); the sub-agent's result is written to the parent's
  owner-only background log.
- **Recursion** — bounded at one level via `disable_background_agents` in
  children; a sub-agent has no `background_agent` tool. Verified by test.
- **TM-LLM** — the sub-agent uses the parent's live provider/model
  (`Arc<RwLock<ProviderChoice>>`); no API keys are logged or written.
- **TM-DEP** — no new dependencies.

## Follow-ups

- Per-sub-agent wall-clock ceiling (scripts have 30 min; a sub-agent turn is
  currently bounded only by the runtime's loop-detection/iteration limits). Add
  a timeout around the child turn so a runaway agentic loop can't consume tokens
  indefinitely.
- Cap on concurrent background tasks (carried over from #139; still unbounded).
- **Phase 3 — live TUI status panel** + `/background` command.
- **Phase 4 — proactive wake** when a watched task finishes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AmVPP3mHu1ALBThQ9ySuxQ)_