### PR TITLE
feat(background): TUI status bar count and /background command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   and set with `/setup approval <level>` (or just by telling yolop to be more
   or less careful). See [Soft approval](#soft-approval) below.
 - **TUI chat** (ratatui): scrolling transcript, multiline composer, status
-  bar (with a `bg` count when background tasks are running), slash commands
+  bar (with a `bg` count whenever the session has background tasks), slash commands
   (`/help`, `/tools`, `/mcp`, `/cwd`, `/setup`, `/model`, `/effort`, `/shell`,
   `/background`, `/clear`, `/quit`), `!<command>` as a direct shell shortcut,
   and natural-language requests for terminal actions such as "exit" or "clear

--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   and set with `/setup approval <level>` (or just by telling yolop to be more
   or less careful). See [Soft approval](#soft-approval) below.
 - **TUI chat** (ratatui): scrolling transcript, multiline composer, status
-  bar, slash commands (`/help`, `/tools`, `/mcp`, `/cwd`, `/setup`, `/model`,
-  `/effort`, `/shell`, `/clear`, `/quit`), `!<command>` as a direct shell
-  shortcut, and natural-language requests for terminal actions such as "exit"
-  or "clear the screen".
+  bar (with a `bg` count when background tasks are running), slash commands
+  (`/help`, `/tools`, `/mcp`, `/cwd`, `/setup`, `/model`, `/effort`, `/shell`,
+  `/background`, `/clear`, `/quit`), `!<command>` as a direct shell shortcut,
+  and natural-language requests for terminal actions such as "exit" or "clear
+  the screen".
 - **Side questions** — `/btw <question>` answers a question about the current
   session out-of-band: same context as the main task, no tools, and nothing
   added to the conversation history.

--- a/specs/background.md
+++ b/specs/background.md
@@ -1,7 +1,8 @@
 # Background execution — background tasks and background agents
 
-Status: scripted background tasks and background sub-agents implemented. A live
-TUI panel and proactive wake remain follow-up phases.
+Status: scripted background tasks, background sub-agents, and user surfaces
+(status-bar indicator + `/background` command) implemented. Proactive wake
+remains a follow-up phase.
 
 ## Why
 
@@ -113,7 +114,21 @@ Each task streams stdout+stderr into `<session_dir>/background/<id>.log`
 (owner-only) as it runs, so `background_output` can show partial progress while
 the task is still running. A per-task output cap (256 KiB) and a wall-clock
 safety ceiling (30 min, → `timed_out`) keep a runaway background command from
-filling the disk or living forever; both are generous for the CI-wait case.
+filling the disk or living forever; both are generous for the CI-wait case. The
+same cap and ceiling apply to sub-agents (a `timed_out` sub-agent abandons its
+child turn).
+
+### User surfaces
+
+Background work is visible to the *user*, not just the model:
+
+- The TUI status bar shows a compact `bg <running>▸/<total>` segment whenever
+  the session has background tasks (hidden otherwise). The `App` reads the
+  shared registry (exposed on `BuiltRuntime`) each frame via a cheap `counts()`.
+- `/background` is a `System` command (contributed by the capability) that lists
+  every task with its kind, status, exit code, summary, and — for sub-agents —
+  the child session id. It works over the TUI and ACP uniformly because it
+  returns a plain `CommandResult`.
 
 ## Phased plan
 
@@ -124,11 +139,12 @@ filling the disk or living forever; both are generous for the CI-wait case.
    child session and drives one turn on a detached task; the parent reads the
    child's result via `background_output`. Each sub-agent is a real session
    folder, so its transcript is resumable. Depth is bounded at one level.
-3. **Phase 3 — live TUI panel.** A background-tasks region in the TUI, fed by a
-   status channel drained in the existing `App` event loop (alongside
-   `TurnEvent`/`UiCommand`), plus a `/background` command. Today background work
-   surfaces through the agent and tool results; this makes it a first-class user
-   view (status, peek, cancel) the way Claude Code's agent view does.
+3. **User surfaces (implemented).** A compact `bg` count in the TUI status bar
+   and a `/background` command listing all tasks (see
+   [User surfaces](#user-surfaces)). A richer interactive view (per-task peek,
+   in-place cancel, a dedicated panel à la Claude Code's agent view) remains a
+   possible enhancement, but the status indicator + command cover the
+   at-a-glance and detail needs.
 4. **Phase 4 — proactive wake.** Optionally inject a turn when a watched task
    finishes, instead of waiting for the user's next prompt, for true
    fire-and-forget CI monitoring.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -158,6 +158,9 @@ pub struct App {
     model_discovery_enabled: bool,
     models_tx: mpsc::UnboundedSender<ModelDiscovery>,
     models_rx: mpsc::UnboundedReceiver<ModelDiscovery>,
+    /// This session's background task registry, polled each frame for the
+    /// status-bar task count. Same registry the `background` capability owns.
+    background: Arc<crate::capabilities::BackgroundRegistry>,
 }
 
 /// Result of one background models API fetch. `Ok(None)` means the provider
@@ -341,6 +344,9 @@ pub(crate) struct ViewState {
     /// Current soft-approval level (`protective` / `normal` / `off`), shown
     /// in the session status bar so the paranoia level is always visible.
     pub approval_mode: String,
+    /// `(running, total)` background task counts, shown in the status bar only
+    /// when there is at least one task this session. `None` hides the segment.
+    pub background: Option<(usize, usize)>,
 }
 
 /// What kind of delta is currently being streamed. Only the assistant
@@ -438,6 +444,7 @@ impl App {
             model_discovery_enabled: true,
             models_tx,
             models_rx,
+            background: runtime.background,
         };
         app.emit_system_banner();
         if should_setup {
@@ -481,6 +488,10 @@ impl App {
                 .approval_mode()
                 .as_str()
                 .to_string(),
+            background: match self.background.counts() {
+                (_, 0) => None,
+                counts => Some(counts),
+            },
         }
     }
 
@@ -2772,7 +2783,40 @@ mod tests {
             status_layout: StatusLayout::Compact,
             hooks_summary: "none".to_string(),
             approval_mode: "normal".to_string(),
+            background: None,
         }
+    }
+
+    #[test]
+    fn status_bar_shows_background_task_count() {
+        let state = ViewState {
+            status_layout: StatusLayout::Expanded,
+            background: Some((1, 2)),
+            ..view_state_idle()
+        };
+        let lines = render_chrome_lines(&state, 120, 8).join("\n");
+        assert!(
+            lines.contains("bg"),
+            "status should show bg segment: {lines}"
+        );
+        assert!(
+            lines.contains("1▸/2"),
+            "status should show running/total: {lines}"
+        );
+    }
+
+    #[test]
+    fn status_bar_hides_background_segment_when_no_tasks() {
+        let state = ViewState {
+            status_layout: StatusLayout::Expanded,
+            background: None,
+            ..view_state_idle()
+        };
+        let lines = render_chrome_lines(&state, 120, 8).join("\n");
+        assert!(
+            !lines.contains("▸"),
+            "no background segment expected when there are no tasks: {lines}"
+        );
     }
 
     /// Render `draw_chrome` into a TestBackend and collect the buffer

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1512,7 +1512,7 @@ fn status_contributions(state: &ViewState) -> Vec<StatusContribution> {
 }
 
 /// Status-bar label for background tasks, e.g. `2▸/3` (2 running of 3), or
-/// `0/2` when none are running. `None` when there are no tasks (segment hidden).
+/// `0▸/2` when none are running. `None` when there are no tasks (segment hidden).
 fn background_label(counts: Option<(usize, usize)>) -> Option<String> {
     let (running, total) = counts?;
     if total == 0 {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1489,14 +1489,36 @@ fn status_contributions(state: &ViewState) -> Vec<StatusContribution> {
             ],
         ),
         StatusContribution::new(
-            vec![status_value(message_count_label(state.lines_count))],
-            vec![
-                status_value(message_count_label(state.lines_count)),
-                status_field("tokens", token_label(state.session_tokens)),
-                status_field("session", short_session_id(&state.session_id)),
-            ],
+            {
+                let mut compact = vec![status_value(message_count_label(state.lines_count))];
+                if let Some(bg) = background_label(state.background) {
+                    compact.push(status_field("bg", bg));
+                }
+                compact
+            },
+            {
+                let mut expanded = vec![
+                    status_value(message_count_label(state.lines_count)),
+                    status_field("tokens", token_label(state.session_tokens)),
+                    status_field("session", short_session_id(&state.session_id)),
+                ];
+                if let Some(bg) = background_label(state.background) {
+                    expanded.push(status_field("bg", bg));
+                }
+                expanded
+            },
         ),
     ]
+}
+
+/// Status-bar label for background tasks, e.g. `2▸/3` (2 running of 3), or
+/// `0/2` when none are running. `None` when there are no tasks (segment hidden).
+fn background_label(counts: Option<(usize, usize)>) -> Option<String> {
+    let (running, total) = counts?;
+    if total == 0 {
+        return None;
+    }
+    Some(format!("{running}▸/{total}"))
 }
 
 pub(crate) fn status_value(value: impl Into<String>) -> StatusField {

--- a/src/capabilities/background.rs
+++ b/src/capabilities/background.rs
@@ -271,9 +271,12 @@ impl BackgroundRegistry {
     }
 
     /// Cheap `(running, total)` task counts for the status bar — avoids cloning
-    /// the whole record set every render frame.
+    /// the whole record set every render frame. The TUI polls this every frame,
+    /// so it also prunes finished handles here (as `list()` does) to keep the
+    /// handle map bounded even on turns where `list()` is never called.
     pub fn counts(&self) -> (usize, usize) {
-        let guard = self.inner.lock().expect("background lock poisoned");
+        let mut guard = self.inner.lock().expect("background lock poisoned");
+        guard.handles.retain(|_, handle| !handle.is_finished());
         let running = guard
             .records
             .iter()
@@ -282,7 +285,8 @@ impl BackgroundRegistry {
         (running, guard.records.len())
     }
 
-    /// Human-readable task list for the `/background` command. Newest first.
+    /// Human-readable task list for the `/background` command, most-recently-
+    /// updated first (same ordering as `list`).
     pub fn render_task_list(&self) -> String {
         let records = self.list();
         if records.is_empty() {

--- a/src/capabilities/background.rs
+++ b/src/capabilities/background.rs
@@ -18,6 +18,9 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
+use everruns_core::command::{
+    CommandDescriptor, CommandExecutionContext, CommandResult, CommandSource, ExecuteCommandRequest,
+};
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -265,6 +268,59 @@ impl BackgroundRegistry {
     pub fn get(&self, id: &str) -> Option<BackgroundRecord> {
         let guard = self.inner.lock().expect("background lock poisoned");
         guard.records.iter().find(|r| r.id == id).cloned()
+    }
+
+    /// Cheap `(running, total)` task counts for the status bar — avoids cloning
+    /// the whole record set every render frame.
+    pub fn counts(&self) -> (usize, usize) {
+        let guard = self.inner.lock().expect("background lock poisoned");
+        let running = guard
+            .records
+            .iter()
+            .filter(|r| r.status == BackgroundStatus::Running)
+            .count();
+        (running, guard.records.len())
+    }
+
+    /// Human-readable task list for the `/background` command. Newest first.
+    pub fn render_task_list(&self) -> String {
+        let records = self.list();
+        if records.is_empty() {
+            return "No background tasks in this session.".to_string();
+        }
+        let (running, total) = (
+            records
+                .iter()
+                .filter(|r| r.status == BackgroundStatus::Running)
+                .count(),
+            records.len(),
+        );
+        let mut out = format!("{total} background task(s), {running} running:\n");
+        for r in &records {
+            let exit = r
+                .exit_code
+                .map(|c| format!(" exit={c}"))
+                .unwrap_or_default();
+            let summary = r
+                .summary
+                .as_deref()
+                .map(|s| format!(" — {s}"))
+                .unwrap_or_default();
+            let child = r
+                .child_session_id
+                .as_deref()
+                .map(|s| format!(" (session {s})"))
+                .unwrap_or_default();
+            out.push_str(&format!(
+                "  [{id}] {kind} {status}{exit}: {label}{summary}{child}\n",
+                id = r.id,
+                kind = r.kind.label(),
+                status = r.status.as_str(),
+                label = r.label,
+            ));
+        }
+        out.push_str("\nRead full output with the background_output tool.");
+        out
     }
 
     /// Start a scripted background task. Returns the new record immediately; the
@@ -924,6 +980,35 @@ impl Capability for BackgroundCapability {
         Some("Execution")
     }
 
+    fn commands(&self) -> Vec<CommandDescriptor> {
+        vec![CommandDescriptor {
+            name: "background".to_string(),
+            description: "list background tasks and their status".to_string(),
+            source: CommandSource::System,
+            args: Vec::new(),
+        }]
+    }
+
+    async fn execute_command(
+        &self,
+        request: &ExecuteCommandRequest,
+        _ctx: &CommandExecutionContext,
+    ) -> everruns_core::Result<CommandResult> {
+        if request.name != "background" {
+            return Err(everruns_core::AgentLoopError::config(format!(
+                "{} cannot execute /{}",
+                self.id(),
+                request.name
+            )));
+        }
+        Ok(CommandResult {
+            success: true,
+            message: self.registry.render_task_list(),
+            error_code: None,
+            error_fields: None,
+        })
+    }
+
     async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
         self.registry.system_prompt_block()
     }
@@ -1417,6 +1502,34 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let reg = registry_in(tmp.path());
         assert!(reg.system_prompt_block().is_none());
+    }
+
+    #[tokio::test]
+    async fn counts_and_render_task_list_reflect_tasks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = registry_in(tmp.path());
+        assert_eq!(reg.counts(), (0, 0));
+        assert!(reg.render_task_list().contains("No background tasks"));
+
+        let record = reg.spawn_script(Some("ci".into()), "echo hi".into());
+        wait_terminal(&reg, &record.id, 100).await;
+
+        let (running, total) = reg.counts();
+        assert_eq!((running, total), (0, 1));
+        let listed = reg.render_task_list();
+        assert!(listed.contains(&record.id), "got: {listed}");
+        assert!(listed.contains("script"), "got: {listed}");
+        assert!(listed.contains("completed"), "got: {listed}");
+    }
+
+    #[test]
+    fn capability_contributes_background_command() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cap = BackgroundCapability {
+            registry: Arc::new(registry_in(tmp.path())),
+        };
+        let names: Vec<String> = cap.commands().iter().map(|c| c.name.clone()).collect();
+        assert_eq!(names, vec!["background"]);
     }
 
     #[tokio::test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1372,6 +1372,10 @@ pub struct BuiltRuntime {
     /// other hosts ignore it. Empty/never-written when
     /// [`BuildOptions::client_commands`] is `false`.
     pub ui_rx: mpsc::UnboundedReceiver<UiCommand>,
+    /// Shared handle to this session's background task registry, so the TUI can
+    /// show a live task count in the status bar (the same registry the
+    /// `background` capability owns).
+    pub background: Arc<BackgroundRegistry>,
 }
 
 #[derive(Clone)]
@@ -1839,8 +1843,9 @@ pub async fn build_with_options(
         });
         background_registry = background_registry.with_spawner(spawner);
     }
+    let background_registry = Arc::new(background_registry);
     capabilities.register(BackgroundCapability {
-        registry: Arc::new(background_registry),
+        registry: background_registry.clone(),
     });
     // Terminal-side commands. Registered only when the host can apply
     // their effects (the TUI). The capability declares help/tools/mcp/cwd/model/
@@ -1994,6 +1999,7 @@ pub async fn build_with_options(
         model: ModelState::new(provider_state),
         settings,
         ui_rx,
+        background: background_registry,
     })
 }
 


### PR DESCRIPTION
## What

**Phase 3** of background execution (after #139 scripted tasks, #140 sub-agents):
make background work visible to the **user**, not just the model.

- **TUI status bar** shows a compact `bg <running>▸/<total>` segment whenever the
  session has background tasks (hidden when there are none). The `App` reads the
  session's background registry — now exposed on `BuiltRuntime` — each frame via
  a cheap `counts()` (a lock + two counts, no clone).
- **`/background` command** (a `System` command contributed by the capability)
  lists every task with its kind, status, exit code, summary, and — for
  sub-agents — the child session id. It returns a plain `CommandResult`, so it
  works over the TUI and ACP uniformly.

## Why

Phases 1–2 surfaced background work to the model (system-prompt disclosure +
tools). The original ask also wanted a user-facing view: an at-a-glance status
indicator plus a way to see the details of all background work. This delivers
both with minimal, low-risk additions rather than a whole new TUI pane.

## How validated

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` — clean (Rust 1.96 stable).
- `cargo test --all-features` — full suite green. New tests:
  - `counts_and_render_task_list_reflect_tasks` and `capability_contributes_background_command` (registry + command surface);
  - `status_bar_shows_background_task_count` / `status_bar_hides_background_segment_when_no_tasks` render the chrome into a `TestBackend` and assert the `bg` segment appears (with `1▸/2`) only when tasks exist.
- Offline boot smoke (`cargo run -- --provider llmsim -p "hi"`) — binary starts, status-bar code path exercised.

The status segment and `/background` are interactive TUI/command surfaces (not
reachable from `--print`), so they're covered by the render and command unit
tests above rather than a live `--print` smoke.

## Security

No security-relevant behavior change. `/background` and the status bar are
read-only views over the existing per-session registry; no new filesystem,
shell, network, or key handling. `counts()`/`render_task_list()` only read state
already persisted owner-only. **TM-*:** n/a.

## Follow-ups

- **Phase 4 — proactive wake** when a watched task finishes (inject a turn
  instead of waiting for the next prompt).
- A richer interactive view (per-task peek/attach, in-place cancel) à la Claude
  Code's agent view, if desired.
- Cap on concurrent background tasks (carried from #139).


---
_Generated by [Claude Code](https://claude.ai/code/session_01AmVPP3mHu1ALBThQ9ySuxQ)_