### PR TITLE
feat(background): proactive wake when a task finishes

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   `background_list`, `background_output`, and `background_cancel` track and read
   them. Output streams to the session folder and a task's *result* survives a
   restart (a task still running when yolop exits is restored as `interrupted`; a
-  sub-agent's child session is resumable with `--session`).
+  sub-agent's child session is resumable with `--session`). When a task finishes
+  while the TUI is idle, yolop proactively wakes the agent with a turn so it
+  reacts without waiting for your next prompt.
   See [`specs/background.md`](./specs/background.md).
 - **Web** — `web_fetch` (HTTP GET/HEAD with markdown/text conversion, DNS-pinned
   SSRF protection) and `duckduckgo_search` (free, no API key). Setting

--- a/specs/background.md
+++ b/specs/background.md
@@ -1,8 +1,8 @@
 # Background execution — background tasks and background agents
 
-Status: scripted background tasks, background sub-agents, and user surfaces
-(status-bar indicator + `/background` command) implemented. Proactive wake
-remains a follow-up phase.
+Status: implemented — scripted background tasks, background sub-agents, user
+surfaces (status-bar indicator + `/background` command), and proactive wake
+(auto-run a turn when a task finishes).
 
 ## Why
 
@@ -130,6 +130,25 @@ Background work is visible to the *user*, not just the model:
   the child session id. It works over the TUI and ACP uniformly because it
   returns a plain `CommandResult`.
 
+### Proactive wake
+
+The system-prompt disclosure lets the agent notice a finished task *on its next
+turn*. Proactive wake closes the gap for true fire-and-forget: when a task
+reaches a terminal state while the TUI session is **idle**, yolop automatically
+starts a turn so the agent reacts (reads the result, continues, or reports)
+without a user prompt.
+
+- The registry tracks which terminal tasks have been reported
+  (`drain_finished_for_wake`); the TUI's idle event loop polls it and, on a
+  non-empty result, prints a one-line notice and starts a turn with a synthetic
+  `[automatic]` prompt (`wake_prompt`). The prompt is explicitly framed as *not*
+  a user message and points at `background_output`.
+- It only fires when idle, so it never interrupts an in-flight turn; each task
+  wakes at most once; and tasks restored from a previous run are pre-marked, so
+  a resumed session never wakes for work that finished before the restart.
+- Scope: the interactive TUI only (the loop that owns turn submission).
+  `--print` is one-shot and ACP turns are editor-driven, so neither auto-wakes.
+
 ## Phased plan
 
 1. **Scripted background tasks (implemented).** The core registry, persistence +
@@ -145,9 +164,9 @@ Background work is visible to the *user*, not just the model:
    in-place cancel, a dedicated panel à la Claude Code's agent view) remains a
    possible enhancement, but the status indicator + command cover the
    at-a-glance and detail needs.
-4. **Phase 4 — proactive wake.** Optionally inject a turn when a watched task
-   finishes, instead of waiting for the user's next prompt, for true
-   fire-and-forget CI monitoring.
+4. **Proactive wake (implemented).** When a task finishes while the TUI session
+   is idle, yolop auto-starts a turn so the agent reacts immediately rather than
+   waiting for the next user prompt (see [Proactive wake](#proactive-wake)).
 
 ## Non-goals (for now)
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2949,6 +2949,10 @@ mod tests {
     async fn proactive_wake_starts_turn_when_background_task_finishes() {
         let mut test = app_with_llmsim().await;
         let app = &mut test.app;
+        // The setup/onboarding overlay opens when no provider credentials are
+        // configured (the case in CI, which has no API keys). Wake is correctly
+        // suppressed while it's open, so clear it to exercise the idle path.
+        app.setup = None;
 
         // Idle with no tasks: nothing to wake for.
         assert!(!app.maybe_wake_for_background());
@@ -2979,6 +2983,32 @@ mod tests {
                 .any(|l| l.text.contains(&record.id) && l.text.contains("waking")),
             "a notice explaining the auto-wake should be shown"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn proactive_wake_suppressed_during_setup_overlay() {
+        let mut test = app_with_llmsim().await;
+        let app = &mut test.app;
+        // With the setup overlay open, a finished task must NOT auto-start a turn.
+        app.setup = None;
+        let record = app.background.spawn_script(None, "echo hi".to_string());
+        for _ in 0..100 {
+            if app.background.counts() == (0, 1) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        // Re-open the overlay, then confirm wake is suppressed and the task is
+        // left undrained (so it can still wake once the overlay closes).
+        app.setup = Some(SetupStep::Provider { selected: 0 });
+        assert!(!app.maybe_wake_for_background(), "no wake during setup");
+        assert!(!app.busy);
+        app.setup = None;
+        assert!(
+            app.maybe_wake_for_background(),
+            "wake should fire once the overlay closes — the task wasn't consumed"
+        );
+        assert!(app.background.get(&record.id).is_some());
     }
 
     impl App {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -651,6 +651,12 @@ impl App {
             return Ok(());
         }
 
+        // 3b) proactive wake: when background tasks finish while the session is
+        // idle, auto-start a turn so the agent reacts without a user prompt.
+        if self.maybe_wake_for_background() {
+            return Ok(());
+        }
+
         // 4) direct terminal input.
         let mut poll_timeout = Duration::from_millis(80);
         while event::poll(poll_timeout)? {
@@ -864,6 +870,32 @@ impl App {
         }
         self.push_user(text.clone());
         self.start_turn(text);
+    }
+
+    /// Proactive wake (Phase 4): when background tasks reach a terminal state
+    /// while the session is idle, automatically start a turn so the agent reacts
+    /// to the result (reads output, continues, or reports) without waiting for a
+    /// user prompt. Returns true if it started a turn. Only fires when idle, so
+    /// it never interrupts an in-flight turn; each task wakes at most once.
+    fn maybe_wake_for_background(&mut self) -> bool {
+        if self.busy || self.rx.is_some() || self.setup.is_some() {
+            return false;
+        }
+        let finished = self.background.drain_finished_for_wake();
+        if finished.is_empty() {
+            return false;
+        }
+        let ids = finished
+            .iter()
+            .map(|t| t.id.clone())
+            .collect::<Vec<_>>()
+            .join(", ");
+        self.push_system(format!(
+            "↻ background task finished ({ids}) — waking agent to review"
+        ));
+        let prompt = crate::capabilities::background::wake_prompt(&finished);
+        self.start_turn(prompt);
+        true
     }
 
     /// Dispatch a slash command. Every command — including the terminal-side
@@ -2911,6 +2943,42 @@ mod tests {
             _workspace: workspace,
             _sessions: sessions,
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn proactive_wake_starts_turn_when_background_task_finishes() {
+        let mut test = app_with_llmsim().await;
+        let app = &mut test.app;
+
+        // Idle with no tasks: nothing to wake for.
+        assert!(!app.maybe_wake_for_background());
+
+        // Start a quick background script and wait for it to finish.
+        let record = app.background.spawn_script(None, "echo hi".to_string());
+        for _ in 0..100 {
+            if app.background.counts() == (0, 1) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        assert_eq!(
+            app.background.counts(),
+            (0, 1),
+            "background script should finish"
+        );
+
+        // Idle + a freshly-finished task ⇒ a turn is auto-started.
+        assert!(
+            app.maybe_wake_for_background(),
+            "a finished background task should wake the agent"
+        );
+        assert!(app.busy, "proactive wake must start a turn");
+        assert!(
+            app.lines
+                .iter()
+                .any(|l| l.text.contains(&record.id) && l.text.contains("waking")),
+            "a notice explaining the auto-wake should be shown"
+        );
     }
 
     impl App {

--- a/src/capabilities/background.rs
+++ b/src/capabilities/background.rs
@@ -24,7 +24,7 @@ use everruns_core::command::{
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -108,7 +108,6 @@ pub enum BackgroundStatus {
 
 impl BackgroundStatus {
     /// Terminal statuses never transition again.
-    #[cfg(test)]
     fn is_terminal(self) -> bool {
         !matches!(self, BackgroundStatus::Running)
     }
@@ -180,6 +179,11 @@ struct Inner {
     /// `cancel`), so this stays bounded by the live task count. Not persisted —
     /// handles cannot outlive the process.
     handles: HashMap<String, JoinHandle<()>>,
+    /// Task ids whose terminal transition has already been reported to the host
+    /// for a proactive wake (see [`BackgroundRegistry::drain_finished_for_wake`]).
+    /// Pre-seeded on load with every restored task so historical results don't
+    /// trigger a wake on resume — only live transitions this process do.
+    notified: HashSet<String>,
 }
 
 /// Per-session owner of background tasks. Cheap to clone via the inner `Arc`.
@@ -217,10 +221,16 @@ impl BackgroundRegistry {
             }
         }
 
+        // Pre-seed `notified` with every restored task so a resumed session
+        // doesn't fire a proactive wake for work that finished before restart;
+        // only transitions that happen live this process should wake the host.
+        let notified: HashSet<String> = records.iter().map(|r| r.id.clone()).collect();
+
         let registry = Self {
             inner: Arc::new(Mutex::new(Inner {
                 records,
                 handles: HashMap::new(),
+                notified,
             })),
             dir,
             index_path,
@@ -283,6 +293,26 @@ impl BackgroundRegistry {
             .filter(|r| r.status == BackgroundStatus::Running)
             .count();
         (running, guard.records.len())
+    }
+
+    /// Return tasks that have reached a terminal status since the last call and
+    /// have not yet been reported for a proactive wake, marking them reported.
+    /// The host (TUI) polls this while idle and, when non-empty, wakes the agent
+    /// so it can react to finished background work without a user prompt. Tasks
+    /// restored from a previous run are pre-marked, so only live transitions
+    /// this process trigger a wake.
+    pub fn drain_finished_for_wake(&self) -> Vec<BackgroundRecord> {
+        let mut guard = self.inner.lock().expect("background lock poisoned");
+        let finished: Vec<BackgroundRecord> = guard
+            .records
+            .iter()
+            .filter(|r| r.status.is_terminal() && !guard.notified.contains(&r.id))
+            .cloned()
+            .collect();
+        for r in &finished {
+            guard.notified.insert(r.id.clone());
+        }
+        finished
     }
 
     /// Human-readable task list for the `/background` command, most-recently-
@@ -887,6 +917,51 @@ fn summarize(last_line: &str, exit_code: Option<i32>, success: bool) -> String {
 fn first_line(s: &str, max: usize) -> String {
     let line = s.lines().next().unwrap_or("").trim();
     truncate(line, max)
+}
+
+/// One-line description of a finished task for the wake prompt.
+fn wake_line(t: &BackgroundRecord) -> String {
+    let exit = t
+        .exit_code
+        .map(|c| format!(", exit {c}"))
+        .unwrap_or_default();
+    let summary = t.summary.as_deref().unwrap_or("(no summary)");
+    format!(
+        "[{id}] {kind} {status}{exit} — {summary}",
+        id = t.id,
+        kind = t.kind.label(),
+        status = t.status.as_str(),
+    )
+}
+
+/// Compose the synthetic turn prompt used to proactively wake the agent when
+/// background work finishes. Phrased as an automatic notification (not a user
+/// message) and points the model at `background_output` for full results.
+pub(crate) fn wake_prompt(finished: &[BackgroundRecord]) -> String {
+    if let [t] = finished {
+        format!(
+            "[automatic] A background task you started has finished: {line}. This is not a user \
+             message. Read its full output with `background_output` (id {id}) if useful, then \
+             continue the work it was for or report the result.",
+            line = wake_line(t),
+            id = t.id,
+        )
+    } else {
+        let mut out = format!(
+            "[automatic] {} background tasks you started have finished:\n",
+            finished.len()
+        );
+        for t in finished {
+            out.push_str("- ");
+            out.push_str(&wake_line(t));
+            out.push('\n');
+        }
+        out.push_str(
+            "This is not a user message. Use `background_output` to read any result, then continue \
+             the work or report back.",
+        );
+        out
+    }
 }
 
 fn truncate(s: &str, max: usize) -> String {
@@ -1524,6 +1599,72 @@ mod tests {
         assert!(listed.contains(&record.id), "got: {listed}");
         assert!(listed.contains("script"), "got: {listed}");
         assert!(listed.contains("completed"), "got: {listed}");
+    }
+
+    #[tokio::test]
+    async fn drain_finished_for_wake_returns_each_task_once() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = registry_in(tmp.path());
+        assert!(reg.drain_finished_for_wake().is_empty());
+
+        let record = reg.spawn_script(None, "echo hi".into());
+        wait_terminal(&reg, &record.id, 100).await;
+
+        let first = reg.drain_finished_for_wake();
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].id, record.id);
+        // A given terminal task only wakes once.
+        assert!(reg.drain_finished_for_wake().is_empty());
+    }
+
+    #[tokio::test]
+    async fn restored_terminal_tasks_do_not_wake_on_resume() {
+        let tmp = tempfile::tempdir().unwrap();
+        let id = {
+            let reg = registry_in(tmp.path());
+            let record = reg.spawn_script(None, "echo hi".into());
+            wait_terminal(&reg, &record.id, 100).await;
+            record.id
+        };
+        // Fresh registry over the same folder = a restart.
+        let reg = registry_in(tmp.path());
+        assert!(reg.get(&id).is_some(), "result survives restart");
+        assert!(
+            reg.drain_finished_for_wake().is_empty(),
+            "historical results must not trigger a proactive wake on resume"
+        );
+    }
+
+    #[test]
+    fn wake_prompt_describes_single_and_multiple_tasks() {
+        let now = Utc::now();
+        let rec = |id: &str, kind: BackgroundKind| BackgroundRecord {
+            id: id.to_string(),
+            kind,
+            label: "x".into(),
+            command: None,
+            status: BackgroundStatus::Completed,
+            created: now,
+            updated: now,
+            exit_code: Some(0),
+            summary: Some("done".into()),
+            log_file: None,
+            child_session_id: None,
+        };
+        let one = wake_prompt(&[rec("bg-1", BackgroundKind::Script)]);
+        assert!(one.contains("bg-1"), "got: {one}");
+        assert!(one.contains("automatic"), "got: {one}");
+        assert!(one.contains("background_output"), "got: {one}");
+
+        let many = wake_prompt(&[
+            rec("bg-1", BackgroundKind::Script),
+            rec("bg-2", BackgroundKind::Agent),
+        ]);
+        assert!(
+            many.contains("bg-1") && many.contains("bg-2"),
+            "got: {many}"
+        );
+        assert!(many.contains("2 background tasks"), "got: {many}");
     }
 
     #[test]


### PR DESCRIPTION
## What

**Phase 4** (final) of background execution: when a background task reaches a
terminal state while the TUI session is **idle**, yolop **auto-starts a turn** so
the agent reacts immediately — reads the result, continues the work, or reports
back — without waiting for the user's next prompt. True fire-and-forget for the
"wait for CI / spin off a sub-agent and act on it" flows.

- `BackgroundRegistry::drain_finished_for_wake()` returns terminal tasks not yet
  reported and marks them reported. The `notified` set is **pre-seeded on load**
  with all restored tasks, so a resumed session never wakes for work that
  finished before the restart — only live transitions this process do.
- `wake_prompt()` composes an `[automatic]` turn prompt, explicitly framed as
  *not* a user message and pointing at `background_output`.
- The TUI's idle event loop (`maybe_wake_for_background`) polls the registry,
  prints a one-line notice (`↻ background task finished (…) — waking agent`), and
  starts a turn. It fires **only when idle**, so it never interrupts an in-flight
  turn; each task wakes **at most once**; finishing tasks during a turn are
  handled when it next goes idle.

Scope: the interactive TUI only (the loop that owns turn submission). `--print`
is one-shot and ACP turns are editor-driven, so neither auto-wakes.

## Why

Phases 1–3 surfaced finished work to the model on its *next* turn and to the user
via the status bar / `/background`. This closes the loop you asked for: the agent
acts on a completed background task on its own.

## How validated

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` — clean (Rust 1.96 stable).
- `cargo test --all-features` — full suite green. New tests drive the real entry points:
  - `drain_finished_for_wake_returns_each_task_once` and `restored_terminal_tasks_do_not_wake_on_resume` (registry semantics);
  - `wake_prompt_describes_single_and_multiple_tasks`;
  - `proactive_wake_starts_turn_when_background_task_finishes` — builds a real (llmsim) TUI `App`, runs a background script to completion, and asserts `maybe_wake_for_background()` starts a turn (`busy`) and prints the notice.
- Offline boot smoke (`cargo run -- --provider llmsim -p "hi"`).

The wake lives in the interactive TUI event loop (not reachable from `--print`),
so it's covered by the App-level test above rather than a `--print` smoke.

## Security

No new external surface. The auto-turn reuses the existing `start_turn` path; the
synthetic prompt is built only from the task's own id/status/summary (no
untrusted external data beyond what the task itself produced, which the model
would read anyway via `background_output`). **TM-LLM:** auto-turns spend tokens
without an explicit prompt — bounded because each task wakes at most once and
only when idle. No keys, files, or shell involved in the wake itself.

## Follow-ups

- A setting to disable proactive wake (currently always-on in the TUI, per the
  chosen design).
- Extend wake to ACP via an unsolicited turn, if desired.
- Cap on concurrent background tasks (carried from #139).

This completes the background execution series: #139 (scripted tasks), #140
(sub-agents), #141 (user surfaces), and this PR (proactive wake).


---
_Generated by [Claude Code](https://claude.ai/code/session_01AmVPP3mHu1ALBThQ9ySuxQ)_