### PR TITLE
feat(background): proactive_wake setting and concurrent-task cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   restart (a task still running when yolop exits is restored as `interrupted`; a
   sub-agent's child session is resumable with `--session`). When a task finishes
   while the TUI is idle, yolop proactively wakes the agent with a turn so it
-  reacts without waiting for your next prompt.
+  reacts without waiting for your next prompt (turn off with the `proactive_wake`
+  setting). Concurrent tasks are capped to keep fan-out bounded.
   See [`specs/background.md`](./specs/background.md).
 - **Web** — `web_fetch` (HTTP GET/HEAD with markdown/text conversion, DNS-pinned
   SSRF protection) and `duckduckgo_search` (free, no API key). Setting

--- a/specs/background.md
+++ b/specs/background.md
@@ -116,7 +116,9 @@ the task is still running. A per-task output cap (256 KiB) and a wall-clock
 safety ceiling (30 min, → `timed_out`) keep a runaway background command from
 filling the disk or living forever; both are generous for the CI-wait case. The
 same cap and ceiling apply to sub-agents (a `timed_out` sub-agent abandons its
-child turn).
+child turn). A cap on concurrently-running tasks (8, scripts + sub-agents
+combined) guards against unbounded fan-out: `background_run` / `background_agent`
+refuse new work past the cap until a running task finishes or is cancelled.
 
 ### User surfaces
 
@@ -146,6 +148,9 @@ without a user prompt.
 - It only fires when idle, so it never interrupts an in-flight turn; each task
   wakes at most once; and tasks restored from a previous run are pre-marked, so
   a resumed session never wakes for work that finished before the restart.
+- Opt-out: the `proactive_wake` setting (on by default) disables the auto-turn.
+  With it off, a finished task still prints a one-line notice (drained once) but
+  the agent waits for the user's next prompt.
 - Scope: the interactive TUI only (the loop that owns turn submission).
   `--print` is one-shot and ACP turns are editor-driven, so neither auto-wakes.
 

--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -39,6 +39,7 @@ Keys are addressed the way a human would name them:
 | `base_urls.<provider>`    | text   | Endpoint base URL (used by the `custom` provider).             |
 | `approval_mode`           | text   | Soft-approval paranoia level (`protective` / `normal` / `off`). |
 | `attribution`             | bool   | Commit/PR attribution on/off.                                  |
+| `proactive_wake`          | bool   | Auto-start a turn when a background task finishes (TUI); on by default. |
 | `capabilities`            | list   | Ordered `[[capabilities]]` harness overrides; `capabilities.<ref>` for schema metadata. |
 
 `default_provider` is persisted under that name on disk; the legacy `provider`

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -885,6 +885,20 @@ impl App {
         if finished.is_empty() {
             return false;
         }
+        // Honor the `proactive_wake` setting: when off, surface a notice but do
+        // not auto-start a turn (the tasks are already drained, so this reports
+        // each finished task exactly once without waking).
+        if !self.settings.snapshot().proactive_wake_enabled() {
+            let ids = finished
+                .iter()
+                .map(|t| t.id.clone())
+                .collect::<Vec<_>>()
+                .join(", ");
+            self.push_system(format!(
+                "✓ background task finished ({ids}) — see /background (proactive wake off)"
+            ));
+            return false;
+        }
         let ids = finished
             .iter()
             .map(|t| t.id.clone())
@@ -3009,6 +3023,31 @@ mod tests {
             "wake should fire once the overlay closes — the task wasn't consumed"
         );
         assert!(app.background.get(&record.id).is_some());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn proactive_wake_disabled_by_setting_does_not_start_turn() {
+        let mut test = app_with_llmsim().await;
+        let app = &mut test.app;
+        app.setup = None;
+        app.settings
+            .set_proactive_wake(false)
+            .expect("disable wake");
+
+        let record = app.background.spawn_script(None, "echo hi".to_string());
+        for _ in 0..100 {
+            if app.background.counts() == (0, 1) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        // Setting off: no turn, but the completion is still surfaced once.
+        assert!(!app.maybe_wake_for_background());
+        assert!(!app.busy, "wake setting off must not start a turn");
+        assert!(
+            app.lines.iter().any(|l| l.text.contains(&record.id)),
+            "finished task should still be surfaced as a notice"
+        );
     }
 
     impl App {

--- a/src/capabilities/background.rs
+++ b/src/capabilities/background.rs
@@ -49,6 +49,11 @@ const DISCLOSED_TASKS: usize = 10;
 /// Default tail size returned by `background_output` when the caller does not
 /// ask for a specific window.
 const DEFAULT_OUTPUT_TAIL_BYTES: usize = 16 * 1024;
+/// Cap on concurrently-running background tasks (scripts + sub-agents). A
+/// model-facing guardrail against unbounded fan-out — `background_run` /
+/// `background_agent` refuse past this until a running task finishes or is
+/// cancelled. Generous enough for normal parallel work.
+const MAX_CONCURRENT_TASKS: usize = 8;
 
 // ---------- data model ----------
 
@@ -313,6 +318,18 @@ impl BackgroundRegistry {
             guard.notified.insert(r.id.clone());
         }
         finished
+    }
+
+    /// `Some(error)` when too many tasks are already running, for the spawn
+    /// tools to reject new work. `None` when there is capacity.
+    pub fn capacity_error(&self) -> Option<String> {
+        let (running, _) = self.counts();
+        (running >= MAX_CONCURRENT_TASKS).then(|| {
+            format!(
+                "too many background tasks already running ({running}/{MAX_CONCURRENT_TASKS}); \
+                 wait for one to finish or cancel one with `background_cancel`"
+            )
+        })
     }
 
     /// Human-readable task list for the `/background` command, most-recently-
@@ -1178,6 +1195,9 @@ impl Tool for BackgroundRunTool {
                 );
             }
         };
+        if let Some(err) = self.registry.capacity_error() {
+            return ToolExecutionResult::tool_error(err);
+        }
         let label = arguments
             .get("label")
             .and_then(Value::as_str)
@@ -1241,6 +1261,9 @@ impl Tool for BackgroundAgentTool {
                 return ToolExecutionResult::tool_error("'task' is required and must be non-empty");
             }
         };
+        if let Some(err) = self.registry.capacity_error() {
+            return ToolExecutionResult::tool_error(err);
+        }
         let label = arguments
             .get("label")
             .and_then(Value::as_str)
@@ -1665,6 +1688,35 @@ mod tests {
             "got: {many}"
         );
         assert!(many.contains("2 background tasks"), "got: {many}");
+    }
+
+    #[tokio::test]
+    async fn capacity_error_blocks_spawn_at_cap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = Arc::new(registry_in(tmp.path()));
+        assert!(reg.capacity_error().is_none());
+
+        // Fill to the cap with long-running scripts (Running synchronously).
+        for _ in 0..MAX_CONCURRENT_TASKS {
+            reg.spawn_script(None, "sleep 30".into());
+        }
+        assert_eq!(reg.counts().0, MAX_CONCURRENT_TASKS);
+        assert!(reg.capacity_error().is_some());
+
+        // The spawn tool refuses past the cap.
+        let run = BackgroundRunTool {
+            registry: reg.clone(),
+        };
+        assert!(
+            run.execute(json!({ "command": "echo hi" }))
+                .await
+                .is_error()
+        );
+
+        // Cancelling a running task frees a slot.
+        let any_id = reg.list()[0].id.clone();
+        assert!(reg.cancel(&any_id));
+        assert!(reg.capacity_error().is_none());
     }
 
     #[test]

--- a/src/capabilities/config.rs
+++ b/src/capabilities/config.rs
@@ -455,6 +455,11 @@ impl SetConfigTool {
                 Ok(saved(format!("attribution = {}", on_off(enabled))))
             }
             KeyTarget::ProactiveWake => {
+                // `clear` reverts to the default (on), keeping settings.toml sparse.
+                if clearing {
+                    self.settings.set_proactive_wake(true).map_err(map_err)?;
+                    return Ok(saved("cleared proactive_wake (default on)".to_string()));
+                }
                 let enabled = parse_on_off(value).ok_or_else(|| {
                     "proactive_wake expects on/off (true/false, yes/no)".to_string()
                 })?;
@@ -658,6 +663,34 @@ mod tests {
 
         let bad = tool
             .execute(json!({ "key": "approval_mode", "value": "whenever" }))
+            .await;
+        assert!(matches!(bad, ToolExecutionResult::ToolError(_)));
+    }
+
+    #[tokio::test]
+    async fn set_config_routes_proactive_wake_with_alias_and_clear() {
+        let (_tmp, settings) = store();
+        let tool = set_config_tool(settings.clone());
+
+        tool.execute(json!({ "key": "proactive_wake", "value": "off" }))
+            .await;
+        assert!(!settings.snapshot().proactive_wake_enabled());
+
+        // Alias routes through the same target.
+        tool.execute(json!({ "key": "wake", "value": "on" })).await;
+        assert!(settings.snapshot().proactive_wake_enabled());
+
+        // `clear` reverts to the default (on).
+        tool.execute(json!({ "key": "proactive_wake", "value": "off" }))
+            .await;
+        let cleared = tool
+            .execute(json!({ "key": "proactive_wake", "value": "clear" }))
+            .await;
+        assert!(matches!(cleared, ToolExecutionResult::Success(_)));
+        assert!(settings.snapshot().proactive_wake_enabled());
+
+        let bad = tool
+            .execute(json!({ "key": "proactive_wake", "value": "maybe" }))
             .await;
         assert!(matches!(bad, ToolExecutionResult::ToolError(_)));
     }

--- a/src/capabilities/config.rs
+++ b/src/capabilities/config.rs
@@ -454,6 +454,13 @@ impl SetConfigTool {
                 self.settings.set_attribution(enabled).map_err(map_err)?;
                 Ok(saved(format!("attribution = {}", on_off(enabled))))
             }
+            KeyTarget::ProactiveWake => {
+                let enabled = parse_on_off(value).ok_or_else(|| {
+                    "proactive_wake expects on/off (true/false, yes/no)".to_string()
+                })?;
+                self.settings.set_proactive_wake(enabled).map_err(map_err)?;
+                Ok(saved(format!("proactive_wake = {}", on_off(enabled))))
+            }
             KeyTarget::ApprovalMode => {
                 let mode = ApprovalMode::parse(value).ok_or_else(|| {
                     "approval_mode expects protective, normal, or off".to_string()

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -162,6 +162,18 @@ pub fn schema() -> &'static [ConfigField] {
             provider_scoped: false,
         },
         ConfigField {
+            key: "proactive_wake",
+            aliases: &["background_wake", "wake"],
+            title: "Proactive background wake",
+            description: "When on, the TUI auto-starts a turn so the agent reacts as soon as a \
+                          background task finishes (instead of waiting for your next prompt). Turn \
+                          off for a quieter session where you review finished tasks yourself.",
+            kind: ValueKind::Bool,
+            default: Some("on"),
+            examples: &["on", "off"],
+            provider_scoped: false,
+        },
+        ConfigField {
             key: "capabilities",
             aliases: &["capability"],
             title: "Harness capabilities",
@@ -194,6 +206,7 @@ pub enum KeyTarget {
     DefaultModel,
     Attribution,
     ApprovalMode,
+    ProactiveWake,
     /// Per-provider model spec, for the named provider.
     Model(String),
     /// Per-provider API token.
@@ -214,6 +227,7 @@ impl KeyTarget {
             KeyTarget::DefaultModel => "default_model",
             KeyTarget::Attribution => "attribution",
             KeyTarget::ApprovalMode => "approval_mode",
+            KeyTarget::ProactiveWake => "proactive_wake",
             KeyTarget::Model(_) => "models",
             KeyTarget::Token(_) => "tokens",
             KeyTarget::BaseUrl(_) => "base_urls",
@@ -264,6 +278,7 @@ pub fn parse_key(input: &str) -> Result<KeyTarget, String> {
         "default_model" | "model" => scalar(KeyTarget::DefaultModel),
         "attribution" => scalar(KeyTarget::Attribution),
         "approval_mode" | "approval" => scalar(KeyTarget::ApprovalMode),
+        "proactive_wake" | "background_wake" | "wake" => scalar(KeyTarget::ProactiveWake),
         "models" | "model_for" => scoped(KeyTarget::Model),
         "tokens" | "token" => scoped(KeyTarget::Token),
         "base_urls" | "base_url" | "url" => scoped(KeyTarget::BaseUrl),

--- a/src/config_service.rs
+++ b/src/config_service.rs
@@ -70,6 +70,7 @@ pub(crate) fn current_value(settings: &Settings, target: &KeyTarget) -> Value {
             .unwrap_or(Value::Null),
         KeyTarget::Attribution => Value::Bool(settings.attribution_enabled()),
         KeyTarget::ApprovalMode => Value::String(settings.approval_mode().as_str().to_string()),
+        KeyTarget::ProactiveWake => Value::Bool(settings.proactive_wake_enabled()),
         KeyTarget::Model(p) => settings
             .model_for(p)
             .map(|s| Value::String(s.to_string()))

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -107,6 +107,9 @@ pub struct Settings {
     /// Soft-approval paranoia level, injected into the system prompt each
     /// turn. Central, cross-session, surfaced in the status bar.
     pub approval_mode: ApprovalMode,
+    /// Whether the TUI auto-starts a turn when a background task finishes while
+    /// idle (proactive wake). On by default; disable for a quieter session.
+    pub proactive_wake: bool,
     /// Ordered harness capability overrides (`[[capabilities]]` in settings.toml).
     pub capabilities: Vec<CapabilityOverride>,
 }
@@ -122,6 +125,7 @@ impl Default for Settings {
             codex_auth: None,
             attribution: true,
             approval_mode: ApprovalMode::Normal,
+            proactive_wake: true,
             capabilities: Vec::new(),
         }
     }
@@ -149,6 +153,10 @@ impl Settings {
             .and_then(Value::as_str)
             .and_then(ApprovalMode::parse)
             .unwrap_or_default();
+        let proactive_wake = table
+            .get("proactive_wake")
+            .and_then(Value::as_bool)
+            .unwrap_or(true);
         let string_map = |key: &str| {
             let mut map = BTreeMap::new();
             if let Some(t) = table.get(key).and_then(Value::as_table) {
@@ -173,6 +181,7 @@ impl Settings {
             codex_auth,
             attribution,
             approval_mode,
+            proactive_wake,
             capabilities: parse_capabilities_table(table),
         }
     }
@@ -187,6 +196,10 @@ impl Settings {
         }
         if !self.attribution {
             table.insert("attribution".to_string(), Value::Boolean(false));
+        }
+        // Only persist when disabled so settings.toml stays sparse.
+        if !self.proactive_wake {
+            table.insert("proactive_wake".to_string(), Value::Boolean(false));
         }
         // Only persist a non-default level so settings.toml stays sparse.
         if self.approval_mode != ApprovalMode::Normal {
@@ -258,6 +271,10 @@ impl Settings {
 
     pub fn approval_mode(&self) -> ApprovalMode {
         self.approval_mode
+    }
+
+    pub fn proactive_wake_enabled(&self) -> bool {
+        self.proactive_wake
     }
 
     pub fn capability_overrides_for(&self, id: &str) -> Vec<(usize, &CapabilityOverride)> {
@@ -420,6 +437,12 @@ impl SettingsStore {
         save_to(&self.path, &guard)
     }
 
+    pub fn set_proactive_wake(&self, enabled: bool) -> Result<()> {
+        let mut guard = self.inner.lock().expect("settings lock poisoned");
+        guard.proactive_wake = enabled;
+        save_to(&self.path, &guard)
+    }
+
     pub fn set_approval_mode(&self, mode: ApprovalMode) -> Result<()> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
         guard.approval_mode = mode;
@@ -552,6 +575,26 @@ mod tests {
 
         assert!(settings.attribution_enabled());
         assert!(!settings.to_table().contains_key("attribution"));
+    }
+
+    #[test]
+    fn proactive_wake_defaults_on_and_round_trips_when_disabled() {
+        let settings = Settings::from_table(&Table::new());
+        assert!(settings.proactive_wake_enabled());
+        // Default stays out of the file to keep it sparse.
+        assert!(!settings.to_table().contains_key("proactive_wake"));
+
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join("settings.toml");
+        let store = SettingsStore::open(path.clone());
+        store.set_proactive_wake(false).expect("save");
+        assert!(!store.snapshot().proactive_wake_enabled());
+        // Survives a reopen.
+        assert!(
+            !SettingsStore::open(path)
+                .snapshot()
+                .proactive_wake_enabled()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Two background-execution guardrails (follow-ups to the #139–#142 series):

1. **`proactive_wake` setting** (bool, default on) — disables the auto-turn from
   #142. With it off, a finished background task still prints a one-line notice
   in the TUI (drained exactly once), but the agent waits for your next prompt
   instead of auto-starting a turn. Plumbed end to end through the config schema,
   settings store, `ConfigService`, and `get_config`/`set_config` (aliases:
   `background_wake`, `wake`), so it's editable via `/setup`-adjacent config
   tooling or the `yolop-config` skill.
2. **Concurrent-task cap** (`MAX_CONCURRENT_TASKS = 8`, scripts + sub-agents
   combined) — `background_run` / `background_agent` refuse new work past the cap
   until a running task finishes or is cancelled, bounding fan-out and (for
   sub-agents) autonomous token spend.

## Why

#142 made yolop auto-act on finished background work; some users will want a
quieter session, hence the opt-out. And the series previously had no ceiling on
concurrent tasks (a noted follow-up) — the cap closes that.

## How validated

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo test --all-features` with provider keys **unset** (mirroring the CI test
  job that tripped #142) — full suite green (442 + 28). New tests:
  - `settings`: `proactive_wake` defaults on, stays out of a sparse file, round-trips when disabled;
  - `background`: `capacity_error_blocks_spawn_at_cap` (fills to cap, tool refuses, cancel frees a slot);
  - `app`: `proactive_wake_disabled_by_setting_does_not_start_turn` (no turn, notice still shown), alongside the existing wake-on / suppressed-during-setup tests.
- Offline boot smoke (`cargo run -- --provider llmsim -p "hi"`).

## Security

No new external surface. `proactive_wake` is a validated on/off config value;
the cap only *reduces* resource use. **TM-LLM:** the cap bounds autonomous
sub-agent token spend (improvement). No filesystem, shell, network, or key
changes.

## Follow-ups

Remaining from the series (not in this PR): extending proactive wake to ACP, and
a richer interactive agent-view-style TUI panel. Happy to take either next.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AmVPP3mHu1ALBThQ9ySuxQ)_