### PR TITLE
feat(background): read-only Ctrl+B background-tasks panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
 - **TUI chat** (ratatui): scrolling transcript, multiline composer, status
   bar (with a `bg` count whenever the session has background tasks), slash commands
   (`/help`, `/tools`, `/mcp`, `/cwd`, `/setup`, `/model`, `/effort`, `/shell`,
-  `/background`, `/clear`, `/quit`), `!<command>` as a direct shell shortcut,
-  and natural-language requests for terminal actions such as "exit" or "clear
-  the screen".
+  `/background`, `/clear`, `/quit`), a read-only background-tasks panel toggled
+  with `Ctrl+B`, `!<command>` as a direct shell shortcut, and natural-language
+  requests for terminal actions such as "exit" or "clear the screen".
 - **Side questions** — `/btw <question>` answers a question about the current
   session out-of-band: same context as the main task, no tools, and nothing
   added to the conversation history.

--- a/specs/background.md
+++ b/specs/background.md
@@ -131,6 +131,10 @@ Background work is visible to the *user*, not just the model:
   every task with its kind, status, exit code, summary, and — for sub-agents —
   the child session id. It works over the TUI and ACP uniformly because it
   returns a plain `CommandResult`.
+- The TUI also has a **read-only panel overlay** (toggle with `Ctrl+B`, ↑/↓ to
+  scroll, `Esc` to close) showing the same `/background` listing live. It mirrors
+  the setup-overlay modal pattern, is suppressed while the setup overlay is open,
+  and captures keys even mid-turn so tasks can be watched during a turn.
 
 ### Proactive wake
 
@@ -163,12 +167,11 @@ without a user prompt.
    child session and drives one turn on a detached task; the parent reads the
    child's result via `background_output`. Each sub-agent is a real session
    folder, so its transcript is resumable. Depth is bounded at one level.
-3. **User surfaces (implemented).** A compact `bg` count in the TUI status bar
-   and a `/background` command listing all tasks (see
-   [User surfaces](#user-surfaces)). A richer interactive view (per-task peek,
-   in-place cancel, a dedicated panel à la Claude Code's agent view) remains a
-   possible enhancement, but the status indicator + command cover the
-   at-a-glance and detail needs.
+3. **User surfaces (implemented).** A compact `bg` count in the TUI status bar,
+   a `/background` command, and a read-only `Ctrl+B` panel overlay (see
+   [User surfaces](#user-surfaces)). Interactive per-task actions in the panel
+   (peek into a task's output, in-place cancel) à la Claude Code's agent view
+   remain a possible enhancement; the current panel is view-only.
 4. **Proactive wake (implemented).** When a task finishes while the TUI session
    is idle, yolop auto-starts a turn so the agent reacts immediately rather than
    waiting for the next user prompt (see [Proactive wake](#proactive-wake)).

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -161,6 +161,9 @@ pub struct App {
     /// This session's background task registry, polled each frame for the
     /// status-bar task count. Same registry the `background` capability owns.
     background: Arc<crate::capabilities::BackgroundRegistry>,
+    /// Open background-tasks panel overlay, holding its scroll offset (in lines).
+    /// `None` when closed. Toggled with Ctrl+B; read-only view of the registry.
+    background_panel: Option<usize>,
 }
 
 /// Result of one background models API fetch. `Ok(None)` means the provider
@@ -445,6 +448,7 @@ impl App {
             models_tx,
             models_rx,
             background: runtime.background,
+            background_panel: None,
         };
         app.emit_system_banner();
         if should_setup {
@@ -784,11 +788,22 @@ impl App {
                     self.should_quit = true;
                     return;
                 }
+                KeyCode::Char('b') => {
+                    self.toggle_background_panel();
+                    return;
+                }
                 _ => {}
             }
         }
 
         self.ctrl_c_pending_exit = false;
+
+        // The background panel overlay captures navigation keys (even mid-turn,
+        // so you can watch tasks while a turn runs).
+        if self.background_panel.is_some() {
+            self.handle_background_panel_key(key);
+            return;
+        }
 
         if self.busy {
             // Block only input editing while a turn is running.
@@ -877,6 +892,40 @@ impl App {
     /// to the result (reads output, continues, or reports) without waiting for a
     /// user prompt. Returns true if it started a turn. Only fires when idle, so
     /// it never interrupts an in-flight turn; each task wakes at most once.
+    /// Open the background-tasks panel (read-only) or close it if already open.
+    /// Suppressed while the setup overlay is up so two modals never stack.
+    fn toggle_background_panel(&mut self) {
+        if self.background_panel.is_some() {
+            self.background_panel = None;
+        } else if self.setup.is_none() {
+            self.background_panel = Some(0);
+        }
+    }
+
+    /// Navigation for the open background panel: Esc/q closes, Up/Down scroll.
+    fn handle_background_panel_key(&mut self, key: KeyEvent) {
+        let Some(offset) = self.background_panel else {
+            return;
+        };
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => self.background_panel = None,
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.background_panel = Some(offset.saturating_sub(1));
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                // Clamp so scrolling can't run past the last line of content.
+                let max = self
+                    .background
+                    .render_task_list()
+                    .lines()
+                    .count()
+                    .saturating_sub(1);
+                self.background_panel = Some(offset.saturating_add(1).min(max));
+            }
+            _ => {}
+        }
+    }
+
     fn maybe_wake_for_background(&mut self) -> bool {
         if self.busy || self.rx.is_some() || self.setup.is_some() {
             return false;
@@ -3048,6 +3097,64 @@ mod tests {
             app.lines.iter().any(|l| l.text.contains(&record.id)),
             "finished task should still be surfaced as a notice"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn background_panel_toggle_scroll_and_close() {
+        let mut test = app_with_llmsim().await;
+        let app = &mut test.app;
+        app.setup = None;
+        assert!(app.background_panel.is_none());
+
+        app.toggle_background_panel();
+        assert_eq!(app.background_panel, Some(0));
+
+        // With no tasks the body is a single line, so Down can't scroll past it.
+        app.handle_background_panel_key(KeyEvent::new(KeyCode::Down, KeyModifiers::empty()));
+        assert_eq!(app.background_panel, Some(0));
+
+        app.handle_background_panel_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()));
+        assert!(app.background_panel.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn background_panel_not_opened_over_setup_overlay() {
+        let mut test = app_with_llmsim().await;
+        let app = &mut test.app;
+        app.setup = Some(SetupStep::Provider { selected: 0 });
+        app.toggle_background_panel();
+        assert!(
+            app.background_panel.is_none(),
+            "panel must not stack on top of the setup overlay"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn background_panel_renders_task_rows() {
+        let mut test = app_with_llmsim().await;
+        let app = &mut test.app;
+        app.setup = None;
+        app.background
+            .spawn_script(Some("ci".into()), "echo hi".into());
+        app.background_panel = Some(0);
+
+        let lines = render_app_lines(app, 120, 20).join("\n");
+        assert!(lines.contains("Background tasks"), "panel header: {lines}");
+        assert!(
+            lines.contains("script"),
+            "panel should list the task: {lines}"
+        );
+    }
+
+    #[test]
+    fn background_panel_lines_header_and_scroll() {
+        let body = "row-a\nrow-b\nrow-c\nrow-d";
+        let lines = render::background_panel_lines(body, 1, 3);
+        assert!(lines[0].contains("Background tasks"));
+        // height 3 ⇒ 1 header + 2 body rows, starting at offset 1.
+        assert_eq!(lines.len(), 3);
+        assert_eq!(lines[1], "row-b");
+        assert_eq!(lines[2], "row-c");
     }
 
     impl App {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -789,6 +789,9 @@ impl App {
                     return;
                 }
                 KeyCode::Char('b') => {
+                    // Clear the armed single-Ctrl+C exit ourselves, since this
+                    // branch returns before the shared reset below.
+                    self.ctrl_c_pending_exit = false;
                     self.toggle_background_panel();
                     return;
                 }
@@ -887,11 +890,6 @@ impl App {
         self.start_turn(text);
     }
 
-    /// Proactive wake (Phase 4): when background tasks reach a terminal state
-    /// while the session is idle, automatically start a turn so the agent reacts
-    /// to the result (reads output, continues, or reports) without waiting for a
-    /// user prompt. Returns true if it started a turn. Only fires when idle, so
-    /// it never interrupts an in-flight turn; each task wakes at most once.
     /// Open the background-tasks panel (read-only) or close it if already open.
     /// Suppressed while the setup overlay is up so two modals never stack.
     fn toggle_background_panel(&mut self) {
@@ -926,6 +924,11 @@ impl App {
         }
     }
 
+    /// Proactive wake (Phase 4): when background tasks reach a terminal state
+    /// while the session is idle, automatically start a turn so the agent reacts
+    /// to the result (reads output, continues, or reports) without waiting for a
+    /// user prompt. Returns true if it started a turn. Only fires when idle, so
+    /// it never interrupts an in-flight turn; each task wakes at most once.
     fn maybe_wake_for_background(&mut self) -> bool {
         if self.busy || self.rx.is_some() || self.setup.is_some() {
             return false;
@@ -3118,6 +3121,23 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ctrl_b_clears_armed_ctrl_c_exit() {
+        let mut test = app_with_llmsim().await;
+        let app = &mut test.app;
+        app.setup = None;
+        app.handle_ctrl_c(); // first Ctrl+C arms the pending exit
+        assert!(app.ctrl_c_pending_exit);
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('b'), KeyModifiers::CONTROL))
+            .await;
+        assert!(
+            !app.ctrl_c_pending_exit,
+            "Ctrl+B must disarm the pending Ctrl+C exit"
+        );
+        assert_eq!(app.background_panel, Some(0));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn background_panel_not_opened_over_setup_overlay() {
         let mut test = app_with_llmsim().await;
         let app = &mut test.app;
@@ -3155,6 +3175,8 @@ mod tests {
         assert_eq!(lines.len(), 3);
         assert_eq!(lines[1], "row-b");
         assert_eq!(lines[2], "row-c");
+        // A zero-height rect yields no lines (not even the header).
+        assert!(render::background_panel_lines(body, 0, 0).is_empty());
     }
 
     impl App {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -345,6 +345,9 @@ pub(crate) fn draw_background_panel(f: &mut ratatui::Frame, area: Rect, app: &Ap
 /// Lines for the background panel: a fixed header followed by the scrolled body
 /// (the `/background` text), clipped to `height` rows. Pure for testability.
 pub(crate) fn background_panel_lines(body: &str, offset: usize, height: usize) -> Vec<String> {
+    if height == 0 {
+        return Vec::new();
+    }
     let mut out = vec!["Background tasks — ↑/↓ scroll · Ctrl+B/Esc to close".to_string()];
     let body_rows = height.saturating_sub(1);
     for line in body.lines().skip(offset).take(body_rows) {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -20,6 +20,7 @@ pub(crate) fn draw(f: &mut ratatui::Frame, app: &mut App) {
     draw_chrome_layout(f, layout.chrome, &state);
     draw_input(f, layout.chrome.input, app);
     draw_setup_overlay(f, area, app);
+    draw_background_panel(f, area, app);
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -295,6 +296,61 @@ pub(crate) fn draw_setup_overlay(f: &mut ratatui::Frame, area: Rect, app: &App) 
                 .saturating_add((row as u16).min(inner.height.saturating_sub(1))),
         ));
     }
+}
+
+/// Read-only background-tasks panel overlay (toggled with Ctrl+B). Reuses the
+/// registry's `/background` rendering for the body, scrolled by the stored
+/// offset, inside the same centered panel as the setup overlay.
+pub(crate) fn draw_background_panel(f: &mut ratatui::Frame, area: Rect, app: &App) {
+    let Some(offset) = app.background_panel else {
+        return;
+    };
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let panel = setup_panel_rect(area);
+    if panel.width == 0 || panel.height == 0 {
+        return;
+    }
+    f.render_widget(Clear, panel);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .style(Style::default().bg(PANEL_BG).fg(TEXT_PRIMARY));
+    f.render_widget(block, panel);
+    let inner = Rect {
+        x: panel.x.saturating_add(2),
+        y: panel.y.saturating_add(1),
+        width: panel.width.saturating_sub(4),
+        height: panel.height.saturating_sub(2),
+    };
+    let body = app.background.render_task_list();
+    let texts = background_panel_lines(&body, offset, inner.height as usize);
+    let mut lines: Vec<Line<'static>> = Vec::with_capacity(texts.len());
+    for (i, text) in texts.into_iter().enumerate() {
+        if i == 0 {
+            lines.push(Line::from(Span::styled(
+                text,
+                Style::default().fg(DIFF_META).add_modifier(Modifier::BOLD),
+            )));
+        } else {
+            lines.push(Line::raw(text));
+        }
+    }
+    f.render_widget(
+        Paragraph::new(lines).style(Style::default().bg(PANEL_BG)),
+        inner,
+    );
+}
+
+/// Lines for the background panel: a fixed header followed by the scrolled body
+/// (the `/background` text), clipped to `height` rows. Pure for testability.
+pub(crate) fn background_panel_lines(body: &str, offset: usize, height: usize) -> Vec<String> {
+    let mut out = vec!["Background tasks — ↑/↓ scroll · Ctrl+B/Esc to close".to_string()];
+    let body_rows = height.saturating_sub(1);
+    for line in body.lines().skip(offset).take(body_rows) {
+        out.push(line.to_string());
+    }
+    out
 }
 
 pub(crate) fn setup_panel_rect(area: Rect) -> Rect {


### PR DESCRIPTION
## What

A read-only **background-tasks panel** in the TUI, toggled with **`Ctrl+B`**
(↑/↓ to scroll, `Esc`/`q` to close). It shows the same listing as `/background`
live, in a centered modal overlay.

- `App.background_panel: Option<usize>` holds the scroll offset (None = closed).
  Toggling is suppressed while the setup overlay is open (no stacked modals), and
  the panel captures navigation keys even mid-turn so tasks can be watched while
  a turn runs.
- `render::draw_background_panel` mirrors the existing setup-overlay rendering and
  reuses the registry's `render_task_list()` for the body — so the panel stays
  consistent with the `/background` command with no duplicated formatting. A pure
  `background_panel_lines` helper handles the header + scroll/clip.

This is the last of the documented background follow-ups (you picked "richer TUI
panel only"). Scoped **view-only**; per-task peek/cancel are left as a future
enhancement (noted in the spec).

## Why

#141 gave an at-a-glance status-bar count + `/background` text. This adds the
dedicated, scrollable panel for eyeballing all background work (scripts and
sub-agents) without scrolling the transcript.

## How validated

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo test --all-features` with provider keys **unset** (mirrors the CI test job) — full suite green (447 + 28). New tests:
  - `background_panel_toggle_scroll_and_close`, `background_panel_not_opened_over_setup_overlay`, `background_panel_renders_task_rows` (renders into a `TestBackend` and asserts the header + a task row appear), and `background_panel_lines_header_and_scroll` (pure header/scroll/clip).
- Offline boot smoke (`cargo run -- --provider llmsim -p "hi"`).

The panel is interactive TUI-only (not reachable from `--print`), so it's covered
by the render + state-transition tests above.

## Security

No security-relevant change: a read-only overlay over the existing per-session
registry. No new filesystem, shell, network, or key handling. **TM-*:** n/a.

## Follow-ups

- Interactive per-task actions in the panel (peek into output, in-place cancel).
- ACP proactive wake (the remaining background follow-up; declined for now).


---
_Generated by [Claude Code](https://claude.ai/code/session_01AmVPP3mHu1ALBThQ9ySuxQ)_