### PR TITLE
feat(tui): paste clipboard images with Ctrl+V

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "ast-grep-core"
 version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,6 +721,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,6 +837,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,6 +859,12 @@ name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
@@ -1012,6 +1054,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1210,6 +1258,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1304,6 +1362,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "euclid"
 version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,7 +1404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
 dependencies = [
  "futures-core",
- "nom",
+ "nom 7.1.3",
  "pin-project-lite",
 ]
 
@@ -1560,6 +1624,21 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "fetchkit"
@@ -1795,6 +1874,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1838,6 +1927,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1867,6 +1966,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2222,6 +2332,35 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]
@@ -2723,6 +2862,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2761,6 +2910,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2824,6 +2982,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.13.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.13.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -2938,6 +3169,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad5fd71b79026fb918650dde6d125000a233764f1c2f1659a1c71118e33ea08f"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3190,6 +3431,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.13.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3417,6 +3677,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
 dependencies = [
  "pulldown-cmark",
+]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4548,7 +4829,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
- "nom",
+ "nom 7.1.3",
  "phf",
  "phf_codegen",
 ]
@@ -4662,6 +4943,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -5235,6 +5530,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5563,6 +5869,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.13.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5599,6 +5975,12 @@ checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wezterm-bidi"
@@ -6048,10 +6430,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "yoke"
@@ -6082,6 +6499,7 @@ version = "0.3.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
+ "arboard",
  "ast-grep-core",
  "ast-grep-language",
  "async-trait",
@@ -6099,6 +6517,7 @@ dependencies = [
  "everruns-openrouter",
  "everruns-runtime",
  "futures",
+ "image",
  "include_dir",
  "portable-pty",
  "rand 0.9.4",
@@ -6214,3 +6633,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,9 @@ everruns-openrouter = "0.13.0"
 everruns-runtime = { version = "0.13.0", features = ["mcp-stdio"] }
 everruns-integrations-duckduckgo = "0.13.0"
 everruns-integrations-daytona = "0.13.0"
+arboard = { version = "3", features = ["wayland-data-control"] }
 futures = "0.3"
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
 
 [dev-dependencies]
 portable-pty = "0.9.0"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -545,7 +545,10 @@ impl App {
                 .collect();
             self.push_system(format!("commands: {}", names.join(", ")));
         }
-        self.push_system("type /help for commands, press Ctrl-C twice (or Ctrl-D) to exit".into());
+        self.push_system(
+            "type /help for commands, Ctrl+V to paste an image, press Ctrl-C twice (or Ctrl-D) to exit"
+                .into(),
+        );
     }
 
     fn push_user(&mut self, text: String) {
@@ -826,6 +829,10 @@ impl App {
                     self.toggle_background_panel();
                     return;
                 }
+                KeyCode::Char('v') => {
+                    self.try_paste_clipboard_image();
+                    return;
+                }
                 _ => {}
             }
         }
@@ -896,6 +903,27 @@ impl App {
     fn input_height(&self, input_width: u16) -> u16 {
         wrapped_input_visual_lines(&self.input, input_width).clamp(1, MAX_INPUT_HEIGHT as usize)
             as u16
+    }
+
+    fn try_paste_clipboard_image(&mut self) {
+        if self.busy || self.setup.is_some() || self.background_panel.is_some() {
+            return;
+        }
+        match crate::clipboard_paste::paste_image_content_part() {
+            Ok((part, info)) => {
+                self.pending_images.push(part);
+                let index = self.pending_images.len();
+                self.push_system(format!(
+                    "attached clipboard image #{index} ({}x{} PNG)",
+                    info.width, info.height
+                ));
+            }
+            Err(crate::clipboard_paste::PasteImageError::NoImage(_)) => {}
+            Err(err) => {
+                tracing::debug!("clipboard image paste failed: {err}");
+                self.push_system(format!("clipboard image paste failed: {err}"));
+            }
+        }
     }
 
     async fn submit_input(&mut self) {
@@ -3556,6 +3584,15 @@ mod tests {
     async fn startup_banner_names_ctrl_c_and_ctrl_d_as_exit_keys() {
         let fixture = app_with_llmsim().await;
 
+        assert!(
+            fixture
+                .app
+                .lines
+                .iter()
+                .any(|line| line.text.contains("Ctrl+V to paste an image")),
+            "startup banner should mention image paste: {:?}",
+            fixture.app.lines
+        );
         assert!(
             fixture
                 .app

--- a/src/clipboard_paste.rs
+++ b/src/clipboard_paste.rs
@@ -36,14 +36,18 @@ impl std::fmt::Display for PasteImageError {
 
 impl std::error::Error for PasteImageError {}
 
+fn part_from_encoded(bytes: &[u8], media_type: &str) -> Result<ContentPart, PasteImageError> {
+    image_input::image_part_from_encoded(bytes, media_type)
+        .map_err(|err| PasteImageError::EncodeFailed(err.to_string()))
+}
+
 /// Read an image from the clipboard and return a PNG content part plus dimensions.
 #[cfg(not(target_os = "android"))]
 pub fn paste_image_content_part() -> Result<(ContentPart, PastedImageInfo), PasteImageError> {
     match paste_image_as_png() {
         Ok(result) => {
             let (png, info) = result;
-            let part = image_input::image_part_from_encoded(&png, "image/png")
-                .map_err(|err| PasteImageError::IoError(err.to_string()))?;
+            let part = part_from_encoded(&png, "image/png")?;
             Ok((part, info))
         }
         Err(err) => {
@@ -56,8 +60,7 @@ pub fn paste_image_content_part() -> Result<(ContentPart, PastedImageInfo), Past
                 {
                     let bytes = std::fs::read(&path)
                         .map_err(|io| PasteImageError::IoError(io.to_string()))?;
-                    let part = image_input::image_part_from_encoded(&bytes, "image/png")
-                        .map_err(|io| PasteImageError::IoError(io.to_string()))?;
+                    let part = part_from_encoded(&bytes, "image/png")?;
                     return Ok((part, info));
                 }
             }
@@ -121,7 +124,7 @@ fn encode_dynamic_image_png(
         .write_to(&mut Cursor::new(&mut png), image::ImageFormat::Png)
         .map_err(|err| PasteImageError::EncodeFailed(err.to_string()))?;
     if png.len() > MAX_IMAGE_BYTES {
-        return Err(PasteImageError::IoError(format!(
+        return Err(PasteImageError::EncodeFailed(format!(
             "clipboard image exceeds {} byte limit",
             MAX_IMAGE_BYTES
         )));
@@ -144,7 +147,7 @@ pub(crate) fn try_wsl_clipboard_png() -> Result<(PathBuf, PastedImageInfo), Past
         ));
     }
 
-    let script = r#"[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; $img = Get-Clipboard -Format Image; if ($img -ne $null) { $p=[System.IO.Path]::GetTempFileName(); $p = [System.IO.Path]::ChangeExtension($p,'png'); $img.Save($p,[System.Drawing.Imaging.ImageFormat]::Png); Write-Output $p } else { exit 1 }"#;
+    let script = r#"[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; $img = Get-Clipboard -Format Image; if ($img -ne $null) { $p = Join-Path $env:TEMP ("yolop-clipboard-" + [guid]::NewGuid().ToString() + ".png"); $img.Save($p,[System.Drawing.Imaging.ImageFormat]::Png); Write-Output $p } else { exit 1 }"#;
 
     for cmd in ["powershell.exe", "pwsh", "powershell"] {
         let Ok(output) = std::process::Command::new(cmd)

--- a/src/clipboard_paste.rs
+++ b/src/clipboard_paste.rs
@@ -1,0 +1,228 @@
+// Clipboard image paste for the interactive TUI (Ctrl+V).
+//
+// Follows Codex CLI's approach: read image bytes or file paths from the
+// system clipboard via `arboard`, normalize to PNG, and attach as a
+// multimodal user-message part.
+
+use crate::image_input::{self, MAX_IMAGE_BYTES};
+use everruns_core::message::ContentPart;
+use std::io::Cursor;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone)]
+pub struct PastedImageInfo {
+    pub width: u32,
+    pub height: u32,
+}
+
+#[derive(Debug, Clone)]
+pub enum PasteImageError {
+    ClipboardUnavailable(String),
+    NoImage(String),
+    EncodeFailed(String),
+    IoError(String),
+}
+
+impl std::fmt::Display for PasteImageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ClipboardUnavailable(msg) => write!(f, "clipboard unavailable: {msg}"),
+            Self::NoImage(msg) => write!(f, "no image on clipboard: {msg}"),
+            Self::EncodeFailed(msg) => write!(f, "could not encode image: {msg}"),
+            Self::IoError(msg) => write!(f, "io error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for PasteImageError {}
+
+/// Read an image from the clipboard and return a PNG content part plus dimensions.
+#[cfg(not(target_os = "android"))]
+pub fn paste_image_content_part() -> Result<(ContentPart, PastedImageInfo), PasteImageError> {
+    match paste_image_as_png() {
+        Ok(result) => {
+            let (png, info) = result;
+            let part = image_input::image_part_from_encoded(&png, "image/png")
+                .map_err(|err| PasteImageError::IoError(err.to_string()))?;
+            Ok((part, info))
+        }
+        Err(err) => {
+            #[cfg(target_os = "linux")]
+            {
+                if matches!(
+                    &err,
+                    PasteImageError::ClipboardUnavailable(_) | PasteImageError::NoImage(_)
+                ) && let Ok((path, info)) = try_wsl_clipboard_png()
+                {
+                    let bytes = std::fs::read(&path)
+                        .map_err(|io| PasteImageError::IoError(io.to_string()))?;
+                    let part = image_input::image_part_from_encoded(&bytes, "image/png")
+                        .map_err(|io| PasteImageError::IoError(io.to_string()))?;
+                    return Ok((part, info));
+                }
+            }
+            Err(err)
+        }
+    }
+}
+
+#[cfg(target_os = "android")]
+pub fn paste_image_content_part() -> Result<(ContentPart, PastedImageInfo), PasteImageError> {
+    Err(PasteImageError::ClipboardUnavailable(
+        "clipboard image paste is unsupported on Android".into(),
+    ))
+}
+
+#[cfg(not(target_os = "android"))]
+fn paste_image_as_png() -> Result<(Vec<u8>, PastedImageInfo), PasteImageError> {
+    let mut clipboard = arboard::Clipboard::new()
+        .map_err(|err| PasteImageError::ClipboardUnavailable(err.to_string()))?;
+
+    let files = clipboard
+        .get()
+        .file_list()
+        .map_err(|err| PasteImageError::ClipboardUnavailable(err.to_string()));
+
+    let dynamic = if let Some(img) = files
+        .unwrap_or_default()
+        .into_iter()
+        .find_map(|path| image::open(path).ok())
+    {
+        img
+    } else {
+        let img = clipboard
+            .get_image()
+            .map_err(|err| PasteImageError::NoImage(err.to_string()))?;
+        let width: u32 = img
+            .width
+            .try_into()
+            .map_err(|_| PasteImageError::EncodeFailed("clipboard image too wide".into()))?;
+        let height: u32 = img
+            .height
+            .try_into()
+            .map_err(|_| PasteImageError::EncodeFailed("clipboard image too tall".into()))?;
+        let Some(rgba) = image::RgbaImage::from_raw(width, height, img.bytes.into_owned()) else {
+            return Err(PasteImageError::EncodeFailed(
+                "invalid RGBA buffer from clipboard".into(),
+            ));
+        };
+        image::DynamicImage::ImageRgba8(rgba)
+    };
+
+    encode_dynamic_image_png(&dynamic)
+}
+
+#[cfg(not(target_os = "android"))]
+fn encode_dynamic_image_png(
+    image: &image::DynamicImage,
+) -> Result<(Vec<u8>, PastedImageInfo), PasteImageError> {
+    let mut png = Vec::new();
+    image
+        .write_to(&mut Cursor::new(&mut png), image::ImageFormat::Png)
+        .map_err(|err| PasteImageError::EncodeFailed(err.to_string()))?;
+    if png.len() > MAX_IMAGE_BYTES {
+        return Err(PasteImageError::IoError(format!(
+            "clipboard image exceeds {} byte limit",
+            MAX_IMAGE_BYTES
+        )));
+    }
+    Ok((
+        png,
+        PastedImageInfo {
+            width: image.width(),
+            height: image.height(),
+        },
+    ))
+}
+
+/// Linux/WSL fallback: ask Windows PowerShell to dump the clipboard image to a temp PNG.
+#[cfg(all(not(target_os = "android"), target_os = "linux"))]
+pub(crate) fn try_wsl_clipboard_png() -> Result<(PathBuf, PastedImageInfo), PasteImageError> {
+    if !is_probably_wsl() {
+        return Err(PasteImageError::ClipboardUnavailable(
+            "not running under WSL".into(),
+        ));
+    }
+
+    let script = r#"[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; $img = Get-Clipboard -Format Image; if ($img -ne $null) { $p=[System.IO.Path]::GetTempFileName(); $p = [System.IO.Path]::ChangeExtension($p,'png'); $img.Save($p,[System.Drawing.Imaging.ImageFormat]::Png); Write-Output $p } else { exit 1 }"#;
+
+    for cmd in ["powershell.exe", "pwsh", "powershell"] {
+        let Ok(output) = std::process::Command::new(cmd)
+            .args(["-NoProfile", "-Command", script])
+            .output()
+        else {
+            continue;
+        };
+        if !output.status.success() {
+            continue;
+        }
+        let win_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if win_path.is_empty() {
+            continue;
+        }
+        let Some(path) = convert_windows_path_to_wsl(&win_path) else {
+            continue;
+        };
+        let (width, height) = image::image_dimensions(&path)
+            .map_err(|err| PasteImageError::IoError(err.to_string()))?;
+        return Ok((path, PastedImageInfo { width, height }));
+    }
+
+    Err(PasteImageError::NoImage(
+        "Windows clipboard did not contain an image".into(),
+    ))
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn is_probably_wsl() -> bool {
+    if let Ok(version) = std::fs::read_to_string("/proc/version") {
+        let version = version.to_lowercase();
+        if version.contains("microsoft") || version.contains("wsl") {
+            return true;
+        }
+    }
+    std::env::var_os("WSL_DISTRO_NAME").is_some() || std::env::var_os("WSL_INTEROP").is_some()
+}
+
+#[cfg(target_os = "linux")]
+fn convert_windows_path_to_wsl(input: &str) -> Option<PathBuf> {
+    if input.starts_with("\\\\") {
+        return None;
+    }
+    let mut chars = input.chars();
+    let drive = chars.next()?.to_ascii_lowercase();
+    if !drive.is_ascii_alphabetic() || input.get(1..2) != Some(":") {
+        return None;
+    }
+    let mut result = PathBuf::from(format!("/mnt/{drive}"));
+    for component in input
+        .get(2..)?
+        .trim_start_matches(['\\', '/'])
+        .split(['\\', '/'])
+        .filter(|component| !component.is_empty())
+    {
+        result.push(component);
+    }
+    Some(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_dynamic_image_png_respects_size_limit() {
+        let image = image::DynamicImage::new_rgba8(4, 4);
+        let (png, info) = encode_dynamic_image_png(&image).expect("encode png");
+        assert!(!png.is_empty());
+        assert_eq!(info.width, 4);
+        assert_eq!(info.height, 4);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn convert_windows_path_to_wsl_maps_drive_paths() {
+        let path = convert_windows_path_to_wsl(r"C:\Users\Alice\shot.png").expect("convert");
+        assert_eq!(path, PathBuf::from("/mnt/c/Users/Alice/shot.png"));
+    }
+}

--- a/src/image_input.rs
+++ b/src/image_input.rs
@@ -40,6 +40,7 @@ pub fn load_image_part(path: &Path) -> Result<ContentPart> {
     let bytes = std::fs::read(path).with_context(|| format!("read image {}", path.display()))?;
     let media_type = detect_media_type(path, &bytes)?;
     image_part_from_encoded(&bytes, &media_type)
+        .with_context(|| format!("image {}", path.display()))
 }
 
 /// Build user-facing transcript text that mentions attached images.

--- a/src/image_input.rs
+++ b/src/image_input.rs
@@ -21,25 +21,25 @@ pub fn load_image_parts(paths: &[PathBuf]) -> Result<Vec<ContentPart>> {
         .collect::<Result<Vec<_>>>()
 }
 
-/// Read a single image file and return a base64 `ContentPart::Image`.
-pub fn load_image_part(path: &Path) -> Result<ContentPart> {
-    let bytes = std::fs::read(path).with_context(|| format!("read image {}", path.display()))?;
+/// Build a `ContentPart::Image` from already-encoded image bytes.
+pub fn image_part_from_encoded(bytes: &[u8], media_type: &str) -> Result<ContentPart> {
     if bytes.is_empty() {
-        bail!("image {} is empty", path.display());
+        bail!("image is empty");
     }
     if bytes.len() > MAX_IMAGE_BYTES {
-        bail!(
-            "image {} is {} bytes (max {})",
-            path.display(),
-            bytes.len(),
-            MAX_IMAGE_BYTES
-        );
+        bail!("image is {} bytes (max {})", bytes.len(), MAX_IMAGE_BYTES);
     }
-    let media_type = detect_media_type(path, &bytes)?;
-    let base64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+    let base64 = base64::engine::general_purpose::STANDARD.encode(bytes);
     Ok(ContentPart::Image(ImageContentPart::from_base64(
         base64, media_type,
     )))
+}
+
+/// Read a single image file and return a base64 `ContentPart::Image`.
+pub fn load_image_part(path: &Path) -> Result<ContentPart> {
+    let bytes = std::fs::read(path).with_context(|| format!("read image {}", path.display()))?;
+    let media_type = detect_media_type(path, &bytes)?;
+    image_part_from_encoded(&bytes, &media_type)
 }
 
 /// Build user-facing transcript text that mentions attached images.

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod acp;
 mod app;
 mod capabilities;
 mod capability_settings;
+mod clipboard_paste;
 mod codex_auth;
 mod codex_driver;
 mod config_schema;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds clipboard image paste to the interactive TUI, following Codex CLI's approach.

Press **Ctrl+V** while composing a message to attach a screenshot or copied image to the next turn. Images are read from the system clipboard, normalized to PNG, and queued in `pending_images` (same path as `--image` / `-i`).

## Behavior

- **Ctrl+V** in the composer (when not busy, in setup, or in the background panel)
- Reads image data or file paths from the clipboard via `arboard` (`wayland-data-control` enabled for native Wayland)
- Encodes to PNG and attaches as `ContentPart::Image`
- Shows a system line: `attached clipboard image #N (WxH PNG)`
- Silent when the clipboard has no image (text-only clipboard)
- **WSL fallback**: PowerShell dumps the Windows clipboard to a temp PNG when `arboard` cannot reach it

## Changes

- `src/clipboard_paste.rs` — clipboard read, PNG encode, WSL fallback
- `src/image_input.rs` — shared `image_part_from_encoded()` helper
- `src/app/mod.rs` — Ctrl+V handler + startup hint
- `Cargo.toml` — `arboard`, `image` dependencies

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- Unit tests: PNG encode, WSL path mapping, startup banner mentions Ctrl+V

## Security

- **TM-FS**: clipboard images become in-memory base64 parts; WSL fallback reads a temp PNG path only after PowerShell writes it. 20MB cap inherited from `image_input`.
- **TM-DEP**: `arboard` (clipboard), `image` (encode/decode) — same roles as Codex CLI.

## Follow-ups

- Bracketed-paste coexistence: Ctrl+V is image-first; terminals that paste text via bracketed paste are unchanged.
- Optional `YOLOP_CLIPBOARD_READER` env hook for headless/SSH environments (Codex pattern).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c71d9a3-7113-4bf9-ac80-297f46be2e10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c71d9a3-7113-4bf9-ac80-297f46be2e10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

