### PR TITLE
fix(runtime): keep todo schema loaded

### DIFF
--- a/specs/tool-search.md
+++ b/specs/tool-search.md
@@ -38,13 +38,14 @@ vendor was deleted and yolop now consumes upstream directly:
    `ToolSearchCapability::new().with_never_defer([...])` so they always keep full
    schemas and common work needs no `tool_search` round-trip: the file/shell
    tools (`read_file`, `write_file`, `edit_file`, `list_directory`,
-   `grep_files`, `bash`) plus `run_yolop_command` (the client-command dispatch
-   tool, which requires a `command` argument and so must never be called against
-   a stub). Yolop does not own those tool definitions (they come from
-   `FileSystemCapability`, yolop's `bash` tool, and the `client_commands`
-   capability), so it sets the policy by name rather than via each tool's
-   `DeferrablePolicy`. The long tail (search, web fetch, memory, skills,
-   history, todos) defers until requested. **MCP server tools defer on the same
+   `grep_files`, `bash`), the planning tool (`write_todos`), plus
+   `run_yolop_command` (the client-command dispatch tool, which requires a
+   `command` argument and so must never be called against a stub). Yolop does
+   not own those tool definitions (they come from `FileSystemCapability`,
+   `StatelessTodoListCapability`, yolop's `bash` tool, and the
+   `client_commands` capability), so it sets the policy by name rather than via
+   each tool's `DeferrablePolicy`. The long tail (search, web fetch, memory,
+   skills, history) defers until requested. **MCP server tools defer on the same
    footing** — with many configured servers their schemas are the largest,
    least-used part of the surface, so only names and descriptions ride each turn
    until `tool_search` loads a schema (execution still routes through the real

--- a/src/clipboard_paste.rs
+++ b/src/clipboard_paste.rs
@@ -7,6 +7,7 @@
 use crate::image_input::{self, MAX_IMAGE_BYTES};
 use everruns_core::message::ContentPart;
 use std::io::Cursor;
+#[cfg(target_os = "linux")]
 use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
@@ -20,6 +21,7 @@ pub enum PasteImageError {
     ClipboardUnavailable(String),
     NoImage(String),
     EncodeFailed(String),
+    #[cfg(target_os = "linux")]
     IoError(String),
 }
 
@@ -29,6 +31,7 @@ impl std::fmt::Display for PasteImageError {
             Self::ClipboardUnavailable(msg) => write!(f, "clipboard unavailable: {msg}"),
             Self::NoImage(msg) => write!(f, "no image on clipboard: {msg}"),
             Self::EncodeFailed(msg) => write!(f, "could not encode image: {msg}"),
+            #[cfg(target_os = "linux")]
             Self::IoError(msg) => write!(f, "io error: {msg}"),
         }
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -394,6 +394,16 @@ const DEFAULT_OLLAMA_API_KEY: &str = "ollama";
 // Generic OpenAI-compatible servers usually ignore the bearer token, but the
 // OpenAI client requires one — same trick as Ollama's placeholder key.
 const DEFAULT_CUSTOM_API_KEY: &str = "unused";
+const YOLOP_NEVER_DEFER_TOOLS: &[&str] = &[
+    "read_file",
+    "write_file",
+    "edit_file",
+    "list_directory",
+    "grep_files",
+    "bash",
+    "write_todos",
+    "run_yolop_command",
+];
 
 #[derive(Clone, Debug)]
 pub enum ProviderChoice {
@@ -1789,21 +1799,15 @@ pub async fn build_with_options(
     // Provider-agnostic deferred tool loading (upstream `everruns-core`, 0.11.0+).
     // Defers the long tail behind a `tool_search` tool and restores real schemas
     // progressively (per-session reveal set). The `never_defer` allowlist keeps
-    // the hot-path file/shell tools fully loaded so the agent never needs a
-    // `tool_search` round-trip before its first read/edit/run — yolop does not
+    // hot-path file/shell/planning tools fully loaded so the agent never needs a
+    // `tool_search` round-trip before its first read/edit/run/todo call — yolop does not
     // own those tool definitions, so it sets the policy by name here. Works on
     // every provider/model, unlike the native `openai_tool_search` (EVE-521).
     // Progressive disclosure + this allowlist landed upstream in EVE-527 (#2130),
     // which retired the previously vendored copy.
-    capabilities.register(ToolSearchCapability::new().with_never_defer([
-        "read_file",
-        "write_file",
-        "edit_file",
-        "list_directory",
-        "grep_files",
-        "bash",
-        "run_yolop_command",
-    ]));
+    capabilities.register(
+        ToolSearchCapability::new().with_never_defer(YOLOP_NEVER_DEFER_TOOLS.iter().copied()),
+    );
     capabilities.register(ToolOutputPersistenceCapability);
     capabilities.register(SessionStorageCapability);
     capabilities.register(DaytonaCapability);
@@ -3665,6 +3669,76 @@ mod tests {
                 "tool_search must be enabled (client_commands={client_commands})"
             );
         }
+    }
+
+    #[test]
+    fn tool_search_keeps_write_todos_schema_loaded() {
+        use everruns_core::capabilities::{Capability, DEFAULT_TOOL_SEARCH_THRESHOLD};
+        use everruns_core::tool_types::{
+            BuiltinTool, DeferrablePolicy, ToolDefinition, ToolHints, ToolPolicy,
+        };
+
+        fn fake_tool(name: impl Into<String>) -> ToolDefinition {
+            ToolDefinition::Builtin(BuiltinTool {
+                name: name.into(),
+                display_name: None,
+                description: "fake tool".to_string(),
+                parameters: serde_json::json!({
+                    "type": "object",
+                    "properties": { "value": { "type": "string" } },
+                    "required": ["value"]
+                }),
+                policy: ToolPolicy::Auto,
+                category: None,
+                deferrable: DeferrablePolicy::Automatic,
+                hints: ToolHints::default(),
+                full_parameters: None,
+            })
+        }
+
+        let mut tools = vec![ToolDefinition::Builtin(BuiltinTool {
+            name: "write_todos".to_string(),
+            display_name: None,
+            description: "write todos".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": { "todos": { "type": "array" } },
+                "required": ["todos"]
+            }),
+            policy: ToolPolicy::Auto,
+            category: None,
+            deferrable: DeferrablePolicy::Automatic,
+            hints: ToolHints::default(),
+            full_parameters: None,
+        })];
+        tools
+            .extend((0..DEFAULT_TOOL_SEARCH_THRESHOLD).map(|idx| fake_tool(format!("fake_{idx}"))));
+
+        let hook = ToolSearchCapability::new()
+            .with_never_defer(YOLOP_NEVER_DEFER_TOOLS.iter().copied())
+            .tool_definition_hooks()
+            .into_iter()
+            .next()
+            .expect("tool_search hook");
+        let transformed = hook.transform(tools);
+
+        let write_todos = transformed
+            .iter()
+            .find(|tool| tool.name() == "write_todos")
+            .expect("write_todos definition");
+        assert!(
+            write_todos.parameters().get("properties").is_some(),
+            "write_todos must keep its full schema so models pass the required todos field"
+        );
+
+        let fake = transformed
+            .iter()
+            .find(|tool| tool.name() == "fake_0")
+            .expect("fake tool definition");
+        assert!(
+            fake.parameters().get("properties").is_none(),
+            "precondition: deferral should be active for non-allowlisted tools"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What
Keep `write_todos` in Yolop's `tool_search` never-defer allowlist so the model always receives the real `{ todos: [...] }` schema instead of a permissive deferred stub.

Also aligns `specs/tool-search.md` with that behavior and fixes a macOS clippy warning from latest `origin/main` by gating Linux-only clipboard paste items.

## Why
When `write_todos` was deferred, models could see the tool name/description without the full required schema and sometimes called it without the required `todos` field. The runtime then rejected the call with `Missing required field: 'todos'`.

## How
- Centralized Yolop's never-defer tool names in `YOLOP_NEVER_DEFER_TOOLS`.
- Added `write_todos` to that list before wiring `ToolSearchCapability`.
- Added a regression test that runs the actual upstream tool-definition hook over an over-threshold tool surface and proves `write_todos` keeps `properties` while a fake tool is deferred.
- Updated the tool-search spec to describe `write_todos` as hot-path rather than long-tail deferred.
- Added cfg guards for Linux-only clipboard paste symbols so rebased clippy is green on macOS.

## Risk
- Low
- The behavior change only affects prompt-facing tool schema deferral. It sends one additional hot-path schema up front and reduces invalid todo calls. No new capabilities, filesystem behavior, shell behavior, dependencies, or secret handling changes.

## Security
- TM-TOOL: `write_todos` was already registered and executable; this only keeps its schema visible instead of deferred. No new tool or capability is added.
- TM-FS/TM-BASH/TM-LLM/TM-DEP: no filesystem access, shell execution, provider key handling, prompt-secret behavior, or dependency changes.
- Clipboard cleanup is cfg-only and does not alter runtime logic.

## Validation
- [x] `cargo fmt --check`
- [x] `cargo test --all-features runtime::tests::tool_search_keeps_write_todos_schema_loaded -- --nocapture`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] `cargo run -- --provider llmsim -p "hi"`
- [x] CI: Format + Clippy
- [x] CI: Build + Tests + Offline Smoke
- [x] CI: Live Provider Smoke (Doppler)
- [x] CI: CodeQL + analysis jobs

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
