### PR TITLE
fix(tui): tighten idle layout spacing

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -96,7 +96,6 @@ pub const COMPOSER_VIEWPORT_HEIGHT: u16 = 18;
 /// so this bounds a permanently dead terminal to ~10s before exit while
 /// letting a briefly unresponsive emulator recover.
 const MAX_TERMINAL_IO_FAILURES: usize = 5;
-const COMPACT_CHROME_HEIGHT: u16 = 5;
 const MAX_INPUT_HEIGHT: u16 = 12;
 const EXPANDED_STATUS_ROWS: u16 = 4;
 const RECENT_TRANSCRIPT_SOURCE_LINES: usize = 80;
@@ -1176,10 +1175,12 @@ impl App {
 
     fn mouse_is_on_status(&self, mouse: MouseEvent, terminal_area: Rect) -> bool {
         let input_width = terminal_area.width.saturating_sub(2);
+        let state = self.view_state();
         let layout = app_layout_for_frame(
             terminal_area,
             self.input_height(input_width),
             self.status_layout,
+            chrome_preview_visible(&state),
         );
         if layout.chrome.session_status.height == 0 {
             return false;
@@ -2111,26 +2112,28 @@ mod tests {
 
     #[test]
     fn chrome_height_reserves_four_expanded_status_rows() {
-        assert_eq!(chrome_height(1, StatusLayout::Compact), 5);
-        assert_eq!(chrome_height(1, StatusLayout::Expanded), 8);
-        assert_eq!(chrome_height(3, StatusLayout::Compact), 5);
-        assert_eq!(chrome_height(3, StatusLayout::Expanded), 8);
-        assert_eq!(chrome_height(4, StatusLayout::Compact), 6);
-        assert_eq!(chrome_height(4, StatusLayout::Expanded), 9);
+        assert_eq!(chrome_height(1, StatusLayout::Compact, false), 4);
+        assert_eq!(chrome_height(1, StatusLayout::Compact, true), 5);
+        assert_eq!(chrome_height(1, StatusLayout::Expanded, false), 7);
+        assert_eq!(chrome_height(1, StatusLayout::Expanded, true), 8);
+        assert_eq!(chrome_height(3, StatusLayout::Compact, false), 5);
+        assert_eq!(chrome_height(3, StatusLayout::Expanded, false), 8);
+        assert_eq!(chrome_height(4, StatusLayout::Compact, false), 6);
+        assert_eq!(chrome_height(4, StatusLayout::Expanded, false), 9);
     }
 
     #[test]
     fn chrome_dimensions_clamp_input_to_visible_frame() {
         assert_eq!(
-            chrome_dimensions(7, MAX_INPUT_HEIGHT, StatusLayout::Expanded),
+            chrome_dimensions(7, MAX_INPUT_HEIGHT, StatusLayout::Expanded, false),
             (7, 1)
         );
         assert_eq!(
-            chrome_dimensions(5, MAX_INPUT_HEIGHT, StatusLayout::Compact),
+            chrome_dimensions(5, MAX_INPUT_HEIGHT, StatusLayout::Compact, false),
             (5, 3)
         );
         assert_eq!(
-            chrome_dimensions(0, MAX_INPUT_HEIGHT, StatusLayout::Compact),
+            chrome_dimensions(0, MAX_INPUT_HEIGHT, StatusLayout::Compact, false),
             (0, 0)
         );
     }
@@ -2161,7 +2164,8 @@ mod tests {
                             width,
                             height,
                         };
-                        let layout = app_layout_for_frame(frame, desired_input, status_layout);
+                        let layout =
+                            app_layout_for_frame(frame, desired_input, status_layout, false);
                         assert_eq!(layout.frame, frame);
                         assert!(
                             rect_inside(frame, layout.transcript),
@@ -3642,6 +3646,34 @@ mod tests {
             rows.iter()
                 .any(|row| row.contains("mirrors resumed history")),
             "inline viewport should show recent assistant transcript: {rows:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn inline_viewport_bottom_aligns_recent_transcript_tail() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+        app.lines.clear();
+        app.lines.push(ChatLine {
+            author: Author::Assistant,
+            text: "Latest answer tail".into(),
+        });
+
+        let rows = render_app_lines(app, 96, COMPOSER_VIEWPORT_HEIGHT);
+        let answer_row = rows
+            .iter()
+            .position(|row| row.contains("Latest answer tail"))
+            .expect("recent answer rendered");
+        let separator_row = rows
+            .iter()
+            .position(|row| row.contains("Enter to send"))
+            .expect("message separator rendered");
+
+        assert_eq!(
+            answer_row + 1,
+            separator_row,
+            "recent answer should sit above the input chrome without a large blank gap: {rows:?}"
         );
     }
 
@@ -5241,10 +5273,10 @@ mod tests {
     #[test]
     fn chrome_idle_shows_enter_to_send_hint() {
         let state = view_state_idle();
-        let rows = render_chrome_lines(&state, 80, 5);
-        // Row 1 = message separator. Idle mode shows the keystroke hint.
+        let rows = render_chrome_lines(&state, 80, 4);
+        // Row 0 = message separator. Idle mode shows the keystroke hint.
         assert!(
-            rows[1].contains("Enter to send"),
+            rows[0].contains("Enter to send"),
             "idle separator missing Enter hint: rows={rows:?}"
         );
     }
@@ -5257,16 +5289,16 @@ mod tests {
             turn_activity: Some("reading files".to_string()),
             ..view_state_idle()
         };
-        let rows = render_chrome_lines(&state, 80, 5);
+        let rows = render_chrome_lines(&state, 80, 4);
         assert!(
-            rows[1].contains("reading files"),
+            rows[0].contains("reading files"),
             "busy separator should display turn activity: {}",
-            rows[1]
+            rows[0]
         );
         assert!(
-            rows[1].contains("input disabled"),
+            rows[0].contains("input disabled"),
             "busy separator should signal input is disabled: {}",
-            rows[1]
+            rows[0]
         );
     }
 
@@ -5276,11 +5308,11 @@ mod tests {
             busy: true,
             ..view_state_idle()
         };
-        let rows = render_chrome_lines(&state, 80, 5);
+        let rows = render_chrome_lines(&state, 80, 4);
         assert!(
-            rows[1].contains("thinking"),
+            rows[0].contains("thinking"),
             "busy separator without activity should show 'thinking': {}",
-            rows[1]
+            rows[0]
         );
     }
 
@@ -5320,8 +5352,8 @@ mod tests {
             lines_count: 42,
             ..view_state_idle()
         };
-        let rows = render_chrome_lines(&state, 120, 5);
-        let status = &rows[4];
+        let rows = render_chrome_lines(&state, 120, 4);
+        let status = &rows[3];
         assert!(
             status.contains("[expand ↓]"),
             "compact status should include expand affordance: {status}"
@@ -5353,7 +5385,7 @@ mod tests {
     }
 
     #[test]
-    fn chrome_session_status_expanded_groups_details_across_three_lines() {
+    fn chrome_session_status_expanded_groups_details_across_four_lines() {
         let state = ViewState {
             model_id: "nvidia/nemotron-3-super-120b-a12b".to_string(),
             provider_name: "openrouter".to_string(),
@@ -5364,44 +5396,42 @@ mod tests {
             status_layout: StatusLayout::Expanded,
             ..view_state_idle()
         };
-        let rows = render_chrome_lines(&state, 180, 8);
+        let rows = render_chrome_lines(&state, 180, 7);
         assert!(
-            rows[4].contains("[collapse ↑]")
-                && rows[4].contains("nvidia/nemotron-3-super-120b-a12b")
-                && rows[4].contains("provider openrouter"),
-            "expanded model row should include selected model and provider: {:?}",
-            rows[4]
+            rows[3].contains("[collapse ↑]")
+                && rows[3].contains("provider openrouter")
+                && rows[3].contains("model nvidia/nemotron-3-super-120b-a12b"),
+            "expanded provider/model row should include selected model and provider: {:?}",
+            rows[3]
         );
         assert!(
-            !rows[4].contains("full "),
+            !rows[3].contains("full "),
             "expanded model row should not duplicate model/provider as a full label: {:?}",
+            rows[3]
+        );
+        assert!(
+            rows[4].contains("effort high")
+                && rows[4].contains("approval normal")
+                && rows[4].contains("hooks none")
+                && rows[4].contains("goal"),
+            "expanded controls row should include effort, approval, hooks, and goal: {:?}",
             rows[4]
         );
         assert!(
-            rows[5].contains("effort high")
-                && rows[5].contains("approval normal")
-                && rows[5].contains("hooks none"),
-            "expanded controls row should include effort, approval, and hooks: {:?}",
+            rows[5].contains("42 msgs") && rows[5].contains("tokens 1234"),
+            "expanded counts row should include messages and tokens: {:?}",
             rows[5]
-        );
-        assert!(
-            rows[6].contains("goal"),
-            "expanded goal row should be present: {:?}",
-            rows[6]
         );
         let session_id_str = state.session_id.to_string();
         assert!(
-            rows[7].contains("42 msgs")
-                && rows[7].contains("tokens 1234")
-                && rows[7].contains("session ")
-                && rows[7].contains('…'),
-            "expanded counts row should include messages, tokens, and shortened session: {:?}",
-            rows[7]
+            rows[6].contains("session ") && rows[6].contains(&session_id_str),
+            "expanded session row should include the full session id: {:?}",
+            rows[6]
         );
         assert!(
-            !rows[7].contains(&session_id_str),
-            "expanded counts row should not show the full session id: {:?}",
-            rows[7]
+            !rows[6].contains('…'),
+            "expanded session row should not shorten the session id: {:?}",
+            rows[6]
         );
     }
 
@@ -5423,25 +5453,25 @@ mod tests {
             rows
         );
         assert!(
-            rows[6].contains("goal"),
-            "expanded goal row should remain visible with multiline input: {:?}",
+            rows[6].contains("3 msgs") && rows[6].contains("tokens n/a"),
+            "expanded counts row should remain visible with multiline input: {:?}",
             rows
         );
         assert!(
-            rows[7].contains("3 msgs") && rows[7].contains("tokens n/a"),
-            "expanded counts row should remain visible with multiline input: {:?}",
+            rows[7].contains("session "),
+            "expanded session row should remain visible with multiline input: {:?}",
             rows
         );
     }
 
     #[test]
-    fn chrome_stream_preview_row_is_empty_when_none() {
+    fn chrome_idle_does_not_reserve_empty_stream_preview_row() {
         let state = view_state_idle();
-        let rows = render_chrome_lines(&state, 80, 5);
+        let rows = render_chrome_lines(&state, 80, 4);
         assert!(
-            rows[0].is_empty(),
-            "stream preview row should be empty when no preview is set: {:?}",
-            rows[0]
+            rows[0].contains("Enter to send"),
+            "idle chrome should start with the separator instead of an empty preview row: {:?}",
+            rows
         );
     }
 }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -11,7 +11,12 @@ pub(crate) fn draw(f: &mut ratatui::Frame, app: &mut App) {
     let input_width = area.width.saturating_sub(2);
     let desired_input_height = app.input_height(input_width);
     let state = app.view_state();
-    let layout = TuiLayout::new(area, desired_input_height, state.status_layout);
+    let layout = TuiLayout::new(
+        area,
+        desired_input_height,
+        state.status_layout,
+        chrome_preview_visible(&state),
+    );
 
     // Chrome renders the non-input rows; we then layer the input field
     // on top into the chrome-reserved input slot.
@@ -31,9 +36,18 @@ pub(crate) struct TuiLayout {
 }
 
 impl TuiLayout {
-    pub(crate) fn new(frame: Rect, desired_input_height: u16, status_layout: StatusLayout) -> Self {
-        let (chrome_height, input_height) =
-            chrome_dimensions(frame.height, desired_input_height, status_layout);
+    pub(crate) fn new(
+        frame: Rect,
+        desired_input_height: u16,
+        status_layout: StatusLayout,
+        preview_visible: bool,
+    ) -> Self {
+        let (chrome_height, input_height) = chrome_dimensions(
+            frame.height,
+            desired_input_height,
+            status_layout,
+            preview_visible,
+        );
         let chrome_area = bottom_rect(frame, chrome_height);
         let transcript = Rect {
             height: frame.height.saturating_sub(chrome_area.height),
@@ -42,7 +56,7 @@ impl TuiLayout {
         Self {
             frame,
             transcript,
-            chrome: ChromeLayout::new(chrome_area, input_height, status_layout),
+            chrome: ChromeLayout::new(chrome_area, input_height, status_layout, preview_visible),
         }
     }
 }
@@ -59,8 +73,13 @@ pub(crate) struct ChromeLayout {
 }
 
 impl ChromeLayout {
-    pub(crate) fn new(area: Rect, input_height: u16, status_layout: StatusLayout) -> Self {
-        let preview_height = u16::from(input_height == 1);
+    pub(crate) fn new(
+        area: Rect,
+        input_height: u16,
+        status_layout: StatusLayout,
+        preview_visible: bool,
+    ) -> Self {
+        let preview_height = u16::from(input_height == 1 && preview_visible);
         let status_height = u16::from(input_height < 3);
         let status_rows = status_layout.row_count();
         let chunks = Layout::default()
@@ -94,31 +113,40 @@ pub(crate) fn bottom_rect(area: Rect, height: u16) -> Rect {
     }
 }
 
-pub(crate) fn chrome_height(input_height: u16, status_layout: StatusLayout) -> u16 {
-    let preview_height = u16::from(input_height == 1);
+pub(crate) fn chrome_height(
+    input_height: u16,
+    status_layout: StatusLayout,
+    preview_visible: bool,
+) -> u16 {
+    let preview_height = u16::from(input_height == 1 && preview_visible);
     let status_separator_height = u16::from(input_height < 3);
     let fixed_rows = preview_height
         .saturating_add(1)
         .saturating_add(status_separator_height)
         .saturating_add(status_layout.row_count());
-    COMPACT_CHROME_HEIGHT.max(input_height.saturating_add(fixed_rows))
+    input_height.saturating_add(fixed_rows)
 }
 
 pub(crate) fn chrome_dimensions(
     frame_height: u16,
     desired_input_height: u16,
     status_layout: StatusLayout,
+    preview_visible: bool,
 ) -> (u16, u16) {
     if frame_height == 0 {
         return (0, 0);
     }
 
     let desired_input_height = desired_input_height.clamp(1, MAX_INPUT_HEIGHT);
-    let chrome_height = chrome_height(desired_input_height, status_layout).min(frame_height);
+    let chrome_height =
+        chrome_height(desired_input_height, status_layout, preview_visible).min(frame_height);
     let mut input_height = desired_input_height.min(chrome_height);
     while input_height > 1
-        && input_height.saturating_add(chrome_fixed_rows(input_height, status_layout))
-            > chrome_height
+        && input_height.saturating_add(chrome_fixed_rows(
+            input_height,
+            status_layout,
+            preview_visible,
+        )) > chrome_height
     {
         input_height -= 1;
     }
@@ -129,12 +157,13 @@ pub(crate) fn app_layout_for_frame(
     frame: Rect,
     desired_input_height: u16,
     status_layout: StatusLayout,
+    preview_visible: bool,
 ) -> TuiLayout {
-    TuiLayout::new(frame, desired_input_height, status_layout)
+    TuiLayout::new(frame, desired_input_height, status_layout, preview_visible)
 }
 
-fn chrome_fixed_rows(input_height: u16, status_layout: StatusLayout) -> u16 {
-    u16::from(input_height == 1)
+fn chrome_fixed_rows(input_height: u16, status_layout: StatusLayout, preview_visible: bool) -> u16 {
+    u16::from(input_height == 1 && preview_visible)
         .saturating_add(1)
         .saturating_add(u16::from(input_height < 3))
         .saturating_add(status_layout.row_count())
@@ -168,7 +197,13 @@ pub(crate) fn draw_recent_transcript(f: &mut ratatui::Frame, area: Rect, app: &A
         return;
     }
 
-    f.render_widget(Paragraph::new(rendered), inner);
+    let rendered_height = (rendered.len() as u16).min(inner.height);
+    let render_area = Rect {
+        y: inner.y + inner.height.saturating_sub(rendered_height),
+        height: rendered_height,
+        ..inner
+    };
+    f.render_widget(Paragraph::new(rendered), render_area);
 }
 
 pub(crate) fn recent_transcript_lines(
@@ -243,9 +278,18 @@ pub(crate) fn draw_chrome(
     input_height: u16,
     state: &ViewState,
 ) -> Rect {
-    let layout = ChromeLayout::new(area, input_height, state.status_layout);
+    let layout = ChromeLayout::new(
+        area,
+        input_height,
+        state.status_layout,
+        chrome_preview_visible(state),
+    );
     draw_chrome_layout(f, layout, state);
     layout.input
+}
+
+pub(crate) fn chrome_preview_visible(state: &ViewState) -> bool {
+    state.stream_preview.is_some() || !state.command_suggestions.is_empty()
 }
 
 pub(crate) fn draw_chrome_layout(f: &mut ratatui::Frame, layout: ChromeLayout, state: &ViewState) {
@@ -1488,7 +1532,6 @@ pub(crate) fn draw_session_status(f: &mut ratatui::Frame, area: Rect, state: &Vi
 #[derive(Clone, Debug)]
 pub(crate) struct StatusContribution {
     compact: Vec<StatusField>,
-    expanded: Vec<StatusField>,
 }
 
 #[derive(Clone, Debug)]
@@ -1498,8 +1541,8 @@ pub(crate) struct StatusField {
 }
 
 impl StatusContribution {
-    pub(crate) fn new(compact: Vec<StatusField>, expanded: Vec<StatusField>) -> Self {
-        Self { compact, expanded }
+    pub(crate) fn new(compact: Vec<StatusField>) -> Self {
+        Self { compact }
     }
 }
 
@@ -1512,10 +1555,36 @@ fn compact_status_lines(state: &ViewState) -> Vec<Line<'static>> {
 }
 
 fn expanded_status_lines(state: &ViewState) -> Vec<Line<'static>> {
-    status_contributions(state)
-        .iter()
-        .map(|section| status_line(section.expanded.iter()))
-        .collect()
+    let mut counts = vec![
+        status_value(message_count_label(state.lines_count)),
+        status_field("tokens", token_label(state.session_tokens)),
+    ];
+    if let Some(bg) = background_label(state.background) {
+        counts.push(status_field("bg", bg));
+    }
+
+    let provider_model = [
+        status_value("[collapse ↑]"),
+        status_field("provider", state.provider_name.clone()),
+        status_field("model", state.model_id.clone()),
+    ];
+    let controls = [
+        status_field("effort", effort_label(state)),
+        status_field("approval", state.approval_mode.clone()),
+        status_field("hooks", state.hooks_summary.clone()),
+        status_field(
+            "goal",
+            state.goal_indicator.clone().unwrap_or_else(|| "—".into()),
+        ),
+    ];
+    let session = [status_field("session", state.session_id.to_string())];
+
+    vec![
+        status_line(provider_model.iter()),
+        status_line(controls.iter()),
+        status_line(counts.iter()),
+        status_line(session.iter()),
+    ]
 }
 
 fn status_contributions(state: &ViewState) -> Vec<StatusContribution> {
@@ -1524,59 +1593,26 @@ fn status_contributions(state: &ViewState) -> Vec<StatusContribution> {
         StatusLayout::Expanded => "[collapse ↑]",
     };
     vec![
-        StatusContribution::new(
-            vec![
-                status_value(toggle_label),
-                status_value(state.provider_name.clone()),
-                status_value(state.model_id.clone()),
-            ],
-            vec![
-                status_value(toggle_label),
-                status_value(state.model_id.clone()),
-                status_field("provider", state.provider_name.clone()),
-            ],
-        ),
-        StatusContribution::new(
-            vec![
-                status_field("effort", effort_label(state)),
-                status_field("approval", state.approval_mode.clone()),
-            ],
-            vec![
-                status_field("effort", effort_label(state)),
-                status_field("approval", state.approval_mode.clone()),
-                status_field("hooks", state.hooks_summary.clone()),
-            ],
-        ),
-        StatusContribution::new(
-            vec![status_field(
-                "goal",
-                state.goal_indicator.clone().unwrap_or_else(|| "—".into()),
-            )],
-            vec![status_field(
-                "goal",
-                state.goal_indicator.clone().unwrap_or_else(|| "—".into()),
-            )],
-        ),
-        StatusContribution::new(
-            {
-                let mut compact = vec![status_value(message_count_label(state.lines_count))];
-                if let Some(bg) = background_label(state.background) {
-                    compact.push(status_field("bg", bg));
-                }
-                compact
-            },
-            {
-                let mut expanded = vec![
-                    status_value(message_count_label(state.lines_count)),
-                    status_field("tokens", token_label(state.session_tokens)),
-                    status_field("session", short_session_id(&state.session_id)),
-                ];
-                if let Some(bg) = background_label(state.background) {
-                    expanded.push(status_field("bg", bg));
-                }
-                expanded
-            },
-        ),
+        StatusContribution::new(vec![
+            status_value(toggle_label),
+            status_value(state.provider_name.clone()),
+            status_value(state.model_id.clone()),
+        ]),
+        StatusContribution::new(vec![
+            status_field("effort", effort_label(state)),
+            status_field("approval", state.approval_mode.clone()),
+        ]),
+        StatusContribution::new(vec![status_field(
+            "goal",
+            state.goal_indicator.clone().unwrap_or_else(|| "—".into()),
+        )]),
+        StatusContribution::new({
+            let mut compact = vec![status_value(message_count_label(state.lines_count))];
+            if let Some(bg) = background_label(state.background) {
+                compact.push(status_field("bg", bg));
+            }
+            compact
+        }),
     ]
 }
 
@@ -1642,19 +1678,4 @@ fn token_label(tokens: Option<u64>) -> String {
 
 fn message_count_label(count: usize) -> String {
     format!("{count} msgs")
-}
-
-fn short_session_id(session_id: &SessionId) -> String {
-    let raw = session_id.to_string();
-    let id = raw.strip_prefix("session_").unwrap_or(&raw);
-    let chars = id.chars().collect::<Vec<_>>();
-    if chars.len() <= 16 {
-        return id.to_string();
-    }
-    let head = chars.iter().take(8).collect::<String>();
-    let tail = chars
-        .iter()
-        .skip(chars.len().saturating_sub(4))
-        .collect::<String>();
-    format!("{head}…{tail}")
 }


### PR DESCRIPTION
## What
Fixes TUI idle layout spacing so recent answer text sits directly above the input separator instead of leaving a large blank band.

## Why
The recent transcript viewport rendered short content from the top, while the idle chrome always reserved an empty stream-preview row. Together they created excessive vertical whitespace between the answer and input panel.

## How
- Bottom-align recent transcript rows inside the transcript viewport.
- Allocate the stream preview row only when a stream preview or command suggestions are visible.
- Rework expanded status rows so provider/model, controls/goal, counts, and the full session id have dedicated rows.
- Add renderer tests for the answer/input row relationship and the no-empty-preview-row idle chrome behavior.

## Risk
- Low
- TUI row positions shift by one row in idle/no-preview mode; covered by renderer tests and real PTY smoke.

## Security
- TM-FS: no filesystem access changes.
- TM-BASH: no shell execution changes.
- TM-LLM: no prompt construction, provider key, or session persistence changes.
- TM-TOOL: no capability registration changes.
- TM-DEP: no dependency changes.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `target/debug/yolop --provider llmsim -p "hi"`

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories