### PR TITLE
fix(tui): add missing horizontal bounds check for status bar mouse clicks

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1185,13 +1185,11 @@ impl App {
         if layout.chrome.session_status.height == 0 {
             return false;
         }
-        mouse.row >= layout.chrome.session_status.y
-            && mouse.row
-                < layout
-                    .chrome
-                    .session_status
-                    .y
-                    .saturating_add(layout.chrome.session_status.height)
+        let status_rect = layout.chrome.session_status;
+        mouse.row >= status_rect.y
+            && mouse.row < status_rect.y.saturating_add(status_rect.height)
+            && mouse.column >= status_rect.x
+            && mouse.column < status_rect.x.saturating_add(status_rect.width)
     }
 
     fn handle_ctrl_c(&mut self) {


### PR DESCRIPTION
## Summary

Fixed the status bar mouse click functionality that was not working reliably when clicking to toggle between compact and expanded views.

## Problem
The  function was only checking vertical bounds (Y coordinate/row) when determining if a mouse click occurred on the status bar. This caused incorrect hit detection where clicks anywhere on the same row as the status bar would register as hits, regardless of column position.

## Solution
Updated the  function in  to properly check both X and Y coordinates:
- Added missing horizontal bounds check using  validation
- Used local  variable for better readability
- Only clicks within the actual status bar bounds now trigger expand/collapse

## Changes
- **File**: 
- **Function**:  (lines 1154-1158)
- **Fix**: Complete bounds checking (both X and Y coordinates)
- **Lines**: 5 inserted, 7 deleted (net -2 lines)

## Testing
- ✅ Code compiles successfully
- ✅ All tests pass (
running 461 tests
test acp::bridge::tests::duplicate_event_id_is_ignored ... ok
test acp::bridge::tests::completed_message_synthesised_when_not_streamed ... ok
test acp::bridge::tests::streaming_deltas_become_message_chunks ... ok
test acp::bridge::tests::replay_mode_emits_user_messages ... ok
test acp::bridge::tests::completed_message_suppressed_after_streaming ... ok
test acp::bridge::tests::live_mode_suppresses_user_messages ... ok
test acp::bridge::tests::thinking_deltas_become_thought_chunks ... ok
test acp::bridge::tests::write_todos_started_becomes_plan ... ok
test acp::protocol::tests::sdk_message_chunk_uses_snake_case_discriminator ... ok
test acp::bridge::tests::tool_completed_failure_maps_to_failed_status ... ok
test acp::protocol::tests::sdk_initialize_result_serializes_camel_case ... ok
test acp::bridge::tests::tool_started_uses_in_progress_status_without_kind ... ok
test acp::protocol::tests::prompt_text_concatenates_text_blocks_only ... ok
test acp::tests::initialize_advertises_protocol_version_and_capabilities ... ok
test acp::tests::load_unknown_session_is_invalid_params ... ok
test acp::tests::prompt_to_unknown_session_is_invalid_params ... ok
test acp::tests::unknown_method_returns_method_not_found ... ok
test acp::tests::disconnect_mid_turn_lets_serve_return ... ok
test acp::tests::new_session_advertises_available_commands ... ok
test acp::tests::slash_system_command_executes_without_model_turn ... ok
test agent_scenarios::scripted_assistant_text_returns_success_with_no_tools ... ok
test agent_scenarios::scripted_default_repeat_last_lets_second_call_succeed_after_exhaustion ... ok
test acp::tests::bang_shell_command_executes_without_model_turn ... ok
test agent_scenarios::scripted_error_turn_marks_run_failed ... ok
test agent_scenarios::scripted_get_config_capabilities_smoke ... ok
test agent_scenarios::scripted_on_exhausted_error_fails_second_call ... ok
test agent_scenarios::scripted_prompt_command_tool_queues_quit_ui_command ... ok
test app::tests::alt_shift_enter_submits_instead_of_inserting_newline ... ok
test app::tests::background_panel_lines_header_and_scroll ... ok
test acp::tests::full_handshake_then_prompt_streams_text_and_ends_turn ... ok
test acp::tests::write_todos_tool_call_streams_plan_update ... ok
test app::tests::background_panel_not_opened_over_setup_overlay ... ok
test app::tests::app_view_state_hides_command_suggestions_when_input_disabled ... ok
test app::tests::app_slash_input_renders_command_suggestions_end_to_end ... ok
test app::tests::bang_shell_parser_accepts_shell_alias_and_bare_command ... ok
test app::tests::bang_shell_suggestions_use_client_command_registry ... ok
test app::tests::capability_commands_appear_in_suggestions ... ok
test app::tests::chrome_busy_falls_back_to_thinking_when_activity_unset ... ok
test app::tests::chrome_busy_shows_thinking_spinner_and_activity ... ok
test app::tests::chrome_command_suggestions_override_stream_preview_row ... ok
test app::tests::chrome_dimensions_clamp_input_to_visible_frame ... ok
test acp::tests::scripted_tool_call_streams_tool_updates ... ok
test app::tests::chrome_height_reserves_four_expanded_status_rows ... ok
test app::tests::chrome_idle_does_not_reserve_empty_stream_preview_row ... ok
test app::tests::chrome_renders_stream_preview_tail_with_kind_label ... ok
test app::tests::chrome_idle_shows_enter_to_send_hint ... ok
test app::tests::chrome_session_status_compact_shows_provider_model_effort_approval_and_messages ... ok
test app::tests::chrome_session_status_expanded_groups_details_across_four_lines ... ok
test app::tests::chrome_session_status_stays_visible_with_multiline_input ... ok
test agent_scenarios::workspace_hook_blocks_matching_bash_call ... ok
test app::tests::command_suggestions_filter_first_arg_by_prefix ... ok
test app::tests::command_suggestions_list_commands_for_slash ... ok
test app::tests::command_suggestions_no_arg_suggestions_means_free_form ... ok
test agent_scenarios::scripted_tool_call_executes_bash_then_assistant_completes ... ok
test app::tests::background_panel_renders_task_rows ... ok
test app::tests::background_panel_toggle_scroll_and_close ... ok
test app::tests::diff_lines_style_adds_deletes_and_metadata ... ok
test app::tests::discovered_model_hints_are_truncated_for_one_row_display ... ok
test app::tests::discovered_models_convert_to_options_with_custom_escape_hatch ... ok
test app::tests::ctrl_c_clears_nonempty_input_without_exiting ... ok
test app::tests::draw_suggestions_ignores_empty_areas ... ok
test app::tests::clicking_status_rows_toggles_layout ... ok
test app::tests::ctrl_b_clears_armed_ctrl_c_exit ... ok
test app::tests::clear_command_wipes_transcript_and_re_emits_banner ... ok
test app::tests::discovered_models_replace_fallback_options_in_open_picker ... ok
test app::tests::cwd_command_prints_workspace_root ... ok
test app::tests::esc_after_cancel_requested_does_not_reprompt ... ok
test app::tests::failed_model_discovery_surfaces_error_in_open_picker ... ok
test app::tests::first_line_truncates_on_char_boundaries ... ok
test app::tests::handle_live_event_deduplicates_by_event_id ... ok
test app::tests::handle_live_event_emits_known_token_counts ... ok
test app::tests::handle_live_event_hides_thinking_delta_from_stream_preview ... ok
test app::tests::handle_live_event_renders_write_todos_from_started_args_when_result_is_counts_only ... ok
test app::tests::handle_live_event_routes_assistant_delta_to_stream_preview ... ok
test app::tests::bang_input_runs_shell_without_model_turn ... ok
test app::tests::first_ctrl_c_prompts_for_second_press_to_exit ... ok
test app::tests::bang_shell_input_runs_shell_from_workspace_without_model_turn ... ok
test app::tests::inline_viewport_bounds_large_recent_entries ... ok
test acp::tests::load_session_replays_history_and_continues_turns ... ok
test app::tests::first_esc_while_busy_prompts_for_second_press_to_cancel ... ok
test app::tests::inline_viewport_bottom_aligns_recent_transcript_tail ... ok
test app::tests::input_area_supports_multiline_and_cursor_editing ... ok
test app::tests::inline_viewport_does_not_mirror_flushed_transcript_lines ... ok
test app::tests::lines_for_event_hides_output_message_thinking ... ok
test app::tests::lines_for_event_renders_long_write_todos_as_rows ... ok
test app::tests::lines_for_event_renders_reason_item_summary_segments ... ok
test app::tests::lines_for_event_renders_short_write_todos_inline ... ok
test app::tests::lines_for_event_surfaces_tool_call_monologue ... ok
test app::tests::markdown_lines_wrap_styled_content_to_available_width ... ok
test app::tests::lines_for_event_limits_write_todo_rows_and_truncates_text ... ok
test app::tests::inline_viewport_shows_recent_transcript_lines ... ok
test app::tests::help_command_names_ctrl_c_and_ctrl_d_as_exit_keys ... ok
test app::tests::model_window_centers_selection_in_long_lists ... ok
test app::tests::inline_viewport_stops_rendering_after_visible_tail_is_full ... ok
test app::tests::narration_lines_use_note_label_and_muted_text ... ok
test app::tests::newline_shortcut_hint_uses_shift_enter_only ... ok
test app::tests::inline_viewport_uses_recent_transcript_tail ... ok
test app::tests::multiline_input_height_is_bounded ... ok
test app::tests::openrouter_ranking_applies_curated_order_and_alphabetical_rest ... ok
test app::tests::non_esc_while_busy_disarms_cancel_prompt ... ok
test app::tests::model_command_opens_model_picker_overlay ... ok
test app::tests::openrouter_model_picker_shows_recommended_divider ... ok
test app::tests::app_layout_rectangles_stay_inside_frame_across_sizes ... ok
test app::tests::rendered_chat_lines_fit_available_width_across_authors ... ok
test app::tests::replayed_events_render_user_assistant_and_tool_lines ... ok
test app::tests::enter_submit_completes_llmsim_turn_in_transcript ... ok
test app::tests::effort_modal_does_not_mark_unset_openrouter_effort_current ... ok
test app::tests::proactive_wake_disabled_by_setting_does_not_start_turn ... ok
test app::tests::proactive_wake_starts_turn_when_background_task_finishes ... ok
test app::tests::proactive_wake_suppressed_during_setup_overlay ... ok
test app::tests::quit_command_and_exit_alias_request_shutdown ... ok
test app::tests::resumed_session_renders_replayed_history_in_inline_viewport ... ok
test app::tests::second_ctrl_c_exits_after_prompt ... ok
test app::tests::second_esc_while_busy_clears_stream_preview_immediately ... ok
test app::tests::second_esc_while_busy_sends_turn_cancel ... ok
test app::tests::model_command_preselects_current_raw_model_id ... ok
test app::tests::setup_command_starts_guided_wizard ... ok
test app::tests::resume_replays_prior_turn_into_transcript ... ok
test app::tests::setup_c_key_opens_credential_panel_even_when_connected ... ok
test app::tests::effort_command_opens_effort_modal_and_confirms_selection ... ok
test app::tests::model_command_with_arg_opens_prefilled_model_modal ... ok
test app::tests::setup_overlay_renders_full_provider_picker ... ok
test app::tests::setup_custom_endpoint_flow_collects_url_and_model ... ok
test app::tests::should_not_insert_chat_gap_inside_tool_blocks ... ok
test app::tests::setup_row_keeps_a_gap_when_label_overflows_column ... ok
test app::tests::setup_wizard_can_select_offline_provider ... ok
test app::tests::status_bar_hides_background_segment_when_no_tasks ... ok
test app::tests::status_bar_shows_background_task_count ... ok
test app::tests::shifted_printable_chars_insert_literal_character ... ok
test app::tests::shift_enter_inserts_newline_without_submitting ... ok
test app::tests::status_for_event_labels_output_iteration ... ok
test app::tests::suggestion_preview_line_keeps_first_match_when_truncated ... ok
test app::tests::suggestion_preview_line_shows_command_dropdown ... ok
test app::tests::suggestions_come_solely_from_the_command_registry ... ok
test app::tests::truncate_end_handles_tiny_limits ... ok
test app::tests::truncate_tail_keeps_visible_cursor ... ok
test app::tests::setup_provider_picker_enters_credential_panel ... ok
test app::tests::startup_banner_is_kept_out_of_inline_viewport ... ok
test app::tests::startup_banner_names_ctrl_c_and_ctrl_d_as_exit_keys ... ok
test app::tests::wrapped_plain_lines_do_not_use_wider_than_view_floor ... ok
test app::tests::typing_after_first_ctrl_c_disarms_exit_prompt ... ok
test capabilities::approval::tests::capability_exposes_both_tools ... ok
test capabilities::approval::tests::contribution_follows_settings ... ok
test capabilities::approval::tests::normal_and_protective_render_expected_guidance ... ok
test capabilities::approval::tests::off_contributes_no_prompt ... ok
test capabilities::approval::tests::record_approval_accepts_empty_arguments_after_spoken_consent ... ok
test capabilities::approval::tests::record_approval_echoes_action ... ok
test app::tests::unsupported_model_discovery_keeps_fallback_options ... ok
test app::tests::wrapped_input_allocates_multiple_render_rows ... ok
test app::tests::tools_command_lists_available_tools ... ok
test app::tests::wrapped_single_line_input_grows_height_with_narrow_width ... ok
test capabilities::approval::tests::set_approval_mode_updates_settings_and_rejects_garbage ... ok
test app::tests::setup_provider_picker_shows_connection_status ... ok
test capabilities::ast_grep::tests::rejects_oversized_numeric_limits_before_casting ... ok
test capabilities::ast_grep::tests::rejects_paths_outside_workspace ... ok
test capabilities::ast_grep::tests::ast_grep_tool_executes_structural_search ... ok
test capabilities::ast_grep::tests::finds_rust_function_pattern ... ok
test capabilities::ast_grep::tests::filters_by_path_and_language ... ok
test capabilities::background::tests::agent_unavailable_without_spawner ... ok
test capabilities::ast_grep::tests::skips_symlinked_directories_during_recursive_scan ... ok
test capabilities::background::tests::agent_tool_offered_when_spawner_present ... ok
test capabilities::background::tests::capability_contributes_background_command ... ok
test app::tests::status_command_switches_between_compact_and_expanded_layouts ... ok
test app::tests::setup_connected_provider_jumps_straight_to_model_picker ... ok
test capabilities::background::tests::agent_failure_marks_failed ... ok
test capabilities::background::tests::agent_task_records_result_and_child_session ... ok
test capabilities::background::tests::no_tasks_means_no_prompt_block ... ok
test app::tests::setup_token_input_masks_secret_and_moves_to_model_picker ... ok
test capabilities::background::tests::capacity_error_blocks_spawn_at_cap ... ok
test capabilities::background::tests::capability_exposes_four_tools_and_discloses_tasks ... ok
test capabilities::background::tests::run_tool_requires_command ... ok
test app::tests::setup_model_picker_preset_selection_applies_and_persists ... ok
test capabilities::background::tests::wake_prompt_describes_single_and_multiple_tasks ... ok
test capabilities::client_commands::tests::prompt_tells_model_to_run_natural_language_commands ... ok
test capabilities::client_commands::tests::run_yolop_command_exit_alias_queues_quit ... ok
test capabilities::client_commands::tests::run_yolop_command_preserves_model_argument ... ok
test capabilities::client_commands::tests::run_yolop_command_preserves_status_layout_argument ... ok
test capabilities::client_commands::tests::run_yolop_command_rejects_shell_dispatch ... ok
test capabilities::config::tests::get_config_capabilities_includes_catalog ... ok
test capabilities::background::tests::counts_and_render_task_list_reflect_tasks ... ok
test capabilities::config::tests::get_config_capabilities_ref_exposes_schema ... ok
test capabilities::config::tests::get_config_lists_all_fields ... ok
test capabilities::config::tests::get_config_renders_attribution_as_bool ... ok
test capabilities::background::tests::drain_finished_for_wake_returns_each_task_once ... ok
test capabilities::config::tests::get_config_redacts_tokens ... ok
test capabilities::config::tests::get_config_scoped_key_keeps_table_and_narrows_current ... ok
test capabilities::config::tests::get_config_table_omits_unsupported_providers ... ok
test capabilities::config::tests::set_and_clear_token_roundtrip ... ok
test capabilities::background::tests::nonzero_exit_is_failed ... ok
test capabilities::config::tests::set_config_capabilities_rejects_invalid_config ... ok
test capabilities::config::tests::set_config_appends_capabilities_override ... ok
test capabilities::background::tests::restored_terminal_tasks_do_not_wake_on_resume ... ok
test capabilities::config::tests::set_config_rejects_unknown_provider_and_key ... ok
test capabilities::config::tests::set_config_validates_base_url_scheme ... ok
test capabilities::config::tests::set_config_capabilities_disable_appends_remove_entry ... ok
test capabilities::config::tests::set_config_persists_default_provider_and_model ... ok
test capabilities::goal::tests::goal_evaluate_marks_goal_achieved ... ok
test capabilities::hooks::tests::capability_exposes_unprefixed_hook_tools_without_slash_command ... ok
test capabilities::config::tests::set_config_routes_approval_mode ... ok
test capabilities::host::tests::environment_context_renders_requested_fields ... ok
test capabilities::host::tests::needs_onboarding_false_when_provider_is_saved ... ok
test capabilities::host::tests::needs_onboarding_false_when_token_is_saved ... ok
test capabilities::host::tests::needs_onboarding_ignores_custom_api_key_without_base_url ... ok
test capabilities::host::tests::needs_onboarding_true_for_empty_settings ... ok
test capabilities::host::tests::redact_git_remote_secret_leaves_https_without_userinfo_unchanged ... ok
test capabilities::host::tests::redact_git_remote_secret_leaves_non_url_remote_unchanged ... ok
test capabilities::host::tests::redact_git_remote_secret_preserves_ssh_url_username ... ok
test capabilities::host::tests::redact_git_remote_secret_removes_http_token_only_userinfo ... ok
test capabilities::host::tests::redact_git_remote_secret_removes_http_userinfo ... ok
test capabilities::host::tests::shell_output_format_ignores_whitespace_only_streams ... ok
test capabilities::config::tests::set_config_warns_when_default_model_mismatches_provider ... ok
test capabilities::background::tests::results_survive_restart_and_running_becomes_interrupted ... ok
test capabilities::background::tests::script_completes_and_captures_output ... ok
test capabilities::memory::tests::capability_config_schema_validates_and_tools_read_config ... ok
test capabilities::memory::tests::config_parses_from_capability_config_value ... ok
test capabilities::config::tests::set_config_routes_proactive_wake_with_alias_and_clear ... ok
test capabilities::memory::tests::capability_exposes_memory_tools_without_slash_command ... ok
test capabilities::host::tests::attribution_prompt_follows_settings ... ok
test capabilities::memory::tests::hand_authored_body_keeps_non_metadata_html_comment ... ok
test capabilities::memory::tests::body_with_markdown_heading_survives_round_trip ... ok
test capabilities::memory::tests::legacy_bullet_file_is_imported_losslessly ... ok
test capabilities::hooks::tests::hook_tools_validate_save_list_and_remove ... ok
test capabilities::memory::tests::empty_query_returns_recent ... ok
test capabilities::memory::tests::legacy_import_preserves_user_headings ... ok
test capabilities::memory::tests::remember_tool_rejects_empty_fields ... ok
test capabilities::background::tests::cancel_marks_cancelled ... ok
test capabilities::memory::tests::render_block_handles_empty_and_overflow ... ok
test capabilities::memory::tests::forget_tool_reports_removal ... ok
test capabilities::memory::tests::soft_cap_warning_only_past_limit ... ok
test capabilities::memory::tests::persists_and_reparses_across_reopen ... ok
test capabilities::model_discovery::tests::discovery_falls_back_to_openai_compatible_endpoint ... ok
test capabilities::model_discovery::tests::discovery_is_unsupported_for_llmsim ... ok
test capabilities::model_discovery::tests::discovery_openrouter_live ... ignored, requires OPENROUTER_API_KEY; performs a live models API call
test capabilities::model_discovery::tests::enrichment_fills_names_and_descriptions_from_core_profiles ... ok
test capabilities::model_discovery::tests::enrichment_keeps_unknown_models_with_bare_ids ... ok
test capabilities::model_discovery::tests::enrichment_prefers_api_display_name_over_core_profile ... ok
test capabilities::model_discovery::tests::pick_catalog_fallback_prefers_provider_default_when_available ... ok
test capabilities::model_ranking::tests::bare_model_id_strips_reasoning_effort_suffix ... ok
test capabilities::model_ranking::tests::non_openrouter_providers_skip_ranking ... ok
test capabilities::model_ranking::tests::openrouter_ranking_puts_curated_and_current_first_then_sorts_rest ... ok
test capabilities::memory::tests::remember_tool_then_recall_by_query_and_id ... ok
test capabilities::memory::tests::remember_creates_then_updates_in_place_by_title ... ok
test capabilities::memory::tests::forget_removes_by_id_and_by_title ... ok
test capabilities::repo_map::tests::collects_rust_symbols_with_parent_context ... ok
test capabilities::memory::tests::remember_update_by_id_changes_title_and_body ... ok
test capabilities::repo_map::tests::rejects_paths_outside_workspace ... ok
test capabilities::memory::tests::recall_reports_more_when_truncated ... ok
test capabilities::skills::tests::activate_rejects_traversal_and_missing ... ok
test capabilities::repo_map::tests::filters_by_language ... ok
test capabilities::skills::tests::capability_exposes_skill_management_tools ... ok
test capabilities::repo_map::tests::repo_symbols_tool_executes_multilanguage_scan ... ok
test capabilities::memory::tests::search_boosts_title_over_body_and_caps_with_total ... ok
test capabilities::skills::tests::activate_substitutes_skill_dir_to_real_path ... ok
test capabilities::repo_map::tests::filters_by_query_and_path ... ok
test capabilities::skills::tests::global_skills_dir_respects_env_override ... ok
test capabilities::repo_map::tests::skips_symlinked_directories_during_recursive_scan ... ok
test capabilities::skills::tests::global_skill_created_after_sources_are_built_is_listed ... ok
test capabilities::skills::tests::list_skills_reports_scope_and_error_entries ... ok
test capabilities::skills::tests::locate_prefers_workspace_then_falls_through ... ok
test capabilities::repo_map::tests::collects_symbols_across_supported_languages ... ok
test capabilities::skills::tests::system_prompt_lists_visible_skills_and_filters_opted_out ... ok
test capabilities::your::tests::capability_exposes_no_hook_tools_or_slash_commands ... ok
test capabilities::your::tests::your_block_frames_personalization_and_routes_memory_and_hooks ... ok
test capability_settings::tests::apply_adds_optional_capability ... ok
test capability_settings::tests::apply_append_allows_duplicate_refs ... ok
test capabilities::skills::tests::write_skill_rejects_unsafe_paths_and_readonly_scopes ... ok
test capability_settings::tests::apply_merges_config_into_first_match ... ok
test capability_settings::tests::apply_removes_all_instances_with_ref ... ok
test capability_settings::tests::capabilities_array_roundtrip ... ok
test capability_settings::tests::validate_rejects_bad_message_metadata_config ... ok
test capability_settings::tests::capability_catalog_list_returns_sorted_entries ... ok
test codex_auth::tests::callback_page_includes_logo_and_success_copy ... ok
test codex_auth::tests::extracts_account_id_from_codex_jwt_claim ... ok
test codex_auth::tests::should_refresh_only_near_expiry ... ok
test codex_driver::tests::codex_request_serializes_store_false ... ok
test codex_driver::tests::converts_tool_result_to_function_call_output ... ok
test codex_driver::tests::parses_text_delta_event ... ok
test config_schema::tests::aliases_resolve_to_canonical_targets ... ok
test config_schema::tests::capabilities_keys_parse ... ok
test config_schema::tests::every_target_maps_to_a_field ... ok
test config_schema::tests::provider_scoped_keys_parse_and_validate ... ok
test config_schema::tests::provider_scoped_requires_segment_and_known_provider ... ok
test config_schema::tests::scalar_key_rejects_provider_segment ... ok
test config_schema::tests::unknown_key_lists_known_keys ... ok
test clipboard_paste::tests::encode_dynamic_image_png_respects_size_limit ... ok
test capabilities::skills::tests::write_skill_rejects_symlinked_skill_dir ... ok
test connectors::catalog::catalog_tests::builder_registers_extra_providers ... ok
test capabilities::skills::tests::embedded_system_skills_materialize_idempotently ... ok
test connectors::capability::tests::list_connectors_includes_daytona ... ok
test capabilities::skills::tests::discover_merges_scopes_and_dedups_by_precedence ... ok
test capabilities::skills::tests::write_skill_installs_global_skill_readable_without_restart ... ok
test goal::tests::format_status_active_and_achieved ... ok
test goal::tests::parse_clear_aliases ... ok
test goal::tests::parse_evaluation_json ... ok
test goal::tests::parse_set_condition ... ok
test connectors::resolver::tests::env_fallback_when_not_stored ... ok
test capabilities::skills::tests::write_skill_rejects_symlinked_extra_file_parent ... ok
test connectors::resolver::tests::prefers_stored_credential_over_env ... ok
test connectors::store::tests::roundtrip_via_disk ... ok
test hooks_config::tests::missing_scopes_load_empty ... ok
test hooks_config::tests::invalid_hook_entry_does_not_sink_valid_entries ... ok
test config_service::tests::service_reads_semantic_getters_and_by_key ... ok
test connectors::store::tests::clear_removes_provider ... ok
test image_input::tests::sniff_png_magic_bytes ... ok
test image_input::tests::user_display_text_labels_images ... ok
test image_input::tests::load_image_part_rejects_empty_file ... ok
test hooks_config::tests::upsert_hook_requires_id_and_persists ... ok
test into::tests::zed_into_leaves_matching_object_unchanged_even_with_env ... ok
test hooks_config::tests::remove_workspace_hook_adds_disable_marker ... ok
test hooks_config::tests::workspace_overrides_global_by_id ... ok
test hooks_config::tests::workspace_disabled_removes_global_hook ... ok
test into::tests::zed_into_creates_missing_settings_file ... ok
test mcp_config::tests::expand_env_handles_multiple_and_adjacent ... ok
test hooks_config::tests::upsert_and_remove_match_malformed_existing_entries_by_raw_id ... ok
test into::tests::zed_into_refuses_non_object_entry_without_force ... ok
test mcp_config::tests::empty_object_is_ok ... ok
test mcp_config::tests::expands_env_placeholders ... ok
test into::tests::zed_into_preserves_existing_settings_and_header_comments ... ok
test mcp_config::tests::missing_file_yields_no_servers ... ok
test mcp_config::tests::malformed_json_is_an_error_at_the_scope_level ... ok
test into::tests::zed_into_updates_existing_object_and_preserves_env ... ok
test into::tests::zed_into_replaces_non_object_entry_with_force ... ok
test mcp_config::tests::parses_http_server_with_headers ... ok
test mcp_config::tests::parses_stdio_server ... ok
test mcp_config::tests::malformed_scope_is_skipped_not_fatal ... ok
test mcp_config::tests::type_defaults_to_http ... ok
test mcp_config::tests::unset_env_placeholder_is_left_intact ... ok
test capabilities::memory::tests::titles_disclosure_caps_and_reports_total ... ok
test runtime::tests::build_exposes_connector_tools_by_default ... ok
test runtime::tests::build_persists_workspace_root_for_session_resume ... ok
test runtime::tests::coding_harness_enables_ast_grep ... ok
test runtime::tests::codex_model_with_provider_uses_external_driver_metadata ... ok
test runtime::tests::coding_harness_enables_connectors_by_default ... ok
test runtime::tests::coding_harness_enables_hooks_authoring_separately_from_your ... ok
test runtime::tests::coding_harness_enables_loop_detection ... ok
test runtime::tests::coding_harness_enables_repo_map ... ok
test runtime::tests::coding_harness_enables_tool_output_persistence ... ok
test runtime::tests::coding_harness_enables_tool_search ... ok
test runtime::tests::coding_harness_enables_yolop_attribution ... ok
test runtime::tests::coding_harness_gates_client_commands_on_flag ... ok
test runtime::tests::custom_model_with_provider_requires_base_url_but_not_model ... ok
test runtime::tests::custom_model_with_provider_resolves_saved_base_url_and_placeholder_key ... ok
test runtime::tests::default_for_provider_name_rejects_unknown ... ok
test runtime::tests::default_for_provider_name_returns_provider_default_model ... ok
test runtime::tests::from_env_or_settings_defaults_to_openai_without_credentials ... ok
test runtime::tests::from_env_or_settings_picks_custom_only_when_a_model_is_known ... ok
test runtime::tests::google_requires_api_key_to_build_model_with_provider ... ok
test runtime::tests::harness_applies_daytona_from_settings ... ok
test runtime::tests::harness_applies_message_metadata_from_settings ... ok
test runtime::tests::harness_prompt_within_budget ... ok
test runtime::tests::model_compatible_with_provider_rejects_obvious_mismatches ... ok
test runtime::tests::model_spec_accepts_google_model_id ... ok
test runtime::tests::model_spec_accepts_llmsim_model_id ... ok
test runtime::tests::model_spec_accepts_ollama_model_id ... ok
test runtime::tests::model_spec_accepts_openai_reasoning_effort ... ok
test runtime::tests::model_spec_accepts_openrouter_model_id_with_slash ... ok
test runtime::tests::model_spec_accepts_openrouter_reasoning_effort ... ok
test runtime::tests::model_spec_on_custom_provider_accepts_effort ... ok
test runtime::tests::model_spec_rejects_invalid_current_provider_model ... ok
test runtime::tests::model_spec_strips_provider_prefix_from_label ... ok
test runtime::tests::model_spec_treats_slashes_as_current_provider_model_id ... ok
test runtime::tests::model_spec_uses_current_provider_without_prefix ... ok
test runtime::tests::model_suggestions_include_1m_context_variants ... ok
test runtime::tests::model_suggestions_include_claude_fable_5 ... ok
test runtime::tests::next_run_preview_includes_resolution_notes ... ok
test runtime::tests::ollama_uses_openai_responses_driver_with_local_base_url ... ok
test runtime::tests::openai_input_message_carries_reasoning_effort ... ok
test runtime::tests::openrouter_input_message_carries_reasoning_effort ... ok
test runtime::tests::openrouter_requires_api_key ... ok
test runtime::tests::openrouter_uses_first_class_openrouter_driver ... ok
test runtime::tests::reasoning_effort_can_update_current_openai_model ... ok
test runtime::tests::reasoning_effort_can_update_current_openrouter_model ... ok
test runtime::tests::reasoning_effort_rejects_unsupported_provider ... ok
test runtime::tests::resolve_for_settings_falls_back_to_global_default_model ... ok
test runtime::tests::resolve_for_settings_ignores_cross_provider_default_model ... ok
test runtime::tests::resolve_for_settings_overlays_persisted_spec_for_same_provider ... ok
test runtime::tests::resolve_for_settings_uses_per_provider_model ... ok
test runtime::tests::build_attaches_yolop_embedder_metadata ... ok
test runtime::tests::build_wires_mcp_servers_from_dot_mcp_json ... ok
test runtime::tests::stored_token_falls_back_when_env_var_missing ... ok
test runtime::tests::tool_search_keeps_write_todos_schema_loaded ... ok
test runtime::tests::background_agent_spawner_runs_child_session_offline ... ok
test runtime::tests::yolop_file_store_displays_workspace_and_session_paths ... ok
test runtime::tests::yolop_file_store_routes_outputs_to_session_dir ... ok
test runtime::tests::yolop_file_store_routes_workspace_files_to_workspace_root ... ok
test runtime::tests::yolop_file_store_secures_nested_output_directories ... ok
test runtime::tests::yolop_file_store_secures_output_permissions ... ok
test session_log::tests::migrate_legacy_session_log_copies_flat_jsonl ... ok
test runtime::tests::btw_answers_a_side_question_without_persisting_it ... ok
test session_log::tests::migrate_legacy_session_log_does_not_overwrite_current_log ... ok
test session_log::tests::open_corrects_loose_events_jsonl_permissions_on_resume ... ok
test session_log::tests::open_corrects_loose_session_dir_permissions_on_resume ... ok
test session_log::tests::open_tightens_session_dir_to_owner_only_on_unix ... ok
test session_log::tests::read_session_workspace_ignores_malformed_metadata ... ok
test session_log::tests::output_message_thinking_is_persisted_for_provider_continuation ... ok
test session_log::tests::reason_completed_event_is_persisted_and_replayed ... ok
test session_log::tests::reason_item_event_is_persisted_and_replayed ... ok
test session_log::tests::replay_binary_garbage_stops_early_and_drops_suffix ... ok
test session_log::tests::replay_blank_lines_in_middle_are_skipped ... ok
test session_log::tests::replay_empty_file_returns_empty_session ... ok
test session_log::tests::replay_missing_file_returns_empty_session ... ok
test session_log::tests::replay_malformed_json_line_does_not_stop_replay ... ok
test session_log::tests::replay_only_blank_lines_returns_empty ... ok
test session_log::tests::replay_skips_events_for_different_session_id ... ok
test session_log::tests::replay_truncated_last_line_is_skipped_without_dropping_prior ... ok
test session_log::tests::replay_tracks_highest_sequence_across_all_valid_events ... ok
test session_log::tests::seed_replayed_populates_collected_events_without_rewrite ... ok
test session_log::tests::seed_replayed_then_emit_keeps_order ... ok
test session_log::tests::subscribe_receives_emitted_events_including_deltas ... ok
test session_log::tests::tool_completed_replay_keeps_scalar_json_as_text ... ok
test session_log::tests::tool_completed_replay_preserves_json_result_shape ... ok
test settings::tests::approval_mode_defaults_to_normal_and_is_omitted ... ok
test settings::tests::approval_mode_parses_canonical_names_and_aliases ... ok
test settings::tests::approval_mode_roundtrips_via_disk ... ok
test runtime::tests::background_agent_tool_present_at_top_level_absent_in_children ... ok
test settings::tests::attribution_defaults_to_enabled ... ok
test settings::tests::attribution_can_be_disabled_via_disk ... ok
test settings::tests::clearing_absent_token_reports_false_but_succeeds ... ok
test runtime::tests::tool_surface_exceeds_tool_search_threshold ... ok
test settings::tests::clearing_base_url_reports_presence ... ok
test session_log::tests::subscribe_does_not_replay_seeded_history ... ok
test settings::tests::clearing_model_reports_presence ... ok
test runtime::tests::goal_command_is_registered_and_sets_active_condition ... ok
test settings::tests::codex_auth_roundtrips_via_disk ... ok
test settings::tests::legacy_provider_key_is_still_read ... ok
test settings::tests::missing_file_yields_default ... ok
test settings::tests::clearing_token_removes_only_that_entry ... ok
test settings::tests::default_provider_roundtrip_via_disk ... ok
test settings::tests::malformed_file_yields_default ... ok
test settings::tests::default_model_roundtrips_and_clears ... ok
test settings::tests::proactive_wake_defaults_on_and_round_trips_when_disabled ... ok
test settings::tests::save_writes_owner_only_permissions ... ok
test settings::tests::model_and_base_url_roundtrip_via_disk ... ok
test settings::tests::save_tightens_permissions_on_preexisting_file ... ok
test tests::inline_viewport_anchor_does_not_scroll_when_already_low_enough ... ok
test tests::inline_viewport_anchor_fills_space_above_bottom_target ... ok
test tests::inline_viewport_anchor_handles_small_terminals ... ok
test settings::tests::token_roundtrip_via_disk ... ok
test tests::pick_provider_applies_saved_model_for_saved_provider ... ok
test tests::pick_provider_ignores_blank_cli_reasoning_effort ... ok
test tests::pick_provider_normalizes_cli_reasoning_effort ... ok
test tests::resolve_workspace_root_prefers_explicit_cwd ... ok
test tests::resolve_workspace_root_uses_saved_session_workspace ... ok
test mcp_e2e_tests::mcp_tool_executes_over_real_stdio_server ... ok
test tools::tests::bash_defaults_to_auto_mode_for_compact_success ... ok
test tools::tests::bash_auto_failure_returns_diagnostic_inline_output ... ok
test tools::tests::bash_explicit_full_returns_unlimited_inline_output ... ok
test tools::tests::bash_tool_missing_command_argument_returns_error ... ok
test tools::tests::bash_tool_non_string_command_returns_error ... ok
test runtime::tests::setup_url_and_custom_model_persist_through_settings ... ok
test tools::tests::bash_tool_requests_output_persistence ... ok
test tools::tests::bash_explicit_normal_still_returns_larger_inline_output ... ok
test tools::tests::bash_success_output_should_be_persistent_first_when_output_is_saved ... ok
test tools::tests::bash_tool_uses_exec_payload_shape_and_raw_output ... ok
test tools::tests::bash_tool_output_persistence_hook_saves_full_output_to_outputs_folder ... ok
test capabilities::background::tests::agent_times_out ... ok
test runtime::tests::setup_is_the_only_provider_configuration_command ... ok
test capabilities::background::tests::timeout_marks_timed_out ... ok
test streaming_tests::broadcast_does_not_persist_delta_events_to_jsonl ... ok
test streaming_tests::live_deltas_drive_streaming_preview_through_handle_live_event ... ok
test streaming_tests::llmsim_emits_multiple_output_message_deltas_on_broadcast ... ok

test result: ok. 460 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 2.97s


running 30 tests
test acp_anthropic_handshake_smoke ... ignored, requires ANTHROPIC_API_KEY; run under doppler with --ignored
test openrouter_tool_call_executes_end_to_end ... ok
test acp_openai_handshake_smoke ... ok
test openrouter_print_smoke ... ok
test openai_print_smoke ... ok
test help_flag_succeeds ... ok
test llmsim_unknown_session_id_is_invalid ... ok
test into_zed_command_writes_acp_settings ... ok
test llmsim_print_smoke ... ok
test print_mode_sends_saved_model_selection_to_endpoint ... ok
test print_mode_attaches_images_to_provider_request ... ok
test tui_double_ctrl_c_exits ... ok
test llmsim_resume_replays_prior_events ... ok
test tui_bang_shell_runs_shell_without_model_turn ... ok
test tui_resize_with_wrapped_input_keeps_cursor_inside_new_frame ... ok
test tui_setup_overlay_renders_in_real_pty ... ok
test acp_stdio_handshake_smoke ... ok
test tui_startup_anchors_composer_from_top_in_tall_terminal ... ok
test tui_startup_anchors_composer_in_short_terminal ... ok
test tui_startup_does_not_enable_mouse_capture ... ok
test version_command_succeeds ... ok
test version_flag_succeeds ... ok
test tui_startup_anchors_composer_when_prompt_is_already_near_bottom ... ok
test tui_alt_enter_sequence_submits_like_enter ... ok
test tui_setup_selects_model_for_connected_provider_in_real_pty ... ok
test tui_submit_turn_renders_assistant_in_scrollback ... ok
test tui_escape_does_not_exit_and_ctrl_c_exits ... ok
test tui_exits_cleanly_when_emulator_stops_answering_cursor_queries ... ok
test tui_starts_when_emulator_answers_only_the_first_cursor_query ... ok
test tui_survives_slow_cursor_position_reply_after_resize ... ok

test result: ok. 29 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 8.15s)
- ✅ Clippy passes with no warnings
- ✅ Code formatting correct ()
- ✅ Binary builds and runs correctly
- ✅ Verified fix addresses the exact issue described

## Verification
The status bar mouse click now works correctly:
- Clicking within the status bar area toggles between compact (1 row) and expanded (4 rows) views
- Clicks outside the status bar area are properly ignored
- No more false positives from clicks on the same row but different column

**Generated with yolop**