### PR TITLE
feat: bump everruns to 0.14.0 with OpenRouter attribution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,9 +1410,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "423d7ebbfc0146d5d657af8207c2414bead224238065b1503f3ffc3f44fc426b"
+checksum = "3384a24705bda1478e0790bb13cd8d9ffb33830a094b777a4e5ea9a305765e73"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1428,18 +1428,18 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a386627f93b0a441287d355c7fe3aa74bd3a4dfdb580f352a37e9953f20be24"
+checksum = "2720ca91048c39ed9a3549511a5a3bafe1964d185a315facf01923cb725b341a"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-core"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9dcc348178ff4283f781d6083d990be3d91202eed9de7817a9813a05f3d132f"
+checksum = "aa9677c89c18adc6be84e25215544c0304b84610a964512b292cfd3f39eaf608"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -1480,9 +1480,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92dfa5f5be8f155429f2da2d45470dbc8b67d9790a8ddbdf162fd83bb1a7c45"
+checksum = "fcbb3c151fe6c4597fb4b79d0593500bab6b042139cae42f0a9451886c595ef1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1497,9 +1497,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5b933cbe4ea581f2cee85ac0e77a19493f11274a1773e85b1bd35d777f9984"
+checksum = "33bd80714a68dc644a16be9afad4e5613694cc34ac98699489903ba78575f34c"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1513,9 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c4fb867859cfde48bd12f777b69dba2a40a9ed9d2cebca7b4a0704d7f5ad22d"
+checksum = "c3250b89febde49f202bee49208f0f61ee153b825c1db7390903d2e685889666"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1528,9 +1528,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747aa3716d9227161b910dc636c6900f296808d8d742bb16f73e53cc02043798"
+checksum = "7baeeb175f0480e05b0cc2d27d0b3e02598d646086f7e50b91d2d90b29645b9e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1549,9 +1549,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f3ae89085eedf0f6b366303a5e99d69d190d92d319b610e279aaffb30cadb6"
+checksum = "fa02dcea9fd12b64826b6d414e34c8f457f68a643eac55d0c44d5773601c67ed"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1563,9 +1563,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd72f772ade3985548499fd960388cb019eece400e0224a2ae79f1dcc1f54f0"
+checksum = "59e444545aac2de7de78fc1e2a088ded6dd54d373dadbe1a8a3b215ed36ba972"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,17 +68,17 @@ tree-sitter-zig = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-everruns-anthropic = "0.13.0"
-everruns-core = "0.13.0"
-everruns-openai = "0.13.0"
+everruns-anthropic = "0.14.0"
+everruns-core = "0.14.0"
+everruns-openai = "0.14.0"
 # OpenRouter's first-class driver was split out of everruns-openai into its own
 # crate in 0.13.0; register it alongside openai to keep DriverId::OpenRouter.
-everruns-openrouter = "0.13.0"
+everruns-openrouter = "0.14.0"
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (specs/mcp.md, upstream runtime-mcp.md D2).
-everruns-runtime = { version = "0.13.0", features = ["mcp-stdio"] }
-everruns-integrations-duckduckgo = "0.13.0"
-everruns-integrations-daytona = "0.13.0"
+everruns-runtime = { version = "0.14.0", features = ["mcp-stdio"] }
+everruns-integrations-duckduckgo = "0.14.0"
+everruns-integrations-daytona = "0.14.0"
 arboard = { version = "3", features = ["wayland-data-control"] }
 futures = "0.3"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp"] }

--- a/src/capabilities/client_commands.rs
+++ b/src/capabilities/client_commands.rs
@@ -292,7 +292,10 @@ mod tests {
 
         assert!(prompt.contains("run_yolop_command"));
         assert!(prompt.contains("TUI client"));
-        assert!(prompt.contains("only use `run_yolop_command` for this listed"));
+        // The prompt source wraps this guidance across two lines, so assert the
+        // two halves separately rather than as one contiguous phrase.
+        assert!(prompt.contains("only use `run_yolop_command` for"));
+        assert!(prompt.contains("this listed client-command set"));
         assert!(prompt.contains("/quit"));
         assert!(prompt.contains("/exit"));
     }

--- a/src/capabilities/model_discovery.rs
+++ b/src/capabilities/model_discovery.rs
@@ -11,8 +11,8 @@ use crate::runtime::ProviderChoice;
 use crate::settings::Settings;
 use anyhow::{Context, Result, anyhow};
 use everruns_core::DriverId;
+use everruns_core::driver_registry::{DiscoveredModel, DriverRegistry, ProviderConfig};
 use everruns_core::get_model_profile;
-use everruns_core::llm_driver_registry::{DiscoveredModel, DriverRegistry, ProviderConfig};
 use std::collections::HashSet;
 
 /// One model offered by a provider, ready for display: bare id plus

--- a/src/codex_driver.rs
+++ b/src/codex_driver.rs
@@ -1,12 +1,12 @@
 use crate::codex_auth::{self, CODEX_ORIGINATOR};
 use async_trait::async_trait;
 use eventsource_stream::Eventsource;
-use everruns_core::error::{AgentLoopError, Result as EverrunsResult};
-use everruns_core::llm_driver_registry::{
+use everruns_core::driver_registry::{
     ChatDriver, DriverConfig, LlmCallConfig, LlmCompletionMetadata, LlmContentPart, LlmMessage,
     LlmMessageContent, LlmMessageRole, LlmResponseStream, LlmStreamEvent, ProviderMetadata,
 };
-use everruns_core::llm_driver_registry::{DiscoveredModel, DriverRegistry};
+use everruns_core::driver_registry::{DiscoveredModel, DriverRegistry};
+use everruns_core::error::{AgentLoopError, Result as EverrunsResult};
 use everruns_core::tool_types::{ToolCall, ToolDefinition};
 use futures::StreamExt;
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -659,7 +659,7 @@ fn metadata_extra_i64(metadata: &ProviderMetadata, key: &str) -> Option<i64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use everruns_core::llm_driver_registry::{LlmMessage, LlmMessageRole};
+    use everruns_core::driver_registry::{LlmMessage, LlmMessageRole};
 
     #[test]
     fn converts_tool_result_to_function_call_output() {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -38,10 +38,10 @@ use everruns_core::capabilities::{
     UserHooksCapability, WebFetchCapability,
 };
 use everruns_core::command::CommandDescriptor;
+use everruns_core::driver_registry::{DriverRegistry, ProviderMetadata};
 use everruns_core::error::AgentLoopError;
 use everruns_core::get_model_profile;
 use everruns_core::in_memory::InMemoryMessageRetriever;
-use everruns_core::llm_driver_registry::{DriverRegistry, ProviderMetadata};
 use everruns_core::llmsim_driver::LlmSimConfig;
 use everruns_core::message::{ContentPart, MessageRole};
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, InitialFile, SessionFile};
@@ -1982,6 +1982,10 @@ pub async fn build_with_options(
         )
         .display_name("Coding CLI")
         .description("Embedded terminal coding agent.")
+        // Attribute LLM calls routed through OpenRouter so they show up under
+        // Yolop on OpenRouter's app dashboards. The driver forwards these as
+        // the `HTTP-Referer` and `X-Title` headers (everruns 0.14+).
+        .openrouter_attribution("https://github.com/everruns/yolop", "Yolop")
         .tag("example")
         .tag("coding");
     for cap in harness_capabilities {
@@ -2248,6 +2252,24 @@ mod tests {
                 .get("everruns_runtime_version")
                 .map(String::as_str),
             Some(env!("YOLOP_EVERRUNS_RUNTIME_VERSION"))
+        );
+        // OpenRouter attribution headers flow through embedder metadata.
+        use everruns_core::driver_registry::{
+            OPENROUTER_HTTP_REFERER_METADATA_KEY, OPENROUTER_X_TITLE_METADATA_KEY,
+        };
+        assert_eq!(
+            context
+                .embedder_metadata
+                .get(OPENROUTER_HTTP_REFERER_METADATA_KEY)
+                .map(String::as_str),
+            Some("https://github.com/everruns/yolop")
+        );
+        assert_eq!(
+            context
+                .embedder_metadata
+                .get(OPENROUTER_X_TITLE_METADATA_KEY)
+                .map(String::as_str),
+            Some("Yolop")
         );
     }
 


### PR DESCRIPTION
## What & why

Bumps every `everruns-*` crate from 0.13.0 to 0.14.0 and adopts the one
user-facing feature the new release adds for an OpenRouter-capable agent.

### Changes
- **`chore(deps)`: bump everruns crates to 0.14.0.** 0.14.0 renamed the
  `llm_driver_registry` module to `driver_registry` (and `llm_driver_helpers`
  to `driver_helpers`). Updated all import paths accordingly. All
  `everruns-*` crates are bumped together to avoid a soft API break.
- **`feat(openrouter)`: send Yolop attribution headers.** Adopts the new
  `HarnessBuilder::openrouter_attribution(...)` helper. LLM calls routed
  through OpenRouter now carry `HTTP-Referer: https://github.com/everruns/yolop`
  and `X-Title: Yolop`, so usage is attributed to Yolop on OpenRouter's app
  dashboards. The values flow through harness embedder metadata; the
  OpenRouter driver forwards them as headers.
- **`fix(test)`: assert wrapped client-command prompt guidance.** A
  pre-existing test (red on `main`) asserted a phrase that the prompt source
  wraps across two lines, so the contiguous-substring check never matched.
  Now asserts the two halves separately.

The other 0.14.0 changes (rate-limit header parsing, `fold_system_messages`
helper, `ProviderMetadata` refinements) are internal to the runtime and
require no yolop changes.

## Validation
- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all-features` — 466 + 29 pass, 0 fail
- `cargo run -- --provider llmsim -p "hi"` — binary starts, agent loop runs
- New assertions in `build_attaches_yolop_embedder_metadata` exercise the
  attribution feature directly by loading session context and checking the
  `openrouter.http_referer` / `openrouter.x_title` embedder metadata keys.

## Security
- **TM-DEP**: all `everruns-*` crates bumped together to 0.14.0 — no version
  mismatch. No new dependencies added.
- **TM-LLM**: attribution values are static literals (repo URL + app name);
  no secrets or user data are added to headers, logs, or session JSONL.
- No filesystem, shell, or capability-registration surfaces changed; write
  blocklist and bounded-execution model are untouched.

## Follow-ups
No follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AudPng3AfiarjTQp5GMyBa)_