### PR TITLE
refactor(skills): use upstream ScopedSkillsCapability, drop vendored copy

### DIFF
--- a/specs/skills.md
+++ b/specs/skills.md
@@ -6,34 +6,48 @@ Skills are instruction packages (`SKILL.md` files) the agent can discover,
 activate, and manage at runtime via skills tools, plus a system-prompt listing
 of what's available.
 
-yolop **vendors** the upstream `skills` capability from `everruns-core`. The
-upstream capability scans a single virtual-filesystem path (`/.agents/skills`)
-through the session filesystem; that is too narrow for global and system scopes,
-and the embedded in-process runtime does not apply the `mounts()` mechanism the
-server uses to inject extra skills. yolop therefore owns the discovery loop and
-reads the scope folders directly from disk, while **reusing** the upstream
-`SKILL.md` parser, validator, and argument/variable substitution verbatim
-(`everruns_core::skill`). This spec owns the scope set and behavior; the
-`SKILL.md` format is owned upstream.
+yolop uses the upstream `ScopedSkillsCapability` from `everruns-core` (0.12.0+).
+That capability owns discovery, precedence, the skills tools (`list_skills`,
+`activate_skill`, `read_skill`, `write_skill`), validation, and `SKILL.md`
+substitution — all driven strictly through the session `SessionFileSystem`. yolop
+supplies only the embedder-specific glue (`crate::capabilities::skills`):
 
-> Forward plan: once this multi-source resolver is stable, the intent is to push
-> it upstream (a capability that accepts multiple labeled skill sources, and/or
-> the planned in-process "mount-overlay resolver") so the vendoring can be
-> retired and duplication removed.
+1. **The scope set and writability** — workspace, global, system (below), passed
+   as `SkillScope`s with labeled **VFS roots** (never host paths).
+2. **A host-path `SkillDirResolver`** — so `${SKILL_DIR}` and the displayed paths
+   expand to real on-disk paths the host `bash` tool can read. (The core default
+   keeps them in the VFS, which is correct only when the shell shares that
+   namespace; yolop's `bash` runs on the host.)
+3. **Bundled system skills** — pre-packed in the binary and materialized once.
+4. **File-store routing** — `CodingCliSessionFileStore` maps each scope's VFS root
+   onto the real directory below, so the capability reaches global/system skills
+   through the VFS without ever being handed a host path.
+
+This spec owns the scope set and the yolop wiring; the capability contract and
+`SKILL.md` format are owned upstream (see `everruns` `specs/skills-registry.md`).
+
+> History: yolop previously **vendored** the whole capability because the
+> upstream `SkillsCapability` scanned a single VFS path and the embedded runtime
+> could not inject multi-scope sources. The multi-source resolver was pushed
+> upstream as `ScopedSkillsCapability` (everruns#2185), so the vendored copy was
+> retired and only the glue above remains.
 
 ## Scopes
 
-A skill is a directory named for the skill, containing `SKILL.md`. Every scope
-resolves to a **real on-disk directory**:
+A skill is a directory named for the skill, containing `SKILL.md`. Each scope is
+a labeled VFS root that yolop's file store maps to a **real on-disk directory**:
 
-1. **Workspace** — `<workspace>/.agents/skills/<name>/`. Lives in the project
-   under version control; ships with the repo it belongs to.
+1. **Workspace** — `<workspace>/.agents/skills/<name>/` (VFS `/.agents/skills`).
+   Lives in the project under version control; ships with the repo it belongs to.
+   Writable.
 2. **Global** — `<config_dir>/yolop/skills/<name>/` (e.g.
-   `~/.config/yolop/skills/` on Linux), installed once per user and shared
-   across every workspace. Overridable with `YOLOP_GLOBAL_SKILLS_DIR`.
+   `~/.config/yolop/skills/` on Linux; VFS `/.yolop/global-skills`), installed
+   once per user and shared across every workspace. Writable. Overridable with
+   `YOLOP_GLOBAL_SKILLS_DIR`.
 3. **System** — pre-packed inside the yolop binary and materialized once to
-   `<data_dir>/yolop/system-skills/<name>/`. Always available. Overridable with
-   `YOLOP_SYSTEM_SKILLS_DIR` (used verbatim, no materialization).
+   `<data_dir>/yolop/system-skills/<name>/` (VFS `/.yolop/system-skills`). Always
+   available, **read-only**. Overridable with `YOLOP_SYSTEM_SKILLS_DIR` (used
+   verbatim, no materialization).
 
 ## Required Behavior
 
@@ -75,7 +89,13 @@ resolves to a **real on-disk directory**:
 
 ## Ownership Boundary
 
-- This spec and `crate::skills` own scope resolution, discovery, precedence, and
-  the skills tools.
+- `everruns_core::capabilities::ScopedSkillsCapability` owns discovery,
+  precedence, the skills tools, validation, and substitution — all through the
+  session `SessionFileSystem`.
+- `crate::capabilities::skills` owns the yolop wiring: the scope set, the
+  host-path `SkillDirResolver`, the embedded system skills + materialization, and
+  the VFS-root constants the file store routes on.
+- `crate::runtime` (`CodingCliSessionFileStore`) owns mapping the scope VFS roots
+  to real on-disk directories.
 - `everruns_core::skill` owns the `SKILL.md` format, parsing, validation, and
   substitution.

--- a/src/capabilities/skills.rs
+++ b/src/capabilities/skills.rs
@@ -1,844 +1,133 @@
-// Skills — vendored from everruns-core's `SkillsCapability`, extended to source
-// skills from three real on-disk folders instead of the single session-VFS path
-// the upstream capability scans.
+// Yolop skills wiring for the upstream `ScopedSkillsCapability`.
 //
-// Why vendored: the upstream `SkillsCapability` discovers skills by scanning one
-// path (`/.agents/skills`) through the session filesystem. Supporting global and
-// system scopes that way meant overlaying extra roots into that VFS path, which
-// loses scope identity and forced system skills onto disk awkwardly. yolop
-// instead owns the discovery loop and reads the scope folders directly. The
-// SKILL.md *parser/validator/substitution* are reused verbatim from
-// `everruns_core::skill` — only discovery and the two tools are reimplemented.
+// The skills *capability* (discovery, precedence, `list_skills` /
+// `activate_skill` / `read_skill` / `write_skill`, validation, substitution)
+// now lives in `everruns_core` as `ScopedSkillsCapability` — yolop no longer
+// vendors it. This module keeps only the yolop-specific glue the core
+// capability cannot own:
 //
-// Scopes (precedence: workspace > global > system; discovery de-dups by skill
-// directory name, so a nearer scope shadows a farther one):
-//   * workspace — `<workspace>/.agents/skills`
-//   * global    — `<config_dir>/yolop/skills` (override: YOLOP_GLOBAL_SKILLS_DIR)
-//   * system    — pre-packed in the binary, materialized once to
-//                 `<data_dir>/yolop/system-skills` (override: YOLOP_SYSTEM_SKILLS_DIR)
+//   * the three scopes and where each maps on the *host* disk,
+//   * a `SkillDirResolver` so `${SKILL_DIR}` expands to a real host path the
+//     `bash` tool can read (the core default keeps it in the VFS),
+//   * the system skills pre-packed in the binary and materialized once.
 //
-// Every scope resolves to a real directory, so `${SKILL_DIR}` in an activated
-// skill points at a real path the host `bash` tool can read — bundled files work
-// for all three scopes. Once this multi-source resolver proves out, it is the
-// natural thing to push upstream so the overlay/vendoring can be retired (see
-// `specs/skills.md`).
+// The capability discovers/reads/writes strictly through the session
+// `SessionFileSystem`. yolop's file store (`CodingCliSessionFileStore`) maps the
+// three scope VFS roots onto the real directories below, so the capability never
+// touches a host path directly — the host mapping lives behind the file store,
+// not in the capability's configuration.
+//
+// Scopes (precedence: workspace > global > system; the core capability de-dups
+// by skill directory name, so a nearer scope shadows a farther one):
+//   * workspace — `<workspace>/.agents/skills`           (writable)
+//   * global    — `<config_dir>/yolop/skills`            (writable; override: YOLOP_GLOBAL_SKILLS_DIR)
+//   * system    — pre-packed, materialized once          (read-only; override: YOLOP_SYSTEM_SKILLS_DIR)
 
-use async_trait::async_trait;
-use everruns_core::ToolContext;
-use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
-use everruns_core::skill::{
-    SkillContext, expand_skill_arguments, parse_skill_md, substitute_activation_vars,
-    validate_skill_name,
-};
-use everruns_core::tool_types::ToolHints;
-use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::capabilities::{SkillDirResolver, SkillScope, SkillsConfig};
 use include_dir::{Dir, include_dir};
-use serde_json::{Value, json};
-use std::ffi::OsString;
-use std::io::Write;
-use std::path::Component;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-
-/// Capability id — kept equal to the upstream constant so the harness capability
-/// wiring (`AgentCapabilityConfig::new(SKILLS_CAPABILITY_ID)`) still resolves.
-pub const SKILLS_CAPABILITY_ID: &str = "skills";
 
 /// Env override for the global skills directory.
 const GLOBAL_SKILLS_DIR_ENV: &str = "YOLOP_GLOBAL_SKILLS_DIR";
 /// Env override for the system skills directory (skips materialization).
 const SYSTEM_SKILLS_DIR_ENV: &str = "YOLOP_SYSTEM_SKILLS_DIR";
 
-/// Max skills listed in the system prompt (the rest are reachable via `list_skills`).
-const MAX_SKILLS_IN_PROMPT: usize = 15;
-/// Max description length in the system-prompt listing (truncated with "…").
-const MAX_DESCRIPTION_CHARS: usize = 76;
-/// Defensive cap for extra files installed with a skill.
-const MAX_EXTRA_SKILL_FILES: usize = 64;
-/// Defensive cap for one skill file body.
-const MAX_SKILL_FILE_BYTES: usize = 1024 * 1024;
+/// VFS root for the workspace scope. Routes through the workspace file store to
+/// `<workspace>/.agents/skills` like any other workspace path.
+pub const WORKSPACE_SKILLS_VFS: &str = "/.agents/skills";
+/// Synthetic VFS root for the global scope, routed by the file store to the
+/// user's global skills directory (outside the workspace).
+pub const GLOBAL_SKILLS_VFS: &str = "/.yolop/global-skills";
+/// Synthetic VFS root for the system scope, routed by the file store to the
+/// materialized system skills directory.
+pub const SYSTEM_SKILLS_VFS: &str = "/.yolop/system-skills";
 
 /// System skills shipped inside the binary. The crate-root `skills/` directory is
 /// embedded at compile time so a `cargo install` / Homebrew build carries them.
 static SYSTEM_SKILLS: Dir<'static> = include_dir!("$CARGO_MANIFEST_DIR/skills");
 
-const SKILLS_SYSTEM_PROMPT: &str = "Skills are reusable instruction packs sourced \
-from your workspace, your global config, and ones built into yolop. Use `list_skills` \
-to see what's available and `activate_skill` (by name) to load one. Only activate \
-skills relevant to the current task.";
-
-/// Where a skill came from. Surfaced to the model so it can reason about trust
-/// and precedence.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum SkillScope {
-    Workspace,
-    Global,
-    System,
+/// The host directories backing each skill scope for a session.
+#[derive(Clone, Debug)]
+pub struct SkillDirs {
+    /// `<workspace>/.agents/skills` — always present (created on demand).
+    pub workspace: PathBuf,
+    /// Global skills directory, or `None` when no platform config dir exists.
+    pub global: Option<PathBuf>,
+    /// Materialized system skills directory, or `None` when unavailable.
+    pub system: Option<PathBuf>,
 }
 
-impl SkillScope {
-    fn label(self) -> &'static str {
-        match self {
-            SkillScope::Workspace => "workspace",
-            SkillScope::Global => "global",
-            SkillScope::System => "system",
-        }
-    }
-}
-
-/// The ordered set of skill folders for a session, highest precedence first.
-pub struct SkillSources {
-    roots: Vec<(SkillScope, PathBuf)>,
-}
-
-/// One discovered skill, after parsing its `SKILL.md`.
-struct DiscoveredSkill {
-    scope: SkillScope,
-    /// Directory name — the identifier used to activate the skill.
-    dir_name: String,
-    dir_path: PathBuf,
-    /// `None` when `SKILL.md` failed to parse (carried in `error` instead).
-    name: String,
-    description: String,
-    version: String,
-    user_invocable: bool,
-    disable_model_invocation: bool,
-    error: Option<String>,
-}
-
-impl SkillSources {
-    /// Resolve the workspace/global/system folders for `workspace_root`.
+impl SkillDirs {
+    /// Resolve the workspace/global/system directories for `workspace_root`.
+    /// Materializes the embedded system skills as a side effect (idempotent).
     pub fn resolve(workspace_root: &Path) -> Self {
-        Self::from_dirs(
-            Some(workspace_root.join(".agents").join("skills")),
-            global_skills_dir(),
-            system_skills_dir(),
-        )
-    }
-
-    /// Build from explicit per-scope directories (used by `resolve` and tests).
-    /// Missing directories are kept so a skill installed later in the same
-    /// process becomes discoverable on the next `list_skills`/`activate_skill`
-    /// call without restarting yolop.
-    pub(crate) fn from_dirs(
-        workspace: Option<PathBuf>,
-        global: Option<PathBuf>,
-        system: Option<PathBuf>,
-    ) -> Self {
-        let mut roots = Vec::new();
-        for (scope, dir) in [
-            (SkillScope::Workspace, workspace),
-            (SkillScope::Global, global),
-            (SkillScope::System, system),
-        ] {
-            if let Some(dir) = dir {
-                roots.push((scope, dir));
-            }
-        }
-        Self { roots }
-    }
-
-    /// Discover every unique skill across scopes, in precedence order. The first
-    /// occurrence of a directory name wins; later (farther-scope) duplicates are
-    /// dropped.
-    fn discover(&self) -> Vec<DiscoveredSkill> {
-        let mut seen = std::collections::HashSet::new();
-        let mut out = Vec::new();
-        for (scope, root) in &self.roots {
-            for dir_name in skill_dir_names(root) {
-                if !seen.insert(dir_name.clone()) {
-                    continue;
-                }
-                let dir_path = root.join(&dir_name);
-                let content =
-                    std::fs::read_to_string(dir_path.join("SKILL.md")).unwrap_or_default();
-                let discovered = match parse_skill_md(&content) {
-                    Ok(parsed) => DiscoveredSkill {
-                        scope: *scope,
-                        dir_name: dir_name.clone(),
-                        dir_path,
-                        name: parsed.name,
-                        description: parsed.description,
-                        version: parsed.version,
-                        user_invocable: parsed.user_invocable,
-                        disable_model_invocation: parsed.disable_model_invocation,
-                        error: None,
-                    },
-                    Err(errors) => DiscoveredSkill {
-                        scope: *scope,
-                        name: dir_name.clone(),
-                        dir_path,
-                        description: String::new(),
-                        version: String::new(),
-                        user_invocable: false,
-                        disable_model_invocation: false,
-                        error: Some(format!("Invalid SKILL.md: {}", errors.join(", "))),
-                        dir_name,
-                    },
-                };
-                out.push(discovered);
-            }
-        }
-        out
-    }
-
-    /// Locate the activatable skill named `dir_name`, honoring precedence.
-    /// Returns the scope, the skill directory, and the raw `SKILL.md` content.
-    fn locate(&self, dir_name: &str) -> Option<(SkillScope, PathBuf, String)> {
-        for (scope, root) in &self.roots {
-            let dir_path = root.join(dir_name);
-            let md_path = dir_path.join("SKILL.md");
-            if let Ok(content) = std::fs::read_to_string(&md_path) {
-                return Some((*scope, dir_path, content));
-            }
-        }
-        None
-    }
-
-    fn root_for(&self, requested: SkillWriteScope) -> Option<PathBuf> {
-        let wanted = requested.skill_scope();
-        self.roots
-            .iter()
-            .find_map(|(scope, root)| (*scope == wanted).then(|| root.clone()))
-    }
-}
-
-/// Immediate subdirectories of `root` that contain a `SKILL.md`, sorted for
-/// deterministic ordering.
-fn skill_dir_names(root: &Path) -> Vec<String> {
-    let mut names = Vec::new();
-    let Ok(entries) = std::fs::read_dir(root) else {
-        return names;
-    };
-    for entry in entries.flatten() {
-        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
-            continue;
-        }
-        if !entry.path().join("SKILL.md").is_file() {
-            continue;
-        }
-        if let Ok(name) = entry.file_name().into_string() {
-            names.push(name);
-        }
-    }
-    names.sort();
-    names
-}
-
-fn truncate_description(s: &str, max_chars: usize) -> String {
-    if s.chars().count() <= max_chars {
-        return s.to_string();
-    }
-    let truncated: String = s.chars().take(max_chars.saturating_sub(1)).collect();
-    format!("{}…", truncated.trim_end())
-}
-
-// ============================================================================
-// Capability
-// ============================================================================
-
-/// yolop's skills capability: discovers + activates skills across the workspace,
-/// global, and system scopes.
-pub struct YolopSkillsCapability {
-    sources: Arc<SkillSources>,
-}
-
-impl YolopSkillsCapability {
-    pub fn new(sources: SkillSources) -> Self {
         Self {
-            sources: Arc::new(sources),
+            workspace: workspace_root.join(".agents").join("skills"),
+            global: global_skills_dir(),
+            system: system_skills_dir(),
         }
     }
 }
 
-#[async_trait]
-impl Capability for YolopSkillsCapability {
-    fn id(&self) -> &str {
-        SKILLS_CAPABILITY_ID
+/// Strip a VFS root prefix, returning the remainder as an absolute path under
+/// that root (`/` for the root itself). Shared with the file-store router.
+pub fn relative_under(path: &str, root: &str) -> Option<String> {
+    if path == root {
+        return Some("/".to_string());
     }
+    path.strip_prefix(&format!("{root}/"))
+        .map(|rest| format!("/{rest}"))
+}
 
-    fn name(&self) -> &str {
-        "Agent Skills"
+/// Build the `ScopedSkillsCapability` configuration for these directories.
+/// Only scopes whose directory resolved are included; the system scope is
+/// read-only, the others writable. `${SKILL_DIR}` and display paths resolve to
+/// real host paths via [`HostSkillDirResolver`].
+pub fn skills_config(dirs: &SkillDirs) -> SkillsConfig {
+    let mut scopes = vec![SkillScope::new("workspace", WORKSPACE_SKILLS_VFS, true)];
+    if dirs.global.is_some() {
+        scopes.push(SkillScope::new("global", GLOBAL_SKILLS_VFS, true));
     }
-
-    fn description(&self) -> &str {
-        "Discover and activate skills from the workspace, global config, and built-in (system) scopes."
+    if dirs.system.is_some() {
+        scopes.push(SkillScope::new("system", SYSTEM_SKILLS_VFS, false));
     }
-
-    fn status(&self) -> CapabilityStatus {
-        CapabilityStatus::Available
-    }
-
-    fn icon(&self) -> Option<&str> {
-        Some("wand")
-    }
-
-    fn category(&self) -> Option<&str> {
-        Some("Skills")
-    }
-
-    fn system_prompt_addition(&self) -> Option<&str> {
-        Some(SKILLS_SYSTEM_PROMPT)
-    }
-
-    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
-        let mut prompt = String::from(SKILLS_SYSTEM_PROMPT);
-
-        // Skills the model may auto-invoke (i.e. not opted out).
-        let visible: Vec<DiscoveredSkill> = self
-            .sources
-            .discover()
-            .into_iter()
-            .filter(|s| s.error.is_none() && !s.disable_model_invocation)
-            .collect();
-
-        if !visible.is_empty() {
-            prompt.push_str("\n\nAvailable skills:\n");
-            for skill in visible.iter().take(MAX_SKILLS_IN_PROMPT) {
-                let desc = truncate_description(&skill.description, MAX_DESCRIPTION_CHARS);
-                let invocable = if skill.user_invocable {
-                    format!(" (/{})", skill.name)
-                } else {
-                    String::new()
-                };
-                prompt.push_str(&format!(
-                    "- **{}** [{}]: {}{}\n",
-                    skill.name,
-                    skill.scope.label(),
-                    desc,
-                    invocable
-                ));
-            }
-            if visible.len() > MAX_SKILLS_IN_PROMPT {
-                prompt.push_str(&format!(
-                    "\n({} more — use `list_skills` to see all)\n",
-                    visible.len() - MAX_SKILLS_IN_PROMPT
-                ));
-            }
-        }
-
-        Some(format!(
-            "<capability id=\"{}\">\n{}\n</capability>",
-            self.id(),
-            prompt
-        ))
-    }
-
-    fn tools(&self) -> Vec<Box<dyn Tool>> {
-        vec![
-            Box::new(ListSkillsTool {
-                sources: self.sources.clone(),
-            }),
-            Box::new(ReadSkillTool {
-                sources: self.sources.clone(),
-            }),
-            Box::new(WriteSkillTool {
-                sources: self.sources.clone(),
-            }),
-            Box::new(ActivateSkillTool {
-                sources: self.sources.clone(),
-            }),
-        ]
+    SkillsConfig {
+        scopes,
+        resolver: Arc::new(HostSkillDirResolver { dirs: dirs.clone() }),
+        manage_tools: true,
     }
 }
 
-// ============================================================================
-// list_skills
-// ============================================================================
-
-struct ListSkillsTool {
-    sources: Arc<SkillSources>,
+/// Resolves `${SKILL_DIR}` and display paths to real host paths so the host
+/// `bash` tool can read a skill's bundled files. yolop's shell runs on the host,
+/// not in the VFS, so the VFS-default resolver would hand the model unreachable
+/// paths.
+struct HostSkillDirResolver {
+    dirs: SkillDirs,
 }
 
-#[async_trait]
-impl Tool for ListSkillsTool {
-    fn name(&self) -> &str {
-        "list_skills"
-    }
-
-    fn display_name(&self) -> Option<&str> {
-        Some("List Skills")
-    }
-
-    fn description(&self) -> &str {
-        "Discover available skills across the workspace, global, and system scopes. \
-         Returns each skill's name, description, and scope."
-    }
-
-    fn parameters_schema(&self) -> Value {
-        json!({ "type": "object", "properties": {}, "required": [] })
-    }
-
-    fn hints(&self) -> ToolHints {
-        ToolHints::default()
-            .with_readonly(true)
-            .with_idempotent(true)
-    }
-
-    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
-        let skills: Vec<Value> = self
-            .sources
-            .discover()
-            .into_iter()
-            .map(|s| match s.error {
-                Some(error) => json!({
-                    "name": s.dir_name,
-                    "scope": s.scope.label(),
-                    "path": s.dir_path.join("SKILL.md").display().to_string(),
-                    "error": error,
-                }),
-                None => json!({
-                    "name": s.name,
-                    "description": s.description,
-                    "scope": s.scope.label(),
-                    "version": s.version,
-                    "user_invocable": s.user_invocable,
-                    "disable_model_invocation": s.disable_model_invocation,
-                    "path": s.dir_path.join("SKILL.md").display().to_string(),
-                }),
-            })
-            .collect();
-
-        ToolExecutionResult::success(json!({
-            "count": skills.len(),
-            "skills": skills,
-        }))
+impl HostSkillDirResolver {
+    fn base_for(&self, label: &str) -> PathBuf {
+        match label {
+            "global" => self.dirs.global.clone(),
+            "system" => self.dirs.system.clone(),
+            _ => Some(self.dirs.workspace.clone()),
+        }
+        .unwrap_or_else(|| self.dirs.workspace.clone())
     }
 }
 
-// ============================================================================
-// read_skill
-// ============================================================================
-
-struct ReadSkillTool {
-    sources: Arc<SkillSources>,
-}
-
-#[async_trait]
-impl Tool for ReadSkillTool {
-    fn name(&self) -> &str {
-        "read_skill"
+impl SkillDirResolver for HostSkillDirResolver {
+    fn skill_dir(&self, scope: &SkillScope, name: &str) -> String {
+        self.base_for(&scope.label).join(name).display().to_string()
     }
 
-    fn display_name(&self) -> Option<&str> {
-        Some("Read Skill")
-    }
-
-    fn description(&self) -> &str {
-        "Read one installed skill's SKILL.md and file manifest. Use before modifying \
-         or upgrading a workspace/global skill."
-    }
-
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "description": "The skill directory name."
-                },
-                "scope": {
-                    "type": "string",
-                    "enum": ["workspace", "local", "global", "system"],
-                    "description": "Optional scope to read from. Omit to use normal precedence."
-                }
-            },
-            "required": ["name"],
-            "additionalProperties": false
-        })
-    }
-
-    fn hints(&self) -> ToolHints {
-        ToolHints::default()
-            .with_readonly(true)
-            .with_idempotent(true)
-    }
-
-    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        let Some(name) = arguments.get("name").and_then(|v| v.as_str()) else {
-            return ToolExecutionResult::tool_error("Missing required parameter: name");
-        };
-        if let Err(e) = validate_requested_skill_name(name) {
-            return ToolExecutionResult::tool_error(e);
-        }
-
-        let located = match arguments.get("scope").and_then(|v| v.as_str()) {
-            Some(raw) => {
-                let Some(scope) = SkillReadScope::parse(raw) else {
-                    return ToolExecutionResult::tool_error(
-                        "'scope' must be one of workspace, local, global, or system",
-                    );
-                };
-                self.sources
-                    .roots
-                    .iter()
-                    .find(|(candidate, _)| *candidate == scope.skill_scope())
-                    .and_then(|(scope, root)| {
-                        let dir_path = root.join(name);
-                        std::fs::read_to_string(dir_path.join("SKILL.md"))
-                            .ok()
-                            .map(|content| (*scope, dir_path, content))
-                    })
-            }
-            None => self.sources.locate(name),
-        };
-
-        let Some((scope, dir_path, content)) = located else {
-            return ToolExecutionResult::tool_error(format!(
-                "Skill '{name}' not found. Use list_skills to see what's available."
-            ));
-        };
-
-        ToolExecutionResult::success(json!({
-            "name": name,
-            "scope": scope.label(),
-            "path": dir_path.join("SKILL.md").display().to_string(),
-            "skill_md": content,
-            "files": skill_file_manifest(&dir_path),
-        }))
+    fn display_dir(&self, scope: &SkillScope, name: &str) -> String {
+        // Show the real path too — it's what the agent passes to `bash`.
+        self.skill_dir(scope, name)
     }
 }
-
-// ============================================================================
-// write_skill
-// ============================================================================
-
-struct WriteSkillTool {
-    sources: Arc<SkillSources>,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum SkillWriteScope {
-    Workspace,
-    Global,
-}
-
-impl SkillWriteScope {
-    fn parse(raw: &str) -> Option<Self> {
-        match raw {
-            "workspace" | "local" => Some(Self::Workspace),
-            "global" => Some(Self::Global),
-            _ => None,
-        }
-    }
-
-    fn skill_scope(self) -> SkillScope {
-        match self {
-            Self::Workspace => SkillScope::Workspace,
-            Self::Global => SkillScope::Global,
-        }
-    }
-
-    fn label(self) -> &'static str {
-        self.skill_scope().label()
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum SkillReadScope {
-    Workspace,
-    Global,
-    System,
-}
-
-impl SkillReadScope {
-    fn parse(raw: &str) -> Option<Self> {
-        match raw {
-            "workspace" | "local" => Some(Self::Workspace),
-            "global" => Some(Self::Global),
-            "system" => Some(Self::System),
-            _ => None,
-        }
-    }
-
-    fn skill_scope(self) -> SkillScope {
-        match self {
-            Self::Workspace => SkillScope::Workspace,
-            Self::Global => SkillScope::Global,
-            Self::System => SkillScope::System,
-        }
-    }
-}
-
-#[async_trait]
-impl Tool for WriteSkillTool {
-    fn name(&self) -> &str {
-        "write_skill"
-    }
-
-    fn display_name(&self) -> Option<&str> {
-        Some("Write Skill")
-    }
-
-    fn description(&self) -> &str {
-        "Install or update a skill in the current workspace or global yolop config. \
-         Provide the full SKILL.md and optional bundled files. Use this to recreate \
-         skills from a registry/GitHub source without requiring npx."
-    }
-
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "scope": {
-                    "type": "string",
-                    "enum": ["workspace", "local", "global"],
-                    "description": "Where to write the skill. 'local' is an alias for 'workspace'."
-                },
-                "name": {
-                    "type": "string",
-                    "description": "Skill directory name. Must match the SKILL.md frontmatter name."
-                },
-                "skill_md": {
-                    "type": "string",
-                    "description": "The complete SKILL.md contents, including frontmatter."
-                },
-                "files": {
-                    "type": "object",
-                    "description": "Optional bundled files to write under the skill directory, keyed by relative path. Do not include SKILL.md here.",
-                    "additionalProperties": { "type": "string" }
-                },
-                "overwrite": {
-                    "type": "boolean",
-                    "description": "Whether to replace existing files. Defaults to true."
-                }
-            },
-            "required": ["scope", "name", "skill_md"],
-            "additionalProperties": false
-        })
-    }
-
-    fn hints(&self) -> ToolHints {
-        ToolHints::default().with_idempotent(true)
-    }
-
-    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        let Some(scope_raw) = arguments.get("scope").and_then(|v| v.as_str()) else {
-            return ToolExecutionResult::tool_error("'scope' is required");
-        };
-        let Some(scope) = SkillWriteScope::parse(scope_raw) else {
-            return ToolExecutionResult::tool_error(
-                "'scope' must be one of workspace, local, or global",
-            );
-        };
-        let Some(name) = arguments.get("name").and_then(|v| v.as_str()) else {
-            return ToolExecutionResult::tool_error("'name' is required");
-        };
-        if let Err(e) = validate_requested_skill_name(name) {
-            return ToolExecutionResult::tool_error(e);
-        }
-        let Some(skill_md) = arguments.get("skill_md").and_then(|v| v.as_str()) else {
-            return ToolExecutionResult::tool_error("'skill_md' is required");
-        };
-        if skill_md.len() > MAX_SKILL_FILE_BYTES {
-            return ToolExecutionResult::tool_error(format!(
-                "'skill_md' exceeds the {MAX_SKILL_FILE_BYTES} byte limit"
-            ));
-        }
-
-        let parsed = match parse_skill_md(skill_md) {
-            Ok(parsed) => parsed,
-            Err(errors) => {
-                return ToolExecutionResult::tool_error(format!(
-                    "Invalid SKILL.md: {}",
-                    errors.join(", ")
-                ));
-            }
-        };
-        if parsed.name != name {
-            return ToolExecutionResult::tool_error(format!(
-                "'name' must match SKILL.md frontmatter name (got '{}')",
-                parsed.name
-            ));
-        }
-
-        let Some(root) = self.sources.root_for(scope) else {
-            return ToolExecutionResult::tool_error(format!(
-                "{} skills directory is unavailable on this host",
-                scope.label()
-            ));
-        };
-        let skill_dir = root.join(name);
-        let overwrite = arguments
-            .get("overwrite")
-            .and_then(Value::as_bool)
-            .unwrap_or(true);
-        let files = match collect_extra_files(arguments.get("files")) {
-            Ok(files) => files,
-            Err(e) => return ToolExecutionResult::tool_error(e),
-        };
-
-        if !overwrite && skill_dir.exists() {
-            return ToolExecutionResult::tool_error(format!(
-                "Skill '{}' already exists in {} scope; pass overwrite=true to update it",
-                name,
-                scope.label()
-            ));
-        }
-
-        let write_result = (|| -> std::io::Result<()> {
-            prepare_skill_dir(&root, &skill_dir)?;
-            std::fs::create_dir_all(&skill_dir)?;
-            save_skill_file(&skill_dir.join("SKILL.md"), skill_md)?;
-            for (rel, content) in &files {
-                let target = checked_skill_file_path(&skill_dir, rel)?;
-                save_skill_file(&target, content)?;
-            }
-            Ok(())
-        })();
-
-        match write_result {
-            Ok(()) => ToolExecutionResult::success(json!({
-                "ok": true,
-                "name": name,
-                "scope": scope.label(),
-                "path": skill_dir.join("SKILL.md").display().to_string(),
-                "files_written": files.len() + 1,
-                "message": "skill written; it is discoverable immediately via list_skills and activate_skill",
-            })),
-            Err(e) => ToolExecutionResult::tool_error(format!("could not write skill: {e}")),
-        }
-    }
-}
-
-// ============================================================================
-// activate_skill
-// ============================================================================
-
-struct ActivateSkillTool {
-    sources: Arc<SkillSources>,
-}
-
-#[async_trait]
-impl Tool for ActivateSkillTool {
-    fn name(&self) -> &str {
-        "activate_skill"
-    }
-
-    fn display_name(&self) -> Option<&str> {
-        Some("Activate Skill")
-    }
-
-    fn description(&self) -> &str {
-        "Activate a skill by name to load its full instructions. Skills are resolved \
-         across the workspace, global, and system scopes (workspace wins on conflict)."
-    }
-
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "description": "The skill directory name (e.g., 'joke')"
-                },
-                "arguments": {
-                    "type": "string",
-                    "description": "Optional arguments to pass to the skill for $ARGUMENTS substitution"
-                }
-            },
-            "required": ["name"]
-        })
-    }
-
-    fn hints(&self) -> ToolHints {
-        ToolHints::default()
-            .with_readonly(true)
-            .with_idempotent(true)
-    }
-
-    fn requires_context(&self) -> bool {
-        // Only for the `${SESSION_ID}` activation variable; discovery itself reads
-        // real folders and needs no session context.
-        true
-    }
-
-    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
-        ToolExecutionResult::tool_error(
-            "activate_skill requires session context and cannot run standalone.",
-        )
-    }
-
-    async fn execute_with_context(
-        &self,
-        arguments: Value,
-        context: &ToolContext,
-    ) -> ToolExecutionResult {
-        let Some(name) = arguments.get("name").and_then(|v| v.as_str()) else {
-            return ToolExecutionResult::tool_error("Missing required parameter: name");
-        };
-        let skill_args = arguments
-            .get("arguments")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-
-        // Reject path separators up front, then enforce the full skill-name rules
-        // (lowercase, digits, single hyphens, 1-64 chars).
-        if name.contains("..") || name.contains('/') || name.contains('\\') {
-            return ToolExecutionResult::tool_error(
-                "Invalid skill name. Must be a simple directory name without path separators.",
-            );
-        }
-        if let Err(errors) = validate_skill_name(name) {
-            return ToolExecutionResult::tool_error(format!(
-                "Invalid skill name '{name}': {}",
-                errors.join(", ")
-            ));
-        }
-
-        let Some((scope, dir_path, content)) = self.sources.locate(name) else {
-            return ToolExecutionResult::tool_error(format!(
-                "Skill '{name}' not found in any scope. Use list_skills to see what's available."
-            ));
-        };
-
-        match parse_skill_md(&content) {
-            Ok(parsed) => {
-                // Substitution pipeline: arguments ($ARGUMENTS, $N) then activation
-                // vars (${SESSION_ID}, ${SKILL_DIR}). `${SKILL_DIR}` is the real
-                // on-disk skill folder, so bundled files are reachable via `bash`.
-                //
-                // Command injection (!`cmd`) is intentionally NOT expanded: yolop
-                // mirrors upstream's conservative trust gate (see everruns-core
-                // skills.rs / EVE-388) — activating a skill must never spawn a
-                // shell on the host.
-                let expanded = expand_skill_arguments(&parsed.instructions, skill_args);
-                let substituted = substitute_activation_vars(
-                    &expanded,
-                    &context.session_id.to_string(),
-                    &dir_path.display().to_string(),
-                );
-                let instructions = format!(
-                    "<skill name=\"{}\">\n{}\n</skill>",
-                    parsed.name, substituted
-                );
-
-                let mut result = json!({
-                    "skill": parsed.name,
-                    "scope": scope.label(),
-                    "description": parsed.description,
-                    "instructions": instructions,
-                });
-                if parsed.context == SkillContext::Fork {
-                    result["context"] = json!("fork");
-                    result["agent"] = json!(parsed.agent.as_deref().unwrap_or("general-purpose"));
-                    if let Some(model) = &parsed.model {
-                        result["model"] = json!(model);
-                    }
-                }
-                ToolExecutionResult::success(result)
-            }
-            Err(errors) => ToolExecutionResult::tool_error(format!(
-                "Invalid SKILL.md for '{name}': {}",
-                errors.join(", ")
-            )),
-        }
-    }
-}
-
-// ============================================================================
-// Scope folder resolution + system-skill materialization
-// ============================================================================
 
 /// Global skills directory, or `None` when no platform config directory exists.
 /// Honors `YOLOP_GLOBAL_SKILLS_DIR`; otherwise `<config_dir>/yolop/skills`.
@@ -937,575 +226,75 @@ fn write_if_changed(target: &Path, contents: &[u8]) -> std::io::Result<()> {
     std::fs::rename(&tmp, target)
 }
 
-fn validate_requested_skill_name(name: &str) -> Result<(), String> {
-    if name.contains("..") || name.contains('/') || name.contains('\\') {
-        return Err(
-            "Invalid skill name. Must be a simple directory name without path separators."
-                .to_string(),
-        );
-    }
-    validate_skill_name(name)
-        .map_err(|errors| format!("Invalid skill name '{name}': {}", errors.join(", ")))
-}
-
-fn collect_extra_files(value: Option<&Value>) -> Result<Vec<(PathBuf, String)>, String> {
-    let Some(value) = value else {
-        return Ok(Vec::new());
-    };
-    let Some(map) = value.as_object() else {
-        return Err("'files' must be an object of relative path to string content".to_string());
-    };
-    if map.len() > MAX_EXTRA_SKILL_FILES {
-        return Err(format!(
-            "'files' contains too many entries (max {MAX_EXTRA_SKILL_FILES})"
-        ));
-    }
-
-    let mut out = Vec::with_capacity(map.len());
-    for (raw_path, value) in map {
-        let Some(content) = value.as_str() else {
-            return Err(format!("file '{raw_path}' content must be a string"));
-        };
-        if content.len() > MAX_SKILL_FILE_BYTES {
-            return Err(format!(
-                "file '{raw_path}' exceeds the {MAX_SKILL_FILE_BYTES} byte limit"
-            ));
-        }
-        let rel = validate_skill_file_path(raw_path)?;
-        out.push((rel, content.to_string()));
-    }
-    Ok(out)
-}
-
-fn validate_skill_file_path(raw: &str) -> Result<PathBuf, String> {
-    if raw.trim().is_empty() || raw.contains('\\') {
-        return Err(format!("invalid skill file path '{raw}'"));
-    }
-    let path = PathBuf::from(raw);
-    if path == Path::new("SKILL.md") || path.is_absolute() {
-        return Err(format!("invalid skill file path '{raw}'"));
-    }
-    for component in path.components() {
-        match component {
-            Component::Normal(_) => {}
-            _ => return Err(format!("invalid skill file path '{raw}'")),
-        }
-    }
-    Ok(path)
-}
-
-fn save_skill_file(path: &Path, content: &str) -> std::io::Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    if let Ok(existing) = std::fs::read_to_string(path)
-        && existing == content
-    {
-        return Ok(());
-    }
-
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    let file_name = path.file_name().unwrap_or_default();
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let mut tmp_name = OsString::from(".");
-    tmp_name.push(file_name);
-    tmp_name.push(format!(".tmp.{}-{seq}", std::process::id()));
-    let tmp_path = parent.join(tmp_name);
-    let write_result = (|| -> std::io::Result<()> {
-        let mut file = std::fs::File::create(&tmp_path)?;
-        file.write_all(content.as_bytes())?;
-        file.sync_all()?;
-        Ok(())
-    })();
-    if let Err(e) = write_result {
-        let _ = std::fs::remove_file(&tmp_path);
-        return Err(e);
-    }
-    std::fs::rename(&tmp_path, path)
-}
-
-fn prepare_skill_dir(root: &Path, skill_dir: &Path) -> std::io::Result<()> {
-    std::fs::create_dir_all(root)?;
-    reject_symlink(skill_dir)?;
-    std::fs::create_dir_all(skill_dir)?;
-
-    let root = root.canonicalize()?;
-    let skill_dir = skill_dir.canonicalize()?;
-    if !skill_dir.starts_with(&root) {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::PermissionDenied,
-            "skill directory resolves outside the configured skills root",
-        ));
-    }
-    Ok(())
-}
-
-fn checked_skill_file_path(skill_dir: &Path, rel: &Path) -> std::io::Result<PathBuf> {
-    let target = skill_dir.join(rel);
-    reject_symlink(&target)?;
-    let parent = target.parent().unwrap_or(skill_dir);
-    std::fs::create_dir_all(parent)?;
-
-    let skill_dir = skill_dir.canonicalize()?;
-    let parent = parent.canonicalize()?;
-    if !parent.starts_with(&skill_dir) {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::PermissionDenied,
-            "skill file path resolves outside the skill directory",
-        ));
-    }
-    Ok(target)
-}
-
-fn reject_symlink(path: &Path) -> std::io::Result<()> {
-    let Ok(metadata) = std::fs::symlink_metadata(path) else {
-        return Ok(());
-    };
-    if metadata.file_type().is_symlink() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::PermissionDenied,
-            format!("refusing to write through symlink {}", path.display()),
-        ));
-    }
-    Ok(())
-}
-
-fn skill_file_manifest(dir_path: &Path) -> Vec<Value> {
-    let mut out = Vec::new();
-    collect_skill_manifest_entries(dir_path, dir_path, &mut out);
-    out.sort_by_key(|entry| {
-        entry
-            .get("path")
-            .and_then(Value::as_str)
-            .unwrap_or_default()
-            .to_string()
-    });
-    out
-}
-
-fn collect_skill_manifest_entries(root: &Path, dir: &Path, out: &mut Vec<Value>) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        let Ok(file_type) = entry.file_type() else {
-            continue;
-        };
-        if file_type.is_dir() {
-            collect_skill_manifest_entries(root, &path, out);
-            continue;
-        }
-        if !file_type.is_file() {
-            continue;
-        }
-        let Ok(rel) = path.strip_prefix(root) else {
-            continue;
-        };
-        out.push(json!({
-            "path": rel.display().to_string(),
-            "bytes": entry.metadata().map(|m| m.len()).unwrap_or(0),
-        }));
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn write_skill(root: &Path, dir: &str, name: &str, description: &str) {
-        let d = root.join(dir);
-        std::fs::create_dir_all(&d).unwrap();
-        std::fs::write(
-            d.join("SKILL.md"),
-            format!("---\nname: {name}\ndescription: {description}\n---\n\n# {name}\nbody\n"),
-        )
-        .unwrap();
-    }
-
     #[test]
-    fn discover_merges_scopes_and_dedups_by_precedence() {
-        let ws = tempfile::tempdir().unwrap();
-        let gl = tempfile::tempdir().unwrap();
-        let sy = tempfile::tempdir().unwrap();
-        write_skill(ws.path(), "ws-only", "ws-only", "workspace skill");
-        write_skill(ws.path(), "shared", "shared", "from workspace");
-        write_skill(gl.path(), "global-only", "global-only", "global skill");
-        write_skill(gl.path(), "shared", "shared", "from global");
-        write_skill(sy.path(), "system-only", "system-only", "system skill");
-
-        let sources = SkillSources::from_dirs(
-            Some(ws.path().into()),
-            Some(gl.path().into()),
-            Some(sy.path().into()),
+    fn relative_under_strips_vfs_roots() {
+        assert_eq!(
+            relative_under("/.yolop/global-skills/foo/SKILL.md", GLOBAL_SKILLS_VFS),
+            Some("/foo/SKILL.md".to_string())
         );
-        let found = sources.discover();
-        let names: std::collections::HashSet<&str> =
-            found.iter().map(|s| s.dir_name.as_str()).collect();
-        assert!(names.contains("ws-only"));
-        assert!(names.contains("global-only"));
-        assert!(names.contains("system-only"));
-
-        // `shared` resolves once, to the workspace scope.
-        let shared: Vec<&DiscoveredSkill> =
-            found.iter().filter(|s| s.dir_name == "shared").collect();
-        assert_eq!(shared.len(), 1);
-        assert_eq!(shared[0].scope, SkillScope::Workspace);
-        assert_eq!(shared[0].description, "from workspace");
-
-        let system = found.iter().find(|s| s.dir_name == "system-only").unwrap();
-        assert_eq!(system.scope, SkillScope::System);
+        assert_eq!(
+            relative_under("/.yolop/system-skills", SYSTEM_SKILLS_VFS),
+            Some("/".to_string())
+        );
+        assert_eq!(relative_under("/src/main.rs", GLOBAL_SKILLS_VFS), None);
+        // A different root must not match.
+        assert_eq!(
+            relative_under("/.agents/skills/foo", GLOBAL_SKILLS_VFS),
+            None
+        );
     }
 
     #[test]
-    fn locate_prefers_workspace_then_falls_through() {
-        let ws = tempfile::tempdir().unwrap();
-        let gl = tempfile::tempdir().unwrap();
-        write_skill(ws.path(), "shared", "shared", "from workspace");
-        write_skill(gl.path(), "shared", "shared", "from global");
-        write_skill(gl.path(), "global-only", "global-only", "global skill");
-        let sources = SkillSources::from_dirs(Some(ws.path().into()), Some(gl.path().into()), None);
-
-        let (scope, _dir, content) = sources.locate("shared").unwrap();
-        assert_eq!(scope, SkillScope::Workspace);
-        assert!(content.contains("from workspace"));
-
-        let (scope, _dir, _content) = sources.locate("global-only").unwrap();
-        assert_eq!(scope, SkillScope::Global);
-
-        assert!(sources.locate("missing").is_none());
-    }
-
-    #[tokio::test]
-    async fn activate_substitutes_skill_dir_to_real_path() {
-        let gl = tempfile::tempdir().unwrap();
-        let d = gl.path().join("bundled");
-        std::fs::create_dir_all(&d).unwrap();
-        std::fs::write(
-            d.join("SKILL.md"),
-            "---\nname: bundled\ndescription: uses a bundled file\n---\n\nRead ${SKILL_DIR}/data.txt\n",
-        )
-        .unwrap();
-
-        let sources = SkillSources::from_dirs(None, Some(gl.path().into()), None);
-        let tool = ActivateSkillTool {
-            sources: Arc::new(sources),
+    fn config_includes_only_resolved_scopes() {
+        let dirs = SkillDirs {
+            workspace: PathBuf::from("/ws/.agents/skills"),
+            global: None,
+            system: Some(PathBuf::from("/data/sys")),
         };
-        let ctx = ToolContext::new(everruns_core::typed_id::SessionId::new());
-        let result = tool
-            .execute_with_context(json!({"name": "bundled"}), &ctx)
-            .await;
-        match result {
-            ToolExecutionResult::Success(v) => {
-                assert_eq!(v["scope"], "global");
-                let instructions = v["instructions"].as_str().unwrap();
-                // ${SKILL_DIR} expanded to the real on-disk directory.
-                assert!(instructions.contains(&d.display().to_string()));
-            }
-            other => panic!("expected success, got {other:?}"),
-        }
-    }
-
-    #[tokio::test]
-    async fn activate_rejects_traversal_and_missing() {
-        let sources = SkillSources::from_dirs(None, None, None);
-        let tool = ActivateSkillTool {
-            sources: Arc::new(sources),
-        };
-        let ctx = ToolContext::new(everruns_core::typed_id::SessionId::new());
-
-        let bad = tool
-            .execute_with_context(json!({"name": "../etc"}), &ctx)
-            .await;
-        assert!(matches!(bad, ToolExecutionResult::ToolError(_)));
-
-        let missing = tool
-            .execute_with_context(json!({"name": "nope"}), &ctx)
-            .await;
-        match missing {
-            ToolExecutionResult::ToolError(m) => assert!(m.contains("not found")),
-            other => panic!("expected ToolError, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn embedded_system_skills_materialize_idempotently() {
-        let tmp = tempfile::tempdir().unwrap();
-        let dest = tmp.path().join("system-skills");
-        materialize_system_skills(&dest).unwrap();
-        let skill = dest.join("joke").join("SKILL.md");
-        assert!(skill.is_file());
-        let first = std::fs::read(&skill).unwrap();
-        // Second pass is a no-op write (identical bytes) and leaves content intact.
-        materialize_system_skills(&dest).unwrap();
-        assert_eq!(std::fs::read(&skill).unwrap(), first);
-    }
-
-    #[test]
-    fn global_skills_dir_respects_env_override() {
-        // Serialize against every other env-mutating test in this binary; the
-        // guard is held for the whole window the var is set (set_var/remove_var
-        // are not thread-safe — see crate::test_env).
-        let _guard = crate::test_env::lock();
-        let tmp = tempfile::tempdir().unwrap();
-        // SAFETY: the test_env lock guarantees no other thread touches the
-        // process environment for the duration of this test.
-        unsafe { std::env::set_var(GLOBAL_SKILLS_DIR_ENV, tmp.path()) };
-        let resolved = global_skills_dir();
-        unsafe { std::env::remove_var(GLOBAL_SKILLS_DIR_ENV) };
-        assert_eq!(resolved.as_deref(), Some(tmp.path()));
-    }
-
-    #[tokio::test]
-    async fn list_skills_reports_scope_and_error_entries() {
-        let ws = tempfile::tempdir().unwrap();
-        let gl = tempfile::tempdir().unwrap();
-        write_skill(ws.path(), "good", "good", "a fine skill");
-        // A directory with a SKILL.md that fails to parse (missing frontmatter
-        // fields) is surfaced as an error entry, not silently dropped.
-        let broken = gl.path().join("broken");
-        std::fs::create_dir_all(&broken).unwrap();
-        std::fs::write(broken.join("SKILL.md"), "no frontmatter here").unwrap();
-
-        let tool = ListSkillsTool {
-            sources: Arc::new(SkillSources::from_dirs(
-                Some(ws.path().into()),
-                Some(gl.path().into()),
-                None,
-            )),
-        };
-        let ToolExecutionResult::Success(v) = tool.execute(json!({})).await else {
-            panic!("expected success");
-        };
-        assert_eq!(v["count"], 2);
-        let skills = v["skills"].as_array().unwrap();
-
-        let good = skills.iter().find(|s| s["name"] == "good").unwrap();
-        assert_eq!(good["scope"], "workspace");
-        assert_eq!(good["description"], "a fine skill");
-        assert!(good.get("error").is_none());
-
-        let broken = skills.iter().find(|s| s["name"] == "broken").unwrap();
-        assert_eq!(broken["scope"], "global");
+        let cfg = skills_config(&dirs);
+        let labels: Vec<&str> = cfg.scopes.iter().map(|s| s.label.as_str()).collect();
+        assert_eq!(labels, vec!["workspace", "system"]);
+        assert!(cfg.manage_tools);
+        // System scope is read-only; workspace is writable.
         assert!(
-            broken["error"]
-                .as_str()
+            !cfg.scopes
+                .iter()
+                .find(|s| s.label == "system")
                 .unwrap()
-                .contains("Invalid SKILL.md")
+                .writable
         );
-    }
-
-    #[tokio::test]
-    async fn global_skill_created_after_sources_are_built_is_listed() {
-        let tmp = tempfile::tempdir().unwrap();
-        let missing_global = tmp.path().join("global-skills");
-        let tool = ListSkillsTool {
-            sources: Arc::new(SkillSources::from_dirs(
-                None,
-                Some(missing_global.clone()),
-                None,
-            )),
-        };
-
-        let ToolExecutionResult::Success(v) = tool.execute(json!({})).await else {
-            panic!("expected success");
-        };
-        assert_eq!(v["count"], 0);
-
-        write_skill(
-            &missing_global,
-            "hot-install",
-            "hot-install",
-            "installed after startup",
+        assert!(
+            cfg.scopes
+                .iter()
+                .find(|s| s.label == "workspace")
+                .unwrap()
+                .writable
         );
-        let ToolExecutionResult::Success(v) = tool.execute(json!({})).await else {
-            panic!("expected success");
-        };
-        assert_eq!(v["count"], 1);
-        assert_eq!(v["skills"][0]["name"], "hot-install");
-        assert_eq!(v["skills"][0]["scope"], "global");
-    }
-
-    #[tokio::test]
-    async fn write_skill_installs_global_skill_readable_without_restart() {
-        let ws = tempfile::tempdir().unwrap();
-        let gl = tempfile::tempdir().unwrap();
-        let sources = Arc::new(SkillSources::from_dirs(
-            Some(ws.path().into()),
-            Some(gl.path().into()),
-            None,
-        ));
-        let writer = WriteSkillTool {
-            sources: sources.clone(),
-        };
-        let skill_md =
-            "---\nname: new-skill\ndescription: installed by tool\n---\n\n# New\nUse data.txt\n";
-
-        let res = writer
-            .execute(json!({
-                "scope": "global",
-                "name": "new-skill",
-                "skill_md": skill_md,
-                "files": {
-                    "data.txt": "hello"
-                }
-            }))
-            .await;
-        assert!(res.is_success(), "got: {res:?}");
-        assert_eq!(
-            std::fs::read_to_string(gl.path().join("new-skill").join("SKILL.md")).unwrap(),
-            skill_md
-        );
-
-        let reader = ReadSkillTool {
-            sources: sources.clone(),
-        };
-        let ToolExecutionResult::Success(v) = reader.execute(json!({"name": "new-skill"})).await
-        else {
-            panic!("expected read success");
-        };
-        assert_eq!(v["scope"], "global");
-        assert_eq!(v["skill_md"], skill_md);
-        assert_eq!(v["files"][0]["path"], "SKILL.md");
-
-        let lister = ListSkillsTool { sources };
-        let ToolExecutionResult::Success(v) = lister.execute(json!({})).await else {
-            panic!("expected list success");
-        };
-        let skill = v["skills"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .find(|s| s["name"] == "new-skill")
-            .unwrap();
-        assert_eq!(skill["scope"], "global");
-    }
-
-    #[tokio::test]
-    async fn write_skill_rejects_unsafe_paths_and_readonly_scopes() {
-        let ws = tempfile::tempdir().unwrap();
-        let writer = WriteSkillTool {
-            sources: Arc::new(SkillSources::from_dirs(Some(ws.path().into()), None, None)),
-        };
-        let skill_md = "---\nname: safe-skill\ndescription: safe\n---\n\nbody\n";
-
-        let system = writer
-            .execute(json!({
-                "scope": "system",
-                "name": "safe-skill",
-                "skill_md": skill_md,
-            }))
-            .await;
-        assert!(system.is_error());
-
-        let traversal = writer
-            .execute(json!({
-                "scope": "workspace",
-                "name": "safe-skill",
-                "skill_md": skill_md,
-                "files": {
-                    "../escape.txt": "nope"
-                }
-            }))
-            .await;
-        assert!(traversal.is_error());
-        assert!(!ws.path().join("escape.txt").exists());
-    }
-
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn write_skill_rejects_symlinked_skill_dir() {
-        use std::os::unix::fs::symlink;
-
-        let ws = tempfile::tempdir().unwrap();
-        let outside = tempfile::tempdir().unwrap();
-        symlink(outside.path(), ws.path().join("linked-skill")).unwrap();
-        let writer = WriteSkillTool {
-            sources: Arc::new(SkillSources::from_dirs(Some(ws.path().into()), None, None)),
-        };
-        let skill_md = "---\nname: linked-skill\ndescription: linked\n---\n\nbody\n";
-
-        let res = writer
-            .execute(json!({
-                "scope": "workspace",
-                "name": "linked-skill",
-                "skill_md": skill_md,
-            }))
-            .await;
-
-        assert!(res.is_error(), "got: {res:?}");
-        assert!(!outside.path().join("SKILL.md").exists());
-    }
-
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn write_skill_rejects_symlinked_extra_file_parent() {
-        use std::os::unix::fs::symlink;
-
-        let ws = tempfile::tempdir().unwrap();
-        let outside = tempfile::tempdir().unwrap();
-        let skill_dir = ws.path().join("safe-skill");
-        std::fs::create_dir_all(&skill_dir).unwrap();
-        symlink(outside.path(), skill_dir.join("data")).unwrap();
-        let writer = WriteSkillTool {
-            sources: Arc::new(SkillSources::from_dirs(Some(ws.path().into()), None, None)),
-        };
-        let skill_md = "---\nname: safe-skill\ndescription: safe\n---\n\nbody\n";
-
-        let res = writer
-            .execute(json!({
-                "scope": "workspace",
-                "name": "safe-skill",
-                "skill_md": skill_md,
-                "files": {
-                    "data/escape.txt": "nope"
-                }
-            }))
-            .await;
-
-        assert!(res.is_error(), "got: {res:?}");
-        assert!(!outside.path().join("escape.txt").exists());
-    }
-
-    #[tokio::test]
-    async fn system_prompt_lists_visible_skills_and_filters_opted_out() {
-        let ws = tempfile::tempdir().unwrap();
-        write_skill(ws.path(), "shown", "shown", "appears in the prompt");
-        // disable-model-invocation skills are reachable via the tool but kept
-        // out of the model-facing prompt listing.
-        let hidden = ws.path().join("hidden");
-        std::fs::create_dir_all(&hidden).unwrap();
-        std::fs::write(
-            hidden.join("SKILL.md"),
-            "---\nname: hidden\ndescription: not auto-listed\ndisable-model-invocation: true\n---\n\nbody\n",
-        )
-        .unwrap();
-
-        let cap =
-            YolopSkillsCapability::new(SkillSources::from_dirs(Some(ws.path().into()), None, None));
-        let ctx =
-            SystemPromptContext::without_file_store(everruns_core::typed_id::SessionId::new());
-        let prompt = cap.system_prompt_contribution(&ctx).await.unwrap();
-
-        assert!(prompt.contains("**shown** [workspace]"));
-        assert!(!prompt.contains("hidden"));
     }
 
     #[test]
-    fn capability_exposes_skill_management_tools() {
-        let ws = tempfile::tempdir().unwrap();
-        let cap =
-            YolopSkillsCapability::new(SkillSources::from_dirs(Some(ws.path().into()), None, None));
-        let names = cap
-            .tools()
-            .iter()
-            .map(|tool| tool.name().to_string())
-            .collect::<Vec<_>>();
-
+    fn resolver_returns_real_host_paths() {
+        let dirs = SkillDirs {
+            workspace: PathBuf::from("/ws/.agents/skills"),
+            global: Some(PathBuf::from("/cfg/yolop/skills")),
+            system: Some(PathBuf::from("/data/sys")),
+        };
+        let r = HostSkillDirResolver { dirs };
+        // Compare as paths so separators are platform-correct.
         assert_eq!(
-            names,
-            vec!["list_skills", "read_skill", "write_skill", "activate_skill"]
+            PathBuf::from(r.skill_dir(&SkillScope::new("global", GLOBAL_SKILLS_VFS, true), "foo")),
+            PathBuf::from("/cfg/yolop/skills").join("foo")
+        );
+        assert_eq!(
+            PathBuf::from(r.skill_dir(
+                &SkillScope::new("workspace", WORKSPACE_SKILLS_VFS, true),
+                "bar"
+            )),
+            PathBuf::from("/ws/.agents/skills").join("bar")
         );
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -33,9 +33,9 @@ use everruns_core::capabilities::{
     BtwCapability, COMPACTION_CAPABILITY_ID, CompactionCapability, FileSystemCapability,
     INFINITY_CONTEXT_CAPABILITY_ID, InfinityContextCapability, LoopDetectionCapability,
     MessageMetadataCapability, PROMPT_CACHING_CAPABILITY_ID, PromptCachingCapability,
-    SKILLS_CAPABILITY_ID, SessionStorageCapability, StatelessTodoListCapability,
-    TOOL_SEARCH_CAPABILITY_ID, ToolOutputPersistenceCapability, ToolSearchCapability,
-    UserHooksCapability, WebFetchCapability,
+    SKILLS_CAPABILITY_ID, ScopedSkillsCapability, SessionStorageCapability,
+    StatelessTodoListCapability, TOOL_SEARCH_CAPABILITY_ID, ToolOutputPersistenceCapability,
+    ToolSearchCapability, UserHooksCapability, WebFetchCapability,
 };
 use everruns_core::command::CommandDescriptor;
 use everruns_core::driver_registry::{DriverRegistry, ProviderMetadata};
@@ -129,6 +129,8 @@ const AGENT_PROMPT: &str = "Investigate before editing. Cite paths and line numb
 struct CodingCliSessionFileSystemFactory {
     workspace_root: PathBuf,
     session_dir: PathBuf,
+    skill_global: Option<PathBuf>,
+    skill_system: Option<PathBuf>,
 }
 
 #[async_trait]
@@ -147,9 +149,22 @@ impl SessionFileSystemFactory for CodingCliSessionFileSystemFactory {
                 self.session_dir.display()
             ))
         })?;
+        // The writable global skills dir may not exist yet; create it so a skill
+        // installed mid-session is discoverable. (System skills are already
+        // materialized by `SkillDirs::resolve`.)
+        for dir in [self.skill_global.as_ref(), self.skill_system.as_ref()]
+            .into_iter()
+            .flatten()
+        {
+            std::fs::create_dir_all(dir).map_err(|e| {
+                AgentLoopError::config(format!("create skills dir {}: {e}", dir.display()))
+            })?;
+        }
         let disk: Arc<dyn SessionFileSystem> = Arc::new(CodingCliSessionFileStore::new(
             self.workspace_root.clone(),
             self.session_dir.clone(),
+            self.skill_global.clone(),
+            self.skill_system.clone(),
         )?);
         Ok(Arc::new(WriteBlocklistFileStore::new(disk)))
     }
@@ -158,14 +173,29 @@ impl SessionFileSystemFactory for CodingCliSessionFileSystemFactory {
 struct CodingCliSessionFileStore {
     workspace: RealDiskFileStore,
     session: RealDiskFileStore,
+    // Backing stores for the global/system skill scope VFS roots, served from
+    // real directories outside the workspace (see `capabilities::skills`).
+    skill_global: Option<RealDiskFileStore>,
+    skill_system: Option<RealDiskFileStore>,
     session_dir: PathBuf,
 }
 
 impl CodingCliSessionFileStore {
-    fn new(workspace_root: PathBuf, session_dir: PathBuf) -> everruns_core::Result<Self> {
+    fn new(
+        workspace_root: PathBuf,
+        session_dir: PathBuf,
+        skill_global: Option<PathBuf>,
+        skill_system: Option<PathBuf>,
+    ) -> everruns_core::Result<Self> {
+        let skill_store =
+            |dir: Option<PathBuf>| -> everruns_core::Result<Option<RealDiskFileStore>> {
+                dir.map(RealDiskFileStore::new).transpose()
+            };
         Ok(Self {
             workspace: RealDiskFileStore::new(workspace_root)?,
             session: RealDiskFileStore::new(session_dir.clone())?,
+            skill_global: skill_store(skill_global)?,
+            skill_system: skill_store(skill_system)?,
             session_dir,
         })
     }
@@ -199,6 +229,20 @@ impl CodingCliSessionFileStore {
     }
 
     fn store_for_path(&self, path: &str) -> (&RealDiskFileStore, String) {
+        // Synthetic skill-scope roots route to dirs outside the workspace so the
+        // upstream skills capability can discover global/system skills through
+        // the VFS. Workspace skills fall through to the normal workspace store.
+        use crate::capabilities::skills::{GLOBAL_SKILLS_VFS, SYSTEM_SKILLS_VFS, relative_under};
+        if let Some(store) = &self.skill_global
+            && let Some(rest) = relative_under(path, GLOBAL_SKILLS_VFS)
+        {
+            return (store, rest);
+        }
+        if let Some(store) = &self.skill_system
+            && let Some(rest) = relative_under(path, SYSTEM_SKILLS_VFS)
+        {
+            return (store, rest);
+        }
         match Self::session_output_path(path) {
             Some(path) => (&self.session, path),
             None => (&self.workspace, path.to_string()),
@@ -1688,6 +1732,11 @@ pub async fn build_with_options(
         .with_context(|| format!("canonicalize workspace: {}", workspace_root.display()))?;
     let workspace = Workspace::new(canonical_root.clone());
 
+    // Resolve the workspace/global/system skill directories once (this also
+    // materializes the embedded system skills). Shared by the skills capability
+    // config and the file-store factory's scope routing.
+    let skill_dirs = crate::capabilities::skills::SkillDirs::resolve(&canonical_root);
+
     // MCP servers from `.mcp.json` (global + workspace, merged). Loading is
     // best-effort per scope: a malformed file is warned about and skipped, so
     // it never sinks the session or masks the other scope.
@@ -1767,9 +1816,10 @@ pub async fn build_with_options(
     //   * agent_instructions   — re-reads AGENTS.md every turn
     //   * session_file_system  — read/write/edit/list/grep/delete/stat tools
     //
-    // Skills (vendored in `crate::capabilities::skills`, reads real folders):
+    // Skills (upstream `ScopedSkillsCapability`, wired in `crate::capabilities::skills`):
     //   * skills               — discovers SKILL.md across workspace / global /
-    //                            system scopes; list_skills + activate_skill
+    //                            system scopes via the session file store;
+    //                            list_skills + activate_skill + read/write_skill
     //
     // Non-filesystem, but useful for a coding agent:
     //   * repo_map            - on-demand multi-language symbol map for broad codebase orientation
@@ -1788,10 +1838,12 @@ pub async fn build_with_options(
     let mut capabilities = CapabilityRegistry::new();
     capabilities.register(AgentInstructionsCapability);
     capabilities.register(FileSystemCapability);
-    // Vendored, multi-scope skills capability: discovers SKILL.md across the
-    // workspace, the user's global config, and skills pre-packed with yolop.
-    capabilities.register(crate::capabilities::skills::YolopSkillsCapability::new(
-        crate::capabilities::skills::SkillSources::resolve(&canonical_root),
+    // Upstream multi-scope skills capability (everruns-core 0.12.0+),
+    // configured with yolop's workspace/global/system scopes and a host-path
+    // resolver so `${SKILL_DIR}` reaches real files. The file store maps the
+    // scope VFS roots onto disk (see `capabilities::skills`).
+    capabilities.register(ScopedSkillsCapability::new(
+        crate::capabilities::skills::skills_config(&skill_dirs),
     ));
     capabilities.register(RepoMapCapability::new(canonical_root.clone()));
     capabilities.register(AstGrepCapability::new(canonical_root.clone()));
@@ -1960,6 +2012,8 @@ pub async fn build_with_options(
         .session_file_system_factory(Arc::new(CodingCliSessionFileSystemFactory {
             workspace_root: canonical_root.clone(),
             session_dir: session_dir.clone(),
+            skill_global: skill_dirs.global.clone(),
+            skill_system: skill_dirs.system.clone(),
         }))
         .build();
 
@@ -3446,8 +3500,13 @@ mod tests {
     async fn yolop_file_store_routes_workspace_files_to_workspace_root() {
         let workspace = tempfile::tempdir().expect("workspace");
         let session = tempfile::tempdir().expect("session");
-        let store = CodingCliSessionFileStore::new(workspace.path().into(), session.path().into())
-            .expect("store");
+        let store = CodingCliSessionFileStore::new(
+            workspace.path().into(),
+            session.path().into(),
+            None,
+            None,
+        )
+        .expect("store");
         let session_id = SessionId::from_seed(1);
 
         store
@@ -3466,8 +3525,13 @@ mod tests {
     async fn yolop_file_store_routes_outputs_to_session_dir() {
         let workspace = tempfile::tempdir().expect("workspace");
         let session = tempfile::tempdir().expect("session");
-        let store = CodingCliSessionFileStore::new(workspace.path().into(), session.path().into())
-            .expect("store");
+        let store = CodingCliSessionFileStore::new(
+            workspace.path().into(),
+            session.path().into(),
+            None,
+            None,
+        )
+        .expect("store");
         let session_id = SessionId::from_seed(2);
 
         store
@@ -3528,8 +3592,13 @@ mod tests {
     fn yolop_file_store_displays_workspace_and_session_paths() {
         let workspace = tempfile::tempdir().expect("workspace");
         let session = tempfile::tempdir().expect("session");
-        let store = CodingCliSessionFileStore::new(workspace.path().into(), session.path().into())
-            .expect("store");
+        let store = CodingCliSessionFileStore::new(
+            workspace.path().into(),
+            session.path().into(),
+            None,
+            None,
+        )
+        .expect("store");
         let workspace_root = std::fs::canonicalize(workspace.path()).expect("canonical workspace");
         let session_root = std::fs::canonicalize(session.path()).expect("canonical session");
 
@@ -3547,6 +3616,118 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn yolop_file_store_routes_skill_scope_roots_outside_workspace() {
+        use crate::capabilities::skills::{GLOBAL_SKILLS_VFS, SYSTEM_SKILLS_VFS};
+        let workspace = tempfile::tempdir().expect("workspace");
+        let session = tempfile::tempdir().expect("session");
+        let global = tempfile::tempdir().expect("global");
+        let system = tempfile::tempdir().expect("system");
+        let store = CodingCliSessionFileStore::new(
+            workspace.path().into(),
+            session.path().into(),
+            Some(global.path().into()),
+            Some(system.path().into()),
+        )
+        .expect("store");
+        let session_id = SessionId::from_seed(7);
+
+        // write_skill into the global scope lands in the global dir, not the workspace.
+        store
+            .write_file(
+                session_id,
+                &format!("{GLOBAL_SKILLS_VFS}/greeter/SKILL.md"),
+                "global skill",
+                "text",
+            )
+            .await
+            .expect("write global skill");
+        assert_eq!(
+            std::fs::read_to_string(global.path().join("greeter/SKILL.md")).expect("global skill"),
+            "global skill"
+        );
+        assert!(!workspace.path().join(".yolop").exists());
+
+        // A skill placed in the system dir is discoverable via the system VFS root.
+        std::fs::create_dir_all(system.path().join("joke")).unwrap();
+        std::fs::write(system.path().join("joke/SKILL.md"), "system skill").unwrap();
+        let listed = store
+            .list_directory(session_id, SYSTEM_SKILLS_VFS)
+            .await
+            .expect("list system skills");
+        assert!(listed.iter().any(|e| e.is_directory && e.name == "joke"));
+        let read = store
+            .read_file(session_id, &format!("{SYSTEM_SKILLS_VFS}/joke/SKILL.md"))
+            .await
+            .expect("read system skill")
+            .expect("system skill exists");
+        assert_eq!(read.content.as_deref(), Some("system skill"));
+    }
+
+    #[tokio::test]
+    async fn skills_capability_discovers_routed_skill_with_host_path() {
+        // End-to-end: the upstream ScopedSkillsCapability, configured by yolop and
+        // driven against yolop's routed file store, discovers a system skill and
+        // reports a real host path (so the agent's host `bash` can read it).
+        use crate::capabilities::skills::{SkillDirs, skills_config};
+        use everruns_core::ToolContext;
+        use everruns_core::capabilities::Capability;
+        use everruns_core::tools::ToolExecutionResult;
+
+        let workspace = tempfile::tempdir().expect("workspace");
+        let session = tempfile::tempdir().expect("session");
+        let system = tempfile::tempdir().expect("system");
+        std::fs::create_dir_all(system.path().join("joke")).unwrap();
+        std::fs::write(
+            system.path().join("joke/SKILL.md"),
+            "---\nname: joke\ndescription: Tell a joke\n---\nBe funny.",
+        )
+        .unwrap();
+
+        let dirs = SkillDirs {
+            workspace: workspace.path().join(".agents").join("skills"),
+            global: None,
+            system: Some(system.path().to_path_buf()),
+        };
+        let store: Arc<dyn SessionFileSystem> = Arc::new(
+            CodingCliSessionFileStore::new(
+                workspace.path().into(),
+                session.path().into(),
+                None,
+                Some(system.path().into()),
+            )
+            .expect("store"),
+        );
+        let cap = ScopedSkillsCapability::new(skills_config(&dirs));
+        let tools = cap.tools();
+        let list = tools
+            .iter()
+            .find(|t| t.name() == "list_skills")
+            .expect("list_skills tool");
+        let ctx = ToolContext::with_file_store(SessionId::from_seed(8), store);
+
+        match list.execute_with_context(serde_json::json!({}), &ctx).await {
+            ToolExecutionResult::Success(val) => {
+                let skills = val["skills"].as_array().expect("skills array");
+                let joke = skills
+                    .iter()
+                    .find(|s| s["name"] == "joke")
+                    .expect("joke discovered");
+                assert_eq!(joke["scope"], "system");
+                // The reported path is a real host path under the system dir,
+                // not a VFS path — that is what `${SKILL_DIR}`/bash needs.
+                // Compare as paths so separators are platform-correct.
+                let path = joke["path"].as_str().unwrap();
+                assert_eq!(
+                    std::path::PathBuf::from(path),
+                    system.path().join("joke").join("SKILL.md"),
+                    "expected the real host path to the skill"
+                );
+            }
+            other => panic!("expected success, got {other:?}"),
+        }
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn yolop_file_store_secures_output_permissions() {
@@ -3554,8 +3735,13 @@ mod tests {
 
         let workspace = tempfile::tempdir().expect("workspace");
         let session = tempfile::tempdir().expect("session");
-        let store = CodingCliSessionFileStore::new(workspace.path().into(), session.path().into())
-            .expect("store");
+        let store = CodingCliSessionFileStore::new(
+            workspace.path().into(),
+            session.path().into(),
+            None,
+            None,
+        )
+        .expect("store");
         let session_id = SessionId::from_seed(3);
 
         store
@@ -3590,8 +3776,13 @@ mod tests {
 
         let workspace = tempfile::tempdir().expect("workspace");
         let session = tempfile::tempdir().expect("session");
-        let store = CodingCliSessionFileStore::new(workspace.path().into(), session.path().into())
-            .expect("store");
+        let store = CodingCliSessionFileStore::new(
+            workspace.path().into(),
+            session.path().into(),
+            None,
+            None,
+        )
+        .expect("store");
         let session_id = SessionId::from_seed(4);
 
         store


### PR DESCRIPTION
## What

Replaces yolop's ~1080-line vendored skills capability with the upstream
`ScopedSkillsCapability` from `everruns-core` (0.14.0). yolop now keeps only the
embedder-specific glue:

- **`capabilities::skills`** builds the workspace/global/system `SkillsConfig` and
  a host-path `SkillDirResolver` (so `${SKILL_DIR}` and displayed paths resolve to
  real on-disk paths the host `bash` tool can read — the core default keeps them
  in the VFS, which is only correct when the shell shares that namespace). It also
  retains the binary-embedded system skills + idempotent materialization.
- **`CodingCliSessionFileStore`** routes the global/system scope VFS roots
  (`/.yolop/global-skills`, `/.yolop/system-skills`) onto their real on-disk dirs,
  so the capability discovers/reads/writes them through the session filesystem
  without ever being handed a host path.

Net **−1389 / +387**. Behavior (three scopes, precedence, `list_skills` /
`activate_skill` / `read_skill` / `write_skill`, immediate hot-install) is
preserved; `read_skill`/`write_skill` now come from upstream.

## Why

The multi-scope resolver was pushed upstream as `ScopedSkillsCapability`
([everruns/everruns#2185](https://github.com/everruns/everruns/pull/2185), shipped
in `everruns-core` 0.12.0+), specifically so this vendored copy could be retired
and the duplication removed. This is the downstream half of that effort.

## How validated

- `cargo fmt --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test --all-features` → **457 + 29 pass** ✅
- **Feature tests (drive the entry point):**
  - `skills_capability_discovers_routed_skill_with_host_path` — constructs the real
    `ScopedSkillsCapability` with yolop's config, runs `list_skills` against the
    routed file store, and asserts a system skill is discovered with a **real host
    path** (not a VFS path).
  - `yolop_file_store_routes_skill_scope_roots_outside_workspace` — proves
    write/read/list through the global & system scope VFS roots land outside the
    workspace.
  - `capabilities::skills` unit tests for scope config, the host resolver, and VFS
    prefix stripping.
- **Real-provider smoke** (`cargo run -- --provider openai -p "Call list_skills …"`):
  the model called `list_skills` and got back workspace skills (`maintenance`,
  `release`, `ship`) **and** the bundled system skills (`joke`, `skill-management`,
  `yolop-config`, `yolop-hooks`), correctly scope-tagged.

## Security

Touches capability registration (TM-TOOL) and the session file store (TM-FS):

- **No new host-path config surface.** Scopes are labeled **VFS roots**; all
  discovery/read/write flows through `SessionFileSystem`. The host mapping lives in
  the file store, not in the capability config — the capability cannot be pointed
  outside the VFS. Matches the upstream guarantee.
- **Write blocklist intact.** The file store is still wrapped in
  `WriteBlocklistFileStore`; the new global/system routing sits behind it. System
  scope is **read-only** (`write_skill` rejects it).
- **Path handling.** Scope VFS roots are stripped with an exact prefix match;
  skill-name/path validation (traversal, `SKILL.md` override) is enforced upstream.
- **TM-DEP:** no new crates; `everruns-*` already bumped together to 0.14.0 on
  `main`. No keys logged.

## Follow-ups

No follow-ups. (Command-substitution `` !`cmd` `` remains gated off upstream, as
before — out of scope here.)


---
_Generated by [Claude Code](https://claude.ai/code/session_01R1DnN8RHq6FyWFz7ggo7sY)_