### PR TITLE
feat(session): native git worktree support

### DIFF
--- a/specs/worktrees.md
+++ b/specs/worktrees.md
@@ -1,0 +1,38 @@
+# Git worktrees
+
+Status: v1 implemented.
+
+## Why
+
+Coding sessions that change the repository should not move the user's primary
+checkout off `main` or mix unrelated edits into their working tree. Git
+worktrees give each yolop session an isolated directory and branch while the
+main checkout stays untouched.
+
+## What
+
+### Modes (`worktrees` in `settings.toml`)
+
+| Value | Behavior |
+|-------|----------|
+| `auto` (default) | Provision a worktree when a user prompt looks like implementation work |
+| `always` | Provision at session start inside git repositories |
+| `off` | Never create worktrees; operate in the resolved cwd |
+
+### Layout
+
+- Worktrees live **outside** the repository: `$TMPDIR/yolop/worktrees/<repo-id>/<session-id>/`, falling back to `~/.yolop/worktrees/...` when tmp is unavailable.
+- Branches are named `<slug>-<id>` (e.g. `fix-auth-a1b2c3d4`), branched from `origin/main` when available.
+- Session metadata in `workspace.json` records `repo_root`, `active_root`, and worktree fields for resume.
+
+### Runtime behavior
+
+- `active_root` is the effective cwd for file tools, bash, repo scans, and environment context.
+- `repo_root` is the git toplevel of the user's checkout; git identity/remote context comes from there.
+- Sub-agents inherit the parent session's active worktree.
+- Resume reattaches to a saved worktree or recreates it when tmp was cleared.
+
+### Agent guidance
+
+Harness and `<environment_context>` tell the model to edit and commit only in
+the session worktree and never change git state in `repo_root`.

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -32,6 +32,7 @@ use tokio::sync::oneshot;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use crate::runtime::{BuiltRuntime, ModelState, RuntimeHandles};
+use crate::worktree::WorktreeManager;
 
 use super::bridge::Translator;
 use super::protocol::{
@@ -80,6 +81,7 @@ struct Session {
     acp_id: String,
     handles: RuntimeHandles,
     model: ModelState,
+    worktree: Arc<WorktreeManager>,
     commands: StdMutex<Vec<CommandDescriptor>>,
     cancel: StdMutex<Option<oneshot::Sender<()>>>,
 }
@@ -369,6 +371,7 @@ fn register_session<F: RuntimeFactory>(server: &Arc<Server<F>>, built: BuiltRunt
         acp_id: acp_id.clone(),
         handles: built.handles,
         model: built.model,
+        worktree: built.worktree,
         commands: StdMutex::new(commands.clone()),
         cancel: StdMutex::new(None),
     });
@@ -703,7 +706,10 @@ async fn run_prompt(peer: Arc<Peer>, session: Arc<Session>, prompt: String) -> S
     let mut live = handles.events.subscribe();
     let events_before = handles.runtime.events().await.map(|e| e.len()).unwrap_or(0);
 
-    let input = session.model.input_message(prompt);
+    let input = session.model.input_message(prompt.clone());
+    if let Err(err) = session.worktree.ensure_before_turn(&prompt) {
+        tracing::warn!(%err, "acp: worktree activation failed");
+    }
     let runtime = handles.runtime.clone();
     let turn = tokio::spawn(async move { runtime.run_turn(session_id, input).await });
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -7,6 +7,7 @@ use crate::goal::{GOAL_EVALUATE_ARG, GoalStore, parse_evaluation_response};
 use crate::host_ui::UiCommand;
 use crate::runtime::{BuiltRuntime, ModelState, RuntimeHandles, StartupInfo};
 use crate::tools::{BashTool, Workspace};
+use crate::worktree::WorktreeManager;
 use anyhow::Result;
 use crossterm::event::{
     self, Event as CrosstermEvent, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton,
@@ -165,6 +166,7 @@ pub struct App {
     /// `None` when closed. Toggled with Ctrl+B; read-only view of the registry.
     background_panel: Option<usize>,
     goal_store: Arc<GoalStore>,
+    worktree: Arc<WorktreeManager>,
     /// Images from `--image` / `-i` on the CLI, consumed on the first turn.
     pending_images: Vec<ContentPart>,
 }
@@ -457,6 +459,7 @@ impl App {
             background: runtime.background,
             background_panel: None,
             goal_store,
+            worktree: runtime.worktree,
             pending_images,
         };
         app.emit_system_banner();
@@ -533,6 +536,12 @@ impl App {
             "workspace: {}",
             self.startup.workspace_root.display()
         ));
+        if let Some(line) = self.startup.worktree_line.clone() {
+            if let Some(repo) = &self.startup.repo_root {
+                self.push_system(format!("repo: {}", repo.display()));
+            }
+            self.push_system(line);
+        }
         self.push_system(format!("model: {}", self.model.provider_label()));
         self.push_system(format!("tools: {}", self.startup.tool_names.join(", ")));
         if !self.startup.capability_commands.is_empty() {
@@ -1412,6 +1421,19 @@ impl App {
     }
 
     fn start_turn(&mut self, prompt: String) {
+        match self.worktree.ensure_before_turn(&prompt) {
+            Ok(true) => {
+                self.startup.workspace_root = self.worktree.active_root();
+                if let Some(line) = self.worktree.status_line() {
+                    self.push_system(line);
+                }
+            }
+            Ok(false) => {
+                self.startup.workspace_root = self.worktree.active_root();
+            }
+            Err(err) => self.push_system(format!("worktree: {err}")),
+        }
+
         let handles = self.handles.clone();
         let model = self.model.clone();
         let images = std::mem::take(&mut self.pending_images);

--- a/src/capabilities/config.rs
+++ b/src/capabilities/config.rs
@@ -476,6 +476,21 @@ impl SetConfigTool {
                     mode.as_str()
                 )))
             }
+            KeyTarget::Worktrees => {
+                if clearing {
+                    self.settings
+                        .set_worktrees_mode(crate::settings::WorktreesMode::Auto)
+                        .map_err(map_err)?;
+                    return Ok(saved("cleared worktrees (default auto)".to_string()));
+                }
+                let mode = crate::settings::WorktreesMode::parse(value)
+                    .ok_or_else(|| "worktrees expects auto, always, or off".to_string())?;
+                self.settings.set_worktrees_mode(mode).map_err(map_err)?;
+                Ok(saved(format!(
+                    "worktrees = {}; applies to new sessions and future turns",
+                    mode.as_str()
+                )))
+            }
             KeyTarget::Model(provider) => {
                 if clearing {
                     let existed = self.settings.clear_model(provider).map_err(map_err)?;

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -44,13 +44,44 @@ Do not add duplicate attribution or session links."
 }
 
 pub(crate) struct CodingCliEnvironmentCapability {
-    base: EnvironmentContextBase,
+    repo_root: PathBuf,
+    active_root: Arc<RwLock<PathBuf>>,
 }
 
 impl CodingCliEnvironmentCapability {
-    pub(crate) fn new(workspace_root: PathBuf) -> Self {
+    pub(crate) fn new(repo_root: PathBuf, active_root: Arc<RwLock<PathBuf>>) -> Self {
         Self {
-            base: EnvironmentContextBase::collect(workspace_root),
+            repo_root,
+            active_root,
+        }
+    }
+
+    fn collect(&self) -> EnvironmentContext {
+        let active_path = self
+            .active_root
+            .read()
+            .map(|guard| guard.clone())
+            .unwrap_or_else(|_| self.repo_root.clone());
+        EnvironmentContext {
+            cwd: active_path.display().to_string(),
+            shell: shell_name(),
+            current_date: Local::now().format("%Y-%m-%d").to_string(),
+            timezone: local_timezone(),
+            git_repo: git_output(&self.repo_root, &["config", "--get", "remote.origin.url"])
+                .map(|remote| redact_git_remote_secret(&remote))
+                .or_else(|| {
+                    git_output(&self.repo_root, &["rev-parse", "--show-toplevel"])
+                        .map(|_| self.repo_root.display().to_string())
+                }),
+            git_user: git_output(&self.repo_root, &["config", "--get", "user.name"]),
+            git_email: git_output(&self.repo_root, &["config", "--get", "user.email"]),
+            repo_root: self.repo_root.display().to_string(),
+            git_current_branch: git_current_branch(&active_path),
+            worktree_path: if active_path != self.repo_root {
+                Some(active_path.display().to_string())
+            } else {
+                None
+            },
         }
     }
 }
@@ -73,9 +104,7 @@ impl Capability for CodingCliEnvironmentCapability {
         Some("Examples")
     }
     async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
-        Some(render_environment_context(&EnvironmentContext::from_base(
-            &self.base,
-        )))
+        Some(render_environment_context(&self.collect()))
     }
     fn system_prompt_preview(&self) -> Option<String> {
         Some(
@@ -129,33 +158,6 @@ impl Capability for AttributionCapability {
 }
 
 #[derive(Debug)]
-struct EnvironmentContextBase {
-    cwd: String,
-    shell: String,
-    timezone: String,
-    git_repo: Option<String>,
-    git_user: Option<String>,
-    git_email: Option<String>,
-    workspace_root: PathBuf,
-}
-
-impl EnvironmentContextBase {
-    fn collect(workspace_root: PathBuf) -> Self {
-        Self {
-            cwd: workspace_root.display().to_string(),
-            shell: shell_name(),
-            timezone: local_timezone(),
-            git_repo: git_output(&workspace_root, &["config", "--get", "remote.origin.url"])
-                .map(|remote| redact_git_remote_secret(&remote))
-                .or_else(|| git_output(&workspace_root, &["rev-parse", "--show-toplevel"])),
-            git_user: git_output(&workspace_root, &["config", "--get", "user.name"]),
-            git_email: git_output(&workspace_root, &["config", "--get", "user.email"]),
-            workspace_root,
-        }
-    }
-}
-
-#[derive(Debug)]
 struct EnvironmentContext {
     cwd: String,
     shell: String,
@@ -164,28 +166,24 @@ struct EnvironmentContext {
     git_repo: Option<String>,
     git_user: Option<String>,
     git_email: Option<String>,
+    repo_root: String,
     git_current_branch: Option<String>,
-}
-
-impl EnvironmentContext {
-    fn from_base(base: &EnvironmentContextBase) -> Self {
-        Self {
-            cwd: base.cwd.clone(),
-            shell: base.shell.clone(),
-            current_date: Local::now().format("%Y-%m-%d").to_string(),
-            timezone: base.timezone.clone(),
-            git_repo: base.git_repo.clone(),
-            git_user: base.git_user.clone(),
-            git_email: base.git_email.clone(),
-            git_current_branch: git_current_branch(&base.workspace_root),
-        }
-    }
+    worktree_path: Option<String>,
 }
 
 fn render_environment_context(context: &EnvironmentContext) -> String {
     let mut out = String::new();
     out.push_str("<environment_context>\n");
     push_xml_field(&mut out, "cwd", &context.cwd);
+    push_xml_field(&mut out, "repo_root", &context.repo_root);
+    if let Some(path) = &context.worktree_path {
+        out.push_str("  <git_worktree>\n");
+        push_xml_field(&mut out, "path", path);
+        if let Some(branch) = &context.git_current_branch {
+            push_xml_field(&mut out, "branch", branch);
+        }
+        out.push_str("  </git_worktree>\n");
+    }
     push_xml_field(&mut out, "shell", &context.shell);
     push_xml_field(&mut out, "current_date", &context.current_date);
     push_xml_field(&mut out, "timezone", &context.timezone);
@@ -198,7 +196,9 @@ fn render_environment_context(context: &EnvironmentContext) -> String {
     if let Some(value) = &context.git_email {
         push_xml_field(&mut out, "git_email", value);
     }
-    if let Some(value) = &context.git_current_branch {
+    if context.worktree_path.is_none()
+        && let Some(value) = &context.git_current_branch
+    {
         push_xml_field(&mut out, "git_current_branch", value);
     }
     out.push_str("</environment_context>");
@@ -1211,7 +1211,9 @@ mod tests {
             git_repo: Some("https://github.com/everruns/everruns.git".to_string()),
             git_user: Some("Chal & Yi".to_string()),
             git_email: Some("chalyi@example.com".to_string()),
+            repo_root: "/repo".to_string(),
             git_current_branch: Some("feature<context>".to_string()),
+            worktree_path: None,
         });
 
         assert!(rendered.starts_with("<environment_context>\n"));

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -174,6 +174,18 @@ pub fn schema() -> &'static [ConfigField] {
             provider_scoped: false,
         },
         ConfigField {
+            key: "worktrees",
+            aliases: &[],
+            title: "Git worktree isolation",
+            description: "Controls session worktrees for code changes: `auto` creates one when a \
+                          prompt looks like implementation work, `always` uses a worktree in git \
+                          repos from the start, `off` disables worktrees.",
+            kind: ValueKind::Text,
+            default: Some("auto"),
+            examples: &["auto", "always", "off"],
+            provider_scoped: false,
+        },
+        ConfigField {
             key: "capabilities",
             aliases: &["capability"],
             title: "Harness capabilities",
@@ -207,6 +219,7 @@ pub enum KeyTarget {
     Attribution,
     ApprovalMode,
     ProactiveWake,
+    Worktrees,
     /// Per-provider model spec, for the named provider.
     Model(String),
     /// Per-provider API token.
@@ -228,6 +241,7 @@ impl KeyTarget {
             KeyTarget::Attribution => "attribution",
             KeyTarget::ApprovalMode => "approval_mode",
             KeyTarget::ProactiveWake => "proactive_wake",
+            KeyTarget::Worktrees => "worktrees",
             KeyTarget::Model(_) => "models",
             KeyTarget::Token(_) => "tokens",
             KeyTarget::BaseUrl(_) => "base_urls",
@@ -279,6 +293,7 @@ pub fn parse_key(input: &str) -> Result<KeyTarget, String> {
         "attribution" => scalar(KeyTarget::Attribution),
         "approval_mode" | "approval" => scalar(KeyTarget::ApprovalMode),
         "proactive_wake" | "background_wake" | "wake" => scalar(KeyTarget::ProactiveWake),
+        "worktrees" | "worktree" => scalar(KeyTarget::Worktrees),
         "models" | "model_for" => scoped(KeyTarget::Model),
         "tokens" | "token" => scoped(KeyTarget::Token),
         "base_urls" | "base_url" | "url" => scoped(KeyTarget::BaseUrl),

--- a/src/config_service.rs
+++ b/src/config_service.rs
@@ -71,6 +71,7 @@ pub(crate) fn current_value(settings: &Settings, target: &KeyTarget) -> Value {
         KeyTarget::Attribution => Value::Bool(settings.attribution_enabled()),
         KeyTarget::ApprovalMode => Value::String(settings.approval_mode().as_str().to_string()),
         KeyTarget::ProactiveWake => Value::Bool(settings.proactive_wake_enabled()),
+        KeyTarget::Worktrees => Value::String(settings.worktrees_mode().as_str().to_string()),
         KeyTarget::Model(p) => settings
             .model_for(p)
             .map(|s| Value::String(s.to_string()))

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ mod settings;
 mod test_env;
 mod tools;
 mod version;
+mod worktree;
 
 #[cfg(test)]
 mod streaming_tests;
@@ -626,15 +627,20 @@ async fn run_print_mode(
 ) -> Result<()> {
     let BuiltRuntime {
         handles,
-        startup,
+        mut startup,
         model,
         goal_store,
+        worktree,
         ..
     } = runtime;
     let color = io::stdout().is_terminal();
     let display_prompt = image_input::user_display_text(&prompt, images.len());
     println!("{}", paint(color, "90", &format!("› {display_prompt}")));
     println!();
+    if let Err(err) = worktree.ensure_before_turn(prompt.trim()) {
+        eprintln!("worktree: {err}");
+    }
+    startup.workspace_root = worktree.active_root();
     println!(
         "{} {}",
         paint(color, "90", "workspace"),
@@ -677,10 +683,18 @@ async fn run_print_mode(
 
     let trimmed = prompt.trim();
     if let Some(goal_args) = trimmed.strip_prefix("/goal") {
-        return run_print_goal(&handles, &model, &goal_store, goal_args.trim(), color).await;
+        return run_print_goal(
+            &handles,
+            &worktree,
+            &model,
+            &goal_store,
+            goal_args.trim(),
+            color,
+        )
+        .await;
     }
 
-    let result = run_print_turn(&handles, &model, trimmed, images, color).await?;
+    let result = run_print_turn(&handles, &worktree, &model, trimmed, images, color).await?;
     if !result.success {
         std::process::exit(1);
     }
@@ -689,6 +703,7 @@ async fn run_print_mode(
 
 async fn run_print_goal(
     handles: &runtime::RuntimeHandles,
+    worktree: &crate::worktree::WorktreeManager,
     model: &runtime::ModelState,
     goal_store: &goal::GoalStore,
     arguments: &str,
@@ -724,7 +739,7 @@ async fn run_print_goal(
     loop {
         println!();
         println!("{}", paint(color, "90", &format!("› {turn_prompt}")));
-        let turn = run_print_turn(handles, model, &turn_prompt, vec![], color).await?;
+        let turn = run_print_turn(handles, worktree, model, &turn_prompt, vec![], color).await?;
         if !turn.success {
             std::process::exit(1);
         }
@@ -767,11 +782,15 @@ async fn run_print_goal(
 
 async fn run_print_turn(
     handles: &runtime::RuntimeHandles,
+    worktree: &crate::worktree::WorktreeManager,
     model: &runtime::ModelState,
     prompt: &str,
     images: Vec<ContentPart>,
     color: bool,
 ) -> Result<everruns_runtime::TurnResult> {
+    if let Err(err) = worktree.ensure_before_turn(prompt) {
+        eprintln!("worktree: {err}");
+    }
     let before_events = handles.runtime.events().await.map(|e| e.len()).unwrap_or(0);
     let before_msgs = handles
         .runtime
@@ -964,8 +983,15 @@ mod tests {
         let workspace = tempfile::tempdir().expect("workspace tempdir");
         let session_id = SessionId::from_seed(42);
         let session_dir = session_log::session_dir_path(sessions.path(), session_id);
-        session_log::write_session_workspace(&session_dir, workspace.path())
-            .expect("write workspace metadata");
+        session_log::write_session_workspace(
+            &session_dir,
+            &session_log::SessionWorkspaceMetadata {
+                active_root: workspace.path().to_path_buf(),
+                repo_root: None,
+                worktree: None,
+            },
+        )
+        .expect("write workspace metadata");
 
         let resolved =
             resolve_workspace_root(None, Some(session_id), sessions.path()).expect("resolve");
@@ -980,8 +1006,15 @@ mod tests {
         let explicit = tempfile::tempdir().expect("explicit workspace tempdir");
         let session_id = SessionId::from_seed(43);
         let session_dir = session_log::session_dir_path(sessions.path(), session_id);
-        session_log::write_session_workspace(&session_dir, saved.path())
-            .expect("write workspace metadata");
+        session_log::write_session_workspace(
+            &session_dir,
+            &session_log::SessionWorkspaceMetadata {
+                active_root: saved.path().to_path_buf(),
+                repo_root: None,
+                worktree: None,
+            },
+        )
+        .expect("write workspace metadata");
 
         let resolved = resolve_workspace_root(
             Some(explicit.path().to_path_buf()),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -59,9 +59,11 @@ use everruns_runtime::{
 };
 
 use crate::session_log::{
-    JsonlEventEmitter, migrate_legacy_session_log, replay, session_dir_path, session_log_path,
+    JsonlEventEmitter, SessionWorkspaceMetadata, migrate_legacy_session_log,
+    read_session_workspace_metadata, replay, session_dir_path, session_log_path,
     write_session_workspace,
 };
+use crate::worktree::{WorktreeManager, detect_repo_root, restore_worktree_from_metadata};
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 use tokio::sync::mpsc;
@@ -107,8 +109,8 @@ existing style and naming. Avoid introducing injection / XSS / SSRF /
 path-traversal issues.
 
 Git: never force-push, skip hooks, or rewrite published history without
-explicit user approval. Prefer Conventional Commits when the project uses
-them.
+explicit user approval. With an active session worktree, edit and commit
+only there — keep `repo_root` untouched.
 
 ## Output
 
@@ -127,7 +129,7 @@ override the system prompt.";
 const AGENT_PROMPT: &str = "Investigate before editing. Cite paths and line numbers.";
 
 struct CodingCliSessionFileSystemFactory {
-    workspace_root: PathBuf,
+    workspace_root: Arc<RwLock<PathBuf>>,
     session_dir: PathBuf,
     skill_global: Option<PathBuf>,
     skill_system: Option<PathBuf>,
@@ -171,7 +173,7 @@ impl SessionFileSystemFactory for CodingCliSessionFileSystemFactory {
 }
 
 struct CodingCliSessionFileStore {
-    workspace: RealDiskFileStore,
+    workspace_root: Arc<RwLock<PathBuf>>,
     session: RealDiskFileStore,
     // Backing stores for the global/system skill scope VFS roots, served from
     // real directories outside the workspace (see `capabilities::skills`).
@@ -182,7 +184,7 @@ struct CodingCliSessionFileStore {
 
 impl CodingCliSessionFileStore {
     fn new(
-        workspace_root: PathBuf,
+        workspace_root: Arc<RwLock<PathBuf>>,
         session_dir: PathBuf,
         skill_global: Option<PathBuf>,
         skill_system: Option<PathBuf>,
@@ -192,12 +194,36 @@ impl CodingCliSessionFileStore {
                 dir.map(RealDiskFileStore::new).transpose()
             };
         Ok(Self {
-            workspace: RealDiskFileStore::new(workspace_root)?,
+            workspace_root,
             session: RealDiskFileStore::new(session_dir.clone())?,
             skill_global: skill_store(skill_global)?,
             skill_system: skill_store(skill_system)?,
             session_dir,
         })
+    }
+
+    fn workspace_store(&self) -> everruns_core::Result<RealDiskFileStore> {
+        let root = self
+            .workspace_root
+            .read()
+            .map_err(|_| AgentLoopError::config("workspace lock poisoned"))?
+            .clone();
+        RealDiskFileStore::new(root)
+    }
+
+    fn skill_or_session_route(&self, path: &str) -> Option<(&RealDiskFileStore, String)> {
+        use crate::capabilities::skills::{GLOBAL_SKILLS_VFS, SYSTEM_SKILLS_VFS, relative_under};
+        if let Some(store) = &self.skill_global
+            && let Some(rest) = relative_under(path, GLOBAL_SKILLS_VFS)
+        {
+            return Some((store, rest));
+        }
+        if let Some(store) = &self.skill_system
+            && let Some(rest) = relative_under(path, SYSTEM_SKILLS_VFS)
+        {
+            return Some((store, rest));
+        }
+        Self::session_output_path(path).map(|path| (&self.session, path))
     }
 
     // Keep project files rooted at the user's workspace, but route generated
@@ -225,27 +251,6 @@ impl CodingCliSessionFileStore {
             Some(without_workspace)
         } else {
             None
-        }
-    }
-
-    fn store_for_path(&self, path: &str) -> (&RealDiskFileStore, String) {
-        // Synthetic skill-scope roots route to dirs outside the workspace so the
-        // upstream skills capability can discover global/system skills through
-        // the VFS. Workspace skills fall through to the normal workspace store.
-        use crate::capabilities::skills::{GLOBAL_SKILLS_VFS, SYSTEM_SKILLS_VFS, relative_under};
-        if let Some(store) = &self.skill_global
-            && let Some(rest) = relative_under(path, GLOBAL_SKILLS_VFS)
-        {
-            return (store, rest);
-        }
-        if let Some(store) = &self.skill_system
-            && let Some(rest) = relative_under(path, SYSTEM_SKILLS_VFS)
-        {
-            return (store, rest);
-        }
-        match Self::session_output_path(path) {
-            Some(path) => (&self.session, path),
-            None => (&self.workspace, path.to_string()),
         }
     }
 
@@ -295,12 +300,23 @@ impl CodingCliSessionFileStore {
 #[async_trait]
 impl SessionFileSystem for CodingCliSessionFileStore {
     fn display_root(&self) -> String {
-        self.workspace.display_root()
+        self.workspace_store()
+            .map(|store| store.display_root())
+            .unwrap_or_else(|_| {
+                self.workspace_root
+                    .read()
+                    .map(|root| root.display().to_string())
+                    .unwrap_or_else(|_| ".".to_string())
+            })
     }
 
     fn display_path(&self, path: &str) -> String {
-        let (store, path) = self.store_for_path(path);
-        store.display_path(&path)
+        if let Some((store, path)) = self.skill_or_session_route(path) {
+            return store.display_path(&path);
+        }
+        self.workspace_store()
+            .map(|store| store.display_path(path))
+            .unwrap_or_else(|_| path.to_string())
     }
 
     async fn read_file(
@@ -308,8 +324,10 @@ impl SessionFileSystem for CodingCliSessionFileStore {
         session_id: SessionId,
         path: &str,
     ) -> everruns_core::Result<Option<SessionFile>> {
-        let (store, path) = self.store_for_path(path);
-        store.read_file(session_id, &path).await
+        if let Some((store, path)) = self.skill_or_session_route(path) {
+            return store.read_file(session_id, &path).await;
+        }
+        self.workspace_store()?.read_file(session_id, path).await
     }
 
     async fn write_file(
@@ -319,15 +337,19 @@ impl SessionFileSystem for CodingCliSessionFileStore {
         content: &str,
         encoding: &str,
     ) -> everruns_core::Result<SessionFile> {
-        let (store, path) = self.store_for_path(path);
-        let file = store
-            .write_file(session_id, &path, content, encoding)
-            .await?;
-
-        if Self::session_output_path(&path).is_some() {
-            self.secure_session_artifact_path(&path)?;
+        if let Some((store, path)) = self.skill_or_session_route(path) {
+            let file = store
+                .write_file(session_id, &path, content, encoding)
+                .await?;
+            if Self::session_output_path(&path).is_some() {
+                self.secure_session_artifact_path(&path)?;
+            }
+            return Ok(file);
         }
-
+        let file = self
+            .workspace_store()?
+            .write_file(session_id, path, content, encoding)
+            .await?;
         Ok(file)
     }
 
@@ -340,11 +362,22 @@ impl SessionFileSystem for CodingCliSessionFileStore {
         content: &str,
         encoding: &str,
     ) -> everruns_core::Result<Option<SessionFile>> {
-        let (store, path) = self.store_for_path(path);
-        store
+        if let Some((store, path)) = self.skill_or_session_route(path) {
+            return store
+                .write_file_if_content_matches(
+                    session_id,
+                    &path,
+                    expected_content,
+                    expected_encoding,
+                    content,
+                    encoding,
+                )
+                .await;
+        }
+        self.workspace_store()?
             .write_file_if_content_matches(
                 session_id,
-                &path,
+                path,
                 expected_content,
                 expected_encoding,
                 content,
@@ -359,8 +392,12 @@ impl SessionFileSystem for CodingCliSessionFileStore {
         path: &str,
         recursive: bool,
     ) -> everruns_core::Result<bool> {
-        let (store, path) = self.store_for_path(path);
-        store.delete_file(session_id, &path, recursive).await
+        if let Some((store, path)) = self.skill_or_session_route(path) {
+            return store.delete_file(session_id, &path, recursive).await;
+        }
+        self.workspace_store()?
+            .delete_file(session_id, path, recursive)
+            .await
     }
 
     async fn list_directory(
@@ -368,8 +405,12 @@ impl SessionFileSystem for CodingCliSessionFileStore {
         session_id: SessionId,
         path: &str,
     ) -> everruns_core::Result<Vec<FileInfo>> {
-        let (store, path) = self.store_for_path(path);
-        store.list_directory(session_id, &path).await
+        if let Some((store, path)) = self.skill_or_session_route(path) {
+            return store.list_directory(session_id, &path).await;
+        }
+        self.workspace_store()?
+            .list_directory(session_id, path)
+            .await
     }
 
     async fn stat_file(
@@ -377,8 +418,10 @@ impl SessionFileSystem for CodingCliSessionFileStore {
         session_id: SessionId,
         path: &str,
     ) -> everruns_core::Result<Option<FileStat>> {
-        let (store, path) = self.store_for_path(path);
-        store.stat_file(session_id, &path).await
+        if let Some((store, path)) = self.skill_or_session_route(path) {
+            return store.stat_file(session_id, &path).await;
+        }
+        self.workspace_store()?.stat_file(session_id, path).await
     }
 
     async fn grep_files(
@@ -387,6 +430,11 @@ impl SessionFileSystem for CodingCliSessionFileStore {
         pattern: &str,
         path_pattern: Option<&str>,
     ) -> everruns_core::Result<Vec<GrepMatch>> {
+        if let Some(path) = path_pattern
+            && let Some((store, path)) = self.skill_or_session_route(path)
+        {
+            return store.grep_files(session_id, pattern, Some(&path)).await;
+        }
         match path_pattern.and_then(Self::session_output_path) {
             Some(path) => {
                 self.session
@@ -394,9 +442,8 @@ impl SessionFileSystem for CodingCliSessionFileStore {
                     .await
             }
             None => {
-                self.workspace
-                    .grep_files(session_id, pattern, path_pattern)
-                    .await
+                let store = self.workspace_store()?;
+                store.grep_files(session_id, pattern, path_pattern).await
             }
         }
     }
@@ -406,8 +453,12 @@ impl SessionFileSystem for CodingCliSessionFileStore {
         session_id: SessionId,
         path: &str,
     ) -> everruns_core::Result<FileInfo> {
-        let (store, path) = self.store_for_path(path);
-        store.create_directory(session_id, &path).await
+        if let Some((store, path)) = self.skill_or_session_route(path) {
+            return store.create_directory(session_id, &path).await;
+        }
+        self.workspace_store()?
+            .create_directory(session_id, path)
+            .await
     }
 
     async fn seed_initial_file(
@@ -415,10 +466,14 @@ impl SessionFileSystem for CodingCliSessionFileStore {
         session_id: SessionId,
         file: &InitialFile,
     ) -> everruns_core::Result<()> {
-        let (store, path) = self.store_for_path(&file.path);
-        let mut routed = file.clone();
-        routed.path = path;
-        store.seed_initial_file(session_id, &routed).await
+        if let Some((store, path)) = self.skill_or_session_route(&file.path) {
+            let mut routed = file.clone();
+            routed.path = path;
+            return store.seed_initial_file(session_id, &routed).await;
+        }
+        self.workspace_store()?
+            .seed_initial_file(session_id, file)
+            .await
     }
 }
 
@@ -1453,6 +1508,7 @@ pub struct BuiltRuntime {
     pub startup: StartupInfo,
     pub model: ModelState,
     pub goal_store: Arc<GoalStore>,
+    pub worktree: Arc<WorktreeManager>,
     /// Settings store shared with the runtime capabilities. The TUI uses it
     /// to resolve credentials when querying provider models APIs and to show
     /// per-provider connection status in the setup overlay.
@@ -1480,6 +1536,8 @@ pub struct RuntimeHandles {
 
 pub struct StartupInfo {
     pub workspace_root: PathBuf,
+    pub repo_root: Option<PathBuf>,
+    pub worktree_line: Option<String>,
     pub tool_names: Vec<String>,
     /// Slash commands contributed by registered capabilities (via
     /// `Capability::commands()`). Resolved once at startup against this
@@ -1730,12 +1788,64 @@ pub async fn build_with_options(
 ) -> Result<BuiltRuntime> {
     let canonical_root = std::fs::canonicalize(&workspace_root)
         .with_context(|| format!("canonicalize workspace: {}", workspace_root.display()))?;
-    let workspace = Workspace::new(canonical_root.clone());
+
+    // Pin the SessionId so resume can re-attach to the same session folder
+    // (directory name is the session id).
+    let session_id = resume_session_id.unwrap_or_default();
+    let session_dir = session_dir_path(&sessions_dir, session_id);
+    let log_path = session_log_path(&session_dir);
+    let _legacy_log = migrate_legacy_session_log(&sessions_dir, &session_dir, session_id)?;
+
+    let saved_metadata = read_session_workspace_metadata(&session_dir)?;
+    let repo_root = detect_repo_root(&canonical_root);
+    let restored_worktree = saved_metadata
+        .as_ref()
+        .and_then(restore_worktree_from_metadata);
+    let initial_active = restored_worktree
+        .as_ref()
+        .map(|w| w.path.clone())
+        .or_else(|| saved_metadata.as_ref().map(|m| m.active_root.clone()))
+        .unwrap_or_else(|| canonical_root.clone());
+    let active_root = std::fs::canonicalize(&initial_active).unwrap_or(initial_active);
+
+    let worktrees_mode = settings.snapshot().worktrees_mode();
+    let worktree = Arc::new(WorktreeManager::new(
+        worktrees_mode,
+        repo_root.clone(),
+        active_root.clone(),
+        session_id,
+        session_dir.clone(),
+        restored_worktree,
+    ));
+    if let Some(metadata) = saved_metadata.as_ref() {
+        let _ = worktree.restore_from_metadata(metadata);
+    } else {
+        let metadata = SessionWorkspaceMetadata {
+            active_root: worktree.active_root(),
+            repo_root: repo_root.clone(),
+            worktree: worktree
+                .worktree_info()
+                .map(|info| crate::session_log::WorktreeMetadata {
+                    path: info.path,
+                    branch: info.branch,
+                    base_ref: info.base_ref,
+                    slug: info.slug,
+                }),
+        };
+        write_session_workspace(&session_dir, &metadata)?;
+    }
+    if worktrees_mode == crate::settings::WorktreesMode::Always {
+        let _ = worktree.ensure_always();
+    }
+
+    let shared_workspace_root = worktree.shared_active_root();
+    let workspace = Workspace::with_shared(shared_workspace_root.clone());
+    let effective_root = worktree.active_root();
 
     // Resolve the workspace/global/system skill directories once (this also
     // materializes the embedded system skills). Shared by the skills capability
     // config and the file-store factory's scope routing.
-    let skill_dirs = crate::capabilities::skills::SkillDirs::resolve(&canonical_root);
+    let skill_dirs = crate::capabilities::skills::SkillDirs::resolve(&effective_root);
 
     // MCP servers from `.mcp.json` (global + workspace, merged). Loading is
     // best-effort per scope: a malformed file is warned about and skipped, so
@@ -1758,14 +1868,6 @@ pub async fn build_with_options(
     let connections = Arc::new(ConnectionStore::open(connections_path));
     let connection_catalog = Arc::new(ConnectionCatalog::with_defaults());
     let connection_resolver = Arc::new(YolopConnectionResolver::new(connections.clone()));
-
-    // Pin the SessionId so resume can re-attach to the same session folder
-    // (directory name is the session id).
-    let session_id = resume_session_id.unwrap_or_default();
-    let session_dir = session_dir_path(&sessions_dir, session_id);
-    let log_path = session_log_path(&session_dir);
-    let _legacy_log = migrate_legacy_session_log(&sessions_dir, &session_dir, session_id)?;
-    write_session_workspace(&session_dir, &canonical_root)?;
 
     // Replay anything already on disk for this id. Missing file → empty.
     // Pass `session_id` so events for any other session get skipped
@@ -1845,8 +1947,8 @@ pub async fn build_with_options(
     capabilities.register(ScopedSkillsCapability::new(
         crate::capabilities::skills::skills_config(&skill_dirs),
     ));
-    capabilities.register(RepoMapCapability::new(canonical_root.clone()));
-    capabilities.register(AstGrepCapability::new(canonical_root.clone()));
+    capabilities.register(RepoMapCapability::new(effective_root.clone()));
+    capabilities.register(AstGrepCapability::new(effective_root.clone()));
     capabilities.register(InfinityContextCapability);
     capabilities.register(CompactionCapability);
     capabilities.register(StatelessTodoListCapability);
@@ -1871,7 +1973,10 @@ pub async fn build_with_options(
     capabilities.register(DuckDuckGoCapability);
     capabilities.register(WebFetchCapability::from_env());
     capabilities.register(MessageMetadataCapability);
-    capabilities.register(CodingCliEnvironmentCapability::new(canonical_root.clone()));
+    capabilities.register(CodingCliEnvironmentCapability::new(
+        repo_root.clone().unwrap_or_else(|| canonical_root.clone()),
+        shared_workspace_root.clone(),
+    ));
     // Read-only consumer of the shared config service. `SettingsStore`
     // implements `ConfigService`, so the same handle that backs writes also
     // serves reads to capabilities that don't need the concrete store.
@@ -1938,13 +2043,13 @@ pub async fn build_with_options(
     // to `<session_dir>/background/` so results survive a restart. Reuses this
     // session's folder, the same durability substrate as the JSONL event log.
     // See specs/background.md.
-    let mut background_registry = BackgroundRegistry::load(&session_dir, canonical_root.clone());
+    let mut background_registry = BackgroundRegistry::load(&session_dir, effective_root.clone());
     // Top-level sessions can spawn sub-agents; child sub-agent sessions cannot
     // (depth bound). The spawner builds a fresh child session per sub-agent,
     // reusing the live provider, this session's sessions dir, and settings.
     if !options.disable_background_agents {
         let spawner: Arc<dyn AgentSpawner> = Arc::new(YolopAgentSpawner {
-            workspace_root: canonical_root.clone(),
+            workspace_root: effective_root.clone(),
             provider: provider_state.clone(),
             sessions_dir: sessions_dir.clone(),
             settings: settings.clone(),
@@ -2010,7 +2115,7 @@ pub async fn build_with_options(
         .driver_registry(driver_registry)
         .connector(everruns_integrations_daytona::connection::DaytonaConnector)
         .session_file_system_factory(Arc::new(CodingCliSessionFileSystemFactory {
-            workspace_root: canonical_root.clone(),
+            workspace_root: shared_workspace_root.clone(),
             session_dir: session_dir.clone(),
             skill_global: skill_dirs.global.clone(),
             skill_system: skill_dirs.system.clone(),
@@ -2019,7 +2124,7 @@ pub async fn build_with_options(
 
     // Seed harness/agent/session explicitly so Yolop can attach harness
     // metadata that Everruns forwards to LLM calls and observability.
-    let session_title = format!("yolop @ {}", canonical_root.display());
+    let session_title = format!("yolop @ {}", effective_root.display());
     let harness_capabilities = coding_harness_capabilities(
         options.client_commands,
         hook_capability_config,
@@ -2097,7 +2202,9 @@ pub async fn build_with_options(
             events: event_bus_typed,
         },
         startup: StartupInfo {
-            workspace_root: canonical_root,
+            workspace_root: effective_root,
+            repo_root,
+            worktree_line: worktree.status_line(),
             tool_names,
             capability_commands,
             session_log_path: log_path,
@@ -2115,6 +2222,7 @@ pub async fn build_with_options(
         ui_rx,
         background: background_registry,
         goal_store,
+        worktree,
     })
 }
 
@@ -2123,6 +2231,19 @@ mod tests {
     use super::*;
     use crate::capabilities::REPO_MAP_CAPABILITY_ID;
     use everruns_core::command::ExecuteCommandRequest;
+
+    fn test_file_store(
+        workspace: &std::path::Path,
+        session: &std::path::Path,
+    ) -> CodingCliSessionFileStore {
+        CodingCliSessionFileStore::new(
+            Arc::new(RwLock::new(workspace.to_path_buf())),
+            session.to_path_buf(),
+            None,
+            None,
+        )
+        .expect("store")
+    }
 
     #[test]
     fn model_spec_rejects_invalid_current_provider_model() {
@@ -3500,13 +3621,7 @@ mod tests {
     async fn yolop_file_store_routes_workspace_files_to_workspace_root() {
         let workspace = tempfile::tempdir().expect("workspace");
         let session = tempfile::tempdir().expect("session");
-        let store = CodingCliSessionFileStore::new(
-            workspace.path().into(),
-            session.path().into(),
-            None,
-            None,
-        )
-        .expect("store");
+        let store = test_file_store(workspace.path(), session.path());
         let session_id = SessionId::from_seed(1);
 
         store
@@ -3525,13 +3640,7 @@ mod tests {
     async fn yolop_file_store_routes_outputs_to_session_dir() {
         let workspace = tempfile::tempdir().expect("workspace");
         let session = tempfile::tempdir().expect("session");
-        let store = CodingCliSessionFileStore::new(
-            workspace.path().into(),
-            session.path().into(),
-            None,
-            None,
-        )
-        .expect("store");
+        let store = test_file_store(workspace.path(), session.path());
         let session_id = SessionId::from_seed(2);
 
         store
@@ -3592,13 +3701,7 @@ mod tests {
     fn yolop_file_store_displays_workspace_and_session_paths() {
         let workspace = tempfile::tempdir().expect("workspace");
         let session = tempfile::tempdir().expect("session");
-        let store = CodingCliSessionFileStore::new(
-            workspace.path().into(),
-            session.path().into(),
-            None,
-            None,
-        )
-        .expect("store");
+        let store = test_file_store(workspace.path(), session.path());
         let workspace_root = std::fs::canonicalize(workspace.path()).expect("canonical workspace");
         let session_root = std::fs::canonicalize(session.path()).expect("canonical session");
 
@@ -3624,10 +3727,10 @@ mod tests {
         let global = tempfile::tempdir().expect("global");
         let system = tempfile::tempdir().expect("system");
         let store = CodingCliSessionFileStore::new(
-            workspace.path().into(),
-            session.path().into(),
-            Some(global.path().into()),
-            Some(system.path().into()),
+            Arc::new(RwLock::new(workspace.path().to_path_buf())),
+            session.path().to_path_buf(),
+            Some(global.path().to_path_buf()),
+            Some(system.path().to_path_buf()),
         )
         .expect("store");
         let session_id = SessionId::from_seed(7);
@@ -3691,10 +3794,10 @@ mod tests {
         };
         let store: Arc<dyn SessionFileSystem> = Arc::new(
             CodingCliSessionFileStore::new(
-                workspace.path().into(),
-                session.path().into(),
+                Arc::new(RwLock::new(workspace.path().to_path_buf())),
+                session.path().to_path_buf(),
                 None,
-                Some(system.path().into()),
+                Some(system.path().to_path_buf()),
             )
             .expect("store"),
         );
@@ -3735,13 +3838,7 @@ mod tests {
 
         let workspace = tempfile::tempdir().expect("workspace");
         let session = tempfile::tempdir().expect("session");
-        let store = CodingCliSessionFileStore::new(
-            workspace.path().into(),
-            session.path().into(),
-            None,
-            None,
-        )
-        .expect("store");
+        let store = test_file_store(workspace.path(), session.path());
         let session_id = SessionId::from_seed(3);
 
         store
@@ -3776,13 +3873,7 @@ mod tests {
 
         let workspace = tempfile::tempdir().expect("workspace");
         let session = tempfile::tempdir().expect("session");
-        let store = CodingCliSessionFileStore::new(
-            workspace.path().into(),
-            session.path().into(),
-            None,
-            None,
-        )
-        .expect("store");
+        let store = test_file_store(workspace.path(), session.path());
         let session_id = SessionId::from_seed(4);
 
         store

--- a/src/session_log.rs
+++ b/src/session_log.rs
@@ -115,12 +115,28 @@ pub fn legacy_session_log_path(sessions_dir: &Path, session_id: SessionId) -> Pa
     sessions_dir.join(format!("{session_id}.jsonl"))
 }
 
-#[derive(Debug, Deserialize, Serialize)]
-struct SessionWorkspaceMetadata {
-    workspace_root: PathBuf,
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct WorktreeMetadata {
+    pub path: PathBuf,
+    pub branch: String,
+    pub base_ref: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub slug: String,
 }
 
-pub fn read_session_workspace(session_dir: &Path) -> Result<Option<PathBuf>> {
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SessionWorkspaceMetadata {
+    #[serde(alias = "workspace_root")]
+    pub active_root: PathBuf,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo_root: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree: Option<WorktreeMetadata>,
+}
+
+pub fn read_session_workspace_metadata(
+    session_dir: &Path,
+) -> Result<Option<SessionWorkspaceMetadata>> {
     let path = session_workspace_path(session_dir);
     if !path.exists() {
         return Ok(None);
@@ -147,10 +163,17 @@ pub fn read_session_workspace(session_dir: &Path) -> Result<Option<PathBuf>> {
             return Ok(None);
         }
     };
-    Ok(Some(metadata.workspace_root))
+    Ok(Some(metadata))
 }
 
-pub fn write_session_workspace(session_dir: &Path, workspace_root: &Path) -> Result<()> {
+pub fn read_session_workspace(session_dir: &Path) -> Result<Option<PathBuf>> {
+    Ok(read_session_workspace_metadata(session_dir)?.map(|m| m.active_root))
+}
+
+pub fn write_session_workspace(
+    session_dir: &Path,
+    metadata: &SessionWorkspaceMetadata,
+) -> Result<()> {
     std::fs::create_dir_all(session_dir).map_err(|e| {
         AgentLoopError::config(format!("create session dir {}: {e}", session_dir.display()))
     })?;
@@ -167,10 +190,7 @@ pub fn write_session_workspace(session_dir: &Path, workspace_root: &Path) -> Res
         )?;
     }
     let path = session_workspace_path(session_dir);
-    let metadata = SessionWorkspaceMetadata {
-        workspace_root: workspace_root.to_path_buf(),
-    };
-    let bytes = serde_json::to_vec_pretty(&metadata)
+    let bytes = serde_json::to_vec_pretty(metadata)
         .map_err(|e| AgentLoopError::config(format!("serialize session workspace: {e}")))?;
     write_private_file(&path, &bytes)
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -34,7 +34,43 @@ pub struct CodexAuth {
     pub email: Option<String>,
 }
 
-/// How aggressively yolop pauses for spoken ("soft") approval before
+/// When yolop provisions an isolated git worktree for code changes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum WorktreesMode {
+    /// Create a worktree when the user prompt looks like implementation work.
+    #[default]
+    Auto,
+    /// Always use a worktree in git repositories.
+    Always,
+    /// Never create worktrees; operate in the resolved cwd.
+    Off,
+}
+
+impl WorktreesMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            WorktreesMode::Auto => "auto",
+            WorktreesMode::Always => "always",
+            WorktreesMode::Off => "off",
+        }
+    }
+
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "auto" | "default" => Some(Self::Auto),
+            "always" | "on" => Some(Self::Always),
+            "off" | "none" | "disabled" => Some(Self::Off),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for WorktreesMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// running critical actions. Soft approval is prompt-engineering, not a
 /// hard gate: the chosen level is injected into the system prompt so the
 /// model itself decides when to ask, batches safe calls, and the user
@@ -110,6 +146,8 @@ pub struct Settings {
     /// Whether the TUI auto-starts a turn when a background task finishes while
     /// idle (proactive wake). On by default; disable for a quieter session.
     pub proactive_wake: bool,
+    /// Git worktree isolation for code changes (`auto`, `always`, `off`).
+    pub worktrees: WorktreesMode,
     /// Ordered harness capability overrides (`[[capabilities]]` in settings.toml).
     pub capabilities: Vec<CapabilityOverride>,
 }
@@ -126,6 +164,7 @@ impl Default for Settings {
             attribution: true,
             approval_mode: ApprovalMode::Normal,
             proactive_wake: true,
+            worktrees: WorktreesMode::Auto,
             capabilities: Vec::new(),
         }
     }
@@ -157,6 +196,11 @@ impl Settings {
             .get("proactive_wake")
             .and_then(Value::as_bool)
             .unwrap_or(true);
+        let worktrees = table
+            .get("worktrees")
+            .and_then(Value::as_str)
+            .and_then(WorktreesMode::parse)
+            .unwrap_or_default();
         let string_map = |key: &str| {
             let mut map = BTreeMap::new();
             if let Some(t) = table.get(key).and_then(Value::as_table) {
@@ -182,6 +226,7 @@ impl Settings {
             attribution,
             approval_mode,
             proactive_wake,
+            worktrees,
             capabilities: parse_capabilities_table(table),
         }
     }
@@ -206,6 +251,12 @@ impl Settings {
             table.insert(
                 "approval_mode".to_string(),
                 Value::String(self.approval_mode.as_str().to_string()),
+            );
+        }
+        if self.worktrees != WorktreesMode::Auto {
+            table.insert(
+                "worktrees".to_string(),
+                Value::String(self.worktrees.as_str().to_string()),
             );
         }
         let mut insert_map = |key: &str, map: &BTreeMap<String, String>| {
@@ -275,6 +326,10 @@ impl Settings {
 
     pub fn proactive_wake_enabled(&self) -> bool {
         self.proactive_wake
+    }
+
+    pub fn worktrees_mode(&self) -> WorktreesMode {
+        self.worktrees
     }
 
     pub fn capability_overrides_for(&self, id: &str) -> Vec<(usize, &CapabilityOverride)> {
@@ -446,6 +501,12 @@ impl SettingsStore {
     pub fn set_approval_mode(&self, mode: ApprovalMode) -> Result<()> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
         guard.approval_mode = mode;
+        save_to(&self.path, &guard)
+    }
+
+    pub fn set_worktrees_mode(&self, mode: WorktreesMode) -> Result<()> {
+        let mut guard = self.inner.lock().expect("settings lock poisoned");
+        guard.worktrees = mode;
         save_to(&self.path, &guard)
     }
 

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -12,27 +12,35 @@ use everruns_core::exec_tool_result::ExecToolResultPayload;
 use everruns_core::tool_types::ToolHints;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use serde_json::{Value, json};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::Stdio;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use tokio::io::AsyncReadExt;
 use tokio::process::Command;
 
-/// Workspace context for the bash tool. Just the root path — path
-/// resolution for file ops now lives inside the configured session filesystem.
+/// Workspace context for the bash tool. The root may be updated when a session
+/// worktree is activated mid-session.
 #[derive(Clone)]
 pub struct Workspace {
-    root: Arc<PathBuf>,
+    root: Arc<RwLock<PathBuf>>,
 }
 
 impl Workspace {
     pub fn new(root: PathBuf) -> Self {
         Self {
-            root: Arc::new(root),
+            root: Arc::new(RwLock::new(root)),
         }
     }
-    pub fn root(&self) -> &Path {
-        &self.root
+
+    pub fn with_shared(root: Arc<RwLock<PathBuf>>) -> Self {
+        Self { root }
+    }
+
+    pub fn root(&self) -> PathBuf {
+        self.root
+            .read()
+            .map(|guard| guard.clone())
+            .unwrap_or_else(|_| PathBuf::from("."))
     }
 }
 

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -1,0 +1,594 @@
+// Git worktree management for yolop sessions.
+//
+// Each session can get an isolated worktree on a dedicated branch, branched
+// from `origin/main`, so the user's primary checkout stays untouched. Worktrees
+// live outside the repo (tmp dir, falling back to `~/.yolop/worktrees/`).
+
+use crate::session_log::{SessionWorkspaceMetadata, WorktreeMetadata, write_session_workspace};
+use crate::settings::WorktreesMode;
+use anyhow::{Context, Result, bail};
+use everruns_core::typed_id::SessionId;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, RwLock};
+
+const IMPLEMENT_VERBS: &[&str] = &[
+    "fix",
+    "implement",
+    "add",
+    "create",
+    "build",
+    "write",
+    "update",
+    "change",
+    "refactor",
+    "ship",
+    "debug",
+    "patch",
+    "remove",
+    "delete",
+    "migrate",
+    "replace",
+    "introduce",
+    "integrate",
+    "wire",
+    "hook",
+    "land",
+    "port",
+    "rewrite",
+    "repair",
+    "correct",
+    "extend",
+    "modify",
+];
+
+const STOP_WORDS: &[&str] = &[
+    "a", "an", "the", "to", "for", "in", "on", "at", "of", "and", "or", "with", "from", "this",
+    "that", "please", "can", "you", "me", "my", "i", "we", "it", "is", "are", "be", "do", "does",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorktreeInfo {
+    pub path: PathBuf,
+    pub branch: String,
+    pub base_ref: String,
+    pub slug: String,
+}
+
+/// Session-scoped worktree coordinator. Thread-safe for concurrent reads; writes
+/// are serialized through the inner `RwLock`s.
+pub struct WorktreeManager {
+    mode: WorktreesMode,
+    repo_root: Option<PathBuf>,
+    active_root: Arc<RwLock<PathBuf>>,
+    worktree: RwLock<Option<WorktreeInfo>>,
+    session_id: SessionId,
+    session_dir: PathBuf,
+    auto_disabled: AtomicBool,
+}
+
+impl WorktreeManager {
+    pub fn new(
+        mode: WorktreesMode,
+        repo_root: Option<PathBuf>,
+        initial_active_root: PathBuf,
+        session_id: SessionId,
+        session_dir: PathBuf,
+        restored: Option<WorktreeInfo>,
+    ) -> Self {
+        let active = restored
+            .as_ref()
+            .map(|w| w.path.clone())
+            .unwrap_or(initial_active_root);
+        Self {
+            mode,
+            repo_root,
+            active_root: Arc::new(RwLock::new(active)),
+            worktree: RwLock::new(restored),
+            session_id,
+            session_dir,
+            auto_disabled: AtomicBool::new(false),
+        }
+    }
+
+    pub fn shared_active_root(&self) -> Arc<RwLock<PathBuf>> {
+        self.active_root.clone()
+    }
+
+    pub fn active_root(&self) -> PathBuf {
+        self.active_root
+            .read()
+            .map(|p| p.clone())
+            .unwrap_or_else(|_| PathBuf::from("."))
+    }
+
+    pub fn worktree_info(&self) -> Option<WorktreeInfo> {
+        self.worktree.read().ok().and_then(|g| g.clone())
+    }
+
+    /// Returns `true` when the active root changed (worktree was created or restored).
+    pub fn ensure_before_turn(&self, prompt: &str) -> Result<bool> {
+        if self.worktree.read().map(|g| g.is_some()).unwrap_or(false) {
+            return Ok(false);
+        }
+        if !self.should_activate(prompt) {
+            return Ok(false);
+        }
+        self.activate(Some(prompt))?;
+        Ok(true)
+    }
+
+    pub fn ensure_always(&self) -> Result<bool> {
+        if self.worktree.read().map(|g| g.is_some()).unwrap_or(false) {
+            return Ok(false);
+        }
+        if !self.can_use_worktrees() {
+            return Ok(false);
+        }
+        self.activate(None)?;
+        Ok(true)
+    }
+
+    fn should_activate(&self, prompt: &str) -> bool {
+        if self.auto_disabled.load(Ordering::SeqCst) {
+            return false;
+        }
+        match self.mode {
+            WorktreesMode::Off => false,
+            WorktreesMode::Always => self.can_use_worktrees(),
+            WorktreesMode::Auto => {
+                self.can_use_worktrees() && looks_like_implementation_intent(prompt)
+            }
+        }
+    }
+
+    fn can_use_worktrees(&self) -> bool {
+        self.repo_root.is_some() && self.mode != WorktreesMode::Off
+    }
+
+    fn activate(&self, prompt: Option<&str>) -> Result<()> {
+        let repo_root = self
+            .repo_root
+            .as_ref()
+            .context("worktree activation requires a git repository")?;
+        let slug = prompt
+            .map(slug_from_prompt)
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "session".to_string());
+        let branch = branch_name(&slug, self.session_id);
+        let base_ref = resolve_base_ref(repo_root);
+        let path = worktree_path(repo_root, &self.session_id.to_string())?;
+
+        let info = if path.exists() && worktree_contains_path(repo_root, &path) {
+            WorktreeInfo {
+                path: path.clone(),
+                branch: branch.clone(),
+                base_ref: base_ref.clone(),
+                slug: slug.clone(),
+            }
+        } else {
+            create_worktree(repo_root, &path, &branch, &base_ref)?;
+            WorktreeInfo {
+                path: path.clone(),
+                branch,
+                base_ref,
+                slug,
+            }
+        };
+
+        {
+            let mut active = self
+                .active_root
+                .write()
+                .map_err(|_| anyhow::anyhow!("active workspace lock poisoned"))?;
+            *active = info.path.clone();
+        }
+        {
+            let mut guard = self
+                .worktree
+                .write()
+                .map_err(|_| anyhow::anyhow!("worktree lock poisoned"))?;
+            *guard = Some(info.clone());
+        }
+        self.persist_metadata(&info)?;
+        Ok(())
+    }
+
+    pub fn restore_from_metadata(&self, metadata: &SessionWorkspaceMetadata) -> Result<()> {
+        let Some(worktree) = metadata.worktree.clone() else {
+            return Ok(());
+        };
+        let repo_root = metadata
+            .repo_root
+            .as_ref()
+            .or(self.repo_root.as_ref())
+            .context("resume worktree metadata missing repo_root")?;
+
+        let info = if worktree.path.exists() && worktree_contains_path(repo_root, &worktree.path) {
+            WorktreeInfo {
+                path: worktree.path.clone(),
+                branch: worktree.branch.clone(),
+                base_ref: worktree.base_ref.clone(),
+                slug: worktree.slug.clone(),
+            }
+        } else {
+            recreate_worktree(repo_root, &worktree)?
+        };
+
+        {
+            let mut active = self
+                .active_root
+                .write()
+                .map_err(|_| anyhow::anyhow!("active workspace lock poisoned"))?;
+            *active = info.path.clone();
+        }
+        {
+            let mut guard = self
+                .worktree
+                .write()
+                .map_err(|_| anyhow::anyhow!("worktree lock poisoned"))?;
+            *guard = Some(info.clone());
+        }
+        self.persist_metadata(&info)?;
+        Ok(())
+    }
+
+    fn persist_metadata(&self, info: &WorktreeInfo) -> Result<()> {
+        let metadata = SessionWorkspaceMetadata {
+            active_root: info.path.clone(),
+            repo_root: self.repo_root.clone(),
+            worktree: Some(WorktreeMetadata {
+                path: info.path.clone(),
+                branch: info.branch.clone(),
+                base_ref: info.base_ref.clone(),
+                slug: info.slug.clone(),
+            }),
+        };
+        write_session_workspace(&self.session_dir, &metadata).map_err(|e| anyhow::anyhow!("{e}"))
+    }
+
+    pub fn status_line(&self) -> Option<String> {
+        let info = self.worktree_info()?;
+        Some(format!(
+            "worktree: {} @ {}",
+            info.branch,
+            info.path.display()
+        ))
+    }
+}
+
+pub fn detect_repo_root(path: &Path) -> Option<PathBuf> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if text.is_empty() {
+        None
+    } else {
+        std::fs::canonicalize(&text).ok()
+    }
+}
+
+pub fn looks_like_implementation_intent(prompt: &str) -> bool {
+    let trimmed = prompt.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    if trimmed.starts_with("/ship") {
+        return true;
+    }
+    let lower = format!(" {lower} ", lower = trimmed.to_ascii_lowercase());
+    IMPLEMENT_VERBS
+        .iter()
+        .any(|verb| lower.contains(&format!(" {verb} ")))
+}
+
+pub fn slug_from_prompt(prompt: &str) -> String {
+    let words: Vec<String> = prompt
+        .to_ascii_lowercase()
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|w| !w.is_empty())
+        .filter(|w| STOP_WORDS.iter().all(|stop| stop != w))
+        .take(5)
+        .map(str::to_string)
+        .collect();
+    if words.is_empty() {
+        "session".to_string()
+    } else {
+        words.join("-")
+    }
+}
+
+pub fn branch_name(slug: &str, session_id: SessionId) -> String {
+    let suffix = session_suffix(session_id);
+    let base = slug.trim_matches('-');
+    if base.is_empty() {
+        format!("session-{suffix}")
+    } else {
+        format!("{base}-{suffix}")
+    }
+}
+
+fn session_suffix(session_id: SessionId) -> String {
+    let compact: String = session_id
+        .to_string()
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .collect();
+    let suffix: String = compact.chars().rev().take(8).collect::<String>();
+    let suffix: String = suffix.chars().rev().collect();
+    if suffix.is_empty() {
+        "00000000".to_string()
+    } else {
+        suffix
+    }
+}
+
+pub fn repo_id(repo_root: &Path) -> String {
+    let mut hasher = DefaultHasher::new();
+    repo_root.display().to_string().hash(&mut hasher);
+    format!("{:08x}", hasher.finish())
+}
+
+pub fn worktree_parent_dir(repo_id: &str) -> PathBuf {
+    let tmp_base = std::env::var_os("TMPDIR")
+        .map(PathBuf::from)
+        .or_else(|| Some(PathBuf::from("/tmp")))
+        .unwrap();
+    let tmp_candidate = tmp_base.join("yolop").join("worktrees").join(repo_id);
+    if std::fs::create_dir_all(&tmp_candidate).is_ok() {
+        return tmp_candidate;
+    }
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".yolop")
+        .join("worktrees")
+        .join(repo_id)
+}
+
+pub fn worktree_path(repo_root: &Path, session_id: &str) -> Result<PathBuf> {
+    let parent = worktree_parent_dir(&repo_id(repo_root));
+    std::fs::create_dir_all(&parent)
+        .with_context(|| format!("create worktree parent {}", parent.display()))?;
+    Ok(parent.join(session_id))
+}
+
+fn resolve_base_ref(repo_root: &Path) -> String {
+    for candidate in ["origin/main", "origin/master", "main", "master"] {
+        if git_verify_ref(repo_root, candidate) {
+            return candidate.to_string();
+        }
+    }
+    "HEAD".to_string()
+}
+
+fn git_verify_ref(repo_root: &Path, reference: &str) -> bool {
+    git_output(repo_root, &["rev-parse", "--verify", reference]).is_some()
+}
+
+fn create_worktree(repo_root: &Path, path: &Path, branch: &str, base_ref: &str) -> Result<()> {
+    if path.exists() {
+        std::fs::remove_dir_all(path).with_context(|| {
+            format!(
+                "remove stale worktree path {} before recreate",
+                path.display()
+            )
+        })?;
+    }
+    // Best-effort fetch so origin/main is current when used as the base.
+    if base_ref.starts_with("origin/") {
+        let remote_branch = base_ref.strip_prefix("origin/").unwrap_or(base_ref);
+        let _ = Command::new("git")
+            .arg("-C")
+            .arg(repo_root)
+            .args(["fetch", "origin", remote_branch])
+            .status();
+    }
+    let status = Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args([
+            "worktree",
+            "add",
+            "-B",
+            branch,
+            &path.display().to_string(),
+            base_ref,
+        ])
+        .status()
+        .with_context(|| format!("git worktree add for {}", path.display()))?;
+    if status.success() {
+        return Ok(());
+    }
+    bail!(
+        "git worktree add -B {branch} {} {base_ref} failed",
+        path.display()
+    );
+}
+
+fn recreate_worktree(repo_root: &Path, saved: &WorktreeMetadata) -> Result<WorktreeInfo> {
+    let path = saved.path.clone();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create worktree parent {}", parent.display()))?;
+    }
+    if path.exists() {
+        let _ = std::fs::remove_dir_all(&path);
+    }
+    if branch_exists(repo_root, &saved.branch) {
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(repo_root)
+            .args([
+                "worktree",
+                "add",
+                &path.display().to_string(),
+                &saved.branch,
+            ])
+            .status()
+            .with_context(|| format!("reattach worktree branch {}", saved.branch))?;
+        if !status.success() {
+            bail!("git worktree add {} {}", path.display(), saved.branch);
+        }
+    } else {
+        create_worktree(repo_root, &path, &saved.branch, &saved.base_ref)?;
+    }
+    Ok(WorktreeInfo {
+        path,
+        branch: saved.branch.clone(),
+        base_ref: saved.base_ref.clone(),
+        slug: saved.slug.clone(),
+    })
+}
+
+fn branch_exists(repo_root: &Path, branch: &str) -> bool {
+    git_output(
+        repo_root,
+        &["show-ref", "--verify", &format!("refs/heads/{branch}")],
+    )
+    .is_some()
+}
+
+fn worktree_contains_path(repo_root: &Path, path: &Path) -> bool {
+    let canonical = match std::fs::canonicalize(path) {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+    let listing = match Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(["worktree", "list", "--porcelain"])
+        .output()
+    {
+        Ok(output) if output.status.success() => {
+            String::from_utf8_lossy(&output.stdout).into_owned()
+        }
+        _ => return false,
+    };
+    listing.lines().any(|line| {
+        line.strip_prefix("worktree ")
+            .and_then(|p| std::fs::canonicalize(p).ok())
+            .is_some_and(|listed| listed == canonical)
+    })
+}
+
+fn git_output(repo_root: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if text.is_empty() { None } else { Some(text) }
+}
+
+pub fn restore_worktree_from_metadata(metadata: &SessionWorkspaceMetadata) -> Option<WorktreeInfo> {
+    let worktree = metadata.worktree.as_ref()?;
+    let repo_root = metadata.repo_root.as_ref()?;
+    if worktree.path.exists() && worktree_contains_path(repo_root, &worktree.path) {
+        return Some(WorktreeInfo {
+            path: worktree.path.clone(),
+            branch: worktree.branch.clone(),
+            base_ref: worktree.base_ref.clone(),
+            slug: worktree.slug.clone(),
+        });
+    }
+    recreate_worktree(repo_root, worktree).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slug_from_prompt_strips_stop_words() {
+        assert_eq!(
+            slug_from_prompt("Please fix the auth bug in login"),
+            "fix-auth-bug-login"
+        );
+    }
+
+    #[test]
+    fn implementation_intent_matches_common_verbs() {
+        assert!(looks_like_implementation_intent("fix the auth bug"));
+        assert!(looks_like_implementation_intent("/ship this change"));
+        assert!(!looks_like_implementation_intent("how does auth work?"));
+        assert!(!looks_like_implementation_intent("explain the module"));
+    }
+
+    #[test]
+    fn branch_name_uses_slug_and_session_suffix() {
+        let id = SessionId::default();
+        let branch = branch_name("fix-auth", id);
+        assert!(branch.starts_with("fix-auth-"));
+        assert!(branch.len() > "fix-auth-".len());
+    }
+
+    #[test]
+    fn worktree_manager_creates_isolated_branch_on_implementation_prompt() {
+        let repo = tempfile::tempdir().expect("repo");
+        std::process::Command::new("git")
+            .args(["init", "-b", "main"])
+            .current_dir(repo.path())
+            .status()
+            .expect("git init");
+        std::fs::write(repo.path().join("README.md"), "hello").expect("readme");
+        std::process::Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(repo.path())
+            .status()
+            .expect("git add");
+        std::process::Command::new("git")
+            .args([
+                "commit",
+                "-m",
+                "init",
+                "--author",
+                "test <test@example.com>",
+            ])
+            .env("GIT_COMMITTER_NAME", "test")
+            .env("GIT_COMMITTER_EMAIL", "test@example.com")
+            .current_dir(repo.path())
+            .status()
+            .expect("git commit");
+
+        let sessions = tempfile::tempdir().expect("sessions");
+        let session_id = SessionId::from_seed(99);
+        let session_dir = sessions.path().join(session_id.to_string());
+        std::fs::create_dir_all(&session_dir).expect("session dir");
+
+        let manager = WorktreeManager::new(
+            WorktreesMode::Auto,
+            detect_repo_root(repo.path()),
+            repo.path().to_path_buf(),
+            session_id,
+            session_dir,
+            None,
+        );
+
+        manager
+            .ensure_before_turn("fix the readme typo")
+            .expect("activate worktree");
+        let info = manager.worktree_info().expect("worktree info");
+        assert!(info.path.exists());
+        assert!(info.branch.starts_with("fix-readme"));
+        assert_ne!(info.path, repo.path());
+
+        let main_branch =
+            git_output(repo.path(), &["branch", "--show-current"]).expect("main branch");
+        assert_eq!(main_branch, "main");
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds session-scoped git worktrees so implementation work runs in an isolated checkout and branch while the user's primary repository stays on `main`.

- **`worktrees = "auto"`** (default): provisions a worktree when a prompt looks like implementation work (`fix`, `implement`, `/ship`, etc.)
- **Location**: `$TMPDIR/yolop/worktrees/<repo-id>/<session-id>/`, falling back to `~/.yolop/worktrees/`
- **Branch naming**: `<slug>-<id>` (e.g. `fix-auth-a1b2c3d4`), based on `origin/main` when available
- **Persistence**: extended `workspace.json` with `repo_root`, `active_root`, and worktree metadata for resume
- **Runtime**: swappable workspace root so file tools, bash, and environment context follow the worktree once activated
- **Context**: `<environment_context>` includes `repo_root` and `<git_worktree>` when active; harness instructs the agent to never touch `repo_root`

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` (470 unit + 29 integration)
- [x] `worktree::worktree_manager_creates_isolated_branch_on_implementation_prompt` — verifies branch creation and main checkout unchanged
- [x] `cargo run -- --provider llmsim -p "hi"` smoke

## Follow-ups

- `/worktree` slash command for status and disabling auto-activation for future turns
- `yolop worktree prune` maintenance CLI for orphaned worktrees under `~/.yolop/worktrees/`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a713b85-93d2-461d-a083-addd356c037e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a713b85-93d2-461d-a083-addd356c037e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

