### PR TITLE
feat(worktree): /worktree command and prune CLI

### DIFF
--- a/specs/worktrees.md
+++ b/specs/worktrees.md
@@ -32,7 +32,13 @@ main checkout stays untouched.
 - Sub-agents inherit the parent session's active worktree.
 - Resume reattaches to a saved worktree or recreates it when tmp was cleared.
 
-### Agent guidance
+### Commands
+
+- `/worktree` — show active worktree, branch, and path (or mode when inactive)
+- `/worktree off` — disable auto-activation for future turns in this session
+- `yolop worktree list` — list worktree directories on disk
+- `yolop worktree prune` — remove worktrees not referenced by any saved session (`--dry-run` to preview)
+
 
 Harness and `<environment_context>` tell the model to edit and commit only in
 the session worktree and never change git state in `repo_root`.

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod model_discovery;
 pub(crate) mod model_ranking;
 pub(crate) mod repo_map;
 pub mod skills;
+pub(crate) mod worktree_cmd;
 pub(crate) mod your;
 
 pub(crate) use crate::goal::GOAL_CAPABILITY_ID;
@@ -35,3 +36,4 @@ pub(crate) use host::{
     SetupCapability,
 };
 pub(crate) use repo_map::{REPO_MAP_CAPABILITY_ID, RepoMapCapability};
+pub(crate) use worktree_cmd::WorktreeCapability;

--- a/src/capabilities/worktree_cmd.rs
+++ b/src/capabilities/worktree_cmd.rs
@@ -1,0 +1,90 @@
+//! `/worktree` — session git worktree status and auto-activation control.
+
+use crate::worktree::WorktreeManager;
+use async_trait::async_trait;
+use everruns_core::capabilities::{Capability, CapabilityStatus};
+use everruns_core::command::{
+    CommandArg, CommandDescriptor, CommandExecutionContext, CommandResult, CommandSource,
+    ExecuteCommandRequest,
+};
+use std::sync::Arc;
+
+pub(crate) const WORKTREE_CAPABILITY_ID: &str = "yolop_worktree";
+const WORKTREE_COMMAND_NAME: &str = "worktree";
+
+pub(crate) struct WorktreeCapability {
+    pub(crate) manager: Arc<WorktreeManager>,
+}
+
+#[async_trait]
+impl Capability for WorktreeCapability {
+    fn id(&self) -> &str {
+        WORKTREE_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Worktree"
+    }
+
+    fn description(&self) -> &str {
+        "Show session git worktree status or disable auto-activation."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("System")
+    }
+
+    fn commands(&self) -> Vec<CommandDescriptor> {
+        vec![CommandDescriptor {
+            name: WORKTREE_COMMAND_NAME.to_string(),
+            description: "Show worktree status, or pass `off` to disable auto-activation."
+                .to_string(),
+            source: CommandSource::System,
+            args: vec![CommandArg {
+                name: "action".to_string(),
+                description: "`off` disables auto worktree creation for future turns.".to_string(),
+                required: false,
+                suggestions: vec!["off".to_string()],
+            }],
+        }]
+    }
+
+    async fn execute_command(
+        &self,
+        request: &ExecuteCommandRequest,
+        _ctx: &CommandExecutionContext,
+    ) -> everruns_core::Result<CommandResult> {
+        if request.name != WORKTREE_COMMAND_NAME {
+            return Err(everruns_core::AgentLoopError::config(format!(
+                "{} cannot execute /{}",
+                self.id(),
+                request.name
+            )));
+        }
+
+        let arg = request.arguments.as_deref().unwrap_or("").trim();
+        let message = if arg.eq_ignore_ascii_case("off") {
+            self.manager.disable_auto();
+            "worktrees: auto activation disabled for this session (already-active worktrees \
+             are unchanged)"
+                .to_string()
+        } else if arg.is_empty() {
+            self.manager.status_message()
+        } else {
+            return Err(everruns_core::AgentLoopError::config(format!(
+                "unknown /worktree argument `{arg}`; use `/worktree` or `/worktree off`"
+            )));
+        };
+
+        Ok(CommandResult {
+            success: true,
+            message,
+            error_code: None,
+            error_fields: None,
+        })
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,6 +129,29 @@ enum Commands {
     Version,
     /// Add yolop into supported editors.
     Into(IntoCommand),
+    /// Git worktree maintenance.
+    Worktree(WorktreeArgs),
+}
+
+#[derive(Args, Debug)]
+struct WorktreeArgs {
+    #[command(subcommand)]
+    command: WorktreeCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum WorktreeCommand {
+    /// List session worktree directories on disk.
+    List,
+    /// Remove worktrees not referenced by any saved session.
+    Prune {
+        /// Print what would be removed without deleting anything.
+        #[arg(long)]
+        dry_run: bool,
+        /// Session storage parent directory (default: platform data dir).
+        #[arg(long)]
+        session_dir: Option<PathBuf>,
+    },
 }
 
 #[derive(Args, Debug)]
@@ -421,12 +444,56 @@ fn resolve_workspace_root(
     std::env::current_dir().context("resolve current workspace directory")
 }
 
+fn run_worktree_command(command: WorktreeCommand) -> Result<()> {
+    match command {
+        WorktreeCommand::List => {
+            let paths = worktree::list_worktree_paths_on_disk()?;
+            if paths.is_empty() {
+                println!("no yolop worktrees found on disk");
+            } else {
+                for path in paths {
+                    println!("{}", path.display());
+                }
+            }
+            Ok(())
+        }
+        WorktreeCommand::Prune {
+            dry_run,
+            session_dir,
+        } => {
+            let sessions_dir = match session_dir {
+                Some(path) => path,
+                None => session_log::default_sessions_dir()?,
+            };
+            let report = worktree::prune_orphan_worktrees(&sessions_dir, dry_run)?;
+            let action = if dry_run { "would remove" } else { "removed" };
+            for path in &report.removed {
+                println!("{action}: {}", path.display());
+            }
+            println!(
+                "kept {} referenced worktree(s); {} orphan(s) {action}",
+                report.kept,
+                report.removed.len()
+            );
+            for err in &report.errors {
+                eprintln!("error: {err}");
+            }
+            if report.errors.is_empty() {
+                Ok(())
+            } else {
+                std::process::exit(1);
+            }
+        }
+    }
+}
+
 fn run_command(command: Commands) -> Result<()> {
     match command {
         Commands::Version => {
             println!("{}", version::VERSION_LINE);
             Ok(())
         }
+        Commands::Worktree(args) => run_worktree_command(args.command),
         Commands::Into(into) => match into.target {
             IntoTarget::Zed(args) => {
                 let command = match args.command {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -14,7 +14,7 @@ use crate::capabilities::{
     CodingBashCapability, CodingCliEnvironmentCapability, ConfigCapability,
     ENVIRONMENT_CONTEXT_CAPABILITY_ID, GOAL_CAPABILITY_ID, GoalCapability, HOOKS_CAPABILITY_ID,
     HooksCapability, REPO_MAP_CAPABILITY_ID, RepoMapCapability, SETUP_CAPABILITY_ID,
-    SetupCapability,
+    SetupCapability, WorktreeCapability,
 };
 use crate::capability_settings::{CapabilityCatalog, apply_capability_settings};
 use crate::connectors::{
@@ -1994,6 +1994,9 @@ pub async fn build_with_options(
     goal_store.load_session(session_id)?;
     capabilities.register(GoalCapability {
         store: goal_store.clone(),
+    });
+    capabilities.register(WorktreeCapability {
+        manager: worktree.clone(),
     });
     // `/setup` (below) is the capability-sourced slash command. It implements
     // `Capability::execute_command` end to end.

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -109,6 +109,42 @@ impl WorktreeManager {
         self.worktree.read().ok().and_then(|g| g.clone())
     }
 
+    pub fn disable_auto(&self) {
+        self.auto_disabled.store(true, Ordering::SeqCst);
+    }
+
+    pub fn auto_disabled(&self) -> bool {
+        self.auto_disabled.load(Ordering::SeqCst)
+    }
+
+    pub fn status_message(&self) -> String {
+        if let Some(info) = self.worktree_info() {
+            let repo = self
+                .repo_root
+                .as_ref()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+            return format!(
+                "active worktree\nrepo: {repo}\nbranch: {}\npath: {}\nbase: {}",
+                info.branch,
+                info.path.display(),
+                info.base_ref,
+            );
+        }
+        if self.repo_root.is_none() {
+            return "worktrees: not in a git repository".to_string();
+        }
+        if self.auto_disabled() {
+            return "worktrees: auto activation disabled for this session (already-active \
+                    worktrees are unchanged)"
+                .to_string();
+        }
+        format!(
+            "worktrees: {} (inactive — activates on implementation prompts)",
+            self.mode.as_str()
+        )
+    }
+
     /// Returns `true` when the active root changed (worktree was created or restored).
     pub fn ensure_before_turn(&self, prompt: &str) -> Result<bool> {
         if self.worktree.read().map(|g| g.is_some()).unwrap_or(false) {
@@ -509,9 +545,150 @@ pub fn restore_worktree_from_metadata(metadata: &SessionWorkspaceMetadata) -> Op
     recreate_worktree(repo_root, worktree).ok()
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PruneReport {
+    pub removed: Vec<PathBuf>,
+    pub kept: usize,
+    pub errors: Vec<String>,
+}
+
+/// Roots that may contain session worktrees (tmp + persistent fallback).
+pub fn worktree_storage_roots() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    let tmp_base = std::env::var_os("TMPDIR")
+        .map(PathBuf::from)
+        .or_else(|| Some(PathBuf::from("/tmp")))
+        .unwrap();
+    roots.push(tmp_base.join("yolop").join("worktrees"));
+    roots.push(
+        dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".yolop")
+            .join("worktrees"),
+    );
+    roots
+}
+
+pub fn referenced_worktree_paths(
+    sessions_dir: &Path,
+) -> Result<std::collections::HashSet<PathBuf>> {
+    use crate::session_log::{read_session_workspace_metadata, session_dir_path};
+    use everruns_core::typed_id::SessionId;
+
+    let mut referenced = std::collections::HashSet::new();
+    if !sessions_dir.is_dir() {
+        return Ok(referenced);
+    }
+    for entry in std::fs::read_dir(sessions_dir)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        let Ok(session_id) = name.parse::<SessionId>() else {
+            continue;
+        };
+        let session_dir = session_dir_path(sessions_dir, session_id);
+        if let Some(metadata) = read_session_workspace_metadata(&session_dir)?
+            && let Some(worktree) = metadata.worktree
+        {
+            if let Ok(path) = std::fs::canonicalize(&worktree.path) {
+                referenced.insert(path);
+            } else {
+                referenced.insert(worktree.path);
+            }
+        }
+    }
+    Ok(referenced)
+}
+
+pub fn list_worktree_paths_on_disk() -> Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    for root in worktree_storage_roots() {
+        if !root.is_dir() {
+            continue;
+        }
+        for repo_entry in std::fs::read_dir(&root)? {
+            let repo_entry = repo_entry?;
+            if !repo_entry.file_type()?.is_dir() {
+                continue;
+            }
+            for session_entry in std::fs::read_dir(repo_entry.path())? {
+                let session_entry = session_entry?;
+                if session_entry.file_type()?.is_dir() {
+                    paths.push(session_entry.path());
+                }
+            }
+        }
+    }
+    paths.sort();
+    Ok(paths)
+}
+
+fn main_repo_for_worktree(worktree_path: &Path) -> Option<PathBuf> {
+    let git_common = git_output(worktree_path, &["rev-parse", "--git-common-dir"])?;
+    let git_path = PathBuf::from(git_common);
+    if git_path.is_absolute() {
+        git_path.parent().map(|p| p.to_path_buf())
+    } else {
+        worktree_path
+            .join(&git_path)
+            .parent()
+            .map(|p| p.to_path_buf())
+    }
+}
+
+pub fn remove_worktree_path(path: &Path) -> Result<()> {
+    if let Some(repo_root) = main_repo_for_worktree(path) {
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(&repo_root)
+            .args(["worktree", "remove", "--force", &path.display().to_string()])
+            .status()
+            .with_context(|| format!("git worktree remove {}", path.display()))?;
+        if status.success() {
+            return Ok(());
+        }
+    }
+    if path.exists() {
+        std::fs::remove_dir_all(path)
+            .with_context(|| format!("remove worktree directory {}", path.display()))?;
+    }
+    Ok(())
+}
+
+pub fn prune_orphan_worktrees(sessions_dir: &Path, dry_run: bool) -> Result<PruneReport> {
+    let referenced = referenced_worktree_paths(sessions_dir)?;
+    let mut report = PruneReport {
+        removed: Vec::new(),
+        kept: 0,
+        errors: Vec::new(),
+    };
+    for path in list_worktree_paths_on_disk()? {
+        let canonical = std::fs::canonicalize(&path).unwrap_or(path.clone());
+        if referenced.contains(&canonical) || referenced.contains(&path) {
+            report.kept += 1;
+            continue;
+        }
+        if dry_run {
+            report.removed.push(path);
+            continue;
+        }
+        match remove_worktree_path(&path) {
+            Ok(()) => report.removed.push(path),
+            Err(err) => report.errors.push(format!("{}: {err}", path.display())),
+        }
+    }
+    Ok(report)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     #[test]
     fn slug_from_prompt_strips_stop_words() {
@@ -590,5 +767,53 @@ mod tests {
         let main_branch =
             git_output(repo.path(), &["branch", "--show-current"]).expect("main branch");
         assert_eq!(main_branch, "main");
+    }
+
+    #[test]
+    fn disable_auto_and_status_message() {
+        let manager = WorktreeManager::new(
+            WorktreesMode::Auto,
+            Some(PathBuf::from("/tmp/repo")),
+            PathBuf::from("/tmp/repo"),
+            SessionId::from_seed(1),
+            PathBuf::from("/tmp/session"),
+            None,
+        );
+        assert!(manager.status_message().contains("auto"));
+        manager.disable_auto();
+        assert!(manager.auto_disabled());
+        assert!(manager.status_message().contains("disabled"));
+    }
+
+    #[test]
+    fn prune_removes_unreferenced_worktree_dirs() {
+        let sessions = tempfile::tempdir().expect("sessions");
+        let storage = tempfile::tempdir().expect("storage");
+        let storage_path = storage.path().to_path_buf();
+        let previous_tmpdir = std::env::var_os("TMPDIR");
+        // SAFETY: test-only TMPDIR override; restored before this test returns.
+        unsafe {
+            std::env::set_var("TMPDIR", &storage_path);
+        }
+
+        let orphan = storage_path
+            .join("yolop")
+            .join("worktrees")
+            .join("abc12345")
+            .join("orphan-session");
+        std::fs::create_dir_all(&orphan).expect("orphan");
+
+        let report = prune_orphan_worktrees(sessions.path(), false).expect("prune");
+        assert_eq!(report.kept, 0);
+        assert_eq!(report.removed.len(), 1);
+        assert!(!orphan.exists());
+
+        // SAFETY: restore prior TMPDIR so later tests see a valid temp root.
+        unsafe {
+            match &previous_tmpdir {
+                Some(value) => std::env::set_var("TMPDIR", value),
+                None => std::env::remove_var("TMPDIR"),
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-ups to the merged worktree support (#156):

- **`/worktree`** — show active branch/path/base, or current mode when inactive
- **`/worktree off`** — disable auto-activation for future turns (does not leave an active worktree)
- **`yolop worktree list`** — list worktree directories under tmp and `~/.yolop/worktrees/`
- **`yolop worktree prune`** — remove on-disk worktrees not referenced by any saved session (`--dry-run` supported)

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] `worktree::disable_auto_and_status_message`
- [x] `worktree::prune_removes_unreferenced_worktree_dirs`

## Security

No new trust boundaries. Prune only removes directories under yolop worktree storage roots that are absent from session `workspace.json` metadata.

## Follow-ups

No follow-ups.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a713b85-93d2-461d-a083-addd356c037e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a713b85-93d2-461d-a083-addd356c037e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

