### PR TITLE
feat(skills): add ast-grep structural-search skill

### DIFF
--- a/skills/ast-grep/SKILL.md
+++ b/skills/ast-grep/SKILL.md
@@ -71,11 +71,13 @@ language=rust    pattern: $X.unwrap()
 # Python — calls to a specific function
 language=python  pattern: requests.get($$$ARGS)
 
-# Python — functions decorated with @app.route
-language=python  pattern: |
-                   @app.route($$$)
-                   def $NAME($$$PARAMS):
-                       $$$BODY
+# Python — functions decorated with @app.route.
+# The `pattern` value is one plain string with embedded newlines — the
+# tool takes a string, not YAML; pass exactly these three lines:
+#   @app.route($$$)
+#   def $NAME($$$PARAMS):
+#       $$$BODY
+language=python  multiline pattern shown above
 
 # TypeScript — console.log calls
 language=typescript  pattern: console.log($$$ARGS)

--- a/skills/ast-grep/SKILL.md
+++ b/skills/ast-grep/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: ast-grep
+description: Write effective ast-grep patterns for the built-in `ast_grep` structural-search tool. Use when searching code by shape rather than text — call expressions, function/struct declarations, wrappers, imports — or when `grep_files` is too noisy, and when a pattern returns nothing or the wrong nodes.
+user-invocable: true
+---
+
+# ast-grep structural search
+
+Yolop ships a built-in `ast_grep` tool: read-only, multi-language structural
+code search backed by the `ast-grep` engine compiled into the binary. This is
+**not** the `sg` command-line tool — there is no `sg run`/`sg scan`, no rule
+YAML files, and no `--rewrite`. Drive the `ast_grep` tool directly with its
+arguments. It never edits code; read matched files with the file tools before
+changing anything.
+
+## When to reach for it
+
+Use `ast_grep` for code **shapes**, after `repo_map`/`grep_files` have narrowed
+the area:
+
+- Call sites of a function regardless of receiver or arguments.
+- Declarations: functions, structs, classes, impls, interfaces.
+- Wrappers and idioms: `unwrap()`, `try/except`, specific decorators/attributes.
+- Anywhere lexical search drowns in comments, strings, or false matches.
+
+Prefer `grep_files` for exact text, identifiers, log strings, or non-code files.
+ast-grep only parses the supported languages below; everything else is skipped.
+
+## Tool arguments
+
+- `pattern` (required): an ast-grep pattern in the **target language's own
+  syntax** (see metavariables below).
+- `language` (recommended): one of `rust`, `python`, `typescript`, `tsx`,
+  `javascript`, `csharp`, `go`, `css`, `html`, `bash`. Without it the pattern is
+  tried against every language and only the ones that parse it contribute.
+- `path` (optional): workspace-relative file or directory. Defaults to the
+  workspace root. Must stay inside the workspace.
+- `limit` (optional): max matches, default 50, max 500.
+- `max_file_bytes` (optional): skip larger source files, default 512 KiB.
+
+Always pass `language` when you know it: it scopes the scan, avoids cross-language
+pattern-compile noise, and is faster.
+
+## Metavariable syntax
+
+Patterns are real code with metavariables standing in for sub-trees:
+
+- `$NAME` — matches exactly one named node (an identifier, expression, etc.).
+  Upper-case, may include digits/underscores. Reusing the same name requires the
+  matches to be identical.
+- `$$$ARGS` — matches zero or more nodes (argument lists, statement bodies,
+  parameter lists). Use it wherever a variable-length sequence appears.
+- `$_` / `$$$` — anonymous wildcards when you don't need the capture text back.
+
+Captured names come back in each match's `captures` array; the matched node's
+`kind`, `text`, and line/column come back too. Use `kind` to confirm you matched
+the construct you intended (e.g. `function_item`, not `call_expression`).
+
+## Pattern recipes
+
+```text
+# Rust — any call to a method named connect, any receiver/args
+language=rust    pattern: $RECV.connect($$$ARGS)
+
+# Rust — function definitions with no parameters
+language=rust    pattern: fn $NAME() { $$$BODY }
+
+# Rust — .unwrap() calls (find panics to harden)
+language=rust    pattern: $X.unwrap()
+
+# Python — calls to a specific function
+language=python  pattern: requests.get($$$ARGS)
+
+# Python — functions decorated with @app.route
+language=python  pattern: |
+                   @app.route($$$)
+                   def $NAME($$$PARAMS):
+                       $$$BODY
+
+# TypeScript — console.log calls
+language=typescript  pattern: console.log($$$ARGS)
+
+# Go — error checks
+language=go      pattern: if err != nil { $$$BODY }
+```
+
+## When a pattern returns nothing
+
+A valid-but-wrong pattern matches zero nodes silently. Work it like this:
+
+1. **Check `pattern_error_languages`** in the result — a non-empty entry means
+   the pattern failed to *compile* for that language (usually a syntax slip or
+   the wrong `language`), not that nothing matched.
+2. **Make the pattern a complete, parseable fragment.** ast-grep parses the
+   pattern with the same grammar as source, so it must stand on its own. Partial
+   fragments like `fn $NAME(` won't parse — write `fn $NAME($$$A) { $$$B }`.
+3. **Loosen with `$$$`.** Replace fixed argument/body content with `$$$` to stop
+   over-constraining; tighten back once you get hits.
+4. **Confirm `kind`.** If matches come back as the wrong node kind, your pattern
+   is matching a sub-expression; add surrounding context to anchor it.
+5. **Widen scope.** Drop `path`, or remove `language` to see which language
+   actually parses the construct, then re-add the right one.
+6. **Fall back to `grep_files`** for a quick identifier sanity check that the
+   symbol exists where you expect.
+
+## Limits
+
+- Read-only: no rewrite/codemod. Make edits with the file tools after locating.
+- Single-pattern only: no relational rules, `inside`/`has`, or YAML configs.
+- Binary, oversized (> `max_file_bytes`), and unsupported-language files are
+  skipped; the result reports those counts.

--- a/src/capabilities/skills.rs
+++ b/src/capabilities/skills.rs
@@ -309,8 +309,11 @@ mod tests {
         materialize_system_skills(&dest).unwrap();
 
         let mut dir_names = Vec::new();
-        for entry in std::fs::read_dir(&dest).unwrap().flatten() {
-            if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+        for entry in std::fs::read_dir(&dest).unwrap() {
+            // Unwrap each entry/file_type so a filesystem error fails the test
+            // loudly instead of silently skipping an embedded skill.
+            let entry = entry.unwrap();
+            if !entry.file_type().unwrap().is_dir() {
                 continue;
             }
             let dir_name = entry.file_name().into_string().unwrap();

--- a/src/capabilities/skills.rs
+++ b/src/capabilities/skills.rs
@@ -297,4 +297,47 @@ mod tests {
             PathBuf::from("/ws/.agents/skills").join("bar")
         );
     }
+
+    #[test]
+    fn embedded_system_skills_parse_with_matching_names() {
+        // Materialize the binary's system skills and validate each through the
+        // upstream parser the capability uses. Every embedded skill must parse,
+        // and its frontmatter `name` must equal its directory name — that name
+        // is the activation/precedence key, so a mismatch is shipped-broken.
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("system-skills");
+        materialize_system_skills(&dest).unwrap();
+
+        let mut dir_names = Vec::new();
+        for entry in std::fs::read_dir(&dest).unwrap().flatten() {
+            if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                continue;
+            }
+            let dir_name = entry.file_name().into_string().unwrap();
+            let md = std::fs::read_to_string(entry.path().join("SKILL.md"))
+                .unwrap_or_else(|_| panic!("{dir_name} has no SKILL.md"));
+            let parsed = everruns_core::skill::parse_skill_md(&md)
+                .unwrap_or_else(|e| panic!("{dir_name}/SKILL.md failed to parse: {e:?}"));
+            assert_eq!(
+                parsed.name, dir_name,
+                "system skill `name` must match its directory"
+            );
+            dir_names.push(dir_name);
+        }
+        assert!(!dir_names.is_empty(), "expected embedded system skills");
+
+        // The ast-grep skill is shipped, parses, and is user-invocable.
+        assert!(
+            dir_names.iter().any(|n| n == "ast-grep"),
+            "ast-grep system skill is shipped: {dir_names:?}"
+        );
+        let md = std::fs::read_to_string(dest.join("ast-grep").join("SKILL.md")).unwrap();
+        let parsed = everruns_core::skill::parse_skill_md(&md).unwrap();
+        assert!(parsed.user_invocable);
+        assert!(
+            parsed.description.to_lowercase().contains("ast-grep"),
+            "description should mention ast-grep: {:?}",
+            parsed.description
+        );
+    }
 }


### PR DESCRIPTION
## What

Adds a new system skill, `skills/ast-grep/SKILL.md`, that documents how to drive
yolop's built-in `ast_grep` tool effectively, plus a test that validates the
shipped system skills.

The skill covers:
- when to reach for structural search vs `grep_files`
- the tool's arguments (`pattern`, `language`, `path`, `limit`, `max_file_bytes`)
- metavariable syntax (`$NAME`, `$$$ARGS`, `$_`) and reading `captures`/`kind`
- per-language pattern recipes (Rust, Python, TS, Go)
- a debugging checklist for the "valid pattern, zero matches" trap

It is scoped deliberately to the **in-process `ast_grep` tool**, not the `sg`
CLI. We don't ship the CLI, and the tool only takes a single `pattern` + optional
`language` (no rule YAML, no rewrite), so CLI-oriented guidance — including the
upstream [`ast-grep/agent-skill`](https://github.com/ast-grep/agent-skill) — was
intentionally **not** imported: it would point the agent at commands and rule
files that don't exist here.

## Why

The `ast_grep` capability already ships a tool plus a one-sentence system-prompt
blurb, but no guidance on *how* to write good patterns — the actual failure mode.
A skill is pulled in on demand, so it closes that gap at zero cost when unused.
`user-invocable: true` makes it available as `/ast-grep` too.

## How it was validated

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all-features` — 461 passed; new test passes. One unrelated
  failure, `worktree::tests::worktree_manager_creates_isolated_branch_on_implementation_prompt`,
  is environmental in this sandbox only: the global git config forces commit
  signing and the local signing server returns HTTP 400, so the test's
  `git commit` / `git worktree add` cannot write a HEAD. That test is in
  `src/worktree.rs` (untouched here; arrived via rebase from #156) and passes on
  GitHub Actions. CI is the source of truth.
- `cargo run -- --provider llmsim -p "hi"` — binary starts, `ast_grep` registered.

### Test

`embedded_system_skills_parse_with_matching_names` materializes the embedded
system skills and runs each through the upstream `parse_skill_md` — asserting
every shipped skill parses and its frontmatter `name` matches its directory, and
that the `ast-grep` skill is present, parses, and is user-invocable. This drives
the real shipped artifact, not a constructor.

## Security

No security-relevant code changes. The change adds a Markdown skill (data
embedded in the binary, read-only system scope) and a test. No new dependencies,
no filesystem/shell/LLM code paths touched.

## Follow-ups

No follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QSsXTXnSQ75GbwKPtrn1Kd)_