### PR TITLE
fix(runtime): keep recent tool output window

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -507,6 +507,7 @@ const YOLOP_NEVER_DEFER_TOOLS: &[&str] = &[
     "write_todos",
     "run_yolop_command",
 ];
+const YOLOP_KEEP_RECENT_TOOL_OUTPUTS: u64 = 3;
 
 #[derive(Clone, Debug)]
 pub enum ProviderChoice {
@@ -1429,7 +1430,7 @@ fn default_coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabi
                 "proactive": true,
                 "budget_percent": 0.20,
                 "observation_masking": {
-                    "keep_recent_tool_outputs": 1,
+                    "keep_recent_tool_outputs": YOLOP_KEEP_RECENT_TOOL_OUTPUTS,
                     "summary_format": "one_line"
                 }
             }),
@@ -4151,6 +4152,23 @@ mod tests {
         assert!(
             ids.iter()
                 .any(|cap| cap.capability_id() == "loop_detection")
+        );
+    }
+
+    #[test]
+    fn coding_harness_keeps_small_recent_tool_output_window() {
+        let ids = coding_harness_capabilities(false, None, &Settings::default());
+        let compaction = ids
+            .iter()
+            .find(|cap| cap.capability_id() == COMPACTION_CAPABILITY_ID)
+            .expect("compaction capability");
+
+        assert_eq!(
+            compaction
+                .config
+                .pointer("/observation_masking/keep_recent_tool_outputs")
+                .and_then(|value| value.as_u64()),
+            Some(3)
         );
     }
 


### PR DESCRIPTION
## What
Raise Yolop's default compaction observation window from one recent tool output to three.

## Why
The pathological local session lost adjacent paginated read context too aggressively. Everruns is getting central fixes, but Yolop should not default to the most brittle possible window for saved-output inspection.

## How
- Add a named `YOLOP_KEEP_RECENT_TOOL_OUTPUTS` default set to `3`.
- Use it in the default `compaction` capability config.
- Add a runtime test that asserts the effective default remains three recent tool outputs.

## Risk
- Low
- Slightly more recent tool output can stay visible in model context, but the window remains bounded and central compaction still masks older outputs.

## Security
No new input, filesystem, command, network, or secret-handling surface.

## Validation
- `cargo fmt --check`
- `cargo test coding_harness_keeps_small_recent_tool_output_window`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features -- --test-threads=1`
- `cargo run -- --provider llmsim -p "hi"`

Note: an initial parallel `cargo test --all-features` hit a process-wide cwd race in `worktree::tests::worktree_manager_creates_isolated_branch_on_implementation_prompt`; the failing test passed in isolation, and the serial full-suite rerun passed.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
