### PR TITLE
fix(model): derive effort from model profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ tools. See [`specs/mcp.md`](specs/mcp.md).
 | `--acp`                    | Speak the Agent Client Protocol over stdio (for editors like Zed)    |
 | `--session <ID>`           | Resume a previous session by id                                      |
 | `--session-dir <PATH>`     | Override the parent directory for session folders                    |
-| `--reasoning-effort <E>`   | OpenAI/Codex/OpenRouter/custom reasoning effort (`minimal` / `low` / `medium` / `high`) |
+| `--reasoning-effort <E>`   | Reasoning effort override when the selected model profile supports it |
 
 ### Commands
 
@@ -304,7 +304,7 @@ tools. See [`specs/mcp.md`](specs/mcp.md).
 | `CUSTOM_BASE_URL`               | Select the custom OpenAI-compatible endpoint (beats the saved base URL) |
 | `CUSTOM_API_KEY`                | Optional key for the custom endpoint (a placeholder is sent otherwise) |
 | `EVERRUNS_CLI_MODEL`            | Override the auto-selected default model (beats the saved model) |
-| `EVERRUNS_CLI_REASONING_EFFORT` | OpenAI/Codex/OpenRouter/custom reasoning effort override     |
+| `EVERRUNS_CLI_REASONING_EFFORT` | Reasoning effort override when the selected model profile supports it |
 
 ### Settings
 
@@ -351,9 +351,10 @@ provider has no saved model, the global `default_model` setting (if set) is
 applied as a cross-provider fallback. At runtime, the
 per-provider env var (`OPENAI_API_KEY`, etc.) always beats the saved token,
 so a per-run env override is always possible. `/model <id>` opens the model
-picker prefilled for the active provider. OpenAI, Codex, OpenRouter, and custom
-endpoint reasoning effort can be changed at runtime with the `/effort` modal
-or `/setup effort <level>` (for example, `high` or `medium`).
+picker prefilled for the active provider. Reasoning effort can be changed at
+runtime with the `/effort` modal or `/setup effort <level>` when the selected
+model profile exposes effort levels. The available values and default come from
+that model profile, so they can vary by model.
 
 `/setup` can store an API token under `[tokens]` in the settings file. The
 Codex subscription provider stores OAuth data under `[codex_auth]` instead.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -293,35 +293,6 @@ pub(crate) struct ModelOption {
     hint: String,
 }
 
-pub(crate) struct EffortOption {
-    value: &'static str,
-    label: &'static str,
-    hint: &'static str,
-}
-
-const EFFORT_OPTIONS: &[EffortOption] = &[
-    EffortOption {
-        value: "minimal",
-        label: "Minimal",
-        hint: "least reasoning",
-    },
-    EffortOption {
-        value: "low",
-        label: "Low",
-        hint: "faster responses",
-    },
-    EffortOption {
-        value: "medium",
-        label: "Medium",
-        hint: "balanced default",
-    },
-    EffortOption {
-        value: "high",
-        label: "High",
-        hint: "more reasoning for hard tasks",
-    },
-];
-
 /// Owned snapshot of the App fields the pure-render chrome helpers
 /// (command suggestions, stream preview, separators, session status)
 /// consume. Extracted from `App` so those helpers can be exercised by
@@ -4924,11 +4895,11 @@ mod tests {
             .await;
 
         assert!(app.setup.is_none(), "wizard should finish: {:?}", app.setup);
-        assert_eq!(app.model.provider_label(), "openai/gpt-5.4 medium");
+        assert_eq!(app.model.provider_label(), "openai/gpt-5.4 none");
         assert!(
             app.lines
                 .iter()
-                .any(|line| line.text == "setup complete: openai/gpt-5.4 medium"),
+                .any(|line| line.text == "setup complete: openai/gpt-5.4 none"),
             "completion line should report the picked model: {:?}",
             app.lines
         );
@@ -4936,7 +4907,7 @@ mod tests {
         // pick_provider_applies_saved_model_for_saved_provider in main.rs).
         let snapshot = app.settings.snapshot();
         assert_eq!(snapshot.default_provider.as_deref(), Some("openai"));
-        assert_eq!(snapshot.model_for("openai"), Some("gpt-5.4 medium"));
+        assert_eq!(snapshot.model_for("openai"), Some("gpt-5.4 none"));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -5152,7 +5123,7 @@ mod tests {
         app.lines.clear();
         app.dispatch_command_for_test("effort high").await;
 
-        assert_eq!(app.model.provider_label(), "openai/gpt-5.4 medium");
+        assert_eq!(app.model.provider_label(), "openai/gpt-5.4 none");
         assert!(matches!(
             app.setup,
             Some(SetupStep::PickEffort { selected: 3, .. })

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -589,31 +589,29 @@ pub(crate) fn setup_overlay_content(app: &App) -> (Vec<Line<'static>>, Option<(u
         Some(SetupStep::PickEffort { selected, error }) => {
             lines.push(setup_title("Select Reasoning Effort"));
             lines.push(setup_hint(
-                "Applies to OpenAI, Codex, OpenRouter, and custom endpoints — this session and future sessions.",
+                "Profile-defined options for the current model — this session and future sessions.",
             ));
             lines.push(Line::from(""));
-            let label = app.model.provider_label();
-            let current = if label.starts_with("openai/") || label.starts_with("codex/") {
-                label
-                    .split_whitespace()
-                    .nth(1)
-                    .unwrap_or("medium")
-                    .to_string()
-            } else if label.starts_with("openrouter/") || label.starts_with("custom/") {
-                label
-                    .split_whitespace()
-                    .nth(1)
-                    .unwrap_or_default()
-                    .to_string()
-            } else {
-                String::new()
-            };
-            for (idx, option) in EFFORT_OPTIONS.iter().enumerate() {
-                let mut hint = option.hint.to_string();
-                if option.value == current {
-                    hint.push_str(" · current");
+            let options = app.model.reasoning_effort_options();
+            let current = app.model.reasoning_effort();
+            let default = app.model.default_reasoning_effort();
+            if options.is_empty() {
+                lines.push(setup_hint(
+                    "No reasoning effort options in this model profile.",
+                ));
+            }
+            for (idx, option) in options.iter().enumerate() {
+                let mut hint = String::new();
+                if Some(option.value.as_str()) == current.as_deref() {
+                    hint.push_str("current");
                 }
-                lines.push(setup_row(idx == *selected, idx + 1, option.label, &hint));
+                if Some(option.value.as_str()) == default.as_deref() {
+                    if !hint.is_empty() {
+                        hint.push_str(" · ");
+                    }
+                    hint.push_str("profile default");
+                }
+                lines.push(setup_row(idx == *selected, idx + 1, &option.label, &hint));
             }
             push_setup_error(&mut lines, error.as_deref());
             lines.push(setup_footer("Enter confirm · ↑/↓ move · Esc cancel"));
@@ -1376,12 +1374,6 @@ pub(crate) fn model_window(selected: usize, total: usize, max_rows: usize) -> (u
     }
     let start = selected.saturating_sub(max_rows / 2).min(total - max_rows);
     (start, start + max_rows)
-}
-
-pub(crate) fn effort_index(value: &str) -> Option<usize> {
-    EFFORT_OPTIONS
-        .iter()
-        .position(|option| option.value.eq_ignore_ascii_case(value))
 }
 
 pub(crate) fn inset_x(area: Rect, pad: u16) -> Rect {

--- a/src/app/setup.rs
+++ b/src/app/setup.rs
@@ -55,10 +55,14 @@ impl App {
 
     pub(crate) fn start_effort_setup(&mut self, raw: &str) {
         let raw = raw.trim();
-        let selected = effort_index(raw).unwrap_or_else(|| self.current_effort_index());
+        let selected = self
+            .effort_index(raw)
+            .unwrap_or_else(|| self.current_effort_index());
         self.setup = Some(SetupStep::PickEffort {
             selected,
-            error: if raw.is_empty() || effort_index(raw).is_some() {
+            error: if self.model.reasoning_effort_options().is_empty() {
+                Some("current model profile does not expose reasoning efforts".to_string())
+            } else if raw.is_empty() || self.effort_index(raw).is_some() {
                 None
             } else {
                 Some(format!("unknown effort: {raw}"))
@@ -67,19 +71,24 @@ impl App {
     }
 
     pub(crate) fn current_effort_index(&self) -> usize {
-        let label = self.model.provider_label();
-        if !label.starts_with("openai/")
-            && !label.starts_with("codex/")
-            && !label.starts_with("openrouter/")
-            && !label.starts_with("custom/")
-        {
-            return effort_index("medium").unwrap_or(0);
-        }
-        label
-            .split_whitespace()
-            .nth(1)
-            .and_then(effort_index)
-            .unwrap_or_else(|| effort_index("medium").unwrap_or(0))
+        self.model
+            .reasoning_effort()
+            .as_deref()
+            .and_then(|effort| self.effort_index(effort))
+            .or_else(|| {
+                self.model
+                    .default_reasoning_effort()
+                    .as_deref()
+                    .and_then(|effort| self.effort_index(effort))
+            })
+            .unwrap_or(0)
+    }
+
+    pub(crate) fn effort_index(&self, value: &str) -> Option<usize> {
+        self.model
+            .reasoning_effort_options()
+            .iter()
+            .position(|option| option.value.eq_ignore_ascii_case(value))
     }
 
     pub(crate) fn current_provider_name(&self) -> String {
@@ -1220,6 +1229,7 @@ impl App {
     }
 
     pub(crate) async fn handle_effort_key(&mut self, key: KeyEvent, selected: usize) {
+        let options_len = self.model.reasoning_effort_options().len();
         match key.code {
             KeyCode::Esc => {
                 self.setup = None;
@@ -1232,12 +1242,12 @@ impl App {
             }
             KeyCode::Down | KeyCode::Char('j') => {
                 self.setup = Some(SetupStep::PickEffort {
-                    selected: (selected + 1).min(EFFORT_OPTIONS.len().saturating_sub(1)),
+                    selected: (selected + 1).min(options_len.saturating_sub(1)),
                     error: None,
                 });
             }
             KeyCode::Char(ch) if ch.is_ascii_digit() => {
-                if let Some(index) = digit_index(ch, EFFORT_OPTIONS.len()) {
+                if let Some(index) = digit_index(ch, options_len) {
                     self.confirm_effort(index).await;
                 }
             }
@@ -1249,10 +1259,11 @@ impl App {
     }
 
     pub(crate) async fn confirm_effort(&mut self, selected: usize) {
-        let Some(option) = EFFORT_OPTIONS.get(selected) else {
+        let options = self.model.reasoning_effort_options();
+        let Some(option) = options.get(selected) else {
             self.setup = Some(SetupStep::PickEffort {
                 selected: 0,
-                error: None,
+                error: Some("current model profile does not expose reasoning efforts".to_string()),
             });
             return;
         };

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -556,12 +556,6 @@ fn setup_command_arg() -> CommandArg {
             .copied()
             .map(|model| format!("model {model}")),
     );
-    suggestions.extend(
-        ProviderChoice::reasoning_effort_suggestions()
-            .iter()
-            .copied()
-            .map(|effort| format!("effort {effort}")),
-    );
 
     CommandArg {
         name: "action".to_string(),
@@ -813,7 +807,12 @@ impl SetupCapability {
                 message: format!(
                     "setup effort: {}; suggestions: {}",
                     current.label(),
-                    ProviderChoice::reasoning_effort_suggestions().join(", ")
+                    current
+                        .reasoning_effort_options()
+                        .iter()
+                        .map(|effort| effort.value.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
                 ),
                 error_code: None,
                 error_fields: None,

--- a/src/capabilities/model_discovery.rs
+++ b/src/capabilities/model_discovery.rs
@@ -377,6 +377,7 @@ mod tests {
         let provider = ProviderChoice::Ollama {
             model: "llama3.2".to_string(),
             base_url: format!("http://{addr}/v1"),
+            reasoning_effort: None,
         };
         let models = discover_provider_models(&provider, &Settings::default())
             .await

--- a/src/codex_driver.rs
+++ b/src/codex_driver.rs
@@ -8,6 +8,7 @@ use everruns_core::driver_registry::{
 use everruns_core::driver_registry::{DiscoveredModel, DriverRegistry};
 use everruns_core::error::{AgentLoopError, Result as EverrunsResult};
 use everruns_core::tool_types::{ToolCall, ToolDefinition};
+use everruns_core::{DriverId, ModelProfile, get_model_profile};
 use futures::StreamExt;
 use reqwest::header::{HeaderMap, HeaderValue};
 use serde::Serialize;
@@ -36,6 +37,10 @@ pub fn register_driver(registry: &mut DriverRegistry) {
     registry.register_external(CODEX_DRIVER_ID, |config| {
         Box::new(CodexChatDriver::from_config(config))
     });
+}
+
+pub(crate) fn model_profile(model_id: &str) -> Option<ModelProfile> {
+    get_model_profile(&DriverId::OpenAI, model_id)
 }
 
 impl CodexChatDriver {

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,57 +249,33 @@ fn pick_provider(cli: &Cli, settings: &SettingsStore) -> (ProviderChoice, Vec<St
 
     notes.extend(resolved.notes);
     let base = resolved.choice;
-    let selected = match (base, cli.model.clone()) {
-        (ProviderChoice::Anthropic { .. }, Some(m)) => ProviderChoice::Anthropic { model: m },
-        (
-            ProviderChoice::OpenAi {
-                reasoning_effort, ..
-            },
-            Some(m),
-        ) => ProviderChoice::OpenAi {
-            model: m,
-            reasoning_effort: cli_reasoning_effort.clone().or(reasoning_effort),
-        },
-        (
-            ProviderChoice::Codex {
-                reasoning_effort, ..
-            },
-            Some(m),
-        ) => ProviderChoice::Codex {
-            model: m,
-            reasoning_effort: cli_reasoning_effort.clone().or(reasoning_effort),
-        },
-        (ProviderChoice::Google { base_url, .. }, Some(m)) => {
-            ProviderChoice::Google { model: m, base_url }
+    let selected = if let Some(model) = cli.model.clone() {
+        let spec = match cli_reasoning_effort.clone() {
+            Some(effort) => format!("{model} {effort}"),
+            None => model,
+        };
+        match base.resolve_model_spec(&spec) {
+            Ok(selected) => selected,
+            Err(err) => {
+                notes.push(format!("model override ignored: {err}"));
+                base
+            }
         }
-        (
-            ProviderChoice::OpenRouter {
-                base_url,
-                reasoning_effort,
-                ..
-            },
-            Some(m),
-        ) => ProviderChoice::OpenRouter {
-            model: m,
-            base_url,
-            reasoning_effort: cli_reasoning_effort.clone().or(reasoning_effort),
-        },
-        (ProviderChoice::Ollama { base_url, .. }, Some(m)) => {
-            ProviderChoice::Ollama { model: m, base_url }
-        }
-        (
-            ProviderChoice::Custom {
-                reasoning_effort, ..
-            },
-            Some(m),
-        ) => ProviderChoice::Custom {
-            model: m,
-            reasoning_effort: cli_reasoning_effort.clone().or(reasoning_effort),
-        },
-        (other, _) => other,
+    } else {
+        base
     };
     let selected = match (selected, cli_reasoning_effort) {
         (
+            ProviderChoice::Anthropic {
+                model,
+                reasoning_effort,
+            },
+            effort,
+        ) => ProviderChoice::Anthropic {
+            model,
+            reasoning_effort: effort.or(reasoning_effort),
+        },
+        (
             ProviderChoice::OpenAi {
                 model,
                 reasoning_effort,
@@ -320,6 +296,18 @@ fn pick_provider(cli: &Cli, settings: &SettingsStore) -> (ProviderChoice, Vec<St
             reasoning_effort: effort.or(reasoning_effort),
         },
         (
+            ProviderChoice::Google {
+                model,
+                base_url,
+                reasoning_effort,
+            },
+            effort,
+        ) => ProviderChoice::Google {
+            model,
+            base_url,
+            reasoning_effort: effort.or(reasoning_effort),
+        },
+        (
             ProviderChoice::OpenRouter {
                 model,
                 base_url,
@@ -327,6 +315,18 @@ fn pick_provider(cli: &Cli, settings: &SettingsStore) -> (ProviderChoice, Vec<St
             },
             effort,
         ) => ProviderChoice::OpenRouter {
+            model,
+            base_url,
+            reasoning_effort: effort.or(reasoning_effort),
+        },
+        (
+            ProviderChoice::Ollama {
+                model,
+                base_url,
+                reasoning_effort,
+            },
+            effort,
+        ) => ProviderChoice::Ollama {
             model,
             base_url,
             reasoning_effort: effort.or(reasoning_effort),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -27,7 +27,6 @@ use crate::settings::{Settings, SettingsStore};
 use crate::tools::Workspace;
 use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
-use everruns_core::DriverId;
 use everruns_core::capabilities::{
     AGENT_INSTRUCTIONS_CAPABILITY_ID, AgentInstructionsCapability, BTW_CAPABILITY_ID,
     BtwCapability, COMPACTION_CAPABILITY_ID, CompactionCapability, FileSystemCapability,
@@ -51,6 +50,7 @@ use everruns_core::{
     ReasoningConfig, ResolvedModel, ScopedMcpServers, SessionFileSystem, SessionFileSystemFactory,
     SessionFileSystemFactoryContext,
 };
+use everruns_core::{DriverId, ModelProfile, ReasoningEffortConfig, ReasoningEffortValue};
 use everruns_integrations_daytona::DaytonaCapability;
 use everruns_integrations_duckduckgo::DuckDuckGoCapability;
 use everruns_runtime::{
@@ -480,9 +480,7 @@ impl SessionFileSystem for CodingCliSessionFileStore {
 // ---------- provider selection ----------
 
 const DEFAULT_OPENAI_MODEL: &str = "gpt-5.5";
-const DEFAULT_OPENAI_REASONING_EFFORT: &str = "medium";
 const DEFAULT_CODEX_MODEL: &str = "gpt-5.5";
-const REASONING_EFFORT_SUGGESTIONS: &[&str] = &["minimal", "low", "medium", "high"];
 const DEFAULT_ANTHROPIC_MODEL: &str = "claude-sonnet-4-5";
 const DEFAULT_GOOGLE_MODEL: &str = "gemini-2.5-flash";
 // Gemini exposes an OpenAI-compatible surface at this base URL, driven through
@@ -512,6 +510,7 @@ const YOLOP_NEVER_DEFER_TOOLS: &[&str] = &[
 pub enum ProviderChoice {
     Anthropic {
         model: String,
+        reasoning_effort: Option<String>,
     },
     OpenAi {
         model: String,
@@ -524,6 +523,7 @@ pub enum ProviderChoice {
     Google {
         model: String,
         base_url: String,
+        reasoning_effort: Option<String>,
     },
     OpenRouter {
         model: String,
@@ -533,6 +533,7 @@ pub enum ProviderChoice {
     Ollama {
         model: String,
         base_url: String,
+        reasoning_effort: Option<String>,
     },
     /// Generic OpenAI-compatible endpoint (vLLM, llama.cpp, LM Studio,
     /// hosted gateways, …). Unlike the other variants the base URL is not
@@ -545,6 +546,12 @@ pub enum ProviderChoice {
         reasoning_effort: Option<String>,
     },
     Sim,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ReasoningEffortOption {
+    pub value: String,
+    pub label: String,
 }
 
 /// Provider names recognized by `/setup` and persisted settings. The order
@@ -573,32 +580,49 @@ impl ProviderChoice {
             return Self::default_codex();
         }
         if env_non_empty("ANTHROPIC_API_KEY").is_some() || settings.has_token("anthropic") {
+            let model = env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_ANTHROPIC_MODEL);
             return Self::Anthropic {
-                model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_ANTHROPIC_MODEL),
+                reasoning_effort: normalize_reasoning_effort(env_non_empty(
+                    "EVERRUNS_CLI_REASONING_EFFORT",
+                ))
+                .or_else(|| profile_default_reasoning_effort(&DriverId::Anthropic, &model)),
+                model,
             };
         }
         if env_non_empty("OPENROUTER_API_KEY").is_some() || settings.has_token("openrouter") {
+            let model = env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_OPENROUTER_MODEL);
             return Self::OpenRouter {
-                model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_OPENROUTER_MODEL),
                 base_url: env_or_default("OPENROUTER_BASE_URL", DEFAULT_OPENROUTER_BASE_URL),
                 reasoning_effort: normalize_reasoning_effort(env_non_empty(
                     "EVERRUNS_CLI_REASONING_EFFORT",
-                )),
+                ))
+                .or_else(|| profile_default_reasoning_effort(&DriverId::OpenRouter, &model)),
+                model,
             };
         }
         if google_api_key().is_some() || settings.has_token("google") {
+            let model = env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_GOOGLE_MODEL);
             return Self::Google {
-                model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_GOOGLE_MODEL),
                 base_url: env_or_default("GOOGLE_BASE_URL", DEFAULT_GOOGLE_BASE_URL),
+                reasoning_effort: normalize_reasoning_effort(env_non_empty(
+                    "EVERRUNS_CLI_REASONING_EFFORT",
+                ))
+                .or_else(|| profile_default_reasoning_effort(&DriverId::OpenAI, &model)),
+                model,
             };
         }
         if env_non_empty("OLLAMA_BASE_URL").is_some()
             || env_non_empty("OLLAMA_API_KEY").is_some()
             || settings.has_token("ollama")
         {
+            let model = env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_OLLAMA_MODEL);
             return Self::Ollama {
-                model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_OLLAMA_MODEL),
                 base_url: env_or_default("OLLAMA_BASE_URL", DEFAULT_OLLAMA_BASE_URL),
+                reasoning_effort: normalize_reasoning_effort(env_non_empty(
+                    "EVERRUNS_CLI_REASONING_EFFORT",
+                ))
+                .or_else(|| profile_default_reasoning_effort(&DriverId::OpenAI, &model)),
+                model,
             };
         }
         // The custom endpoint has no default model, so it is auto-selected
@@ -610,72 +634,51 @@ impl ProviderChoice {
             && (env_non_empty("EVERRUNS_CLI_MODEL").is_some()
                 || settings.model_for("custom").is_some())
         {
+            let model = env_or_default("EVERRUNS_CLI_MODEL", "");
             return Self::Custom {
-                model: env_or_default("EVERRUNS_CLI_MODEL", ""),
                 reasoning_effort: normalize_reasoning_effort(env_non_empty(
                     "EVERRUNS_CLI_REASONING_EFFORT",
-                )),
+                ))
+                .or_else(|| profile_default_reasoning_effort(&DriverId::OpenAICompletions, &model)),
+                model,
             };
         }
         Self::default_openai()
     }
 
     fn default_openai() -> Self {
+        let model = env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_OPENAI_MODEL);
         Self::OpenAi {
-            model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_OPENAI_MODEL),
-            reasoning_effort: Some(env_or_default(
+            reasoning_effort: normalize_reasoning_effort(env_non_empty(
                 "EVERRUNS_CLI_REASONING_EFFORT",
-                DEFAULT_OPENAI_REASONING_EFFORT,
-            )),
+            ))
+            .or_else(|| profile_default_reasoning_effort(&DriverId::OpenAI, &model)),
+            model,
         }
     }
 
     fn default_codex() -> Self {
+        let model = env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_CODEX_MODEL);
         Self::Codex {
-            model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_CODEX_MODEL),
-            reasoning_effort: Some(env_or_default(
+            reasoning_effort: normalize_reasoning_effort(env_non_empty(
                 "EVERRUNS_CLI_REASONING_EFFORT",
-                DEFAULT_OPENAI_REASONING_EFFORT,
-            )),
+            ))
+            .or_else(|| {
+                crate::codex_driver::model_profile(&model)
+                    .and_then(|profile| profile.reasoning_effort)
+                    .and_then(|config| reasoning_effort_value(&config.default))
+            }),
+            model,
         }
     }
 
     pub fn label(&self) -> String {
-        match self {
-            Self::Anthropic { model } => format!("anthropic/{model}"),
-            Self::OpenAi {
-                model,
-                reasoning_effort,
-            } => match reasoning_effort {
-                Some(effort) => format!("openai/{model} {effort}"),
-                None => format!("openai/{model}"),
-            },
-            Self::Codex {
-                model,
-                reasoning_effort,
-            } => match reasoning_effort {
-                Some(effort) => format!("codex/{model} {effort}"),
-                None => format!("codex/{model}"),
-            },
-            Self::Google { model, .. } => format!("google/{model}"),
-            Self::OpenRouter {
-                model,
-                reasoning_effort,
-                ..
-            } => match reasoning_effort {
-                Some(effort) => format!("openrouter/{model} {effort}"),
-                None => format!("openrouter/{model}"),
-            },
-            Self::Ollama { model, .. } => format!("ollama/{model}"),
-            Self::Custom {
-                model,
-                reasoning_effort,
-            } => match reasoning_effort {
-                Some(effort) => format!("custom/{model} {effort}"),
-                None => format!("custom/{model}"),
-            },
-            Self::Sim => "llmsim/llmsim-yolop".to_string(),
+        let mut label = format!("{}/{}", self.provider_name(), self.model_id());
+        if let Some(effort) = self.reasoning_effort() {
+            label.push(' ');
+            label.push_str(effort);
         }
+        label
     }
 
     /// Short name used in settings and command suggestions.
@@ -699,33 +702,64 @@ impl ProviderChoice {
         match name.trim().to_ascii_lowercase().as_str() {
             "openai" => Ok(Self::default_openai()),
             "codex" => Ok(Self::default_codex()),
-            "anthropic" => Ok(Self::Anthropic {
-                model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_ANTHROPIC_MODEL),
-            }),
-            "google" => Ok(Self::Google {
-                model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_GOOGLE_MODEL),
-                base_url: env_or_default("GOOGLE_BASE_URL", DEFAULT_GOOGLE_BASE_URL),
-            }),
-            "openrouter" => Ok(Self::OpenRouter {
-                model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_OPENROUTER_MODEL),
-                base_url: env_or_default("OPENROUTER_BASE_URL", DEFAULT_OPENROUTER_BASE_URL),
-                reasoning_effort: normalize_reasoning_effort(env_non_empty(
-                    "EVERRUNS_CLI_REASONING_EFFORT",
-                )),
-            }),
-            "ollama" => Ok(Self::Ollama {
-                model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_OLLAMA_MODEL),
-                base_url: env_or_default("OLLAMA_BASE_URL", DEFAULT_OLLAMA_BASE_URL),
-            }),
+            "anthropic" => {
+                let model = env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_ANTHROPIC_MODEL);
+                Ok(Self::Anthropic {
+                    reasoning_effort: normalize_reasoning_effort(env_non_empty(
+                        "EVERRUNS_CLI_REASONING_EFFORT",
+                    ))
+                    .or_else(|| profile_default_reasoning_effort(&DriverId::Anthropic, &model)),
+                    model,
+                })
+            }
+            "google" => {
+                let model = env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_GOOGLE_MODEL);
+                Ok(Self::Google {
+                    base_url: env_or_default("GOOGLE_BASE_URL", DEFAULT_GOOGLE_BASE_URL),
+                    reasoning_effort: normalize_reasoning_effort(env_non_empty(
+                        "EVERRUNS_CLI_REASONING_EFFORT",
+                    ))
+                    .or_else(|| profile_default_reasoning_effort(&DriverId::OpenAI, &model)),
+                    model,
+                })
+            }
+            "openrouter" => {
+                let model = env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_OPENROUTER_MODEL);
+                Ok(Self::OpenRouter {
+                    base_url: env_or_default("OPENROUTER_BASE_URL", DEFAULT_OPENROUTER_BASE_URL),
+                    reasoning_effort: normalize_reasoning_effort(env_non_empty(
+                        "EVERRUNS_CLI_REASONING_EFFORT",
+                    ))
+                    .or_else(|| profile_default_reasoning_effort(&DriverId::OpenRouter, &model)),
+                    model,
+                })
+            }
+            "ollama" => {
+                let model = env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_OLLAMA_MODEL);
+                Ok(Self::Ollama {
+                    base_url: env_or_default("OLLAMA_BASE_URL", DEFAULT_OLLAMA_BASE_URL),
+                    reasoning_effort: normalize_reasoning_effort(env_non_empty(
+                        "EVERRUNS_CLI_REASONING_EFFORT",
+                    ))
+                    .or_else(|| profile_default_reasoning_effort(&DriverId::OpenAI, &model)),
+                    model,
+                })
+            }
             // No sensible default model exists for an arbitrary endpoint; an
             // empty model is rejected later by `model_with_provider` so the
             // setup wizard (or a saved model from settings) must fill it in.
-            "custom" => Ok(Self::Custom {
-                model: env_or_default("EVERRUNS_CLI_MODEL", ""),
-                reasoning_effort: normalize_reasoning_effort(env_non_empty(
-                    "EVERRUNS_CLI_REASONING_EFFORT",
-                )),
-            }),
+            "custom" => {
+                let model = env_or_default("EVERRUNS_CLI_MODEL", "");
+                Ok(Self::Custom {
+                    reasoning_effort: normalize_reasoning_effort(env_non_empty(
+                        "EVERRUNS_CLI_REASONING_EFFORT",
+                    ))
+                    .or_else(|| {
+                        profile_default_reasoning_effort(&DriverId::OpenAICompletions, &model)
+                    }),
+                    model,
+                })
+            }
             "llmsim" => Ok(Self::Sim),
             other => Err(anyhow!(
                 "unknown provider {other}; expected one of {}",
@@ -910,7 +944,7 @@ pub fn resolve_for_settings(provider: &str, settings: &Settings) -> Result<Resol
 impl ProviderChoice {
     pub fn model_id(&self) -> &str {
         match self {
-            Self::Anthropic { model }
+            Self::Anthropic { model, .. }
             | Self::OpenAi { model, .. }
             | Self::Codex { model, .. }
             | Self::Google { model, .. }
@@ -922,16 +956,57 @@ impl ProviderChoice {
     }
 
     pub fn reasoning_effort(&self) -> Option<&str> {
+        self.reasoning_effort_value().and_then(Option::as_deref)
+    }
+
+    pub(crate) fn reasoning_effort_options(&self) -> Vec<ReasoningEffortOption> {
+        self.reasoning_effort_config()
+            .map(|config| config.values.iter().map(reasoning_effort_option).collect())
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn default_reasoning_effort(&self) -> Option<String> {
+        self.reasoning_effort_config()
+            .and_then(|config| reasoning_effort_value(&config.default))
+    }
+
+    fn reasoning_effort_config(&self) -> Option<ReasoningEffortConfig> {
+        self.model_profile()?.reasoning_effort
+    }
+
+    fn model_profile(&self) -> Option<ModelProfile> {
+        match self {
+            Self::Codex { model, .. } => crate::codex_driver::model_profile(model),
+            _ => {
+                let resolved = self.model_without_stored_key();
+                get_model_profile(&resolved.provider_type, &resolved.model)
+            }
+        }
+    }
+
+    fn reasoning_effort_value(&self) -> Option<&Option<String>> {
         match self {
             Self::OpenAi {
+                reasoning_effort, ..
+            }
+            | Self::Anthropic {
+                reasoning_effort, ..
+            }
+            | Self::Codex {
+                reasoning_effort, ..
+            }
+            | Self::Google {
                 reasoning_effort, ..
             }
             | Self::OpenRouter {
                 reasoning_effort, ..
             }
+            | Self::Ollama {
+                reasoning_effort, ..
+            }
             | Self::Custom {
                 reasoning_effort, ..
-            } => reasoning_effort.as_deref(),
+            } => Some(reasoning_effort),
             _ => None,
         }
     }
@@ -1010,52 +1085,64 @@ impl ProviderChoice {
         }
         match self {
             Self::Anthropic { .. } => {
-                if reasoning_effort.is_some() {
-                    return Err(anyhow!(
-                        "anthropic model switching does not accept reasoning effort"
-                    ));
-                }
-                Ok(Self::Anthropic { model })
+                let reasoning_effort =
+                    self.resolve_model_reasoning_effort(&model, reasoning_effort)?;
+                Ok(Self::Anthropic {
+                    model,
+                    reasoning_effort,
+                })
             }
-            Self::OpenAi { .. } => Ok(Self::OpenAi {
-                model,
-                reasoning_effort: normalize_openai_reasoning_effort(reasoning_effort),
-            }),
-            Self::Codex { .. } => Ok(Self::Codex {
-                model,
-                reasoning_effort: normalize_openai_reasoning_effort(reasoning_effort),
-            }),
+            Self::OpenAi { .. } => {
+                let reasoning_effort =
+                    self.resolve_model_reasoning_effort(&model, reasoning_effort)?;
+                Ok(Self::OpenAi {
+                    model,
+                    reasoning_effort,
+                })
+            }
+            Self::Codex { .. } => {
+                let reasoning_effort =
+                    self.resolve_model_reasoning_effort(&model, reasoning_effort)?;
+                Ok(Self::Codex {
+                    model,
+                    reasoning_effort,
+                })
+            }
             Self::Google { base_url, .. } => {
-                if reasoning_effort.is_some() {
-                    return Err(anyhow!(
-                        "google model switching does not accept reasoning effort"
-                    ));
-                }
+                let reasoning_effort =
+                    self.resolve_model_reasoning_effort(&model, reasoning_effort)?;
                 Ok(Self::Google {
                     model,
                     base_url: base_url.clone(),
+                    reasoning_effort,
                 })
             }
-            Self::OpenRouter { base_url, .. } => Ok(Self::OpenRouter {
-                model,
-                base_url: base_url.clone(),
-                reasoning_effort: normalize_reasoning_effort(reasoning_effort),
-            }),
+            Self::OpenRouter { base_url, .. } => {
+                let reasoning_effort =
+                    self.resolve_model_reasoning_effort(&model, reasoning_effort)?;
+                Ok(Self::OpenRouter {
+                    model,
+                    base_url: base_url.clone(),
+                    reasoning_effort,
+                })
+            }
             Self::Ollama { base_url, .. } => {
-                if reasoning_effort.is_some() {
-                    return Err(anyhow!(
-                        "ollama model switching does not accept reasoning effort"
-                    ));
-                }
+                let reasoning_effort =
+                    self.resolve_model_reasoning_effort(&model, reasoning_effort)?;
                 Ok(Self::Ollama {
                     model,
                     base_url: base_url.clone(),
+                    reasoning_effort,
                 })
             }
-            Self::Custom { .. } => Ok(Self::Custom {
-                model,
-                reasoning_effort: normalize_reasoning_effort(reasoning_effort),
-            }),
+            Self::Custom { .. } => {
+                let reasoning_effort =
+                    self.resolve_model_reasoning_effort(&model, reasoning_effort)?;
+                Ok(Self::Custom {
+                    model,
+                    reasoning_effort,
+                })
+            }
             Self::Sim => {
                 if reasoning_effort.is_some() {
                     return Err(anyhow!("offline llmsim does not support reasoning effort"));
@@ -1069,49 +1156,80 @@ impl ProviderChoice {
         }
     }
 
+    fn resolve_model_reasoning_effort(
+        &self,
+        model: &str,
+        reasoning_effort: Option<String>,
+    ) -> Result<Option<String>> {
+        let requested = normalize_reasoning_effort(reasoning_effort);
+        let Some(config) = self.reasoning_effort_config_for_model(model) else {
+            return Ok(requested);
+        };
+        let allowed = config
+            .values
+            .iter()
+            .filter_map(|option| reasoning_effort_value(&option.value))
+            .collect::<Vec<_>>();
+        if let Some(effort) = requested {
+            if allowed.iter().any(|allowed| allowed == &effort) {
+                return Ok(Some(effort));
+            }
+            return Err(anyhow!(
+                "model {} supports reasoning efforts: {}",
+                self.model_label_for(model),
+                allowed.join(", ")
+            ));
+        }
+        reasoning_effort_value(&config.default)
+            .ok_or_else(|| {
+                anyhow!(
+                    "model {} has an invalid profile default",
+                    self.model_label_for(model)
+                )
+            })
+            .map(Some)
+    }
+
+    fn reasoning_effort_config_for_model(&self, model: &str) -> Option<ReasoningEffortConfig> {
+        match self {
+            Self::Codex { .. } => crate::codex_driver::model_profile(model),
+            _ => {
+                let resolved = self.model_without_stored_key_for_model(model);
+                get_model_profile(&resolved.provider_type, &resolved.model)
+            }
+        }
+        .and_then(|profile| profile.reasoning_effort)
+    }
+
+    fn model_label_for(&self, model: &str) -> String {
+        format!("{}/{}", self.provider_name(), model)
+    }
+
     pub(crate) fn resolve_reasoning_effort(&self, raw: &str) -> Result<Self> {
         let mut parts = raw.split_whitespace();
         let effort = parts.next().unwrap_or_default();
         if effort.is_empty() || parts.next().is_some() {
+            let suggestions = self
+                .reasoning_effort_options()
+                .iter()
+                .map(|option| option.value.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
             return Err(anyhow!(
                 "expected one reasoning effort (suggestions: {})",
-                REASONING_EFFORT_SUGGESTIONS.join(", ")
+                if suggestions.is_empty() {
+                    "none".to_string()
+                } else {
+                    suggestions
+                }
             ));
         }
-        match self {
-            Self::OpenAi { model, .. } => Ok(Self::OpenAi {
-                model: model.clone(),
-                reasoning_effort: normalize_openai_reasoning_effort(Some(effort.to_string())),
-            }),
-            Self::Codex { model, .. } => Ok(Self::Codex {
-                model: model.clone(),
-                reasoning_effort: normalize_openai_reasoning_effort(Some(effort.to_string())),
-            }),
-            Self::OpenRouter {
-                model, base_url, ..
-            } => Ok(Self::OpenRouter {
-                model: model.clone(),
-                base_url: base_url.clone(),
-                reasoning_effort: normalize_reasoning_effort(Some(effort.to_string())),
-            }),
-            Self::Custom { model, .. } => Ok(Self::Custom {
-                model: model.clone(),
-                reasoning_effort: normalize_reasoning_effort(Some(effort.to_string())),
-            }),
-            other => Err(anyhow!(
-                "reasoning effort only applies to OpenAI, Codex, OpenRouter, and custom models (current provider: {})",
-                other.provider_name()
-            )),
-        }
-    }
-
-    pub(crate) fn reasoning_effort_suggestions() -> &'static [&'static str] {
-        REASONING_EFFORT_SUGGESTIONS
+        self.with_current_provider_model(self.model_id().to_string(), Some(effort.to_string()))
     }
 
     pub(crate) fn model_with_provider(&self, settings: &Settings) -> Result<ResolvedModel> {
         match self {
-            ProviderChoice::Anthropic { model } => {
+            ProviderChoice::Anthropic { model, .. } => {
                 let key = resolve_token(settings, "anthropic", &["ANTHROPIC_API_KEY"])
                     .ok_or_else(|| anyhow!("ANTHROPIC_API_KEY not set (and no token stored)"))?;
                 Ok(ResolvedModel {
@@ -1159,7 +1277,9 @@ impl ProviderChoice {
                     base_url: None,
                 })
             }
-            ProviderChoice::Google { model, base_url } => {
+            ProviderChoice::Google {
+                model, base_url, ..
+            } => {
                 let key = resolve_token(settings, "google", &["GEMINI_API_KEY", "GOOGLE_API_KEY"])
                     .ok_or_else(|| {
                         anyhow!("GEMINI_API_KEY (or GOOGLE_API_KEY) not set (and no token stored)")
@@ -1194,7 +1314,9 @@ impl ProviderChoice {
                     base_url: Some(base_url.clone()),
                 })
             }
-            ProviderChoice::Ollama { model, base_url } => {
+            ProviderChoice::Ollama {
+                model, base_url, ..
+            } => {
                 let key = resolve_token(settings, "ollama", &["OLLAMA_API_KEY"])
                     .unwrap_or_else(|| DEFAULT_OLLAMA_API_KEY.to_string());
                 Ok(ResolvedModel {
@@ -1237,7 +1359,7 @@ impl ProviderChoice {
 
     fn model_without_stored_key(&self) -> ResolvedModel {
         match self {
-            ProviderChoice::Anthropic { model } => ResolvedModel {
+            ProviderChoice::Anthropic { model, .. } => ResolvedModel {
                 model: model.clone(),
                 provider_type: DriverId::Anthropic,
                 provider_metadata: None,
@@ -1258,7 +1380,9 @@ impl ProviderChoice {
                 api_key: None,
                 base_url: None,
             },
-            ProviderChoice::Google { model, base_url } => ResolvedModel {
+            ProviderChoice::Google {
+                model, base_url, ..
+            } => ResolvedModel {
                 model: model.clone(),
                 provider_type: DriverId::OpenAI,
                 provider_metadata: None,
@@ -1276,7 +1400,9 @@ impl ProviderChoice {
                 api_key: None,
                 base_url: Some(base_url.clone()),
             },
-            ProviderChoice::Ollama { model, base_url } => ResolvedModel {
+            ProviderChoice::Ollama {
+                model, base_url, ..
+            } => ResolvedModel {
                 model: model.clone(),
                 provider_type: DriverId::OpenAI,
                 provider_metadata: None,
@@ -1300,6 +1426,12 @@ impl ProviderChoice {
         }
     }
 
+    fn model_without_stored_key_for_model(&self, model: &str) -> ResolvedModel {
+        let mut resolved = self.model_without_stored_key();
+        resolved.model = model.to_string();
+        resolved
+    }
+
     fn input_message(&self, text: impl Into<String>) -> InputMessage {
         self.input_message_with_parts(vec![ContentPart::text(text)])
     }
@@ -1316,21 +1448,7 @@ impl ProviderChoice {
             metadata: None,
             tags: vec![],
         };
-        if let Some(effort) = match self {
-            Self::OpenAi {
-                reasoning_effort, ..
-            }
-            | Self::Codex {
-                reasoning_effort, ..
-            }
-            | Self::OpenRouter {
-                reasoning_effort, ..
-            }
-            | Self::Custom {
-                reasoning_effort, ..
-            } => reasoning_effort.as_deref(),
-            _ => None,
-        } {
+        if let Some(effort) = self.reasoning_effort() {
             input.controls = Some(Controls {
                 reasoning: Some(ReasoningConfig {
                     effort: Some(effort.to_string()),
@@ -1387,18 +1505,29 @@ fn env_or_default(name: &str, default: &str) -> String {
     env_non_empty(name).unwrap_or_else(|| default.to_string())
 }
 
-fn normalize_openai_reasoning_effort(reasoning_effort: Option<String>) -> Option<String> {
-    normalize_reasoning_effort(Some(
-        reasoning_effort
-            .filter(|effort| !effort.trim().is_empty())
-            .unwrap_or_else(|| DEFAULT_OPENAI_REASONING_EFFORT.to_string()),
-    ))
-}
-
 pub(crate) fn normalize_reasoning_effort(reasoning_effort: Option<String>) -> Option<String> {
     reasoning_effort
         .map(|effort| effort.trim().to_ascii_lowercase())
         .filter(|effort| !effort.is_empty())
+}
+
+fn profile_default_reasoning_effort(provider_type: &DriverId, model: &str) -> Option<String> {
+    get_model_profile(provider_type, model)
+        .and_then(|profile| profile.reasoning_effort)
+        .and_then(|config| reasoning_effort_value(&config.default))
+}
+
+fn reasoning_effort_option(value: &ReasoningEffortValue) -> ReasoningEffortOption {
+    ReasoningEffortOption {
+        value: reasoning_effort_value(&value.value).unwrap_or_default(),
+        label: value.name.clone(),
+    }
+}
+
+fn reasoning_effort_value(value: &everruns_core::ReasoningEffort) -> Option<String> {
+    serde_json::to_value(value)
+        .ok()
+        .and_then(|value| value.as_str().map(str::to_string))
 }
 
 fn default_coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabilityConfig> {
@@ -1640,6 +1769,20 @@ impl ModelState {
             .expect("provider lock poisoned")
             .reasoning_effort()
             .map(str::to_string)
+    }
+
+    pub(crate) fn reasoning_effort_options(&self) -> Vec<ReasoningEffortOption> {
+        self.provider
+            .read()
+            .expect("provider lock poisoned")
+            .reasoning_effort_options()
+    }
+
+    pub(crate) fn default_reasoning_effort(&self) -> Option<String> {
+        self.provider
+            .read()
+            .expect("provider lock poisoned")
+            .default_reasoning_effort()
     }
 
     /// Snapshot of the current provider choice (including any custom base
@@ -3023,7 +3166,7 @@ mod tests {
             .resolve_model_spec("anthropic/claude-sonnet-4-5")
             .unwrap();
 
-        assert_eq!(next.label(), "openai/anthropic/claude-sonnet-4-5 medium");
+        assert_eq!(next.label(), "openai/anthropic/claude-sonnet-4-5");
     }
 
     #[test]
@@ -3036,9 +3179,10 @@ mod tests {
 
         let provider = ProviderChoice::Anthropic {
             model: "claude-sonnet-4-5".to_string(),
+            reasoning_effort: None,
         };
         let next = provider.resolve_model_spec("claude-fable-5").unwrap();
-        assert_eq!(next.label(), "anthropic/claude-fable-5");
+        assert_eq!(next.label(), "anthropic/claude-fable-5 high");
     }
 
     #[test]
@@ -3052,9 +3196,10 @@ mod tests {
 
         let provider = ProviderChoice::Anthropic {
             model: "claude-sonnet-4-5".to_string(),
+            reasoning_effort: None,
         };
         let next = provider.resolve_model_spec("claude-fable-5[1m]").unwrap();
-        assert_eq!(next.label(), "anthropic/claude-fable-5[1m]");
+        assert_eq!(next.label(), "anthropic/claude-fable-5[1m] high");
     }
 
     #[test]
@@ -3065,7 +3210,7 @@ mod tests {
         };
         let next = provider.resolve_model_spec("gpt-5.4").unwrap();
 
-        assert_eq!(next.label(), "openai/gpt-5.4 medium");
+        assert_eq!(next.label(), "openai/gpt-5.4 none");
     }
 
     #[test]
@@ -3115,6 +3260,7 @@ mod tests {
         let provider = ProviderChoice::Ollama {
             model: "llama3.2".to_string(),
             base_url: DEFAULT_OLLAMA_BASE_URL.to_string(),
+            reasoning_effort: None,
         };
         let next = provider.resolve_model_spec("llama3.3").unwrap();
 
@@ -3126,6 +3272,7 @@ mod tests {
         let provider = ProviderChoice::Google {
             model: "gemini-2.5-flash".to_string(),
             base_url: DEFAULT_GOOGLE_BASE_URL.to_string(),
+            reasoning_effort: None,
         };
         let next = provider.resolve_model_spec("gemini-2.5-pro").unwrap();
 
@@ -3142,7 +3289,7 @@ mod tests {
         assert!(codex.label().starts_with("codex/gpt-5.5"));
 
         let anthropic = ProviderChoice::default_for_provider_name("anthropic").unwrap();
-        assert_eq!(anthropic.label(), "anthropic/claude-sonnet-4-5");
+        assert_eq!(anthropic.label(), "anthropic/claude-sonnet-4-5 medium");
 
         let google = ProviderChoice::default_for_provider_name("google").unwrap();
         assert_eq!(google.label(), "google/gemini-2.5-flash");
@@ -3286,8 +3433,8 @@ mod tests {
         settings
             .models
             .insert("openai".to_string(), "gpt-5.4 high".to_string());
-        // A spec the provider rejects (anthropic takes no effort) is
-        // ignored, not fatal.
+        // Anthropic profiles own their effort support too, so a persisted
+        // model+effort spec is restored when the model profile allows it.
         settings
             .models
             .insert("anthropic".to_string(), "claude-opus-4-5 high".to_string());
@@ -3300,7 +3447,7 @@ mod tests {
         let anthropic = resolve_for_settings("anthropic", &settings)
             .expect("resolve")
             .choice;
-        assert_eq!(anthropic.label(), "anthropic/claude-sonnet-4-5");
+        assert_eq!(anthropic.label(), "anthropic/claude-opus-4-5 high");
     }
 
     #[test]
@@ -3318,7 +3465,7 @@ mod tests {
         let anthropic = resolve_for_settings("anthropic", &settings)
             .expect("resolve")
             .choice;
-        assert_eq!(anthropic.label(), "anthropic/claude-opus-4-5");
+        assert_eq!(anthropic.label(), "anthropic/claude-opus-4-5 medium");
 
         // A per-provider pick still wins over the global default.
         settings
@@ -3327,7 +3474,7 @@ mod tests {
         let anthropic = resolve_for_settings("anthropic", &settings)
             .expect("resolve")
             .choice;
-        assert_eq!(anthropic.label(), "anthropic/claude-haiku-4-5");
+        assert_eq!(anthropic.label(), "anthropic/claude-haiku-4-5 medium");
     }
 
     #[test]
@@ -3343,7 +3490,10 @@ mod tests {
         };
 
         let resolved = resolve_for_settings("anthropic", &settings).expect("resolve");
-        assert_eq!(resolved.choice.label(), "anthropic/claude-sonnet-4-5");
+        assert_eq!(
+            resolved.choice.label(),
+            "anthropic/claude-sonnet-4-5 medium"
+        );
         assert_eq!(resolved.source, ModelResolutionSource::ProviderDefault);
         assert!(
             resolved.notes.iter().any(|n| n.contains("default_model")),
@@ -3432,6 +3582,7 @@ mod tests {
         let provider = ProviderChoice::Google {
             model: "gemini-2.5-flash".to_string(),
             base_url: DEFAULT_GOOGLE_BASE_URL.to_string(),
+            reasoning_effort: None,
         };
         let err = provider
             .model_with_provider(&Settings::default())
@@ -3504,6 +3655,7 @@ mod tests {
         let provider = ProviderChoice::Ollama {
             model: "llama3.2".to_string(),
             base_url: DEFAULT_OLLAMA_BASE_URL.to_string(),
+            reasoning_effort: None,
         };
 
         let model = provider.model_with_provider(&Settings::default()).unwrap();
@@ -3526,6 +3678,7 @@ mod tests {
 
         let provider = ProviderChoice::Anthropic {
             model: "claude-sonnet-4-5".to_string(),
+            reasoning_effort: None,
         };
         let model = provider.model_with_provider(&settings).unwrap();
         assert_eq!(model.api_key, Some("stored-anth-key".to_string()));
@@ -3608,15 +3761,34 @@ mod tests {
     }
 
     #[test]
-    fn reasoning_effort_rejects_unsupported_provider() {
-        let provider = ProviderChoice::Anthropic {
-            model: "claude-sonnet-4-5".to_string(),
+    fn reasoning_effort_options_come_from_model_profile() {
+        let provider = ProviderChoice::OpenAi {
+            model: "gpt-5.5".to_string(),
+            reasoning_effort: None,
         };
-        let err = provider.resolve_reasoning_effort("high").unwrap_err();
+        let options = provider.reasoning_effort_options();
 
         assert!(
-            err.to_string()
-                .contains("only applies to OpenAI, Codex, OpenRouter, and custom")
+            options.iter().any(|option| option.value == "xhigh"),
+            "profile-defined xhigh option should be exposed: {options:?}"
+        );
+        assert_eq!(
+            provider.default_reasoning_effort().as_deref(),
+            Some("medium")
+        );
+    }
+
+    #[test]
+    fn codex_reasoning_effort_options_come_from_driver_profile() {
+        let provider = ProviderChoice::Codex {
+            model: "gpt-5.5".to_string(),
+            reasoning_effort: None,
+        };
+        let options = provider.reasoning_effort_options();
+
+        assert!(
+            options.iter().any(|option| option.value == "xhigh"),
+            "Codex driver profile should expose OpenAI-family effort metadata: {options:?}"
         );
     }
 

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -716,6 +716,7 @@ mod tests {
 
     #[test]
     fn worktree_manager_creates_isolated_branch_on_implementation_prompt() {
+        let _guard = crate::test_env::lock();
         let repo = tempfile::tempdir().expect("repo");
         std::process::Command::new("git")
             .args(["init", "-b", "main"])
@@ -787,6 +788,7 @@ mod tests {
 
     #[test]
     fn prune_removes_unreferenced_worktree_dirs() {
+        let _guard = crate::test_env::lock();
         let sessions = tempfile::tempdir().expect("sessions");
         let storage = tempfile::tempdir().expect("storage");
         let storage_path = storage.path().to_path_buf();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -664,7 +664,7 @@ fn tui_setup_selects_model_for_connected_provider_in_real_pty() {
     tui.write_input(b"2");
     assert!(
         tui.wait_for_output(
-            "setup complete: openai/gpt-5.4 medium",
+            "setup complete: openai/gpt-5.4 none",
             Duration::from_secs(3)
         ),
         "model selection should complete with the picked model: {}",
@@ -678,7 +678,7 @@ fn tui_setup_selects_model_for_connected_provider_in_real_pty() {
         "provider switch should persist: {settings}"
     );
     assert!(
-        settings.contains("openai = \"gpt-5.4 medium\""),
+        settings.contains("openai = \"gpt-5.4 none\""),
         "picked model should persist under [models]: {settings}"
     );
 


### PR DESCRIPTION
## What
Profile-drive reasoning effort handling instead of hardcoding provider-specific effort support in the Yolop UI/runtime path.

- Derive effort options/defaults from `ModelProfile.reasoning_effort`.
- Route `/effort`, `/setup effort`, status labels, model overrides, and persisted model specs through the current model profile.
- Keep Codex's OpenAI-family model profile alias inside the Codex driver module.
- Add effort storage for all model-backed `ProviderChoice` variants so effort handling is not gated by a provider allowlist.
- Stabilize worktree tests that mutate `TMPDIR` by sharing the existing test env lock.

## Why
Adding a new driver/model should not require Yolop to maintain a separate list of providers or effort levels. The model profile already owns that metadata, and the status/setup UI should reflect it directly.

## How
Centralized effort lookup and validation in `ProviderChoice`:

- `reasoning_effort_options()` and `default_reasoning_effort()` read model profile metadata.
- `resolve_model_reasoning_effort()` validates explicit effort against profile values when a profile is available, otherwise preserves explicit effort for compatible/custom surfaces.
- The TUI effort picker renders the current model's profile-defined options and marks current/default values.
- README language now describes profile-backed effort support instead of fixed provider/value sets.

## Risk
- Medium
- Changes startup/model selection and setup/status display paths.
- Existing saved model specs with explicit efforts remain supported when the active model profile allows the value; invalid values now fail with model-profile suggestions.

## Security
- TM-FS: No production filesystem access changes. The only filesystem-related change is test-only locking around temp worktree tests.
- TM-BASH: No shell execution behavior changes.
- TM-LLM: Reasoning effort is still attached only as `InputMessage.controls.reasoning.effort`; API keys/tokens are not logged or persisted by this change.
- TM-TOOL: No capability registration changes.
- TM-DEP: No dependency changes.

## Validation
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] `cargo run -- --provider llmsim -p "hi"`
- [x] CI: Analyze (actions), Analyze (python), Analyze (rust), CodeQL, Format + Clippy, Build + Tests + Offline Smoke, Live Provider Smoke (Doppler)

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
