### PR TITLE
refactor(narration): drop yolop fallback, narrate in capabilities

### DIFF
--- a/src/app/transcript.rs
+++ b/src/app/transcript.rs
@@ -440,62 +440,9 @@ fn todo_lines_for_result_or_args(
 
 fn tool_started_label(data: &ToolStartedData) -> String {
     data.narration
-        .as_deref()
-        .map(ToOwned::to_owned)
-        .or_else(|| tool_display_name_with_arguments(data))
-        .or_else(|| data.display_name.clone())
+        .clone()
+        .or(data.display_name.clone())
         .unwrap_or_else(|| data.tool_call.name.clone())
-}
-
-// TODO: Remove this Yolop-side fallback once everruns lets capabilities/tools
-// provide their own argument-aware narration. Until then, this only fills gaps
-// after everruns-provided `data.narration` is missing.
-fn tool_display_name_with_arguments(data: &ToolStartedData) -> Option<String> {
-    let (prefix, field) = match data.tool_call.name.as_str() {
-        "tool_search" => ("Search tools", "query"),
-        "activate_skill" => ("Activate skill", "name"),
-        "read_skill" => ("Read skill", "name"),
-        "run_yolop_command" => ("Run command", "command"),
-        "duckduckgo_search" => ("Search DuckDuckGo", "query"),
-        "web_fetch" => ("Fetch URL", "url"),
-        "grep_files" | "ast_grep" => ("Search files", "pattern"),
-        "repo_symbols" => ("Search symbols", "query"),
-        "read_file" => ("Read file", "path"),
-        "list_directory" => ("List directory", "path"),
-        "write_file" | "edit_file" | "delete_file" | "stat_file" => (
-            data.display_name
-                .as_deref()
-                .unwrap_or(data.tool_call.name.as_str()),
-            "path",
-        ),
-        _ => return None,
-    };
-
-    let value = data
-        .tool_call
-        .arguments
-        .get(field)
-        .and_then(|value| value.as_str())
-        .map(str::trim)
-        .filter(|value| !value.is_empty())?;
-    Some(format!("{prefix}: {}", compact_tool_argument(value)))
-}
-
-fn compact_tool_argument(value: &str) -> String {
-    const MAX_CHARS: usize = 80;
-    let normalized = value.split_whitespace().collect::<Vec<_>>().join(" ");
-    let mut chars = normalized.chars();
-    let mut compact = String::new();
-    for _ in 0..MAX_CHARS {
-        match chars.next() {
-            Some(ch) => compact.push(ch),
-            None => return normalized,
-        }
-    }
-    if chars.next().is_some() {
-        compact.push('…');
-    }
-    compact
 }
 
 /// One-line summary of a tool result, used in the transcript and `--print` output.
@@ -610,16 +557,9 @@ mod tests {
     }
 
     #[test]
-    fn tool_started_label_includes_search_query() {
-        let data = started_tool("tool_search", json!({ "query": "schema metadata" }));
+    fn tool_started_label_falls_back_to_display_name() {
+        let data = started_tool("tool_search", json!({ "query": "hooks" }));
 
-        assert_eq!(tool_started_label(&data), "Search tools: schema metadata");
-    }
-
-    #[test]
-    fn tool_started_label_includes_skill_name() {
-        let data = started_tool("activate_skill", json!({ "name": "ship" }));
-
-        assert_eq!(tool_started_label(&data), "Activate skill: ship");
+        assert_eq!(tool_started_label(&data), "Hardcoded label");
     }
 }

--- a/src/capabilities/ast_grep.rs
+++ b/src/capabilities/ast_grep.rs
@@ -12,6 +12,8 @@ use ast_grep_core::{AstGrep, Node};
 use ast_grep_language::SupportLang;
 use async_trait::async_trait;
 use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
+use everruns_core::tool_narration::ToolNarrationPhase;
+use everruns_core::tool_types::ToolCall;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -107,6 +109,19 @@ struct AstGrepTool {
 
 #[async_trait]
 impl Tool for AstGrepTool {
+    fn narrate(
+        &self,
+        tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        locale: Option<&str>,
+    ) -> Option<String> {
+        Some(everruns_core::tool_narration::narrate_grep_files(
+            &tool_call.arguments,
+            phase,
+            locale,
+        ))
+    }
+
     fn name(&self) -> &str {
         "ast_grep"
     }

--- a/src/capabilities/ast_grep.rs
+++ b/src/capabilities/ast_grep.rs
@@ -696,6 +696,8 @@ fn truncate_chars(value: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use everruns_core::tool_narration::ToolNarrationPhase;
+    use everruns_core::tool_types::ToolCall;
 
     fn write(path: &Path, content: &str) {
         if let Some(parent) = path.parent() {
@@ -763,6 +765,22 @@ mod tests {
                 .iter()
                 .any(|capture| capture.name == "A" && capture.text == "value")
         );
+    }
+
+    #[test]
+    fn ast_grep_narration_includes_pattern() {
+        let tool = AstGrepTool {
+            workspace_root: PathBuf::from("/tmp"),
+        };
+        let call = ToolCall {
+            id: "call-1".to_owned(),
+            name: "ast_grep".to_owned(),
+            arguments: json!({ "pattern": "fn main" }),
+        };
+
+        let narration = tool.narrate(&call, ToolNarrationPhase::Started, None);
+
+        assert_eq!(narration.as_deref(), Some("Searching files for fn main"));
     }
 
     #[tokio::test]

--- a/src/capabilities/client_commands.rs
+++ b/src/capabilities/client_commands.rs
@@ -284,6 +284,8 @@ fn arg(name: &str, required: bool) -> CommandArg {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use everruns_core::tool_narration::ToolNarrationPhase;
+    use everruns_core::tool_types::ToolCall;
     use std::sync::{Arc, Mutex};
 
     #[derive(Default)]
@@ -402,5 +404,21 @@ mod tests {
                 arg: Some("expanded".to_string())
             }]
         );
+    }
+
+    #[test]
+    fn run_yolop_command_narration_includes_command() {
+        let tool = RunYolopCommandTool {
+            ui: Arc::new(RecordingUi::default()),
+        };
+        let call = ToolCall {
+            id: "call-1".to_owned(),
+            name: "run_yolop_command".to_owned(),
+            arguments: json!({ "command": "/help" }),
+        };
+
+        let narration = tool.narrate(&call, ToolNarrationPhase::Started, None);
+
+        assert_eq!(narration.as_deref(), Some("Run command: /help"));
     }
 }

--- a/src/capabilities/client_commands.rs
+++ b/src/capabilities/client_commands.rs
@@ -19,6 +19,8 @@ use everruns_core::command::{
     CommandArg, CommandDescriptor, CommandExecutionContext, CommandResult, CommandSource,
     ExecuteCommandRequest,
 };
+use everruns_core::tool_narration::{ToolNarrationPhase, arg_str, labeled_phrase, truncate};
+use everruns_core::tool_types::ToolCall;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use serde_json::{Value, json};
 use std::sync::Arc;
@@ -156,6 +158,23 @@ struct RunYolopCommandTool {
 
 #[async_trait]
 impl Tool for RunYolopCommandTool {
+    fn narrate(
+        &self,
+        tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        locale: Option<&str>,
+    ) -> Option<String> {
+        let _ = locale;
+        let command = arg_str(&tool_call.arguments, &["command"]).map(|value| truncate(value, 48));
+        Some(labeled_phrase(
+            "Run command",
+            "Ran command",
+            "Failed to run command",
+            command,
+            phase,
+        ))
+    }
+
     fn name(&self) -> &str {
         "run_yolop_command"
     }

--- a/src/capabilities/repo_map.rs
+++ b/src/capabilities/repo_map.rs
@@ -1109,6 +1109,8 @@ fn truncate_chars(value: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use everruns_core::tool_narration::ToolNarrationPhase;
+    use everruns_core::tool_types::ToolCall;
 
     fn write(path: &Path, content: &str) {
         if let Some(parent) = path.parent() {
@@ -1371,5 +1373,37 @@ trait Named {
         .expect_err("outside path should fail");
 
         assert!(err.to_string().contains("inside the workspace"));
+    }
+
+    #[test]
+    fn repo_symbols_narration_includes_query() {
+        let tool = RepoSymbolsTool {
+            workspace_root: PathBuf::from("/tmp"),
+        };
+        let call = ToolCall {
+            id: "call-1".to_owned(),
+            name: "repo_symbols".to_owned(),
+            arguments: json!({ "query": "Widget" }),
+        };
+
+        let narration = tool.narrate(&call, ToolNarrationPhase::Started, None);
+
+        assert_eq!(narration.as_deref(), Some("Search symbols: Widget"));
+    }
+
+    #[test]
+    fn repo_map_narration_uses_bare_verb_without_query() {
+        let tool = RepoMapTool {
+            workspace_root: PathBuf::from("/tmp"),
+        };
+        let call = ToolCall {
+            id: "call-1".to_owned(),
+            name: "repo_map".to_owned(),
+            arguments: json!({}),
+        };
+
+        let narration = tool.narrate(&call, ToolNarrationPhase::Started, None);
+
+        assert_eq!(narration.as_deref(), Some("Build repo map"));
     }
 }

--- a/src/capabilities/repo_map.rs
+++ b/src/capabilities/repo_map.rs
@@ -7,6 +7,8 @@
 use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
 use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
+use everruns_core::tool_narration::{ToolNarrationPhase, arg_str, labeled_phrase, truncate};
+use everruns_core::tool_types::ToolCall;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -106,6 +108,23 @@ struct RepoMapTool {
 
 #[async_trait]
 impl Tool for RepoMapTool {
+    fn narrate(
+        &self,
+        tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        locale: Option<&str>,
+    ) -> Option<String> {
+        let _ = locale;
+        let query = scan_narration_query(&tool_call.arguments);
+        Some(labeled_phrase(
+            "Build repo map",
+            "Built repo map",
+            "Repo map failed",
+            query,
+            phase,
+        ))
+    }
+
     fn name(&self) -> &str {
         "repo_map"
     }
@@ -153,6 +172,23 @@ struct RepoSymbolsTool {
 
 #[async_trait]
 impl Tool for RepoSymbolsTool {
+    fn narrate(
+        &self,
+        tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        locale: Option<&str>,
+    ) -> Option<String> {
+        let _ = locale;
+        let query = scan_narration_query(&tool_call.arguments);
+        Some(labeled_phrase(
+            "Search symbols",
+            "Searched symbols",
+            "Symbol search failed",
+            query,
+            phase,
+        ))
+    }
+
     fn name(&self) -> &str {
         "repo_symbols"
     }
@@ -192,6 +228,10 @@ impl Tool for RepoSymbolsTool {
             Err(err) => ToolExecutionResult::tool_error(err.to_string()),
         }
     }
+}
+
+fn scan_narration_query(arguments: &Value) -> Option<String> {
+    arg_str(arguments, &["query"]).map(|query| truncate(query, 48))
 }
 
 fn scan_schema(query_description: &str) -> Value {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Everruns 0.14 contributes tool narration from capabilities via `Tool::narrate` and the `tool_narration` helpers. Yolop still had a legacy transcript fallback (`tool_display_name_with_arguments`) that duplicated argument-aware labels for built-in and yolop tools.

This PR removes that fallback and moves narration for yolop-owned tools into their capability implementations.

## Changes

- **Remove legacy transcript fallback** in `src/app/transcript.rs`:
  - Deleted `tool_display_name_with_arguments` and `compact_tool_argument`
  - `tool_started_label` now uses runtime `narration`, then `display_name`, then tool name
- **Add `Tool::narrate` to yolop capabilities**:
  - `ast_grep` → `narrate_grep_files`
  - `repo_map` / `repo_symbols` → `labeled_phrase` with optional query
  - `run_yolop_command` → `labeled_phrase` with command argument
- **Tests** exercise `Tool::narrate` on each yolop-owned tool above, plus the transcript fallback chain.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (469 unit + 29 integration tests)
- `cargo run -- --provider llmsim -p "hi"` (offline smoke — binary starts and completes a turn)

## Security

No security-relevant code changes. This refactor moves UI label generation from a transcript-side name→argument map into existing capability `narrate` hooks. No new filesystem, shell, capability registration, or dependency surface.

## Follow-ups

No follow-ups.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e9b3f42-402e-4ccb-8bca-09e7a6c8cc1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e9b3f42-402e-4ccb-8bca-09e7a6c8cc1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

