### PR TITLE
feat(tui): render markdown tables with comfy-table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,6 +883,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "comfy-table"
+version = "7.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+dependencies = [
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6506,6 +6516,7 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "comfy-table",
  "crossterm",
  "dirs",
  "eventsource-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ everruns-integrations-daytona = "0.14.0"
 arboard = { version = "3", features = ["wayland-data-control"] }
 futures = "0.3"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
+comfy-table = { version = "7.2.2", default-features = false }
 
 [dev-dependencies]
 portable-pty = "0.9.0"

--- a/src/app/markdown_table.rs
+++ b/src/app/markdown_table.rs
@@ -81,9 +81,9 @@ pub(crate) fn append_markdown_table_lines<'a>(
 }
 
 fn table_render_fits(rendered: &[String], inner_width: usize, prefix_len: usize) -> bool {
-    rendered.iter().all(|line| {
-        prefix_len.saturating_add(line.chars().count()) <= inner_width
-    })
+    rendered
+        .iter()
+        .all(|line| prefix_len.saturating_add(line.chars().count()) <= inner_width)
 }
 
 pub(crate) fn render_table(table: &MarkdownTable, width: usize) -> Vec<String> {
@@ -121,12 +121,8 @@ pub(crate) fn render_table(table: &MarkdownTable, width: usize) -> Vec<String> {
 }
 
 fn style_table_line(line: &str) -> Vec<Span<'static>> {
-    let has_cell_delimiters = line.contains('│')
-        || line
-            .chars()
-            .filter(|ch| *ch == '|')
-            .count()
-            >= 2;
+    let has_cell_delimiters =
+        line.contains('│') || line.chars().filter(|ch| *ch == '|').count() >= 2;
     if !has_cell_delimiters || is_border_only_line(line) {
         return vec![Span::styled(
             line.to_string(),

--- a/src/app/markdown_table.rs
+++ b/src/app/markdown_table.rs
@@ -1,0 +1,381 @@
+//! Markdown pipe-table parsing and terminal layout via `comfy-table`.
+
+use comfy_table::modifiers::UTF8_ROUND_CORNERS;
+use comfy_table::presets::UTF8_FULL;
+use comfy_table::{Cell, CellAlignment, ContentArrangement, Table};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+
+use super::{TEXT_DIM, TEXT_PRIMARY, push_markdown_line};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MarkdownTable {
+    pub headers: Vec<String>,
+    pub alignments: Vec<CellAlignment>,
+    pub rows: Vec<Vec<String>>,
+}
+
+/// Returns `(table, next_line_index)` when `lines[start]` begins a GFM table.
+pub(crate) fn try_parse_table_at(lines: &[&str], start: usize) -> Option<(MarkdownTable, usize)> {
+    if start + 1 >= lines.len() {
+        return None;
+    }
+    if !is_table_row(lines[start]) || !is_table_separator(lines[start + 1]) {
+        return None;
+    }
+
+    let headers = parse_cells(lines[start]);
+    if headers.is_empty() {
+        return None;
+    }
+
+    let alignments = parse_alignments(lines[start + 1], headers.len());
+    let mut rows = Vec::new();
+    let mut index = start + 2;
+    while index < lines.len() && is_table_row(lines[index]) && !is_table_separator(lines[index]) {
+        let mut row = parse_cells(lines[index]);
+        row.resize(headers.len(), String::new());
+        row.truncate(headers.len());
+        rows.push(row);
+        index += 1;
+    }
+
+    Some((
+        MarkdownTable {
+            headers,
+            alignments,
+            rows,
+        },
+        index,
+    ))
+}
+
+pub(crate) fn append_markdown_table_lines<'a>(
+    lines: &mut Vec<Line<'a>>,
+    first_prefix: &str,
+    prefix_style: Style,
+    table: &MarkdownTable,
+    inner_width: usize,
+    first: &mut bool,
+) -> bool {
+    let prefix_len = first_prefix.chars().count();
+    let wrap_width = inner_width.saturating_sub(prefix_len).max(1);
+    let rendered = render_table(table, wrap_width);
+    if !table_render_fits(&rendered, inner_width, prefix_len) {
+        return false;
+    }
+
+    let continuation = " ".repeat(prefix_len);
+    for rendered_line in rendered {
+        let spans = style_table_line(&rendered_line);
+        push_markdown_line(
+            lines,
+            first_prefix,
+            &continuation,
+            prefix_style,
+            first,
+            spans,
+        );
+    }
+    true
+}
+
+fn table_render_fits(rendered: &[String], inner_width: usize, prefix_len: usize) -> bool {
+    rendered.iter().all(|line| {
+        prefix_len.saturating_add(line.chars().count()) <= inner_width
+    })
+}
+
+pub(crate) fn render_table(table: &MarkdownTable, width: usize) -> Vec<String> {
+    let mut comfy = Table::new();
+    comfy
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_content_arrangement(ContentArrangement::Dynamic)
+        .set_width(width.max(1) as u16);
+
+    let header_cells = table
+        .headers
+        .iter()
+        .map(|header| Cell::new(header.as_str()))
+        .collect::<Vec<_>>();
+    comfy.set_header(header_cells);
+
+    for row in &table.rows {
+        let cells = row
+            .iter()
+            .enumerate()
+            .map(|(index, value)| {
+                let cell = Cell::new(value.as_str());
+                if let Some(alignment) = table.alignments.get(index) {
+                    cell.set_alignment(*alignment)
+                } else {
+                    cell
+                }
+            })
+            .collect::<Vec<_>>();
+        comfy.add_row(cells);
+    }
+
+    comfy.to_string().lines().map(str::to_owned).collect()
+}
+
+fn style_table_line(line: &str) -> Vec<Span<'static>> {
+    let has_cell_delimiters = line.contains('│')
+        || line
+            .chars()
+            .filter(|ch| *ch == '|')
+            .count()
+            >= 2;
+    if !has_cell_delimiters || is_border_only_line(line) {
+        return vec![Span::styled(
+            line.to_string(),
+            Style::default().fg(TEXT_DIM),
+        )];
+    }
+
+    let border_style = Style::default().fg(TEXT_DIM);
+    let content_style = if is_header_content_line(line) {
+        Style::default()
+            .fg(TEXT_PRIMARY)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(TEXT_PRIMARY)
+    };
+
+    let mut spans = Vec::new();
+    let mut cell = String::new();
+    for ch in line.chars() {
+        if ch == '│' || ch == '|' {
+            if !cell.is_empty() {
+                spans.push(Span::styled(std::mem::take(&mut cell), content_style));
+            }
+            spans.push(Span::styled(ch.to_string(), border_style));
+        } else {
+            cell.push(ch);
+        }
+    }
+    if !cell.is_empty() {
+        spans.push(Span::styled(cell, content_style));
+    }
+    if spans.is_empty() {
+        spans.push(Span::styled(line.to_string(), content_style));
+    }
+    spans
+}
+
+fn is_header_content_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.starts_with(['│', '|']) && !trimmed.contains(['═', '=']) && !is_border_only_line(line)
+}
+
+fn is_border_only_line(line: &str) -> bool {
+    line.trim().chars().all(|ch| {
+        matches!(
+            ch,
+            '│' | '┃'
+                | '├'
+                | '┤'
+                | '┼'
+                | '─'
+                | '━'
+                | '┴'
+                | '┬'
+                | '╭'
+                | '╮'
+                | '╰'
+                | '╯'
+                | '╞'
+                | '╡'
+                | '╪'
+                | '╌'
+                | '┆'
+                | '+'
+                | '-'
+                | '='
+                | '|'
+                | ' '
+        )
+    })
+}
+
+pub(crate) fn is_table_row(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.starts_with('|') && trimmed[1..].contains('|')
+}
+
+pub(crate) fn is_table_separator(line: &str) -> bool {
+    if !is_table_row(line) {
+        return false;
+    }
+    parse_cells(line)
+        .iter()
+        .all(|cell| cell_contains_only_alignment_markers(cell))
+}
+
+fn cell_contains_only_alignment_markers(cell: &str) -> bool {
+    let trimmed = cell.trim();
+    !trimmed.is_empty() && trimmed.chars().all(|ch| matches!(ch, '-' | ':' | ' '))
+}
+
+pub(crate) fn parse_cells(line: &str) -> Vec<String> {
+    line.trim()
+        .trim_start_matches('|')
+        .trim_end_matches('|')
+        .split('|')
+        .map(str::trim)
+        .map(str::to_owned)
+        .collect()
+}
+
+fn parse_alignments(separator: &str, column_count: usize) -> Vec<CellAlignment> {
+    let mut alignments = parse_cells(separator)
+        .into_iter()
+        .map(|cell| parse_alignment(&cell))
+        .collect::<Vec<_>>();
+    alignments.resize(column_count, CellAlignment::Left);
+    alignments.truncate(column_count);
+    alignments
+}
+
+fn parse_alignment(cell: &str) -> CellAlignment {
+    let trimmed = cell.trim();
+    let left = trimmed.starts_with(':');
+    let right = trimmed.ends_with(':');
+    match (left, right) {
+        (true, true) => CellAlignment::Center,
+        (_, true) => CellAlignment::Right,
+        _ => CellAlignment::Left,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_basic_table_block() {
+        let lines = vec![
+            "| Name | Value |",
+            "| --- | --- |",
+            "| foo | bar |",
+            "plain text",
+        ];
+        let (table, next) = try_parse_table_at(&lines, 0).expect("table");
+        assert_eq!(table.headers, vec!["Name", "Value"]);
+        assert_eq!(table.rows, vec![vec!["foo", "bar"]]);
+        assert_eq!(next, 3);
+    }
+
+    #[test]
+    fn parses_column_alignments() {
+        let lines = vec![
+            "| Left | Center | Right |",
+            "|:---|:---:|---:|",
+            "| a | b | c |",
+        ];
+        let (table, _) = try_parse_table_at(&lines, 0).expect("table");
+        assert_eq!(
+            table.alignments,
+            vec![
+                CellAlignment::Left,
+                CellAlignment::Center,
+                CellAlignment::Right,
+            ]
+        );
+    }
+
+    #[test]
+    fn render_table_respects_width() {
+        let table = MarkdownTable {
+            headers: vec!["Command".into(), "Description".into()],
+            alignments: vec![CellAlignment::Left, CellAlignment::Left],
+            rows: vec![vec![
+                "cargo test --all-features".into(),
+                "Run the full test suite before shipping".into(),
+            ]],
+        };
+
+        for width in [24, 40, 80] {
+            let rendered = render_table(&table, width);
+            assert!(
+                !rendered.is_empty(),
+                "expected table output at width {width}"
+            );
+            assert!(
+                rendered.iter().all(|line| line.chars().count() <= width),
+                "table line exceeded width {width}: {rendered:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn render_table_changes_layout_when_width_changes() {
+        let table = MarkdownTable {
+            headers: vec!["Key".into(), "Value".into()],
+            alignments: vec![CellAlignment::Left, CellAlignment::Left],
+            rows: vec![vec![
+                "description".into(),
+                "a deliberately long value that should wrap".into(),
+            ]],
+        };
+
+        let narrow = render_table(&table, 28);
+        let wide = render_table(&table, 80);
+        assert_ne!(
+            narrow, wide,
+            "dynamic layout should reflow when width changes: narrow={narrow:?} wide={wide:?}"
+        );
+    }
+
+    #[test]
+    fn separator_detection_rejects_plain_pipe_text() {
+        assert!(!is_table_separator("| just | one | row |"));
+    }
+
+    #[test]
+    fn table_line_styles_use_dim_borders() {
+        let spans = style_table_line("╭──────┬──────╮");
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].style.fg, Some(TEXT_DIM));
+    }
+
+    #[test]
+    fn table_line_styles_bold_header_cells() {
+        let spans = style_table_line("│ Name     │ Value    │");
+        assert!(
+            spans
+                .iter()
+                .any(|span| span.style.add_modifier.contains(Modifier::BOLD)),
+            "header row should include bold spans: {spans:?}"
+        );
+    }
+
+    #[test]
+    fn table_line_styles_dim_header_separator() {
+        let spans = style_table_line("╞═══╪═══╡");
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].style.fg, Some(TEXT_DIM));
+    }
+
+    #[test]
+    fn append_table_falls_back_when_width_is_too_narrow() {
+        let table = MarkdownTable {
+            headers: vec!["Col A".into(), "Col B".into()],
+            alignments: vec![CellAlignment::Left, CellAlignment::Left],
+            rows: vec![vec!["alpha".into(), "beta".into()]],
+        };
+        let mut lines = Vec::new();
+        let mut first = true;
+        let fitted = append_markdown_table_lines(
+            &mut lines,
+            "agent › ",
+            Style::default(),
+            &table,
+            12,
+            &mut first,
+        );
+        assert!(!fitted, "narrow terminals should reject boxed tables");
+        assert!(lines.is_empty());
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -32,6 +32,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{broadcast, mpsc, oneshot};
 
+mod markdown_table;
 mod render;
 mod setup;
 mod transcript;
@@ -2880,6 +2881,87 @@ mod tests {
     }
 
     #[test]
+    fn markdown_table_renders_columns_within_width() {
+        let width = 48;
+        let mut lines = Vec::new();
+        append_chat_lines(
+            &mut lines,
+            &ChatLine {
+                author: Author::Assistant,
+                text: "| Name | Value |\n| --- | --- |\n| foo | bar |".to_string(),
+            },
+            width,
+        );
+
+        let body = lines.iter().map(line_text).collect::<Vec<_>>().join("\n");
+        assert!(
+            body.contains("Name") && body.contains("foo"),
+            "table content should survive rendering: {body}"
+        );
+        assert!(
+            lines.iter().all(|line| line_width(line) <= width),
+            "table rows should fit width {width}: {lines:?}"
+        );
+        assert!(
+            lines
+                .iter()
+                .flat_map(|line| line.spans.iter())
+                .any(|span| span.style.fg == Some(TEXT_DIM)),
+            "table borders should use dim styling: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn markdown_table_reflows_when_terminal_width_changes() {
+        let text = "| Key | Notes |\n| --- | --- |\n| resize | should reflow columns cleanly |"
+            .to_string();
+        let chat = ChatLine {
+            author: Author::Assistant,
+            text,
+        };
+
+        let mut narrow = Vec::new();
+        append_chat_lines(&mut narrow, &chat, 28);
+        let mut wide = Vec::new();
+        append_chat_lines(&mut wide, &chat, 80);
+
+        assert_ne!(
+            narrow.iter().map(line_text).collect::<Vec<_>>(),
+            wide.iter().map(line_text).collect::<Vec<_>>(),
+            "table layout should change with width"
+        );
+        for (width, rendered) in [(28, &narrow), (80, &wide)] {
+            assert!(
+                rendered.iter().all(|line| line_width(line) <= width),
+                "table should fit width {width}: {rendered:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn markdown_table_inside_code_fence_stays_literal() {
+        let mut lines = Vec::new();
+        append_chat_lines(
+            &mut lines,
+            &ChatLine {
+                author: Author::Assistant,
+                text: "```\n| not | a table |\n| --- | --- |\n```".to_string(),
+            },
+            60,
+        );
+
+        let body = lines.iter().map(line_text).collect::<Vec<_>>().join("\n");
+        assert!(
+            !body.contains('╭') && !body.contains('╮'),
+            "fenced pipe rows should not be rendered as a table: {body}"
+        );
+        assert!(
+            body.contains("| not | a table |"),
+            "literal pipes preserved"
+        );
+    }
+
+    #[test]
     fn markdown_lines_wrap_styled_content_to_available_width() {
         let width = 32;
         let mut lines = Vec::new();
@@ -2935,6 +3017,10 @@ mod tests {
             ChatLine {
                 author: Author::User,
                 text: "this is a deliberately long user prompt with one-super-long-token".into(),
+            },
+            ChatLine {
+                author: Author::Assistant,
+                text: "| Col A | Col B |\n| --- | --- |\n| alpha | beta |".into(),
             },
             ChatLine {
                 author: Author::Assistant,

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1037,9 +1037,13 @@ pub(crate) fn append_markdown_lines<'a>(
         .max(1);
     let mut first = true;
     let mut in_code = false;
+    let source_lines = text.lines().collect::<Vec<_>>();
+    let mut index = 0;
 
-    for raw in text.lines() {
+    while index < source_lines.len() {
+        let raw = source_lines[index];
         let trimmed = raw.trim_end();
+
         if let Some(lang) = trimmed.trim_start().strip_prefix("```") {
             in_code = !in_code;
             let code_lang = lang.trim();
@@ -1063,6 +1067,23 @@ pub(crate) fn append_markdown_lines<'a>(
                     Style::default().fg(TEXT_DIM).add_modifier(Modifier::ITALIC),
                 )],
             );
+            index += 1;
+            continue;
+        }
+
+        if !in_code
+            && let Some((table, next)) =
+                super::markdown_table::try_parse_table_at(&source_lines, index)
+            && super::markdown_table::append_markdown_table_lines(
+                lines,
+                first_prefix,
+                prefix_style,
+                &table,
+                inner_width,
+                &mut first,
+            )
+        {
+            index = next;
             continue;
         }
 
@@ -1087,6 +1108,7 @@ pub(crate) fn append_markdown_lines<'a>(
                 &mut first,
                 vec![],
             );
+            index += 1;
             continue;
         }
         let mut search_from = 0;
@@ -1104,6 +1126,7 @@ pub(crate) fn append_markdown_lines<'a>(
                 piece_spans,
             );
         }
+        index += 1;
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Assistant markdown tables are now rendered as bordered terminal tables instead of raw pipe text.

- Detects GFM pipe tables (`| col |`, `|---|`, data rows) in assistant messages
- Lays out tables with [`comfy-table`](https://crates.io/crates/comfy-table) (UTF-8 rounded borders, dynamic column widths)
- Applies TUI styling: dim borders, bold header cells
- **Resize-aware**: tables reflow automatically because transcript lines are re-rendered from source text on every draw using the current viewport width
- **Narrow-terminal fallback**: when a boxed table cannot fit the available width, rendering falls back to the existing plain pipe-row formatter

## Testing

- 12 new/updated unit tests covering parsing, alignments, width bounds, resize reflow, code-fence safety, border/header styling, and narrow-width fallback
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"` (offline smoke)

## Security review

- Parses only assistant transcript markdown at render time; no new network or file I/O
- `comfy-table` added with `default-features = false` (no tty ioctl); explicit table width is always supplied

## Follow-ups

No follow-ups.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b86168c-1b94-4f5c-b7ff-384d26ba8f8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b86168c-1b94-4f5c-b7ff-384d26ba8f8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

