### PR TITLE
feat(setup): live model/provider/effort tools + delete_skill

### DIFF
--- a/specs/conversational-control.md
+++ b/specs/conversational-control.md
@@ -1,0 +1,96 @@
+# Conversational Control Specification
+
+## Abstract
+
+Every user-facing control over a yolop session must be reachable **conversationally**:
+the agent can perform it by calling a tool in response to ordinary prose, or on its
+own initiative when the task calls for it — without the user typing a slash command
+and without an interactive overlay the user must confirm. Slash commands and TUI
+overlays remain as convenient front-ends, but they are never the *only* path.
+
+This spec is the durable contract behind that promise. It says **what** must be
+conversational and **how new control surfaces inherit the same treatment**; it does
+not duplicate each tool's schema (those live in source).
+
+## Motivation
+
+yolop is an agent first. If the agent decides it needs more reasoning budget for a
+hard step, a different model for a task, or wants to uninstall a stale skill, it
+should just do it — the same way a human collaborator would — rather than printing
+"please type `/effort high`". Controls that are reachable only through a slash
+command, an overlay confirmation, or a next-run-only settings write fail this bar.
+
+## Required behavior
+
+1. **Live, agent-invocable, no confirmation.** Each control surface listed below
+   exposes a model-facing tool that (a) the agent can call from a natural-language
+   request or autonomously, (b) takes effect on the **live session** (at the latest,
+   the next turn — never "next process run only"), and (c) does not require the user
+   to confirm an interactive overlay.
+
+2. **One implementation, many front-ends.** A control's mutation logic lives in one
+   place; the slash command, any overlay, and the agent tool all route through it.
+   Adding a tool must not fork the logic — it shares the command's code path so
+   validation, persistence, and live application are identical. (`SetupController` is
+   the reference: `/setup`, the model picker overlay, and the `set_*` tools all call
+   its `change_*` methods.)
+
+3. **Errors are recoverable.** A bad argument (unknown effort, unknown provider,
+   missing skill) returns a tool error whose message names the valid options or the
+   reason, so the agent can correct itself without user help.
+
+4. **Discoverability.** The agent is told these tools exist and when to use them via
+   a capability system-prompt contribution, so it reaches for them instead of
+   instructing the user. Keep that guidance short and conservative ("prefer the
+   smallest change; do not thrash").
+
+5. **New control surfaces inherit this contract.** Any future setting, mode, or
+   resource a user can change in a session ships with its conversational tool in the
+   same change — not as a follow-up. A control that is only a slash command, only an
+   overlay, or only a next-run settings key is incomplete and should be treated as a
+   bug against this spec.
+
+## Current control surfaces
+
+| Surface | Conversational tool | Front-ends sharing the logic |
+|---|---|---|
+| Reasoning effort | `set_reasoning_effort` | `/effort` overlay, `/setup effort` |
+| Model | `set_model` | `/model` overlay, `/setup model` |
+| Provider | `set_provider` | `/setup provider` |
+| Skills — list | `list_skills` (upstream) | system-prompt listing |
+| Skills — install/update | `write_skill` (upstream) | — |
+| Skills — uninstall | `delete_skill` | — |
+| Settings (provider/model/tokens/urls/capabilities, next-run) | `get_config` / `set_config` | `/setup`, `yolop-config` skill |
+| Terminal/UI actions (help, tools, mcp, cwd, status, model, effort, clear, quit) | `run_yolop_command` (TUI only) | the slash commands themselves |
+
+Notes:
+
+- `set_model` / `set_provider` / `set_reasoning_effort` apply to the live session; the
+  `/model` and `/effort` overlays still exist for humans, but the agent no longer
+  needs them (it does not pre-seed an overlay the user must confirm).
+- `set_config` is intentionally next-run for provider/model edits — it edits the
+  settings file. The *live* equivalents are the `set_*` tools above.
+- `run_yolop_command` is gated to the interactive TUI because its effects (clearing
+  the transcript, quitting) only exist there; see [`commands.md`](./commands.md).
+
+## Known gap
+
+- **Mid-turn reasoning-effort change** (within a single `run_turn`, not just at the
+  next turn boundary) requires upstream `everruns-runtime` support and is tracked in
+  **EVE-595**. `set_reasoning_effort` delivers turn-boundary escalation today.
+
+## Ownership boundary
+
+- This spec owns the conversational-control contract and the inventory above.
+- `crate::capabilities::host` owns `SetupController` and the `set_*` tools.
+- `crate::capabilities::skills` owns `delete_skill`; the upstream
+  `ScopedSkillsCapability` owns `list_skills` / `write_skill` (see [`skills.md`](./skills.md)).
+- `crate::capabilities::config` owns `get_config` / `set_config` (see
+  [`configuration.md`](./configuration.md)).
+- The command registry and `run_yolop_command` are owned by [`commands.md`](./commands.md).
+
+## Related
+
+- [`commands.md`](./commands.md) — slash-command surface and natural-language dispatch.
+- [`skills.md`](./skills.md) — skill scopes and management tools.
+- [`configuration.md`](./configuration.md) — the settings file and its schema.

--- a/specs/skills.md
+++ b/specs/skills.md
@@ -76,6 +76,12 @@ a labeled VFS root that yolop's file store maps to a **real on-disk directory**:
    `write_skill` validates the skill name and `SKILL.md`, requires the
    frontmatter `name` to match the directory name, bounds extra files, rejects
    path traversal, and never writes system skills.
+8. **Uninstall.** The yolop-owned `delete_skill` tool removes an installed skill
+   from a writable scope (`workspace` or `global`). It validates the name as a
+   single path segment (no separators, `.`, or `..`), refuses a directory with no
+   `SKILL.md`, and never touches the read-only system scope. This is the
+   conversational uninstall path (see [`conversational-control.md`](./conversational-control.md));
+   the upstream capability has no removal.
 8. **Absent scopes are silent.** A missing workspace/global directory is simply
    empty until a skill is installed. A failure to materialize system skills
    disables that scope without failing the session.
@@ -93,8 +99,9 @@ a labeled VFS root that yolop's file store maps to a **real on-disk directory**:
   precedence, the skills tools, validation, and substitution — all through the
   session `SessionFileSystem`.
 - `crate::capabilities::skills` owns the yolop wiring: the scope set, the
-  host-path `SkillDirResolver`, the embedded system skills + materialization, and
-  the VFS-root constants the file store routes on.
+  host-path `SkillDirResolver`, the embedded system skills + materialization, the
+  VFS-root constants the file store routes on, and the `SkillManagementCapability`
+  that contributes the `delete_skill` (uninstall) tool.
 - `crate::runtime` (`CodingCliSessionFileStore`) owns mapping the scope VFS roots
   to real on-disk directories.
 - `everruns_core::skill` owns the `SKILL.md` format, parsing, validation, and

--- a/specs/skills.md
+++ b/specs/skills.md
@@ -82,13 +82,13 @@ a labeled VFS root that yolop's file store maps to a **real on-disk directory**:
    `SKILL.md`, and never touches the read-only system scope. This is the
    conversational uninstall path (see [`conversational-control.md`](./conversational-control.md));
    the upstream capability has no removal.
-8. **Absent scopes are silent.** A missing workspace/global directory is simply
+9. **Absent scopes are silent.** A missing workspace/global directory is simply
    empty until a skill is installed. A failure to materialize system skills
    disables that scope without failing the session.
-9. **Materialization is safe.** System-skill materialization is idempotent and
-   concurrency-safe (atomic per-file writes, skipped when bytes are unchanged),
-   so parallel processes do not race on the shared cache directory.
-10. **Management guidance is bundled.** Yolop ships a `skill-management` system
+10. **Materialization is safe.** System-skill materialization is idempotent and
+    concurrency-safe (atomic per-file writes, skipped when bytes are unchanged),
+    so parallel processes do not race on the shared cache directory.
+11. **Management guidance is bundled.** Yolop ships a `skill-management` system
     skill that tells the agent how to inspect, install, search for, and upgrade
     skills, including reconstructing `npx skill add ...` style installs by
     fetching source files directly and writing them with `write_skill`.

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -580,9 +580,9 @@ const SETUP_TOOLS_PROMPT: &str = "<capability id=\"yolop_setup\">\n\
     `set_reasoning_effort` changes the model's reasoning effort (escalate before \
     a hard step, deescalate for cheap follow-ups), `set_model` switches the model, \
     and `set_provider` switches the provider. All three apply on the next turn of \
-    this session — no restart. Effort options are model-specific; call \
-    `set_reasoning_effort` with no change to learn the current set, or read the \
-    error it returns. Prefer the smallest change that fits; do not thrash the model \
+    this session — no restart. Effort options are model-specific; if the level is \
+    unknown, `set_reasoning_effort` returns the accepted values, so retry with one \
+    of those. Prefer the smallest change that fits; do not thrash the model \
     or provider mid-task.\n\
     </capability>";
 

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -14,7 +14,7 @@ use everruns_core::command::{
 };
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_runtime::RuntimeProviderStore;
-use serde_json::json;
+use serde_json::{Value, json};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Arc, RwLock};
@@ -459,6 +459,35 @@ pub(crate) struct SetupCapability {
     pub(crate) settings: Arc<SettingsStore>,
 }
 
+impl SetupCapability {
+    /// The shared, cloneable handle the `/setup` command and the model-facing
+    /// `set_*` tools both drive. Everything that mutates the live provider/model
+    /// lives on [`SetupController`] so the slash command and the agent tools
+    /// route through one implementation — there is no second config path.
+    fn controller(&self) -> SetupController {
+        SetupController {
+            provider: self.provider.clone(),
+            provider_store: self.provider_store.clone(),
+            config: self.config.clone(),
+            settings: self.settings.clone(),
+        }
+    }
+}
+
+/// Live provider/model/effort controller. Holds the same handles as
+/// [`SetupCapability`] and owns every mutation (`change_provider`,
+/// `change_model`, `change_effort`, tokens, urls, attribution, approval). The
+/// slash command (`execute_command`) and the agent-facing `set_*` tools both
+/// call these methods, so a natural-language request and a typed `/setup`
+/// apply identically and take effect on the live session.
+#[derive(Clone)]
+pub(crate) struct SetupController {
+    provider: Arc<RwLock<ProviderChoice>>,
+    provider_store: Arc<dyn RuntimeProviderStore>,
+    config: Arc<dyn ConfigService>,
+    settings: Arc<SettingsStore>,
+}
+
 #[async_trait]
 impl Capability for SetupCapability {
     fn id(&self) -> &str {
@@ -477,7 +506,7 @@ impl Capability for SetupCapability {
         Some("Examples")
     }
     fn system_prompt_addition(&self) -> Option<&str> {
-        None
+        Some(SETUP_TOOLS_PROMPT)
     }
     fn commands(&self) -> Vec<CommandDescriptor> {
         vec![CommandDescriptor {
@@ -486,6 +515,25 @@ impl Capability for SetupCapability {
             source: CommandSource::System,
             args: vec![setup_command_arg()],
         }]
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        // The model-facing surface for live session control. Each tool routes
+        // through the same `SetupController` the `/setup` command uses, so a
+        // natural-language request ("switch to high effort", "use gpt-5.4")
+        // applies to the running session exactly like the slash command — no
+        // overlay, no next-run-only deferral. See specs/conversational-control.md.
+        vec![
+            Box::new(SetReasoningEffortTool {
+                controller: self.controller(),
+            }),
+            Box::new(SetModelTool {
+                controller: self.controller(),
+            }),
+            Box::new(SetProviderTool {
+                controller: self.controller(),
+            }),
+        ]
     }
 
     async fn execute_command(
@@ -500,28 +548,43 @@ impl Capability for SetupCapability {
                 request.name
             )));
         }
+        let controller = self.controller();
         let raw = request.arguments.as_deref().unwrap_or("").trim();
         if raw.is_empty() || raw == "status" {
-            return Ok(self.status_result());
+            return Ok(controller.status_result());
         }
 
         let mut parts = raw.splitn(2, char::is_whitespace);
         let action = parts.next().unwrap_or_default();
         let rest = parts.next().unwrap_or_default().trim();
         match action {
-            "provider" => self.change_provider(rest).await,
-            "model" => self.change_model(rest).await,
-            "effort" => self.change_effort(rest).await,
-            "token" => self.change_token(rest),
-            "url" => self.change_base_url(rest),
-            "attribution" => self.change_attribution(rest),
-            "approval" => self.change_approval(rest),
+            "provider" => controller.change_provider(rest).await,
+            "model" => controller.change_model(rest).await,
+            "effort" => controller.change_effort(rest).await,
+            "token" => controller.change_token(rest),
+            "url" => controller.change_base_url(rest),
+            "attribution" => controller.change_attribution(rest),
+            "approval" => controller.change_approval(rest),
             _ => Ok(failed_result(
                 "usage: /setup — run guided setup; internal forms: status, provider <name> [model], token <provider> <value|clear>, url <provider> <base-url|clear>, model <id> [reasoning-effort], effort <reasoning-effort>, attribution <on|off>, approval <protective|normal|off>".to_string(),
             )),
         }
     }
 }
+
+/// Always-on guidance so the agent knows it can reconfigure the live session
+/// itself, in prose, without the user typing a slash command or touching an
+/// overlay. Mirrors the conversational-control contract (specs/conversational-control.md).
+const SETUP_TOOLS_PROMPT: &str = "<capability id=\"yolop_setup\">\n\
+    You can reconfigure the live session yourself when it helps the task:\n\
+    `set_reasoning_effort` changes the model's reasoning effort (escalate before \
+    a hard step, deescalate for cheap follow-ups), `set_model` switches the model, \
+    and `set_provider` switches the provider. All three apply on the next turn of \
+    this session — no restart. Effort options are model-specific; call \
+    `set_reasoning_effort` with no change to learn the current set, or read the \
+    error it returns. Prefer the smallest change that fits; do not thrash the model \
+    or provider mid-task.\n\
+    </capability>";
 
 fn setup_command_arg() -> CommandArg {
     let mut suggestions = vec![
@@ -565,7 +628,7 @@ fn setup_command_arg() -> CommandArg {
     }
 }
 
-impl SetupCapability {
+impl SetupController {
     fn status_result(&self) -> CommandResult {
         let current = self
             .provider
@@ -1058,6 +1121,175 @@ fn failed_result(message: String) -> CommandResult {
     }
 }
 
+// ---------- model-facing live-config tools ----------
+//
+// These expose the `SetupController` mutations as agent tools so the model can
+// reconfigure the running session from a natural-language request (or on its
+// own), instead of asking the user to type `/setup` or confirm an overlay. They
+// reuse the exact `change_*` logic the slash command uses, so behavior — live
+// application, validation, persistence — is identical across both entry points.
+
+/// Map a `change_*` outcome onto a tool result: a failed (but non-erroring)
+/// `CommandResult` becomes a recoverable tool error carrying the same message
+/// (e.g. an unknown effort plus the valid set), so the model can correct itself.
+fn into_tool_result(outcome: everruns_core::Result<CommandResult>) -> ToolExecutionResult {
+    match outcome {
+        Ok(result) if result.success => ToolExecutionResult::success(json!({
+            "success": true,
+            "message": result.message,
+        })),
+        Ok(result) => ToolExecutionResult::tool_error(result.message),
+        Err(err) => ToolExecutionResult::tool_error(err.to_string()),
+    }
+}
+
+fn required_str_arg<'a>(arguments: &'a Value, key: &str) -> Result<&'a str, ToolExecutionResult> {
+    match arguments.get(key).and_then(Value::as_str) {
+        Some(value) if !value.trim().is_empty() => Ok(value.trim()),
+        _ => Err(ToolExecutionResult::tool_error(format!(
+            "'{key}' is required"
+        ))),
+    }
+}
+
+struct SetReasoningEffortTool {
+    controller: SetupController,
+}
+
+#[async_trait]
+impl Tool for SetReasoningEffortTool {
+    fn name(&self) -> &str {
+        "set_reasoning_effort"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Set reasoning effort")
+    }
+    fn description(&self) -> &str {
+        "Change the current model's reasoning effort for this session (e.g. escalate to think \
+         harder before a difficult step, or deescalate for cheap follow-ups). Applies on the next \
+         turn — no restart. The valid set is model-specific; if the level is unknown the tool \
+         returns the accepted values so you can retry."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "effort": {
+                    "type": "string",
+                    "description": "Reasoning-effort level for the active model, e.g. low / medium / high (model-specific)."
+                }
+            },
+            "required": ["effort"],
+            "additionalProperties": false
+        })
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let effort = match required_str_arg(&arguments, "effort") {
+            Ok(value) => value,
+            Err(err) => return err,
+        };
+        into_tool_result(self.controller.change_effort(effort).await)
+    }
+}
+
+struct SetModelTool {
+    controller: SetupController,
+}
+
+#[async_trait]
+impl Tool for SetModelTool {
+    fn name(&self) -> &str {
+        "set_model"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Set model")
+    }
+    fn description(&self) -> &str {
+        "Switch the model used for this session. Applies on the next turn — no restart. The id is \
+         resolved against the current provider; an optional reasoning effort can be set at the same \
+         time. Avoid switching mid-task unless it clearly helps."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "model": {
+                    "type": "string",
+                    "description": "Model id for the active provider, e.g. `gpt-5.4` or `claude-sonnet-4-5`."
+                },
+                "reasoning_effort": {
+                    "type": "string",
+                    "description": "Optional reasoning-effort level to apply with the model (model-specific)."
+                }
+            },
+            "required": ["model"],
+            "additionalProperties": false
+        })
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let model = match required_str_arg(&arguments, "model") {
+            Ok(value) => value,
+            Err(err) => return err,
+        };
+        // `change_model` accepts the `model [reasoning-effort]` spec the
+        // `/setup model` command takes, so join the optional effort onto it.
+        let spec = match arguments.get("reasoning_effort").and_then(Value::as_str) {
+            Some(effort) if !effort.trim().is_empty() => format!("{model} {}", effort.trim()),
+            _ => model.to_string(),
+        };
+        into_tool_result(self.controller.change_model(&spec).await)
+    }
+}
+
+struct SetProviderTool {
+    controller: SetupController,
+}
+
+#[async_trait]
+impl Tool for SetProviderTool {
+    fn name(&self) -> &str {
+        "set_provider"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Set provider")
+    }
+    fn description(&self) -> &str {
+        "Switch the LLM provider for this session. Applies on the next turn — no restart. \
+         Optionally pin a model for the new provider at the same time. Requires that provider's \
+         credentials to already be configured."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "provider": {
+                    "type": "string",
+                    "description": "Provider name.",
+                    "enum": SUPPORTED_PROVIDERS
+                },
+                "model": {
+                    "type": "string",
+                    "description": "Optional model id to select for the new provider."
+                }
+            },
+            "required": ["provider"],
+            "additionalProperties": false
+        })
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let provider = match required_str_arg(&arguments, "provider") {
+            Ok(value) => value,
+            Err(err) => return err,
+        };
+        // `change_provider` accepts `provider [model]`, switching both at once.
+        let spec = match arguments.get("model").and_then(Value::as_str) {
+            Some(model) if !model.trim().is_empty() => format!("{provider} {}", model.trim()),
+            _ => provider.to_string(),
+        };
+        into_tool_result(self.controller.change_provider(&spec).await)
+    }
+}
+
 impl SetupCapability {
     /// True when no provider preference is saved and no API token is set —
     /// either via env var or in the settings file. Used by the TUI at
@@ -1095,6 +1327,153 @@ fn env_credential_present() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---------- live-config tools (set_model / set_provider / set_reasoning_effort) ----------
+
+    /// Minimal provider store for controller tests: `change_*` only ever calls
+    /// `set_default_model`, which we accept; the reads are never exercised here.
+    struct StubProviderStore;
+
+    #[async_trait::async_trait]
+    impl everruns_core::ProviderStore for StubProviderStore {
+        async fn get_resolved_model(
+            &self,
+            _model_id: everruns_core::ModelId,
+        ) -> everruns_core::Result<Option<everruns_core::ResolvedModel>> {
+            Ok(None)
+        }
+        async fn get_default_model(
+            &self,
+        ) -> everruns_core::Result<Option<everruns_core::ResolvedModel>> {
+            Ok(None)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl RuntimeProviderStore for StubProviderStore {
+        async fn set_default_model(
+            &self,
+            _model: everruns_core::ResolvedModel,
+        ) -> everruns_core::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// A controller wired to a temp settings file and the stub store, plus the
+    /// shared provider handle so the test can observe live changes. The returned
+    /// `TempDir` must be kept alive for the settings path to stay valid.
+    fn test_controller(
+        provider: ProviderChoice,
+    ) -> (
+        SetupController,
+        Arc<RwLock<ProviderChoice>>,
+        tempfile::TempDir,
+    ) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let settings = Arc::new(SettingsStore::open(dir.path().join("settings.toml")));
+        // Seed credentials in the settings file so model resolution never depends
+        // on ambient env vars (other tests in this binary clear API keys). This
+        // keeps the controller tests deterministic without holding the env lock.
+        settings
+            .set_token("openai".to_string(), "sk-test".to_string())
+            .expect("seed openai token");
+        settings
+            .set_token("anthropic".to_string(), "sk-test".to_string())
+            .expect("seed anthropic token");
+        let provider = Arc::new(RwLock::new(provider));
+        let controller = SetupController {
+            provider: provider.clone(),
+            provider_store: Arc::new(StubProviderStore),
+            config: settings.clone(),
+            settings,
+        };
+        (controller, provider, dir)
+    }
+
+    #[tokio::test]
+    async fn set_reasoning_effort_tool_applies_live_and_validates() {
+        let (controller, provider, _dir) = test_controller(ProviderChoice::OpenAi {
+            model: "gpt-5.5".to_string(),
+            reasoning_effort: Some("medium".to_string()),
+        });
+        let tool = SetReasoningEffortTool {
+            controller: controller.clone(),
+        };
+
+        // Escalate: the shared handle reflects the new effort immediately.
+        let result = tool.execute(json!({ "effort": "high" })).await;
+        assert!(result.is_success(), "escalate: {result:?}");
+        assert_eq!(provider.read().unwrap().reasoning_effort(), Some("high"));
+
+        // A missing argument is a tool error before anything is mutated.
+        let result = tool.execute(json!({})).await;
+        assert!(result.is_error(), "missing effort should error");
+
+        // An unknown level errors and leaves the prior selection intact.
+        let result = tool.execute(json!({ "effort": "ludicrous" })).await;
+        assert!(result.is_error(), "unknown effort should error");
+        assert_eq!(provider.read().unwrap().reasoning_effort(), Some("high"));
+    }
+
+    #[tokio::test]
+    async fn set_model_tool_switches_model_and_optional_effort() {
+        let (controller, provider, _dir) = test_controller(ProviderChoice::OpenAi {
+            model: "gpt-5.5".to_string(),
+            reasoning_effort: Some("medium".to_string()),
+        });
+        let tool = SetModelTool { controller };
+
+        let result = tool
+            .execute(json!({ "model": "gpt-5.4", "reasoning_effort": "high" }))
+            .await;
+        assert!(result.is_success(), "set_model: {result:?}");
+        assert_eq!(provider.read().unwrap().model_id(), "gpt-5.4");
+        assert_eq!(provider.read().unwrap().reasoning_effort(), Some("high"));
+
+        let result = tool.execute(json!({})).await;
+        assert!(result.is_error(), "missing model should error");
+    }
+
+    #[test]
+    fn setup_capability_exposes_live_config_tools() {
+        let (controller, _provider, _dir) = test_controller(ProviderChoice::Sim);
+        let capability = SetupCapability {
+            provider: controller.provider.clone(),
+            provider_store: controller.provider_store.clone(),
+            config: controller.config.clone(),
+            settings: controller.settings.clone(),
+        };
+        let names: Vec<String> = capability
+            .tools()
+            .iter()
+            .map(|t| t.name().to_string())
+            .collect();
+        for expected in ["set_reasoning_effort", "set_model", "set_provider"] {
+            assert!(
+                names.iter().any(|n| n == expected),
+                "{expected} should be exposed by SetupCapability: {names:?}"
+            );
+        }
+        // The agent is told these tools exist so it uses them instead of asking
+        // the user to type a slash command.
+        let prompt = capability.system_prompt_addition().expect("setup prompt");
+        assert!(prompt.contains("set_reasoning_effort"));
+        assert!(prompt.contains("set_model"));
+        assert!(prompt.contains("set_provider"));
+    }
+
+    #[tokio::test]
+    async fn set_provider_tool_switches_provider_live() {
+        let (controller, provider, _dir) = test_controller(ProviderChoice::Sim);
+        let tool = SetProviderTool { controller };
+
+        let result = tool.execute(json!({ "provider": "openai" })).await;
+        assert!(result.is_success(), "set_provider: {result:?}");
+        assert_eq!(provider.read().unwrap().provider_name(), "openai");
+
+        let result = tool.execute(json!({ "provider": "nope" })).await;
+        assert!(result.is_error(), "unknown provider should error");
+    }
 
     #[test]
     fn needs_onboarding_true_for_empty_settings() {

--- a/src/capabilities/skills.rs
+++ b/src/capabilities/skills.rs
@@ -293,7 +293,9 @@ impl DeleteSkillTool {
     /// silently falling back to the workspace.
     fn base_for(&self, scope: &str) -> Result<PathBuf, String> {
         match scope {
-            "workspace" | "local" => Ok(self.dirs.workspace.clone()),
+            // Only the scopes advertised in the tool schema are accepted, so the
+            // documented surface and the behavior stay in lockstep.
+            "workspace" => Ok(self.dirs.workspace.clone()),
             "global" => self
                 .dirs
                 .global
@@ -380,29 +382,42 @@ impl Tool for DeleteSkillTool {
             Err(err) => return ToolExecutionResult::tool_error(err),
         };
         let target = base.join(name);
-        if !target.is_dir() {
-            return ToolExecutionResult::tool_error(format!(
-                "no `{name}` skill installed in the {scope} scope"
-            ));
-        }
-        // Guard against deleting an unrelated directory: a real skill always
-        // carries a SKILL.md. Refuse anything that does not look like a skill.
-        if !target.join("SKILL.md").is_file() {
-            return ToolExecutionResult::tool_error(format!(
-                "`{}` is not a skill (no SKILL.md); refusing to delete",
-                target.display()
-            ));
-        }
-        match std::fs::remove_dir_all(&target) {
-            Ok(()) => ToolExecutionResult::success(json!({
+        // The stat checks and the recursive delete are blocking filesystem work;
+        // run them off the async runtime so a large skill directory can't stall a
+        // tokio worker. The guard messages are built here so the closure owns
+        // everything it needs.
+        let name_owned = name.to_string();
+        let scope_owned = scope.to_string();
+        let target_for_delete = target.clone();
+        let outcome = tokio::task::spawn_blocking(move || -> Result<(), String> {
+            if !target_for_delete.is_dir() {
+                return Err(format!(
+                    "no `{name_owned}` skill installed in the {scope_owned} scope"
+                ));
+            }
+            // Guard against deleting an unrelated directory: a real skill always
+            // carries a SKILL.md. Refuse anything that does not look like a skill.
+            if !target_for_delete.join("SKILL.md").is_file() {
+                return Err(format!(
+                    "`{}` is not a skill (no SKILL.md); refusing to delete",
+                    target_for_delete.display()
+                ));
+            }
+            std::fs::remove_dir_all(&target_for_delete)
+                .map_err(|err| format!("failed to delete `{name_owned}`: {err}"))
+        })
+        .await;
+        match outcome {
+            Ok(Ok(())) => ToolExecutionResult::success(json!({
                 "success": true,
                 "name": name,
                 "scope": scope,
                 "removed": target.display().to_string(),
                 "message": format!("uninstalled `{name}` from the {scope} scope"),
             })),
-            Err(err) => {
-                ToolExecutionResult::tool_error(format!("failed to delete `{name}`: {err}"))
+            Ok(Err(message)) => ToolExecutionResult::tool_error(message),
+            Err(join_err) => {
+                ToolExecutionResult::tool_error(format!("delete task failed: {join_err}"))
             }
         }
     }

--- a/src/capabilities/skills.rs
+++ b/src/capabilities/skills.rs
@@ -23,8 +23,13 @@
 //   * global    — `<config_dir>/yolop/skills`            (writable; override: YOLOP_GLOBAL_SKILLS_DIR)
 //   * system    — pre-packed, materialized once          (read-only; override: YOLOP_SYSTEM_SKILLS_DIR)
 
-use everruns_core::capabilities::{SkillDirResolver, SkillScope, SkillsConfig};
+use async_trait::async_trait;
+use everruns_core::capabilities::{
+    Capability, CapabilityStatus, SkillDirResolver, SkillScope, SkillsConfig,
+};
+use everruns_core::tools::{Tool, ToolExecutionResult};
 use include_dir::{Dir, include_dir};
+use serde_json::{Value, json};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -226,6 +231,183 @@ fn write_if_changed(target: &Path, contents: &[u8]) -> std::io::Result<()> {
     std::fs::rename(&tmp, target)
 }
 
+pub(crate) const SKILL_MANAGEMENT_CAPABILITY_ID: &str = "yolop_skill_management";
+
+const SKILL_MANAGEMENT_PROMPT: &str = "<capability id=\"yolop_skill_management\">\n\
+    To uninstall a skill, call `delete_skill` with its name and scope \
+    (`workspace` or `global`). It removes the installed skill directory in that \
+    scope. System skills are read-only and cannot be deleted. Install and update \
+    still go through `write_skill`; this only handles removal.\n\
+    </capability>";
+
+/// Skill removal for yolop's writable scopes. The upstream
+/// `ScopedSkillsCapability` owns discovery and `list/activate/read/write_skill`
+/// but has no uninstall, so yolop contributes `delete_skill` here. It operates
+/// on the same workspace/global directories the resolver exposes (system stays
+/// read-only), giving the agent a first-class, conversational uninstall instead
+/// of shelling out to `rm`.
+pub(crate) struct SkillManagementCapability {
+    dirs: SkillDirs,
+}
+
+impl SkillManagementCapability {
+    pub(crate) fn new(dirs: SkillDirs) -> Self {
+        Self { dirs }
+    }
+}
+
+#[async_trait]
+impl Capability for SkillManagementCapability {
+    fn id(&self) -> &str {
+        SKILL_MANAGEMENT_CAPABILITY_ID
+    }
+    fn name(&self) -> &str {
+        "Skill Management"
+    }
+    fn description(&self) -> &str {
+        "Uninstall workspace or global skills (delete_skill)."
+    }
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+    fn category(&self) -> Option<&str> {
+        Some("Examples")
+    }
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(SKILL_MANAGEMENT_PROMPT)
+    }
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![Box::new(DeleteSkillTool {
+            dirs: self.dirs.clone(),
+        })]
+    }
+}
+
+struct DeleteSkillTool {
+    dirs: SkillDirs,
+}
+
+impl DeleteSkillTool {
+    /// Resolve the host directory for a writable scope. `system` is rejected
+    /// (read-only); an unconfigured `global` scope is reported rather than
+    /// silently falling back to the workspace.
+    fn base_for(&self, scope: &str) -> Result<PathBuf, String> {
+        match scope {
+            "workspace" | "local" => Ok(self.dirs.workspace.clone()),
+            "global" => self
+                .dirs
+                .global
+                .clone()
+                .ok_or_else(|| "no global skills directory is configured".to_string()),
+            "system" => Err("system skills are read-only and cannot be deleted".to_string()),
+            other => Err(format!(
+                "unknown scope `{other}`; expected `workspace` or `global`"
+            )),
+        }
+    }
+}
+
+/// A skill name must be a single, plain path component — no separators, no `.`
+/// or `..`. This keeps `delete_skill` from escaping the scope directory.
+fn validate_skill_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("'name' is required".to_string());
+    }
+    let mut components = Path::new(name).components();
+    let only = components.next();
+    if components.next().is_some() {
+        return Err(format!(
+            "invalid skill name `{name}`: must be a single path segment"
+        ));
+    }
+    match only {
+        Some(std::path::Component::Normal(segment)) if segment == name => Ok(()),
+        _ => Err(format!(
+            "invalid skill name `{name}`: must not contain path separators, `.`, or `..`"
+        )),
+    }
+}
+
+#[async_trait]
+impl Tool for DeleteSkillTool {
+    fn name(&self) -> &str {
+        "delete_skill"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Delete skill")
+    }
+    fn description(&self) -> &str {
+        "Uninstall a skill by removing its directory from a writable scope \
+         (`workspace` or `global`). System skills cannot be deleted. Use this to \
+         remove a skill the user no longer wants; install/update go through `write_skill`."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The skill's directory name (matches its SKILL.md `name`)."
+                },
+                "scope": {
+                    "type": "string",
+                    "description": "Which writable scope to remove it from.",
+                    "enum": ["workspace", "global"],
+                    "default": "workspace"
+                }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+        })
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let name = arguments
+            .get("name")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .trim();
+        if let Err(err) = validate_skill_name(name) {
+            return ToolExecutionResult::tool_error(err);
+        }
+        let scope = arguments
+            .get("scope")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or("workspace");
+        let base = match self.base_for(scope) {
+            Ok(base) => base,
+            Err(err) => return ToolExecutionResult::tool_error(err),
+        };
+        let target = base.join(name);
+        if !target.is_dir() {
+            return ToolExecutionResult::tool_error(format!(
+                "no `{name}` skill installed in the {scope} scope"
+            ));
+        }
+        // Guard against deleting an unrelated directory: a real skill always
+        // carries a SKILL.md. Refuse anything that does not look like a skill.
+        if !target.join("SKILL.md").is_file() {
+            return ToolExecutionResult::tool_error(format!(
+                "`{}` is not a skill (no SKILL.md); refusing to delete",
+                target.display()
+            ));
+        }
+        match std::fs::remove_dir_all(&target) {
+            Ok(()) => ToolExecutionResult::success(json!({
+                "success": true,
+                "name": name,
+                "scope": scope,
+                "removed": target.display().to_string(),
+                "message": format!("uninstalled `{name}` from the {scope} scope"),
+            })),
+            Err(err) => {
+                ToolExecutionResult::tool_error(format!("failed to delete `{name}`: {err}"))
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -342,5 +524,158 @@ mod tests {
             "description should mention ast-grep: {:?}",
             parsed.description
         );
+    }
+
+    // ---------- delete_skill ----------
+
+    #[test]
+    fn skill_management_capability_exposes_delete_skill() {
+        let dirs = SkillDirs {
+            workspace: PathBuf::from("/ws/.agents/skills"),
+            global: None,
+            system: None,
+        };
+        let capability = SkillManagementCapability::new(dirs);
+        let names: Vec<String> = capability
+            .tools()
+            .iter()
+            .map(|t| t.name().to_string())
+            .collect();
+        assert!(
+            names.iter().any(|n| n == "delete_skill"),
+            "delete_skill should be exposed: {names:?}"
+        );
+        assert!(
+            capability
+                .system_prompt_addition()
+                .expect("prompt")
+                .contains("delete_skill")
+        );
+    }
+
+    /// Build a tool whose workspace/global scopes point at fresh temp dirs.
+    fn delete_tool_with_dirs(workspace: &Path, global: Option<&Path>) -> DeleteSkillTool {
+        DeleteSkillTool {
+            dirs: SkillDirs {
+                workspace: workspace.to_path_buf(),
+                global: global.map(Path::to_path_buf),
+                system: None,
+            },
+        }
+    }
+
+    fn install_skill(base: &Path, name: &str) {
+        let dir = base.join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: test\n---\nbody"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn validate_skill_name_rejects_traversal_and_separators() {
+        assert!(validate_skill_name("good-skill").is_ok());
+        assert!(validate_skill_name("").is_err());
+        assert!(validate_skill_name(".").is_err());
+        assert!(validate_skill_name("..").is_err());
+        assert!(validate_skill_name("a/b").is_err());
+        assert!(validate_skill_name("../escape").is_err());
+        assert!(validate_skill_name("/abs").is_err());
+    }
+
+    #[tokio::test]
+    async fn delete_skill_removes_workspace_skill() {
+        let ws = tempfile::tempdir().unwrap();
+        install_skill(ws.path(), "ship");
+        let tool = delete_tool_with_dirs(ws.path(), None);
+
+        let result = tool.execute(json!({ "name": "ship" })).await;
+
+        assert!(result.is_success(), "result: {result:?}");
+        assert!(
+            !ws.path().join("ship").exists(),
+            "skill directory should be gone"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_skill_defaults_to_workspace_and_uninstalls_global_when_asked() {
+        let ws = tempfile::tempdir().unwrap();
+        let global = tempfile::tempdir().unwrap();
+        install_skill(ws.path(), "dup");
+        install_skill(global.path(), "dup");
+        let tool = delete_tool_with_dirs(ws.path(), Some(global.path()));
+
+        // Default scope is workspace.
+        assert!(tool.execute(json!({ "name": "dup" })).await.is_success());
+        assert!(!ws.path().join("dup").exists());
+        assert!(global.path().join("dup").exists(), "global untouched");
+
+        // Explicit global scope removes the global copy.
+        assert!(
+            tool.execute(json!({ "name": "dup", "scope": "global" }))
+                .await
+                .is_success()
+        );
+        assert!(!global.path().join("dup").exists());
+    }
+
+    #[tokio::test]
+    async fn delete_skill_rejects_system_scope() {
+        let ws = tempfile::tempdir().unwrap();
+        let tool = delete_tool_with_dirs(ws.path(), None);
+        let result = tool
+            .execute(json!({ "name": "anything", "scope": "system" }))
+            .await;
+        assert!(result.is_error(), "system skills must be read-only");
+    }
+
+    #[tokio::test]
+    async fn delete_skill_errors_on_unconfigured_global_scope() {
+        let ws = tempfile::tempdir().unwrap();
+        let tool = delete_tool_with_dirs(ws.path(), None);
+        let result = tool
+            .execute(json!({ "name": "x", "scope": "global" }))
+            .await;
+        assert!(result.is_error());
+    }
+
+    #[tokio::test]
+    async fn delete_skill_errors_when_missing() {
+        let ws = tempfile::tempdir().unwrap();
+        let tool = delete_tool_with_dirs(ws.path(), None);
+        let result = tool.execute(json!({ "name": "ghost" })).await;
+        assert!(result.is_error(), "deleting a missing skill should fail");
+    }
+
+    #[tokio::test]
+    async fn delete_skill_refuses_directory_without_skill_md() {
+        let ws = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(ws.path().join("notaskill")).unwrap();
+        let tool = delete_tool_with_dirs(ws.path(), None);
+        let result = tool.execute(json!({ "name": "notaskill" })).await;
+        assert!(result.is_error(), "must refuse non-skill directories");
+        assert!(
+            ws.path().join("notaskill").exists(),
+            "directory must be left intact"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_skill_rejects_path_traversal_argument() {
+        let ws = tempfile::tempdir().unwrap();
+        // A sibling dir outside the scope that must never be touched.
+        let outside = ws.path().parent().unwrap().join("outside-skill");
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(outside.join("SKILL.md"), "---\nname: x\n---\n").unwrap();
+        let tool = delete_tool_with_dirs(ws.path(), None);
+
+        let result = tool.execute(json!({ "name": "../outside-skill" })).await;
+
+        assert!(result.is_error(), "traversal must be rejected");
+        assert!(outside.exists(), "outside directory must survive");
+        let _ = std::fs::remove_dir_all(&outside);
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2091,6 +2091,11 @@ pub async fn build_with_options(
     capabilities.register(ScopedSkillsCapability::new(
         crate::capabilities::skills::skills_config(&skill_dirs),
     ));
+    // yolop-owned skill uninstall (`delete_skill`); the upstream capability has
+    // no removal. Shares the same resolved scope directories.
+    capabilities.register(crate::capabilities::skills::SkillManagementCapability::new(
+        skill_dirs.clone(),
+    ));
     capabilities.register(RepoMapCapability::new(effective_root.clone()));
     capabilities.register(AstGrepCapability::new(effective_root.clone()));
     capabilities.register(InfinityContextCapability);
@@ -3074,6 +3079,15 @@ mod tests {
         assert!(!unknown.success);
         assert!(unknown.message.contains("model <id>"));
     }
+
+    // The live-config tools (`set_provider` / `set_model` / `set_reasoning_effort`)
+    // and `delete_skill` are registered via SetupCapability / SkillManagementCapability
+    // in `build_with_options`. Because ToolSearchCapability defers the long tail
+    // behind `tool_search`, they are not in the immediate `runtime_agent.tools`
+    // snapshot, so their presence is asserted at the capability level
+    // (`capabilities::host::tests::setup_capability_exposes_live_config_tools`,
+    // `capabilities::skills::tests::skill_management_capability_exposes_delete_skill`)
+    // and their behavior by the SetupController / DeleteSkillTool unit tests.
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn setup_url_and_custom_model_persist_through_settings() {


### PR DESCRIPTION
## What

Makes every session control conversational: the agent can reconfigure the running session from a natural-language request (or on its own), without the user typing a slash command or confirming an interactive overlay.

### New agent tools (live, no overlay, no restart)
- **`set_reasoning_effort`** — escalate before a hard step / deescalate for cheap follow-ups. Applies on the next turn (effort is read live from the shared provider handle each turn).
- **`set_model`** — switch the model (optional effort) for the live session.
- **`set_provider`** — switch the provider (optional model). Requires that provider's credentials to be configured.
- **`delete_skill`** — uninstall a skill from a writable scope (`workspace`/`global`). Closes the skills-management gap (upstream has list/activate/read/write but no removal).

### How it's wired
- `set_*` tools route through a new **`SetupController`** that owns the exact `change_*` logic the `/setup` command uses. One implementation, multiple front-ends (slash command, overlay, tool) — validation, persistence, and live application are identical. No forked config path.
- `delete_skill` ships in a small yolop **`SkillManagementCapability`**; it validates the name as a single path segment (blocks `/`, `.`, `..`), refuses directories without a `SKILL.md`, and never touches the read-only system scope.
- A short system-prompt nudge tells the agent these tools exist and to prefer the smallest change (don't thrash model/provider).

### Spec
- New **`specs/conversational-control.md`** establishes the durable contract: every user-facing control ships with a live, agent-invocable tool that applies to the session (never next-run-only, never overlay-gated), and **new control surfaces inherit the same treatment**. Updated `specs/skills.md` for `delete_skill`.

## Why not "change effort mid-turn"?
Effort is bound to the input message once per `run_turn`; re-reading controls per LLM step within a single turn needs upstream `everruns-runtime` support. Tracked in **EVE-595**. The tools here deliver turn-boundary escalation, which covers the practical "this got harder, run hotter" case.

## Tests
- `SetupController` tool unit tests: live apply + validation, made deterministic by seeding settings tokens (other tests in the binary clear ambient API keys).
- `delete_skill` unit tests: happy path, default/explicit scope, system-scope rejection, unconfigured global, missing skill, non-skill directory refusal, path-traversal rejection.
- Capability-level tool-presence tests (the tools are deferred behind `tool_search`, so presence is asserted via the capabilities rather than the immediate tool snapshot).

`cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` all pass locally. (One pre-existing, environment-specific failure — `worktree_manager_creates_isolated_branch_on_implementation_prompt`, `git worktree add` in this sandbox — fails on the pristine tree too and is unrelated to this change.)


---
_Generated by [Claude Code](https://claude.ai/code/session_015RBxW32hDoornEm3xYHrwJ)_