### PR TITLE
refactor(attribution): extract AttributionCapability into its own module

### DIFF
--- a/src/capabilities/attribution.rs
+++ b/src/capabilities/attribution.rs
@@ -1,0 +1,98 @@
+// The `attribution` capability — yolop's optional commit / PR attribution.
+//
+// When enabled (central `attribution` flag in settings.toml), this capability
+// injects guidance asking the model to keep the user's git identity intact and
+// append a single `Co-Authored-By` trailer to commits it creates, plus a short
+// footer to pull request descriptions. It is prompt guidance only — there is no
+// hard enforcement — so it lives entirely in `system_prompt_contribution` and
+// reads the flag live through the shared config service each turn.
+
+use crate::config_service::ConfigService;
+use async_trait::async_trait;
+use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
+use std::sync::Arc;
+
+pub(crate) const ATTRIBUTION_CAPABILITY_ID: &str = "yolop_attribution";
+pub(crate) const YOLOP_ATTRIBUTION_TRAILER: &str = "Co-Authored-By: yolop <yolop@everruns.com>";
+pub(crate) const YOLOP_PR_ATTRIBUTION: &str = "Generated with yolop";
+
+/// Render the `## Attribution` system-prompt block. Pure so it is unit-testable
+/// without a `SystemPromptContext`.
+fn yolop_attribution_prompt() -> String {
+    format!(
+        "\
+## Attribution
+
+When you create or amend commits for changes you made, keep the user's
+git author/committer identity intact and append this git trailer once:
+{YOLOP_ATTRIBUTION_TRAILER}
+
+When creating or editing pull request descriptions with `gh`, add this
+footer once:
+{YOLOP_PR_ATTRIBUTION}
+
+Do not add duplicate attribution or session links."
+    )
+}
+
+pub(crate) struct AttributionCapability {
+    /// Reads through the shared config service rather than the concrete store —
+    /// it only needs to know whether attribution is enabled.
+    pub(crate) config: Arc<dyn ConfigService>,
+}
+
+#[async_trait]
+impl Capability for AttributionCapability {
+    fn id(&self) -> &str {
+        ATTRIBUTION_CAPABILITY_ID
+    }
+    fn name(&self) -> &str {
+        "Yolop Attribution"
+    }
+    fn description(&self) -> &str {
+        "Adds optional commit and pull request attribution guidance."
+    }
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+    fn category(&self) -> Option<&str> {
+        Some("Examples")
+    }
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        self.config
+            .attribution_enabled()
+            .then(yolop_attribution_prompt)
+    }
+    fn system_prompt_preview(&self) -> Option<String> {
+        Some(yolop_attribution_prompt())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::SettingsStore;
+
+    #[tokio::test]
+    async fn attribution_prompt_follows_settings() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let settings = Arc::new(SettingsStore::open(tmp.path().join("settings.toml")));
+        let capability = AttributionCapability {
+            config: settings.clone(),
+        };
+        let ctx =
+            SystemPromptContext::without_file_store(everruns_core::typed_id::SessionId::new());
+
+        let enabled = capability
+            .system_prompt_contribution(&ctx)
+            .await
+            .expect("enabled attribution prompt");
+        assert!(enabled.contains(YOLOP_ATTRIBUTION_TRAILER));
+        assert!(enabled.contains(YOLOP_PR_ATTRIBUTION));
+
+        settings
+            .set_attribution(false)
+            .expect("disable attribution");
+        assert!(capability.system_prompt_contribution(&ctx).await.is_none());
+    }
+}

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -22,26 +22,6 @@ use std::sync::{Arc, RwLock};
 // ---------- environment context ----------
 
 pub(crate) const ENVIRONMENT_CONTEXT_CAPABILITY_ID: &str = "code_environment_context";
-pub(crate) const ATTRIBUTION_CAPABILITY_ID: &str = "yolop_attribution";
-pub(crate) const YOLOP_ATTRIBUTION_TRAILER: &str = "Co-Authored-By: yolop <yolop@everruns.com>";
-pub(crate) const YOLOP_PR_ATTRIBUTION: &str = "Generated with yolop";
-
-fn yolop_attribution_prompt() -> String {
-    format!(
-        "\
-## Attribution
-
-When you create or amend commits for changes you made, keep the user's
-git author/committer identity intact and append this git trailer once:
-{YOLOP_ATTRIBUTION_TRAILER}
-
-When creating or editing pull request descriptions with `gh`, add this
-footer once:
-{YOLOP_PR_ATTRIBUTION}
-
-Do not add duplicate attribution or session links."
-    )
-}
 
 pub(crate) struct CodingCliEnvironmentCapability {
     repo_root: PathBuf,
@@ -121,39 +101,6 @@ impl Capability for CodingCliEnvironmentCapability {
 </environment_context>"
                 .to_string(),
         )
-    }
-}
-
-pub(crate) struct AttributionCapability {
-    /// Reads through the shared config service rather than the concrete store —
-    /// it only needs to know whether attribution is enabled.
-    pub(crate) config: Arc<dyn ConfigService>,
-}
-
-#[async_trait]
-impl Capability for AttributionCapability {
-    fn id(&self) -> &str {
-        ATTRIBUTION_CAPABILITY_ID
-    }
-    fn name(&self) -> &str {
-        "Yolop Attribution"
-    }
-    fn description(&self) -> &str {
-        "Adds optional commit and pull request attribution guidance."
-    }
-    fn status(&self) -> CapabilityStatus {
-        CapabilityStatus::Available
-    }
-    fn category(&self) -> Option<&str> {
-        Some("Examples")
-    }
-    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
-        self.config
-            .attribution_enabled()
-            .then(yolop_attribution_prompt)
-    }
-    fn system_prompt_preview(&self) -> Option<String> {
-        Some(yolop_attribution_prompt())
     }
 }
 
@@ -1164,29 +1111,6 @@ mod tests {
             ..Default::default()
         };
         assert!(!SetupCapability::needs_onboarding(&settings));
-    }
-
-    #[tokio::test]
-    async fn attribution_prompt_follows_settings() {
-        let tmp = tempfile::tempdir().expect("tmp");
-        let settings = Arc::new(SettingsStore::open(tmp.path().join("settings.toml")));
-        let capability = AttributionCapability {
-            config: settings.clone(),
-        };
-        let ctx =
-            SystemPromptContext::without_file_store(everruns_core::typed_id::SessionId::new());
-
-        let enabled = capability
-            .system_prompt_contribution(&ctx)
-            .await
-            .expect("enabled attribution prompt");
-        assert!(enabled.contains(YOLOP_ATTRIBUTION_TRAILER));
-        assert!(enabled.contains(YOLOP_PR_ATTRIBUTION));
-
-        settings
-            .set_attribution(false)
-            .expect("disable attribution");
-        assert!(capability.system_prompt_contribution(&ctx).await.is_none());
     }
 
     #[test]

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -5,6 +5,7 @@
 
 pub(crate) mod approval;
 pub(crate) mod ast_grep;
+pub(crate) mod attribution;
 pub(crate) mod background;
 pub(crate) mod client_commands;
 pub(crate) mod config;
@@ -22,6 +23,7 @@ pub(crate) mod your;
 pub(crate) use crate::goal::GOAL_CAPABILITY_ID;
 pub(crate) use approval::{APPROVAL_CAPABILITY_ID, ApprovalCapability};
 pub(crate) use ast_grep::{AST_GREP_CAPABILITY_ID, AstGrepCapability};
+pub(crate) use attribution::{ATTRIBUTION_CAPABILITY_ID, AttributionCapability};
 pub(crate) use background::{
     AgentRunResult, AgentSpawner, BACKGROUND_CAPABILITY_ID, BackgroundCapability,
     BackgroundRegistry,
@@ -31,9 +33,8 @@ pub(crate) use config::{CONFIG_CAPABILITY_ID, ConfigCapability};
 pub(crate) use goal::GoalCapability;
 pub(crate) use hooks::{HOOKS_CAPABILITY_ID, HooksCapability};
 pub(crate) use host::{
-    ATTRIBUTION_CAPABILITY_ID, AttributionCapability, CodingBashCapability,
-    CodingCliEnvironmentCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID, SETUP_CAPABILITY_ID,
-    SetupCapability,
+    CodingBashCapability, CodingCliEnvironmentCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID,
+    SETUP_CAPABILITY_ID, SetupCapability,
 };
 pub(crate) use repo_map::{REPO_MAP_CAPABILITY_ID, RepoMapCapability};
 pub(crate) use worktree_cmd::WorktreeCapability;


### PR DESCRIPTION
## What

`AttributionCapability` was already a registered `Capability`, but it lived
inside the catch-all `host.rs` module rather than in its own file like every
other first-class capability (`your.rs`, `approval.rs`, etc.). This moves it to
a dedicated `src/capabilities/attribution.rs`:

- New `src/capabilities/attribution.rs` — `ATTRIBUTION_CAPABILITY_ID`, the
  `Co-Authored-By` trailer / PR footer constants, `yolop_attribution_prompt()`,
  the `AttributionCapability` impl, and its test, with a module doc comment in
  the style of `your.rs` / `approval.rs`.
- `host.rs` — all attribution code removed; the module now only carries
  host/environment/bash/setup concerns.
- `mod.rs` — adds `mod attribution;` and a dedicated re-export. `runtime.rs`
  imports are unchanged because the public path
  (`crate::capabilities::AttributionCapability`) still resolves.

## Why

Consistency and discoverability: capabilities in this repo follow a
one-module-per-capability convention, and attribution was the outlier buried in
a grab-bag module. No behavior change — same capability, same registration,
same system-prompt output.

Note: I also confirmed that `your` and `soft_approval` already contribute to the
system prompt via their capabilities' `system_prompt_contribution`
(`your.rs:65`, `approval.rs:109`), with no parallel hardcoded prompt path, so no
change was needed there.

## Validation

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all-features` — 470 + 29 pass, 0 fail
- The moved test `attribution_prompt_follows_settings` drives
  `AttributionCapability::system_prompt_contribution` directly (enabled +
  disabled paths).
- Offline smoke: `cargo run -- --provider llmsim -p "hi"` starts and completes.

## Security

No security-relevant code changes — this is a pure module move. Capability
registration (TM-TOOL) is unchanged; attribution is prompt-only and exposes no
tools, so the write blocklist is unaffected. No dependency, filesystem, shell,
or key-handling surface touched.

## Follow-ups

No follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhUfzU8jgEVfYhAjm9yF6G)_