### PR TITLE
fix(runtime): order volatile prompt context last

### DIFF
--- a/src/capabilities/client_commands.rs
+++ b/src/capabilities/client_commands.rs
@@ -27,16 +27,14 @@ use std::sync::Arc;
 
 pub(crate) const CLIENT_COMMANDS_CAPABILITY_ID: &str = "yolop_client_commands";
 
-const CLIENT_COMMANDS_PROMPT: &str = r#"<capability id="yolop_client_commands">
-For natural-language requests, `run_yolop_command` can perform these TUI client
+const CLIENT_COMMANDS_PROMPT: &str = r#"For natural-language requests, `run_yolop_command` can perform these TUI client
 commands: `/help`, `/tools`, `/mcp`, `/cwd`, `/status [compact|expanded|toggle]`,
 `/model [id]`, `/effort [level]`, `/clear`, and `/quit` (`/exit` is an alias).
 The TUI may expose other slash commands, but only use `run_yolop_command` for
 this listed client-command set. When the user asks for one of these terminal
 actions — for example "exit", "clear the screen", "show tools", "switch model",
 or "expand the status bar" — call `run_yolop_command`; do not merely tell the
-user to type the slash command.
-</capability>"#;
+user to type the slash command."#;
 
 pub(crate) struct ClientCommandsCapability {
     ui: Arc<dyn HostUi>,
@@ -319,6 +317,10 @@ mod tests {
         assert!(prompt.contains("this listed client-command set"));
         assert!(prompt.contains("/quit"));
         assert!(prompt.contains("/exit"));
+        assert!(
+            !prompt.contains("<capability"),
+            "system_prompt_addition is wrapped by the runtime"
+        );
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1614,6 +1614,20 @@ fn ensure_harness_capability_dependencies(caps: &mut Vec<AgentCapabilityConfig>)
     }
 }
 
+fn push_before_environment_context(
+    caps: &mut Vec<AgentCapabilityConfig>,
+    cap: AgentCapabilityConfig,
+) {
+    if let Some(index) = caps
+        .iter()
+        .position(|c| c.capability_id() == ENVIRONMENT_CONTEXT_CAPABILITY_ID)
+    {
+        caps.insert(index, cap);
+    } else {
+        caps.push(cap);
+    }
+}
+
 fn coding_harness_capabilities(
     client_commands: bool,
     hook_config: Option<serde_json::Value>,
@@ -1625,7 +1639,10 @@ fn coding_harness_capabilities(
     );
     ensure_harness_capability_dependencies(&mut caps);
     if let Some(config) = hook_config {
-        caps.push(AgentCapabilityConfig::with_config("user_hooks", config));
+        push_before_environment_context(
+            &mut caps,
+            AgentCapabilityConfig::with_config("user_hooks", config),
+        );
     }
     caps
 }
@@ -4443,6 +4460,23 @@ mod tests {
             agent_instructions.config["files"],
             serde_json::json!(["AGENTS.md"])
         );
+    }
+
+    #[test]
+    fn coding_harness_keeps_environment_context_last_with_user_hooks() {
+        let ids = coding_harness_capabilities(
+            true,
+            Some(serde_json::json!({ "hooks": [] })),
+            &Settings::default(),
+        );
+        let position = |id: &str| {
+            ids.iter()
+                .position(|cap| cap.capability_id() == id)
+                .unwrap_or_else(|| panic!("{id} should be enabled"))
+        };
+
+        assert!(position("user_hooks") < position(ENVIRONMENT_CONTEXT_CAPABILITY_ID));
+        assert_eq!(position(ENVIRONMENT_CONTEXT_CAPABILITY_ID), ids.len() - 1);
     }
 
     /// Harness prompt is paid on every turn — keep it small enough that the

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1538,12 +1538,6 @@ fn default_coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabi
         caps.push(AgentCapabilityConfig::new(CLIENT_COMMANDS_CAPABILITY_ID));
     }
     caps.extend([
-        AgentCapabilityConfig::new(ENVIRONMENT_CONTEXT_CAPABILITY_ID),
-        // AGENTS.md is the sole project-instructions file, live-reloaded.
-        AgentCapabilityConfig::with_config(
-            AGENT_INSTRUCTIONS_CAPABILITY_ID,
-            serde_json::json!({ "files": ["AGENTS.md"] }),
-        ),
         AgentCapabilityConfig::new("session_file_system"),
         AgentCapabilityConfig::new(SKILLS_CAPABILITY_ID),
         AgentCapabilityConfig::new(REPO_MAP_CAPABILITY_ID),
@@ -1594,6 +1588,14 @@ fn default_coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabi
         AgentCapabilityConfig::new(APPROVAL_CAPABILITY_ID),
         AgentCapabilityConfig::new("yolop_bash"),
         AgentCapabilityConfig::new(BACKGROUND_CAPABILITY_ID),
+        // Project policy changes more often than tool-use guidance, so keep it
+        // late in the prompt prefix for better cache reuse.
+        AgentCapabilityConfig::with_config(
+            AGENT_INSTRUCTIONS_CAPABILITY_ID,
+            serde_json::json!({ "files": ["AGENTS.md"] }),
+        ),
+        // Per-turn facts are the most volatile prompt contribution.
+        AgentCapabilityConfig::new(ENVIRONMENT_CONTEXT_CAPABILITY_ID),
     ]);
     caps
 }
@@ -4409,6 +4411,37 @@ mod tests {
             with.iter()
                 .any(|cap| cap.capability_id() == CLIENT_COMMANDS_CAPABILITY_ID),
             "the TUI host enables the terminal-side commands"
+        );
+    }
+
+    #[test]
+    fn coding_harness_orders_stable_prompt_before_project_context() {
+        let ids = coding_harness_capabilities(true, None, &Settings::default());
+        let position = |id: &str| {
+            ids.iter()
+                .position(|cap| cap.capability_id() == id)
+                .unwrap_or_else(|| panic!("{id} should be enabled"))
+        };
+
+        assert!(
+            position(CLIENT_COMMANDS_CAPABILITY_ID) < position(AGENT_INSTRUCTIONS_CAPABILITY_ID)
+        );
+        assert!(position("session_file_system") < position(AGENT_INSTRUCTIONS_CAPABILITY_ID));
+        assert!(position(SKILLS_CAPABILITY_ID) < position(AGENT_INSTRUCTIONS_CAPABILITY_ID));
+        assert!(position(APPROVAL_CAPABILITY_ID) < position(AGENT_INSTRUCTIONS_CAPABILITY_ID));
+        assert!(
+            position(AGENT_INSTRUCTIONS_CAPABILITY_ID)
+                < position(ENVIRONMENT_CONTEXT_CAPABILITY_ID)
+        );
+        assert_eq!(position(ENVIRONMENT_CONTEXT_CAPABILITY_ID), ids.len() - 1);
+
+        let agent_instructions = ids
+            .iter()
+            .find(|cap| cap.capability_id() == AGENT_INSTRUCTIONS_CAPABILITY_ID)
+            .expect("agent instructions");
+        assert_eq!(
+            agent_instructions.config["files"],
+            serde_json::json!(["AGENTS.md"])
         );
     }
 


### PR DESCRIPTION
## What
- Keep the base system prompt ahead of capability prompt additions by relying on Everruns' runtime composition.
- Remove the manual `<capability>` wrapper from Yolop's client-command prompt contribution.
- Move project instructions near the end of the stable capability list and keep environment context last.
- Align with `claude/sleepy-wozniak-1m711c` by letting `agent_instructions` own project-policy framing and reading only `AGENTS.md`.

## Why
Prompt-cache reuse is hurt when volatile project or environment context appears early in the prompt. Yolop should keep stable runtime/tool guidance before frequently changing project files and per-turn environment facts.

## How
- Updated the default coding harness capability order.
- Changed the base system prompt to keep only the general untrusted-input guardrail.
- Added tests for capability ordering and client-command prompt wrapping.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"`

Local live-provider smoke was attempted with `doppler run -- cargo run -- --provider openai -p "Reply with OK."`, but this worktree has no Doppler project/fallback configured.

## Security
- TM-LLM: reviewed prompt construction changes; no secrets are added to prompts, logs, or session files.
- TM-TOOL: capability registration order changes only; no new capabilities or write permissions are introduced.
- TM-DEP: no dependency changes.
- TM-FS/TM-BASH: no filesystem or shell execution behavior changed.

## Follow-ups
- Configure Doppler for this worktree if local live OpenAI smoke is required outside CI.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
