### PR TITLE
fix(goal): pause continuation on turn cancel

### DIFF
--- a/specs/goal.md
+++ b/specs/goal.md
@@ -37,8 +37,8 @@ After each agent turn while a goal is active:
    as guidance.
 
 In the interactive TUI, pressing `Esc` twice during a goal turn cancels the
-current turn and pauses the goal. The condition remains available in
-`/goal status`; `/goal resume` restarts auto-continuation.
+current turn and pauses the goal. The condition remains available in `/goal`;
+`/goal resume` restarts auto-continuation.
 
 Conditions may be up to 4,000 characters. Users can bound runs in the condition
 itself (for example `or stop after 20 turns`); the evaluator judges that clause

--- a/specs/goal.md
+++ b/specs/goal.md
@@ -21,6 +21,8 @@ the transcript.
 | --- | --- |
 | `/goal <condition>` | Replace any active goal, persist it, and start a turn immediately with the condition as the directive. |
 | `/goal` | Show status: condition, elapsed time, evaluated turns, session tokens, last evaluator reason. |
+| `/goal pause` | Pause auto-continuation without clearing the active condition. |
+| `/goal resume` | Resume a paused goal and start the next turn. |
 | `/goal clear` | Clear the active goal (`stop`, `off`, `reset`, `none`, `cancel` are aliases). |
 | `/clear` | Also clears an active goal (new conversation). |
 
@@ -33,6 +35,10 @@ After each agent turn while a goal is active:
 3. If `met` is true, the goal clears and the host prints `goal achieved`.
 4. If `met` is false, the host starts another turn with the evaluator reason
    as guidance.
+
+In the interactive TUI, pressing `Esc` twice during a goal turn cancels the
+current turn and pauses the goal. The condition remains available in
+`/goal status`; `/goal resume` restarts auto-continuation.
 
 Conditions may be up to 4,000 characters. Users can bound runs in the condition
 itself (for example `or stop after 20 turns`); the evaluator judges that clause
@@ -50,7 +56,8 @@ from the transcript, matching the Claude Code contract.
 
 Active goals are stored in `<session_dir>/goal.json` so a resumed session
 (`--session`) restores the condition. Timer and evaluated-turn counters reset
-on resume; an already-achieved goal is not restored as active.
+on resume; an already-achieved goal is not restored as active. Paused goals are
+restored without starting a turn until `/goal resume`.
 
 ## Ownership
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -436,6 +436,12 @@ impl App {
         app.emit_system_banner();
         if should_setup {
             app.start_first_run_setup();
+        } else if app.goal_store.is_paused(session_id)
+            && let Some(condition) = app.goal_store.active_condition(session_id)
+        {
+            app.push_system(format!(
+                "restored paused goal: {condition} (run /goal resume to continue)"
+            ));
         } else if app.goal_store.take_pending_turn(session_id)
             && let Some(condition) = app.goal_store.active_condition(session_id)
         {
@@ -497,9 +503,13 @@ impl App {
             .goal_store
             .status(self.handles.session_id, self.session_tokens)
             .active
-            .map(|active| active.evaluated_turns)
-            .unwrap_or(0);
-        Some(format!("◎ goal ({turns})"))
+            .map(|active| (active.evaluated_turns, active.paused))
+            .unwrap_or((0, false));
+        if turns.1 {
+            Some(format!("◎ goal paused ({})", turns.0))
+        } else {
+            Some(format!("◎ goal ({})", turns.0))
+        }
     }
 
     fn emit_system_banner(&mut self) {
@@ -1204,6 +1214,12 @@ impl App {
 
     fn cancel_current_turn(&mut self) {
         self.esc_pending_cancel = false;
+        if self.goal_store.is_active(self.handles.session_id) {
+            match self.goal_store.pause_active(self.handles.session_id) {
+                Ok(message) => self.push_system(message),
+                Err(err) => self.push_system(format!("goal pause failed: {err}")),
+            }
+        }
         if let Some(cancel) = self.turn_cancel.take() {
             let _ = cancel.send(());
             self.turn_activity = Some("cancelling".into());
@@ -1236,6 +1252,9 @@ impl App {
     async fn after_turn_goal_check(&mut self) {
         let session_id = self.handles.session_id;
         if !self.goal_store.is_active(session_id) {
+            return;
+        }
+        if self.goal_store.is_paused(session_id) {
             return;
         }
         let request = ExecuteCommandRequest {
@@ -3973,6 +3992,46 @@ mod tests {
             "second Esc should notify the turn worker"
         );
         assert_eq!(app.turn_activity.as_deref(), Some("cancelling"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn second_esc_while_goal_active_pauses_goal_continuation() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        let session_id = app.handles.session_id;
+        let (cancel_tx, cancel_rx) = oneshot::channel::<()>();
+        app.setup = None;
+        app.goal_store
+            .set_active(session_id, "ship the change".into())
+            .expect("set active goal");
+        assert!(
+            app.goal_store.take_pending_turn(session_id),
+            "test starts from an in-progress goal turn"
+        );
+        app.busy = true;
+        app.turn_cancel = Some(cancel_tx);
+
+        app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
+            .await;
+        app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
+            .await;
+
+        assert!(cancel_rx.await.is_ok(), "second Esc should cancel the turn");
+        assert!(
+            app.goal_store.is_paused(session_id),
+            "cancelled goal turn should pause auto-continuation"
+        );
+        assert!(
+            !app.goal_store.take_pending_turn(session_id),
+            "paused goal should not keep a pending continuation"
+        );
+        assert!(
+            app.lines
+                .iter()
+                .any(|line| line.text.contains("goal paused")),
+            "cancellation should explain how to resume the goal: {:?}",
+            app.lines
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/capabilities/goal.rs
+++ b/src/capabilities/goal.rs
@@ -53,8 +53,9 @@ impl Capability for GoalCapability {
             source: CommandSource::System,
             args: vec![CommandArg {
                 name: "condition".to_string(),
-                description: "Verifiable end state, `clear` to stop, or omit for status."
-                    .to_string(),
+                description:
+                    "Verifiable end state, `pause`/`resume`, `clear` to stop, or omit for status."
+                        .to_string(),
                 required: false,
                 suggestions: vec![],
             }],

--- a/src/goal.rs
+++ b/src/goal.rs
@@ -37,6 +37,8 @@ transcript. Otherwise set `met` to false and explain what is still missing or \
 what the agent should do next.";
 
 const CLEAR_ALIASES: &[&str] = &["clear", "stop", "off", "reset", "none", "cancel"];
+const PAUSE_ALIASES: &[&str] = &["pause", "paused"];
+const RESUME_ALIASES: &[&str] = &["resume", "continue"];
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct GoalAchieved {
@@ -49,6 +51,8 @@ pub(crate) struct GoalAchieved {
 pub(crate) struct PersistedGoal {
     pub condition: String,
     pub active: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub paused: bool,
     pub evaluated_turns: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_reason: Option<String>,
@@ -67,6 +71,8 @@ pub(crate) struct GoalStatus {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum GoalCommandOutcome {
     Set { condition: String },
+    Paused,
+    Resumed,
     Cleared,
     Status(GoalStatus),
 }
@@ -106,13 +112,14 @@ impl GoalStore {
         let persisted: PersistedGoal = serde_json::from_str(&raw)
             .with_context(|| format!("parse goal state: {}", path.display()))?;
         if persisted.active {
+            let pending_turn = !persisted.paused;
             let mut sessions = self.sessions.write().expect("goal store lock poisoned");
             sessions.insert(
                 session_id,
                 SessionGoalRuntime {
                     persisted,
                     started_at: Instant::now(),
-                    pending_turn: true,
+                    pending_turn,
                 },
             );
         }
@@ -134,6 +141,18 @@ impl GoalStore {
             .any(|alias| trimmed.eq_ignore_ascii_case(alias))
         {
             return Ok(GoalCommandOutcome::Cleared);
+        }
+        if PAUSE_ALIASES
+            .iter()
+            .any(|alias| trimmed.eq_ignore_ascii_case(alias))
+        {
+            return Ok(GoalCommandOutcome::Paused);
+        }
+        if RESUME_ALIASES
+            .iter()
+            .any(|alias| trimmed.eq_ignore_ascii_case(alias))
+        {
+            return Ok(GoalCommandOutcome::Resumed);
         }
         if trimmed.len() > MAX_GOAL_CONDITION_LEN {
             bail!("goal condition is too long (max {MAX_GOAL_CONDITION_LEN} characters)");
@@ -157,6 +176,8 @@ impl GoalStore {
                 self.clear_active(session_id);
                 Ok("goal cleared".into())
             }
+            GoalCommandOutcome::Paused => self.pause_active(session_id),
+            GoalCommandOutcome::Resumed => self.resume_active(session_id),
             GoalCommandOutcome::Status(_) => Ok(String::new()),
         }
     }
@@ -197,6 +218,7 @@ impl GoalStore {
                 persisted: PersistedGoal {
                     condition: condition.clone(),
                     active: true,
+                    paused: false,
                     evaluated_turns: 0,
                     last_reason: None,
                     achieved: None,
@@ -225,12 +247,51 @@ impl GoalStore {
         }
     }
 
+    pub(crate) fn pause_active(&self, session_id: SessionId) -> Result<String> {
+        let mut sessions = self.sessions.write().expect("goal store lock poisoned");
+        let Some(runtime) = sessions.get_mut(&session_id) else {
+            return Ok("no active goal".into());
+        };
+        if !runtime.persisted.active {
+            return Ok("no active goal".into());
+        }
+        runtime.persisted.paused = true;
+        runtime.pending_turn = false;
+        drop(sessions);
+        self.persist(session_id)?;
+        Ok("goal paused; run /goal resume to continue".into())
+    }
+
+    pub(crate) fn resume_active(&self, session_id: SessionId) -> Result<String> {
+        let mut sessions = self.sessions.write().expect("goal store lock poisoned");
+        let Some(runtime) = sessions.get_mut(&session_id) else {
+            return Ok("no active goal".into());
+        };
+        if !runtime.persisted.active {
+            return Ok("no active goal".into());
+        }
+        runtime.persisted.paused = false;
+        runtime.pending_turn = true;
+        let condition = runtime.persisted.condition.clone();
+        drop(sessions);
+        self.persist(session_id)?;
+        Ok(format!("goal resumed: {condition}"))
+    }
+
     pub(crate) fn is_active(&self, session_id: SessionId) -> bool {
         self.sessions
             .read()
             .expect("goal store lock poisoned")
             .get(&session_id)
             .is_some_and(|runtime| runtime.persisted.active)
+    }
+
+    pub(crate) fn is_paused(&self, session_id: SessionId) -> bool {
+        self.sessions
+            .read()
+            .expect("goal store lock poisoned")
+            .get(&session_id)
+            .is_some_and(|runtime| runtime.persisted.active && runtime.persisted.paused)
     }
 
     pub(crate) fn active_condition(&self, session_id: SessionId) -> Option<String> {
@@ -247,7 +308,12 @@ impl GoalStore {
             .write()
             .expect("goal store lock poisoned")
             .get_mut(&session_id)
-            .is_some_and(|runtime| std::mem::take(&mut runtime.pending_turn))
+            .is_some_and(|runtime| {
+                if runtime.persisted.paused {
+                    return false;
+                }
+                std::mem::take(&mut runtime.pending_turn)
+            })
     }
 
     pub(crate) fn record_evaluation(
@@ -269,9 +335,10 @@ impl GoalStore {
             };
             runtime.persisted.active = false;
             runtime.persisted.achieved = Some(achieved);
+            runtime.persisted.paused = false;
             runtime.pending_turn = false;
         } else {
-            runtime.pending_turn = true;
+            runtime.pending_turn = !runtime.persisted.paused;
         }
         drop(sessions);
         self.persist(session_id)
@@ -280,7 +347,7 @@ impl GoalStore {
     pub(crate) fn continuation_prompt(&self, session_id: SessionId) -> Option<String> {
         let sessions = self.sessions.read().expect("goal store lock poisoned");
         let runtime = sessions.get(&session_id)?;
-        if !runtime.persisted.active {
+        if !runtime.persisted.active || runtime.persisted.paused {
             return None;
         }
         let reason = runtime
@@ -335,8 +402,18 @@ pub(crate) fn format_status(status: &GoalStatus) -> String {
             .filter(|value| !value.is_empty())
             .map(|value| format!("\nlast evaluation: {value}"))
             .unwrap_or_default();
+        let state = if active.paused {
+            "goal paused"
+        } else {
+            "goal active"
+        };
+        let resume = if active.paused {
+            "\nresume: /goal resume"
+        } else {
+            ""
+        };
         return format!(
-            "goal active\ncondition: {}\nrunning: {elapsed}\nevaluated turns: {}\nsession tokens: {tokens}{reason}",
+            "{state}\ncondition: {}\nrunning: {elapsed}\nevaluated turns: {}\nsession tokens: {tokens}{reason}{resume}",
             active.condition, active.evaluated_turns
         );
     }
@@ -347,6 +424,10 @@ pub(crate) fn format_status(status: &GoalStatus) -> String {
         );
     }
     "no active goal".into()
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 fn format_duration(duration: Duration) -> String {
@@ -492,6 +573,68 @@ mod tests {
     }
 
     #[test]
+    fn parse_pause_and_resume_aliases() {
+        for alias in PAUSE_ALIASES {
+            let outcome = GoalStore::parse_user_args(Some(alias)).expect("parse");
+            assert_eq!(outcome, GoalCommandOutcome::Paused);
+        }
+        for alias in RESUME_ALIASES {
+            let outcome = GoalStore::parse_user_args(Some(alias)).expect("parse");
+            assert_eq!(outcome, GoalCommandOutcome::Resumed);
+        }
+    }
+
+    #[test]
+    fn pause_blocks_continuation_until_resume() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = GoalStore::open(dir.path().to_path_buf());
+        let session_id = SessionId::new();
+        store
+            .set_active(session_id, "ship the fix".into())
+            .expect("set");
+        assert!(store.take_pending_turn(session_id));
+
+        let message = store.pause_active(session_id).expect("pause");
+        assert!(message.contains("goal paused"));
+        assert!(store.is_active(session_id));
+        assert!(store.is_paused(session_id));
+        assert!(!store.take_pending_turn(session_id));
+        assert!(store.continuation_prompt(session_id).is_none());
+
+        let evaluation = GoalEvaluation {
+            met: false,
+            reason: "not done".into(),
+        };
+        store
+            .record_evaluation(session_id, &evaluation)
+            .expect("record");
+        assert!(!store.take_pending_turn(session_id));
+
+        let message = store.resume_active(session_id).expect("resume");
+        assert!(message.contains("ship the fix"));
+        assert!(!store.is_paused(session_id));
+        assert!(store.take_pending_turn(session_id));
+    }
+
+    #[test]
+    fn paused_goal_restores_without_pending_turn() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionId::new();
+        let store = GoalStore::open(dir.path().to_path_buf());
+        store
+            .set_active(session_id, "ship the fix".into())
+            .expect("set");
+        store.pause_active(session_id).expect("pause");
+
+        let restored = GoalStore::open(dir.path().to_path_buf());
+        restored.load_session(session_id).expect("load");
+
+        assert!(restored.is_active(session_id));
+        assert!(restored.is_paused(session_id));
+        assert!(!restored.take_pending_turn(session_id));
+    }
+
+    #[test]
     fn parse_set_condition() {
         let outcome = GoalStore::parse_user_args(Some("all tests pass")).expect("parse");
         assert_eq!(
@@ -518,6 +661,7 @@ mod tests {
             active: Some(PersistedGoal {
                 condition: "tests pass".into(),
                 active: true,
+                paused: false,
                 evaluated_turns: 2,
                 last_reason: Some("still failing".into()),
                 achieved: None,


### PR DESCRIPTION
## What
Add persisted pause/resume state for `/goal` and pause goal auto-continuation when a TUI turn is cancelled with double `Esc`.

## Why
Cancelling an active goal turn previously stopped only the current turn. The unmet goal could immediately schedule another continuation, making it feel like there was no way to stop the active goal without knowing `/goal clear`.

## How
- Add `paused` to persisted goal state and expose `/goal pause` plus `/goal resume`.
- Suppress pending continuations and continuation prompts while a goal is paused.
- On double `Esc`, cancel the active turn and pause the active goal without clearing its condition.
- Restore paused goals on session resume without starting a turn.
- Update goal docs and command help.

## Risk
- Low
- Existing active `goal.json` files deserialize with `paused: false` by default.
- The main behavior risk is accidentally suppressing goal continuation; covered by store and TUI regression tests.

## Security
- Threat categories reviewed: TM-FS, TM-LLM, TM-TOOL, TM-DEP.
- TM-FS: no new filesystem access pattern; the existing goal store continues writing only session-scoped `goal.json`.
- TM-LLM: no new prompt content or secret handling.
- TM-TOOL: no new capability/tool registration beyond command argument handling for the existing `/goal` command.
- TM-DEP: no dependency changes.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (486 passed, 1 ignored in unit tests; 29 passed, 1 ignored in integration tests)
- `doppler run --project yolop --config ci -- cargo run -- --provider openai -p "Say ok, then stop."` (`done success=true iterations=1 tool_calls=0`)

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
