### PR TITLE
feat(help): add yolop skill and expand /help output

### DIFF
--- a/skills/yolop/SKILL.md
+++ b/skills/yolop/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: yolop
+description: Built-in guide to using yolop — slash commands, keyboard shortcuts, CLI flags, tools, and session controls. Use when the user asks how yolop works, what commands or shortcuts are available, what yolop can do, or wants help using the terminal UI.
+user-invocable: true
+---
+
+# Yolop user guide
+
+This skill is the durable reference for how to use yolop interactively. The live
+command list always comes from the session registry (`/help` in the TUI, or
+`list_commands` for the agent); this document explains what those commands do
+and how the UI behaves.
+
+## Quick reference in the TUI
+
+- `/help` — commands with descriptions plus keyboard shortcuts
+- `/tools` — comma-separated list of tools available this session
+- `/mcp` — configured MCP servers (or where to add them)
+- `/cwd` — workspace root
+- Startup banner — workspace, model, tools, command names, and the most common
+  shortcuts
+
+## Slash commands
+
+Commands are contributed by capabilities. The interactive TUI registers all of
+the following; `--print` and ACP omit the terminal-only client commands.
+
+### Terminal client commands
+
+These act on the TUI itself (clear transcript, open overlays, quit). The agent
+can also run them via `run_yolop_command` when the user asks in plain language.
+
+| Command | Description |
+| --- | --- |
+| `/help` | Show commands, descriptions, and keyboard shortcuts |
+| `/tools` | List available tools for this session |
+| `/mcp` | List configured MCP servers |
+| `/cwd` | Print the workspace root |
+| `/status [compact\|expanded\|toggle]` | Change session status bar layout (clicking the status bar toggles too) |
+| `/model [id]` | Open the model picker; an argument pre-fills selection |
+| `/effort [level]` | Open the reasoning-effort picker; an argument pre-fills selection |
+| `/clear` | Clear the transcript and re-show the startup banner |
+| `/shell <command>` | Run a shell command from the workspace root with bounded inline output |
+| `/quit` or `/exit` | Exit yolop |
+
+Shell aliases: `!<command>` and `!shell <command>` run the same bounded shell
+path as `/shell` (handy for quick one-offs).
+
+### Session and agent commands
+
+| Command | Description |
+| --- | --- |
+| `/setup [subcommand]` | Guided provider/model setup, or direct forms: `status`, `provider`, `model`, `effort`, `token`, `url`, `attribution`, `approval` |
+| `/goal [condition]` | Set a completion condition and keep working until met; `pause`/`resume`, `clear`, or omit for status |
+| `/background` | List background tasks and their status |
+| `/btw <question>` | Ask a side question with session context — no tools, not added to history |
+| `/worktree [off]` | Show worktree status, or `off` to disable auto worktree activation |
+
+User-invocable skills (for example `/yolop`, `/yolop-config`, `/skill-management`)
+also appear in the registry when installed.
+
+## Keyboard shortcuts
+
+### Composer (idle)
+
+| Shortcut | Action |
+| --- | --- |
+| `Enter` | Send message |
+| `Shift-Enter` | Insert newline in the composer |
+| `Alt-Shift-Enter` | Send (alternative submit) |
+| `Tab` | Accept the first slash-command suggestion, or insert a literal tab |
+| `←` / `→` | Move cursor in the composer |
+| `/` then type | Command palette suggestions (accept with Tab) |
+| `Ctrl+V` | Paste a clipboard image as an attachment |
+
+### Session control
+
+| Shortcut | Action |
+| --- | --- |
+| `Ctrl-C` (once, empty input) | Arm exit — press again to quit |
+| `Ctrl-C` (with draft text) | Clear the composer |
+| `Ctrl-D` | Exit immediately |
+| `Esc` twice (while a turn runs) | Cancel the current turn |
+| `Ctrl+B` | Toggle the read-only background-tasks panel |
+
+### Background-tasks panel
+
+| Shortcut | Action |
+| --- | --- |
+| `↑` / `↓` or `k` / `j` | Scroll the task list |
+| `Esc` or `q` | Close the panel |
+
+Transcript history scrolls through the terminal's own scrollback (ratatui inline
+viewport); there is no in-app page-up/page-down.
+
+### Setup overlays (`/setup`, `/model`, `/effort`)
+
+| Shortcut | Action |
+| --- | --- |
+| `↑` / `↓` or `k` / `j` | Move selection |
+| `Enter` | Confirm |
+| `Esc` | Cancel / go back |
+| `0`–`9` | Jump to numbered entry (where shown) |
+
+## What yolop can do
+
+yolop is an autonomous coding agent for the workspace it was started in.
+
+- **Files** — read, write, edit, grep, delete, and map the repository
+- **Shell** — `bash -lc` from the workspace root (120 s timeout, capped output)
+- **AST search** — structural `ast_grep` across common languages
+- **Background work** — detached shell commands and focused sub-agents
+- **Web** — `web_fetch` and `duckduckgo_search`
+- **Memory** — durable cross-session notes via `remember` / `recall` / `forget`
+- **Skills** — `SKILL.md` packages in workspace, global, and bundled system scopes
+- **MCP** — extra tools from `.mcp.json` / global `mcp.json`
+- **Hooks** — block, allow, or audit tool calls (see `yolop-hooks` skill)
+- **Goal loops** — `/goal` keeps working until an evaluator confirms the condition
+- **Soft approval** — optional spoken consent before destructive steps (`/setup approval`)
+- **Sessions** — resume with `--session <id>`; every run logs to `events.jsonl`
+
+Natural-language control: the agent can switch model, effort, or provider, clear
+the screen, show help, and more without the user typing slash commands — see
+`specs/conversational-control.md`.
+
+## CLI flags (non-interactive)
+
+| Flag | Description |
+| --- | --- |
+| `-C, --cwd <PATH>` | Workspace root (default: current directory) |
+| `--provider <P>` | Force a provider |
+| `-m, --model <ID>` | Override model for the chosen provider |
+| `-p, --print <PROMPT>` | One-shot mode — print result and exit |
+| `--acp` | Agent Client Protocol over stdio (editors like Zed) |
+| `--session <ID>` | Resume a previous session |
+| `--session-dir <PATH>` | Override where session folders are stored |
+| `--reasoning-effort <E>` | Reasoning effort when the model profile supports it |
+
+Subcommands: `yolop version`, `yolop into zed`, `yolop worktree list|prune`.
+
+## Related skills
+
+| Skill | When to use |
+| --- | --- |
+| `yolop-config` | Change `settings.toml` — provider, tokens, models, capabilities |
+| `yolop-hooks` | Configure behavioral hooks |
+| `skill-management` | Install, upgrade, or remove skills |
+| `ast-grep` | Structural code search patterns |
+
+## Answering help requests
+
+When the user asks what yolop can do or how to use it:
+
+1. Summarize the relevant section from this skill (commands, shortcuts, or
+   features — match what they asked).
+2. For the **live** command or tool list, prefer `/help`, `/tools`, or
+   `run_yolop_command` / `list_skills` rather than guessing.
+3. Point power users at `README.md` and `specs/` for protocol and configuration
+   depth; keep conversational answers short.

--- a/specs/skills.md
+++ b/specs/skills.md
@@ -92,6 +92,10 @@ a labeled VFS root that yolop's file store maps to a **real on-disk directory**:
     skill that tells the agent how to inspect, install, search for, and upgrade
     skills, including reconstructing `npx skill add ...` style installs by
     fetching source files directly and writing them with `write_skill`.
+12. **User guide is bundled.** Yolop ships a `yolop` system skill (`skills/yolop/SKILL.md`)
+    as the durable reference for slash commands, keyboard shortcuts, CLI flags,
+    and session controls. `/help` in the TUI summarizes the live command registry
+    and shortcuts; the skill carries the full guide for conversational help.
 
 ## Ownership Boundary
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1026,20 +1026,24 @@ impl App {
 
     fn show_help(&mut self) {
         if !self.startup.capability_commands.is_empty() {
-            let caps = self
+            let command_lines: Vec<String> = self
                 .startup
                 .capability_commands
                 .iter()
-                .map(capability_command_usage)
-                .collect::<Vec<_>>()
-                .join(" · ");
-            self.push_system(format!("commands: {caps}"));
+                .map(help_command_line)
+                .collect();
+            self.push_system("commands:".into());
+            for line in command_lines {
+                self.push_system(line);
+            }
         }
-        self.push_system(format!(
-            "input: ←/→ edit · {} newline · scroll: use the terminal scrollback",
-            newline_shortcut_hint()
-        ));
-        self.push_system("exit: Ctrl-C twice / Ctrl-D".into());
+        self.push_system("shortcuts:".into());
+        for line in help_shortcut_lines() {
+            self.push_system(line.to_string());
+        }
+        self.push_system(
+            "more: /tools · /mcp · /yolop skill · type naturally for terminal actions".into(),
+        );
     }
 
     fn set_status_layout(&mut self, raw: Option<&str>) {
@@ -1422,6 +1426,23 @@ fn capability_command_display_usage(descriptor: &CommandDescriptor) -> String {
 
 fn capability_command_usage(descriptor: &CommandDescriptor) -> String {
     capability_command_usage_with_prefix(descriptor, "/")
+}
+
+fn help_command_line(descriptor: &CommandDescriptor) -> String {
+    format!(
+        "  {} — {}",
+        capability_command_usage(descriptor),
+        descriptor.description
+    )
+}
+
+fn help_shortcut_lines() -> [&'static str; 4] {
+    [
+        "  Enter send · Shift-Enter newline · Tab complete slash command · ←/→ edit",
+        "  Ctrl+V paste image · Ctrl+B background tasks · !<cmd> shell alias",
+        "  exit: Ctrl-C twice / Ctrl-D · Esc twice cancel turn (while busy)",
+        "  scroll: terminal scrollback (no in-app page keys)",
+    ]
 }
 
 fn capability_command_usage_with_prefix(descriptor: &CommandDescriptor, prefix: &str) -> String {
@@ -3570,19 +3591,43 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn help_command_names_ctrl_c_and_ctrl_d_as_exit_keys() {
+    async fn help_command_lists_commands_shortcuts_and_exit_keys() {
         let mut fixture = app_with_llmsim().await;
         let app = &mut fixture.app;
         app.lines.clear();
 
         app.dispatch_command_for_test("help").await;
 
+        let help_lines: Vec<_> = app.lines.iter().map(|line| line.text.as_str()).collect();
         assert!(
-            app.lines
+            help_lines.contains(&"commands:"),
+            "help should introduce the command list: {help_lines:?}"
+        );
+        assert!(
+            help_lines
                 .iter()
-                .any(|line| line.text.contains("exit: Ctrl-C twice / Ctrl-D")),
-            "help output should name Ctrl-C/Ctrl-D exits: {:?}",
-            app.lines
+                .any(|line| line.starts_with("  /help —")),
+            "help should list /help with a description: {help_lines:?}"
+        );
+        assert!(
+            help_lines.contains(&"shortcuts:"),
+            "help should introduce keyboard shortcuts: {help_lines:?}"
+        );
+        assert!(
+            help_lines
+                .iter()
+                .any(|line| line.contains("exit: Ctrl-C twice / Ctrl-D")),
+            "help output should name Ctrl-C/Ctrl-D exits: {help_lines:?}"
+        );
+        assert!(
+            help_lines
+                .iter()
+                .any(|line| line.contains("Ctrl+V paste image")),
+            "help output should mention image paste: {help_lines:?}"
+        );
+        assert!(
+            help_lines.iter().any(|line| line.contains("/yolop skill")),
+            "help output should point at the yolop skill: {help_lines:?}"
         );
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1429,18 +1429,20 @@ fn capability_command_usage(descriptor: &CommandDescriptor) -> String {
 }
 
 fn help_command_line(descriptor: &CommandDescriptor) -> String {
-    format!(
-        "  {} — {}",
-        capability_command_usage(descriptor),
-        descriptor.description
-    )
+    let usage = if descriptor.name == "quit" {
+        "/quit (/exit)".to_string()
+    } else {
+        capability_command_usage(descriptor)
+    };
+    format!("  {} — {}", usage, descriptor.description)
 }
 
-fn help_shortcut_lines() -> [&'static str; 4] {
+fn help_shortcut_lines() -> [&'static str; 5] {
     [
         "  Enter send · Shift-Enter newline · Tab complete slash command · ←/→ edit",
         "  Ctrl+V paste image · Ctrl+B background tasks · !<cmd> shell alias",
-        "  exit: Ctrl-C twice / Ctrl-D · Esc twice cancel turn (while busy)",
+        "  exit: Ctrl-C twice / Ctrl-D",
+        "  cancel turn: Esc twice (while model is busy)",
         "  scroll: terminal scrollback (no in-app page keys)",
     ]
 }
@@ -3616,6 +3618,14 @@ mod tests {
                 .iter()
                 .any(|line| line.contains("exit: Ctrl-C twice / Ctrl-D")),
             "help output should name Ctrl-C/Ctrl-D exits: {help_lines:?}"
+        );
+        assert!(
+            help_lines.iter().any(|line| line.contains("cancel turn")),
+            "help output should label Esc as cancel turn: {help_lines:?}"
+        );
+        assert!(
+            help_lines.iter().any(|line| line.contains("/exit")),
+            "help output should mention /exit alias for /quit: {help_lines:?}"
         );
         assert!(
             help_lines

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3604,9 +3604,7 @@ mod tests {
             "help should introduce the command list: {help_lines:?}"
         );
         assert!(
-            help_lines
-                .iter()
-                .any(|line| line.starts_with("  /help —")),
+            help_lines.iter().any(|line| line.starts_with("  /help —")),
             "help should list /help with a description: {help_lines:?}"
         );
         assert!(

--- a/src/capabilities/skills.rs
+++ b/src/capabilities/skills.rs
@@ -526,10 +526,14 @@ mod tests {
         }
         assert!(!dir_names.is_empty(), "expected embedded system skills");
 
-        // The ast-grep skill is shipped, parses, and is user-invocable.
+        // The ast-grep and yolop skills are shipped, parse, and are user-invocable.
         assert!(
             dir_names.iter().any(|n| n == "ast-grep"),
             "ast-grep system skill is shipped: {dir_names:?}"
+        );
+        assert!(
+            dir_names.iter().any(|n| n == "yolop"),
+            "yolop system skill is shipped: {dir_names:?}"
         );
         let md = std::fs::read_to_string(dest.join("ast-grep").join("SKILL.md")).unwrap();
         let parsed = everruns_core::skill::parse_skill_md(&md).unwrap();
@@ -538,6 +542,14 @@ mod tests {
             parsed.description.to_lowercase().contains("ast-grep"),
             "description should mention ast-grep: {:?}",
             parsed.description
+        );
+        let yolop_md = std::fs::read_to_string(dest.join("yolop").join("SKILL.md")).unwrap();
+        let yolop_parsed = everruns_core::skill::parse_skill_md(&yolop_md).unwrap();
+        assert!(yolop_parsed.user_invocable);
+        assert!(
+            yolop_parsed.description.to_lowercase().contains("keyboard"),
+            "yolop skill description should mention keyboard shortcuts: {:?}",
+            yolop_parsed.description
         );
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Review found built-in help was thin: `/help` listed command names only (no descriptions) and omitted several keyboard shortcuts. There was also no bundled `yolop` skill for conversational help.

This change:

- **Ships `skills/yolop/SKILL.md`** — user-invocable as `/yolop`, covering slash commands, keyboard shortcuts, CLI flags, capabilities overview, and related skills (`yolop-config`, `yolop-hooks`, etc.)
- **Expands `/help`** — one line per command with description, a dedicated shortcuts section (Ctrl+V, Ctrl+B, Esc cancel, `!shell`, etc.), and a pointer to the `/yolop` skill
- **Updates `specs/skills.md`** — documents the bundled user guide skill

## Before / after (`/help`)

**Before:** single-line command list (usage only) + minimal input/exit hints

**After:**
```
commands:
  /help — show commands
  /tools — list available tools
  ...
shortcuts:
  Enter send · Shift-Enter newline · Tab complete slash command · ←/→ edit
  Ctrl+V paste image · Ctrl+B background tasks · !<cmd> shell alias
  exit: Ctrl-C twice / Ctrl-D · Esc twice cancel turn (while busy)
  scroll: terminal scrollback (no in-app page keys)
more: /tools · /mcp · /yolop skill · type naturally for terminal actions
```

## Tests

- `help_command_lists_commands_shortcuts_and_exit_keys`
- `embedded_system_skills_parse_with_matching_names` (asserts `yolop` skill ships and is user-invocable)
- Full `cargo test --all-features` and `cargo clippy --all-targets --all-features -- -D warnings` green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ebdd745-22a4-4b1f-b431-ec354bbbeb26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ebdd745-22a4-4b1f-b431-ec354bbbeb26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

