### PR TITLE
refactor(app): introduce Session facade + transcript boundary

### DIFF
--- a/src/acp/bridge.rs
+++ b/src/acp/bridge.rs
@@ -171,7 +171,7 @@ impl Translator {
 /// One concise text block summarising a finished tool call, or `None` when
 /// there is nothing worth surfacing.
 fn tool_result_content(data: &ToolCompletedData) -> Option<ContentBlock> {
-    let summary = crate::app::summarize_tool_result(data);
+    let summary = crate::transcript::summarize_tool_result(data);
     let trimmed = summary.trim();
     if trimmed.is_empty() {
         None

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -5,18 +5,16 @@
 
 use crate::goal::{GOAL_EVALUATE_ARG, GoalStore, parse_evaluation_response};
 use crate::host_ui::UiCommand;
-use crate::runtime::{BuiltRuntime, ModelState, RuntimeHandles, StartupInfo};
-use crate::tools::{BashTool, Workspace};
+use crate::runtime::{BuiltRuntime, ModelState, StartupInfo};
+use crate::session::Session;
 use crate::worktree::WorktreeManager;
 use anyhow::Result;
 use crossterm::event::{
     self, Event as CrosstermEvent, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton,
     MouseEvent, MouseEventKind,
 };
-use everruns_core::command::{CommandDescriptor, CommandSource, ExecuteCommandRequest};
-use everruns_core::events::{Event as RuntimeEvent, EventData, ToolCompletedData};
-use everruns_core::message::{ContentPart, Message, MessageRole};
-use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::command::{CommandDescriptor, CommandSource};
+use everruns_core::message::ContentPart;
 use everruns_core::typed_id::SessionId;
 use ratatui::Terminal;
 use ratatui::backend::Backend;
@@ -26,63 +24,23 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget};
 use ratatui_textarea::{CursorMove, TextArea, WrapMode};
-use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot};
 
 mod render;
 mod setup;
-mod transcript;
 
 // Re-export the moved free items so the rest of the crate (and the test module)
 // can keep referring to them as `crate::app::*`. `setup` exposes only `impl App`
 // methods, so it needs no re-export. The rendering module is named `render`
 // rather than `draw` so it does not collide with the free `draw` fn it exports.
-pub(crate) use self::{render::*, transcript::*};
-
-#[derive(Clone, Debug)]
-pub enum Author {
-    User,
-    Assistant,
-    Narration,
-    Tool,
-    ToolDetail,
-    Diff,
-    System,
-}
-
-impl Author {
-    pub fn label(&self) -> &'static str {
-        match self {
-            Author::User => "you",
-            Author::Assistant => "agent",
-            Author::Narration => "note",
-            Author::Tool => "tool",
-            Author::ToolDetail => "",
-            Author::Diff => "diff",
-            Author::System => "system",
-        }
-    }
-    pub fn color(&self) -> Color {
-        match self {
-            Author::User => ACCENT_BLUE,
-            Author::Assistant => ACCENT_GOLD,
-            Author::Narration => TEXT_MUTED,
-            Author::Tool => TEXT_MUTED,
-            Author::ToolDetail => TEXT_MUTED,
-            Author::Diff => ACCENT_BLUE,
-            Author::System => TEXT_DIM,
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct ChatLine {
-    pub author: Author,
-    pub text: String,
-}
+// The view-model types and runtime-event translation live in `crate::transcript`
+// (the single boundary that interprets `everruns_core` events); re-export them
+// here so the TUI's own submodules keep referring to them as `crate::app::*`.
+pub(crate) use self::render::*;
+pub(crate) use crate::transcript::*;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct CommandSuggestion {
@@ -113,7 +71,7 @@ const CODE_BG: Color = Color::Rgb(18, 18, 20);
 const PANEL_BG: Color = Color::Rgb(28, 28, 34);
 
 pub struct App {
-    handles: RuntimeHandles,
+    session: Session,
     startup: StartupInfo,
     model: ModelState,
     pub lines: Vec<ChatLine>,
@@ -333,40 +291,6 @@ pub(crate) struct ViewState {
 /// What kind of delta is currently being streamed. Only the assistant
 /// output is finalized into the transcript at end-of-turn (via the
 /// message store); thinking and tool output are display-only.
-#[derive(Clone, Debug)]
-pub struct StreamPreview {
-    pub kind: StreamKind,
-    pub text: String,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum StreamKind {
-    Assistant,
-    Tool,
-}
-
-impl StreamKind {
-    fn label(self) -> &'static str {
-        match self {
-            StreamKind::Assistant => "agent",
-            StreamKind::Tool => "tool",
-        }
-    }
-
-    fn color(self) -> Color {
-        match self {
-            StreamKind::Assistant => ACCENT_GOLD,
-            StreamKind::Tool => TEXT_MUTED,
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct ActivityStatus {
-    pub text: String,
-    fallback: bool,
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum StatusLayout {
     Compact,
@@ -382,26 +306,15 @@ impl StatusLayout {
     }
 }
 
-#[derive(Debug)]
-pub(crate) enum TurnEvent {
-    Lines(Vec<ChatLine>),
-    Activity(ActivityStatus),
-    /// Replace the live streaming preview shown above the input.
-    /// `None` clears the preview.
-    Stream(Option<StreamPreview>),
-    Tokens(u64),
-    Done,
-    Failed(String),
-}
-
 impl App {
     pub fn new(runtime: BuiltRuntime, pending_images: Vec<ContentPart>) -> Self {
         let should_setup = runtime.startup.setup_recommended;
         let goal_store = runtime.goal_store.clone();
         let session_id = runtime.handles.session_id;
+        let session = Session::new(runtime.handles, runtime.model.clone());
         let (models_tx, models_rx) = mpsc::unbounded_channel::<ModelDiscovery>();
         let mut app = Self {
-            handles: runtime.handles,
+            session,
             startup: runtime.startup,
             model: runtime.model,
             lines: Vec::new(),
@@ -457,7 +370,7 @@ impl App {
     }
 
     pub fn session_id(&self) -> SessionId {
-        self.handles.session_id
+        self.session.session_id()
     }
 
     /// Snapshot the renderer-relevant fields into a `ViewState`. Called
@@ -476,7 +389,7 @@ impl App {
             model_id: self.model.model_id(),
             provider_name: self.model.provider_name(),
             reasoning_effort: self.model.reasoning_effort(),
-            session_id: self.handles.session_id,
+            session_id: self.session.session_id(),
             lines_count: self.lines.len(),
             session_tokens: self.session_tokens,
             status_layout: self.status_layout,
@@ -496,12 +409,12 @@ impl App {
     }
 
     fn goal_indicator(&self) -> Option<String> {
-        if !self.goal_store.is_active(self.handles.session_id) {
+        if !self.goal_store.is_active(self.session.session_id()) {
             return None;
         }
         let turns = self
             .goal_store
-            .status(self.handles.session_id, self.session_tokens)
+            .status(self.session.session_id(), self.session_tokens)
             .active
             .map(|active| (active.evaluated_turns, active.paused))
             .unwrap_or((0, false));
@@ -750,19 +663,14 @@ impl App {
             return;
         }
 
-        let events = match self.handles.runtime.events().await {
-            Ok(events) => events,
-            Err(err) => {
-                self.push_system(format!("load replayed transcript: {err}"));
-                return;
-            }
-        };
-        let replayed_lines = events
-            .iter()
-            .take(self.startup.replayed_events)
-            .flat_map(lines_for_replayed_event)
-            .collect::<Vec<_>>();
-        self.lines.extend(replayed_lines);
+        match self
+            .session
+            .replayed_lines(self.startup.replayed_events)
+            .await
+        {
+            Ok(replayed_lines) => self.lines.extend(replayed_lines),
+            Err(err) => self.push_system(format!("load replayed transcript: {err}")),
+        }
     }
 
     fn flush_transcript<B>(&mut self, terminal: &mut Terminal<B>) -> Result<()>
@@ -1094,7 +1002,7 @@ impl App {
             UiCommand::ClearTranscript => {
                 self.lines.clear();
                 self.printed_lines = 0;
-                self.goal_store.clear_active(self.handles.session_id);
+                self.goal_store.clear_active(self.session.session_id());
                 self.emit_system_banner();
             }
             UiCommand::RunShell { command } => self.start_shell_command(command),
@@ -1214,8 +1122,8 @@ impl App {
 
     fn cancel_current_turn(&mut self) {
         self.esc_pending_cancel = false;
-        if self.goal_store.is_active(self.handles.session_id) {
-            match self.goal_store.pause_active(self.handles.session_id) {
+        if self.goal_store.is_active(self.session.session_id()) {
+            match self.goal_store.pause_active(self.session.session_id()) {
                 Ok(message) => self.push_system(message),
                 Err(err) => self.push_system(format!("goal pause failed: {err}")),
             }
@@ -1238,7 +1146,7 @@ impl App {
     }
 
     fn maybe_start_goal_turn(&mut self) {
-        let session_id = self.handles.session_id;
+        let session_id = self.session.session_id();
         if !self.goal_store.take_pending_turn(session_id) {
             return;
         }
@@ -1250,22 +1158,16 @@ impl App {
     }
 
     async fn after_turn_goal_check(&mut self) {
-        let session_id = self.handles.session_id;
+        let session_id = self.session.session_id();
         if !self.goal_store.is_active(session_id) {
             return;
         }
         if self.goal_store.is_paused(session_id) {
             return;
         }
-        let request = ExecuteCommandRequest {
-            name: "goal".to_string(),
-            arguments: Some(GOAL_EVALUATE_ARG.to_string()),
-            controls: None,
-        };
         let result = match self
-            .handles
-            .runtime
-            .execute_command(session_id, request)
+            .session
+            .execute_command("goal", Some(GOAL_EVALUATE_ARG.to_string()))
             .await
         {
             Ok(result) => result,
@@ -1332,19 +1234,10 @@ impl App {
                     return;
                 }
 
-                let request = everruns_core::command::ExecuteCommandRequest {
-                    name: descriptor.name.clone(),
-                    arguments: if trimmed.is_empty() {
-                        None
-                    } else {
-                        Some(trimmed.to_string())
-                    },
-                    controls: None,
-                };
+                let arguments = (!trimmed.is_empty()).then(|| trimmed.to_string());
                 let result = self
-                    .handles
-                    .runtime
-                    .execute_command(self.handles.session_id, request)
+                    .session
+                    .execute_command(&descriptor.name, arguments)
                     .await;
                 match result {
                     Ok(result) => {
@@ -1376,38 +1269,20 @@ impl App {
 
     fn start_shell_command(&mut self, command: String) {
         let workspace_root = self.startup.workspace_root.clone();
-        let display_command = command.clone();
-        let (tx, rx) = mpsc::unbounded_channel::<TurnEvent>();
-        let (cancel_tx, mut cancel_rx) = oneshot::channel::<()>();
-        self.rx = Some(rx);
-        self.turn_cancel = Some(cancel_tx);
+        self.push_user(format!("!shell {command}"));
+        let handle = self.session.run_shell(command, workspace_root);
+        self.begin_turn(handle, Some("running shell command".into()));
+    }
+
+    /// Wire a freshly started [`crate::session::TurnHandle`] into the event loop:
+    /// store its receiver and cancel trigger and flip into the busy state.
+    fn begin_turn(&mut self, handle: crate::session::TurnHandle, activity: Option<String>) {
+        self.rx = Some(handle.events);
+        self.turn_cancel = Some(handle.cancel);
         self.esc_pending_cancel = false;
         self.busy = true;
-        self.turn_activity = Some("running shell command".into());
+        self.turn_activity = activity;
         self.stream_preview = None;
-        self.push_user(format!("!shell {display_command}"));
-
-        tokio::spawn(async move {
-            let tool = BashTool::new(Workspace::new(workspace_root));
-            let run = tool.execute(serde_json::json!({
-                "command": command,
-                // Direct shell output is not persisted through a tool-call
-                // lifecycle, so render a useful bounded window inline.
-                "output": "normal",
-            }));
-            tokio::select! {
-                result = run => {
-                    let _ = tx.send(TurnEvent::Lines(shell_result_lines(result)));
-                }
-                _ = &mut cancel_rx => {
-                    let _ = tx.send(TurnEvent::Lines(vec![ChatLine {
-                        author: Author::System,
-                        text: "turn cancelled".into(),
-                    }]));
-                }
-            }
-            let _ = tx.send(TurnEvent::Done);
-        });
     }
 
     fn start_turn(&mut self, prompt: String) {
@@ -1424,179 +1299,10 @@ impl App {
             Err(err) => self.push_system(format!("worktree: {err}")),
         }
 
-        let handles = self.handles.clone();
-        let model = self.model.clone();
         let images = std::mem::take(&mut self.pending_images);
-        let (tx, rx) = mpsc::unbounded_channel::<TurnEvent>();
-        let (cancel_tx, mut cancel_rx) = oneshot::channel::<()>();
-        self.rx = Some(rx);
-        self.turn_cancel = Some(cancel_tx);
-        self.esc_pending_cancel = false;
-        self.busy = true;
-        self.turn_activity = None;
-        self.stream_preview = None;
-
-        // Subscribe BEFORE spawning the turn so we don't miss the first
-        // few events (turn.started, reason.started). The broadcast only
-        // delivers events emitted after subscribe().
-        let mut live = handles.events.subscribe();
-
-        tokio::spawn(async move {
-            let session_id = handles.session_id;
-            let before = match handles.runtime.messages(session_id).await {
-                Ok(m) => m.len(),
-                Err(e) => {
-                    let _ = tx.send(TurnEvent::Failed(format!("load history: {e}")));
-                    let _ = tx.send(TurnEvent::Done);
-                    return;
-                }
-            };
-            let events_before = match handles.runtime.events().await {
-                Ok(e) => e.len(),
-                Err(_) => 0,
-            };
-
-            let input = model.input_message_with_images(prompt, images);
-            let runtime = handles.runtime.clone();
-            let turn = tokio::spawn(async move { runtime.run_turn(session_id, input).await });
-
-            let mut emitted_events = HashSet::new();
-            let mut delta_router = DeltaRouter::default();
-            let mut cancelled = false;
-            loop {
-                tokio::select! {
-                    biased;
-                    _ = &mut cancel_rx => {
-                        cancelled = true;
-                        turn.abort();
-                        break;
-                    }
-                    recv = live.recv() => match recv {
-                        Ok(event) => {
-                            if event.session_id != session_id {
-                                continue;
-                            }
-                            handle_live_event(
-                                &event,
-                                &mut emitted_events,
-                                &mut delta_router,
-                                &tx,
-                            );
-                        }
-                        Err(broadcast::error::RecvError::Lagged(_)) => {
-                            // Receiver overflow: catch up from the canonical
-                            // event vec so we don't lose persistent events.
-                            // Resubscribe to restart from the current head.
-                            live = handles.events.subscribe();
-                            catch_up_events(
-                                &handles,
-                                events_before,
-                                &mut emitted_events,
-                                &mut delta_router,
-                                &tx,
-                            )
-                            .await;
-                        }
-                        Err(broadcast::error::RecvError::Closed) => break,
-                    },
-                    _ = tokio::time::sleep(Duration::from_millis(200)) => {
-                        if turn.is_finished() {
-                            break;
-                        }
-                    }
-                }
-            }
-
-            if cancelled {
-                let _ = tx.send(TurnEvent::Stream(None));
-                let _ = tx.send(TurnEvent::Lines(vec![ChatLine {
-                    author: Author::System,
-                    text: "turn cancelled".into(),
-                }]));
-                let _ = tx.send(TurnEvent::Done);
-                return;
-            }
-
-            // Drain any tail events emitted between the last broadcast
-            // poll and the turn's actual completion.
-            catch_up_events(
-                &handles,
-                events_before,
-                &mut emitted_events,
-                &mut delta_router,
-                &tx,
-            )
-            .await;
-            // Clear any in-flight streaming preview before we finalize.
-            let _ = tx.send(TurnEvent::Stream(None));
-
-            let result = match turn.await {
-                Ok(result) => result,
-                Err(e) => {
-                    let _ = tx.send(TurnEvent::Failed(format!("turn task: {e}")));
-                    let _ = tx.send(TurnEvent::Done);
-                    return;
-                }
-            };
-            let response = match result {
-                Ok(r) => r,
-                Err(e) => {
-                    let _ = tx.send(TurnEvent::Failed(format!("{e}")));
-                    let _ = tx.send(TurnEvent::Done);
-                    return;
-                }
-            };
-
-            let messages = handles
-                .runtime
-                .messages(session_id)
-                .await
-                .unwrap_or_default();
-
-            let mut out = Vec::new();
-            // Assistant text from the turn.
-            for msg in messages.iter().skip(before) {
-                if msg.role == MessageRole::Agent
-                    && !msg.has_tool_calls()
-                    && let Some(text) = msg.text()
-                {
-                    let trimmed = text.trim();
-                    if !trimmed.is_empty() {
-                        out.push(ChatLine {
-                            author: Author::Assistant,
-                            text: trimmed.to_string(),
-                        });
-                    }
-                }
-            }
-            if out.is_empty() && !response.response.is_empty() {
-                out.push(ChatLine {
-                    author: Author::Assistant,
-                    text: response.response,
-                });
-            }
-            if !response.success
-                && let Some(err) = response.error
-            {
-                out.push(ChatLine {
-                    author: Author::System,
-                    text: format!("turn error: {err}"),
-                });
-            }
-            let _ = tx.send(TurnEvent::Lines(out));
-            let _ = tx.send(TurnEvent::Done);
-        });
+        let handle = self.session.run_turn(prompt, images);
+        self.begin_turn(handle, None);
     }
-}
-
-/// Tracks the most recently active delta stream so we can drop the
-/// preview as soon as a matching `*.completed` arrives. Per-turn state
-/// — one `DeltaRouter` per `start_turn` invocation.
-#[derive(Default)]
-pub(crate) struct DeltaRouter {
-    last_assistant_turn: Option<everruns_core::typed_id::TurnId>,
-    last_tool_call: Option<String>,
-    write_todos_args: HashMap<String, Value>,
 }
 
 fn parse_bang_shell_command(input: &str) -> Option<&str> {
@@ -1615,79 +1321,6 @@ fn parse_bang_shell_command(input: &str) -> Option<&str> {
         return Some("");
     }
     Some(rest.trim())
-}
-
-fn shell_result_lines(result: ToolExecutionResult) -> Vec<ChatLine> {
-    match result {
-        ToolExecutionResult::Success(value) => shell_success_lines(&value),
-        ToolExecutionResult::SuccessWithImages { result, .. } => shell_success_lines(&result),
-        ToolExecutionResult::ToolError(message) => vec![ChatLine {
-            author: Author::System,
-            text: format!("shell failed: {message}"),
-        }],
-        ToolExecutionResult::InternalError(_) => vec![ChatLine {
-            author: Author::System,
-            text: "shell failed: internal error".into(),
-        }],
-        ToolExecutionResult::ConnectionRequired { provider } => vec![ChatLine {
-            author: Author::System,
-            text: format!("shell failed: connection required for {provider}"),
-        }],
-    }
-}
-
-fn shell_success_lines(value: &Value) -> Vec<ChatLine> {
-    let exit_code = value.get("exit_code").and_then(Value::as_i64).unwrap_or(-1);
-    let success = value
-        .get("success")
-        .and_then(Value::as_bool)
-        .unwrap_or(exit_code == 0);
-    let mut out = vec![ChatLine {
-        author: Author::Tool,
-        text: format!("shell exited with code {exit_code}"),
-    }];
-
-    for (label, author) in [
-        ("stdout", Author::ToolDetail),
-        ("stderr", Author::ToolDetail),
-    ] {
-        if let Some(text) = value.get(label).and_then(Value::as_str) {
-            let text = text.trim_end();
-            if !text.is_empty() {
-                out.push(ChatLine {
-                    author,
-                    text: format!("{label}:\n{text}"),
-                });
-            }
-        }
-    }
-    if value
-        .get("truncated")
-        .and_then(Value::as_bool)
-        .unwrap_or(false)
-        || value
-            .get("output_limited")
-            .and_then(Value::as_bool)
-            .unwrap_or(false)
-    {
-        out.push(ChatLine {
-            author: Author::System,
-            text: "shell output was truncated".into(),
-        });
-    }
-    if out.len() == 1 {
-        out.push(ChatLine {
-            author: Author::ToolDetail,
-            text: "(no output)".into(),
-        });
-    }
-    if !success {
-        out.push(ChatLine {
-            author: Author::System,
-            text: "shell command exited non-zero".into(),
-        });
-    }
-    out
 }
 
 fn command_suggestions(
@@ -1887,8 +1520,8 @@ mod tests {
     use super::*;
     use crate::capabilities::model_discovery::DiscoveredProviderModel;
     use everruns_core::events::{
-        EventContext, InputMessageData, OutputMessageCompletedData, OutputMessageStartedData,
-        ReasonCompletedData,
+        Event as RuntimeEvent, EventContext, InputMessageData, OutputMessageCompletedData,
+        OutputMessageStartedData, ReasonCompletedData, ToolCompletedData,
     };
     use everruns_core::message::Message;
     use everruns_core::tool_types::ToolCall;
@@ -3998,7 +3631,7 @@ mod tests {
     async fn second_esc_while_goal_active_pauses_goal_continuation() {
         let mut fixture = app_with_llmsim().await;
         let app = &mut fixture.app;
-        let session_id = app.handles.session_id;
+        let session_id = app.session.session_id();
         let (cancel_tx, cancel_rx) = oneshot::channel::<()>();
         app.setup = None;
         app.goal_store

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -5,6 +5,50 @@
 
 use super::*;
 
+// Presentation for the transcript view-model types defined in
+// `crate::transcript`. The data lives there; colors/labels live here so the
+// translation layer stays free of `ratatui`.
+impl Author {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Author::User => "you",
+            Author::Assistant => "agent",
+            Author::Narration => "note",
+            Author::Tool => "tool",
+            Author::ToolDetail => "",
+            Author::Diff => "diff",
+            Author::System => "system",
+        }
+    }
+    pub fn color(&self) -> Color {
+        match self {
+            Author::User => ACCENT_BLUE,
+            Author::Assistant => ACCENT_GOLD,
+            Author::Narration => TEXT_MUTED,
+            Author::Tool => TEXT_MUTED,
+            Author::ToolDetail => TEXT_MUTED,
+            Author::Diff => ACCENT_BLUE,
+            Author::System => TEXT_DIM,
+        }
+    }
+}
+
+impl StreamKind {
+    fn label(self) -> &'static str {
+        match self {
+            StreamKind::Assistant => "agent",
+            StreamKind::Tool => "tool",
+        }
+    }
+
+    fn color(self) -> Color {
+        match self {
+            StreamKind::Assistant => ACCENT_GOLD,
+            StreamKind::Tool => TEXT_MUTED,
+        }
+    }
+}
+
 pub(crate) fn draw(f: &mut ratatui::Frame, app: &mut App) {
     let area = f.area();
     // Match `draw_input`: the `> ` prompt consumes two columns.

--- a/src/app/setup.rs
+++ b/src/app/setup.rs
@@ -1287,15 +1287,9 @@ impl App {
     pub(crate) async fn execute_setup_command(
         &mut self,
         arg: Option<&str>,
-    ) -> Result<everruns_core::command::CommandResult, String> {
-        let request = everruns_core::command::ExecuteCommandRequest {
-            name: "setup".to_string(),
-            arguments: arg.map(str::to_string),
-            controls: None,
-        };
-        self.handles
-            .runtime
-            .execute_command(self.handles.session_id, request)
+    ) -> Result<crate::session::CommandOutcome, String> {
+        self.session
+            .execute_command("setup", arg.map(str::to_string))
             .await
             .map_err(|err| err.to_string())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,11 +19,13 @@ mod image_input;
 mod into;
 mod mcp_config;
 mod runtime;
+mod session;
 mod session_log;
 mod settings;
 #[cfg(test)]
 mod test_env;
 mod tools;
+mod transcript;
 mod version;
 mod worktree;
 
@@ -876,10 +878,10 @@ async fn run_print_turn(
         .unwrap_or_default();
 
     for event in events.iter().skip(before_events) {
-        if let Some(status) = app::status_for_event(event) {
+        if let Some(status) = transcript::status_for_event(event) {
             print_status_line(&status.text, color);
         }
-        for line in app::lines_for_event(event) {
+        for line in transcript::lines_for_event(event) {
             print_transcript_line(&line, color);
         }
     }
@@ -892,8 +894,8 @@ async fn run_print_turn(
             if !t.is_empty() {
                 println!();
                 print_transcript_line(
-                    &app::ChatLine {
-                        author: app::Author::Assistant,
+                    &transcript::ChatLine {
+                        author: transcript::Author::Assistant,
                         text: t.to_string(),
                     },
                     color,
@@ -916,12 +918,12 @@ async fn run_print_turn(
     Ok(result)
 }
 
-fn print_transcript_line(line: &app::ChatLine, color: bool) {
+fn print_transcript_line(line: &transcript::ChatLine, color: bool) {
     match line.author {
-        app::Author::Assistant => {
+        transcript::Author::Assistant => {
             println!("{} {}", paint(color, "90", "•"), line.text);
         }
-        app::Author::Narration => {
+        transcript::Author::Narration => {
             println!(
                 "{} {} {}",
                 paint(color, "90", "•"),
@@ -929,7 +931,7 @@ fn print_transcript_line(line: &app::ChatLine, color: bool) {
                 paint(color, "90", &line.text)
             );
         }
-        app::Author::Tool => {
+        transcript::Author::Tool => {
             println!(
                 "{} {} {}",
                 paint(color, "92", "•"),
@@ -937,13 +939,13 @@ fn print_transcript_line(line: &app::ChatLine, color: bool) {
                 line.text
             );
         }
-        app::Author::ToolDetail => {
+        transcript::Author::ToolDetail => {
             println!("           {}", line.text);
         }
-        app::Author::Diff => {
+        transcript::Author::Diff => {
             println!("  {}", paint(color, "95", &line.text));
         }
-        app::Author::System | app::Author::User => {
+        transcript::Author::System | transcript::Author::User => {
             println!(
                 "{} {} {}",
                 paint(color, "90", "•"),

--- a/src/session.rs
+++ b/src/session.rs
@@ -10,7 +10,6 @@
 
 use std::collections::HashSet;
 use std::path::PathBuf;
-use std::time::Duration;
 
 use anyhow::Result;
 use everruns_core::command::ExecuteCommandRequest;
@@ -125,11 +124,19 @@ impl Session {
 
             let input = model.input_message_with_images(prompt, images);
             let runtime = handles.runtime.clone();
-            let turn = tokio::spawn(async move { runtime.run_turn(session_id, input).await });
+            let mut turn = tokio::spawn(async move { runtime.run_turn(session_id, input).await });
 
             let mut emitted_events = HashSet::new();
             let mut delta_router = DeltaRouter::default();
+            // High-water mark into the persisted event vec. Each catch-up
+            // advances it to `events.len()` so a later catch-up only scans the
+            // newly persisted suffix — repeated `Lagged` recoveries on a long
+            // session stay O(total new events), not O(n²) re-scans.
+            let mut events_cursor = events_before;
             let mut cancelled = false;
+            // Set once the turn task joins from within the loop, so we don't
+            // await the `JoinHandle` twice.
+            let mut joined = None;
             loop {
                 tokio::select! {
                     biased;
@@ -157,7 +164,7 @@ impl Session {
                             live = handles.events.subscribe();
                             catch_up_events(
                                 &handles,
-                                events_before,
+                                &mut events_cursor,
                                 &mut emitted_events,
                                 &mut delta_router,
                                 &tx,
@@ -166,10 +173,12 @@ impl Session {
                         }
                         Err(broadcast::error::RecvError::Closed) => break,
                     },
-                    _ = tokio::time::sleep(Duration::from_millis(200)) => {
-                        if turn.is_finished() {
-                            break;
-                        }
+                    // Turn finished: no poll/latency. Live events buffered
+                    // before this point are preferred (biased order); the tail
+                    // is drained by the catch-up below.
+                    res = &mut turn => {
+                        joined = Some(res);
+                        break;
                     }
                 }
             }
@@ -188,7 +197,7 @@ impl Session {
             // poll and the turn's actual completion.
             catch_up_events(
                 &handles,
-                events_before,
+                &mut events_cursor,
                 &mut emitted_events,
                 &mut delta_router,
                 &tx,
@@ -197,7 +206,13 @@ impl Session {
             // Clear any in-flight streaming preview before we finalize.
             let _ = tx.send(TurnEvent::Stream(None));
 
-            let result = match turn.await {
+            // `joined` is set unless the loop broke on a closed broadcast
+            // before the turn finished; await the handle in that rare case.
+            let result = match joined {
+                Some(res) => res,
+                None => turn.await,
+            };
+            let result = match result {
                 Ok(result) => result,
                 Err(e) => {
                     let _ = tx.send(TurnEvent::Failed(format!("turn task: {e}")));
@@ -286,14 +301,16 @@ impl Session {
 /// end-of-turn so the transcript is never missing tool/reason completion lines.
 async fn catch_up_events(
     handles: &RuntimeHandles,
-    events_before: usize,
+    cursor: &mut usize,
     emitted_events: &mut HashSet<String>,
     router: &mut DeltaRouter,
     tx: &mpsc::UnboundedSender<TurnEvent>,
 ) {
     let events = handles.runtime.events().await.unwrap_or_default();
     let mut lines = Vec::new();
-    for event in events.iter().skip(events_before) {
+    // Only scan the suffix persisted since the last catch-up; `emitted_events`
+    // still de-dupes overlap with events already delivered live.
+    for event in events.iter().skip(*cursor) {
         let event_id = event.id.to_string();
         if !emitted_events.insert(event_id) {
             continue;
@@ -307,6 +324,7 @@ async fn catch_up_events(
         }
         lines.extend(lines_for_event_with_router(event, router));
     }
+    *cursor = events.len();
     if !lines.is_empty() {
         let _ = tx.send(TurnEvent::Lines(lines));
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,0 +1,313 @@
+//! The session facade: the single owner of [`RuntimeHandles`] and the only
+//! place that drives `everruns_core` runtime APIs (`run_turn`, `messages`,
+//! `events`, `execute_command`, the live event broadcast).
+//!
+//! The TUI (`crate::app`) talks to a [`Session`] and consumes the
+//! [`crate::transcript::TurnEvent`] stream it produces; it never subscribes to
+//! the raw runtime event bus or reaches into runtime internals. This keeps the
+//! `everruns_core` event/message model from leaking across the UI surface and
+//! makes the turn lifecycle independently testable.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::Result;
+use everruns_core::command::ExecuteCommandRequest;
+use everruns_core::message::ContentPart;
+use everruns_core::tools::Tool;
+use everruns_core::typed_id::SessionId;
+use tokio::sync::{broadcast, mpsc, oneshot};
+
+use crate::runtime::{ModelState, RuntimeHandles};
+use crate::tools::{BashTool, Workspace};
+use crate::transcript::{
+    Author, ChatLine, DeltaRouter, TurnEvent, assistant_lines_since, handle_live_event,
+    lines_for_event_with_router, lines_for_replayed_event, remember_write_todos_args,
+    shell_result_lines, status_for_event, tokens_for_event,
+};
+
+/// Outcome of a capability-provided slash command, reduced to what the host UI
+/// needs so the `everruns_core` command result type does not leak past the
+/// facade.
+pub(crate) struct CommandOutcome {
+    pub success: bool,
+    pub message: String,
+}
+
+/// A running turn (or `!shell` command): the event stream the host drains and a
+/// one-shot cancel trigger.
+pub(crate) struct TurnHandle {
+    pub events: mpsc::UnboundedReceiver<TurnEvent>,
+    pub cancel: oneshot::Sender<()>,
+}
+
+/// Facade over the runtime for a single session. Cheap to construct; holds
+/// shared handles (`Arc`-backed) plus a [`ModelState`] clone (also `Arc`-shared,
+/// so model changes made elsewhere are observed here).
+#[derive(Clone)]
+pub(crate) struct Session {
+    handles: RuntimeHandles,
+    model: ModelState,
+}
+
+impl Session {
+    pub fn new(handles: RuntimeHandles, model: ModelState) -> Self {
+        Self { handles, model }
+    }
+
+    pub fn session_id(&self) -> SessionId {
+        self.handles.session_id
+    }
+
+    /// Translate the prefix of persisted events that were replayed from disk
+    /// into transcript lines (used to seed the transcript on resume).
+    pub async fn replayed_lines(&self, count: usize) -> Result<Vec<ChatLine>> {
+        let events = self.handles.runtime.events().await?;
+        Ok(events
+            .iter()
+            .take(count)
+            .flat_map(lines_for_replayed_event)
+            .collect())
+    }
+
+    /// Execute a capability-provided command through the runtime, returning a
+    /// host-facing [`CommandOutcome`].
+    pub async fn execute_command(
+        &self,
+        name: &str,
+        arguments: Option<String>,
+    ) -> Result<CommandOutcome> {
+        let request = ExecuteCommandRequest {
+            name: name.to_string(),
+            arguments,
+            controls: None,
+        };
+        let result = self
+            .handles
+            .runtime
+            .execute_command(self.handles.session_id, request)
+            .await?;
+        Ok(CommandOutcome {
+            success: result.success,
+            message: result.message,
+        })
+    }
+
+    /// Run an agent turn for `prompt` (with any pending `images`). Spawns the
+    /// turn task and returns a [`TurnHandle`]; the task emits `TurnEvent`s and
+    /// finishes with `Done` (or `Failed`).
+    pub fn run_turn(&self, prompt: String, images: Vec<ContentPart>) -> TurnHandle {
+        let handles = self.handles.clone();
+        let model = self.model.clone();
+        let (tx, rx) = mpsc::unbounded_channel::<TurnEvent>();
+        let (cancel_tx, mut cancel_rx) = oneshot::channel::<()>();
+
+        // Subscribe BEFORE spawning the turn so we don't miss the first
+        // few events (turn.started, reason.started). The broadcast only
+        // delivers events emitted after subscribe().
+        let mut live = handles.events.subscribe();
+
+        tokio::spawn(async move {
+            let session_id = handles.session_id;
+            let before = match handles.runtime.messages(session_id).await {
+                Ok(m) => m.len(),
+                Err(e) => {
+                    let _ = tx.send(TurnEvent::Failed(format!("load history: {e}")));
+                    let _ = tx.send(TurnEvent::Done);
+                    return;
+                }
+            };
+            let events_before = match handles.runtime.events().await {
+                Ok(e) => e.len(),
+                Err(_) => 0,
+            };
+
+            let input = model.input_message_with_images(prompt, images);
+            let runtime = handles.runtime.clone();
+            let turn = tokio::spawn(async move { runtime.run_turn(session_id, input).await });
+
+            let mut emitted_events = HashSet::new();
+            let mut delta_router = DeltaRouter::default();
+            let mut cancelled = false;
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = &mut cancel_rx => {
+                        cancelled = true;
+                        turn.abort();
+                        break;
+                    }
+                    recv = live.recv() => match recv {
+                        Ok(event) => {
+                            if event.session_id != session_id {
+                                continue;
+                            }
+                            handle_live_event(
+                                &event,
+                                &mut emitted_events,
+                                &mut delta_router,
+                                &tx,
+                            );
+                        }
+                        Err(broadcast::error::RecvError::Lagged(_)) => {
+                            // Receiver overflow: catch up from the canonical
+                            // event vec so we don't lose persistent events.
+                            // Resubscribe to restart from the current head.
+                            live = handles.events.subscribe();
+                            catch_up_events(
+                                &handles,
+                                events_before,
+                                &mut emitted_events,
+                                &mut delta_router,
+                                &tx,
+                            )
+                            .await;
+                        }
+                        Err(broadcast::error::RecvError::Closed) => break,
+                    },
+                    _ = tokio::time::sleep(Duration::from_millis(200)) => {
+                        if turn.is_finished() {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if cancelled {
+                let _ = tx.send(TurnEvent::Stream(None));
+                let _ = tx.send(TurnEvent::Lines(vec![ChatLine {
+                    author: Author::System,
+                    text: "turn cancelled".into(),
+                }]));
+                let _ = tx.send(TurnEvent::Done);
+                return;
+            }
+
+            // Drain any tail events emitted between the last broadcast
+            // poll and the turn's actual completion.
+            catch_up_events(
+                &handles,
+                events_before,
+                &mut emitted_events,
+                &mut delta_router,
+                &tx,
+            )
+            .await;
+            // Clear any in-flight streaming preview before we finalize.
+            let _ = tx.send(TurnEvent::Stream(None));
+
+            let result = match turn.await {
+                Ok(result) => result,
+                Err(e) => {
+                    let _ = tx.send(TurnEvent::Failed(format!("turn task: {e}")));
+                    let _ = tx.send(TurnEvent::Done);
+                    return;
+                }
+            };
+            let response = match result {
+                Ok(r) => r,
+                Err(e) => {
+                    let _ = tx.send(TurnEvent::Failed(format!("{e}")));
+                    let _ = tx.send(TurnEvent::Done);
+                    return;
+                }
+            };
+
+            let messages = handles
+                .runtime
+                .messages(session_id)
+                .await
+                .unwrap_or_default();
+
+            // Assistant text from the turn.
+            let mut out = assistant_lines_since(&messages, before);
+            if out.is_empty() && !response.response.is_empty() {
+                out.push(ChatLine {
+                    author: Author::Assistant,
+                    text: response.response,
+                });
+            }
+            if !response.success
+                && let Some(err) = response.error
+            {
+                out.push(ChatLine {
+                    author: Author::System,
+                    text: format!("turn error: {err}"),
+                });
+            }
+            let _ = tx.send(TurnEvent::Lines(out));
+            let _ = tx.send(TurnEvent::Done);
+        });
+
+        TurnHandle {
+            events: rx,
+            cancel: cancel_tx,
+        }
+    }
+
+    /// Run a host-local `!shell` command (not part of a tool-call lifecycle).
+    /// Output is rendered inline; nothing is persisted to the session.
+    pub fn run_shell(&self, command: String, workspace_root: PathBuf) -> TurnHandle {
+        let (tx, rx) = mpsc::unbounded_channel::<TurnEvent>();
+        let (cancel_tx, mut cancel_rx) = oneshot::channel::<()>();
+
+        tokio::spawn(async move {
+            let tool = BashTool::new(Workspace::new(workspace_root));
+            let run = tool.execute(serde_json::json!({
+                "command": command,
+                // Direct shell output is not persisted through a tool-call
+                // lifecycle, so render a useful bounded window inline.
+                "output": "normal",
+            }));
+            tokio::select! {
+                result = run => {
+                    let _ = tx.send(TurnEvent::Lines(shell_result_lines(result)));
+                }
+                _ = &mut cancel_rx => {
+                    let _ = tx.send(TurnEvent::Lines(vec![ChatLine {
+                        author: Author::System,
+                        text: "turn cancelled".into(),
+                    }]));
+                }
+            }
+            let _ = tx.send(TurnEvent::Done);
+        });
+
+        TurnHandle {
+            events: rx,
+            cancel: cancel_tx,
+        }
+    }
+}
+
+/// Drain any persisted events (from `runtime.events()`) that the broadcast
+/// receiver may have missed — used after a `Lagged` recv error and once more at
+/// end-of-turn so the transcript is never missing tool/reason completion lines.
+async fn catch_up_events(
+    handles: &RuntimeHandles,
+    events_before: usize,
+    emitted_events: &mut HashSet<String>,
+    router: &mut DeltaRouter,
+    tx: &mpsc::UnboundedSender<TurnEvent>,
+) {
+    let events = handles.runtime.events().await.unwrap_or_default();
+    let mut lines = Vec::new();
+    for event in events.iter().skip(events_before) {
+        let event_id = event.id.to_string();
+        if !emitted_events.insert(event_id) {
+            continue;
+        }
+        if let Some(tokens) = tokens_for_event(event) {
+            let _ = tx.send(TurnEvent::Tokens(tokens));
+        }
+        remember_write_todos_args(event, router);
+        if let Some(activity) = status_for_event(event) {
+            let _ = tx.send(TurnEvent::Activity(activity));
+        }
+        lines.extend(lines_for_event_with_router(event, router));
+    }
+    if !lines.is_empty() {
+        let _ = tx.send(TurnEvent::Lines(lines));
+    }
+}

--- a/src/streaming_tests.rs
+++ b/src/streaming_tests.rs
@@ -247,3 +247,52 @@ async fn broadcast_does_not_persist_delta_events_to_jsonl() {
         "JSONL log must not persist tool output delta events: {on_disk}"
     );
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn session_run_turn_emits_lines_and_finishes_with_done() {
+    // End-to-end exercise of the `Session` facade — the boundary the TUI now
+    // drives instead of touching the runtime/event bus directly. Drains the
+    // `TurnEvent` channel the facade produces and asserts the turn streams
+    // assistant content and terminates with `Done` (never `Failed`).
+    use crate::session::Session;
+
+    let runtime = build_llmsim_runtime().await;
+    let session = Session::new(runtime.handles.clone(), runtime.model.clone());
+
+    let mut handle = session.run_turn("anything".to_string(), Vec::new());
+
+    let mut saw_assistant_lines = false;
+    let mut saw_done = false;
+    let mut failure: Option<String> = None;
+    let deadline = tokio::time::Instant::now() + TURN_TIMEOUT;
+    while tokio::time::Instant::now() < deadline {
+        let remaining = deadline - tokio::time::Instant::now();
+        match tokio::time::timeout(remaining, handle.events.recv()).await {
+            Ok(Some(TurnEvent::Lines(lines))) => {
+                if lines
+                    .iter()
+                    .any(|l| matches!(l.author, crate::app::Author::Assistant))
+                {
+                    saw_assistant_lines = true;
+                }
+            }
+            Ok(Some(TurnEvent::Failed(err))) => failure = Some(err),
+            Ok(Some(TurnEvent::Done)) => {
+                saw_done = true;
+                break;
+            }
+            Ok(Some(_)) => {}
+            Ok(None) | Err(_) => break,
+        }
+    }
+
+    assert!(failure.is_none(), "turn failed via facade: {failure:?}");
+    assert!(
+        saw_done,
+        "facade turn did not emit Done within {TURN_TIMEOUT:?}"
+    );
+    assert!(
+        saw_assistant_lines,
+        "facade turn produced no assistant lines"
+    );
+}

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -1,14 +1,88 @@
-//! Translation of runtime events into transcript `ChatLine`s and status text,
-//! plus tool-result summarization. Pure functions over `RuntimeEvent` /
-//! `ToolCompletedData`; no terminal I/O. `DeltaRouter` (the per-turn dedup
-//! state these consume) is defined in the parent module.
+//! The TUI view model and the single place that interprets `everruns_core`
+//! runtime events / tool results.
+//!
+//! This module owns the display data types (`ChatLine`, `Author`,
+//! `ActivityStatus`, `StreamPreview`, `StreamKind`) and the `TurnEvent` channel
+//! protocol that [`crate::session::Session`] emits while a turn runs. It is the
+//! one boundary that knows about `EventData` / `Message`; the rest of the TUI
+//! (`crate::app`) consumes only the view-model types defined here. Functions are
+//! pure over runtime types — no terminal I/O. Presentation concerns (colors)
+//! live in `crate::app::render`.
 
-use super::*;
-use everruns_core::events::ToolStartedData;
+use everruns_core::events::{Event as RuntimeEvent, EventData, ToolCompletedData, ToolStartedData};
+use everruns_core::message::{ContentPart, Message, MessageRole};
+use everruns_core::tools::ToolExecutionResult;
+use serde_json::Value;
+use std::collections::HashMap;
+use tokio::sync::mpsc;
+
+// ---------- view-model types ----------
+
+#[derive(Clone, Debug)]
+pub enum Author {
+    User,
+    Assistant,
+    Narration,
+    Tool,
+    ToolDetail,
+    Diff,
+    System,
+}
+
+#[derive(Clone, Debug)]
+pub struct ChatLine {
+    pub author: Author,
+    pub text: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct StreamPreview {
+    pub kind: StreamKind,
+    pub text: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StreamKind {
+    Assistant,
+    Tool,
+}
+
+#[derive(Clone, Debug)]
+pub struct ActivityStatus {
+    pub text: String,
+    pub(crate) fallback: bool,
+}
+
+/// Events emitted by [`crate::session::Session`] while a turn (or `!shell`
+/// command) runs. The TUI drains these from the per-turn channel; it never sees
+/// the underlying runtime events.
+#[derive(Debug)]
+pub(crate) enum TurnEvent {
+    Lines(Vec<ChatLine>),
+    Activity(ActivityStatus),
+    /// Replace the live streaming preview shown above the input.
+    /// `None` clears the preview.
+    Stream(Option<StreamPreview>),
+    Tokens(u64),
+    Done,
+    Failed(String),
+}
+
+/// Tracks the most recently active delta stream so we can drop the streaming
+/// preview as soon as a matching `*.completed` arrives. Per-turn state — one
+/// `DeltaRouter` per turn.
+#[derive(Default)]
+pub(crate) struct DeltaRouter {
+    last_assistant_turn: Option<everruns_core::typed_id::TurnId>,
+    last_tool_call: Option<String>,
+    write_todos_args: HashMap<String, Value>,
+}
+
+// ---------- live event translation ----------
 
 pub(crate) fn handle_live_event(
     event: &RuntimeEvent,
-    emitted_events: &mut HashSet<String>,
+    emitted_events: &mut std::collections::HashSet<String>,
     router: &mut DeltaRouter,
     tx: &mpsc::UnboundedSender<TurnEvent>,
 ) {
@@ -67,39 +141,7 @@ pub(crate) fn handle_live_event(
     }
 }
 
-/// Drain any persisted events (from `runtime.events()`) that the broadcast
-/// receiver may have missed — used after a `Lagged` recv error and once
-/// more at end-of-turn so the transcript is never missing tool/reason
-/// completion lines.
-pub(crate) async fn catch_up_events(
-    handles: &RuntimeHandles,
-    events_before: usize,
-    emitted_events: &mut HashSet<String>,
-    router: &mut DeltaRouter,
-    tx: &mpsc::UnboundedSender<TurnEvent>,
-) {
-    let events = handles.runtime.events().await.unwrap_or_default();
-    let mut lines = Vec::new();
-    for event in events.iter().skip(events_before) {
-        let event_id = event.id.to_string();
-        if !emitted_events.insert(event_id) {
-            continue;
-        }
-        if let Some(tokens) = tokens_for_event(event) {
-            let _ = tx.send(TurnEvent::Tokens(tokens));
-        }
-        remember_write_todos_args(event, router);
-        if let Some(activity) = status_for_event(event) {
-            let _ = tx.send(TurnEvent::Activity(activity));
-        }
-        lines.extend(lines_for_event_with_router(event, router));
-    }
-    if !lines.is_empty() {
-        let _ = tx.send(TurnEvent::Lines(lines));
-    }
-}
-
-fn remember_write_todos_args(event: &RuntimeEvent, router: &mut DeltaRouter) {
+pub(crate) fn remember_write_todos_args(event: &RuntimeEvent, router: &mut DeltaRouter) {
     if let EventData::ToolStarted(data) = &event.data
         && data.tool_call.name == "write_todos"
     {
@@ -116,7 +158,10 @@ pub(crate) fn tokens_for_event(event: &RuntimeEvent) -> Option<u64> {
     }
 }
 
-fn lines_for_event_with_router(event: &RuntimeEvent, router: &mut DeltaRouter) -> Vec<ChatLine> {
+pub(crate) fn lines_for_event_with_router(
+    event: &RuntimeEvent,
+    router: &mut DeltaRouter,
+) -> Vec<ChatLine> {
     match &event.data {
         EventData::ToolCompleted(data) if data.tool_name == "write_todos" => {
             todo_lines_for_result_or_args(data, &mut router.write_todos_args)
@@ -213,6 +258,28 @@ pub(crate) fn lines_for_replayed_event(event: &RuntimeEvent) -> Vec<ChatLine> {
         }
         _ => lines_for_event(event),
     }
+}
+
+/// Assistant text lines produced by a turn, read from the messages appended
+/// after `skip`. Mirrors the message-loop reconciliation the session does at
+/// end of turn.
+pub(crate) fn assistant_lines_since(messages: &[Message], skip: usize) -> Vec<ChatLine> {
+    let mut out = Vec::new();
+    for msg in messages.iter().skip(skip) {
+        if msg.role == MessageRole::Agent
+            && !msg.has_tool_calls()
+            && let Some(text) = msg.text()
+        {
+            let trimmed = text.trim();
+            if !trimmed.is_empty() {
+                out.push(ChatLine {
+                    author: Author::Assistant,
+                    text: trimmed.to_string(),
+                });
+            }
+        }
+    }
+    out
 }
 
 pub(crate) fn message_line(author: Author, message: &Message) -> Option<ChatLine> {
@@ -527,6 +594,81 @@ pub fn summarize_tool_result(data: &ToolCompletedData) -> String {
 /// never panics on a mid-codepoint byte index.
 pub(crate) fn first_line(s: &str, max: usize) -> String {
     truncate_chars(s.lines().next().unwrap_or(""), max)
+}
+
+// ---------- `!shell` result translation ----------
+
+pub(crate) fn shell_result_lines(result: ToolExecutionResult) -> Vec<ChatLine> {
+    match result {
+        ToolExecutionResult::Success(value) => shell_success_lines(&value),
+        ToolExecutionResult::SuccessWithImages { result, .. } => shell_success_lines(&result),
+        ToolExecutionResult::ToolError(message) => vec![ChatLine {
+            author: Author::System,
+            text: format!("shell failed: {message}"),
+        }],
+        ToolExecutionResult::InternalError(_) => vec![ChatLine {
+            author: Author::System,
+            text: "shell failed: internal error".into(),
+        }],
+        ToolExecutionResult::ConnectionRequired { provider } => vec![ChatLine {
+            author: Author::System,
+            text: format!("shell failed: connection required for {provider}"),
+        }],
+    }
+}
+
+fn shell_success_lines(value: &Value) -> Vec<ChatLine> {
+    let exit_code = value.get("exit_code").and_then(Value::as_i64).unwrap_or(-1);
+    let success = value
+        .get("success")
+        .and_then(Value::as_bool)
+        .unwrap_or(exit_code == 0);
+    let mut out = vec![ChatLine {
+        author: Author::Tool,
+        text: format!("shell exited with code {exit_code}"),
+    }];
+
+    for (label, author) in [
+        ("stdout", Author::ToolDetail),
+        ("stderr", Author::ToolDetail),
+    ] {
+        if let Some(text) = value.get(label).and_then(Value::as_str) {
+            let text = text.trim_end();
+            if !text.is_empty() {
+                out.push(ChatLine {
+                    author,
+                    text: format!("{label}:\n{text}"),
+                });
+            }
+        }
+    }
+    if value
+        .get("truncated")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+        || value
+            .get("output_limited")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    {
+        out.push(ChatLine {
+            author: Author::System,
+            text: "shell output was truncated".into(),
+        });
+    }
+    if out.len() == 1 {
+        out.push(ChatLine {
+            author: Author::ToolDetail,
+            text: "(no output)".into(),
+        });
+    }
+    if !success {
+        out.push(ChatLine {
+            author: Author::System,
+            text: "shell command exited non-zero".into(),
+        });
+    }
+    out
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What & why

This is **PR 1 of 3** from an architectural review focused on abstractions, interfaces, and leaked abstractions (not code style).

**Problem:** the TUI had no boundary between itself and the runtime. `App` imported the `everruns_core` event/message model directly, subscribed to the raw event broadcast, and drove `run_turn`/`messages`/`events`/`execute_command` by hand inside a ~180-line `start_turn`. Rendering was coupled to runtime internals, so every upstream event-model change risked rippling into the UI, and the turn loop could not be tested without a live runtime.

**Fix:** introduce two boundaries.

- **`crate::transcript`** — the single place that interprets `EventData` / `Message`. Owns the view-model types (`ChatLine`, `Author`, `ActivityStatus`, `StreamPreview`, `StreamKind`, `TurnEvent`, `DeltaRouter`) and all runtime-event / tool-result translation, moved out from under `app/`. Presentation (colors/labels) stays in `app::render`, so the translation layer carries no `ratatui` dependency. This module already had three consumers (TUI, `--print`, ACP bridge), which is why it belongs at crate level.
- **`crate::session::Session`** — the only owner of `RuntimeHandles` and the only caller of runtime APIs. Exposes `run_turn` / `run_shell` (returning a `TurnHandle` with the `TurnEvent` stream + cancel trigger), `replayed_lines`, and `execute_command` (returning a host-facing `CommandOutcome` so the runtime command-result type stays behind the facade).

After this change `app/` no longer imports `everruns_core::events` or `everruns_core::message::{Message, MessageRole}` in production code, and never touches the runtime outside the facade. `--print` (`main.rs`) and the ACP bridge call `crate::transcript` directly — the same shared translation the TUI uses.

Net: `app/mod.rs` shrinks ~470 lines; the turn lifecycle is now independently testable.

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo test --all-features` — 491 + 29 pass, 0 failures.
- **New test** `streaming_tests::session_run_turn_emits_lines_and_finishes_with_done` drives `Session::run_turn` end-to-end over llmsim and asserts assistant lines stream out and the turn terminates with `Done` (never `Failed`).
- Offline smoke test `yolop --provider llmsim -p "hi"` works (exercises the `--print` path now routed through `transcript`).

## Security

No security-relevant behavior change. This is a pure structural refactor: code paths (bash output caps, write blocklist, key handling, capability registration) are moved verbatim, not modified. The `!shell` path keeps its bounded `output: "normal"` window. No new dependencies, no new trust boundaries.

## Follow-ups

- The translation unit tests still live in `app/mod.rs`'s test module (they reach the functions via the `crate::app` re-export). Moving them next to the code in `crate::transcript` is a tidy-up worth doing but out of scope here. Listed, not silently dropped.
- `CommandDescriptor` / `CommandSource` (command *palette metadata*) intentionally remain in `app` — they are descriptors surfaced by `StartupInfo`, not part of the runtime event model this PR isolates.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7VFG2RxNDFrAd8rhAoxoA)_