### PR TITLE
fix(tui): re-anchor inline viewport after terminal resize

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -32,6 +32,7 @@ use tokio::sync::{mpsc, oneshot};
 mod markdown_table;
 mod render;
 mod setup;
+mod viewport;
 
 // Re-export the moved free items so the rest of the crate (and the test module)
 // can keep referring to them as `crate::app::*`. `setup` exposes only `impl App`
@@ -40,7 +41,7 @@ mod setup;
 // The view-model types and runtime-event translation live in `crate::transcript`
 // (the single boundary that interprets `everruns_core` events); re-export them
 // here so the TUI's own submodules keep referring to them as `crate::app::*`.
-pub(crate) use self::render::*;
+pub(crate) use self::{render::*, viewport::*};
 pub(crate) use crate::transcript::*;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -528,6 +529,11 @@ impl App {
         B::Error: std::error::Error + Send + Sync + 'static,
     {
         self.flush_transcript(terminal)?;
+        // Ratatui keeps the inline viewport row fixed across vertical grows and
+        // resets it to the top on horizontal shrinks. Re-anchor before each draw
+        // so the composer stays pinned to the terminal bottom after resize.
+        terminal.autoresize()?;
+        maybe_reanchor_inline_viewport(terminal)?;
         terminal.draw(|f| draw(f, self))?;
 
         // 1) drain background turn events

--- a/src/app/viewport.rs
+++ b/src/app/viewport.rs
@@ -1,0 +1,108 @@
+//! Inline-viewport anchoring helpers. Ratatui anchors inline viewports to the
+//! cursor row at init and keeps that row fixed across vertical grows; a
+//! horizontal shrink resets the origin to the top. Yolop wants the composer
+//! pinned to the terminal bottom, so we re-insert blank scrollback lines when
+//! the viewport drifts away from that target.
+
+use anyhow::Result;
+use ratatui::Terminal;
+use ratatui::backend::Backend;
+
+/// Blank lines to insert above the inline viewport so its bottom edge sits on
+/// the terminal bottom.
+pub(crate) fn blank_lines_after_inline_viewport(
+    viewport_top: u16,
+    viewport_height: u16,
+    terminal_height: u16,
+) -> u16 {
+    terminal_height.saturating_sub(viewport_top.saturating_add(viewport_height))
+}
+
+/// Push the inline viewport to the terminal bottom when it has drifted upward.
+/// No-op when already flush with the bottom edge.
+pub(crate) fn maybe_reanchor_inline_viewport<B>(terminal: &mut Terminal<B>) -> Result<()>
+where
+    B: Backend,
+    B::Error: std::error::Error + Send + Sync + 'static,
+{
+    let terminal_height = terminal.size()?.height;
+    let viewport_area = terminal.get_frame().area();
+    let blank_lines =
+        blank_lines_after_inline_viewport(viewport_area.y, viewport_area.height, terminal_height);
+    if blank_lines == 0 {
+        return Ok(());
+    }
+    terminal.insert_before(blank_lines, |_| {})?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::TerminalOptions;
+    use ratatui::Viewport;
+    use ratatui::backend::TestBackend;
+    use ratatui::layout::Position;
+
+    fn viewport_bottom<B: Backend>(terminal: &mut Terminal<B>) -> u16 {
+        let area = terminal.get_frame().area();
+        area.y.saturating_add(area.height)
+    }
+
+    #[test]
+    fn reanchor_after_terminal_grow_moves_viewport_to_bottom() {
+        let mut backend = TestBackend::new(80, 24);
+        backend
+            .set_cursor_position(Position { x: 0, y: 1 })
+            .unwrap();
+        let mut terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Inline(18),
+            },
+        )
+        .unwrap();
+
+        maybe_reanchor_inline_viewport(&mut terminal).expect("initial anchor");
+        assert_eq!(viewport_bottom(&mut terminal), 24);
+
+        terminal.backend_mut().resize(80, 40);
+        terminal.autoresize().expect("autoresize grow");
+        assert!(
+            viewport_bottom(&mut terminal) < 40,
+            "ratatui keeps the viewport row fixed across a grow"
+        );
+
+        maybe_reanchor_inline_viewport(&mut terminal).expect("re-anchor after grow");
+        assert_eq!(viewport_bottom(&mut terminal), 40);
+    }
+
+    #[test]
+    fn reanchor_after_horizontal_shrink_moves_viewport_back_to_bottom() {
+        let mut backend = TestBackend::new(80, 24);
+        backend
+            .set_cursor_position(Position { x: 0, y: 1 })
+            .unwrap();
+        let mut terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Inline(18),
+            },
+        )
+        .unwrap();
+
+        maybe_reanchor_inline_viewport(&mut terminal).expect("initial anchor");
+        assert_eq!(viewport_bottom(&mut terminal), 24);
+
+        terminal.backend_mut().resize(60, 24);
+        terminal.autoresize().expect("autoresize shrink");
+        assert_eq!(
+            terminal.get_frame().area().y,
+            0,
+            "ratatui resets inline origin to the top on horizontal shrink"
+        );
+
+        maybe_reanchor_inline_viewport(&mut terminal).expect("re-anchor after shrink");
+        assert_eq!(viewport_bottom(&mut terminal), 24);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ use anyhow::{Context, Result};
 // Force-link integration crates whose inventory registrations must survive
 // LTO/dead-code elimination when we register capabilities explicitly.
 extern crate everruns_integrations_daytona;
-use app::{App, COMPOSER_VIEWPORT_HEIGHT};
+use app::{App, COMPOSER_VIEWPORT_HEIGHT, maybe_reanchor_inline_viewport};
 use clap::{Args, Parser, Subcommand};
 use crossterm::event::{
     KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
@@ -553,7 +553,7 @@ async fn run_tui(runtime: BuiltRuntime, pending_images: Vec<ContentPart>) -> Res
     // the cursor (via `Terminal::clear`) with a blocking `CSI 6n` query that
     // slow emulators (ttyd / xterm.js) may not answer before crossterm's ~2s
     // timeout. Start unanchored rather than dying.
-    if let Err(err) = anchor_inline_viewport_at_bottom(&mut terminal) {
+    if let Err(err) = maybe_reanchor_inline_viewport(&mut terminal) {
         tracing::warn!("inline viewport anchoring failed, starting unanchored: {err:#}");
     }
 
@@ -586,30 +586,6 @@ async fn run_tui(runtime: BuiltRuntime, pending_images: Vec<ContentPart>) -> Res
         print_centered_ukraine_banner();
     }
     result
-}
-
-fn anchor_inline_viewport_at_bottom<B>(terminal: &mut Terminal<B>) -> Result<()>
-where
-    B: ratatui::backend::Backend,
-    B::Error: std::error::Error + Send + Sync + 'static,
-{
-    let terminal_height = terminal.size()?.height;
-    let viewport_area = terminal.get_frame().area();
-    let blank_lines =
-        blank_lines_after_inline_viewport(viewport_area.y, viewport_area.height, terminal_height);
-    if blank_lines == 0 {
-        return Ok(());
-    }
-    terminal.insert_before(blank_lines, |_| {})?;
-    Ok(())
-}
-
-fn blank_lines_after_inline_viewport(
-    viewport_top: u16,
-    viewport_height: u16,
-    terminal_height: u16,
-) -> u16 {
-    terminal_height.saturating_sub(viewport_top.saturating_add(viewport_height))
 }
 
 struct RawModeGuard {
@@ -1097,17 +1073,17 @@ mod tests {
 
     #[test]
     fn inline_viewport_anchor_fills_space_above_bottom_target() {
-        assert_eq!(blank_lines_after_inline_viewport(4, 18, 60), 38);
+        assert_eq!(app::blank_lines_after_inline_viewport(4, 18, 60), 38);
     }
 
     #[test]
     fn inline_viewport_anchor_does_not_scroll_when_already_low_enough() {
-        assert_eq!(blank_lines_after_inline_viewport(42, 18, 60), 0);
-        assert_eq!(blank_lines_after_inline_viewport(50, 18, 60), 0);
+        assert_eq!(app::blank_lines_after_inline_viewport(42, 18, 60), 0);
+        assert_eq!(app::blank_lines_after_inline_viewport(50, 18, 60), 0);
     }
 
     #[test]
     fn inline_viewport_anchor_handles_small_terminals() {
-        assert_eq!(blank_lines_after_inline_viewport(0, 18, 10), 0);
+        assert_eq!(app::blank_lines_after_inline_viewport(0, 18, 10), 0);
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -467,6 +467,85 @@ fn tui_resize_with_wrapped_input_keeps_cursor_inside_new_frame() {
     );
 }
 
+#[test]
+fn tui_resize_grow_reanchors_composer_to_bottom() {
+    let mut tui = spawn_tui_llmsim_with(
+        &yolop_binary(),
+        TuiSpawnOptions {
+            rows: 24,
+            cols: 80,
+            ..TuiSpawnOptions::default()
+        },
+    );
+    assert!(
+        tui.wait_for_output("type /help", Duration::from_secs(3)),
+        "TUI did not render startup banner: {}",
+        tui.output_text()
+    );
+
+    tui.write_input(b"hi\r");
+    assert!(
+        tui.wait_for_output("offline mode", Duration::from_secs(5)),
+        "turn did not complete: {}",
+        tui.output_text()
+    );
+
+    tui.clear_output();
+    tui.resize(80, 40);
+    tui.write_input(b" ");
+    assert!(
+        tui.wait_for_output("[expand", Duration::from_secs(3)),
+        "TUI did not redraw after grow resize: {}",
+        tui.output_text()
+    );
+
+    assert_cursor_near_bottom(&mut tui, 40);
+
+    tui.write_input(b"\x03\x03");
+    let status = tui.wait_or_kill(Duration::from_secs(5));
+    assert!(
+        status.success(),
+        "double Ctrl-C should exit cleanly after grow resize, got {status:?}: {}",
+        tui.output_text()
+    );
+}
+
+#[test]
+fn tui_resize_shrink_width_reanchors_composer_to_bottom() {
+    let mut tui = spawn_tui_llmsim(&yolop_binary());
+    assert!(
+        tui.wait_for_output("type /help", Duration::from_secs(3)),
+        "TUI did not render startup banner: {}",
+        tui.output_text()
+    );
+
+    tui.write_input(b"hi\r");
+    assert!(
+        tui.wait_for_output("offline mode", Duration::from_secs(5)),
+        "turn did not complete: {}",
+        tui.output_text()
+    );
+
+    tui.clear_output();
+    tui.resize(60, 24);
+    tui.write_input(b" ");
+    assert!(
+        tui.wait_for_output("[expand", Duration::from_secs(3)),
+        "TUI did not redraw after width shrink: {}",
+        tui.output_text()
+    );
+
+    assert_cursor_near_bottom(&mut tui, 24);
+
+    tui.write_input(b"\x03\x03");
+    let status = tui.wait_or_kill(Duration::from_secs(5));
+    assert!(
+        status.success(),
+        "double Ctrl-C should exit cleanly after width shrink, got {status:?}: {}",
+        tui.output_text()
+    );
+}
+
 // ratatui 0.30.1 `Terminal::clear` snapshots the cursor with a blocking
 // `CSI 6n` query, and the inline viewport calls `clear` inside
 // `insert_before` — so viewport anchoring, every transcript flush, and exit


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resize was breaking the TUI layout because bottom-anchoring only ran once at startup.

Ratatui's inline viewport behavior:
- **Vertical grow**: keeps the viewport's row fixed, leaving a large empty band below the composer
- **Horizontal shrink**: resets the viewport origin to the top (`y = 0`), detaching it from the bottom

The earlier layout work (`ece0419`, `e4d6ee7`) fixed chrome math and idle spacing inside the viewport, and the test suite validated that — but those tests use a plain `TestBackend` without `Viewport::Inline`, and the PTY resize tests only checked crash survival / cursor bounds, not bottom anchoring after resize.

This change re-runs viewport bottom-anchoring after `autoresize()` on every event-loop iteration (no-op when already flush with the bottom).

## Testing

- 2 new unit tests in `src/app/viewport.rs` (grow + horizontal-shrink re-anchor)
- 2 new PTY integration tests (`tui_resize_grow_reanchors_composer_to_bottom`, `tui_resize_shrink_width_reanchors_composer_to_bottom`)
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (506 unit + 31 integration)
- `cargo run -- --provider llmsim -p "hi"` (offline smoke)

## Security

No security-relevant code changes. Cosmetic terminal layout only; no filesystem, shell, prompt, or capability changes.

## Follow-ups

No follow-ups.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f548fd59-2d04-4cb8-bf80-1f19b10957dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f548fd59-2d04-4cb8-bf80-1f19b10957dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

