### PR TITLE
docs(cli): clarify --reasoning-effort applies to all providers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,9 @@ struct Cli {
     #[arg(short, long)]
     model: Option<String>,
 
-    /// Reasoning effort for OpenAI and OpenRouter model calls
+    /// Reasoning effort for model calls (validated against the model's
+    /// supported values, e.g. minimal/low/medium/high). Applies to any
+    /// provider whose selected model exposes a reasoning-effort setting.
     #[arg(long)]
     reasoning_effort: Option<String>,
 


### PR DESCRIPTION
## What

The `--reasoning-effort` help text claimed it was "for OpenAI and OpenRouter model calls", but `pick_provider` in `src/main.rs` applies the flag to **every** provider whose selected model exposes a reasoning-effort setting (Anthropic, Codex, Google, etc.). Reword the help to match the actual behavior and mention values are validated against the model's supported set.

## Why

Came out of a benchmark deep-dive into why yolop runs more turns than peer agents (codex/pi) on SWE-bench. While confirming that reasoning effort is already fully configurable (CLI flag, `EVERRUNS_CLI_REASONING_EFFORT`, per-model settings), the CLI flag's help text was found to understate its scope, making it look provider-limited.

## Scope

Help-text only — no behavior change. `cargo fmt --check` passes; `--help` renders the corrected text.

## Context

The larger finding from that investigation — yolop issues ~1 tool call per turn while codex batches — is tracked upstream in everruns (request-level `parallel_tool_calls` plumbing) rather than here. A prompt change to encourage batching was prototyped and **validated as inert on its own** (0 batching on sonnet, marginal on gpt-5.5), so it is intentionally held back until the upstream signal lands. This PR is deliberately limited to the safe docs fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1tdiP8vNAEuxiBH4HXQhM)_