### PR TITLE
fix(runtime): require verification before finishing edits

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -81,9 +81,11 @@ commands on the host. There is no sandbox.
 
 ## Workflow
 
-Read before editing. Test after changing behavior. When a command fails,
-read the full output, fix the root cause, and re-run — do not retry the
-identical command. If stuck after two attempts, explain and ask.
+Read before editing. Before finishing an edit, verify it empirically: run the
+nearest tests or a self-contained repro; if blocked, say why. Search sibling
+call sites/patterns for completeness. Review your diff for regressions. When a
+command fails, read the full output, fix the root cause, and re-run — do not
+retry the identical command. If stuck after two attempts, explain and ask.
 
 ## Permanent Tools
 
@@ -4400,6 +4402,20 @@ mod tests {
             !HARNESS_PROMPT.contains("## Tools at a glance"),
             "the old combined section should stay split"
         );
+    }
+
+    #[test]
+    fn harness_prompt_requires_verification_before_finishing_edits() {
+        let workflow = HARNESS_PROMPT
+            .split("## Workflow")
+            .nth(1)
+            .and_then(|tail| tail.split("## Permanent Tools").next())
+            .expect("workflow section should be present");
+
+        assert!(workflow.contains("Before finishing an edit"));
+        assert!(workflow.contains("nearest tests or a self-contained repro"));
+        assert!(workflow.contains("Search sibling"));
+        assert!(workflow.contains("Review your diff for regressions"));
     }
 
     #[test]


### PR DESCRIPTION
## What
Require Yolop's coding harness to verify edits before finishing: run nearest tests or a self-contained repro, search sibling call sites/patterns for completeness, and review the produced diff for regressions.

## Why
The tracking-v1 failures point to one recurring behavior: Yolop edited and stopped without enough empirical verification. The six unresolved eval artifacts are committed under `bench/results/swebench_verified/openai-default__tracking-v1/`:

- `django__django-11141`: target passed, one PASS_TO_PASS regression (`test_load_empty_dir`)
- `django__django-10097`: 7 FAIL_TO_PASS failures and 5 PASS_TO_PASS failures
- `django__django-10999`: 2 FAIL_TO_PASS failures
- `django__django-10973`: 4 target successes, 1 target failure
- `astropy__astropy-13398`: 4 target failures and 5 PASS_TO_PASS failures
- `pylint-dev__pylint-4551`: 10 target failures

## How
Updated the durable harness prompt in `src/runtime.rs` so every coding session gets explicit completion gates before reporting done. Added a prompt regression test that checks the workflow section keeps those gates.

## Risk
- Low
- This changes prompt policy only. It may spend extra tool calls on verification/search before final answers, which is intentional for coding tasks.

## Security
- No security-relevant code changes beyond harness prompt text and a unit test.
- Reviewed TM-FS, TM-BASH, TM-LLM, TM-TOOL, and TM-DEP: no filesystem behavior, shell execution behavior, secret handling, tool registration, or dependencies changed.

## Validation
- `cargo fmt --check`
- `cargo test harness_prompt --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `python3 -m unittest discover -s bench/tests`
- `cargo run -- --provider llmsim -p "hi"`
- Attempted `doppler run -- cargo run -- --provider openai -p "Reply with exactly: verification smoke"`, but local Doppler is not configured in this worktree (`You must specify a project`). CI's same-repo `live-smoke` job runs Doppler-backed provider tests.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
