### PR TITLE
feat(tui): attach large text pastes as placeholders

### DIFF
--- a/skills/yolop/SKILL.md
+++ b/skills/yolop/SKILL.md
@@ -71,7 +71,8 @@ also appear in the registry when installed.
 | `Tab` | Accept the first slash-command suggestion, or insert a literal tab |
 | `←` / `→` | Move cursor in the composer |
 | `/` then type | Command palette suggestions (accept with Tab) |
-| `Ctrl+V` | Paste a clipboard image as an attachment |
+| `Ctrl+V` | Paste a clipboard image as an attachment, or attach large text as a placeholder |
+| Terminal paste | Large pastes (>1000 chars) attach as `[Pasted Content N chars]` placeholders |
 
 ### Session control
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -129,6 +129,8 @@ pub struct App {
     worktree: Arc<WorktreeManager>,
     /// Images from `--image` / `-i` on the CLI, consumed on the first turn.
     pending_images: Vec<ContentPart>,
+    /// Large paste placeholders mapped to their full clipboard/terminal payloads.
+    pending_pastes: Vec<(String, String)>,
 }
 
 /// Result of one background models API fetch. `Ok(None)` means the provider
@@ -347,6 +349,7 @@ impl App {
             goal_store,
             worktree: runtime.worktree,
             pending_images,
+            pending_pastes: Vec::new(),
         };
         app.emit_system_banner();
         if should_setup {
@@ -450,7 +453,7 @@ impl App {
             self.push_system(format!("commands: {}", names.join(", ")));
         }
         self.push_system(
-            "type /help for commands, Ctrl+V to paste an image, press Ctrl-C twice (or Ctrl-D) to exit"
+            "type /help for commands, Ctrl+V to paste an image, large pastes attach as placeholders, press Ctrl-C twice (or Ctrl-D) to exit"
                 .into(),
         );
     }
@@ -624,6 +627,13 @@ impl App {
                         return Ok(());
                     }
                 }
+                CrosstermEvent::Paste(pasted) => {
+                    if self.setup.is_some() {
+                        self.handle_setup_paste(pasted).await;
+                    } else {
+                        self.handle_paste(pasted);
+                    }
+                }
                 _ => {}
             }
             if self.should_quit {
@@ -734,7 +744,7 @@ impl App {
                     return;
                 }
                 KeyCode::Char('v') => {
-                    self.try_paste_clipboard_image();
+                    self.try_paste_clipboard();
                     return;
                 }
                 _ => {}
@@ -802,6 +812,7 @@ impl App {
 
     fn reset_input(&mut self) {
         self.input = new_input_area(vec![String::new()]);
+        self.pending_pastes.clear();
     }
 
     fn input_height(&self, input_width: u16) -> u16 {
@@ -809,7 +820,38 @@ impl App {
             as u16
     }
 
-    fn try_paste_clipboard_image(&mut self) {
+    fn handle_paste(&mut self, pasted: String) {
+        if self.busy || self.setup.is_some() || self.background_panel.is_some() {
+            return;
+        }
+
+        let pasted = crate::paste_attachment::normalize_pasted_text(&pasted);
+        if pasted.is_empty() {
+            return;
+        }
+
+        if pasted.len() > crate::paste_attachment::MAX_PASTE_ATTACHMENT_BYTES {
+            self.push_system(format!(
+                "paste too large (max {} KiB)",
+                crate::paste_attachment::MAX_PASTE_ATTACHMENT_BYTES / 1024
+            ));
+            return;
+        }
+
+        if crate::paste_attachment::is_large_paste(&pasted) {
+            let char_count = pasted.chars().count();
+            let placeholder = crate::paste_attachment::next_large_paste_placeholder(
+                char_count,
+                &self.pending_pastes,
+            );
+            self.input.insert_str(&placeholder);
+            self.pending_pastes.push((placeholder, pasted));
+        } else {
+            self.input.insert_str(&pasted);
+        }
+    }
+
+    fn try_paste_clipboard(&mut self) {
         if self.busy || self.setup.is_some() || self.background_panel.is_some() {
             return;
         }
@@ -822,7 +864,11 @@ impl App {
                     info.width, info.height
                 ));
             }
-            Err(crate::clipboard_paste::PasteImageError::NoImage(_)) => {}
+            Err(crate::clipboard_paste::PasteImageError::NoImage(_)) => {
+                if let Ok(text) = crate::clipboard_paste::paste_clipboard_text() {
+                    self.handle_paste(text);
+                }
+            }
             Err(err) => {
                 tracing::debug!("clipboard image paste failed: {err}");
                 self.push_system(format!("clipboard image paste failed: {err}"));
@@ -832,8 +878,12 @@ impl App {
 
     async fn submit_input(&mut self) {
         let raw = self.input_text();
+        crate::paste_attachment::prune_pending_pastes(&raw, &mut self.pending_pastes);
+        let pending_pastes = std::mem::take(&mut self.pending_pastes);
+        let expanded = crate::paste_attachment::expand_pending_pastes(&raw, &pending_pastes);
         self.reset_input();
-        let text = raw.trim().to_string();
+        let text = expanded.trim().to_string();
+        let display_text = raw.trim().to_string();
         if let Some(command) = parse_bang_shell_command(&text) {
             if command.is_empty() {
                 self.push_system("usage: !<command>".into());
@@ -850,7 +900,7 @@ impl App {
             return;
         }
         let image_count = self.pending_images.len();
-        let display = crate::image_input::user_display_text(&text, image_count);
+        let display = crate::image_input::user_display_text(&display_text, image_count);
         self.push_user(display);
         self.start_turn(text);
     }
@@ -1440,7 +1490,7 @@ fn help_command_line(descriptor: &CommandDescriptor) -> String {
 fn help_shortcut_lines() -> [&'static str; 5] {
     [
         "  Enter send · Shift-Enter newline · Tab complete slash command · ←/→ edit",
-        "  Ctrl+V paste image · Ctrl+B background tasks · !<cmd> shell alias",
+        "  Ctrl+V paste image/text · Ctrl+B background tasks · !<cmd> shell alias",
         "  exit: Ctrl-C twice / Ctrl-D",
         "  cancel turn: Esc twice (while model is busy)",
         "  scroll: terminal scrollback (no in-app page keys)",
@@ -3367,6 +3417,47 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn large_paste_attaches_placeholder_and_expands_on_submit() {
+        use crate::paste_attachment::LARGE_PASTE_CHAR_THRESHOLD;
+
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+        app.lines.clear();
+
+        let payload = format!("paste-marker-{}", "x".repeat(LARGE_PASTE_CHAR_THRESHOLD));
+        app.handle_paste(payload.clone());
+        let placeholder = app.input_text();
+        assert!(
+            placeholder.contains("[Pasted Content"),
+            "large paste should insert a placeholder: {placeholder:?}"
+        );
+        assert_eq!(app.pending_pastes.len(), 1);
+
+        app.submit_input().await;
+
+        assert!(
+            app.busy,
+            "submit should start a turn with the expanded paste"
+        );
+        assert!(
+            app.lines.iter().any(|line| {
+                matches!(line.author, Author::User) && line.text.contains("[Pasted Content")
+            }),
+            "transcript should show the compact placeholder: {:?}",
+            app.lines
+        );
+        assert!(
+            !app.lines.iter().any(|line| {
+                matches!(line.author, Author::User) && line.text.contains("paste-marker-")
+            }),
+            "transcript should not inline the full pasted payload: {:?}",
+            app.lines
+        );
+        assert!(app.pending_pastes.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn startup_banner_is_kept_out_of_inline_viewport() {
         let mut fixture = app_with_llmsim().await;
         let rows = render_app_lines(&mut fixture.app, 96, COMPOSER_VIEWPORT_HEIGHT);
@@ -3630,7 +3721,7 @@ mod tests {
         assert!(
             help_lines
                 .iter()
-                .any(|line| line.contains("Ctrl+V paste image")),
+                .any(|line| line.contains("Ctrl+V paste image/text")),
             "help output should mention image paste: {help_lines:?}"
         );
         assert!(

--- a/src/app/setup.rs
+++ b/src/app/setup.rs
@@ -535,6 +535,49 @@ impl App {
         }
     }
 
+    pub(crate) async fn handle_setup_paste(&mut self, pasted: String) {
+        let Some(step) = self.setup.clone() else {
+            return;
+        };
+        let pasted = crate::paste_attachment::normalize_pasted_text(&pasted);
+        if pasted.is_empty() {
+            return;
+        }
+        match step {
+            SetupStep::BaseUrlInput { mut value, .. } => {
+                value.push_str(&pasted);
+                self.setup = Some(SetupStep::BaseUrlInput { value, error: None });
+            }
+            SetupStep::TokenInput {
+                mut token,
+                provider,
+                ..
+            } => {
+                token.push_str(&pasted);
+                self.setup = Some(SetupStep::TokenInput {
+                    provider,
+                    token,
+                    error: None,
+                });
+            }
+            SetupStep::PickModel {
+                provider,
+                selected,
+                custom: Some(mut value),
+                ..
+            } => {
+                value.push_str(&pasted);
+                self.setup = Some(SetupStep::PickModel {
+                    provider,
+                    selected,
+                    custom: Some(value),
+                    error: None,
+                });
+            }
+            _ => {}
+        }
+    }
+
     pub(crate) async fn handle_setup_key(&mut self, key: KeyEvent) {
         let Some(step) = self.setup.clone() else {
             return;

--- a/src/clipboard_paste.rs
+++ b/src/clipboard_paste.rs
@@ -212,6 +212,23 @@ fn convert_windows_path_to_wsl(input: &str) -> Option<PathBuf> {
     Some(result)
 }
 
+/// Read plain text from the clipboard.
+#[cfg(not(target_os = "android"))]
+pub fn paste_clipboard_text() -> Result<String, PasteImageError> {
+    let mut clipboard = arboard::Clipboard::new()
+        .map_err(|err| PasteImageError::ClipboardUnavailable(err.to_string()))?;
+    clipboard
+        .get_text()
+        .map_err(|err| PasteImageError::NoImage(err.to_string()))
+}
+
+#[cfg(target_os = "android")]
+pub fn paste_clipboard_text() -> Result<String, PasteImageError> {
+    Err(PasteImageError::ClipboardUnavailable(
+        "clipboard text paste is unsupported on Android".into(),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod host_ui;
 mod image_input;
 mod into;
 mod mcp_config;
+mod paste_attachment;
 mod runtime;
 mod session;
 mod session_log;
@@ -46,7 +47,8 @@ extern crate everruns_integrations_daytona;
 use app::{App, COMPOSER_VIEWPORT_HEIGHT, maybe_reanchor_inline_viewport};
 use clap::{Args, Parser, Subcommand};
 use crossterm::event::{
-    KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+    DisableBracketedPaste, EnableBracketedPaste, KeyboardEnhancementFlags,
+    PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
 };
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 use crossterm::{execute, queue};
@@ -543,6 +545,7 @@ fn run_command(command: Commands) -> Result<()> {
 async fn run_tui(runtime: BuiltRuntime, pending_images: Vec<ContentPart>) -> Result<()> {
     let mut raw_mode = RawModeGuard::new()?;
     let mut keyboard_enhancements = KeyboardEnhancementGuard::new();
+    let mut bracketed_paste = BracketedPasteGuard::new();
     let stdout = io::stdout();
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::with_options(
@@ -577,6 +580,7 @@ async fn run_tui(runtime: BuiltRuntime, pending_images: Vec<ContentPart>) -> Res
         tracing::warn!("cursor restore failed: {err:#}");
     }
     drop(terminal);
+    bracketed_paste.disable();
     keyboard_enhancements.disable();
     raw_mode.disable()?;
 
@@ -642,6 +646,32 @@ impl KeyboardEnhancementGuard {
 }
 
 impl Drop for KeyboardEnhancementGuard {
+    fn drop(&mut self) {
+        self.disable();
+    }
+}
+
+struct BracketedPasteGuard {
+    active: bool,
+}
+
+impl BracketedPasteGuard {
+    fn new() -> Self {
+        let mut stdout = io::stdout();
+        let active = execute!(stdout, EnableBracketedPaste).is_ok();
+        Self { active }
+    }
+
+    fn disable(&mut self) {
+        if self.active {
+            let mut stdout = io::stdout();
+            let _ = execute!(stdout, DisableBracketedPaste);
+            self.active = false;
+        }
+    }
+}
+
+impl Drop for BracketedPasteGuard {
     fn drop(&mut self) {
         self.disable();
     }

--- a/src/paste_attachment.rs
+++ b/src/paste_attachment.rs
@@ -1,0 +1,120 @@
+// Large clipboard/terminal paste handling for the interactive TUI.
+//
+// Mirrors Codex TUI: pastes above `LARGE_PASTE_CHAR_THRESHOLD` characters
+// insert a compact placeholder in the composer while the full payload is
+// stored in `pending_pastes` and expanded on submit.
+
+/// Pastes larger than this attach as a placeholder instead of inline text.
+pub const LARGE_PASTE_CHAR_THRESHOLD: usize = 1000;
+
+/// Upper bound on attached paste payload size (512 KiB).
+pub const MAX_PASTE_ATTACHMENT_BYTES: usize = 512 * 1024;
+
+/// Normalize line endings from clipboard or terminal paste events.
+pub fn normalize_pasted_text(pasted: &str) -> String {
+    pasted.replace("\r\n", "\n").replace('\r', "\n")
+}
+
+/// Whether pasted text should attach as a placeholder rather than inline.
+pub fn is_large_paste(text: &str) -> bool {
+    text.chars().count() > LARGE_PASTE_CHAR_THRESHOLD
+}
+
+/// Build the next placeholder label for a large paste of `char_count` chars.
+pub fn next_large_paste_placeholder(
+    char_count: usize,
+    pending_pastes: &[(String, String)],
+) -> String {
+    let base = format!("[Pasted Content {char_count} chars]");
+    let prefix = format!("{base} #");
+    let mut max_suffix = 0usize;
+
+    for (placeholder, _) in pending_pastes {
+        if placeholder == &base {
+            max_suffix = max_suffix.max(1);
+            continue;
+        }
+        if let Some(suffix) = placeholder.strip_prefix(&prefix)
+            && let Ok(value) = suffix.parse::<usize>()
+        {
+            max_suffix = max_suffix.max(value);
+        }
+    }
+
+    if max_suffix == 0 {
+        base
+    } else {
+        format!("{base} #{}", max_suffix + 1)
+    }
+}
+
+/// Drop pending pastes whose placeholder no longer appears in the composer.
+pub fn prune_pending_pastes(text: &str, pending_pastes: &mut Vec<(String, String)>) {
+    pending_pastes.retain(|(placeholder, _)| text.contains(placeholder));
+}
+
+/// Replace placeholder labels in `text` with their stored payloads.
+pub fn expand_pending_pastes(text: &str, pending_pastes: &[(String, String)]) -> String {
+    let mut expanded = text.to_string();
+    for (placeholder, payload) in pending_pastes {
+        expanded = expanded.replace(placeholder, payload);
+    }
+    expanded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_pasted_text_unifies_line_endings() {
+        assert_eq!(normalize_pasted_text("a\r\nb\rc"), "a\nb\nc");
+    }
+
+    #[test]
+    fn is_large_paste_uses_char_count() {
+        let exact = "x".repeat(LARGE_PASTE_CHAR_THRESHOLD);
+        assert!(!is_large_paste(&exact));
+        assert!(is_large_paste(&format!("{exact}x")));
+    }
+
+    #[test]
+    fn next_large_paste_placeholder_adds_suffix_for_duplicates() {
+        let pending = vec![
+            ("[Pasted Content 1200 chars]".to_string(), "first".to_string()),
+            (
+                "[Pasted Content 1200 chars] #2".to_string(),
+                "second".to_string(),
+            ),
+        ];
+        assert_eq!(
+            next_large_paste_placeholder(1200, &pending),
+            "[Pasted Content 1200 chars] #3"
+        );
+    }
+
+    #[test]
+    fn expand_pending_pastes_replaces_placeholders_in_order() {
+        let first = "a".repeat(LARGE_PASTE_CHAR_THRESHOLD + 1);
+        let second = "b".repeat(LARGE_PASTE_CHAR_THRESHOLD + 2);
+        let first_ph = next_large_paste_placeholder(first.chars().count(), &[]);
+        let pending = vec![
+            (first_ph.clone(), first.clone()),
+            (
+                next_large_paste_placeholder(second.chars().count(), &[(first_ph, first.clone())]),
+                second.clone(),
+            ),
+        ];
+        let composed = format!("before {} middle {} after", pending[0].0, pending[1].0);
+        let expanded = expand_pending_pastes(&composed, &pending);
+        assert_eq!(expanded, format!("before {first} middle {second} after"));
+    }
+
+    #[test]
+    fn prune_pending_pastes_drops_removed_placeholders() {
+        let placeholder = "[Pasted Content 1500 chars]";
+        let mut pending = vec![(placeholder.to_string(), "payload".to_string())];
+        prune_pending_pastes("typed only", &mut pending);
+        assert!(pending.is_empty());
+    }
+}

--- a/src/paste_attachment.rs
+++ b/src/paste_attachment.rs
@@ -81,7 +81,10 @@ mod tests {
     #[test]
     fn next_large_paste_placeholder_adds_suffix_for_duplicates() {
         let pending = vec![
-            ("[Pasted Content 1200 chars]".to_string(), "first".to_string()),
+            (
+                "[Pasted Content 1200 chars]".to_string(),
+                "first".to_string(),
+            ),
             (
                 "[Pasted Content 1200 chars] #2".to_string(),
                 "second".to_string(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Large clipboard and terminal pastes in the TUI now attach as compact placeholders (Codex-style), similar to image attachments.

- Pastes over **1000 characters** insert `[Pasted Content N chars]` into the composer instead of flooding the input area.
- Full paste payloads are stored in `pending_pastes` and expanded into the submitted prompt on send.
- The transcript keeps the compact placeholder; the model receives the full text.
- **Bracketed paste** is enabled so terminals emit `Event::Paste` for terminal paste.
- **Ctrl+V** still attaches clipboard images first; when no image is present it reads clipboard text and applies the same large/small paste rules.

## Why

Pasting logs, stack traces, or file dumps made the composer unusable and sent huge blobs inline. Codex TUI solves this with placeholder attachments; this mirrors that UX.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (528 tests)
- Offline smoke: `cargo run -- --provider llmsim -p "hi"`
- New unit tests in `src/paste_attachment.rs`
- New integration test: `large_paste_attaches_placeholder_and_expands_on_submit`

## Security

- **TM-LLM**: Paste payloads are capped at 512 KiB before attachment; expansion happens only on explicit submit. No keys or secrets are logged.
- **TM-FS / TM-BASH / TM-TOOL / TM-DEP**: No changes to filesystem, shell, tool registration, or dependencies beyond existing TUI/event-loop code.

## Risks

- Terminals without bracketed paste still deliver large pastes as character streams (unchanged behavior). Windows paste-burst detection is not implemented yet.

## Follow-ups

- Add paste-burst detection (Codex `PasteBurst`) for non-bracketed terminals, especially Windows, so large pastes attach even when the terminal does not emit `Event::Paste`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b04970de-f92b-4709-81fa-2f64b961689e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b04970de-f92b-4709-81fa-2f64b961689e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

