### PR TITLE
feat(tui): show worktree in status bar with lighter switch notice

### DIFF
--- a/specs/worktrees.md
+++ b/specs/worktrees.md
@@ -54,6 +54,9 @@ config/secrets.json
 - `repo_root` is the git toplevel of the user's checkout; git identity/remote context comes from there.
 - Sub-agents inherit the parent session's active worktree.
 - Resume reattaches to a saved worktree or recreates it when tmp was cleared.
+- The TUI compact status bar shows `wt <slug>` when a worktree is active; expand
+  the status bar for branch and path. Mid-session activation posts a light
+  `Switched to worktree · <branch>` system line instead of the raw path.
 
 ### Commands
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -290,6 +290,10 @@ pub(crate) struct ViewState {
     pub background: Option<(usize, usize)>,
     /// Short label when a `/goal` loop is active (for example `◎ goal`).
     pub goal_indicator: Option<String>,
+    /// Worktree slug for the compact status bar (for example `bump-outdated-crates-ship`).
+    pub worktree_compact: Option<String>,
+    /// Branch and path shown in the expanded status bar when a worktree is active.
+    pub worktree_expanded: Option<(String, String)>,
 }
 
 /// What kind of delta is currently being streamed. Only the assistant
@@ -302,11 +306,21 @@ pub(crate) enum StatusLayout {
 }
 
 impl StatusLayout {
-    pub(crate) fn row_count(self) -> u16 {
+    pub(crate) fn base_row_count(self) -> u16 {
         match self {
             Self::Compact => 1,
             Self::Expanded => EXPANDED_STATUS_ROWS,
         }
+    }
+}
+
+impl ViewState {
+    pub(crate) fn status_row_count(&self) -> u16 {
+        self.status_layout.base_row_count() + self.worktree_extra_status_rows()
+    }
+
+    fn worktree_extra_status_rows(&self) -> u16 {
+        u16::from(self.status_layout == StatusLayout::Expanded && self.worktree_expanded.is_some())
     }
 }
 
@@ -410,6 +424,8 @@ impl App {
                 counts => Some(counts),
             },
             goal_indicator: self.goal_indicator(),
+            worktree_compact: self.worktree.status_bar_compact(),
+            worktree_expanded: self.worktree.status_bar_expanded(),
         }
     }
 
@@ -435,12 +451,6 @@ impl App {
             "workspace: {}",
             self.startup.workspace_root.display()
         ));
-        if let Some(line) = self.startup.worktree_line.clone() {
-            if let Some(repo) = &self.startup.repo_root {
-                self.push_system(format!("repo: {}", repo.display()));
-            }
-            self.push_system(line);
-        }
         self.push_system(format!("model: {}", self.model.provider_label()));
         self.push_system(format!("tools: {}", self.startup.tool_names.join(", ")));
         if !self.startup.capability_commands.is_empty() {
@@ -1138,7 +1148,7 @@ impl App {
         let layout = app_layout_for_frame(
             terminal_area,
             self.input_height(input_width),
-            self.status_layout,
+            state.status_row_count(),
             chrome_preview_visible(&state),
         );
         if layout.chrome.session_status.height == 0 {
@@ -1350,8 +1360,8 @@ impl App {
         match self.worktree.ensure_before_turn(&prompt) {
             Ok(true) => {
                 self.startup.workspace_root = self.worktree.active_root();
-                if let Some(line) = self.worktree.status_line() {
-                    self.push_system(line);
+                if let Some(notice) = self.worktree.switch_notice() {
+                    self.push_system(notice);
                 }
             }
             Ok(false) => {
@@ -1835,30 +1845,21 @@ mod tests {
 
     #[test]
     fn chrome_height_reserves_four_expanded_status_rows() {
-        assert_eq!(chrome_height(1, StatusLayout::Compact, false), 4);
-        assert_eq!(chrome_height(1, StatusLayout::Compact, true), 5);
-        assert_eq!(chrome_height(1, StatusLayout::Expanded, false), 7);
-        assert_eq!(chrome_height(1, StatusLayout::Expanded, true), 8);
-        assert_eq!(chrome_height(3, StatusLayout::Compact, false), 5);
-        assert_eq!(chrome_height(3, StatusLayout::Expanded, false), 8);
-        assert_eq!(chrome_height(4, StatusLayout::Compact, false), 6);
-        assert_eq!(chrome_height(4, StatusLayout::Expanded, false), 9);
+        assert_eq!(chrome_height(1, 1, false), 4);
+        assert_eq!(chrome_height(1, 1, true), 5);
+        assert_eq!(chrome_height(1, 4, false), 7);
+        assert_eq!(chrome_height(1, 4, true), 8);
+        assert_eq!(chrome_height(3, 1, false), 5);
+        assert_eq!(chrome_height(3, 4, false), 8);
+        assert_eq!(chrome_height(4, 1, false), 6);
+        assert_eq!(chrome_height(4, 4, false), 9);
     }
 
     #[test]
     fn chrome_dimensions_clamp_input_to_visible_frame() {
-        assert_eq!(
-            chrome_dimensions(7, MAX_INPUT_HEIGHT, StatusLayout::Expanded, false),
-            (7, 1)
-        );
-        assert_eq!(
-            chrome_dimensions(5, MAX_INPUT_HEIGHT, StatusLayout::Compact, false),
-            (5, 3)
-        );
-        assert_eq!(
-            chrome_dimensions(0, MAX_INPUT_HEIGHT, StatusLayout::Compact, false),
-            (0, 0)
-        );
+        assert_eq!(chrome_dimensions(7, MAX_INPUT_HEIGHT, 4, false), (7, 1));
+        assert_eq!(chrome_dimensions(5, MAX_INPUT_HEIGHT, 1, false), (5, 3));
+        assert_eq!(chrome_dimensions(0, MAX_INPUT_HEIGHT, 1, false), (0, 0));
     }
 
     fn rect_inside(parent: Rect, child: Rect) -> bool {
@@ -1887,8 +1888,12 @@ mod tests {
                             width,
                             height,
                         };
-                        let layout =
-                            app_layout_for_frame(frame, desired_input, status_layout, false);
+                        let layout = app_layout_for_frame(
+                            frame,
+                            desired_input,
+                            status_layout.base_row_count(),
+                            false,
+                        );
                         assert_eq!(layout.frame, frame);
                         assert!(
                             rect_inside(frame, layout.transcript),
@@ -2818,6 +2823,8 @@ mod tests {
             approval_mode: "normal".to_string(),
             background: None,
             goal_indicator: None,
+            worktree_compact: None,
+            worktree_expanded: None,
         }
     }
 
@@ -5301,6 +5308,57 @@ mod tests {
             !status.contains("session "),
             "compact status should keep session id for expanded layout: {status}"
         );
+    }
+
+    #[test]
+    fn chrome_session_status_compact_shows_worktree_indicator() {
+        let state = ViewState {
+            worktree_compact: Some("bump-outdated-crates-ship".to_string()),
+            ..view_state_idle()
+        };
+        let rows = render_chrome_lines(&state, 120, 4);
+        let status = &rows[3];
+        assert!(
+            status.contains("wt bump-outdated-crat"),
+            "compact status should include worktree slug: {status}"
+        );
+    }
+
+    #[test]
+    fn chrome_session_status_expanded_shows_worktree_subsection() {
+        let state = ViewState {
+            status_layout: StatusLayout::Expanded,
+            worktree_compact: Some("bump-outdated-crates-ship".to_string()),
+            worktree_expanded: Some((
+                "bump-outdated-crates-ship-f6dd3e41".to_string(),
+                "…/session_019ee6c2dfd27223853ea56ff6dd3e41".to_string(),
+            )),
+            ..view_state_idle()
+        };
+        assert_eq!(state.status_row_count(), 5);
+        let rows = render_chrome_lines(&state, 180, 8);
+        assert!(
+            rows[7].contains("worktree bump-outdated-crates-ship-f6dd3e41")
+                && rows[7].contains("path …/session_019ee6"),
+            "expanded status should include worktree branch and path: {:?}",
+            rows[7]
+        );
+    }
+
+    #[test]
+    fn view_state_status_row_count_adds_worktree_row_only_when_expanded() {
+        let compact = ViewState {
+            worktree_expanded: Some(("branch".into(), "path".into())),
+            ..view_state_idle()
+        };
+        assert_eq!(compact.status_row_count(), 1);
+
+        let expanded = ViewState {
+            status_layout: StatusLayout::Expanded,
+            worktree_expanded: Some(("branch".into(), "path".into())),
+            ..view_state_idle()
+        };
+        assert_eq!(expanded.status_row_count(), 5);
     }
 
     #[test]

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -58,7 +58,7 @@ pub(crate) fn draw(f: &mut ratatui::Frame, app: &mut App) {
     let layout = TuiLayout::new(
         area,
         desired_input_height,
-        state.status_layout,
+        state.status_row_count(),
         chrome_preview_visible(&state),
     );
 
@@ -83,13 +83,13 @@ impl TuiLayout {
     pub(crate) fn new(
         frame: Rect,
         desired_input_height: u16,
-        status_layout: StatusLayout,
+        status_rows: u16,
         preview_visible: bool,
     ) -> Self {
         let (chrome_height, input_height) = chrome_dimensions(
             frame.height,
             desired_input_height,
-            status_layout,
+            status_rows,
             preview_visible,
         );
         let chrome_area = bottom_rect(frame, chrome_height);
@@ -100,7 +100,7 @@ impl TuiLayout {
         Self {
             frame,
             transcript,
-            chrome: ChromeLayout::new(chrome_area, input_height, status_layout, preview_visible),
+            chrome: ChromeLayout::new(chrome_area, input_height, status_rows, preview_visible),
         }
     }
 }
@@ -120,12 +120,11 @@ impl ChromeLayout {
     pub(crate) fn new(
         area: Rect,
         input_height: u16,
-        status_layout: StatusLayout,
+        status_rows: u16,
         preview_visible: bool,
     ) -> Self {
         let preview_height = u16::from(input_height == 1 && preview_visible);
         let status_height = u16::from(input_height < 3);
-        let status_rows = status_layout.row_count();
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
@@ -157,24 +156,20 @@ pub(crate) fn bottom_rect(area: Rect, height: u16) -> Rect {
     }
 }
 
-pub(crate) fn chrome_height(
-    input_height: u16,
-    status_layout: StatusLayout,
-    preview_visible: bool,
-) -> u16 {
+pub(crate) fn chrome_height(input_height: u16, status_rows: u16, preview_visible: bool) -> u16 {
     let preview_height = u16::from(input_height == 1 && preview_visible);
     let status_separator_height = u16::from(input_height < 3);
     let fixed_rows = preview_height
         .saturating_add(1)
         .saturating_add(status_separator_height)
-        .saturating_add(status_layout.row_count());
+        .saturating_add(status_rows);
     input_height.saturating_add(fixed_rows)
 }
 
 pub(crate) fn chrome_dimensions(
     frame_height: u16,
     desired_input_height: u16,
-    status_layout: StatusLayout,
+    status_rows: u16,
     preview_visible: bool,
 ) -> (u16, u16) {
     if frame_height == 0 {
@@ -183,12 +178,12 @@ pub(crate) fn chrome_dimensions(
 
     let desired_input_height = desired_input_height.clamp(1, MAX_INPUT_HEIGHT);
     let chrome_height =
-        chrome_height(desired_input_height, status_layout, preview_visible).min(frame_height);
+        chrome_height(desired_input_height, status_rows, preview_visible).min(frame_height);
     let mut input_height = desired_input_height.min(chrome_height);
     while input_height > 1
         && input_height.saturating_add(chrome_fixed_rows(
             input_height,
-            status_layout,
+            status_rows,
             preview_visible,
         )) > chrome_height
     {
@@ -200,17 +195,17 @@ pub(crate) fn chrome_dimensions(
 pub(crate) fn app_layout_for_frame(
     frame: Rect,
     desired_input_height: u16,
-    status_layout: StatusLayout,
+    status_rows: u16,
     preview_visible: bool,
 ) -> TuiLayout {
-    TuiLayout::new(frame, desired_input_height, status_layout, preview_visible)
+    TuiLayout::new(frame, desired_input_height, status_rows, preview_visible)
 }
 
-fn chrome_fixed_rows(input_height: u16, status_layout: StatusLayout, preview_visible: bool) -> u16 {
+fn chrome_fixed_rows(input_height: u16, status_rows: u16, preview_visible: bool) -> u16 {
     u16::from(input_height == 1 && preview_visible)
         .saturating_add(1)
         .saturating_add(u16::from(input_height < 3))
-        .saturating_add(status_layout.row_count())
+        .saturating_add(status_rows)
 }
 
 pub(crate) fn clear_transcript_viewport(f: &mut ratatui::Frame, area: Rect) {
@@ -325,7 +320,7 @@ pub(crate) fn draw_chrome(
     let layout = ChromeLayout::new(
         area,
         input_height,
-        state.status_layout,
+        state.status_row_count(),
         chrome_preview_visible(state),
     );
     draw_chrome_layout(f, layout, state);
@@ -1638,12 +1633,20 @@ fn expanded_status_lines(state: &ViewState) -> Vec<Line<'static>> {
     ];
     let session = [status_field("session", state.session_id.to_string())];
 
-    vec![
+    let mut lines = vec![
         status_line(provider_model.iter()),
         status_line(controls.iter()),
         status_line(counts.iter()),
         status_line(session.iter()),
-    ]
+    ];
+    if let Some((branch, path)) = &state.worktree_expanded {
+        let worktree = [
+            status_field("worktree", branch.clone()),
+            status_field("path", path.clone()),
+        ];
+        lines.push(status_line(worktree.iter()));
+    }
+    lines
 }
 
 fn status_contributions(state: &ViewState) -> Vec<StatusContribution> {
@@ -1669,6 +1672,9 @@ fn status_contributions(state: &ViewState) -> Vec<StatusContribution> {
             let mut compact = vec![status_value(message_count_label(state.lines_count))];
             if let Some(bg) = background_label(state.background) {
                 compact.push(status_field("bg", bg));
+            }
+            if let Some(wt) = &state.worktree_compact {
+                compact.push(status_field("wt", wt.clone()));
             }
             compact
         }),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1795,8 +1795,6 @@ pub struct RuntimeHandles {
 
 pub struct StartupInfo {
     pub workspace_root: PathBuf,
-    pub repo_root: Option<PathBuf>,
-    pub worktree_line: Option<String>,
     pub tool_names: Vec<String>,
     /// Slash commands contributed by registered capabilities (via
     /// `Capability::commands()`). Resolved once at startup against this
@@ -2506,8 +2504,6 @@ pub async fn build_with_options(
         },
         startup: StartupInfo {
             workspace_root: effective_root,
-            repo_root,
-            worktree_line: worktree.status_line(),
             tool_names,
             capability_commands,
             session_log_path: log_path,

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -294,14 +294,35 @@ impl WorktreeManager {
         write_session_workspace(&self.session_dir, &metadata).map_err(|e| anyhow::anyhow!("{e}"))
     }
 
-    pub fn status_line(&self) -> Option<String> {
-        let info = self.worktree_info()?;
-        Some(format!(
-            "worktree: {} @ {}",
-            info.branch,
-            info.path.display()
-        ))
+    /// Short slug for the compact session status bar.
+    pub fn status_bar_compact(&self) -> Option<String> {
+        self.worktree_info().map(|info| info.slug)
     }
+
+    /// Branch and filesystem path for the expanded status bar subsection.
+    pub fn status_bar_expanded(&self) -> Option<(String, String)> {
+        self.worktree_info().map(|info| {
+            (
+                info.branch,
+                truncate_status_path(&info.path.display().to_string(), 72),
+            )
+        })
+    }
+
+    /// Light transcript notice when a worktree is activated mid-session.
+    pub fn switch_notice(&self) -> Option<String> {
+        self.worktree_info()
+            .map(|info| format!("Switched to worktree · {}", info.branch))
+    }
+}
+
+fn truncate_status_path(path: &str, max_len: usize) -> String {
+    if path.chars().count() <= max_len {
+        return path.to_string();
+    }
+    let tail_len = max_len.saturating_sub(1);
+    let tail: String = path.chars().rev().take(tail_len).collect::<String>();
+    format!("…{}", tail.chars().rev().collect::<String>())
 }
 
 pub fn detect_repo_root(path: &Path) -> Option<PathBuf> {
@@ -834,6 +855,15 @@ mod tests {
         let branch = branch_name("fix-auth", id);
         assert!(branch.starts_with("fix-auth-"));
         assert!(branch.len() > "fix-auth-".len());
+    }
+
+    #[test]
+    fn truncate_status_path_keeps_tail() {
+        let path = "/var/folders/rs/tcmw11q17s961ch7pb76czc0000gn/T/yolop/worktrees/b85662b381593c9f/session_019ee6c2";
+        let truncated = truncate_status_path(path, 40);
+        assert!(truncated.starts_with('…'));
+        assert!(truncated.contains("session_019ee6c2"));
+        assert!(truncated.chars().count() <= 40);
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Worktree activation no longer dumps a long `worktree: branch @ /var/folders/...` system line into the transcript. Instead:

- **Compact status bar** shows `wt <slug>` when a worktree is active (e.g. `wt bump-outdated-crates-ship`).
- **Expanded status bar** adds a worktree subsection with branch and a truncated path tail.
- **Mid-session switch** posts a lighter notice: `Switched to worktree · <branch>`.

Startup banner no longer repeats branch/path details that are now in the status bar.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] `cargo run -- --provider llmsim -p "hi"` (offline smoke)
- [x] Added unit tests for compact/expanded worktree status rendering and path truncation

## Security

No security-relevant code changes. TUI-only presentation and status-bar wiring; no changes to filesystem, shell, tool registration, or credential handling.

## Follow-ups

No follow-ups.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e528b71-d602-4c20-bc4f-dea98d91e2e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e528b71-d602-4c20-bc4f-dea98d91e2e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

