### PR TITLE
feat(user-ask): track user requests and validate after turns

### DIFF
--- a/specs/user-ask.md
+++ b/specs/user-ask.md
@@ -1,0 +1,92 @@
+# User ask — request tracking and turn-end validation
+
+Status: implemented in yolop (`yolop_user_ask` capability). **Disabled by default** —
+enable via `[[capabilities]]` in `settings.toml` or `set_config key=capabilities`.
+
+## Why
+
+Users state what they want in natural language and often refine or change direction
+over several turns. The agent needs a durable record of the current request,
+independent of `/goal` completion loops, so it can stay aligned and the host can
+judge whether the latest turn actually addressed what was asked.
+
+`/goal` is for autonomous multi-turn work toward a verifiable end state with
+auto-continuation. User ask is lighter: one tracked request per session, revision
+history when the user pivots, and a post-turn evaluator that reports achieved,
+blocked, or in progress — without starting another turn automatically.
+
+## Behavior
+
+| Surface | Effect |
+| --- | --- |
+| User message (TUI / `--print`) | Host records the message as the active user ask (superseding the previous ask in revision history). |
+| `set_user_ask` tool | Agent records or replaces the tracked ask (for refinement or when the user pivots in conversation). |
+| `clear_user_ask` tool | Clears the tracked ask when the user abandons the request. |
+| `/ask <text>` | Set or replace the tracked ask manually. |
+| `/ask` | Show status: current ask, evaluated turns, last outcome, revision history. |
+| `/ask clear` | Clear the tracked ask (`stop`, `off`, `reset`, `none`, `cancel` are aliases). |
+| `/clear` | Also clears the tracked user ask (new conversation). |
+
+After each agent turn while a user ask is active:
+
+1. The host calls an internal evaluator through `CommandHost::completion` — no
+   tools, nothing extra persisted beyond the evaluation result.
+2. The evaluator returns JSON
+   `{"outcome": "achieved"|"blocked"|"in_progress", "reason": "..."}` judged only
+   from the conversation transcript.
+3. The host surfaces the result as a system message (`user ask achieved`, `user ask
+   blocked`, or `user ask in progress`).
+4. Achieved and blocked outcomes deactivate the ask; a new user message starts a
+   fresh ask. In-progress keeps the ask active for the next turn.
+
+Unlike `/goal`, there is no auto-continuation loop.
+
+## Enabling
+
+Off the default harness. Opt in with:
+
+```toml
+[[capabilities]]
+ref = "yolop_user_ask"
+```
+
+Or conversationally via `set_config key=capabilities json={"ref":"yolop_user_ask"}`.
+Takes effect on the next run.
+
+## System prompt
+
+The capability contributes a `<capability id="yolop_user_ask">` block each turn
+with the current ask, optional revision history, and last evaluation. It instructs
+the model to call `set_user_ask` when the user changes direction.
+
+## Hosts
+
+| Host | Support |
+| --- | --- |
+| Interactive TUI | Records user prompts, end-of-turn evaluation, `? ask (N)` status indicator. |
+| `--print` | Records the prompt, evaluates after the turn. |
+| ACP | Tools and `/ask` are listed; end-of-turn evaluation requires the TUI/print host today. |
+
+## Persistence
+
+Active asks are stored in `<session_dir>/user_ask.json` so a resumed session
+(`--session`) restores the ask. Evaluated-turn counters reset on resume.
+
+## Independence from `/goal`
+
+- Separate store, capability id, tools, and evaluator.
+- Either capability can be disabled in `[[capabilities]]` without affecting the other.
+- `/goal` may auto-continue turns; user ask only records and evaluates.
+
+## Ownership
+
+- `UserAskCapability` and `UserAskStore` live in yolop (`src/capabilities/user_ask.rs`,
+  `src/user_ask.rs`).
+- Evaluator calls use upstream `CommandHost::completion` (everruns-core).
+
+## Related
+
+- [`goal.md`](./goal.md) — autonomous completion loops.
+- [`conversational-control.md`](./conversational-control.md) — `set_user_ask` /
+  `clear_user_ask` tools.
+- [`commands.md`](./commands.md) — `/ask` in the command registry.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -7,6 +7,10 @@ use crate::goal::{GOAL_EVALUATE_ARG, GoalStore, parse_evaluation_response};
 use crate::host_ui::UiCommand;
 use crate::runtime::{BuiltRuntime, ModelState, StartupInfo};
 use crate::session::Session;
+use crate::user_ask::{
+    USER_ASK_EVALUATE_ARG, UserAskStore, evaluation_status_message,
+    parse_evaluation_response as parse_user_ask_evaluation,
+};
 use crate::worktree::WorktreeManager;
 use anyhow::Result;
 use crossterm::event::{
@@ -126,6 +130,8 @@ pub struct App {
     /// `None` when closed. Toggled with Ctrl+B; read-only view of the registry.
     background_panel: Option<usize>,
     goal_store: Arc<GoalStore>,
+    user_ask_store: Arc<UserAskStore>,
+    user_ask_enabled: bool,
     worktree: Arc<WorktreeManager>,
     /// Images from `--image` / `-i` on the CLI, consumed on the first turn.
     pending_images: Vec<ContentPart>,
@@ -284,6 +290,8 @@ impl App {
     pub fn new(runtime: BuiltRuntime, pending_images: Vec<ContentPart>) -> Self {
         let should_setup = runtime.startup.setup_recommended;
         let goal_store = runtime.goal_store.clone();
+        let user_ask_store = runtime.user_ask_store.clone();
+        let user_ask_enabled = runtime.user_ask_enabled;
         let session_id = runtime.handles.session_id;
         let session = Session::new(runtime.handles, runtime.model.clone());
         let (models_tx, models_rx) = mpsc::unbounded_channel::<ModelDiscovery>();
@@ -317,6 +325,8 @@ impl App {
             background: runtime.background,
             background_panel: None,
             goal_store,
+            user_ask_store,
+            user_ask_enabled,
             worktree: runtime.worktree,
             pending_images,
             pending_pastes: Vec::new(),
@@ -387,9 +397,26 @@ impl App {
                 counts => Some(counts),
             },
             goal_indicator: self.goal_indicator(),
+            ask_indicator: self.ask_indicator(),
             worktree_compact: self.worktree.status_bar_compact(),
             worktree_expanded: self.worktree.status_bar_expanded(),
         }
+    }
+
+    fn ask_indicator(&self) -> Option<String> {
+        if !self.user_ask_enabled {
+            return None;
+        }
+        if !self.user_ask_store.is_active(self.session.session_id()) {
+            return None;
+        }
+        let turns = self
+            .user_ask_store
+            .status(self.session.session_id())
+            .active
+            .map(|active| active.evaluated_turns)
+            .unwrap_or(0);
+        Some(format!("? ask ({turns})"))
     }
 
     fn goal_indicator(&self) -> Option<String> {
@@ -537,6 +564,7 @@ impl App {
                 Ok(TurnEvent::Done) => {
                     self.finish_busy();
                     self.after_turn_goal_check().await;
+                    self.after_turn_user_ask_check().await;
                     return Ok(());
                 }
                 Ok(TurnEvent::Failed(err)) => {
@@ -875,6 +903,13 @@ impl App {
         let image_count = self.pending_images.len();
         let display = crate::image_input::user_display_text(&display_text, image_count);
         self.push_user(display);
+        if self.user_ask_enabled
+            && let Err(err) = self
+                .user_ask_store
+                .record_user_prompt(self.session.session_id(), &text)
+        {
+            self.push_system(format!("user ask: {err}"));
+        }
         self.start_turn(text);
     }
 
@@ -1033,6 +1068,7 @@ impl App {
                 self.lines.clear();
                 self.printed_lines = 0;
                 self.goal_store.clear_active(self.session.session_id());
+                self.user_ask_store.clear_active(self.session.session_id());
                 self.emit_system_banner();
             }
             UiCommand::RunShell { command } => self.start_shell_command(command),
@@ -1231,6 +1267,39 @@ impl App {
         };
         self.push_user(prompt.clone());
         self.start_turn(prompt);
+    }
+
+    async fn after_turn_user_ask_check(&mut self) {
+        if !self.user_ask_enabled {
+            return;
+        }
+        let session_id = self.session.session_id();
+        if !self.user_ask_store.is_active(session_id) {
+            return;
+        }
+        let result = match self
+            .session
+            .execute_command("ask", Some(USER_ASK_EVALUATE_ARG.to_string()))
+            .await
+        {
+            Ok(result) => result,
+            Err(err) => {
+                self.push_system(format!("user ask evaluation failed: {err}"));
+                return;
+            }
+        };
+        if !result.success {
+            self.push_system(format!("user ask evaluation failed: {}", result.message));
+            return;
+        }
+        let evaluation = match parse_user_ask_evaluation(&result.message) {
+            Ok(evaluation) => evaluation,
+            Err(err) => {
+                self.push_system(format!("user ask evaluation failed: {err}"));
+                return;
+            }
+        };
+        self.push_system(evaluation_status_message(&evaluation));
     }
 
     /// Dispatch a capability-provided slash command.
@@ -2784,6 +2853,7 @@ mod tests {
             approval_mode: "normal".to_string(),
             background: None,
             goal_indicator: None,
+            ask_indicator: None,
             worktree_compact: None,
             worktree_expanded: None,
         }
@@ -5312,7 +5382,7 @@ mod tests {
         let rows = render_chrome_lines(&state, 120, 4);
         let status = &rows[3];
         assert!(
-            status.contains("wt bump-outdated-crat"),
+            status.contains("wt bump-out"),
             "compact status should include worktree slug: {status}"
         );
     }

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -19,10 +19,12 @@ pub(crate) mod model_ranking;
 pub(crate) mod narration;
 pub(crate) mod repo_map;
 pub mod skills;
+pub(crate) mod user_ask;
 pub(crate) mod worktree_cmd;
 pub(crate) mod yolop;
 
 pub(crate) use crate::goal::GOAL_CAPABILITY_ID;
+pub(crate) use crate::user_ask::USER_ASK_CAPABILITY_ID;
 pub(crate) use approval::{APPROVAL_CAPABILITY_ID, ApprovalCapability};
 pub(crate) use ast_grep::{AST_GREP_CAPABILITY_ID, AstGrepCapability};
 pub(crate) use attribution::{ATTRIBUTION_CAPABILITY_ID, AttributionCapability};
@@ -39,4 +41,5 @@ pub(crate) use host::{
     ENVIRONMENT_CONTEXT_CAPABILITY_ID, SETUP_CAPABILITY_ID, SetupCapability,
 };
 pub(crate) use repo_map::{REPO_MAP_CAPABILITY_ID, RepoMapCapability};
+pub(crate) use user_ask::UserAskCapability;
 pub(crate) use worktree_cmd::WorktreeCapability;

--- a/src/capabilities/user_ask.rs
+++ b/src/capabilities/user_ask.rs
@@ -1,0 +1,377 @@
+//! `yolop_user_ask` — track the user's request and validate it after each turn.
+//!
+//! Independent of `/goal`: records what the user wants, allows updates when they
+//! pivot, and runs a tool-less evaluator at turn end. Does not auto-continue turns.
+
+use crate::capabilities::narration::stable_labeled;
+use crate::user_ask::{
+    USER_ASK_CAPABILITY_ID, USER_ASK_COMMAND_NAME, UserAskCommandOutcome, UserAskStore,
+    evaluate_active_user_ask, evaluation_result_message, format_status,
+    is_user_ask_evaluate_request, system_prompt_block,
+};
+use async_trait::async_trait;
+use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
+use everruns_core::command::{
+    CommandArg, CommandDescriptor, CommandExecutionContext, CommandResult, CommandSource,
+    ExecuteCommandRequest,
+};
+use everruns_core::tool_narration::{ToolNarrationPhase, arg_str, truncate};
+use everruns_core::tool_types::ToolCall;
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::typed_id::SessionId;
+use serde_json::{Value, json};
+use std::sync::Arc;
+
+pub(crate) struct UserAskCapability {
+    pub(crate) store: Arc<UserAskStore>,
+    pub(crate) session_id: SessionId,
+}
+
+#[async_trait]
+impl Capability for UserAskCapability {
+    fn id(&self) -> &str {
+        USER_ASK_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "User ask"
+    }
+
+    fn description(&self) -> &str {
+        "Track the user's request across turns and evaluate whether it was achieved."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("message-circle-question")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("System")
+    }
+
+    fn commands(&self) -> Vec<CommandDescriptor> {
+        vec![CommandDescriptor {
+            name: USER_ASK_COMMAND_NAME.to_string(),
+            description: "Set or inspect the tracked user request.".to_string(),
+            source: CommandSource::System,
+            args: vec![CommandArg {
+                name: "ask".to_string(),
+                description: "What the user wants, `clear` to stop tracking, or omit for status."
+                    .to_string(),
+                required: false,
+                suggestions: vec![],
+            }],
+        }]
+    }
+
+    async fn execute_command(
+        &self,
+        request: &ExecuteCommandRequest,
+        ctx: &CommandExecutionContext,
+    ) -> everruns_core::Result<CommandResult> {
+        if request.name != USER_ASK_COMMAND_NAME {
+            return Err(everruns_core::AgentLoopError::config(format!(
+                "{} cannot execute /{}",
+                self.id(),
+                request.name
+            )));
+        }
+
+        if is_user_ask_evaluate_request(request) {
+            let ask = self.store.active_text(ctx.session_id).ok_or_else(|| {
+                everruns_core::AgentLoopError::config("no active user ask to evaluate")
+            })?;
+            let evaluation = evaluate_active_user_ask(ctx, &ask).await?;
+            self.store
+                .record_evaluation(ctx.session_id, &evaluation)
+                .map_err(|err| everruns_core::AgentLoopError::config(err.to_string()))?;
+            return Ok(CommandResult {
+                success: true,
+                message: evaluation_result_message(&evaluation),
+                error_code: None,
+                error_fields: None,
+            });
+        }
+
+        let outcome = UserAskStore::parse_user_args(request.arguments.as_deref())
+            .map_err(|err| everruns_core::AgentLoopError::config(err.to_string()))?;
+
+        if let UserAskCommandOutcome::Status(_) = &outcome {
+            let status = self.store.status(ctx.session_id);
+            return Ok(CommandResult {
+                success: true,
+                message: format_status(&status),
+                error_code: None,
+                error_fields: None,
+            });
+        }
+
+        let message = self
+            .store
+            .apply_outcome(ctx.session_id, outcome)
+            .map_err(|err| everruns_core::AgentLoopError::config(err.to_string()))?;
+        Ok(CommandResult {
+            success: true,
+            message,
+            error_code: None,
+            error_fields: None,
+        })
+    }
+
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        Some(system_prompt_block(&self.store.status(self.session_id)))
+    }
+
+    fn system_prompt_preview(&self) -> Option<String> {
+        Some(system_prompt_block(&crate::user_ask::UserAskStatus {
+            active: None,
+        }))
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(SetUserAskTool {
+                store: self.store.clone(),
+                session_id: self.session_id,
+            }),
+            Box::new(ClearUserAskTool {
+                store: self.store.clone(),
+                session_id: self.session_id,
+            }),
+        ]
+    }
+}
+
+struct SetUserAskTool {
+    store: Arc<UserAskStore>,
+    session_id: SessionId,
+}
+
+#[async_trait]
+impl Tool for SetUserAskTool {
+    fn narrate(
+        &self,
+        tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        locale: Option<&str>,
+    ) -> Option<String> {
+        let _ = locale;
+        let ask = arg_str(&tool_call.arguments, &["ask", "text", "request"])
+            .map(|value| truncate(value, 48));
+        Some(stable_labeled("Set user ask", ask, phase))
+    }
+
+    fn name(&self) -> &str {
+        "set_user_ask"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Set user ask")
+    }
+
+    fn description(&self) -> &str {
+        "Record or replace the user's current request. Use when the user states what they want \
+         or changes direction. Keep the summary concise and faithful to their wording."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "ask": {
+                    "type": "string",
+                    "description": "Concise summary of what the user is asking for."
+                }
+            },
+            "required": ["ask"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let ask = match arguments.get("ask").and_then(Value::as_str) {
+            Some(value) => value.trim(),
+            None => return ToolExecutionResult::tool_error("'ask' is required"),
+        };
+        if ask.is_empty() {
+            return ToolExecutionResult::tool_error("'ask' must not be empty");
+        }
+        match self.store.set_ask(self.session_id, ask.to_string()) {
+            Ok(()) => ToolExecutionResult::success(json!({
+                "ok": true,
+                "ask": ask,
+                "message": format!("user ask recorded: {ask}"),
+            })),
+            Err(err) => ToolExecutionResult::tool_error(err.to_string()),
+        }
+    }
+}
+
+struct ClearUserAskTool {
+    store: Arc<UserAskStore>,
+    session_id: SessionId,
+}
+
+#[async_trait]
+impl Tool for ClearUserAskTool {
+    fn narrate(
+        &self,
+        _tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        locale: Option<&str>,
+    ) -> Option<String> {
+        let _ = locale;
+        Some(stable_labeled("Clear user ask", None, phase))
+    }
+
+    fn name(&self) -> &str {
+        "clear_user_ask"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Clear user ask")
+    }
+
+    fn description(&self) -> &str {
+        "Stop tracking the current user request. Use only when the user explicitly abandons \
+         or withdraws what they were asking for."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({ "type": "object", "properties": {}, "additionalProperties": false })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        self.store.clear_active(self.session_id);
+        ToolExecutionResult::success(json!({
+            "ok": true,
+            "message": "user ask cleared",
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::user_ask::USER_ASK_EVALUATE_ARG;
+    use everruns_core::command_host::{
+        CommandHost, CommandTurnContext, SessionCompletion, SessionCompletionError,
+    };
+    use everruns_core::session::{Session, SessionStatus};
+    use everruns_core::typed_id::{HarnessId, SessionId};
+    use std::sync::Mutex;
+
+    fn test_session(session_id: SessionId) -> Session {
+        Session {
+            id: session_id,
+            workspace_id: everruns_core::WorkspaceId::from_uuid(session_id.uuid()),
+            organization_id: everruns_core::DEFAULT_ORG_PUBLIC_ID.to_string(),
+            harness_id: HarnessId::new(),
+            agent_id: None,
+            agent_version_id: None,
+            agent_identity_id: None,
+            owner_principal_id: everruns_core::PrincipalId::from_seed(1),
+            resolved_owner_user_id: None,
+            owner: None,
+            effective_owner: None,
+            title: None,
+            locale: None,
+            preview: None,
+            output_preview: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: vec![],
+            tools: vec![],
+            mcp_servers: Default::default(),
+            system_prompt: None,
+            initial_files: vec![],
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            parallel_tool_calls: None,
+            status: SessionStatus::Started,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            started_at: None,
+            finished_at: None,
+            usage: None,
+            is_pinned: None,
+            active_schedule_count: None,
+            features: vec![],
+            parent_session_id: None,
+            blueprint_id: None,
+            blueprint_config: None,
+        }
+    }
+
+    struct FakeHost {
+        completion: Mutex<String>,
+    }
+
+    #[async_trait]
+    impl CommandHost for FakeHost {
+        async fn turn_context(&self) -> everruns_core::Result<CommandTurnContext> {
+            let session_id = SessionId::new();
+            Ok(CommandTurnContext {
+                session: test_session(session_id),
+                messages: vec![everruns_core::message::Message::user(
+                    "I upgraded the dependency and ran tests",
+                )],
+                system_prompt: "system".into(),
+                model: "test-model".into(),
+                provider_type: "llmsim".into(),
+                resolved_locale: None,
+            })
+        }
+
+        async fn completion(
+            &self,
+            _request: everruns_core::command_host::SessionCompletionRequest,
+        ) -> std::result::Result<SessionCompletion, SessionCompletionError> {
+            Ok(SessionCompletion {
+                text: self.completion.lock().expect("lock").clone(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn user_ask_evaluate_marks_achieved() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(UserAskStore::open(dir.path().to_path_buf()));
+        let session_id = SessionId::new();
+        store
+            .set_ask(session_id, "upgrade the dependency".into())
+            .expect("set");
+
+        let capability = UserAskCapability {
+            store: store.clone(),
+            session_id,
+        };
+        let host = Arc::new(FakeHost {
+            completion: Mutex::new(
+                r#"{"outcome": "achieved", "reason": "dependency upgraded in transcript"}"#.into(),
+            ),
+        });
+        let ctx = CommandExecutionContext::new(session_id, host);
+        let result = capability
+            .execute_command(
+                &ExecuteCommandRequest {
+                    name: USER_ASK_COMMAND_NAME.to_string(),
+                    arguments: Some(USER_ASK_EVALUATE_ARG.to_string()),
+                    controls: None,
+                },
+                &ctx,
+            )
+            .await
+            .expect("evaluate");
+        assert!(result.success);
+        let evaluation =
+            crate::user_ask::parse_evaluation_response(&result.message).expect("parse");
+        assert_eq!(evaluation.outcome, crate::user_ask::AskOutcome::Achieved);
+        assert!(!store.is_active(session_id));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ mod settings;
 mod test_env;
 mod tools;
 mod transcript;
+mod user_ask;
 mod version;
 mod worktree;
 
@@ -708,6 +709,8 @@ async fn run_print_mode(
         mut startup,
         model,
         goal_store,
+        user_ask_store,
+        user_ask_enabled,
         worktree,
         ..
     } = runtime;
@@ -772,9 +775,38 @@ async fn run_print_mode(
         .await;
     }
 
+    if user_ask_enabled
+        && let Err(err) = user_ask_store.record_user_prompt(handles.session_id, trimmed)
+    {
+        eprintln!("user ask: {err}");
+    }
+
     let result = run_print_turn(&handles, &worktree, &model, trimmed, images, color).await?;
     if !result.success {
         std::process::exit(1);
+    }
+    if user_ask_enabled && user_ask_store.is_active(handles.session_id) {
+        let evaluation = handles
+            .runtime
+            .execute_command(
+                handles.session_id,
+                ExecuteCommandRequest {
+                    name: "ask".to_string(),
+                    arguments: Some(user_ask::USER_ASK_EVALUATE_ARG.to_string()),
+                    controls: None,
+                },
+            )
+            .await?;
+        if evaluation.success {
+            if let Ok(parsed) = user_ask::parse_evaluation_response(&evaluation.message) {
+                println!(
+                    "{}",
+                    paint(color, "94", &user_ask::evaluation_status_message(&parsed))
+                );
+            }
+        } else {
+            eprintln!("user ask evaluation failed: {}", evaluation.message);
+        }
     }
     Ok(())
 }

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -31,6 +31,7 @@ pub(crate) struct PresentationState {
     pub approval_mode: String,
     pub background: Option<(usize, usize)>,
     pub goal_indicator: Option<String>,
+    pub ask_indicator: Option<String>,
     pub worktree_compact: Option<String>,
     pub worktree_expanded: Option<(String, String)>,
 }
@@ -159,6 +160,7 @@ fn expanded_status_lines(state: &PresentationState) -> Vec<StatusLine> {
                 status_field("approval", state.approval_mode.clone()),
                 status_field("hooks", state.hooks_summary.clone()),
                 status_field("goal", goal_label(state)),
+                status_field("ask", ask_label(state)),
             ],
         },
         StatusLine { fields: counts },
@@ -199,13 +201,20 @@ fn status_contributions(state: &PresentationState) -> Vec<Vec<StatusField>> {
             status_field("effort", effort_label(state)),
             status_field("approval", state.approval_mode.clone()),
         ],
-        vec![status_field("goal", goal_label(state))],
+        vec![
+            status_field("goal", goal_label(state)),
+            status_field("ask", ask_label(state)),
+        ],
         counts,
     ]
 }
 
 fn goal_label(state: &PresentationState) -> String {
     state.goal_indicator.clone().unwrap_or_else(|| "—".into())
+}
+
+fn ask_label(state: &PresentationState) -> String {
+    state.ask_indicator.clone().unwrap_or_else(|| "—".into())
 }
 
 fn background_label(counts: Option<(usize, usize)>) -> Option<String> {
@@ -272,6 +281,7 @@ mod tests {
             approval_mode: "normal".to_string(),
             background: None,
             goal_indicator: None,
+            ask_indicator: None,
             worktree_compact: None,
             worktree_expanded: None,
         }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3223,8 +3223,7 @@ mod tests {
     fn coding_harness_excludes_user_ask_by_default() {
         let ids = coding_harness_capabilities(false, None, &Settings::default());
         assert!(
-            !ids
-                .iter()
+            !ids.iter()
                 .any(|cap| cap.capability_id() == USER_ASK_CAPABILITY_ID),
             "user ask should be opt-in via settings"
         );

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -14,7 +14,8 @@ use crate::capabilities::{
     ClientCommandsCapability, CodingBashCapability, CodingCliEnvironmentCapability,
     ConfigCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID, GOAL_CAPABILITY_ID, GoalCapability,
     HOOKS_CAPABILITY_ID, HooksCapability, REPO_MAP_CAPABILITY_ID, RepoMapCapability,
-    SETUP_CAPABILITY_ID, SetupCapability, WorktreeCapability,
+    SETUP_CAPABILITY_ID, SetupCapability, USER_ASK_CAPABILITY_ID, UserAskCapability,
+    WorktreeCapability,
 };
 use crate::capability_settings::{CapabilityCatalog, apply_capability_settings};
 use crate::connectors::{
@@ -25,6 +26,7 @@ use crate::goal::GoalStore;
 use crate::host_ui::{HostUi, TuiHandle, UiCommand};
 use crate::settings::{Settings, SettingsStore};
 use crate::tools::Workspace;
+use crate::user_ask::UserAskStore;
 use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 use everruns_core::capabilities::{
@@ -1772,6 +1774,9 @@ pub struct BuiltRuntime {
     pub startup: StartupInfo,
     pub model: ModelState,
     pub goal_store: Arc<GoalStore>,
+    pub user_ask_store: Arc<UserAskStore>,
+    /// Whether `yolop_user_ask` is on the session harness (off by default).
+    pub user_ask_enabled: bool,
     pub worktree: Arc<WorktreeManager>,
     /// Settings store shared with the runtime capabilities. The TUI uses it
     /// to resolve credentials when querying provider models APIs and to show
@@ -2311,6 +2316,12 @@ pub async fn build_with_options(
     capabilities.register(GoalCapability {
         store: goal_store.clone(),
     });
+    let user_ask_store = Arc::new(UserAskStore::open(session_dir.clone()));
+    user_ask_store.load_session(session_id)?;
+    capabilities.register(UserAskCapability {
+        store: user_ask_store.clone(),
+        session_id,
+    });
     capabilities.register(WorktreeCapability {
         manager: worktree.clone(),
     });
@@ -2448,6 +2459,9 @@ pub async fn build_with_options(
         hook_capability_config,
         &settings_snapshot,
     );
+    let user_ask_enabled = harness_capabilities
+        .iter()
+        .any(|cap| cap.capability_id() == USER_ASK_CAPABILITY_ID);
     let session_mcp_servers = mcp_servers.clone();
 
     let mut harness_builder = HarnessBuilder::new("yolop", HARNESS_PROMPT)
@@ -2538,6 +2552,8 @@ pub async fn build_with_options(
         ui_rx,
         background: background_registry,
         goal_store,
+        user_ask_store,
+        user_ask_enabled,
         worktree,
     })
 }
@@ -3132,6 +3148,103 @@ mod tests {
             goal.description.contains("completion"),
             "descriptor: {}",
             goal.description
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn user_ask_command_is_registered_when_enabled_in_settings() {
+        use crate::capability_settings::CapabilityOverride;
+
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+        settings
+            .append_capability_override(CapabilityOverride {
+                capability_ref: USER_ASK_CAPABILITY_ID.to_string(),
+                enabled: Some(true),
+                append: false,
+                config: serde_json::json!({}),
+            })
+            .expect("append user ask override");
+
+        let built = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Sim,
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            BuildOptions::default(),
+        )
+        .await
+        .expect("build runtime");
+        assert!(built.user_ask_enabled);
+
+        let commands = built
+            .handles
+            .runtime
+            .list_commands(built.handles.session_id)
+            .await
+            .expect("commands");
+        let ask = commands
+            .iter()
+            .find(|c| c.name == "ask")
+            .expect("/ask surfaced when capability is enabled");
+
+        let result = built
+            .handles
+            .runtime
+            .execute_command(
+                built.handles.session_id,
+                ExecuteCommandRequest {
+                    name: "ask".to_string(),
+                    arguments: Some("upgrade dependencies".to_string()),
+                    controls: None,
+                },
+            )
+            .await
+            .expect("execute /ask");
+        assert!(result.success, "result: {}", result.message);
+        assert!(built.user_ask_store.is_active(built.handles.session_id));
+        assert_eq!(
+            built
+                .user_ask_store
+                .active_text(built.handles.session_id)
+                .as_deref(),
+            Some("upgrade dependencies")
+        );
+        assert!(
+            ask.description.contains("tracked"),
+            "descriptor: {}",
+            ask.description
+        );
+    }
+
+    #[test]
+    fn coding_harness_excludes_user_ask_by_default() {
+        let ids = coding_harness_capabilities(false, None, &Settings::default());
+        assert!(
+            !ids
+                .iter()
+                .any(|cap| cap.capability_id() == USER_ASK_CAPABILITY_ID),
+            "user ask should be opt-in via settings"
+        );
+    }
+
+    #[test]
+    fn harness_applies_user_ask_from_settings() {
+        use crate::capability_settings::CapabilityOverride;
+
+        let mut settings = Settings::default();
+        settings.capabilities.push(CapabilityOverride {
+            capability_ref: USER_ASK_CAPABILITY_ID.to_string(),
+            enabled: Some(true),
+            append: false,
+            config: serde_json::json!({}),
+        });
+        let ids = coding_harness_capabilities(false, None, &settings);
+        assert!(
+            ids.iter()
+                .any(|cap| cap.capability_id() == USER_ASK_CAPABILITY_ID)
         );
     }
 

--- a/src/user_ask.rs
+++ b/src/user_ask.rs
@@ -1,0 +1,606 @@
+//! Session-scoped user-ask tracking and end-of-turn validation.
+//!
+//! Records what the user is asking for, allows updates when they change direction,
+//! and evaluates after each turn whether the ask was achieved, blocked, or still
+//! in progress. Independent of `/goal` — no auto-continuation loop.
+
+use anyhow::{Context, Result, bail};
+use everruns_core::command::{CommandExecutionContext, ExecuteCommandRequest};
+use everruns_core::command_host::SessionCompletionRequest;
+use everruns_core::message::Message;
+use everruns_core::typed_id::SessionId;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::RwLock;
+
+pub(crate) const USER_ASK_CAPABILITY_ID: &str = "yolop_user_ask";
+pub(crate) const USER_ASK_COMMAND_NAME: &str = "ask";
+/// Internal `execute_command` argument — not user-facing.
+pub(crate) const USER_ASK_EVALUATE_ARG: &str = "\x00evaluate";
+
+pub(crate) const MAX_USER_ASK_LEN: usize = 4_000;
+pub(crate) const MAX_USER_ASK_REVISIONS: usize = 8;
+
+const USER_ASK_FILE: &str = "user_ask.json";
+
+const EVALUATOR_SYSTEM_PROMPT: &str = "\
+You evaluate whether the user's request was addressed using only the conversation \
+transcript below. You cannot run commands or read files independently — judge \
+only what the agent has already surfaced in the conversation.\n\
+\n\
+Respond with exactly one JSON object and no other text:\n\
+{\"outcome\": \"achieved\"|\"blocked\"|\"in_progress\", \"reason\": \"short explanation\"}\n\
+\n\
+- `achieved`: the user's request is clearly satisfied from the transcript.\n\
+- `blocked`: the agent hit a blocker that needs user input, permission, or an \
+external dependency before work can continue.\n\
+- `in_progress`: work is underway but not finished and no hard blocker is evident.";
+
+const CLEAR_ALIASES: &[&str] = &["clear", "stop", "off", "reset", "none", "cancel"];
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AskOutcome {
+    Achieved,
+    Blocked,
+    InProgress,
+}
+
+impl AskOutcome {
+    fn parse_str(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "achieved" | "done" | "complete" | "completed" => Some(Self::Achieved),
+            "blocked" | "blocker" | "stuck" => Some(Self::Blocked),
+            "in_progress" | "in-progress" | "progress" | "ongoing" | "pending" => {
+                Some(Self::InProgress)
+            }
+            _ => None,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Achieved => "achieved",
+            Self::Blocked => "blocked",
+            Self::InProgress => "in_progress",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct AskRevision {
+    pub text: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct PersistedUserAsk {
+    pub text: String,
+    pub active: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub revisions: Vec<AskRevision>,
+    pub evaluated_turns: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_outcome: Option<AskOutcome>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_reason: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct UserAskStatus {
+    pub active: Option<PersistedUserAsk>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum UserAskCommandOutcome {
+    Set { text: String },
+    Cleared,
+    Status(UserAskStatus),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct UserAskEvaluation {
+    pub outcome: AskOutcome,
+    pub reason: String,
+}
+
+struct SessionUserAskRuntime {
+    persisted: PersistedUserAsk,
+}
+
+pub(crate) struct UserAskStore {
+    session_dir: PathBuf,
+    sessions: RwLock<HashMap<SessionId, SessionUserAskRuntime>>,
+}
+
+impl UserAskStore {
+    pub(crate) fn open(session_dir: PathBuf) -> Self {
+        Self {
+            session_dir,
+            sessions: RwLock::new(HashMap::new()),
+        }
+    }
+
+    pub(crate) fn load_session(&self, session_id: SessionId) -> Result<()> {
+        let path = self.ask_path(session_id);
+        if !path.is_file() {
+            return Ok(());
+        }
+        let raw = std::fs::read_to_string(&path)
+            .with_context(|| format!("read user ask state: {}", path.display()))?;
+        let persisted: PersistedUserAsk = serde_json::from_str(&raw)
+            .with_context(|| format!("parse user ask state: {}", path.display()))?;
+        if persisted.active {
+            let mut sessions = self.sessions.write().expect("user ask store lock poisoned");
+            sessions.insert(session_id, SessionUserAskRuntime { persisted });
+        }
+        Ok(())
+    }
+
+    pub(crate) fn parse_user_args(arguments: Option<&str>) -> Result<UserAskCommandOutcome> {
+        let trimmed = arguments.map(str::trim).unwrap_or_default();
+        if trimmed.is_empty() {
+            return Ok(UserAskCommandOutcome::Status(UserAskStatus {
+                active: None,
+            }));
+        }
+        if CLEAR_ALIASES
+            .iter()
+            .any(|alias| trimmed.eq_ignore_ascii_case(alias))
+        {
+            return Ok(UserAskCommandOutcome::Cleared);
+        }
+        if trimmed.len() > MAX_USER_ASK_LEN {
+            bail!("user ask is too long (max {MAX_USER_ASK_LEN} characters)");
+        }
+        Ok(UserAskCommandOutcome::Set {
+            text: trimmed.to_string(),
+        })
+    }
+
+    pub(crate) fn apply_outcome(
+        &self,
+        session_id: SessionId,
+        outcome: UserAskCommandOutcome,
+    ) -> Result<String> {
+        match outcome {
+            UserAskCommandOutcome::Set { text } => {
+                self.set_ask(session_id, text.clone())?;
+                Ok(format!("user ask recorded: {text}"))
+            }
+            UserAskCommandOutcome::Cleared => {
+                self.clear_active(session_id);
+                Ok("user ask cleared".into())
+            }
+            UserAskCommandOutcome::Status(_) => Ok(String::new()),
+        }
+    }
+
+    pub(crate) fn status(&self, session_id: SessionId) -> UserAskStatus {
+        let sessions = self.sessions.read().expect("user ask store lock poisoned");
+        if let Some(runtime) = sessions.get(&session_id)
+            && runtime.persisted.active
+        {
+            return UserAskStatus {
+                active: Some(runtime.persisted.clone()),
+            };
+        }
+        UserAskStatus { active: None }
+    }
+
+    pub(crate) fn record_user_prompt(&self, session_id: SessionId, text: &str) -> Result<()> {
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            return Ok(());
+        }
+        if trimmed.len() > MAX_USER_ASK_LEN {
+            bail!("user ask is too long (max {MAX_USER_ASK_LEN} characters)");
+        }
+        self.set_ask(session_id, trimmed.to_string())
+    }
+
+    pub(crate) fn set_ask(&self, session_id: SessionId, text: String) -> Result<()> {
+        if text.len() > MAX_USER_ASK_LEN {
+            bail!("user ask is too long (max {MAX_USER_ASK_LEN} characters)");
+        }
+        let mut sessions = self.sessions.write().expect("user ask store lock poisoned");
+        match sessions.get_mut(&session_id) {
+            Some(runtime) if runtime.persisted.active => {
+                if runtime.persisted.text != text {
+                    let previous = runtime.persisted.text.clone();
+                    push_revision(&mut runtime.persisted, previous);
+                    runtime.persisted.text = text;
+                    runtime.persisted.evaluated_turns = 0;
+                    runtime.persisted.last_outcome = None;
+                    runtime.persisted.last_reason = None;
+                }
+            }
+            _ => {
+                sessions.insert(
+                    session_id,
+                    SessionUserAskRuntime {
+                        persisted: PersistedUserAsk {
+                            text: text.clone(),
+                            active: true,
+                            revisions: Vec::new(),
+                            evaluated_turns: 0,
+                            last_outcome: None,
+                            last_reason: None,
+                        },
+                    },
+                );
+            }
+        }
+        drop(sessions);
+        self.persist(session_id)
+    }
+
+    pub(crate) fn clear_active(&self, session_id: SessionId) {
+        let mut sessions = self.sessions.write().expect("user ask store lock poisoned");
+        sessions.remove(&session_id);
+        drop(sessions);
+        let path = self.ask_path(session_id);
+        if path.is_file() {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+
+    pub(crate) fn is_active(&self, session_id: SessionId) -> bool {
+        self.sessions
+            .read()
+            .expect("user ask store lock poisoned")
+            .get(&session_id)
+            .is_some_and(|runtime| runtime.persisted.active)
+    }
+
+    pub(crate) fn active_text(&self, session_id: SessionId) -> Option<String> {
+        self.sessions
+            .read()
+            .expect("user ask store lock poisoned")
+            .get(&session_id)
+            .filter(|runtime| runtime.persisted.active)
+            .map(|runtime| runtime.persisted.text.clone())
+    }
+
+    pub(crate) fn record_evaluation(
+        &self,
+        session_id: SessionId,
+        evaluation: &UserAskEvaluation,
+    ) -> Result<()> {
+        let mut sessions = self.sessions.write().expect("user ask store lock poisoned");
+        let Some(runtime) = sessions.get_mut(&session_id) else {
+            return Ok(());
+        };
+        runtime.persisted.evaluated_turns = runtime.persisted.evaluated_turns.saturating_add(1);
+        runtime.persisted.last_outcome = Some(evaluation.outcome);
+        runtime.persisted.last_reason = Some(evaluation.reason.clone());
+        if matches!(
+            evaluation.outcome,
+            AskOutcome::Achieved | AskOutcome::Blocked
+        ) {
+            runtime.persisted.active = false;
+        }
+        drop(sessions);
+        self.persist(session_id)
+    }
+
+    fn ask_path(&self, _session_id: SessionId) -> PathBuf {
+        self.session_dir.join(USER_ASK_FILE)
+    }
+
+    fn persist(&self, session_id: SessionId) -> Result<()> {
+        let sessions = self.sessions.read().expect("user ask store lock poisoned");
+        let Some(runtime) = sessions.get(&session_id) else {
+            return Ok(());
+        };
+        if !runtime.persisted.active && runtime.persisted.last_outcome.is_none() {
+            return Ok(());
+        }
+        let path = self.ask_path(session_id);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create user ask parent dir: {}", parent.display()))?;
+        }
+        let encoded = serde_json::to_string_pretty(&runtime.persisted)?;
+        std::fs::write(&path, encoded)
+            .with_context(|| format!("write user ask state: {}", path.display()))?;
+        Ok(())
+    }
+}
+
+fn push_revision(persisted: &mut PersistedUserAsk, previous: String) {
+    if previous.trim().is_empty() {
+        return;
+    }
+    persisted.revisions.push(AskRevision { text: previous });
+    if persisted.revisions.len() > MAX_USER_ASK_REVISIONS {
+        let overflow = persisted.revisions.len() - MAX_USER_ASK_REVISIONS;
+        persisted.revisions.drain(0..overflow);
+    }
+}
+
+pub(crate) fn format_status(status: &UserAskStatus) -> String {
+    let Some(active) = &status.active else {
+        return "no active user ask".into();
+    };
+    let reason = active
+        .last_reason
+        .as_deref()
+        .filter(|value| !value.is_empty())
+        .map(|value| format!("\nlast evaluation: {value}"))
+        .unwrap_or_default();
+    let outcome = active
+        .last_outcome
+        .map(|value| format!("\nlast outcome: {}", value.as_str()))
+        .unwrap_or_default();
+    let revisions = if active.revisions.is_empty() {
+        String::new()
+    } else {
+        let lines: Vec<String> = active
+            .revisions
+            .iter()
+            .map(|revision| format!("- {}", revision.text))
+            .collect();
+        format!("\nprevious asks:\n{}", lines.join("\n"))
+    };
+    format!(
+        "user ask active\nask: {}\nevaluated turns: {}{}{}{}",
+        active.text, active.evaluated_turns, outcome, reason, revisions
+    )
+}
+
+pub(crate) fn system_prompt_block(status: &UserAskStatus) -> String {
+    let Some(active) = &status.active else {
+        return "<capability id=\"yolop_user_ask\">\n\
+When the user states or changes what they want, call `set_user_ask` with a concise \
+summary of their request. The host also records raw user messages, but refine or \
+replace the tracked ask when the user pivots or clarifies. Use `clear_user_ask` only \
+when the user explicitly abandons the request.\n\
+After each turn the host evaluates whether the ask was achieved, blocked, or still \
+in progress — keep working until achieved or a blocker is clear.\n\
+</capability>"
+            .to_string();
+    };
+    let revisions = if active.revisions.is_empty() {
+        String::new()
+    } else {
+        let lines: Vec<String> = active
+            .revisions
+            .iter()
+            .map(|revision| format!("- {}", revision.text))
+            .collect();
+        format!("\nPrevious asks (superseded):\n{}\n", lines.join("\n"))
+    };
+    let evaluation = active
+        .last_reason
+        .as_deref()
+        .filter(|value| !value.is_empty())
+        .map(|reason| {
+            let outcome = active
+                .last_outcome
+                .map(|value| value.as_str())
+                .unwrap_or("in_progress");
+            format!("\nLast evaluation ({outcome}): {reason}\n")
+        })
+        .unwrap_or_default();
+    format!(
+        "<capability id=\"yolop_user_ask\">\n\
+Track and satisfy the user's request. Call `set_user_ask` when they change direction; \
+`clear_user_ask` only when they abandon it.\n\
+{revisions}\
+Current user ask: {}\n\
+{evaluation}\
+</capability>",
+        active.text
+    )
+}
+
+pub(crate) async fn evaluate_active_user_ask(
+    ctx: &CommandExecutionContext,
+    ask: &str,
+) -> everruns_core::Result<UserAskEvaluation> {
+    let turn = ctx.host.turn_context().await?;
+    let transcript = format_transcript(&turn.messages);
+    let user_prompt = format!("User request:\n{ask}\n\nConversation transcript:\n{transcript}");
+    let completion_request = SessionCompletionRequest {
+        system_prompts: vec![EVALUATOR_SYSTEM_PROMPT.to_string()],
+        messages: vec![Message::user(user_prompt)],
+        controls: None,
+        metadata: std::collections::HashMap::from([(
+            "command".to_string(),
+            "user_ask_evaluate".to_string(),
+        )]),
+    };
+    let completion = ctx
+        .host
+        .completion(completion_request)
+        .await
+        .map_err(map_completion_error)?;
+    parse_evaluation_response(&completion.text)
+}
+
+fn map_completion_error(
+    error: everruns_core::command_host::SessionCompletionError,
+) -> everruns_core::AgentLoopError {
+    match error {
+        everruns_core::command_host::SessionCompletionError::InvalidRequest(err) => err,
+        everruns_core::command_host::SessionCompletionError::StreamingUnsupported => {
+            everruns_core::AgentLoopError::config("user ask evaluator does not support streaming")
+        }
+        everruns_core::command_host::SessionCompletionError::Completion { error, .. } => {
+            everruns_core::AgentLoopError::config(error)
+        }
+    }
+}
+
+fn format_transcript(messages: &[Message]) -> String {
+    if messages.is_empty() {
+        return "(empty)".into();
+    }
+    messages
+        .iter()
+        .filter_map(|message| {
+            let role = match message.role {
+                everruns_core::message::MessageRole::User => "user",
+                everruns_core::message::MessageRole::Agent => "assistant",
+                everruns_core::message::MessageRole::System => "system",
+                everruns_core::message::MessageRole::ToolResult => "tool",
+            };
+            message
+                .text()
+                .map(|text| format!("{role}: {}", text.trim()))
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+pub(crate) fn parse_evaluation_response(text: &str) -> everruns_core::Result<UserAskEvaluation> {
+    let trimmed = text.trim();
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) {
+        return parse_evaluation_value(&value);
+    }
+    if let Some(start) = trimmed.find('{')
+        && let Some(end) = trimmed.rfind('}')
+    {
+        let slice = &trimmed[start..=end];
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(slice) {
+            return parse_evaluation_value(&value);
+        }
+    }
+    Ok(UserAskEvaluation {
+        outcome: AskOutcome::InProgress,
+        reason: trimmed.to_string(),
+    })
+}
+
+fn parse_evaluation_value(value: &serde_json::Value) -> everruns_core::Result<UserAskEvaluation> {
+    let outcome_raw = value
+        .get("outcome")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            everruns_core::AgentLoopError::config(
+                "user ask evaluator returned JSON without `outcome`",
+            )
+        })?;
+    let outcome = AskOutcome::parse_str(outcome_raw).ok_or_else(|| {
+        everruns_core::AgentLoopError::config(format!(
+            "user ask evaluator returned unknown outcome: {outcome_raw}"
+        ))
+    })?;
+    let reason = value
+        .get("reason")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    Ok(UserAskEvaluation { outcome, reason })
+}
+
+pub(crate) fn evaluation_result_message(evaluation: &UserAskEvaluation) -> String {
+    serde_json::json!({
+        "outcome": evaluation.outcome.as_str(),
+        "reason": evaluation.reason,
+    })
+    .to_string()
+}
+
+pub(crate) fn evaluation_status_message(evaluation: &UserAskEvaluation) -> String {
+    match evaluation.outcome {
+        AskOutcome::Achieved => format!("user ask achieved: {}", evaluation.reason),
+        AskOutcome::Blocked => format!("user ask blocked: {}", evaluation.reason),
+        AskOutcome::InProgress => format!("user ask in progress: {}", evaluation.reason),
+    }
+}
+
+pub(crate) fn is_user_ask_evaluate_request(request: &ExecuteCommandRequest) -> bool {
+    request.name == USER_ASK_COMMAND_NAME
+        && request
+            .arguments
+            .as_deref()
+            .is_some_and(|args| args == USER_ASK_EVALUATE_ARG)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_clear_aliases() {
+        for alias in CLEAR_ALIASES {
+            let outcome = UserAskStore::parse_user_args(Some(alias)).expect("parse");
+            assert_eq!(outcome, UserAskCommandOutcome::Cleared);
+        }
+    }
+
+    #[test]
+    fn set_ask_records_revision_on_change() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = UserAskStore::open(dir.path().to_path_buf());
+        let session_id = SessionId::new();
+        store.set_ask(session_id, "add tests".into()).expect("set");
+        store
+            .set_ask(session_id, "ship the fix".into())
+            .expect("set");
+        let status = store.status(session_id);
+        let active = status.active.expect("active");
+        assert_eq!(active.text, "ship the fix");
+        assert_eq!(active.revisions.len(), 1);
+        assert_eq!(active.revisions[0].text, "add tests");
+    }
+
+    #[test]
+    fn record_user_prompt_updates_active_ask() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = UserAskStore::open(dir.path().to_path_buf());
+        let session_id = SessionId::new();
+        store
+            .record_user_prompt(session_id, "fix the login bug")
+            .expect("record");
+        assert_eq!(
+            store.active_text(session_id).as_deref(),
+            Some("fix the login bug")
+        );
+    }
+
+    #[test]
+    fn evaluation_marks_achieved_inactive() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = UserAskStore::open(dir.path().to_path_buf());
+        let session_id = SessionId::new();
+        store.set_ask(session_id, "run tests".into()).expect("set");
+        let evaluation = UserAskEvaluation {
+            outcome: AskOutcome::Achieved,
+            reason: "tests passed".into(),
+        };
+        store
+            .record_evaluation(session_id, &evaluation)
+            .expect("record");
+        assert!(!store.is_active(session_id));
+    }
+
+    #[test]
+    fn parse_evaluation_json() {
+        let evaluation = parse_evaluation_response(
+            r#"{"outcome": "blocked", "reason": "needs API key from user"}"#,
+        )
+        .expect("parse");
+        assert_eq!(evaluation.outcome, AskOutcome::Blocked);
+        assert!(evaluation.reason.contains("API key"));
+    }
+
+    #[test]
+    fn system_prompt_includes_current_ask() {
+        let block = system_prompt_block(&UserAskStatus {
+            active: Some(PersistedUserAsk {
+                text: "upgrade dependencies".into(),
+                active: true,
+                revisions: Vec::new(),
+                evaluated_turns: 0,
+                last_outcome: None,
+                last_reason: None,
+            }),
+        });
+        assert!(block.contains("upgrade dependencies"));
+        assert!(block.contains("set_user_ask"));
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the `yolop_user_ask` capability — session-scoped tracking of what the user is asking for, with revision history when they pivot, and a post-turn evaluator reporting `achieved`, `blocked`, or `in_progress`.

**Disabled by default.** Opt in via:

```toml
[[capabilities]]
ref = "yolop_user_ask"
```

Independent of `/goal` (no auto-continuation loop; either capability can be enabled alone).

## What it does

- Host records user messages when the capability is enabled (TUI / `--print`)
- `set_user_ask` / `clear_user_ask` tools for agent-driven updates
- `/ask` command for manual set/status/clear
- System prompt discloses current ask each turn
- End-of-turn evaluator (tool-less, same pattern as `/goal`) — no auto-loop
- Persistence in `<session_dir>/user_ask.json`
- Status bar shows `? ask (N)` while active

## Validation

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` (559 unit + integration tests)
- [x] `cargo run -- --provider llmsim -p "hi"` smoke test
- [x] Unit tests for store, evaluator, capability evaluate path, harness opt-in

## Security

- **TM-FS**: Session-scoped `user_ask.json` under existing session dir; no new workspace write paths.
- **TM-LLM**: Evaluator uses same tool-less `CommandHost::completion` path as `/goal`; transcript-only judgment.
- **TM-TOOL**: Capability registered on platform catalog; harness enablement gated via settings. Ask text capped at 4,000 chars; revision history capped at 8 entries.
- **TM-DEP**: No new dependencies.

## Follow-ups

No follow-ups.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8a0f1bf-9455-4d85-9625-48105c0102f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8a0f1bf-9455-4d85-9625-48105c0102f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

