### PR TITLE
feat(tui): add testable presentation model

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -42,6 +42,9 @@ Use this skill when the user asks to:
      compiles. Add or update the test as part of the change.
    - The test must actually drive the feature's entry point (e.g. dispatch the
      command, call the handler, run the turn), not just assert on a constructor.
+   - Changes to user-visible transcript output, live activity, or status values
+     must assert the terminal-independent presentation model directly. Terminal
+     buffer tests alone are layout coverage, not proof of visible semantics.
    - If a behavior is genuinely impractical to cover automatically, say so
      explicitly in the PR body, describe the manual verification you performed
      instead, and list the gap under **Follow-ups**. "Hard to test" is not a

--- a/specs/maintenance.md
+++ b/specs/maintenance.md
@@ -50,12 +50,15 @@ Deferred items are not failures. Untracked ones are.
 ## Feature Completeness Drift
 
 A feature is not release-ready merely because one surface exists. Yolop's
-surfaces are the CLI flags, the TUI behavior, `specs/`, `README.md`, the test
-suite, and the bundled `skills/`. Maintenance should catch:
+surfaces are the CLI flags, the presentation model, the TUI behavior, `--print`
+output, ACP output, `specs/`, `README.md`, the test suite, and the bundled
+`skills/`. Maintenance should catch:
 
 - flags or behavior present in `src/` but absent from `README.md` or `specs/`
 - specs or README describing behavior the binary no longer has
 - shipped features with no test exercising them
+- user-visible transcript/status behavior tested only through terminal buffers
+  instead of the terminal-independent presentation model
 
 The outcome is either a small fix that reconnects the surfaces or a crisp
 finding naming the missing surface and its user-visible impact — not a

--- a/specs/presentation.md
+++ b/specs/presentation.md
@@ -1,0 +1,69 @@
+# Presentation Model Specification
+
+## Abstract
+
+Yolop has terminal and non-terminal hosts, but the user-visible agent output is
+one product surface. Transcript entries, live activity, stream previews, and
+status-bar values must be represented by a terminal-independent presentation
+model before any TUI, `--print`, or editor-specific rendering.
+
+The presentation model is the testable contract for "what the user sees." It
+must not depend on ratatui, crossterm, ANSI color, terminal buffers, or a real
+terminal.
+
+## Required Model
+
+The model must expose structured values for:
+
+1. **Transcript output** — user, assistant, narration, tool, tool-detail, diff,
+   and system entries with stable labels and text. Tool completion wording lives
+   here, including success/failure markers and summaries.
+2. **Live activity** — current turn status such as thinking, running tools,
+   waiting for client results, cancelled, or failed.
+3. **Stream previews** — assistant and tool delta previews while a turn is
+   active.
+4. **Session status** — every value shown in the status bar, including provider
+   and model, approval mode, goal state, background-task counts, token counts,
+   current session, worktree state, and busy/idle state when present.
+
+The TUI may still own layout, colors, wrapping, scrollback anchoring, input
+widgets, overlays, and terminal-specific affordances. It must not be the only
+place where a user-visible transcript label, tool wording, or status-bar value
+is assembled.
+
+`--print` and ACP may project the model differently, but shared semantics should
+come from the same presentation model rather than parallel ad hoc formatting.
+
+## Test Coverage Contract
+
+Any change that affects user-visible agent output or current status must add or
+update automated tests against the terminal-independent presentation model.
+Terminal-buffer tests are still useful for layout regressions, but they are not
+sufficient proof for transcript wording, status values, or live activity text.
+
+Required coverage examples:
+
+- Tool transcript lines must be asserted as visible output, for example
+  ``tool › ✓ Bash `git status --short` exit=0``, not only as internal tool
+  result JSON or a ratatui `Line`.
+- Regressions for fallback wording such as `Ran Bash` / `Ran Read File` must be
+  covered with presenter-level fixtures built from runtime tool-completion
+  events.
+- Status-bar segments must be asserted through the presentation model whenever a
+  feature adds or changes a visible status value.
+- TUI tests should focus on terminal-only concerns: geometry, wrapping, colors,
+  scrollback, overlays, key handling, and input behavior.
+
+## Ownership Boundary
+
+- Runtime events, messages, and tool results are source data.
+- The presentation model owns user-visible semantics.
+- Hosts own projection: terminal layout for the TUI, plain text for `--print`,
+  and protocol objects for ACP.
+
+## Related
+
+- [`specs/commands.md`](./commands.md) — terminal-side commands and host effects.
+- [`specs/shipping.md`](./shipping.md) — required validation before merge.
+- [`specs/maintenance.md`](./maintenance.md) — drift checks across user-facing
+  surfaces.

--- a/specs/shipping.md
+++ b/specs/shipping.md
@@ -24,7 +24,7 @@ Every shipped change MUST satisfy ALL of these. These are mandatory, not suggest
 
 1. **Safe branch state.** No shipping from `main` or `master`. Working tree clean before final push. Prefer rebasing onto latest `origin/main` before merge.
 2. **Goal achieved with evidence.** The requested behavior is implemented and validated with proof matching the risk.
-3. **Feature tested before merge.** Every behavior change is covered by an automated test that exercises the new or changed behavior directly — driving its real entry point, not merely adjacent code that still compiles — added or updated as part of the change. A behavior that is genuinely impractical to test automatically is the only exception: the PR body must say so, describe the manual verification performed instead, and list the gap under **Follow-ups**. Docs-only or config-only changes with no behavior change are exempt with stated justification.
+3. **Feature tested before merge.** Every behavior change is covered by an automated test that exercises the new or changed behavior directly — driving its real entry point, not merely adjacent code that still compiles — added or updated as part of the change. A behavior that is genuinely impractical to test automatically is the only exception: the PR body must say so, describe the manual verification performed instead, and list the gap under **Follow-ups**. Docs-only or config-only changes with no behavior change are exempt with stated justification. Changes to user-visible agent output, live activity, or status values must include tests against the terminal-independent presentation model in [`presentation.md`](./presentation.md); terminal-buffer tests alone are not enough.
 4. **Merge-ready code.** Touched code is reviewed for avoidable complexity. A structured security review is performed (see `.agents/skills/ship/SKILL.md` § Security Review). Issues are addressed or explicitly blocked.
 5. **Synced artifacts.** Affected artifacts are updated: README, AGENTS.md, specs. No code-duplicating prose.
 6. **Smoke test impacted functionality.** In addition to the automated test in outcome 3, smoke test the affected flows end-to-end. Mandatory unless the change is docs-only or config-only with explicit justification. For runtime changes, run at least one live-provider smoke through Doppler.
@@ -53,7 +53,7 @@ Use the smallest set that gives high confidence.
 5. `doppler run -- cargo test --all-features --test integration` for live-provider proof when the change touches the agent loop or tool wiring.
 6. `doppler run -- cargo run -- --provider openai -p "<focused prompt>"` for end-to-end smoke.
 7. `cargo run -- --provider llmsim -p "hi"` for offline smoke when CI access to provider keys is unavailable.
-8. Ensure test coverage proves the fix or acceptance criteria, including important negative paths.
+8. Ensure test coverage proves the fix or acceptance criteria, including important negative paths. For visible transcript or status changes, assert the presentation model output directly.
 9. Update `README.md`, `AGENTS.md`, and `specs/` when relevant.
 
 ## Merge Discipline
@@ -69,3 +69,4 @@ Use the smallest set that gives high confidence.
 - [`specs/maintenance.md`](./maintenance.md)
 - [`.agents/skills/ship/SKILL.md`](../.agents/skills/ship/SKILL.md)
 - [`.agents/skills/maintenance/SKILL.md`](../.agents/skills/maintenance/SKILL.md)
+- [`specs/presentation.md`](./presentation.md)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -42,6 +42,7 @@ mod viewport;
 // (the single boundary that interprets `everruns_core` events); re-export them
 // here so the TUI's own submodules keep referring to them as `crate::app::*`.
 pub(crate) use self::{render::*, viewport::*};
+pub(crate) use crate::presentation::*;
 pub(crate) use crate::transcript::*;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -58,7 +59,6 @@ pub const COMPOSER_VIEWPORT_HEIGHT: u16 = 18;
 /// letting a briefly unresponsive emulator recover.
 const MAX_TERMINAL_IO_FAILURES: usize = 5;
 const MAX_INPUT_HEIGHT: u16 = 12;
-const EXPANDED_STATUS_ROWS: u16 = 4;
 const RECENT_TRANSCRIPT_SOURCE_LINES: usize = 80;
 const RECENT_TRANSCRIPT_MAX_TEXT_BYTES: usize = 4_000;
 const ACCENT_BLUE: Color = Color::Rgb(45, 91, 158);
@@ -269,58 +269,14 @@ pub(crate) struct ModelOption {
 /// the chrome render itself.
 #[derive(Clone, Debug)]
 pub(crate) struct ViewState {
-    pub stream_preview: Option<StreamPreview>,
+    pub presentation: PresentationState,
     pub command_suggestions: Vec<CommandSuggestion>,
-    pub busy: bool,
     pub busy_frame: u64,
-    pub turn_activity: Option<String>,
-    pub model_id: String,
-    pub provider_name: String,
-    pub reasoning_effort: Option<String>,
-    pub session_id: SessionId,
-    pub lines_count: usize,
-    pub session_tokens: Option<u64>,
-    pub status_layout: StatusLayout,
-    pub hooks_summary: String,
-    /// Current soft-approval level (`protective` / `normal` / `off`), shown
-    /// in the session status bar so the paranoia level is always visible.
-    pub approval_mode: String,
-    /// `(running, total)` background task counts, shown in the status bar only
-    /// when there is at least one task this session. `None` hides the segment.
-    pub background: Option<(usize, usize)>,
-    /// Short label when a `/goal` loop is active (for example `◎ goal`).
-    pub goal_indicator: Option<String>,
-    /// Worktree slug for the compact status bar (for example `bump-outdated-crates-ship`).
-    pub worktree_compact: Option<String>,
-    /// Branch and path shown in the expanded status bar when a worktree is active.
-    pub worktree_expanded: Option<(String, String)>,
-}
-
-/// What kind of delta is currently being streamed. Only the assistant
-/// output is finalized into the transcript at end-of-turn (via the
-/// message store); thinking and tool output are display-only.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum StatusLayout {
-    Compact,
-    Expanded,
-}
-
-impl StatusLayout {
-    pub(crate) fn base_row_count(self) -> u16 {
-        match self {
-            Self::Compact => 1,
-            Self::Expanded => EXPANDED_STATUS_ROWS,
-        }
-    }
 }
 
 impl ViewState {
     pub(crate) fn status_row_count(&self) -> u16 {
-        self.status_layout.base_row_count() + self.worktree_extra_status_rows()
-    }
-
-    fn worktree_extra_status_rows(&self) -> u16 {
-        u16::from(self.status_layout == StatusLayout::Expanded && self.worktree_expanded.is_some())
+        self.presentation.status_row_count()
     }
 }
 
@@ -395,20 +351,27 @@ impl App {
     /// Snapshot the renderer-relevant fields into a `ViewState`. Called
     /// once per frame; the clones are dominated by small `String`s.
     pub(crate) fn view_state(&self) -> ViewState {
+        let presentation = self.presentation_state();
         ViewState {
-            stream_preview: self.stream_preview.clone(),
-            command_suggestions: if !self.busy && self.setup.is_none() {
+            command_suggestions: if !presentation.busy && self.setup.is_none() {
                 self.suggestions()
             } else {
                 Vec::new()
             },
-            busy: self.busy,
             busy_frame: self.busy_frame,
+            presentation,
+        }
+    }
+
+    pub(crate) fn presentation_state(&self) -> PresentationState {
+        PresentationState {
+            stream_preview: self.stream_preview.clone(),
+            busy: self.busy,
             turn_activity: self.turn_activity.clone(),
             model_id: self.model.model_id(),
             provider_name: self.model.provider_name(),
             reasoning_effort: self.model.reasoning_effort(),
-            session_id: self.session.session_id(),
+            session_id: self.session.session_id().to_string(),
             lines_count: self.lines.len(),
             session_tokens: self.session_tokens,
             status_layout: self.status_layout,
@@ -2805,17 +2768,15 @@ mod tests {
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
 
-    fn view_state_idle() -> ViewState {
-        ViewState {
+    fn presentation_state_idle() -> PresentationState {
+        PresentationState {
             stream_preview: None,
-            command_suggestions: Vec::new(),
             busy: false,
-            busy_frame: 0,
             turn_activity: None,
             model_id: "gpt-5.5".to_string(),
             provider_name: "openai".to_string(),
             reasoning_effort: Some("medium".to_string()),
-            session_id: SessionId::from_seed(770001),
+            session_id: SessionId::from_seed(770001).to_string(),
             lines_count: 3,
             session_tokens: None,
             status_layout: StatusLayout::Compact,
@@ -2828,11 +2789,22 @@ mod tests {
         }
     }
 
+    fn view_state_idle() -> ViewState {
+        ViewState {
+            presentation: presentation_state_idle(),
+            command_suggestions: Vec::new(),
+            busy_frame: 0,
+        }
+    }
+
     #[test]
     fn status_bar_shows_background_task_count() {
         let state = ViewState {
-            status_layout: StatusLayout::Expanded,
-            background: Some((1, 2)),
+            presentation: PresentationState {
+                status_layout: StatusLayout::Expanded,
+                background: Some((1, 2)),
+                ..presentation_state_idle()
+            },
             ..view_state_idle()
         };
         let lines = render_chrome_lines(&state, 120, 8).join("\n");
@@ -2849,8 +2821,11 @@ mod tests {
     #[test]
     fn status_bar_hides_background_segment_when_no_tasks() {
         let state = ViewState {
-            status_layout: StatusLayout::Expanded,
-            background: None,
+            presentation: PresentationState {
+                status_layout: StatusLayout::Expanded,
+                background: None,
+                ..presentation_state_idle()
+            },
             ..view_state_idle()
         };
         let lines = render_chrome_lines(&state, 120, 8).join("\n");
@@ -5135,10 +5110,13 @@ mod tests {
     #[test]
     fn chrome_command_suggestions_override_stream_preview_row() {
         let state = ViewState {
-            stream_preview: Some(StreamPreview {
-                kind: StreamKind::Assistant,
-                text: "streaming response".to_string(),
-            }),
+            presentation: PresentationState {
+                stream_preview: Some(StreamPreview {
+                    kind: StreamKind::Assistant,
+                    text: "streaming response".to_string(),
+                }),
+                ..presentation_state_idle()
+            },
             command_suggestions: vec![CommandSuggestion {
                 completion: "/help".to_string(),
                 label: "/help    show commands".to_string(),
@@ -5210,9 +5188,12 @@ mod tests {
     #[test]
     fn chrome_busy_shows_thinking_spinner_and_activity() {
         let state = ViewState {
-            busy: true,
+            presentation: PresentationState {
+                busy: true,
+                turn_activity: Some("reading files".to_string()),
+                ..presentation_state_idle()
+            },
             busy_frame: 4,
-            turn_activity: Some("reading files".to_string()),
             ..view_state_idle()
         };
         let rows = render_chrome_lines(&state, 80, 4);
@@ -5231,7 +5212,10 @@ mod tests {
     #[test]
     fn chrome_busy_falls_back_to_thinking_when_activity_unset() {
         let state = ViewState {
-            busy: true,
+            presentation: PresentationState {
+                busy: true,
+                ..presentation_state_idle()
+            },
             ..view_state_idle()
         };
         let rows = render_chrome_lines(&state, 80, 4);
@@ -5245,10 +5229,13 @@ mod tests {
     #[test]
     fn chrome_renders_stream_preview_tail_with_kind_label() {
         let state = ViewState {
-            stream_preview: Some(StreamPreview {
-                kind: StreamKind::Assistant,
-                text: "first line\nsecond line tail".to_string(),
-            }),
+            presentation: PresentationState {
+                stream_preview: Some(StreamPreview {
+                    kind: StreamKind::Assistant,
+                    text: "first line\nsecond line tail".to_string(),
+                }),
+                ..presentation_state_idle()
+            },
             ..view_state_idle()
         };
         let rows = render_chrome_lines(&state, 80, 5);
@@ -5274,8 +5261,11 @@ mod tests {
     #[test]
     fn chrome_session_status_compact_shows_provider_model_effort_approval_and_messages() {
         let state = ViewState {
-            provider_name: "openrouter".to_string(),
-            lines_count: 42,
+            presentation: PresentationState {
+                provider_name: "openrouter".to_string(),
+                lines_count: 42,
+                ..presentation_state_idle()
+            },
             ..view_state_idle()
         };
         let rows = render_chrome_lines(&state, 120, 4);
@@ -5313,7 +5303,10 @@ mod tests {
     #[test]
     fn chrome_session_status_compact_shows_worktree_indicator() {
         let state = ViewState {
-            worktree_compact: Some("bump-outdated-crates-ship".to_string()),
+            presentation: PresentationState {
+                worktree_compact: Some("bump-outdated-crates-ship".to_string()),
+                ..presentation_state_idle()
+            },
             ..view_state_idle()
         };
         let rows = render_chrome_lines(&state, 120, 4);
@@ -5327,12 +5320,15 @@ mod tests {
     #[test]
     fn chrome_session_status_expanded_shows_worktree_subsection() {
         let state = ViewState {
-            status_layout: StatusLayout::Expanded,
-            worktree_compact: Some("bump-outdated-crates-ship".to_string()),
-            worktree_expanded: Some((
-                "bump-outdated-crates-ship-f6dd3e41".to_string(),
-                "…/session_019ee6c2dfd27223853ea56ff6dd3e41".to_string(),
-            )),
+            presentation: PresentationState {
+                status_layout: StatusLayout::Expanded,
+                worktree_compact: Some("bump-outdated-crates-ship".to_string()),
+                worktree_expanded: Some((
+                    "bump-outdated-crates-ship-f6dd3e41".to_string(),
+                    "…/session_019ee6c2dfd27223853ea56ff6dd3e41".to_string(),
+                )),
+                ..presentation_state_idle()
+            },
             ..view_state_idle()
         };
         assert_eq!(state.status_row_count(), 5);
@@ -5348,14 +5344,20 @@ mod tests {
     #[test]
     fn view_state_status_row_count_adds_worktree_row_only_when_expanded() {
         let compact = ViewState {
-            worktree_expanded: Some(("branch".into(), "path".into())),
+            presentation: PresentationState {
+                worktree_expanded: Some(("branch".into(), "path".into())),
+                ..presentation_state_idle()
+            },
             ..view_state_idle()
         };
         assert_eq!(compact.status_row_count(), 1);
 
         let expanded = ViewState {
-            status_layout: StatusLayout::Expanded,
-            worktree_expanded: Some(("branch".into(), "path".into())),
+            presentation: PresentationState {
+                status_layout: StatusLayout::Expanded,
+                worktree_expanded: Some(("branch".into(), "path".into())),
+                ..presentation_state_idle()
+            },
             ..view_state_idle()
         };
         assert_eq!(expanded.status_row_count(), 5);
@@ -5363,14 +5365,18 @@ mod tests {
 
     #[test]
     fn chrome_session_status_expanded_groups_details_across_four_lines() {
+        let session_id = SessionId::from_seed(99887766).to_string();
         let state = ViewState {
-            model_id: "nvidia/nemotron-3-super-120b-a12b".to_string(),
-            provider_name: "openrouter".to_string(),
-            reasoning_effort: Some("high".to_string()),
-            session_id: SessionId::from_seed(99887766),
-            lines_count: 42,
-            session_tokens: Some(1234),
-            status_layout: StatusLayout::Expanded,
+            presentation: PresentationState {
+                model_id: "nvidia/nemotron-3-super-120b-a12b".to_string(),
+                provider_name: "openrouter".to_string(),
+                reasoning_effort: Some("high".to_string()),
+                session_id: session_id.clone(),
+                lines_count: 42,
+                session_tokens: Some(1234),
+                status_layout: StatusLayout::Expanded,
+                ..presentation_state_idle()
+            },
             ..view_state_idle()
         };
         let rows = render_chrome_lines(&state, 180, 7);
@@ -5399,9 +5405,8 @@ mod tests {
             "expanded counts row should include messages and tokens: {:?}",
             rows[5]
         );
-        let session_id_str = state.session_id.to_string();
         assert!(
-            rows[6].contains("session ") && rows[6].contains(&session_id_str),
+            rows[6].contains("session ") && rows[6].contains(&session_id),
             "expanded session row should include the full session id: {:?}",
             rows[6]
         );
@@ -5415,7 +5420,10 @@ mod tests {
     #[test]
     fn chrome_session_status_stays_visible_with_multiline_input() {
         let state = ViewState {
-            status_layout: StatusLayout::Expanded,
+            presentation: PresentationState {
+                status_layout: StatusLayout::Expanded,
+                ..presentation_state_idle()
+            },
             ..view_state_idle()
         };
         let rows = render_chrome_lines_with_input_height(&state, 120, 8, 3);

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -5,21 +5,10 @@
 
 use super::*;
 
-// Presentation for the transcript view-model types defined in
-// `crate::transcript`. The data lives there; colors/labels live here so the
-// translation layer stays free of `ratatui`.
+// Color presentation for the transcript view-model types defined in
+// `crate::transcript`. Labels and status semantics live in `crate::presentation`
+// so they can be tested without a terminal renderer.
 impl Author {
-    pub fn label(&self) -> &'static str {
-        match self {
-            Author::User => "you",
-            Author::Assistant => "agent",
-            Author::Narration => "note",
-            Author::Tool => "tool",
-            Author::ToolDetail => "",
-            Author::Diff => "diff",
-            Author::System => "system",
-        }
-    }
     pub fn color(&self) -> Color {
         match self {
             Author::User => ACCENT_BLUE,
@@ -34,13 +23,6 @@ impl Author {
 }
 
 impl StreamKind {
-    fn label(self) -> &'static str {
-        match self {
-            StreamKind::Assistant => "agent",
-            StreamKind::Tool => "tool",
-        }
-    }
-
     fn color(self) -> Color {
         match self {
             StreamKind::Assistant => ACCENT_GOLD,
@@ -328,7 +310,7 @@ pub(crate) fn draw_chrome(
 }
 
 pub(crate) fn chrome_preview_visible(state: &ViewState) -> bool {
-    state.stream_preview.is_some() || !state.command_suggestions.is_empty()
+    state.presentation.stream_preview.is_some() || !state.command_suggestions.is_empty()
 }
 
 pub(crate) fn draw_chrome_layout(f: &mut ratatui::Frame, layout: ChromeLayout, state: &ViewState) {
@@ -790,7 +772,7 @@ pub(crate) fn draw_stream_preview(f: &mut ratatui::Frame, area: Rect, state: &Vi
     if area.height == 0 {
         return;
     }
-    let Some(preview) = state.stream_preview.as_ref() else {
+    let Some(preview) = state.presentation.stream_preview.as_ref() else {
         return;
     };
     let inner_width = area.width as usize;
@@ -892,36 +874,55 @@ pub(crate) fn append_chat_lines<'a>(
     chat: &ChatLine,
     inner_width: usize,
 ) {
-    if matches!(chat.author, Author::ToolDetail) {
+    let presented = present_transcript_line(chat);
+    if matches!(presented.author, Author::ToolDetail) {
         append_wrapped_plain(
             lines,
             "           ",
             Style::default().fg(TEXT_MUTED),
-            &chat.text,
+            &presented.text,
             inner_width,
         );
         return;
     }
 
-    let header_text = format!("{} › ", chat.author.label());
+    let header_text = format!("{} › ", presented.label.unwrap_or_default());
     let header_style = Style::default()
-        .fg(chat.author.color())
+        .fg(presented.author.color())
         .add_modifier(Modifier::BOLD);
-    if matches!(chat.author, Author::Assistant) {
-        append_markdown_lines(lines, &header_text, header_style, &chat.text, inner_width);
-    } else if matches!(chat.author, Author::Narration) {
+    if matches!(presented.author, Author::Assistant) {
+        append_markdown_lines(
+            lines,
+            &header_text,
+            header_style,
+            &presented.text,
+            inner_width,
+        );
+    } else if matches!(presented.author, Author::Narration) {
         append_wrapped_styled(
             lines,
             &header_text,
             header_style,
-            &chat.text,
+            &presented.text,
             inner_width,
             Style::default().fg(TEXT_MUTED),
         );
-    } else if matches!(chat.author, Author::Diff) {
-        append_wrapped_diff(lines, &header_text, header_style, &chat.text, inner_width);
+    } else if matches!(presented.author, Author::Diff) {
+        append_wrapped_diff(
+            lines,
+            &header_text,
+            header_style,
+            &presented.text,
+            inner_width,
+        );
     } else {
-        append_wrapped_plain(lines, &header_text, header_style, &chat.text, inner_width);
+        append_wrapped_plain(
+            lines,
+            &header_text,
+            header_style,
+            &presented.text,
+            inner_width,
+        );
     }
 }
 
@@ -1528,11 +1529,8 @@ pub(crate) fn draw_input_cursor(f: &mut ratatui::Frame, area: Rect, app: &App) {
 }
 
 pub(crate) fn message_separator_title(state: &ViewState) -> Line<'static> {
-    if state.busy {
-        return thinking_title(
-            state.busy_frame,
-            state.turn_activity.as_deref().unwrap_or("thinking"),
-        );
+    if let Some(activity) = state.presentation.activity_text() {
+        return thinking_title(state.busy_frame, activity);
     }
     Line::from(vec![
         Span::styled("─── ", Style::default().fg(ACCENT_BLUE)),
@@ -1576,139 +1574,19 @@ pub(crate) fn draw_status_separator(f: &mut ratatui::Frame, area: Rect) {
 }
 
 pub(crate) fn draw_session_status(f: &mut ratatui::Frame, area: Rect, state: &ViewState) {
-    let lines = match state.status_layout {
-        StatusLayout::Compact => compact_status_lines(state),
-        StatusLayout::Expanded => expanded_status_lines(state),
-    };
+    let lines = state
+        .presentation
+        .status_lines()
+        .iter()
+        .map(status_line)
+        .collect::<Vec<_>>();
     f.render_widget(Paragraph::new(lines), area);
 }
 
-#[derive(Clone, Debug)]
-pub(crate) struct StatusContribution {
-    compact: Vec<StatusField>,
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct StatusField {
-    label: Option<&'static str>,
-    value: String,
-}
-
-impl StatusContribution {
-    pub(crate) fn new(compact: Vec<StatusField>) -> Self {
-        Self { compact }
-    }
-}
-
-fn compact_status_lines(state: &ViewState) -> Vec<Line<'static>> {
-    vec![status_line(
-        status_contributions(state)
-            .iter()
-            .flat_map(|section| section.compact.iter()),
-    )]
-}
-
-fn expanded_status_lines(state: &ViewState) -> Vec<Line<'static>> {
-    let mut counts = vec![
-        status_value(message_count_label(state.lines_count)),
-        status_field("tokens", token_label(state.session_tokens)),
-    ];
-    if let Some(bg) = background_label(state.background) {
-        counts.push(status_field("bg", bg));
-    }
-
-    let provider_model = [
-        status_value("[collapse ↑]"),
-        status_field("provider", state.provider_name.clone()),
-        status_field("model", state.model_id.clone()),
-    ];
-    let controls = [
-        status_field("effort", effort_label(state)),
-        status_field("approval", state.approval_mode.clone()),
-        status_field("hooks", state.hooks_summary.clone()),
-        status_field(
-            "goal",
-            state.goal_indicator.clone().unwrap_or_else(|| "—".into()),
-        ),
-    ];
-    let session = [status_field("session", state.session_id.to_string())];
-
-    let mut lines = vec![
-        status_line(provider_model.iter()),
-        status_line(controls.iter()),
-        status_line(counts.iter()),
-        status_line(session.iter()),
-    ];
-    if let Some((branch, path)) = &state.worktree_expanded {
-        let worktree = [
-            status_field("worktree", branch.clone()),
-            status_field("path", path.clone()),
-        ];
-        lines.push(status_line(worktree.iter()));
-    }
-    lines
-}
-
-fn status_contributions(state: &ViewState) -> Vec<StatusContribution> {
-    let toggle_label = match state.status_layout {
-        StatusLayout::Compact => "[expand ↓]",
-        StatusLayout::Expanded => "[collapse ↑]",
-    };
-    vec![
-        StatusContribution::new(vec![
-            status_value(toggle_label),
-            status_value(state.provider_name.clone()),
-            status_value(state.model_id.clone()),
-        ]),
-        StatusContribution::new(vec![
-            status_field("effort", effort_label(state)),
-            status_field("approval", state.approval_mode.clone()),
-        ]),
-        StatusContribution::new(vec![status_field(
-            "goal",
-            state.goal_indicator.clone().unwrap_or_else(|| "—".into()),
-        )]),
-        StatusContribution::new({
-            let mut compact = vec![status_value(message_count_label(state.lines_count))];
-            if let Some(bg) = background_label(state.background) {
-                compact.push(status_field("bg", bg));
-            }
-            if let Some(wt) = &state.worktree_compact {
-                compact.push(status_field("wt", wt.clone()));
-            }
-            compact
-        }),
-    ]
-}
-
-/// Status-bar label for background tasks, e.g. `2▸/3` (2 running of 3), or
-/// `0▸/2` when none are running. `None` when there are no tasks (segment hidden).
-fn background_label(counts: Option<(usize, usize)>) -> Option<String> {
-    let (running, total) = counts?;
-    if total == 0 {
-        return None;
-    }
-    Some(format!("{running}▸/{total}"))
-}
-
-pub(crate) fn status_value(value: impl Into<String>) -> StatusField {
-    StatusField {
-        label: None,
-        value: value.into(),
-    }
-}
-
-pub(crate) fn status_field(label: &'static str, value: impl Into<String>) -> StatusField {
-    StatusField {
-        label: Some(label),
-        value: value.into(),
-    }
-}
-
-fn status_line<'a>(fields: impl IntoIterator<Item = &'a StatusField>) -> Line<'static> {
+fn status_line(line: &StatusLine) -> Line<'static> {
     let mut spans = vec![Span::styled(" ", Style::default().fg(TEXT_MUTED))];
     let mut first = true;
-    for field in fields {
+    for field in &line.fields {
         if !first {
             spans.push(Span::styled("  ·  ", Style::default().fg(TEXT_DIM)));
         }
@@ -1726,21 +1604,4 @@ fn status_line<'a>(fields: impl IntoIterator<Item = &'a StatusField>) -> Line<'s
     }
     spans.push(Span::styled(" ", Style::default().fg(TEXT_MUTED)));
     Line::from(spans)
-}
-
-fn effort_label(state: &ViewState) -> String {
-    state
-        .reasoning_effort
-        .clone()
-        .unwrap_or_else(|| "n/a".to_string())
-}
-
-fn token_label(tokens: Option<u64>) -> String {
-    tokens
-        .map(|tokens| tokens.to_string())
-        .unwrap_or_else(|| "n/a".to_string())
-}
-
-fn message_count_label(count: usize) -> String {
-    format!("{count} msgs")
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ mod image_input;
 mod into;
 mod mcp_config;
 mod paste_attachment;
+mod presentation;
 mod runtime;
 mod session;
 mod session_log;

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -1,0 +1,353 @@
+//! Terminal-independent presentation model for user-visible yolop output.
+//!
+//! Runtime events are translated into transcript view-model entries in
+//! `crate::transcript`; this module turns those entries plus live app state into
+//! the semantic output hosts display. It intentionally has no ratatui/crossterm
+//! dependency so transcript wording and status values can be tested without a
+//! terminal buffer.
+
+use crate::transcript::{Author, ChatLine, StreamKind, StreamPreview};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PresentedTranscriptLine {
+    pub author: Author,
+    pub label: Option<&'static str>,
+    pub text: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PresentationState {
+    pub stream_preview: Option<StreamPreview>,
+    pub busy: bool,
+    pub turn_activity: Option<String>,
+    pub model_id: String,
+    pub provider_name: String,
+    pub reasoning_effort: Option<String>,
+    pub session_id: String,
+    pub lines_count: usize,
+    pub session_tokens: Option<u64>,
+    pub status_layout: StatusLayout,
+    pub hooks_summary: String,
+    pub approval_mode: String,
+    pub background: Option<(usize, usize)>,
+    pub goal_indicator: Option<String>,
+    pub worktree_compact: Option<String>,
+    pub worktree_expanded: Option<(String, String)>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum StatusLayout {
+    Compact,
+    Expanded,
+}
+
+impl StatusLayout {
+    pub(crate) fn base_row_count(self) -> u16 {
+        match self {
+            Self::Compact => 1,
+            Self::Expanded => 4,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct StatusLine {
+    pub fields: Vec<StatusField>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct StatusField {
+    pub label: Option<&'static str>,
+    pub value: String,
+}
+
+impl Author {
+    pub(crate) fn label(&self) -> &'static str {
+        match self {
+            Author::User => "you",
+            Author::Assistant => "agent",
+            Author::Narration => "note",
+            Author::Tool => "tool",
+            Author::ToolDetail => "",
+            Author::Diff => "diff",
+            Author::System => "system",
+        }
+    }
+}
+
+impl StreamKind {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            StreamKind::Assistant => "agent",
+            StreamKind::Tool => "tool",
+        }
+    }
+}
+
+impl PresentationState {
+    pub(crate) fn status_row_count(&self) -> u16 {
+        self.status_layout.base_row_count() + self.worktree_extra_status_rows()
+    }
+
+    fn worktree_extra_status_rows(&self) -> u16 {
+        u16::from(self.status_layout == StatusLayout::Expanded && self.worktree_expanded.is_some())
+    }
+
+    pub(crate) fn status_lines(&self) -> Vec<StatusLine> {
+        match self.status_layout {
+            StatusLayout::Compact => compact_status_lines(self),
+            StatusLayout::Expanded => expanded_status_lines(self),
+        }
+    }
+
+    pub(crate) fn activity_text(&self) -> Option<&str> {
+        self.busy
+            .then(|| self.turn_activity.as_deref().unwrap_or("thinking"))
+    }
+}
+
+pub(crate) fn present_transcript_line(chat: &ChatLine) -> PresentedTranscriptLine {
+    let label = match chat.author {
+        Author::ToolDetail => None,
+        _ => Some(chat.author.label()),
+    };
+    PresentedTranscriptLine {
+        author: chat.author.clone(),
+        label,
+        text: chat.text.clone(),
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn plain_transcript_line(chat: &ChatLine) -> String {
+    let line = present_transcript_line(chat);
+    match line.label {
+        Some(label) => format!("{label} › {}", line.text),
+        None => format!("           {}", line.text),
+    }
+}
+
+fn compact_status_lines(state: &PresentationState) -> Vec<StatusLine> {
+    vec![StatusLine {
+        fields: status_contributions(state)
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>(),
+    }]
+}
+
+fn expanded_status_lines(state: &PresentationState) -> Vec<StatusLine> {
+    let mut counts = vec![
+        status_value(message_count_label(state.lines_count)),
+        status_field("tokens", token_label(state.session_tokens)),
+    ];
+    if let Some(bg) = background_label(state.background) {
+        counts.push(status_field("bg", bg));
+    }
+
+    let mut lines = vec![
+        StatusLine {
+            fields: vec![
+                status_value("[collapse ↑]"),
+                status_field("provider", state.provider_name.clone()),
+                status_field("model", state.model_id.clone()),
+            ],
+        },
+        StatusLine {
+            fields: vec![
+                status_field("effort", effort_label(state)),
+                status_field("approval", state.approval_mode.clone()),
+                status_field("hooks", state.hooks_summary.clone()),
+                status_field("goal", goal_label(state)),
+            ],
+        },
+        StatusLine { fields: counts },
+        StatusLine {
+            fields: vec![status_field("session", state.session_id.clone())],
+        },
+    ];
+    if let Some((branch, path)) = &state.worktree_expanded {
+        lines.push(StatusLine {
+            fields: vec![
+                status_field("worktree", branch.clone()),
+                status_field("path", path.clone()),
+            ],
+        });
+    }
+    lines
+}
+
+fn status_contributions(state: &PresentationState) -> Vec<Vec<StatusField>> {
+    let toggle_label = match state.status_layout {
+        StatusLayout::Compact => "[expand ↓]",
+        StatusLayout::Expanded => "[collapse ↑]",
+    };
+    let mut counts = vec![status_value(message_count_label(state.lines_count))];
+    if let Some(bg) = background_label(state.background) {
+        counts.push(status_field("bg", bg));
+    }
+    if let Some(wt) = &state.worktree_compact {
+        counts.push(status_field("wt", wt.clone()));
+    }
+    vec![
+        vec![
+            status_value(toggle_label),
+            status_value(state.provider_name.clone()),
+            status_value(state.model_id.clone()),
+        ],
+        vec![
+            status_field("effort", effort_label(state)),
+            status_field("approval", state.approval_mode.clone()),
+        ],
+        vec![status_field("goal", goal_label(state))],
+        counts,
+    ]
+}
+
+fn goal_label(state: &PresentationState) -> String {
+    state.goal_indicator.clone().unwrap_or_else(|| "—".into())
+}
+
+fn background_label(counts: Option<(usize, usize)>) -> Option<String> {
+    let (running, total) = counts?;
+    if total == 0 {
+        return None;
+    }
+    Some(format!("{running}▸/{total}"))
+}
+
+fn status_value(value: impl Into<String>) -> StatusField {
+    StatusField {
+        label: None,
+        value: value.into(),
+    }
+}
+
+fn status_field(label: &'static str, value: impl Into<String>) -> StatusField {
+    StatusField {
+        label: Some(label),
+        value: value.into(),
+    }
+}
+
+fn effort_label(state: &PresentationState) -> String {
+    state
+        .reasoning_effort
+        .clone()
+        .unwrap_or_else(|| "n/a".to_string())
+}
+
+fn token_label(tokens: Option<u64>) -> String {
+    tokens
+        .map(|tokens| tokens.to_string())
+        .unwrap_or_else(|| "n/a".to_string())
+}
+
+fn message_count_label(count: usize) -> String {
+    format!("{count} msgs")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transcript::lines_for_event;
+    use everruns_core::events::{Event as RuntimeEvent, EventContext, ToolCompletedData};
+    use everruns_core::message::ContentPart;
+    use everruns_core::typed_id::SessionId;
+    use serde_json::json;
+
+    fn state() -> PresentationState {
+        PresentationState {
+            stream_preview: None,
+            busy: false,
+            turn_activity: None,
+            model_id: "gpt-5.5".to_string(),
+            provider_name: "openai".to_string(),
+            reasoning_effort: Some("medium".to_string()),
+            session_id: "sess_123".to_string(),
+            lines_count: 3,
+            session_tokens: Some(42),
+            status_layout: StatusLayout::Compact,
+            hooks_summary: "none".to_string(),
+            approval_mode: "normal".to_string(),
+            background: None,
+            goal_indicator: None,
+            worktree_compact: None,
+            worktree_expanded: None,
+        }
+    }
+
+    #[test]
+    fn plain_transcript_line_exposes_user_visible_tool_output() {
+        let line = ChatLine {
+            author: Author::Tool,
+            text: "✓ Bash `git status --short` exit=0".to_string(),
+        };
+
+        assert_eq!(
+            plain_transcript_line(&line),
+            "tool › ✓ Bash `git status --short` exit=0"
+        );
+    }
+
+    #[test]
+    fn plain_transcript_line_keeps_fallback_wording_visible_to_tests() {
+        let mut data = ToolCompletedData::success(
+            "call_bash".to_string(),
+            "bash".to_string(),
+            vec![ContentPart::text(
+                json!({
+                    "command": "git status --short",
+                    "exit_code": 0
+                })
+                .to_string(),
+            )],
+            None,
+        );
+        data.narration = Some("Ran Bash".to_string());
+        let event = RuntimeEvent::new(SessionId::new(), EventContext::empty(), data);
+        let lines = lines_for_event(&event);
+
+        let rendered = plain_transcript_line(&lines[0]);
+
+        assert_eq!(rendered, "tool › ✓ Ran Bash  `git status --short` exit=0");
+    }
+
+    #[test]
+    fn status_model_exposes_compact_status_values_without_terminal() {
+        let lines = state().status_lines();
+
+        assert_eq!(lines.len(), 1);
+        let values = lines[0]
+            .fields
+            .iter()
+            .map(|field| (field.label, field.value.as_str()))
+            .collect::<Vec<_>>();
+        assert!(values.contains(&(None, "[expand ↓]")));
+        assert!(values.contains(&(None, "openai")));
+        assert!(values.contains(&(None, "gpt-5.5")));
+        assert!(values.contains(&(Some("effort"), "medium")));
+        assert!(values.contains(&(Some("approval"), "normal")));
+        assert!(values.contains(&(Some("goal"), "—")));
+        assert!(values.contains(&(None, "3 msgs")));
+    }
+
+    #[test]
+    fn status_model_exposes_expanded_background_and_session_values() {
+        let model = PresentationState {
+            status_layout: StatusLayout::Expanded,
+            background: Some((2, 5)),
+            ..state()
+        };
+
+        let lines = model.status_lines();
+
+        assert_eq!(lines.len(), 4);
+        assert_eq!(lines[0].fields[1].label, Some("provider"));
+        assert_eq!(lines[0].fields[1].value, "openai");
+        assert_eq!(lines[2].fields[2].label, Some("bg"));
+        assert_eq!(lines[2].fields[2].value, "2▸/5");
+        assert_eq!(lines[3].fields[0].label, Some("session"));
+        assert_eq!(lines[3].fields[0].value, "sess_123");
+    }
+}

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -18,7 +18,7 @@ use tokio::sync::mpsc;
 
 // ---------- view-model types ----------
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Author {
     User,
     Assistant,
@@ -29,13 +29,13 @@ pub enum Author {
     System,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ChatLine {
     pub author: Author,
     pub text: String,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StreamPreview {
     pub kind: StreamKind,
     pub text: String,


### PR DESCRIPTION
## What
Add a terminal-independent presentation model for user-visible transcript lines, live activity, stream previews, and status-bar values. The TUI now consumes that model instead of assembling transcript labels and status semantics directly in terminal rendering.

## Why
The visible output contract needs to be testable without ratatui buffers so regressions like incorrect tool prefixes are caught at the semantic layer.

## How
- Added `src/presentation.rs` with presenter structs for transcript lines and status lines.
- Moved status-bar value assembly behind `PresentationState`, including provider/model, approval, goal, background task counts, tokens, session id, and worktree status.
- Updated the TUI renderer to keep terminal-only concerns in `render.rs`: layout, colors, wrapping, and drawing.
- Added `specs/presentation.md` and updated shipping/maintenance guidance plus the ship skill to require presentation-model tests for visible output/status changes.

## Risk
- Low / Medium / High: Low
- What can break: status-bar labels or row counts if presenter state diverges from TUI expectations. Covered with presenter tests plus existing TUI chrome tests.

## Security
No new I/O, credentials, subprocess behavior, or network behavior. This is a display-model refactor plus tests/specs.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

## Validation
- `cargo fmt --check`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- --provider llmsim -p "hi"`

## Follow-ups
None required.
