### PR TITLE
feat(runtime): adopt everruns-local backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,6 +1521,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns-local"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bed6a171166d9a0643461629e190f05dfe9ff55261b43c7442d305ed5258efd"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "everruns-core",
+ "everruns-runtime",
+ "parking_lot",
+ "rusqlite",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "everruns-mcp"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1589,6 +1608,18 @@ dependencies = [
  "tracing",
  "uuid",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
@@ -2021,6 +2052,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+dependencies = [
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -2664,6 +2704,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4119,6 +4170,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+dependencies = [
+ "bitflags 2.13.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4689,6 +4765,18 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5775,6 +5863,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6462,6 +6556,7 @@ dependencies = [
  "everruns-core",
  "everruns-integrations-daytona",
  "everruns-integrations-duckduckgo",
+ "everruns-local",
  "everruns-openai",
  "everruns-openrouter",
  "everruns-runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ everruns-openai = "0.16.0"
 # OpenRouter's first-class driver was split out of everruns-openai into its own
 # crate in 0.13.0; register it alongside openai to keep DriverId::OpenRouter.
 everruns-openrouter = "0.16.0"
+everruns-local = "0.16.0"
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (specs/mcp.md, upstream runtime-mcp.md D2).
 everruns-runtime = { version = "0.16.0", features = ["mcp-stdio"] }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -29,12 +29,13 @@ use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 use everruns_core::capabilities::{
     AGENT_INSTRUCTIONS_CAPABILITY_ID, AgentInstructionsCapability, BTW_CAPABILITY_ID,
-    BtwCapability, COMPACTION_CAPABILITY_ID, CompactionCapability, FileSystemCapability,
-    INFINITY_CONTEXT_CAPABILITY_ID, InfinityContextCapability, LOOP_DETECTION_CAPABILITY_ID,
-    LoopDetectionCapability, MessageMetadataCapability, PROMPT_CACHING_CAPABILITY_ID,
-    PromptCachingCapability, SESSION_FILE_SYSTEM_CAPABILITY_ID, SESSION_STORAGE_CAPABILITY_ID,
-    SKILLS_CAPABILITY_ID, STATELESS_TODO_LIST_CAPABILITY_ID, ScopedSkillsCapability,
-    SessionStorageCapability, StatelessTodoListCapability, TOOL_OUTPUT_PERSISTENCE_CAPABILITY_ID,
+    BackgroundExecutionCapability, BtwCapability, COMPACTION_CAPABILITY_ID, CompactionCapability,
+    FileSystemCapability, INFINITY_CONTEXT_CAPABILITY_ID, InfinityContextCapability,
+    LOOP_DETECTION_CAPABILITY_ID, LoopDetectionCapability, MessageMetadataCapability,
+    PROMPT_CACHING_CAPABILITY_ID, PromptCachingCapability, SESSION_FILE_SYSTEM_CAPABILITY_ID,
+    SESSION_STORAGE_CAPABILITY_ID, SESSION_TASKS_CAPABILITY_ID, SKILLS_CAPABILITY_ID,
+    STATELESS_TODO_LIST_CAPABILITY_ID, ScopedSkillsCapability, SessionStorageCapability,
+    SessionTasksCapability, StatelessTodoListCapability, TOOL_OUTPUT_PERSISTENCE_CAPABILITY_ID,
     TOOL_SEARCH_CAPABILITY_ID, ToolOutputPersistenceCapability, ToolSearchCapability,
     USER_HOOKS_CAPABILITY_ID, UserHooksCapability, WEB_FETCH_CAPABILITY_ID, WebFetchCapability,
 };
@@ -55,6 +56,7 @@ use everruns_core::{
 use everruns_core::{DriverId, ModelProfile, ReasoningEffortConfig, ReasoningEffortValue};
 use everruns_integrations_daytona::DaytonaCapability;
 use everruns_integrations_duckduckgo::DuckDuckGoCapability;
+use everruns_local::{LocalBackends, LocalProfile};
 use everruns_runtime::{
     AgentBuilder, HarnessBuilder, InProcessRuntime, InProcessRuntimeBuilder, RealDiskFileStore,
     RuntimeBackends, SessionBuilder, WriteBlocklistFileStore,
@@ -1644,6 +1646,7 @@ fn default_coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabi
         // tools (see DEFAULT_TOOL_SEARCH_THRESHOLD).
         AgentCapabilityConfig::new(TOOL_SEARCH_CAPABILITY_ID),
         AgentCapabilityConfig::new(TOOL_OUTPUT_PERSISTENCE_CAPABILITY_ID),
+        AgentCapabilityConfig::new(SESSION_TASKS_CAPABILITY_ID),
         AgentCapabilityConfig::new(DUCKDUCKGO_CAPABILITY_ID),
         AgentCapabilityConfig::new(ATTRIBUTION_CAPABILITY_ID),
         // enable_file_download=true: saved responses land on disk through
@@ -2191,13 +2194,18 @@ pub async fn build_with_options(
         message_store.seed(session_id, replayed.messages).await;
     }
 
-    // Non-filesystem backends: in-memory for everything except the
-    // JsonlEventEmitter (so events also land on disk) and the
-    // pre-seeded message store (so replayed history is available).
-    let backends = RuntimeBackends::in_memory()
+    // Start from the in-memory backend bundle, preserving Yolop's durable
+    // event bus and replay-seeded message store, then let everruns-local attach
+    // the SQLite-backed task registry and schedule store.
+    let base_backends = RuntimeBackends::in_memory()
         .with_event_bus(event_bus)
         .with_message_store(message_store)
         .with_connection_resolver(connection_resolver);
+    let local_profile = LocalProfile::new(sessions_dir.join("everruns-local"))
+        .with_workspace_root(effective_root.clone());
+    let backends = LocalBackends::new(local_profile, base_backends)
+        .context("initialize everruns-local backend stores")?
+        .runtime_backends;
     // Shared between `ModelState` (for banner labels) and
     // `SetupCapability` (which mutates it on a successful `/setup`).
     let provider_state = Arc::new(RwLock::new(provider.clone()));
@@ -2266,6 +2274,8 @@ pub async fn build_with_options(
         ToolSearchCapability::new().with_never_defer(YOLOP_NEVER_DEFER_TOOLS.iter().copied()),
     );
     capabilities.register(ToolOutputPersistenceCapability);
+    capabilities.register(SessionTasksCapability);
+    capabilities.register(BackgroundExecutionCapability);
     capabilities.register(SessionStorageCapability);
     capabilities.register(DaytonaCapability);
     capabilities.register(UserHooksCapability);
@@ -2744,6 +2754,58 @@ mod tests {
                 .is_none(),
             "no credential configured yet"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn build_uses_everruns_local_backend_stores() {
+        use everruns_runtime::RuntimeHostAdapter;
+
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+
+        let built = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Sim,
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            BuildOptions::default(),
+        )
+        .await
+        .expect("build runtime");
+
+        assert!(
+            sessions.path().join("everruns-local/local.db").exists(),
+            "local backend database should be created under the Yolop sessions dir"
+        );
+        assert!(
+            built.handles.runtime.session_task_registry().is_some(),
+            "everruns-local should install a session task registry"
+        );
+        assert!(
+            built
+                .handles
+                .runtime
+                .schedule_store(everruns_runtime::in_process_internal_org_id(
+                    everruns_core::DEFAULT_ORG_PUBLIC_ID
+                ))
+                .is_some(),
+            "everruns-local should install a schedule store factory"
+        );
+        for task_tool in [
+            "list_tasks",
+            "get_task",
+            "message_task",
+            "cancel_task",
+            "wait_task",
+        ] {
+            assert!(
+                built.startup.tool_names.contains(&task_tool.to_string()),
+                "session task tools: {:?}",
+                built.startup.tool_names
+            );
+        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## What
Adopts the published `everruns-local` crate for Yolop's embedded runtime backend stores.

## Why
Yolop should consume Everruns' generic local backend layer instead of keeping every local runtime primitive embedded in Yolop-specific code.

## How
- Adds `everruns-local = "0.16.0"` and updates `Cargo.lock`.
- Wraps Yolop's existing `RuntimeBackends` with `LocalBackends`, preserving the existing event bus, message store, and connection resolver.
- Stores the local SQLite database under the Yolop sessions directory at `everruns-local/local.db`.
- Registers and enables upstream `session_tasks` so task inspection tools are available.
- Registers upstream `background_execution` so Everruns can auto-expose `spawn_background` when a tool advertises background support.

## Risk
- Low / Medium / High: Medium
- What can break: runtime startup now creates/open a SQLite-backed local backend database. Failure to initialize that store now fails runtime construction. Tool surface expands with session task tools.

## Security
- TM-FS: Local backend data is rooted under Yolop's sessions directory, not the workspace file store. Existing workspace file write blocklist remains unchanged.
- TM-BASH: No shell execution code changed; existing bash timeouts/output caps are untouched.
- TM-LLM: No provider token handling, prompt secret handling, or JSONL logging paths changed.
- TM-TOOL: New upstream `session_tasks` tools are exposed. They operate on the runtime task registry; no workspace write permission is added.
- TM-DEP: Adds first-party `everruns-local` at the same `0.16.0` version as the existing Everruns crates. The transitive SQLite dependency is required by that first-party local backend implementation.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"`

Live-provider smoke note: `doppler run -- cargo run -- --provider openai ...` was attempted but blocked locally because Doppler has no project/fallback file configured in this worktree.

## Follow-ups
- Replace Yolop's custom `background` capability with Everruns background primitives once Yolop tools implement the upstream background execution contracts and/or a local platform runner exists for subagent delegation.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
