### PR TITLE
feat(runtime): enable spawn_background for bash

### DIFF
--- a/src/agent_scenarios.rs
+++ b/src/agent_scenarios.rs
@@ -212,6 +212,60 @@ async fn scripted_tool_call_executes_bash_then_assistant_completes() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn scripted_spawn_background_runs_bash_detached() {
+    let marker = "spawn_background_bash.marker";
+    let cmd = format!("printf background-ok > {marker}");
+    let (runtime, workspace) = build_scripted_runtime(LlmSimConfig::scripted(vec![
+        SimTurn::ToolCalls(vec![SimToolCall {
+            name: "spawn_background".to_string(),
+            arguments: json!({
+                "tool": "bash",
+                "args": { "command": cmd },
+                "title": "write marker",
+                "signal_on_completion": false
+            }),
+            id: None,
+        }]),
+        SimTurn::Assistant("background started".to_string()),
+    ]))
+    .await;
+
+    assert!(
+        runtime
+            .startup
+            .tool_names
+            .contains(&"spawn_background".to_string()),
+        "spawn_background should be visible when bash supports background: {:?}",
+        runtime.startup.tool_names
+    );
+
+    let result = run_single_turn(&runtime, "start the background marker write").await;
+
+    assert!(
+        result.success,
+        "spawn_background turn must succeed: {result:?}"
+    );
+    assert_eq!(
+        result.tool_calls_count, 1,
+        "the scripted turn should call spawn_background once"
+    );
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            if workspace.join(marker).exists() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("background bash did not create marker in time");
+    let marker_text = tokio::fs::read_to_string(workspace.join(marker))
+        .await
+        .expect("read marker");
+    assert_eq!(marker_text, "background-ok");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn workspace_hook_blocks_matching_bash_call() {
     let marker = "git_hook_should_block.marker";
     let cmd = format!("git status > {marker}");

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -504,6 +504,7 @@ const YOLOP_NEVER_DEFER_TOOLS: &[&str] = &[
     "list_directory",
     "grep_files",
     "bash",
+    "spawn_background",
     "write_todos",
     "run_yolop_command",
 ];

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -12,10 +12,15 @@ use everruns_core::exec_tool_result::ExecToolResultPayload;
 use everruns_core::tool_narration::ToolNarrationPhase;
 use everruns_core::tool_types::ToolHints;
 use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::{
+    BackgroundEventSink, BackgroundExecutableTool, BackgroundOutcome, BackgroundProgress,
+    ToolContext,
+};
 use serde_json::{Value, json};
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
 use tokio::io::AsyncReadExt;
 use tokio::process::Command;
 
@@ -51,6 +56,15 @@ pub struct BashTool {
     max_output_bytes: usize,
 }
 
+struct BashRunOutput {
+    stdout_text: String,
+    stderr_text: String,
+    exit_code: i32,
+    out_truncated: bool,
+    err_truncated: bool,
+    duration: Duration,
+}
+
 impl BashTool {
     pub fn new(ws: Workspace) -> Self {
         Self {
@@ -58,6 +72,109 @@ impl BashTool {
             timeout_secs: 120,
             max_output_bytes: 1024 * 1024,
         }
+    }
+
+    async fn run_command(
+        &self,
+        command: &str,
+        sink: Option<Arc<dyn BackgroundEventSink>>,
+    ) -> Result<BashRunOutput, ToolExecutionResult> {
+        let root = self.ws.root().to_path_buf();
+        let timeout = Duration::from_secs(self.timeout_secs);
+        let max_bytes = self.max_output_bytes;
+
+        if let Some(sink) = &sink {
+            let _ = sink.status("Running bash command").await;
+        }
+
+        // kill_on_drop ensures a timed-out or canceled background command is
+        // reaped when the owning future is dropped.
+        let mut child = Command::new("bash")
+            .arg("-lc")
+            .arg(command)
+            .current_dir(&root)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|e| ToolExecutionResult::tool_error(format!("spawn failed: {e}")))?;
+        let mut stdout = child.stdout.take().unwrap();
+        let mut stderr = child.stderr.take().unwrap();
+
+        let start = Instant::now();
+        let run = async {
+            let mut out_buf = Vec::with_capacity(4096);
+            let mut err_buf = Vec::with_capacity(4096);
+            let mut o = vec![0u8; 4096];
+            let mut e = vec![0u8; 4096];
+            let mut out_truncated = false;
+            let mut err_truncated = false;
+            let mut out_done = false;
+            let mut err_done = false;
+            while !(out_done && err_done) {
+                tokio::select! {
+                    n = stdout.read(&mut o), if !out_done => match n {
+                        Ok(0) | Err(_) => out_done = true,
+                        Ok(n) => {
+                            let remaining = max_bytes.saturating_sub(out_buf.len());
+                            let accepted = n.min(remaining);
+                            if accepted > 0 {
+                                out_buf.extend_from_slice(&o[..accepted]);
+                                if let Some(sink) = &sink {
+                                    let text = String::from_utf8_lossy(&o[..accepted]);
+                                    let _ = sink.output("stdout", &text).await;
+                                }
+                            }
+                            if accepted < n {
+                                out_truncated = true;
+                                let _ = child.start_kill();
+                                break;
+                            }
+                        },
+                    },
+                    n = stderr.read(&mut e), if !err_done => match n {
+                        Ok(0) | Err(_) => err_done = true,
+                        Ok(n) => {
+                            let remaining = max_bytes.saturating_sub(err_buf.len());
+                            let accepted = n.min(remaining);
+                            if accepted > 0 {
+                                err_buf.extend_from_slice(&e[..accepted]);
+                                if let Some(sink) = &sink {
+                                    let text = String::from_utf8_lossy(&e[..accepted]);
+                                    let _ = sink.output("stderr", &text).await;
+                                }
+                            }
+                            if accepted < n {
+                                err_truncated = true;
+                                let _ = child.start_kill();
+                                break;
+                            }
+                        },
+                    },
+                }
+            }
+            let status = child.wait().await;
+            (status, out_buf, err_buf, out_truncated, err_truncated)
+        };
+
+        let (status, out_buf, err_buf, out_truncated, err_truncated) =
+            match tokio::time::timeout(timeout, run).await {
+                Ok(r) => r,
+                Err(_) => {
+                    return Err(ToolExecutionResult::tool_error(format!(
+                        "command timed out after {}s",
+                        self.timeout_secs
+                    )));
+                }
+            };
+        Ok(BashRunOutput {
+            stdout_text: String::from_utf8_lossy(&out_buf).to_string(),
+            stderr_text: String::from_utf8_lossy(&err_buf).to_string(),
+            exit_code: status.ok().and_then(|s| s.code()).unwrap_or(-1),
+            out_truncated,
+            err_truncated,
+            duration: start.elapsed(),
+        })
     }
 }
 
@@ -101,6 +218,7 @@ impl Tool for BashTool {
         ToolHints::default()
             .with_long_running(true)
             .with_persist_output(true)
+            .with_supports_background(true)
     }
     async fn execute(&self, arguments: Value) -> ToolExecutionResult {
         let command = match arguments.get("command").and_then(Value::as_str) {
@@ -116,86 +234,16 @@ impl Tool for BashTool {
             .get("output")
             .and_then(Value::as_str)
             .unwrap_or("auto");
-        let root = self.ws.root().to_path_buf();
-        let timeout = std::time::Duration::from_secs(self.timeout_secs);
-        let max_bytes = self.max_output_bytes;
-
-        // kill_on_drop ensures a timed-out command is reaped: if we drop the
-        // Child (via the timeout future being canceled) the OS process is
-        // killed and waited on by tokio's background reaper.
-        let mut child = match Command::new("bash")
-            .arg("-lc")
-            .arg(&command)
-            .current_dir(&root)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .kill_on_drop(true)
-            .spawn()
-        {
-            Ok(c) => c,
-            Err(e) => return ToolExecutionResult::tool_error(format!("spawn failed: {e}")),
+        let output = match self.run_command(&command, None).await {
+            Ok(output) => output,
+            Err(err) => return err,
         };
-        let mut stdout = child.stdout.take().unwrap();
-        let mut stderr = child.stderr.take().unwrap();
-
-        let run = async {
-            let mut out_buf = Vec::with_capacity(4096);
-            let mut err_buf = Vec::with_capacity(4096);
-            let mut o = vec![0u8; 4096];
-            let mut e = vec![0u8; 4096];
-            // Track per-stream EOF so we stop polling a closed pipe instead
-            // of busy-looping on `Ok(0)` (which would starve the other stream).
-            let mut out_done = false;
-            let mut err_done = false;
-            while !(out_done && err_done) {
-                tokio::select! {
-                    // Bias the select toward stdout so we drain it first on
-                    // every wake — this keeps reasoning about ordering simple.
-                    biased;
-                    n = stdout.read(&mut o), if !out_done => match n {
-                        Ok(0) | Err(_) => out_done = true,
-                        Ok(n) => out_buf.extend_from_slice(&o[..n]),
-                    },
-                    n = stderr.read(&mut e), if !err_done => match n {
-                        Ok(0) | Err(_) => err_done = true,
-                        Ok(n) => err_buf.extend_from_slice(&e[..n]),
-                    },
-                }
-                if out_buf.len() > max_bytes || err_buf.len() > max_bytes {
-                    // Per-stream cap exceeded — kill the child and stop
-                    // reading. Each stream is also truncated to `max_bytes`
-                    // after the wait below, matching the documented
-                    // per-stream 1 MiB cap.
-                    let _ = child.start_kill();
-                    break;
-                }
-            }
-            let status = child.wait().await;
-            (status, out_buf, err_buf)
-        };
-        let (status, mut out_buf, mut err_buf) = match tokio::time::timeout(timeout, run).await {
-            Ok(r) => r,
-            Err(_) => {
-                // child (owned by `run`) is dropped here, kill_on_drop reaps.
-                return ToolExecutionResult::tool_error(format!(
-                    "command timed out after {}s",
-                    self.timeout_secs
-                ));
-            }
-        };
-        let out_truncated = out_buf.len() > max_bytes;
-        if out_truncated {
-            out_buf.truncate(max_bytes);
-        }
-        let err_truncated = err_buf.len() > max_bytes;
-        if err_truncated {
-            err_buf.truncate(max_bytes);
-        }
-        let stdout_text = String::from_utf8_lossy(&out_buf).to_string();
-        let stderr_text = String::from_utf8_lossy(&err_buf).to_string();
-        let exit_code = status.ok().and_then(|s| s.code()).unwrap_or(-1);
-        let payload =
-            ExecToolResultPayload::new(&stdout_text, &stderr_text, exit_code, output_mode);
+        let payload = ExecToolResultPayload::new(
+            &output.stdout_text,
+            &output.stderr_text,
+            output.exit_code,
+            output_mode,
+        );
         let ExecToolResultPayload {
             stdout,
             stderr,
@@ -213,12 +261,86 @@ impl Tool for BashTool {
                 "success": success,
                 "stdout": stdout,
                 "stderr": stderr,
-                "truncated": truncated || out_truncated || err_truncated,
+                "truncated": truncated || output.out_truncated || output.err_truncated,
                 "total_lines": total_lines,
-                "output_limited": out_truncated || err_truncated,
+                "output_limited": output.out_truncated || output.err_truncated,
             }),
             raw_output,
         )
+    }
+
+    fn as_background_executable(&self) -> Option<&dyn BackgroundExecutableTool> {
+        Some(self)
+    }
+}
+
+#[async_trait]
+impl BackgroundExecutableTool for BashTool {
+    async fn execute_background(
+        &self,
+        arguments: Value,
+        _context: ToolContext,
+        sink: Arc<dyn BackgroundEventSink>,
+    ) -> Result<BackgroundOutcome, ToolExecutionResult> {
+        let command = match arguments.get("command").and_then(Value::as_str) {
+            Some(c) => c.to_string(),
+            None => return Err(ToolExecutionResult::tool_error("'command' is required")),
+        };
+        let output_mode = arguments
+            .get("output")
+            .and_then(Value::as_str)
+            .unwrap_or("auto");
+        let output = self.run_command(&command, Some(sink.clone())).await?;
+        let payload = ExecToolResultPayload::new(
+            &output.stdout_text,
+            &output.stderr_text,
+            output.exit_code,
+            output_mode,
+        );
+        let ExecToolResultPayload {
+            stdout,
+            stderr,
+            exit_code,
+            success,
+            truncated,
+            total_lines,
+            raw_output,
+        } = payload;
+        let output_limited = output.out_truncated || output.err_truncated;
+        let _ = sink
+            .progress(BackgroundProgress {
+                current: Some(output.duration.as_millis() as u64),
+                total: None,
+                unit: Some("ms".to_string()),
+                label: Some("runtime".to_string()),
+            })
+            .await;
+        let result = json!({
+            "command": command,
+            "exit_code": exit_code,
+            "success": success,
+            "stdout": stdout,
+            "stderr": stderr,
+            "truncated": truncated || output_limited,
+            "total_lines": total_lines,
+            "output_limited": output_limited,
+        });
+
+        if success {
+            Ok(BackgroundOutcome {
+                summary: format!(
+                    "Bash command exited with code {exit_code} after {} ms",
+                    output.duration.as_millis()
+                ),
+                result,
+                raw_output: Some(raw_output),
+            })
+        } else {
+            Err(ToolExecutionResult::tool_error(format!(
+                "Bash command exited with code {exit_code} after {} ms",
+                output.duration.as_millis()
+            )))
+        }
     }
 }
 
@@ -226,8 +348,10 @@ impl Tool for BashTool {
 mod tests {
     use super::*;
     use everruns_core::capabilities::{Capability, ToolOutputPersistenceCapability};
+    use everruns_core::typed_id::SessionId;
     use everruns_core::{ToolCall, ToolContext};
     use everruns_runtime::RealDiskFileStore;
+    use std::sync::Mutex;
 
     #[test]
     fn bash_tool_requests_output_persistence() {
@@ -235,6 +359,162 @@ mod tests {
 
         assert_eq!(tool.hints().persist_output, Some(true));
         assert_eq!(tool.hints().long_running, Some(true));
+        assert_eq!(tool.hints().supports_background, Some(true));
+        assert!(tool.as_background_executable().is_some());
+    }
+
+    #[tokio::test]
+    async fn bash_background_executable_streams_and_returns_success_outcome() {
+        #[derive(Default)]
+        struct RecordingSink {
+            output: Mutex<Vec<(String, String)>>,
+            statuses: Mutex<Vec<String>>,
+        }
+
+        #[async_trait]
+        impl BackgroundEventSink for RecordingSink {
+            async fn status(&self, message: &str) -> everruns_core::Result<()> {
+                self.statuses.lock().unwrap().push(message.to_string());
+                Ok(())
+            }
+
+            async fn output(&self, stream: &str, delta: &str) -> everruns_core::Result<()> {
+                self.output
+                    .lock()
+                    .unwrap()
+                    .push((stream.to_string(), delta.to_string()));
+                Ok(())
+            }
+
+            async fn progress(&self, _progress: BackgroundProgress) -> everruns_core::Result<()> {
+                Ok(())
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let tool = BashTool::new(Workspace::new(dir.path().to_path_buf()));
+        let sink = Arc::new(RecordingSink::default());
+        let outcome = tool
+            .as_background_executable()
+            .expect("background executor")
+            .execute_background(
+                json!({ "command": "printf stdout-line; printf stderr-line >&2" }),
+                ToolContext::new(SessionId::new()),
+                sink.clone(),
+            )
+            .await
+            .expect("background bash succeeds");
+
+        assert_eq!(outcome.result["success"], true);
+        assert_eq!(outcome.result["exit_code"], 0);
+        assert_eq!(outcome.result["stdout"], "stdout-line");
+        assert_eq!(outcome.result["stderr"], "stderr-line");
+        assert!(
+            sink.statuses
+                .lock()
+                .unwrap()
+                .contains(&"Running bash command".to_string())
+        );
+        let output = sink.output.lock().unwrap();
+        assert!(
+            output
+                .iter()
+                .any(|(stream, chunk)| { stream == "stdout" && chunk.contains("stdout-line") })
+        );
+        assert!(
+            output
+                .iter()
+                .any(|(stream, chunk)| { stream == "stderr" && chunk.contains("stderr-line") })
+        );
+    }
+
+    #[tokio::test]
+    async fn bash_background_executable_marks_nonzero_exit_as_failure() {
+        #[derive(Default)]
+        struct NoopSink;
+
+        #[async_trait]
+        impl BackgroundEventSink for NoopSink {
+            async fn status(&self, _message: &str) -> everruns_core::Result<()> {
+                Ok(())
+            }
+
+            async fn output(&self, _stream: &str, _delta: &str) -> everruns_core::Result<()> {
+                Ok(())
+            }
+
+            async fn progress(&self, _progress: BackgroundProgress) -> everruns_core::Result<()> {
+                Ok(())
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let tool = BashTool::new(Workspace::new(dir.path().to_path_buf()));
+        let err = tool
+            .as_background_executable()
+            .expect("background executor")
+            .execute_background(
+                json!({ "command": "printf nope; exit 7" }),
+                ToolContext::new(SessionId::new()),
+                Arc::new(NoopSink),
+            )
+            .await
+            .expect_err("nonzero shell exit should fail the background task");
+
+        match err {
+            ToolExecutionResult::ToolError(message) => {
+                assert!(message.contains("code 7"), "got: {message}");
+            }
+            other => panic!("expected ToolError, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn bash_background_streaming_respects_output_cap() {
+        #[derive(Default)]
+        struct RecordingSink {
+            output: Mutex<Vec<(String, String)>>,
+        }
+
+        #[async_trait]
+        impl BackgroundEventSink for RecordingSink {
+            async fn status(&self, _message: &str) -> everruns_core::Result<()> {
+                Ok(())
+            }
+
+            async fn output(&self, stream: &str, delta: &str) -> everruns_core::Result<()> {
+                self.output
+                    .lock()
+                    .unwrap()
+                    .push((stream.to_string(), delta.to_string()));
+                Ok(())
+            }
+
+            async fn progress(&self, _progress: BackgroundProgress) -> everruns_core::Result<()> {
+                Ok(())
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut tool = BashTool::new(Workspace::new(dir.path().to_path_buf()));
+        tool.max_output_bytes = 5;
+        let sink = Arc::new(RecordingSink::default());
+        let output = tool
+            .run_command("printf 1234567890", Some(sink.clone()))
+            .await
+            .expect("background command should return capped output");
+
+        assert!(output.out_truncated);
+        assert_eq!(output.stdout_text, "12345");
+        let streamed_stdout: String = sink
+            .output
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(stream, _)| stream == "stdout")
+            .map(|(_, chunk)| chunk.as_str())
+            .collect();
+        assert_eq!(streamed_stdout, "12345");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What
Enable Yolop's `bash` tool to run through Everruns' generic `spawn_background` path by implementing `BackgroundExecutableTool` and advertising `supports_background=true`.

## Why
This starts the background migration at the generic runtime boundary. `spawn_background` can now launch bash work through Everruns' session task registry while Yolop's legacy `background_*` tools remain available during the UI/status migration.

## How
- Factored `BashTool` command execution into a shared bounded runner used by foreground and background execution.
- Implemented `BackgroundExecutableTool` for `BashTool`, streaming stdout/stderr into the background sink and returning the same structured bash payload on success.
- Kept nonzero exits as failed background tasks, matching Yolop's legacy `background_run` behavior.
- Marked `spawn_background` as non-deferred so the upstream tool is visible when activated.
- Added unit coverage for bash background success/failure and an agent scenario that calls `spawn_background` to run bash detached.

## Risk
- Low / Medium
- Touches shell execution plumbing and tool exposure. The bounded execution model is preserved, but this does expose the new upstream `spawn_background` tool alongside Yolop's legacy background tools.

## Security
- TM-FS: No file-store changes. Yolop still wraps the session filesystem with `WriteBlocklistFileStore`, whose default blocklist includes `.git`, `node_modules`, `target`, `dist`, `build`, `.next`, `.venv`, `venv`, `.tox`, and `.gradle`.
- TM-BASH: Preserves host `bash -lc`, workspace-root cwd, `kill_on_drop(true)`, 120s timeout, and 1 MiB per-stream output caps. Background execution streams chunks to the Everruns sink but keeps the same caps and timeout.
- TM-LLM: No prompt construction, provider, API-key, or logging changes.
- TM-TOOL: `spawn_background` is surfaced only through Everruns' generic background capability for tools that advertise background support; legacy background tools remain unchanged.
- TM-DEP: No dependency changes.

## Validation
- `git fetch origin main && git rebase --autostash origin/main`
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"` confirmed startup includes `spawn_background`
- Attempted `doppler run -- cargo run -- --provider openai -p "Say ok after confirming the yolop runtime starts."`; local Doppler is not configured in this worktree (`You must specify a project`, no fallback file). CI should provide the secret-backed live provider coverage.

## Follow-ups
- Migrate Yolop UI/status and `/background` command data from `BackgroundRegistry` to Everruns `session_tasks`.
- Move subagent delegation through a Yolop `LocalSessionRunner` plus `LocalPlatformStore`, then replace `background_agent` with the generic local platform/session path.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered