### PR TITLE
chore(deps): bump everruns crates to 0.16.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
  "blocking",
  "futures",
  "futures-concurrency",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -463,14 +463,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "base64",
  "bytes",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
- "hyper",
- "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -478,12 +475,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
- "serde_json",
- "serde_path_to_error",
- "sha1 0.10.6",
  "sync_wrapper",
- "tokio",
- "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -547,7 +539,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha1 0.11.0",
+ "sha1",
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
@@ -1013,6 +1005,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "cron"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5877d3fbf742507b66bc2a1945106bd30dd8504019d596901ddd012a4dd01740"
+dependencies = [
+ "chrono",
+ "once_cell",
+ "winnow 0.6.26",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,12 +1171,6 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
-
-[[package]]
-name = "data-encoding"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deltae"
@@ -1419,9 +1416,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f058270d0076733564d61a961c175b1f650958bfe05e8023dfb0245d05b0da48"
+checksum = "86a196159ef97555783fa212e661e4fbc608b551e3fb3bc606831d6d58a9e62e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1437,18 +1434,18 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda887bbd9df94b1174ff958b5a0be8d8a1431838558b0d7a7f342481a42d6d6"
+checksum = "69715520c46e1958374b1fa8a32e16616141c2f0f17b6cbe7ef63c2fb54c4dca"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-core"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978417245b8778dcb4ecbb97ace33cfaf07ce9f7e71ca9e176dcbf5f9f259cf0"
+checksum = "7f54202c81661997453f0a0947cda729030f9a5f59a4e095dd88cd5cb245a3b2"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -1458,6 +1455,7 @@ dependencies = [
  "bashkit",
  "bytes",
  "chrono",
+ "cron",
  "ed25519-dalek",
  "eventsource-stream",
  "everruns-config",
@@ -1489,9 +1487,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801305aeed7cd9349127bf4242d9a895f5464c0a8948f4711374576a25a33836"
+checksum = "3b5e67af1a7442324e6d7357a2e73b1bf4dada581cc449f954e0c8ee5f85cbb4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1506,9 +1504,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def584309254cd85e40b66f373eeb2bb40e1f4a153f5076c42f5d1ee567d9168"
+checksum = "583e6ddbd053ff25e260aa3e1113476a4a9fac81d3a27ab638951b2b868459c9"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1522,9 +1520,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b650f0bcab21f34b3df1101471920b31e065171b0c4547e4718e75526f254fd4"
+checksum = "aa6bdaca527ed3df1ea8eeff1a9da2b09fe8d0b18e183d10e460304783d02b70"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1541,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f93a51a9da76fb19394020e81a93dfe6f232ccb74fc7e6ce420bc365025519"
+checksum = "7949049f0433eccb1a89fc428a56e420be2394db85c5a2871c834fd22f2ff955"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1556,9 +1554,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc7b2989be16fd2e210bb69627dae58245ccae3158499e64413fb5cab25f11f"
+checksum = "e3a82f96e25bd30aab16ad77ea749c8762452e023ba52502f59210ad20a8eee1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1577,9 +1575,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77d39bb899df27385f0b7b9432a5832ab1c5af76fa1760ec26c06f688a7beb9"
+checksum = "f24cba1982fb8043e91aefd7d780b1456e027e09d42308732cdc430680dee7c8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1591,9 +1589,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22c3eaf1cb8f25ca47d94b2f37f947ce212c6032270171d9d41edc8a5a421f21"
+checksum = "d9004c50b26bf8ba7897dea6bc1454bebc60cc63b3bedfbb30f180e2e1ddcac6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1629,17 +1627,6 @@ checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
  "bit-set 0.5.3",
  "regex",
-]
-
-[[package]]
-name = "fancy-regex"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
-dependencies = [
- "bit-set 0.8.0",
- "regex-automata",
- "regex-syntax",
 ]
 
 [[package]]
@@ -2746,25 +2733,20 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llmsim"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf2c7d8ebf2b6c24175cb89658e4818ca04b98b69a39ee3b5a110d0e7187f80"
+checksum = "539672f1cd48a53f2554427acb6c69cf4e2c24a706acb89c22b4681fe0c4b2a0"
 dependencies = [
  "async-stream",
- "axum",
- "clap",
  "futures-core",
  "futures-util",
  "rand 0.10.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "tiktoken-rs",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
- "tower-http",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -3747,7 +3729,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -3768,7 +3750,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -4196,12 +4178,6 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
@@ -4478,17 +4454,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
-dependencies = [
- "itoa",
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4572,17 +4537,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -5057,21 +5011,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiktoken-rs"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4a168cfc1d8ed65bf17a6ee0843ad9a68f863c63c0fb2fa7eab67838782ee"
-dependencies = [
- "anyhow",
- "base64",
- "bstr",
- "fancy-regex 0.17.0",
- "lazy_static",
- "regex",
- "rustc-hash 1.1.0",
-]
-
-[[package]]
 name = "time"
 version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5175,18 +5114,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite",
 ]
 
 [[package]]
@@ -5390,7 +5317,6 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
  "url",
 ]
 
@@ -5466,16 +5392,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5485,15 +5401,12 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]
@@ -5712,22 +5625,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "tungstenite"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
-dependencies = [
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.9.4",
- "sha1 0.10.6",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "typed-arena"
@@ -6440,6 +6337,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.6.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,18 +77,18 @@ tree-sitter-zig = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-everruns-anthropic = "0.16.1"
-everruns-core = "0.16.1"
-everruns-openai = "0.16.1"
+everruns-anthropic = "0.16.2"
+everruns-core = "0.16.2"
+everruns-openai = "0.16.2"
 # OpenRouter's first-class driver was split out of everruns-openai into its own
 # crate in 0.13.0; register it alongside openai to keep DriverId::OpenRouter.
-everruns-openrouter = "0.16.1"
-everruns-local = "0.16.1"
+everruns-openrouter = "0.16.2"
+everruns-local = "0.16.2"
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (specs/mcp.md, upstream runtime-mcp.md D2).
-everruns-runtime = { version = "0.16.1", features = ["mcp-stdio"] }
-everruns-integrations-duckduckgo = "0.16.1"
-everruns-integrations-daytona = "0.16.1"
+everruns-runtime = { version = "0.16.2", features = ["mcp-stdio"] }
+everruns-integrations-duckduckgo = "0.16.2"
+everruns-integrations-daytona = "0.16.2"
 arboard = { version = "3", features = ["wayland-data-control"] }
 futures = "0.3"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp"] }


### PR DESCRIPTION
## What

Bumps all `everruns-*` crates from `0.16.1` to `0.16.2` (latest published, released today). Crates updated in lockstep: `everruns-anthropic`, `everruns-core`, `everruns-openai`, `everruns-openrouter`, `everruns-local`, `everruns-runtime`, `everruns-integrations-duckduckgo`, `everruns-integrations-daytona`. `Cargo.lock` regenerated; transitive deps (`everruns-config`, `everruns-mcp`, `llmsim` 0.5.0) moved with them.

## Why

Keep yolop in lockstep with the latest published runtime crates, per AGENTS.md ("Keep public runtime crate versions in lockstep with what is published on crates.io").

## Validation

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo build --all-features` — ok
- `cargo test --all-features` — 540 + 31 passed, 0 failed (2 suites green); no API breaks
- `cargo run -- --provider llmsim -p "hi"` — binary starts, agent loop runs to completion

The passing suite against 0.16.2 with no source changes is the API-compatibility evidence.

## Security

No security-relevant code changes — version-only dependency bump. All `everruns-*` crates moved together (no mismatched-version soft API break). No new direct crates introduced.

## Follow-ups

No follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Waoz9fJbNvy4KoZuwQhTAb)_