### PR TITLE
refactor(evals): adopt mira-eval SDK; install mira from registries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,10 +71,11 @@ doppler run -- cargo run -- --provider openai -p "hi"
 The `evals/` directory holds [Mira](https://github.com/everruns/mira) eval
 studies for benchmarking yolop and other agents. `evals/swebench_verified/` is
 the SWE-bench Verified study — a single self-contained `swebench_verified.py`
-with PEP 723 inline deps; the `mira` host CLI drives it from that directory
-(`mira --cmd "uv run swebench_verified.py" run`). It is outside the Cargo
-workspace; `uv run` provisions its deps on first use, and its stdlib-only tests
-run with `python3 -m unittest discover -s evals/swebench_verified/tests`. See
+built on the `mira-eval` Python SDK, with PEP 723 inline deps; the `mira` host
+CLI drives it from that directory (`mira --cmd "uv run swebench_verified.py"
+run`). It is outside the Cargo workspace; `uv run` provisions its deps on first
+use, and its tests (which import the SDK) run with `uv run --with mira-eval -m
+unittest discover -s evals/swebench_verified/tests`. See
 [`evals/README.md`](evals/README.md).
 
 ## Git and commits

--- a/evals/README.md
+++ b/evals/README.md
@@ -12,9 +12,11 @@ agent, scoring). One study per subfolder.
 
 ## Running a study with mira
 
-Install the host CLI once (`brew install everruns/tap/mira`), then drive a study
-from its own directory so its `mira.toml` is found and `--save` archives land in
-that study's `results/`:
+Install the host CLI once (`brew install everruns/tap/mira`, or from crates.io
+with `cargo install mira-cli --locked`), then drive a study from its own
+directory so its `mira.toml` is found and `--save` archives land in that study's
+`results/`. (Authoring a Python study? The [`mira-eval`](https://pypi.org/project/mira-eval/)
+SDK is on PyPI — `pip install mira-eval`.)
 
 ```bash
 cd evals/swebench_verified

--- a/evals/swebench_verified/README.md
+++ b/evals/swebench_verified/README.md
@@ -184,8 +184,13 @@ with `AGENTS=codex,pi evals/swebench_verified/bootstrap.sh`. Manual equivalent:
 ```bash
 ( cd ../.. && cargo build --release )    # produces target/release/yolop
 brew install everruns/tap/mira           # the host CLI that drives the study
+# …or from crates.io:  cargo install mira-cli --locked
 # Python deps need nothing — `uv run swebench_verified.py` installs them on first use.
 ```
+
+This study speaks the Mira protocol directly (stdlib only). To author a new
+Python study ergonomically, the [`mira-eval`](https://pypi.org/project/mira-eval/)
+SDK is on PyPI (`pip install mira-eval`).
 
 Requires a running **Docker** daemon (SWE-bench runs the hidden tests in
 per-instance containers) and provider keys in the environment: `OPENAI_API_KEY`

--- a/evals/swebench_verified/README.md
+++ b/evals/swebench_verified/README.md
@@ -183,8 +183,9 @@ with `AGENTS=codex,pi evals/swebench_verified/bootstrap.sh`. Manual equivalent:
 
 ```bash
 ( cd ../.. && cargo build --release )    # produces target/release/yolop
-brew install everruns/tap/mira           # the host CLI that drives the study
-# …or from crates.io:  cargo install mira-cli --locked
+brew install everruns/tap/mira           # the host CLI (prebuilt binary, recommended)
+# …or from crates.io:  cargo install mira-cli --locked   (compiles from source)
+# bootstrap.sh prefers a prebuilt binary via cargo-binstall when available.
 # Python deps need nothing — `uv run swebench_verified.py` installs them on first use.
 ```
 

--- a/evals/swebench_verified/README.md
+++ b/evals/swebench_verified/README.md
@@ -149,10 +149,11 @@ self-contained.
 evals/swebench_verified/
   swebench_verified.py   # the whole study: one file, PEP 723 inline deps
                          #   matrix, agents (yolop/claude-code/codex/pi), event-log
-                         #   metrics, SWE-bench load + Docker scoring, protocol loop
+                         #   metrics, SWE-bench load + Docker scoring; the protocol
+                         #   loop is the mira-eval SDK (the `mira` package)
   mira.toml              # host config: [results].dir -> ./results
   suites/                # curated instance subsets (tracking-v1.json + selector)
-  tests/                 # stdlib-only unit tests (run with plain python3)
+  tests/                 # unit tests; need the SDK (uv run --with mira-eval -m unittest …)
   results/               # mira --save run archives (<run_id>/) + pre-Mira history
   .cache/                # gitignored: dataset parquet, checkouts, raw logs, eval scratch
 ```
@@ -189,9 +190,12 @@ brew install everruns/tap/mira           # the host CLI (prebuilt binary, recomm
 # Python deps need nothing — `uv run swebench_verified.py` installs them on first use.
 ```
 
-This study speaks the Mira protocol directly (stdlib only). To author a new
-Python study ergonomically, the [`mira-eval`](https://pypi.org/project/mira-eval/)
-SDK is on PyPI (`pip install mira-eval`).
+This study is built on the [`mira-eval`](https://pypi.org/project/mira-eval/)
+Python SDK (the `mira` package on PyPI): the SDK owns the stdio protocol loop
+(initialize / list / run / execute / score) and `uv run` installs it from the
+PEP 723 deps, so `uv run swebench_verified.py` needs nothing extra. To run the
+unit tests outside `uv run`, install the SDK first (`pip install mira-eval`, or
+`uv run --with mira-eval -m unittest discover -s tests`).
 
 Requires a running **Docker** daemon (SWE-bench runs the hidden tests in
 per-instance containers) and provider keys in the environment: `OPENAI_API_KEY`

--- a/evals/swebench_verified/bootstrap.sh
+++ b/evals/swebench_verified/bootstrap.sh
@@ -52,8 +52,8 @@ if have mira; then
 elif have brew; then
   brew install everruns/tap/mira || echo "  ! mira install failed; install manually"
 elif have cargo; then
-  # mira-cli isn't on crates.io yet — install from the upstream repo.
-  cargo install --git https://github.com/everruns/mira mira-cli --locked \
+  # The mira host CLI is published on crates.io as `mira-cli`.
+  cargo install mira-cli --locked \
     || echo "  ! mira install failed; install manually"
 else
   echo "  ! no brew/cargo; install mira manually (brew install everruns/tap/mira)"

--- a/evals/swebench_verified/bootstrap.sh
+++ b/evals/swebench_verified/bootstrap.sh
@@ -51,10 +51,19 @@ if have mira; then
   mira --version 2>&1 | head -1 || true
 elif have brew; then
   brew install everruns/tap/mira || echo "  ! mira install failed; install manually"
-elif have cargo; then
-  # The mira host CLI is published on crates.io as `mira-cli`.
-  cargo install mira-cli --locked \
-    || echo "  ! mira install failed; install manually"
+elif have cargo-binstall || have cargo; then
+  # Prefer a prebuilt binary (seconds) over compiling mira-cli from source
+  # (minutes). mira-cli ships no [package.metadata.binstall], and its release
+  # assets are named after the binary (mira-<target>.tar.gz, tag v<version>),
+  # not the crate, so cargo-binstall needs explicit URL/layout overrides.
+  if have cargo-binstall && cargo binstall -y mira-cli \
+       --pkg-url "{ repo }/releases/download/v{ version }/mira-{ target }.tar.gz" \
+       --pkg-fmt tgz --bin-dir "mira{ binary-ext }"; then
+    :
+  else
+    cargo install mira-cli --locked \
+      || echo "  ! mira install failed; install manually"
+  fi
 else
   echo "  ! no brew/cargo; install mira manually (brew install everruns/tap/mira)"
 fi

--- a/evals/swebench_verified/swebench_verified.py
+++ b/evals/swebench_verified/swebench_verified.py
@@ -1,14 +1,16 @@
 # /// script
 # requires-python = ">=3.11"
-# dependencies = ["pandas>=2.0", "pyarrow>=14.0", "swebench>=4.1.0"]
+# dependencies = ["mira-eval>=0.1.0", "pandas>=2.0", "pyarrow>=14.0", "swebench>=4.1.0"]
 # ///
 """swebench_verified — a single-file Mira eval study for SWE-bench Verified.
 
 Mira's host CLI speaks newline-delimited JSON over stdio to a child process, so
 an eval study can be any program in any language. This is that program for
-yolop's SWE-bench Verified benchmark — one self-contained file with its
-dependencies declared inline (PEP 723), so `uv` builds an ephemeral env and runs
-it with no project scaffolding:
+yolop's SWE-bench Verified benchmark, built on the `mira-eval` Python SDK (the
+`mira` package on PyPI) — the SDK owns the stdio protocol loop (initialize / list
+/ run / execute / score) while this file owns the SWE-bench-specific work. One
+self-contained file with its dependencies declared inline (PEP 723), so `uv`
+builds an ephemeral env and runs it with no project scaffolding:
 
     cd evals/swebench_verified
     mira --cmd "uv run swebench_verified.py" list
@@ -47,14 +49,16 @@ import sys
 import time
 import urllib.request
 import uuid
+from collections import abc
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Iterator, Mapping, Sequence
 
-# Mira collapsed its pre-release minors back to a single 1.0 baseline; everything
-# we emit (open-ended `metadata`, the numeric `metrics` map, `error_kind`, and
-# per-target `metadata` columns) is part of that baseline.
-PROTOCOL_VERSION = "1.0"
+import mira  # the mira-eval SDK: protocol types + the stdio serve loop
+
+# The mira-eval SDK pins the protocol version (`mira.PROTOCOL_VERSION`, currently
+# "1.0"); everything we emit (open-ended `metadata`, the numeric `metrics` map,
+# `error_kind`, and per-target `metadata` columns) is part of that 1.0 baseline.
 STUDY_VERSION = "0.5.0"
 
 HERE = Path(__file__).resolve().parent
@@ -858,14 +862,127 @@ def suite_membership() -> dict[str, list[str]]:
 
 
 # ============================================================================ #
-# The study — answers Mira initialize/list/run over stdio. One process serves
-# many run requests, so the dataset is loaded once and reused.
+# The study — owns the SWE-bench-specific work behind the mira-eval SDK. The SDK
+# (`mira.Study`) owns the stdio protocol loop (initialize/list/run/execute/score)
+# and the scoring/verdict machinery; this `Study` holds the dataset cache and the
+# Docker-scoring config, and exposes a subject `(sample, cx) -> mira.Transcript`.
+# One process serves many run requests, so the dataset is loaded once and reused.
 # ============================================================================ #
 def _sanitize(s: str) -> str:
     return "".join(c if c.isalnum() or c in "-._" else "_" for c in s)
 
 
+def _run_agent_cell(inst: Instance, target: str, spec: dict, *,
+                    max_workers: int, namespace: str, eval_timeout: int,
+                    do_eval: bool) -> tuple[AgentRun, bool, dict, str | None]:
+    """Checkout + run the agent + (optionally) Docker-score one cell. Module-level
+    so the unit tests can patch `checkout`/`run_agent`/`capture_patch`/
+    `evaluate_predictions` as globals. Returns (run, resolved, report, error_kind)."""
+    run = _run_agent(inst, target, spec)
+    # A checkout/setup failure is infra (not the agent's fault).
+    error_kind = "infra" if (run.error or "").startswith("runner:") else None
+    resolved, report, eval_err = _score(inst, run, target, do_eval=do_eval,
+                                        max_workers=max_workers, namespace=namespace,
+                                        eval_timeout=eval_timeout)
+    if eval_err and not run.error:
+        run.error = eval_err  # Docker/harness failed to score
+        error_kind = "infra"
+    return run, resolved, report, error_kind
+
+
+def _run_agent(inst: Instance, target: str, spec: dict) -> AgentRun:
+    run_id = f"{_sanitize(target)}-{_sanitize(inst.instance_id)}-{uuid.uuid4().hex[:6]}"
+    workdir = CACHE_DIR / "work" / run_id
+    session_dir = CACHE_DIR / "sessions" / run_id
+    session_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        checkout(inst, workdir)
+        run = run_agent(spec, inst, str(workdir), str(session_dir))
+        run.patch = capture_patch(workdir)
+    except Exception as e:  # report, don't crash the study loop
+        log(f"agent run failed for {target}/{inst.instance_id}: {e}")
+        run = AgentRun(patch="", metrics=RunMetrics(), error=f"runner: {e}")
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+    return run
+
+
+def _score(inst: Instance, run: AgentRun, target: str, *, do_eval: bool,
+           max_workers: int, namespace: str, eval_timeout: int):
+    if not do_eval:
+        return False, {}, None
+    try:
+        run_id = f"{_sanitize(target)}-{_sanitize(inst.instance_id)}-{uuid.uuid4().hex[:6]}"
+        results = evaluate_predictions({inst.instance_id: run.patch}, [inst], run_id,
+                                       max_workers=max_workers, namespace=namespace,
+                                       timeout=eval_timeout)
+        ev = results.get(inst.instance_id)
+        if ev is None:
+            return False, {}, "no eval result"
+        return bool(ev.resolved), ev.report, ev.error
+    except Exception as e:  # Docker/infra failure: not resolved, surface it
+        log(f"eval failed for {target}/{inst.instance_id}: {e}")
+        return False, {}, f"eval: {e}"
+
+
+def _build_transcript(run: AgentRun, resolved: bool, report: dict,
+                      spec: dict, inst: Instance, error_kind: str | None) -> mira.Transcript:
+    m = run.metrics
+    tools = [name for name, count in m.tools_used.items() for _ in range(count)]
+    # `metrics` is the numeric map the host's generic budget scorers read; keep
+    # anything numeric here (incl. cache_creation_tokens, which mira.Usage has no
+    # field for). `metadata` is open-ended JSON: structured values, not strings.
+    metrics: dict[str, float] = {
+        "turns": m.turns, "iterations": m.iterations, "tool_calls": m.tool_calls,
+        "tool_calls_failed": m.tool_calls_failed,
+        "cache_read_tokens": m.tokens.cache_read_tokens,
+        "cache_creation_tokens": m.tokens.cache_creation_tokens,
+    }
+    if m.agent_reported_time_s is not None:
+        metrics["agent_reported_time_s"] = m.agent_reported_time_s
+    return mira.Transcript(
+        final_response=f"resolved={resolved}",
+        iterations=m.iterations,
+        tool_calls_count=m.tool_calls,
+        tool_calls=tools,
+        usage=mira.Usage(input_tokens=m.tokens.input_tokens, output_tokens=m.tokens.output_tokens,
+                         cache_read_tokens=m.tokens.cache_read_tokens, cost_usd=m.cost_usd),
+        timing=mira.Timing(duration_ms=int(m.wall_time_s * 1000)),
+        metrics=metrics,
+        files={"model_patch.diff": run.patch} if run.patch else {},
+        # No `config` here: mira already records the target id as the case `model`
+        # column, so echoing it again only invites rename drift.
+        metadata={
+            "agent": spec.get("agent", "yolop"),
+            "provider": spec.get("provider") or "", "model": spec.get("model") or "",
+            "reasoning_effort": m.reasoning_effort, "stop_reason": m.stop_reason,
+            "resolved": resolved, "repo": inst.repo,
+            "difficulty": (inst.extra or {}).get("difficulty"),
+            "tools_used": m.tools_used, "eval_report": report or {},
+        },
+        error=run.error,
+        # Infra errors (Docker/harness, checkout) are surfaced as N/A by the SDK's
+        # scorer short-circuit and retried — not counted as the model getting it
+        # wrong. `error_kind` left None on a clean run (omitted on the wire).
+        error_kind=error_kind,
+    )
+
+
+def _resolved_scorer() -> mira.Scorer:
+    """The benchmark gate: did the hidden FAIL_TO_PASS suite pass? Reads the
+    verdict the subject already computed (and stashed in transcript metadata) so
+    a score-later pass needs no Docker."""
+    def fn(_sample, transcript) -> mira.Score:
+        resolved = bool(transcript.metadata.get("resolved"))
+        return mira.make_score("resolved", 1.0 if resolved else 0.0, resolved,
+                               "FAIL_TO_PASS passed" if resolved else "not resolved")
+    return mira.scorer("resolved", fn)
+
+
 class Study:
+    """SWE-bench study state: the dataset cache plus the Docker-scoring config.
+    `protocol()` wires it into a `mira.Study` (the SDK protocol layer)."""
+
     def __init__(self, *, do_eval: bool = True, max_workers: int = 4,
                  namespace: str = "swebench", eval_timeout: int = 1800):
         self.do_eval = do_eval
@@ -879,149 +996,78 @@ class Study:
             self._instances = {i.instance_id: i for i in load_instances()}
         return self._instances
 
-    # -- protocol handlers -------------------------------------------------
-    def initialize(self) -> dict[str, Any]:
-        return {"protocol_version": PROTOCOL_VERSION, "study": "swebench_verified",
-                "study_version": STUDY_VERSION, "evals": 1, "capabilities": ["usage"]}
+    def _subject(self, sample: mira.Sample, cx: mira.RunCx) -> mira.Transcript:
+        """Run one (instance, config) cell. The SDK has already skipped
+        unavailable targets, so any target reaching here is runnable."""
+        spec = MATRIX.get(cx.target)
+        if spec is None:
+            raise ValueError(f"unknown target/config: {cx.target!r}")
+        inst = self.instances().get(sample.id)
+        if inst is None:
+            raise ValueError(f"unknown sample/instance: {sample.id!r}")
+        run, resolved, report, error_kind = _run_agent_cell(
+            inst, cx.target, spec, max_workers=self.max_workers, namespace=self.namespace,
+            eval_timeout=self.eval_timeout, do_eval=self.do_eval)
+        return _build_transcript(run, resolved, report, spec, inst, error_kind)
 
-    def list(self) -> dict[str, Any]:
+    def _build_samples(self) -> list[mira.Sample]:
         membership = suite_membership()
-        samples = []
+        samples: list[mira.Sample] = []
         for iid, inst in self.instances().items():
             tags = [inst.repo] if inst.repo else []
             difficulty = (inst.extra or {}).get("difficulty")
             if difficulty:
                 tags.append(_sanitize(str(difficulty)))
             tags.extend(membership.get(iid, []))
-            samples.append({"id": iid, "tags": tags,
-                            "metadata": {"repo": inst.repo or "", "difficulty": str(difficulty or "")}})
+            # The subject pulls the full problem statement from the Instance, so
+            # the Sample carries only the routing metadata (the SDK doesn't put a
+            # prompt on the wire `list` anyway).
+            samples.append(mira.Sample(
+                iid, tags=tags,
+                metadata={"repo": inst.repo or "", "difficulty": str(difficulty or "")}))
+        return samples
+
+    def _targets(self) -> list[mira.Target]:
         # Each MATRIX entry is a Mira *target* (the thing under evaluation — here a
-        # harness/agent config, not just a model). label = config name.
-        targets = [{"label": name, "provider": spec.get("provider") or spec.get("agent", "yolop"),
-                    "available": config_available(spec), "metadata": _target_metadata(spec)}
-                   for name, spec in MATRIX.items()]
-        return {"evals": [{
-            "name": "swebench_verified",
-            "description": "Resolve SWE-bench instances; FAIL_TO_PASS via the official Docker harness",
-            "samples": samples, "scorers": ["succeeded", "resolved"], "targets": targets,
-            "max_turns": 0, "metadata": {"benchmark": "swebench_verified"},
-        }]}
+        # harness/agent config, not just a model). label = config name; an absent
+        # provider key marks it unavailable so the SDK reports it N/A and skips it.
+        return [mira.target(name, provider=spec.get("provider") or spec.get("agent", "yolop"),
+                            available=config_available(spec), metadata=_target_metadata(spec))
+                for name, spec in MATRIX.items()]
 
-    def run(self, params: dict[str, Any]) -> dict[str, Any]:
-        eval_name, sample_id, target = params.get("eval"), params.get("sample"), params.get("target")
-        if eval_name != "swebench_verified":
-            raise ValueError(f"unknown eval: {eval_name!r}")
-        spec = MATRIX.get(target)
-        if spec is None:
-            raise ValueError(f"unknown target/config: {target!r}")
-        inst = self.instances().get(sample_id)
-        if inst is None:
-            raise ValueError(f"unknown sample/instance: {sample_id!r}")
-        if not config_available(spec):
-            return self._result(eval_name, sample_id, target, skipped=True)
+    def protocol(self) -> mira.Study:
+        study = mira.Study("swebench_verified", version=STUDY_VERSION)
+        # Samples are lazy (_LazySamples): the dataset loads on the first `list`/
+        # `run`, not at construction, so `initialize` stays cheap and works offline
+        # (the SDK's `initialize` only counts evals, never enumerates samples).
+        study.add(mira.Eval(
+            name="swebench_verified", subject=self._subject,
+            samples=_LazySamples(self), targets=self._targets(),
+            scorers=[mira.succeeded(), _resolved_scorer()],
+            description="Resolve SWE-bench instances; FAIL_TO_PASS via the official Docker harness",
+            metadata={"benchmark": "swebench_verified"}))
+        return study
 
-        run = self._run_agent(inst, target, spec)
-        # A checkout/setup failure is infra (not the agent's fault).
-        error_kind = "infra" if (run.error or "").startswith("runner:") else None
-        resolved, report, eval_err = self._score(inst, run, target)
-        if eval_err and not run.error:
-            run.error = eval_err  # Docker/harness failed to score
-            error_kind = "infra"
 
-        scores = [
-            {"scorer": "succeeded", "value": 0.0 if run.error else 1.0,
-             "pass": run.error is None, "reason": run.error or "agent run completed"},
-            {"scorer": "resolved", "value": 1.0 if resolved else 0.0, "pass": resolved,
-             "reason": "FAIL_TO_PASS passed" if resolved else "not resolved"},
-        ]
-        aggregate = sum(s["value"] for s in scores) / len(scores)
-        # `resolved` is the benchmark gate; `succeeded` is reported for signal.
-        # On an infra error the host overrides these to a single N/A.
-        return self._result(eval_name, sample_id, target, passed=resolved, aggregate=aggregate,
-                            scores=scores,
-                            transcript=self._transcript(run, resolved, report, spec, inst, error_kind))
+class _LazySamples(abc.Sequence):
+    """A Sequence of the study's samples that materializes (loading the dataset)
+    only on first access, then caches. Lets `protocol()` build the Eval — and the
+    host answer `initialize` — without touching the dataset."""
 
-    # -- helpers -----------------------------------------------------------
-    def _run_agent(self, inst: Instance, target: str, spec: dict) -> AgentRun:
-        run_id = f"{_sanitize(target)}-{_sanitize(inst.instance_id)}-{uuid.uuid4().hex[:6]}"
-        workdir = CACHE_DIR / "work" / run_id
-        session_dir = CACHE_DIR / "sessions" / run_id
-        session_dir.mkdir(parents=True, exist_ok=True)
-        try:
-            checkout(inst, workdir)
-            run = run_agent(spec, inst, str(workdir), str(session_dir))
-            run.patch = capture_patch(workdir)
-        except Exception as e:  # report, don't crash the study loop
-            log(f"agent run failed for {target}/{inst.instance_id}: {e}")
-            run = AgentRun(patch="", metrics=RunMetrics(), error=f"runner: {e}")
-        finally:
-            shutil.rmtree(workdir, ignore_errors=True)
-        return run
+    def __init__(self, study: Study):
+        self._study = study
+        self._cache: list[mira.Sample] | None = None
 
-    def _score(self, inst: Instance, run: AgentRun, target: str):
-        if not self.do_eval:
-            return False, {}, None
-        try:
-            run_id = f"{_sanitize(target)}-{_sanitize(inst.instance_id)}-{uuid.uuid4().hex[:6]}"
-            results = evaluate_predictions({inst.instance_id: run.patch}, [inst], run_id,
-                                           max_workers=self.max_workers, namespace=self.namespace,
-                                           timeout=self.eval_timeout)
-            ev = results.get(inst.instance_id)
-            if ev is None:
-                return False, {}, "no eval result"
-            return bool(ev.resolved), ev.report, ev.error
-        except Exception as e:  # Docker/infra failure: not resolved, surface it
-            log(f"eval failed for {target}/{inst.instance_id}: {e}")
-            return False, {}, f"eval: {e}"
+    def _materialized(self) -> list[mira.Sample]:
+        if self._cache is None:
+            self._cache = self._study._build_samples()
+        return self._cache
 
-    def _transcript(self, run: AgentRun, resolved: bool, report: dict,
-                    spec: dict, inst: Instance, error_kind: str | None):
-        m = run.metrics
-        tools = [name for name, count in m.tools_used.items() for _ in range(count)]
-        files = {"model_patch.diff": run.patch} if run.patch else {}
-        # metadata is open-ended JSON (protocol 1.4): structured values, not
-        # stringified. Use `metrics` (1.2) for anything numeric so it surfaces in
-        # reports and feeds generic budget scorers.
-        metrics = {
-            "turns": m.turns, "iterations": m.iterations, "tool_calls": m.tool_calls,
-            "tool_calls_failed": m.tool_calls_failed,
-            "cache_read_tokens": m.tokens.cache_read_tokens,
-            "cache_creation_tokens": m.tokens.cache_creation_tokens,
-        }
-        if m.agent_reported_time_s is not None:
-            metrics["agent_reported_time_s"] = m.agent_reported_time_s
-        transcript = {
-            "final_response": f"resolved={resolved}", "iterations": m.iterations,
-            "tool_calls_count": m.tool_calls, "tool_calls": tools,
-            "usage": {"input_tokens": m.tokens.input_tokens, "output_tokens": m.tokens.output_tokens,
-                      "cache_read_tokens": m.tokens.cache_read_tokens,
-                      "cache_creation_tokens": m.tokens.cache_creation_tokens,
-                      "total_tokens": m.tokens.total_tokens, "cost_usd": m.cost_usd},
-            "timing": {"duration_ms": int(m.wall_time_s * 1000)},
-            "metrics": metrics, "files": files,
-            # No `config` here: mira already records the target id as the case
-            # `model` column, so echoing it again only invites rename drift.
-            "metadata": {
-                "agent": spec.get("agent", "yolop"),
-                "provider": spec.get("provider") or "", "model": spec.get("model") or "",
-                "reasoning_effort": m.reasoning_effort, "stop_reason": m.stop_reason,
-                "resolved": resolved, "repo": inst.repo,
-                "difficulty": (inst.extra or {}).get("difficulty"),
-                "tools_used": m.tools_used, "eval_report": report or {},
-            },
-            "error": run.error,
-        }
-        # Infra errors (Docker/harness, checkout) are surfaced as N/A by the host
-        # and retried — not counted as the model getting it wrong.
-        if error_kind:
-            transcript["error_kind"] = error_kind
-        return transcript
+    def __getitem__(self, index):
+        return self._materialized()[index]
 
-    def _result(self, eval_name, sample_id, target, *, passed=False, aggregate=0.0,
-                scores=None, transcript=None, skipped=False) -> dict[str, Any]:
-        return {"eval": eval_name, "sample": sample_id, "target": target, "passed": passed,
-                "aggregate": aggregate, "scores": scores or [],
-                "transcript": transcript or {"final_response": "", "error": None}, "skipped": skipped}
+    def __len__(self) -> int:
+        return len(self._materialized())
 
 
 def _build_study() -> Study:
@@ -1039,33 +1085,10 @@ def _build_study() -> Study:
 
 
 def serve(study: Study | None = None) -> None:
-    """Run the stdio protocol loop until stdin closes."""
+    """Build the study and run the SDK's stdio protocol loop until stdin closes."""
     study = study or _build_study()
     log(f"ready: study=swebench_verified do_eval={study.do_eval}")
-    for line in sys.stdin:
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            msg = json.loads(line)
-        except json.JSONDecodeError:
-            print(json.dumps({"method": "log", "params": {"message": "bad json"}}), flush=True)
-            continue
-        rid, method, params = msg.get("id"), msg.get("method"), msg.get("params", {})
-        try:
-            if method == "initialize":
-                result = study.initialize()
-            elif method == "list":
-                result = study.list()
-            elif method == "run":
-                result = study.run(params)
-            else:
-                raise ValueError(f"unknown method: {method!r}")
-            print(json.dumps({"id": rid, "result": result}), flush=True)
-        except Exception as exc:  # noqa: BLE001 — report, never crash the loop
-            log(f"error handling {method}: {exc}")
-            print(json.dumps({"id": rid, "error": {"message": str(exc)}}), flush=True)
-    log("stdin closed, exiting")
+    study.protocol().serve()
 
 
 def main() -> int:

--- a/evals/swebench_verified/tests/test_study.py
+++ b/evals/swebench_verified/tests/test_study.py
@@ -1,15 +1,19 @@
-"""Tests for the Mira eval study protocol layer.
+"""Tests for the study's SWE-bench-specific logic.
 
-The study is built on the `mira-eval` SDK (the `mira` package); these tests drive
-it through the SDK's protocol dispatch (`Study.protocol().handle(method, params)`)
-with the dataset, agent, and Docker scorer faked, so they exercise the protocol
-mapping (initialize/list/run/execute, sample tagging, target availability,
-transcript + score shape, stdout cleanliness) with no network or Docker.
+The protocol loop, scoring/verdict math, pagination, and wire serialization
+belong to the `mira-eval` SDK and are covered by its own conformance suite — we
+don't re-test them here. These tests exercise only what this study owns:
 
-Needs `mira-eval` installed (the study imports it); run, e.g.:
+* sample tagging (instance -> repo/difficulty/suite tags),
+* the target matrix (availability from env, config metadata),
+* transcript building (usage/metrics/metadata/files mapping, infra error_kind),
+* the `resolved` scorer and the cell orchestration (checkout + agent + score),
+* stdout cleanliness of the Docker scorer.
+
+Plus one thin integration smoke that the study registers with the SDK and a run
+flows through it. Needs `mira-eval` installed (the study imports it):
 
     uv run --with mira-eval -m unittest discover -s evals/swebench_verified/tests
-    # or: pip install mira-eval && python3 -m unittest discover -s evals/swebench_verified/tests
 """
 
 import sys
@@ -19,6 +23,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+import mira  # noqa: E402  (SDK types for the unit tests below)
 import swebench_verified as sv  # noqa: E402
 from swebench_verified import AgentRun, EvalResult, Instance, RunMetrics, Study, TokenUsage  # noqa: E402
 
@@ -39,137 +44,153 @@ def _fake_agent_run(*_a, **_k):
     m = RunMetrics(
         wall_time_s=1.5, turns=3, iterations=3, tool_calls=2,
         tools_used={"edit_file": 1, "read_file": 1},
-        tokens=TokenUsage(input_tokens=100, output_tokens=20),
-        cost_usd=0.01, stop_reason="completed",
+        tokens=TokenUsage(input_tokens=100, output_tokens=20,
+                          cache_read_tokens=5, cache_creation_tokens=7),
+        cost_usd=0.01, reasoning_effort="high", stop_reason="completed",
     )
     return AgentRun(patch="diff --git a b", metrics=m)
 
 
-class InitializeListTest(unittest.TestCase):
-    def test_initialize_announces_study(self):
-        info = _study().protocol().handle("initialize", {})
-        self.assertEqual(info["protocol_version"], "1.0")
-        self.assertEqual(info["study"], "swebench_verified")
-        self.assertIn("usage", info["capabilities"])
+class SamplesTest(unittest.TestCase):
+    """`_build_samples`: instances -> mira.Sample with our tags/metadata."""
 
-    def test_list_maps_instances_to_samples(self):
-        ev = _study().protocol().handle("list", {})["evals"][0]
-        self.assertEqual(ev["name"], "swebench_verified")
-        sample = ev["samples"][0]
-        self.assertEqual(sample["id"], "org__repo-1")
-        self.assertIn("org/repo", sample["tags"])             # repo tag
-        self.assertIn("15_min_-_1_hour", sample["tags"])      # sanitized difficulty
+    def test_tags_repo_and_sanitized_difficulty(self):
+        sample = _study()._build_samples()[0]
+        self.assertEqual(sample.id, "org__repo-1")
+        self.assertIn("org/repo", sample.tags)            # repo tag
+        self.assertIn("15_min_-_1_hour", sample.tags)     # sanitized difficulty
+        self.assertEqual(sample.metadata["repo"], "org/repo")
 
-    def test_list_targets_reflect_availability(self):
-        # Availability is baked into the targets when the protocol study is built,
-        # so build it under the patched environment.
+
+class TargetsTest(unittest.TestCase):
+    """`_targets`: the MATRIX as mira.Target columns."""
+
+    def test_availability_reflects_env(self):
         with mock.patch.dict("os.environ", {"OPENAI_API_KEY": "", "ANTHROPIC_API_KEY": ""}):
-            targets = {m["label"]: m for m in
-                       _study().protocol().handle("list", {})["evals"][0]["targets"]}
-        self.assertTrue(targets["llmsim"]["available"])           # offline provider
-        self.assertFalse(targets["openai-gpt-5.5"]["available"])  # no key -> skipped
+            targets = {t.label: t for t in _study()._targets()}
+        self.assertTrue(targets["llmsim"].available)            # offline provider
+        self.assertFalse(targets["openai-gpt-5.5"].available)   # no key -> skipped
 
-    def test_list_targets_carry_config_metadata(self):
-        targets = {m["label"]: m for m in
-                   _study().protocol().handle("list", {})["evals"][0]["targets"]}
+    def test_carry_config_metadata(self):
+        targets = {t.label: t for t in _study()._targets()}
         # config detail rides the target column for `mira run --group-by agent`
-        self.assertEqual(targets["openai-gpt-5.5-high"]["metadata"]["agent"], "yolop")
-        self.assertEqual(targets["openai-gpt-5.5-high"]["metadata"]["reasoning_effort"], "high")
-        self.assertEqual(targets["codex"]["metadata"]["agent"], "codex")
-        self.assertIn("price", targets["codex"]["metadata"])
+        self.assertEqual(targets["openai-gpt-5.5-high"].metadata["agent"], "yolop")
+        self.assertEqual(targets["openai-gpt-5.5-high"].metadata["reasoning_effort"], "high")
+        self.assertEqual(targets["codex"].metadata["agent"], "codex")
+        self.assertIn("price", targets["codex"].metadata)
 
 
-class RunTest(unittest.TestCase):
-    def _handle(self, method, *, resolved=True, do_eval=True, model="llmsim",
-                sample="org__repo-1"):
+class TranscriptTest(unittest.TestCase):
+    """`_build_transcript`: RunMetrics + scoring -> mira.Transcript."""
+
+    def _transcript(self, *, resolved=True, error=None, error_kind=None, patch="diff --git a b"):
+        run = AgentRun(patch=patch, metrics=_fake_agent_run().metrics, error=error)
+        return sv._build_transcript(
+            run, resolved, {"resolved": resolved},
+            {"agent": "yolop", "provider": "openai", "model": "gpt-5.5"},
+            _INSTANCE, error_kind)
+
+    def test_usage_and_metrics(self):
+        t = self._transcript()
+        self.assertEqual(t.usage.input_tokens, 100)
+        self.assertEqual(t.usage.cost_usd, 0.01)
+        self.assertEqual(t.usage.cache_read_tokens, 5)
+        self.assertEqual(t.metrics["turns"], 3)
+        self.assertEqual(t.metrics["tool_calls"], 2)
+        # cache_creation has no mira.Usage field, so it rides the metrics map
+        self.assertEqual(t.metrics["cache_creation_tokens"], 7)
+
+    def test_metadata_is_structured(self):
+        md = self._transcript(resolved=True).metadata
+        self.assertIs(md["resolved"], True)               # bool, not stringified
+        self.assertEqual(md["repo"], "org/repo")
+        self.assertEqual(md["tools_used"], {"edit_file": 1, "read_file": 1})
+        self.assertEqual(md["eval_report"], {"resolved": True})
+        self.assertEqual(md["agent"], "yolop")            # harness identity carried
+        self.assertNotIn("config", md)                    # target id not duplicated
+
+    def test_patch_rides_files(self):
+        self.assertEqual(self._transcript().files["model_patch.diff"], "diff --git a b")
+        self.assertEqual(self._transcript(patch="").files, {})  # no patch -> no file
+
+    def test_error_kind_passthrough(self):
+        self.assertIsNone(self._transcript().error_kind)  # clean run
+        self.assertEqual(self._transcript(error="x", error_kind="infra").error_kind, "infra")
+
+
+class ResolvedScorerTest(unittest.TestCase):
+    """The `resolved` scorer reads the verdict the subject stashed in metadata."""
+
+    def test_reads_resolved_from_metadata(self):
+        sc = sv._resolved_scorer()
+        ok = sc.score(None, mira.Transcript(metadata={"resolved": True}))
+        self.assertTrue(ok.pass_)
+        self.assertEqual(ok.value, 1.0)
+        bad = sc.score(None, mira.Transcript(metadata={"resolved": False}))
+        self.assertFalse(bad.pass_)
+
+
+class CellTest(unittest.TestCase):
+    """`_run_agent_cell` / `_subject`: checkout + agent + Docker-score one cell,
+    classifying infra failures and honouring do_eval."""
+
+    def _cell(self, *, do_eval, run_agent=_fake_agent_run, evaluate=None):
+        evaluate = evaluate or (lambda *a, **k: {_INSTANCE.instance_id: EvalResult(True, {"resolved": True})})
+        with mock.patch.object(sv, "checkout", lambda *a, **k: None), \
+             mock.patch.object(sv, "capture_patch", lambda *a, **k: "diff --git a b"), \
+             mock.patch.object(sv, "run_agent", run_agent), \
+             mock.patch.object(sv, "evaluate_predictions", evaluate):
+            return sv._run_agent_cell(_INSTANCE, "llmsim", {"agent": "yolop"},
+                                      max_workers=1, namespace="x", eval_timeout=1, do_eval=do_eval)
+
+    def test_runner_failure_is_infra(self):
+        def boom(*_a, **_k):
+            raise RuntimeError("boom")
+        run, _resolved, _report, error_kind = self._cell(do_eval=False, run_agent=boom)
+        self.assertEqual(error_kind, "infra")
+        self.assertTrue(run.error.startswith("runner:"))
+
+    def test_eval_failure_is_infra(self):
+        evaluate = lambda *a, **k: {_INSTANCE.instance_id: EvalResult(False, {}, "no report.json")}
+        run, _resolved, _report, error_kind = self._cell(do_eval=True, evaluate=evaluate)
+        self.assertEqual(error_kind, "infra")
+        self.assertEqual(run.error, "no report.json")
+
+    def test_no_eval_skips_scoring(self):
+        called = []
+        evaluate = lambda *a, **k: called.append(1) or {}
+        _run, resolved, _report, error_kind = self._cell(do_eval=False, evaluate=evaluate)
+        self.assertFalse(resolved)        # unscored -> not resolved
+        self.assertIsNone(error_kind)     # a clean (if unscored) run
+        self.assertEqual(called, [])      # Docker scorer not invoked
+
+    def test_unknown_target_raises(self):
+        # Our subject guards an unknown config (the host should never send one).
+        with self.assertRaises(ValueError):
+            _study()._subject(mira.Sample("org__repo-1"), mira.RunCx(target="nope"))
+
+
+class SdkIntegrationTest(unittest.TestCase):
+    """One smoke that the study registers with the SDK and a run flows through —
+    not a re-test of the SDK's dispatch/scoring internals."""
+
+    def test_initialize_exposes_study_identity(self):
+        info = _study().protocol().handle("initialize", {})
+        self.assertEqual(info["study"], "swebench_verified")
+        self.assertEqual(info["study_version"], sv.STUDY_VERSION)
+
+    def test_run_wires_subject_and_scorers(self):
         study = _study()
-        study.do_eval = do_eval
         with mock.patch.object(sv, "checkout", lambda *a, **k: None), \
              mock.patch.object(sv, "capture_patch", lambda *a, **k: "diff --git a b"), \
              mock.patch.object(sv, "run_agent", _fake_agent_run), \
              mock.patch.object(sv, "evaluate_predictions",
-                               lambda *a, **k: {sample: EvalResult(resolved, {"resolved": resolved})}):
-            return study.protocol().handle(
-                method, {"eval": "swebench_verified", "sample": sample, "target": model})
-
-    def test_resolved_cell_passes(self):
-        res = self._handle("run", resolved=True)
-        self.assertTrue(res["passed"])
-        self.assertFalse(res["skipped"])
-        names = {s["scorer"]: s for s in res["scores"]}
-        self.assertTrue(names["resolved"]["pass"])
-        self.assertTrue(names["succeeded"]["pass"])
-        tr = res["transcript"]
-        self.assertEqual(tr["usage"]["input_tokens"], 100)
-        self.assertEqual(tr["usage"]["cost_usd"], 0.01)
-        # numeric metrics map: values are plain numbers
-        self.assertEqual(tr["metrics"]["tool_calls"], 2)
-        self.assertEqual(tr["metrics"]["turns"], 3)
-        # open-ended metadata: structured, not stringified
-        md = tr["metadata"]
-        self.assertIs(md["resolved"], True)
-        self.assertEqual(md["repo"], "org/repo")
-        self.assertEqual(md["tools_used"], {"edit_file": 1, "read_file": 1})
-        self.assertEqual(md["eval_report"], {"resolved": True})
-        self.assertEqual(md["agent"], "yolop")  # harness identity still carried
-        # No `config` echo: the target id is the host's case `model` column, so
-        # the study must not duplicate it into transcript metadata.
-        self.assertNotIn("config", md)
-        self.assertNotIn("error_kind", tr)  # clean run: no infra error
-
-    def test_files_ride_the_execute_transcript(self):
-        # The run summary is lightweight (no files); the model patch rides the
-        # full transcript returned by `execute` (the SDK's artifact path).
-        tr = self._handle("execute", resolved=True)["transcript"]
-        self.assertIn("model_patch.diff", tr["files"])
-        self.assertEqual(tr["files"]["model_patch.diff"], "diff --git a b")
-
-    def test_infra_eval_failure_is_marked_na(self):
-        # When the Docker harness fails to score, the cell is an infra error
-        # (error_kind=infra) so the host treats it as N/A, not a model failure.
-        study = _study()
-        with mock.patch.object(sv, "checkout", lambda *a, **k: None), \
-             mock.patch.object(sv, "capture_patch", lambda *a, **k: "d"), \
-             mock.patch.object(sv, "run_agent", _fake_agent_run), \
-             mock.patch.object(sv, "evaluate_predictions",
-                               lambda *a, **k: {"org__repo-1": EvalResult(False, {}, "no report.json")}):
+                               lambda *a, **k: {"org__repo-1": EvalResult(True, {"resolved": True})}):
             res = study.protocol().handle(
                 "run", {"eval": "swebench_verified", "sample": "org__repo-1", "target": "llmsim"})
-        self.assertEqual(res["transcript"]["error_kind"], "infra")
-
-    def test_unresolved_cell_fails(self):
-        res = self._handle("run", resolved=False)
-        self.assertFalse(res["passed"])
-        self.assertFalse({s["scorer"]: s for s in res["scores"]}["resolved"]["pass"])
-
-    def test_no_eval_skips_scoring(self):
-        called = []
-        study = _study()
-        study.do_eval = False
-        with mock.patch.object(sv, "checkout", lambda *a, **k: None), \
-             mock.patch.object(sv, "capture_patch", lambda *a, **k: "d"), \
-             mock.patch.object(sv, "run_agent", _fake_agent_run), \
-             mock.patch.object(sv, "evaluate_predictions", lambda *a, **k: called.append(1) or {}):
-            res = study.protocol().handle(
-                "run", {"eval": "swebench_verified", "sample": "org__repo-1", "target": "llmsim"})
-        self.assertFalse(res["passed"])   # unscored -> not resolved
-        self.assertEqual(called, [])      # Docker scorer not invoked
-
-    def test_unavailable_config_is_skipped(self):
-        with mock.patch.dict("os.environ", {"OPENAI_API_KEY": ""}):
-            res = _study().protocol().handle(
-                "run", {"eval": "swebench_verified", "sample": "org__repo-1", "target": "openai-gpt-5.5"})
-        self.assertTrue(res["skipped"])
-
-    def test_unknown_sample_raises(self):
-        with self.assertRaises(ValueError):
-            _study().protocol().handle(
-                "run", {"eval": "swebench_verified", "sample": "nope", "target": "llmsim"})
-
-    def test_unknown_model_raises(self):
-        with self.assertRaises(ValueError):
-            _study().protocol().handle(
-                "run", {"eval": "swebench_verified", "sample": "org__repo-1", "target": "nope"})
+        self.assertEqual({s["scorer"] for s in res["scores"]}, {"succeeded", "resolved"})
+        self.assertTrue(res["passed"])  # both scorers pass on a resolved cell
+        self.assertEqual(res["transcript"]["metadata"]["repo"], "org/repo")  # our data flows out
 
 
 class StdoutCleanlinessTest(unittest.TestCase):

--- a/evals/swebench_verified/tests/test_study.py
+++ b/evals/swebench_verified/tests/test_study.py
@@ -1,11 +1,15 @@
 """Tests for the Mira eval study protocol layer.
 
-Fully offline: the dataset, agent, and Docker scorer are faked so the test
-exercises the protocol mapping (initialize/list/run, sample tagging, model
-availability, transcript + score shape, stdout cleanliness) with no network or
-Docker. Stdlib-only:
+The study is built on the `mira-eval` SDK (the `mira` package); these tests drive
+it through the SDK's protocol dispatch (`Study.protocol().handle(method, params)`)
+with the dataset, agent, and Docker scorer faked, so they exercise the protocol
+mapping (initialize/list/run/execute, sample tagging, target availability,
+transcript + score shape, stdout cleanliness) with no network or Docker.
 
-    python3 -m unittest discover -s evals/swebench_verified/tests
+Needs `mira-eval` installed (the study imports it); run, e.g.:
+
+    uv run --with mira-eval -m unittest discover -s evals/swebench_verified/tests
+    # or: pip install mira-eval && python3 -m unittest discover -s evals/swebench_verified/tests
 """
 
 import sys
@@ -43,13 +47,13 @@ def _fake_agent_run(*_a, **_k):
 
 class InitializeListTest(unittest.TestCase):
     def test_initialize_announces_study(self):
-        info = _study().initialize()
+        info = _study().protocol().handle("initialize", {})
         self.assertEqual(info["protocol_version"], "1.0")
         self.assertEqual(info["study"], "swebench_verified")
         self.assertIn("usage", info["capabilities"])
 
     def test_list_maps_instances_to_samples(self):
-        ev = _study().list()["evals"][0]
+        ev = _study().protocol().handle("list", {})["evals"][0]
         self.assertEqual(ev["name"], "swebench_verified")
         sample = ev["samples"][0]
         self.assertEqual(sample["id"], "org__repo-1")
@@ -57,22 +61,27 @@ class InitializeListTest(unittest.TestCase):
         self.assertIn("15_min_-_1_hour", sample["tags"])      # sanitized difficulty
 
     def test_list_targets_reflect_availability(self):
+        # Availability is baked into the targets when the protocol study is built,
+        # so build it under the patched environment.
         with mock.patch.dict("os.environ", {"OPENAI_API_KEY": "", "ANTHROPIC_API_KEY": ""}):
-            models = {m["label"]: m for m in _study().list()["evals"][0]["targets"]}
-        self.assertTrue(models["llmsim"]["available"])        # offline provider
-        self.assertFalse(models["openai-gpt-5.5"]["available"])  # no key -> skipped
+            targets = {m["label"]: m for m in
+                       _study().protocol().handle("list", {})["evals"][0]["targets"]}
+        self.assertTrue(targets["llmsim"]["available"])           # offline provider
+        self.assertFalse(targets["openai-gpt-5.5"]["available"])  # no key -> skipped
 
     def test_list_targets_carry_config_metadata(self):
-        models = {m["label"]: m for m in _study().list()["evals"][0]["targets"]}
-        # config detail rides the model column for `mira run --group-by agent`
-        self.assertEqual(models["openai-gpt-5.5-high"]["metadata"]["agent"], "yolop")
-        self.assertEqual(models["openai-gpt-5.5-high"]["metadata"]["reasoning_effort"], "high")
-        self.assertEqual(models["codex"]["metadata"]["agent"], "codex")
-        self.assertIn("price", models["codex"]["metadata"])
+        targets = {m["label"]: m for m in
+                   _study().protocol().handle("list", {})["evals"][0]["targets"]}
+        # config detail rides the target column for `mira run --group-by agent`
+        self.assertEqual(targets["openai-gpt-5.5-high"]["metadata"]["agent"], "yolop")
+        self.assertEqual(targets["openai-gpt-5.5-high"]["metadata"]["reasoning_effort"], "high")
+        self.assertEqual(targets["codex"]["metadata"]["agent"], "codex")
+        self.assertIn("price", targets["codex"]["metadata"])
 
 
 class RunTest(unittest.TestCase):
-    def _run(self, *, resolved=True, do_eval=True, model="llmsim", sample="org__repo-1"):
+    def _handle(self, method, *, resolved=True, do_eval=True, model="llmsim",
+                sample="org__repo-1"):
         study = _study()
         study.do_eval = do_eval
         with mock.patch.object(sv, "checkout", lambda *a, **k: None), \
@@ -80,10 +89,11 @@ class RunTest(unittest.TestCase):
              mock.patch.object(sv, "run_agent", _fake_agent_run), \
              mock.patch.object(sv, "evaluate_predictions",
                                lambda *a, **k: {sample: EvalResult(resolved, {"resolved": resolved})}):
-            return study.run({"eval": "swebench_verified", "sample": sample, "target": model})
+            return study.protocol().handle(
+                method, {"eval": "swebench_verified", "sample": sample, "target": model})
 
     def test_resolved_cell_passes(self):
-        res = self._run(resolved=True)
+        res = self._handle("run", resolved=True)
         self.assertTrue(res["passed"])
         self.assertFalse(res["skipped"])
         names = {s["scorer"]: s for s in res["scores"]}
@@ -92,11 +102,10 @@ class RunTest(unittest.TestCase):
         tr = res["transcript"]
         self.assertEqual(tr["usage"]["input_tokens"], 100)
         self.assertEqual(tr["usage"]["cost_usd"], 0.01)
-        self.assertIn("model_patch.diff", tr["files"])
-        # numeric metrics map (protocol 1.2): values are plain numbers
+        # numeric metrics map: values are plain numbers
         self.assertEqual(tr["metrics"]["tool_calls"], 2)
         self.assertEqual(tr["metrics"]["turns"], 3)
-        # open-ended metadata (protocol 1.4): structured, not stringified
+        # open-ended metadata: structured, not stringified
         md = tr["metadata"]
         self.assertIs(md["resolved"], True)
         self.assertEqual(md["repo"], "org/repo")
@@ -108,6 +117,13 @@ class RunTest(unittest.TestCase):
         self.assertNotIn("config", md)
         self.assertNotIn("error_kind", tr)  # clean run: no infra error
 
+    def test_files_ride_the_execute_transcript(self):
+        # The run summary is lightweight (no files); the model patch rides the
+        # full transcript returned by `execute` (the SDK's artifact path).
+        tr = self._handle("execute", resolved=True)["transcript"]
+        self.assertIn("model_patch.diff", tr["files"])
+        self.assertEqual(tr["files"]["model_patch.diff"], "diff --git a b")
+
     def test_infra_eval_failure_is_marked_na(self):
         # When the Docker harness fails to score, the cell is an infra error
         # (error_kind=infra) so the host treats it as N/A, not a model failure.
@@ -117,11 +133,12 @@ class RunTest(unittest.TestCase):
              mock.patch.object(sv, "run_agent", _fake_agent_run), \
              mock.patch.object(sv, "evaluate_predictions",
                                lambda *a, **k: {"org__repo-1": EvalResult(False, {}, "no report.json")}):
-            res = study.run({"eval": "swebench_verified", "sample": "org__repo-1", "target": "llmsim"})
+            res = study.protocol().handle(
+                "run", {"eval": "swebench_verified", "sample": "org__repo-1", "target": "llmsim"})
         self.assertEqual(res["transcript"]["error_kind"], "infra")
 
     def test_unresolved_cell_fails(self):
-        res = self._run(resolved=False)
+        res = self._handle("run", resolved=False)
         self.assertFalse(res["passed"])
         self.assertFalse({s["scorer"]: s for s in res["scores"]}["resolved"]["pass"])
 
@@ -133,24 +150,26 @@ class RunTest(unittest.TestCase):
              mock.patch.object(sv, "capture_patch", lambda *a, **k: "d"), \
              mock.patch.object(sv, "run_agent", _fake_agent_run), \
              mock.patch.object(sv, "evaluate_predictions", lambda *a, **k: called.append(1) or {}):
-            res = study.run({"eval": "swebench_verified", "sample": "org__repo-1", "target": "llmsim"})
+            res = study.protocol().handle(
+                "run", {"eval": "swebench_verified", "sample": "org__repo-1", "target": "llmsim"})
         self.assertFalse(res["passed"])   # unscored -> not resolved
         self.assertEqual(called, [])      # Docker scorer not invoked
 
     def test_unavailable_config_is_skipped(self):
         with mock.patch.dict("os.environ", {"OPENAI_API_KEY": ""}):
-            res = _study().run(
-                {"eval": "swebench_verified", "sample": "org__repo-1", "target": "openai-gpt-5.5"}
-            )
+            res = _study().protocol().handle(
+                "run", {"eval": "swebench_verified", "sample": "org__repo-1", "target": "openai-gpt-5.5"})
         self.assertTrue(res["skipped"])
 
     def test_unknown_sample_raises(self):
         with self.assertRaises(ValueError):
-            _study().run({"eval": "swebench_verified", "sample": "nope", "target": "llmsim"})
+            _study().protocol().handle(
+                "run", {"eval": "swebench_verified", "sample": "nope", "target": "llmsim"})
 
     def test_unknown_model_raises(self):
         with self.assertRaises(ValueError):
-            _study().run({"eval": "swebench_verified", "sample": "org__repo-1", "target": "nope"})
+            _study().protocol().handle(
+                "run", {"eval": "swebench_verified", "sample": "org__repo-1", "target": "nope"})
 
 
 class StdoutCleanlinessTest(unittest.TestCase):


### PR DESCRIPTION
## What

Migrate the SWE-bench Verified eval study and its tooling onto Mira's now-published artifacts (PyPI + crates.io), instead of git/source.

- **crates.io** — `bootstrap.sh` installs the `mira` host CLI from crates.io (`mira-cli`) instead of `cargo install --git …`. It prefers a prebuilt binary via `cargo-binstall` (seconds) and only compiles from source as a fallback. Homebrew remains the recommended path.
- **PyPI** — `evals/swebench_verified/swebench_verified.py` is rebuilt on the `mira-eval` Python SDK (the `mira` package). The SDK now owns the stdio protocol loop (`initialize`/`list`/`run`/`execute`/`score`), scoring/verdict math, pagination, and wire serialization; this file keeps the SWE-bench-specific work (checkout, agent run, event-log metrics, Docker `FAIL_TO_PASS` scoring) behind a subject `(sample, cx) -> mira.Transcript` plus a `resolved` scorer.
- Docs (`AGENTS.md`, `evals/README.md`, `evals/swebench_verified/README.md`) updated for the new dependency, install paths, and test command.

## Why

`mira-cli` and `mira-eval` are now published, so the study no longer needs to track upstream git or hand-roll the wire protocol. The hand-rolled loop only implemented `initialize`/`list`/`run`; adopting the SDK adds `execute`/`score`/`list_samples`/`cancel`/pagination for free and keeps the wire format in lockstep with the Rust host (generated from `schema/v1/`), so it can't drift.

## Notable design choices

- **Lazy samples** (`_LazySamples`): the dataset loads on first `list`/`run`, not at construction, so `initialize` stays cheap and works offline — matching the pre-migration behavior and keeping `bootstrap.sh`'s `initialize`-only pre-warm from triggering a dataset download.
- **Files contract**: the model patch (`model_patch.diff`) rides the full `execute` transcript per the SDK/Rust-host convention; the `run` summary stays lightweight. Tests assert it on the `execute` path.
- No backward-compat shims (yolop is pre-1.0).

## Validation

- `python3 -m unittest discover -s evals/swebench_verified/tests` → **32 passed**. The protocol tests were reworked to test *our* logic (sample tagging, target matrix, transcript mapping, the `resolved` scorer, cell orchestration + infra classification) plus one thin SDK-integration smoke — not to re-test the SDK (it has its own conformance suite).
- **End-to-end smoke** (`initialize` + `list` via `uv run swebench_verified.py` on the real dataset): `uv` resolved the new `mira-eval` dep; `initialize` returned protocol `1.0` + capabilities; `list` loaded all **500** SWE-bench Verified instances through the SDK with correct tags/metadata, 12 targets, `[succeeded, resolved]` scorers, single page (`next_cursor: null`), and correct availability (only `llmsim` with no keys set).
- No Rust/Cargo files changed, so the Rust build/lint/test surface is unaffected.

## Security

No Rust touched, so yolop's filesystem/shell/tool/LLM (TM-FS/TM-BASH/TM-TOOL/TM-LLM) surfaces are unchanged.
- **TM-DEP**: new deps `mira-eval` (PyPI; zero runtime deps, pure stdlib) and `mira-cli` (crates.io), both published by Everruns — the same org behind `everruns-runtime` that yolop already depends on. `cargo-binstall`'s `--pkg-url` resolves `{ repo }` to the crate's official `repository` (github.com/everruns/mira), the same source Homebrew uses; the template is a constant with binstall-resolved vars (no injection).
- Provider keys are still read from process env only and never logged or written to session files (unchanged).

## Follow-ups

- **CI does not run this study's tests** (`.github/workflows/ci.yml` is Rust-only) — true before this change too, so no regression. Wiring `uv run --with mira-eval -m unittest discover -s evals/swebench_verified/tests` into CI would guard the new SDK dependency. Deferred (scope: CI infra, not this migration).
- **Real agent-run + Docker-scoring path is not automatically tested** — it needs the `mira` host binary, provider keys, and a Docker daemon, none available in this environment. Covered indirectly by the protocol/mapping unit tests and the `list` smoke above; the agent run + `FAIL_TO_PASS` scoring should be smoke-checked manually once (`SWEBENCH_NO_EVAL=1 mira --cmd "uv run swebench_verified.py" run astropy__astropy-12907 --targets llmsim`). Deferred (environment-gated).

---
_Generated by [Claude Code](https://claude.ai/code/session_01T2JpnwVLuV2aJzD48jiLJy)_