### PR TITLE
feat: cut gpt-5.5 harness overhead (edit_file + prompt steering)

### DIFF
--- a/evals/swebench_verified/README.md
+++ b/evals/swebench_verified/README.md
@@ -253,8 +253,8 @@ sliced differently, not separate evals. A preset only subsets the grid;
 
 | Preset | Purpose | Samples | Targets | Typical run |
 |--------|---------|---------|---------|-------------|
-| `compare` | Evidence of how yolop benches vs other configs & coding agents | 1 (you supply) | all 8 agents (yolop ×4 + claude-code ×2 + codex + pi) | `./compare.sh <instance>` |
-| `astropy-12907` | The compare set with the instance **pinned** (`filter`) | astropy-12907 | all 8 agents | `mira … run --preset astropy-12907 --group-by agent --save` |
+| `compare` | Evidence of how yolop benches vs other configs & coding agents | 1 (you supply) | 10 targets (yolop ×6, incl. gpt-5.5 none/minimal/medium/high + claude-code ×2 + codex + pi) | `./compare.sh <instance>` |
+| `astropy-12907` | The compare set with the instance **pinned** (`filter`) | astropy-12907 | same 10 targets | `mira … run --preset astropy-12907 --group-by agent --save` |
 | `tracking` | Weekly yolop quality tracking | 20 (`tracking-v1`) | gpt-5.5 high · glm-5.2 · opus-4.8 | `mira … run --preset tracking --group-by difficulty --save` |
 | `full` | Whole benchmark, run rarely | all 500 | same as tracking (edit as needed) | `mira … run --preset full --group-by repo --checkpoint ck/full.json --save` |
 

--- a/evals/swebench_verified/README.md
+++ b/evals/swebench_verified/README.md
@@ -253,7 +253,7 @@ sliced differently, not separate evals. A preset only subsets the grid;
 
 | Preset | Purpose | Samples | Targets | Typical run |
 |--------|---------|---------|---------|-------------|
-| `compare` | Evidence of how yolop benches vs other configs & coding agents | 1 (you supply) | 10 targets (yolop ×6, incl. gpt-5.5 none/minimal/medium/high + claude-code ×2 + codex + pi) | `./compare.sh <instance>` |
+| `compare` | Evidence of how yolop benches vs other configs & coding agents | 1 (you supply) | 10 targets (yolop ×6, incl. gpt-5.5 none/low/medium/high + claude-code ×2 + codex + pi) | `./compare.sh <instance>` |
 | `astropy-12907` | The compare set with the instance **pinned** (`filter`) | astropy-12907 | same 10 targets | `mira … run --preset astropy-12907 --group-by agent --save` |
 | `tracking` | Weekly yolop quality tracking | 20 (`tracking-v1`) | gpt-5.5 high · glm-5.2 · opus-4.8 | `mira … run --preset tracking --group-by difficulty --save` |
 | `full` | Whole benchmark, run rarely | all 500 | same as tracking (edit as needed) | `mira … run --preset full --group-by repo --checkpoint ck/full.json --save` |

--- a/evals/swebench_verified/mira.toml
+++ b/evals/swebench_verified/mira.toml
@@ -26,7 +26,8 @@ benchmark = "swebench_verified"
 # codex, pi (Opus 4.8 on yolop and claude-code). You supply the instance.
 #   ./compare.sh <instance>     # = run <instance> --preset compare --group-by agent --save
 [presets.compare]
-targets = ["anthropic-claude-sonnet-4.5", "openai-gpt-5.5", "openai-gpt-5.5-high", "anthropic-claude-opus-4.8",
+targets = ["anthropic-claude-sonnet-4.5", "openai-gpt-5.5", "openai-gpt-5.5-high",
+           "openai-gpt-5.5-minimal", "openai-gpt-5.5-none", "anthropic-claude-opus-4.8",
            "claude-code-sonnet-4.5", "claude-code-opus-4.8", "codex", "pi"]
 
 # ASTROPY-12907 — the compare set with the instance pinned via `filter` (a
@@ -35,7 +36,8 @@ targets = ["anthropic-claude-sonnet-4.5", "openai-gpt-5.5", "openai-gpt-5.5-high
 #   mira ... run --preset astropy-12907 --group-by agent --save
 [presets.astropy-12907]
 filter = "astropy__astropy-12907"
-targets = ["anthropic-claude-sonnet-4.5", "openai-gpt-5.5", "openai-gpt-5.5-high", "anthropic-claude-opus-4.8",
+targets = ["anthropic-claude-sonnet-4.5", "openai-gpt-5.5", "openai-gpt-5.5-high",
+           "openai-gpt-5.5-minimal", "openai-gpt-5.5-none", "anthropic-claude-opus-4.8",
            "claude-code-sonnet-4.5", "claude-code-opus-4.8", "codex", "pi"]
 
 # TRACKING — weekly yolop quality tracking: the fixed 20-instance tracking-v1

--- a/evals/swebench_verified/mira.toml
+++ b/evals/swebench_verified/mira.toml
@@ -27,7 +27,7 @@ benchmark = "swebench_verified"
 #   ./compare.sh <instance>     # = run <instance> --preset compare --group-by agent --save
 [presets.compare]
 targets = ["anthropic-claude-sonnet-4.5", "openai-gpt-5.5", "openai-gpt-5.5-high",
-           "openai-gpt-5.5-minimal", "openai-gpt-5.5-none", "anthropic-claude-opus-4.8",
+           "openai-gpt-5.5-low", "openai-gpt-5.5-none", "anthropic-claude-opus-4.8",
            "claude-code-sonnet-4.5", "claude-code-opus-4.8", "codex", "pi"]
 
 # ASTROPY-12907 — the compare set with the instance pinned via `filter` (a
@@ -37,7 +37,7 @@ targets = ["anthropic-claude-sonnet-4.5", "openai-gpt-5.5", "openai-gpt-5.5-high
 [presets.astropy-12907]
 filter = "astropy__astropy-12907"
 targets = ["anthropic-claude-sonnet-4.5", "openai-gpt-5.5", "openai-gpt-5.5-high",
-           "openai-gpt-5.5-minimal", "openai-gpt-5.5-none", "anthropic-claude-opus-4.8",
+           "openai-gpt-5.5-low", "openai-gpt-5.5-none", "anthropic-claude-opus-4.8",
            "claude-code-sonnet-4.5", "claude-code-opus-4.8", "codex", "pi"]
 
 # TRACKING — weekly yolop quality tracking: the fixed 20-instance tracking-v1

--- a/evals/swebench_verified/swebench_verified.py
+++ b/evals/swebench_verified/swebench_verified.py
@@ -148,11 +148,12 @@ MATRIX: dict[str, dict[str, Any]] = {
     # default effort to gpt-5.5, so these isolate how much of yolop's turn/cost
     # overhead is reasoning vs harness — and put it on equal footing with `pi`,
     # which runs gpt-5.5 with no reasoning controls. effort "none" omits the
-    # reasoning param entirely; "minimal" is the lowest reasoning tier.
+    # reasoning param entirely; "low" is the lowest reasoning tier. (gpt-5.5
+    # supports none/low/medium/high/xhigh — "minimal" is rejected by the API.)
     "openai-gpt-5.5-none": {"agent": "yolop", "provider": "openai", "model": "gpt-5.5",
                     "reasoning_effort": "none"},
-    "openai-gpt-5.5-minimal": {"agent": "yolop", "provider": "openai", "model": "gpt-5.5",
-                    "reasoning_effort": "minimal"},
+    "openai-gpt-5.5-low": {"agent": "yolop", "provider": "openai", "model": "gpt-5.5",
+                    "reasoning_effort": "low"},
     # yolop x Anthropic (secondary provider)
     "anthropic-claude-sonnet-4.5": {"agent": "yolop", "provider": "anthropic", "model": "claude-sonnet-4-5"},
     "anthropic-claude-opus-4.8": {"agent": "yolop", "provider": "anthropic", "model": "claude-opus-4-8"},

--- a/evals/swebench_verified/swebench_verified.py
+++ b/evals/swebench_verified/swebench_verified.py
@@ -144,6 +144,15 @@ MATRIX: dict[str, dict[str, Any]] = {
     "openai-gpt-5.5": {"agent": "yolop", "provider": "openai", "model": "gpt-5.5"},
     "openai-gpt-5.5-high": {"agent": "yolop", "provider": "openai", "model": "gpt-5.5",
                     "reasoning_effort": "high"},
+    # Low/no-reasoning baselines. yolop otherwise applies the model profile's
+    # default effort to gpt-5.5, so these isolate how much of yolop's turn/cost
+    # overhead is reasoning vs harness — and put it on equal footing with `pi`,
+    # which runs gpt-5.5 with no reasoning controls. effort "none" omits the
+    # reasoning param entirely; "minimal" is the lowest reasoning tier.
+    "openai-gpt-5.5-none": {"agent": "yolop", "provider": "openai", "model": "gpt-5.5",
+                    "reasoning_effort": "none"},
+    "openai-gpt-5.5-minimal": {"agent": "yolop", "provider": "openai", "model": "gpt-5.5",
+                    "reasoning_effort": "minimal"},
     # yolop x Anthropic (secondary provider)
     "anthropic-claude-sonnet-4.5": {"agent": "yolop", "provider": "anthropic", "model": "claude-sonnet-4-5"},
     "anthropic-claude-opus-4.8": {"agent": "yolop", "provider": "anthropic", "model": "claude-opus-4-8"},

--- a/evals/swebench_verified/tests/test_agent_metrics.py
+++ b/evals/swebench_verified/tests/test_agent_metrics.py
@@ -155,6 +155,16 @@ class RegistryTest(unittest.TestCase):
         self.assertEqual(sv._AGENTS["pi"], sv.run_pi)
         self.assertEqual(sv._AGENTS["yolop"], sv.run_yolop)
 
+    def test_gpt55_reasoning_effort_baselines(self):
+        # Low/no-reasoning baselines so yolop can be compared to `pi` (which runs
+        # gpt-5.5 with no reasoning controls) on equal footing. effort flows to
+        # the yolop CLI via run_yolop's --reasoning-effort.
+        self.assertEqual(MATRIX["openai-gpt-5.5-none"]["reasoning_effort"], "none")
+        self.assertEqual(MATRIX["openai-gpt-5.5-minimal"]["reasoning_effort"], "minimal")
+        self.assertEqual(MATRIX["openai-gpt-5.5-high"]["reasoning_effort"], "high")
+        # the medium default rides the model profile, so it carries no explicit key
+        self.assertNotIn("reasoning_effort", MATRIX["openai-gpt-5.5"])
+
     def test_unknown_agent_raises(self):
         # dispatch rejects an unknown agent before touching the workspace
         with self.assertRaises(ValueError):

--- a/evals/swebench_verified/tests/test_agent_metrics.py
+++ b/evals/swebench_verified/tests/test_agent_metrics.py
@@ -160,7 +160,8 @@ class RegistryTest(unittest.TestCase):
         # gpt-5.5 with no reasoning controls) on equal footing. effort flows to
         # the yolop CLI via run_yolop's --reasoning-effort.
         self.assertEqual(MATRIX["openai-gpt-5.5-none"]["reasoning_effort"], "none")
-        self.assertEqual(MATRIX["openai-gpt-5.5-minimal"]["reasoning_effort"], "minimal")
+        # gpt-5.5 supports none/low/medium/high/xhigh; "minimal" is rejected.
+        self.assertEqual(MATRIX["openai-gpt-5.5-low"]["reasoning_effort"], "low")
         self.assertEqual(MATRIX["openai-gpt-5.5-high"]["reasoning_effort"], "high")
         # the medium default rides the model profile, so it carries no explicit key
         self.assertNotIn("reasoning_effort", MATRIX["openai-gpt-5.5"])

--- a/src/capabilities/edit_file_override.rs
+++ b/src/capabilities/edit_file_override.rs
@@ -1,0 +1,269 @@
+//! TODO(EVE-620): remove this entire module once everruns ships an `edits[]`-only
+//! `edit_file`. Then restore the plain `capabilities.register(FileSystemCapability)`
+//! call in `runtime.rs`. See
+//! <https://linear.app/everruns/issue/EVE-620>.
+//!
+//! Why this exists: everruns' `edit_file` advertises two overlapping ways to
+//! specify an edit in one call — top-level `old_text`/`new_text` *and* an
+//! `edits[]` array. gpt-5.5 reliably populates *both* on its first attempt
+//! (duplicating the same edit), which the tool rejects as ambiguous — burning a
+//! turn before it self-corrects. pi/codex/claude-code each expose a single edit
+//! shape and never hit this. This wrapper makes yolop's `edit_file` `edits[]`-only
+//! (dropping the scalar fields from the advertised schema) and folds any stray
+//! top-level `old_text`/`new_text` into `edits[]` before delegating, so the
+//! upstream tool never sees the ambiguous shape. Execution and narration are
+//! delegated unchanged to the upstream tool.
+
+use async_trait::async_trait;
+use everruns_core::capabilities::{
+    Capability, CapabilityLocalization, CapabilityStatus, SystemPromptContext,
+};
+use everruns_core::tool_narration::ToolNarrationPhase;
+use everruns_core::tool_types::{ToolCall, ToolHints, ToolPolicy};
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::{FileSystemCapability, ToolContext};
+use serde_json::{Value, json};
+
+const EDIT_FILE: &str = "edit_file";
+
+const EDIT_FILE_DESCRIPTION: &str = "Apply one or more exact text replacements to an existing text \
+file. Requires the current content hash from read_file or write_file. Put every replacement in the \
+`edits` array — each `old_text` must match the file exactly and be unique.";
+
+/// `FileSystemCapability` with `edit_file` swapped for an `edits[]`-only variant.
+/// Everything else delegates to the inner capability unchanged.
+pub(crate) struct EditsOnlyFileSystemCapability {
+    inner: FileSystemCapability,
+}
+
+impl EditsOnlyFileSystemCapability {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: FileSystemCapability,
+        }
+    }
+}
+
+impl Default for EditsOnlyFileSystemCapability {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Capability for EditsOnlyFileSystemCapability {
+    fn id(&self) -> &str {
+        self.inner.id()
+    }
+
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn description(&self) -> &str {
+        self.inner.description()
+    }
+
+    fn localizations(&self) -> Vec<CapabilityLocalization> {
+        self.inner.localizations()
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        self.inner.status()
+    }
+
+    fn icon(&self) -> Option<&str> {
+        self.inner.icon()
+    }
+
+    fn category(&self) -> Option<&str> {
+        self.inner.category()
+    }
+
+    fn features(&self) -> Vec<&'static str> {
+        self.inner.features()
+    }
+
+    fn system_prompt_preview(&self) -> Option<String> {
+        self.inner.system_prompt_preview()
+    }
+
+    async fn system_prompt_contribution(&self, ctx: &SystemPromptContext) -> Option<String> {
+        self.inner.system_prompt_contribution(ctx).await
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        self.inner
+            .tools()
+            .into_iter()
+            .map(|tool| {
+                if tool.name() == EDIT_FILE {
+                    Box::new(EditsOnlyEditFileTool { inner: tool }) as Box<dyn Tool>
+                } else {
+                    tool
+                }
+            })
+            .collect()
+    }
+}
+
+/// `edit_file` that advertises only the `edits[]` shape. Delegates execution and
+/// narration to the upstream tool; coerces away any stray top-level
+/// `old_text`/`new_text` first so the upstream never sees the ambiguous dual mode.
+struct EditsOnlyEditFileTool {
+    inner: Box<dyn Tool>,
+}
+
+impl EditsOnlyEditFileTool {
+    /// Strip top-level `old_text`/`new_text`, folding them into `edits[]` when no
+    /// `edits` was supplied. Defensive: the advertised schema no longer offers
+    /// the scalar fields, but a model may still emit them out of habit.
+    fn coerce_arguments(mut arguments: Value) -> Value {
+        if let Some(obj) = arguments.as_object_mut() {
+            let old_text = obj.remove("old_text");
+            let new_text = obj.remove("new_text");
+            let has_edits = obj.get("edits").is_some_and(|edits| !edits.is_null());
+            if !has_edits && let (Some(old_text), Some(new_text)) = (old_text, new_text) {
+                obj.insert(
+                    "edits".to_string(),
+                    json!([{ "old_text": old_text, "new_text": new_text }]),
+                );
+            }
+        }
+        arguments
+    }
+}
+
+#[async_trait]
+impl Tool for EditsOnlyEditFileTool {
+    fn name(&self) -> &str {
+        EDIT_FILE
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        self.inner.display_name()
+    }
+
+    fn description(&self) -> &str {
+        EDIT_FILE_DESCRIPTION
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute path to the existing text file (e.g., '/workspace/src/main.rs')"
+                },
+                "expected_hash": {
+                    "type": "string",
+                    "description": "Current content hash from read_file or write_file (format: 'sha256:...')"
+                },
+                "edits": {
+                    "type": "array",
+                    "description": "One or more exact text replacements, each matched against the original file content. Order-independent; replacements must not overlap.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "old_text": {
+                                "type": "string",
+                                "description": "Exact text to replace (must be unique in the file)"
+                            },
+                            "new_text": {
+                                "type": "string",
+                                "description": "Replacement text"
+                            }
+                        },
+                        "required": ["old_text", "new_text"],
+                        "additionalProperties": false
+                    },
+                    "minItems": 1
+                }
+            },
+            "required": ["path", "expected_hash", "edits"],
+            "additionalProperties": false
+        })
+    }
+
+    fn requires_context(&self) -> bool {
+        self.inner.requires_context()
+    }
+
+    fn policy(&self) -> ToolPolicy {
+        self.inner.policy()
+    }
+
+    fn hints(&self) -> ToolHints {
+        self.inner.hints()
+    }
+
+    fn narrate(
+        &self,
+        tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        locale: Option<&str>,
+    ) -> Option<String> {
+        self.inner.narrate(tool_call, phase, locale)
+    }
+
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        self.inner.execute(Self::coerce_arguments(arguments)).await
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        self.inner
+            .execute_with_context(Self::coerce_arguments(arguments), context)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_is_edits_only() {
+        let tool = EditsOnlyEditFileTool {
+            inner: FileSystemCapability
+                .tools()
+                .into_iter()
+                .find(|t| t.name() == EDIT_FILE)
+                .expect("edit_file tool"),
+        };
+        let schema = tool.parameters_schema();
+        let props = &schema["properties"];
+        assert!(props.get("old_text").is_none(), "old_text must be gone");
+        assert!(props.get("new_text").is_none(), "new_text must be gone");
+        assert!(props.get("edits").is_some(), "edits[] must remain");
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.iter().any(|r| r == "edits"));
+    }
+
+    #[test]
+    fn coerce_folds_scalars_into_edits() {
+        let out = EditsOnlyEditFileTool::coerce_arguments(json!({
+            "path": "/workspace/f.rs", "expected_hash": "sha256:x",
+            "old_text": "a", "new_text": "b"
+        }));
+        assert!(out.get("old_text").is_none());
+        assert!(out.get("new_text").is_none());
+        assert_eq!(out["edits"], json!([{ "old_text": "a", "new_text": "b" }]));
+    }
+
+    #[test]
+    fn coerce_drops_scalars_when_edits_present() {
+        let out = EditsOnlyEditFileTool::coerce_arguments(json!({
+            "path": "/workspace/f.rs", "expected_hash": "sha256:x",
+            "old_text": "a", "new_text": "b",
+            "edits": [{ "old_text": "c", "new_text": "d" }]
+        }));
+        assert!(out.get("old_text").is_none());
+        assert!(out.get("new_text").is_none());
+        assert_eq!(out["edits"], json!([{ "old_text": "c", "new_text": "d" }]));
+    }
+}

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod attribution;
 pub(crate) mod background;
 pub(crate) mod client_commands;
 pub(crate) mod config;
+pub(crate) mod edit_file_override;
 pub(crate) mod goal;
 pub(crate) mod hooks;
 mod host;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -82,14 +82,19 @@ root; `bash` runs on the host. There is no sandbox.
 
 ## Workflow
 
-Read before editing. Before finishing an edit, verify empirically: run nearest
-tests or a repro with assertions for expected values, not non-crash checks. For
-parser, regex, math, date/time, or serialization fixes, include
-positive and negative/edge cases from the issue or nearby tests. Search sibling call
-sites/patterns before assuming a local fix is complete. Review your diff for
-regressions, removed behavior, and nearby tests. Finish with
-verification command(s) and result(s), or the blocker. On failure, read output, fix root
-cause, and re-run; do not retry unchanged. If stuck twice, explain and ask.
+Investigate the minimum needed, then act. Use `repo_map`/`grep_files`/`ast_grep`
+to locate code; read only the files you must and batch independent reads. Avoid
+broad directory sweeps and re-reading what you already have.
+
+Make the smallest correct fix. Before finishing, verify empirically with
+assertions for expected values (not non-crash checks); for parser, regex, math,
+date/time, or serialization fixes cover positive and edge cases from the issue.
+Check sibling call sites once if a local fix may be incomplete, then review your
+diff for regressions.
+
+Verify with a single decisive command, then stop — do not re-run passing checks
+or keep exploring once the fix is confirmed. On failure, read the output, fix the
+root cause, and re-run; never retry unchanged. If stuck twice, explain and ask.
 
 ## Permanent Tools
 
@@ -106,8 +111,8 @@ you have enough evidence.
 `bash` output is summarized inline and saved under `/outputs/` when large;
 commands are killed past 2 MiB output or 120s wall time.
 
-`write_todos` is for non-trivial multi-step work. Skip it for greetings,
-single-step edits, or read-only checks.
+`write_todos` is only for genuinely multi-step work (3+ distinct steps). Skip it
+for single-file fixes, single-step edits, greetings, or read-only checks.
 
 ## Code quality and safety
 
@@ -505,7 +510,10 @@ const YOLOP_NEVER_DEFER_TOOLS: &[&str] = &[
     "grep_files",
     "bash",
     "spawn_background",
-    "write_todos",
+    // write_todos intentionally NOT hot: keep it behind tool_search so the model
+    // doesn't reach for it reflexively on simple single-fix tasks (it was burning
+    // ~4 turns on one-file fixes). It's still available via tool_search for
+    // genuinely multi-step work.
     "run_yolop_command",
 ];
 const YOLOP_KEEP_RECENT_TOOL_OUTPUTS: u64 = 3;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -30,14 +30,14 @@ use async_trait::async_trait;
 use everruns_core::capabilities::{
     AGENT_INSTRUCTIONS_CAPABILITY_ID, AgentInstructionsCapability, BTW_CAPABILITY_ID,
     BackgroundExecutionCapability, BtwCapability, COMPACTION_CAPABILITY_ID, CompactionCapability,
-    FileSystemCapability, INFINITY_CONTEXT_CAPABILITY_ID, InfinityContextCapability,
-    LOOP_DETECTION_CAPABILITY_ID, LoopDetectionCapability, MessageMetadataCapability,
-    PROMPT_CACHING_CAPABILITY_ID, PromptCachingCapability, SESSION_FILE_SYSTEM_CAPABILITY_ID,
-    SESSION_STORAGE_CAPABILITY_ID, SESSION_TASKS_CAPABILITY_ID, SKILLS_CAPABILITY_ID,
-    STATELESS_TODO_LIST_CAPABILITY_ID, ScopedSkillsCapability, SessionStorageCapability,
-    SessionTasksCapability, StatelessTodoListCapability, TOOL_OUTPUT_PERSISTENCE_CAPABILITY_ID,
-    TOOL_SEARCH_CAPABILITY_ID, ToolOutputPersistenceCapability, ToolSearchCapability,
-    USER_HOOKS_CAPABILITY_ID, UserHooksCapability, WEB_FETCH_CAPABILITY_ID, WebFetchCapability,
+    INFINITY_CONTEXT_CAPABILITY_ID, InfinityContextCapability, LOOP_DETECTION_CAPABILITY_ID,
+    LoopDetectionCapability, MessageMetadataCapability, PROMPT_CACHING_CAPABILITY_ID,
+    PromptCachingCapability, SESSION_FILE_SYSTEM_CAPABILITY_ID, SESSION_STORAGE_CAPABILITY_ID,
+    SESSION_TASKS_CAPABILITY_ID, SKILLS_CAPABILITY_ID, STATELESS_TODO_LIST_CAPABILITY_ID,
+    ScopedSkillsCapability, SessionStorageCapability, SessionTasksCapability,
+    StatelessTodoListCapability, TOOL_OUTPUT_PERSISTENCE_CAPABILITY_ID, TOOL_SEARCH_CAPABILITY_ID,
+    ToolOutputPersistenceCapability, ToolSearchCapability, USER_HOOKS_CAPABILITY_ID,
+    UserHooksCapability, WEB_FETCH_CAPABILITY_ID, WebFetchCapability,
 };
 use everruns_core::command::CommandDescriptor;
 use everruns_core::driver_registry::{DriverRegistry, ProviderMetadata};
@@ -2242,7 +2242,12 @@ pub async fn build_with_options(
     //                            global/workspace hook config
     let mut capabilities = CapabilityRegistry::new();
     capabilities.register(AgentInstructionsCapability);
-    capabilities.register(FileSystemCapability);
+    // TODO(EVE-620): revert to `capabilities.register(FileSystemCapability)` once
+    // everruns ships an edits[]-only edit_file. This wrapper drops the ambiguous
+    // top-level old_text/new_text from edit_file's schema (gpt-5.5 populates both
+    // and eats a rejection). https://linear.app/everruns/issue/EVE-620
+    capabilities
+        .register(crate::capabilities::edit_file_override::EditsOnlyFileSystemCapability::new());
     // Upstream multi-scope skills capability (everruns-core 0.12.0+),
     // configured with yolop's workspace/global/system scopes and a host-path
     // resolver so `${SKILL_DIR}` reaches real files. The file store maps the

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -111,8 +111,9 @@ you have enough evidence.
 `bash` output is summarized inline and saved under `/outputs/` when large;
 commands are killed past 2 MiB output or 120s wall time.
 
-`write_todos` is only for genuinely multi-step work (3+ distinct steps). Skip it
-for single-file fixes, single-step edits, greetings, or read-only checks.
+`write_todos` is only for complex, multi-step work — 3+ distinct steps spanning
+multiple files or phases. Skip it for single-file fixes, single-step edits,
+greetings, or read-only checks.
 
 ## Code quality and safety
 
@@ -510,10 +511,7 @@ const YOLOP_NEVER_DEFER_TOOLS: &[&str] = &[
     "grep_files",
     "bash",
     "spawn_background",
-    // write_todos intentionally NOT hot: keep it behind tool_search so the model
-    // doesn't reach for it reflexively on simple single-fix tasks (it was burning
-    // ~4 turns on one-file fixes). It's still available via tool_search for
-    // genuinely multi-step work.
+    "write_todos",
     "run_yolop_command",
 ];
 const YOLOP_KEEP_RECENT_TOOL_OUTPUTS: u64 = 3;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -82,19 +82,14 @@ root; `bash` runs on the host. There is no sandbox.
 
 ## Workflow
 
-Investigate the minimum needed, then act. Use `repo_map`/`grep_files`/`ast_grep`
-to locate code; read only the files you must and batch independent reads. Avoid
-broad directory sweeps and re-reading what you already have.
-
-Make the smallest correct fix. Before finishing, verify empirically with
-assertions for expected values (not non-crash checks); for parser, regex, math,
-date/time, or serialization fixes cover positive and edge cases from the issue.
-Check sibling call sites once if a local fix may be incomplete, then review your
-diff for regressions.
-
-Verify with a single decisive command, then stop — do not re-run passing checks
-or keep exploring once the fix is confirmed. On failure, read the output, fix the
-root cause, and re-run; never retry unchanged. If stuck twice, explain and ask.
+Investigate minimally: prefer `repo_map`/`grep_files`/`ast_grep` over sweeps;
+read only needed files; batch reads. Make the smallest correct fix. Before
+finishing, verify with assertions for expected values (not non-crash checks);
+for parser, regex, math, date/time, or serialization fixes cover positive and
+edge cases. Check sibling call sites if the fix may be incomplete, then review
+your diff for regressions. Verify with a single decisive command, then stop;
+don't re-run passing checks. On failure, read output, fix root cause; never
+retry unchanged. If stuck twice, explain and ask.
 
 ## Permanent Tools
 
@@ -4534,14 +4529,17 @@ mod tests {
             .nth(1)
             .and_then(|tail| tail.split("## Permanent Tools").next())
             .expect("workflow section should be present");
+        // Normalize whitespace so line-wrapping in the prompt can't split an
+        // asserted phrase across a newline.
+        let workflow = workflow.split_whitespace().collect::<Vec<_>>().join(" ");
 
-        assert!(workflow.contains("Before finishing an edit"));
+        assert!(workflow.contains("Before finishing"));
         assert!(workflow.contains("assertions for expected values"));
-        assert!(workflow.contains("positive and negative/edge cases"));
-        assert!(workflow.contains("Search sibling"));
-        assert!(workflow.contains("Review your diff"));
+        assert!(workflow.contains("positive and edge cases"));
+        assert!(workflow.contains("sibling call sites"));
+        assert!(workflow.contains("review your diff"));
         assert!(workflow.contains("regressions"));
-        assert!(workflow.contains("verification command(s) and result(s)"));
+        assert!(workflow.contains("single decisive command"));
     }
 
     #[test]


### PR DESCRIPTION
## What & why

Benchmarking yolop vs pi/codex/claude-code on the **same** SWE-bench instance (`astropy-12907`, real Docker scoring) showed yolop spending **4–5× the tool calls and cost of pi/claude-code for the identical fix** — the gap is **harness overhead, not the model** (yolop-on-Opus cost $1.25 vs claude-code-on-Opus $0.50). This PR attacks the two biggest drivers — a tool-schema bug and prompt-induced thrash — plus adds the eval baselines used to measure them.

### Changes
1. **`edit_file` → `edits[]`-only** (`src/capabilities/edit_file_override.rs`, wires into `runtime.rs`). everruns' `edit_file` advertises two overlapping edit shapes (`old_text`/`new_text` *and* `edits[]`); gpt-5.5 populates **both** on its first attempt and eats a rejection (4–6× loops → `write_file` fallback on the old schema). The wrapper advertises only `edits[]`, delegates execution/narration unchanged to the upstream tool, and coerces stray scalars. Temporary local fix for upstream **EVE-620** (TODO to remove on bump).
2. **Prompt steering** (`HARNESS_PROMPT` in `runtime.rs`):
   - Workflow: investigate minimally, prefer `repo_map`/`grep_files`/`ast_grep` over sweeps, batch reads; **verify with a single decisive command then stop** (no re-running passing checks / endless exploration). Verification rigor (assertions/expected values, edge cases, sibling sites, diff review) preserved.
   - `write_todos` gated to genuinely complex (3+ step) work; kept in the hot tool set (steered by prompt, not deferred — avoids a `tool_search` round-trip on complex tasks).
3. **Eval baselines** (`swebench_verified.py`, `mira.toml`, README): add `openai-gpt-5.5-none` / `-low` targets to the compare presets to isolate reasoning vs harness cost.

## Evidence (astropy-12907, gpt-5.5 default, Docker-scored)

| metric | before | after | Δ |
|---|---|---|---|
| cost | $0.894 | $0.505 | **−43%** |
| tool calls | 31 | 18 | −42% |
| `write_todos` | 4 | 0 | eliminated (prompt-only) |
| `edit_file` failures | (loops on old schema) | 0 | eliminated |
| input tokens | 661k | 331k | −50% |
| **resolved** | ✅ | ✅ | held |

After lands at **claude-code-opus cost parity** ($0.50). Full 10-target scored comparison run during development: 8/10 resolved (codex = env auth issue, one sonnet scoring flake). n=1 per cell — magnitudes directional, but the structural wins (`write_todos`→0, edit-loops→0) are deterministic.

## Validation
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings` — clean.
- `cargo test --all-features` — 543 + 31 pass, 0 fail (incl. 3 new `edit_file_override` unit tests + prompt-budget/verification guardrails).
- Eval study: `uv run --with mira-eval -m unittest discover -s tests` — 33 pass (incl. new `test_gpt55_reasoning_effort_baselines`).
- End-to-end smoke: real scored `astropy-12907` runs (yolop gpt-5.5 none/low/medium/high) all **resolved** on this build.
- Prompt behavior (write_todos suppression, fewer turns) is **not unit-testable** — validated via the scored evals above (see **Follow-ups**).

## Security
No security-relevant risk. The `edit_file` override **delegates execution to the upstream tool unchanged** — the write blocklist and `expected_hash` CAS still apply; the wrapper only narrows the advertised schema and reshapes `old_text`/`new_text` → `edits[]` (no path/content manipulation, no traversal surface). Other changes are prompt text and eval config. No new crates. The untrusted-input guard in the system prompt is preserved.

## Follow-ups
- **EVE-620**: remove `edit_file_override.rs` and restore plain `FileSystemCapability` once everruns ships an `edits[]`-only `edit_file`.
- **Lever 3b**: shrink standing per-turn context further to chase pi's ~21k-token footprint (yolop still ~331k).
- **Exploration consistency**: the prompt nudges structural search over grep/read sweeps but doesn't enforce it (one after-run still swept); worth firming up.
- Confirm gains on the full `tracking-v1` suite (scored) for statistical weight beyond n=1.

https://claude.ai/code/session_01WzDfubgktwhrCi3owSjhMJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzDfubgktwhrCi3owSjhMJ)_