### PR TITLE
fix(tools): repo_map /workspace + hidden-skip; document stateless bash

### DIFF
--- a/evals/swebench_verified/README.md
+++ b/evals/swebench_verified/README.md
@@ -240,8 +240,11 @@ Study-internal knobs that the host doesn't own are read from the environment so
 they can be set on the `--cmd` line: `SWEBENCH_NO_EVAL=1` (skip Docker scoring),
 `SWEBENCH_MAX_WORKERS=N` (Docker eval parallelism), `SWEBENCH_NAMESPACE=none`
 (build images locally instead of pulling prebuilt), `SWEBENCH_EVAL_TIMEOUT`,
-`SWEBENCH_YOLOP_BIN` (override the yolop binary). The per-instance USD cap is set
-per config in the matrix (`max_cost_usd`, default `$5`).
+`SWEBENCH_YOLOP_BIN` (override the yolop binary), `SWEBENCH_CACHE_LEVEL=instance`
+(keep the per-instance Docker image so a multi-target matrix pulls it once
+rather than re-pulling per cell — avoids Docker Hub anonymous pull-rate limits;
+default `env`). The per-instance USD cap is set per config in the matrix
+(`max_cost_usd`, default `$5`).
 
 ### Presets — named runs
 

--- a/evals/swebench_verified/swebench_verified.py
+++ b/evals/swebench_verified/swebench_verified.py
@@ -33,7 +33,9 @@ absent so the host skips it.
 Study-internal knobs come from the environment (the host can't pass study CLI
 flags): `SWEBENCH_NO_EVAL=1` skips Docker scoring, `SWEBENCH_MAX_WORKERS`,
 `SWEBENCH_NAMESPACE` (`none` builds images locally), `SWEBENCH_EVAL_TIMEOUT`,
-`SWEBENCH_YOLOP_BIN` (override the yolop binary path).
+`SWEBENCH_YOLOP_BIN` (override the yolop binary path), `SWEBENCH_CACHE_LEVEL`
+(SWE-bench image cache level; `instance` keeps the per-instance image so a
+matrix run pulls it once instead of re-pulling per cell — default `env`).
 
 stdout carries ONLY protocol JSON (one object per line); logs go to stderr.
 """
@@ -818,10 +820,16 @@ def evaluate_predictions(predictions: Mapping[str, str], instances: list[Instanc
         for iid in ids:
             fh.write(json.dumps({"instance_id": iid, "model_name_or_path": model_name,
                                  "model_patch": predictions.get(iid, "")}) + "\n")
+    # SWE-bench's default cache_level "env" deletes the per-instance image after
+    # each cell, so a multi-target matrix re-pulls the same prebuilt image once
+    # per cell — which trips Docker Hub's anonymous pull rate limit. "instance"
+    # keeps the instance image so the matrix pulls it once and reuses it.
+    cache_level = os.environ.get("SWEBENCH_CACHE_LEVEL", "env")
     cmd = [sys.executable, "-m", "swebench.harness.run_evaluation",
            "--dataset_name", str(dataset_file), "--predictions_path", str(preds_file),
            "--run_id", run_id, "--instance_ids", *ids, "--max_workers", str(max_workers),
-           "--namespace", namespace, "--timeout", str(timeout), "--report_dir", str(work)]
+           "--namespace", namespace, "--timeout", str(timeout), "--report_dir", str(work),
+           "--cache_level", cache_level]
     log(f"running evaluation: {' '.join(cmd)}")
     # Keep the harness's copious output OFF this process's stdout (the protocol
     # channel under the Mira host); route it all to stderr.

--- a/src/capabilities/repo_map.rs
+++ b/src/capabilities/repo_map.rs
@@ -950,7 +950,15 @@ fn resolve_scope(root: &Path, path: Option<&str>) -> Result<PathBuf> {
     let Some(path) = path else {
         return Ok(root.to_path_buf());
     };
-    let relative = path.trim_start_matches('/');
+    // The file tools address the workspace through a VFS rooted at `/workspace`,
+    // so models naturally pass `/workspace` or `/workspace/<subpath>` to repo_map
+    // too (repo_map otherwise scans real host paths). Strip that root alias so
+    // the namespace matches read_file/grep_files instead of erroring with
+    // "path not found: /workspace". Mirrors the file store's own normalization.
+    let trimmed = path.trim_start_matches('/');
+    let relative = trimmed
+        .strip_prefix("workspace/")
+        .unwrap_or(if trimmed == "workspace" { "" } else { trimmed });
     let candidate = Path::new(relative);
     if candidate.components().any(|component| {
         matches!(
@@ -1833,6 +1841,85 @@ trait Named {
             },
         )
         .expect_err("outside path should fail");
+
+        assert!(err.to_string().contains("inside the workspace"));
+    }
+
+    // The file tools expose the workspace as a VFS rooted at `/workspace`, so a
+    // model addresses repo_map the same way. The bare root alias must resolve to
+    // the workspace root rather than erroring with "path not found: /workspace"
+    // (the very first call the nemotron eval run wasted a turn on).
+    #[test]
+    fn accepts_workspace_root_alias() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(&dir.path().join("src/lib.rs"), "pub fn inside_fn() {}\n");
+
+        for alias in ["/workspace", "workspace", "/workspace/"] {
+            let report = collect_repo_symbols(
+                dir.path(),
+                SymbolScanOptions {
+                    path: Some(alias.to_string()),
+                    query: None,
+                    language: Some("rust".to_string()),
+                    limit: 20,
+                    max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+                },
+            )
+            .unwrap_or_else(|e| panic!("alias {alias:?} should resolve to root: {e}"));
+
+            assert!(
+                report.symbols.iter().any(|s| s.name == "inside_fn"),
+                "alias {alias:?} did not scan the workspace root"
+            );
+        }
+    }
+
+    // A `/workspace/<subpath>` prefix scopes to that subpath, matching how the
+    // file tools resolve the same string.
+    #[test]
+    fn accepts_workspace_prefixed_subpath() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(&dir.path().join("pkg/inside.rs"), "pub fn pkg_fn() {}\n");
+        write(
+            &dir.path().join("other/elsewhere.rs"),
+            "pub fn other_fn() {}\n",
+        );
+
+        let report = collect_repo_symbols(
+            dir.path(),
+            SymbolScanOptions {
+                path: Some("/workspace/pkg".to_string()),
+                query: None,
+                language: Some("rust".to_string()),
+                limit: 20,
+                max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+            },
+        )
+        .expect("subpath under /workspace should scan");
+
+        assert!(report.symbols.iter().any(|s| s.name == "pkg_fn"));
+        assert!(
+            !report.symbols.iter().any(|s| s.name == "other_fn"),
+            "scope should be limited to /workspace/pkg"
+        );
+    }
+
+    // The alias must not become an escape hatch: `/workspace/../outside` still
+    // resolves through the root and is rejected.
+    #[test]
+    fn workspace_alias_does_not_bypass_containment() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let err = collect_repo_symbols(
+            dir.path(),
+            SymbolScanOptions {
+                path: Some("/workspace/../outside".to_string()),
+                query: None,
+                language: None,
+                limit: 20,
+                max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+            },
+        )
+        .expect_err("escaping the workspace via the alias should fail");
 
         assert!(err.to_string().contains("inside the workspace"));
     }

--- a/src/capabilities/repo_map.rs
+++ b/src/capabilities/repo_map.rs
@@ -29,19 +29,10 @@ const MAX_SIGNATURE_CHARS: usize = 180;
 // the candidate pool is bounded independently of `limit` to keep ranking work
 // predictable on large workspaces.
 const MAX_CANDIDATES: usize = 5000;
-const SKIP_DIRS: &[&str] = &[
-    ".git",
-    ".hg",
-    ".svn",
-    "target",
-    "node_modules",
-    ".next",
-    "dist",
-    "build",
-    ".direnv",
-    ".venv",
-    "venv",
-];
+// Non-hidden directories that are dependency/build output, not source. Hidden
+// entries (any name starting with `.` — `.git`, `.cache`, `.venv`, …) are
+// skipped separately, so they don't need listing here.
+const SKIP_DIRS: &[&str] = &["target", "node_modules", "dist", "build", "venv"];
 
 #[derive(Clone)]
 pub(crate) struct RepoMapCapability {
@@ -1009,12 +1000,20 @@ fn collect_supported_files(
         let Ok(file_type) = entry.file_type() else {
             continue;
         };
+        let name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("");
+        // Skip hidden entries (files and dirs): VCS, caches, virtualenvs, tool
+        // config — noise that crowds out real source and truncates the map. The
+        // swebench eval run showed `.cache/work/<vendored astropy>` dominating
+        // the map of this repo. An explicit scope INTO a hidden dir is still
+        // honored: only the recursive walk filters them.
+        if name.starts_with('.') {
+            continue;
+        }
         if file_type.is_dir() {
-            if path
-                .file_name()
-                .and_then(|name| name.to_str())
-                .is_some_and(|name| SKIP_DIRS.contains(&name))
-            {
+            if SKIP_DIRS.contains(&name) {
                 continue;
             }
             collect_supported_files(&path, language_filter, files, skipped_unsupported_files)?;
@@ -1902,6 +1901,49 @@ trait Named {
             !report.symbols.iter().any(|s| s.name == "other_fn"),
             "scope should be limited to /workspace/pkg"
         );
+    }
+
+    // Hidden files and directories (`.cache`, `.git`, `.env`, …) are noise for a
+    // symbol map and crowded out real source in the swebench eval run, where a
+    // vendored astropy checkout under `.cache/work/` dominated the map. The
+    // recursive walk skips every `.`-prefixed entry.
+    #[test]
+    fn recursive_scan_skips_hidden_files_and_dirs() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(&dir.path().join("src/real.rs"), "pub fn real_fn() {}\n");
+        write(
+            &dir.path().join(".cache/work/vendored.rs"),
+            "pub fn vendored_fn() {}\n",
+        );
+        write(
+            &dir.path().join(".git/hooks/hook.rs"),
+            "pub fn hook_fn() {}\n",
+        );
+        write(
+            &dir.path().join(".hidden.rs"),
+            "pub fn hidden_file_fn() {}\n",
+        );
+
+        let report = collect_repo_symbols(
+            dir.path(),
+            SymbolScanOptions {
+                path: None,
+                query: None,
+                language: Some("rust".to_string()),
+                limit: 50,
+                max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+            },
+        )
+        .expect("scan");
+
+        let names: Vec<&str> = report.symbols.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"real_fn"), "real source should be mapped");
+        for hidden in ["vendored_fn", "hook_fn", "hidden_file_fn"] {
+            assert!(
+                !names.contains(&hidden),
+                "hidden entry {hidden} should be skipped"
+            );
+        }
     }
 
     // The alias must not become an escape hatch: `/workspace/../outside` still

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -201,7 +201,12 @@ impl Tool for BashTool {
         Some("Bash")
     }
     fn description(&self) -> &str {
-        "Run a bash command from the workspace root. Captures stdout/stderr with configurable verbosity. 120s timeout."
+        "Run a bash command. Each call is a fresh non-interactive shell already \
+         rooted at the workspace, so no state persists between calls: the working \
+         directory, shell variables, and exports reset every time. A bare `cd` is \
+         pointless — you are already at the workspace root; use paths relative to \
+         it, or chain within one call (`cd sub && cmd`). Captures stdout/stderr \
+         with configurable verbosity. 120s timeout."
     }
     fn parameters_schema(&self) -> Value {
         json!({
@@ -361,6 +366,50 @@ mod tests {
         assert_eq!(tool.hints().long_running, Some(true));
         assert_eq!(tool.hints().supports_background, Some(true));
         assert!(tool.as_background_executable().is_some());
+    }
+
+    // The description must warn that the shell is stateless and already at the
+    // workspace root. A weak model (nemotron-3-ultra in the swebench matrix run)
+    // burned ~30 turns issuing bare `cd <workdir>` commands expecting the cwd to
+    // persist; spelling out the contract is what steers it away.
+    #[test]
+    fn bash_description_documents_stateless_shell() {
+        let tool = BashTool::new(Workspace::new(std::env::current_dir().unwrap()));
+        let desc = tool.description().to_lowercase();
+        assert!(desc.contains("no state persists") || desc.contains("state persists"));
+        assert!(desc.contains("cd"));
+        assert!(desc.contains("workspace root"));
+    }
+
+    // Lock the behavior the description promises: a `cd` in one call does not
+    // carry into the next; every call starts at the workspace root.
+    #[tokio::test]
+    async fn bash_cwd_does_not_persist_between_calls() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("sub")).unwrap();
+        let tool = BashTool::new(Workspace::new(dir.path().to_path_buf()));
+
+        let ToolExecutionResult::Success(first) =
+            tool.execute(json!({ "command": "cd sub && pwd" })).await
+        else {
+            panic!("expected success");
+        };
+        assert_eq!(first["success"], true);
+
+        // The next call must be back at the root, not in `sub`.
+        let ToolExecutionResult::Success(second) = tool
+            .execute(json!({ "command": "basename \"$PWD\"" }))
+            .await
+        else {
+            panic!("expected success");
+        };
+        let out = second["stdout"].as_str().unwrap_or("");
+        let root_name = dir.path().file_name().unwrap().to_string_lossy();
+        assert_eq!(
+            out.trim(),
+            root_name,
+            "cwd should reset to the workspace root between calls"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Three fixes surfaced by a SWE-bench Verified matrix run (astropy-12907) where weak
models thrashed on yolop tool footguns. Tool-behavior fixes plus one eval-harness
fix. (The eval **results archive** from that run is intentionally not included — fixes only.)

## Changes

1. **`repo_map` accepts the `/workspace` path** (`src/capabilities/repo_map.rs`).
   The file tools expose the workspace via a VFS rooted at `/workspace`, but
   `repo_map` scanned real host paths — so the natural first call,
   `repo_map(/workspace)`, errored `path not found: /workspace`. `resolve_scope`
   now strips the `/workspace` root alias so the namespace matches
   `read_file`/`grep_files`. Containment is preserved (`/workspace/../outside`
   still rejected).

2. **`repo_map` skips hidden files and dirs** (`src/capabilities/repo_map.rs`).
   The recursive walk only filtered a fixed `SKIP_DIRS` list, so a vendored
   astropy checkout under `evals/.../.cache/work/` dominated the map of this very
   repo and truncated it before reaching `src/`. The walk now skips every
   `.`-prefixed entry (`.cache`, `.git`, `.venv`, tool config); an explicit scope
   *into* a hidden dir is still honored. Redundant dotted names trimmed from
   `SKIP_DIRS`.

3. **bash tool documents the stateless shell** (`src/tools.rs`). Each call is a
   fresh `bash -lc` rooted at the workspace with no persisted state; the
   description only said "from the workspace root", so models issued dozens of
   bare `cd <workdir>` commands expecting cwd to persist. The description now
   states no state persists and a bare `cd` is pointless.

4. **eval: keep the per-instance Docker image** (`swebench_verified.py`, README).
   `SWEBENCH_CACHE_LEVEL` knob (default `env`, unchanged); `instance` keeps the
   prebuilt image so a multi-target matrix pulls it once instead of re-pulling per
   cell — which trips Docker Hub's anonymous pull-rate limit.

## Why / evidence

In the matrix run, `nemotron-3-ultra` spent **176 turns / 4.9M tokens / $2.10**;
`repo_map(/workspace)` failed on turn 0 and it then issued ~30 wasted bare `cd`
commands. `gpt-5.5` showed the same `cd`/path friction at smaller scale. These
fixes remove the footguns (model judgment, e.g. env-setup thrash, is out of scope).

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings` — clean.
- `cargo test --all-features` — green (new tests: `accepts_workspace_root_alias`,
  `accepts_workspace_prefixed_subpath`, `workspace_alias_does_not_bypass_containment`,
  `recursive_scan_skips_hidden_files_and_dirs`, `bash_description_documents_stateless_shell`,
  `bash_cwd_does_not_persist_between_calls`).
- Offline smoke (`--provider llmsim -p hi`) starts and completes.
- **Live smoke** (glm-5.2, real OpenRouter): `repo_map(path="/workspace")` now
  returns success, and the map surfaces real yolop source (`build.rs`, etc.)
  instead of the `.cache/` astropy noise.

## Security

Reviewed (TM-FS / TM-BASH / TM-DEP). `repo_map` stays read-only and
workspace-contained — the `/workspace` alias is stripped *before* the existing
containment check, so `../` escapes are still rejected (test-covered); hidden-skip
only narrows read scope. The bash change is description text only — timeout
(120s), output cap (1 MiB), and `current_dir` are unchanged. No new dependencies.
The eval `cache_level` value is passed as a single argv element to the swebench
harness (which validates it against a fixed enum) — no shell injection. No
key/log exposure.

## Follow-ups

- End-to-end nemotron re-run through the eval harness is blocked in this
  environment by git egress policy (SWE-bench source repos return 403); validated
  the fix via the live `repo_map` smoke instead. Re-run when egress allows.
- Optional: a one-line SWE-bench prompt nudge telling the agent not to build/run
  the project to self-verify (the dominant cost driver was env-setup thrash). Eval
  scope; deferred.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K3QA9HVYXEZw93ZEykvzdt)_