### PR TITLE
chore(evals): adopt mira 0.2.0 launchers; bump mira-eval to 0.2.0

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -12,26 +12,27 @@ agent, scoring). One study per subfolder.
 
 ## Running a study with mira
 
-Install the host CLI once (`brew install everruns/tap/mira`, or from crates.io
-with `cargo install mira-cli --locked`), then drive a study from its own
+Install the host CLI once (`brew install everruns/tap/mira`, `cargo binstall
+mira-cli`, or `cargo install mira-cli --locked`), then drive a study from its own
 directory so its `mira.toml` is found and `--save` archives land in that study's
-`results/`. (Authoring a Python study? The [`mira-eval`](https://pypi.org/project/mira-eval/)
-SDK is on PyPI — `pip install mira-eval`.)
+`results/`. Each study's `mira.toml` declares a `default_launcher` (mira >=0.2.0),
+so a bare `mira run`/`mira list` from that directory starts it — no
+`--uv`/`--cmd` needed. (Authoring a Python study? The
+[`mira-eval`](https://pypi.org/project/mira-eval/) SDK is on PyPI —
+`pip install mira-eval`.)
 
 ```bash
 cd evals/swebench_verified
 ./bootstrap.sh                      # yolop build + mira + agent CLIs (+ pre-warm uv deps)
 
-STUDY="uv run swebench_verified.py"   # single-file study; uv installs its inline deps
-
 # What the study advertises: the eval, its samples, and the matrix of targets.
-mira --cmd "$STUDY" list
+mira list
 
 # Offline plumbing check — one instance, no API key, no Docker, not saved.
-SWEBENCH_NO_EVAL=1 mira --cmd "$STUDY" run astropy__astropy-12907 --targets llmsim
+SWEBENCH_NO_EVAL=1 mira run astropy__astropy-12907 --targets llmsim
 
 # Real run: solve + Docker-score one instance, archive the run under ./results.
-doppler run -- mira --cmd "$STUDY" run astropy__astropy-12907 \
+doppler run -- mira run astropy__astropy-12907 \
     --targets anthropic-claude-sonnet-4.5 --save
 ```
 

--- a/evals/swebench_verified/README.md
+++ b/evals/swebench_verified/README.md
@@ -8,7 +8,7 @@ protocol — owns the SWE-bench-specific work (loading instances, checking out
 repos, running agent CLIs, and the Docker `FAIL_TO_PASS` scoring). Designed to
 grow: new benchmarks and new agents plug in behind small interfaces.
 
-See [Usage](#usage) for the `mira --cmd …` invocations.
+See [Usage](#usage) for how to drive it with `mira`.
 
 ## Agents
 
@@ -91,9 +91,9 @@ column carries its config (`agent`, `model`, `reasoning_effort`, `price`, …), 
 the host can break results down by any of them:
 
 ```bash
-mira --cmd "$STUDY" run --tag tracking-v1 --group-by repo         # resolve rate per repo
-mira --cmd "$STUDY" run --group-by difficulty                     # per difficulty tier
-mira --cmd "$STUDY" run --group-by agent                          # yolop vs claude-code vs …
+mira run --tag tracking-v1 --group-by repo         # resolve rate per repo
+mira run --group-by difficulty                     # per difficulty tier
+mira run --group-by agent                          # yolop vs claude-code vs …
 ```
 
 Cost is cache-aware (`cache_read`/`cache_creation` tokens are priced), so cost
@@ -130,8 +130,8 @@ Every sample is tagged with the suites it belongs to. The **`tracking` preset**
 (gpt-5.5 high · glm-5.2 · opus-4.8); or select it ad-hoc with `--tag`:
 
 ```bash
-mira --cmd "uv run swebench_verified.py" run --preset tracking --group-by difficulty --save
-mira --cmd "uv run swebench_verified.py" run --tag tracking-v1 --targets openai-gpt-5.5 --save
+mira run --preset tracking --group-by difficulty --save
+mira run --tag tracking-v1 --targets openai-gpt-5.5 --save
 ```
 
 Re-running `select_tracking.py` on the same dataset reproduces the committed set
@@ -185,7 +185,8 @@ with `AGENTS=codex,pi evals/swebench_verified/bootstrap.sh`. Manual equivalent:
 ```bash
 ( cd ../.. && cargo build --release )    # produces target/release/yolop
 brew install everruns/tap/mira           # the host CLI (prebuilt binary, recommended)
-# …or from crates.io:  cargo install mira-cli --locked   (compiles from source)
+# …or:  cargo binstall mira-cli          # prebuilt binary (mira-cli >=0.2.0 ships binstall metadata)
+# …or:  cargo install mira-cli --locked  # compiles from source
 # bootstrap.sh prefers a prebuilt binary via cargo-binstall when available.
 # Python deps need nothing — `uv run swebench_verified.py` installs them on first use.
 ```
@@ -213,31 +214,32 @@ reproducible against the binaries it was produced with.
 `swebench_verified` is a [Mira](https://github.com/everruns/mira) eval study: the `mira`
 host CLI drives it over a stdio JSON protocol, owning the matrix, selection,
 checkpoints, and reporting, while the study owns the SWE-bench-specific run +
-Docker scoring. Drive it with `--cmd` pointed at the script:
+Docker scoring. `mira.toml` declares a `default_launcher` (mira >=0.2.0), so from
+this directory a bare `mira run`/`mira list` starts the study — no `--uv
+swebench_verified.py` (or the older `--cmd "uv run swebench_verified.py"`) needed:
 
 ```bash
 cd evals/swebench_verified      # so the adjacent mira.toml is found; --save lands in ./results
-STUDY="uv run swebench_verified.py"
 
 # What the study advertises: the eval, its samples (instances), and the models
 # (matrix configs); configs with a missing provider key show as unavailable.
-mira --cmd "$STUDY" list
+mira list
 
 # Plumbing only: one instance on the offline llmsim config, skip Docker eval.
-SWEBENCH_NO_EVAL=1 mira --cmd "$STUDY" run astropy__astropy-12907 --targets llmsim
+SWEBENCH_NO_EVAL=1 mira run astropy__astropy-12907 --targets llmsim
 
 # Real end-to-end on one instance, selected configs (substring selection on the
 # case key, like `cargo test`), archived under ./results.
-doppler run -- mira --cmd "$STUDY" run astropy__astropy-12907 \
+doppler run -- mira run astropy__astropy-12907 \
     --targets openai-gpt-5.5,openai-gpt-5.5-high --save
 
 # Whole benchmark (all 500), one config, resumable + saved run archive.
-doppler run -- mira --cmd "$STUDY" run --targets openai-gpt-5.5 \
+doppler run -- mira run --targets openai-gpt-5.5 \
     --checkpoint ck/openai-gpt-5.5.json --save
 ```
 
 Study-internal knobs that the host doesn't own are read from the environment so
-they can be set on the `--cmd` line: `SWEBENCH_NO_EVAL=1` (skip Docker scoring),
+they can be set on the `mira` line: `SWEBENCH_NO_EVAL=1` (skip Docker scoring),
 `SWEBENCH_MAX_WORKERS=N` (Docker eval parallelism), `SWEBENCH_NAMESPACE=none`
 (build images locally instead of pulling prebuilt), `SWEBENCH_EVAL_TIMEOUT`,
 `SWEBENCH_YOLOP_BIN` (override the yolop binary), `SWEBENCH_CACHE_LEVEL=instance`

--- a/evals/swebench_verified/bootstrap.sh
+++ b/evals/swebench_verified/bootstrap.sh
@@ -53,12 +53,9 @@ elif have brew; then
   brew install everruns/tap/mira || echo "  ! mira install failed; install manually"
 elif have cargo-binstall || have cargo; then
   # Prefer a prebuilt binary (seconds) over compiling mira-cli from source
-  # (minutes). mira-cli ships no [package.metadata.binstall], and its release
-  # assets are named after the binary (mira-<target>.tar.gz, tag v<version>),
-  # not the crate, so cargo-binstall needs explicit URL/layout overrides.
-  if have cargo-binstall && cargo binstall -y mira-cli \
-       --pkg-url "{ repo }/releases/download/v{ version }/mira-{ target }.tar.gz" \
-       --pkg-fmt tgz --bin-dir "mira{ binary-ext }"; then
+  # (minutes). mira-cli >=0.2.0 ships [package.metadata.binstall], so
+  # cargo-binstall resolves the release tarball without URL/layout overrides.
+  if have cargo-binstall && cargo binstall -y mira-cli; then
     :
   else
     cargo install mira-cli --locked \
@@ -95,10 +92,10 @@ cat <<'EOF'
 
   Docker daemon must be running for SWE-bench evaluation.
 
-  Run from this study directory (so mira.toml is found and runs save here):
+  Run from this study directory (so mira.toml is found, its default_launcher
+  drives the study, and runs save here):
     cd evals/swebench_verified
 
   Smoke test (offline, skips Docker):
-    SWEBENCH_NO_EVAL=1 mira --cmd "uv run swebench_verified.py" \
-      run astropy__astropy-12907 --models llmsim
+    SWEBENCH_NO_EVAL=1 mira run astropy__astropy-12907 --targets llmsim
 EOF

--- a/evals/swebench_verified/compare.sh
+++ b/evals/swebench_verified/compare.sh
@@ -23,6 +23,7 @@ else
   SELECT=(--preset compare)
 fi
 
-cd "$(dirname "$0")"   # so mira.toml (presets + results dir) is found
-exec doppler run -- "$MIRA" --cmd "uv run swebench_verified.py" \
+cd "$(dirname "$0")"   # so mira.toml (launcher + presets + results dir) is found
+# mira.toml's default_launcher starts the study, so no --uv/--cmd needed here.
+exec doppler run -- "$MIRA" \
   run "$INSTANCE" "${SELECT[@]}" --group-by agent --save "$@"

--- a/evals/swebench_verified/mira.toml
+++ b/evals/swebench_verified/mira.toml
@@ -8,6 +8,15 @@
 # Layout per saved run: results/<run_id>/{report.json,report.html,meta.json}
 # (run_id = YYYYMMDDThhmmssZ-xxxx, sortable by time).
 
+# Named launcher: how `mira` (>=0.2.0) starts this study. With `default_launcher`
+# set, a bare `mira list` / `mira run …` from this directory drives the study —
+# no `--uv swebench_verified.py` (or the older `--cmd "uv run
+# swebench_verified.py"`) needed. Explicit launch flags still override it.
+default_launcher = "study"
+
+[launchers.study]
+uv = "swebench_verified.py"   # single-file PEP 723 study; uv installs inline deps
+
 [results]
 dir = "./results"
 

--- a/evals/swebench_verified/swebench_verified.py
+++ b/evals/swebench_verified/swebench_verified.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.11"
-# dependencies = ["mira-eval>=0.1.0", "pandas>=2.0", "pyarrow>=14.0", "swebench>=4.1.0"]
+# dependencies = ["mira-eval>=0.2.0", "pandas>=2.0", "pyarrow>=14.0", "swebench>=4.1.0"]
 # ///
 """swebench_verified — a single-file Mira eval study for SWE-bench Verified.
 
@@ -13,8 +13,11 @@ self-contained file with its dependencies declared inline (PEP 723), so `uv`
 builds an ephemeral env and runs it with no project scaffolding:
 
     cd evals/swebench_verified
-    mira --cmd "uv run swebench_verified.py" list
-    mira --cmd "uv run swebench_verified.py" run astropy__astropy-12907 --targets anthropic-claude-sonnet-4.5 --save
+    mira list                  # mira.toml's default_launcher drives this study
+    mira run astropy__astropy-12907 --targets anthropic-claude-sonnet-4.5 --save
+
+(`mira --uv swebench_verified.py …` is the explicit equivalent; `--cmd "uv run
+swebench_verified.py"` still works for arbitrary command lines.)
 
 The `mira` host owns the target matrix, selection, concurrency, checkpoints, and
 reporting; this study owns the SWE-bench-specific work:


### PR DESCRIPTION
## What

Pull the next `mira` release (0.2.0, up from 0.1.0) into the
`swebench_verified` eval study and adopt its new ergonomics.

mira 0.2.0's relevant additions (from its [release notes](https://github.com/everruns/mira/releases/tag/v0.2.0)):
- **Named + polyglot launchers** — `[launchers.NAME]` in `mira.toml` with
  `default_launcher`, plus `mira --uv/--python/--python3 SCRIPT` flags,
  replacing the verbose `--cmd "uv run …"`.
- **`cargo binstall mira-cli`** — `mira-cli` now ships
  `[package.metadata.binstall]`, so the prebuilt binary installs with no
  URL/layout overrides.

Adopted here:
- **`mira.toml`**: add `[launchers.study]` (`uv = "swebench_verified.py"`) +
  `default_launcher = "study"`, so a bare `mira run`/`mira list` from the
  study dir drives it.
- **`compare.sh`** + **docs/docstring**: drop `--cmd "uv run swebench_verified.py"`
  in favor of the default launcher; document `--uv` and the `--cmd` fallback.
- **`bootstrap.sh`**: simplify the `mira-cli` install to plain
  `cargo binstall -y mira-cli`; fix a stale `--models` flag (now `--targets`)
  in the offline smoke test.
- **`swebench_verified.py`**: bump the PEP 723 pin to `mira-eval>=0.2.0`.

## Why

Removes the per-invocation `--cmd "uv run swebench_verified.py"` boilerplate
and keeps the study in lockstep with the published `mira`/`mira-eval` 0.2.0,
as called for in AGENTS.md ("Keep public runtime crate versions in lockstep").

## Validation

- **SDK bump is safe**: diffed `mira-eval` 0.1.0 → 0.2.0 — the Python API and
  exports are unchanged (only docstring "cell"→"case" wording); protocol stays
  `1.0`. All **33 study unit tests pass** under mira-eval 0.2.0
  (`uv run --with mira-eval -m unittest discover -s tests`).
- **Launcher verified end-to-end** with the real prebuilt `mira 0.2.0` binary
  from the study dir: bare `mira list` (via `default_launcher`),
  `mira --uv swebench_verified.py list`, and `mira --launcher study list` all
  resolve and start the study (`ready: study=swebench_verified · protocol 1.0`).
  The only error observed was a flaky partial HF dataset download through the
  sandbox proxy — unrelated to this change.
- `mira.toml` parses (`tomllib`); `bash -n` clean on both scripts; CI green.

## Security

No security-relevant code changes — config/docs only, plus a dependency
**minor** bump of the dev/eval-only `mira-eval` SDK (study lives outside the
Cargo workspace; no change to the `yolop` binary, its filesystem/shell/LLM
surface, or any runtime capability).

## Follow-ups

- mira 0.2.0 renamed the host vocabulary "cell" → "case"; this study's prose
  and internal identifiers (`_run_agent_cell`, README "per-cell") still say
  "cell". Deferred as a cosmetic, churny rename to keep this PR focused.