### PR TITLE
fix(paths): unify workspace VFS alias handling and spawn cwd

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1302,7 +1302,8 @@ impl App {
     }
 
     fn start_shell_command(&mut self, command: String) {
-        let workspace_root = self.startup.workspace_root.clone();
+        let workspace_root = self.worktree.active_root();
+        self.startup.workspace_root = workspace_root.clone();
         self.push_user(format!("!shell {command}"));
         let handle = self.session.run_shell(command, workspace_root);
         self.begin_turn(handle, Some("running shell command".into()));

--- a/src/capabilities/ast_grep.rs
+++ b/src/capabilities/ast_grep.rs
@@ -4,6 +4,7 @@
 //! code shapes: call expressions, function declarations, wrappers, and other
 //! patterns where lexical search is too noisy.
 
+use crate::workspace_path::{self, SharedWorkspaceRoot};
 use anyhow::{Context, Result, bail};
 use ast_grep_core::matcher::Pattern;
 use ast_grep_core::meta_var::MetaVariable;
@@ -18,7 +19,7 @@ use serde::Serialize;
 use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::fs;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 
 pub(crate) const AST_GREP_CAPABILITY_ID: &str = "ast_grep";
 
@@ -44,11 +45,11 @@ const SKIP_DIRS: &[&str] = &[
 
 #[derive(Clone)]
 pub(crate) struct AstGrepCapability {
-    workspace_root: PathBuf,
+    workspace_root: SharedWorkspaceRoot,
 }
 
 impl AstGrepCapability {
-    pub(crate) fn new(workspace_root: PathBuf) -> Self {
+    pub(crate) fn new(workspace_root: SharedWorkspaceRoot) -> Self {
         Self { workspace_root }
     }
 }
@@ -103,7 +104,7 @@ impl Capability for AstGrepCapability {
 }
 
 struct AstGrepTool {
-    workspace_root: PathBuf,
+    workspace_root: SharedWorkspaceRoot,
 }
 
 #[async_trait]
@@ -169,10 +170,15 @@ impl Tool for AstGrepTool {
     }
 
     async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        match ast_grep_from_arguments(&self.workspace_root, &arguments) {
+        let workspace_root = self
+            .workspace_root
+            .read()
+            .map(|guard| guard.clone())
+            .unwrap_or_else(|_| PathBuf::from("."));
+        match ast_grep_from_arguments(&workspace_root, &arguments) {
             Ok(report) => ToolExecutionResult::success(json!({
                 "ok": true,
-                "workspace_root": self.workspace_root.display().to_string(),
+                "workspace_root": workspace_root.display().to_string(),
                 "path": report.path,
                 "pattern": report.pattern,
                 "language": report.language,
@@ -386,7 +392,7 @@ fn ast_grep(workspace_root: &Path, options: AstGrepOptions) -> Result<AstGrepRep
     let root = workspace_root
         .canonicalize()
         .context("canonicalize workspace root")?;
-    let scope = resolve_scope(&root, options.path.as_deref())?;
+    let scope = workspace_path::resolve_workspace_scope(&root, options.path.as_deref())?;
     let language_filter = match options.language.as_deref() {
         Some(language) => Some(resolve_language_filter(language)?),
         None => None,
@@ -577,33 +583,6 @@ fn bounded_usize(value: Option<&Value>, default: usize, max: usize, name: &str) 
     Ok(number as usize)
 }
 
-fn resolve_scope(root: &Path, path: Option<&str>) -> Result<PathBuf> {
-    let Some(path) = path else {
-        return Ok(root.to_path_buf());
-    };
-    let relative = path.trim().trim_start_matches('/');
-    if relative.is_empty() || relative == "." {
-        return Ok(root.to_path_buf());
-    }
-    let candidate = Path::new(relative);
-    if candidate.components().any(|component| {
-        matches!(
-            component,
-            Component::ParentDir | Component::RootDir | Component::Prefix(_)
-        )
-    }) {
-        bail!("`path` must stay inside the workspace");
-    }
-    let scope = root.join(candidate);
-    let canonical = scope
-        .canonicalize()
-        .with_context(|| format!("path not found: {path}"))?;
-    if !canonical.starts_with(root) {
-        bail!("`path` must stay inside the workspace");
-    }
-    Ok(canonical)
-}
-
 fn collect_supported_files(
     path: &Path,
     language_filter: Option<&str>,
@@ -695,6 +674,11 @@ fn truncate_chars(value: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Arc, RwLock};
+
+    fn shared_root(path: &Path) -> SharedWorkspaceRoot {
+        Arc::new(RwLock::new(path.to_path_buf()))
+    }
 
     fn write(path: &Path, content: &str) {
         if let Some(parent) = path.parent() {
@@ -769,7 +753,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         write(&dir.path().join("src/lib.rs"), "fn target() {}\n");
 
-        let capability = AstGrepCapability::new(dir.path().to_path_buf());
+        let capability = AstGrepCapability::new(shared_root(dir.path()));
         let tools = capability.tools();
         let tool = tools
             .iter()
@@ -790,6 +774,27 @@ mod tests {
         assert_eq!(value["matches"][0]["path"], json!("src/lib.rs"));
         assert_eq!(value["matches"][0]["captures"][0]["name"], json!("NAME"));
         assert_eq!(value["matches"][0]["captures"][0]["text"], json!("target"));
+    }
+
+    #[test]
+    fn accepts_workspace_root_alias() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(&dir.path().join("src/lib.rs"), "fn target() {}\n");
+
+        let report = ast_grep(
+            dir.path(),
+            AstGrepOptions {
+                pattern: "fn $NAME() {}".to_string(),
+                path: Some("/workspace/src".to_string()),
+                language: Some("rust".to_string()),
+                limit: 20,
+                max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+            },
+        )
+        .expect("vfs subpath should scan");
+
+        assert_eq!(report.matches.len(), 1);
+        assert_eq!(report.matches[0].path, "src/lib.rs");
     }
 
     #[test]

--- a/src/capabilities/background.rs
+++ b/src/capabilities/background.rs
@@ -16,6 +16,7 @@
 // Results survive a restart; in-flight processes do not. See specs/background.md.
 
 use crate::capabilities::narration::stable_labeled;
+use crate::workspace_path::{self, SharedWorkspaceRoot};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
@@ -203,7 +204,7 @@ pub struct BackgroundRegistry {
     inner: Arc<Mutex<Inner>>,
     dir: PathBuf,
     index_path: PathBuf,
-    workspace_root: PathBuf,
+    workspace_root: SharedWorkspaceRoot,
     max_runtime_secs: u64,
     /// Present only when this session may spawn sub-agents (absent in child
     /// sessions — see [`AgentSpawner`]).
@@ -214,7 +215,7 @@ impl BackgroundRegistry {
     /// Open (or restore) the registry for a session. Reads the index if present;
     /// any task still marked `running` is re-labelled `interrupted` (its process
     /// died with the previous yolop) and the corrected index is re-persisted.
-    pub fn load(session_dir: &Path, workspace_root: PathBuf) -> Self {
+    pub fn load(session_dir: &Path, workspace_root: SharedWorkspaceRoot) -> Self {
         let dir = session_dir.join(BACKGROUND_SUBDIR);
         let index_path = dir.join(INDEX_FILE);
         let mut records = read_index(&index_path);
@@ -418,7 +419,11 @@ impl BackgroundRegistry {
         let max_runtime = self.max_runtime_secs;
         let task_id = id.clone();
         let handle = tokio::spawn(async move {
-            let outcome = run_script(&dir, &log_file, &workspace_root, &command, max_runtime).await;
+            let root = workspace_root
+                .read()
+                .map(|guard| guard.clone())
+                .unwrap_or_else(|_| PathBuf::from("."));
+            let outcome = run_script(&dir, &log_file, &root, &command, max_runtime).await;
             update_record(&inner, &index_path, &task_id, |r| {
                 // Only apply the outcome if the task is still running. A
                 // concurrent `cancel` may have already marked it `cancelled`
@@ -702,10 +707,20 @@ async fn run_script(
         let _ = tokio::fs::set_permissions(&log_path, std::fs::Permissions::from_mode(0o600)).await;
     }
 
+    let cwd = match workspace_path::resolve_spawn_cwd(workspace_root) {
+        Ok(cwd) => cwd,
+        Err(message) => {
+            return ScriptOutcome {
+                status: BackgroundStatus::Failed,
+                exit_code: None,
+                summary: message,
+            };
+        }
+    };
     let mut child = match Command::new("bash")
         .arg("-lc")
         .arg(command)
-        .current_dir(workspace_root)
+        .current_dir(&cwd)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true)
@@ -1516,9 +1531,10 @@ impl Tool for BackgroundCancelTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::RwLock;
 
     fn registry_in(dir: &Path) -> BackgroundRegistry {
-        BackgroundRegistry::load(dir, dir.to_path_buf())
+        BackgroundRegistry::load(dir, Arc::new(RwLock::new(dir.to_path_buf())))
     }
 
     /// Test spawner that returns a canned outcome, so the registry's sub-agent

--- a/src/capabilities/repo_map.rs
+++ b/src/capabilities/repo_map.rs
@@ -5,6 +5,7 @@
 //! lexical search is too narrow.
 
 use crate::capabilities::narration::stable_labeled;
+use crate::workspace_path::{self, SharedWorkspaceRoot};
 use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
 use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
@@ -15,7 +16,7 @@ use serde::Serialize;
 use serde_json::{Value, json};
 use std::cmp::Ordering;
 use std::fs;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use tree_sitter::{Language, Node, Parser};
 
 pub(crate) const REPO_MAP_CAPABILITY_ID: &str = "repo_map";
@@ -36,11 +37,11 @@ const SKIP_DIRS: &[&str] = &["target", "node_modules", "dist", "build", "venv"];
 
 #[derive(Clone)]
 pub(crate) struct RepoMapCapability {
-    workspace_root: PathBuf,
+    workspace_root: SharedWorkspaceRoot,
 }
 
 impl RepoMapCapability {
-    pub(crate) fn new(workspace_root: PathBuf) -> Self {
+    pub(crate) fn new(workspace_root: SharedWorkspaceRoot) -> Self {
         Self { workspace_root }
     }
 }
@@ -100,7 +101,7 @@ impl Capability for RepoMapCapability {
 }
 
 struct RepoMapTool {
-    workspace_root: PathBuf,
+    workspace_root: SharedWorkspaceRoot,
 }
 
 #[async_trait]
@@ -136,10 +137,15 @@ impl Tool for RepoMapTool {
     }
 
     async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        match scan_from_arguments(&self.workspace_root, &arguments) {
+        let workspace_root = self
+            .workspace_root
+            .read()
+            .map(|guard| guard.clone())
+            .unwrap_or_else(|_| PathBuf::from("."));
+        match scan_from_arguments(&workspace_root, &arguments) {
             Ok(report) => ToolExecutionResult::success(json!({
                 "ok": true,
-                "workspace_root": self.workspace_root.display().to_string(),
+                "workspace_root": workspace_root.display().to_string(),
                 "path": report.path,
                 "query": report.query,
                 "languages": report.languages,
@@ -158,7 +164,7 @@ impl Tool for RepoMapTool {
 }
 
 struct RepoSymbolsTool {
-    workspace_root: PathBuf,
+    workspace_root: SharedWorkspaceRoot,
 }
 
 #[async_trait]
@@ -194,10 +200,15 @@ impl Tool for RepoSymbolsTool {
     }
 
     async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        match scan_from_arguments(&self.workspace_root, &arguments) {
+        let workspace_root = self
+            .workspace_root
+            .read()
+            .map(|guard| guard.clone())
+            .unwrap_or_else(|_| PathBuf::from("."));
+        match scan_from_arguments(&workspace_root, &arguments) {
             Ok(report) => ToolExecutionResult::success(json!({
                 "ok": true,
-                "workspace_root": self.workspace_root.display().to_string(),
+                "workspace_root": workspace_root.display().to_string(),
                 "path": report.path,
                 "query": report.query,
                 "languages": report.languages,
@@ -353,7 +364,7 @@ fn collect_repo_symbols(
     let root = workspace_root
         .canonicalize()
         .with_context(|| format!("canonicalize workspace root {}", workspace_root.display()))?;
-    let scope = resolve_scope(&root, options.path.as_deref())?;
+    let scope = workspace_path::resolve_workspace_scope(&root, options.path.as_deref())?;
     let language_filter = options.language.as_deref().map(normalize_language_filter);
     if let Some(filter) = language_filter.as_deref()
         && !LANGUAGES
@@ -937,38 +948,6 @@ fn normalize_language_filter(language: &str) -> String {
     language.trim().to_ascii_lowercase()
 }
 
-fn resolve_scope(root: &Path, path: Option<&str>) -> Result<PathBuf> {
-    let Some(path) = path else {
-        return Ok(root.to_path_buf());
-    };
-    // The file tools address the workspace through a VFS rooted at `/workspace`,
-    // so models naturally pass `/workspace` or `/workspace/<subpath>` to repo_map
-    // too (repo_map otherwise scans real host paths). Strip that root alias so
-    // the namespace matches read_file/grep_files instead of erroring with
-    // "path not found: /workspace". Mirrors the file store's own normalization.
-    let trimmed = path.trim_start_matches('/');
-    let relative = trimmed
-        .strip_prefix("workspace/")
-        .unwrap_or(if trimmed == "workspace" { "" } else { trimmed });
-    let candidate = Path::new(relative);
-    if candidate.components().any(|component| {
-        matches!(
-            component,
-            Component::ParentDir | Component::RootDir | Component::Prefix(_)
-        )
-    }) {
-        bail!("`path` must stay inside the workspace");
-    }
-    let scope = root.join(candidate);
-    let canonical = scope
-        .canonicalize()
-        .with_context(|| format!("path not found: {path}"))?;
-    if !canonical.starts_with(root) {
-        bail!("`path` must stay inside the workspace");
-    }
-    Ok(canonical)
-}
-
 fn collect_supported_files(
     path: &Path,
     language_filter: Option<&str>,
@@ -1407,6 +1386,11 @@ fn truncate_chars(value: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Arc, RwLock};
+
+    fn shared_root(path: &Path) -> SharedWorkspaceRoot {
+        Arc::new(RwLock::new(path.to_path_buf()))
+    }
 
     fn write(path: &Path, content: &str) {
         if let Some(parent) = path.parent() {
@@ -1764,7 +1748,7 @@ trait Named {
         let dir = tempfile::tempdir().expect("tempdir");
         write(&dir.path().join("app.py"), "def py_fn():\n    pass\n");
 
-        let capability = RepoMapCapability::new(dir.path().to_path_buf());
+        let capability = RepoMapCapability::new(shared_root(dir.path()));
         let tools = capability.tools();
         let tool = tools
             .iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ mod test_env;
 mod tools;
 mod transcript;
 mod version;
+mod workspace_path;
 mod worktree;
 
 #[cfg(test)]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2261,8 +2261,8 @@ pub async fn build_with_options(
     capabilities.register(crate::capabilities::skills::SkillManagementCapability::new(
         skill_dirs.clone(),
     ));
-    capabilities.register(RepoMapCapability::new(effective_root.clone()));
-    capabilities.register(AstGrepCapability::new(effective_root.clone()));
+    capabilities.register(RepoMapCapability::new(shared_workspace_root.clone()));
+    capabilities.register(AstGrepCapability::new(shared_workspace_root.clone()));
     capabilities.register(InfinityContextCapability);
     capabilities.register(CompactionCapability);
     capabilities.register(StatelessTodoListCapability);
@@ -2361,7 +2361,8 @@ pub async fn build_with_options(
     // to `<session_dir>/background/` so results survive a restart. Reuses this
     // session's folder, the same durability substrate as the JSONL event log.
     // See specs/background.md.
-    let mut background_registry = BackgroundRegistry::load(&session_dir, effective_root.clone());
+    let mut background_registry =
+        BackgroundRegistry::load(&session_dir, shared_workspace_root.clone());
     // Top-level sessions can spawn sub-agents; child sub-agent sessions cannot
     // (depth bound). The spawner builds a fresh child session per sub-agent,
     // reusing the live provider, this session's sessions dir, and settings.

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -7,6 +7,7 @@
 // security model for unsandboxed shell-on-host needs yolop-specific policy
 // (timeout, output cap). See EVE-478 for the eventual runtime-side story.
 
+use crate::workspace_path;
 use async_trait::async_trait;
 use everruns_core::exec_tool_result::ExecToolResultPayload;
 use everruns_core::tool_narration::ToolNarrationPhase;
@@ -80,6 +81,12 @@ impl BashTool {
         sink: Option<Arc<dyn BackgroundEventSink>>,
     ) -> Result<BashRunOutput, ToolExecutionResult> {
         let root = self.ws.root().to_path_buf();
+        let cwd = match workspace_path::resolve_spawn_cwd(&root) {
+            Ok(cwd) => cwd,
+            Err(message) => {
+                return Err(ToolExecutionResult::tool_error(message));
+            }
+        };
         let timeout = Duration::from_secs(self.timeout_secs);
         let max_bytes = self.max_output_bytes;
 
@@ -92,7 +99,7 @@ impl BashTool {
         let mut child = Command::new("bash")
             .arg("-lc")
             .arg(command)
-            .current_dir(&root)
+            .current_dir(&cwd)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true)
@@ -409,6 +416,22 @@ mod tests {
             out.trim(),
             root_name,
             "cwd should reset to the workspace root between calls"
+        );
+    }
+
+    #[tokio::test]
+    async fn bash_reports_missing_workspace_directory_instead_of_spawn_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("removed");
+        let tool = BashTool::new(Workspace::new(missing));
+
+        let result = tool.execute(json!({ "command": "true" })).await;
+        let ToolExecutionResult::ToolError(message) = result else {
+            panic!("expected tool error, got {result:?}");
+        };
+        assert!(
+            message.contains("workspace directory does not exist"),
+            "got: {message}"
         );
     }
 

--- a/src/workspace_path.rs
+++ b/src/workspace_path.rs
@@ -1,0 +1,121 @@
+// Shared workspace path helpers.
+//
+// Yolop exposes two path namespaces to models:
+// - **VFS** (`/workspace`, `/src/foo.rs`, `/outputs/...`) for file tools
+// - **Host** (real filesystem paths) for bash, environment context, and spawn cwd
+//
+// Models trained on cloud-agent layouts often pass `/workspace/...` to every
+// tool. File tools and repo_map normalize that alias; bash runs on the host and
+// must use a directory that actually exists on disk.
+
+use anyhow::{Context, Result, bail};
+use std::path::{Component, Path, PathBuf};
+
+/// Shared, session-mutable workspace root (worktree switches update this).
+pub type SharedWorkspaceRoot = std::sync::Arc<std::sync::RwLock<PathBuf>>;
+
+/// Strip the `/workspace` VFS root alias that file tools expose to models.
+///
+/// Accepts `/workspace`, `/workspace/`, `workspace`, and `/workspace/<subpath>`.
+pub fn strip_workspace_vfs_prefix(path: &str) -> &str {
+    let trimmed = path.trim().trim_start_matches('/');
+    trimmed
+        .strip_prefix("workspace/")
+        .unwrap_or(if trimmed == "workspace" { "" } else { trimmed })
+}
+
+/// Resolve an optional path argument against a canonical workspace root.
+///
+/// Mirrors file-store normalization: `/workspace/foo` scopes to `foo` under
+/// `root`, not a literal `root/workspace/foo` host path.
+pub fn resolve_workspace_scope(root: &Path, path: Option<&str>) -> Result<PathBuf> {
+    let Some(path) = path else {
+        return Ok(root.to_path_buf());
+    };
+    let relative = strip_workspace_vfs_prefix(path);
+    if relative.is_empty() || relative == "." {
+        return Ok(root.to_path_buf());
+    }
+    let candidate = Path::new(relative);
+    if candidate.components().any(|component| {
+        matches!(
+            component,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        )
+    }) {
+        bail!("`path` must stay inside the workspace");
+    }
+    let scope = root.join(candidate);
+    let canonical = scope
+        .canonicalize()
+        .with_context(|| format!("path not found: {path}"))?;
+    if !canonical.starts_with(root) {
+        bail!("`path` must stay inside the workspace");
+    }
+    Ok(canonical)
+}
+
+/// Return a directory suitable for `Command::current_dir`.
+///
+/// When the workspace directory was removed (e.g. `git worktree remove .`), spawn
+/// would otherwise fail with the opaque `spawn failed: No such file or directory`.
+pub fn resolve_spawn_cwd(root: &Path) -> Result<PathBuf, String> {
+    if root.is_dir() {
+        return Ok(root.to_path_buf());
+    }
+    Err(format!(
+        "workspace directory does not exist: {}",
+        root.display()
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn strip_workspace_vfs_prefix_handles_root_aliases() {
+        assert_eq!(strip_workspace_vfs_prefix("/workspace"), "");
+        assert_eq!(strip_workspace_vfs_prefix("/workspace/"), "");
+        assert_eq!(strip_workspace_vfs_prefix("workspace"), "");
+        assert_eq!(strip_workspace_vfs_prefix("/workspace/src"), "src");
+        assert_eq!(strip_workspace_vfs_prefix("workspace/pkg"), "pkg");
+        assert_eq!(strip_workspace_vfs_prefix("/src/lib.rs"), "src/lib.rs");
+    }
+
+    #[test]
+    fn resolve_workspace_scope_accepts_vfs_alias() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::create_dir_all(dir.path().join("pkg")).expect("pkg dir");
+        let root = fs::canonicalize(dir.path()).expect("canonical root");
+
+        let scope = resolve_workspace_scope(&root, Some("/workspace/pkg")).expect("vfs subpath");
+        assert_eq!(scope, root.join("pkg"));
+
+        let root_scope = resolve_workspace_scope(&root, Some("/workspace")).expect("vfs root");
+        assert_eq!(root_scope, root);
+    }
+
+    #[test]
+    fn resolve_workspace_scope_rejects_escape() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = fs::canonicalize(dir.path()).expect("canonical root");
+        let err =
+            resolve_workspace_scope(&root, Some("/workspace/../outside")).expect_err("escape");
+        assert!(err.to_string().contains("inside the workspace"));
+    }
+
+    #[test]
+    fn resolve_spawn_cwd_requires_existing_directory() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert_eq!(
+            resolve_spawn_cwd(dir.path()).expect("existing dir"),
+            dir.path()
+        );
+
+        let missing = dir.path().join("removed");
+        let err = resolve_spawn_cwd(&missing).expect_err("missing dir");
+        assert!(err.contains("does not exist"));
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Yolop exposes two path namespaces to models:

- **VFS** (`/workspace`, `/src/foo.rs`) for file tools
- **Host** (real filesystem paths) for bash and environment context

Models trained on cloud layouts often pass `/workspace/...` to every tool. `repo_map` was fixed to strip that alias, but `ast_grep` was not. Capabilities like `repo_map`, `ast_grep`, and `background` also held a build-time `PathBuf` snapshot, so they could drift from bash/file tools after a worktree switch.

Separately, when the workspace directory is removed (e.g. `git worktree remove .`), bash spawn failed with the opaque `spawn failed: No such file or directory` because `current_dir` pointed at a missing path.

## Solution

- Add `src/workspace_path.rs` with shared VFS alias stripping (`strip_workspace_vfs_prefix`), scope resolution (`resolve_workspace_scope`), and spawn cwd validation (`resolve_spawn_cwd`).
- Wire `repo_map`, `ast_grep`, and `background` to the shared `active_root` `Arc<RwLock<PathBuf>>` (same as bash and file tools).
- Validate bash/background spawn cwd and return a clear error when the workspace directory no longer exists.
- Fix `!shell` to use the current worktree `active_root` instead of a stale snapshot.

## Tests

- `workspace_path` unit tests for alias stripping, scope resolution, and spawn cwd
- `ast_grep` accepts `/workspace/src` alias
- bash reports `workspace directory does not exist` instead of spawn error
- All existing tests pass (`cargo test --all-features`, `cargo clippy -D warnings`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7052c67-15a0-4240-8139-b4343614f32d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7052c67-15a0-4240-8139-b4343614f32d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

