### PR TITLE
chore(deps): bump ast-grep-core and ast-grep-language to 0.44

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "ast-grep-core"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce81c07a23ebe5012b2053ba72af27e36699bf5f8ae6c204cdc2906aa277e5a6"
+checksum = "ab2fa110038b1047f503b5af156db45c5ee713f192be471ad95cfd04005dd3b4"
 dependencies = [
  "bit-set 0.10.0",
  "regex",
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "ast-grep-language"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b41f5cc1c89eaef8330a873ba26030dbb5b917076de5890d0446e549e4187c"
+checksum = "f2db9b32955734bc7b49bd0bdd33aa22a888aebc3cd2f69d07dcf5bfc7732985"
 dependencies = [
  "ast-grep-core",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ path = "src/main.rs"
 [dependencies]
 agent-client-protocol = "1.0.0"
 anyhow = "1.0"
-ast-grep-core = "0.43"
-ast-grep-language = { version = "0.43", default-features = false, features = [
+ast-grep-core = "0.44"
+ast-grep-language = { version = "0.44", default-features = false, features = [
     "tree-sitter-bash",
     "tree-sitter-c-sharp",
     "tree-sitter-css",


### PR DESCRIPTION
## Summary

- Bumps both `ast-grep-core` and `ast-grep-language` from 0.43 to 0.44 in a single commit
- These are companion crates that must move together — bumping one alone breaks the `LanguageExt` bound on `StrDoc<SupportLang>`, causing compile errors (as seen in individual dependabot PRs #208 and #209)
- No code changes needed; the 0.44 breaking changes are in rule-config internals not used by yolop
- All 31 tests pass locally

Supersedes #208 and #209 (those individual PRs fail CI because neither crate satisfies the other's trait bound when only one is upgraded).

---
_Generated by [Claude Code](https://claude.ai/code/session_015fBeiYnSaaNrxzbGacCTKf)_