### PR TITLE
docs(repo-map): drop Related diagrams section from feature page

### DIFF
--- a/docs/features/repo-map/repo-map.md
+++ b/docs/features/repo-map/repo-map.md
@@ -137,7 +137,3 @@ Unsupported files are counted and skipped rather than failing the scan.
 - **Sandboxed.** Scans cannot escape the workspace root.
 - **Bounded.** Per-file size limits, a candidate cap, and the `limit` parameter
   keep responses compact and fast; `truncated` reports when output was clipped.
-
-## Related
-
-- Diagram source: [`repo-map.mmd`](repo-map.mmd)


### PR DESCRIPTION
## What

Removes the trailing `## Related` section from `docs/features/repo-map/repo-map.md`:

```
## Related

- Diagram source: [`repo-map.mmd`](repo-map.mmd)
```

## Why

`repo-map.md` is the index/overview page for the repo-map feature folder. A standalone "list of diagrams" (just a pointer to the `.mmd` source) doesn't belong on an overview page. The inline pipeline diagram (`[…](repo-map.svg)` in *How it works*) is untouched, and the `repo-map.mmd` / `repo-map.svg` source files remain in the folder for anyone who needs them.

## Validation

Docs-only change — no behavior change, so the automated-test and smoke-test outcomes are exempt. Verified the remaining doc still renders: the SVG image reference in *How it works* and all tables/sections are intact; only the final two-line section was removed.

## Security

No security-relevant code changes — documentation only.

## Follow-ups

No follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_013QkKmm5Zd7FX3MRtcEnJoY)_