### PR TITLE
feat(background): show everruns session tasks

### DIFF
--- a/specs/background.md
+++ b/specs/background.md
@@ -1,8 +1,10 @@
 # Background execution — background tasks and background agents
 
-Status: implemented — scripted background tasks, background sub-agents, user
-surfaces (status-bar indicator + `/background` command), and proactive wake
-(auto-run a turn when a task finishes).
+Status: partially moved to Everruns primitives. Generic `spawn_background`
+tasks are recorded in Everruns `session_tasks` through `everruns-local`; Yolop's
+status bar, `/background` command, and panel read those session tasks first.
+Legacy Yolop `background_run` / `background_agent` tasks still use
+`BackgroundRegistry` until they are migrated.
 
 ## Why
 
@@ -22,17 +24,33 @@ a process restart except the conversation itself (replayed from
 `events.jsonl`). Background execution is the missing primitive.
 
 The design goal is a **single generic background-execution core** that both
-scripted tasks and background agents are *kinds* of — not two parallel
-mechanisms. yolop already has the right substrate for durability: every session
-owns a private folder under `<data_dir>/yolop/sessions/<session_id>/` (see
-`specs/` neighbours and `src/session_log.rs`). Background state lives there, so
-it is naturally per-session, owner-only, and restorable on `--session` resume.
+scripted tasks and background agents are *kinds* of, not two parallel
+mechanisms. The target owner is Everruns `session_tasks`: a generic runtime
+task registry, backed locally by `everruns-local`, with task ids, kind, state,
+display name, result paths, links, wake policy, and messages. Yolop should add
+domain-specific launchers on top of that generic model, not own a competing
+task system.
+
+Yolop currently keeps a transitional legacy registry for `background_run` and
+`background_agent`. That registry remains only for task types that have not
+moved to `session_tasks`; user-facing status/listing surfaces now prefer
+Everruns session tasks and append legacy tasks separately.
 
 ## Core abstraction
 
 A **background task** is a unit of work that runs detached from the foreground
-turn. It has an id, a kind, a lifecycle status, captured output, and is
-cancellable and observable. The registry owns them:
+turn. It has an id, a kind, a lifecycle status, captured output or result
+artifacts, and is cancellable and observable. In the generic path, Everruns'
+`SessionTaskRegistry` owns that record:
+
+- `SessionTaskRegistry` — generic Everruns task table for a session. In local
+  Yolop runs it is backed by `everruns-local`, so `spawn_background` tasks are
+  durable through the same runtime-local backend stack as other session data.
+- `SessionTask` — the runtime-owned task record: `id`, `kind`, `display_name`,
+  `state`, optional `state_detail`, `summary`, `result_path`, `links`, wake
+  policy, and timestamps.
+
+The legacy Yolop registry remains during migration:
 
 - `BackgroundRegistry` — an `Arc`-shared handle holding the live task table and
   persisting an index to `<session_dir>/background/index.json`. One registry per
@@ -45,9 +63,12 @@ cancellable and observable. The registry owns them:
 
 ### Status lifecycle
 
+Everruns session tasks use the generic runtime lifecycle (`queued`, `running`,
+`succeeded`, `failed`, `canceled`, and other states supported by
+`SessionTaskState`). Legacy Yolop tasks still use
 `running → {completed | failed | cancelled | timed_out}`, plus `interrupted`
 which is assigned on restore (below). `completed`/`failed`/`cancelled`/
-`timed_out`/`interrupted` are terminal.
+`timed_out`/`interrupted` are terminal for the legacy registry.
 
 ### Surviving a restart
 
@@ -71,7 +92,12 @@ transcript is durable and its child session id is recorded for resume.
 
 ### Tools
 
-The `background` capability contributes:
+The generic Everruns runtime contributes `spawn_background` for tools that
+implement the runtime's background-executable abstraction. Yolop's bash tool
+uses that path, so detached bash work can be recorded as Everruns session tasks.
+
+The Yolop `background` capability still contributes legacy tools during
+migration:
 
 - `background_run` — start a scripted task. `command` (required), `label`
   (optional human tag). Returns the new task id and status. Non-blocking.
@@ -136,12 +162,15 @@ refuse new work past the cap until a running task finishes or is cancelled.
 Background work is visible to the *user*, not just the model:
 
 - The TUI status bar shows a compact `bg <running>▸/<total>` segment whenever
-  the session has background tasks (hidden otherwise). The `App` reads the
-  shared registry (exposed on `BuiltRuntime`) each frame via a cheap `counts()`.
+  the session has background tasks (hidden otherwise). The `App` reads Everruns
+  `session_tasks` from the runtime's task registry and includes legacy Yolop
+  registry counts only for task types that have not moved to the generic
+  session-task path yet.
 - `/background` is a `System` command (contributed by the capability) that lists
-  every task with its kind, status, exit code, summary, and — for sub-agents —
-  the child session id. It works over the TUI and ACP uniformly because it
-  returns a plain `CommandResult`.
+  Everruns session tasks first, including kind, state, display name, detail, and
+  result path. During migration it appends a separate legacy Yolop task section
+  for task types that still use the old registry. It works over the TUI and ACP
+  uniformly because it returns a plain `CommandResult`.
 - The TUI also has a **read-only panel overlay** (toggle with `Ctrl+B`, ↑/↓ to
   scroll, `Esc` to close) showing the same `/background` listing live. It mirrors
   the setup-overlay modal pattern, is suppressed while the setup overlay is open,
@@ -193,7 +222,8 @@ without a user prompt.
   final state survive a restart.
 - No cross-session background work — tasks belong to the session that spawned
   them and live in that session's folder.
-- No second persistence engine — the per-session folder and atomic-write
-  pattern already used by `session_log.rs` / `memory` are reused as-is.
+- No new Yolop-owned persistence engine for generic task records — local
+  session-task durability belongs to `everruns-local`; the legacy background
+  index remains only for unmigrated Yolop task types.
 - No new approval gate — `background_run` runs the same unsandboxed shell as the
   `bash` tool and inherits the same standing guardrails.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -19,6 +19,7 @@ use crossterm::event::{
 };
 use everruns_core::command::{CommandDescriptor, CommandSource};
 use everruns_core::message::ContentPart;
+use everruns_core::session_task::{SessionTask, SessionTaskRegistry};
 use everruns_core::typed_id::SessionId;
 use ratatui::Terminal;
 use ratatui::backend::Backend;
@@ -56,6 +57,7 @@ pub(crate) struct CommandSuggestion {
 }
 
 pub const COMPOSER_VIEWPORT_HEIGHT: u16 = 18;
+const SESSION_TASK_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 /// Consecutive failed event-loop iterations tolerated before the terminal is
 /// considered gone and the error becomes fatal. The slowest failure mode (an
 /// unanswered cursor-position query) blocks ~2s per attempt inside crossterm,
@@ -126,11 +128,18 @@ pub struct App {
     model_discovery_enabled: bool,
     models_tx: mpsc::UnboundedSender<ModelDiscovery>,
     models_rx: mpsc::UnboundedReceiver<ModelDiscovery>,
-    /// This session's background task registry, polled each frame for the
-    /// status-bar task count. Same registry the `background` capability owns.
+    /// Legacy Yolop background registry. Kept during migration for task types
+    /// that have not moved to Everruns `session_tasks` yet.
     background: Arc<crate::capabilities::BackgroundRegistry>,
-    /// Open background-tasks panel overlay, holding its scroll offset (in lines).
-    /// `None` when closed. Toggled with Ctrl+B; read-only view of the registry.
+    /// Everruns session-task registry used by `spawn_background`; the TUI reads
+    /// it for the background status segment and panel.
+    task_registry: Arc<dyn SessionTaskRegistry>,
+    session_tasks: Vec<SessionTask>,
+    session_tasks_error: Option<String>,
+    last_session_tasks_refresh: Option<Instant>,
+    /// Open background-tasks panel overlay, holding its scroll offset (in
+    /// lines). `None` when closed. Toggled with Ctrl+B; read-only view of the
+    /// session task list.
     background_panel: Option<usize>,
     goal_store: Arc<GoalStore>,
     user_ask_store: Arc<UserAskStore>,
@@ -326,6 +335,10 @@ impl App {
             models_tx,
             models_rx,
             background: runtime.background,
+            task_registry: runtime.task_registry,
+            session_tasks: Vec::new(),
+            session_tasks_error: None,
+            last_session_tasks_refresh: None,
             background_panel: None,
             goal_store,
             user_ask_store,
@@ -395,10 +408,7 @@ impl App {
                 .approval_mode()
                 .as_str()
                 .to_string(),
-            background: match self.background.counts() {
-                (_, 0) => None,
-                counts => Some(counts),
-            },
+            background: self.background_counts(),
             goal_indicator: self.goal_indicator(),
             ask_indicator: self.ask_indicator(),
             worktree_compact: self.worktree.status_bar_compact(),
@@ -420,6 +430,47 @@ impl App {
             .map(|active| active.evaluated_turns)
             .unwrap_or(0);
         Some(format!("? ask ({turns})"))
+    }
+
+    fn background_counts(&self) -> Option<(usize, usize)> {
+        crate::session_tasks_view::combined_counts(&self.session_tasks, self.background.counts())
+    }
+
+    fn background_panel_body(&self) -> String {
+        crate::session_tasks_view::render_combined_task_list(
+            &self.session_tasks,
+            self.session_tasks_error.as_deref(),
+            self.background.counts(),
+            &self.background.render_task_list(),
+        )
+    }
+
+    async fn refresh_session_tasks(&mut self) {
+        match self
+            .task_registry
+            .list(self.session.session_id(), None)
+            .await
+        {
+            Ok(tasks) => {
+                self.session_tasks = tasks;
+                self.session_tasks_error = None;
+            }
+            Err(err) => {
+                self.session_tasks.clear();
+                self.session_tasks_error = Some(err.to_string());
+            }
+        }
+        self.last_session_tasks_refresh = Some(Instant::now());
+    }
+
+    async fn refresh_session_tasks_if_due(&mut self) {
+        if self
+            .last_session_tasks_refresh
+            .is_some_and(|last| last.elapsed() < SESSION_TASK_REFRESH_INTERVAL)
+        {
+            return;
+        }
+        self.refresh_session_tasks().await;
     }
 
     fn goal_indicator(&self) -> Option<String> {
@@ -535,6 +586,7 @@ impl App {
         B::Error: std::error::Error + Send + Sync + 'static,
     {
         self.flush_transcript(terminal)?;
+        self.refresh_session_tasks_if_due().await;
         // Ratatui keeps the inline viewport row fixed across vertical grows and
         // resets it to the top on horizontal shrinks. Re-anchor before each draw
         // so the composer stays pinned to the terminal bottom after resize.
@@ -939,8 +991,7 @@ impl App {
             KeyCode::Down | KeyCode::Char('j') => {
                 // Clamp so scrolling can't run past the last line of content.
                 let max = self
-                    .background
-                    .render_task_list()
+                    .background_panel_body()
                     .lines()
                     .count()
                     .saturating_sub(1);
@@ -1665,6 +1716,9 @@ mod tests {
         OutputMessageStartedData, ReasonCompletedData, ToolCompletedData,
     };
     use everruns_core::message::Message;
+    use everruns_core::session_task::{
+        CreateSessionTask, SessionTaskState, TASK_KIND_BACKGROUND_TOOL,
+    };
     use everruns_core::tool_types::ToolCall;
     use everruns_core::{SessionId, TurnId};
 
@@ -3157,19 +3211,36 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn background_panel_renders_task_rows() {
+    async fn background_panel_renders_everruns_session_task_rows() {
         let mut test = app_with_llmsim().await;
         let app = &mut test.app;
         app.setup = None;
-        app.background
-            .spawn_script(Some("ci".into()), "echo hi".into());
+        app.task_registry
+            .create(CreateSessionTask {
+                session_id: app.session.session_id(),
+                id: Some("task_panel".to_string()),
+                kind: TASK_KIND_BACKGROUND_TOOL.to_string(),
+                display_name: "write marker".to_string(),
+                spec: serde_json::json!({ "tool": "bash", "command": "echo hi" }),
+                state: SessionTaskState::Running,
+                links: Default::default(),
+                wake_policy: Default::default(),
+            })
+            .await
+            .expect("create session task");
+        app.refresh_session_tasks().await;
         app.background_panel = Some(0);
 
+        assert_eq!(app.presentation_state().background, Some((1, 1)));
         let lines = render_app_lines(app, 120, 20).join("\n");
         assert!(lines.contains("Background tasks"), "panel header: {lines}");
         assert!(
-            lines.contains("script"),
-            "panel should list the task: {lines}"
+            lines.contains("Everruns session task"),
+            "panel should list session tasks: {lines}"
+        );
+        assert!(
+            lines.contains("[task_panel] background_tool running: write marker"),
+            "panel should list the Everruns task row: {lines}"
         );
     }
 

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -388,7 +388,7 @@ pub(crate) fn draw_background_panel(f: &mut ratatui::Frame, area: Rect, app: &Ap
         width: panel.width.saturating_sub(4),
         height: panel.height.saturating_sub(2),
     };
-    let body = app.background.render_task_list();
+    let body = app.background_panel_body();
     let texts = background_panel_lines(&body, offset, inner.height as usize);
     let mut lines: Vec<Line<'static>> = Vec::with_capacity(texts.len());
     for (i, text) in texts.into_iter().enumerate() {

--- a/src/capabilities/background.rs
+++ b/src/capabilities/background.rs
@@ -16,15 +16,18 @@
 // Results survive a restart; in-flight processes do not. See specs/background.md.
 
 use crate::capabilities::narration::stable_labeled;
+use crate::session_tasks_view::render_combined_task_list;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
 use everruns_core::command::{
     CommandDescriptor, CommandExecutionContext, CommandResult, CommandSource, ExecuteCommandRequest,
 };
+use everruns_core::session_task::SessionTaskRegistry;
 use everruns_core::tool_narration::{ToolNarrationPhase, arg_str};
 use everruns_core::tool_types::ToolCall;
 use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::typed_id::SessionId;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::{HashMap, HashSet};
@@ -1076,6 +1079,8 @@ fn write_index(path: &Path, records: &[BackgroundRecord]) -> std::io::Result<()>
 
 pub(crate) struct BackgroundCapability {
     pub(crate) registry: Arc<BackgroundRegistry>,
+    pub(crate) session_id: SessionId,
+    pub(crate) task_registry: Arc<dyn SessionTaskRegistry>,
 }
 
 #[async_trait]
@@ -1118,9 +1123,18 @@ impl Capability for BackgroundCapability {
                 request.name
             )));
         }
+        let (tasks, task_error) = match self.task_registry.list(self.session_id, None).await {
+            Ok(tasks) => (tasks, None),
+            Err(err) => (Vec::new(), Some(err.to_string())),
+        };
         Ok(CommandResult {
             success: true,
-            message: self.registry.render_task_list(),
+            message: render_combined_task_list(
+                &tasks,
+                task_error.as_deref(),
+                self.registry.counts(),
+                &self.registry.render_task_list(),
+            ),
             error_code: None,
             error_fields: None,
         })
@@ -1516,9 +1530,28 @@ impl Tool for BackgroundCancelTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use everruns_core::session_task::{
+        CreateSessionTask, SessionTaskState, TASK_KIND_BACKGROUND_TOOL,
+    };
+    use everruns_local::{LocalSessionTaskRegistry, SqliteDb};
 
     fn registry_in(dir: &Path) -> BackgroundRegistry {
         BackgroundRegistry::load(dir, dir.to_path_buf())
+    }
+
+    fn task_registry_in(dir: &Path) -> Arc<dyn SessionTaskRegistry> {
+        Arc::new(
+            LocalSessionTaskRegistry::new(SqliteDb::open(dir.join("tasks.sqlite")).unwrap())
+                .unwrap(),
+        )
+    }
+
+    fn capability_in(dir: &Path, registry: Arc<BackgroundRegistry>) -> BackgroundCapability {
+        BackgroundCapability {
+            registry,
+            session_id: SessionId::from_seed(123),
+            task_registry: task_registry_in(dir),
+        }
     }
 
     /// Test spawner that returns a canned outcome, so the registry's sub-agent
@@ -1703,9 +1736,7 @@ mod tests {
         let record = reg.spawn_script(Some("ci".into()), "echo hi".into());
         wait_terminal(&reg, &record.id, 100).await;
 
-        let cap = BackgroundCapability {
-            registry: reg.clone(),
-        };
+        let cap = capability_in(tmp.path(), reg.clone());
         let names: Vec<String> = cap.tools().iter().map(|t| t.name().to_string()).collect();
         assert_eq!(
             names,
@@ -1845,11 +1876,57 @@ mod tests {
     #[test]
     fn capability_contributes_background_command() {
         let tmp = tempfile::tempdir().unwrap();
-        let cap = BackgroundCapability {
-            registry: Arc::new(registry_in(tmp.path())),
-        };
+        let cap = capability_in(tmp.path(), Arc::new(registry_in(tmp.path())));
         let names: Vec<String> = cap.commands().iter().map(|c| c.name.clone()).collect();
         assert_eq!(names, vec!["background"]);
+    }
+
+    #[tokio::test]
+    async fn background_command_lists_everruns_session_tasks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let legacy = Arc::new(registry_in(tmp.path()));
+        let session_id = SessionId::from_seed(123);
+        let task_registry = task_registry_in(tmp.path());
+        task_registry
+            .create(CreateSessionTask {
+                session_id,
+                id: Some("task_cmd".to_string()),
+                kind: TASK_KIND_BACKGROUND_TOOL.to_string(),
+                display_name: "write marker".to_string(),
+                spec: json!({ "tool": "bash", "command": "echo hi" }),
+                state: SessionTaskState::Running,
+                links: Default::default(),
+                wake_policy: Default::default(),
+            })
+            .await
+            .expect("create session task");
+        let cap = BackgroundCapability {
+            registry: legacy,
+            session_id,
+            task_registry,
+        };
+
+        let result = cap
+            .execute_command(
+                &ExecuteCommandRequest {
+                    name: "background".to_string(),
+                    arguments: None,
+                    controls: None,
+                },
+                &CommandExecutionContext::without_host(session_id),
+            )
+            .await
+            .expect("execute /background");
+
+        assert!(result.success);
+        assert!(result.message.contains("Everruns session task"));
+        assert!(
+            result
+                .message
+                .contains("[task_cmd] background_tool running: write marker"),
+            "unexpected /background output: {}",
+            result.message
+        );
     }
 
     #[tokio::test]
@@ -1968,9 +2045,7 @@ mod tests {
         assert!(!reg.can_spawn_agents());
         assert!(reg.spawn_agent(None, "x".into(), None).is_err());
 
-        let cap = BackgroundCapability {
-            registry: Arc::new(reg),
-        };
+        let cap = capability_in(tmp.path(), Arc::new(reg));
         let names: Vec<String> = cap.tools().iter().map(|t| t.name().to_string()).collect();
         assert!(!names.contains(&"background_agent".to_string()));
         assert_eq!(names.len(), 4);
@@ -1983,9 +2058,7 @@ mod tests {
             final_text: None,
             success: true,
         }));
-        let cap = BackgroundCapability {
-            registry: Arc::new(reg),
-        };
+        let cap = capability_in(tmp.path(), Arc::new(reg));
         let names: Vec<String> = cap.tools().iter().map(|t| t.name().to_string()).collect();
         assert!(names.contains(&"background_agent".to_string()));
         assert_eq!(names.len(), 5);

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod presentation;
 mod runtime;
 mod session;
 mod session_log;
+mod session_tasks_view;
 mod settings;
 #[cfg(test)]
 mod test_env;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -49,6 +49,7 @@ use everruns_core::in_memory::InMemoryMessageRetriever;
 use everruns_core::llmsim_driver::LlmSimConfig;
 use everruns_core::message::{ContentPart, MessageRole};
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, InitialFile, SessionFile};
+use everruns_core::session_task::SessionTaskRegistry;
 use everruns_core::typed_id::SessionId;
 use everruns_core::{
     AgentCapabilityConfig, CapabilityRegistry, Controls, InputMessage, PlatformDefinition,
@@ -1791,6 +1792,10 @@ pub struct BuiltRuntime {
     /// show a live task count in the status bar (the same registry the
     /// `background` capability owns).
     pub background: Arc<BackgroundRegistry>,
+    /// Shared Everruns session task registry, backed by `everruns-local`. The
+    /// TUI reads this to show `spawn_background` tasks through the generic
+    /// runtime task model.
+    pub task_registry: Arc<dyn SessionTaskRegistry>,
 }
 
 #[derive(Clone)]
@@ -2210,9 +2215,10 @@ pub async fn build_with_options(
         .with_connection_resolver(connection_resolver);
     let local_profile = LocalProfile::new(sessions_dir.join("everruns-local"))
         .with_workspace_root(effective_root.clone());
-    let backends = LocalBackends::new(local_profile, base_backends)
-        .context("initialize everruns-local backend stores")?
-        .runtime_backends;
+    let local_backends = LocalBackends::new(local_profile, base_backends)
+        .context("initialize everruns-local backend stores")?;
+    let task_registry: Arc<dyn SessionTaskRegistry> = local_backends.task_registry.clone();
+    let backends = local_backends.runtime_backends;
     // Shared between `ModelState` (for banner labels) and
     // `SetupCapability` (which mutates it on a successful `/setup`).
     let provider_state = Arc::new(RwLock::new(provider.clone()));
@@ -2388,6 +2394,8 @@ pub async fn build_with_options(
     let background_registry = Arc::new(background_registry);
     capabilities.register(BackgroundCapability {
         registry: background_registry.clone(),
+        session_id,
+        task_registry: task_registry.clone(),
     });
     // Terminal-side commands. Registered only when the host can apply
     // their effects (the TUI). The capability declares help/tools/mcp/cwd/model/
@@ -2551,6 +2559,7 @@ pub async fn build_with_options(
         settings,
         ui_rx,
         background: background_registry,
+        task_registry,
         goal_store,
         user_ask_store,
         user_ask_enabled,

--- a/src/session_tasks_view.rs
+++ b/src/session_tasks_view.rs
@@ -1,0 +1,138 @@
+use everruns_core::SessionTask;
+
+pub(crate) fn combined_counts(
+    tasks: &[SessionTask],
+    legacy_counts: (usize, usize),
+) -> Option<(usize, usize)> {
+    let active = tasks
+        .iter()
+        .filter(|task| !task.state.is_terminal())
+        .count()
+        .saturating_add(legacy_counts.0);
+    let total = tasks.len().saturating_add(legacy_counts.1);
+    (total > 0).then_some((active, total))
+}
+
+pub(crate) fn render_combined_task_list(
+    tasks: &[SessionTask],
+    task_error: Option<&str>,
+    legacy_counts: (usize, usize),
+    legacy_body: &str,
+) -> String {
+    let has_session_tasks = !tasks.is_empty();
+    let has_legacy_tasks = legacy_counts.1 > 0;
+
+    if !has_session_tasks && !has_legacy_tasks {
+        if let Some(error) = task_error {
+            return format!(
+                "No background tasks in this session.\n\nSession task registry: {error}"
+            );
+        }
+        return "No background tasks in this session.".to_string();
+    }
+
+    let mut out = String::new();
+    if has_session_tasks {
+        let active = tasks
+            .iter()
+            .filter(|task| !task.state.is_terminal())
+            .count();
+        out.push_str(&format!(
+            "{} Everruns session task(s), {} active:\n",
+            tasks.len(),
+            active
+        ));
+        let mut sorted = tasks.to_vec();
+        sorted.sort_by(|a, b| {
+            b.updated_at
+                .cmp(&a.updated_at)
+                .then_with(|| b.created_at.cmp(&a.created_at))
+        });
+        for task in sorted {
+            out.push_str("- ");
+            out.push_str(&format!(
+                "[{}] {} {}: {}",
+                task.id, task.kind, task.state, task.display_name
+            ));
+            if let Some(detail) = task.state_detail.as_deref() {
+                out.push_str(" -- ");
+                out.push_str(detail);
+            } else if let Some(summary) = task.summary.as_deref() {
+                out.push_str(" -- ");
+                out.push_str(summary);
+            } else if let Some(error) = task.error.as_ref() {
+                out.push_str(" -- ");
+                out.push_str(&error.message);
+            }
+            if let Some(path) = task.result_path.as_deref() {
+                out.push_str(&format!(" (result: {path})"));
+            }
+            out.push('\n');
+        }
+        out.push_str("\nInspect Everruns tasks with list_tasks/get_task.");
+    } else if let Some(error) = task_error {
+        out.push_str("Everruns session tasks could not be loaded:\n");
+        out.push_str(error);
+    }
+
+    if has_legacy_tasks {
+        if !out.is_empty() {
+            out.push_str("\n\n");
+        }
+        out.push_str("Legacy Yolop background tasks:\n");
+        out.push_str(legacy_body);
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use everruns_core::session_task::{
+        SessionTaskState, TASK_KIND_BACKGROUND_TOOL, new_session_task,
+    };
+    use everruns_core::{CreateSessionTask, SessionId};
+    use serde_json::json;
+
+    fn task(id: &str, state: SessionTaskState, name: &str) -> SessionTask {
+        let mut task = new_session_task(
+            CreateSessionTask {
+                session_id: SessionId::from_seed(42),
+                id: Some(id.to_string()),
+                kind: TASK_KIND_BACKGROUND_TOOL.to_string(),
+                display_name: name.to_string(),
+                spec: json!({}),
+                state,
+                links: Default::default(),
+                wake_policy: Default::default(),
+            },
+            Utc::now(),
+        );
+        task.summary = Some("done".to_string());
+        task
+    }
+
+    #[test]
+    fn counts_include_session_tasks_and_legacy_tasks() {
+        let tasks = vec![
+            task("task_a", SessionTaskState::Running, "run"),
+            task("task_b", SessionTaskState::Succeeded, "done"),
+        ];
+
+        assert_eq!(combined_counts(&tasks, (1, 3)), Some((2, 5)));
+        assert_eq!(combined_counts(&[], (0, 0)), None);
+    }
+
+    #[test]
+    fn render_prefers_everruns_tasks_and_keeps_legacy_section() {
+        let tasks = vec![task("task_a", SessionTaskState::Succeeded, "write marker")];
+        let rendered =
+            render_combined_task_list(&tasks, None, (0, 1), "1 background task(s), 0 running:");
+
+        assert!(rendered.contains("Everruns session task"));
+        assert!(rendered.contains("[task_a] background_tool succeeded: write marker"));
+        assert!(rendered.contains("Legacy Yolop background tasks"));
+    }
+}


### PR DESCRIPTION
## What
Moves Yolop's user-facing background status/listing surfaces to read Everruns `session_tasks` first.

- Exposes the `everruns-local` session task registry from `BuiltRuntime`.
- Makes `/background` list Everruns session tasks before legacy Yolop background tasks.
- Makes the TUI status segment and `Ctrl+B` panel count/render Everruns session tasks plus legacy tasks.
- Adds a shared formatter with focused command and presentation tests.
- Updates `specs/background.md` to document the transitional ownership boundary.

## Why
`spawn_background` now records work through Everruns runtime primitives, but Yolop's user-facing status and `/background` surfaces still only read `BackgroundRegistry`. This made generic runtime background work visible to the model through `list_tasks`, but not to Yolop's UI/status affordances.

## How
The runtime keeps the `LocalBackends` handle long enough to pass its `LocalSessionTaskRegistry` into `BuiltRuntime` and `BackgroundCapability`. The app refreshes session tasks at a bounded cadence and renders them with a shared formatter. Legacy `BackgroundRegistry` output is preserved as a separate section so unmigrated `background_run` and `background_agent` tasks remain visible.

## Risk
- Low / Medium / High: Medium
- What can break: background status counts, `/background` formatting, and the `Ctrl+B` panel. The app now reads SQLite-backed session tasks periodically, so refresh cadence is bounded to avoid per-frame storage polling.

## Security
- TM-FS: No new filesystem read/write authority. Runtime reuses the existing `everruns-local` task registry already wired into local backends; tests use temp SQLite files.
- TM-BASH: No shell execution behavior changed. Existing bash timeouts/output caps are untouched.
- TM-LLM: No prompt/API-key handling changed. No secrets are logged or persisted by this change.
- TM-TOOL: No new capability registration. Existing `spawn_background`/session task tools remain owned by Everruns; Yolop only changes display/status surfaces.
- TM-DEP: No new dependencies. Current branch uses the existing `everruns-* 0.17.0` pins from main.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"`
- Focused tests: `background_command_lists_everruns_session_tasks`, `background_panel_renders_everruns_session_task_rows`, `session_tasks_view`
- Attempted live smoke: `doppler run -- cargo run -- --provider openai -p "Reply with exactly: ok"` blocked locally because Doppler has no project/fallback configured and `OPENAI_API_KEY`/`DOPPLER_TOKEN` are unset.

## Follow-ups
- Wire TUI proactive wake/notification to Everruns `session_tasks`; legacy wake still drains `BackgroundRegistry`.
- Migrate `background_run` and `background_agent` or replace them through the generic runtime/session path.
- Implement a Yolop `LocalSessionRunner` and attach `LocalBackends::with_platform_runner` before replacing subagent delegation with the generic local platform/session path.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
