### PR TITLE
fix(evals): count codex iterations from per-round-trip events

### DIFF
--- a/evals/swebench_verified/swebench_verified.py
+++ b/evals/swebench_verified/swebench_verified.py
@@ -508,6 +508,7 @@ def extract_codex(log_path: str | Path, price: dict | None = None) -> RunMetrics
         return m
     summed = TokenUsage()
     cumulative: dict | None = None
+    reasoning_steps = 0
     for ev in iter_events(path):
         msg = ev.get("msg") or {}
         etype = ev.get("type") or msg.get("type")
@@ -523,6 +524,8 @@ def extract_codex(log_path: str | Path, price: dict | None = None) -> RunMetrics
             m.tools_used["file_change"] = m.tools_used.get("file_change", 0) + 1
         elif etype == "item.completed" and itype == "agent_message":
             m.assistant_messages += 1
+        elif etype == "item.completed" and itype == "reasoning":
+            reasoning_steps += 1
         elif etype == "exec_command_end":  # older schema
             m.tool_calls += 1
             m.tools_used["command"] = m.tools_used.get("command", 0) + 1
@@ -530,6 +533,8 @@ def extract_codex(log_path: str | Path, price: dict | None = None) -> RunMetrics
                 m.tool_calls_failed += 1
         elif etype == "agent_message":  # older schema
             m.assistant_messages += 1
+        elif etype == "agent_reasoning":  # older schema
+            reasoning_steps += 1
         elif etype == "token_count":  # older schema, cumulative
             info = msg.get("info") or {}
             cumulative = info.get("total_token_usage") or cumulative
@@ -542,7 +547,12 @@ def extract_codex(log_path: str | Path, price: dict | None = None) -> RunMetrics
     else:
         m.tokens = summed
     m.llm_calls = m.assistant_messages
-    m.iterations = m.turns or m.assistant_messages
+    # `codex exec` emits a single turn.completed for the whole run, so `turns`
+    # is not a measure of agentic loop steps. Count model round-trips instead:
+    # each round-trip emits one `reasoning` item (codex runs reasoning models
+    # here). Fall back to assistant messages, then turns, when reasoning
+    # summaries are absent.
+    m.iterations = reasoning_steps or m.assistant_messages or m.turns
     if not m.turns:
         m.turns = m.iterations
     _finalize_cost(m, None, price)  # codex reports no cost

--- a/evals/swebench_verified/tests/test_agent_metrics.py
+++ b/evals/swebench_verified/tests/test_agent_metrics.py
@@ -87,11 +87,14 @@ class CodexMetricsTest(unittest.TestCase):
         events = [
             {"type": "thread.started"},
             {"type": "turn.started"},
+            {"type": "item.completed", "item": {"type": "reasoning"}},
             {"type": "item.completed", "item": {"type": "command_execution",
                                                 "exit_code": 0}},
             {"type": "item.completed", "item": {"type": "command_execution",
                                                 "exit_code": 1}},
+            {"type": "item.completed", "item": {"type": "reasoning"}},
             {"type": "item.completed", "item": {"type": "file_change"}},
+            {"type": "item.completed", "item": {"type": "reasoning"}},
             {"type": "item.completed", "item": {"type": "agent_message"}},
             {"type": "turn.completed", "usage": {"input_tokens": 100,
                                                  "cached_input_tokens": 40,
@@ -104,12 +107,28 @@ class CodexMetricsTest(unittest.TestCase):
         self.assertEqual(m.tools_used, {"command": 2, "file_change": 1})
         self.assertEqual(m.assistant_messages, 1)
         self.assertEqual(m.turns, 1)
+        # codex emits one turn.completed for the whole run; iterations must come
+        # from per-round-trip reasoning items, not the single turn count.
+        self.assertEqual(m.iterations, 3)
         # input_tokens (100) includes the 40 cached -> 60 non-cached reported
         self.assertEqual(m.tokens.input_tokens, 60)
         self.assertEqual(m.tokens.cache_read_tokens, 40)
         self.assertEqual(m.tokens.output_tokens, 25)
         self.assertAlmostEqual(
             m.cost_usd, (60 * 1.0 + 25 * 10.0 + 40 * 0.1) / 1e6, places=9)
+
+    def test_iterations_fall_back_when_no_reasoning_items(self):
+        # Models without reasoning summaries emit no `reasoning` items; iterations
+        # then fall back to assistant messages (and finally the turn count).
+        events = [
+            {"type": "item.completed", "item": {"type": "agent_message"}},
+            {"type": "item.completed", "item": {"type": "agent_message"}},
+            {"type": "turn.completed", "usage": {"input_tokens": 10,
+                                                 "output_tokens": 5}},
+        ]
+        m = extract_codex(_write_log(events))
+        self.assertEqual(m.turns, 1)
+        self.assertEqual(m.iterations, 2)  # 2 assistant messages, not 1 turn
 
 
 class PiMetricsTest(unittest.TestCase):


### PR DESCRIPTION
## What

`extract_codex` in the SWE-bench Verified study mined `iterations` (and `turns`) from `turn.completed` events. But `codex exec --json` emits a **single** `turn.completed` for the entire run, so the reported `iterations` was always `1` regardless of how many agentic loop steps actually ran. A recorded result shows `iterations: 1` against `tool_calls_count: 25` — making codex non-comparable to the other agents, which all count model round-trips.

## Why this is the right signal

Codex emits one `item.completed` with `item.type == "reasoning"` per model round-trip ([codex JSON docs](https://developers.openai.com/codex/noninteractive)). That maps directly to the "model round-trips / agentic loop steps" definition the other extractors already use (claude-code: assistant messages; yolop: `reason.completed`; pi: `message_end`).

## Change

- Count `reasoning` items (and legacy `agent_reasoning` events) as iterations.
- `iterations = reasoning_steps or assistant_messages or turns` — falls back to assistant messages, then the turn count, when reasoning summaries are absent.
- `turns` is left as codex's genuine per-run turn count (`1`); only `iterations` is corrected. The two are distinct fields.

## Validation

- `uv run --with mira-eval -m unittest discover -s evals/swebench_verified/tests` — 43 tests pass.
- Updated `CodexMetricsTest` to assert `iterations == 3` from three reasoning items, and added a fallback test (no reasoning items → iterations follow assistant-message count, not the single turn).
- `ruff check` clean.

This is eval-harness / metrics tooling only; it does not touch the `yolop` binary or agent loop, so the Cargo gates and live-provider smoke test don't apply — the Python unittest suite is the relevant gate.

## Security

No security-relevant code changes. Pure metrics parsing over a local JSONL event log in eval tooling; no filesystem, shell, network, or secret handling involved.

## Follow-ups

- The primary signal relies on reasoning summaries being present, which holds for the gpt-5.x configs this study runs. If a future config disables reasoning output entirely, codex `iterations` degrades to the assistant-message count rather than true round-trips — still strictly better than the old constant `1`. No action needed now; noted for awareness.


---
_Generated by [Claude Code](https://claude.ai/code/session_018X4jRSTkCWBMsQTY62uSsS)_