### PR TITLE
revert: restore Related diagrams section on repo-map page

### DIFF
--- a/docs/features/repo-map/repo-map.md
+++ b/docs/features/repo-map/repo-map.md
@@ -137,3 +137,7 @@ Unsupported files are counted and skipped rather than failing the scan.
 - **Sandboxed.** Scans cannot escape the workspace root.
 - **Bounded.** Per-file size limits, a candidate cap, and the `limit` parameter
   keep responses compact and fast; `truncated` reports when output was clipped.
+
+## Related
+
+- Diagram source: [`repo-map.mmd`](repo-map.mmd)


### PR DESCRIPTION
Reverts #213 at the user's request — that change was merged to the wrong target. This restores the `## Related` section (diagram source link) on `docs/features/repo-map/repo-map.md`.

Docs-only revert; no behavior change.

---
_Generated by [Claude Code](https://claude.ai/code/session_013QkKmm5Zd7FX3MRtcEnJoY)_