### PR TITLE
feat(runtime): bump everruns to 0.17.1 and adopt set_host_root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,9 +1417,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c09514958f69ca18202b3f68c77802c61e7ceb0e1ecb22f5102a1cdcc961c8"
+checksum = "6783a0afbc21e5fe5597a74a621a808d81cdc567c8352f7bf132e6cc67faebd7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1435,18 +1435,18 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f98a43753dcd7b1b690fcba9dd365de3adee29ef666b05e8e4d95f626dcbbfd"
+checksum = "1cbefd11a044834ca23df5384271ad471985410d55f48d9f05485c4ac94148cf"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-core"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c1cb89445258c111f8a157f127e1fd620db69045bfe3d0d28acde10fdf34e"
+checksum = "28024a449e2cddf2104d40c4e4dae37119bf8f9ba98a0597bc87718786cca236"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -1488,9 +1488,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d57b7cba1075f36fae25c7f379e2994b584677def140eafd49557e0d641cfd60"
+checksum = "185e463a4eeeff541b0ec2dc465828829e7f9c291b2713e7673367bd7ecbd313"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1505,9 +1505,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e153a143c08672590dad07f812be0bc85b652d6156bf0fcb502e7be634c6398"
+checksum = "7ad4b735afbc99eaf4d77efb7fb7216832abe28533b6f9dd652d6e6a43cb73ef"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1521,9 +1521,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed4358e98635b27465d27f225056d0329f4de28d7ed974729e36bf3eac3cd12d"
+checksum = "c036b187ba001e22023058565e0c35de97e35deeae509c2cb25531366f3f9a8e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1540,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081fabc2c0b42eb49cff233ec790efc0e6a3026e50c5e6ca6aedb53a68156a12"
+checksum = "124b7091edc4781026463e3095e2d74d53ce882f91c0f28b25a1e9f7beb61f9a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1555,9 +1555,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7302f24418bbb842513cf1d6acd1ed3c24eec3d46ffae80de56e35b1d1af792b"
+checksum = "adebecf8f7024341c3292991859ddb85f6b8d7a1d3dffff86067813a93005b65"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1576,9 +1576,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e71d4c79cde67fb99dd7f7106b21364821edfa06f69c02fd41b47976ca681eab"
+checksum = "49a86ed112f0f4ad6c7dd4764fb1cbfaee1724fbfae1795704196b72327de7df"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1590,9 +1590,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "badc77e634b850651021e6d3b3b111c8e0baa63a9c62477c2871c80b40ce1305"
+checksum = "66e08268cf7c61316a349d8a2ad2a9cd4d5484cfda8e45ff819b3458343b407d"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,18 +77,18 @@ tree-sitter-zig = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-everruns-anthropic = "0.17.0"
-everruns-core = "0.17.0"
-everruns-openai = "0.17.0"
+everruns-anthropic = "0.17.1"
+everruns-core = "0.17.1"
+everruns-openai = "0.17.1"
 # OpenRouter's first-class driver was split out of everruns-openai into its own
 # crate in 0.13.0; register it alongside openai to keep DriverId::OpenRouter.
-everruns-openrouter = "0.17.0"
-everruns-local = "0.17.0"
+everruns-openrouter = "0.17.1"
+everruns-local = "0.17.1"
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (specs/mcp.md, upstream runtime-mcp.md D2).
-everruns-runtime = { version = "0.17.0", features = ["mcp-stdio"] }
-everruns-integrations-duckduckgo = "0.17.0"
-everruns-integrations-daytona = "0.17.0"
+everruns-runtime = { version = "0.17.1", features = ["mcp-stdio"] }
+everruns-integrations-duckduckgo = "0.17.1"
+everruns-integrations-daytona = "0.17.1"
 arboard = { version = "3", features = ["wayland-data-control"] }
 futures = "0.3"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp"] }

--- a/src/capabilities/goal.rs
+++ b/src/capabilities/goal.rs
@@ -166,6 +166,8 @@ mod tests {
             active_schedule_count: None,
             features: vec![],
             parent_session_id: None,
+            forked_from_session_id: None,
+            forked_from_sequence: None,
             blueprint_id: None,
             blueprint_config: None,
         }

--- a/src/capabilities/user_ask.rs
+++ b/src/capabilities/user_ask.rs
@@ -303,6 +303,8 @@ mod tests {
             active_schedule_count: None,
             features: vec![],
             parent_session_id: None,
+            forked_from_session_id: None,
+            forked_from_sequence: None,
             blueprint_id: None,
             blueprint_config: None,
         }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -72,7 +72,7 @@ use crate::session_log::{
 };
 use crate::worktree::{WorktreeManager, detect_repo_root, restore_worktree_from_metadata};
 use std::path::PathBuf;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use tokio::sync::mpsc;
 
 // The harness prompt is the durable instruction surface — borrowed in shape
@@ -180,6 +180,12 @@ impl SessionFileSystemFactory for CodingCliSessionFileSystemFactory {
 
 struct CodingCliSessionFileStore {
     workspace_root: Arc<RwLock<PathBuf>>,
+    // Single workspace store, repointed via `set_host_root` (EVE-660) when the
+    // active worktree changes, instead of recreating it per file operation.
+    workspace: RealDiskFileStore,
+    // Raw active root last pushed to `workspace`. Lets steady state skip the
+    // canonicalize+repoint syscall and only re-resolve on an actual switch.
+    applied_root: Mutex<PathBuf>,
     session: RealDiskFileStore,
     // Backing stores for the global/system skill scope VFS roots, served from
     // real directories outside the workspace (see `capabilities::skills`).
@@ -199,7 +205,13 @@ impl CodingCliSessionFileStore {
             |dir: Option<PathBuf>| -> everruns_core::Result<Option<RealDiskFileStore>> {
                 dir.map(RealDiskFileStore::new).transpose()
             };
+        let initial_root = workspace_root
+            .read()
+            .map_err(|_| AgentLoopError::config("workspace lock poisoned"))?
+            .clone();
         Ok(Self {
+            workspace: RealDiskFileStore::new(initial_root.clone())?,
+            applied_root: Mutex::new(initial_root),
             workspace_root,
             session: RealDiskFileStore::new(session_dir.clone())?,
             skill_global: skill_store(skill_global)?,
@@ -208,13 +220,25 @@ impl CodingCliSessionFileStore {
         })
     }
 
-    fn workspace_store(&self) -> everruns_core::Result<RealDiskFileStore> {
-        let root = self
+    /// The single workspace store, repointed via `set_host_root` (EVE-660) when
+    /// the active worktree changes. Recreating the store per file operation would
+    /// re-canonicalize the root on every read/write/grep; tracking the
+    /// last-applied root lets steady state skip that and repoint only on a switch.
+    fn workspace_store(&self) -> everruns_core::Result<&RealDiskFileStore> {
+        let current = self
             .workspace_root
             .read()
             .map_err(|_| AgentLoopError::config("workspace lock poisoned"))?
             .clone();
-        RealDiskFileStore::new(root)
+        let mut applied = self
+            .applied_root
+            .lock()
+            .map_err(|_| AgentLoopError::config("workspace root lock poisoned"))?;
+        if *applied != current {
+            self.workspace.set_host_root(current.clone())?;
+            *applied = current;
+        }
+        Ok(&self.workspace)
     }
 
     fn skill_or_session_route(&self, path: &str) -> Option<(&RealDiskFileStore, String)> {
@@ -4291,6 +4315,96 @@ mod tests {
             "workspace note"
         );
         assert!(!session.path().join("notes.md").exists());
+    }
+
+    #[tokio::test]
+    async fn yolop_file_store_repoints_workspace_on_worktree_switch() {
+        // A worktree switch mutates the shared active-root lock; the workspace
+        // store must follow it via `set_host_root` (EVE-660) rather than staying
+        // pinned to the original checkout.
+        let first = tempfile::tempdir().expect("first workspace");
+        let second = tempfile::tempdir().expect("second workspace");
+        let session = tempfile::tempdir().expect("session");
+        let active_root = Arc::new(RwLock::new(first.path().to_path_buf()));
+        let store = CodingCliSessionFileStore::new(
+            active_root.clone(),
+            session.path().to_path_buf(),
+            None,
+            None,
+        )
+        .expect("store");
+        let session_id = SessionId::from_seed(7);
+
+        store
+            .write_file(session_id, "/before.md", "in first", "text")
+            .await
+            .expect("write to first workspace");
+        assert_eq!(
+            std::fs::read_to_string(first.path().join("before.md")).expect("first file"),
+            "in first"
+        );
+        assert_eq!(
+            store.display_root(),
+            std::fs::canonicalize(first.path())
+                .expect("canonical first")
+                .display()
+                .to_string()
+        );
+
+        // Simulate the worktree activating: swap the shared active root.
+        *active_root.write().expect("lock") = second.path().to_path_buf();
+
+        store
+            .write_file(session_id, "/after.md", "in second", "text")
+            .await
+            .expect("write to second workspace");
+        assert_eq!(
+            std::fs::read_to_string(second.path().join("after.md")).expect("second file"),
+            "in second"
+        );
+        // The new file must land in the switched-to root, not the original.
+        assert!(!first.path().join("after.md").exists());
+        assert_eq!(
+            store.display_root(),
+            std::fs::canonicalize(second.path())
+                .expect("canonical second")
+                .display()
+                .to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn yolop_file_store_enforces_seeded_readonly_across_operations() {
+        // The persistent workspace store keeps `is_readonly` marks from
+        // `seed_initial_file`; recreating it per operation (the prior behavior)
+        // dropped them, so a seeded read-only file was silently writable.
+        let workspace = tempfile::tempdir().expect("workspace");
+        let session = tempfile::tempdir().expect("session");
+        let store = test_file_store(workspace.path(), session.path());
+        let session_id = SessionId::from_seed(11);
+
+        store
+            .seed_initial_file(
+                session_id,
+                &InitialFile {
+                    path: "/locked.md".to_string(),
+                    content: "do not touch".to_string(),
+                    encoding: "text".to_string(),
+                    is_readonly: true,
+                },
+            )
+            .await
+            .expect("seed readonly workspace file");
+
+        // A later write to the same path — a distinct operation — must be rejected.
+        store
+            .write_file(session_id, "/locked.md", "tampered", "text")
+            .await
+            .expect_err("write to seeded read-only file must be rejected");
+        assert_eq!(
+            std::fs::read_to_string(workspace.path().join("locked.md")).expect("locked file"),
+            "do not touch"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Bumps the `everruns-*` crates from **0.17.0 → 0.17.1** in lockstep and adopts the new 0.17.1 embedder API (EVE-660).

- `everruns-{runtime,core,anthropic,openai,openrouter,local,integrations-duckduckgo,integrations-daytona}` → `0.17.1`.
- `everruns_core::Session` gained `forked_from_session_id` / `forked_from_sequence`; the two test-helper `Session` literals (`capabilities/goal.rs`, `capabilities/user_ask.rs`) were updated to set them to `None`. No other public API used by yolop changed behaviorally.

## Why

0.17.1's EVE-660 makes `RealDiskFileStore`'s root **shareable and repointable** via the new `set_host_root`, designed for the exact embedder/worktree scenario yolop drives.

Previously `CodingCliSessionFileStore::workspace_store()` recreated a `RealDiskFileStore` — re-canonicalizing the root and re-`stat`ing the directory — on **every** workspace file operation (read/write/edit/list/grep/stat/delete/seed), reading the worktree's shared active-root lock each time.

Now the store holds **one** workspace `RealDiskFileStore` and repoints it via `set_host_root` only when the active root actually changes (tracked by a last-applied root), so steady state skips the per-op syscalls. The worktree's shared `Arc<RwLock<PathBuf>>` observer model is preserved — the store just follows it instead of rebuilding.

### Latent bug fixed as a side effect

Seeded `is_readonly` workspace files are now enforced across operations. The old per-op recreation discarded the store's in-memory read-only mark immediately, so a seeded read-only workspace file was silently writable on the next operation. The persistent store honors the mark, matching the `RealDiskFileStore` trait contract.

## How it was validated

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo test --all-features` — 566 unit + 31 integration passing (2 ignored: require live API keys).
- `cargo fetch --locked` — `Cargo.lock` consistent; all `everruns-*` at `0.17.1`.
- Offline smoke: `cargo run -- --provider llmsim -p "hi"` starts, registers the file tools, and completes a turn.
- New tests (drive the changed store directly):
  - `yolop_file_store_repoints_workspace_on_worktree_switch` — swaps the shared active root and asserts subsequent writes/`display_root` follow the new checkout.
  - `yolop_file_store_enforces_seeded_readonly_across_operations` — seeds a read-only workspace file, then asserts a later write is rejected and the content is untouched (fails under the old per-op behavior).

A real-provider smoke (`doppler run -- cargo run -- --provider openai`) was not possible: Doppler and provider keys are not available in this environment. The changed surface — workspace file routing, worktree repointing, and read-only enforcement — is covered by the automated tests above, which exercise the store's entry points directly.

## Security

Reviewed per the relevant threat-model categories:

- **TM-FS** — path containment, `..`-traversal rejection, and symlink checks all live inside `RealDiskFileStore` (strengthened by EVE-660) and are unchanged. `set_host_root` canonicalizes the new root and enforces containment relative to it; every op resolves against the current root after syncing, so a path cannot leak across a switch. The `WriteBlocklistFileStore` wrapper (`.git/`, `target/`, etc.) is untouched.
- **TM-LLM / TM-BASH / TM-TOOL** — no key handling, shell execution, or capability-registration changes.
- **TM-DEP** — `everruns-*` bumped together (no version skew); no new crates.

A poisoned `applied_root`/`workspace_root` lock fails the operation with a config error rather than bypassing resolution.

## Follow-ups

No follow-ups.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UiLsqQezKKowBdSWNfdpXj)_