### PR TITLE
chore(evals): bump mira-eval to 0.3.0; adopt case terms and configs

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -2,7 +2,7 @@
 
 This directory holds yolop's evaluation studies, each a
 [Mira](https://github.com/everruns/mira) eval **study**: the generic `mira` host
-CLI owns the target matrix, selection, concurrency, checkpoints, and reporting,
+CLI owns the target matrix, selection, concurrency, saved run folders, and reporting,
 while a study owns the benchmark-specific work (loading instances, running the
 agent, scoring). One study per subfolder.
 
@@ -14,9 +14,9 @@ agent, scoring). One study per subfolder.
 
 Install the host CLI once (`brew install everruns/tap/mira`, `cargo binstall
 mira-cli`, or `cargo install mira-cli --locked`), then drive a study from its own
-directory so its `mira.toml` is found and `--save` archives land in that study's
-`results/`. Each study's `mira.toml` declares a `default_launcher` (mira >=0.2.0),
-so a bare `mira run`/`mira list` from that directory starts it — no
+directory so its `mira.toml` is found and the auto-saved run folders land in that
+study's `results/`. Each study's `mira.toml` declares a `default_launcher` (these
+studies target mira >=0.3.0), so a bare `mira run`/`mira list` from that directory starts it — no
 `--uv`/`--cmd` needed. (Authoring a Python study? The
 [`mira-eval`](https://pypi.org/project/mira-eval/) SDK is on PyPI —
 `pip install mira-eval`.)
@@ -28,36 +28,42 @@ cd evals/swebench_verified
 # What the study advertises: the eval, its samples, and the matrix of targets.
 mira list
 
-# Offline plumbing check — one instance, no API key, no Docker, not saved.
-SWEBENCH_NO_EVAL=1 mira run astropy__astropy-12907 --targets llmsim
+# Offline plumbing check — one instance, no API key, no Docker; --dry-run skips
+# the saved run folder.
+SWEBENCH_NO_EVAL=1 mira run --samples astropy__astropy-12907 --targets llmsim --dry-run
 
-# Real run: solve + Docker-score one instance, archive the run under ./results.
-doppler run -- mira run astropy__astropy-12907 \
-    --targets anthropic-claude-sonnet-4.5 --save
+# Real run: solve + Docker-score one instance, archived under ./results.
+doppler run -- mira run --samples astropy__astropy-12907 \
+    --targets anthropic-claude-sonnet-4.5
 ```
 
-`mira run` selects like `cargo test` — by case-key substring
-(`run astropy__astropy-12907`), `--tag tracking-v1`, or `--targets <config>` — and
-takes the cross-product of the chosen samples and targets. Provider keys live only
-in the study's environment (inject them with `doppler run --`); a config whose
-key is missing is reported `unavailable` and skipped, so a keyless run stays
-green.
+`mira run` selects like `cargo test` — by `--samples <glob>`
+(`--samples astropy__astropy-12907`), `--tag tracking-v1`, or `--targets <glob>` —
+and takes the cross-product of the chosen samples and targets (the positional
+`mira run [filter]` is still a case-key substring). `--samples`/`--targets`/
+`--evals` glob-match (`*`, `?`, `[set]`, `{a,b}`). Provider keys live only in the
+study's environment (inject them with `doppler run --`); a config whose key is
+missing is reported `unavailable` and skipped, so a keyless run stays green.
 
-## Saved runs (`--save`)
+## Saved runs
 
-`--save` archives a run into a timestamped, self-contained folder so runs
-accumulate and can be compared over time:
+Every `mira run` archives into a timestamped, self-contained run folder by default
+(opt out with `--dry-run`), so runs accumulate and can be compared over time:
 
 ```
 <study>/results/<run_id>/         # run_id = YYYYMMDDThhmmssZ-xxxx (time-sortable)
-  report.json                     # per-cell scores + usage (tokens/cost/latency)
+  report.json                     # per-case scores + usage (tokens/cost/latency)
   report.html                     # self-contained viewer
   meta.json                       # run id, study, start/finish, summary
+  cases/<key>/result.json         # one self-describing result per finished case
 ```
 
-The results directory comes from `--save <dir>`, else `[results].dir` in the
-study's `mira.toml` (a relative path resolves against the `mira.toml`'s own
-directory), else `./results`. For a resumable long run use `--checkpoint`; for a
-one-off report without the archive, use `--format html --out report.html`.
+The results directory comes from `[results].dir` in the study's `mira.toml` (a
+relative path resolves against the `mira.toml`'s own directory), else `./results`.
+An interrupted long run resumes with `mira run --resume <run_id>` (it skips the
+cases already recorded and runs only what's missing); re-render a saved run's
+reports later with `mira report <run_id>`. Analysis-ready exports come from
+`--format jsonl` (one result per line) or `--format csv` (long-format, one row
+per case × score).
 
 See each study's own `README.md` for its matrix, agents, suites, and details.

--- a/evals/swebench_verified/.gitignore
+++ b/evals/swebench_verified/.gitignore
@@ -6,7 +6,3 @@ __pycache__/
 # Local caches: dataset parquet, repo checkouts, raw session logs, eval scratch.
 # Results (results/**/*.json) are committed; raw logs are uploaded separately.
 .cache/
-
-# Mira checkpoints — transient run/resume state (the durable artifact is the
-# --save run archive under results/<run_id>/).
-ck/

--- a/evals/swebench_verified/README.md
+++ b/evals/swebench_verified/README.md
@@ -2,7 +2,7 @@
 
 Benchmarks yolop on coding benchmarks, starting with **SWE-bench Verified**.
 swebench_verified is a [Mira](https://github.com/everruns/mira) eval **study**: the
-generic `mira` host CLI owns the target matrix, selection, checkpoints, and
+generic `mira` host CLI owns the target matrix, selection, saved run folders, and
 JSON/HTML/JUnit reporting, while this Python study — driven over Mira's stdio
 protocol — owns the SWE-bench-specific work (loading instances, checking out
 repos, running agent CLIs, and the Docker `FAIL_TO_PASS` scoring). Designed to
@@ -61,7 +61,7 @@ run the full set per config for leaderboard-comparable numbers.
 
 ## What it measures
 
-For every `(instance, config)` cell it records, mined from the agent's event log
+For every `(instance, config)` case it records, mined from the agent's event log
 and surfaced in the host's transcript/usage:
 
 - **success** — `resolved` (did the hidden test suite pass?)
@@ -71,11 +71,11 @@ and surfaced in the host's transcript/usage:
 - **tokens** — input, output, `cache_read_tokens`, `cache_creation_tokens`, total
 - **cost** — `cost_usd` (tool-reported where available, else estimated from `price`)
 - **efficiency** — cost per resolved instance ("score per dollar"), computable
-  from the host's per-cell `resolved` + `cost_usd`
+  from the host's per-case `resolved` + `cost_usd`
 - **stop_reason** — `completed` / `timeout` / `budget` / `error`
 - **config metadata** — agent, provider, model, reasoning effort, stop reason
 
-Each cell's transcript carries these on Mira's open channels: a numeric
+Each case's transcript carries these on Mira's open channels: a numeric
 **`metrics`** map (`turns`, `iterations`, `tool_calls`, `tool_calls_failed`,
 cache tokens, `agent_reported_time_s`) that feeds the host's generic budget
 scorers, and structured **`metadata`** (`agent`, `provider`, `model`,
@@ -98,9 +98,10 @@ mira run --group-by agent                          # yolop vs claude-code vs …
 
 Cost is cache-aware (`cache_read`/`cache_creation` tokens are priced), so cost
 per resolved instance is a fair cross-model comparison. The host surfaces all of
-the above per cell in its JSON and HTML reports — emit one with
-`mira ... run --format html --out report.html` (a single self-contained file) or
-`--format json --out run.json` for the raw rows. Each saved run also stamps
+the above per case in its JSON and HTML reports — emit one with
+`mira ... run --format html --out report.html` (a single self-contained file),
+`--format json --out run.json` for the raw rows, or `--format jsonl`/`--format csv`
+for un-aggregated, analysis-ready exports (one row per case, resp. per case × score). Each saved run also stamps
 `meta.json` with an `environment` block (git commit/branch/dirty, box, mira
 version) plus the `benchmark` label from `mira.toml`.
 
@@ -139,9 +140,8 @@ exactly; bump to `tracking-v2` rather than editing v1, so historical numbers sta
 comparable.
 
 **Baseline:** yolop · gpt-5.5 (OpenAI) scores **14/20** on tracking-v1 (all cases
-ran to completion). Point `--checkpoint` at a per-suite path (e.g.
-`--checkpoint ck/tracking-v1.json`) to keep a run resumable and its results
-self-contained.
+ran to completion). The run folder saves each case as it lands, so an interrupted
+run resumes with `mira run --resume <run_id>`.
 
 ## Layout
 
@@ -165,9 +165,9 @@ builds an ephemeral env and runs it — no package, `pyproject.toml`, or venv.
 The `mira` host owns durable run output. Every run auto-archives a self-contained run
 folder under `results/` (`results/<run_id>/{report.json,report.html,meta.json}`,
 `run_id = YYYYMMDDThhmmssZ-xxxx`); the dir comes from `mira.toml`'s
-`[results].dir`. For a resumable long run point `--checkpoint <path>` at a JSON
-session (saved after every cell); for a one-off report use `--format html --out
-report.html`. Raw `events.jsonl` logs stay in `.cache/sessions/` and are **not**
+`[results].dir`. An interrupted long run resumes with `mira run --resume <run_id>`
+(it skips the cases already saved under `cases/` and runs only what's missing); a
+saved run's reports re-render later with `mira report <run_id>`. Raw `events.jsonl` logs stay in `.cache/sessions/` and are **not**
 committed (see [Session data upload](#session-data-upload)). The `swebench_verified/`
 subdirs under `results/` are pre-Mira historical runs in the old per-config format.
 
@@ -213,8 +213,9 @@ reproducible against the binaries it was produced with.
 
 `swebench_verified` is a [Mira](https://github.com/everruns/mira) eval study: the `mira`
 host CLI drives it over a stdio JSON protocol, owning the matrix, selection,
-checkpoints, and reporting, while the study owns the SWE-bench-specific run +
-Docker scoring. `mira.toml` declares a `default_launcher` (mira >=0.2.0), so from
+saved run folders, and reporting, while the study owns the SWE-bench-specific run +
+Docker scoring. `mira.toml` declares a `default_launcher` (and uses mira >=0.3.0
+`samples` presets), so from
 this directory a bare `mira run`/`mira list` starts the study — no `--uv
 swebench_verified.py` (or the older `--cmd "uv run swebench_verified.py"`) needed:
 
@@ -226,16 +227,16 @@ cd evals/swebench_verified      # so the adjacent mira.toml is found; saved runs
 mira list
 
 # Plumbing only: one instance on the offline llmsim config, skip Docker eval.
-SWEBENCH_NO_EVAL=1 mira run astropy__astropy-12907 --targets llmsim
+SWEBENCH_NO_EVAL=1 mira run --samples astropy__astropy-12907 --targets llmsim --dry-run
 
 # Real end-to-end on one instance, selected configs (substring selection on the
 # case key, like `cargo test`), archived under ./results.
-doppler run -- mira run astropy__astropy-12907 \
+doppler run -- mira run --samples astropy__astropy-12907 \
     --targets openai-gpt-5.5,openai-gpt-5.5-high
 
-# Whole benchmark (all 500), one config, resumable + saved run archive.
-doppler run -- mira run --targets openai-gpt-5.5 \
-    --checkpoint ck/openai-gpt-5.5.json
+# Whole benchmark (all 500), one config; the run folder saves each case as it
+# lands, so an interrupted run resumes with `mira run --resume <run_id>`.
+doppler run -- mira run --targets openai-gpt-5.5
 ```
 
 Study-internal knobs that the host doesn't own are read from the environment so
@@ -244,27 +245,28 @@ they can be set on the `mira` line: `SWEBENCH_NO_EVAL=1` (skip Docker scoring),
 (build images locally instead of pulling prebuilt), `SWEBENCH_EVAL_TIMEOUT`,
 `SWEBENCH_YOLOP_BIN` (override the yolop binary), `SWEBENCH_CACHE_LEVEL=instance`
 (keep the per-instance Docker image so a multi-target matrix pulls it once
-rather than re-pulling per cell — avoids Docker Hub anonymous pull-rate limits;
+rather than re-pulling per case — avoids Docker Hub anonymous pull-rate limits;
 default `env`). The per-instance USD cap is set per config in the matrix
 (`max_cost_usd`, default `$5`).
 
 ### Presets — named runs
 
 A **preset** (`[presets.NAME]` in `mira.toml`, applied with `--preset NAME`) is a
-saved *selection* bundle — which samples (`tag`/`filter`) and which targets — so
+saved *selection* bundle — which samples (`tag`/`samples`) and which targets — so
 the recurring run scenarios have names. It's the same one eval (`swebench_verified`)
 sliced differently, not separate evals. A preset only subsets the grid;
 `--group-by` isn't selection, so pass it too (the run folder is always saved).
 
 | Preset | Purpose | Samples | Targets | Typical run |
 |--------|---------|---------|---------|-------------|
-| `astropy-12907-compare` | Evidence of how yolop benches vs other configs & coding agents on one **pinned** instance (`filter`) | astropy-12907 | 13 targets (yolop ×6 incl. gpt-5.5 none/low/medium/high + nvidia/glm/kimi OpenRouter top models + claude-code ×2 + codex + pi) | `mira … run --preset astropy-12907-compare --group-by agent` |
+| `astropy-12907-compare` | Evidence of how yolop benches vs other configs & coding agents on one **pinned** instance (`samples`) | astropy-12907 | 13 targets (yolop ×6 incl. gpt-5.5 none/low/medium/high + nvidia/glm/kimi OpenRouter top models + claude-code ×2 + codex + pi) | `mira … run --preset astropy-12907-compare --group-by agent` |
 | `tracking` | Weekly yolop quality tracking | 20 (`tracking-v1`) | gpt-5.5 high · glm-5.2 · opus-4.8 | `mira … run --preset tracking --group-by difficulty` |
-| `full` | Whole benchmark, run rarely | all 500 | same as tracking (edit as needed) | `mira … run --preset full --group-by repo --checkpoint ck/full.json` |
+| `full` | Whole benchmark, run rarely | all 500 | same as tracking (edit as needed) | `mira … run --preset full --group-by repo` |
 
-A preset's `filter` is a substring on the case key `eval/sample@target`, so it can
-**pin a sample** — clone the `astropy-12907-compare` block (new name + `filter`) to
-pin other instances. A **target** is Mira's comparison axis — a model *or* a
+A preset's `samples` is a glob on the sample id (here the instance id), so it can
+**pin a sample** — clone the `astropy-12907-compare` block (new name + `samples`) to
+pin other instances. (The cross-cutting case-key substring stays available as the
+positional `mira run [filter]`.) A **target** is Mira's comparison axis — a model *or* a
 harness — so agent configs are first-class targets, not models faked into the
 model slot.
 
@@ -303,7 +305,7 @@ It's one file — extend it in place:
 ## Session data upload
 
 Full `events.jsonl` logs are large and noisy, so they stay out of git (in
-`.cache/sessions/`). The agent records each log's path; the cell transcript
+`.cache/sessions/`). The agent records each log's path; the case transcript
 returned to the host carries the metrics mined from it. Uploading these logs to
 durable storage (object store /
 dataset) is a deliberate, still-open integration point — the harness keeps the
@@ -313,11 +315,11 @@ result record).
 
 ## How an instance runs
 
-The host asks the study to run one `(instance, config)` cell at a time; for each:
+The host asks the study to run one `(instance, config)` case at a time; for each:
 
 1. Shallow-fetch the repo at `base_commit` into a scratch worktree.
 2. Run `yolop -C <worktree> -p "<problem statement prompt>" --session-dir …`.
 3. Capture `git diff` as the model patch.
 4. Hand the patch to SWE-bench's official Docker evaluator and parse the
-   `report.json` for `resolved`, returned to the host as the cell's score.
+   `report.json` for `resolved`, returned to the host as the case's score.
 ```

--- a/evals/swebench_verified/bootstrap.sh
+++ b/evals/swebench_verified/bootstrap.sh
@@ -45,7 +45,7 @@ else
 fi
 
 # --- Mira host CLI ---------------------------------------------------------- #
-# The study is driven by `mira` (matrix, selection, checkpoints, reporting).
+# The study is driven by `mira` (matrix, selection, saved run folders, reporting).
 note "mira host CLI"
 if have mira; then
   mira --version 2>&1 | head -1 || true
@@ -97,5 +97,5 @@ cat <<'EOF'
     cd evals/swebench_verified
 
   Smoke test (offline, skips Docker):
-    SWEBENCH_NO_EVAL=1 mira run astropy__astropy-12907 --targets llmsim
+    SWEBENCH_NO_EVAL=1 mira run --samples astropy__astropy-12907 --targets llmsim --dry-run
 EOF

--- a/evals/swebench_verified/mira.toml
+++ b/evals/swebench_verified/mira.toml
@@ -8,10 +8,11 @@
 # Layout per saved run: results/<run_id>/{report.json,report.html,meta.json}
 # (run_id = YYYYMMDDThhmmssZ-xxxx, sortable by time).
 
-# Named launcher: how `mira` (>=0.2.0) starts this study. With `default_launcher`
-# set, a bare `mira list` / `mira run …` from this directory drives the study —
-# no `--uv swebench_verified.py` (or the older `--cmd "uv run
-# swebench_verified.py"`) needed. Explicit launch flags still override it.
+# Named launcher: how `mira` starts this study (this config targets mira >=0.3.0,
+# for the glob `samples` presets below). With `default_launcher` set, a bare
+# `mira list` / `mira run …` from this directory drives the study — no `--uv
+# swebench_verified.py` (or the older `--cmd "uv run swebench_verified.py"`)
+# needed. Explicit launch flags still override it.
 default_launcher = "study"
 
 [launchers.study]
@@ -26,19 +27,19 @@ dir = "./results"
 benchmark = "swebench_verified"
 
 # Named selection presets, applied with `mira run --preset NAME` (explicit flags
-# override). A preset only *subsets* the declared grid (targets / samples via
-# tag|filter). `--group-by` is not selection, so pass it too. The run folder
-# is always saved (use `--dry-run` to skip).
+# override). A preset only *subsets* the declared grid: `targets`/`samples`/`evals`
+# (each a glob, or a list of globs) plus `tag`. `--group-by` is not selection, so
+# pass it too. The run folder is always saved (use `--dry-run` to skip).
 # The README "Presets" table documents each one's purpose.
 
 # ASTROPY-12907-COMPARE — evidence of how yolop benches against different configs
 # and other coding agents on ONE instance (astropy__astropy-12907, pinned via
-# `filter`, a substring on the case key `eval/sample@target`): yolop across
+# `samples`, a glob on the sample id — here the instance id): yolop across
 # providers/effort + the nvidia/glm/kimi OpenRouter top models + claude-code,
-# codex, pi. Clone this block (new name + filter) to pin other instances.
+# codex, pi. Clone this block (new name + samples) to pin other instances.
 #   mira ... run --preset astropy-12907-compare --group-by agent
 [presets.astropy-12907-compare]
-filter = "astropy__astropy-12907"
+samples = "astropy__astropy-12907"
 targets = ["anthropic-claude-sonnet-4.5", "openai-gpt-5.5", "openai-gpt-5.5-high",
            "openai-gpt-5.5-low", "openai-gpt-5.5-none", "anthropic-claude-opus-4.8",
            "openrouter-nemotron-3-ultra", "openrouter-glm-5.2", "openrouter-kimi-k2.7-code",
@@ -53,7 +54,8 @@ targets = ["openai-gpt-5.5-high", "openrouter-glm-5.2", "anthropic-claude-opus-4
 
 # FULL — the whole SWE-bench Verified (all 500), run rarely (e.g. a release
 # headline). Same model matrix as tracking by default — edit the targets for the
-# run you want. This is large (500 × targets cells); use --checkpoint to resume.
-#   mira ... run --preset full --group-by repo --checkpoint ck/full.json
+# run you want. This is large (500 × targets cases); the run folder saves each
+# case as it lands, so an interrupted run resumes with `mira run --resume <run_id>`.
+#   mira ... run --preset full --group-by repo
 [presets.full]
 targets = ["openai-gpt-5.5-high", "openrouter-glm-5.2", "anthropic-claude-opus-4.8"]

--- a/evals/swebench_verified/swebench_verified.py
+++ b/evals/swebench_verified/swebench_verified.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.11"
-# dependencies = ["mira-eval>=0.2.0", "pandas>=2.0", "pyarrow>=14.0", "swebench>=4.1.0"]
+# dependencies = ["mira-eval>=0.3.0", "pandas>=2.0", "pyarrow>=14.0", "swebench>=4.1.0"]
 # ///
 """swebench_verified — a single-file Mira eval study for SWE-bench Verified.
 
@@ -14,13 +14,13 @@ builds an ephemeral env and runs it with no project scaffolding:
 
     cd evals/swebench_verified
     mira list                  # mira.toml's default_launcher drives this study
-    mira run astropy__astropy-12907 --targets anthropic-claude-sonnet-4.5
+    mira run --samples astropy__astropy-12907 --targets anthropic-claude-sonnet-4.5
 
 (`mira --uv swebench_verified.py …` is the explicit equivalent; `--cmd "uv run
 swebench_verified.py"` still works for arbitrary command lines.)
 
-The `mira` host owns the target matrix, selection, concurrency, checkpoints, and
-reporting; this study owns the SWE-bench-specific work:
+The `mira` host owns the target matrix, selection, concurrency, saved run folders,
+and reporting; this study owns the SWE-bench-specific work:
 
 * loads SWE-bench Verified instances (the HF parquet),
 * runs a coding agent (yolop, claude-code, codex, or pi) in a fresh checkout,
@@ -38,7 +38,7 @@ flags): `SWEBENCH_NO_EVAL=1` skips Docker scoring, `SWEBENCH_MAX_WORKERS`,
 `SWEBENCH_NAMESPACE` (`none` builds images locally), `SWEBENCH_EVAL_TIMEOUT`,
 `SWEBENCH_YOLOP_BIN` (override the yolop binary path), `SWEBENCH_CACHE_LEVEL`
 (SWE-bench image cache level; `instance` keeps the per-instance image so a
-matrix run pulls it once instead of re-pulling per cell — default `env`).
+matrix run pulls it once instead of re-pulling per case — default `env`).
 
 stdout carries ONLY protocol JSON (one object per line); logs go to stderr.
 """
@@ -64,7 +64,7 @@ import mira  # the mira-eval SDK: protocol types + the stdio serve loop
 # The mira-eval SDK pins the protocol version (`mira.PROTOCOL_VERSION`, currently
 # "1.0"); everything we emit (open-ended `metadata`, the numeric `metrics` map,
 # `error_kind`, and per-target `metadata` columns) is part of that 1.0 baseline.
-STUDY_VERSION = "0.5.0"
+STUDY_VERSION = "0.6.0"
 
 HERE = Path(__file__).resolve().parent
 REPO_ROOT = HERE.parents[1]                      # evals/swebench_verified -> repo root
@@ -806,7 +806,7 @@ def checkout(instance: Instance, dest: Path) -> None:
 
 def capture_patch(workdir: Path) -> str:
     # Fail loudly: a silent git error here would yield an empty/partial patch and
-    # mis-score the cell. The caller treats the raise as an infra error.
+    # mis-score the case. The caller treats the raise as an infra error.
     add = _git(["add", "-A"], workdir)
     if add.returncode != 0:
         raise RuntimeError(f"git add failed in {workdir}: {add.stderr.strip()}")
@@ -887,8 +887,8 @@ def evaluate_predictions(predictions: Mapping[str, str], instances: list[Instanc
             fh.write(json.dumps({"instance_id": iid, "model_name_or_path": model_name,
                                  "model_patch": predictions.get(iid, "")}) + "\n")
     # SWE-bench's default cache_level "env" deletes the per-instance image after
-    # each cell, so a multi-target matrix re-pulls the same prebuilt image once
-    # per cell — which trips Docker Hub's anonymous pull rate limit. "instance"
+    # each case, so a multi-target matrix re-pulls the same prebuilt image once
+    # per case — which trips Docker Hub's anonymous pull rate limit. "instance"
     # keeps the instance image so the matrix pulls it once and reuses it.
     cache_level = os.environ.get("SWEBENCH_CACHE_LEVEL", "env")
     cmd = [sys.executable, "-m", "swebench.harness.run_evaluation",
@@ -956,10 +956,10 @@ def _sanitize(s: str) -> str:
     return "".join(c if c.isalnum() or c in "-._" else "_" for c in s)
 
 
-def _run_agent_cell(inst: Instance, target: str, spec: dict, *,
+def _run_agent_case(inst: Instance, target: str, spec: dict, *,
                     max_workers: int, namespace: str, eval_timeout: int,
                     do_eval: bool) -> tuple[AgentRun, bool, dict, str | None]:
-    """Checkout + run the agent + (optionally) Docker-score one cell. Module-level
+    """Checkout + run the agent + (optionally) Docker-score one case. Module-level
     so the unit tests can patch `checkout`/`run_agent`/`capture_patch`/
     `evaluate_predictions` as globals. Returns (run, resolved, report, error_kind)."""
     run = _run_agent(inst, target, spec)
@@ -1081,7 +1081,7 @@ class Study:
         return self._instances
 
     def _subject(self, sample: mira.Sample, cx: mira.RunCx) -> mira.Transcript:
-        """Run one (instance, config) cell. The SDK has already skipped
+        """Run one (instance, config) case. The SDK has already skipped
         unavailable targets, so any target reaching here is runnable."""
         spec = MATRIX.get(cx.target)
         if spec is None:
@@ -1089,7 +1089,7 @@ class Study:
         inst = self.instances().get(sample.id)
         if inst is None:
             raise ValueError(f"unknown sample/instance: {sample.id!r}")
-        run, resolved, report, error_kind = _run_agent_cell(
+        run, resolved, report, error_kind = _run_agent_case(
             inst, cx.target, spec, max_workers=self.max_workers, namespace=self.namespace,
             eval_timeout=self.eval_timeout, do_eval=self.do_eval)
         return _build_transcript(run, resolved, report, spec, inst, error_kind)

--- a/evals/swebench_verified/tests/test_study.py
+++ b/evals/swebench_verified/tests/test_study.py
@@ -7,7 +7,7 @@ don't re-test them here. These tests exercise only what this study owns:
 * sample tagging (instance -> repo/difficulty/suite tags),
 * the target matrix (availability from env, config metadata),
 * transcript building (usage/metrics/metadata/files mapping, infra error_kind),
-* the `resolved` scorer and the cell orchestration (checkout + agent + score),
+* the `resolved` scorer and the case orchestration (checkout + agent + score),
 * stdout cleanliness of the Docker scorer.
 
 Plus one thin integration smoke that the study registers with the SDK and a run
@@ -130,36 +130,36 @@ class ResolvedScorerTest(unittest.TestCase):
         self.assertFalse(bad.pass_)
 
 
-class CellTest(unittest.TestCase):
-    """`_run_agent_cell` / `_subject`: checkout + agent + Docker-score one cell,
+class CaseTest(unittest.TestCase):
+    """`_run_agent_case` / `_subject`: checkout + agent + Docker-score one case,
     classifying infra failures and honouring do_eval."""
 
-    def _cell(self, *, do_eval, run_agent=_fake_agent_run, evaluate=None):
+    def _case(self, *, do_eval, run_agent=_fake_agent_run, evaluate=None):
         evaluate = evaluate or (lambda *a, **k: {_INSTANCE.instance_id: EvalResult(True, {"resolved": True})})
         with mock.patch.object(sv, "checkout", lambda *a, **k: None), \
              mock.patch.object(sv, "capture_patch", lambda *a, **k: "diff --git a b"), \
              mock.patch.object(sv, "run_agent", run_agent), \
              mock.patch.object(sv, "evaluate_predictions", evaluate):
-            return sv._run_agent_cell(_INSTANCE, "llmsim", {"agent": "yolop"},
+            return sv._run_agent_case(_INSTANCE, "llmsim", {"agent": "yolop"},
                                       max_workers=1, namespace="x", eval_timeout=1, do_eval=do_eval)
 
     def test_runner_failure_is_infra(self):
         def boom(*_a, **_k):
             raise RuntimeError("boom")
-        run, _resolved, _report, error_kind = self._cell(do_eval=False, run_agent=boom)
+        run, _resolved, _report, error_kind = self._case(do_eval=False, run_agent=boom)
         self.assertEqual(error_kind, "infra")
         self.assertTrue(run.error.startswith("runner:"))
 
     def test_eval_failure_is_infra(self):
         evaluate = lambda *a, **k: {_INSTANCE.instance_id: EvalResult(False, {}, "no report.json")}
-        run, _resolved, _report, error_kind = self._cell(do_eval=True, evaluate=evaluate)
+        run, _resolved, _report, error_kind = self._case(do_eval=True, evaluate=evaluate)
         self.assertEqual(error_kind, "infra")
         self.assertEqual(run.error, "no report.json")
 
     def test_no_eval_skips_scoring(self):
         called = []
         evaluate = lambda *a, **k: called.append(1) or {}
-        _run, resolved, _report, error_kind = self._cell(do_eval=False, evaluate=evaluate)
+        _run, resolved, _report, error_kind = self._case(do_eval=False, evaluate=evaluate)
         self.assertFalse(resolved)        # unscored -> not resolved
         self.assertIsNone(error_kind)     # a clean (if unscored) run
         self.assertEqual(called, [])      # Docker scorer not invoked
@@ -295,7 +295,7 @@ class SdkIntegrationTest(unittest.TestCase):
             res = study.protocol().handle(
                 "run", {"eval": "swebench_verified", "sample": "org__repo-1", "target": "llmsim"})
         self.assertEqual({s["scorer"] for s in res["scores"]}, {"succeeded", "resolved"})
-        self.assertTrue(res["passed"])  # both scorers pass on a resolved cell
+        self.assertTrue(res["passed"])  # both scorers pass on a resolved case
         self.assertEqual(res["transcript"]["metadata"]["repo"], "org/repo")  # our data flows out
 
 


### PR DESCRIPTION
## What & why

Bumps the `swebench_verified` Mira study to **mira-eval 0.3.0** and brings the
study, its tests, and its docs in line with the terminology and config that
landed in mira 0.2.0/0.3.0 (the previous 0.2.0 adoption updated launchers but
left the old "cell" wording and the removed `--save`/`--checkpoint`/`filter`
surface in place).

Changes:

- **Dep bump:** PEP 723 `mira-eval>=0.2.0` → `>=0.3.0`; `STUDY_VERSION` 0.5.0 → 0.6.0.
- **`cell` → `case`** throughout the study, tests, and docs (the execution unit
  was renamed upstream: `Cell` → `Case`). Internal `_run_agent_cell` → `_run_agent_case`.
- **Preset config (breaking upstream):** the removed preset `filter` key is
  replaced by the 0.3.0 per-dimension `samples` glob on sample id —
  `[presets.astropy-12907-compare]` now uses `samples = "astropy__astropy-12907"`.
- **Removed-flag cleanup:** `--save`/`--checkpoint` (gone since 0.2.0) are
  dropped from the docs and examples. Runs save by default into a run folder;
  docs now describe `mira run --resume <run_id>`, `mira report <run_id>`, the new
  `--format jsonl`/`--format csv` exports, and glob `--samples`/`--targets`/`--evals`
  selection. Dropped the dead `ck/` gitignore entry.

## How validated

Mira's CLI isn't installed in this env, so validation was the study's own suite
plus a protocol smoke against the real SDK:

- `uv run --with mira-eval -m unittest discover -s tests` → **43 passed** with
  mira-eval 0.3.0 (the SDK resolves to 0.3.0; the study's `Study`/`Eval`/`Sample`/
  `target`/`Transcript`/`make_score` calls are all unchanged in 0.3.0).
- `echo '{"id":1,"method":"initialize"}' | uv run swebench_verified.py` → clean
  `protocol_version: 1.0`, `study_version: 0.6.0`.
- `mira.toml` parses; the `astropy-12907-compare` preset resolves `samples =
  "astropy__astropy-12907"`.

Note: `mira list`/`run` need the SWE-bench Verified parquet from HuggingFace,
whose egress is blocked in this environment — not exercised here and not touched
by this change.

## Security

No security-relevant code changes — docs, config, an internal rename, and a
dependency floor bump. The SDK has zero runtime deps; no new attack surface, no
key handling, filesystem, or shell changes.

## Follow-ups

No follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6HfD1C3bRuUkrj1pKMepB)_