### PR TITLE
feat(into): add paseo target

### DIFF
--- a/src/into.rs
+++ b/src/into.rs
@@ -12,7 +12,23 @@ pub struct ZedIntoOptions {
 }
 
 #[derive(Debug)]
+pub struct PaseoIntoOptions {
+    pub settings_path: Option<PathBuf>,
+    pub agent_name: String,
+    pub command: PathBuf,
+    pub force: bool,
+}
+
+#[derive(Debug)]
 pub struct ZedIntoResult {
+    pub settings_path: PathBuf,
+    pub agent_name: String,
+    pub command: String,
+    pub status: IntoStatus,
+}
+
+#[derive(Debug)]
+pub struct PaseoIntoResult {
     pub settings_path: PathBuf,
     pub agent_name: String,
     pub command: String,
@@ -35,20 +51,8 @@ pub fn into_zed(options: ZedIntoOptions) -> Result<ZedIntoResult> {
         .settings_path
         .unwrap_or_else(default_zed_settings_path);
     let command = path_to_json_string(&options.command)?;
-    let desired = zed_agent_server(&command);
-    let existing_text = match std::fs::read_to_string(&settings_path) {
-        Ok(text) => Some(text),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
-        Err(err) => {
-            return Err(err)
-                .with_context(|| format!("read Zed settings file {}", settings_path.display()));
-        }
-    };
-    let mut root = match existing_text.as_deref() {
-        Some(text) if !text.trim().is_empty() => parse_zed_settings(text)
-            .with_context(|| format!("parse Zed settings file {}", settings_path.display()))?,
-        _ => json!({}),
-    };
+    let existing_text = read_optional_settings(&settings_path, "Zed")?;
+    let mut root = parse_settings_or_empty(existing_text.as_deref(), &settings_path, "Zed")?;
 
     let root_object = root
         .as_object_mut()
@@ -60,14 +64,69 @@ pub fn into_zed(options: ZedIntoOptions) -> Result<ZedIntoResult> {
         .as_object_mut()
         .context("Zed settings `agent_servers` must be a JSON object")?;
 
-    let status = merge_agent_server(agent_servers, &options.agent_name, desired, options.force)?;
+    let status = merge_agent_server(
+        agent_servers,
+        &options.agent_name,
+        zed_agent_server(&command),
+        options.force,
+        "Zed agent_servers",
+    )?;
 
     if status != IntoStatus::Unchanged {
-        let rendered = render_settings(&root, existing_text.as_deref())?;
+        let rendered = render_settings(&root, existing_text.as_deref(), "Zed")?;
         write_file_atomically(&settings_path, rendered.as_bytes())?;
     }
 
     Ok(ZedIntoResult {
+        settings_path,
+        agent_name: options.agent_name,
+        command,
+        status,
+    })
+}
+
+pub fn into_paseo(options: PaseoIntoOptions) -> Result<PaseoIntoResult> {
+    if options.agent_name.trim().is_empty() {
+        bail!("agent server name cannot be empty");
+    }
+
+    let settings_path = options
+        .settings_path
+        .unwrap_or_else(default_paseo_settings_path);
+    let command = path_to_json_string(&options.command)?;
+    let existing_text = read_optional_settings(&settings_path, "Paseo")?;
+    let mut root = parse_settings_or_empty(existing_text.as_deref(), &settings_path, "Paseo")?;
+
+    let root_object = root
+        .as_object_mut()
+        .context("Paseo settings root must be a JSON object")?;
+    let agents = root_object
+        .entry("agents")
+        .or_insert_with(|| Value::Object(Map::new()));
+    let agents = agents
+        .as_object_mut()
+        .context("Paseo config `agents` must be a JSON object")?;
+    let providers = agents
+        .entry("providers")
+        .or_insert_with(|| Value::Object(Map::new()));
+    let providers = providers
+        .as_object_mut()
+        .context("Paseo config `agents.providers` must be a JSON object")?;
+
+    let status = merge_agent_server(
+        providers,
+        &options.agent_name,
+        paseo_acp_provider(&options.agent_name, &command),
+        options.force,
+        "Paseo agents.providers",
+    )?;
+
+    if status != IntoStatus::Unchanged {
+        let rendered = render_settings(&root, existing_text.as_deref(), "Paseo")?;
+        write_file_atomically(&settings_path, rendered.as_bytes())?;
+    }
+
+    Ok(PaseoIntoResult {
         settings_path,
         agent_name: options.agent_name,
         command,
@@ -84,11 +143,20 @@ fn zed_agent_server(command: &str) -> Value {
     })
 }
 
+fn paseo_acp_provider(label: &str, command: &str) -> Value {
+    json!({
+        "extends": "acp",
+        "label": label,
+        "command": [command, "--acp"]
+    })
+}
+
 fn merge_agent_server(
     agent_servers: &mut Map<String, Value>,
     agent_name: &str,
     desired: Value,
     force: bool,
+    config_path: &str,
 ) -> Result<IntoStatus> {
     let Some(current) = agent_servers.get_mut(agent_name) else {
         agent_servers.insert(agent_name.to_string(), desired);
@@ -105,22 +173,22 @@ fn merge_agent_server(
     }
 
     let Some(current_object) = current.as_object_mut() else {
-        bail!("Zed agent_servers.{agent_name} is not an object; re-run with --force to replace it");
+        bail!("{config_path}.{agent_name} is not an object; re-run with --force to replace it");
     };
     let desired_object = desired
         .as_object()
-        .expect("desired Zed agent server is an object");
+        .expect("desired agent server is an object");
     let mut changed = false;
-    for key in ["type", "command", "args"] {
-        if current_object.get(key) != desired_object.get(key) {
-            current_object.insert(
-                key.to_string(),
-                desired_object.get(key).expect("desired key exists").clone(),
-            );
+    for (key, value) in desired_object {
+        if key == "env" {
+            continue;
+        }
+        if current_object.get(key) != Some(value) {
+            current_object.insert(key.clone(), value.clone());
             changed = true;
         }
     }
-    if !current_object.contains_key("env") {
+    if desired_object.contains_key("env") && !current_object.contains_key("env") {
         current_object.insert("env".to_string(), json!({}));
         changed = true;
     }
@@ -130,6 +198,39 @@ fn merge_agent_server(
     } else {
         IntoStatus::Unchanged
     })
+}
+
+fn default_paseo_settings_path() -> PathBuf {
+    if let Some(home) = std::env::var_os("HOME")
+        && !home.is_empty()
+    {
+        return PathBuf::from(home).join(".paseo").join("config.json");
+    }
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("paseo")
+        .join("config.json")
+}
+
+fn read_optional_settings(settings_path: &Path, app_name: &str) -> Result<Option<String>> {
+    match std::fs::read_to_string(settings_path) {
+        Ok(text) => Ok(Some(text)),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err)
+            .with_context(|| format!("read {app_name} settings file {}", settings_path.display())),
+    }
+}
+
+fn parse_settings_or_empty(
+    existing_text: Option<&str>,
+    settings_path: &Path,
+    app_name: &str,
+) -> Result<Value> {
+    match existing_text {
+        Some(text) if !text.trim().is_empty() => parse_jsonc_settings(text)
+            .with_context(|| format!("parse {app_name} settings file {}", settings_path.display())),
+        _ => Ok(json!({})),
+    }
 }
 
 fn default_zed_settings_path() -> PathBuf {
@@ -158,13 +259,13 @@ fn path_to_json_string(path: &Path) -> Result<String> {
         .with_context(|| format!("command path is not valid UTF-8: {}", path.display()))
 }
 
-fn parse_zed_settings(text: &str) -> Result<Value> {
+fn parse_jsonc_settings(text: &str) -> Result<Value> {
     let without_comments = strip_jsonc_comments(text);
     let strict_json = strip_trailing_commas(&without_comments);
     Ok(serde_json::from_str(&strict_json)?)
 }
 
-fn render_settings(root: &Value, original_text: Option<&str>) -> Result<String> {
+fn render_settings(root: &Value, original_text: Option<&str>, app_name: &str) -> Result<String> {
     let mut rendered = String::new();
     if let Some(header) = original_text.and_then(leading_comment_header) {
         rendered.push_str(header);
@@ -172,7 +273,10 @@ fn render_settings(root: &Value, original_text: Option<&str>) -> Result<String> 
             rendered.push('\n');
         }
     }
-    rendered.push_str(&serde_json::to_string_pretty(root).context("serialize Zed settings")?);
+    rendered.push_str(
+        &serde_json::to_string_pretty(root)
+            .with_context(|| format!("serialize {app_name} settings"))?,
+    );
     rendered.push('\n');
     Ok(rendered)
 }
@@ -354,6 +458,15 @@ mod tests {
         })
     }
 
+    fn into_paseo_at(path: PathBuf, command: &str, force: bool) -> Result<PaseoIntoResult> {
+        into_paseo(PaseoIntoOptions {
+            settings_path: Some(path),
+            agent_name: "yolop".to_string(),
+            command: PathBuf::from(command),
+            force,
+        })
+    }
+
     #[test]
     fn zed_into_creates_missing_settings_file() {
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -390,7 +503,7 @@ mod tests {
         assert_eq!(result.status, IntoStatus::Created);
         let text = std::fs::read_to_string(path).expect("settings");
         assert!(text.starts_with("// Zed settings\n"));
-        let parsed = parse_zed_settings(&text).expect("parse");
+        let parsed = parse_jsonc_settings(&text).expect("parse");
         assert_eq!(parsed["theme"], "One Dark");
         assert_eq!(parsed["agent_servers"]["yolop"]["args"], json!(["--acp"]));
     }
@@ -408,7 +521,7 @@ mod tests {
         let result = into_at(path.clone(), "/bin/yolop", false).expect("into");
 
         assert_eq!(result.status, IntoStatus::Updated);
-        let parsed = parse_zed_settings(&std::fs::read_to_string(path).unwrap()).unwrap();
+        let parsed = parse_jsonc_settings(&std::fs::read_to_string(path).unwrap()).unwrap();
         assert_eq!(parsed["agent_servers"]["yolop"]["command"], "/bin/yolop");
         assert_eq!(parsed["agent_servers"]["yolop"]["args"], json!(["--acp"]));
         assert_eq!(
@@ -437,6 +550,71 @@ mod tests {
     }
 
     #[test]
+    fn paseo_into_creates_acp_provider_in_documented_config_shape() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("config.json");
+        std::fs::write(
+            &path,
+            r#"{
+  "agents": {
+    "providers": {
+      "claude-work": {
+        "extends": "claude",
+        "label": "Claude (Work)"
+      }
+    }
+  }
+}
+"#,
+        )
+        .expect("write settings");
+
+        let result = into_paseo_at(path.clone(), "/bin/yolop", false).expect("into");
+
+        assert_eq!(result.status, IntoStatus::Created);
+        let parsed: Value = serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        assert_eq!(
+            parsed["agents"]["providers"]["claude-work"]["label"],
+            "Claude (Work)"
+        );
+        assert_eq!(
+            parsed["agents"]["providers"]["yolop"],
+            json!({
+                "extends": "acp",
+                "label": "yolop",
+                "command": ["/bin/yolop", "--acp"]
+            })
+        );
+    }
+
+    #[test]
+    fn paseo_into_updates_existing_acp_provider_and_preserves_env() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("config.json");
+        std::fs::write(
+            &path,
+            r#"{"agents":{"providers":{"yolop":{"extends":"acp","label":"Old Label","command":["old","--old"],"env":{"OPENAI_API_KEY":"keep"},"enabled":true}}}}"#,
+        )
+        .expect("write settings");
+
+        let result = into_paseo_at(path.clone(), "/bin/yolop", false).expect("into");
+
+        assert_eq!(result.status, IntoStatus::Updated);
+        let parsed: Value = serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        assert_eq!(parsed["agents"]["providers"]["yolop"]["extends"], "acp");
+        assert_eq!(parsed["agents"]["providers"]["yolop"]["label"], "yolop");
+        assert_eq!(
+            parsed["agents"]["providers"]["yolop"]["command"],
+            json!(["/bin/yolop", "--acp"])
+        );
+        assert_eq!(
+            parsed["agents"]["providers"]["yolop"]["env"]["OPENAI_API_KEY"],
+            "keep"
+        );
+        assert_eq!(parsed["agents"]["providers"]["yolop"]["enabled"], true);
+    }
+
+    #[test]
     fn zed_into_refuses_non_object_entry_without_force() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let path = tmp.path().join("settings.json");
@@ -456,7 +634,7 @@ mod tests {
         let result = into_at(path.clone(), "/bin/yolop", true).expect("into");
 
         assert_eq!(result.status, IntoStatus::Updated);
-        let parsed = parse_zed_settings(&std::fs::read_to_string(path).unwrap()).unwrap();
+        let parsed = parse_jsonc_settings(&std::fs::read_to_string(path).unwrap()).unwrap();
         assert_eq!(parsed["agent_servers"]["yolop"]["command"], "/bin/yolop");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,25 +172,22 @@ struct IntoCommand {
 
 #[derive(Subcommand, Debug)]
 enum IntoTarget {
+    /// Configure Paseo to launch yolop as a custom ACP provider.
+    Paseo(PaseoIntoArgs),
     /// Configure Zed to launch yolop as a custom ACP agent.
     Zed(ZedIntoArgs),
 }
 
 #[derive(Args, Debug)]
-struct ZedIntoArgs {
-    /// Zed settings file to update (default: ~/.config/zed/settings.json).
-    #[arg(long = "settings")]
-    settings_path: Option<PathBuf>,
-
-    /// Agent server name to write under `agent_servers`.
-    #[arg(long, default_value = "yolop")]
-    name: String,
-
-    /// Command path Zed should spawn (default: this yolop executable).
+struct PaseoIntoArgs {
+    /// Replace an existing `agents.providers.yolop` entry instead of preserving its env/extra fields.
     #[arg(long)]
-    command: Option<PathBuf>,
+    force: bool,
+}
 
-    /// Replace an existing `agent_servers.<name>` entry instead of preserving its env/extra fields.
+#[derive(Args, Debug)]
+struct ZedIntoArgs {
+    /// Replace an existing `agent_servers.yolop` entry instead of preserving its env/extra fields.
     #[arg(long)]
     force: bool,
 }
@@ -505,14 +502,46 @@ fn run_command(command: Commands) -> Result<()> {
         }
         Commands::Worktree(args) => run_worktree_command(args.command),
         Commands::Into(into) => match into.target {
+            IntoTarget::Paseo(args) => {
+                let command = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("yolop"));
+                let result = into::into_paseo(into::PaseoIntoOptions {
+                    settings_path: None,
+                    agent_name: "yolop".to_string(),
+                    command,
+                    force: args.force,
+                })?;
+                match result.status {
+                    into::IntoStatus::Unchanged => {
+                        println!(
+                            "yolop: Paseo already has `{}` ACP provider configured at {}",
+                            result.agent_name,
+                            result.settings_path.display()
+                        );
+                    }
+                    into::IntoStatus::Created => {
+                        println!(
+                            "yolop: added `{}` ACP provider to {}",
+                            result.agent_name,
+                            result.settings_path.display()
+                        );
+                    }
+                    into::IntoStatus::Updated => {
+                        println!(
+                            "yolop: updated `{}` ACP provider in {}",
+                            result.agent_name,
+                            result.settings_path.display()
+                        );
+                    }
+                }
+                println!("yolop: Paseo command: {} --acp", result.command);
+                println!("yolop: restart the Paseo daemon to reload this configuration");
+                Ok(())
+            }
             IntoTarget::Zed(args) => {
-                let command = match args.command {
-                    Some(path) => path,
-                    None => std::env::current_exe().unwrap_or_else(|_| PathBuf::from("yolop")),
-                };
+                let command = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("yolop"));
                 let result = into::into_zed(into::ZedIntoOptions {
-                    settings_path: args.settings_path,
-                    agent_name: args.name,
+                    settings_path: None,
+                    agent_name: "yolop".to_string(),
                     command,
                     force: args.force,
                 })?;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -105,17 +105,13 @@ fn assert_version_output(stdout: &str) {
 #[test]
 fn into_zed_command_writes_acp_settings() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let settings = tmp.path().join("zed/settings.json");
+    let settings = tmp.path().join(".config/zed/settings.json");
+    let binary = yolop_binary();
 
-    let output = Command::new(yolop_binary())
-        .args([
-            "into",
-            "zed",
-            "--settings",
-            settings.to_str().unwrap(),
-            "--command",
-            "/tmp/yolop",
-        ])
+    let output = Command::new(&binary)
+        .args(["into", "zed"])
+        .env("HOME", tmp.path())
+        .env("XDG_CONFIG_HOME", tmp.path().join(".config"))
         .output()
         .expect("spawn yolop into zed");
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -131,10 +127,48 @@ fn into_zed_command_writes_acp_settings() {
     let value: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(settings).expect("settings")).unwrap();
     assert_eq!(value["agent_servers"]["yolop"]["type"], "custom");
-    assert_eq!(value["agent_servers"]["yolop"]["command"], "/tmp/yolop");
+    assert_eq!(
+        value["agent_servers"]["yolop"]["command"],
+        serde_json::Value::String(binary.to_string_lossy().into_owned())
+    );
     assert_eq!(
         value["agent_servers"]["yolop"]["args"],
         serde_json::json!(["--acp"])
+    );
+}
+
+#[test]
+fn into_paseo_command_writes_acp_provider() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let settings = tmp.path().join(".paseo/config.json");
+    let binary = yolop_binary();
+
+    let output = Command::new(&binary)
+        .args(["into", "paseo"])
+        .env("HOME", tmp.path())
+        .output()
+        .expect("spawn yolop into paseo");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "into paseo failed: stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        stdout.contains("added `yolop` ACP provider"),
+        "unexpected into stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("restart the Paseo daemon to reload this configuration"),
+        "missing restart hint: {stdout}"
+    );
+    let value: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(settings).expect("settings")).unwrap();
+    assert_eq!(value["agents"]["providers"]["yolop"]["extends"], "acp");
+    assert_eq!(value["agents"]["providers"]["yolop"]["label"], "yolop");
+    assert_eq!(
+        value["agents"]["providers"]["yolop"]["command"],
+        serde_json::json!([binary.to_string_lossy(), "--acp"])
     );
 }
 


### PR DESCRIPTION
## Summary

- Add `yolop into paseo` to configure Yolop as a Paseo ACP provider.
- Keep `into` subcommands minimal: `yolop into zed [--force]` and `yolop into paseo [--force]`.
- Preserve existing env/extra provider fields during updates unless `--force` is used.
- Print a Paseo daemon restart reminder after writing config.

## Validation

- `cargo fmt --check`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Smoke tested `./target/debug/yolop into paseo` with a temporary `HOME` and verified `~/.paseo/config.json` contains `agents.providers.yolop.command = [<current exe>, "--acp"]`.
- Smoke tested `./target/debug/yolop into zed` with a temporary `HOME` and verified `~/.config/zed/settings.json` still contains `agent_servers.yolop.args = ["--acp"]`.

## Security

- TM-FS: writes remain constrained to the default app config paths for Zed and Paseo in this command path; test helper paths are only used by unit tests. No write blocklist/tool filesystem behavior changed.
- TM-BASH: no shell execution behavior changed.
- TM-LLM: no prompt construction or provider key handling changed; existing env fields are preserved without logging their values.
- TM-TOOL: no capability registration changed.
- TM-DEP: no dependency changes.

## Follow-ups

No follow-ups.

Generated with yolop
