### PR TITLE
chore(deps): bump everruns to 0.17.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,9 +1475,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.3"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd7dde3ce764fcbb73b0cf1ac73a498fb18c614dab8741b08d2a9bc68ccb238"
+checksum = "236e5772b8a53c6ca5ca27610eced36a71230cc4587f9de8ac3b7819f4cd1b26"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1493,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.3"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabd089a4d7c4403c22cf1adf1c1a7ec1da73ed0394dcc65ffd23e68b078676f"
+checksum = "01f5a9972d5493297cd1dfd46f715060ca58fdf3c8f1c97447d54213c9f444d4"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -1537,9 +1537,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.3"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5abed2ab2fd2fda245c42ab35de79e2ffb85890dd73724bacfb4bc3ba7fd403"
+checksum = "c80e5f86625fb2b58b8cd83d530c91a99c6f3b28468574925d6a33f47e66d0e5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1554,9 +1554,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.3"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168b48ac87b4a9a21b5cc0703960af7d9bc85f895962918fbc909e0e61e2a8c1"
+checksum = "a34289988a98e630a39b86a554c7b08ef14e4254447cafdae6639643f16e1adc"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1570,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.3"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ed4246eb87e4691bf113e8ec173b510f3ab0ed54f86ed6b5ac7f44d73281726"
+checksum = "b886430e183a608083938ce27fbbe46c3c82cabf2b4ad23736791d76f136d7c4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1591,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.3"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b36e27413303bdac8056e0f04bcf80c54357030cf91f3c10268225e37eae140d"
+checksum = "1096e310a92ecf1be65a9d120bea81f099a707b7886cd86a6e22b88d3cd55514"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1606,9 +1606,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.3"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf783e65ae4b08fa7a67b5b24cbf21985521278e58344daf52419b06975093f"
+checksum = "41e1ce594ab26451fc5121d8332c4903e812d8a26281c01ae89d906418a59468"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1627,9 +1627,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.3"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1956630622c38b10d8a331108d3905bf776c43f84d669ff0017ad7b3bab1be8b"
+checksum = "99c4a43d91d07103acaa543c8cd0535012ef6ae75071eaf445689ef566362d95"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1641,9 +1641,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.3"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18733965ca3f71042afe4bdd590da1eddad69b3415abb143dc2b34d26ba69849"
+checksum = "7255806db563ad8ff50ab2e0c4be61e40640cb6797a949611687726b00a9c50f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1721,9 +1721,9 @@ dependencies = [
 
 [[package]]
 name = "fetchkit"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82150b89249abf4f7a6bce136567c795803faa601fcb041157b7a43f4c1e856b"
+checksum = "0402bf4c57789d00a50f3b9a6ead70eb991c95021669bc68c8b9d7c73af78c34"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,18 +77,18 @@ tree-sitter-zig = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-everruns-anthropic = "0.17.3"
-everruns-core = "0.17.3"
-everruns-openai = "0.17.3"
+everruns-anthropic = "0.17.4"
+everruns-core = "0.17.4"
+everruns-openai = "0.17.4"
 # OpenRouter's first-class driver was split out of everruns-openai into its own
 # crate in 0.13.0; register it alongside openai to keep DriverId::OpenRouter.
-everruns-openrouter = "0.17.3"
-everruns-local = "0.17.3"
+everruns-openrouter = "0.17.4"
+everruns-local = "0.17.4"
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (specs/mcp.md, upstream runtime-mcp.md D2).
-everruns-runtime = { version = "0.17.3", features = ["mcp-stdio"] }
-everruns-integrations-duckduckgo = "0.17.3"
-everruns-integrations-daytona = "0.17.3"
+everruns-runtime = { version = "0.17.4", features = ["mcp-stdio"] }
+everruns-integrations-duckduckgo = "0.17.4"
+everruns-integrations-daytona = "0.17.4"
 arboard = { version = "3", features = ["wayland-data-control"] }
 futures = "0.3"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp"] }


### PR DESCRIPTION
## What
Bump the everruns dependency family from 0.17.3 to 0.17.4.

This updates:
- everruns-anthropic
- everruns-core
- everruns-integrations-daytona
- everruns-integrations-duckduckgo
- everruns-local
- everruns-mcp
- everruns-openai
- everruns-openrouter
- everruns-runtime

Cargo also refreshed the transitive `fetchkit` lockfile entry from 0.4.0 to 0.4.1.

## Why
Keep yolop on the latest released everruns patch version while keeping the family in lockstep.

## How
Updated the manifest pins and refreshed `Cargo.lock` with Cargo. No source changes were required.

## Risk
Low. This is a patch-level dependency bump and `cargo check --all-targets --all-features` found no API drift requiring yolop source changes.

## Security
Reviewed TM-DEP. This PR updates the existing everruns dependency family in lockstep; no new direct crates are introduced. The only transitive lockfile movement is `fetchkit` 0.4.0 -> 0.4.1 through everruns. No code, tool registration, filesystem access, shell execution, prompt construction, session logging, or provider-key handling changed.

## Validation
- `cargo fmt --check`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (573 unit tests passed, 1 ignored; 32 integration tests passed, 1 ignored)
- `cargo run -- --provider llmsim -p "hi"`

Automated feature-test note: exempt as a dependency manifest/lockfile bump with no behavior code change. Compatibility is covered by the full existing automated suite and runtime smoke above.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated, or exemption stated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)