### PR TITLE
fix(web): surface failed tool errors

### DIFF
--- a/src/acp/bridge.rs
+++ b/src/acp/bridge.rs
@@ -393,6 +393,39 @@ mod tests {
     }
 
     #[test]
+    fn tool_completed_failure_with_result_payload_still_includes_error_content() {
+        let mut t = Translator::new();
+        let updates = t.on_event(&event(EventData::ToolCompleted(ToolCompletedData {
+            tool_call_id: "call_1".into(),
+            tool_name: "web_fetch".into(),
+            tool_call_fingerprint: None,
+            tool_result_fingerprint: None,
+            display_name: Some("Web Fetch".into()),
+            success: false,
+            status: "error".into(),
+            result: Some(vec![ContentPart::text(json!({ "ok": false }).to_string())]),
+            error: Some("Invalid URL: must start with http:// or https://".into()),
+            duration_ms: None,
+            capability_id: None,
+            capability_name: None,
+            narration: None,
+        })));
+        assert_eq!(updates.len(), 1);
+        match &updates[0] {
+            SessionUpdate::ToolCallUpdate(update) => {
+                assert_eq!(update.fields.status, Some(ToolCallStatus::Failed));
+                assert_eq!(
+                    update.fields.content,
+                    Some(vec![protocol::content(
+                        "error: Invalid URL: must start with http:// or https://"
+                    )])
+                );
+            }
+            other => panic!("expected tool_call_update, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn write_todos_started_becomes_plan() {
         let mut t = Translator::new();
         let updates = t.on_event(&event(EventData::ToolStarted(ToolStartedData {

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -514,6 +514,11 @@ fn tool_started_label(data: &ToolStartedData) -> String {
 
 /// One-line summary of a tool result, used in the transcript and `--print` output.
 pub fn summarize_tool_result(data: &ToolCompletedData) -> String {
+    if !data.success
+        && let Some(err) = &data.error
+    {
+        return format!("error: {}", first_line(err, 120));
+    }
     let Some(v) = result_value(data) else {
         if let Some(err) = &data.error {
             return format!("error: {}", first_line(err, 120));
@@ -711,5 +716,29 @@ mod tests {
         data.display_name = None;
 
         assert_eq!(tool_started_label(&data), "tool_search");
+    }
+
+    #[test]
+    fn failed_unknown_tool_with_result_payload_still_summarizes_error() {
+        let data = ToolCompletedData {
+            tool_call_id: "call-1".into(),
+            tool_name: "web_fetch".into(),
+            tool_call_fingerprint: None,
+            tool_result_fingerprint: None,
+            display_name: Some("Web Fetch".into()),
+            success: false,
+            status: "error".into(),
+            result: Some(vec![ContentPart::text(json!({ "ok": false }).to_string())]),
+            error: Some("Invalid URL: must start with http:// or https://".into()),
+            duration_ms: None,
+            capability_id: None,
+            capability_name: None,
+            narration: None,
+        };
+
+        assert_eq!(
+            summarize_tool_result(&data),
+            "error: Invalid URL: must start with http:// or https://"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- keep Yolop on the upstream `WebFetchCapability` path, which now reaches `fetchkit v0.4.1` through `everruns-core v0.17.4` on current main
- surface `ToolCompletedData.error` for failed tool calls even when the runtime also attaches a result payload
- add transcript and ACP regressions for failed `web_fetch` calls that include both `result` and `error`

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test failed_unknown_tool_with_result_payload_still_summarizes_error`
- `cargo test tool_completed_failure_with_result_payload_still_includes_error_content`
- `cargo test --all-features`
- `cargo tree -i fetchkit` shows `fetchkit v0.4.1` via `everruns-core v0.17.4`
- `cargo run -- --provider llmsim -p "hi"` confirms startup and the `web_fetch` tool is exposed

Live OpenAI smoke was attempted with Doppler, but this worktree has no Doppler project or fallback secrets configured (`OPENAI_API_KEY` is also unset).

## Security review
- No new network fetch behavior is added in Yolop; bare-host URL normalization stays upstream in fetchkit.
- No SSRF, file save, schema, or capability-registration logic is changed here.
- Error presentation now prefers the runtime error string only when the tool call failed, avoiding a false-success-looking payload in ACP/transcript output.
- No secrets or tool payloads are newly logged.

## Follow-ups
None.