### PR TITLE
feat(runtime): add progress guard

### DIFF
--- a/evals/harness_basic/.gitignore
+++ b/evals/harness_basic/.gitignore
@@ -2,3 +2,5 @@
 /target
 # Raw per-case session logs (events.jsonl) preserved for debugging.
 /.cache
+# Timestamped Mira reports from local runs.
+/results

--- a/evals/harness_basic/README.md
+++ b/evals/harness_basic/README.md
@@ -4,7 +4,8 @@ A [Mira](https://github.com/everruns/mira) eval **study** for evaluating
 **yolop feature improvements**: the same small, self-contained coding tasks run
 across models × reasoning efforts × **yolop harness configurations**, so a
 feature (a new tool, a capability toggle, a prompt change) can be A/B'd on pass
-rate, turns, tool calls, tokens, and cost.
+rate, turns, tool calls, tokens, cost, and trajectory metrics such as
+exploration before first mutation.
 
 Unlike `swebench_verified/` (Python, benchmark-scale), this study is pure Rust
 on the [`mira-eval`](https://crates.io/crates/mira-eval) SDK — no Python
@@ -13,13 +14,13 @@ the runtime path; the TUI is never involved).
 
 ## The matrix
 
-Three axes, crossed with 6 samples (small edit / refactor / search tasks):
+Three axes, crossed with 7 samples (small edit / refactor / search / guardrail tasks):
 
 | Axis | Values | Where |
 |------|--------|-------|
 | **target** (model) | `anthropic/claude-sonnet-4-5` · `anthropic/claude-opus-4-8` · `openai/gpt-5.5` · `openrouter/z-ai/glm-5.2` | `targets()` in `src/main.rs` |
 | **effort** | `default` (yolop's per-model default; no flag) · `low` · `high` | `EFFORTS` |
-| **harness** | `default` (out-of-the-box yolop) · `no-ast-grep` | `HARNESS_VARIANTS` |
+| **harness** | `default` (out-of-the-box yolop) · `no-progress-guard` · `no-ast-grep` | `HARNESS_VARIANTS` |
 
 Every target gates on its provider key env var (`ANTHROPIC_API_KEY`,
 `OPENAI_API_KEY`, `OPENROUTER_API_KEY`) and is *skipped* (not failed) when the
@@ -40,13 +41,16 @@ search/refactor, and read-only code navigation.
 | `find-constant` [smoke] | 3 Python files; `MAGIC_TIMEOUT_MS = 7321` buried in `settings/defaults.py` | Answer its value, number only | final response contains `7321` | read-only navigation/search, no edits |
 | `implement-todo` | JS `clamp()` stub that throws, with a TODO spec comment | Implement per the TODO, remove the comment | `utils.js` has `function clamp` + `module.exports`, no `TODO`/`not implemented` | spec-comment comprehension, stub completion |
 | `add-module` | Rust lib with one existing fn | Create `src/util.rs` with `pub fn double`, wire `pub mod util;` into lib.rs | both files contain the required items | new-file creation + wiring across files |
+| `progress-guard-sequential-read` [`progress-guard`] | 24 numbered notes; answer in `notes/24.txt` | Read notes sequentially and answer the final code | final response contains `KITE-7429` | long exploration streak that should trigger `progress_guard` |
 
 ### Harness variants — the point of this study
 
-A variant is a yolop `settings.toml` written into an isolated per-case
-`XDG_CONFIG_HOME`, on top of a base that only turns linked worktrees off
+A variant is a yolop `settings.toml` written into isolated per-case config dirs
+(`XDG_CONFIG_HOME` and a scratch `HOME` for macOS), on top of a base that only turns linked worktrees off
 (study plumbing: the case workdir is a plain temp dir and file scorers read
 edits back from it). `default` adds nothing — it is yolop out of the box.
+`no-progress-guard` disables the progress-guard capability so guardrail
+changes can be compared against the same binary with that capability removed.
 
 Adding a configuration to the matrix is one entry in `src/main.rs`:
 
@@ -60,13 +64,13 @@ HarnessVariant {
 Any `settings.toml` content works (capability toggles and configs, feature
 settings), so future yolop features slot in without new plumbing. The variant
 name becomes the `harness` axis value in case keys
-(`basic_coding/add-fn@openai/gpt-5.5[effort=default,harness=no-ast-grep]`),
-selection (`--axis harness=no-ast-grep`), and `--group-by harness`.
+(`basic_coding/add-fn@openai/gpt-5.5[effort=default,harness=no-progress-guard]`),
+selection (`--axis harness=no-progress-guard`), and `--group-by harness`.
 
 ## How a case runs
 
 1. Seed the sample's files into a fresh temp workdir (never a git repo).
-2. Write the variant's `settings.toml` into a scratch `XDG_CONFIG_HOME`
+2. Write the variant's `settings.toml` into scratch config dirs
    (config/data/state/cache are all isolated — the developer's real
    `~/.config/yolop` never leaks in).
 3. Spawn `yolop -C <workdir> --provider … --model … [--reasoning-effort …]
@@ -74,8 +78,8 @@ selection (`--axis harness=no-ast-grep`), and `--group-by harness`.
    `HARNESS_BASIC_TIMEOUT_S`).
 4. Mine the session `events.jsonl` for usage/cost (once per
    `output.message.completed`; yolop repeats usage on `reason.completed`),
-   tool calls + failures, iterations/turns, the final response, and the
-   reasoning effort actually applied.
+  tool calls + failures, trajectory counters, iterations/turns, the final
+  response, and the reasoning effort actually applied.
 5. Read the workdir back so file scorers grade what yolop actually wrote.
 
 Raw per-case `events.jsonl` logs are kept under the gitignored
@@ -94,9 +98,10 @@ one generic scorer — adding a sample needs no new code:
 Alongside it: `succeeded` (yolop exited cleanly) and lenient guardrail budgets
 (`turns_within(32)`, `tool_calls_within(64)`, `cost_within($2)`). The A/B
 comparison itself reads the per-case numbers the transcript carries — tokens,
-cost, `llm_calls`, `turns`, `tool_calls_failed`, `agent_reported_ms` — plus
-metadata (`provider`, `model`, `effort`, `reasoning_effort_applied`,
-`harness`, `stop_reason`) for `--group-by`.
+cost, `llm_calls`, `turns`, `tool_calls_failed`, `agent_reported_ms`,
+`exploration_tools_before_first_mutation`, `max_exploration_tools_without_progress`,
+and `progress_guard_warnings` — plus metadata (`provider`, `model`, `effort`,
+`reasoning_effort_applied`, `harness`, `stop_reason`) for `--group-by`.
 
 ## Setup
 
@@ -123,6 +128,9 @@ doppler run -- mira run --preset smoke
 # The core loop: A/B the harness variants on one model.
 doppler run -- mira run --preset harness-compare --group-by harness
 
+# Focused guardrail proof: default vs no-progress-guard on the long-read trap.
+doppler run -- mira run --preset progress-guard --group-by harness
+
 # Reasoning-effort sweep, out-of-the-box harness.
 doppler run -- mira run --preset effort-compare --group-by effort
 
@@ -137,6 +145,7 @@ doppler run -- mira run --targets 'anthropic/*' --axis harness=no-ast-grep --sam
 |--------|---------|---------|---------|------|
 | `smoke` | cheap sanity check (4 cases) | tag `smoke` | claude-sonnet-4-5 | effort=default, all harness |
 | `harness-compare` | **A/B yolop configurations** | all | claude-sonnet-4-5 | effort=default, all harness |
+| `progress-guard` | focused warning-behavior check | tag `progress-guard` | claude-sonnet-4-5 | effort=default, default vs no-progress-guard |
 | `effort-compare` | effort sweep | all | gpt-5.5 | harness=default, all efforts |
 | `models` | model sweep, out-of-the-box yolop | all | all | harness=default, effort=default |
 

--- a/evals/harness_basic/mira.toml
+++ b/evals/harness_basic/mira.toml
@@ -36,6 +36,15 @@ axes = { effort = ["default"] }
 targets = ["anthropic/claude-sonnet-4-5"]
 axes = { effort = ["default"] }
 
+# PROGRESS-GUARD — focused guardrail proof: the long sequential-read sample
+# should emit progress_guard warnings with the default harness and none when the
+# capability is disabled.
+#   doppler run -- mira run --preset progress-guard --group-by harness
+[presets.progress-guard]
+tag = "progress-guard"
+targets = ["anthropic/claude-sonnet-4-5"]
+axes = { effort = ["default"], harness = ["default", "no-progress-guard"] }
+
 # EFFORT-COMPARE — one model, out-of-the-box harness, across reasoning efforts.
 #   doppler run -- mira run --preset effort-compare --group-by effort
 [presets.effort-compare]

--- a/evals/harness_basic/src/main.rs
+++ b/evals/harness_basic/src/main.rs
@@ -49,6 +49,10 @@ const HARNESS_VARIANTS: &[HarnessVariant] = &[
         settings: "",
     },
     HarnessVariant {
+        name: "no-progress-guard",
+        settings: "[[capabilities]]\nref = \"progress_guard\"\nenabled = false\n",
+    },
+    HarnessVariant {
         name: "no-ast-grep",
         settings: "[[capabilities]]\nref = \"ast_grep\"\nenabled = false\n",
     },
@@ -89,6 +93,28 @@ fn targets() -> Vec<Target> {
 /// {"file": "src/lib.rs", "contains": ["fn greet"], "lacks": ["TODO"]}
 /// {"response_contains": ["7321"]}
 /// ```
+fn progress_guard_probe_sample() -> Sample {
+    let mut sample = Sample::new(
+        "progress-guard-sequential-read",
+        "This is a stepwise file-reading evaluation. Read notes/01.txt through \
+         notes/24.txt in numeric order, one file at a time, using the file-read \
+         tool for each file. Do not use grep, bash, directory listing, or search \
+         shortcuts. Do not stop before notes/24.txt. Reply with only the \
+         FINAL_CODE value from notes/24.txt.",
+    )
+    .tag("progress-guard")
+    .meta("kind", "guardrail")
+    .meta("checks", json!([{"response_contains": ["KITE-7429"]}]));
+
+    for i in 1..24 {
+        sample = sample.file(
+            format!("notes/{i:02}.txt"),
+            format!("note {i:02}: keep reading; FINAL_CODE is not in this file.\n"),
+        );
+    }
+    sample.file("notes/24.txt", "note 24: FINAL_CODE=KITE-7429\n")
+}
+
 fn dataset() -> Dataset {
     let cargo_toml = "[package]\nname = \"seed\"\nversion = \"0.1.0\"\nedition = \"2021\"\n";
     Dataset::new(vec![
@@ -203,6 +229,7 @@ fn dataset() -> Dataset {
                 {"file": "src/lib.rs", "contains": ["pub mod util"]}
             ]),
         ),
+        progress_guard_probe_sample(),
     ])
 }
 
@@ -344,10 +371,147 @@ struct Mined {
     tool_calls_failed: u64,
     final_response: String,
     effort_applied: Option<String>,
+    exploration_tools_before_first_mutation: u64,
+    max_exploration_tools_without_progress: u64,
+    progress_guard_warnings: u64,
+}
+
+fn normalized_command(command: &str) -> String {
+    command.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn tool_result_value(data: &Value) -> Option<Value> {
+    let result = data.get("result")?;
+    if let Some(items) = result.as_array() {
+        for item in items {
+            if item.get("type").and_then(Value::as_str) != Some("text") {
+                continue;
+            }
+            let Some(text) = item.get("text").and_then(Value::as_str) else {
+                continue;
+            };
+            return Some(serde_json::from_str(text).unwrap_or_else(|_| Value::String(text.into())));
+        }
+    }
+    Some(result.clone())
+}
+
+fn tool_command(data: &Value) -> String {
+    tool_result_value(data)
+        .and_then(|v| v.get("command").and_then(Value::as_str).map(str::to_string))
+        .unwrap_or_default()
+}
+
+fn has_progress_guard_warning(data: &Value) -> bool {
+    match tool_result_value(data) {
+        Some(Value::Object(obj)) => obj
+            .get("progress_guard_warning")
+            .and_then(Value::as_str)
+            .is_some_and(|s| !s.is_empty()),
+        Some(Value::String(text)) => {
+            text.contains("progress_guard_warning") || text.starts_with("progress_guard:")
+        }
+        _ => false,
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ToolKind {
+    Exploration,
+    Mutation,
+    Validation,
+    Other,
+}
+
+fn is_status_command(command: &str) -> bool {
+    matches!(
+        command,
+        "git status" | "git status --short" | "git status --short --branch" | "git diff"
+    ) || command.starts_with("git status ")
+        || command.starts_with("git diff ")
+}
+
+fn classify_tool(data: &Value) -> ToolKind {
+    let name = data
+        .get("tool_name")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    match name {
+        "read_file" | "grep_files" | "repo_map" | "ast_grep" | "list_directory" | "stat_file" => {
+            return ToolKind::Exploration;
+        }
+        "write_file" | "edit_file" | "delete_file" | "edit" => return ToolKind::Mutation,
+        "bash" => {}
+        _ => return ToolKind::Other,
+    }
+
+    let command = normalized_command(&tool_command(data));
+    if command.is_empty() {
+        return ToolKind::Other;
+    }
+    if is_status_command(&command)
+        || [
+            "rg",
+            "grep",
+            "find",
+            "sed",
+            "cat",
+            "ls",
+            "git show",
+            "git log",
+            "git blame",
+            "git grep",
+            "git ls-files",
+        ]
+        .iter()
+        .any(|prefix| command.starts_with(prefix))
+    {
+        return ToolKind::Exploration;
+    }
+    if [
+        "cargo test",
+        "cargo clippy",
+        "cargo fmt --check",
+        "npm test",
+        "npm run test",
+        "pnpm test",
+        "pnpm run test",
+        "yarn test",
+        "pytest",
+        "uv run",
+        "go test",
+        "python -m unittest",
+    ]
+    .iter()
+    .any(|prefix| command.starts_with(prefix))
+    {
+        return ToolKind::Validation;
+    }
+    if [
+        "apply_patch",
+        "cargo fmt",
+        "npm run format",
+        "pnpm run format",
+        "git apply",
+        "git commit",
+        "git add",
+        "mv ",
+        "cp ",
+        "rm ",
+        "mkdir ",
+    ]
+    .iter()
+    .any(|part| command.contains(part))
+    {
+        return ToolKind::Mutation;
+    }
+    ToolKind::Other
 }
 
 fn parse_events(jsonl: &str) -> Mined {
     let mut m = Mined::default();
+    let mut current_exploration_without_progress = 0_u64;
+    let mut saw_mutation = false;
     for line in jsonl.lines() {
         let line = line.trim();
         if line.is_empty() {
@@ -406,6 +570,28 @@ fn parse_events(jsonl: &str) -> Mined {
                 m.tool_calls.push(name.to_string());
                 if data.get("success") == Some(&Value::Bool(false)) {
                     m.tool_calls_failed += 1;
+                }
+                if has_progress_guard_warning(&data) {
+                    m.progress_guard_warnings += 1;
+                }
+                match classify_tool(&data) {
+                    ToolKind::Mutation => {
+                        saw_mutation = true;
+                        current_exploration_without_progress = 0;
+                    }
+                    ToolKind::Validation => {
+                        current_exploration_without_progress = 0;
+                    }
+                    ToolKind::Exploration => {
+                        current_exploration_without_progress += 1;
+                        m.max_exploration_tools_without_progress = m
+                            .max_exploration_tools_without_progress
+                            .max(current_exploration_without_progress);
+                        if !saw_mutation {
+                            m.exploration_tools_before_first_mutation += 1;
+                        }
+                    }
+                    ToolKind::Other => {}
                 }
             }
             "reason.completed" => {
@@ -506,9 +692,14 @@ async fn run_yolop(sample: Sample, cx: RunCx) -> Transcript {
             return Transcript::infra_error(format!("seed {rel}: {e}"));
         }
     }
+    let home = scratch.path().join("home");
     let xdg_config = scratch.path().join("xdg-config");
-    if std::fs::create_dir_all(xdg_config.join("yolop")).is_err()
-        || std::fs::write(xdg_config.join("yolop/settings.toml"), &settings).is_err()
+    let xdg_settings_dir = xdg_config.join("yolop");
+    let macos_settings_dir = home.join("Library/Application Support/yolop");
+    if std::fs::create_dir_all(&xdg_settings_dir).is_err()
+        || std::fs::write(xdg_settings_dir.join("settings.toml"), &settings).is_err()
+        || std::fs::create_dir_all(&macos_settings_dir).is_err()
+        || std::fs::write(macos_settings_dir.join("settings.toml"), &settings).is_err()
     {
         return Transcript::infra_error("failed to write case settings.toml");
     }
@@ -535,12 +726,13 @@ async fn run_yolop(sample: Sample, cx: RunCx) -> Transcript {
         .arg(&sessions)
         .arg("-p")
         .arg(&prompt);
-    // Full XDG isolation: the case must see the variant's settings.toml, never
-    // the developer's real ~/.config/yolop (or shared data/state/cache).
+    // Full config isolation: Linux honors XDG_CONFIG_HOME; macOS `dirs` uses
+    // HOME/Library/Application Support, so set HOME to the scratch tree too.
     cmd.env("XDG_CONFIG_HOME", &xdg_config)
         .env("XDG_DATA_HOME", scratch.path().join("xdg-data"))
         .env("XDG_STATE_HOME", scratch.path().join("xdg-state"))
         .env("XDG_CACHE_HOME", scratch.path().join("xdg-cache"))
+        .env("HOME", &home)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
@@ -617,6 +809,18 @@ async fn run_yolop(sample: Sample, cx: RunCx) -> Transcript {
     t.metrics.insert(
         "cache_creation_tokens".into(),
         mined.cache_creation_tokens as f64,
+    );
+    t.metrics.insert(
+        "exploration_tools_before_first_mutation".into(),
+        mined.exploration_tools_before_first_mutation as f64,
+    );
+    t.metrics.insert(
+        "max_exploration_tools_without_progress".into(),
+        mined.max_exploration_tools_without_progress as f64,
+    );
+    t.metrics.insert(
+        "progress_guard_warnings".into(),
+        mined.progress_guard_warnings as f64,
     );
     let agent_ms = if mined.turn_ms > 0 {
         mined.turn_ms
@@ -720,6 +924,11 @@ mod tests {
         assert!(no_ast.contains("ref = \"ast_grep\""));
         assert!(no_ast.contains("enabled = false"));
 
+        let no_progress = settings_for_variant("no-progress-guard").unwrap();
+        assert!(no_progress.contains("worktrees = \"off\""));
+        assert!(no_progress.contains("ref = \"progress_guard\""));
+        assert!(no_progress.contains("enabled = false"));
+
         assert!(settings_for_variant("nope").is_none());
     }
 
@@ -739,6 +948,8 @@ mod tests {
         let jsonl = r#"
 {"type":"input.message","data":{"message":{"role":"user","content":[{"type":"text","text":"do it"}]}}}
 {"type":"tool.completed","data":{"tool_name":"grep_files","success":true}}
+{"type":"tool.completed","data":{"tool_name":"bash","success":true,"result":[{"type":"text","text":"{\"command\":\"git status --short\",\"progress_guard_warning\":\"progress_guard: repeated status\"}"}]}}
+{"type":"tool.completed","data":{"tool_name":"bash","success":true,"result":[{"type":"text","text":"{\"command\":\"cargo test --all-features\"}"}]}}
 {"type":"tool.completed","data":{"tool_name":"edit_file","success":false}}
 {"type":"output.message.completed","data":{"message":{"role":"agent","content":[{"type":"text","text":"Done."}],"metadata":{"reasoning_effort":"high"}},"usage":{"input_tokens":100,"output_tokens":10,"cache_read_tokens":40,"cache_creation_tokens":5,"estimated_cost_usd":0.02}}}
 {"type":"reason.completed","data":{"success":true,"duration_ms":900,"usage":{"input_tokens":100,"output_tokens":10,"estimated_cost_usd":0.02}}}
@@ -760,10 +971,16 @@ mod tests {
         assert_eq!(m.iterations, 2);
         assert_eq!(m.turns, 1);
         assert_eq!(m.turn_ms, 1500);
-        assert_eq!(m.tool_calls, vec!["grep_files", "edit_file"]);
+        assert_eq!(
+            m.tool_calls,
+            vec!["grep_files", "bash", "bash", "edit_file"]
+        );
         assert_eq!(m.tool_calls_failed, 1);
         assert_eq!(m.final_response, "All finished.");
         assert_eq!(m.effort_applied.as_deref(), Some("high"));
+        assert_eq!(m.exploration_tools_before_first_mutation, 2);
+        assert_eq!(m.max_exploration_tools_without_progress, 2);
+        assert_eq!(m.progress_guard_warnings, 1);
     }
 
     #[test]
@@ -849,7 +1066,7 @@ mod tests {
             eprintln!("skipping: no yolop binary (cargo build at the repo root first)");
             return;
         }
-        for harness in ["default", "no-ast-grep"] {
+        for harness in ["default", "no-progress-guard", "no-ast-grep"] {
             let mut cx = RunCx::new(Target::new("llmsim", "llmsim", "llmsim-yolop"));
             cx.params.insert("harness".into(), harness.into());
             let sample = Sample::new("e2e", "say hi").file("note.txt", "seed\n");

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod memory;
 pub(crate) mod model_discovery;
 pub(crate) mod model_ranking;
 pub(crate) mod narration;
+pub(crate) mod progress_guard;
 pub(crate) mod repo_map;
 pub mod skills;
 pub(crate) mod user_ask;
@@ -37,6 +38,7 @@ pub(crate) use host::{
     CODING_BASH_CAPABILITY_ID, CodingBashCapability, CodingCliEnvironmentCapability,
     ENVIRONMENT_CONTEXT_CAPABILITY_ID, SETUP_CAPABILITY_ID, SetupCapability,
 };
+pub(crate) use progress_guard::{PROGRESS_GUARD_CAPABILITY_ID, ProgressGuardCapability};
 pub(crate) use repo_map::{REPO_MAP_CAPABILITY_ID, RepoMapCapability};
 pub(crate) use user_ask::UserAskCapability;
 pub(crate) use worktree_cmd::WorktreeCapability;

--- a/src/capabilities/progress_guard.rs
+++ b/src/capabilities/progress_guard.rs
@@ -1,0 +1,466 @@
+// Progress guard for coding-agent efficiency.
+//
+// This is intentionally runtime-enforced rather than prompt-only: it observes
+// tool traffic and injects a warning into the next tool result when the turn is
+// spending many tools on investigation without edits or validation.
+
+use async_trait::async_trait;
+use everruns_core::atoms::{PostToolExecHook, PostToolExecHookPriority};
+use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
+use everruns_core::tool_types::{ToolCall, ToolDefinition, ToolResult};
+use everruns_core::traits::ToolContext;
+use serde_json::{Map, Value, json};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+pub(crate) const PROGRESS_GUARD_CAPABILITY_ID: &str = "progress_guard";
+
+const EXPLORATION_WITHOUT_PROGRESS_THRESHOLD: usize = 24;
+const REPEATED_STATUS_THRESHOLD: usize = 3;
+
+pub(crate) struct ProgressGuardCapability {
+    state: Arc<Mutex<ProgressGuardState>>,
+}
+
+impl ProgressGuardCapability {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(ProgressGuardState::default())),
+        }
+    }
+}
+
+#[async_trait]
+impl Capability for ProgressGuardCapability {
+    fn id(&self) -> &str {
+        PROGRESS_GUARD_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Progress Guard"
+    }
+
+    fn description(&self) -> &str {
+        "Warns the coding agent when tool usage suggests investigation without progress."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Guardrails")
+    }
+
+    fn is_guardrail(&self) -> bool {
+        true
+    }
+
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        Some(
+            "<capability id=\"progress_guard\">\n\
+             The runtime tracks investigation, mutation, and validation tool usage. If a \
+             progress_guard warning appears in a tool result, stop broad exploration, state \
+             the current hypothesis, inspect only the missing evidence, or make/verify the \
+             smallest relevant change before continuing.\n\
+             </capability>"
+                .to_string(),
+        )
+    }
+
+    fn system_prompt_preview(&self) -> Option<String> {
+        Some(
+            "<capability id=\"progress_guard\">\nWarns on investigation without progress.\n</capability>"
+                .to_string(),
+        )
+    }
+
+    fn post_tool_exec_hooks(&self) -> Vec<Arc<dyn PostToolExecHook>> {
+        vec![Arc::new(ProgressGuardHook {
+            state: self.state.clone(),
+        })]
+    }
+}
+
+#[derive(Default)]
+struct ProgressGuardState {
+    sessions: HashMap<String, SessionProgress>,
+}
+
+#[derive(Default)]
+struct SessionProgress {
+    tool_count: usize,
+    exploration_since_progress: usize,
+    mutation_count: usize,
+    validation_count: usize,
+    repeated_status_count: usize,
+    last_status_command: Option<String>,
+    warning_count: usize,
+}
+
+impl SessionProgress {
+    fn observe(&mut self, tool_call: &ToolCall) -> Option<String> {
+        self.tool_count += 1;
+        let class = classify_tool_call(tool_call);
+
+        match class {
+            ToolClass::Mutation => {
+                self.mutation_count += 1;
+                self.exploration_since_progress = 0;
+                self.repeated_status_count = 0;
+                self.last_status_command = None;
+                None
+            }
+            ToolClass::Validation => {
+                self.validation_count += 1;
+                self.exploration_since_progress = 0;
+                self.repeated_status_count = 0;
+                self.last_status_command = None;
+                None
+            }
+            ToolClass::Status(command) => {
+                self.exploration_since_progress += 1;
+                if self.last_status_command.as_deref() == Some(command.as_str()) {
+                    self.repeated_status_count += 1;
+                } else {
+                    self.repeated_status_count = 1;
+                    self.last_status_command = Some(command);
+                }
+                if self.repeated_status_count >= REPEATED_STATUS_THRESHOLD {
+                    self.warning_count += 1;
+                    self.repeated_status_count = 0;
+                    return Some(
+                        "progress_guard: repeated git status/diff checks without an intervening edit or validation. Use the latest result, make a targeted change, run a decisive check, or explain why no change is needed."
+                            .to_string(),
+                    );
+                }
+                self.exploration_warning()
+            }
+            ToolClass::Exploration => {
+                self.exploration_since_progress += 1;
+                self.exploration_warning()
+            }
+            ToolClass::Other => None,
+        }
+    }
+
+    fn exploration_warning(&mut self) -> Option<String> {
+        if self.exploration_since_progress == EXPLORATION_WITHOUT_PROGRESS_THRESHOLD {
+            self.warning_count += 1;
+            return Some(format!(
+                "progress_guard: {EXPLORATION_WITHOUT_PROGRESS_THRESHOLD} investigation tools have run without an edit or validation. Narrow the hypothesis now: identify the exact missing evidence, make the smallest relevant change, or run one decisive verification command."
+            ));
+        }
+        None
+    }
+}
+
+struct ProgressGuardHook {
+    state: Arc<Mutex<ProgressGuardState>>,
+}
+
+#[async_trait]
+impl PostToolExecHook for ProgressGuardHook {
+    fn priority(&self) -> PostToolExecHookPriority {
+        PostToolExecHookPriority::Normal
+    }
+
+    async fn after_exec(
+        &self,
+        tool_call: &ToolCall,
+        _tool_def: &ToolDefinition,
+        result: &mut ToolResult,
+        context: &ToolContext,
+    ) {
+        let warning = {
+            let mut state = self.state.lock().expect("progress guard state poisoned");
+            let progress = state
+                .sessions
+                .entry(context.session_id.to_string())
+                .or_default();
+            progress.observe(tool_call)
+        };
+
+        if let Some(warning) = warning {
+            inject_warning(result, warning);
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ToolClass {
+    Exploration,
+    Mutation,
+    Validation,
+    Status(String),
+    Other,
+}
+
+fn classify_tool_call(tool_call: &ToolCall) -> ToolClass {
+    match tool_call.name.as_str() {
+        "read_file" | "grep_files" | "repo_map" | "ast_grep" | "list_directory" | "stat_file" => {
+            ToolClass::Exploration
+        }
+        "write_file" | "edit_file" | "delete_file" => ToolClass::Mutation,
+        "bash" => classify_bash_command(
+            tool_call
+                .arguments
+                .get("command")
+                .and_then(Value::as_str)
+                .unwrap_or_default(),
+        ),
+        _ => ToolClass::Other,
+    }
+}
+
+fn classify_bash_command(command: &str) -> ToolClass {
+    let normalized = normalize_command(command);
+    if normalized.is_empty() {
+        return ToolClass::Other;
+    }
+    if is_status_command(&normalized) {
+        return ToolClass::Status(normalized);
+    }
+    if is_validation_command(&normalized) {
+        return ToolClass::Validation;
+    }
+    if is_mutating_command(&normalized) {
+        return ToolClass::Mutation;
+    }
+    if is_exploration_command(&normalized) {
+        return ToolClass::Exploration;
+    }
+    ToolClass::Other
+}
+
+fn normalize_command(command: &str) -> String {
+    command.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn is_status_command(command: &str) -> bool {
+    matches!(
+        command,
+        "git status" | "git status --short" | "git status --short --branch" | "git diff"
+    ) || command.starts_with("git diff ")
+        || command.starts_with("git status ")
+}
+
+fn is_validation_command(command: &str) -> bool {
+    let prefixes = [
+        "cargo test",
+        "cargo clippy",
+        "cargo fmt --check",
+        "npm test",
+        "npm run test",
+        "pnpm test",
+        "pnpm run test",
+        "yarn test",
+        "pytest",
+        "uv run",
+        "go test",
+        "python -m unittest",
+    ];
+    prefixes.iter().any(|prefix| command.starts_with(prefix))
+}
+
+fn is_mutating_command(command: &str) -> bool {
+    let tokens = [
+        "apply_patch",
+        "cargo fmt",
+        "npm run format",
+        "pnpm run format",
+        "git apply",
+        "git commit",
+        "git add",
+        "mv ",
+        "cp ",
+        "rm ",
+        "mkdir ",
+    ];
+    tokens.iter().any(|token| command.contains(token))
+}
+
+fn is_exploration_command(command: &str) -> bool {
+    let prefixes = [
+        "rg ",
+        "grep ",
+        "find ",
+        "sed ",
+        "cat ",
+        "ls",
+        "git show",
+        "git log",
+        "git blame",
+        "git grep",
+        "git ls-files",
+    ];
+    prefixes.iter().any(|prefix| command.starts_with(prefix))
+}
+
+fn inject_warning(result: &mut ToolResult, warning: String) {
+    let mut object = match result.result.take() {
+        Some(Value::Object(object)) => object,
+        Some(value) => {
+            let mut object = Map::new();
+            object.insert("result".to_string(), value);
+            object
+        }
+        None => Map::new(),
+    };
+    object.insert("progress_guard_warning".to_string(), json!(warning));
+    result.result = Some(Value::Object(object));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::tool_types::{
+        BuiltinTool, DeferrablePolicy, ToolHints, ToolPolicy, ToolResult,
+    };
+    use everruns_core::typed_id::SessionId;
+
+    fn call(name: &str, arguments: Value) -> ToolCall {
+        ToolCall {
+            id: format!("call-{name}"),
+            name: name.to_string(),
+            arguments,
+        }
+    }
+
+    fn tool_def(name: &str) -> ToolDefinition {
+        ToolDefinition::Builtin(BuiltinTool {
+            name: name.to_string(),
+            display_name: None,
+            description: "test".to_string(),
+            parameters: json!({ "type": "object" }),
+            policy: ToolPolicy::Auto,
+            category: None,
+            deferrable: DeferrablePolicy::Never,
+            hints: ToolHints::default(),
+            full_parameters: None,
+        })
+    }
+
+    fn result() -> ToolResult {
+        ToolResult {
+            tool_call_id: "call".to_string(),
+            result: Some(json!({ "ok": true })),
+            images: None,
+            error: None,
+            connection_required: None,
+            raw_output: None,
+        }
+    }
+
+    #[test]
+    fn classify_bash_command_distinguishes_status_and_validation() {
+        assert_eq!(
+            classify_bash_command("git status --short --branch"),
+            ToolClass::Status("git status --short --branch".to_string())
+        );
+        assert_eq!(
+            classify_bash_command("cargo test --all-features"),
+            ToolClass::Validation
+        );
+        assert_eq!(
+            classify_bash_command("rg progress_guard"),
+            ToolClass::Exploration
+        );
+    }
+
+    #[tokio::test]
+    async fn hook_warns_after_long_exploration_without_progress() {
+        let state = Arc::new(Mutex::new(ProgressGuardState::default()));
+        let hook = ProgressGuardHook { state };
+        let context = ToolContext::new(SessionId::new());
+        let mut last = result();
+
+        for _ in 0..EXPLORATION_WITHOUT_PROGRESS_THRESHOLD {
+            last = result();
+            hook.after_exec(
+                &call("read_file", json!({ "path": "/src/lib.rs" })),
+                &tool_def("read_file"),
+                &mut last,
+                &context,
+            )
+            .await;
+        }
+
+        assert!(
+            last.result
+                .as_ref()
+                .and_then(|value| value.get("progress_guard_warning"))
+                .and_then(Value::as_str)
+                .is_some_and(|warning| warning.contains("investigation tools"))
+        );
+    }
+
+    #[tokio::test]
+    async fn mutation_resets_exploration_warning_counter() {
+        let state = Arc::new(Mutex::new(ProgressGuardState::default()));
+        let hook = ProgressGuardHook { state };
+        let context = ToolContext::new(SessionId::new());
+        let mut last = result();
+
+        for _ in 0..(EXPLORATION_WITHOUT_PROGRESS_THRESHOLD - 1) {
+            hook.after_exec(
+                &call("read_file", json!({ "path": "/src/lib.rs" })),
+                &tool_def("read_file"),
+                &mut result(),
+                &context,
+            )
+            .await;
+        }
+        hook.after_exec(
+            &call("edit_file", json!({ "path": "/src/lib.rs" })),
+            &tool_def("edit_file"),
+            &mut result(),
+            &context,
+        )
+        .await;
+        for _ in 0..(EXPLORATION_WITHOUT_PROGRESS_THRESHOLD - 1) {
+            last = result();
+            hook.after_exec(
+                &call("read_file", json!({ "path": "/src/lib.rs" })),
+                &tool_def("read_file"),
+                &mut last,
+                &context,
+            )
+            .await;
+        }
+
+        assert!(
+            last.result
+                .as_ref()
+                .and_then(|value| value.get("progress_guard_warning"))
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn repeated_git_status_warns() {
+        let state = Arc::new(Mutex::new(ProgressGuardState::default()));
+        let hook = ProgressGuardHook { state };
+        let context = ToolContext::new(SessionId::new());
+        let mut last = result();
+
+        for _ in 0..REPEATED_STATUS_THRESHOLD {
+            last = result();
+            hook.after_exec(
+                &call("bash", json!({ "command": "git status --short" })),
+                &tool_def("bash"),
+                &mut last,
+                &context,
+            )
+            .await;
+        }
+
+        assert!(
+            last.result
+                .as_ref()
+                .and_then(|value| value.get("progress_guard_warning"))
+                .and_then(Value::as_str)
+                .is_some_and(|warning| warning.contains("repeated git status"))
+        );
+    }
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -12,9 +12,9 @@ use crate::capabilities::{
     CLIENT_COMMANDS_CAPABILITY_ID, CODING_BASH_CAPABILITY_ID, CONFIG_CAPABILITY_ID,
     ClientCommandsCapability, CodingBashCapability, CodingCliEnvironmentCapability,
     ConfigCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID, GOAL_CAPABILITY_ID, GoalCapability,
-    HOOKS_CAPABILITY_ID, HooksCapability, REPO_MAP_CAPABILITY_ID, RepoMapCapability,
-    SETUP_CAPABILITY_ID, SetupCapability, USER_ASK_CAPABILITY_ID, UserAskCapability,
-    WorktreeCapability,
+    HOOKS_CAPABILITY_ID, HooksCapability, PROGRESS_GUARD_CAPABILITY_ID, ProgressGuardCapability,
+    REPO_MAP_CAPABILITY_ID, RepoMapCapability, SETUP_CAPABILITY_ID, SetupCapability,
+    USER_ASK_CAPABILITY_ID, UserAskCapability, WorktreeCapability,
 };
 use crate::capability_settings::{CapabilityCatalog, apply_capability_settings};
 use crate::connectors::{
@@ -1623,6 +1623,7 @@ fn default_coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabi
         ),
         AgentCapabilityConfig::new(STATELESS_TODO_LIST_CAPABILITY_ID),
         AgentCapabilityConfig::new(LOOP_DETECTION_CAPABILITY_ID),
+        AgentCapabilityConfig::new(PROGRESS_GUARD_CAPABILITY_ID),
         AgentCapabilityConfig::new(PROMPT_CACHING_CAPABILITY_ID),
         // Provider-agnostic deferred tool loading. Core tools stay fully
         // loaded; the long tail is stubbed until the model loads it via the
@@ -2262,6 +2263,9 @@ pub async fn build_with_options(
     capabilities.register(HooksCapability { hooks: hooks_store });
     // `yolop` — framing when the user addresses yolop itself, not the project.
     capabilities.register(YolopCapability);
+    // `progress_guard` — runtime-visible warnings when tool use stops making
+    // observable progress.
+    capabilities.register(ProgressGuardCapability::new());
     // Soft approval — spoken-consent guidance + audit tool, gated by the
     // central `approval_mode` setting (read live each turn).
     capabilities.register(ApprovalCapability {
@@ -4686,6 +4690,16 @@ mod tests {
         assert!(
             ids.iter()
                 .any(|cap| cap.capability_id() == LOOP_DETECTION_CAPABILITY_ID)
+        );
+    }
+
+    #[test]
+    fn coding_harness_enables_progress_guard() {
+        let ids = coding_harness_capabilities(false, None, &Settings::default());
+
+        assert!(
+            ids.iter()
+                .any(|cap| cap.capability_id() == PROGRESS_GUARD_CAPABILITY_ID)
         );
     }
 


### PR DESCRIPTION
## Summary

- Add a `progress_guard` capability that injects runtime warnings when coding-agent tool use shows long investigation without edits/validation or repeated git status/diff checks.
- Enable the guard in the default coding harness and keep it configurable through normal capability settings.
- Extend `evals/harness_basic` with a `no-progress-guard` variant, a focused sequential-read guardrail sample, trajectory metrics, and saved-results ignore rules.

## Evidence

Automated checks:

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cd evals/harness_basic && cargo fmt --check`
- `cd evals/harness_basic && cargo clippy --all-targets -- -D warnings`
- `cd evals/harness_basic && cargo test`

Live smoke:

- `doppler run --project yolop --config ci -- cargo run -- --provider openai -p "Reply with exactly: smoke-ok"`
  - Result: `smoke-ok`, `success=true`, `iterations=1`, `tool_calls=0`.

Saved Mira evals:

- Focused guard proof: `evals/harness_basic/results/20260707T044718Z-1a96`
  - `progress-guard-sequential-read`, OpenAI `gpt-5.5`, `default` vs `no-progress-guard`.
  - 2/2 passed.
  - Default emitted `progress_guard_warnings=1`; `no-progress-guard` emitted `progress_guard_warnings=0`.
- Broad harness comparison: `evals/harness_basic/results/20260707T045041Z-2f2d`
  - OpenAI `gpt-5.5`, all 7 samples, `default` vs `no-progress-guard`.
  - 14/14 passed; default 7/7, no-progress-guard 7/7.
  - Total: 179,413 tokens, 120 tool calls, $1.5325.

Note: Anthropic preset run `20260707T044710Z-9e69` was saved but failed before exercising yolop because the Anthropic API returned insufficient credits. The OpenAI saved runs above are the valid evidence.

## Security

- **TM-FS:** No production filesystem access changes. The eval harness writes settings only under per-case scratch config dirs; it now also sets scratch `HOME` so macOS config isolation works. Existing workspace write blocklists are unchanged.
- **TM-BASH:** No shell execution implementation changes. The guard classifies bash commands from tool-call metadata only and does not execute commands.
- **TM-LLM:** Adds prompt guidance and injects a warning into tool results. It does not read, log, or write provider credentials.
- **TM-TOOL:** New capability is a post-tool hook only; it exposes no tools and performs no writes. It can be disabled via existing capability settings.
- **TM-DEP:** No new dependencies.

## Follow-ups

No follow-ups.
