### PR TITLE
feat(cli): add --trajectory-out ATIF trajectory export

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ tools. See [`specs/mcp.md`](specs/mcp.md).
 | `--session <ID>`           | Resume a previous session by id                                      |
 | `--session-dir <PATH>`     | Override the parent directory for session folders                    |
 | `--reasoning-effort <E>`   | Reasoning effort override when the selected model profile supports it |
+| `--trajectory-out <PATH>`  | Write the session as an [ATIF](https://github.com/harbor-framework/harbor/blob/main/rfcs/0001-trajectory-format.md) v1.7 trajectory JSON file at end of run (interactive and `--print`) |
 
 ### Commands
 

--- a/specs/trajectory.md
+++ b/specs/trajectory.md
@@ -1,0 +1,31 @@
+# Trajectory export (ATIF)
+
+Status: implemented.
+
+## Why
+
+Benchmark harnesses and trajectory tooling (Harbor, Mira eval studies,
+trajectory viewers) consume agent runs in the Agent Trajectory Interchange
+Format ([ATIF, harbor-framework RFC 0001](https://github.com/harbor-framework/harbor/blob/main/rfcs/0001-trajectory-format.md))
+rather than yolop's internal JSONL event log. A first-class export lets any
+yolop run feed those tools without a bespoke converter per consumer.
+
+## What
+
+`--trajectory-out <path>` writes the whole session — including events replayed
+on `--session` resume — as a single ATIF-v1.7 JSON document when the run ends.
+It works in the interactive TUI and in headless `-p/--print` mode (including
+failed turns and `/goal` runs); `--acp` ignores it because the editor owns the
+session lifecycle there.
+
+`src/atif.rs` owns the serializer: it folds the runtime event log into steps
+(user input → user step, each reason/act iteration → one agent step with
+reasoning, tool calls, and tool results keyed by `source_call_id`, token usage
+into per-step and final metrics). Export is best-effort and never fails the
+run.
+
+## Non-goals
+
+- Not a replay or resume format — the per-session JSONL log stays the local
+  source of truth (see `src/session_log.rs`).
+- No image/multimodal export yet; text content only.

--- a/src/atif.rs
+++ b/src/atif.rs
@@ -1,0 +1,563 @@
+//! ATIF (Agent Trajectory Interchange Format) export.
+//!
+//! Spec: harbor-framework/harbor `rfcs/0001-trajectory-format.md`, pinned to
+//! `ATIF-v1.7`. `--trajectory-out <path>` writes the whole session as one
+//! ATIF JSON document at end of run (see `specs/trajectory.md`).
+//!
+//! The trajectory is folded from the session's runtime event log rather than
+//! the message store because events carry timestamps, per-generation token
+//! usage, and tool results in one ordered stream:
+//!
+//! * `input.message`             → one `user` (or `system`) step
+//! * `reason.item`               → reasoning summaries buffered for the next
+//!   agent step (OpenAI Responses-style providers)
+//! * `output.message.completed`  → one `agent` step per reason/act iteration,
+//!   carrying text, `reasoning_content` (message thinking, else buffered
+//!   summaries), `tool_calls`, and per-call `metrics`
+//! * `tool.completed`            → an observation result attached to the agent
+//!   step that issued the call, keyed by `source_call_id`
+//!
+//! Only text content is exported; image parts are dropped (ATIF image parts
+//! reference on-disk paths, which yolop does not materialize). Empty and
+//! `None` fields are skipped when serializing, per the RFC's convention.
+
+use everruns_core::events::{Event, EventData, TokenUsage, ToolCompletedData};
+use everruns_core::message::{ContentPart, Message, MessageRole};
+use everruns_core::typed_id::SessionId;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::Path;
+
+pub const SCHEMA_VERSION: &str = "ATIF-v1.7";
+
+/// Identity block for the `agent` object. The caller supplies the resolved
+/// model id; name/version are the yolop crate's.
+pub struct AgentInfo {
+    pub name: String,
+    pub version: String,
+    pub model_name: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Trajectory {
+    pub schema_version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    pub agent: Agent,
+    pub steps: Vec<Step>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub final_metrics: Option<FinalMetrics>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Agent {
+    pub name: String,
+    pub version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StepSource {
+    System,
+    User,
+    Agent,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Step {
+    /// 1-based sequential id.
+    pub step_id: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+    pub source: StepSource,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tool_calls: Vec<ToolCall>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub observation: Option<Observation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metrics: Option<StepMetrics>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ToolCall {
+    pub tool_call_id: String,
+    pub function_name: String,
+    pub arguments: serde_json::Value,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct Observation {
+    pub results: Vec<ObservationResult>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ObservationResult {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_call_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct StepMetrics {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completion_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cached_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cost_usd: Option<f64>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct FinalMetrics {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_prompt_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_completion_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_cached_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_cost_usd: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_steps: Option<u64>,
+}
+
+/// Fold the ordered session event log into one ATIF trajectory.
+pub fn trajectory_from_events(
+    agent: AgentInfo,
+    session_id: SessionId,
+    events: &[Event],
+) -> Trajectory {
+    let mut steps: Vec<Step> = Vec::new();
+    // tool_call_id → index of the agent step that issued the call.
+    let mut call_step: HashMap<String, usize> = HashMap::new();
+    // reason.item summaries buffered until the next agent step.
+    let mut pending_reasoning: Vec<String> = Vec::new();
+
+    for event in events {
+        match &event.data {
+            EventData::InputMessage(data) => {
+                let source = match data.message.role {
+                    MessageRole::System => StepSource::System,
+                    MessageRole::User => StepSource::User,
+                    // Agent/tool-result inputs are runtime plumbing, not
+                    // conversation steps.
+                    _ => continue,
+                };
+                steps.push(Step {
+                    step_id: steps.len() as u64 + 1,
+                    timestamp: Some(timestamp(event)),
+                    source,
+                    message: message_text(&data.message),
+                    model_name: None,
+                    reasoning_content: None,
+                    tool_calls: Vec::new(),
+                    observation: None,
+                    metrics: None,
+                });
+            }
+            EventData::ReasonItem(data) => {
+                pending_reasoning.extend(
+                    data.summary
+                        .iter()
+                        .map(|s| s.trim())
+                        .filter(|s| !s.is_empty())
+                        .map(str::to_string),
+                );
+            }
+            EventData::OutputMessageCompleted(data) => {
+                if data.message.role != MessageRole::Agent {
+                    continue;
+                }
+                let reasoning_content = data
+                    .message
+                    .thinking
+                    .clone()
+                    .filter(|t| !t.trim().is_empty())
+                    .or_else(|| {
+                        (!pending_reasoning.is_empty()).then(|| pending_reasoning.join("\n\n"))
+                    });
+                pending_reasoning.clear();
+                let tool_calls: Vec<ToolCall> = data
+                    .message
+                    .tool_calls()
+                    .into_iter()
+                    .map(|tc| ToolCall {
+                        tool_call_id: tc.id.clone(),
+                        function_name: tc.name.clone(),
+                        arguments: tc.arguments.clone(),
+                    })
+                    .collect();
+                let index = steps.len();
+                for call in &tool_calls {
+                    call_step.insert(call.tool_call_id.clone(), index);
+                }
+                steps.push(Step {
+                    step_id: index as u64 + 1,
+                    timestamp: Some(timestamp(event)),
+                    source: StepSource::Agent,
+                    message: message_text(&data.message),
+                    model_name: data.metadata.as_ref().map(|m| m.model.clone()),
+                    reasoning_content,
+                    tool_calls,
+                    observation: None,
+                    metrics: data.usage.as_ref().map(step_metrics),
+                });
+            }
+            EventData::ToolCompleted(data) => {
+                // Fall back to the most recent agent step for results whose
+                // call id was never seen (e.g. repaired/replayed logs).
+                let index = call_step.get(&data.tool_call_id).copied().or_else(|| {
+                    steps
+                        .iter()
+                        .rposition(|s| s.source == StepSource::Agent && !s.tool_calls.is_empty())
+                });
+                let Some(index) = index else { continue };
+                steps[index]
+                    .observation
+                    .get_or_insert_default()
+                    .results
+                    .push(observation_result(data));
+            }
+            _ => {}
+        }
+    }
+
+    let final_metrics = fold_final_metrics(&steps);
+    Trajectory {
+        schema_version: SCHEMA_VERSION.to_string(),
+        session_id: Some(session_id.to_string()),
+        agent: Agent {
+            name: agent.name,
+            version: agent.version,
+            model_name: agent.model_name,
+        },
+        steps,
+        final_metrics,
+    }
+}
+
+/// Serialize `trajectory` as pretty-printed JSON at `path`, creating parent
+/// directories as needed.
+pub fn write_trajectory_file(path: &Path, trajectory: &Trajectory) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut json = serde_json::to_string_pretty(trajectory)?;
+    json.push('\n');
+    std::fs::write(path, json)?;
+    Ok(())
+}
+
+fn timestamp(event: &Event) -> String {
+    event
+        .ts
+        .to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
+/// All text parts joined with newlines. Image and tool-call parts are
+/// intentionally dropped (tool calls are exported via `tool_calls`).
+fn message_text(message: &Message) -> String {
+    message
+        .content
+        .iter()
+        .filter_map(ContentPart::as_text)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn step_metrics(usage: &TokenUsage) -> StepMetrics {
+    // ATIF's prompt_tokens is the full prompt; everruns buckets are disjoint
+    // (input + cache_read + cache_creation = total prompt).
+    let prompt = u64::from(usage.input_tokens)
+        + u64::from(usage.cache_read_tokens.unwrap_or(0))
+        + u64::from(usage.cache_creation_tokens.unwrap_or(0));
+    StepMetrics {
+        prompt_tokens: Some(prompt),
+        completion_tokens: Some(u64::from(usage.output_tokens)),
+        cached_tokens: usage.cache_read_tokens.map(u64::from),
+        cost_usd: usage.actual_cost_usd.or(usage.estimated_cost_usd),
+    }
+}
+
+fn observation_result(data: &ToolCompletedData) -> ObservationResult {
+    let text = data
+        .result
+        .as_ref()
+        .map(|parts| {
+            parts
+                .iter()
+                .filter_map(ContentPart::as_text)
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .filter(|t| !t.is_empty())
+        .or_else(|| data.error.clone());
+    let extra = (!data.success).then(|| serde_json::json!({ "status": data.status.clone() }));
+    ObservationResult {
+        source_call_id: Some(data.tool_call_id.clone()),
+        content: text,
+        extra,
+    }
+}
+
+fn fold_final_metrics(steps: &[Step]) -> Option<FinalMetrics> {
+    if steps.is_empty() {
+        return None;
+    }
+    let mut totals = FinalMetrics {
+        total_steps: Some(steps.len() as u64),
+        ..FinalMetrics::default()
+    };
+    for metrics in steps.iter().filter_map(|s| s.metrics.as_ref()) {
+        add(&mut totals.total_prompt_tokens, metrics.prompt_tokens);
+        add(
+            &mut totals.total_completion_tokens,
+            metrics.completion_tokens,
+        );
+        add(&mut totals.total_cached_tokens, metrics.cached_tokens);
+        add_f64(&mut totals.total_cost_usd, metrics.cost_usd);
+    }
+    Some(totals)
+}
+
+fn add(total: &mut Option<u64>, value: Option<u64>) {
+    if let Some(value) = value {
+        *total = Some(total.unwrap_or(0) + value);
+    }
+}
+
+fn add_f64(total: &mut Option<f64>, value: Option<f64>) {
+    if let Some(value) = value {
+        *total = Some(total.unwrap_or(0.0) + value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::events::{
+        EventContext, InputMessageData, OutputMessageCompletedData, ReasonItemData,
+        ToolCompletedData,
+    };
+    use everruns_core::message::Message;
+    use everruns_core::tool_types::ToolCall as RuntimeToolCall;
+
+    fn session() -> SessionId {
+        SessionId::from_seed(7)
+    }
+
+    fn event(data: impl Into<EventData>) -> Event {
+        Event::new(session(), EventContext::empty(), data)
+    }
+
+    fn agent_info() -> AgentInfo {
+        AgentInfo {
+            name: "yolop".to_string(),
+            version: "0.0.0-test".to_string(),
+            model_name: Some("sim-model".to_string()),
+        }
+    }
+
+    /// A full synthetic turn: user input, a reasoning+act iteration with one
+    /// tool call and result, then the final assistant message, with usage on
+    /// both generations.
+    fn synthetic_events() -> Vec<Event> {
+        let mut with_tools = Message::assistant_with_tools(
+            "Let me check the file.",
+            vec![RuntimeToolCall {
+                id: "call_1".to_string(),
+                name: "read_file".to_string(),
+                arguments: serde_json::json!({ "path": "src/lib.rs" }),
+            }],
+        );
+        with_tools.thinking = Some("The user wants the file contents.".to_string());
+        vec![
+            event(EventData::InputMessage(InputMessageData::new(
+                Message::user("fix the bug"),
+            ))),
+            event(EventData::ReasonItem(ReasonItemData {
+                turn_id: everruns_core::typed_id::TurnId::from_seed(1),
+                provider: "sim".to_string(),
+                model: None,
+                item_id: "ri_1".to_string(),
+                encrypted_content: None,
+                summary: vec!["Looking at the bug report.".to_string()],
+                token_count: Some(5),
+            })),
+            event(EventData::OutputMessageCompleted(
+                OutputMessageCompletedData::new(with_tools).with_usage(TokenUsage::with_cache(
+                    100,
+                    20,
+                    Some(50),
+                    None,
+                )),
+            )),
+            event(EventData::ToolCompleted(ToolCompletedData::success(
+                "call_1".to_string(),
+                "read_file".to_string(),
+                vec![ContentPart::text("fn main() {}")],
+                Some(12),
+            ))),
+            event(EventData::OutputMessageCompleted(
+                OutputMessageCompletedData::new(Message::assistant("Fixed."))
+                    .with_usage(TokenUsage::new(30, 10)),
+            )),
+        ]
+    }
+
+    #[test]
+    fn folds_synthetic_turn_into_steps() {
+        let trajectory = trajectory_from_events(agent_info(), session(), &synthetic_events());
+
+        assert_eq!(trajectory.schema_version, SCHEMA_VERSION);
+        assert_eq!(trajectory.session_id, Some(session().to_string()));
+        assert_eq!(trajectory.agent.name, "yolop");
+        assert_eq!(trajectory.agent.model_name.as_deref(), Some("sim-model"));
+
+        let steps = &trajectory.steps;
+        assert_eq!(steps.len(), 3);
+        assert_eq!(
+            steps.iter().map(|s| s.step_id).collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+
+        assert_eq!(steps[0].source, StepSource::User);
+        assert_eq!(steps[0].message, "fix the bug");
+        assert!(steps[0].timestamp.is_some());
+
+        let act = &steps[1];
+        assert_eq!(act.source, StepSource::Agent);
+        assert_eq!(act.message, "Let me check the file.");
+        // Message-level thinking wins over buffered reason.item summaries.
+        assert_eq!(
+            act.reasoning_content.as_deref(),
+            Some("The user wants the file contents.")
+        );
+        assert_eq!(act.tool_calls.len(), 1);
+        assert_eq!(act.tool_calls[0].tool_call_id, "call_1");
+        assert_eq!(act.tool_calls[0].function_name, "read_file");
+        assert_eq!(
+            act.tool_calls[0].arguments,
+            serde_json::json!({ "path": "src/lib.rs" })
+        );
+        let results = &act.observation.as_ref().expect("observation").results;
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].source_call_id.as_deref(), Some("call_1"));
+        assert_eq!(results[0].content.as_deref(), Some("fn main() {}"));
+        assert!(results[0].extra.is_none());
+        let metrics = act.metrics.as_ref().expect("act metrics");
+        assert_eq!(metrics.prompt_tokens, Some(150)); // input 100 + cache_read 50
+        assert_eq!(metrics.completion_tokens, Some(20));
+        assert_eq!(metrics.cached_tokens, Some(50));
+
+        let last = &steps[2];
+        assert_eq!(last.source, StepSource::Agent);
+        assert_eq!(last.message, "Fixed.");
+        assert!(last.tool_calls.is_empty());
+        assert!(last.observation.is_none());
+        // No thinking and no pending summaries left → no reasoning_content.
+        assert!(last.reasoning_content.is_none());
+
+        let totals = trajectory.final_metrics.expect("final metrics");
+        assert_eq!(totals.total_prompt_tokens, Some(180));
+        assert_eq!(totals.total_completion_tokens, Some(30));
+        assert_eq!(totals.total_cached_tokens, Some(50));
+        assert_eq!(totals.total_steps, Some(3));
+    }
+
+    #[test]
+    fn reason_item_summaries_feed_next_agent_step() {
+        let events = vec![
+            event(EventData::InputMessage(InputMessageData::new(
+                Message::user("hi"),
+            ))),
+            event(EventData::ReasonItem(ReasonItemData {
+                turn_id: everruns_core::typed_id::TurnId::from_seed(2),
+                provider: "sim".to_string(),
+                model: None,
+                item_id: "ri_2".to_string(),
+                encrypted_content: None,
+                summary: vec!["First thought.".to_string(), "Second thought.".to_string()],
+                token_count: None,
+            })),
+            event(EventData::OutputMessageCompleted(
+                OutputMessageCompletedData::new(Message::assistant("Hello!")),
+            )),
+        ];
+        let trajectory = trajectory_from_events(agent_info(), session(), &events);
+        assert_eq!(
+            trajectory.steps[1].reasoning_content.as_deref(),
+            Some("First thought.\n\nSecond thought.")
+        );
+        // No usage anywhere → totals carry only the step count.
+        let totals = trajectory.final_metrics.expect("final metrics");
+        assert!(totals.total_prompt_tokens.is_none());
+        assert_eq!(totals.total_steps, Some(2));
+    }
+
+    #[test]
+    fn failed_tool_result_exports_error_and_status() {
+        let events = vec![
+            event(EventData::OutputMessageCompleted(
+                OutputMessageCompletedData::new(Message::assistant_with_tools(
+                    "",
+                    vec![RuntimeToolCall {
+                        id: "call_9".to_string(),
+                        name: "bash".to_string(),
+                        arguments: serde_json::json!({ "command": "false" }),
+                    }],
+                )),
+            )),
+            event(EventData::ToolCompleted(ToolCompletedData::failure(
+                "call_9".to_string(),
+                "bash".to_string(),
+                "error".to_string(),
+                "exit status 1".to_string(),
+                None,
+            ))),
+        ];
+        let trajectory = trajectory_from_events(agent_info(), session(), &events);
+        let results = &trajectory.steps[0]
+            .observation
+            .as_ref()
+            .expect("observation")
+            .results;
+        assert_eq!(results[0].content.as_deref(), Some("exit status 1"));
+        assert_eq!(
+            results[0].extra,
+            Some(serde_json::json!({ "status": "error" }))
+        );
+    }
+
+    #[test]
+    fn serialization_skips_empty_fields() {
+        let trajectory = trajectory_from_events(agent_info(), session(), &synthetic_events());
+        let json = serde_json::to_value(&trajectory).expect("serialize");
+
+        assert_eq!(json["schema_version"], SCHEMA_VERSION);
+        let user_step = &json["steps"][0];
+        assert!(user_step.get("tool_calls").is_none());
+        assert!(user_step.get("observation").is_none());
+        assert!(user_step.get("metrics").is_none());
+        assert!(user_step.get("reasoning_content").is_none());
+        let final_step = &json["steps"][2];
+        assert!(final_step.get("tool_calls").is_none());
+        // Round-trips through the serde types.
+        let parsed: Trajectory = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(parsed.steps.len(), 3);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 
 mod acp;
 mod app;
+mod atif;
 mod background_wake;
 mod capabilities;
 mod capability_settings;
@@ -132,6 +133,12 @@ struct Cli {
     /// `%APPDATA%\yolop\sessions\` on Windows).
     #[arg(long)]
     session_dir: Option<PathBuf>,
+
+    /// Write the full session as an ATIF v1.7 trajectory JSON file to this
+    /// path at end of run. Works interactively and with `-p/--print`; see
+    /// `specs/trajectory.md`.
+    #[arg(long, value_name = "PATH")]
+    trajectory_out: Option<PathBuf>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -407,6 +414,9 @@ async fn main() -> Result<()> {
     // ACP mode builds runtimes per session (cwd arrives via `session/new`), so
     // it bypasses the up-front runtime build and the TUI.
     if cli.acp {
+        if cli.trajectory_out.is_some() {
+            eprintln!("yolop: --trajectory-out is ignored in --acp mode");
+        }
         return acp::run_stdio(provider, settings, sessions_dir).await;
     }
 
@@ -429,10 +439,10 @@ async fn main() -> Result<()> {
 
     if let Some(prompt) = cli.print {
         let image_parts = image_input::load_image_parts(&cli.images)?;
-        return run_print_mode(runtime, prompt, image_parts).await;
+        return run_print_mode(runtime, prompt, image_parts, cli.trajectory_out).await;
     }
     let pending_images = image_input::load_image_parts(&cli.images)?;
-    run_tui(runtime, pending_images).await
+    run_tui(runtime, pending_images, cli.trajectory_out).await
 }
 
 fn resolve_workspace_root(
@@ -576,7 +586,15 @@ fn run_command(command: Commands) -> Result<()> {
     }
 }
 
-async fn run_tui(runtime: BuiltRuntime, pending_images: Vec<ContentPart>) -> Result<()> {
+async fn run_tui(
+    runtime: BuiltRuntime,
+    pending_images: Vec<ContentPart>,
+    trajectory_out: Option<PathBuf>,
+) -> Result<()> {
+    // Cheap Arc clones taken before `App` consumes the runtime, so the
+    // trajectory can be exported after the TUI loop ends.
+    let trajectory_handles = runtime.handles.clone();
+    let trajectory_model = runtime.model.clone();
     let mut raw_mode = RawModeGuard::new()?;
     let mut keyboard_enhancements = KeyboardEnhancementGuard::new();
     let mut bracketed_paste = BracketedPasteGuard::new();
@@ -617,6 +635,13 @@ async fn run_tui(runtime: BuiltRuntime, pending_images: Vec<ContentPart>) -> Res
     bracketed_paste.disable();
     keyboard_enhancements.disable();
     raw_mode.disable()?;
+
+    write_trajectory_if_requested(
+        &trajectory_handles,
+        &trajectory_model,
+        trajectory_out.as_deref(),
+    )
+    .await;
 
     if show_resume_hint {
         println!();
@@ -731,10 +756,44 @@ fn print_centered_ukraine_banner() {
     );
 }
 
+/// Export the session as an ATIF trajectory when `--trajectory-out` was
+/// given. Best-effort: export problems are reported on stderr and never turn
+/// a finished run into a failure.
+async fn write_trajectory_if_requested(
+    handles: &runtime::RuntimeHandles,
+    model: &runtime::ModelState,
+    path: Option<&Path>,
+) {
+    let Some(path) = path else { return };
+    let events = match handles.runtime.events().await {
+        Ok(events) => events,
+        Err(err) => {
+            eprintln!("yolop: trajectory export failed to read session events: {err}");
+            return;
+        }
+    };
+    let trajectory = atif::trajectory_from_events(
+        atif::AgentInfo {
+            name: "yolop".to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            model_name: Some(model.model_id()),
+        },
+        handles.session_id,
+        &events,
+    );
+    if let Err(err) = atif::write_trajectory_file(path, &trajectory) {
+        eprintln!(
+            "yolop: failed to write trajectory to {}: {err}",
+            path.display()
+        );
+    }
+}
+
 async fn run_print_mode(
     runtime: BuiltRuntime,
     prompt: String,
     images: Vec<ContentPart>,
+    trajectory_out: Option<PathBuf>,
 ) -> Result<()> {
     let BuiltRuntime {
         handles,
@@ -796,7 +855,9 @@ async fn run_print_mode(
 
     let trimmed = prompt.trim();
     if let Some(goal_args) = trimmed.strip_prefix("/goal") {
-        return run_print_goal(
+        // `run_print_goal` reports failure as a flag (not `process::exit`)
+        // so the trajectory export still runs on failed goal runs.
+        let success = run_print_goal(
             &handles,
             &worktree,
             &model,
@@ -804,7 +865,12 @@ async fn run_print_mode(
             goal_args.trim(),
             color,
         )
-        .await;
+        .await?;
+        write_trajectory_if_requested(&handles, &model, trajectory_out.as_deref()).await;
+        if !success {
+            std::process::exit(1);
+        }
+        return Ok(());
     }
 
     if user_ask_enabled
@@ -815,6 +881,7 @@ async fn run_print_mode(
 
     let result = run_print_turn(&handles, &worktree, &model, trimmed, images, color).await?;
     if !result.success {
+        write_trajectory_if_requested(&handles, &model, trajectory_out.as_deref()).await;
         std::process::exit(1);
     }
     if user_ask_enabled && user_ask_store.is_active(handles.session_id) {
@@ -840,9 +907,12 @@ async fn run_print_mode(
             eprintln!("user ask evaluation failed: {}", evaluation.message);
         }
     }
+    write_trajectory_if_requested(&handles, &model, trajectory_out.as_deref()).await;
     Ok(())
 }
 
+/// Returns `Ok(false)` on goal/turn failure instead of exiting so the caller
+/// can finish end-of-run work (trajectory export) before setting the exit code.
 async fn run_print_goal(
     handles: &runtime::RuntimeHandles,
     worktree: &crate::worktree::WorktreeManager,
@@ -850,7 +920,7 @@ async fn run_print_goal(
     goal_store: &goal::GoalStore,
     arguments: &str,
     color: bool,
-) -> Result<()> {
+) -> Result<bool> {
     let session_id = handles.session_id;
     let request = ExecuteCommandRequest {
         name: "goal".to_string(),
@@ -867,15 +937,15 @@ async fn run_print_goal(
     }
     if !result.success {
         eprintln!("goal command failed: {}", result.message);
-        std::process::exit(1);
+        return Ok(false);
     }
 
     if !goal_store.take_pending_turn(session_id) {
-        return Ok(());
+        return Ok(true);
     }
 
     let Some(mut turn_prompt) = goal_store.active_condition(session_id) else {
-        return Ok(());
+        return Ok(true);
     };
 
     loop {
@@ -883,10 +953,10 @@ async fn run_print_goal(
         println!("{}", paint(color, "90", &format!("› {turn_prompt}")));
         let turn = run_print_turn(handles, worktree, model, &turn_prompt, vec![], color).await?;
         if !turn.success {
-            std::process::exit(1);
+            return Ok(false);
         }
         if !goal_store.is_active(session_id) {
-            return Ok(());
+            return Ok(true);
         }
 
         let evaluation = handles
@@ -902,7 +972,7 @@ async fn run_print_goal(
             .await?;
         if !evaluation.success {
             eprintln!("goal evaluation failed: {}", evaluation.message);
-            std::process::exit(1);
+            return Ok(false);
         }
         let parsed = goal::parse_evaluation_response(&evaluation.message)?;
         if parsed.met {
@@ -910,7 +980,7 @@ async fn run_print_goal(
                 "{}",
                 paint(color, "92", &format!("goal achieved: {}", parsed.reason))
             );
-            return Ok(());
+            return Ok(true);
         }
         println!(
             "{}",
@@ -1057,6 +1127,7 @@ mod tests {
             acp: false,
             session: None,
             session_dir: None,
+            trajectory_out: None,
         }
     }
 
@@ -1112,6 +1183,7 @@ mod tests {
             acp: false,
             session: None,
             session_dir: None,
+            trajectory_out: None,
         };
 
         let (provider, _notes) = pick_provider(&cli, &settings);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -214,6 +214,62 @@ fn llmsim_print_smoke() {
 }
 
 #[test]
+fn llmsim_print_writes_atif_trajectory() {
+    // End-to-end offline smoke for `--trajectory-out`: a one-shot llmsim run
+    // must leave a parseable ATIF-v1.7 document with the user prompt and at
+    // least one agent step.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let trajectory_path = tmp.path().join("trajectory.json");
+    let output = Command::new(yolop_binary())
+        .args([
+            "--provider",
+            "llmsim",
+            "--session-dir",
+            tmp.path().to_str().unwrap(),
+            "-p",
+            "hi",
+            "--trajectory-out",
+            trajectory_path.to_str().unwrap(),
+        ])
+        .env_remove("OPENAI_API_KEY")
+        .env_remove("ANTHROPIC_API_KEY")
+        .env_remove("OPENROUTER_API_KEY")
+        .env_remove("OLLAMA_BASE_URL")
+        .env_remove("OLLAMA_API_KEY")
+        .output()
+        .expect("spawn yolop --provider llmsim -p hi --trajectory-out");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "yolop llmsim run failed: stdout={stdout} stderr={stderr}"
+    );
+
+    let raw = std::fs::read_to_string(&trajectory_path)
+        .unwrap_or_else(|e| panic!("trajectory file missing: {e} stderr={stderr}"));
+    let trajectory: serde_json::Value =
+        serde_json::from_str(&raw).expect("trajectory is valid JSON");
+    assert_eq!(trajectory["schema_version"], "ATIF-v1.7");
+    assert_eq!(trajectory["agent"]["name"], "yolop");
+    assert_eq!(trajectory["agent"]["version"], env!("CARGO_PKG_VERSION"));
+    let steps = trajectory["steps"].as_array().expect("steps array");
+    assert!(!steps.is_empty(), "steps must not be empty: {raw}");
+    assert_eq!(steps[0]["source"], "user");
+    assert_eq!(steps[0]["message"], "hi");
+    assert!(
+        steps.iter().any(|s| s["source"] == "agent"),
+        "expected at least one agent step: {raw}"
+    );
+    for (i, step) in steps.iter().enumerate() {
+        assert_eq!(
+            step["step_id"].as_u64(),
+            Some(i as u64 + 1),
+            "step ids must be 1-based and sequential: {raw}"
+        );
+    }
+}
+
+#[test]
 fn llmsim_resume_replays_prior_events() {
     // Two-shot test: the first invocation starts a fresh session and writes a
     // JSONL log; the second invocation resumes that session via `--session <id>`


### PR DESCRIPTION
## What

Adds `--trajectory-out PATH`: at end of run, yolop writes the full session as a single [ATIF v1.7](https://github.com/harbor-framework/harbor/blob/main/rfcs/0001-trajectory-format.md) (Agent Trajectory Interchange Format, harbor RFC 0001) JSON document. Works in the interactive TUI and headless `-p/--print` mode (including failed turns and `/goal` runs); `--acp` ignores the flag with a stderr note since the editor owns the session lifecycle there.

## Why

Benchmark harnesses and trajectory tooling (Harbor, Mira eval studies, SFT/RL data pipelines, trajectory viewers) consume agent runs in ATIF rather than yolop's internal JSONL event log. A first-class export lets any yolop run feed those tools without a bespoke converter per consumer.

## How

- New `src/atif.rs` owns the serializer: it folds the runtime event log into ATIF steps — user input becomes a user step, each reason/act iteration becomes one agent step with reasoning, tool calls, and tool results keyed by `source_call_id`; token usage is aggregated into per-step and final metrics.
- `src/main.rs` adds the clap flag and a shared best-effort `write_trajectory_if_requested` used by both the TUI exit path and print mode. Export problems are reported on stderr and never turn a finished run into a failure. `run_print_goal` now returns success as a flag instead of exiting, so the export runs even on failed goal runs.
- `specs/trajectory.md` documents intent and non-goals; README gains a flags-table row.

## Validation

All run on this branch (`cfe84b2`, parented on latest `origin/main` `639fcbc`), with `CARGO_INCREMENTAL=0`:

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all-features` — 562 passed / 0 failed / 1 ignored (unit, incl. 4 new atif tests) and 33 passed / 0 failed / 1 ignored (integration, incl. new offline llmsim trajectory test)
- Offline smoke: `cargo run -- --provider llmsim -p "hi" --trajectory-out /tmp/ship-smoke-traj.json` — run succeeded; output file parses as JSON with `schema_version: "ATIF-v1.7"`, 2 steps, `agent: {name: yolop, version: 0.4.0, model_name: llmsim-yolop}`.

The feature is exercised directly by an automated test (offline llmsim integration test drives `-p` with `--trajectory-out` and asserts on the emitted file) plus 4 unit tests on the event-fold logic. No live-provider smoke: the change does not alter the agent loop, providers, or tool wiring — it reads the already-recorded event log after the run ends; the offline smoke exercises the identical export path.

## Security

Reviewed per `specs/threat-model.md` categories:

- **TM-FS**: The flag introduces a file write to a user-supplied path (with `create_dir_all` on the parent). This is a local CLI output path provided directly by the invoking user — the same trust level as `--session-dir` — not an agent/tool-driven write, so the agent write blocklist does not apply. Acceptable for a local CLI tool.
- **Data exposure**: The export serializes session content (messages, reasoning, tool calls/results, usage) to disk. This is the same data already persisted locally in the per-session JSONL log, so no new class of data leaves the process; export is local-only and user-invoked. Yolop performs no secrets scrubbing on session content today, and neither the ship skill nor `specs/threat-model.md` requires one for local session artifacts — the export inherits the session log's existing posture. Users should treat trajectory files like session logs before sharing them.
- **TM-LLM**: No key handling changes; provider keys are read from process env only and never appear in the event log, so they cannot appear in the export.
- **TM-BASH / TM-TOOL**: `tools.rs` and capability registration untouched.
- **TM-DEP**: No new dependencies (Cargo.toml unchanged), no new network surface.
- **Resource exhaustion**: Export is a one-shot serialization bounded by session size; failures are reported on stderr without failing the run.

## Follow-ups

- Image content parts are not exported (text only) — documented as a non-goal in `specs/trajectory.md`; add multimodal export if a consumer needs it.
- The event-log-to-trajectory fold could be upstreamed to `everruns-runtime` so other runtime consumers get ATIF export for free; deferred as a future consolidation.