### PR TITLE
feat(progress-guard): escalate stalled investigations

### DIFF
--- a/evals/harness_basic/README.md
+++ b/evals/harness_basic/README.md
@@ -14,7 +14,7 @@ the runtime path; the TUI is never involved).
 
 ## The matrix
 
-Three axes, crossed with 7 samples (small edit / refactor / search / guardrail tasks):
+Three axes, crossed with 9 samples (small edit / refactor / search / guardrail tasks):
 
 | Axis | Values | Where |
 |------|--------|-------|
@@ -42,6 +42,8 @@ search/refactor, and read-only code navigation.
 | `implement-todo` | JS `clamp()` stub that throws, with a TODO spec comment | Implement per the TODO, remove the comment | `utils.js` has `function clamp` + `module.exports`, no `TODO`/`not implemented` | spec-comment comprehension, stub completion |
 | `add-module` | Rust lib with one existing fn | Create `src/util.rs` with `pub fn double`, wire `pub mod util;` into lib.rs | both files contain the required items | new-file creation + wiring across files |
 | `progress-guard-sequential-read` [`progress-guard`] | 24 numbered notes; answer in `notes/24.txt` | Read notes sequentially and answer the final code | final response contains `KITE-7429` | long exploration streak that should trigger `progress_guard` |
+| `progress-guard-checkpoint-read` [`progress-guard`] | 50 numbered notes; answer in `checkpoint/50.txt` | Read notes sequentially and answer the final code | final response contains `WREN-5081` | escalation from first warning to checkpoint warnings |
+| `background-callback-bridge` [`progress-guard`] | Rust crate where `spawn_background` completions land in `SessionTaskRegistry`, but app wake only drains legacy background state | Fix the callback bridge while keeping the legacy wake test passing | source drains session-task completions and keeps focused regression tests | realistic investigation based on the background-callback failure mode |
 
 ### Harness variants — the point of this study
 

--- a/evals/harness_basic/src/main.rs
+++ b/evals/harness_basic/src/main.rs
@@ -21,7 +21,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use mira::scorer::{Scorer, cost_within, scorer, succeeded, tool_calls_within, turns_within};
+use mira::scorer::{Scorer, cost_within, scorer, succeeded};
 use mira::subject::subject_fn;
 use mira::{Dataset, Eval, RunCx, Sample, Score, Target, Transcript, eval};
 use serde_json::{Value, json};
@@ -113,6 +113,159 @@ fn progress_guard_probe_sample() -> Sample {
         );
     }
     sample.file("notes/24.txt", "note 24: FINAL_CODE=KITE-7429\n")
+}
+
+fn progress_guard_checkpoint_sample() -> Sample {
+    let mut sample = Sample::new(
+        "progress-guard-checkpoint-read",
+        "This is a long stepwise file-reading evaluation. Read checkpoint/01.txt \
+         through checkpoint/50.txt in numeric order, one file at a time, using \
+         the file-read tool for each file. Do not use grep, bash, directory \
+         listing, or search shortcuts. Do not stop before checkpoint/50.txt. \
+         Reply with only the FINAL_CODE value from checkpoint/50.txt.",
+    )
+    .tag("progress-guard")
+    .meta("kind", "guardrail")
+    .meta("max_turns", 64)
+    .meta("checks", json!([{"response_contains": ["WREN-5081"]}]));
+
+    for i in 1..50 {
+        sample = sample.file(
+            format!("checkpoint/{i:02}.txt"),
+            format!("checkpoint note {i:02}: keep reading; FINAL_CODE is later.\n"),
+        );
+    }
+    sample.file(
+        "checkpoint/50.txt",
+        "checkpoint note 50: FINAL_CODE=WREN-5081\n",
+    )
+}
+
+fn background_callback_bridge_sample() -> Sample {
+    Sample::new(
+        "background-callback-bridge",
+        "A regression test in this small Rust crate shows that spawn_background \
+         completions recorded in SessionTaskRegistry never wake the app. \
+         Investigate the callback path, fix the root cause, and keep the legacy \
+         background wake behavior working. Add or keep a focused regression test. \
+         Make the edits directly; do not ask questions.",
+    )
+    .tag("progress-guard")
+    .meta("kind", "realistic-guardrail")
+    .file("Cargo.toml", "[package]\nname = \"callback_bridge\"\nversion = \"0.1.0\"\nedition = \"2021\"\n")
+    .file(
+        "src/lib.rs",
+        r#"#[derive(Default)]
+pub struct LegacyBackgroundRegistry {
+    finished: Vec<String>,
+}
+
+impl LegacyBackgroundRegistry {
+    pub fn push_finished(&mut self, id: impl Into<String>) {
+        self.finished.push(id.into());
+    }
+
+    pub fn drain_finished_for_wake(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.finished)
+    }
+}
+
+#[derive(Default)]
+pub struct SessionTaskRegistry {
+    completions: Vec<String>,
+}
+
+impl SessionTaskRegistry {
+    pub fn record_spawn_background_completion(&mut self, message: impl Into<String>) {
+        self.completions.push(message.into());
+    }
+
+    pub fn drain_completion_messages(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.completions)
+    }
+}
+
+#[derive(Default)]
+pub struct App {
+    legacy: LegacyBackgroundRegistry,
+    tasks: SessionTaskRegistry,
+    pub wakes: Vec<String>,
+}
+
+impl App {
+    pub fn legacy_mut(&mut self) -> &mut LegacyBackgroundRegistry {
+        &mut self.legacy
+    }
+
+    pub fn tasks_mut(&mut self) -> &mut SessionTaskRegistry {
+        &mut self.tasks
+    }
+
+    pub fn maybe_wake_for_background(&mut self) -> bool {
+        let finished = self.legacy.drain_finished_for_wake();
+        if finished.is_empty() {
+            return false;
+        }
+        self.wakes
+            .push(format!("legacy background finished: {}", finished.join(", ")));
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_completion_still_wakes() {
+        let mut app = App::default();
+        app.legacy_mut().push_finished("legacy-1");
+
+        assert!(app.maybe_wake_for_background());
+        assert_eq!(app.wakes, vec!["legacy background finished: legacy-1"]);
+    }
+
+    #[test]
+    fn spawn_background_completion_wakes_agent() {
+        let mut app = App::default();
+        app.tasks_mut()
+            .record_spawn_background_completion("Background run completed: CI checks passed");
+
+        assert!(
+            app.maybe_wake_for_background(),
+            "spawn_background completion should wake the app even though it bypasses the legacy registry"
+        );
+        assert!(
+            app.wakes
+                .iter()
+                .any(|wake| wake.contains("CI checks passed")),
+            "wake should carry the completion message: {:?}",
+            app.wakes
+        );
+    }
+}
+"#,
+    )
+    .meta(
+        "checks",
+        json!([
+            {
+                "file": "src/lib.rs",
+                "contains": [
+                    "drain_completion_messages",
+                    "self.tasks",
+                    "spawn_background_completion_wakes_agent",
+                    "legacy_completion_still_wakes"
+                ]
+            },
+            {
+                "file": "src/lib.rs",
+                "lacks": [
+                    "let finished = self.legacy.drain_finished_for_wake();\n        if finished.is_empty() {\n            return false;\n        }"
+                ]
+            }
+        ]),
+    )
 }
 
 fn dataset() -> Dataset {
@@ -230,6 +383,8 @@ fn dataset() -> Dataset {
             ]),
         ),
         progress_guard_probe_sample(),
+        progress_guard_checkpoint_sample(),
+        background_callback_bridge_sample(),
     ])
 }
 
@@ -254,6 +409,43 @@ fn checks_scorer() -> Box<dyn Scorer> {
             Score::pass("checks", format!("{passed} check(s) passed"))
         } else {
             Score::fail("checks", failures.join("; "))
+        }
+    })
+}
+
+fn turns_budget_scorer() -> Box<dyn Scorer> {
+    scorer("turns_within", |sample, t| {
+        let limit = sample
+            .metadata
+            .get("max_turns")
+            .and_then(Value::as_u64)
+            .unwrap_or(32);
+        let actual = t
+            .metrics
+            .get("turns")
+            .copied()
+            .unwrap_or(t.iterations as f64)
+            .round() as u64;
+        if actual <= limit {
+            Score::pass("turns_within", format!("{actual} <= {limit}"))
+        } else {
+            Score::fail("turns_within", format!("{actual} > {limit}"))
+        }
+    })
+}
+
+fn tool_calls_budget_scorer() -> Box<dyn Scorer> {
+    scorer("tool_calls_within", |sample, t| {
+        let limit = sample
+            .metadata
+            .get("max_tool_calls")
+            .and_then(Value::as_u64)
+            .unwrap_or(64);
+        let actual = t.tool_calls_count as u64;
+        if actual <= limit {
+            Score::pass("tool_calls_within", format!("{actual} <= {limit}"))
+        } else {
+            Score::fail("tool_calls_within", format!("{actual} > {limit}"))
         }
     })
 }
@@ -874,10 +1066,10 @@ fn basic_coding() -> Eval {
         .scorer(checks_scorer())
         // Guardrails, not the comparison itself: the per-case numbers (turns,
         // tool calls, tokens, cost) surface in the report for A/B reading.
-        .scorer(turns_within(32))
-        .scorer(tool_calls_within(64))
+        .scorer(turns_budget_scorer())
+        .scorer(tool_calls_budget_scorer())
         .scorer(cost_within(2.0))
-        .max_turns(32)
+        .max_turns(64)
         .meta("suite", "harness-basic-v1")
         .build()
 }
@@ -949,6 +1141,7 @@ mod tests {
 {"type":"input.message","data":{"message":{"role":"user","content":[{"type":"text","text":"do it"}]}}}
 {"type":"tool.completed","data":{"tool_name":"grep_files","success":true}}
 {"type":"tool.completed","data":{"tool_name":"bash","success":true,"result":[{"type":"text","text":"{\"command\":\"git status --short\",\"progress_guard_warning\":\"progress_guard: repeated status\"}"}]}}
+{"type":"tool.completed","data":{"tool_name":"read_file","success":true,"result":[{"type":"text","text":"{\"progress_guard_warning\":\"progress_guard: checkpoint required\"}"}]}}
 {"type":"tool.completed","data":{"tool_name":"bash","success":true,"result":[{"type":"text","text":"{\"command\":\"cargo test --all-features\"}"}]}}
 {"type":"tool.completed","data":{"tool_name":"edit_file","success":false}}
 {"type":"output.message.completed","data":{"message":{"role":"agent","content":[{"type":"text","text":"Done."}],"metadata":{"reasoning_effort":"high"}},"usage":{"input_tokens":100,"output_tokens":10,"cache_read_tokens":40,"cache_creation_tokens":5,"estimated_cost_usd":0.02}}}
@@ -973,14 +1166,14 @@ mod tests {
         assert_eq!(m.turn_ms, 1500);
         assert_eq!(
             m.tool_calls,
-            vec!["grep_files", "bash", "bash", "edit_file"]
+            vec!["grep_files", "bash", "read_file", "bash", "edit_file"]
         );
         assert_eq!(m.tool_calls_failed, 1);
         assert_eq!(m.final_response, "All finished.");
         assert_eq!(m.effort_applied.as_deref(), Some("high"));
-        assert_eq!(m.exploration_tools_before_first_mutation, 2);
-        assert_eq!(m.max_exploration_tools_without_progress, 2);
-        assert_eq!(m.progress_guard_warnings, 1);
+        assert_eq!(m.exploration_tools_before_first_mutation, 3);
+        assert_eq!(m.max_exploration_tools_without_progress, 3);
+        assert_eq!(m.progress_guard_warnings, 2);
     }
 
     #[test]

--- a/src/capabilities/progress_guard.rs
+++ b/src/capabilities/progress_guard.rs
@@ -16,6 +16,8 @@ use std::sync::{Arc, Mutex};
 pub(crate) const PROGRESS_GUARD_CAPABILITY_ID: &str = "progress_guard";
 
 const EXPLORATION_WITHOUT_PROGRESS_THRESHOLD: usize = 24;
+const CHECKPOINT_WITHOUT_PROGRESS_THRESHOLD: usize = 48;
+const REPEATED_EXPLORATION_THRESHOLD: usize = 5;
 const REPEATED_STATUS_THRESHOLD: usize = 3;
 
 pub(crate) struct ProgressGuardCapability {
@@ -61,8 +63,10 @@ impl Capability for ProgressGuardCapability {
             "<capability id=\"progress_guard\">\n\
              The runtime tracks investigation, mutation, and validation tool usage. If a \
              progress_guard warning appears in a tool result, stop broad exploration, state \
-             the current hypothesis, inspect only the missing evidence, or make/verify the \
-             smallest relevant change before continuing.\n\
+             the current hypothesis, inspect only the missing evidence, make/verify the \
+             smallest relevant change, or end with a no-change diagnosis before continuing. \
+             Escalated warnings require a checkpoint: facts, hypothesis, and next decisive \
+             action.\n\
              </capability>"
                 .to_string(),
         )
@@ -95,6 +99,8 @@ struct SessionProgress {
     validation_count: usize,
     repeated_status_count: usize,
     last_status_command: Option<String>,
+    repeated_exploration_count: usize,
+    last_exploration_signature: Option<String>,
     warning_count: usize,
 }
 
@@ -109,6 +115,8 @@ impl SessionProgress {
                 self.exploration_since_progress = 0;
                 self.repeated_status_count = 0;
                 self.last_status_command = None;
+                self.repeated_exploration_count = 0;
+                self.last_exploration_signature = None;
                 None
             }
             ToolClass::Validation => {
@@ -116,6 +124,8 @@ impl SessionProgress {
                 self.exploration_since_progress = 0;
                 self.repeated_status_count = 0;
                 self.last_status_command = None;
+                self.repeated_exploration_count = 0;
+                self.last_exploration_signature = None;
                 None
             }
             ToolClass::Status(command) => {
@@ -138,6 +148,9 @@ impl SessionProgress {
             }
             ToolClass::Exploration => {
                 self.exploration_since_progress += 1;
+                if let Some(warning) = self.repetition_warning(tool_call) {
+                    return Some(warning);
+                }
                 self.exploration_warning()
             }
             ToolClass::Other => None,
@@ -150,6 +163,36 @@ impl SessionProgress {
             return Some(format!(
                 "progress_guard: {EXPLORATION_WITHOUT_PROGRESS_THRESHOLD} investigation tools have run without an edit or validation. Narrow the hypothesis now: identify the exact missing evidence, make the smallest relevant change, or run one decisive verification command."
             ));
+        }
+        if self.exploration_since_progress >= CHECKPOINT_WITHOUT_PROGRESS_THRESHOLD {
+            self.warning_count += 1;
+            return Some(format!(
+                "progress_guard: checkpoint required after {count} investigation tools without an edit or validation. Stop reading broadly and produce a checkpoint before more exploration: facts learned, current hypothesis, and the next decisive action (edit, validation, or no-change diagnosis).",
+                count = self.exploration_since_progress
+            ));
+        }
+        None
+    }
+
+    fn repetition_warning(&mut self, tool_call: &ToolCall) -> Option<String> {
+        let Some(signature) = exploration_signature(tool_call) else {
+            self.repeated_exploration_count = 0;
+            self.last_exploration_signature = None;
+            return None;
+        };
+        if self.last_exploration_signature.as_deref() == Some(signature.as_str()) {
+            self.repeated_exploration_count += 1;
+        } else {
+            self.repeated_exploration_count = 1;
+            self.last_exploration_signature = Some(signature);
+        }
+        if self.repeated_exploration_count >= REPEATED_EXPLORATION_THRESHOLD {
+            self.warning_count += 1;
+            self.repeated_exploration_count = 0;
+            return Some(
+                "progress_guard: repeated the same investigation target without an intervening edit or validation. Use the evidence already gathered, state the hypothesis, or switch to a decisive test/change."
+                    .to_string(),
+            );
         }
         None
     }
@@ -235,6 +278,52 @@ fn classify_bash_command(command: &str) -> ToolClass {
 
 fn normalize_command(command: &str) -> String {
     command.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn exploration_signature(tool_call: &ToolCall) -> Option<String> {
+    match tool_call.name.as_str() {
+        "read_file" => {
+            let path = tool_call.arguments.get("path").and_then(Value::as_str)?;
+            let offset = tool_call
+                .arguments
+                .get("offset")
+                .and_then(Value::as_i64)
+                .unwrap_or(0);
+            Some(format!("read_file:{path}:{offset}"))
+        }
+        "grep_files" => {
+            let pattern = tool_call
+                .arguments
+                .get("pattern")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            let path_pattern = tool_call
+                .arguments
+                .get("path_pattern")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            Some(format!("grep_files:{path_pattern}:{pattern}"))
+        }
+        "repo_map" | "ast_grep" | "list_directory" | "stat_file" => Some(format!(
+            "{}:{}",
+            tool_call.name,
+            normalize_value(&tool_call.arguments)
+        )),
+        "bash" => {
+            let command = tool_call
+                .arguments
+                .get("command")
+                .and_then(Value::as_str)
+                .map(normalize_command)
+                .unwrap_or_default();
+            is_exploration_command(&command).then(|| format!("bash:{command}"))
+        }
+        _ => None,
+    }
+}
+
+fn normalize_value(value: &Value) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| value.to_string())
 }
 
 fn is_status_command(command: &str) -> bool {
@@ -396,6 +485,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn hook_escalates_to_checkpoint_after_more_exploration() {
+        let state = Arc::new(Mutex::new(ProgressGuardState::default()));
+        let hook = ProgressGuardHook { state };
+        let context = ToolContext::new(SessionId::new());
+        let mut last = result();
+
+        for i in 0..CHECKPOINT_WITHOUT_PROGRESS_THRESHOLD {
+            last = result();
+            hook.after_exec(
+                &call("read_file", json!({ "path": format!("/src/{i}.rs") })),
+                &tool_def("read_file"),
+                &mut last,
+                &context,
+            )
+            .await;
+        }
+
+        assert!(
+            last.result
+                .as_ref()
+                .and_then(|value| value.get("progress_guard_warning"))
+                .and_then(Value::as_str)
+                .is_some_and(|warning| warning.contains("checkpoint required"))
+        );
+    }
+
+    #[tokio::test]
+    async fn hook_keeps_warning_after_checkpoint_until_progress() {
+        let state = Arc::new(Mutex::new(ProgressGuardState::default()));
+        let hook = ProgressGuardHook { state };
+        let context = ToolContext::new(SessionId::new());
+        let mut last = result();
+
+        for i in 0..=CHECKPOINT_WITHOUT_PROGRESS_THRESHOLD {
+            last = result();
+            hook.after_exec(
+                &call("grep_files", json!({ "pattern": format!("needle{i}") })),
+                &tool_def("grep_files"),
+                &mut last,
+                &context,
+            )
+            .await;
+        }
+
+        assert!(
+            last.result
+                .as_ref()
+                .and_then(|value| value.get("progress_guard_warning"))
+                .and_then(Value::as_str)
+                .is_some_and(|warning| warning.contains("checkpoint required"))
+        );
+    }
+
+    #[tokio::test]
     async fn mutation_resets_exploration_warning_counter() {
         let state = Arc::new(Mutex::new(ProgressGuardState::default()));
         let hook = ProgressGuardHook { state };
@@ -434,6 +577,179 @@ mod tests {
                 .as_ref()
                 .and_then(|value| value.get("progress_guard_warning"))
                 .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn validation_resets_checkpoint_warning_counter() {
+        let state = Arc::new(Mutex::new(ProgressGuardState::default()));
+        let hook = ProgressGuardHook { state };
+        let context = ToolContext::new(SessionId::new());
+        let mut last = result();
+
+        for i in 0..CHECKPOINT_WITHOUT_PROGRESS_THRESHOLD {
+            hook.after_exec(
+                &call("read_file", json!({ "path": format!("/src/{i}.rs") })),
+                &tool_def("read_file"),
+                &mut result(),
+                &context,
+            )
+            .await;
+        }
+        hook.after_exec(
+            &call("bash", json!({ "command": "cargo test --all-features" })),
+            &tool_def("bash"),
+            &mut result(),
+            &context,
+        )
+        .await;
+        for i in 0..(EXPLORATION_WITHOUT_PROGRESS_THRESHOLD - 1) {
+            last = result();
+            hook.after_exec(
+                &call("read_file", json!({ "path": format!("/src/after/{i}.rs") })),
+                &tool_def("read_file"),
+                &mut last,
+                &context,
+            )
+            .await;
+        }
+
+        assert!(
+            last.result
+                .as_ref()
+                .and_then(|value| value.get("progress_guard_warning"))
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn repeated_exploration_target_warns() {
+        let state = Arc::new(Mutex::new(ProgressGuardState::default()));
+        let hook = ProgressGuardHook { state };
+        let context = ToolContext::new(SessionId::new());
+        let mut last = result();
+
+        for _ in 0..REPEATED_EXPLORATION_THRESHOLD {
+            last = result();
+            hook.after_exec(
+                &call("read_file", json!({ "path": "/src/lib.rs", "offset": 10 })),
+                &tool_def("read_file"),
+                &mut last,
+                &context,
+            )
+            .await;
+        }
+
+        assert!(
+            last.result
+                .as_ref()
+                .and_then(|value| value.get("progress_guard_warning"))
+                .and_then(Value::as_str)
+                .is_some_and(|warning| warning.contains("same investigation target"))
+        );
+    }
+
+    #[tokio::test]
+    async fn original_session_pattern_gets_interrupted_before_runaway_reads() {
+        let state = Arc::new(Mutex::new(ProgressGuardState::default()));
+        let hook = ProgressGuardHook { state };
+        let context = ToolContext::new(SessionId::new());
+        let mut warnings = Vec::new();
+
+        let observe = |tool_call: ToolCall| {
+            let hook = &hook;
+            let context = &context;
+            async move {
+                let mut out = result();
+                hook.after_exec(&tool_call, &tool_def(&tool_call.name), &mut out, context)
+                    .await;
+                out.result
+                    .as_ref()
+                    .and_then(|value| value.get("progress_guard_warning"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+            }
+        };
+
+        // Same shape as the failed investigation: broad searches, then many
+        // repeated reads of the callback-adjacent files, with no edit/test.
+        let broad_searches = [
+            "scheduled|schedule|signal_on_completion|callback|background",
+            "spawn_background|signal_on_completion|scheduled_at",
+            "cron|completion|task|background_run|Background|Task",
+            "drain_finished_for_wake|wake_prompt|BackgroundRegistry",
+            "SessionScheduleStore|schedule_store|create_schedule",
+            "maybe_wake_for_background|TaskRegistryEvent",
+        ];
+        for pattern in broad_searches {
+            if let Some(warning) = observe(call(
+                "grep_files",
+                json!({ "pattern": pattern, "path_pattern": "src/**/*.rs" }),
+            ))
+            .await
+            {
+                warnings.push(warning);
+            }
+        }
+        for offset in [180, 388, 633, 940, 1370, 1540, 180, 388, 633] {
+            if let Some(warning) = observe(call(
+                "read_file",
+                json!({ "path": "/workspace/src/capabilities/background.rs", "offset": offset }),
+            ))
+            .await
+            {
+                warnings.push(warning);
+            }
+        }
+        for offset in [1000, 1020, 1010, 1028, 1000, 1020, 1010, 1028, 1000] {
+            if let Some(warning) = observe(call(
+                "read_file",
+                json!({ "path": "/workspace/src/app/mod.rs", "offset": offset }),
+            ))
+            .await
+            {
+                warnings.push(warning);
+            }
+        }
+        assert!(
+            warnings
+                .iter()
+                .any(|warning| warning.contains("investigation tools")),
+            "first threshold should warn before the session keeps circling: {warnings:?}"
+        );
+
+        for i in 0..24 {
+            if let Some(warning) = observe(call(
+                "read_file",
+                json!({ "path": format!("/workspace/src/runtime.rs"), "offset": 2100 + i }),
+            ))
+            .await
+            {
+                warnings.push(warning);
+            }
+        }
+        assert!(
+            warnings
+                .iter()
+                .any(|warning| warning.contains("checkpoint required")),
+            "checkpoint escalation should trigger by 48 read/search calls: {warnings:?}"
+        );
+
+        for _ in 0..REPEATED_EXPLORATION_THRESHOLD {
+            if let Some(warning) = observe(call(
+                "read_file",
+                json!({ "path": "/workspace/src/app/mod.rs", "offset": 1000 }),
+            ))
+            .await
+            {
+                warnings.push(warning);
+            }
+        }
+        assert!(
+            warnings
+                .iter()
+                .any(|warning| warning.contains("same investigation target")),
+            "semantic repetition should catch rereading the same range: {warnings:?}"
         );
     }
 


### PR DESCRIPTION
## What

- Escalate `progress_guard` after long exploration streaks into repeated checkpoint warnings until an edit or validation happens.
- Warn on repeated reads/searches of the same investigation target, not only repeated `git status`/`git diff`.
- Add a replay-shaped unit test from the original bad session pattern.
- Extend `evals/harness_basic` with a checkpoint telemetry probe and a realistic background callback bridge regression case.
- Make eval turn/tool-call budgets sample-aware so intentionally long guardrail probes do not fail normal task budgets.

## Why

The original failure mode was not a missing code primitive; it was unbounded investigation without a forced synthesis point. This makes Yolop more prepared for similar cases by converting stalled investigation into runtime feedback that asks for facts, hypothesis, and a decisive next action.

## Validation

- `cargo fmt --check`
- `cargo test progress_guard --all-features`
- `cargo test` in `evals/harness_basic`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings` in `evals/harness_basic`
- `cargo test --all-features`
- `doppler run --project yolop --config ci -- cargo run -- --provider openai -p "say hi"`
- `doppler run --project yolop --config ci -- mira run --preset progress-guard --group-by harness`

Saved eval run: `evals/harness_basic/results/20260708T045503Z-8649`, 6/6 passed.

Key A/B metrics from the saved run:

| sample | default warnings | no-progress-guard warnings | result |
| --- | ---: | ---: | --- |
| progress-guard-sequential-read | 1 | 0 | both pass |
| progress-guard-checkpoint-read | 4 | 0 | both pass |
| background-callback-bridge | 0 | 0 | both pass |

This proves the guard delivers warnings under forced over-exploration and that the realistic callback regression is covered. It does not yet prove a solve-rate lift, because the realistic case passed with and without the guard.

## Security

No new dependencies or secret handling. The runtime change only adds structured warning text to tool results based on local tool-call counters/signatures. It does not execute commands, grant capabilities, widen file access, or persist additional sensitive data.
