### PR TITLE
docs(readme): add project badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Yolop
 
+[![CI](https://github.com/everruns/yolop/actions/workflows/ci.yml/badge.svg)](https://github.com/everruns/yolop/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Crates.io](https://img.shields.io/crates/v/yolop.svg)](https://crates.io/crates/yolop)
+[![docs.rs](https://img.shields.io/docsrs/yolop)](https://docs.rs/yolop)
+[![Homebrew](https://img.shields.io/badge/Homebrew-everruns%2Ftap-blue)](https://github.com/everruns/homebrew-tap)
+[![Repo: Agent Friendly](https://img.shields.io/badge/Repo-Agent%20Friendly-blue)](AGENTS.md)
+
 A terminal coding agent built on
 [`everruns-runtime`](https://crates.io/crates/everruns-runtime). One binary
 that plans, edits, runs, and verifies code in your repository — autonomous by


### PR DESCRIPTION
## What

Adds a README badge block for CI, MIT license, crates.io, docs.rs, Homebrew tap, and Agent Friendly status.

## Why

Matches the project presentation style used by everruns/bashkit and makes the README's release/status links easier to scan.

## How

Inserted shields/GitHub badges directly below the `# Yolop` heading, keeping the rest of the README unchanged.

## Validation

- `git diff --check`
- `cargo fmt --check`
- Verified badge/link endpoints used by the README badge block return HTTP 200, including CI, docs.rs, Homebrew tap, and shields.io badge assets.
- Automated feature test exemption: README-only docs change with no runtime behavior change.
- Smoke test exemption: README-only docs change with no runtime behavior change.

## Risk

Low. The change only affects rendered README metadata links.

## Security

No security-relevant code changes. This is a README-only badge/link update and does not alter code, configuration, dependencies, build behavior, secrets handling, shell execution, or filesystem access.

## Follow-ups

No follow-ups.