### PR TITLE
chore: standardize PR descriptions on functional change + before/after

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## What changed
+Describe the change functionally — what behavior changes and its impact on users
+or callers. Lead with outcomes; don't walk through code locations, the diff shows
+where and how. Keep any code-level notes short and specific.
+
+## Why
+Problem or motivation.
+
+## Before / After
+Show the effect with evidence. Include before and after whenever behavior changes —
+CLI/API output, logs, metrics, or screenshots for UI (attach working screenshots
+when possible). For changes with no observable behavior (pure refactor, docs), say so.
+
+## Risk
+- Low / Medium / High
+- What can break
+
+## Checklist
+- [ ] Tests added or updated
+- [ ] Backward compatibility considered

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,10 @@ agent-like, stop and ask before committing.
 
 ## PRs and CI
 
+- Use `.github/pull_request_template.md`. Center the description on functional
+  change and impact, not a code-location walkthrough (the diff shows that). Add a
+  Before / After with proof — CLI output, logs, or screenshots for UI — whenever
+  behavior changes.
 - PR titles must be Conventional Commits and under 70 characters.
 - Use **Squash and Merge**.
 - GitHub Actions is the CI source of truth.


### PR DESCRIPTION
## What changed

PR descriptions now center on **functional change and impact** instead of a code-location walkthrough, and the repo gains a `.github/pull_request_template.md` with a **Before / After** section that asks for proof — CLI output, logs, or screenshots for UI. The `AGENTS.md` PR guidance is updated to match, so humans and coding agents write PRs the same way.

## Why

The diff already shows *where* and *how* code changed. A description should add what the diff can't: the behavior that changed, who it affects, and evidence it works — shifting effort from restating code to demonstrating impact.

## Before / After

Docs/templates only — no runtime behavior changes.

- **Before:** no PR template; `AGENTS.md` gave PR rules but no body structure.
- **After:** `## What changed` (functional summary + impact) + `## Before / After` (proof: output/logs, screenshots for UI when possible), referenced from `AGENTS.md`.

## Risk

- Low
- Documentation and PR-template only; no source, config, or CI logic touched.

## Checklist

- [x] Tests added or updated — N/A (docs/templates only)
- [x] Backward compatibility considered — no code paths affected

---
_Generated by [Claude Code](https://claude.ai/code/session_013LSB82Db25Rf3tVPqWb1JQ)_