### PR TITLE
fix(print): emit only final output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -797,7 +797,7 @@ async fn run_print_mode(
 ) -> Result<()> {
     let BuiltRuntime {
         handles,
-        mut startup,
+        startup,
         model,
         goal_store,
         user_ask_store,
@@ -806,52 +806,10 @@ async fn run_print_mode(
         ..
     } = runtime;
     let color = io::stdout().is_terminal();
-    let display_prompt = image_input::user_display_text(&prompt, images.len());
-    println!("{}", paint(color, "90", &format!("› {display_prompt}")));
-    println!();
     if let Err(err) = worktree.ensure_before_turn(prompt.trim()) {
         eprintln!("worktree: {err}");
     }
-    startup.workspace_root = worktree.active_root();
-    println!(
-        "{} {}",
-        paint(color, "90", "workspace"),
-        startup.workspace_root.display()
-    );
-    println!(
-        "{}  {}",
-        paint(color, "90", "provider"),
-        paint(color, "96", &model.provider_label())
-    );
-    println!(
-        "{}     {}",
-        paint(color, "90", "tools"),
-        startup.tool_names.join(", ")
-    );
-    println!(
-        "{}   {} (folder: {}; log: {}; {} prior event(s))",
-        paint(color, "90", "session"),
-        handles.session_id,
-        startup.session_dir.display(),
-        startup.session_log_path.display(),
-        startup.replayed_events,
-    );
-    if !startup.capability_commands.is_empty() {
-        let names: Vec<String> = startup
-            .capability_commands
-            .iter()
-            .map(|c| format!("/{}", c.name))
-            .collect();
-        println!("{} {}", paint(color, "90", "commands"), names.join(", "));
-    }
-    if startup.hook_configured {
-        println!(
-            "{}     {}",
-            paint(color, "90", "hooks"),
-            startup.hook_summary()
-        );
-    }
-    println!();
+    let _ = (&startup.session_dir, &startup.session_log_path);
 
     let trimmed = prompt.trim();
     if let Some(goal_args) = trimmed.strip_prefix("/goal") {
@@ -879,8 +837,9 @@ async fn run_print_mode(
         eprintln!("user ask: {err}");
     }
 
-    let result = run_print_turn(&handles, &worktree, &model, trimmed, images, color).await?;
-    if !result.success {
+    let turn = collect_print_turn(&handles, &worktree, &model, trimmed, images).await?;
+    print_final_output(&turn.output);
+    if !turn.result.success {
         write_trajectory_if_requested(&handles, &model, trajectory_out.as_deref()).await;
         std::process::exit(1);
     }
@@ -897,12 +856,7 @@ async fn run_print_mode(
             )
             .await?;
         if evaluation.success {
-            if let Ok(parsed) = user_ask::parse_evaluation_response(&evaluation.message) {
-                println!(
-                    "{}",
-                    paint(color, "94", &user_ask::evaluation_status_message(&parsed))
-                );
-            }
+            let _ = user_ask::parse_evaluation_response(&evaluation.message);
         } else {
             eprintln!("user ask evaluation failed: {}", evaluation.message);
         }
@@ -932,15 +886,15 @@ async fn run_print_goal(
         controls: None,
     };
     let result = handles.runtime.execute_command(session_id, request).await?;
-    if !result.message.is_empty() {
-        println!("{}", paint(color, "90", &result.message));
-    }
     if !result.success {
         eprintln!("goal command failed: {}", result.message);
         return Ok(false);
     }
 
     if !goal_store.take_pending_turn(session_id) {
+        if !result.message.is_empty() {
+            println!("{}", paint(color, "90", &result.message));
+        }
         return Ok(true);
     }
 
@@ -949,13 +903,13 @@ async fn run_print_goal(
     };
 
     loop {
-        println!();
-        println!("{}", paint(color, "90", &format!("› {turn_prompt}")));
-        let turn = run_print_turn(handles, worktree, model, &turn_prompt, vec![], color).await?;
-        if !turn.success {
+        let turn = collect_print_turn(handles, worktree, model, &turn_prompt, vec![]).await?;
+        if !turn.result.success {
+            print_final_output(&turn.output);
             return Ok(false);
         }
         if !goal_store.is_active(session_id) {
+            print_final_output(&turn.output);
             return Ok(true);
         }
 
@@ -976,34 +930,30 @@ async fn run_print_goal(
         }
         let parsed = goal::parse_evaluation_response(&evaluation.message)?;
         if parsed.met {
-            println!(
-                "{}",
-                paint(color, "92", &format!("goal achieved: {}", parsed.reason))
-            );
+            print_final_output(&turn.output);
             return Ok(true);
         }
-        println!(
-            "{}",
-            paint(color, "94", &format!("goal: {}", parsed.reason))
-        );
         turn_prompt = goal_store
             .continuation_prompt(session_id)
             .unwrap_or_else(|| turn_prompt.clone());
     }
 }
 
-async fn run_print_turn(
+struct PrintTurn {
+    result: everruns_runtime::TurnResult,
+    output: Vec<String>,
+}
+
+async fn collect_print_turn(
     handles: &runtime::RuntimeHandles,
     worktree: &crate::worktree::WorktreeManager,
     model: &runtime::ModelState,
     prompt: &str,
     images: Vec<ContentPart>,
-    color: bool,
-) -> Result<everruns_runtime::TurnResult> {
+) -> Result<PrintTurn> {
     if let Err(err) = worktree.ensure_before_turn(prompt) {
         eprintln!("worktree: {err}");
     }
-    let before_events = handles.runtime.events().await.map(|e| e.len()).unwrap_or(0);
     let before_msgs = handles
         .runtime
         .messages(handles.session_id)
@@ -1013,21 +963,13 @@ async fn run_print_turn(
 
     let input = model.input_message_with_images(prompt, images);
     let result = handles.runtime.run_turn(handles.session_id, input).await?;
-    let events = handles.runtime.events().await.unwrap_or_default();
     let messages = handles
         .runtime
         .messages(handles.session_id)
         .await
         .unwrap_or_default();
 
-    for event in events.iter().skip(before_events) {
-        if let Some(status) = transcript::status_for_event(event) {
-            print_status_line(&status.text, color);
-        }
-        for line in transcript::lines_for_event(event) {
-            print_transcript_line(&line, color);
-        }
-    }
+    let mut output = Vec::new();
     for msg in messages.iter().skip(before_msgs) {
         if msg.role == MessageRole::Agent
             && !msg.has_tool_calls()
@@ -1035,72 +977,25 @@ async fn run_print_turn(
         {
             let t = text.trim();
             if !t.is_empty() {
-                println!();
-                print_transcript_line(
-                    &transcript::ChatLine {
-                        author: transcript::Author::Assistant,
-                        text: t.to_string(),
-                    },
-                    color,
-                );
+                output.push(t.to_string());
             }
         }
     }
-    println!(
-        "\n{} success={} iterations={} tool_calls={}",
-        paint(color, if result.success { "92" } else { "91" }, "done"),
-        result.success,
-        result.iterations,
-        result.tool_calls_count
-    );
     if !result.success
         && let Some(err) = &result.error
     {
         eprintln!("turn error: {err}");
     }
-    Ok(result)
+    Ok(PrintTurn { result, output })
 }
 
-fn print_transcript_line(line: &transcript::ChatLine, color: bool) {
-    match line.author {
-        transcript::Author::Assistant => {
-            println!("{} {}", paint(color, "90", "•"), line.text);
+fn print_final_output(output: &[String]) {
+    for (index, text) in output.iter().enumerate() {
+        if index > 0 {
+            println!();
         }
-        transcript::Author::Narration => {
-            println!(
-                "{} {} {}",
-                paint(color, "90", "•"),
-                paint(color, "90", line.author.label()),
-                paint(color, "90", &line.text)
-            );
-        }
-        transcript::Author::Tool => {
-            println!(
-                "{} {} {}",
-                paint(color, "92", "•"),
-                paint(color, "93", line.author.label()),
-                line.text
-            );
-        }
-        transcript::Author::ToolDetail => {
-            println!("           {}", line.text);
-        }
-        transcript::Author::Diff => {
-            println!("  {}", paint(color, "95", &line.text));
-        }
-        transcript::Author::System | transcript::Author::User => {
-            println!(
-                "{} {} {}",
-                paint(color, "90", "•"),
-                paint(color, "90", line.author.label()),
-                line.text
-            );
-        }
+        println!("{text}");
     }
-}
-
-fn print_status_line(text: &str, color: bool) {
-    println!("{} {}", paint(color, "94", "•"), text);
 }
 
 fn paint(enabled: bool, code: &str, text: &str) -> String {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -22,7 +22,7 @@
 mod support;
 
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::mpsc::{self, Receiver};
 use std::thread;
@@ -38,6 +38,43 @@ use support::tui_harness::{
 fn yolop_binary() -> PathBuf {
     // CARGO_BIN_EXE_<name> is set by Cargo for integration tests.
     PathBuf::from(env!("CARGO_BIN_EXE_yolop"))
+}
+
+fn session_ids(sessions_dir: &Path) -> Vec<String> {
+    let mut ids: Vec<String> = std::fs::read_dir(sessions_dir)
+        .expect("read sessions dir")
+        .filter_map(|entry| {
+            let entry = entry.expect("session dir entry");
+            entry
+                .file_type()
+                .expect("session entry type")
+                .is_dir()
+                .then(|| {
+                    entry
+                        .file_name()
+                        .to_str()
+                        .expect("utf8 session dir")
+                        .to_string()
+                })
+        })
+        .filter(|name| name.starts_with("session_"))
+        .collect();
+    ids.sort();
+    ids
+}
+
+fn single_session_id(sessions_dir: &Path) -> String {
+    let ids = session_ids(sessions_dir);
+    assert_eq!(ids.len(), 1, "expected one session dir: {ids:?}");
+    ids[0].clone()
+}
+
+fn session_log_line_count(sessions_dir: &Path, session_id: &str) -> usize {
+    let log = sessions_dir.join(session_id).join("events.jsonl");
+    std::fs::read_to_string(&log)
+        .unwrap_or_else(|e| panic!("read session log {}: {e}", log.display()))
+        .lines()
+        .count()
 }
 
 #[test]
@@ -200,17 +237,27 @@ fn llmsim_print_smoke() {
         output.status.success(),
         "yolop llmsim run failed: stdout={stdout} stderr={stderr}"
     );
-    // The print driver always emits a `done success=...` summary line.
     assert!(
-        stdout.contains("done") && stdout.contains("success="),
-        "missing done summary line: {stdout}"
+        stdout.contains("offline mode") && stdout.contains("OPENAI_API_KEY"),
+        "expected only the llmsim final response in stdout: {stdout}"
     );
-    // Session line should mention the llmsim model so we know the provider
-    // wiring picked the offline driver.
-    assert!(
-        stdout.contains("llmsim"),
-        "expected llmsim in stdout: {stdout}"
-    );
+    for hidden in [
+        "› hi",
+        "workspace",
+        "provider",
+        "tools",
+        "session",
+        "commands",
+        "thinking",
+        "iteration",
+        "done",
+        "success=",
+    ] {
+        assert!(
+            !stdout.contains(hidden),
+            "print mode should not emit {hidden:?}: {stdout}"
+        );
+    }
 }
 
 #[test]
@@ -273,8 +320,7 @@ fn llmsim_print_writes_atif_trajectory() {
 fn llmsim_resume_replays_prior_events() {
     // Two-shot test: the first invocation starts a fresh session and writes a
     // JSONL log; the second invocation resumes that session via `--session <id>`
-    // and must replay the prior events (startup line reports "N prior event(s)"
-    // with N > 0). Proves the session_dir + session id wiring round-trips.
+    // and appends to the same log without relying on print-mode chrome.
     let tmp = tempfile::tempdir().expect("tempdir");
     let session_dir = tmp.path().to_str().unwrap();
 
@@ -300,12 +346,9 @@ fn llmsim_resume_replays_prior_events() {
         first.status.success(),
         "first run failed: stdout={first_stdout} stderr={first_stderr}"
     );
-    let session_id = extract_session_id(&first_stdout)
-        .unwrap_or_else(|| panic!("could not find session id in stdout: {first_stdout}"));
-    assert!(
-        first_stdout.contains("0 prior event(s)"),
-        "first run should start with no replayed events: {first_stdout}"
-    );
+    let session_id = single_session_id(tmp.path());
+    let first_log_lines = session_log_line_count(tmp.path(), &session_id);
+    assert!(first_log_lines > 0, "first run should write a session log");
 
     let second = Command::new(yolop_binary())
         .args([
@@ -331,17 +374,13 @@ fn llmsim_resume_replays_prior_events() {
         second.status.success(),
         "resume run failed: stdout={second_stdout} stderr={second_stderr}"
     );
-    // Resume should reuse the same session id and report a non-zero replay count.
+    let sessions = session_ids(tmp.path());
     assert!(
-        second_stdout.contains(&session_id),
-        "resume stdout should mention reused session id {session_id}: {second_stdout}"
+        sessions == [session_id.clone()],
+        "resume should reuse the existing session dir: {sessions:?}"
     );
-    let prior = parse_prior_events(&second_stdout)
-        .unwrap_or_else(|| panic!("could not find prior event count in stdout: {second_stdout}"));
-    assert!(
-        prior > 0,
-        "resume run must replay >0 events, got {prior}: {second_stdout}"
-    );
+    let second_log_lines = session_log_line_count(tmp.path(), &session_id);
+    assert!(second_log_lines > first_log_lines);
 }
 
 #[test]
@@ -911,14 +950,7 @@ fn print_mode_sends_saved_model_selection_to_endpoint() {
         output.status.success(),
         "saved-model run failed: stdout={stdout} stderr={stderr}"
     );
-    assert!(
-        stdout.contains("custom/picked-model-x"),
-        "startup banner should show the restored model: {stdout}"
-    );
-    assert!(
-        stdout.contains("hello from custom endpoint"),
-        "mock reply should reach the transcript: {stdout}"
-    );
+    assert_eq!(stdout.trim(), "hello from custom endpoint");
 
     let request = mock.next_request(Duration::from_secs(5));
     assert_eq!(
@@ -989,10 +1021,7 @@ fn print_mode_attaches_images_to_provider_request() {
         output.status.success(),
         "image attach run failed: stdout={stdout} stderr={stderr}"
     );
-    assert!(
-        stdout.contains("[Image #1]"),
-        "prompt banner should mention attached image: {stdout}"
-    );
+    assert_eq!(stdout.trim(), "saw the image");
 
     let request = mock.next_request(Duration::from_secs(5));
     let messages = request["messages"]
@@ -1129,42 +1158,6 @@ fn tui_startup_does_not_enable_mouse_capture() {
         "double Ctrl-C should exit cleanly, got {status:?}: {}",
         tui.output_text()
     );
-}
-
-/// Parse the session id printed on the `session …` line of `--print` stdout.
-/// The line shape is:
-/// `session   <id> (folder: ...; log: ...; N prior event(s))`
-fn extract_session_id(stdout: &str) -> Option<String> {
-    for line in stdout.lines() {
-        // The line begins with a possibly-coloured "session" token and a run
-        // of whitespace before the id. Strip ANSI escapes defensively.
-        let stripped = strip_ansi(line);
-        let trimmed = stripped.trim_start();
-        if let Some(rest) = trimmed.strip_prefix("session") {
-            let rest = rest.trim_start();
-            // First whitespace-delimited token is the id.
-            let id = rest.split_whitespace().next()?;
-            if !id.is_empty() {
-                return Some(id.to_string());
-            }
-        }
-    }
-    None
-}
-
-/// Parse the `N prior event(s)` count from the same session line.
-fn parse_prior_events(stdout: &str) -> Option<u64> {
-    for line in stdout.lines() {
-        let stripped = strip_ansi(line);
-        if let Some(idx) = stripped.find(" prior event(s)") {
-            let head = &stripped[..idx];
-            let count = head.rsplit(|c: char| !c.is_ascii_digit()).next()?;
-            if !count.is_empty() {
-                return count.parse().ok();
-            }
-        }
-    }
-    None
 }
 
 /// Result of one scripted ACP handshake against the real binary.
@@ -1458,10 +1451,7 @@ fn openai_print_smoke() {
         stdout.to_lowercase().contains("pong"),
         "expected `pong` in stdout: {stdout}"
     );
-    assert!(
-        stdout.contains("success=true"),
-        "expected success=true: {stdout}"
-    );
+    assert!(!stdout.contains("success="), "unexpected footer: {stdout}");
 }
 
 /// Model used by the live OpenRouter smoke tests. Defaults to a Nemotron 3
@@ -1527,10 +1517,7 @@ fn openrouter_print_smoke() {
         stdout.to_lowercase().contains("pong"),
         "expected `pong` in stdout: {stdout}"
     );
-    assert!(
-        stdout.contains("success=true"),
-        "expected success=true: {stdout}"
-    );
+    assert!(!stdout.contains("success="), "unexpected footer: {stdout}");
 }
 
 /// Live regression test for the OpenRouter tool-calling path (everruns EVE-522
@@ -1600,8 +1587,5 @@ fn openrouter_tool_call_executes_end_to_end() {
         "expected sentinel {sentinel} in stdout (proves read_file executed and \
          its result reached the model): {stdout}"
     );
-    assert!(
-        stdout.contains("success=true"),
-        "expected success=true: {stdout}"
-    );
+    assert!(!stdout.contains("success="), "unexpected footer: {stdout}");
 }


### PR DESCRIPTION
## What changed

yolop print mode now writes only the final assistant output to stdout. It no longer emits the prompt echo, workspace/provider/session banner, tool/status transcript, user-ask status, goal-loop progress, or done/success footer in plain `-p/--print` runs.

Tests now pin this behavior through the real CLI entry points, including llmsim, mock OpenAI-compatible providers, image input, session resume, and live-provider print smoke expectations.

## Why

Plain `-p` output should match pipe-friendly CLI behavior and Claude Code's default print mode: final answer only, with diagnostics reserved for stderr.

## Before / After

Before:

```
› hi

workspace ...
provider  llmsim/llmsim-yolop
tools     ...
session   ...
commands  ...

• thinking
• iteration 1: writing response

• I'm running in offline mode ...

done success=true iterations=1 tool_calls=0
```

After:

```
I'm running in offline mode (llmsim — no API key set). Set ANTHROPIC_API_KEY or OPENAI_API_KEY for real responses.
```

Doppler/OpenAI smoke:

```
pong
```

## Risk

- Low / Medium / High: Low
- What can break: scripts that were parsing yolop's old plain print-mode banner/progress/footer from stdout. The intended behavior is final-output-only stdout; session logs and trajectory export still retain detailed run data.

## Security

Reviewed TM-FS, TM-BASH, TM-LLM, TM-TOOL, and TM-DEP for this diff.

- TM-FS: no filesystem access policy changes; session logs/trajectory export continue through existing paths.
- TM-BASH: no shell execution changes.
- TM-LLM: reduces stdout exposure by suppressing provider/session/tool metadata; does not change prompt construction or credential handling.
- TM-TOOL: no capability registration changes.
- TM-DEP: no dependency changes.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo build --release`
- `target/debug/yolop --provider llmsim -p "hi"`
- `doppler run --project yolop --config ci -- cargo run -- --provider openai -p "Reply with exactly the single word: pong"`

Note: the repo-local bare `doppler run -- ...` first failed because this worktree has no Doppler project configured. Retried with the explicit `yolop/ci` project and config successfully.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered