### PR TITLE
feat(extensions): installable extension PoC with LSP

### DIFF
--- a/extensions/yaml-lsp/extension.toml
+++ b/extensions/yaml-lsp/extension.toml
@@ -1,0 +1,12 @@
+id = "yaml-lsp"
+name = "YAML Language Support"
+version = "0.1.0"
+description = "Adds yaml-language-server for .yaml and .yml files via the lsp capability."
+publisher = "yolop"
+
+# Contributes an LSP server definition. Installing this extension auto-enables
+# the `lsp` capability and merges the server into its config — no recompilation.
+[contributions.capabilities.lsp.servers.yaml]
+command = "yaml-language-server"
+args = ["--stdio"]
+extensions = ["yaml", "yml"]

--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -1,0 +1,88 @@
+# Extensions — user-installable capability contributions
+
+Status: PoC in `src/extensions/`. **Illustrated with LSP.**
+
+## Why
+
+Yolop capabilities (LSP, MCP, providers, UI, …) are compiled into the
+binary today. Users can opt in via `settings.toml`, but adding a new language
+server, MCP server, or provider still requires a yolop release. A declarative
+extension format lets users install feature packs without recompilation —
+similar to how VS Code extensions contribute language servers and MCP configs.
+
+## What
+
+An **extension** is a directory with an `extension.toml` manifest, installed
+under:
+
+- **global**: `<config_dir>/yolop/extensions/<id>/`
+- **workspace**: `<workspace>/.yolop/extensions/<id>/`
+
+Workspace extensions with the same `id` override global ones.
+
+### Manifest
+
+```toml
+id = "yaml-lsp"
+name = "YAML Language Support"
+version = "0.1.0"
+description = "Optional description"
+publisher = "optional"
+
+# Capability contributions — merged like [[capabilities]] config
+[contributions.capabilities.lsp.servers.yaml]
+command = "yaml-language-server"
+args = ["--stdio"]
+extensions = ["yaml", "yml"]
+
+# MCP contributions (parsed; merged into session MCP config)
+# [contributions.mcp.my-server]
+# type = "stdio"
+# command = "my-mcp-server"
+```
+
+### CLI
+
+```bash
+yolop ext list
+yolop ext install ./extensions/yaml-lsp          # workspace scope (default)
+yolop ext install ./extensions/yaml-lsp --global
+yolop ext uninstall yaml-lsp
+```
+
+### Runtime behavior
+
+At session build:
+
+1. Discover extensions (global, then workspace).
+2. Merge `contributions.capabilities` into the harness. Extensions
+   **auto-enable** opt-in capabilities they contribute to (e.g. installing
+   `yaml-lsp` enables `lsp` without editing `settings.toml`).
+3. Merge `contributions.mcp` into the session MCP server map.
+
+Contributions are deep-merged (nested maps like `servers` combine per key).
+Invalid contributions are warned and skipped.
+
+## Design notes
+
+- **Contract mirrors capabilities** — extensions contribute config fragments
+  keyed by capability id, not arbitrary code. Future kinds (`providers`, `ui`,
+  everruns plugins) get their own contribution tables.
+- **No recompilation** — install copies files; runtime reads manifests.
+- **Trust** — extensions run with the same trust model as `settings.toml` and
+  `.mcp.json`: the user explicitly installs them. No sandbox in PoC.
+- **Example** — `extensions/yaml-lsp/` in the repo demonstrates LSP server
+  contribution.
+
+## Non-goals (PoC)
+
+- Extension marketplace / remote install
+- Cryptographic signing or sandboxing
+- Dynamic Rust/WASM plugin loading
+- UI contribution rendering
+
+## Follow-ups
+
+- Provider and UI contribution wiring
+- Extension-aware `get_config` / catalog listing
+- Remote install (`yolop ext install <url>`)

--- a/src/extensions/apply.rs
+++ b/src/extensions/apply.rs
@@ -1,0 +1,155 @@
+//! Apply extension contributions to the harness and MCP config.
+
+use super::discovery::DiscoveredExtension;
+use super::manifest::{deep_merge_json, merge_capability_contributions, merge_mcp_contributions};
+use crate::capability_settings::CapabilityCatalog;
+use everruns_core::AgentCapabilityConfig;
+use everruns_core::ScopedMcpServers;
+
+/// Merge extension capability contributions into the harness list.
+///
+/// Extensions auto-enable opt-in capabilities they contribute to (e.g. `lsp`).
+/// Invalid contributions are warned and skipped.
+pub fn apply_extension_capability_contributions(
+    mut caps: Vec<AgentCapabilityConfig>,
+    extensions: &[DiscoveredExtension],
+    catalog: &CapabilityCatalog,
+) -> Vec<AgentCapabilityConfig> {
+    if extensions.is_empty() {
+        return caps;
+    }
+
+    let manifests: Vec<_> = extensions.iter().map(|e| &e.manifest).collect();
+    let contributions = merge_capability_contributions(&manifests);
+
+    for (cap_id, config) in contributions {
+        if let Err(error) = catalog.validate(&cap_id, &config) {
+            tracing::warn!(
+                capability = %cap_id,
+                %error,
+                "ignoring invalid extension capability contribution"
+            );
+            continue;
+        }
+
+        if let Some(existing) = caps.iter_mut().find(|c| c.capability_id() == cap_id) {
+            existing.config = deep_merge_json(&existing.config, &config);
+        } else {
+            tracing::info!(
+                capability = %cap_id,
+                "extension auto-enabled capability"
+            );
+            caps.push(AgentCapabilityConfig::with_config(cap_id, config));
+        }
+    }
+
+    caps
+}
+
+/// Merge extension MCP contributions into scoped MCP servers.
+///
+/// Extension MCP entries are added to the workspace scope (PoC). Malformed
+/// entries are skipped with a warning.
+pub fn apply_extension_mcp_contributions(
+    mut servers: ScopedMcpServers,
+    extensions: &[DiscoveredExtension],
+) -> ScopedMcpServers {
+    if extensions.is_empty() {
+        return servers;
+    }
+
+    let manifests: Vec<_> = extensions.iter().map(|e| &e.manifest).collect();
+    let contributions = merge_mcp_contributions(&manifests);
+
+    for (name, config) in contributions {
+        match serde_json::from_value::<everruns_core::ScopedMcpServer>(config.clone()) {
+            Ok(server) => {
+                servers.insert(name, server);
+            }
+            Err(error) => {
+                tracing::warn!(
+                    server = %name,
+                    %error,
+                    "ignoring invalid extension MCP contribution"
+                );
+            }
+        }
+    }
+
+    servers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capabilities::lsp::LspCapability;
+    use crate::capability_settings::CapabilityCatalog;
+    use crate::extensions::discovery::{DiscoveredExtension, ExtensionScope};
+    use crate::extensions::manifest::ExtensionManifest;
+    use crate::workspace_host::WorkspaceHost;
+    use serde_json::json;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    fn catalog_with_lsp(tmp: &tempfile::TempDir) -> CapabilityCatalog {
+        let mut catalog = CapabilityCatalog::new();
+        let root = tmp.path().to_path_buf();
+        std::fs::create_dir_all(&root).expect("workspace dir");
+        let host = Arc::new(
+            WorkspaceHost::new(Arc::new(std::sync::RwLock::new(root.clone())), root)
+                .expect("workspace host"),
+        );
+        catalog.register_arc(Arc::new(LspCapability::new(host)));
+        catalog
+    }
+
+    fn ext_with_lsp_yaml() -> DiscoveredExtension {
+        let manifest = ExtensionManifest::from_toml_str(
+            r#"
+id = "yaml-lsp"
+name = "YAML"
+version = "0.1.0"
+
+[contributions.capabilities.lsp.servers.yaml]
+command = "yaml-language-server"
+args = ["--stdio"]
+extensions = ["yaml", "yml"]
+"#,
+        )
+        .unwrap();
+        DiscoveredExtension {
+            manifest,
+            root: PathBuf::from("/ext/yaml-lsp"),
+            scope: ExtensionScope::Global,
+        }
+    }
+
+    #[test]
+    fn auto_enables_lsp_and_merges_servers() {
+        let tmp = tempfile::tempdir().unwrap();
+        let catalog = catalog_with_lsp(&tmp);
+        let defaults = vec![];
+        let applied =
+            apply_extension_capability_contributions(defaults, &[ext_with_lsp_yaml()], &catalog);
+        assert_eq!(applied.len(), 1);
+        assert_eq!(applied[0].capability_id(), "lsp");
+        let servers = applied[0].config.get("servers").unwrap();
+        assert!(servers.get("yaml").is_some());
+        assert!(servers.get("rust").is_none());
+    }
+
+    #[test]
+    fn merges_into_existing_lsp_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        let catalog = catalog_with_lsp(&tmp);
+        let defaults = vec![AgentCapabilityConfig::with_config(
+            "lsp",
+            json!({ "request_timeout_ms": 45000 }),
+        )];
+        let applied =
+            apply_extension_capability_contributions(defaults, &[ext_with_lsp_yaml()], &catalog);
+        assert_eq!(applied.len(), 1);
+        assert_eq!(applied[0].config["request_timeout_ms"], 45000);
+        assert!(applied[0].config["servers"]["yaml"].is_object());
+    }
+}

--- a/src/extensions/discovery.rs
+++ b/src/extensions/discovery.rs
@@ -1,0 +1,188 @@
+//! Discover installed extensions from global and workspace scopes.
+
+use super::manifest::{ExtensionManifest, MANIFEST_FILE};
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+/// Where an extension was discovered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExtensionScope {
+    Global,
+    Workspace,
+}
+
+impl ExtensionScope {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Global => "global",
+            Self::Workspace => "workspace",
+        }
+    }
+}
+
+/// One installed extension on disk.
+#[derive(Debug, Clone)]
+pub struct DiscoveredExtension {
+    pub manifest: ExtensionManifest,
+    pub root: PathBuf,
+    pub scope: ExtensionScope,
+}
+
+/// Global extensions directory: `<config_dir>/yolop/extensions/`.
+pub fn global_extensions_dir() -> Option<PathBuf> {
+    dirs::config_dir().map(|p| p.join("yolop").join("extensions"))
+}
+
+/// Workspace extensions directory: `<workspace>/.yolop/extensions/`.
+pub fn workspace_extensions_dir(workspace_root: &Path) -> PathBuf {
+    workspace_root.join(".yolop").join("extensions")
+}
+
+/// Discover extensions from global then workspace scopes. Workspace entries
+/// with the same `id` override global ones (later wins in contribution merge).
+pub fn discover_extensions(workspace_root: &Path) -> Vec<DiscoveredExtension> {
+    let mut by_id: std::collections::BTreeMap<String, DiscoveredExtension> =
+        std::collections::BTreeMap::new();
+
+    if let Some(global_dir) = global_extensions_dir() {
+        for ext in discover_scope(&global_dir, ExtensionScope::Global) {
+            by_id.insert(ext.manifest.id.clone(), ext);
+        }
+    }
+
+    let workspace_dir = workspace_extensions_dir(workspace_root);
+    for ext in discover_scope(&workspace_dir, ExtensionScope::Workspace) {
+        by_id.insert(ext.manifest.id.clone(), ext);
+    }
+
+    by_id.into_values().collect()
+}
+
+fn discover_scope(dir: &Path, scope: ExtensionScope) -> Vec<DiscoveredExtension> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut extensions = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let manifest_path = path.join(MANIFEST_FILE);
+        if !manifest_path.is_file() {
+            tracing::warn!(
+                path = %path.display(),
+                "extension directory missing {MANIFEST_FILE}; skipping"
+            );
+            continue;
+        }
+        match ExtensionManifest::from_file(&manifest_path) {
+            Ok(manifest) => {
+                if manifest.id != path.file_name().and_then(|n| n.to_str()).unwrap_or("") {
+                    tracing::warn!(
+                        path = %path.display(),
+                        manifest_id = %manifest.id,
+                        "extension directory name does not match manifest id; using manifest id"
+                    );
+                }
+                extensions.push(DiscoveredExtension {
+                    manifest,
+                    root: path,
+                    scope,
+                });
+            }
+            Err(error) => {
+                tracing::warn!(
+                    path = %manifest_path.display(),
+                    %error,
+                    "ignoring malformed extension manifest"
+                );
+            }
+        }
+    }
+    extensions.sort_by(|a, b| a.manifest.id.cmp(&b.manifest.id));
+    extensions
+}
+
+/// Install target directory for an extension id.
+pub fn install_dir(scope: ExtensionScope, workspace_root: &Path, id: &str) -> Result<PathBuf> {
+    let base = match scope {
+        ExtensionScope::Global => {
+            global_extensions_dir().context("no platform config directory for global extensions")?
+        }
+        ExtensionScope::Workspace => workspace_extensions_dir(workspace_root),
+    };
+    Ok(base.join(id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn write_extension(dir: &Path, id: &str, extra_toml: &str) {
+        fs::create_dir_all(dir).unwrap();
+        let manifest = format!(
+            r#"
+id = "{id}"
+name = "Test {id}"
+version = "0.0.1"
+
+{extra_toml}
+"#
+        );
+        fs::write(dir.join(MANIFEST_FILE), manifest).unwrap();
+    }
+
+    #[test]
+    fn workspace_overrides_global_same_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let global = tmp.path().join("global");
+        let workspace = tmp.path().join("ws");
+        fs::create_dir_all(&global).unwrap();
+        fs::create_dir_all(&workspace).unwrap();
+
+        write_extension(
+            &global.join("demo"),
+            "demo",
+            r#"
+[contributions.capabilities.lsp.servers.yaml]
+command = "global-server"
+extensions = ["yaml"]
+"#,
+        );
+        write_extension(
+            &workspace.join(".yolop/extensions/demo"),
+            "demo",
+            r#"
+[contributions.capabilities.lsp.servers.yaml]
+command = "workspace-server"
+extensions = ["yml"]
+"#,
+        );
+
+        // Simulate discovery without patching global_extensions_dir
+        let mut by_id = std::collections::BTreeMap::new();
+        for ext in discover_scope(&global, ExtensionScope::Global) {
+            by_id.insert(ext.manifest.id.clone(), ext);
+        }
+        for ext in discover_scope(
+            &workspace.join(".yolop/extensions"),
+            ExtensionScope::Workspace,
+        ) {
+            by_id.insert(ext.manifest.id.clone(), ext);
+        }
+        let exts: Vec<_> = by_id.into_values().collect();
+        assert_eq!(exts.len(), 1);
+        assert_eq!(exts[0].scope, ExtensionScope::Workspace);
+        let lsp = exts[0]
+            .manifest
+            .contributions
+            .capabilities
+            .get("lsp")
+            .unwrap();
+        assert!(lsp.to_string().contains("workspace-server"));
+    }
+}

--- a/src/extensions/install.rs
+++ b/src/extensions/install.rs
@@ -1,0 +1,131 @@
+//! Install and uninstall extensions from a local directory.
+
+use super::discovery::{ExtensionScope, install_dir};
+use super::manifest::{ExtensionManifest, MANIFEST_FILE};
+use anyhow::{Context, Result, bail};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Copy an extension bundle from `source` into the target scope.
+///
+/// `source` must be a directory containing `extension.toml`. The manifest
+/// `id` determines the install directory name.
+pub fn install_extension(
+    source: &Path,
+    scope: ExtensionScope,
+    workspace_root: &Path,
+    force: bool,
+) -> Result<PathBuf> {
+    if !source.is_dir() {
+        bail!("extension source must be a directory: {}", source.display());
+    }
+    let manifest_path = source.join(MANIFEST_FILE);
+    if !manifest_path.is_file() {
+        bail!(
+            "extension source missing {MANIFEST_FILE}: {}",
+            source.display()
+        );
+    }
+
+    let manifest = ExtensionManifest::from_file(&manifest_path)?;
+    if !manifest.has_contributions() {
+        tracing::warn!(
+            id = %manifest.id,
+            "extension has no contributions; installing anyway"
+        );
+    }
+
+    let dest = install_dir(scope, workspace_root, &manifest.id)?;
+    if dest.exists() {
+        if force {
+            fs::remove_dir_all(&dest)
+                .with_context(|| format!("remove existing extension {}", dest.display()))?;
+        } else {
+            bail!(
+                "extension `{}` already installed at {} (pass --force to replace)",
+                manifest.id,
+                dest.display()
+            );
+        }
+    }
+
+    fs::create_dir_all(dest.parent().unwrap()).with_context(|| {
+        format!(
+            "create extensions parent {}",
+            dest.parent().unwrap().display()
+        )
+    })?;
+    copy_dir_recursive(source, &dest)?;
+
+    Ok(dest)
+}
+
+/// Remove an installed extension by id from the given scope.
+pub fn uninstall_extension(id: &str, scope: ExtensionScope, workspace_root: &Path) -> Result<()> {
+    if id.trim().is_empty() {
+        bail!("extension id must not be empty");
+    }
+    let dest = install_dir(scope, workspace_root, id)?;
+    if !dest.exists() {
+        bail!(
+            "extension `{id}` is not installed in {} scope at {}",
+            scope.label(),
+            dest.display()
+        );
+    }
+    fs::remove_dir_all(&dest).with_context(|| format!("remove extension {}", dest.display()))?;
+    Ok(())
+}
+
+fn copy_dir_recursive(src: &Path, dest: &Path) -> Result<()> {
+    fs::create_dir_all(dest)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let src_path = entry.path();
+        let dest_path = dest.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_dir_recursive(&src_path, &dest_path)?;
+        } else if file_type.is_file() {
+            fs::copy(&src_path, &dest_path).with_context(|| {
+                format!("copy {} to {}", src_path.display(), dest_path.display())
+            })?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn install_copies_manifest_and_rejects_duplicate() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("bundle");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(
+            source.join(MANIFEST_FILE),
+            r#"
+id = "demo-ext"
+name = "Demo"
+version = "0.1.0"
+
+[contributions.capabilities.lsp.servers.demo]
+command = "demo-lsp"
+extensions = ["demo"]
+"#,
+        )
+        .unwrap();
+
+        let ws = tmp.path().join("workspace");
+        fs::create_dir_all(&ws).unwrap();
+        let dest = install_extension(&source, ExtensionScope::Workspace, &ws, false).unwrap();
+        assert!(dest.join(MANIFEST_FILE).is_file());
+        assert!(install_extension(&source, ExtensionScope::Workspace, &ws, false).is_err());
+        install_extension(&source, ExtensionScope::Workspace, &ws, true).unwrap();
+        uninstall_extension("demo-ext", ExtensionScope::Workspace, &ws).unwrap();
+        assert!(!dest.exists());
+    }
+}

--- a/src/extensions/manifest.rs
+++ b/src/extensions/manifest.rs
@@ -1,0 +1,208 @@
+//! Extension manifest (`extension.toml`) parsing.
+//!
+//! An extension is a directory with an `extension.toml` that declares
+//! contributions to yolop subsystems — capabilities, MCP servers, providers,
+//! UI, etc. Contributions are declarative JSON-shaped config merged at
+//! runtime; no recompilation required.
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+use serde_json::{Map, Value};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+pub const MANIFEST_FILE: &str = "extension.toml";
+
+/// Parsed `extension.toml` for one installed extension.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct ExtensionManifest {
+    /// Stable identifier (directory name). Must be unique per scope.
+    pub id: String,
+    pub name: String,
+    pub version: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub publisher: Option<String>,
+    #[serde(default)]
+    pub contributions: ExtensionContributions,
+}
+
+/// Declarative contributions keyed by subsystem.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize)]
+pub struct ExtensionContributions {
+    /// Per-capability config fragments, keyed by capability id (`lsp`, `mcp`, …).
+    /// Merged into the harness like `[[capabilities]]` overrides.
+    #[serde(default)]
+    pub capabilities: BTreeMap<String, Value>,
+    /// MCP server entries merged into the session MCP config (future).
+    #[serde(default)]
+    pub mcp: BTreeMap<String, Value>,
+}
+
+impl ExtensionManifest {
+    pub fn from_toml_str(contents: &str) -> Result<Self> {
+        let manifest: Self = toml::from_str(contents).context("parse extension.toml")?;
+        manifest.validate()?;
+        Ok(manifest)
+    }
+
+    pub fn from_file(path: &Path) -> Result<Self> {
+        let contents = std::fs::read_to_string(path)
+            .with_context(|| format!("read extension manifest {}", path.display()))?;
+        Self::from_toml_str(&contents)
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        if self.id.trim().is_empty() {
+            bail!("extension `id` must not be empty");
+        }
+        if self.name.trim().is_empty() {
+            bail!("extension `name` must not be empty");
+        }
+        if self.version.trim().is_empty() {
+            bail!("extension `version` must not be empty");
+        }
+        if self.id.contains('/') || self.id.contains('\\') {
+            bail!("extension `id` must not contain path separators");
+        }
+        Ok(())
+    }
+
+    /// Whether this extension contributes anything yolop can apply.
+    pub fn has_contributions(&self) -> bool {
+        !self.contributions.capabilities.is_empty() || !self.contributions.mcp.is_empty()
+    }
+}
+
+/// Deep-merge two JSON values. Objects recurse; other types are replaced.
+pub fn deep_merge_json(base: &Value, over: &Value) -> Value {
+    if over.is_null() {
+        return base.clone();
+    }
+    match (base, over) {
+        (Value::Object(base_map), Value::Object(over_map)) => {
+            let mut merged = base_map.clone();
+            for (key, over_val) in over_map {
+                let merged_val = match merged.get(key) {
+                    Some(base_val) if base_val.is_object() && over_val.is_object() => {
+                        deep_merge_json(base_val, over_val)
+                    }
+                    _ => over_val.clone(),
+                };
+                merged.insert(key.clone(), merged_val);
+            }
+            Value::Object(merged)
+        }
+        (_, over) => over.clone(),
+    }
+}
+
+/// Merge capability contributions from multiple extensions into one map.
+pub fn merge_capability_contributions(
+    extensions: &[&ExtensionManifest],
+) -> BTreeMap<String, Value> {
+    let mut merged: BTreeMap<String, Value> = BTreeMap::new();
+    for manifest in extensions {
+        for (cap_id, config) in &manifest.contributions.capabilities {
+            let entry = merged
+                .entry(cap_id.clone())
+                .or_insert_with(|| Value::Object(Map::new()));
+            *entry = deep_merge_json(entry, config);
+        }
+    }
+    merged
+}
+
+/// Merge MCP contributions from extensions into a flat server map.
+pub fn merge_mcp_contributions(extensions: &[&ExtensionManifest]) -> BTreeMap<String, Value> {
+    let mut merged: BTreeMap<String, Value> = BTreeMap::new();
+    for manifest in extensions {
+        for (name, config) in &manifest.contributions.mcp {
+            let entry = merged
+                .entry(name.clone())
+                .or_insert_with(|| Value::Object(Map::new()));
+            *entry = deep_merge_json(entry, config);
+        }
+    }
+    merged
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parses_lsp_contribution() {
+        let toml = r#"
+id = "yaml-lsp"
+name = "YAML Language Support"
+version = "0.1.0"
+description = "YAML via yaml-language-server"
+
+[contributions.capabilities.lsp.servers.yaml]
+command = "yaml-language-server"
+args = ["--stdio"]
+extensions = ["yaml", "yml"]
+"#;
+        let manifest = ExtensionManifest::from_toml_str(toml).unwrap();
+        assert_eq!(manifest.id, "yaml-lsp");
+        assert_eq!(manifest.contributions.capabilities.len(), 1);
+        let lsp = manifest.contributions.capabilities.get("lsp").unwrap();
+        assert_eq!(
+            lsp,
+            &json!({
+                "servers": {
+                    "yaml": {
+                        "command": "yaml-language-server",
+                        "args": ["--stdio"],
+                        "extensions": ["yaml", "yml"]
+                    }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn deep_merge_nested_servers() {
+        let base = json!({
+            "servers": {
+                "rust": { "enabled": false }
+            },
+            "request_timeout_ms": 30000
+        });
+        let over = json!({
+            "servers": {
+                "yaml": {
+                    "command": "yaml-language-server",
+                    "extensions": ["yaml"]
+                }
+            }
+        });
+        let merged = deep_merge_json(&base, &over);
+        assert_eq!(
+            merged,
+            json!({
+                "servers": {
+                    "rust": { "enabled": false },
+                    "yaml": {
+                        "command": "yaml-language-server",
+                        "extensions": ["yaml"]
+                    }
+                },
+                "request_timeout_ms": 30000
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_empty_id() {
+        let toml = r#"
+id = ""
+name = "Bad"
+version = "0.1.0"
+"#;
+        assert!(ExtensionManifest::from_toml_str(toml).is_err());
+    }
+}

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -1,0 +1,23 @@
+//! User-installable extensions — declarative contributions without recompilation.
+//!
+//! Extensions are directories with an `extension.toml` manifest installed under:
+//! - **global**: `<config_dir>/yolop/extensions/<id>/`
+//! - **workspace**: `<workspace>/.yolop/extensions/<id>/`
+//!
+//! Contributions mirror capability-level config (LSP servers, MCP entries, …)
+//! and are merged at session build time. See `specs/extensions.md`.
+
+#![allow(unused_imports)]
+
+mod apply;
+mod discovery;
+mod install;
+mod manifest;
+
+pub use apply::{apply_extension_capability_contributions, apply_extension_mcp_contributions};
+pub use discovery::{
+    DiscoveredExtension, ExtensionScope, discover_extensions, global_extensions_dir,
+    workspace_extensions_dir,
+};
+pub use install::{install_extension, uninstall_extension};
+pub use manifest::{ExtensionManifest, MANIFEST_FILE};

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod codex_driver;
 mod config_schema;
 mod config_service;
 mod connectors;
+mod extensions;
 mod goal;
 mod hooks_config;
 mod host_ui;
@@ -149,6 +150,52 @@ enum Commands {
     Into(IntoCommand),
     /// Git worktree maintenance.
     Worktree(WorktreeArgs),
+    /// Installable extensions (capabilities, MCP, …).
+    Ext(ExtArgs),
+}
+
+#[derive(Args, Debug)]
+struct ExtArgs {
+    #[command(subcommand)]
+    command: ExtCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum ExtCommand {
+    /// List installed extensions (global and workspace).
+    List {
+        /// Workspace root for workspace-scoped extensions (default: current dir).
+        #[arg(short = 'C', long = "cwd")]
+        cwd: Option<PathBuf>,
+    },
+    /// Install an extension from a local directory.
+    Install {
+        /// Path to an extension bundle directory containing `extension.toml`.
+        path: PathBuf,
+        /// Install into the global extensions directory.
+        #[arg(long, conflicts_with = "workspace")]
+        global: bool,
+        /// Install into the workspace `.yolop/extensions/` directory (default).
+        #[arg(long, conflicts_with = "global")]
+        workspace: bool,
+        /// Replace an existing installation with the same id.
+        #[arg(long)]
+        force: bool,
+        /// Workspace root when installing to workspace scope.
+        #[arg(short = 'C', long = "cwd")]
+        cwd: Option<PathBuf>,
+    },
+    /// Remove an installed extension by id.
+    Uninstall {
+        /// Extension id (manifest `id` field).
+        id: String,
+        #[arg(long, conflicts_with = "workspace")]
+        global: bool,
+        #[arg(long, conflicts_with = "global")]
+        workspace: bool,
+        #[arg(short = 'C', long = "cwd")]
+        cwd: Option<PathBuf>,
+    },
 }
 
 #[derive(Args, Debug)]
@@ -462,6 +509,68 @@ fn resolve_workspace_root(
     std::env::current_dir().context("resolve current workspace directory")
 }
 
+fn run_ext_command(command: ExtCommand) -> Result<()> {
+    use extensions::{ExtensionScope, discover_extensions, install_extension, uninstall_extension};
+
+    match command {
+        ExtCommand::List { cwd } => {
+            let workspace = cwd.unwrap_or_else(|| std::env::current_dir().expect("cwd"));
+            let extensions = discover_extensions(&workspace);
+            if extensions.is_empty() {
+                println!("no extensions installed");
+                return Ok(());
+            }
+            for ext in extensions {
+                println!(
+                    "{}  {} v{}  [{}]  {}",
+                    ext.manifest.id,
+                    ext.manifest.name,
+                    ext.manifest.version,
+                    ext.scope.label(),
+                    ext.root.display()
+                );
+                if let Some(desc) = &ext.manifest.description {
+                    println!("  {desc}");
+                }
+            }
+            Ok(())
+        }
+        ExtCommand::Install {
+            path,
+            global,
+            workspace: _,
+            force,
+            cwd,
+        } => {
+            let scope = if global {
+                ExtensionScope::Global
+            } else {
+                ExtensionScope::Workspace
+            };
+            let workspace_root = cwd.unwrap_or_else(|| std::env::current_dir().expect("cwd"));
+            let dest = install_extension(&path, scope, &workspace_root, force)?;
+            println!("installed extension to {}", dest.display());
+            Ok(())
+        }
+        ExtCommand::Uninstall {
+            id,
+            global,
+            workspace: _,
+            cwd,
+        } => {
+            let scope = if global {
+                ExtensionScope::Global
+            } else {
+                ExtensionScope::Workspace
+            };
+            let workspace_root = cwd.unwrap_or_else(|| std::env::current_dir().expect("cwd"));
+            uninstall_extension(&id, scope, &workspace_root)?;
+            println!("removed extension `{id}`");
+            Ok(())
+        }
+    }
+}
+
 fn run_worktree_command(command: WorktreeCommand) -> Result<()> {
     match command {
         WorktreeCommand::List => {
@@ -512,6 +621,7 @@ fn run_command(command: Commands) -> Result<()> {
             Ok(())
         }
         Commands::Worktree(args) => run_worktree_command(args.command),
+        Commands::Ext(args) => run_ext_command(args.command),
         Commands::Into(into) => match into.target {
             IntoTarget::Paseo(args) => {
                 let command = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("yolop"));

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2062,8 +2062,6 @@ pub async fn build_with_options(
     // best-effort per scope: a malformed file is warned about and skipped, so
     // it never sinks the session or masks the other scope.
     let mcp_servers: ScopedMcpServers = crate::mcp_config::load_mcp_servers(&canonical_root);
-    let mut mcp_server_names: Vec<String> = mcp_servers.keys().cloned().collect();
-    mcp_server_names.sort();
     let hooks_store = Arc::new(crate::hooks_config::HooksStore::beside_settings(
         &settings,
         canonical_root.clone(),
@@ -2316,10 +2314,11 @@ pub async fn build_with_options(
     for cap in capabilities.list() {
         catalog.register_arc(cap.clone());
     }
+    let catalog = Arc::new(catalog);
 
     capabilities.register(ConfigCapability {
         settings: settings.clone(),
-        catalog: Arc::new(catalog),
+        catalog: catalog.clone(),
     });
 
     let mut driver_registry = DriverRegistry::new();
@@ -2364,18 +2363,29 @@ pub async fn build_with_options(
         }))
         .build();
 
+    // User-installable extensions (global + workspace). Contributions merge
+    // into the harness and MCP config without recompilation.
+    let discovered_extensions = crate::extensions::discover_extensions(&canonical_root);
+
     // Seed harness/agent/session explicitly so Yolop can attach harness
     // metadata that Everruns forwards to LLM calls and observability.
     let session_title = format!("yolop @ {}", effective_root.display());
-    let harness_capabilities = coding_harness_capabilities(
-        options.client_commands,
-        hook_capability_config,
-        &settings_snapshot,
+    let harness_capabilities = crate::extensions::apply_extension_capability_contributions(
+        coding_harness_capabilities(
+            options.client_commands,
+            hook_capability_config,
+            &settings_snapshot,
+        ),
+        &discovered_extensions,
+        catalog.as_ref(),
     );
     let user_ask_enabled = harness_capabilities
         .iter()
         .any(|cap| cap.capability_id() == USER_ASK_CAPABILITY_ID);
-    let session_mcp_servers = mcp_servers.clone();
+    let session_mcp_servers =
+        crate::extensions::apply_extension_mcp_contributions(mcp_servers, &discovered_extensions);
+    let mut mcp_server_names: Vec<String> = session_mcp_servers.keys().cloned().collect();
+    mcp_server_names.sort();
 
     let mut harness_builder = HarnessBuilder::new("yolop", HARNESS_PROMPT)
         .metadata_entry("app", "yolop")
@@ -4680,6 +4690,57 @@ mod tests {
             ids.iter()
                 .any(|cap| cap.capability_id() == LSP_CAPABILITY_ID),
             "a [[capabilities]] override should enable lsp"
+        );
+    }
+
+    #[test]
+    fn extension_contribution_auto_enables_lsp_with_yaml_server() {
+        use crate::capabilities::lsp::LSP_CAPABILITY_ID;
+        use crate::extensions::{
+            ExtensionScope, apply_extension_capability_contributions, discover_extensions,
+            install_extension,
+        };
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let workspace = tmp.path().join("ws");
+        std::fs::create_dir_all(&workspace).expect("workspace");
+
+        let bundle = workspace.join("bundle");
+        std::fs::create_dir_all(&bundle).expect("bundle");
+        std::fs::copy(
+            std::path::Path::new("extensions/yaml-lsp/extension.toml"),
+            bundle.join("extension.toml"),
+        )
+        .expect("copy example extension");
+
+        install_extension(&bundle, ExtensionScope::Workspace, &workspace, false)
+            .expect("install yaml-lsp");
+
+        let extensions = discover_extensions(&workspace);
+        assert_eq!(extensions.len(), 1);
+
+        let mut catalog = CapabilityCatalog::new();
+        let host = Arc::new(
+            WorkspaceHost::new(
+                Arc::new(std::sync::RwLock::new(workspace.clone())),
+                workspace.clone(),
+            )
+            .expect("workspace host"),
+        );
+        catalog.register_arc(Arc::new(LspCapability::new(host)));
+
+        let caps = apply_extension_capability_contributions(
+            coding_harness_capabilities(false, None, &Settings::default()),
+            &extensions,
+            &catalog,
+        );
+        let lsp = caps
+            .iter()
+            .find(|c| c.capability_id() == LSP_CAPABILITY_ID)
+            .expect("yaml-lsp extension should auto-enable lsp");
+        assert_eq!(
+            lsp.config["servers"]["yaml"]["command"],
+            "yaml-language-server"
         );
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Yolop now supports **user-installable extensions** — declarative bundles that contribute capability-level config without recompiling the binary.

- Extensions are directories with an `extension.toml` manifest, installed under:
  - global: `<config_dir>/yolop/extensions/<id>/`
  - workspace: `<workspace>/.yolop/extensions/<id>/`
- At session build, contributions merge into the harness (capability config) and MCP server map.
- Extensions **auto-enable** opt-in capabilities they contribute to (e.g. installing `yaml-lsp` enables `lsp` without editing `settings.toml`).
- New CLI: `yolop ext list`, `yolop ext install <path>`, `yolop ext uninstall <id>` (with `--global` / `--force`).
- Example extension: `extensions/yaml-lsp/` contributes a YAML language server via the existing `lsp` capability.
- Spec: `specs/extensions.md`.

## Why

Capabilities like LSP, MCP, providers, and UI are compiled in today. Users can opt in via `settings.toml`, but adding a new language server or integration still requires a release. A manifest-based extension contract mirrors capability config and can grow to cover providers, MCP, UI, and everruns plugins.

## Before / After

**Before** — LSP servers only via `settings.toml` or built-ins:

```bash
$ yolop ext list
no extensions installed
```

**After** — install a declarative extension; it merges at runtime:

```bash
$ yolop ext install extensions/yaml-lsp
installed extension to /workspace/.yolop/extensions/yaml-lsp

$ yolop ext list
yaml-lsp  YAML Language Support v0.1.0  [workspace]  /workspace/.yolop/extensions/yaml-lsp
  Adds yaml-language-server for .yaml and .yml files via the lsp capability.
```

Installing `yaml-lsp` auto-enables the `lsp` capability with a `yaml` server entry (validated by `extension_contribution_auto_enables_lsp_with_yaml_server`).

## Risk

- **Medium** — new runtime merge path for harness and MCP config; malformed manifests are warned and skipped (same best-effort model as `.mcp.json`).
- Extensions are user-trusted install artifacts (like `settings.toml` edits); no sandbox in PoC.

## Security

- **TM-FS** — install copies files only into configured extension directories; no change to workspace write blocklist.
- **TM-TOOL** — contributions validated against registered capability schemas before merge; invalid entries skipped.
- **TM-BASH / TM-LLM** — no changes.
- **TM-DEP** — no new crates.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (extensions are additive; default harness unchanged without installed extensions)

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (606 unit + 33 integration tests)
- CLI smoke: `yolop ext list|install|uninstall`

## Follow-ups

- Provider and UI contribution wiring
- Extension-aware catalog / `get_config` listing
- Remote install (`yolop ext install <url>`)
- Extension marketplace and signing (out of PoC scope)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-daf517c0-9863-4c35-955b-7aef5768cfde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-daf517c0-9863-4c35-955b-7aef5768cfde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

