### PR TITLE
chore: guide agents to narrow after repo map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ repository, so keep it short, factual, and project-specific.
 
 - Telegraph. Drop filler. Keep updates short and factual.
 - Fix the root cause. If unsure, read more code; if still stuck, ask with short options.
+- When `repo_map` or `repo_symbols` reveals a likely owning module, narrow to that module next. Read it and one or two call sites/tests before doing more broad grep; resume broad search only if the owner is disproven.
 - Unrecognized working-tree changes are probably from another agent or the user. Work with them. Stop only if they make the task unsafe.
 - Start from latest `main` by default: `git fetch origin main`, then branch from or rebase onto `origin/main`.
 - Keep changes small, PR-sized, testable, and runnable locally.


### PR DESCRIPTION
## What changed
Added repository guidance telling agents to narrow to a likely owning module after `repo_map` or `repo_symbols` identifies one, then read that module plus nearby call sites/tests before doing more broad grep.

## Why
The analyzed session found the right ownership signal but kept broad-searching instead of capitalizing on it. This guidance should reduce repeated grep loops without making `repo_map` mandatory for simple or exact-search tasks.

## Before / After
Before: agents were told to prefer map/symbol tools for orientation, but not what to do immediately after a likely owner appeared.

After: agents are explicitly directed to narrow to the owner and only resume broad search if that owner is disproven.

Validation evidence:

```text
AGENTS.md contains exactly one repo_map narrowing guidance line
```

## Risk
- Low
- Docs/guidance-only change; risk is over-constraining agent exploration. The wording preserves fallback to broad search when the likely owner is disproven.

## Checklist
- [x] Tests added or updated — docs/guidance-only change, so no automated feature test is applicable; assertion verified the guidance is present exactly once.
- [x] Backward compatibility considered

## Security
No security-relevant code changes. This only updates repository agent guidance.

## Follow-ups
No follow-ups.

Generated with yolop
