### PR TITLE
docs(attribution): update PR footer text

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ configure the base URL, optional key, and model interactively via `/setup`.
 Enabled by default and configurable. When yolop creates commits, it keeps
 your git author/committer identity and appends
 `Co-Authored-By: yolop <yolop@everruns.com>` once. PR descriptions created or
-edited through `gh` get a `Generated with yolop` footer. Disable with
+edited through `gh` get a `Produced by [yolop](https://everruns.com/yolop)` footer. Disable with
 `/setup attribution off`.
 
 ### Soft approval

--- a/src/capabilities/attribution.rs
+++ b/src/capabilities/attribution.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 
 pub(crate) const ATTRIBUTION_CAPABILITY_ID: &str = "yolop_attribution";
 pub(crate) const YOLOP_ATTRIBUTION_TRAILER: &str = "Co-Authored-By: yolop <yolop@everruns.com>";
-pub(crate) const YOLOP_PR_ATTRIBUTION: &str = "Generated with yolop";
+pub(crate) const YOLOP_PR_ATTRIBUTION: &str = "Produced by [yolop](https://everruns.com/yolop)";
 
 /// Render the `## Attribution` system-prompt block. Pure so it is unit-testable
 /// without a `SystemPromptContext`.
@@ -88,6 +88,10 @@ mod tests {
             .await
             .expect("enabled attribution prompt");
         assert!(enabled.contains(YOLOP_ATTRIBUTION_TRAILER));
+        assert_eq!(
+            YOLOP_PR_ATTRIBUTION,
+            "Produced by [yolop](https://everruns.com/yolop)"
+        );
         assert!(enabled.contains(YOLOP_PR_ATTRIBUTION));
 
         settings


### PR DESCRIPTION
## Summary

- Update the default PR attribution footer to link to yolop's product page.
- Refresh README attribution docs to show the new footer text.
- Add a direct assertion that the PR footer constant matches the expected markdown text.

## Before / After

Before:

```markdown
Generated with yolop
```

After:

```markdown
Produced by [yolop](https://everruns.com/yolop)
```

## Validation

- `cargo fmt --check`
- `cargo test --all-features attribution`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- --provider llmsim -p "hi"`

## Security

No security-relevant code changes. This only changes a static prompt footer string, README text, and a direct unit assertion; no filesystem, shell, secrets, dependency, or capability-boundary behavior changed.

## Follow-ups

No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
