### PR TITLE
feat(background): steer external-event waits to detached watches

### DIFF
--- a/specs/background.md
+++ b/specs/background.md
@@ -38,6 +38,22 @@ The run executes on a detached task, streams to a session-file log
 lifecycle onto a `background_tool` session task (`Running` → `Succeeded` /
 `Failed` / `Canceled`). `signal_on_completion` defaults to `true`.
 
+### Steering (poll-proofing)
+
+Detaching a wait only saves tokens if the model actually chooses it, so the
+harness steers there at the three places poll loops start, on any repo:
+
+- The `background` capability's system prompt says waits on external events
+  (CI, reviews, deploys) must not consume turns: detach one blocking watch,
+  end the turn, let the completion wake continue — or `wait_task` it in
+  one-shot mode, where there is no wake.
+- `progress_guard` classifies external-event probes (`gh pr checks`,
+  `gh run …`, bare/leading `sleep`) as *waiting* and, on consecutive repeats,
+  injects a warning that names `spawn_background` as the fix.
+- The `bash` tool's 120s-timeout error points foreground watches at
+  `spawn_background` instead of leaving the model to fall back to
+  sleep-and-recheck turns.
+
 Sub-agents were intentionally **not** migrated: Everruns' `spawn_subagent` is
 foreground/blocking, and Yolop's former detached `background_agent` was dropped
 rather than reimplemented. If detached sub-agents return, they should be a

--- a/src/capabilities/background.rs
+++ b/src/capabilities/background.rs
@@ -14,7 +14,7 @@
 
 use crate::session_tasks_view::render_task_list;
 use async_trait::async_trait;
-use everruns_core::capabilities::{Capability, CapabilityStatus};
+use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
 use everruns_core::command::{
     CommandDescriptor, CommandExecutionContext, CommandResult, CommandSource, ExecuteCommandRequest,
 };
@@ -23,6 +23,21 @@ use everruns_core::typed_id::SessionId;
 use std::sync::Arc;
 
 pub(crate) const BACKGROUND_CAPABILITY_ID: &str = "background";
+
+// Prompt-side half of the poll-proofing seam (the runtime-enforced half is
+// `progress_guard`'s Waiting class): waiting on an external event must cost
+// zero turns, so steer the model to detach the wait and rely on the
+// completion wake instead of foreground watches or poll-sleep turns.
+const BACKGROUND_SYSTEM_PROMPT: &str = "<capability id=\"background\">\n\
+    Waiting on an external event — a CI run, a PR review window, a deploy, a long \
+    build — must not consume turns. Do not run watch commands in the foreground and \
+    do not poll status across turns. Start one blocking watch detached via \
+    `spawn_background` (e.g. `gh pr checks --watch`, `gh run watch --exit-status`, \
+    or `until <check>; do sleep 30; done`), say what you are waiting for, and end \
+    the turn: completion wakes you with the result. You can keep working on other \
+    steps while it runs. In one-shot (`-p`) runs there is no wake — block on the \
+    spawned task with `wait_task` instead of ending the turn.\n\
+    </capability>";
 
 pub(crate) struct BackgroundCapability {
     pub(crate) session_id: SessionId,
@@ -47,6 +62,17 @@ impl Capability for BackgroundCapability {
     }
     fn category(&self) -> Option<&str> {
         Some("Execution")
+    }
+
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        Some(BACKGROUND_SYSTEM_PROMPT.to_string())
+    }
+
+    fn system_prompt_preview(&self) -> Option<String> {
+        Some(
+            "<capability id=\"background\">\nDetach waits on external events via `spawn_background`; completion wakes the agent.\n</capability>"
+                .to_string(),
+        )
     }
 
     fn commands(&self) -> Vec<CommandDescriptor> {
@@ -80,5 +106,89 @@ impl Capability for BackgroundCapability {
             error_code: None,
             error_fields: None,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::session_task::{
+        CreateSessionTask, NewTaskMessage, SessionTask, SessionTaskFilter, SessionTaskUpdate,
+        TaskMessage,
+    };
+
+    /// The prompt contribution never touches the registry.
+    struct StubRegistry;
+
+    #[async_trait]
+    impl SessionTaskRegistry for StubRegistry {
+        async fn create(&self, _input: CreateSessionTask) -> everruns_core::Result<SessionTask> {
+            unimplemented!("stub")
+        }
+        async fn update(
+            &self,
+            _session_id: SessionId,
+            _task_id: &str,
+            _update: SessionTaskUpdate,
+        ) -> everruns_core::Result<Option<SessionTask>> {
+            unimplemented!("stub")
+        }
+        async fn get(
+            &self,
+            _session_id: SessionId,
+            _task_id: &str,
+        ) -> everruns_core::Result<Option<SessionTask>> {
+            unimplemented!("stub")
+        }
+        async fn list(
+            &self,
+            _session_id: SessionId,
+            _filter: Option<&SessionTaskFilter>,
+        ) -> everruns_core::Result<Vec<SessionTask>> {
+            Ok(Vec::new())
+        }
+        async fn request_cancel(
+            &self,
+            _session_id: SessionId,
+            _task_id: &str,
+        ) -> everruns_core::Result<Option<SessionTask>> {
+            unimplemented!("stub")
+        }
+        async fn record_message(
+            &self,
+            _session_id: SessionId,
+            _task_id: &str,
+            _message: NewTaskMessage,
+        ) -> everruns_core::Result<TaskMessage> {
+            unimplemented!("stub")
+        }
+        async fn list_messages(
+            &self,
+            _session_id: SessionId,
+            _task_id: &str,
+            _limit: Option<u32>,
+            _after_id: Option<&str>,
+        ) -> everruns_core::Result<Vec<TaskMessage>> {
+            unimplemented!("stub")
+        }
+    }
+
+    #[tokio::test]
+    async fn system_prompt_teaches_detached_waits_per_host() {
+        let capability = BackgroundCapability {
+            session_id: SessionId::new(),
+            task_registry: Arc::new(StubRegistry),
+        };
+        let ctx = SystemPromptContext::without_file_store(SessionId::new());
+
+        let prompt = capability
+            .system_prompt_contribution(&ctx)
+            .await
+            .expect("background capability contributes a prompt");
+        // Interactive hosts detach and get woken; one-shot runs must block
+        // instead because `-p` exits before any wake can be delivered.
+        assert!(prompt.contains("spawn_background"));
+        assert!(prompt.contains("end the turn"));
+        assert!(prompt.contains("wait_task"));
     }
 }

--- a/src/capabilities/progress_guard.rs
+++ b/src/capabilities/progress_guard.rs
@@ -19,6 +19,7 @@ const EXPLORATION_WITHOUT_PROGRESS_THRESHOLD: usize = 24;
 const CHECKPOINT_WITHOUT_PROGRESS_THRESHOLD: usize = 48;
 const REPEATED_EXPLORATION_THRESHOLD: usize = 5;
 const REPEATED_STATUS_THRESHOLD: usize = 3;
+const REPEATED_WAITING_THRESHOLD: usize = 3;
 
 pub(crate) struct ProgressGuardCapability {
     state: Arc<Mutex<ProgressGuardState>>,
@@ -99,6 +100,7 @@ struct SessionProgress {
     validation_count: usize,
     repeated_status_count: usize,
     last_status_command: Option<String>,
+    repeated_waiting_count: usize,
     repeated_exploration_count: usize,
     last_exploration_signature: Option<String>,
     warning_count: usize,
@@ -115,6 +117,7 @@ impl SessionProgress {
                 self.exploration_since_progress = 0;
                 self.repeated_status_count = 0;
                 self.last_status_command = None;
+                self.repeated_waiting_count = 0;
                 self.repeated_exploration_count = 0;
                 self.last_exploration_signature = None;
                 None
@@ -124,12 +127,27 @@ impl SessionProgress {
                 self.exploration_since_progress = 0;
                 self.repeated_status_count = 0;
                 self.last_status_command = None;
+                self.repeated_waiting_count = 0;
                 self.repeated_exploration_count = 0;
                 self.last_exploration_signature = None;
                 None
             }
+            ToolClass::Waiting => {
+                self.exploration_since_progress += 1;
+                self.repeated_waiting_count += 1;
+                if self.repeated_waiting_count >= REPEATED_WAITING_THRESHOLD {
+                    self.warning_count += 1;
+                    self.repeated_waiting_count = 0;
+                    return Some(
+                        "progress_guard: repeated checks of an external event (CI run, PR checks/reviews) without other progress. Do not poll across turns: run one blocking watch detached via spawn_background (e.g. `gh pr checks --watch` or an `until <check>; do sleep 30; done` loop) and end the turn — completion wakes the agent. In one-shot mode, block on the spawned task with wait_task instead."
+                            .to_string(),
+                    );
+                }
+                self.exploration_warning()
+            }
             ToolClass::Status(command) => {
                 self.exploration_since_progress += 1;
+                self.repeated_waiting_count = 0;
                 if self.last_status_command.as_deref() == Some(command.as_str()) {
                     self.repeated_status_count += 1;
                 } else {
@@ -148,12 +166,19 @@ impl SessionProgress {
             }
             ToolClass::Exploration => {
                 self.exploration_since_progress += 1;
+                self.repeated_waiting_count = 0;
                 if let Some(warning) = self.repetition_warning(tool_call) {
                     return Some(warning);
                 }
                 self.exploration_warning()
             }
-            ToolClass::Other => None,
+            ToolClass::Other => {
+                // The waiting counter is strictly consecutive (any other tool
+                // resets it) so legitimate one-off PR/CI checks between real
+                // work never accumulate into a false poll warning.
+                self.repeated_waiting_count = 0;
+                None
+            }
         }
     }
 
@@ -236,6 +261,10 @@ enum ToolClass {
     Mutation,
     Validation,
     Status(String),
+    /// Checking on an external event (CI run, PR checks/reviews) or plain
+    /// sleeping — the poll-loop shape that should instead be one detached
+    /// `spawn_background` watch.
+    Waiting,
     Other,
 }
 
@@ -261,6 +290,18 @@ fn classify_bash_command(command: &str) -> ToolClass {
     if normalized.is_empty() {
         return ToolClass::Other;
     }
+    // A leading `sleep N && …` is a poll delay: classify the probed command
+    // (`sleep 5 && cargo test` is still validation). A bare `sleep` is pure
+    // waiting.
+    if let Some(tail) = poll_delay_tail(&normalized) {
+        if tail.is_empty() {
+            return ToolClass::Waiting;
+        }
+        return classify_bash_command(tail);
+    }
+    if is_waiting_command(&normalized) {
+        return ToolClass::Waiting;
+    }
     if is_status_command(&normalized) {
         return ToolClass::Status(normalized);
     }
@@ -274,6 +315,22 @@ fn classify_bash_command(command: &str) -> ToolClass {
         return ToolClass::Exploration;
     }
     ToolClass::Other
+}
+
+/// For a command starting with `sleep`, everything after the first `&&`/`;`
+/// (empty when the sleep is the whole command). `None` when the command does
+/// not start with a sleep.
+fn poll_delay_tail(command: &str) -> Option<&str> {
+    let rest = command.strip_prefix("sleep")?;
+    if !rest.is_empty() && !rest.starts_with(' ') {
+        return None;
+    }
+    let tail = rest
+        .find("&&")
+        .map(|at| &rest[at + 2..])
+        .or_else(|| rest.find(';').map(|at| &rest[at + 1..]))
+        .unwrap_or("");
+    Some(tail.trim())
 }
 
 fn normalize_command(command: &str) -> String {
@@ -324,6 +381,19 @@ fn exploration_signature(tool_call: &ToolCall) -> Option<String> {
 
 fn normalize_value(value: &Value) -> String {
     serde_json::to_string(value).unwrap_or_else(|_| value.to_string())
+}
+
+fn is_waiting_command(command: &str) -> bool {
+    let prefixes = [
+        "gh pr checks",
+        "gh pr status",
+        "gh pr view",
+        "gh run list",
+        "gh run view",
+        "gh run watch",
+        "gh workflow view",
+    ];
+    prefixes.iter().any(|prefix| command.starts_with(prefix))
 }
 
 fn is_status_command(command: &str) -> bool {
@@ -455,6 +525,27 @@ mod tests {
             classify_bash_command("rg progress_guard"),
             ToolClass::Exploration
         );
+    }
+
+    #[test]
+    fn classify_bash_command_detects_external_event_waits() {
+        assert_eq!(classify_bash_command("gh pr checks 42"), ToolClass::Waiting);
+        assert_eq!(
+            classify_bash_command("gh run list --branch main --limit 5"),
+            ToolClass::Waiting
+        );
+        assert_eq!(classify_bash_command("sleep 120"), ToolClass::Waiting);
+        assert_eq!(
+            classify_bash_command("sleep 30 && gh pr checks 42"),
+            ToolClass::Waiting
+        );
+        // A sleep in front of real work classifies as the work itself.
+        assert_eq!(
+            classify_bash_command("sleep 5 && cargo test --all-features"),
+            ToolClass::Validation
+        );
+        // `sleepwalk` must not parse as a sleep prefix.
+        assert_eq!(classify_bash_command("sleepwalk"), ToolClass::Other);
     }
 
     #[tokio::test]
@@ -751,6 +842,74 @@ mod tests {
                 .any(|warning| warning.contains("same investigation target")),
             "semantic repetition should catch rereading the same range: {warnings:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn repeated_ci_polling_warns_toward_spawn_background() {
+        let state = Arc::new(Mutex::new(ProgressGuardState::default()));
+        let hook = ProgressGuardHook { state };
+        let context = ToolContext::new(SessionId::new());
+        let mut last = result();
+
+        // The classic poll loop: delay-then-check, over and over. Different
+        // probe commands still count — polling rarely repeats verbatim.
+        let polls = [
+            "gh pr checks 42",
+            "sleep 30 && gh pr checks 42",
+            "gh run list --limit 1",
+        ];
+        for command in polls {
+            last = result();
+            hook.after_exec(
+                &call("bash", json!({ "command": command })),
+                &tool_def("bash"),
+                &mut last,
+                &context,
+            )
+            .await;
+        }
+
+        assert!(
+            last.result
+                .as_ref()
+                .and_then(|value| value.get("progress_guard_warning"))
+                .and_then(Value::as_str)
+                .is_some_and(|warning| warning.contains("spawn_background"))
+        );
+    }
+
+    #[tokio::test]
+    async fn interleaved_work_resets_waiting_counter() {
+        let state = Arc::new(Mutex::new(ProgressGuardState::default()));
+        let hook = ProgressGuardHook { state };
+        let context = ToolContext::new(SessionId::new());
+
+        // Check CI, fix something, check again — legitimate, never a poll
+        // warning because the counter is strictly consecutive.
+        for _ in 0..(REPEATED_WAITING_THRESHOLD * 2) {
+            let mut check = result();
+            hook.after_exec(
+                &call("bash", json!({ "command": "gh pr checks 42" })),
+                &tool_def("bash"),
+                &mut check,
+                &context,
+            )
+            .await;
+            assert!(
+                check
+                    .result
+                    .as_ref()
+                    .and_then(|value| value.get("progress_guard_warning"))
+                    .is_none()
+            );
+            hook.after_exec(
+                &call("edit_file", json!({ "path": "/src/lib.rs" })),
+                &tool_def("edit_file"),
+                &mut result(),
+                &context,
+            )
+            .await;
+        }
     }
 
     #[tokio::test]

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -161,8 +161,14 @@ impl BashTool {
             match tokio::time::timeout(timeout, run).await {
                 Ok(r) => r,
                 Err(_) => {
+                    // The timeout is where poll loops are born: a foreground
+                    // watch dies here and the model falls back to
+                    // sleep-and-recheck turns. Name the escape hatch instead.
                     return Err(ToolExecutionResult::tool_error(format!(
-                        "command timed out after {}s",
+                        "command timed out after {}s. If it was waiting on an external \
+                         event (CI run, deploy, long build), re-run it detached via \
+                         spawn_background and end the turn — completion wakes the agent \
+                         (in one-shot mode, block on the task with wait_task instead).",
                         self.timeout_secs
                     )));
                 }
@@ -206,7 +212,9 @@ impl Tool for BashTool {
          directory, shell variables, and exports reset every time. A bare `cd` is \
          pointless — you are already at the workspace root; use paths relative to \
          it, or chain within one call (`cd sub && cmd`). Captures stdout/stderr \
-         with configurable verbosity. 120s timeout."
+         with configurable verbosity. 120s timeout; run commands that wait on \
+         external events (CI runs, deploys) detached via `spawn_background` \
+         instead."
     }
     fn parameters_schema(&self) -> Value {
         json!({


### PR DESCRIPTION
## What changed

Waiting on an external event (a CI run, a PR review window, a deploy, a long build) no longer degrades into token-burning poll-sleep turns. The harness now steers the model to the existing `spawn_background` + completion-wake path at the three places poll loops start, on any repo — no project skills required:

- The `background` capability contributes a system-prompt section: detach one blocking watch, end the turn, and let the completion wake continue — or block with `wait_task` in one-shot (`-p`) mode, where there is no wake.
- `progress_guard` gains a `Waiting` tool class for external-event probes (`gh pr checks/status/view`, `gh run list/view/watch`, `gh workflow view`, bare or leading `sleep`). Three consecutive waiting commands inject a warning naming `spawn_background` as the fix. The counter is strictly consecutive — any other tool resets it — so legitimate one-off CI checks between real work never warn. A leading `sleep N &&` is treated as a poll delay and the probed command is classified instead (`sleep 5 && cargo test` still counts as validation).
- The `bash` tool's 120s-timeout error — the exact moment a foreground watch dies and poll loops are born — now names `spawn_background` (or `wait_task` in one-shot mode) as the escape hatch, and the tool description mentions detaching waits.

`specs/background.md` documents the steering seam.

## Why

The whole detach-and-wake pipeline (spawn_background → session task → platform-store signal → proactive wake turn) already exists and is tested, and `specs/background.md` names "waiting for CI" as its canonical case — but nothing steered the model to it. In practice the model ran watches in the foreground, hit the 120s timeout with an unhelpful error, and fell back to sleep-and-recheck turns, each one re-reading the full conversation context. A detached watch costs zero tokens while waiting and exactly one wake turn on completion.

## Before / After

Before — the timeout error gave no way out, and polling was unchecked:

```
command timed out after 120s
```

After — the timeout points at the detached path:

```
command timed out after 120s. If it was waiting on an external event (CI run, deploy, long build), re-run it detached via spawn_background and end the turn — completion wakes the agent (in one-shot mode, block on the task with wait_task instead).
```

and a third consecutive external-event probe (e.g. `gh pr checks 42`, `sleep 30 && gh pr checks 42`, `gh run list --limit 1`) gets a `progress_guard_warning` injected into the tool result:

```
progress_guard: repeated checks of an external event (CI run, PR checks/reviews) without other progress. Do not poll across turns: run one blocking watch detached via spawn_background (e.g. `gh pr checks --watch` or an `until <check>; do sleep 30; done` loop) and end the turn — completion wakes the agent. In one-shot mode, block on the spawned task with wait_task instead.
```

Proof: new tests drive the guard hook through `after_exec` with the poll-loop shape (warning fires, names `spawn_background`), the interleaved check-fix-check shape (never warns), the classifier variants (including the `sleepwalk` boundary and `sleep && <work>` passthrough), and the prompt contribution through `system_prompt_contribution` on the capability. Full suite passes on the branch rebased onto latest `main`; `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean; offline smoke `cargo run -- --provider llmsim -p "hi"` runs.

## Risk

- Low
- What can break: over-eager guard warnings on legitimate `gh`/`sleep` usage (mitigated by the strictly-consecutive counter and threshold of 3); prompt-text growth in the system prompt (one short static section). Classification changes affect only advisory warnings, never execution.

## Security

- **TM-BASH**: `tools.rs` changes are message/description text only — the 120s timeout, 1 MiB output caps, and bounded execution model are unchanged.
- **TM-LLM**: prompt construction adds one static const; no key handling, logging, or session-file changes.
- **TM-TOOL / TM-FS**: no new capabilities or filesystem access; the write blocklist is untouched.
- **TM-DEP**: no dependency changes.
- Injection/exhaustion: the classifier only inspects already-normalized command strings for advisory classification (no execution); `classify_bash_command` recursion on chained `sleep` prefixes strictly shrinks its input, so it is bounded.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0, no compat requirement; changes are additive prompts/warnings)

## Follow-ups

- Replay background completions that finish while yolop is down as a wake on session resume (today they are only observed on the next `/background`/`get_task`) — makes detached CI waits trustworthy across restarts.
- Consider a bundled `pr-shepherd` system skill so clean repos get a full open-PR → detached-watch → wake → fix/merge playbook, not just steering.
- Upstream (everruns): a detached, small-context subagent variant of `spawn_subagent` for handing off PR babysitting entirely.