### PR TITLE
feat(mcp): manage authenticated servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,24 @@ merged (workspace overrides global by name):
 - Discovered tools are exposed to the model as `mcp_<server>__<tool>`;
   `/mcp` lists the configured servers.
 
+Linear works as a global HTTP MCP server. Put this in the global `mcp.json`,
+start yolop with `LINEAR_API_KEY` set, and keep any repo-specific Linear
+server in `.mcp.json` if that repo needs to override it:
+
+```json
+{
+  "mcpServers": {
+    "linear": {
+      "type": "http",
+      "url": "https://mcp.linear.app/sse",
+      "headers": {
+        "Authorization": "Bearer ${LINEAR_API_KEY}"
+      }
+    }
+  }
+}
+```
+
 Trust model: HTTP requests keep yolop's DNS-pinned SSRF protection; stdio
 servers run local processes you listed yourself, so authoring `.mcp.json` is
 the act of consent. MCP tools run autonomously like the rest of yolop's

--- a/src/capabilities/config.rs
+++ b/src/capabilities/config.rs
@@ -565,6 +565,10 @@ impl SetConfigTool {
             KeyTarget::Capabilities | KeyTarget::CapabilityRef(_) => {
                 Err("capabilities are configured via set_config with key=capabilities".to_string())
             }
+            KeyTarget::Mcp => Err(
+                "mcp servers are configured in settings.toml under [mcp.servers.<name>]"
+                    .to_string(),
+            ),
         }
     }
 }

--- a/src/capabilities/mcp.rs
+++ b/src/capabilities/mcp.rs
@@ -1,0 +1,292 @@
+use crate::capabilities::narration::stable_labeled;
+use crate::mcp_config::{McpConfigScope, McpConfigStore, McpServerEntry};
+use async_trait::async_trait;
+use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
+use everruns_core::tool_narration::ToolNarrationPhase;
+use everruns_core::tool_types::ToolCall;
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use serde_json::{Value, json};
+use std::sync::Arc;
+
+pub(crate) const MCP_CAPABILITY_ID: &str = "mcp";
+
+pub(crate) struct McpCapability {
+    pub(crate) store: Arc<McpConfigStore>,
+}
+
+#[async_trait]
+impl Capability for McpCapability {
+    fn id(&self) -> &str {
+        MCP_CAPABILITY_ID
+    }
+    fn name(&self) -> &str {
+        "MCP"
+    }
+    fn description(&self) -> &str {
+        "Manage global and workspace Model Context Protocol server configuration."
+    }
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+    fn category(&self) -> Option<&str> {
+        Some("Extensibility")
+    }
+
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        Some(
+            "<capability id=\"mcp\">\n\
+              Manage global and workspace MCP servers with `list_mcp_servers`, \
+              `upsert_mcp_server`, `remove_mcp_server`, and `set_mcp_server_enabled`. \
+              Global servers live in settings.toml under `[mcp.servers.<name>]`; workspace \
+              servers live in `.mcp.json` and override global servers by name. Server changes \
+              are picked up by new sessions; use `enabled=false` to deactivate without deleting.\n\
+              </capability>"
+                .to_string(),
+        )
+    }
+
+    fn system_prompt_preview(&self) -> Option<String> {
+        Some("<capability id=\"mcp\">Manage global/workspace MCP servers with list/upsert/remove/enable tools.</capability>".to_string())
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(ListMcpServersTool {
+                store: self.store.clone(),
+            }),
+            Box::new(UpsertMcpServerTool {
+                store: self.store.clone(),
+            }),
+            Box::new(RemoveMcpServerTool {
+                store: self.store.clone(),
+            }),
+            Box::new(SetMcpServerEnabledTool {
+                store: self.store.clone(),
+            }),
+        ]
+    }
+}
+
+struct ListMcpServersTool {
+    store: Arc<McpConfigStore>,
+}
+
+#[async_trait]
+impl Tool for ListMcpServersTool {
+    fn narrate(
+        &self,
+        _tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        _locale: Option<&str>,
+    ) -> Option<String> {
+        Some(stable_labeled("List MCP servers", None, phase))
+    }
+    fn name(&self) -> &str {
+        "list_mcp_servers"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("List MCP servers")
+    }
+    fn description(&self) -> &str {
+        "List global and workspace MCP server configuration, including enabled state and override source."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({ "type": "object", "properties": {}, "additionalProperties": false })
+    }
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        match self.store.effective() {
+            Ok(effective) => ToolExecutionResult::success(json!({
+                "ok": true,
+                "global_path": effective.global_path,
+                "workspace_path": effective.workspace_path,
+                "servers": effective.servers,
+            })),
+            Err(err) => ToolExecutionResult::tool_error(err),
+        }
+    }
+}
+
+struct UpsertMcpServerTool {
+    store: Arc<McpConfigStore>,
+}
+
+#[async_trait]
+impl Tool for UpsertMcpServerTool {
+    fn narrate(
+        &self,
+        _tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        _locale: Option<&str>,
+    ) -> Option<String> {
+        Some(stable_labeled("Upsert MCP server", None, phase))
+    }
+    fn name(&self) -> &str {
+        "upsert_mcp_server"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Upsert MCP server")
+    }
+    fn description(&self) -> &str {
+        "Create or replace one global or workspace MCP server. Changes apply to new sessions."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "scope": { "type": "string", "enum": ["global", "workspace"], "default": "global" },
+                "name": { "type": "string", "minLength": 1 },
+                "server": {
+                    "type": "object",
+                    "description": "MCP server config. Supports remote HTTP servers and OAuth-capable metadata such as auth_mode='oauth', oauth_provider_id, headers, and enabled=false.",
+                    "additionalProperties": true
+                }
+            },
+            "required": ["name", "server"],
+            "additionalProperties": false
+        })
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let scope = parse_scope(arguments.get("scope"));
+        let name = match arguments
+            .get("name")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            Some(name) => name.to_string(),
+            None => return ToolExecutionResult::tool_error("name is required"),
+        };
+        let server_value = match arguments.get("server") {
+            Some(value) => value.clone(),
+            None => return ToolExecutionResult::tool_error("server is required"),
+        };
+        let entry: McpServerEntry = match serde_json::from_value(server_value) {
+            Ok(entry) => entry,
+            Err(err) => {
+                return ToolExecutionResult::tool_error(format!(
+                    "invalid MCP server config: {err}"
+                ));
+            }
+        };
+        match self.store.upsert(scope, &name, entry) {
+            Ok(summary) => ToolExecutionResult::success(json!({ "ok": true, "server": summary })),
+            Err(err) => ToolExecutionResult::tool_error(err),
+        }
+    }
+}
+
+struct RemoveMcpServerTool {
+    store: Arc<McpConfigStore>,
+}
+
+#[async_trait]
+impl Tool for RemoveMcpServerTool {
+    fn narrate(
+        &self,
+        _tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        _locale: Option<&str>,
+    ) -> Option<String> {
+        Some(stable_labeled("Remove MCP server", None, phase))
+    }
+    fn name(&self) -> &str {
+        "remove_mcp_server"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Remove MCP server")
+    }
+    fn description(&self) -> &str {
+        "Remove one MCP server from global settings or workspace .mcp.json."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "scope": { "type": "string", "enum": ["global", "workspace"], "default": "global" },
+                "name": { "type": "string", "minLength": 1 }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+        })
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let scope = parse_scope(arguments.get("scope"));
+        let name = match arguments
+            .get("name")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            Some(name) => name,
+            None => return ToolExecutionResult::tool_error("name is required"),
+        };
+        match self.store.remove(scope, name) {
+            Ok(removed) => ToolExecutionResult::success(json!({ "ok": true, "removed": removed })),
+            Err(err) => ToolExecutionResult::tool_error(err),
+        }
+    }
+}
+
+struct SetMcpServerEnabledTool {
+    store: Arc<McpConfigStore>,
+}
+
+#[async_trait]
+impl Tool for SetMcpServerEnabledTool {
+    fn narrate(
+        &self,
+        _tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        _locale: Option<&str>,
+    ) -> Option<String> {
+        Some(stable_labeled("Set MCP server enabled", None, phase))
+    }
+    fn name(&self) -> &str {
+        "set_mcp_server_enabled"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Set MCP server enabled")
+    }
+    fn description(&self) -> &str {
+        "Enable or disable one MCP server without deleting it. Changes apply to new sessions."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "scope": { "type": "string", "enum": ["global", "workspace"], "default": "global" },
+                "name": { "type": "string", "minLength": 1 },
+                "enabled": { "type": "boolean" }
+            },
+            "required": ["name", "enabled"],
+            "additionalProperties": false
+        })
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let scope = parse_scope(arguments.get("scope"));
+        let name = match arguments
+            .get("name")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            Some(name) => name,
+            None => return ToolExecutionResult::tool_error("name is required"),
+        };
+        let enabled = match arguments.get("enabled").and_then(Value::as_bool) {
+            Some(enabled) => enabled,
+            None => return ToolExecutionResult::tool_error("enabled is required"),
+        };
+        match self.store.set_enabled(scope, name, enabled) {
+            Ok(summary) => ToolExecutionResult::success(json!({ "ok": true, "server": summary })),
+            Err(err) => ToolExecutionResult::tool_error(err),
+        }
+    }
+}
+
+fn parse_scope(value: Option<&Value>) -> McpConfigScope {
+    match value.and_then(Value::as_str) {
+        Some("workspace") | Some("local") => McpConfigScope::Workspace,
+        _ => McpConfigScope::Global,
+    }
+}

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod goal;
 pub(crate) mod hooks;
 mod host;
 pub(crate) mod lsp;
+pub(crate) mod mcp;
 pub(crate) mod memory;
 pub(crate) mod model_discovery;
 pub(crate) mod model_ranking;

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -206,6 +206,21 @@ pub fn schema() -> &'static [ConfigField] {
             ],
             provider_scoped: true,
         },
+        ConfigField {
+            key: "mcp",
+            aliases: &["mcp_servers"],
+            title: "Global MCP servers",
+            description: "Global Model Context Protocol servers loaded from settings.toml under \
+                          `[mcp.servers.<name>]`. Workspace `.mcp.json` entries override global \
+                          servers by name. Use `${ENV_VAR}` placeholders for secrets.",
+            kind: ValueKind::List,
+            default: Some("{}"),
+            examples: &[
+                "get_config key=mcp",
+                "[mcp.servers.linear] type = 'http' url = 'https://mcp.linear.app/sse'",
+            ],
+            provider_scoped: false,
+        },
     ];
     FIELDS
 }
@@ -228,6 +243,8 @@ pub enum KeyTarget {
     BaseUrl(String),
     /// The ordered `[[capabilities]]` override list.
     Capabilities,
+    /// Global MCP server table.
+    Mcp,
     /// Catalog metadata for one harness capability ref (`capabilities.<ref>`).
     CapabilityRef(String),
 }
@@ -246,6 +263,7 @@ impl KeyTarget {
             KeyTarget::Token(_) => "tokens",
             KeyTarget::BaseUrl(_) => "base_urls",
             KeyTarget::Capabilities | KeyTarget::CapabilityRef(_) => "capabilities",
+            KeyTarget::Mcp => "mcp",
         };
         schema()
             .iter()
@@ -297,6 +315,7 @@ pub fn parse_key(input: &str) -> Result<KeyTarget, String> {
         "models" | "model_for" => scoped(KeyTarget::Model),
         "tokens" | "token" => scoped(KeyTarget::Token),
         "base_urls" | "base_url" | "url" => scoped(KeyTarget::BaseUrl),
+        "mcp" | "mcp_servers" => scalar(KeyTarget::Mcp),
         "capabilities" | "capability" => {
             if let Some(cap_ref) = sub.filter(|s| !s.is_empty()) {
                 Ok(KeyTarget::CapabilityRef(cap_ref.to_string()))

--- a/src/config_service.rs
+++ b/src/config_service.rs
@@ -17,6 +17,7 @@ use crate::config_schema::{KeyTarget, parse_key};
 use crate::runtime::SUPPORTED_PROVIDERS;
 use crate::settings::{ApprovalMode, Settings, SettingsStore};
 use serde_json::Value;
+use toml::Value as TomlValue;
 
 /// Read-only view of yolop configuration, injectable into capabilities.
 ///
@@ -91,6 +92,10 @@ pub(crate) fn current_value(settings: &Settings, target: &KeyTarget) -> Value {
         KeyTarget::Capabilities => {
             crate::capability_settings::overrides_to_json(&settings.capabilities)
         }
+        KeyTarget::Mcp => TomlValue::try_from(&settings.mcp)
+            .ok()
+            .and_then(|value| serde_json::to_value(value).ok())
+            .unwrap_or_else(|| Value::Object(serde_json::Map::new())),
         KeyTarget::CapabilityRef(cap_ref) => {
             let stored: Vec<Value> = settings
                 .capability_overrides_for(cap_ref)

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -1,342 +1,442 @@
-//! Load MCP servers from `.mcp.json` (workspace + global, merged).
-//!
-//! The file shape matches the `mcpServers` object every MCP client
-//! understands, so a project's `.mcp.json` works across tools:
-//!
-//! ```json
-//! {
-//!   "mcpServers": {
-//!     "docs": { "type": "http", "url": "https://example.com/mcp",
-//!               "headers": { "Authorization": "Bearer ${DOCS_TOKEN}" } },
-//!     "fs":   { "type": "stdio", "command": "mcp-server-filesystem",
-//!               "args": ["${WORKSPACE}"] }
-//!   }
-//! }
-//! ```
-//!
-//! Two scopes are read and merged (global first, workspace second, so a
-//! project can override a global server of the same name):
-//!
-//! - **global**: `<config_dir>/yolop/mcp.json` (e.g. `~/.config/yolop/mcp.json`)
-//! - **workspace**: `<workspace_root>/.mcp.json`
-//!
-//! Each scope is best-effort: a missing file contributes nothing, and a
-//! malformed file is warned about and skipped so it cannot mask the other
-//! scope. String values support `${VAR}` environment expansion (matching how
-//! every other MCP client lets you keep secrets out of the file). Both remote
-//! HTTP and local stdio servers are supported; stdio requires the runtime's
-//! `mcp-stdio` feature, which yolop enables.
-
-use std::collections::HashMap;
+use crate::settings::{SettingsStore, default_settings_path};
+use everruns_core::{ScopedMcpServer, ScopedMcpServers};
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value as JsonValue;
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
-use everruns_core::{ScopedMcpServer, ScopedMcpServers, merge_scoped_mcp_servers};
-use serde::Deserialize;
+const MCP_CONFIG_FILE: &str = "mcp.json";
+const WORKSPACE_MCP_CONFIG_FILE: &str = ".mcp.json";
 
-/// File name read from the workspace root.
-pub const MCP_CONFIG_FILE: &str = ".mcp.json";
-
-#[derive(Debug, Deserialize)]
-struct McpConfigFile {
-    #[serde(default, rename = "mcpServers")]
-    mcp_servers: ScopedMcpServers,
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum McpConfigScope {
+    Global,
+    Workspace,
 }
 
-/// Path to the global MCP config (`<config_dir>/yolop/mcp.json`), if a config
-/// directory can be resolved on this platform.
-pub fn global_mcp_config_path() -> Option<PathBuf> {
-    dirs::config_dir().map(|p| p.join("yolop").join("mcp.json"))
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct EffectiveMcpConfig {
+    pub(crate) global_path: PathBuf,
+    pub(crate) workspace_path: PathBuf,
+    pub(crate) servers: Vec<McpServerSummary>,
 }
 
-/// Load the effective scoped MCP servers for a workspace: the global config
-/// overlaid by the workspace `.mcp.json`, with `${VAR}` placeholders expanded
-/// from the environment. Each scope is best-effort (a malformed or unreadable
-/// file is warned about and skipped), so one bad file never masks the other.
-pub fn load_mcp_servers(workspace_root: &Path) -> ScopedMcpServers {
-    load_merged(global_mcp_config_path().as_deref(), workspace_root)
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct McpServerSummary {
+    pub(crate) name: String,
+    pub(crate) scope: McpConfigScope,
+    pub(crate) enabled: bool,
+    pub(crate) effective: bool,
+    pub(crate) overrides_global: bool,
+    #[serde(flatten)]
+    pub(crate) server: McpServerEntry,
 }
 
-/// Merge an explicit global path (or none) with the workspace `.mcp.json`.
-/// Split out from [`load_mcp_servers`] so tests can pin both scopes and stay
-/// independent of the host's real `<config_dir>/yolop/mcp.json`.
-fn load_merged(global_path: Option<&Path>, workspace_root: &Path) -> ScopedMcpServers {
-    let global = global_path.map(read_scope).unwrap_or_default();
-    let workspace = read_scope(&workspace_root.join(MCP_CONFIG_FILE));
-    let mut merged = merge_scoped_mcp_servers(&global, &workspace);
-    for server in merged.values_mut() {
-        expand_server_env(server);
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct McpServerEntry {
+    #[serde(default = "default_enabled")]
+    pub(crate) enabled: bool,
+    #[serde(flatten)]
+    pub(crate) server: ScopedMcpServer,
+}
+
+impl<'de> Deserialize<'de> for McpServerEntry {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = normalize_server_entry_value(JsonValue::deserialize(deserializer)?);
+        #[derive(Deserialize)]
+        struct Entry {
+            #[serde(default = "default_enabled")]
+            enabled: bool,
+            #[serde(flatten)]
+            server: ScopedMcpServer,
+        }
+        let entry = Entry::deserialize(value).map_err(serde::de::Error::custom)?;
+        Ok(Self {
+            enabled: entry.enabled,
+            server: entry.server,
+        })
     }
-    merged
 }
 
-/// Read one scope, downgrading any read/parse failure to a warning + no
-/// servers so a malformed file in one scope cannot sink the other.
-fn read_scope(path: &Path) -> ScopedMcpServers {
-    match read_config(path) {
-        Ok(servers) => servers,
-        Err(error) => {
-            tracing::warn!(path = %path.display(), %error, "ignoring malformed MCP config");
-            ScopedMcpServers::default()
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub(crate) struct McpSettings {
+    #[serde(default)]
+    pub(crate) servers: BTreeMap<String, McpServerEntry>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+struct WorkspaceMcpSettings {
+    #[serde(default)]
+    #[serde(alias = "mcp_servers")]
+    #[serde(alias = "mcpServers")]
+    servers: BTreeMap<String, McpServerEntry>,
+}
+
+pub(crate) struct McpConfigStore {
+    settings_path: PathBuf,
+    workspace_mcp_path: PathBuf,
+}
+
+impl McpConfigStore {
+    pub(crate) fn new(settings_path: PathBuf, workspace_root: PathBuf) -> Self {
+        Self {
+            settings_path,
+            workspace_mcp_path: workspace_root.join(WORKSPACE_MCP_CONFIG_FILE),
         }
     }
-}
 
-/// Read one `.mcp.json`-shaped file. Absent file → no servers; malformed file
-/// → error (callers decide whether to skip it).
-fn read_config(path: &Path) -> Result<ScopedMcpServers> {
-    let raw = match std::fs::read_to_string(path) {
-        Ok(raw) => raw,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return Ok(ScopedMcpServers::default());
+    pub(crate) fn default_for_workspace(workspace_root: &Path) -> Self {
+        Self::new(
+            default_settings_path().unwrap_or_else(|| PathBuf::from("settings.toml")),
+            workspace_root.to_path_buf(),
+        )
+    }
+
+    pub(crate) fn effective(&self) -> Result<EffectiveMcpConfig, String> {
+        let global = SettingsStore::open(self.settings_path.clone())
+            .snapshot()
+            .mcp;
+        let workspace = load_workspace_mcp_settings(&self.workspace_mcp_path)?;
+        let mut summaries = Vec::new();
+        for (name, entry) in &global.servers {
+            summaries.push(McpServerSummary {
+                name: name.clone(),
+                scope: McpConfigScope::Global,
+                enabled: entry.enabled,
+                effective: entry.enabled && !workspace.servers.contains_key(name),
+                overrides_global: false,
+                server: entry.clone(),
+            });
         }
-        Err(error) => return Err(error).with_context(|| format!("reading {}", path.display())),
-    };
-    let config: McpConfigFile =
-        serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))?;
-    Ok(config.mcp_servers)
-}
-
-/// Expand `${VAR}` references in every string field of a scoped server, so
-/// secrets and paths can come from the environment instead of the file.
-fn expand_server_env(server: &mut ScopedMcpServer) {
-    server.url = expand_env(&server.url);
-    server.command = server.command.as_deref().map(expand_env);
-    for arg in &mut server.args {
-        *arg = expand_env(arg);
+        for (name, entry) in &workspace.servers {
+            summaries.push(McpServerSummary {
+                name: name.clone(),
+                scope: McpConfigScope::Workspace,
+                enabled: entry.enabled,
+                effective: entry.enabled,
+                overrides_global: global.servers.contains_key(name),
+                server: entry.clone(),
+            });
+        }
+        Ok(EffectiveMcpConfig {
+            global_path: self.settings_path.clone(),
+            workspace_path: self.workspace_mcp_path.clone(),
+            servers: summaries,
+        })
     }
-    replace_values(&mut server.headers);
-    replace_values(&mut server.env);
-}
 
-fn replace_values(map: &mut HashMap<String, String>) {
-    for value in map.values_mut() {
-        *value = expand_env(value);
+    pub(crate) fn upsert(
+        &self,
+        scope: McpConfigScope,
+        name: &str,
+        entry: McpServerEntry,
+    ) -> Result<McpServerSummary, String> {
+        validate_name(name)?;
+        match scope {
+            McpConfigScope::Global => {
+                let store = SettingsStore::open(self.settings_path.clone());
+                let mut settings = store.snapshot();
+                settings.mcp.servers.insert(name.to_string(), entry);
+                store
+                    .replace_mcp(settings.mcp)
+                    .map_err(|err| err.to_string())?;
+            }
+            McpConfigScope::Workspace => {
+                let mut settings = load_workspace_mcp_settings(&self.workspace_mcp_path)?;
+                settings.servers.insert(name.to_string(), entry);
+                save_workspace_mcp_settings(&self.workspace_mcp_path, &settings)?;
+            }
+        }
+        self.summary(scope, name)
     }
-}
 
-/// Replace `${VAR}` occurrences with the value of `VAR` from the environment.
-/// Unset variables are left untouched (so a stray placeholder is visible in
-/// `/mcp` output and discovery errors rather than silently blanked).
-fn expand_env(input: &str) -> String {
-    let mut out = String::with_capacity(input.len());
-    let mut rest = input;
-    while let Some(start) = rest.find("${") {
-        out.push_str(&rest[..start]);
-        let after = &rest[start + 2..];
-        match after.find('}') {
-            Some(end) => {
-                let name = &after[..end];
-                match std::env::var(name) {
-                    Ok(value) => out.push_str(&value),
-                    Err(_) => {
-                        // Leave the original `${VAR}` so the gap is debuggable.
-                        out.push_str(&rest[start..start + 2 + end + 1]);
-                    }
+    pub(crate) fn remove(&self, scope: McpConfigScope, name: &str) -> Result<bool, String> {
+        validate_name(name)?;
+        match scope {
+            McpConfigScope::Global => {
+                let store = SettingsStore::open(self.settings_path.clone());
+                let mut settings = store.snapshot();
+                let removed = settings.mcp.servers.remove(name).is_some();
+                if removed {
+                    store
+                        .replace_mcp(settings.mcp)
+                        .map_err(|err| err.to_string())?;
                 }
-                rest = &after[end + 1..];
+                Ok(removed)
             }
-            None => {
-                // No closing brace: emit the rest verbatim.
-                out.push_str(&rest[start..]);
-                rest = "";
+            McpConfigScope::Workspace => {
+                let mut settings = load_workspace_mcp_settings(&self.workspace_mcp_path)?;
+                let removed = settings.servers.remove(name).is_some();
+                if removed {
+                    save_workspace_mcp_settings(&self.workspace_mcp_path, &settings)?;
+                }
+                Ok(removed)
             }
         }
     }
-    out.push_str(rest);
-    out
+
+    pub(crate) fn set_enabled(
+        &self,
+        scope: McpConfigScope,
+        name: &str,
+        enabled: bool,
+    ) -> Result<McpServerSummary, String> {
+        validate_name(name)?;
+        match scope {
+            McpConfigScope::Global => {
+                let store = SettingsStore::open(self.settings_path.clone());
+                let mut settings = store.snapshot();
+                let entry =
+                    settings.mcp.servers.get_mut(name).ok_or_else(|| {
+                        format!("MCP server '{name}' not found in global settings")
+                    })?;
+                entry.enabled = enabled;
+                store
+                    .replace_mcp(settings.mcp)
+                    .map_err(|err| err.to_string())?;
+            }
+            McpConfigScope::Workspace => {
+                let mut settings = load_workspace_mcp_settings(&self.workspace_mcp_path)?;
+                let entry = settings.servers.get_mut(name).ok_or_else(|| {
+                    format!("MCP server '{name}' not found in workspace settings")
+                })?;
+                entry.enabled = enabled;
+                save_workspace_mcp_settings(&self.workspace_mcp_path, &settings)?;
+            }
+        }
+        self.summary(scope, name)
+    }
+
+    fn summary(&self, scope: McpConfigScope, name: &str) -> Result<McpServerSummary, String> {
+        self.effective()?
+            .servers
+            .into_iter()
+            .find(|summary| summary.scope == scope && summary.name == name)
+            .ok_or_else(|| format!("MCP server '{name}' not found"))
+    }
+}
+
+pub(crate) fn global_mcp_config_path() -> Option<PathBuf> {
+    default_settings_path().map(|path| path.with_file_name(MCP_CONFIG_FILE))
+}
+
+pub(crate) fn load_mcp_servers(workspace_root: &Path) -> ScopedMcpServers {
+    let mut servers = default_settings_path()
+        .map(|path| enabled_servers(SettingsStore::open(path).snapshot().mcp))
+        .unwrap_or_default();
+
+    for (name, server) in load_global_mcp_legacy().into_iter() {
+        servers.entry(name).or_insert(server);
+    }
+
+    if let Ok(workspace) =
+        load_workspace_mcp_settings(&workspace_root.join(WORKSPACE_MCP_CONFIG_FILE))
+    {
+        for (name, entry) in workspace.servers {
+            if entry.enabled {
+                servers.insert(name, entry.server);
+            } else {
+                servers.remove(&name);
+            }
+        }
+    }
+
+    servers.into_iter().collect()
+}
+
+fn enabled_servers(settings: McpSettings) -> BTreeMap<String, ScopedMcpServer> {
+    settings
+        .servers
+        .into_iter()
+        .filter_map(|(name, entry)| entry.enabled.then_some((name, entry.server)))
+        .collect()
+}
+
+fn load_global_mcp_legacy() -> BTreeMap<String, ScopedMcpServer> {
+    let Some(path) = default_settings_path().map(|path| path.with_file_name(MCP_CONFIG_FILE))
+    else {
+        return BTreeMap::new();
+    };
+    let Ok(bytes) = std::fs::read(&path) else {
+        return BTreeMap::new();
+    };
+    let Ok(scoped) = serde_json::from_slice::<ScopedMcpServers>(&bytes) else {
+        return BTreeMap::new();
+    };
+    scoped.into_iter().collect()
+}
+
+fn load_workspace_mcp_settings(path: &Path) -> Result<WorkspaceMcpSettings, String> {
+    let bytes = match std::fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Default::default()),
+        Err(err) => return Err(format!("read {}: {err}", path.display())),
+    };
+    if bytes.iter().all(u8::is_ascii_whitespace) {
+        return Ok(Default::default());
+    }
+    let value: JsonValue =
+        serde_json::from_slice(&bytes).map_err(|err| format!("parse {}: {err}", path.display()))?;
+    if value.get("servers").is_some()
+        || value.get("mcp_servers").is_some()
+        || value.get("mcpServers").is_some()
+    {
+        serde_json::from_value(value).map_err(|err| format!("parse {}: {err}", path.display()))
+    } else {
+        let scoped: BTreeMap<String, McpServerEntry> = serde_json::from_value(value)
+            .map_err(|err| format!("parse {}: {err}", path.display()))?;
+        Ok(WorkspaceMcpSettings { servers: scoped })
+    }
+}
+
+fn save_workspace_mcp_settings(path: &Path, settings: &WorkspaceMcpSettings) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|err| format!("create {}: {err}", parent.display()))?;
+    }
+    let bytes = serde_json::to_vec_pretty(settings).map_err(|err| err.to_string())?;
+    std::fs::write(path, bytes).map_err(|err| format!("write {}: {err}", path.display()))
+}
+
+fn normalize_server_entry_value(mut value: JsonValue) -> JsonValue {
+    if let JsonValue::Object(object) = &mut value {
+        if let Some(transport_type) = object.remove("transport_type") {
+            object.entry("type".to_string()).or_insert(transport_type);
+        }
+        if object.get("auth_mode").and_then(JsonValue::as_str) == Some("oauth") {
+            object.insert(
+                "auth_mode".to_string(),
+                JsonValue::String("o_auth".to_string()),
+            );
+        }
+    }
+    value
+}
+
+fn validate_name(name: &str) -> Result<(), String> {
+    if name.trim().is_empty() {
+        return Err("MCP server name must not be empty".to_string());
+    }
+    if name.contains('/') || name.contains('\\') {
+        return Err("MCP server name must not contain path separators".to_string());
+    }
+    Ok(())
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+impl From<ScopedMcpServers> for McpSettings {
+    fn from(scoped: ScopedMcpServers) -> Self {
+        Self {
+            servers: scoped
+                .into_iter()
+                .map(|(name, server)| {
+                    (
+                        name,
+                        McpServerEntry {
+                            enabled: true,
+                            server,
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+}
+
+impl From<McpSettings> for ScopedMcpServers {
+    fn from(settings: McpSettings) -> Self {
+        enabled_servers(settings).into_iter().collect()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use everruns_core::McpServerTransportType;
-
-    fn write(dir: &Path, contents: &str) {
-        std::fs::write(dir.join(MCP_CONFIG_FILE), contents).unwrap();
-    }
-
-    /// Workspace-only load with no global scope — deterministic regardless of
-    /// the host's real `<config_dir>/yolop/mcp.json`.
-    fn load_workspace(dir: &Path) -> ScopedMcpServers {
-        load_merged(None, dir)
-    }
+    use everruns_core::McpServerAuthMode;
+    use tempfile::TempDir;
 
     #[test]
-    fn missing_file_yields_no_servers() {
-        let dir = tempfile::tempdir().unwrap();
-        assert!(load_workspace(dir.path()).is_empty());
-    }
+    fn store_manages_global_and_workspace_mcp_servers() {
+        let dir = TempDir::new().expect("tempdir");
+        let settings_path = dir.path().join("settings.toml");
+        let workspace = dir.path().join("workspace");
+        let store = McpConfigStore::new(settings_path.clone(), workspace.clone());
 
-    #[test]
-    fn parses_http_server_with_headers() {
-        let dir = tempfile::tempdir().unwrap();
-        write(
-            dir.path(),
-            r#"{ "mcpServers": {
-                "docs": {
-                    "type": "http",
-                    "url": "https://example.com/mcp",
-                    "headers": { "Authorization": "Bearer t0ken" }
-                }
-            }}"#,
-        );
+        let entry: McpServerEntry = serde_json::from_value(serde_json::json!({
+            "type": "http",
+            "url": "https://mcp.linear.app/sse",
+            "auth_mode": "oauth",
+            "oauth_provider_id": "linear",
+            "headers": { "Authorization": "Bearer ${LINEAR_API_KEY}" }
+        }))
+        .expect("entry");
+        let summary = store
+            .upsert(McpConfigScope::Global, "linear", entry)
+            .expect("upsert global");
+        assert_eq!(summary.name, "linear");
+        assert!(summary.enabled);
+        assert!(summary.effective);
+        assert_eq!(summary.server.server.auth_mode, McpServerAuthMode::OAuth);
 
-        let servers = load_workspace(dir.path());
-        let docs = servers.get("docs").expect("docs server");
-        assert_eq!(docs.transport_type, McpServerTransportType::Http);
-        assert_eq!(docs.url, "https://example.com/mcp");
+        let disabled = store
+            .set_enabled(McpConfigScope::Global, "linear", false)
+            .expect("disable");
+        assert!(!disabled.enabled);
+        assert!(!disabled.effective);
+        assert!(load_mcp_servers_from_paths(&settings_path, &workspace).is_empty());
+
+        let workspace_entry: McpServerEntry = serde_json::from_value(serde_json::json!({
+            "type": "http",
+            "url": "https://workspace.example/sse"
+        }))
+        .expect("workspace entry");
+        let workspace_summary = store
+            .upsert(McpConfigScope::Workspace, "linear", workspace_entry)
+            .expect("upsert workspace");
+        assert!(workspace_summary.overrides_global);
+        assert!(workspace_summary.effective);
         assert_eq!(
-            docs.headers.get("Authorization").map(String::as_str),
-            Some("Bearer t0ken")
-        );
-        assert!(docs.tool_discovery, "tool discovery defaults on");
-    }
-
-    #[test]
-    fn type_defaults_to_http() {
-        let dir = tempfile::tempdir().unwrap();
-        write(
-            dir.path(),
-            r#"{ "mcpServers": { "b": { "url": "https://b.example.com/mcp" } } }"#,
-        );
-        let servers = load_workspace(dir.path());
-        assert_eq!(servers["b"].transport_type, McpServerTransportType::Http);
-    }
-
-    #[test]
-    fn empty_object_is_ok() {
-        let dir = tempfile::tempdir().unwrap();
-        write(dir.path(), "{}");
-        assert!(load_workspace(dir.path()).is_empty());
-    }
-
-    #[test]
-    fn malformed_json_is_an_error_at_the_scope_level() {
-        // `read_config` surfaces the parse error...
-        let dir = tempfile::tempdir().unwrap();
-        write(dir.path(), "{ not json");
-        assert!(read_config(&dir.path().join(MCP_CONFIG_FILE)).is_err());
-    }
-
-    #[test]
-    fn malformed_scope_is_skipped_not_fatal() {
-        // ...but a malformed file in one scope must not mask the other. A bad
-        // global config still lets a valid workspace `.mcp.json` load.
-        let global = tempfile::tempdir().unwrap();
-        let global_path = global.path().join("mcp.json");
-        std::fs::write(&global_path, "{ not json").unwrap();
-
-        let workspace = tempfile::tempdir().unwrap();
-        write(
-            workspace.path(),
-            r#"{ "mcpServers": { "ws": { "url": "https://ws.example.com/mcp" } } }"#,
+            load_mcp_servers_from_paths(&settings_path, &workspace)
+                .get("linear")
+                .map(|server| server.url.as_str()),
+            Some("https://workspace.example/sse")
         );
 
-        let servers = load_merged(Some(&global_path), workspace.path());
         assert!(
-            servers.contains_key("ws"),
-            "valid workspace server survives a malformed global config: {servers:?}"
+            store
+                .remove(McpConfigScope::Workspace, "linear")
+                .expect("remove")
         );
+        assert!(load_mcp_servers_from_paths(&settings_path, &workspace).is_empty());
     }
 
-    #[test]
-    fn parses_stdio_server() {
-        let dir = tempfile::tempdir().unwrap();
-        write(
-            dir.path(),
-            r#"{ "mcpServers": {
-                "fs": {
-                    "type": "stdio",
-                    "command": "mcp-server-filesystem",
-                    "args": ["/work"],
-                    "env": { "RUST_LOG": "info" }
+    fn load_mcp_servers_from_paths(
+        settings_path: &Path,
+        workspace_root: &Path,
+    ) -> BTreeMap<String, ScopedMcpServer> {
+        let mut servers = enabled_servers(
+            SettingsStore::open(settings_path.to_path_buf())
+                .snapshot()
+                .mcp,
+        );
+        if let Ok(workspace) =
+            load_workspace_mcp_settings(&workspace_root.join(WORKSPACE_MCP_CONFIG_FILE))
+        {
+            for (name, entry) in workspace.servers {
+                if entry.enabled {
+                    servers.insert(name, entry.server);
+                } else {
+                    servers.remove(&name);
                 }
-            }}"#,
-        );
-
-        let servers = load_workspace(dir.path());
-        let fs = servers.get("fs").expect("fs server");
-        assert_eq!(fs.transport_type, McpServerTransportType::Stdio);
-        assert_eq!(fs.command.as_deref(), Some("mcp-server-filesystem"));
-        assert_eq!(fs.args, vec!["/work".to_string()]);
-        assert_eq!(fs.env.get("RUST_LOG").map(String::as_str), Some("info"));
-    }
-
-    #[test]
-    fn expands_env_placeholders() {
-        // Serialize against every other env-mutating test in this binary.
-        let _guard = crate::test_env::lock();
-        unsafe {
-            std::env::set_var("YOLOP_TEST_MCP_TOKEN", "s3cret");
-            std::env::set_var("YOLOP_TEST_MCP_ROOT", "/srv/work");
+            }
         }
-        let dir = tempfile::tempdir().unwrap();
-        write(
-            dir.path(),
-            r#"{ "mcpServers": {
-                "docs": {
-                    "type": "http",
-                    "url": "https://example.com/mcp",
-                    "headers": { "Authorization": "Bearer ${YOLOP_TEST_MCP_TOKEN}" }
-                },
-                "fs": {
-                    "type": "stdio",
-                    "command": "mcp-server-filesystem",
-                    "args": ["${YOLOP_TEST_MCP_ROOT}"]
-                }
-            }}"#,
-        );
-
-        let servers = load_workspace(dir.path());
-        assert_eq!(
-            servers["docs"]
-                .headers
-                .get("Authorization")
-                .map(String::as_str),
-            Some("Bearer s3cret")
-        );
-        assert_eq!(servers["fs"].args, vec!["/srv/work".to_string()]);
-        unsafe {
-            std::env::remove_var("YOLOP_TEST_MCP_TOKEN");
-            std::env::remove_var("YOLOP_TEST_MCP_ROOT");
-        }
-    }
-
-    #[test]
-    fn unset_env_placeholder_is_left_intact() {
-        let _guard = crate::test_env::lock();
-        unsafe {
-            std::env::remove_var("YOLOP_UNSET_VAR_XYZ");
-        }
-        let dir = tempfile::tempdir().unwrap();
-        write(
-            dir.path(),
-            r#"{ "mcpServers": {
-                "docs": { "type": "http", "url": "https://example.com/${YOLOP_UNSET_VAR_XYZ}" }
-            }}"#,
-        );
-        let servers = load_workspace(dir.path());
-        assert_eq!(
-            servers["docs"].url,
-            "https://example.com/${YOLOP_UNSET_VAR_XYZ}"
-        );
-    }
-
-    #[test]
-    fn expand_env_handles_multiple_and_adjacent() {
-        let _guard = crate::test_env::lock();
-        unsafe {
-            std::env::set_var("YOLOP_TEST_A", "a");
-            std::env::set_var("YOLOP_TEST_B", "b");
-        }
-        assert_eq!(expand_env("${YOLOP_TEST_A}-${YOLOP_TEST_B}"), "a-b");
-        assert_eq!(expand_env("x${YOLOP_TEST_A}${YOLOP_TEST_B}y"), "xaby");
-        assert_eq!(expand_env("no placeholders"), "no placeholders");
-        assert_eq!(expand_env("${unterminated"), "${unterminated");
-        unsafe {
-            std::env::remove_var("YOLOP_TEST_A");
-            std::env::remove_var("YOLOP_TEST_B");
-        }
+        servers
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4,6 +4,7 @@
 // actual workspace. Only the `bash` tool is custom — it shells out to the host
 // instead of running against the VFS.
 
+use crate::capabilities::mcp::McpCapability as YolopMcpCapability;
 use crate::capabilities::memory::{GlobalMemoryCapability, MEMORY_CAPABILITY_ID, MemoryStore};
 use crate::capabilities::yolop::{YOLOP_CAPABILITY_ID, YolopCapability};
 use crate::capabilities::{
@@ -23,6 +24,7 @@ use crate::connectors::{
 };
 use crate::goal::GoalStore;
 use crate::host_ui::{HostUi, TuiHandle, UiCommand};
+use crate::mcp_config::McpConfigStore;
 use crate::settings::{Settings, SettingsStore};
 use crate::tools::Workspace;
 use crate::user_ask::UserAskStore;
@@ -2058,7 +2060,7 @@ pub async fn build_with_options(
     // config and the file-store factory's scope routing.
     let skill_dirs = crate::capabilities::skills::SkillDirs::resolve(&effective_root);
 
-    // MCP servers from `.mcp.json` (global + workspace, merged). Loading is
+    // MCP servers from global settings and workspace `.mcp.json`, merged. Loading is
     // best-effort per scope: a malformed file is warned about and skipped, so
     // it never sinks the session or masks the other scope.
     let mcp_servers: ScopedMcpServers = crate::mcp_config::load_mcp_servers(&canonical_root);
@@ -2281,6 +2283,9 @@ pub async fn build_with_options(
     capabilities.register(HooksCapability { hooks: hooks_store });
     // `yolop` — framing when the user addresses yolop itself, not the project.
     capabilities.register(YolopCapability);
+    capabilities.register(YolopMcpCapability {
+        store: Arc::new(McpConfigStore::default_for_workspace(&canonical_root)),
+    });
     // `progress_guard` — runtime-visible warnings when tool use stops making
     // observable progress.
     capabilities.register(ProgressGuardCapability::new());

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -15,6 +15,7 @@
 use crate::capability_settings::{
     CapabilityOverride, capabilities_to_toml, parse_capabilities_table,
 };
+use crate::mcp_config::McpSettings;
 use anyhow::{Context, Result};
 use std::collections::BTreeMap;
 use std::io::Write;
@@ -148,6 +149,8 @@ pub struct Settings {
     pub proactive_wake: bool,
     /// Git worktree isolation for code changes (`auto`, `always`, `off`).
     pub worktrees: WorktreesMode,
+    /// Global MCP servers (`[mcp.servers.<name>]` in settings.toml). Repo `.mcp.json` entries override these by name.
+    pub mcp: McpSettings,
     /// Ordered harness capability overrides (`[[capabilities]]` in settings.toml).
     pub capabilities: Vec<CapabilityOverride>,
 }
@@ -165,6 +168,7 @@ impl Default for Settings {
             approval_mode: ApprovalMode::Normal,
             proactive_wake: true,
             worktrees: WorktreesMode::Auto,
+            mcp: McpSettings::default(),
             capabilities: Vec::new(),
         }
     }
@@ -227,6 +231,7 @@ impl Settings {
             approval_mode,
             proactive_wake,
             worktrees,
+            mcp: parse_mcp_settings(table),
             capabilities: parse_capabilities_table(table),
         }
     }
@@ -275,6 +280,12 @@ impl Settings {
             table.insert(
                 "codex_auth".to_string(),
                 Value::Table(codex_auth_to_table(auth)),
+            );
+        }
+        if !self.mcp.servers.is_empty() {
+            table.insert(
+                "mcp".to_string(),
+                Value::Table(mcp_settings_to_table(&self.mcp)),
             );
         }
         let caps = capabilities_to_toml(&self.capabilities);
@@ -341,6 +352,19 @@ impl Settings {
     }
 }
 
+fn parse_mcp_settings(table: &Table) -> McpSettings {
+    table
+        .get("mcp")
+        .and_then(|value| value.clone().try_into::<McpSettings>().ok())
+        .unwrap_or_default()
+}
+
+fn mcp_settings_to_table(settings: &McpSettings) -> Table {
+    toml::Value::try_from(settings)
+        .ok()
+        .and_then(|value| value.as_table().cloned())
+        .unwrap_or_default()
+}
 fn parse_codex_auth(table: &Table) -> Option<CodexAuth> {
     let access_token = table
         .get("access_token")
@@ -573,6 +597,12 @@ impl SettingsStore {
         Ok(existed)
     }
 
+    pub fn replace_mcp(&self, mcp: McpSettings) -> Result<()> {
+        let mut guard = self.inner.lock().expect("settings lock poisoned");
+        guard.mcp = mcp;
+        save_to(&self.path, &guard)
+    }
+
     /// Append a harness capability override to the ordered settings list.
     pub fn append_capability_override(&self, entry: CapabilityOverride) -> Result<usize> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
@@ -593,6 +623,7 @@ impl SettingsStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use everruns_core::McpServerAuthMode;
 
     #[test]
     fn default_provider_roundtrip_via_disk() {
@@ -805,6 +836,50 @@ mod tests {
         let store = SettingsStore::open(path);
         let removed = store.clear_token("openai").expect("clear");
         assert!(!removed);
+    }
+
+    #[test]
+    fn global_mcp_servers_roundtrip_via_settings_toml() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join("settings.toml");
+        std::fs::write(
+            &path,
+            r#"
+[mcp.servers.linear]
+type = "http"
+url = "https://mcp.linear.app/sse"
+auth_mode = "oauth"
+oauth_provider_id = "linear"
+
+[mcp.servers.linear.headers]
+Authorization = "Bearer ${LINEAR_API_KEY}"
+"#,
+        )
+        .expect("write");
+
+        let store = SettingsStore::open(path.clone());
+        let snapshot = store.snapshot();
+        let linear = snapshot.mcp.servers.get("linear").expect("linear server");
+        assert!(linear.enabled);
+        assert_eq!(linear.server.url, "https://mcp.linear.app/sse");
+        assert_eq!(linear.server.auth_mode, McpServerAuthMode::OAuth);
+        assert_eq!(linear.server.oauth_provider_id.as_deref(), Some("linear"));
+        assert_eq!(
+            linear
+                .server
+                .headers
+                .get("Authorization")
+                .map(String::as_str),
+            Some("Bearer ${LINEAR_API_KEY}")
+        );
+
+        save_to(&path, &snapshot).expect("save");
+        let on_disk = std::fs::read_to_string(&path).expect("read");
+        assert!(on_disk.contains("[mcp.servers.linear]"), "got: {on_disk}");
+        assert!(
+            on_disk.contains(r#"auth_mode = "o_auth""#),
+            "got: {on_disk}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What
- Adds MCP server management tools for listing, upserting, removing, and enabling/disabling configured servers.
- Persists MCP servers in global settings and workspace `.mcp.json`, including effective global/workspace override resolution.
- Documents authenticated Linear MCP setup using environment variable based bearer headers.

## Why
Users could have an unauthenticated MCP server entry but had no first-class way to add or update authenticated MCP configuration from yolop.

## How
- Introduces an MCP config store that reads global settings, legacy global MCP config, and workspace `.mcp.json`.
- Registers an MCP management capability in the normal tool set.
- Extends config schema/service handling so MCP settings are visible through configuration APIs.
- Preserves legacy workspace formats while adding `enabled` state and OAuth spelling normalization.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"`

## Security
- TM-FS: MCP writes are limited to the global settings file and workspace `.mcp.json`; server names reject path separators.
- TM-BASH: No shell execution changes.
- TM-LLM: Secrets are configured through environment-variable placeholders; no API keys are logged or embedded by the implementation.
- TM-TOOL: New MCP management tools only mutate MCP config and reuse existing runtime MCP loading.
- TM-DEP: No new dependencies.

## Follow-ups
No follow-ups.

Generated with yolop
