### PR TITLE
feat(ast-grep): add opt-in ast_edit with harness eval proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,11 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   targeted grep/read.
 - **AST grep** — `ast_grep` runs read-only structural pattern search with
   ast-grep syntax across Rust, Python, TypeScript/TSX, JavaScript/JSX, C#,
-  Go, CSS, HTML, and Bash. `ast_edit` applies pattern/replacement rewrites
-  with a preview-first `dry_run` flow (default) before writing.
+  Go, CSS, HTML, and Bash.
+- **AST edit** *(optional, off by default)* — `ast_edit` applies
+  pattern/replacement rewrites with a preview-first `dry_run` flow (default)
+  before writing. Enable with `[[capabilities]] ref = "ast_edit"` in
+  `settings.toml`.
 - **LSP** *(optional, off by default)* — real language servers
   (rust-analyzer, typescript-language-server, pyright, gopls, clangd, or any
   configured binary) behind `lsp_diagnostics`, `lsp_definition`,

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   targeted grep/read.
 - **AST grep** — `ast_grep` runs read-only structural pattern search with
   ast-grep syntax across Rust, Python, TypeScript/TSX, JavaScript/JSX, C#,
-  Go, CSS, HTML, and Bash.
+  Go, CSS, HTML, and Bash. `ast_edit` applies pattern/replacement rewrites
+  with a preview-first `dry_run` flow (default) before writing.
 - **LSP** *(optional, off by default)* — real language servers
   (rust-analyzer, typescript-language-server, pyright, gopls, clangd, or any
   configured binary) behind `lsp_diagnostics`, `lsp_definition`,

--- a/evals/harness_basic/README.md
+++ b/evals/harness_basic/README.md
@@ -14,13 +14,13 @@ the runtime path; the TUI is never involved).
 
 ## The matrix
 
-Three axes, crossed with 9 samples (small edit / refactor / search / guardrail tasks):
+Three axes, crossed with 12 samples (small edit / refactor / search / guardrail / structural-rewrite tasks):
 
 | Axis | Values | Where |
 |------|--------|-------|
 | **target** (model) | `anthropic/claude-sonnet-4-5` · `anthropic/claude-opus-4-8` · `openai/gpt-5.5` · `openrouter/z-ai/glm-5.2` | `targets()` in `src/main.rs` |
 | **effort** | `default` (yolop's per-model default; no flag) · `low` · `high` | `EFFORTS` |
-| **harness** | `default` (out-of-the-box yolop) · `no-progress-guard` · `no-ast-grep` | `HARNESS_VARIANTS` |
+| **harness** | `default` (out-of-the-box yolop) · `with-ast-edit` (opt-in `ast_edit` capability) · `no-progress-guard` · `no-ast-grep` | `HARNESS_VARIANTS` |
 
 Every target gates on its provider key env var (`ANTHROPIC_API_KEY`,
 `OPENAI_API_KEY`, `OPENROUTER_API_KEY`) and is *skipped* (not failed) when the
@@ -44,6 +44,9 @@ search/refactor, and read-only code navigation.
 | `progress-guard-sequential-read` [`progress-guard`] | 24 numbered notes; answer in `notes/24.txt` | Read notes sequentially and answer the final code | final response contains `KITE-7429` | long exploration streak that should trigger `progress_guard` |
 | `progress-guard-checkpoint-read` [`progress-guard`] | 50 numbered notes; answer in `checkpoint/50.txt` | Read notes sequentially and answer the final code | final response contains `WREN-5081` | escalation from first warning to checkpoint warnings |
 | `background-callback-bridge` [`progress-guard`] | Rust crate where `spawn_background` completions land in `SessionTaskRegistry`, but app wake only drains legacy background state | Fix the callback bridge while keeping the legacy wake test passing | source drains session-task completions and keeps focused regression tests | realistic investigation based on the background-callback failure mode |
+| `replace-console-log` [`ast-edit`] | TS: `api.ts`/`worker.ts` call `console.log`; `logger.ts` exports `logger.info` | Replace every `console.log(...)` with `logger.info(...)` | both TS files use `logger.info`, no `console.log` | multi-file shape rewrite (`console.log` → `logger.info`) |
+| `strip-print-debug` [`ast-edit`] | Python `app.py`/`helpers.py` with standalone `print(...)` debug lines | Remove every standalone `print(...)` statement | neither file contains `print(` | bulk statement removal across files |
+| `unwrap-to-expect` [`ast-edit`] [smoke] | Rust `src/lib.rs` with `.unwrap()` on `first`/`last` | Replace every `.unwrap()` with `.expect("failed")` | file contains `.expect("failed")`, no `.unwrap()` | small Rust structural rewrite |
 
 ### Harness variants — the point of this study
 
@@ -51,8 +54,10 @@ A variant is a yolop `settings.toml` written into isolated per-case config dirs
 (`XDG_CONFIG_HOME` and a scratch `HOME` for macOS), on top of a base that only turns linked worktrees off
 (study plumbing: the case workdir is a plain temp dir and file scorers read
 edits back from it). `default` adds nothing — it is yolop out of the box.
-`no-progress-guard` disables the progress-guard capability so guardrail
-changes can be compared against the same binary with that capability removed.
+`with-ast-edit` enables the opt-in `ast_edit` capability for previewed
+structural rewrites. `no-progress-guard` disables the progress-guard capability
+so guardrail changes can be compared against the same binary with that
+capability removed.
 
 Adding a configuration to the matrix is one entry in `src/main.rs`:
 
@@ -102,7 +107,8 @@ Alongside it: `succeeded` (yolop exited cleanly) and lenient guardrail budgets
 comparison itself reads the per-case numbers the transcript carries — tokens,
 cost, `llm_calls`, `turns`, `tool_calls_failed`, `agent_reported_ms`,
 `exploration_tools_before_first_mutation`, `max_exploration_tools_without_progress`,
-and `progress_guard_warnings` — plus metadata (`provider`, `model`, `effort`,
+`progress_guard_warnings`, `ast_edit_tool_calls`, and `ast_edit_tool_calls_failed`
+— plus metadata (`provider`, `model`, `effort`,
 `reasoning_effort_applied`, `harness`, `stop_reason`) for `--group-by`.
 
 ## Setup
@@ -133,6 +139,9 @@ doppler run -- mira run --preset harness-compare --group-by harness
 # Focused guardrail proof: default vs no-progress-guard on the long-read trap.
 doppler run -- mira run --preset progress-guard --group-by harness
 
+# Structural-rewrite A/B: default vs with-ast-edit on ast-edit-tagged cases.
+doppler run -- mira run --preset ast-edit-compare --group-by harness
+
 # Reasoning-effort sweep, out-of-the-box harness.
 doppler run -- mira run --preset effort-compare --group-by effort
 
@@ -148,6 +157,7 @@ doppler run -- mira run --targets 'anthropic/*' --axis harness=no-ast-grep --sam
 | `smoke` | cheap sanity check (4 cases) | tag `smoke` | claude-sonnet-4-5 | effort=default, all harness |
 | `harness-compare` | **A/B yolop configurations** | all | claude-sonnet-4-5 | effort=default, all harness |
 | `progress-guard` | focused warning-behavior check | tag `progress-guard` | claude-sonnet-4-5 | effort=default, default vs no-progress-guard |
+| `ast-edit-compare` | **A/B ast_edit capability** | tag `ast-edit` | claude-sonnet-4-5 | effort=default, default vs with-ast-edit |
 | `effort-compare` | effort sweep | all | gpt-5.5 | harness=default, all efforts |
 | `models` | model sweep, out-of-the-box yolop | all | all | harness=default, effort=default |
 

--- a/evals/harness_basic/mira.toml
+++ b/evals/harness_basic/mira.toml
@@ -45,6 +45,14 @@ tag = "progress-guard"
 targets = ["anthropic/claude-sonnet-4-5"]
 axes = { effort = ["default"], harness = ["default", "no-progress-guard"] }
 
+# AST-EDIT-COMPARE — structural-rewrite traps: default harness vs ast_edit
+# enabled. Pass rate plus `ast_edit_used` adoption on the enabled variant.
+#   doppler run -- mira run --preset ast-edit-compare --group-by harness
+[presets.ast-edit-compare]
+tag = "ast-edit"
+targets = ["anthropic/claude-sonnet-4-5"]
+axes = { effort = ["default"], harness = ["default", "with-ast-edit"] }
+
 # EFFORT-COMPARE — one model, out-of-the-box harness, across reasoning efforts.
 #   doppler run -- mira run --preset effort-compare --group-by effort
 [presets.effort-compare]

--- a/evals/harness_basic/src/main.rs
+++ b/evals/harness_basic/src/main.rs
@@ -49,6 +49,10 @@ const HARNESS_VARIANTS: &[HarnessVariant] = &[
         settings: "",
     },
     HarnessVariant {
+        name: "with-ast-edit",
+        settings: "[[capabilities]]\nref = \"ast_edit\"\n",
+    },
+    HarnessVariant {
         name: "no-progress-guard",
         settings: "[[capabilities]]\nref = \"progress_guard\"\nenabled = false\n",
     },
@@ -385,6 +389,74 @@ fn dataset() -> Dataset {
         progress_guard_probe_sample(),
         progress_guard_checkpoint_sample(),
         background_callback_bridge_sample(),
+        Sample::new(
+            "replace-console-log",
+            "Replace every `console.log(...)` call with `logger.info(...)` across all \
+             TypeScript files. Keep imports and other logic unchanged. Make the edits \
+             directly; do not ask questions.",
+        )
+        .file(
+            "logger.ts",
+            "export const logger = {\n  info: (...args: unknown[]) => console.info(...args),\n};\n",
+        )
+        .file(
+            "api.ts",
+            "import { logger } from \"./logger\";\n\nexport function ping() {\n  console.log(\"ping\");\n  return true;\n}\n",
+        )
+        .file(
+            "worker.ts",
+            "import { logger } from \"./logger\";\n\nexport function run() {\n  console.log(\"start\");\n  console.log(\"done\");\n}\n",
+        )
+        .tag("ast-edit")
+        .meta("kind", "structural-rewrite")
+        .meta(
+            "checks",
+            json!([
+                {"file": "api.ts", "contains": ["logger.info"], "lacks": ["console.log"]},
+                {"file": "worker.ts", "contains": ["logger.info"], "lacks": ["console.log"]}
+            ]),
+        ),
+        Sample::new(
+            "strip-print-debug",
+            "Remove every standalone `print(...)` debug statement from the Python files. \
+             Do not remove real logic. Make the edits directly; do not ask questions.",
+        )
+        .file(
+            "app.py",
+            "from helpers import greet\n\n\ndef main():\n    print(\"boot\")\n    greet()\n    print(\"shutdown\")\n",
+        )
+        .file("helpers.py", "def greet():\n    print(\"hello\")\n    return \"ok\"\n")
+        .tag("ast-edit")
+        .meta("kind", "structural-rewrite")
+        .meta(
+            "checks",
+            json!([
+                {"file": "app.py", "lacks": ["print("]},
+                {"file": "helpers.py", "lacks": ["print("]}
+            ]),
+        ),
+        Sample::new(
+            "unwrap-to-expect",
+            "Replace every `.unwrap()` call in src/lib.rs with `.expect(\"failed\")`. \
+             Make the edit directly; do not ask questions.",
+        )
+        .file("Cargo.toml", cargo_toml)
+        .file(
+            "src/lib.rs",
+            "pub fn first(xs: &[i32]) -> i32 {\n    xs.first().unwrap()\n}\n\n\
+             pub fn last(xs: &[i32]) -> i32 {\n    xs.last().unwrap()\n}\n",
+        )
+        .tag("ast-edit")
+        .tag("smoke")
+        .meta("kind", "structural-rewrite")
+        .meta(
+            "checks",
+            json!([{
+                "file": "src/lib.rs",
+                "contains": [".expect(\"failed\")"],
+                "lacks": [".unwrap()"]
+            }]),
+        ),
     ])
 }
 
@@ -446,6 +518,23 @@ fn tool_calls_budget_scorer() -> Box<dyn Scorer> {
             Score::pass("tool_calls_within", format!("{actual} <= {limit}"))
         } else {
             Score::fail("tool_calls_within", format!("{actual} > {limit}"))
+        }
+    })
+}
+
+/// Adoption signal: on the `with-ast-edit` variant, did the model call `ast_edit`?
+/// A failed `ast_edit_used` next to a passed `checks` means the task was solved
+/// around the capability. N/A on the baseline variant.
+fn ast_edit_used_scorer() -> Box<dyn Scorer> {
+    scorer("ast_edit_used", |_sample, t| {
+        if t.metadata.get("harness") != Some(&json!("with-ast-edit")) {
+            return Score::na("ast_edit_used", "baseline variant; ast_edit not offered");
+        }
+        let calls = t.metrics.get("ast_edit_tool_calls").copied().unwrap_or(0.0);
+        if calls > 0.0 {
+            Score::pass("ast_edit_used", format!("{calls} ast_edit call(s)"))
+        } else {
+            Score::fail("ast_edit_used", "ast_edit enabled but tool was not called")
         }
     })
 }
@@ -566,6 +655,8 @@ struct Mined {
     exploration_tools_before_first_mutation: u64,
     max_exploration_tools_without_progress: u64,
     progress_guard_warnings: u64,
+    ast_edit_tool_calls: u64,
+    ast_edit_tool_calls_failed: u64,
 }
 
 fn normalized_command(command: &str) -> String {
@@ -632,7 +723,9 @@ fn classify_tool(data: &Value) -> ToolKind {
         "read_file" | "grep_files" | "repo_map" | "ast_grep" | "list_directory" | "stat_file" => {
             return ToolKind::Exploration;
         }
-        "write_file" | "edit_file" | "delete_file" | "edit" => return ToolKind::Mutation,
+        "write_file" | "edit_file" | "delete_file" | "ast_edit" | "edit" => {
+            return ToolKind::Mutation;
+        }
         "bash" => {}
         _ => return ToolKind::Other,
     }
@@ -765,6 +858,12 @@ fn parse_events(jsonl: &str) -> Mined {
                 }
                 if has_progress_guard_warning(&data) {
                     m.progress_guard_warnings += 1;
+                }
+                if name == "ast_edit" {
+                    m.ast_edit_tool_calls += 1;
+                    if data.get("success") == Some(&Value::Bool(false)) {
+                        m.ast_edit_tool_calls_failed += 1;
+                    }
                 }
                 match classify_tool(&data) {
                     ToolKind::Mutation => {
@@ -1014,6 +1113,12 @@ async fn run_yolop(sample: Sample, cx: RunCx) -> Transcript {
         "progress_guard_warnings".into(),
         mined.progress_guard_warnings as f64,
     );
+    t.metrics
+        .insert("ast_edit_tool_calls".into(), mined.ast_edit_tool_calls as f64);
+    t.metrics.insert(
+        "ast_edit_tool_calls_failed".into(),
+        mined.ast_edit_tool_calls_failed as f64,
+    );
     let agent_ms = if mined.turn_ms > 0 {
         mined.turn_ms
     } else {
@@ -1068,6 +1173,7 @@ fn basic_coding() -> Eval {
         // tool calls, tokens, cost) surface in the report for A/B reading.
         .scorer(turns_budget_scorer())
         .scorer(tool_calls_budget_scorer())
+        .scorer(ast_edit_used_scorer())
         .scorer(cost_within(2.0))
         .max_turns(64)
         .meta("suite", "harness-basic-v1")
@@ -1120,6 +1226,11 @@ mod tests {
         assert!(no_progress.contains("worktrees = \"off\""));
         assert!(no_progress.contains("ref = \"progress_guard\""));
         assert!(no_progress.contains("enabled = false"));
+
+        let with_ast_edit = settings_for_variant("with-ast-edit").unwrap();
+        assert!(with_ast_edit.contains("worktrees = \"off\""));
+        assert!(with_ast_edit.contains("ref = \"ast_edit\""));
+        assert!(!with_ast_edit.contains("enabled = false"));
 
         assert!(settings_for_variant("nope").is_none());
     }
@@ -1174,6 +1285,37 @@ mod tests {
         assert_eq!(m.exploration_tools_before_first_mutation, 3);
         assert_eq!(m.max_exploration_tools_without_progress, 3);
         assert_eq!(m.progress_guard_warnings, 2);
+    }
+
+    #[test]
+    fn parse_events_counts_ast_edit_tool_calls() {
+        let jsonl = r#"
+{"type":"tool.completed","data":{"tool_name":"ast_edit","success":true}}
+{"type":"tool.completed","data":{"tool_name":"ast_edit","success":false}}
+{"type":"tool.completed","data":{"tool_name":"edit_file","success":true}}
+"#;
+        let m = parse_events(jsonl);
+        assert_eq!(m.ast_edit_tool_calls, 2);
+        assert_eq!(m.ast_edit_tool_calls_failed, 1);
+        assert_eq!(m.exploration_tools_before_first_mutation, 0);
+    }
+
+    #[tokio::test]
+    async fn ast_edit_used_scorer_gates_on_variant() {
+        let sample = Sample::new("a", "x");
+        let mut t = graded_transcript();
+        t.metadata.insert("harness".into(), json!("with-ast-edit"));
+        t.metrics.insert("ast_edit_tool_calls".into(), 0.0);
+        let score = ast_edit_used_scorer().score(&sample, &t).await;
+        assert!(!score.pass && !score.na);
+
+        t.metrics.insert("ast_edit_tool_calls".into(), 2.0);
+        let score = ast_edit_used_scorer().score(&sample, &t).await;
+        assert!(score.pass);
+
+        t.metadata.insert("harness".into(), json!("default"));
+        let score = ast_edit_used_scorer().score(&sample, &t).await;
+        assert!(score.na);
     }
 
     #[test]
@@ -1259,7 +1401,7 @@ mod tests {
             eprintln!("skipping: no yolop binary (cargo build at the repo root first)");
             return;
         }
-        for harness in ["default", "no-progress-guard", "no-ast-grep"] {
+        for harness in ["default", "with-ast-edit", "no-progress-guard", "no-ast-grep"] {
             let mut cx = RunCx::new(Target::new("llmsim", "llmsim", "llmsim-yolop"));
             cx.params.insert("harness".into(), harness.into());
             let sample = Sample::new("e2e", "say hi").file("note.txt", "seed\n");

--- a/src/bundled/system-skills/ast-grep/SKILL.md
+++ b/src/bundled/system-skills/ast-grep/SKILL.md
@@ -6,8 +6,9 @@ user-invocable: true
 
 # ast-grep structural search and rewrite
 
-Yolop ships built-in `ast_grep` (read-only search) and `ast_edit` (pattern/replacement
-rewrites) backed by the `ast-grep` engine compiled into the binary. This is **not** the
+Yolop ships built-in `ast_grep` (read-only search, default harness) and `ast_edit`
+(pattern/replacement rewrites, opt-in via `[[capabilities]] ref = "ast_edit"` in
+`settings.toml`) backed by the `ast-grep` engine compiled into the binary. This is **not** the
 `sg` command-line tool — there is no `sg run`/`sg scan`, no rule YAML files, and no
 `--rewrite` CLI. Drive the tools directly with their arguments.
 

--- a/src/bundled/system-skills/ast-grep/SKILL.md
+++ b/src/bundled/system-skills/ast-grep/SKILL.md
@@ -1,17 +1,15 @@
 ---
 name: ast-grep
-description: Write effective ast-grep patterns for the built-in `ast_grep` structural-search tool. Use when searching code by shape rather than text — call expressions, function/struct declarations, wrappers, imports — or when `grep_files` is too noisy, and when a pattern returns nothing or the wrong nodes.
+description: Write effective ast-grep patterns for the built-in `ast_grep` structural-search tool and `ast_edit` rewrites. Use when searching or refactoring code by shape rather than text — call expressions, function/struct declarations, wrappers, imports — or when a pattern returns nothing or the wrong nodes.
 user-invocable: true
 ---
 
-# ast-grep structural search
+# ast-grep structural search and rewrite
 
-Yolop ships a built-in `ast_grep` tool: read-only, multi-language structural
-code search backed by the `ast-grep` engine compiled into the binary. This is
-**not** the `sg` command-line tool — there is no `sg run`/`sg scan`, no rule
-YAML files, and no `--rewrite`. Drive the `ast_grep` tool directly with its
-arguments. It never edits code; read matched files with the file tools before
-changing anything.
+Yolop ships built-in `ast_grep` (read-only search) and `ast_edit` (pattern/replacement
+rewrites) backed by the `ast-grep` engine compiled into the binary. This is **not** the
+`sg` command-line tool — there is no `sg run`/`sg scan`, no rule YAML files, and no
+`--rewrite` CLI. Drive the tools directly with their arguments.
 
 ## When to reach for it
 
@@ -23,10 +21,15 @@ the area:
 - Wrappers and idioms: `unwrap()`, `try/except`, specific decorators/attributes.
 - Anywhere lexical search drowns in comments, strings, or false matches.
 
+Use `ast_edit` when the same ast-grep pattern should be **rewritten** everywhere it
+matches — rename a call shape, swap an import path, delete a wrapper, modernize an
+idiom. Always confirm the pattern with `ast_grep` first, then preview with `ast_edit`
+before applying.
+
 Prefer `grep_files` for exact text, identifiers, log strings, or non-code files.
 ast-grep only parses the supported languages below; everything else is skipped.
 
-## Tool arguments
+## Tool arguments (`ast_grep`)
 
 - `pattern` (required): an ast-grep pattern in the **target language's own
   syntax** (see metavariables below).
@@ -37,6 +40,28 @@ ast-grep only parses the supported languages below; everything else is skipped.
   workspace root. Must stay inside the workspace.
 - `limit` (optional): max matches, default 50, max 500.
 - `max_file_bytes` (optional): skip larger source files, default 512 KiB.
+
+## Tool arguments (`ast_edit`)
+
+- `pattern` (required): ast-grep pattern to match (same syntax as `ast_grep`).
+- `replacement` (required): rewrite template using the same metavariables, for
+  example `logger.info($$$ARGS)` or an empty string to delete matched nodes.
+- `language` (recommended): same values as `ast_grep`.
+- `path` (optional): workspace-relative file or directory scope.
+- `dry_run` (optional): preview without writing files. **Defaults to `true`.**
+  Show the user the returned `diff`, get acceptance, then call again with
+  `dry_run=false` to apply.
+- `limit` (optional): max replacements across all scanned files, default 50.
+- `max_file_bytes` (optional): skip larger source files, default 512 KiB.
+
+## Preview / apply workflow
+
+1. Narrow with `repo_map` / `grep_files`.
+2. Confirm matches with `ast_grep`.
+3. Call `ast_edit` with `dry_run=true` (default) and review `diff` + per-file
+   `replacements_detail`.
+4. After the user accepts, call `ast_edit` again with the same arguments and
+   `dry_run=false`.
 
 Always pass `language` when you know it: it scopes the scan, avoids cross-language
 pattern-compile noise, and is faster.
@@ -107,7 +132,8 @@ A valid-but-wrong pattern matches zero nodes silently. Work it like this:
 
 ## Limits
 
-- Read-only: no rewrite/codemod. Make edits with the file tools after locating.
+- `ast_grep` is read-only. `ast_edit` writes only after an explicit
+  `dry_run=false` call.
 - Single-pattern only: no relational rules, `inside`/`has`, or YAML configs.
 - Binary, oversized (> `max_file_bytes`), and unsupported-language files are
   skipped; the result reports those counts.

--- a/src/bundled/system-skills/yolop/SKILL.md
+++ b/src/bundled/system-skills/yolop/SKILL.md
@@ -109,7 +109,7 @@ yolop is an autonomous coding agent for the workspace it was started in.
 
 - **Files** — read, write, edit, grep, delete, and map the repository
 - **Shell** — `bash -lc` from the workspace root (120 s timeout, capped output)
-- **AST search** — structural `ast_grep` across common languages
+- **AST search & rewrite** — structural `ast_grep` and previewed `ast_edit` across common languages
 - **Background work** — detached shell commands and focused sub-agents
 - **Web** — `web_fetch` and `duckduckgo_search`
 - **Memory** — durable cross-session notes via `remember` / `recall` / `forget`
@@ -146,7 +146,7 @@ Subcommands: `yolop version`, `yolop into zed`, `yolop worktree list|prune`.
 | `yolop-config` | Change `settings.toml` — provider, tokens, models, capabilities |
 | `yolop-hooks` | Configure behavioral hooks |
 | `skill-management` | Install, upgrade, or remove skills |
-| `ast-grep` | Structural code search patterns |
+| `ast-grep` | Structural code search and rewrite patterns |
 
 ## Answering help requests
 

--- a/src/bundled/system-skills/yolop/SKILL.md
+++ b/src/bundled/system-skills/yolop/SKILL.md
@@ -109,7 +109,8 @@ yolop is an autonomous coding agent for the workspace it was started in.
 
 - **Files** — read, write, edit, grep, delete, and map the repository
 - **Shell** — `bash -lc` from the workspace root (120 s timeout, capped output)
-- **AST search & rewrite** — structural `ast_grep` and previewed `ast_edit` across common languages
+- **AST search** — structural `ast_grep` across common languages (default harness)
+- **AST edit** *(opt-in)* — previewed `ast_edit` rewrites; enable with `[[capabilities]] ref = "ast_edit"`
 - **Background work** — detached shell commands and focused sub-agents
 - **Web** — `web_fetch` and `duckduckgo_search`
 - **Memory** — durable cross-session notes via `remember` / `recall` / `forget`

--- a/src/capabilities/ast_grep.rs
+++ b/src/capabilities/ast_grep.rs
@@ -292,8 +292,9 @@ impl Tool for AstEditTool {
     }
 
     fn description(&self) -> &str {
-        "Apply ast-grep pattern/replacement rewrites across workspace source files. Defaults to \
-         `dry_run=true` so the first call previews changes without writing; call again with \
+        "Apply ast-grep pattern/replacement rewrites across workspace source files. Supports \
+         Rust, Python, TypeScript/TSX, JavaScript/JSX, C#, Go, CSS, HTML, and Bash. Defaults \
+         to `dry_run=true` so the first call previews changes without writing; call again with \
          `dry_run=false` after the user accepts the preview."
     }
 

--- a/src/capabilities/ast_grep.rs
+++ b/src/capabilities/ast_grep.rs
@@ -1,8 +1,8 @@
-//! Read-only structural search backed by ast-grep.
+//! Structural search and rewrite backed by ast-grep.
 //!
-//! `grep_files` remains the right first move for exact text. This tool is for
-//! code shapes: call expressions, function declarations, wrappers, and other
-//! patterns where lexical search is too noisy.
+//! `grep_files` remains the right first move for exact text. `ast_grep` is for
+//! read-only code shapes; `ast_edit` applies pattern/replacement rewrites with a
+//! preview-first `dry_run` flow before writing.
 
 use crate::workspace_host::WorkspaceHost;
 use anyhow::{Context, Result, bail};
@@ -14,6 +14,7 @@ use ast_grep_language::SupportLang;
 use async_trait::async_trait;
 use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
 use everruns_core::tool_narration::ToolNarrationPhase;
+use everruns_core::tool_types::ToolHints;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -30,6 +31,8 @@ const DEFAULT_MAX_FILE_BYTES: usize = 512 * 1024;
 const MAX_FILE_BYTES: usize = 2 * 1024 * 1024;
 const MAX_MATCH_TEXT_CHARS: usize = 500;
 const MAX_CAPTURE_TEXT_CHARS: usize = 240;
+const MAX_REPLACEMENT_TEXT_CHARS: usize = 500;
+const MAX_PREVIEW_DIFF_CHARS: usize = 8_000;
 const SKIP_DIRS: &[&str] = &[
     ".git",
     ".hg",
@@ -62,11 +65,11 @@ impl Capability for AstGrepCapability {
     }
 
     fn name(&self) -> &str {
-        "AST Grep"
+        "AST Grep & Edit"
     }
 
     fn description(&self) -> &str {
-        "Read-only multi-language structural code search backed by ast-grep patterns."
+        "Structural code search and ast-grep pattern rewrites across common languages."
     }
 
     fn status(&self) -> CapabilityStatus {
@@ -81,8 +84,10 @@ impl Capability for AstGrepCapability {
         Some(
             "<capability id=\"ast_grep\">\n\
              For structural code search, call `ast_grep` with an ast-grep pattern and usually \
-             a language filter. Use it after repo-map/grep have narrowed the area, and read \
-             matched files before editing.\n\
+             a language filter. For shape-based rewrites, call `ast_edit` with `pattern` and \
+             `replacement` — preview with `dry_run=true` (the default), show the user the diff, \
+             then apply with `dry_run=false` after they accept. Use `ast_grep` first to confirm \
+             the pattern matches the intended nodes.\n\
              </capability>"
                 .to_string(),
         )
@@ -91,16 +96,21 @@ impl Capability for AstGrepCapability {
     fn system_prompt_preview(&self) -> Option<String> {
         Some(
             "<capability id=\"ast_grep\">\n\
-             Use `ast_grep` for read-only structural pattern search.\n\
+             Use `ast_grep` for read-only structural search; use `ast_edit` for previewed rewrites.\n\
              </capability>"
                 .to_string(),
         )
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
-        vec![Box::new(AstGrepTool {
-            workspace: self.workspace.clone(),
-        })]
+        vec![
+            Box::new(AstGrepTool {
+                workspace: self.workspace.clone(),
+            }),
+            Box::new(AstEditTool {
+                workspace: self.workspace.clone(),
+            }),
+        ]
     }
 }
 
@@ -200,6 +210,171 @@ impl Tool for AstGrepTool {
     }
 }
 
+struct AstEditTool {
+    workspace: Arc<WorkspaceHost>,
+}
+
+#[async_trait]
+impl Tool for AstEditTool {
+    fn narrate(
+        &self,
+        tool_call: &everruns_core::tool_types::ToolCall,
+        phase: ToolNarrationPhase,
+        locale: Option<&str>,
+    ) -> Option<String> {
+        Some(everruns_core::tool_narration::narrate_grep_files(
+            &tool_call.arguments,
+            phase,
+            locale,
+        ))
+    }
+
+    fn name(&self) -> &str {
+        "ast_edit"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("AST edit")
+    }
+
+    fn description(&self) -> &str {
+        "Apply ast-grep pattern/replacement rewrites across workspace source files. Defaults to \
+         `dry_run=true` so the first call previews changes without writing; call again with \
+         `dry_run=false` after the user accepts the preview."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "Required ast-grep pattern to match, for example `console.log($$$ARGS)`."
+                },
+                "replacement": {
+                    "type": "string",
+                    "description": "Replacement template using the same metavariables as `pattern`, for example `logger.info($$$ARGS)`."
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Optional workspace-relative file or directory to rewrite. Defaults to the workspace root."
+                },
+                "language": {
+                    "type": "string",
+                    "description": "Optional language filter. Supported values include rust, python, typescript, tsx, javascript, csharp, go, css, html, and bash."
+                },
+                "dry_run": {
+                    "type": "boolean",
+                    "description": "Preview replacements without writing files. Defaults to true."
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": MAX_LIMIT,
+                    "description": "Maximum number of replacements to apply across all scanned files. Defaults to 50."
+                },
+                "max_file_bytes": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": MAX_FILE_BYTES,
+                    "description": "Skip supported source files larger than this many bytes. Defaults to 524288."
+                }
+            },
+            "required": ["pattern", "replacement"],
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default().with_readonly(false)
+    }
+
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let workspace_root = match self.workspace.host_root() {
+            Ok(root) => root,
+            Err(err) => {
+                return ToolExecutionResult::tool_error(err.to_string());
+            }
+        };
+        match ast_edit_from_arguments(&workspace_root, &arguments) {
+            Ok(report) => ToolExecutionResult::success(json!({
+                "ok": true,
+                "workspace_root": workspace_root.display().to_string(),
+                "path": report.path,
+                "pattern": report.pattern,
+                "replacement": report.replacement,
+                "language": report.language,
+                "dry_run": report.dry_run,
+                "applied": report.applied,
+                "count": report.count,
+                "files_changed": report.files_changed,
+                "scanned_files": report.scanned_files,
+                "skipped_unsupported_files": report.skipped_unsupported_files,
+                "skipped_files": report.skipped_files,
+                "skipped_large_files": report.skipped_large_files,
+                "parse_error_files": report.parse_error_files,
+                "pattern_error_languages": report.pattern_error_languages,
+                "truncated": report.truncated,
+                "diff": report.diff,
+                "diff_truncated": report.diff_truncated,
+                "files": report.files,
+            })),
+            Err(err) => ToolExecutionResult::tool_error(err.to_string()),
+        }
+    }
+}
+
+fn ast_edit_from_arguments(workspace_root: &Path, arguments: &Value) -> Result<AstEditReport> {
+    let pattern = arguments
+        .get("pattern")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|pattern| !pattern.is_empty())
+        .context("`pattern` is required")?
+        .to_string();
+    let replacement = arguments
+        .get("replacement")
+        .and_then(Value::as_str)
+        .context("`replacement` is required")?
+        .to_string();
+    let path = arguments
+        .get("path")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .map(ToOwned::to_owned);
+    let language = arguments
+        .get("language")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|language| !language.is_empty())
+        .map(ToOwned::to_owned);
+    let dry_run = arguments
+        .get("dry_run")
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
+    let limit = bounded_usize(arguments.get("limit"), DEFAULT_LIMIT, MAX_LIMIT, "limit")?;
+    let max_file_bytes = bounded_usize(
+        arguments.get("max_file_bytes"),
+        DEFAULT_MAX_FILE_BYTES,
+        MAX_FILE_BYTES,
+        "max_file_bytes",
+    )?;
+
+    ast_edit(
+        workspace_root,
+        AstEditOptions {
+            pattern,
+            replacement,
+            path,
+            language,
+            dry_run,
+            limit,
+            max_file_bytes,
+        },
+    )
+}
+
 fn ast_grep_from_arguments(workspace_root: &Path, arguments: &Value) -> Result<AstGrepReport> {
     let pattern = arguments
         .get("pattern")
@@ -238,6 +413,17 @@ fn ast_grep_from_arguments(workspace_root: &Path, arguments: &Value) -> Result<A
             max_file_bytes,
         },
     )
+}
+
+#[derive(Clone, Debug)]
+struct AstEditOptions {
+    pattern: String,
+    replacement: String,
+    path: Option<String>,
+    language: Option<String>,
+    dry_run: bool,
+    limit: usize,
+    max_file_bytes: usize,
 }
 
 #[derive(Clone, Debug)]
@@ -390,6 +576,46 @@ struct AstGrepCapture {
     text: String,
 }
 
+#[derive(Debug, Serialize)]
+struct AstEditReport {
+    path: String,
+    pattern: String,
+    replacement: String,
+    language: Option<String>,
+    dry_run: bool,
+    applied: bool,
+    count: usize,
+    files_changed: usize,
+    scanned_files: usize,
+    skipped_unsupported_files: usize,
+    skipped_files: usize,
+    skipped_large_files: usize,
+    parse_error_files: usize,
+    pattern_error_languages: Vec<PatternLanguageError>,
+    truncated: bool,
+    diff: String,
+    diff_truncated: bool,
+    files: Vec<AstEditFileReport>,
+}
+
+#[derive(Debug, Serialize)]
+struct AstEditFileReport {
+    path: String,
+    language: String,
+    replacements: usize,
+    replacements_detail: Vec<AstEditReplacement>,
+    #[serde(skip_serializing)]
+    diff: String,
+}
+
+#[derive(Debug, Serialize)]
+struct AstEditReplacement {
+    line: usize,
+    column: usize,
+    old_text: String,
+    new_text: String,
+}
+
 fn ast_grep(workspace_root: &Path, options: AstGrepOptions) -> Result<AstGrepReport> {
     let root = workspace_root
         .canonicalize()
@@ -504,6 +730,226 @@ fn ast_grep(workspace_root: &Path, options: AstGrepOptions) -> Result<AstGrepRep
         truncated: matches.len() >= options.limit,
         matches,
     })
+}
+
+fn ast_edit(workspace_root: &Path, options: AstEditOptions) -> Result<AstEditReport> {
+    let root = workspace_root
+        .canonicalize()
+        .context("canonicalize workspace root")?;
+    let scope = crate::workspace_host::resolve_host_scope(&root, options.path.as_deref())?;
+    let language_filter = match options.language.as_deref() {
+        Some(language) => Some(resolve_language_filter(language)?),
+        None => None,
+    };
+
+    let mut files = Vec::new();
+    let mut skipped_unsupported_files = 0;
+    collect_supported_files(
+        &scope,
+        language_filter,
+        &mut files,
+        &mut skipped_unsupported_files,
+    )?;
+
+    let mut file_reports = Vec::new();
+    let mut total_replacements = 0;
+    let mut scanned_files = 0;
+    let mut skipped_files = 0;
+    let mut skipped_large_files = 0;
+    let mut parse_error_files = 0;
+    let mut pattern_errors = HashMap::<&'static str, String>::new();
+    let mut compiled_patterns = HashMap::<&'static str, Pattern>::new();
+
+    for file in files {
+        if total_replacements >= options.limit {
+            break;
+        }
+        let metadata = match fs::metadata(&file.path) {
+            Ok(metadata) => metadata,
+            Err(_) => {
+                skipped_files += 1;
+                continue;
+            }
+        };
+        if !metadata.is_file() {
+            skipped_files += 1;
+            continue;
+        }
+        if metadata.len() as usize > options.max_file_bytes {
+            skipped_large_files += 1;
+            continue;
+        }
+        let pattern = match compiled_patterns.get(file.language.name) {
+            Some(pattern) => pattern,
+            None if pattern_errors.contains_key(file.language.name) => continue,
+            None => match Pattern::try_new(&options.pattern, file.language.ast_lang) {
+                Ok(pattern) => {
+                    compiled_patterns.insert(file.language.name, pattern);
+                    compiled_patterns
+                        .get(file.language.name)
+                        .expect("compiled pattern inserted")
+                }
+                Err(err) => {
+                    pattern_errors.insert(file.language.name, err.to_string());
+                    continue;
+                }
+            },
+        };
+        let source = match fs::read_to_string(&file.path) {
+            Ok(source) => source,
+            Err(_) => {
+                skipped_files += 1;
+                continue;
+            }
+        };
+        scanned_files += 1;
+        let remaining = options.limit - total_replacements;
+        let rewrite = rewrite_source(
+            &source,
+            file.language.ast_lang,
+            pattern,
+            &options.replacement,
+            remaining,
+        );
+        let rewrite = match rewrite {
+            Ok(rewrite) => rewrite,
+            Err(_) => {
+                parse_error_files += 1;
+                continue;
+            }
+        };
+        if rewrite.replacements.is_empty() {
+            continue;
+        }
+        total_replacements += rewrite.replacements.len();
+        if !options.dry_run {
+            fs::write(&file.path, &rewrite.updated)
+                .with_context(|| format!("write rewritten file {}", file.path.display()))?;
+        }
+        let relative = relative_path(&root, &file.path);
+        let file_diff = render_file_diff(&relative, &source, &rewrite.updated);
+        file_reports.push(AstEditFileReport {
+            path: relative,
+            language: file.language.name.to_string(),
+            replacements: rewrite.replacements.len(),
+            replacements_detail: rewrite.replacements,
+            diff: file_diff,
+        });
+    }
+
+    let mut pattern_error_languages = pattern_errors
+        .into_iter()
+        .map(|(language, error)| PatternLanguageError {
+            language: language.to_string(),
+            error,
+        })
+        .collect::<Vec<_>>();
+    pattern_error_languages.sort_by(|left, right| left.language.cmp(&right.language));
+
+    let (diff, diff_truncated) = truncate_diff(
+        file_reports
+            .iter()
+            .map(|file| file.diff.as_str())
+            .filter(|chunk| !chunk.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n"),
+    );
+
+    Ok(AstEditReport {
+        path: options.path.unwrap_or_else(|| ".".to_string()),
+        pattern: options.pattern,
+        replacement: options.replacement,
+        language: options.language,
+        dry_run: options.dry_run,
+        applied: !options.dry_run && !file_reports.is_empty(),
+        count: total_replacements,
+        files_changed: file_reports.len(),
+        scanned_files,
+        skipped_unsupported_files,
+        skipped_files,
+        skipped_large_files,
+        parse_error_files,
+        pattern_error_languages,
+        truncated: total_replacements >= options.limit,
+        diff,
+        diff_truncated,
+        files: file_reports,
+    })
+}
+
+struct RewriteResult {
+    updated: String,
+    replacements: Vec<AstEditReplacement>,
+}
+
+fn rewrite_source(
+    source: &str,
+    lang: SupportLang,
+    pattern: &Pattern,
+    replacement: &str,
+    limit: usize,
+) -> Result<RewriteResult> {
+    let doc = StrDoc::try_new(source, lang).map_err(|err| anyhow::anyhow!(err))?;
+    let mut root = AstGrep::doc(doc);
+    let mut replacements = Vec::new();
+    while replacements.len() < limit {
+        let node = root.root();
+        let Some(node_match) = node.find(pattern) else {
+            break;
+        };
+        let matched_node = node_match.get_node();
+        let start = matched_node.start_pos();
+        let old_text = matched_node.text().to_string();
+        let edit = node_match.replace_by(replacement);
+        let new_text = String::from_utf8_lossy(&edit.inserted_text).into_owned();
+        replacements.push(AstEditReplacement {
+            line: start.line() + 1,
+            column: start.column(matched_node) + 1,
+            old_text: truncate_chars(&old_text, MAX_REPLACEMENT_TEXT_CHARS),
+            new_text: truncate_chars(&new_text, MAX_REPLACEMENT_TEXT_CHARS),
+        });
+        root.edit(edit).map_err(|err| anyhow::anyhow!(err))?;
+    }
+    Ok(RewriteResult {
+        updated: root.get_text().to_string(),
+        replacements,
+    })
+}
+
+fn render_file_diff(path: &str, before: &str, after: &str) -> String {
+    let mut out = format!("--- a/{path}\n+++ b/{path}\n");
+    let before_lines: Vec<&str> = before.lines().collect();
+    let after_lines: Vec<&str> = after.lines().collect();
+    let max = before_lines.len().max(after_lines.len());
+    for index in 0..max {
+        let old_line = before_lines.get(index).copied().unwrap_or("");
+        let new_line = after_lines.get(index).copied().unwrap_or("");
+        if old_line == new_line {
+            continue;
+        }
+        if !old_line.is_empty() {
+            out.push('-');
+            out.push_str(old_line);
+            out.push('\n');
+        }
+        if !new_line.is_empty() {
+            out.push('+');
+            out.push_str(new_line);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+fn truncate_diff(diff: String) -> (String, bool) {
+    if diff.chars().count() <= MAX_PREVIEW_DIFF_CHARS {
+        return (diff, false);
+    }
+    let truncated: String = diff.chars().take(MAX_PREVIEW_DIFF_CHARS).collect();
+    (
+        format!("{truncated}\n... diff truncated after {MAX_PREVIEW_DIFF_CHARS} characters ..."),
+        true,
+    )
 }
 
 fn format_match(
@@ -872,5 +1318,105 @@ mod tests {
                 .iter()
                 .any(|mat| mat.text == "fn outside_fn() {}")
         );
+    }
+
+    #[test]
+    fn ast_edit_dry_run_previews_without_writing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("app.ts");
+        write(&path, "console.log(value);\n");
+
+        let report = ast_edit(
+            dir.path(),
+            AstEditOptions {
+                pattern: "console.log($$$ARGS)".to_string(),
+                replacement: "logger.info($$$ARGS)".to_string(),
+                path: None,
+                language: Some("typescript".to_string()),
+                dry_run: true,
+                limit: 20,
+                max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+            },
+        )
+        .expect("preview rewrite");
+
+        assert_eq!(report.count, 1);
+        assert!(report.dry_run);
+        assert!(!report.applied);
+        assert!(report.diff.contains("console.log"));
+        assert!(report.diff.contains("logger.info"));
+        assert_eq!(
+            fs::read_to_string(&path).expect("read"),
+            "console.log(value);\n"
+        );
+    }
+
+    #[test]
+    fn ast_edit_applies_rewrite_when_dry_run_false() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("app.ts");
+        write(&path, "console.log(value);\n");
+
+        let report = ast_edit(
+            dir.path(),
+            AstEditOptions {
+                pattern: "console.log($$$ARGS)".to_string(),
+                replacement: "logger.info($$$ARGS)".to_string(),
+                path: None,
+                language: Some("typescript".to_string()),
+                dry_run: false,
+                limit: 20,
+                max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+            },
+        )
+        .expect("apply rewrite");
+
+        assert_eq!(report.count, 1);
+        assert!(!report.dry_run);
+        assert!(report.applied);
+        assert_eq!(
+            fs::read_to_string(&path).expect("read"),
+            "logger.info(value);\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn ast_edit_tool_defaults_to_preview_mode() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(&dir.path().join("app.ts"), "console.log(value);\n");
+
+        let capability = AstGrepCapability::new(host(dir.path()));
+        let tool = capability
+            .tools()
+            .into_iter()
+            .find(|tool| tool.name() == "ast_edit")
+            .expect("ast_edit tool");
+        let result = tool
+            .execute(json!({
+                "pattern": "console.log($$$ARGS)",
+                "replacement": "logger.info($$$ARGS)",
+                "language": "typescript"
+            }))
+            .await;
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("expected success, got {result:?}");
+        };
+
+        assert_eq!(value["dry_run"], json!(true));
+        assert_eq!(value["applied"], json!(false));
+        assert_eq!(value["count"], json!(1));
+        assert!(value["diff"].as_str().unwrap_or("").contains("logger.info"));
+    }
+
+    #[test]
+    fn capability_exposes_ast_grep_and_ast_edit_tools() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let capability = AstGrepCapability::new(host(dir.path()));
+        let names: Vec<String> = capability
+            .tools()
+            .iter()
+            .map(|tool| tool.name().to_string())
+            .collect();
+        assert_eq!(names, vec!["ast_grep", "ast_edit"]);
     }
 }

--- a/src/capabilities/ast_grep.rs
+++ b/src/capabilities/ast_grep.rs
@@ -24,6 +24,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 pub(crate) const AST_GREP_CAPABILITY_ID: &str = "ast_grep";
+pub(crate) const AST_EDIT_CAPABILITY_ID: &str = "ast_edit";
 
 const DEFAULT_LIMIT: usize = 50;
 const MAX_LIMIT: usize = 500;
@@ -65,11 +66,11 @@ impl Capability for AstGrepCapability {
     }
 
     fn name(&self) -> &str {
-        "AST Grep & Edit"
+        "AST Grep"
     }
 
     fn description(&self) -> &str {
-        "Structural code search and ast-grep pattern rewrites across common languages."
+        "Read-only multi-language structural code search backed by ast-grep patterns."
     }
 
     fn status(&self) -> CapabilityStatus {
@@ -84,10 +85,8 @@ impl Capability for AstGrepCapability {
         Some(
             "<capability id=\"ast_grep\">\n\
              For structural code search, call `ast_grep` with an ast-grep pattern and usually \
-             a language filter. For shape-based rewrites, call `ast_edit` with `pattern` and \
-             `replacement` — preview with `dry_run=true` (the default), show the user the diff, \
-             then apply with `dry_run=false` after they accept. Use `ast_grep` first to confirm \
-             the pattern matches the intended nodes.\n\
+             a language filter. Use it after repo-map/grep have narrowed the area, and read \
+             matched files before editing.\n\
              </capability>"
                 .to_string(),
         )
@@ -96,21 +95,76 @@ impl Capability for AstGrepCapability {
     fn system_prompt_preview(&self) -> Option<String> {
         Some(
             "<capability id=\"ast_grep\">\n\
-             Use `ast_grep` for read-only structural search; use `ast_edit` for previewed rewrites.\n\
+             Use `ast_grep` for read-only structural pattern search.\n\
              </capability>"
                 .to_string(),
         )
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
-        vec![
-            Box::new(AstGrepTool {
-                workspace: self.workspace.clone(),
-            }),
-            Box::new(AstEditTool {
-                workspace: self.workspace.clone(),
-            }),
-        ]
+        vec![Box::new(AstGrepTool {
+            workspace: self.workspace.clone(),
+        })]
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct AstEditCapability {
+    workspace: Arc<WorkspaceHost>,
+}
+
+impl AstEditCapability {
+    pub(crate) fn new(workspace: Arc<WorkspaceHost>) -> Self {
+        Self { workspace }
+    }
+}
+
+#[async_trait]
+impl Capability for AstEditCapability {
+    fn id(&self) -> &str {
+        AST_EDIT_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "AST Edit"
+    }
+
+    fn description(&self) -> &str {
+        "Previewed ast-grep pattern rewrites across common languages (opt-in)."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Code Navigation")
+    }
+
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        Some(
+            "<capability id=\"ast_edit\">\n\
+             For shape-based rewrites, call `ast_edit` with `pattern` and `replacement`. \
+             Preview with `dry_run=true` (the default), show the user the diff, then apply with \
+             `dry_run=false` after they accept. Confirm the pattern with `ast_grep` first.\n\
+             </capability>"
+                .to_string(),
+        )
+    }
+
+    fn system_prompt_preview(&self) -> Option<String> {
+        Some(
+            "<capability id=\"ast_edit\">\n\
+             Use `ast_edit` for previewed structural rewrites.\n\
+             </capability>"
+                .to_string(),
+        )
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![Box::new(AstEditTool {
+            workspace: self.workspace.clone(),
+        })]
     }
 }
 
@@ -1385,7 +1439,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         write(&dir.path().join("app.ts"), "console.log(value);\n");
 
-        let capability = AstGrepCapability::new(host(dir.path()));
+        let capability = AstEditCapability::new(host(dir.path()));
         let tool = capability
             .tools()
             .into_iter()
@@ -1409,7 +1463,7 @@ mod tests {
     }
 
     #[test]
-    fn capability_exposes_ast_grep_and_ast_edit_tools() {
+    fn capability_exposes_ast_grep_tool() {
         let dir = tempfile::tempdir().expect("tempdir");
         let capability = AstGrepCapability::new(host(dir.path()));
         let names: Vec<String> = capability
@@ -1417,6 +1471,18 @@ mod tests {
             .iter()
             .map(|tool| tool.name().to_string())
             .collect();
-        assert_eq!(names, vec!["ast_grep", "ast_edit"]);
+        assert_eq!(names, vec!["ast_grep"]);
+    }
+
+    #[test]
+    fn capability_exposes_ast_edit_tool() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let capability = AstEditCapability::new(host(dir.path()));
+        let names: Vec<String> = capability
+            .tools()
+            .iter()
+            .map(|tool| tool.name().to_string())
+            .collect();
+        assert_eq!(names, vec!["ast_edit"]);
     }
 }

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -29,7 +29,7 @@ pub(crate) mod yolop;
 pub(crate) use crate::goal::GOAL_CAPABILITY_ID;
 pub(crate) use crate::user_ask::USER_ASK_CAPABILITY_ID;
 pub(crate) use approval::{APPROVAL_CAPABILITY_ID, ApprovalCapability};
-pub(crate) use ast_grep::{AST_GREP_CAPABILITY_ID, AstGrepCapability};
+pub(crate) use ast_grep::{AST_GREP_CAPABILITY_ID, AstEditCapability, AstGrepCapability};
 pub(crate) use attribution::{ATTRIBUTION_CAPABILITY_ID, AttributionCapability};
 pub(crate) use background::{BACKGROUND_CAPABILITY_ID, BackgroundCapability};
 pub(crate) use client_commands::{CLIENT_COMMANDS_CAPABILITY_ID, ClientCommandsCapability};

--- a/src/capabilities/progress_guard.rs
+++ b/src/capabilities/progress_guard.rs
@@ -273,7 +273,7 @@ fn classify_tool_call(tool_call: &ToolCall) -> ToolClass {
         "read_file" | "grep_files" | "repo_map" | "ast_grep" | "list_directory" | "stat_file" => {
             ToolClass::Exploration
         }
-        "write_file" | "edit_file" | "delete_file" => ToolClass::Mutation,
+        "write_file" | "edit_file" | "delete_file" | "ast_edit" => ToolClass::Mutation,
         "bash" => classify_bash_command(
             tool_call
                 .arguments

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -9,13 +9,14 @@ use crate::capabilities::memory::{GlobalMemoryCapability, MEMORY_CAPABILITY_ID, 
 use crate::capabilities::yolop::{YOLOP_CAPABILITY_ID, YolopCapability};
 use crate::capabilities::{
     APPROVAL_CAPABILITY_ID, AST_GREP_CAPABILITY_ID, ATTRIBUTION_CAPABILITY_ID, ApprovalCapability,
-    AstGrepCapability, AttributionCapability, BACKGROUND_CAPABILITY_ID, BackgroundCapability,
-    CLIENT_COMMANDS_CAPABILITY_ID, CODING_BASH_CAPABILITY_ID, CONFIG_CAPABILITY_ID,
-    ClientCommandsCapability, CodingBashCapability, CodingCliEnvironmentCapability,
-    ConfigCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID, GOAL_CAPABILITY_ID, GoalCapability,
-    HOOKS_CAPABILITY_ID, HooksCapability, LspCapability, PROGRESS_GUARD_CAPABILITY_ID,
-    ProgressGuardCapability, REPO_MAP_CAPABILITY_ID, RepoMapCapability, SETUP_CAPABILITY_ID,
-    SetupCapability, USER_ASK_CAPABILITY_ID, UserAskCapability, WorktreeCapability,
+    AstEditCapability, AstGrepCapability, AttributionCapability, BACKGROUND_CAPABILITY_ID,
+    BackgroundCapability, CLIENT_COMMANDS_CAPABILITY_ID, CODING_BASH_CAPABILITY_ID,
+    CONFIG_CAPABILITY_ID, ClientCommandsCapability, CodingBashCapability,
+    CodingCliEnvironmentCapability, ConfigCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID,
+    GOAL_CAPABILITY_ID, GoalCapability, HOOKS_CAPABILITY_ID, HooksCapability, LspCapability,
+    PROGRESS_GUARD_CAPABILITY_ID, ProgressGuardCapability, REPO_MAP_CAPABILITY_ID,
+    RepoMapCapability, SETUP_CAPABILITY_ID, SetupCapability, USER_ASK_CAPABILITY_ID,
+    UserAskCapability, WorktreeCapability,
 };
 use crate::capability_settings::{CapabilityCatalog, apply_capability_settings};
 use crate::connectors::{
@@ -2190,7 +2191,8 @@ pub async fn build_with_options(
     //
     // Non-filesystem, but useful for a coding agent:
     //   * repo_map            - on-demand multi-language symbol map for broad codebase orientation
-    //   * ast_grep            - structural code search and ast_edit rewrites
+    //   * ast_grep            - read-only structural code search
+    //   * ast_edit            - previewed ast-grep rewrites (opt-in)
     //   * infinity_context     — keeps long sessions usable; adds query_history
     //   * compaction           — proactively masks older large tool outputs
     //   * stateless_todo_list  — write_todos tool for multi-step tasks
@@ -2224,6 +2226,10 @@ pub async fn build_with_options(
     ));
     capabilities.register(RepoMapCapability::new(workspace_host.clone()));
     capabilities.register(AstGrepCapability::new(workspace_host.clone()));
+    // `ast_edit` — structural rewrites with preview-first `dry_run`. Registered
+    // for the catalog but intentionally NOT part of the default harness; enable
+    // with `[[capabilities]] ref = "ast_edit"` in settings.toml.
+    capabilities.register(AstEditCapability::new(workspace_host.clone()));
     // `lsp` — real language servers (diagnostics, go-to-def, references,
     // rename, symbols, code actions). Registered so it appears in the catalog
     // and can be switched on, but intentionally NOT part of the default
@@ -4730,6 +4736,36 @@ mod tests {
             ids.iter()
                 .any(|cap| cap.capability_id() == AST_GREP_CAPABILITY_ID),
             "ast_grep should be available for structural code search"
+        );
+    }
+
+    /// `ast_edit` is registered for the catalog but stays off the default harness
+    /// until explicitly enabled in settings.toml.
+    #[test]
+    fn coding_harness_does_not_enable_ast_edit_by_default() {
+        use crate::capabilities::ast_grep::AST_EDIT_CAPABILITY_ID;
+
+        let ids = coding_harness_capabilities(false, None, &Settings::default());
+        assert!(
+            !ids.iter()
+                .any(|cap| cap.capability_id() == AST_EDIT_CAPABILITY_ID),
+            "ast_edit must remain opt-in"
+        );
+
+        let mut settings = Settings::default();
+        settings
+            .capabilities
+            .push(crate::capability_settings::CapabilityOverride {
+                capability_ref: AST_EDIT_CAPABILITY_ID.to_string(),
+                enabled: Some(true),
+                append: false,
+                config: serde_json::Value::Null,
+            });
+        let ids = coding_harness_capabilities(false, None, &settings);
+        assert!(
+            ids.iter()
+                .any(|cap| cap.capability_id() == AST_EDIT_CAPABILITY_ID),
+            "a [[capabilities]] override should enable ast_edit"
         );
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -488,6 +488,8 @@ const YOLOP_NEVER_DEFER_TOOLS: &[&str] = &[
     "edit_file",
     "list_directory",
     "grep_files",
+    "ast_grep",
+    "ast_edit",
     "bash",
     "spawn_background",
     "write_todos",
@@ -2188,7 +2190,7 @@ pub async fn build_with_options(
     //
     // Non-filesystem, but useful for a coding agent:
     //   * repo_map            - on-demand multi-language symbol map for broad codebase orientation
-    //   * ast_grep            - read-only structural code search with ast-grep patterns
+    //   * ast_grep            - structural code search and ast_edit rewrites
     //   * infinity_context     — keeps long sessions usable; adds query_history
     //   * compaction           — proactively masks older large tool outputs
     //   * stateless_todo_list  — write_todos tool for multi-step tasks

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -226,7 +226,7 @@ pub fn lines_for_event(event: &RuntimeEvent) -> Vec<ChatLine> {
                     format!("{marker} {label}  {summary}")
                 },
             }];
-            if data.tool_name == "edit_file"
+            if (data.tool_name == "edit_file" || data.tool_name == "ast_edit")
                 && let Some(diff) = extract_field(data, "diff")
             {
                 for line in diff.lines().take(40) {
@@ -557,6 +557,13 @@ pub fn summarize_tool_result(data: &ToolCompletedData) -> String {
             let path = v.get("path").and_then(Value::as_str).unwrap_or("");
             let n = v.get("applied_edits").and_then(Value::as_u64).unwrap_or(0);
             format!("{path} ({n} edit(s))")
+        }
+        "ast_edit" => {
+            let n = v.get("count").and_then(Value::as_u64).unwrap_or(0);
+            let files = v.get("files_changed").and_then(Value::as_u64).unwrap_or(0);
+            let preview = v.get("dry_run").and_then(Value::as_bool).unwrap_or(true);
+            let mode = if preview { "preview" } else { "applied" };
+            format!("{n} replacement(s) in {files} file(s) ({mode})")
         }
         "list_directory" => {
             let path = v.get("path").and_then(Value::as_str).unwrap_or("");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds **`ast_edit`**, an opt-in capability for previewed ast-grep structural rewrites (`dry_run=true` by default, then `dry_run=false` to apply). Splits it from the default `ast_grep` harness (read-only search stays on by default). Enable with `[[capabilities]] ref = "ast_edit"` in `settings.toml`.

Also adds harness_basic A/B eval cases, a `with-ast-edit` variant, `ast-edit-compare` preset, and adoption metrics (`ast_edit_used`, `ast_edit_tool_calls`).

## Why

Bulk shape rewrites (rename call patterns, strip debug statements, swap idioms) are tedious with per-file `edit_file`. `ast_edit` applies pattern/replacement across files with a preview-first flow, but stays opt-in until adoption is measured.

## Before / After

**Before:** No structural rewrite tool; agents used `grep_files` + repeated `edit_file`.

**After (default harness):** unchanged — `ast_grep` only.

**After (`ast_edit` enabled):** agent can preview/apply rewrites. Eval evidence (`ast-edit-compare`, claude-sonnet-4-5):

| Case | default | with-ast-edit |
|------|---------|---------------|
| `replace-console-log` | pass, 8 tool calls, $0.072, 18s | pass, **2 tool calls**, **$0.048**, **8s**, `ast_grep`→`ast_edit` |
| `strip-print-debug` | pass | pass via `edit_file` (no adoption) |
| `unwrap-to-expect` | pass | pass via `edit_file` (no adoption) |

Functional checks: **6/6 pass** on both harnesses. Adoption when enabled: **1/3** on sonnet; opus also adopted on the TS case. Archives: `evals/harness_basic/results/20260711T052608Z-4b10/` (local, gitignored).

Run: `cd evals/harness_basic && doppler run -- mira run --preset ast-edit-compare --group-by harness`

## Risk

- **Low** — default harness unchanged; `ast_edit` only when explicitly enabled.
- Writes respect existing workspace host / write blocklist (same as `edit_file`).
- `dry_run` defaults true; transcript renders `diff` preview like `edit_file`.

## Security

- **TM-FS:** `ast_edit` writes only through `WorkspaceHost` inside the workspace root; unsupported/skipped files unchanged. No bypass of write blocklist.
- **TM-BASH:** unchanged.
- **TM-LLM:** no new secret handling; tool schemas only.
- **TM-TOOL:** opt-in capability registration; `ast_edit` classified as mutation in progress guard.
- **TM-DEP:** no new crates; uses existing `ast-grep-core` / `ast-grep-language`.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (596 tests)
- `cargo test` in `evals/harness_basic` (11 tests)
- `cargo run --release -- --provider llmsim -p "hi"` (offline smoke)
- `doppler run -- mira run --preset ast-edit-compare` (saved runs under `evals/harness_basic/results/`)

## Follow-ups

- Add `gpt-5.6-sol` to harness_basic targets and re-run cross-model adoption compare.
- Optional `specs/ast_edit.md` (mirror `specs/lsp.md`) if we want a durable spec doc.
- Prompt/skill tuning to improve `ast_edit` adoption on smaller single-file rewrites.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9186a03-7237-4d89-9678-6151aa2954cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9186a03-7237-4d89-9678-6151aa2954cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

