### PR TITLE
chore(release): prepare v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,40 @@ mechanical `### What's Changed` list of merged PRs.
 Releases are cut via [`/release`](./.agents/skills/release/SKILL.md), which
 tags the version and publishes to crates.io and the Homebrew tap.
 
+## [0.6.0] - 2026-07-11
+
+### Highlights
+
+- **Structural code edits with `ast_edit`.** An opt-in ast-grep–backed tool
+  performs syntax-aware find-and-replace across a codebase, with a harness
+  eval proving the benefit.
+- **Authenticated MCP server management.** First-class tools list, add,
+  update, remove, and enable/disable MCP servers, persisting to global
+  settings and workspace `.mcp.json` with authenticated (env-var bearer)
+  setup documented.
+- **GPT-5.6 in the model picker.** New GPT-5.6 entries are selectable from
+  the runtime model picker.
+- **Smarter background waits.** External-event waits are steered toward
+  detached watches so long-running turns don't block on foreground polling.
+- **Cleaner print mode.** Plain `-p/--print` runs now emit only the final
+  assistant output on stdout; banners, progress, and footers move to stderr.
+
+### What's Changed
+
+* fix(tui): anchor inline viewport to terminal bottom reliably ([#250](https://github.com/everruns/yolop/pull/250)) by @chaliy
+* feat(ast-grep): add opt-in ast_edit with harness eval proof ([#249](https://github.com/everruns/yolop/pull/249)) by @chaliy
+* feat(mcp): manage authenticated servers ([#248](https://github.com/everruns/yolop/pull/248)) by @chaliy
+* feat(background): steer external-event waits to detached watches ([#247](https://github.com/everruns/yolop/pull/247)) by @chaliy
+* docs(attribution): update PR footer text ([#246](https://github.com/everruns/yolop/pull/246)) by @chaliy
+* chore: guide agents to narrow after repo map ([#245](https://github.com/everruns/yolop/pull/245)) by @chaliy
+* feat(runtime): add GPT-5.6 model picker entries ([#244](https://github.com/everruns/yolop/pull/244)) by @chaliy
+* chore(deps): bump everruns runtime ([#243](https://github.com/everruns/yolop/pull/243)) by @chaliy
+* chore(deps): bump everruns runtime ([#242](https://github.com/everruns/yolop/pull/242)) by @chaliy
+* fix(print): emit only final output ([#240](https://github.com/everruns/yolop/pull/240)) by @chaliy
+* chore(deps): bump the cargo-minor-and-patch group across 1 directory with 9 updates ([#238](https://github.com/everruns/yolop/pull/238)) by @dependabot
+
+**Full Changelog**: https://github.com/everruns/yolop/compare/v0.5.0...v0.6.0
+
 ## [0.5.0] - 2026-07-09
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6526,7 +6526,7 @@ dependencies = [
 
 [[package]]
 name = "yolop"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yolop"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["Everruns <support@everruns.com>"]
 license = "MIT"


### PR DESCRIPTION
## What changed

Cuts release **v0.6.0** (minor bump from v0.5.0): bumps `Cargo.toml` /
`Cargo.lock` to `0.6.0` and adds the `## [0.6.0]` section to `CHANGELOG.md`.
On merge, `release.yml` tags `v0.6.0`, then `publish.yml` (crates.io) and
`cli-binaries.yml` (GitHub Release binaries + Homebrew tap) publish.

This release collects 11 commits since v0.5.0, headlined by opt-in structural
edits (`ast_edit`), authenticated MCP server management, GPT-5.6 model picker
entries, detached background watches, and print-mode output cleanup.

## Why

Ship the accumulated work since v0.5.0 to crates.io and the Homebrew tap.

## Changelog

## [0.6.0] - 2026-07-11

### Highlights

- **Structural code edits with `ast_edit`.** An opt-in ast-grep–backed tool performs syntax-aware find-and-replace across a codebase, with a harness eval proving the benefit.
- **Authenticated MCP server management.** First-class tools list, add, update, remove, and enable/disable MCP servers, persisting to global settings and workspace `.mcp.json` with authenticated (env-var bearer) setup documented.
- **GPT-5.6 in the model picker.** New GPT-5.6 entries are selectable from the runtime model picker.
- **Smarter background waits.** External-event waits are steered toward detached watches so long-running turns don't block on foreground polling.
- **Cleaner print mode.** Plain `-p/--print` runs now emit only the final assistant output on stdout; banners, progress, and footers move to stderr.

### What's Changed

* fix(tui): anchor inline viewport to terminal bottom reliably ([#250](https://github.com/everruns/yolop/pull/250)) by @chaliy
* feat(ast-grep): add opt-in ast_edit with harness eval proof ([#249](https://github.com/everruns/yolop/pull/249)) by @chaliy
* feat(mcp): manage authenticated servers ([#248](https://github.com/everruns/yolop/pull/248)) by @chaliy
* feat(background): steer external-event waits to detached watches ([#247](https://github.com/everruns/yolop/pull/247)) by @chaliy
* docs(attribution): update PR footer text ([#246](https://github.com/everruns/yolop/pull/246)) by @chaliy
* chore: guide agents to narrow after repo map ([#245](https://github.com/everruns/yolop/pull/245)) by @chaliy
* feat(runtime): add GPT-5.6 model picker entries ([#244](https://github.com/everruns/yolop/pull/244)) by @chaliy
* chore(deps): bump everruns runtime ([#243](https://github.com/everruns/yolop/pull/243)) by @chaliy
* chore(deps): bump everruns runtime ([#242](https://github.com/everruns/yolop/pull/242)) by @chaliy
* fix(print): emit only final output ([#240](https://github.com/everruns/yolop/pull/240)) by @chaliy
* chore(deps): bump the cargo-minor-and-patch group across 1 directory with 9 updates ([#238](https://github.com/everruns/yolop/pull/238)) by @dependabot

**Full Changelog**: https://github.com/everruns/yolop/compare/v0.5.0...v0.6.0

## Publish-readiness

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` (34 passed, 1 ignored)
- [x] `cargo publish --dry-run -p yolop` succeeds
- [x] crates.io currently serves `0.5.0` → publishing `0.6.0`
- [x] `Cargo.toml` + `Cargo.lock` agree on `0.6.0`

## Post-merge verification

The release is not complete until all of the following are confirmed:

- [ ] `release.yml` created tag `v0.6.0` and the GitHub Release
- [ ] `publish.yml` finished green
- [ ] `cli-binaries.yml` finished green
- [ ] crates.io serves `0.6.0`
- [ ] Homebrew tap formula points at `v0.6.0`

## Before / After

No runtime behavior change in this PR — it is a version/changelog bump. The
functional changes are the merged PRs listed above.

## Risk
- Low
- What can break: a broken publish path would surface in CI post-merge; the `cargo publish --dry-run` gate passed, so the packaging boundary is validated.

## Checklist
- [x] Tests added or updated (n/a — release metadata only; suite passes)
- [x] Backward compatibility considered