### PR TITLE
feat(mcp): add authenticated server management

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,3 +482,20 @@ each version.
 ## License
 
 MIT — see [`LICENSE`](./LICENSE).
+
+## MCP servers
+
+Yolop can load MCP servers from global settings or a workspace `.mcp.json` file.
+Use `yolop mcp` to manage them from the CLI:
+
+```bash
+yolop mcp list --scope effective
+yolop mcp add linear --scope global --type http --url https://mcp.linear.app/mcp --auth-mode oauth --oauth-provider-id linear
+yolop mcp enable linear --scope global
+yolop mcp enable linear --scope global --disable
+yolop mcp remove linear --scope global
+```
+
+In an interactive session, `/mcp` lists startup MCP servers and
+`/mcp enable|disable|remove <name> [global|workspace]` updates the config. MCP
+connection changes take effect in the next yolop session.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1129,22 +1129,7 @@ impl App {
             UiCommand::ShowTools => {
                 self.push_system(format!("tools: {}", self.startup.tool_names.join(", ")));
             }
-            UiCommand::ShowMcp => {
-                if self.startup.mcp_server_names.is_empty() {
-                    let global = crate::mcp_config::global_mcp_config_path()
-                        .map(|p| p.display().to_string())
-                        .unwrap_or_else(|| "the yolop config dir".to_string());
-                    self.push_system(format!(
-                        "no MCP servers configured (add them to .mcp.json in the workspace \
-                         root or {global})"
-                    ));
-                } else {
-                    self.push_system(format!(
-                        "MCP servers: {}",
-                        self.startup.mcp_server_names.join(", ")
-                    ));
-                }
-            }
+            UiCommand::ManageMcp { arg } => self.manage_mcp_command(arg.as_deref()),
             UiCommand::ShowCwd => {
                 self.push_system(format!(
                     "workspace root: {}",
@@ -1168,6 +1153,88 @@ impl App {
             UiCommand::OpenEffortOverlay { arg } => {
                 self.start_effort_setup(arg.as_deref().unwrap_or(""))
             }
+        }
+    }
+
+    fn manage_mcp_command(&mut self, raw: Option<&str>) {
+        let Some(raw) = raw.map(str::trim).filter(|s| !s.is_empty()) else {
+            if self.startup.mcp_server_names.is_empty() {
+                let global = crate::mcp_config::global_mcp_config_path()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_else(|| "the yolop config dir".to_string());
+                self.push_system(format!(
+                    "no MCP servers configured (add them with `yolop mcp add`, .mcp.json in the workspace root, or {global})"
+                ));
+            } else {
+                self.push_system(format!(
+                    "MCP servers: {}",
+                    self.startup.mcp_server_names.join(", ")
+                ));
+            }
+            self.push_system(
+                "usage: /mcp [enable|disable|remove <name> [global|workspace]]".into(),
+            );
+            return;
+        };
+
+        let mut parts = raw.split_whitespace();
+        let action = parts.next().unwrap_or_default();
+        let name = parts.next();
+        let scope = match parts.next() {
+            None | Some("global") => crate::mcp_config::McpConfigScope::Global,
+            Some("workspace") => crate::mcp_config::McpConfigScope::Workspace,
+            Some(other) => {
+                self.push_system(format!(
+                    "usage: /mcp [enable|disable|remove <name> [global|workspace]] (unknown scope: {other})"
+                ));
+                return;
+            }
+        };
+        if parts.next().is_some() {
+            self.push_system(
+                "usage: /mcp [enable|disable|remove <name> [global|workspace]]".into(),
+            );
+            return;
+        }
+        let Some(name) = name else {
+            self.push_system(
+                "usage: /mcp [enable|disable|remove <name> [global|workspace]]".into(),
+            );
+            return;
+        };
+
+        let store =
+            crate::mcp_config::McpConfigStore::default_for_workspace(&self.startup.workspace_root);
+        let result = match action {
+            "enable" => store
+                .set_enabled(scope, name, true)
+                .map(|_| format!("enabled MCP server `{name}`")),
+            "disable" => store
+                .set_enabled(scope, name, false)
+                .map(|_| format!("disabled MCP server `{name}`")),
+            "remove" => store.remove(scope, name).map(|removed| {
+                if removed {
+                    format!("removed MCP server `{name}`")
+                } else {
+                    format!("MCP server `{name}` was not configured")
+                }
+            }),
+            other => {
+                self.push_system(format!(
+                    "usage: /mcp [enable|disable|remove <name> [global|workspace]] (unknown action: {other})"
+                ));
+                return;
+            }
+        };
+        match result {
+            Ok(message) => {
+                self.push_system(message);
+                self.push_system(
+                    "restart or start a new yolop session for MCP connection changes to take effect"
+                        .into(),
+                );
+            }
+            Err(error) => self.push_system(format!("failed to update MCP config: {error}")),
         }
     }
 

--- a/src/capabilities/client_commands.rs
+++ b/src/capabilities/client_commands.rs
@@ -139,7 +139,7 @@ fn ui_command_for(name: &str, arg: Option<String>) -> Option<UiCommand> {
     match name {
         "help" => Some(UiCommand::ShowHelp),
         "tools" => Some(UiCommand::ShowTools),
-        "mcp" => Some(UiCommand::ShowMcp),
+        "mcp" => Some(UiCommand::ManageMcp { arg }),
         "cwd" => Some(UiCommand::ShowCwd),
         "status" => Some(UiCommand::SetStatusLayout { arg }),
         "clear" => Some(UiCommand::ClearTranscript),

--- a/src/host_ui.rs
+++ b/src/host_ui.rs
@@ -20,8 +20,8 @@ pub enum UiCommand {
     ShowHelp,
     /// Print the list of available tools.
     ShowTools,
-    /// Print the configured MCP servers.
-    ShowMcp,
+    /// Inspect or update configured MCP servers.
+    ManageMcp { arg: Option<String> },
     /// Print the workspace root.
     ShowCwd,
     /// Change the inline session status layout.

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,7 @@ use crossterm::{execute, queue};
 use everruns_core::command::ExecuteCommandRequest;
 use everruns_core::message::{ContentPart, MessageRole};
 use everruns_core::typed_id::SessionId;
+use mcp_config::{McpConfigScope, McpConfigStore};
 use ratatui::backend::CrosstermBackend;
 use ratatui::{Terminal, TerminalOptions, Viewport};
 use runtime::{BuiltRuntime, ProviderChoice, ResolvedProviderChoice, resolve_for_settings};
@@ -149,6 +150,104 @@ enum Commands {
     Into(IntoCommand),
     /// Git worktree maintenance.
     Worktree(WorktreeArgs),
+    /// Manage MCP servers in global settings or workspace `.mcp.json`.
+    Mcp(McpArgs),
+}
+
+#[derive(Args, Debug)]
+struct McpArgs {
+    #[command(subcommand)]
+    command: McpCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum McpCommand {
+    /// List configured MCP servers.
+    List {
+        /// Scope to inspect (`global`, `workspace`, or `effective`).
+        #[arg(long, default_value = "effective")]
+        scope: McpScopeArg,
+        /// Workspace root for workspace/effective config.
+        #[arg(short = 'C', long = "cwd")]
+        cwd: Option<PathBuf>,
+    },
+    /// Add or replace an MCP server.
+    Add {
+        /// Scope to write (`global` or `workspace`).
+        #[arg(long, default_value = "global")]
+        scope: McpScopeArg,
+        /// Server name.
+        name: String,
+        /// Transport type (`stdio`, `http`, or `sse`).
+        #[arg(long = "type")]
+        transport_type: String,
+        /// Command for stdio servers.
+        #[arg(long)]
+        command: Option<String>,
+        /// Command arguments for stdio servers. Repeat or comma-separate.
+        #[arg(long, value_delimiter = ',', num_args = 0..)]
+        args: Vec<String>,
+        /// URL for http/sse servers.
+        #[arg(long)]
+        url: Option<String>,
+        /// Header as KEY=VALUE. Repeat for multiple headers.
+        #[arg(long = "header", value_parser = parse_key_value)]
+        headers: Vec<(String, String)>,
+        /// Auth mode (`bearer`, `oauth`, or `none`).
+        #[arg(long)]
+        auth_mode: Option<String>,
+        /// OAuth provider id for auth-mode=oauth.
+        #[arg(long)]
+        oauth_provider_id: Option<String>,
+        /// Disable the server immediately after adding it.
+        #[arg(long, default_value_t = false)]
+        disabled: bool,
+        /// Workspace root when writing workspace config.
+        #[arg(short = 'C', long = "cwd")]
+        cwd: Option<PathBuf>,
+    },
+    /// Remove an MCP server.
+    Remove {
+        /// Scope to write (`global` or `workspace`).
+        #[arg(long, default_value = "global")]
+        scope: McpScopeArg,
+        /// Server name.
+        name: String,
+        /// Workspace root when writing workspace config.
+        #[arg(short = 'C', long = "cwd")]
+        cwd: Option<PathBuf>,
+    },
+    /// Enable or disable an MCP server without deleting it.
+    Enable {
+        /// Scope to write (`global` or `workspace`).
+        #[arg(long, default_value = "global")]
+        scope: McpScopeArg,
+        /// Server name.
+        name: String,
+        /// Disable instead of enable.
+        #[arg(long, default_value_t = false)]
+        disable: bool,
+        /// Workspace root when writing workspace config.
+        #[arg(short = 'C', long = "cwd")]
+        cwd: Option<PathBuf>,
+    },
+}
+
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+enum McpScopeArg {
+    Global,
+    Workspace,
+    Effective,
+}
+
+fn parse_key_value(value: &str) -> Result<(String, String), String> {
+    let (key, val) = value
+        .split_once('=')
+        .ok_or_else(|| "expected KEY=VALUE".to_string())?;
+    if key.trim().is_empty() {
+        return Err("header key cannot be empty".to_string());
+    }
+    Ok((key.trim().to_string(), val.to_string()))
 }
 
 #[derive(Args, Debug)]
@@ -462,6 +561,195 @@ fn resolve_workspace_root(
     std::env::current_dir().context("resolve current workspace directory")
 }
 
+fn run_mcp_command(command: McpCommand) -> Result<()> {
+    use crate::mcp_config::{McpServerEntry, McpServerSummary};
+    use everruns_core::{McpServerTransportType, ScopedMcpServer};
+    use std::collections::HashMap;
+
+    fn store(cwd: Option<PathBuf>) -> Result<McpConfigStore> {
+        let workspace_root = match cwd {
+            Some(path) => path,
+            None => std::env::current_dir().context("resolve current workspace directory")?,
+        };
+        Ok(McpConfigStore::default_for_workspace(&workspace_root))
+    }
+
+    fn write_scope(scope: McpScopeArg) -> Result<McpConfigScope> {
+        match scope {
+            McpScopeArg::Global => Ok(McpConfigScope::Global),
+            McpScopeArg::Workspace => Ok(McpConfigScope::Workspace),
+            McpScopeArg::Effective => anyhow::bail!(
+                "effective scope is read-only; use --scope global or --scope workspace"
+            ),
+        }
+    }
+
+    match command {
+        McpCommand::List { scope, cwd } => {
+            let store = store(cwd)?;
+            let servers: Vec<McpServerSummary> = match scope {
+                McpScopeArg::Global => store
+                    .effective()
+                    .map_err(anyhow::Error::msg)?
+                    .servers
+                    .into_iter()
+                    .filter(|server| server.scope == McpConfigScope::Global)
+                    .collect(),
+                McpScopeArg::Workspace => store
+                    .effective()
+                    .map_err(anyhow::Error::msg)?
+                    .servers
+                    .into_iter()
+                    .filter(|server| server.scope == McpConfigScope::Workspace)
+                    .collect(),
+                McpScopeArg::Effective => store
+                    .effective()
+                    .map_err(anyhow::Error::msg)?
+                    .servers
+                    .into_iter()
+                    .filter(|server| server.effective)
+                    .collect(),
+            };
+            if servers.is_empty() {
+                println!("no MCP servers configured");
+            } else {
+                for server in servers {
+                    let enabled = if server.enabled {
+                        "enabled"
+                    } else {
+                        "disabled"
+                    };
+                    println!(
+                        "{}	{}	{}",
+                        server.name,
+                        mcp_scope_label(server.scope),
+                        enabled
+                    );
+                }
+            }
+            Ok(())
+        }
+        McpCommand::Add {
+            scope,
+            name,
+            transport_type,
+            command,
+            args,
+            url,
+            headers,
+            auth_mode,
+            oauth_provider_id,
+            disabled,
+            cwd,
+        } => {
+            let transport = transport_type.to_ascii_lowercase();
+            let server = match transport.as_str() {
+                "stdio" => ScopedMcpServer {
+                    transport_type: McpServerTransportType::Stdio,
+                    command: Some(command.context("--command is required for stdio MCP servers")?),
+                    args,
+                    env: HashMap::new(),
+                    ..ScopedMcpServer::default()
+                },
+                "http" | "sse" => ScopedMcpServer {
+                    transport_type: McpServerTransportType::Http,
+                    url: url.context("--url is required for remote MCP servers")?,
+                    headers: headers.into_iter().collect(),
+                    auth_mode: auth_mode
+                        .as_deref()
+                        .map(parse_mcp_auth_mode)
+                        .transpose()?
+                        .unwrap_or_default(),
+                    oauth_provider_id,
+                    ..ScopedMcpServer::default()
+                },
+                other => anyhow::bail!(
+                    "unsupported MCP transport `{other}`; expected stdio, http, or sse"
+                ),
+            };
+            let store = store(cwd)?;
+            let _summary = store
+                .upsert(
+                    write_scope(scope)?,
+                    &name,
+                    McpServerEntry {
+                        enabled: !disabled,
+                        server,
+                    },
+                )
+                .map_err(anyhow::Error::msg)?;
+            let action = "saved";
+            println!(
+                "{action} MCP server `{name}` in {} scope",
+                mcp_scope_label(write_scope(scope)?)
+            );
+            println!(
+                "restart or start a new yolop session for MCP connection changes to take effect"
+            );
+            Ok(())
+        }
+        McpCommand::Remove { scope, name, cwd } => {
+            let store = store(cwd)?;
+            let removed = store
+                .remove(write_scope(scope)?, &name)
+                .map_err(anyhow::Error::msg)?;
+            if removed {
+                println!(
+                    "removed MCP server `{name}` from {} scope",
+                    mcp_scope_label(write_scope(scope)?)
+                );
+                println!(
+                    "restart or start a new yolop session for MCP connection changes to take effect"
+                );
+            } else {
+                println!(
+                    "MCP server `{name}` was not configured in {} scope",
+                    mcp_scope_label(write_scope(scope)?)
+                );
+            }
+            Ok(())
+        }
+        McpCommand::Enable {
+            scope,
+            name,
+            disable,
+            cwd,
+        } => {
+            let store = store(cwd)?;
+            store
+                .set_enabled(write_scope(scope)?, &name, !disable)
+                .map_err(anyhow::Error::msg)?;
+            println!(
+                "{} MCP server `{name}` in {} scope",
+                if disable { "disabled" } else { "enabled" },
+                mcp_scope_label(write_scope(scope)?)
+            );
+            println!(
+                "restart or start a new yolop session for MCP connection changes to take effect"
+            );
+            Ok(())
+        }
+    }
+}
+
+fn mcp_scope_label(scope: McpConfigScope) -> &'static str {
+    match scope {
+        McpConfigScope::Global => "global",
+        McpConfigScope::Workspace => "workspace",
+    }
+}
+
+fn parse_mcp_auth_mode(value: &str) -> Result<everruns_core::McpServerAuthMode> {
+    match value.to_ascii_lowercase().as_str() {
+        "none" => Ok(everruns_core::McpServerAuthMode::None),
+        "bearer" | "api_key" | "api-key" => Ok(everruns_core::McpServerAuthMode::ApiKey),
+        "oauth" | "o_auth" => Ok(everruns_core::McpServerAuthMode::OAuth),
+        other => anyhow::bail!(
+            "unsupported auth mode `{other}`; expected none, bearer/api_key, or oauth"
+        ),
+    }
+}
+
 fn run_worktree_command(command: WorktreeCommand) -> Result<()> {
     match command {
         WorktreeCommand::List => {
@@ -512,6 +800,7 @@ fn run_command(command: Commands) -> Result<()> {
             Ok(())
         }
         Commands::Worktree(args) => run_worktree_command(args.command),
+        Commands::Mcp(args) => run_mcp_command(args.command),
         Commands::Into(into) => match into.target {
             IntoTarget::Paseo(args) => {
                 let command = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("yolop"));


### PR DESCRIPTION
## What
Adds MCP server management commands that can configure authenticated remote MCP servers, including OAuth-backed servers such as Linear.

## Why
Users could see a configured MCP server but had no built-in way to add or authenticate one from yolop.

## How
- Adds `yolop mcp list/add/enable/remove` with global and workspace scopes.
- Supports remote MCP auth modes, including OAuth provider ids.
- Extends interactive `/mcp` to list startup servers and enable, disable, or remove configured servers.
- Documents Linear OAuth setup in the README.

## Validation
- `cargo fmt --check`
- `cargo test --all-features`
- MCP OAuth CLI assertion against a temp workspace:
  - `yolop mcp add --scope workspace -C "$tmp" linear --type http --url https://mcp.linear.app/mcp --auth-mode oauth --oauth-provider-id linear`
  - `yolop mcp list --scope effective -C "$tmp"`
  - Asserted saved URL, OAuth auth mode, OAuth provider id, enabled state, and effective list output.

## Risk
- Low / Medium
- MCP config changes are persisted immediately, but active MCP connections are still created at session startup; users must restart or start a new yolop session for connection changes to take effect.

## Security
- TM-TOOL/TM-LLM reviewed: stores OAuth auth mode and provider id only; no OAuth tokens, API keys, or headers are logged or surfaced.
- TM-FS reviewed: workspace MCP config writes remain scoped to the workspace `.mcp.json`; global writes use the existing settings path.
- TM-DEP reviewed: no new dependencies.

## Follow-ups
No follow-ups.

Generated with yolop
