### PR TITLE
fix(acp): avoid duplicated command hints

### DIFF
--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -527,6 +527,11 @@ mod tests {
             .iter()
             .find(|c| c["name"] == "setup")
             .expect("setup command");
+        assert_eq!(
+            setup["description"],
+            "Configure provider, API key, and model."
+        );
+        assert_eq!(setup["input"]["hint"], "<action>");
         let suggestions = setup["_meta"]["yolop.dev/command"]["args"][0]["suggestions"]
             .as_array()
             .expect("setup suggestions");

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -556,15 +556,9 @@ fn command_input(command: &CommandDescriptor) -> Option<AvailableCommandInput> {
     let hint = command
         .args
         .iter()
-        .map(|arg| {
-            if arg.description.trim().is_empty() {
-                arg.name.as_str()
-            } else {
-                arg.description.as_str()
-            }
-        })
+        .map(|arg| format!("<{}>", arg.name))
         .collect::<Vec<_>>()
-        .join(", ");
+        .join(" ");
     Some(AvailableCommandInput::Unstructured(
         UnstructuredCommandInput::new(hint),
     ))


### PR DESCRIPTION
## What changed
ACP slash-command argument hints now show compact placeholders such as `<action>` instead of repeating the full argument description. The command description remains available separately, so clients no longer render duplicated explanatory text for commands like `/setup`.

## Why
ACP clients can display both the command description and the command input hint. Reusing argument descriptions for the hint made those surfaces redundant and noisy.

## Before / After
Before:
- `/setup` command description: `Configure provider, API key, and model.`
- `/setup` input hint repeated argument prose.

After:
- `/setup` command description: `Configure provider, API key, and model.`
- `/setup` input hint: `<action>`

Validation:
- `cargo fmt --check`
- `cargo test --all-features acp_commands_include_metadata`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"`

## Risk
- Low
- Could affect ACP clients that expected verbose input hints, but the full argument metadata and suggestions remain in `_meta`.

## Security
No security-relevant code changes. This only changes ACP command presentation metadata and a test assertion; it does not affect filesystem, shell, LLM, capability registration, dependencies, secrets, or trust boundaries.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

Produced by [yolop](https://everruns.com/yolop)
