### PR TITLE
chore(deps): bump everruns to 0.17.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44135ff8104e5fbdcd5e0a8a8850b083694762530aa0212cac3a71158ac90a42"
 dependencies = [
- "bit-set 0.10.1",
+ "bit-set 0.10.0",
  "regex",
  "thiserror 2.0.18",
  "tree-sitter",
@@ -595,11 +595,11 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0f1f60a6be1155c81f2f9fca48157aa87ecb61361d71b0be6e83c8d34f5527"
+checksum = "09ec2f926cc3060f09db9ebc5b52823d85268d24bb917e472c0c4bea35780a7d"
 dependencies = [
- "bit-vec 0.10.0",
+ "bit-vec 0.9.1",
 ]
 
 [[package]]
@@ -616,11 +616,10 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bit-vec"
-version = "0.10.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27072b69db792194938b8a1ae8f1e4a003ba53437a719cf6ddc21f32229f0586"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 dependencies = [
- "borsh",
  "serde",
 ]
 
@@ -665,30 +664,6 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
-]
-
-[[package]]
-name = "borsh"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
-dependencies = [
- "borsh-derive",
- "bytes",
- "cfg_aliases 0.2.1",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
-dependencies = [
- "once_cell",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -746,9 +721,9 @@ checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
 
 [[package]]
 name = "byteorder-lite"
@@ -758,9 +733,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "castaway"
@@ -773,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1063,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1073,18 +1048,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -1535,9 +1510,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.6"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cd0f70bcf83d6ca8558bf417ad08d2ca4e0848340c06752e2c083ac2d4d56d"
+checksum = "cc609849a129c0f87c22eeeaa7f2c54f5e1ec90d1f82754e2f217777f294cb5c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1553,9 +1528,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.6"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e5f6529af12477ffc344690d958b99dbfd35862179e1dd1bcbe022e4fac25e"
+checksum = "8c8c4e3608b2e425363f19a05a2f62e2f963283f24861e946e8ce36dd0adecff"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -1597,9 +1572,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.6"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae5853ec5646e76c381c3fe59cb17b7d448f78b310be417c0e0da04a703f193b"
+checksum = "da054d7021b1c4912a7353fc376329bb68a37b2ac92bb6973b23c7ba84bbd0e4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1614,9 +1589,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.6"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390637b8430b405b6589eec32e6348966c33b749ab44bfae8fbcf6387824b248"
+checksum = "a61575d3b325e1ed807a60e1eacd6e2ed6979b5832fba4d37023fe4f2222d5ce"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1630,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.6"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "247213428b01a401e4f767e42abda4a4c03c11f94ca23330e2a8455566342566"
+checksum = "ddf870f2c8a31b33099e2108d9fa1413659864bc6662dfeb1ed453b63242870a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1651,9 +1626,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.6"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b68c302b291a7e2dfee7cf37c4a4352882bf4ecca1dca81d8eb4a39df664c92b"
+checksum = "998a46680c7b15d922d0a6503a75d2d89bb3ef4290e738a8e23b54b640225d44"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1666,9 +1641,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.6"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87d75106761ec3756e201f740fe6d690b213d9ee8814c35f37da0cf97bba26c"
+checksum = "c3b8c10dff5b8e9224108d68f0714722f134c737e9c58e006bb591c6817c6dcd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1687,9 +1662,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.6"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc875ce7f41873676f283e66d1aa94278c79be16a9ac9ccc99f1e52c912795a9"
+checksum = "eaf778d440736725974f0939ae047c327001e7df779cd32e80ccbf62148ccc3b"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1701,9 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.6"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4109d35d38a0f3fb458d894a0f23d553970b16bcefb34c231fd6ce44440570ec"
+checksum = "fa0eab743b3edf02123294199812c318d553c42be51c3fe26ff79702642f5298"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2048,11 +2023,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2472,9 +2445,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f"
+checksum = "2adf14691c72bcfc1058740436a35bdd3ae9c07d1a941ef00b749e9ea16aefa7"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -2664,9 +2637,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
+checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
 dependencies = [
  "defmt",
  "jiff-static",
@@ -2680,9 +2653,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
+checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2691,9 +2664,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6142247df1a93c2b3587402a19710be3e6e942f1581a1702e76408f2c21d6590"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
 
 [[package]]
 name = "jiff-tzdb-platform"
@@ -2755,11 +2728,11 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -2891,9 +2864,9 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -2941,9 +2914,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmem"
@@ -3075,9 +3048,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -3284,7 +3257,7 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "portable-atomic",
- "rand 0.9.4",
+ "rand 0.9.5",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -3500,7 +3473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -3676,15 +3649,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3832,9 +3796,9 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quick-error"
@@ -3873,15 +3837,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3895,16 +3860,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3930,18 +3895,18 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -3991,6 +3956,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "ratatui"
@@ -4148,9 +4122,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4160,9 +4134,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4425,9 +4399,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -5125,9 +5099,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -5202,9 +5176,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5300,18 +5274,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
-dependencies = [
- "indexmap 2.14.0",
- "toml_datetime",
- "toml_parser",
- "winnow 1.0.3",
 ]
 
 [[package]]
@@ -6471,9 +6433,6 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winreg"
@@ -6625,18 +6584,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,18 +77,18 @@ tree-sitter-zig = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-everruns-anthropic = "0.17.6"
-everruns-core = "0.17.6"
-everruns-openai = "0.17.6"
+everruns-anthropic = "0.17.7"
+everruns-core = "0.17.7"
+everruns-openai = "0.17.7"
 # OpenRouter's first-class driver was split out of everruns-openai into its own
 # crate in 0.13.0; register it alongside openai to keep DriverId::OpenRouter.
-everruns-openrouter = "0.17.6"
-everruns-local = "0.17.6"
+everruns-openrouter = "0.17.7"
+everruns-local = "0.17.7"
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (specs/mcp.md, upstream runtime-mcp.md D2).
-everruns-runtime = { version = "0.17.6", features = ["mcp-stdio"] }
-everruns-integrations-duckduckgo = "0.17.6"
-everruns-integrations-daytona = "0.17.6"
+everruns-runtime = { version = "0.17.7", features = ["mcp-stdio"] }
+everruns-integrations-duckduckgo = "0.17.7"
+everruns-integrations-daytona = "0.17.7"
 arboard = { version = "3", features = ["wayland-data-control"] }
 futures = "0.3"
 html-escape = "0.2"

--- a/README.md
+++ b/README.md
@@ -120,8 +120,10 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   idle, yolop proactively wakes the agent with a turn so it reacts without
   waiting for your next prompt (turn off with the `proactive_wake` setting).
   See [`specs/background.md`](./specs/background.md).
-- **Web** — `web_fetch` (HTTP GET/HEAD with markdown/text conversion, DNS-pinned
-  SSRF protection) and `duckduckgo_search` (free, no API key). Setting
+- **Web** — `free_web_search` (best-effort SERP/developer search), `web_fetch`
+  (HTTP GET/HEAD with markdown/text conversion and DNS-pinned SSRF protection),
+  and `duckduckgo_instant_answer` (curated facts and abstracts). All work
+  without an API key. Setting
   `EVERRUNS_SYSTEM_ALLOWLIST_ENABLED=true` restricts `web_fetch` to the
   runtime's curated allowlist of well-known public resources (package
   registries, source hosting, AI/cloud provider APIs, OS mirrors); off by

--- a/specs/background.md
+++ b/specs/background.md
@@ -54,10 +54,13 @@ harness steers there at the three places poll loops start, on any repo:
   `spawn_background` instead of leaving the model to fall back to
   sleep-and-recheck turns.
 
-Sub-agents were intentionally **not** migrated: Everruns' `spawn_subagent` is
-foreground/blocking, and Yolop's former detached `background_agent` was dropped
-rather than reimplemented. If detached sub-agents return, they should be a
-background-capable tool wrapped by `spawn_background`, not a separate registry.
+Sub-agents are intentionally **not enabled**. Everruns 0.17.7 can run linked
+sub-agents in the background and spawn detached peer sessions, but both require a
+local session runner that can create and drive child sessions. Yolop's runner is
+deliberately narrower: it only delivers completion wakes for background tools.
+Registering the upstream sub-agent capability without a real child-session host
+would advertise tools that fail at execution time. `spawn_background` therefore
+remains Yolop's detached-work primitive.
 
 ### Inspecting and controlling
 

--- a/src/bundled/system-skills/yolop/SKILL.md
+++ b/src/bundled/system-skills/yolop/SKILL.md
@@ -111,8 +111,8 @@ yolop is an autonomous coding agent for the workspace it was started in.
 - **Shell** — `bash -lc` from the workspace root (120 s timeout, capped output)
 - **AST search** — structural `ast_grep` across common languages (default harness)
 - **AST edit** *(opt-in)* — previewed `ast_edit` rewrites; enable with `[[capabilities]] ref = "ast_edit"`
-- **Background work** — detached shell commands and focused sub-agents
-- **Web** — `web_fetch` and `duckduckgo_search`
+- **Background work** — detached shell commands with completion wakes
+- **Web** — `web_fetch`, `free_web_search`, and `duckduckgo_instant_answer`
 - **Memory** — durable cross-session notes via `remember` / `recall` / `forget`
 - **Skills** — `SKILL.md` packages in workspace, global, and bundled system scopes
 - **MCP** — extra tools from `.mcp.json` / global `mcp.json`

--- a/src/capabilities/goal.rs
+++ b/src/capabilities/goal.rs
@@ -142,6 +142,7 @@ mod tests {
             owner: None,
             effective_owner: None,
             title: None,
+            goal: None,
             locale: None,
             preview: None,
             output_preview: None,

--- a/src/capabilities/user_ask.rs
+++ b/src/capabilities/user_ask.rs
@@ -279,6 +279,7 @@ mod tests {
             owner: None,
             effective_owner: None,
             title: None,
+            goal: None,
             locale: None,
             preview: None,
             output_preview: None,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -293,18 +293,21 @@ impl CodingCliSessionFileStore {
 #[async_trait]
 impl SessionFileSystem for CodingCliSessionFileStore {
     fn display_root(&self) -> String {
-        self.workspace_store()
-            .map(|store| store.display_root())
-            .unwrap_or_else(|_| "/workspace".to_string())
+        // Yolop's file tools and persisted output pointers use one stable
+        // model-facing namespace even while the host worktree root changes.
+        // Everruns 0.17.7 preserves real-disk backend identity through
+        // `MountFs`, so this embedder boundary must opt back into `/workspace`.
+        everruns_core::session_path::WORKSPACE_PREFIX.to_string()
     }
 
     fn display_path(&self, path: &str) -> String {
+        if Self::session_output_path(path).is_some() {
+            return everruns_core::session_path::to_display_path(path);
+        }
         if let Some((store, path)) = self.skill_or_session_route(path) {
             return store.display_path(&path);
         }
-        self.workspace_store()
-            .map(|store| store.display_path(path))
-            .unwrap_or_else(|_| path.to_string())
+        everruns_core::session_path::to_display_path(path)
     }
 
     async fn read_file(
@@ -2198,7 +2201,7 @@ pub async fn build_with_options(
     //   * stateless_todo_list  — write_todos tool for multi-step tasks
     //   * loop_detection       — safety net against repeated identical tool calls
     //   * prompt_caching       — Anthropic prompt caching; free token savings
-    //   * duckduckgo           — DuckDuckGo Instant Answer lookup (`duckduckgo_search`); no API key
+    //   * duckduckgo           — DuckDuckGo Instant Answer lookup (`duckduckgo_instant_answer`); no API key
     //   * free_search          — best-effort free SERP/dev search (`free_web_search`); no API key
     //   * session_storage      — session kv/secret store (Daytona dependency)
     //   * daytona              — remote cloud sandboxes (`daytona_*` tools)
@@ -2622,6 +2625,22 @@ mod tests {
                 built.startup.tool_names
             );
         }
+        assert!(
+            built
+                .startup
+                .tool_names
+                .contains(&"duckduckgo_instant_answer".to_string()),
+            "DuckDuckGo Instant Answer tool: {:?}",
+            built.startup.tool_names
+        );
+        assert!(
+            !built
+                .startup
+                .tool_names
+                .contains(&"duckduckgo_search".to_string()),
+            "retired DuckDuckGo tool name must not remain: {:?}",
+            built.startup.tool_names
+        );
         assert!(
             built
                 .handles

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -649,9 +649,12 @@ mod tests {
             .and_then(|value| value.as_array())
             .expect("output_files should be populated");
         assert_eq!(output_files.len(), 1);
+        let expected_display_path = std::fs::canonicalize(dir.path())
+            .expect("canonical tempdir")
+            .join("outputs/call-persist.stdout");
         assert_eq!(
             output_files[0].as_str(),
-            Some("/workspace/outputs/call-persist.stdout")
+            Some(expected_display_path.to_string_lossy().as_ref())
         );
 
         let saved = tokio::fs::read_to_string(dir.path().join("outputs/call-persist.stdout"))


### PR DESCRIPTION
## What changed

- Bumped the full Everruns dependency family from 0.17.6 to 0.17.7 and refreshed compatible transitive dependencies.
- Adopted the renamed `duckduckgo_instant_answer` tool across runtime registration proof, README, and the bundled Yolop skill.
- Adapted Everruns' new real-disk display identity: raw real-disk stores expose canonical host paths, while Yolop's mounted workspace and persisted output pointers retain the stable `/workspace` namespace across worktree switches.
- Updated Everruns `Session` fixtures for the new `goal` field and corrected the background/subagent ownership documentation.

## Why

Keep Yolop on the current Everruns release in lockstep and adopt its changed public contracts without leaking host-specific paths into Yolop's model-facing workspace namespace or advertising unsupported child-session tools.

## Before / After

Before:

- Everruns crates resolved to 0.17.6.
- Yolop documented and expected the retired `duckduckgo_search` name.
- Everruns 0.17.7's display-path change made three workspace/output tests report canonical host paths instead of Yolop's stable `/workspace` paths.

After:

- Every direct Everruns crate resolves to 0.17.7.
- Runtime integration coverage proves `duckduckgo_instant_answer` is present and `duckduckgo_search` is absent.
- Full filesystem tests prove mounted workspaces and session outputs retain `/workspace`, worktree repointing still works, and raw real-disk persistence uses canonical host paths.
- Live smoke: `doppler run --project everruns-dev --config dev -- cargo run -- --provider openai -p "Reply only: hi"` returned `hi`.

## Risk

- Medium: dependency and filesystem display-path behavior changed.
- The main risk is a mismatch between model-facing paths, real-disk paths, and session-output routing. Existing routing, worktree-switch, output-permission, and persistence tests cover these boundaries.

## Security

- TM-FS: verified `WriteBlocklistFileStore` still wraps the mounted store and Everruns 0.17.7 retains the full default blocklist (`.git`, `node_modules`, `target`, `dist`, `build`, `.next`, `.venv`, `venv`, `.tox`, `.gradle`). Workspace reads/writes remain contained by `RealDiskFileStore`; session outputs retain private permissions.
- TM-BASH: `tools.rs` behavior is test-only adaptation; the shell remains bounded to a 120-second wall clock and 1 MiB per-stream output cap.
- TM-LLM/TM-TOOL: no prompt trust boundary or credential handling changed. The renamed DuckDuckGo tool is asserted through the built runtime surface; unsupported subagent tools remain unregistered.
- TM-DEP: all Everruns crates are pinned in lockstep at 0.17.7; no new direct dependencies were added. `cargo audit` reports two existing `quick-xml 0.39.4` advisories through the target-specific Wayland scanner and the existing unmaintained `rustls-pemfile` through Everruns A2A. No compatible fixed Wayland scanner release exists; the affected parser runs at build time over packaged protocol XML, not runtime user input.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` — 608 unit tests passed (2 ignored); 34 integration tests passed (1 ignored)
- `cargo fetch --locked`
- `cargo tree --depth 1` — all direct Everruns crates at 0.17.7
- `cargo run -- --provider llmsim -p "hi"`
- Live OpenAI smoke through Doppler returned `hi`

## Follow-ups

- Upgrade the Wayland dependency chain once `wayland-scanner` accepts `quick-xml >=0.41`; current releases constrain it to `^0.39`.
- Pick up the upstream Everruns/A2A replacement for unmaintained `rustls-pemfile` when released.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed
