### PR TITLE
fix(paths): expose real workspace paths

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2247,7 +2247,7 @@ mod tests {
             vec![ToolCall {
                 id: "call_read".to_string(),
                 name: "read_file".to_string(),
-                arguments: serde_json::json!({ "path": "/workspace/Cargo.toml" }),
+                arguments: serde_json::json!({ "path": "/repo/Cargo.toml" }),
             }],
         );
         message.thinking = Some(
@@ -2773,7 +2773,7 @@ mod tests {
             &mut lines,
             &ChatLine {
                 author: Author::Diff,
-                text: "--- /workspace/src/app.rs (before)\n+++ /workspace/src/app.rs (after)\n@@ -1 +1 @@\n-old\n+new\n unchanged".to_string(),
+                text: "--- /repo/src/app.rs (before)\n+++ /repo/src/app.rs (after)\n@@ -1 +1 @@\n-old\n+new\n unchanged".to_string(),
             },
             96,
         );
@@ -2958,7 +2958,7 @@ mod tests {
             },
             ChatLine {
                 author: Author::Diff,
-                text: "+changed line with a very long path /workspace/src/app/render.rs".into(),
+                text: "+changed line with a very long path /repo/src/app/render.rs".into(),
             },
             ChatLine {
                 author: Author::ToolDetail,

--- a/src/capabilities/ast_grep.rs
+++ b/src/capabilities/ast_grep.rs
@@ -1240,7 +1240,7 @@ mod tests {
             dir.path(),
             AstGrepOptions {
                 pattern: "console.log($A)".to_string(),
-                path: Some("/web".to_string()),
+                path: Some("web".to_string()),
                 language: Some("typescript".to_string()),
                 limit: 20,
                 max_file_bytes: DEFAULT_MAX_FILE_BYTES,
@@ -1288,7 +1288,7 @@ mod tests {
     }
 
     #[test]
-    fn accepts_workspace_root_alias() {
+    fn accepts_host_absolute_subpath() {
         let dir = tempfile::tempdir().expect("tempdir");
         write(&dir.path().join("src/lib.rs"), "fn target() {}\n");
 
@@ -1296,13 +1296,13 @@ mod tests {
             dir.path(),
             AstGrepOptions {
                 pattern: "fn $NAME() {}".to_string(),
-                path: Some("/workspace/src".to_string()),
+                path: Some(dir.path().join("src").display().to_string()),
                 language: Some("rust".to_string()),
                 limit: 20,
                 max_file_bytes: DEFAULT_MAX_FILE_BYTES,
             },
         )
-        .expect("vfs subpath should scan");
+        .expect("host subpath should scan");
 
         assert_eq!(report.matches.len(), 1);
         assert_eq!(report.matches[0].path, "src/lib.rs");

--- a/src/capabilities/edit_file_override.rs
+++ b/src/capabilities/edit_file_override.rs
@@ -154,7 +154,7 @@ impl Tool for EditsOnlyEditFileTool {
             "properties": {
                 "path": {
                     "type": "string",
-                    "description": "Absolute path to the existing text file (e.g., '/workspace/src/main.rs')"
+                    "description": "Absolute host path to the existing text file"
                 },
                 "expected_hash": {
                     "type": "string",
@@ -248,7 +248,7 @@ mod tests {
     #[test]
     fn coerce_folds_scalars_into_edits() {
         let out = EditsOnlyEditFileTool::coerce_arguments(json!({
-            "path": "/workspace/f.rs", "expected_hash": "sha256:x",
+            "path": "/repo/f.rs", "expected_hash": "sha256:x",
             "old_text": "a", "new_text": "b"
         }));
         assert!(out.get("old_text").is_none());
@@ -259,7 +259,7 @@ mod tests {
     #[test]
     fn coerce_drops_scalars_when_edits_present() {
         let out = EditsOnlyEditFileTool::coerce_arguments(json!({
-            "path": "/workspace/f.rs", "expected_hash": "sha256:x",
+            "path": "/repo/f.rs", "expected_hash": "sha256:x",
             "old_text": "a", "new_text": "b",
             "edits": [{ "old_text": "c", "new_text": "d" }]
         }));

--- a/src/capabilities/progress_guard.rs
+++ b/src/capabilities/progress_guard.rs
@@ -954,7 +954,7 @@ mod tests {
         for offset in [180, 388, 633, 940, 1370, 1540, 180, 388, 633] {
             if let Some(warning) = observe(call(
                 "read_file",
-                json!({ "path": "/workspace/src/capabilities/background.rs", "offset": offset }),
+                json!({ "path": "/repo/src/capabilities/background.rs", "offset": offset }),
             ))
             .await
             {
@@ -964,7 +964,7 @@ mod tests {
         for offset in [1000, 1020, 1010, 1028, 1000, 1020, 1010, 1028, 1000] {
             if let Some(warning) = observe(call(
                 "read_file",
-                json!({ "path": "/workspace/src/app/mod.rs", "offset": offset }),
+                json!({ "path": "/repo/src/app/mod.rs", "offset": offset }),
             ))
             .await
             {
@@ -981,7 +981,7 @@ mod tests {
         for i in 0..24 {
             if let Some(warning) = observe(call(
                 "read_file",
-                json!({ "path": format!("/workspace/src/runtime.rs"), "offset": 2100 + i }),
+                json!({ "path": "/repo/src/runtime.rs", "offset": 2100 + i }),
             ))
             .await
             {
@@ -998,7 +998,7 @@ mod tests {
         for _ in 0..REPEATED_EXPLORATION_THRESHOLD {
             if let Some(warning) = observe(call(
                 "read_file",
-                json!({ "path": "/workspace/src/app/mod.rs", "offset": 1000 }),
+                json!({ "path": "/repo/src/app/mod.rs", "offset": 1000 }),
             ))
             .await
             {

--- a/src/capabilities/repo_map.rs
+++ b/src/capabilities/repo_map.rs
@@ -1901,39 +1901,28 @@ trait Named {
         assert!(err.to_string().contains("inside the workspace"));
     }
 
-    // The file tools expose the workspace as a VFS rooted at `/workspace`, so a
-    // model addresses repo_map the same way. The bare root alias must resolve to
-    // the workspace root rather than erroring with "path not found: /workspace"
-    // (the very first call the nemotron eval run wasted a turn on).
     #[test]
-    fn accepts_workspace_root_alias() {
+    fn accepts_host_workspace_root() {
         let dir = tempfile::tempdir().expect("tempdir");
         write(&dir.path().join("src/lib.rs"), "pub fn inside_fn() {}\n");
 
-        for alias in ["/workspace", "workspace", "/workspace/"] {
-            let report = collect_repo_symbols(
-                dir.path(),
-                SymbolScanOptions {
-                    path: Some(alias.to_string()),
-                    query: None,
-                    language: Some("rust".to_string()),
-                    limit: 20,
-                    max_file_bytes: DEFAULT_MAX_FILE_BYTES,
-                },
-            )
-            .unwrap_or_else(|e| panic!("alias {alias:?} should resolve to root: {e}"));
+        let report = collect_repo_symbols(
+            dir.path(),
+            SymbolScanOptions {
+                path: Some(dir.path().display().to_string()),
+                query: None,
+                language: Some("rust".to_string()),
+                limit: 20,
+                max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+            },
+        )
+        .expect("host root should scan");
 
-            assert!(
-                report.symbols.iter().any(|s| s.name == "inside_fn"),
-                "alias {alias:?} did not scan the workspace root"
-            );
-        }
+        assert!(report.symbols.iter().any(|s| s.name == "inside_fn"));
     }
 
-    // A `/workspace/<subpath>` prefix scopes to that subpath, matching how the
-    // file tools resolve the same string.
     #[test]
-    fn accepts_workspace_prefixed_subpath() {
+    fn accepts_host_absolute_subpath() {
         let dir = tempfile::tempdir().expect("tempdir");
         write(&dir.path().join("pkg/inside.rs"), "pub fn pkg_fn() {}\n");
         write(
@@ -1944,19 +1933,19 @@ trait Named {
         let report = collect_repo_symbols(
             dir.path(),
             SymbolScanOptions {
-                path: Some("/workspace/pkg".to_string()),
+                path: Some(dir.path().join("pkg").display().to_string()),
                 query: None,
                 language: Some("rust".to_string()),
                 limit: 20,
                 max_file_bytes: DEFAULT_MAX_FILE_BYTES,
             },
         )
-        .expect("subpath under /workspace should scan");
+        .expect("host subpath should scan");
 
         assert!(report.symbols.iter().any(|s| s.name == "pkg_fn"));
         assert!(
             !report.symbols.iter().any(|s| s.name == "other_fn"),
-            "scope should be limited to /workspace/pkg"
+            "scope should be limited to the requested host subpath"
         );
     }
 
@@ -2003,22 +1992,21 @@ trait Named {
         }
     }
 
-    // The alias must not become an escape hatch: `/workspace/../outside` still
-    // resolves through the root and is rejected.
     #[test]
-    fn workspace_alias_does_not_bypass_containment() {
+    fn absolute_host_path_does_not_bypass_containment() {
         let dir = tempfile::tempdir().expect("tempdir");
+        let outside = tempfile::tempdir().expect("outside");
         let err = collect_repo_symbols(
             dir.path(),
             SymbolScanOptions {
-                path: Some("/workspace/../outside".to_string()),
+                path: Some(outside.path().display().to_string()),
                 query: None,
                 language: None,
                 limit: 20,
                 max_file_bytes: DEFAULT_MAX_FILE_BYTES,
             },
         )
-        .expect_err("escaping the workspace via the alias should fail");
+        .expect_err("an absolute path outside the workspace should fail");
 
         assert!(err.to_string().contains("inside the workspace"));
     }

--- a/src/codex_driver.rs
+++ b/src/codex_driver.rs
@@ -182,7 +182,9 @@ impl ChatDriver for CodexChatDriver {
                         &finish_reason,
                         &accumulated_tool_calls,
                     )),
-                    Err(err) => Ok(stream_error(format!("Codex stream error: {err}"))),
+                    Err(err) => Ok(LlmStreamEvent::Error(
+                        format!("Codex stream error: {err}").into(),
+                    )),
                 }
             }
         }));
@@ -542,16 +544,11 @@ fn handle_event(
             cache_read_tokens,
             finish_reason,
         ),
-        Some("response.failed") | Some("error") => stream_error(format_codex_error(&json)),
+        Some("response.failed") | Some("error") => {
+            LlmStreamEvent::Error(format_codex_error(&json).into())
+        }
         _ => LlmStreamEvent::TextDelta(String::new()),
     }
-}
-
-// Everruns 0.17.7 stores a String here; main uses the structured LlmStreamError
-// planned for 0.17.8. Keep this source compatible with both dependency states.
-#[allow(clippy::useless_conversion)]
-fn stream_error(message: String) -> LlmStreamEvent {
-    LlmStreamEvent::Error(message.into())
 }
 
 fn upsert_tool_call(item: &Value, accumulated_tool_calls: &Mutex<Vec<ToolCallAccumulator>>) {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -294,9 +294,7 @@ impl CodingCliSessionFileStore {
 #[async_trait]
 impl SessionFileSystem for CodingCliSessionFileStore {
     fn is_mount_resolver(&self) -> bool {
-        // This store already routes the workspace, session artifacts, and skill
-        // scopes. Wrapping it in another MountFs would collapse that table.
-        true
+        false
     }
 
     fn display_root(&self) -> String {
@@ -4385,6 +4383,30 @@ mod tests {
             store.display_path("/outputs/call.stdout"),
             "/outputs/call.stdout"
         );
+    }
+
+    #[test]
+    fn file_tool_narration_uses_real_workspace_path() {
+        use everruns_core::tool_narration::{
+            ToolNarrationContext, ToolNarrationPhase, narrate_list_directory,
+        };
+
+        let workspace = tempfile::tempdir().expect("workspace");
+        let session = tempfile::tempdir().expect("session");
+        let store = test_file_store(workspace.path(), session.path());
+        let workspace_root = std::fs::canonicalize(workspace.path()).expect("canonical workspace");
+        let narration = narrate_list_directory(
+            &serde_json::json!({ "path": "/workspace/src" }),
+            ToolNarrationPhase::Completed,
+            None,
+            ToolNarrationContext::new(Some(store.as_ref())),
+        );
+
+        assert!(
+            narration.contains(&workspace_root.join("src").display().to_string()),
+            "narration should use the active host path: {narration}"
+        );
+        assert!(!narration.contains("/workspace"));
     }
 
     #[tokio::test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -300,21 +300,18 @@ impl SessionFileSystem for CodingCliSessionFileStore {
     }
 
     fn display_root(&self) -> String {
-        // Yolop's file tools and persisted output pointers use one stable
-        // model-facing namespace even while the host worktree root changes.
-        // Everruns 0.17.7 preserves real-disk backend identity through
-        // `MountFs`, so this embedder boundary must opt back into `/workspace`.
-        everruns_core::session_path::WORKSPACE_PREFIX.to_string()
+        self.workspace_store()
+            .map(|store| store.display_root())
+            .unwrap_or_else(|_| self.workspace_disk.display_root())
     }
 
     fn display_path(&self, path: &str) -> String {
-        if Self::session_output_path(path).is_some() {
-            return everruns_core::session_path::to_display_path(path);
+        if self.skill_or_session_route(path).is_some() {
+            return everruns_core::session_path::to_session_path(path);
         }
-        if let Some((store, path)) = self.skill_or_session_route(path) {
-            return store.display_path(&path);
-        }
-        everruns_core::session_path::to_display_path(path)
+        self.workspace_store()
+            .map(|store| store.display_path(path))
+            .unwrap_or_else(|_| path.to_string())
     }
 
     async fn read_file(
@@ -4237,22 +4234,34 @@ mod tests {
                 .expect("store"),
         ));
         let session_id = SessionId::from_seed(7);
+        let first_root = std::fs::canonicalize(first.path()).expect("canonical first");
+        let second_root = std::fs::canonicalize(second.path()).expect("canonical second");
 
         store
-            .write_file(session_id, "/workspace/before.md", "in first", "text")
+            .write_file(
+                session_id,
+                &first_root.join("before.md").display().to_string(),
+                "in first",
+                "text",
+            )
             .await
             .expect("write to first workspace");
         assert_eq!(
             std::fs::read_to_string(first.path().join("before.md")).expect("first file"),
             "in first"
         );
-        assert_eq!(store.display_root(), "/workspace");
+        assert_eq!(store.display_root(), first_root.display().to_string());
 
         // Simulate the worktree activating: swap the shared active root.
         *active_root.write().expect("lock") = second.path().to_path_buf();
 
         store
-            .write_file(session_id, "/workspace/after.md", "in second", "text")
+            .write_file(
+                session_id,
+                &second_root.join("after.md").display().to_string(),
+                "in second",
+                "text",
+            )
             .await
             .expect("write to second workspace");
         assert_eq!(
@@ -4261,7 +4270,7 @@ mod tests {
         );
         // The new file must land in the switched-to root, not the original.
         assert!(!first.path().join("after.md").exists());
-        assert_eq!(store.display_root(), "/workspace");
+        assert_eq!(store.display_root(), second_root.display().to_string());
     }
 
     #[tokio::test]
@@ -4322,13 +4331,14 @@ mod tests {
         );
         assert!(!workspace.path().join("outputs/call.stdout").exists());
 
-        let via_workspace_prefix = store
-            .read_file(session_id, "/workspace/outputs/call.stdout")
+        let displayed_output = store.display_path("/outputs/call.stdout");
+        let via_display_path = store
+            .read_file(session_id, &displayed_output)
             .await
             .expect("read output")
             .expect("output file");
         assert_eq!(
-            via_workspace_prefix.content.as_deref(),
+            via_display_path.content.as_deref(),
             Some("large command output")
         );
 
@@ -4344,7 +4354,7 @@ mod tests {
             .await
             .expect("write workspace file");
         let workspace_grep = store
-            .grep_files(session_id, "grep target", Some("/workspace/src"))
+            .grep_files(session_id, "grep target", Some("src"))
             .await
             .expect("grep workspace");
         assert_eq!(workspace_grep.len(), 1);
@@ -4360,16 +4370,20 @@ mod tests {
     }
 
     #[test]
-    fn yolop_file_store_displays_workspace_and_session_paths() {
+    fn yolop_file_store_displays_real_workspace_and_session_paths() {
         let workspace = tempfile::tempdir().expect("workspace");
         let session = tempfile::tempdir().expect("session");
         let store = test_file_store(workspace.path(), session.path());
+        let workspace_root = std::fs::canonicalize(workspace.path()).expect("canonical workspace");
 
-        assert_eq!(store.display_root(), "/workspace");
-        assert_eq!(store.display_path("/src/lib.rs"), "/workspace/src/lib.rs");
+        assert_eq!(store.display_root(), workspace_root.display().to_string());
+        assert_eq!(
+            store.display_path("/src/lib.rs"),
+            workspace_root.join("src/lib.rs").display().to_string()
+        );
         assert_eq!(
             store.display_path("/outputs/call.stdout"),
-            "/workspace/outputs/call.stdout"
+            "/outputs/call.stdout"
         );
     }
 

--- a/src/session_log.rs
+++ b/src/session_log.rs
@@ -1050,7 +1050,7 @@ mod tests {
             "read_file".to_string(),
             vec![ContentPart::text(
                 serde_json::json!({
-                    "path": "/workspace/src/lib.rs",
+                    "path": "/repo/src/lib.rs",
                     "content": "1|fn main() {}"
                 })
                 .to_string(),
@@ -1064,7 +1064,7 @@ mod tests {
             .and_then(|content| content.result.as_ref())
             .expect("tool result should be present");
 
-        assert_eq!(result["path"], "/workspace/src/lib.rs");
+        assert_eq!(result["path"], "/repo/src/lib.rs");
         assert_eq!(result["content"], "1|fn main() {}");
     }
 

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -684,12 +684,12 @@ mod tests {
             .and_then(|value| value.as_array())
             .expect("output_files should be populated");
         assert_eq!(output_files.len(), 1);
-        let expected_display_path = std::fs::canonicalize(dir.path())
+        let expected_output = std::fs::canonicalize(dir.path())
             .expect("canonical tempdir")
             .join("outputs/call-persist.stdout");
         assert_eq!(
             output_files[0].as_str(),
-            Some(expected_display_path.to_string_lossy().as_ref())
+            Some(expected_output.to_string_lossy().as_ref())
         );
 
         let saved = tokio::fs::read_to_string(dir.path().join("outputs/call-persist.stdout"))

--- a/src/workspace_host.rs
+++ b/src/workspace_host.rs
@@ -1,10 +1,8 @@
 // Shared workspace host for yolop tools that shell out against disk.
 //
-// everruns 0.17.1 (EVE-660) centralizes VFS addressing in `MountFs` and host
-// repointing in `RealDiskFileStore::set_host_root`. File tools see `/workspace`
-// through the mount resolver; repo_map, ast_grep, background, and bash still
-// run on the host and share one repointable disk handle synced from the
-// worktree's active-root lock.
+// Everruns centralizes path presentation and containment in `MountFs` and
+// `RealDiskFileStore`. File tools and host-backed capabilities share one
+// repointable disk handle synced from the worktree's active-root lock.
 
 use anyhow::{Context, Result, bail};
 use everruns_runtime::RealDiskFileStore;
@@ -82,7 +80,7 @@ pub fn resolve_host_scope(root: &Path, path: Option<&str>) -> Result<PathBuf> {
     };
     let trimmed = path.trim();
     let candidate = Path::new(trimmed);
-    if candidate.is_absolute() && candidate.starts_with(root) {
+    if candidate.is_absolute() {
         let canonical = candidate
             .canonicalize()
             .with_context(|| format!("path not found: {path}"))?;
@@ -92,20 +90,18 @@ pub fn resolve_host_scope(root: &Path, path: Option<&str>) -> Result<PathBuf> {
         return Ok(canonical);
     }
 
-    let normalized = if trimmed == "workspace" || trimmed == "workspace/" {
-        "/workspace"
-    } else {
-        trimmed
-    };
-    let session = everruns_core::session_path::to_session_path(normalized);
-    let relative = session.trim_start_matches('/');
-    if relative.is_empty() || relative == "." {
+    if trimmed.is_empty() || trimmed == "." {
         return Ok(root.to_path_buf());
     }
-    if relative.split('/').any(|segment| segment == "..") {
+    if candidate.components().any(|component| {
+        matches!(
+            component,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        )
+    }) {
         bail!("`path` must stay inside the workspace");
     }
-    let scope = root.join(relative);
+    let scope = root.join(candidate);
     let canonical = scope
         .canonicalize()
         .with_context(|| format!("path not found: {path}"))?;
@@ -135,26 +131,27 @@ mod tests {
     use std::fs;
 
     #[test]
-    fn resolve_host_scope_accepts_workspace_alias() {
+    fn resolve_host_scope_accepts_host_and_relative_paths() {
         let dir = tempfile::tempdir().expect("tempdir");
         fs::create_dir_all(dir.path().join("pkg")).expect("pkg dir");
         let root = fs::canonicalize(dir.path()).expect("canonical root");
 
-        let scope = resolve_host_scope(&root, Some("/workspace/pkg")).expect("vfs subpath");
+        let host_path = root.join("pkg");
+        let scope = resolve_host_scope(&root, host_path.to_str()).expect("host subpath");
         assert_eq!(scope, root.join("pkg"));
 
-        let root_scope = resolve_host_scope(&root, Some("/workspace")).expect("vfs root");
+        let root_scope = resolve_host_scope(&root, root.to_str()).expect("host root");
         assert_eq!(root_scope, root);
 
-        let bare = resolve_host_scope(&root, Some("workspace")).expect("bare alias");
-        assert_eq!(bare, root);
+        let relative = resolve_host_scope(&root, Some("pkg")).expect("relative subpath");
+        assert_eq!(relative, root.join("pkg"));
     }
 
     #[test]
     fn resolve_host_scope_rejects_escape() {
         let dir = tempfile::tempdir().expect("tempdir");
         let root = fs::canonicalize(dir.path()).expect("canonical root");
-        let err = resolve_host_scope(&root, Some("/workspace/../outside")).expect_err("escape");
+        let err = resolve_host_scope(&root, Some("../outside")).expect_err("escape");
         assert!(err.to_string().contains("inside the workspace"));
     }
 


### PR DESCRIPTION
## What changed

Yolop now presents the active checkout canonical host path consistently across environment context, file tools, tool narration, persisted-output pointers, repo map, AST operations, and worktree switches.

The runtime consumes Everruns 0.17.8 path presentation and narration context. Session outputs and external skill scopes retain their explicit logical routes.

## Why

Yolop forced the model-facing filesystem back to /workspace while shell commands ran in the real checkout. That gave the model two names for one repository and caused repeated searches, incorrect narration, and inconsistent context.

## Before / After

Before:

```text
<cwd>/repo</cwd>
file tools: /workspace/src/...
narration: Listed files in /workspace/src
```

After:

```text
<cwd>/repo</cwd>
file tools: /repo/src/...
narration: Listed files in /repo/src
```

Automated proof passes a legacy /workspace/src argument through the production path-presentation contract and asserts that narration contains the canonical active host path and no /workspace alias. Additional tests cover display paths, persisted outputs, host-absolute and relative repo-map/AST scopes, containment, and active worktree switching.

## Validation

- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features: 641 unit tests passed, 2 ignored; 34 integration tests passed, 1 credential-gated ignored; plugin integration passed
- cargo run -- --provider llmsim smoke passed
- Live-provider smoke delegated to CI because this worktree has no Doppler project configuration

## Risk

- Medium
- Callers that relied on Yolop emitting the synthetic /workspace alias now receive canonical host paths.
- Relative paths remain supported; absolute paths outside the active checkout remain rejected.

## Security

Reviewed TM-FS, TM-BASH, TM-TOOL, and TM-DEP. Filesystem containment still canonicalizes before root checks; traversal and symlink escapes remain rejected; write blocklist coverage and bounded shell execution are unchanged. All Everruns crates remain on the same published 0.17.8 version. No new dependencies or secret-handling changes.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review completed
- [x] Rebased onto latest origin/main