### PR TITLE
fix(tui): mirror session system notices above composer

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2998,6 +2998,54 @@ mod tests {
         assert!(!should_insert_chat_gap(&Author::ToolDetail, None));
     }
 
+    #[test]
+    fn recent_transcript_mirror_excludes_startup_banner_system_lines() {
+        let lines = vec![
+            ChatLine {
+                author: Author::System,
+                text: "workspace: /tmp".into(),
+            },
+            ChatLine {
+                author: Author::User,
+                text: "hello".into(),
+            },
+        ];
+        assert!(!include_line_in_recent_transcript_mirror(
+            &lines[0], 0, &lines
+        ));
+        assert!(include_line_in_recent_transcript_mirror(
+            &lines[1], 1, &lines
+        ));
+    }
+
+    #[test]
+    fn recent_transcript_mirror_includes_session_system_notices_after_chat() {
+        let lines = vec![
+            ChatLine {
+                author: Author::System,
+                text: "workspace: /tmp".into(),
+            },
+            ChatLine {
+                author: Author::User,
+                text: "hello".into(),
+            },
+            ChatLine {
+                author: Author::Assistant,
+                text: "hi".into(),
+            },
+            ChatLine {
+                author: Author::System,
+                text: "attached clipboard image #1 (640x480 PNG)".into(),
+            },
+        ];
+        assert!(!include_line_in_recent_transcript_mirror(
+            &lines[0], 0, &lines
+        ));
+        assert!(include_line_in_recent_transcript_mirror(
+            &lines[3], 3, &lines
+        ));
+    }
+
     // ====================================================================
     // ViewState + draw_chrome snapshot tests.
     //
@@ -3022,6 +3070,39 @@ mod tests {
 
     /// Render the composer through the same inline viewport + bottom anchoring
     /// path the real TUI uses (`Terminal::with_options` + `maybe_reanchor`).
+    fn inline_terminal(width: u16, height: u16) -> Terminal<TestBackend> {
+        let mut backend = TestBackend::new(width, height);
+        backend
+            .set_cursor_position(Position { x: 0, y: 1 })
+            .unwrap();
+        let mut terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Inline(COMPOSER_VIEWPORT_HEIGHT),
+            },
+        )
+        .expect("terminal");
+        maybe_reanchor_inline_viewport(&mut terminal).expect("anchor inline viewport");
+        terminal
+    }
+
+    fn inline_transcript_rows(terminal: &mut Terminal<TestBackend>) -> Vec<String> {
+        let viewport_top = terminal.get_frame().area().y;
+        let buffer = terminal.backend().buffer();
+        let height = buffer.area.height;
+        let width = buffer.area.width;
+        (viewport_top..height)
+            .map(|y| {
+                let mut row = String::with_capacity(width as usize);
+                for x in 0..width {
+                    row.push_str(buffer[(x, y)].symbol());
+                }
+                row.trim_end().to_string()
+            })
+            .filter(|row| row.contains('›'))
+            .collect()
+    }
+
     fn render_inline_composer(
         app: &mut App,
         width: u16,
@@ -3736,6 +3817,93 @@ mod tests {
             app.lines
         );
         assert!(app.pending_pastes.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn inline_viewport_mirrors_session_system_notices_after_chat() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+        app.lines.clear();
+        app.push_user("first question".into());
+        app.lines.push(ChatLine {
+            author: Author::Assistant,
+            text: "first answer".into(),
+        });
+        app.push_system("attached clipboard image #1 (640x480 PNG)".into());
+
+        let rows = render_app_lines(app, 96, COMPOSER_VIEWPORT_HEIGHT);
+
+        assert!(
+            rows.iter()
+                .any(|row| row.contains("attached clipboard image #1")),
+            "session system notices should mirror above the composer: {rows:?}"
+        );
+        assert!(
+            !rows.iter().any(|row| row.contains("workspace:")),
+            "startup banner should stay out of the inline viewport: {rows:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn incremental_system_notice_stays_adjacent_to_composer_after_flush() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+        app.lines.clear();
+        app.push_user("first question".into());
+        app.lines.push(ChatLine {
+            author: Author::Assistant,
+            text: "first answer".into(),
+        });
+
+        let mut terminal = inline_terminal(100, 60);
+        app.flush_transcript(&mut terminal)
+            .expect("flush prior turn");
+        app.push_system("attached clipboard image #1 (640x480 PNG)".into());
+        app.flush_transcript(&mut terminal)
+            .expect("flush image notice");
+        terminal.draw(|f| draw(f, app)).expect("draw after notice");
+
+        let inline_rows = inline_transcript_rows(&mut terminal);
+        let notice_row = inline_rows
+            .iter()
+            .position(|row| row.contains("attached clipboard image #1"))
+            .expect("image paste notice in inline viewport");
+
+        assert!(
+            notice_row + 1 >= inline_rows.len().saturating_sub(1),
+            "incremental system notice should sit near the composer, not above a mirrored tail: inline={inline_rows:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn incremental_turn_failed_notice_stays_adjacent_to_composer_after_flush() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+        app.lines.clear();
+        app.push_user("run it".into());
+        app.lines.push(ChatLine {
+            author: Author::Assistant,
+            text: "done".into(),
+        });
+
+        let mut terminal = inline_terminal(100, 60);
+        app.flush_transcript(&mut terminal)
+            .expect("flush prior turn");
+        app.push_system("turn failed: provider timeout".into());
+        app.flush_transcript(&mut terminal)
+            .expect("flush turn notice");
+        terminal.draw(|f| draw(f, app)).expect("draw after notice");
+
+        let inline_rows = inline_transcript_rows(&mut terminal);
+        assert!(
+            inline_rows
+                .iter()
+                .any(|row| row.contains("turn failed: provider timeout")),
+            "turn-failed notice should mirror above the composer: {inline_rows:?}"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -227,6 +227,28 @@ pub(crate) fn draw_recent_transcript(f: &mut ratatui::Frame, area: Rect, app: &A
     f.render_widget(Paragraph::new(rendered), render_area);
 }
 
+/// Whether a transcript line belongs in the inline viewport mirror.
+///
+/// Startup banner system lines stay scrollback-only. Once the session has user
+/// or assistant content, later system notices (image paste, turn status, etc.)
+/// should appear above the composer instead of only in the flushed band.
+pub(crate) fn include_line_in_recent_transcript_mirror(
+    line: &ChatLine,
+    index: usize,
+    lines: &[ChatLine],
+) -> bool {
+    if !matches!(line.author, Author::System) {
+        return true;
+    }
+    let Some(first_chat) = lines
+        .iter()
+        .position(|entry| !matches!(entry.author, Author::System))
+    else {
+        return false;
+    };
+    index >= first_chat
+}
+
 pub(crate) fn recent_transcript_lines(
     app: &App,
     width: usize,
@@ -242,13 +264,17 @@ pub(crate) fn recent_transcript_lines(
 
     // Keep the recent tail visible above the composer even after lines are
     // flushed into native scrollback.
-    for chat in app
+    let mirror_lines: Vec<&ChatLine> = app
         .lines
         .iter()
+        .enumerate()
         .rev()
-        .filter(|line| !matches!(line.author, Author::System))
+        .filter(|(index, line)| include_line_in_recent_transcript_mirror(line, *index, &app.lines))
         .take(RECENT_TRANSCRIPT_SOURCE_LINES)
-    {
+        .map(|(_, line)| line)
+        .collect();
+
+    for chat in mirror_lines {
         let chat = bounded_recent_chat_line(chat);
         let mut chunk = Vec::new();
         append_chat_lines(&mut chunk, &chat, width);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Session system notices (image paste attachments, turn failures, goal/status messages, etc.) now appear in the inline viewport above the composer once chat has started. The startup banner stays scrollback-only.

## Why

The TUI uses two transcript projections:

1. **Scrollback flush** — `flush_transcript` pushes new lines above the inline viewport via `insert_before`.
2. **Inline mirror** — `recent_transcript_lines` keeps the recent tail visible above the composer.

The mirror excluded all `Author::System` lines. After history existed, incremental system notices (e.g. `attached clipboard image #1`) were flushed into the band above the viewport but not mirrored below — so scrolling showed them sandwiched between flushed history and the duplicated user/assistant mirror.

## Before / After

**Before:** After a turn, Ctrl+V image paste showed `system › attached clipboard image #1 …` in the middle of history (above mirrored `you ›` / `agent ›` lines).

**After:** The notice mirrors above the composer with the recent tail.

```
cargo test --all-features inline_viewport_mirrors_session
cargo test --all-features incremental_system
cargo test --all-features incremental_turn_failed
cargo test --all-features startup_banner_is_kept
```

## Test coverage

- `include_line_in_recent_transcript_mirror` unit tests (startup banner vs session notices)
- `inline_viewport_mirrors_session_system_notices_after_chat`
- `incremental_system_notice_stays_adjacent_to_composer_after_flush` (image paste path)
- `incremental_turn_failed_notice_stays_adjacent_to_composer_after_flush` (generic incremental system group)

## Security

No security-relevant code changes. Rendering-only change to inline transcript mirroring.

## Risk

- Low — narrows the system-line filter to startup banner only (system lines before first user/assistant message). Startup banner test unchanged.

## Follow-ups

No follow-ups.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8e6b82c-5129-4fe3-b297-4949318104a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8e6b82c-5129-4fe3-b297-4949318104a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

