### PR TITLE
fix(codex): strip empty HTML-comment reasoning summary placeholders

### DIFF
--- a/src/codex_driver.rs
+++ b/src/codex_driver.rs
@@ -431,6 +431,38 @@ fn sanitize_parameters(params: &Value) -> Value {
     params
 }
 
+/// The literal placeholder the OpenAI Responses API injects for an *empty*
+/// reasoning-summary part — a part that carries a `**bold heading**` but no
+/// prose. It arrives verbatim in `response.reasoning_summary_text.delta`.
+const REASONING_SUMMARY_PLACEHOLDER: &str = "<!-- -->";
+
+/// Drop empty reasoning-summary placeholders from a streamed summary delta.
+///
+/// Without this, `<!-- -->` reaches every downstream consumer of the thinking
+/// stream — the ACP thought view (`acp/bridge.rs`) and the session log — since
+/// the TUI is the only surface that already discards summary text. We strip the
+/// marker at the driver so all surfaces stay clean at the source.
+///
+/// This mirrors the Codex fix for the same OpenAI Responses behavior:
+///   - PR: https://github.com/openai/codex/pull/31652
+///   - `split_reasoning_summary_parts` in
+///     codex-rs/tui/src/history_cell/messages.rs (strips a part whose body
+///     equals `<!-- -->`).
+///
+/// FUTURE — recheck whether this workaround is still needed. OpenAI may stop
+/// emitting the placeholder server-side, at which point this can be deleted.
+/// To verify, stream a reasoning-heavy prompt with `summary: "detailed"` and
+/// grep the raw SSE for the marker across many runs; if it never appears, drop
+/// this guard:
+///   curl https://api.openai.com/v1/responses -H "Authorization: Bearer $KEY" \
+///     -d '{"model":"gpt-5.6-sol","stream":true,
+///          "reasoning":{"effort":"high","summary":"detailed"},
+///          "input":[{"role":"user","content":"<reasoning-heavy prompt>"}]}' \
+///     | grep -- '<!--'
+fn strip_reasoning_placeholder(delta: &str) -> String {
+    delta.replace(REASONING_SUMMARY_PLACEHOLDER, "")
+}
+
 fn handle_event(
     event_data: &str,
     model: &str,
@@ -454,7 +486,10 @@ fn handle_event(
         | Some("response.reasoning.delta") => json
             .get("delta")
             .and_then(Value::as_str)
-            .map(|delta| LlmStreamEvent::ThinkingDelta(delta.to_string()))
+            .map(|delta| match strip_reasoning_placeholder(delta) {
+                cleaned if cleaned.is_empty() => LlmStreamEvent::TextDelta(String::new()),
+                cleaned => LlmStreamEvent::ThinkingDelta(cleaned),
+            })
             .unwrap_or_else(|| LlmStreamEvent::TextDelta(String::new())),
         Some("response.function_call_arguments.delta") => {
             if let (Some(item_id), Some(delta)) = (
@@ -704,6 +739,48 @@ mod tests {
             &Mutex::new(Vec::new()),
         );
         assert!(matches!(event, LlmStreamEvent::TextDelta(text) if text == "hello"));
+    }
+
+    fn reasoning_event(delta_json: &str) -> LlmStreamEvent {
+        handle_event(
+            delta_json,
+            "gpt-test",
+            &Mutex::new(0),
+            &Mutex::new(0),
+            &Mutex::new(None),
+            &Mutex::new(None),
+            &Mutex::new(Vec::new()),
+        )
+    }
+
+    #[test]
+    fn keeps_reasoning_summary_prose() {
+        // A normal summary part with real prose passes through as thinking.
+        let event = reasoning_event(
+            r#"{"type":"response.reasoning_summary_text.delta","delta":"**Planning** real prose"}"#,
+        );
+        assert!(
+            matches!(event, LlmStreamEvent::ThinkingDelta(text) if text == "**Planning** real prose")
+        );
+    }
+
+    #[test]
+    fn drops_empty_reasoning_summary_placeholder() {
+        // An empty summary part arrives as the literal `<!-- -->` placeholder
+        // (see PR #31652 linked above). It must not reach the thinking stream.
+        let event = reasoning_event(
+            r#"{"type":"response.reasoning_summary_text.delta","delta":"<!-- -->"}"#,
+        );
+        assert!(matches!(event, LlmStreamEvent::TextDelta(text) if text.is_empty()));
+    }
+
+    #[test]
+    fn strips_placeholder_but_keeps_heading_in_same_delta() {
+        // When a whole part arrives in one delta, drop the marker and keep the heading.
+        let event = reasoning_event(
+            r#"{"type":"response.reasoning_summary_text.delta","delta":"**Header**\n\n<!-- -->"}"#,
+        );
+        assert!(matches!(event, LlmStreamEvent::ThinkingDelta(text) if text == "**Header**\n\n"));
     }
 
     #[test]


### PR DESCRIPTION
## What changed
The Codex driver now strips the empty `&lt;!-- --&gt;` reasoning-summary placeholder from streamed summary deltas before they become thinking content. Real prose (including bold headings) still passes through unchanged; a delta that is only the placeholder is dropped, and a placeholder embedded next to a heading in the same delta is removed while the heading is kept.

_(Note: this PR body escapes the marker as `&amp;lt;!-- --&amp;gt;` so it renders — a literal `<!-- -->` would be swallowed as an HTML comment, which is exactly the bug being fixed.)_

## Why
The OpenAI Responses API injects a literal `&lt;!-- --&gt;` HTML-comment placeholder for a reasoning-summary part that carries a `**bold heading**` but no prose. `codex_driver` mapped `response.reasoning_summary_text.delta` (and the `reasoning_text` / `reasoning` variants) straight to `ThinkingDelta` with no filtering, so the marker leaked into every downstream consumer of the thinking stream:

- **ACP thought view** (`acp/bridge.rs`, editor integrations like Zed) — forwarded verbatim as thought chunks.
- **Session log** — persisted into the thinking text.

Two surfaces were already immune and stay unaffected: the TUI never renders reasoning-summary *text* (only a `thinking` status label), and the API round-trip re-sends only `encrypted_content`, never the summary text.

Same root cause and fix as [openai/codex#31652](https://github.com/openai/codex/pull/31652); this mirrors its `split_reasoning_summary_parts` guard for yolop's own Responses client. A `FUTURE` note in the code documents how to recheck (stream a reasoning-heavy prompt with `summary: "detailed"` and grep the raw SSE for the marker) and delete the workaround if OpenAI stops emitting it server-side.

## Before / After
Behavior of `handle_event` on a `response.reasoning_summary_text.delta` event, by delta payload:

| delta payload | Before | After |
|---|---|---|
| `&lt;!-- --&gt;` | `ThinkingDelta("&lt;!-- --&gt;")` — marker leaks | dropped (no-op) |
| `**Header**\n\n&lt;!-- --&gt;` | `ThinkingDelta("**Header**\n\n&lt;!-- --&gt;")` | `ThinkingDelta("**Header**\n\n")` |
| `**Planning** real prose` | `ThinkingDelta(...)` | `ThinkingDelta(...)` — unchanged |

Empirical basis: I probed the live gpt-5.6-sol Responses endpoint (~35 requests, `summary: "detailed"`) and confirmed it emits the same multi-part `**heading** + prose` summary structure this placeholder comes from. The empty-part variant is intermittent (not reproduced live in this batch), so the three cases above are covered by unit tests driving `handle_event` directly.

## Risk
- **Low**
- The change only removes a fixed marker from a display/log stream. No trust boundary, no key handling, no control flow, no new dependencies. Worst case if the API ever put the marker in legitimate prose (never observed in a reasoning summary) is that substring being dropped — the same tradeoff Codex accepts.

## Security
Reviewed against the ship-skill categories. Only **TM-LLM** is relevant: this touches reasoning-summary parsing in `codex_driver`. No API keys are read, logged, or written; provider env handling is untouched; the change strips content rather than adding any injection or trust-boundary surface. TM-FS, TM-BASH, TM-TOOL, TM-DEP: no changes.

## Follow-ups
- The OpenAI-API-key path parses reasoning summaries inside the `everruns-runtime` crate, which is out of scope for this repo. If it exhibits the same leak, it needs the equivalent guard upstream in `everruns/everruns`.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; internal driver behavior, no public surface change)
