### PR TITLE
feat(auth): prepare MCP OAuth foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1604,6 +1604,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns-integrations-parallel"
+version = "0.17.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62d49d573d262d289ec04be5bbf385fb719d99b4344ca039162bb994aaf959b0"
+dependencies = [
+ "async-trait",
+ "everruns-core",
+ "inventory",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "everruns-local"
 version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6534,6 +6548,7 @@ dependencies = [
  "everruns-core",
  "everruns-integrations-daytona",
  "everruns-integrations-duckduckgo",
+ "everruns-integrations-parallel",
  "everruns-local",
  "everruns-openai",
  "everruns-openrouter",
@@ -6543,6 +6558,7 @@ dependencies = [
  "ignore",
  "image",
  "include_dir",
+ "inventory",
  "portable-pty",
  "rand 0.10.2",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ everruns-local = "0.17.7"
 # everruns server/worker never enable it (specs/mcp.md, upstream runtime-mcp.md D2).
 everruns-runtime = { version = "0.17.7", features = ["mcp-stdio"] }
 everruns-integrations-duckduckgo = "0.17.7"
+everruns-integrations-parallel = "0.17.7"
 everruns-integrations-daytona = "0.17.7"
 arboard = { version = "3", features = ["wayland-data-control"] }
 futures = "0.3"
@@ -98,6 +99,7 @@ urlencoding = "2"
 comfy-table = { version = "7.2.2", default-features = false }
 
 [dev-dependencies]
+inventory = "0.3"
 portable-pty = "0.9.0"
 tempfile = "3"
 tiny_http = "0.12"

--- a/src/codex_auth.rs
+++ b/src/codex_auth.rs
@@ -1,10 +1,8 @@
+use crate::oauth_flow;
 use crate::settings::CodexAuth;
 use anyhow::{Context, Result, anyhow};
-use base64::Engine as _;
-use rand::RngExt;
 use reqwest::Url;
 use serde::Deserialize;
-use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -60,9 +58,9 @@ struct DeviceTokenResponse {
 
 pub async fn login_with_browser() -> Result<CodexAuth> {
     let redirect_uri = format!("http://localhost:{CALLBACK_PORT}{CALLBACK_PATH}");
-    let state = random_token(32);
-    let verifier = random_pkce_verifier();
-    let challenge = pkce_challenge(&verifier);
+    let state = oauth_flow::random_token(32);
+    let verifier = oauth_flow::random_pkce_verifier();
+    let challenge = oauth_flow::pkce_challenge(&verifier);
     let listener = tokio::net::TcpListener::bind(("127.0.0.1", CALLBACK_PORT))
         .await
         .with_context(|| format!("bind Codex OAuth callback on localhost:{CALLBACK_PORT}"))?;
@@ -193,7 +191,7 @@ pub fn now_epoch_millis() -> i64 {
 }
 
 pub fn extract_account_id(access_token: &str) -> Option<String> {
-    jwt_payload(access_token).and_then(|payload| {
+    oauth_flow::jwt_payload(access_token).and_then(|payload| {
         payload
             .get("https://api.openai.com/auth")
             .and_then(|auth| auth.get("chatgpt_account_id"))
@@ -209,7 +207,7 @@ pub fn extract_account_id(access_token: &str) -> Option<String> {
 }
 
 fn extract_email(access_token: &str) -> Option<String> {
-    jwt_payload(access_token).and_then(|payload| {
+    oauth_flow::jwt_payload(access_token).and_then(|payload| {
         payload
             .get("https://api.openai.com/profile")
             .and_then(|profile| profile.get("email"))
@@ -453,18 +451,18 @@ fn callback_page(status: &str, message: &str) -> String {
   </main>
 </body>
 </html>"#,
-        title = html_escape(title),
+        title = oauth_flow::html_escape(title),
         accent = if ok { "var(--gold)" } else { "var(--bad)" },
         class = class,
         logo = include_str!("../logo.svg"),
-        eyebrow = html_escape(eyebrow),
+        eyebrow = oauth_flow::html_escape(eyebrow),
         headline = if ok {
             "Codex is connected."
         } else {
             "Almost there."
         },
-        message = html_escape(message),
-        fun = html_escape(fun),
+        message = oauth_flow::html_escape(message),
+        fun = oauth_flow::html_escape(fun),
     )
 }
 
@@ -486,48 +484,10 @@ fn open_browser(url: &str) -> Result<()> {
     }
 }
 
-fn random_pkce_verifier() -> String {
-    const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
-    let mut rng = rand::rng();
-    (0..64)
-        .map(|_| CHARS[rng.random_range(0..CHARS.len())] as char)
-        .collect()
-}
-
-fn random_token(bytes: usize) -> String {
-    let mut data = vec![0u8; bytes];
-    rand::rng().fill(data.as_mut_slice());
-    base64_url(&data)
-}
-
-fn pkce_challenge(verifier: &str) -> String {
-    let digest = Sha256::digest(verifier.as_bytes());
-    base64_url(&digest)
-}
-
-fn base64_url(bytes: &[u8]) -> String {
-    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
-}
-
-fn jwt_payload(token: &str) -> Option<serde_json::Value> {
-    let payload = token.split('.').nth(1)?;
-    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
-        .decode(payload)
-        .ok()?;
-    serde_json::from_slice(&bytes).ok()
-}
-
-fn html_escape(input: &str) -> String {
-    input
-        .replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::Engine as _;
 
     fn jwt_with_payload(payload: serde_json::Value) -> String {
         format!(

--- a/src/connectors/mod.rs
+++ b/src/connectors/mod.rs
@@ -13,4 +13,4 @@ mod store;
 pub(crate) use capability::{CONNECTORS_CAPABILITY_ID, ConnectorsCapability};
 pub(crate) use catalog::ConnectionCatalog;
 pub(crate) use resolver::YolopConnectionResolver;
-pub(crate) use store::{ConnectionStore, default_connections_path};
+pub(crate) use store::{ConnectionStore, StoredConnection, default_connections_path};

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,8 @@ mod host_ui;
 mod image_input;
 mod into;
 mod mcp_config;
+mod mcp_oauth;
+mod oauth_flow;
 mod paste_attachment;
 mod presentation;
 mod runtime;
@@ -50,6 +52,7 @@ use anyhow::{Context, Result};
 // Force-link integration crates whose inventory registrations must survive
 // LTO/dead-code elimination when we register capabilities explicitly.
 extern crate everruns_integrations_daytona;
+extern crate everruns_integrations_parallel;
 use app::{App, COMPOSER_VIEWPORT_HEIGHT, maybe_reanchor_inline_viewport};
 use clap::{Args, Parser, Subcommand};
 use crossterm::event::{

--- a/src/mcp_oauth.rs
+++ b/src/mcp_oauth.rs
@@ -1,0 +1,182 @@
+use crate::connectors::{ConnectionStore, StoredConnection};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+const KIND_FIELD: &str = "kind";
+const KIND_OAUTH: &str = "oauth";
+const ACCESS_TOKEN_FIELD: &str = "access_token";
+const REFRESH_TOKEN_FIELD: &str = "refresh_token";
+const TOKEN_TYPE_FIELD: &str = "token_type";
+const EXPIRES_AT_FIELD: &str = "expires_at";
+const SCOPE_FIELD: &str = "scope";
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct McpOAuthTokenSet {
+    pub(crate) access_token: String,
+    pub(crate) refresh_token: Option<String>,
+    #[serde(default = "default_token_type")]
+    pub(crate) token_type: String,
+    pub(crate) expires_at: Option<DateTime<Utc>>,
+    pub(crate) scope: Option<String>,
+}
+
+impl McpOAuthTokenSet {
+    #[allow(dead_code)]
+    pub(crate) fn is_expired(&self, now: DateTime<Utc>) -> bool {
+        self.expires_at.is_some_and(|expires_at| expires_at <= now)
+    }
+}
+
+fn default_token_type() -> String {
+    "Bearer".to_string()
+}
+
+#[allow(dead_code)]
+pub(crate) fn connection_id(provider_id: &str) -> String {
+    format!("mcp-oauth:{provider_id}")
+}
+
+#[allow(dead_code)]
+pub(crate) fn save_tokens(
+    store: &ConnectionStore,
+    provider_id: &str,
+    tokens: McpOAuthTokenSet,
+) -> anyhow::Result<()> {
+    store.save(&connection_id(provider_id), tokens.into())
+}
+
+#[allow(dead_code)]
+pub(crate) fn load_tokens(store: &ConnectionStore, provider_id: &str) -> Option<McpOAuthTokenSet> {
+    store
+        .get(&connection_id(provider_id))
+        .and_then(|connection| connection.try_into().ok())
+}
+
+impl From<McpOAuthTokenSet> for StoredConnection {
+    fn from(tokens: McpOAuthTokenSet) -> Self {
+        let mut fields = BTreeMap::new();
+        fields.insert(KIND_FIELD.to_string(), KIND_OAUTH.to_string());
+        fields.insert(ACCESS_TOKEN_FIELD.to_string(), tokens.access_token);
+        if let Some(refresh_token) = tokens.refresh_token {
+            fields.insert(REFRESH_TOKEN_FIELD.to_string(), refresh_token);
+        }
+        fields.insert(TOKEN_TYPE_FIELD.to_string(), tokens.token_type);
+        if let Some(expires_at) = tokens.expires_at {
+            fields.insert(EXPIRES_AT_FIELD.to_string(), expires_at.to_rfc3339());
+        }
+        if let Some(scope) = tokens.scope {
+            fields.insert(SCOPE_FIELD.to_string(), scope);
+        }
+        StoredConnection {
+            fields,
+            metadata: None,
+        }
+    }
+}
+
+impl TryFrom<StoredConnection> for McpOAuthTokenSet {
+    type Error = ();
+
+    fn try_from(connection: StoredConnection) -> Result<Self, Self::Error> {
+        if connection.fields.get(KIND_FIELD).map(String::as_str) != Some(KIND_OAUTH) {
+            return Err(());
+        }
+        let access_token = connection
+            .fields
+            .get(ACCESS_TOKEN_FIELD)
+            .filter(|token| !token.trim().is_empty())
+            .cloned()
+            .ok_or(())?;
+        let refresh_token = connection
+            .fields
+            .get(REFRESH_TOKEN_FIELD)
+            .filter(|token| !token.trim().is_empty())
+            .cloned();
+        let token_type = connection
+            .fields
+            .get(TOKEN_TYPE_FIELD)
+            .filter(|token_type| !token_type.trim().is_empty())
+            .cloned()
+            .unwrap_or_else(default_token_type);
+        let expires_at = connection
+            .fields
+            .get(EXPIRES_AT_FIELD)
+            .map(|raw| DateTime::parse_from_rfc3339(raw).map(|dt| dt.with_timezone(&Utc)))
+            .transpose()
+            .map_err(|_| ())?;
+        let scope = connection
+            .fields
+            .get(SCOPE_FIELD)
+            .filter(|scope| !scope.trim().is_empty())
+            .cloned();
+        Ok(Self {
+            access_token,
+            refresh_token,
+            token_type,
+            expires_at,
+            scope,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn stores_oauth_tokens_under_provider_connection_id() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let store = ConnectionStore::open(tmp.path().join("connections.toml"));
+        let expires_at = Utc.with_ymd_and_hms(2030, 1, 2, 3, 4, 5).unwrap();
+        save_tokens(
+            &store,
+            "parallel",
+            McpOAuthTokenSet {
+                access_token: "access".to_string(),
+                refresh_token: Some("refresh".to_string()),
+                token_type: "Bearer".to_string(),
+                expires_at: Some(expires_at),
+                scope: Some("search".to_string()),
+            },
+        )
+        .expect("save tokens");
+
+        let raw = store.get("mcp-oauth:parallel").expect("stored raw");
+        assert_eq!(raw.fields.get("kind").map(String::as_str), Some("oauth"));
+        assert_eq!(
+            raw.fields.get("refresh_token").map(String::as_str),
+            Some("refresh")
+        );
+        let loaded = load_tokens(&store, "parallel").expect("loaded tokens");
+        assert_eq!(loaded.access_token, "access");
+        assert_eq!(loaded.refresh_token.as_deref(), Some("refresh"));
+        assert_eq!(loaded.expires_at, Some(expires_at));
+        assert_eq!(loaded.scope.as_deref(), Some("search"));
+    }
+
+    #[test]
+    fn rejects_non_oauth_connections() {
+        let connection = StoredConnection {
+            fields: BTreeMap::from([("api_key".to_string(), "secret".to_string())]),
+            metadata: None,
+        };
+        assert!(McpOAuthTokenSet::try_from(connection).is_err());
+    }
+
+    #[test]
+    fn detects_expired_tokens_at_boundary() {
+        let expires_at = Utc.with_ymd_and_hms(2030, 1, 2, 3, 4, 5).unwrap();
+        let tokens = McpOAuthTokenSet {
+            access_token: "access".to_string(),
+            refresh_token: None,
+            token_type: "Bearer".to_string(),
+            expires_at: Some(expires_at),
+            scope: None,
+        };
+        assert!(!tokens.is_expired(expires_at - chrono::TimeDelta::seconds(1)));
+        assert!(tokens.is_expired(expires_at));
+    }
+}

--- a/src/oauth_flow.rs
+++ b/src/oauth_flow.rs
@@ -1,0 +1,91 @@
+use base64::Engine as _;
+use rand::RngExt;
+use sha2::{Digest, Sha256};
+
+pub fn random_pkce_verifier() -> String {
+    const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
+    let mut rng = rand::rng();
+    (0..64)
+        .map(|_| CHARS[rng.random_range(0..CHARS.len())] as char)
+        .collect()
+}
+
+pub fn random_token(bytes: usize) -> String {
+    let mut data = vec![0u8; bytes];
+    rand::rng().fill(data.as_mut_slice());
+    base64_url(&data)
+}
+
+pub fn pkce_challenge(verifier: &str) -> String {
+    let digest = Sha256::digest(verifier.as_bytes());
+    base64_url(&digest)
+}
+
+pub fn base64_url(bytes: &[u8]) -> String {
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+pub fn jwt_payload(token: &str) -> Option<serde_json::Value> {
+    let payload = token.split('.').nth(1)?;
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+pub fn html_escape(input: &str) -> String {
+    input
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pkce_challenge_matches_rfc7636_example() {
+        let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+        assert_eq!(
+            pkce_challenge(verifier),
+            "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+        );
+    }
+
+    #[test]
+    fn generated_pkce_verifier_is_valid_length_and_charset() {
+        let verifier = random_pkce_verifier();
+        assert_eq!(verifier.len(), 64);
+        assert!(
+            verifier
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric()
+                    || matches!(byte, b'-' | b'.' | b'_' | b'~'))
+        );
+    }
+
+    #[test]
+    fn random_token_uses_unpadded_base64_url() {
+        let token = random_token(32);
+        assert!(!token.contains('='));
+        assert!(!token.contains('+'));
+        assert!(!token.contains('/'));
+    }
+
+    #[test]
+    fn jwt_payload_decodes_middle_segment() {
+        let payload = serde_json::json!({"sub": "user_123"});
+        let token = format!(
+            "header.{}.sig",
+            base64_url(&serde_json::to_vec(&payload).unwrap())
+        );
+        assert_eq!(jwt_payload(&token), Some(payload));
+    }
+
+    #[test]
+    fn html_escape_escapes_callback_message_characters() {
+        assert_eq!(html_escape("<&>\"ok"), "&lt;&amp;&gt;&quot;ok");
+    }
+}

--- a/tests/parallel_integration.rs
+++ b/tests/parallel_integration.rs
@@ -1,0 +1,14 @@
+use everruns_core::IntegrationPlugin;
+use everruns_integrations_parallel as _;
+
+#[test]
+fn parallel_search_plugin_is_registered() {
+    let plugins: Vec<&IntegrationPlugin> = inventory::iter::<IntegrationPlugin>().collect();
+    assert!(
+        plugins.iter().any(|plugin| {
+            let capability = (plugin.factory)();
+            capability.id() == "parallel_search"
+        }),
+        "expected parallel_search integration plugin to be registered"
+    );
+}


### PR DESCRIPTION
## Summary

- extract reusable OAuth primitives from the stable Codex auth flow without changing Codex token storage or login behavior
- add typed MCP OAuth token persistence backed by the existing connector connection store
- link the `everruns-integrations-parallel` plugin and assert `parallel_search` registration

## Before / After

Before: OAuth helper logic lived inside Codex auth only, and Yolop did not link the Parallel integration.

After: shared OAuth helpers cover PKCE/state/JWT/callback escaping, MCP OAuth tokens have a connector-backed storage shape, and `parallel_search` is registered for later MCP OAuth runtime wiring.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"`

## Security

- TM-LLM: OAuth helpers still treat tokens as data; no token logging or session output was added. MCP OAuth tests use dummy token values.
- TM-TOOL: Parallel is a read/search integration registered through the existing Everruns integration inventory path; no write-capable tool behavior was introduced.
- TM-DEP: Added `everruns-integrations-parallel = 0.17.7`, matching the existing Everruns runtime/integration version stack. Added direct dev dependency `inventory = 0.3` only so the registration test can exercise plugin discovery.
- TM-FS/TM-BASH: No filesystem write blocklist or shell execution behavior changed.

## Follow-ups

- Implement generic MCP OAuth provider metadata and browser sign-in UX using the extracted helpers.
- Inject and refresh OAuth bearer tokens when connecting to OAuth MCP servers.
- Configure Parallel's OAuth MCP endpoint through that generic runtime path.

Generated with yolop
