### PR TITLE
fix(background): execute local scheduled monitors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,6 +802,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
+]
+
+[[package]]
 name = "chunked_transfer"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,7 +1042,7 @@ checksum = "a5dcd6f69605c2956916ce24e8af637b754964c9a83f4662d3a2361654cdba09"
 dependencies = [
  "chrono",
  "once_cell",
- "phf",
+ "phf 0.11.3",
  "winnow 0.7.15",
 ]
 
@@ -1121,7 +1131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
- "phf",
+ "phf 0.11.3",
 ]
 
 [[package]]
@@ -1510,9 +1520,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc609849a129c0f87c22eeeaa7f2c54f5e1ec90d1f82754e2f217777f294cb5c"
+checksum = "d40de0d921d088d72df731008043975d238bc7a4a9df4f786de214432f610195"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1528,9 +1538,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c8c4e3608b2e425363f19a05a2f62e2f963283f24861e946e8ce36dd0adecff"
+checksum = "58cecfd2d8bea37ef8879d328dca4a76456498ecf11cb6fba65ca21dcac17eba"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -1572,9 +1582,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da054d7021b1c4912a7353fc376329bb68a37b2ac92bb6973b23c7ba84bbd0e4"
+checksum = "175c5d0273ad9e356978796cff872691dca8a52bf48aeab799978213601bc783"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1589,9 +1599,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61575d3b325e1ed807a60e1eacd6e2ed6979b5832fba4d37023fe4f2222d5ce"
+checksum = "86fea4828b2a8697ab31b6bacef184f749b62388da46d2a6331606a45da33b6e"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1605,9 +1615,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d49d573d262d289ec04be5bbf385fb719d99b4344ca039162bb994aaf959b0"
+checksum = "ba1e39ac8770b2ce2319d37937336a2feea24a37beae4859bd1dcf2539b62f8b"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1619,15 +1629,18 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddf870f2c8a31b33099e2108d9fa1413659864bc6662dfeb1ed453b63242870a"
+checksum = "c803eaaf9bcc778bc485ab29cbfec857851a156e0cb9ba4f5656a2f60c9f09e4"
 dependencies = [
  "async-trait",
  "chrono",
+ "chrono-tz",
+ "cron",
  "dirs",
  "everruns-core",
  "everruns-runtime",
+ "futures",
  "libc",
  "parking_lot",
  "rusqlite",
@@ -1640,9 +1653,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998a46680c7b15d922d0a6503a75d2d89bb3ef4290e738a8e23b54b640225d44"
+checksum = "ea719527ec420ac82c195de3f694c3047e6000f78baaf5eacf13a3263a5ff9e1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1655,9 +1668,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b8c10dff5b8e9224108d68f0714722f134c737e9c58e006bb591c6817c6dcd"
+checksum = "6c4b2939204d6b6de614ca23faff059b317174a7f06af6b2259f660577a63c9d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1676,9 +1689,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf778d440736725974f0939ae047c327001e7df779cd32e80ccbf62148ccc3b"
+checksum = "30a1aa47aa9944d6e99f682508de4c796d654cb5945d8b71183b508087bcc6e4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1690,9 +1703,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0eab743b3edf02123294199812c318d553c42be51c3fe26ff79702642f5298"
+checksum = "bfda8cdd17cbbcf90f27a325727925fe9df37a0c25effb35f204a20bb6d95414"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3467,7 +3480,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
 ]
 
 [[package]]
@@ -3477,7 +3499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -3486,7 +3508,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.7",
 ]
 
@@ -3497,7 +3519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -3508,6 +3530,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]
@@ -5005,7 +5036,7 @@ checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
  "nom 7.1.3",
- "phf",
+ "phf 0.11.3",
  "phf_codegen",
 ]
 
@@ -5042,7 +5073,7 @@ dependencies = [
  "ordered-float",
  "pest",
  "pest_derive",
- "phf",
+ "phf 0.11.3",
  "sha2 0.10.9",
  "signal-hook",
  "siphasher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,19 +77,19 @@ tree-sitter-zig = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-everruns-anthropic = "0.17.7"
-everruns-core = "0.17.7"
-everruns-openai = "0.17.7"
+everruns-anthropic = "0.17.8"
+everruns-core = "0.17.8"
+everruns-openai = "0.17.8"
 # OpenRouter's first-class driver was split out of everruns-openai into its own
 # crate in 0.13.0; register it alongside openai to keep DriverId::OpenRouter.
-everruns-openrouter = "0.17.7"
-everruns-local = "0.17.7"
+everruns-openrouter = "0.17.8"
+everruns-local = "0.17.8"
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (specs/mcp.md, upstream runtime-mcp.md D2).
-everruns-runtime = { version = "0.17.7", features = ["mcp-stdio"] }
-everruns-integrations-duckduckgo = "0.17.7"
-everruns-integrations-parallel = "0.17.7"
-everruns-integrations-daytona = "0.17.7"
+everruns-runtime = { version = "0.17.8", features = ["mcp-stdio"] }
+everruns-integrations-duckduckgo = "0.17.8"
+everruns-integrations-parallel = "0.17.8"
+everruns-integrations-daytona = "0.17.8"
 arboard = { version = "3", features = ["wayland-data-control"] }
 futures = "0.3"
 html-escape = "0.2"

--- a/README.md
+++ b/README.md
@@ -116,9 +116,12 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   to a session-file log, writes a `result.json`, and tracks a background session
   task. Inspect and control them with `list_tasks`, `get_task`, and
   `cancel_task` (the `/background` command and the `Ctrl+B` panel list them). A
-  task's result survives a restart. When a task finishes while the session is
-  idle, yolop proactively wakes the agent with a turn so it reacts without
-  waiting for your next prompt (turn off with the `proactive_wake` setting).
+  task's result survives a restart. `spawn_background` can also schedule a
+  one-shot or recurring monitor; yolop executes due schedules while the TUI or
+  ACP session is running and recovers overdue schedules after restart. When a
+  schedule fires or a task finishes while the session is idle, yolop
+  proactively wakes the agent with a turn so it reacts without waiting for
+  your next prompt (turn off with the `proactive_wake` setting).
   See [`specs/background.md`](./specs/background.md).
 - **Web** — `free_web_search` (best-effort SERP/developer search), `web_fetch`
   (HTTP GET/HEAD with markdown/text conversion and DNS-pinned SSRF protection),

--- a/specs/background.md
+++ b/specs/background.md
@@ -38,6 +38,18 @@ The run executes on a detached task, streams to a session-file log
 lifecycle onto a `background_tool` session task (`Running` → `Succeeded` /
 `Failed` / `Canceled`). `signal_on_completion` defaults to `true`.
 
+For delayed or recurring work, `spawn_background` accepts a `schedule` instead
+of starting the wrapped tool immediately. Everruns persists the monitor and its
+payload in the local SQLite store. Yolop starts one `LocalScheduleRunner` per
+live host session; when a schedule becomes due, the runner sends the stored
+monitor prompt through the same `WakeRunner` used by background completions.
+The resulting turn starts the wrapped tool, and that tool's eventual completion
+produces the ordinary second wake. The TUI and ACP session objects retain the
+runner handle for their lifetimes, preventing polling from outliving its host.
+Schedule claims are org-scoped, so `WakeRunner` routes every delivery by
+`SessionId`; an inactive target rejects delivery and leaves the occurrence
+retryable rather than waking whichever ACP session happened to claim it.
+
 ### Steering (poll-proofing)
 
 Detaching a wait only saves tokens if the model actually chooses it, so the
@@ -78,6 +90,11 @@ On completion `spawn_background`'s sink calls
 platform store that call is a silent no-op — which is why finished background
 work previously never reached the agent.
 
+Due schedules enter through the same host boundary: `everruns-local` calls
+`LocalSessionRunner::send_message(session_id, <stored monitor prompt>)`. The
+single channel and host turn lock serialize schedule wakes, foreground prompts,
+and background completions.
+
 Yolop installs a platform store to close that gap (`crate::background_wake`):
 
 - `runtime.rs` wires a `LocalPlatformStore` backed by a `WakeRunner` via
@@ -109,6 +126,12 @@ unless an orphan reaper re-attaches it (Yolop runs none, so non-reattachable
 runs simply stop). The wake is a live, in-process signal — a completion that
 happened while Yolop was down is observed on the next `/background` / `get_task`,
 not replayed as a wake.
+
+Schedules are different: their trigger state is durable. The local runner uses
+atomic, leased SQLite claims, advances recurring schedules only after delivery,
+and disables successful one-shot schedules. A due schedule that could not fire
+while Yolop was down is claimed after the session is loaded again; stale claims
+from an interrupted runner become retryable after the upstream claim timeout.
 
 ## Safety
 

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -949,4 +949,116 @@ mod tests {
             "expected a proactive wake turn after spawn_background finished (via the wake seam)"
         );
     }
+
+    /// A persisted local schedule must wake an idle ACP session at its due time,
+    /// let that turn start the requested background command, then deliver the
+    /// command's ordinary completion wake through the same serialized channel.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn scheduled_background_run_wakes_agent_through_completion() {
+        let scheduled_at = (chrono::Utc::now() + chrono::Duration::seconds(3)).to_rfc3339();
+        let config = LlmSimConfig::scripted(vec![
+            SimTurn::ToolCalls(vec![SimToolCall {
+                name: "spawn_background".to_string(),
+                arguments: json!({
+                    "tool": "bash",
+                    "args": { "command": "true" },
+                    "title": "scheduled ACP wake regression",
+                    "schedule": { "scheduled_at": scheduled_at },
+                    "signal_on_completion": true,
+                }),
+                id: None,
+            }]),
+            SimTurn::Assistant("scheduled background bash".to_string()),
+            SimTurn::ToolCalls(vec![SimToolCall {
+                name: "spawn_background".to_string(),
+                arguments: json!({
+                    "tool": "bash",
+                    "args": { "command": "true" },
+                    "title": "scheduled ACP wake regression",
+                    "signal_on_completion": true,
+                }),
+                id: None,
+            }]),
+            SimTurn::Assistant("scheduled monitor fired and started run".to_string()),
+            SimTurn::Assistant("scheduled run completed".to_string()),
+        ]);
+
+        let sessions = tempfile::tempdir().expect("sessions tempdir").keep();
+        let (mut client_w, mut reader, _server) = start_raw_server(config, sessions);
+
+        send_json(
+            &mut client_w,
+            json!({ "jsonrpc": "2.0", "id": 0, "method": "initialize", "params": { "protocolVersion": 1 } }),
+        )
+        .await;
+        collect_until_response_id(&mut reader, 0).await;
+
+        let cwd = tempfile::tempdir().expect("cwd tempdir").keep();
+        send_json(
+            &mut client_w,
+            json!({ "jsonrpc": "2.0", "id": 1, "method": "session/new", "params": { "cwd": cwd.to_str().unwrap(), "mcpServers": [] } }),
+        )
+        .await;
+        let (new_session, _) = collect_until_response_id(&mut reader, 1).await;
+        let session_id = new_session["result"]["sessionId"]
+            .as_str()
+            .expect("sessionId")
+            .to_string();
+
+        send_json(
+            &mut client_w,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/prompt",
+                "params": { "sessionId": session_id, "prompt": [{ "type": "text", "text": "check CI in a moment" }] },
+            }),
+        )
+        .await;
+        let (_prompt_response, prompt_updates) = collect_until_response_id(&mut reader, 2).await;
+        assert!(
+            update_texts(&prompt_updates, "agent_message_chunk")
+                .iter()
+                .any(|text| text.contains("scheduled background bash")),
+            "expected the foreground turn to create the schedule, got: {prompt_updates:?}"
+        );
+
+        let messages = tokio::time::timeout(Duration::from_secs(25), async {
+            let mut messages = Vec::new();
+            while !messages
+                .iter()
+                .any(|text: &String| text.contains("scheduled run completed"))
+            {
+                let msg = next_json(&mut reader).await;
+                if msg.get("method").and_then(Value::as_str) != Some("session/update") {
+                    continue;
+                }
+                if let Some(text) = msg
+                    .get("params")
+                    .and_then(|params| params.get("update"))
+                    .and_then(|update| update.get("content"))
+                    .and_then(|content| content.get("text"))
+                    .and_then(Value::as_str)
+                {
+                    messages.push(text.to_string());
+                }
+            }
+            messages
+        })
+        .await
+        .expect("scheduled run and its completion wake must arrive");
+
+        assert!(
+            messages
+                .iter()
+                .any(|text| text.contains("scheduled monitor fired and started run")),
+            "expected the due schedule to start a wake turn, got: {messages:?}"
+        );
+        assert!(
+            messages
+                .iter()
+                .any(|text| text.contains("scheduled run completed")),
+            "expected the scheduled run completion to wake the session, got: {messages:?}"
+        );
+    }
 }

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -89,6 +89,8 @@ struct Session {
     cancel: StdMutex<Option<oneshot::Sender<()>>>,
     /// Settings source, read for the `proactive_wake` opt-out.
     settings: Arc<SettingsStore>,
+    /// Retained for the ACP session lifetime so due local schedules keep polling.
+    _schedule_runner: everruns_local::LocalScheduleRunnerHandle,
     /// Serializes turns for this session. Both a client prompt and a background
     /// wake turn take it, so two `run_turn`s never overlap.
     turn_lock: tokio::sync::Mutex<()>,
@@ -410,6 +412,7 @@ fn register_session<F: RuntimeFactory>(
         commands: StdMutex::new(commands.clone()),
         cancel: StdMutex::new(None),
         settings: built.settings,
+        _schedule_runner: built.schedule_runner,
         turn_lock: tokio::sync::Mutex::new(()),
     });
     server

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -133,6 +133,8 @@ pub struct App {
     /// auto-start a turn so the agent reacts to finished work. See
     /// specs/background.md.
     background_wake: crate::background_wake::WakeReceiver,
+    /// Retained for the TUI lifetime so due local schedules keep polling.
+    _schedule_runner: everruns_local::LocalScheduleRunnerHandle,
     /// Everruns session-task registry used by `spawn_background`; the TUI reads
     /// it for the background status segment and panel.
     task_registry: Arc<dyn SessionTaskRegistry>,
@@ -341,6 +343,7 @@ impl App {
             models_tx,
             models_rx,
             background_wake: runtime.background_wake,
+            _schedule_runner: runtime.schedule_runner,
             task_registry: runtime.task_registry,
             session_tasks: Vec::new(),
             session_tasks_error: None,

--- a/src/background_wake.rs
+++ b/src/background_wake.rs
@@ -12,9 +12,9 @@
 //! turn synchronously (the behavior the `LocalSessionRunner` contract assumes,
 //! which only fits child sub-agent sessions) — that would re-enter the session
 //! from a detached background task's context, bypassing the host's streaming
-//! turn loop. Instead it hands the completion message to the host over an
-//! unbounded channel; the host (TUI event loop or ACP session loop) runs it as
-//! an ordinary streamed turn when idle. See specs/background.md.
+//! turn loop. Instead it routes the completion message by session id to the
+//! host's unbounded channel; the host (TUI event loop or ACP session loop) runs
+//! it as an ordinary streamed turn when idle. See specs/background.md.
 
 use async_trait::async_trait;
 use everruns_core::error::{AgentLoopError, Result};
@@ -22,6 +22,8 @@ use everruns_core::platform_store::PlatformMessage;
 use everruns_core::session::Session;
 use everruns_core::typed_id::{AgentId, HarnessId, SessionId};
 use everruns_local::LocalSessionRunner;
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
 use tokio::sync::mpsc;
 
 /// Sender half of a session's wake channel. The `LocalPlatformStore`'s
@@ -31,9 +33,16 @@ pub type WakeSender = mpsc::UnboundedSender<String>;
 /// Receiver half a host drains to react to finished background tasks.
 pub type WakeReceiver = mpsc::UnboundedReceiver<String>;
 
-/// `LocalSessionRunner` whose `send_message` enqueues a wake for the host
-/// session instead of running a turn inline. One per built session; `wake_tx`
-/// feeds that session's [`WakeReceiver`].
+fn wake_routes() -> &'static Mutex<HashMap<SessionId, WakeSender>> {
+    static ROUTES: OnceLock<Mutex<HashMap<SessionId, WakeSender>>> = OnceLock::new();
+    ROUTES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// `LocalSessionRunner` whose `send_message` routes a wake to the target host
+/// session instead of running a turn inline. Every built session registers its
+/// sender for its lifetime. This matters because the local schedule runner
+/// claims from an org-wide store and may encounter another live ACP session's
+/// schedule.
 ///
 /// The other trait methods are unused today: a background *tool* run signals its
 /// own (parent) session, so only `send_message` is exercised. Child sub-agent
@@ -41,12 +50,32 @@ pub type WakeReceiver = mpsc::UnboundedReceiver<String>;
 /// synchronous `send_message` — are handled separately if/when the sub-agent
 /// path migrates onto this runner.
 pub struct WakeRunner {
+    session_id: SessionId,
     wake_tx: WakeSender,
 }
 
 impl WakeRunner {
-    pub fn new(wake_tx: WakeSender) -> Self {
-        Self { wake_tx }
+    pub fn new(session_id: SessionId, wake_tx: WakeSender) -> Self {
+        wake_routes()
+            .lock()
+            .unwrap()
+            .insert(session_id, wake_tx.clone());
+        Self {
+            session_id,
+            wake_tx,
+        }
+    }
+}
+
+impl Drop for WakeRunner {
+    fn drop(&mut self) {
+        let mut routes = wake_routes().lock().unwrap();
+        if routes
+            .get(&self.session_id)
+            .is_some_and(|current| current.same_channel(&self.wake_tx))
+        {
+            routes.remove(&self.session_id);
+        }
     }
 }
 
@@ -63,11 +92,25 @@ pub fn frame_wake_prompt(message: &str) -> String {
 
 #[async_trait]
 impl LocalSessionRunner for WakeRunner {
-    async fn send_message(&self, _session_id: SessionId, content: &str) -> Result<()> {
-        // Non-blocking hand-off to the host loop. A closed receiver (host gone)
-        // is not an error — the process is winding down.
-        let _ = self.wake_tx.send(content.to_string());
-        Ok(())
+    async fn send_message(&self, session_id: SessionId, content: &str) -> Result<()> {
+        let sender = wake_routes().lock().unwrap().get(&session_id).cloned();
+        let Some(sender) = sender else {
+            return Err(AgentLoopError::tool(format!(
+                "session {session_id} is not active; wake remains retryable"
+            )));
+        };
+        sender.send(content.to_string()).map_err(|_| {
+            let mut routes = wake_routes().lock().unwrap();
+            if routes
+                .get(&session_id)
+                .is_some_and(|current| current.same_channel(&sender))
+            {
+                routes.remove(&session_id);
+            }
+            AgentLoopError::tool(format!(
+                "session {session_id} wake receiver is closed; wake remains retryable"
+            ))
+        })
     }
 
     async fn create_session(
@@ -110,4 +153,42 @@ fn unsupported(op: &str) -> AgentLoopError {
     AgentLoopError::tool(format!(
         "the local wake runner does not support '{op}' (background completions only)"
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn routes_wakes_to_the_target_session() {
+        let session_a = SessionId::from_seed(910_001);
+        let session_b = SessionId::from_seed(910_002);
+        let (tx_a, mut rx_a) = mpsc::unbounded_channel();
+        let (tx_b, mut rx_b) = mpsc::unbounded_channel();
+        let runner_a = WakeRunner::new(session_a, tx_a);
+        let _runner_b = WakeRunner::new(session_b, tx_b);
+
+        runner_a
+            .send_message(session_b, "for b")
+            .await
+            .expect("route to active session b");
+
+        assert_eq!(rx_b.recv().await.as_deref(), Some("for b"));
+        assert!(rx_a.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn inactive_session_wakes_remain_retryable() {
+        let active = SessionId::from_seed(910_003);
+        let inactive = SessionId::from_seed(910_004);
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let runner = WakeRunner::new(active, tx);
+
+        let error = runner
+            .send_message(inactive, "later")
+            .await
+            .expect_err("inactive session must reject delivery");
+
+        assert!(error.to_string().contains("not active"));
+    }
 }

--- a/src/capabilities/approval.rs
+++ b/src/capabilities/approval.rs
@@ -180,6 +180,7 @@ impl Tool for RecordApprovalTool {
         tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let _ = locale;
         let action = arg_str(&tool_call.arguments, &["action"]).map(|value| truncate(value, 48));
@@ -247,6 +248,7 @@ impl Tool for SetApprovalModeTool {
         tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let _ = locale;
         let mode =

--- a/src/capabilities/ast_grep.rs
+++ b/src/capabilities/ast_grep.rs
@@ -179,6 +179,7 @@ impl Tool for AstGrepTool {
         tool_call: &everruns_core::tool_types::ToolCall,
         phase: ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         Some(everruns_core::tool_narration::narrate_grep_files(
             &tool_call.arguments,
@@ -275,6 +276,7 @@ impl Tool for AstEditTool {
         tool_call: &everruns_core::tool_types::ToolCall,
         phase: ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         Some(everruns_core::tool_narration::narrate_grep_files(
             &tool_call.arguments,

--- a/src/capabilities/client_commands.rs
+++ b/src/capabilities/client_commands.rs
@@ -164,6 +164,7 @@ impl Tool for RunYolopCommandTool {
         tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let _ = locale;
         let command = arg_str(&tool_call.arguments, &["command"]).map(|value| truncate(value, 48));
@@ -328,7 +329,12 @@ mod tests {
         };
 
         assert_eq!(
-            tool.narrate(&tool_call, ToolNarrationPhase::Started, None),
+            tool.narrate(
+                &tool_call,
+                ToolNarrationPhase::Started,
+                None,
+                everruns_core::tool_narration::ToolNarrationContext::default(),
+            ),
             Some("Run command: /model".to_string())
         );
     }

--- a/src/capabilities/config.rs
+++ b/src/capabilities/config.rs
@@ -140,6 +140,7 @@ impl Tool for GetConfigTool {
         tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let _ = locale;
         Some(narrate_get_config(tool_call, phase))
@@ -276,6 +277,7 @@ impl Tool for SetConfigTool {
         tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let _ = locale;
         Some(narrate_set_config(tool_call, phase))
@@ -627,7 +629,12 @@ mod tests {
             name: "set_config".to_owned(),
             arguments: json!({ "key": "attribution", "value": "on" }),
         };
-        let narration = tool.narrate(&call, ToolNarrationPhase::Completed, None);
+        let narration = tool.narrate(
+            &call,
+            ToolNarrationPhase::Completed,
+            None,
+            everruns_core::tool_narration::ToolNarrationContext::default(),
+        );
         assert_eq!(narration.as_deref(), Some("Set config: attribution=true"));
     }
 
@@ -640,7 +647,12 @@ mod tests {
             name: "get_config".to_owned(),
             arguments: json!({}),
         };
-        let narration = tool.narrate(&call, ToolNarrationPhase::Completed, None);
+        let narration = tool.narrate(
+            &call,
+            ToolNarrationPhase::Completed,
+            None,
+            everruns_core::tool_narration::ToolNarrationContext::default(),
+        );
         assert_eq!(narration.as_deref(), Some("Get config"));
     }
 

--- a/src/capabilities/edit_file_override.rs
+++ b/src/capabilities/edit_file_override.rs
@@ -203,8 +203,9 @@ impl Tool for EditsOnlyEditFileTool {
         tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         locale: Option<&str>,
+        ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
-        self.inner.narrate(tool_call, phase, locale)
+        self.inner.narrate(tool_call, phase, locale, ctx)
     }
 
     async fn execute(&self, arguments: Value) -> ToolExecutionResult {

--- a/src/capabilities/hooks.rs
+++ b/src/capabilities/hooks.rs
@@ -93,6 +93,7 @@ impl Tool for ListHooksTool {
         _tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let _ = locale;
         Some(stable_labeled("List hooks", None, phase))
@@ -139,6 +140,7 @@ impl Tool for ValidateHookTool {
         tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let _ = locale;
         let id = tool_call
@@ -193,6 +195,7 @@ impl Tool for UpsertHookTool {
         tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let _ = locale;
         let id = tool_call
@@ -268,6 +271,7 @@ impl Tool for RemoveHookTool {
         tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let _ = locale;
         let id = arg_str(&tool_call.arguments, &["id"]).map(|value| truncate(value, 48));

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -1115,6 +1115,7 @@ impl Tool for SetReasoningEffortTool {
         tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let _ = locale;
         let effort = arg_str(&tool_call.arguments, &["effort"]).map(|value| truncate(value, 24));
@@ -1166,6 +1167,7 @@ impl Tool for SetModelTool {
         tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let _ = locale;
         let model = arg_str(&tool_call.arguments, &["model"]).map(|value| truncate(value, 48));
@@ -1226,6 +1228,7 @@ impl Tool for SetProviderTool {
         tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let _ = locale;
         let provider =

--- a/src/capabilities/mcp.rs
+++ b/src/capabilities/mcp.rs
@@ -78,6 +78,7 @@ impl Tool for ListMcpServersTool {
         _tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         Some(stable_labeled("List MCP servers", None, phase))
     }
@@ -117,6 +118,7 @@ impl Tool for UpsertMcpServerTool {
         _tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         Some(stable_labeled("Upsert MCP server", None, phase))
     }
@@ -186,6 +188,7 @@ impl Tool for RemoveMcpServerTool {
         _tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         Some(stable_labeled("Remove MCP server", None, phase))
     }
@@ -238,6 +241,7 @@ impl Tool for SetMcpServerEnabledTool {
         _tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         Some(stable_labeled("Set MCP server enabled", None, phase))
     }

--- a/src/capabilities/memory.rs
+++ b/src/capabilities/memory.rs
@@ -808,6 +808,7 @@ impl Tool for RememberTool {
         tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let _ = locale;
         let title = arg_str(&tool_call.arguments, &["title"]).map(|value| truncate(value, 48));
@@ -911,6 +912,7 @@ impl Tool for RecallTool {
         tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let _ = locale;
         let detail =
@@ -1018,6 +1020,7 @@ impl Tool for ForgetTool {
         tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let _ = locale;
         let detail =

--- a/src/capabilities/repo_map.rs
+++ b/src/capabilities/repo_map.rs
@@ -114,6 +114,7 @@ impl Tool for RepoMapTool {
         tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let _ = locale;
         let query = scan_narration_query(&tool_call.arguments);
@@ -179,6 +180,7 @@ impl Tool for RepoSymbolsTool {
         tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let _ = locale;
         let query = scan_narration_query(&tool_call.arguments);

--- a/src/capabilities/session_history.rs
+++ b/src/capabilities/session_history.rs
@@ -99,6 +99,7 @@ impl Tool for SearchSessionsTool {
         tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let _ = locale;
         let query = tool_call

--- a/src/capabilities/skills.rs
+++ b/src/capabilities/skills.rs
@@ -341,6 +341,7 @@ impl Tool for DeleteSkillTool {
         tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let _ = locale;
         let detail = arg_str(&tool_call.arguments, &["name"]).map(|name| {

--- a/src/capabilities/user_ask.rs
+++ b/src/capabilities/user_ask.rs
@@ -158,6 +158,7 @@ impl Tool for SetUserAskTool {
         tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let _ = locale;
         let ask = arg_str(&tool_call.arguments, &["ask", "text", "request"])
@@ -223,6 +224,7 @@ impl Tool for ClearUserAskTool {
         _tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let _ = locale;
         Some(stable_labeled("Clear user ask", None, phase))

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -62,7 +62,7 @@ use everruns_core::{
 use everruns_core::{DriverId, ModelProfile, ReasoningEffortConfig, ReasoningEffortValue};
 use everruns_integrations_daytona::DaytonaCapability;
 use everruns_integrations_duckduckgo::DuckDuckGoCapability;
-use everruns_local::{LocalBackends, LocalProfile};
+use everruns_local::{LocalBackends, LocalProfile, LocalScheduleRunnerHandle};
 use everruns_runtime::{
     AgentBuilder, HarnessBuilder, InProcessRuntime, InProcessRuntimeBuilder, RealDiskFileStore,
     RuntimeBackends, SessionBuilder, WriteBlocklistFileStore,
@@ -293,6 +293,12 @@ impl CodingCliSessionFileStore {
 
 #[async_trait]
 impl SessionFileSystem for CodingCliSessionFileStore {
+    fn is_mount_resolver(&self) -> bool {
+        // This store already routes the workspace, session artifacts, and skill
+        // scopes. Wrapping it in another MountFs would collapse that table.
+        true
+    }
+
     fn display_root(&self) -> String {
         // Yolop's file tools and persisted output pointers use one stable
         // model-facing namespace even while the host worktree root changes.
@@ -1829,6 +1835,10 @@ pub struct BuiltRuntime {
     /// the wake seam (`background_wake`). The host (TUI/ACP) drains it and runs
     /// a streamed turn so the agent reacts to finished `spawn_background` work.
     pub background_wake: crate::background_wake::WakeReceiver,
+    /// Owns the local schedule poller for this host session. Dropping the host
+    /// stops new schedule claims; due prompts share `background_wake` with
+    /// ordinary background-task completion signals.
+    pub schedule_runner: LocalScheduleRunnerHandle,
     /// Shared repointable workspace disk for host-path tools (`bash`, `!shell`).
     pub workspace_host: Arc<WorkspaceHost>,
     /// Shared Everruns session task registry, backed by `everruns-local`. The
@@ -2172,9 +2182,14 @@ pub async fn build_with_options(
     // completion signal is a silent no-op and finished background work never
     // reaches the agent.
     let (background_wake_tx, background_wake_rx) = mpsc::unbounded_channel::<String>();
-    let local_backends = local_backends.with_platform_runner(Arc::new(
-        crate::background_wake::WakeRunner::new(background_wake_tx),
+    let wake_runner = Arc::new(crate::background_wake::WakeRunner::new(
+        session_id,
+        background_wake_tx,
     ));
+    let schedule_runner = local_backends
+        .start_schedule_runner(wake_runner.clone())
+        .context("start everruns-local schedule runner")?;
+    let local_backends = local_backends.with_platform_runner(wake_runner);
     let backends = local_backends.runtime_backends;
     // Shared between `ModelState` (for banner labels) and
     // `SetupCapability` (which mutates it on a successful `/setup`).
@@ -2523,6 +2538,7 @@ pub async fn build_with_options(
         settings,
         ui_rx,
         background_wake: background_wake_rx,
+        schedule_runner,
         workspace_host,
         task_registry,
         goal_store,

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -200,6 +200,7 @@ impl Tool for BashTool {
         tool_call: &everruns_core::tool_types::ToolCall,
         phase: ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         Some(everruns_core::tool_narration::narrate_shell_exec(
             &tool_call.arguments,


### PR DESCRIPTION
## What changed

Yolop now executes one-shot and recurring `spawn_background` monitors through
the released `everruns-local` scheduler. TUI and ACP sessions retain the
scheduler for their host lifetime, and scheduled prompts plus ordinary
background completions share the existing serialized wake path.

Wake delivery is routed by `SessionId`, so an org-scoped scheduler cannot wake
the wrong ACP session. Inactive targets reject delivery and remain retryable
until the session is resumed.

The Everruns crate family is upgraded in lockstep to 0.17.8, which contains the
upstream scheduler from everruns/everruns#2706.

## Why

Yolop previously persisted scheduled monitors but never polled or executed
them. The tool returned `status: scheduled`, while the SQLite record stayed
enabled with no trigger metadata and the linked monitor task remained running
forever.

## Before / After

Before:

```text
next_trigger_at: 2026-07-11T21:24:15Z
last_triggered_at: null
trigger_count: 0
task state: running
```

No automatic turn arrived after the due time.

After, the new ACP regression drives the full observable path:

```text
scheduled monitor due
→ automatic ACP wake turn
→ wrapped background command starts
→ command completion wakes ACP again
```

Validation:

- `cargo fetch --locked`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` — 627 unit tests, 34 passing integration tests,
  and the Parallel integration test
- `cargo build --release`
- Live Anthropic smoke through Doppler — returned `READY`
- OpenAI smoke reached the provider but the configured account returned
  `insufficient_quota`; Anthropic provided the required live-provider proof

## Risk

- Medium — this starts a durable poller for every live host session and changes
  the common wake boundary.
- Mitigations: upstream claims are atomic, leased, and bounded; Yolop routes by
  typed session ID, removes closed routes, holds no routing mutex across await,
  and directly tests inactive and cross-session behavior.

## Security

- **TM-FS:** no access expansion. The new `is_mount_resolver` implementation
  preserves Yolop's existing workspace/output/skills router instead of nesting
  another mount table; write-blocklist tests remain green.
- **TM-BASH:** no timeout, output-cap, or approval changes.
- **TM-LLM:** scheduled prompts use the existing wake channel and are routed to
  the exact session; no prompt or credential content is added to logs.
- **TM-TOOL:** no new Yolop capability is registered.
- **TM-DEP:** every public Everruns crate is pinned together at 0.17.8. New
  `chrono-tz`/PHF packages are transitive requirements of the upstream scheduler
  for timezone-correct recurring triggers.
- Resource use remains bounded by upstream batch size, poll interval, and claim
  timeout. The route registry contains only live in-process sessions and removes
  entries on runner drop or closed-channel delivery.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
