### PR TITLE
feat(context): expose active client UI

### DIFF
--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -23,7 +23,8 @@ use std::sync::Arc;
 use anyhow::Result;
 use async_trait::async_trait;
 
-use crate::runtime::{self, BuiltRuntime, ProviderChoice};
+use crate::capabilities::ClientUiContext;
+use crate::runtime::{BuildOptions, BuiltRuntime, ProviderChoice, build_with_options};
 use crate::session_log::{legacy_session_log_path, session_dir_path, session_log_path};
 use crate::settings::SettingsStore;
 use everruns_core::typed_id::SessionId as RuntimeSessionId;
@@ -53,12 +54,16 @@ impl RuntimeFactory for ConfigRuntimeFactory {
         cwd: PathBuf,
         resume_session_id: Option<RuntimeSessionId>,
     ) -> Result<BuiltRuntime> {
-        runtime::build(
+        build_with_options(
             cwd,
             self.provider.clone(),
             resume_session_id,
             self.sessions_dir.clone(),
             self.settings.clone(),
+            BuildOptions {
+                client_ui: ClientUiContext::Acp,
+                ..BuildOptions::default()
+            },
         )
         .await
     }
@@ -83,7 +88,6 @@ pub async fn run_stdio(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::runtime::{BuildOptions, build_with_options};
     use agent_client_protocol::schema::v1::{
         InitializeRequest, InitializeResponse, NewSessionRequest, PromptRequest, SessionId,
         SessionNotification, SessionUpdate, StopReason,
@@ -130,6 +134,7 @@ mod tests {
                 self.settings.clone(),
                 BuildOptions {
                     llmsim_override: Some(self.config.clone().with_model("llmsim-yolop")),
+                    client_ui: ClientUiContext::Acp,
                     ..BuildOptions::default()
                 },
             )

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -29,13 +29,38 @@ pub(crate) const ENVIRONMENT_CONTEXT_CAPABILITY_ID: &str = "code_environment_con
 pub(crate) struct CodingCliEnvironmentCapability {
     repo_root: PathBuf,
     active_root: Arc<RwLock<PathBuf>>,
+    client_ui: ClientUiContext,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum ClientUiContext {
+    Acp,
+    Print,
+    Tui,
+    None,
+}
+
+impl ClientUiContext {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Acp => "ACP",
+            Self::Print => "print",
+            Self::Tui => "TUI",
+            Self::None => "none",
+        }
+    }
 }
 
 impl CodingCliEnvironmentCapability {
-    pub(crate) fn new(repo_root: PathBuf, active_root: Arc<RwLock<PathBuf>>) -> Self {
+    pub(crate) fn new(
+        repo_root: PathBuf,
+        active_root: Arc<RwLock<PathBuf>>,
+        client_ui: ClientUiContext,
+    ) -> Self {
         Self {
             repo_root,
             active_root,
+            client_ui,
         }
     }
 
@@ -47,6 +72,7 @@ impl CodingCliEnvironmentCapability {
             .unwrap_or_else(|_| self.repo_root.clone());
         EnvironmentContext {
             cwd: active_path.display().to_string(),
+            client_ui: self.client_ui.clone(),
             shell: shell_name(),
             current_date: Local::now().format("%Y-%m-%d").to_string(),
             timezone: local_timezone(),
@@ -94,6 +120,7 @@ impl Capability for CodingCliEnvironmentCapability {
             "\
 <environment_context>
   <cwd>/path/to/workspace</cwd>
+  <client_ui>TUI|print|ACP|none</client_ui>
   <shell>zsh</shell>
   <current_date>YYYY-MM-DD</current_date>
   <timezone>Region/City</timezone>
@@ -110,6 +137,7 @@ impl Capability for CodingCliEnvironmentCapability {
 #[derive(Debug)]
 struct EnvironmentContext {
     cwd: String,
+    client_ui: ClientUiContext,
     shell: String,
     current_date: String,
     timezone: String,
@@ -125,6 +153,7 @@ fn render_environment_context(context: &EnvironmentContext) -> String {
     let mut out = String::new();
     out.push_str("<environment_context>\n");
     push_xml_field(&mut out, "cwd", &context.cwd);
+    push_xml_field(&mut out, "client_ui", context.client_ui.as_str());
     push_xml_field(&mut out, "repo_root", &context.repo_root);
     if let Some(path) = &context.worktree_path {
         out.push_str("  <git_worktree>\n");
@@ -1549,6 +1578,7 @@ mod tests {
     fn environment_context_renders_requested_fields() {
         let rendered = render_environment_context(&EnvironmentContext {
             cwd: "/repo".to_string(),
+            client_ui: ClientUiContext::Tui,
             shell: "zsh".to_string(),
             current_date: "2026-05-20".to_string(),
             timezone: "America/Chicago".to_string(),
@@ -1562,6 +1592,7 @@ mod tests {
 
         assert!(rendered.starts_with("<environment_context>\n"));
         assert!(rendered.contains("  <cwd>/repo</cwd>\n"));
+        assert!(rendered.contains("  <client_ui>TUI</client_ui>\n"));
         assert!(rendered.contains("  <shell>zsh</shell>\n"));
         assert!(rendered.contains("  <current_date>2026-05-20</current_date>\n"));
         assert!(rendered.contains("  <timezone>America/Chicago</timezone>\n"));

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -40,8 +40,9 @@ pub(crate) use free_search::FreeSearchCapability;
 pub(crate) use goal::GoalCapability;
 pub(crate) use hooks::{HOOKS_CAPABILITY_ID, HooksCapability};
 pub(crate) use host::{
-    CODING_BASH_CAPABILITY_ID, CodingBashCapability, CodingCliEnvironmentCapability,
-    ENVIRONMENT_CONTEXT_CAPABILITY_ID, SETUP_CAPABILITY_ID, SetupCapability,
+    CODING_BASH_CAPABILITY_ID, ClientUiContext, CodingBashCapability,
+    CodingCliEnvironmentCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID, SETUP_CAPABILITY_ID,
+    SetupCapability,
 };
 pub(crate) use lsp::LspCapability;
 pub(crate) use progress_guard::{PROGRESS_GUARD_CAPABILITY_ID, ProgressGuardCapability};

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,7 @@ mod mcp_e2e_tests;
 #[cfg(test)]
 mod agent_scenarios;
 
+use crate::capabilities::ClientUiContext;
 use anyhow::{Context, Result};
 
 // Force-link integration crates whose inventory registrations must survive
@@ -534,6 +535,11 @@ async fn main() -> Result<()> {
         settings,
         runtime::BuildOptions {
             client_commands: interactive,
+            client_ui: if interactive {
+                ClientUiContext::Tui
+            } else {
+                ClientUiContext::Print
+            },
             ..Default::default()
         },
     )

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -11,7 +11,7 @@ use crate::capabilities::{
     APPROVAL_CAPABILITY_ID, AST_GREP_CAPABILITY_ID, ATTRIBUTION_CAPABILITY_ID, ApprovalCapability,
     AstEditCapability, AstGrepCapability, AttributionCapability, BACKGROUND_CAPABILITY_ID,
     BackgroundCapability, CLIENT_COMMANDS_CAPABILITY_ID, CODING_BASH_CAPABILITY_ID,
-    CONFIG_CAPABILITY_ID, ClientCommandsCapability, CodingBashCapability,
+    CONFIG_CAPABILITY_ID, ClientCommandsCapability, ClientUiContext, CodingBashCapability,
     CodingCliEnvironmentCapability, ConfigCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID,
     GOAL_CAPABILITY_ID, GoalCapability, HOOKS_CAPABILITY_ID, HooksCapability, LspCapability,
     PROGRESS_GUARD_CAPABILITY_ID, ProgressGuardCapability, REPO_MAP_CAPABILITY_ID,
@@ -2011,7 +2011,6 @@ impl ModelState {
 /// batch window) with one that produces real multi-delta streams. All
 /// fields default to "no override" so callers that don't care keep the
 /// existing behavior.
-#[derive(Default)]
 pub struct BuildOptions {
     pub llmsim_override: Option<LlmSimConfig>,
     /// Register [`ClientCommandsCapability`], which contributes the
@@ -2020,24 +2019,17 @@ pub struct BuildOptions {
     /// the effects sets this: the interactive TUI (and the `app` unit tests
     /// that exercise it). ACP and `--print` leave it `false`.
     pub client_commands: bool,
+    pub client_ui: ClientUiContext,
 }
 
-pub async fn build(
-    workspace_root: PathBuf,
-    provider: ProviderChoice,
-    resume_session_id: Option<SessionId>,
-    sessions_dir: PathBuf,
-    settings: Arc<SettingsStore>,
-) -> Result<BuiltRuntime> {
-    build_with_options(
-        workspace_root,
-        provider,
-        resume_session_id,
-        sessions_dir,
-        settings,
-        BuildOptions::default(),
-    )
-    .await
+impl Default for BuildOptions {
+    fn default() -> Self {
+        Self {
+            llmsim_override: None,
+            client_commands: false,
+            client_ui: ClientUiContext::None,
+        }
+    }
 }
 
 pub async fn build_with_options(
@@ -2292,6 +2284,7 @@ pub async fn build_with_options(
     capabilities.register(CodingCliEnvironmentCapability::new(
         repo_root.clone().unwrap_or_else(|| canonical_root.clone()),
         shared_workspace_root.clone(),
+        options.client_ui.clone(),
     ));
     // Read-only consumer of the shared config service. `SettingsStore`
     // implements `ConfigService`, so the same handle that backs writes also


### PR DESCRIPTION
## Summary
- Add active client UI metadata to the environment context prompt.
- Wire TUI, print, ACP, and default no-UI runtime modes into runtime construction.
- Cover the rendered environment context with an automated assertion for the new field.

## Before / After
Before, yolop knew cwd, shell, date/time, git metadata, and session state, but not which client surface was active.

After, environment context includes:

```xml
<client_ui>TUI|print|ACP|none</client_ui>
```

This lets the agent reason about currently available UI capabilities.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"`
- After rebasing onto `origin/main`: `cargo fmt --check && cargo test --all-features capabilities::host::tests::environment_context_renders_requested_fields`

## Security
- TM-LLM: Adds prompt metadata only. The field is a fixed enum value (`TUI`, `print`, `ACP`, `none`), so no user input, secrets, or untrusted strings are injected into the prompt.
- TM-FS/TM-BASH/TM-TOOL/TM-DEP: No filesystem access, shell execution, tool capability behavior, or dependencies changed.

## Follow-ups
No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
