### PR TITLE
fix(mcp): supply bearer auth from environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6581,6 +6581,7 @@ dependencies = [
  "everruns-integrations-duckduckgo",
  "everruns-integrations-parallel",
  "everruns-local",
+ "everruns-mcp",
  "everruns-openai",
  "everruns-openrouter",
  "everruns-runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ everruns-openai = "0.17.8"
 # crate in 0.13.0; register it alongside openai to keep DriverId::OpenRouter.
 everruns-openrouter = "0.17.8"
 everruns-local = "0.17.8"
+everruns-mcp = "0.17.8"
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (specs/mcp.md, upstream runtime-mcp.md D2).
 everruns-runtime = { version = "0.17.8", features = ["mcp-stdio"] }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -63,6 +63,7 @@ use everruns_core::{DriverId, ModelProfile, ReasoningEffortConfig, ReasoningEffo
 use everruns_integrations_daytona::DaytonaCapability;
 use everruns_integrations_duckduckgo::DuckDuckGoCapability;
 use everruns_local::{LocalBackends, LocalProfile, LocalScheduleRunnerHandle};
+use everruns_mcp::{McpAuthProvider, McpAuthRequest, McpCredential};
 use everruns_runtime::{
     AgentBuilder, HarnessBuilder, InProcessRuntime, InProcessRuntimeBuilder, RealDiskFileStore,
     RuntimeBackends, SessionBuilder, WriteBlocklistFileStore,
@@ -83,6 +84,62 @@ use tokio::sync::mpsc;
 // from `crates/server/src/harnesses/coding_container.rs` and trimmed for
 // yolop's single-level (no-sandbox) execution model and our specific tool
 // names. The agent prompt below stays small on purpose; harness covers it.
+
+#[derive(Debug, Default)]
+struct EnvMcpAuthProvider;
+
+#[async_trait]
+impl McpAuthProvider for EnvMcpAuthProvider {
+    async fn authorization(
+        &self,
+        request: &McpAuthRequest<'_>,
+    ) -> anyhow::Result<Option<McpCredential>> {
+        let Some(token) = env_token_names(request)
+            .into_iter()
+            .find_map(|name| std::env::var(name).ok())
+        else {
+            return Ok(None);
+        };
+        let token = token.trim().to_string();
+        if token.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(McpCredential::bearer(token)))
+    }
+}
+
+fn env_token_names(request: &McpAuthRequest<'_>) -> Vec<String> {
+    let mut keys = Vec::new();
+    if let Some(provider) = request.oauth_provider_id {
+        let prefix = env_key_prefix(provider);
+        keys.push(format!("{prefix}_ACCESS_TOKEN"));
+        keys.push(format!("{prefix}_API_KEY"));
+        keys.push(format!("{prefix}_TOKEN"));
+    }
+    let server = env_key_prefix(request.server_name);
+    keys.push(format!("MCP_{server}_ACCESS_TOKEN"));
+    keys.push(format!("MCP_{server}_API_KEY"));
+    keys.push(format!("MCP_{server}_TOKEN"));
+    keys
+}
+
+fn env_key_prefix(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_uppercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>()
+        .split('_')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("_")
+}
+
 const HARNESS_PROMPT: &str = "\
 You are an expert terminal coding agent. File tools write under the workspace
 root; `bash` runs on the host. There is no sandbox.
@@ -2475,6 +2532,7 @@ pub async fn build_with_options(
         .tag("coding");
 
     let mut builder = InProcessRuntimeBuilder::new()
+        .mcp_auth_provider(Arc::new(EnvMcpAuthProvider))
         .platform_definition(platform)
         .default_model(default_model)
         .backends(backends)
@@ -2540,7 +2598,68 @@ pub async fn build_with_options(
 mod tests {
     use super::*;
     use crate::capabilities::REPO_MAP_CAPABILITY_ID;
+    use everruns_core::McpServerAuthMode;
     use everruns_core::command::ExecuteCommandRequest;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn env_token_names_prefers_oauth_provider_then_server_specific_keys() {
+        let request = McpAuthRequest {
+            server_name: "linear-prod",
+            auth_mode: McpServerAuthMode::OAuth,
+            oauth_provider_id: Some("linear"),
+        };
+
+        assert_eq!(
+            env_token_names(&request),
+            vec![
+                "LINEAR_ACCESS_TOKEN",
+                "LINEAR_API_KEY",
+                "LINEAR_TOKEN",
+                "MCP_LINEAR_PROD_ACCESS_TOKEN",
+                "MCP_LINEAR_PROD_API_KEY",
+                "MCP_LINEAR_PROD_TOKEN",
+            ]
+        );
+    }
+
+    #[test]
+    fn env_key_prefix_normalizes_separators_and_case() {
+        assert_eq!(env_key_prefix("Acme Linear/OAuth"), "ACME_LINEAR_OAUTH");
+        assert_eq!(env_key_prefix("linear"), "LINEAR");
+    }
+
+    #[test]
+    fn env_mcp_auth_provider_returns_bearer_credential_from_provider_env() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        unsafe {
+            std::env::set_var("LINEAR_ACCESS_TOKEN", "linear-test-token");
+        }
+        let request = McpAuthRequest {
+            server_name: "linear",
+            auth_mode: McpServerAuthMode::OAuth,
+            oauth_provider_id: Some("linear"),
+        };
+
+        let credential = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime")
+            .block_on(EnvMcpAuthProvider.authorization(&request))
+            .expect("auth provider result")
+            .expect("credential from env");
+
+        assert_eq!(
+            credential.authorization.as_deref(),
+            Some("Bearer linear-test-token")
+        );
+        assert!(credential.headers.is_empty());
+        unsafe {
+            std::env::remove_var("LINEAR_ACCESS_TOKEN");
+        }
+    }
 
     fn test_file_store(
         workspace: &std::path::Path,


### PR DESCRIPTION
## Summary
- Add an MCP auth provider so OAuth/static-auth MCP servers receive bearer credentials from process env.
- Support provider-derived and server-specific token variables, including `LINEAR_ACCESS_TOKEN`, `LINEAR_API_KEY`, and `MCP_LINEAR_TOKEN`.
- Cover the provider entry point and env-name normalization with unit tests.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `LINEAR_ACCESS_TOKEN=linear-test-token cargo run -- --provider llmsim -p "hi"`

## Security
- TM-LLM/data exposure: bearer tokens are read from process env only, trimmed, and passed directly to the MCP runtime; they are not logged or written to config/session files.
- TM-DEP: adds direct `everruns-mcp` dependency at the same `0.17.8` version as the rest of the `everruns-*` runtime crates already in use, avoiding version skew.
- TM-FS/TM-BASH/TM-TOOL: no filesystem, shell execution, or capability-registration behavior changes.

## Follow-ups
- Implement a full OAuth browser/device authorization flow for MCP providers instead of requiring users to provide an env token.

Produced by [yolop](https://everruns.com/yolop)
