### PR TITLE
fix(runtime): keep activate skill schema visible

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -500,6 +500,9 @@ const YOLOP_NEVER_DEFER_TOOLS: &[&str] = &[
     "bash",
     "spawn_background",
     "write_todos",
+    // Skill activation is a routing tool with required arguments; hiding its
+    // tiny schema makes malformed calls like activate_skill({}) more likely.
+    "activate_skill",
     "run_yolop_command",
     // LSP tools exist only when the optional `lsp` capability is enabled
     // (absent names are ignored by the allowlist). When they exist, stub
@@ -4718,7 +4721,7 @@ mod tests {
     }
 
     #[test]
-    fn tool_search_keeps_write_todos_schema_loaded() {
+    fn tool_search_keeps_routing_tool_schemas_loaded() {
         use everruns_core::capabilities::{Capability, DEFAULT_TOOL_SEARCH_THRESHOLD};
         use everruns_core::tool_types::{
             BuiltinTool, DeferrablePolicy, ToolDefinition, ToolHints, ToolPolicy,
@@ -4742,21 +4745,38 @@ mod tests {
             })
         }
 
-        let mut tools = vec![ToolDefinition::Builtin(BuiltinTool {
-            name: "write_todos".to_string(),
-            display_name: None,
-            description: "write todos".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": { "todos": { "type": "array" } },
-                "required": ["todos"]
+        let mut tools = vec![
+            ToolDefinition::Builtin(BuiltinTool {
+                name: "write_todos".to_string(),
+                display_name: None,
+                description: "write todos".to_string(),
+                parameters: serde_json::json!({
+                    "type": "object",
+                    "properties": { "todos": { "type": "array" } },
+                    "required": ["todos"]
+                }),
+                policy: ToolPolicy::Auto,
+                category: None,
+                deferrable: DeferrablePolicy::Automatic,
+                hints: ToolHints::default(),
+                full_parameters: None,
             }),
-            policy: ToolPolicy::Auto,
-            category: None,
-            deferrable: DeferrablePolicy::Automatic,
-            hints: ToolHints::default(),
-            full_parameters: None,
-        })];
+            ToolDefinition::Builtin(BuiltinTool {
+                name: "activate_skill".to_string(),
+                display_name: None,
+                description: "activate skill".to_string(),
+                parameters: serde_json::json!({
+                    "type": "object",
+                    "properties": { "name": { "type": "string" } },
+                    "required": ["name"]
+                }),
+                policy: ToolPolicy::Auto,
+                category: None,
+                deferrable: DeferrablePolicy::Automatic,
+                hints: ToolHints::default(),
+                full_parameters: None,
+            }),
+        ];
         tools
             .extend((0..DEFAULT_TOOL_SEARCH_THRESHOLD).map(|idx| fake_tool(format!("fake_{idx}"))));
 
@@ -4775,6 +4795,15 @@ mod tests {
         assert!(
             write_todos.parameters().get("properties").is_some(),
             "write_todos must keep its full schema so models pass the required todos field"
+        );
+
+        let activate_skill = transformed
+            .iter()
+            .find(|tool| tool.name() == "activate_skill")
+            .expect("activate_skill definition");
+        assert!(
+            activate_skill.parameters().get("properties").is_some(),
+            "activate_skill must keep its full schema so models pass the required name field"
         );
 
         let fake = transformed


### PR DESCRIPTION
## What changed
Keep the `activate_skill` tool schema eagerly visible instead of deferring it behind tool search. This makes the required `name` argument available to models during skill-routing decisions and reduces malformed empty `activate_skill({})` calls.

## Why
A session investigating a model-picker issue attempted to activate a skill without the required `name` parameter. The upstream runtime should still improve that error, but yolop can avoid the common failure mode by not hiding this tiny routing-tool schema.

## Before / After
Before: `activate_skill` could be converted into a deferred/searchable tool definition, leaving the model without the required `name` schema at call time.

After: `activate_skill` remains fully described in the prompt alongside other never-deferred routing tools.

Proof:
```text
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all-features
cargo run -- --provider llmsim -p "hi"
```

## Risk
- Low
- Capability registration only. The main risk is a tiny prompt-size increase from keeping one small schema visible.

## Security
- TM-TOOL: Reviewed capability registration change. No new capability is added and existing tool permissions are unchanged.
- TM-FS/TM-BASH/TM-LLM/TM-DEP: No filesystem access, shell execution, prompt secret handling, or dependency behavior changed.

## Follow-ups
- Improve the upstream `everruns-core` missing-parameter error for `activate_skill` so malformed calls receive actionable guidance including an example shape and `list_skills` hint.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

Generated with yolop
