### PR TITLE
test(evals): cover stale history grounding

### DIFF
--- a/evals/harness_basic/src/main.rs
+++ b/evals/harness_basic/src/main.rs
@@ -145,6 +145,33 @@ fn progress_guard_checkpoint_sample() -> Sample {
     )
 }
 
+fn stale_history_local_state_sample() -> Sample {
+    Sample::new(
+        "stale-history-local-state",
+        "A previous conversation from yesterday said the model picker listed \
+         gpt-5.6-sol because it appeared in docs/history.txt. The current local \
+         config may have changed. Answer with the CURRENT_PICKER_VALUE from the \
+         current workspace only; do not rely on the old conversation note.",
+    )
+    .tag("context-recency")
+    .meta("kind", "grounding")
+    .meta(
+        "checks",
+        json!([{"response_contains": ["claude-sonnet-4"], "response_lacks": ["gpt-5.6-sol"]}]),
+    )
+    .file(
+        "docs/history.txt",
+        "[time yesterday] User: I do not see gpt-5.6 sol in the model picker.
+[time yesterday] Assistant: The picker lists gpt-5.6-sol.
+",
+    )
+    .file(
+        "config/current-model-picker.txt",
+        "CURRENT_PICKER_VALUE=claude-sonnet-4
+",
+    )
+}
+
 fn background_callback_bridge_sample() -> Sample {
     Sample::new(
         "background-callback-bridge",
@@ -388,6 +415,7 @@ fn dataset() -> Dataset {
         ),
         progress_guard_probe_sample(),
         progress_guard_checkpoint_sample(),
+        stale_history_local_state_sample(),
         background_callback_bridge_sample(),
         Sample::new(
             "replace-console-log",


### PR DESCRIPTION
## Summary

- Add a harness-basic eval sample for stale conversation history conflicting with current local state.
- Require the answer to use the current workspace model-picker value and reject the stale historical value.

## Before / After

Before: harness-basic did not directly represent a prior-session answer becoming stale for local model-picker/config state.

After: `stale-history-local-state` covers that case with a positive check for `claude-sonnet-4` and a negative check for `gpt-5.6-sol`.

## Validation

- `cargo fmt --check`
- `cargo test --manifest-path evals/harness_basic/Cargo.toml`

## Security

No security-relevant code changes. This is an eval-only change that adds fixture files and scorer expectations; it does not alter runtime filesystem, shell, prompt, provider, or capability behavior.

## Follow-ups

- Strengthen the upstream `everruns-core` infinity-context prompt so recency/timestamp metadata is explicitly treated as stale for mutable local state, then bump yolop's `everruns-*` dependencies together.

Produced by [yolop](https://everruns.com/yolop)
