### PR TITLE
fix(ci): update Node 24 workflow actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: lcov-coverage
           path: lcov.info
@@ -114,7 +114,7 @@ jobs:
           fi
 
       - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@v3
+        uses: dopplerhq/cli-action@v4
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -171,7 +171,7 @@ jobs:
           cat yolop.rb
 
       - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@v3
+        uses: dopplerhq/cli-action@v4
 
       - name: Push formula to homebrew-tap
         env:


### PR DESCRIPTION
## What changed
Updated CI workflow action pins to versions that run on Node.js 24, removing the Node.js 20 deprecation warnings from GitHub Actions annotations.

## Why
GitHub Actions now warns when Node.js 20 actions are forced onto Node.js 24. The affected workflows pinned older action majors for artifact upload and Doppler setup.

## Before / After
Before:
- CI annotations warned that `actions/upload-artifact@v4` targeted Node.js 20.
- CI annotations warned that `dopplerhq/cli-action@v3` targeted Node.js 20.

After:
- `.github/workflows/ci.yml` uses `actions/upload-artifact@v7` and `dopplerhq/cli-action@v4`.
- `.github/workflows/cli-binaries.yml` uses `dopplerhq/cli-action@v4`.
- Validation output:

```text
workflow action versions updated and legacy Node 20 action pins removed
```

## Risk
- Low
- CI workflow action major updates could expose upstream action interface changes. The existing inputs remain valid for the updated actions.

## Security
No security-relevant code changes. This only updates GitHub Actions action versions; no secrets, permissions, filesystem, shell, or runtime agent code changed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — not applicable; config-only workflow pin update with assertion-based validation instead.
- [x] Backward compatibility considered

Produced by [yolop](https://everruns.com/yolop)
