### PR TITLE
chore(specs): add extensions mechanism proposal (YEP)

### DIFF
--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -1,0 +1,370 @@
+# Extensions — installable, capability-level packages
+
+Status: **proposal** (design record, nothing implemented). Companion analysis
+of prior art and alternatives is inline; the recommended design is
+[Proposal A](#proposal-a-recommended--extension-packages-on-existing-seams).
+
+## Why
+
+Yolop's unit of functionality is the everruns **capability**: one `Capability`
+implementation contributes tools, system-prompt text, hooks, MCP servers,
+skills, commands, config schema, and facts through well-defined trait seams.
+The harness is just an ordered list of capability refs + configs, already
+user-editable via `[[capabilities]]` in `settings.toml`.
+
+The contract is right; the *delivery* is wrong. Today every capability is
+compiled into the binary. The recent `lsp` capability (#236) is the canonical
+example: ~3.4k lines of Rust, a spec, and an eval study — all of which had to
+land in this repo, ride the release train, and grow the binary of every user,
+including the majority for whom it stays off by default. Anything
+community-authored (a Kubernetes toolset, a Jira connector, a odd-language LSP
+adapter, an alternative provider) has no path in at all.
+
+An **extension** is an installable package that contributes at the capability
+level — the same seams the trait exposes — without recompiling yolop.
+Near-term contributions: tools + prompt + config (the LSP class). Later:
+LLM providers, UI features, MCP server bundles, everruns plugins.
+
+## What already exists (and must not be reinvented)
+
+1. **The contract.** `everruns_core::capabilities::Capability` already
+   enumerates every contribution kind an extension could want: `tools`,
+   `system_prompt_contribution`, `config_schema`/`validate_config`,
+   `mcp_servers`, `commands`, `mounts`, `dependencies`, `features`,
+   pre/post tool hooks, tool-definition hooks, facts, message filters.
+   The extension mechanism's job is to let that contract be *fulfilled by an
+   installed artifact* instead of compiled code.
+2. **Harness composition.** `[[capabilities]]` overrides (ordered
+   remove/merge/append with JSON-schema validation, `set_config` tools,
+   catalog listing) already control *which* capabilities are active and how
+   they're configured. Extensions must plug into this, not add a parallel
+   enable/disable system.
+3. **Upstream plugins.** everruns-core ≥0.17 ships a plugin subsystem:
+   a plugin directory (Claude Code / Codex / Cursor-compatible `plugin.json`
+   dialect) compiles into a `DeclarativeCapabilityDefinition` — display
+   metadata, system prompt, skills, user-invocable commands, bundled files,
+   MCP servers, dependencies, risk level — registered as a `plugin:{name}`
+   capability ref. Critically, the definition travels *inside the capability
+   config*: the runtime hydrates `plugin:*` refs at collection time with no
+   compile-time registration. Prompt/skills/MCP contributions therefore
+   already flow through every existing path (prompt assembly, skill
+   discovery, scoped MCP merge, dependency resolution).
+4. **Scoped config surfaces.** Skills (workspace/global/system dirs), hooks
+   (`hooks.json` global/workspace → upstream `user_hooks`), MCP (`.mcp.json`
+   global/workspace), connectors (credential store) all follow one pattern:
+   *workspace overrides global; broken optional files warn, never sink
+   startup*. Extensions adopt the same pattern.
+
+What is missing in yolop: an install/discovery/trust layer for packages, and a
+way for an installed package to contribute **executable tool logic** — the
+part that makes the LSP case work.
+
+## Prior art
+
+| Host | Unit & install | Code carrier | Contract breadth | Versioning |
+|---|---|---|---|---|
+| **pi** (Zechner) | TS files / npm / git packages, `pi install`, hot reload | in-process TypeScript via jiti, full trust | Maximal: ~35 loop events, tools, commands, **providers**, TUI renderers, flags | pre-1.0; pinning + compat shims |
+| **Zed** | git repo → curated registry, prebuilt `extension.wasm` | in-process WASM (WIT contract), sandboxed; heavy work (LSP servers) spawned by host | Language servers, slash commands, MCP wrappers, DAP, themes | best-in-class: `zed:api-version` + per-version WIT snapshots |
+| **goose** (Block) | config entry; any MCP server is an extension | stdio/HTTP MCP subprocess | Tools/resources/prompts only; no loop hooks, no prompt shaping | delegated to MCP negotiation |
+| **Claude Code** | plugin dir via marketplaces (git), copied to cache | none in-process: markdown + JSON registering subprocesses (MCP, hooks, **`.lsp.json`**, bin/) | skills, commands, agents, hooks, MCP, LSP servers, monitors | `version` field or commit SHA; marketplace pinning |
+| **OpenCode** | JS files / npm in config | in-process JS (Bun), full trust | tool intercept middleware, custom tools, events | npm semver of types package |
+| **VS Code** | VSIX marketplace | separate Node "extension host" process | manifest contribution points + lazy activation events | `engines.vscode` + append-only API |
+
+Takeaways that shape this design:
+
+- **The in-process scripting model (pi, OpenCode) is a property of having a
+  dynamic runtime.** It buys maximal contract breadth and a trivial authoring
+  loop, at the price of zero isolation and single-language lock-in. A Rust
+  binary gets this only by embedding an engine (Lua/JS/WASM) — a deliberate
+  platform decision, not a default.
+- **Everyone with a Rust/Go host converged on subprocess + protocol** for
+  code-bearing extensions (goose, Crush, Claude Code, and Zed for anything
+  heavy). It is the LSP pattern itself: language-neutral, crash-isolated,
+  self-versioning via handshake.
+- **Zed's split is the architectural insight**: sandboxed logic as *control
+  plane*, host-spawned subprocesses as *data plane*. Its WIT snapshot
+  versioning is the strongest compat story surveyed — and also the highest
+  host-machinery cost.
+- **Claude Code proves declarative-plus-subprocess covers most real demand**
+  — including LSP servers via `.lsp.json` — with prompt-level contributions
+  (skills/agents) as first-class citizens. Upstream everruns already bet on
+  this dialect.
+- **pi's anti-MCP stance is a warning about context cost, not transport**:
+  many servers burn 5–10% of the context window on tool schemas before work
+  starts. Yolop already has the antidote (`tool_search` deferral +
+  never-defer allowlist); extensions must be able to *declare* their tool
+  economics rather than dump schemas.
+
+## Design space: how does logic arrive after compile time?
+
+| Option | Verdict | Why |
+|---|---|---|
+| Rust `dylib` (`abi_stable`/`stabby`) | **Rejected** | No stable Rust ABI; per-platform artifacts; toolchain lockstep; no isolation. Unusable for third parties. |
+| In-process scripting (Lua exists upstream; JS/`rquickjs`) | **Deferred** | Single language, engine surface to maintain, sandbox liability for FS/process/net access — which is exactly what LSP-class extensions need. Revisit for tiny in-loop logic (custom guardrail predicates) if demand shows. |
+| WASM component (wasmtime + WIT, or Extism) | **Deferred** | The right *untrusted-marketplace* endgame, but heavy host machinery (WIT snapshots, bindgen per version), Rust-centric guest authoring, and WASI can't spawn/manage host processes — the LSP data plane still needs subprocesses. Adopt later as a control-plane tier if a public registry materializes. |
+| Subprocess + protocol (the LSP/MCP pattern) | **Chosen** | Matches yolop precedent (LSP servers, stdio MCP, hook executors are all subprocesses). Any language, crash-isolated, protocol-versioned. Trust model identical to `.mcp.json` today. |
+| Declarative-only bundle (Claude Code / everruns plugin) | **Chosen (base layer)** | Already implemented upstream; zero new runtime machinery; covers prompt/skills/commands/MCP/hooks. |
+
+The two chosen rows compose: **an extension is a declarative bundle that may
+carry subprocess servers as its code.** That is also exactly what upstream
+`plugin.json` + `mcpServers` already expresses.
+
+## Proposal A (recommended) — extension packages on existing seams
+
+### The unit
+
+An extension is a directory (installed from git, a local path, or later a
+registry) in the upstream plugin dialect, with yolop-specific facets under a
+single namespaced key so the package remains loadable by other hosts
+(upstream parsing tolerates unknown fields):
+
+```
+my-ext/
+  plugin.json            # upstream dialect + optional "yolop" facet block
+  skills/<name>/SKILL.md # → declarative skills
+  commands/*.md          # → user-invocable skills (slash commands)
+  agents/*.md            # → system-prompt contribution
+  .mcp.json              # → MCP servers (stdio/http), ${VAR} expansion
+  hooks/hooks.json       # → user_hooks contributions (yolop facet)
+```
+
+Identity: capability ref `plugin:<name>` (upstream namespace, ≤43 bytes).
+One extension ⇒ one capability ref, so enable/disable/configure rides the
+existing `[[capabilities]]` machinery and `set_config` tools unchanged.
+
+### Contribution mapping
+
+| Facet | Carried by | Runtime seam (exists today) |
+|---|---|---|
+| System prompt | `agents/*.md` | `DeclarativeCapabilityDefinition.system_prompt` |
+| Skills | `skills/` | declarative skills → scoped skills discovery |
+| Slash commands | `commands/` | declarative user-invocable skills (`/name`) |
+| Tools (code!) | `.mcp.json` stdio/http servers | scoped-MCP merge → runtime MCP client |
+| Bundled files | `files` | capability mounts |
+| Hooks | `hooks/hooks.json` (yolop facet) | `user_hooks` capability-contributed specs; mutable via `disabled_contributions` |
+| Config schema | `yolop.config_schema` in manifest (yolop facet) | capability catalog validation + `set_config` |
+| Tool policy | `yolop.tools` in manifest (yolop facet) | tool-search never-defer list, naming, approval hints |
+| Dependencies | manifest `dependencies` | capability dependency resolution |
+
+The first five rows are **pure reuse** of the upstream plugin compiler. The
+yolop facets are the new work, and they are thin:
+
+**Tool policy** (`yolop.tools`). MCP tools normally surface as
+`mcp_<server>__<tool>` and may be deferred behind `tool_search`. The LSP eval
+showed both matter enormously: stub schemas behind `tool_search` drove
+adoption to ~zero, and prompt guidance names exact tools. So an extension can
+declare, per tool: a **canonical name** (unprefixed alias; registered only if
+it doesn't collide with a built-in or another extension — collision falls back
+to the prefixed form with a startup warning), **`never_defer`** (schema always
+loaded — budgeted, e.g. ≤8 tools per extension, so one package can't blow the
+context), and approval/risk hints consumed by the approval capability.
+
+**Config schema** (`yolop.config_schema`). JSON Schema for the extension's
+`[[capabilities]]` config, exposed through the catalog like any built-in.
+The config is delivered to the extension's servers as env
+(`YOLOP_EXT_CONFIG` JSON) and/or `${config.*}` substitution in `.mcp.json` —
+the same expansion mechanism `${VAR}` uses today. This gives an extension
+exactly what `lsp` has: validated, discoverable, self-configurable settings.
+
+**Hooks** (`hooks/hooks.json`). Same envelope as the existing hooks spec;
+entries are namespaced `plugin:<name>:<hook_id>` and merged as
+capability-contributed hooks, so users mute them with the existing
+`disabled_contributions` list rather than editing the package.
+
+### Discovery, install, trust
+
+Scopes mirror skills/hooks/mcp exactly:
+
+- **Workspace**: `<workspace>/.agents/extensions/<name>/` — ships with the
+  repo.
+- **Global**: `<config_dir>/yolop/extensions/<name>/` — per user.
+
+Workspace overrides global by name. Malformed packages warn and are skipped.
+Enablement: installing does **not** activate. An extension activates the same
+way `lsp` does today — `[[capabilities]] ref = "plugin:<name>"` (written by
+`/extensions enable`, `set_config`, or by hand). A manifest may declare
+`yolop.default_enabled = true`, honored only for *global* installs (an act of
+explicit user consent).
+
+Install verbs (System commands + capability tools, so both the user and the
+model can drive them):
+
+```
+/extensions install <git-url>[@rev] | <path>   # clone/copy into global scope
+/extensions list | update [<name>] | remove <name>
+/extensions enable|disable <name>
+```
+
+Git installs are pinned: `extensions.lock` (beside `settings.toml`) records
+source URL, resolved commit, and a content hash; `update` is explicit.
+Local-path installs are referenced, not copied (dev loop), and marked as such.
+
+Trust model, in line with `.mcp.json` precedent but stricter for the new
+attack path:
+
+- **Global install = consent.** The user ran the install command; stdio
+  servers and hook executors run with user privileges, same as `.mcp.json`
+  today. `/extensions install` prints what the package will contribute
+  (servers, hooks, prompt size, tool names) before confirming.
+- **Workspace extensions arrive with someone else's repo.** They are
+  discovered but **inert until approved once per content-hash**: first
+  activation shows the contribution summary and records the approved hash in
+  user-level state (not the repo). A changed package re-prompts. This is the
+  VS Code workspace-trust lesson applied at package granularity.
+- Hooks and prompt contributions are the sharpest edges (silent policy or
+  instruction injection), which is why approval summarizes them explicitly.
+- No sandbox is claimed. Sandboxing is what the WASM tier is *for*, later.
+
+### Versioning and compatibility
+
+- Manifest `version` (semver) + `engines.yolop = ">=0.6"`; incompatible
+  packages load nothing and warn.
+- The tool wire protocol is MCP — self-versioned by its own handshake, SDKs
+  in every language, zero yolop-owned protocol surface.
+- Yolop facets are versioned by the manifest schema; unknown facet keys warn
+  and are ignored (tolerant, like upstream).
+- No hot reload in v1: changes apply on next session (matches how
+  `[[capabilities]]` config behaves today).
+
+### Illustration: `lsp` as an extension
+
+The existing capability decomposes cleanly:
+
+- **Data plane** (already subprocesses): rust-analyzer, gopls, … unchanged.
+- **Control plane** (today ~3.4k lines of in-tree Rust): becomes `yolop-lsp`,
+  a standalone binary speaking MCP over stdio — the LSP client, server
+  lifecycle manager, position-encoding conversion, workspace-edit safety
+  checks move there verbatim. It exposes the seven `lsp_*` tools.
+- **Everything else** becomes the package:
+
+```json
+{
+  "name": "lsp",
+  "description": "Semantic code intelligence from real language servers.",
+  "version": "0.1.0",
+  "engines": { "yolop": ">=0.6" },
+  "mcpServers": { "lsp": { "type": "stdio", "command": "yolop-lsp",
+                            "env": { "YOLOP_EXT_CONFIG": "${config}" } } },
+  "yolop": {
+    "config_schema": { "$ref": "./config.schema.json" },
+    "tools": {
+      "canonical_names": true,
+      "never_defer": ["lsp_definition", "lsp_references", "lsp_hover",
+                       "lsp_diagnostics", "lsp_rename", "lsp_symbols",
+                       "lsp_code_actions"]
+    }
+  }
+}
+```
+
+plus `agents/lsp.md` carrying the directive "call `lsp_*` FIRST for
+symbol-level questions" prompt (verbatim from today's capability — the eval
+showed the wording is load-bearing), and the same config schema
+(`servers.<key>.command/args/extensions`, timeouts).
+
+What this buys: a new language ecosystem integration (say, a JVM-heavy shop
+wrapping jdtls with warmup quirks) is a package on a git URL, not a PR to
+yolop. What it costs: MCP round-trip per tool call (noise against LSP server
+latencies) and cross-process config delivery.
+
+Migration policy: the built-in `lsp` capability **stays** until the extension
+packaging reaches parity on `evals/lsp_integration` (pass rate, `lsp_*`
+adoption, tokens). The eval is the gate; the extension is the dogfood that
+proves the mechanism. If parity holds, the in-tree capability retires and the
+binary shrinks — the mechanism pays for itself.
+
+### Future facets (design now, build later)
+
+- **LLM providers.** Two tiers. (1) *Declarative descriptors*: most
+  OpenAI-compatible endpoints (Groq, Mistral, gateways) need only
+  `base_url + auth env + model list + profiles` — a manifest facet feeding
+  the existing `Custom`/Completions path. Prerequisite refactor: `Provider`
+  moves from a closed enum to the catalog pattern the codebase already
+  prefers. (2) *Provider proxies*: exotic protocols ship a subprocess
+  exposing an OpenAI-compatible endpoint on a local socket (the pattern
+  Ollama/llama.cpp normalized; `codex_driver`'s `DriverId::external` shows
+  the driver-side seam). Native in-process drivers stay compiled-in.
+- **UI features.** Extensions never run code in the TUI. Near-term surface:
+  slash commands, config UI schema (`config_ui_schema` exists on the trait),
+  and `user_ask`-style forms. If richer needs appear, upstream already has
+  declarative UI precedent (`a2ui`/`openui`): extensions would emit
+  component *trees*, yolop renders them with its own widgets. pi's
+  TypeScript renderers are the counterexample that doesn't translate to a
+  Rust host.
+- **everruns plugin convergence.** The package format *is* the upstream
+  plugin format plus a tolerated `yolop` facet. Anything installable in the
+  hosted everruns product should load in yolop unchanged; yolop facets
+  upstream one by one when the hosted product wants them (config schema and
+  tool policy are obvious candidates). Keep in lockstep per the friendly-fork
+  rule.
+- **Registry.** Out of scope for v1 (git URLs suffice). If added: a curated
+  index file in a git repo (Claude Code marketplace / Zed extensions-repo
+  shape), commit-pinned entries.
+
+## Proposal B (deferred) — a full capability wire protocol
+
+Mirror the entire `Capability` trait over stdio JSON-RPC ("everything MCP
+can't express"): dynamic prompt contributions, facts, message filters,
+model-view providers, tool-definition hooks, narration. Rejected for now:
+
+- The uncovered seams are the **hot loop**. Facts and message filters run per
+  request and are documented as "cheap and side-effect free" — a cross-process
+  round-trip in prompt assembly on every turn is hostile to latency and
+  cache-friendliness. In-loop transformation is precisely where in-process
+  execution (WASM tier, or upstream Rust) is the right tool.
+- It creates a yolop-owned protocol with a versioning burden Zed needed WIT
+  snapshots to manage — for demand that is, today, hypothetical.
+- Static-but-per-session needs (prompt text chosen by config) are already
+  covered by manifest + config substitution.
+
+Revisit trigger: a concrete extension that cannot be expressed as
+manifest + MCP (e.g. a community progress-guard variant needing message
+filtering). Then prefer *narrow* extension methods negotiated on top of the
+existing MCP connection (`experimental`/`yolop/*` namespaced) over a second
+protocol.
+
+## Proposal C (deferred) — WASM control-plane tier
+
+wasmtime + WIT (or Extism) hosting sandboxed extension logic in-process, with
+host functions for spawn-subprocess/read-workspace/HTTP mirroring Zed's
+capability declarations. This is the only path to *untrusted* third-party
+code and to in-loop hooks without RPC latency. Costs: WIT snapshot
+versioning machinery, guest-language friction, and a second execution model
+to support forever. Adopt only alongside a public registry where untrusted
+authorship is the norm, and keep Proposal A's manifest as the outer package
+format (a WASM module becomes one more facet, not a new unit).
+
+## Rollout
+
+1. **Loader + declarative facets.** Discover both scopes, compile via the
+   upstream plugin compiler, inject `plugin:<name>` configs into the harness,
+   workspace trust gate, `/extensions` list/enable/disable. Exit: a
+   prompt+skills+MCP package (e.g. a docs-search extension) works end to end.
+2. **Yolop facets.** `config_schema` into the catalog + config delivery to
+   servers; tool policy (canonical names, `never_defer` budget, approval
+   hints); hooks contributions; `extensions.lock` + install/update/remove
+   from git. Exit: facets exercised by a reference extension in CI.
+3. **`yolop-lsp` dogfood.** Extract the LSP control plane into an MCP binary
+   packaged as an extension; run `evals/lsp_integration` against
+   built-in vs extension. Exit: parity → retire the in-tree capability.
+4. **Providers, then UI.** Declarative provider descriptors (after the
+   Provider-catalog refactor); provider proxies and declarative UI on demand.
+
+## Non-goals
+
+- No in-process native code (dylibs) — ever, per the ABI analysis.
+- No arbitrary TUI code from extensions.
+- No hot reload, no central registry, no sandbox claims in v1.
+- No second hook engine, skill format, MCP config shape, or enable/disable
+  surface — every facet lands on an existing seam.
+
+## Open questions
+
+- Config delivery to servers: env blob vs `${config.*}` substitution vs both;
+  restart-on-config-change semantics for long-lived stdio servers.
+- `never_defer` budget size and whether the allowlist should be
+  model-adaptive (mirrors `auto_tool_search`).
+- Whether workspace-scope extensions may contribute hooks at all, or only
+  with a separate per-hook approval step.
+- Naming: `.agents/extensions/` (host-neutral, matches `.agents/skills/`)
+  vs `.yolop/extensions/`.

--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -398,18 +398,30 @@ upstream; yolop adds one facet:
     must already be resolvable (PATH or the package's `bin/`) — a missing
     binary is a call-time tool error with install guidance, exactly like a
     missing `rust-analyzer` today.
-  - `crates.io:<crate>[@version]` — the Rust-native path that provisions
-    package *and binary* in one step. Yolop downloads the `.crate` tarball
-    (checksummed via the registry index) and reads the extension manifest
-    from it — `plugin.json` at the crate root or
+  - `crates.io:<crate>[@version]` — provisions package *and binary* in one
+    step, **with no cargo or Rust toolchain required**. The pieces that
+    don't need a toolchain are compiled into yolop: the sparse index
+    (`index.crates.io`) is plain HTTPS + JSON and the `.crate` file is a
+    checksummed tar.gz, so yolop resolves the version, downloads the
+    tarball, verifies the registry checksum, and reads the extension
+    manifest from it — `plugin.json` at the crate root or
     `[package.metadata.yolop]` in `Cargo.toml` — **without executing
-    anything**, preserving the D4 invariant; after consent it runs
-    `cargo install <crate> --version <v> --locked --root
-    <config_dir>/yolop/extensions/<name>/` so the binary lands inside the
-    package dir, not in the user's cargo bin. Lock records crate, version,
-    and registry checksum (a stronger supply-chain pin than a git rev).
-    Requires a Rust toolchain — acceptable for yolop's audience; prebuilt
-    binaries (`cargo binstall`-style) are a deferred optimization.
+    anything**, preserving the D4 invariant. Binary provisioning after
+    consent, in order:
+    1. **Prebuilt artifact (primary).** The crate's metadata names
+       per-platform release artifacts (URL template + sha256 per target,
+       `cargo-binstall`-compatible metadata accepted); yolop downloads the
+       artifact for the host target, verifies the digest, and unpacks it
+       into the package dir. Chain of custody: the digests live inside the
+       registry-checksummed crate, so the lock's crate checksum transitively
+       pins the binary.
+    2. **`cargo install --locked --root <package dir>` (secondary).** Only
+       if no artifact matches the host target *and* a toolchain happens to
+       be present.
+    3. Otherwise: install completes package-only and the missing binary is
+       a call-time tool error with guidance — same policy as git installs.
+    Lock records crate, version, registry checksum, and the artifact
+    digest actually installed.
   - `<path>` — referenced in place, not copied (dev loop).
 - **Trust**: install is consent by action (same stance as authoring
   `.mcp.json`), preceded by a printed contribution summary (server command,

--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -323,7 +323,7 @@ shape:
   from `meta.json` — the version string and method/capability vocabulary
   are generated, not hardcoded — plus a hand-written ergonomic layer: a
   `serve()` stdio loop and tool/hook registration helpers. Rust
-  (`yolop-extension`, dogfooded by `yolop-lsp`) first; TypeScript and
+  (`yolop-extension`, dogfooded by `yolop-extension-lsp`) first; TypeScript and
   Python when demand shows, following `mira/specs/sdks.md` including its
   drift-guard table (handled-methods ⊇ meta methods, advertised
   capabilities ⊆ meta tokens, emitted messages validate against schema).
@@ -363,7 +363,7 @@ upstream; yolop adds one facet:
   "engines": { "yolop": ">=0.6" },
   "yolop": {
     "protocol_version": "1.0",
-    "capabilityServer": { "command": "yolop-lsp", "args": [] },
+    "capabilityServer": { "command": "yolop-extension-lsp", "args": [] },
     "config_schema": { "$ref": "./config.schema.json" },
     "tools": [
       { "name": "lsp_definition", "never_defer": true },
@@ -389,10 +389,20 @@ upstream; yolop adds one facet:
   using the agent-neutral surfaces they already have (`.mcp.json`,
   `.agents/skills/`, `.agents/hooks.json`); a project README may *recommend*
   extensions, and the user installs them once, globally, by choice.
+- **Naming convention**: crates.io extensions are named
+  `yolop-extension-<name>` (the `cargo-<subcommand>` pattern). The suffix is
+  the extension name — crate `yolop-extension-lsp` is extension `lsp`,
+  capability ref `ext:lsp`. The prefix gives yolop a de-facto namespace and
+  catalog on crates.io with no registry of its own: prefix search is
+  discovery (`/extensions search <term>` can ride the crates.io API later),
+  and squatting/typo risk is scoped to one greppable prefix. Crates should
+  also set `keywords = ["yolop-extension"]`.
 - **Install**: `/extensions install <source>`, plus
   `list | update | remove | enable | disable | doctor` — System commands
   *and* capability tools, so both the user and the model can drive setup.
   Sources, all pinned in `extensions.lock` and updated only explicitly:
+  - `<name>` (bare) — shorthand for `crates.io:yolop-extension-<name>`;
+    `/extensions install lsp` is the whole UX for the common case.
   - `<git-url>[@rev]` — cloned into the global dir; lock records source,
     resolved commit, content hash. Carries the package; the server binary
     must already be resolvable (PATH or the package's `bin/`) — a missing
@@ -438,7 +448,8 @@ Decomposition of the existing capability:
 
 - **Data plane** — rust-analyzer, gopls, pyright, … : already subprocesses;
   now spawned and kept warm by the extension process instead of by yolop.
-- **Control plane** — `yolop-lsp`, a standalone binary on the reference SDK:
+- **Control plane** — `yolop-extension-lsp` (crate name per the convention;
+  binary ditto), a standalone binary on the reference SDK:
   the transport-generic LSP client, server lifecycle manager,
   position-encoding conversion, and workspace-edit safety checks move there
   ~verbatim (`client.rs` is already transport-generic; only `manager.rs`
@@ -518,7 +529,7 @@ the protocol and the SDK.
 4. **Hooks + dynamic prompt + ui/ask.** `hook/fire`, `prompt/contribution`,
    `ui/ask`, `workspace/changed`. Exit: a guardrail-style reference
    extension (block writes to generated files) works.
-5. **`yolop-lsp` dogfood.** Extract the control plane onto the SDK; A/B on
+5. **`yolop-extension-lsp` dogfood.** Extract the control plane onto the SDK; A/B on
    `evals/lsp_integration`; parity retires the built-in.
 6. **Providers.** Descriptor tier after the Provider-catalog refactor;
    provider handshake facet after.

--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -1,370 +1,360 @@
-# Extensions — installable, capability-level packages
+# Extensions — capability servers over a subprocess protocol
 
-Status: **proposal** (design record, nothing implemented). Companion analysis
-of prior art and alternatives is inline; the recommended design is
-[Proposal A](#proposal-a-recommended--extension-packages-on-existing-seams).
+Status: **proposal** (design record, nothing implemented).
 
 ## Why
 
 Yolop's unit of functionality is the everruns **capability**: one `Capability`
-implementation contributes tools, system-prompt text, hooks, MCP servers,
-skills, commands, config schema, and facts through well-defined trait seams.
-The harness is just an ordered list of capability refs + configs, already
-user-editable via `[[capabilities]]` in `settings.toml`.
+implementation contributes tools, system-prompt text, config schema, hooks,
+MCP servers, skills, and commands through well-defined trait seams, and the
+harness is an ordered, user-editable list of capability refs
+(`[[capabilities]]` in `settings.toml`). The contract is right; the delivery
+is wrong: every capability is compiled in. The `lsp` capability (#236) is the
+canonical example — ~3.4k lines of Rust that had to land in this repo, ride
+the release train, and grow everyone's binary, including the majority who
+keep it off.
 
-The contract is right; the *delivery* is wrong. Today every capability is
-compiled into the binary. The recent `lsp` capability (#236) is the canonical
-example: ~3.4k lines of Rust, a spec, and an eval study — all of which had to
-land in this repo, ride the release train, and grow the binary of every user,
-including the majority for whom it stays off by default. Anything
-community-authored (a Kubernetes toolset, a Jira connector, a odd-language LSP
-adapter, an alternative provider) has no path in at all.
+An **extension** delivers a capability as an installed artifact, no
+recompilation. Near-term: tools + prompt + config + hooks (the LSP class).
+Later: LLM providers, UI features, everruns plugins.
 
-An **extension** is an installable package that contributes at the capability
-level — the same seams the trait exposes — without recompiling yolop.
-Near-term contributions: tools + prompt + config (the LSP class). Later:
-LLM providers, UI features, MCP server bundles, everruns plugins.
+**Scoping decision.** Declarative contributions (prompt text, skills,
+commands, plain MCP server registrations) are arriving upstream as **everruns
+plugins**: a plugin directory (Claude Code–compatible `plugin.json` dialect)
+compiles to a `DeclarativeCapabilityDefinition` carried *inside* the
+`plugin:{name}` capability config and hydrated at collection time. Yolop
+inherits that layer by staying in lockstep; this spec does not redesign it.
+What yolop must own is the tier upstream does not have: **executable,
+stateful, capability-level logic in a subprocess** — the *capability server*
+— and the protocol between yolop and it. That is the subject of this spec.
 
-## What already exists (and must not be reinvented)
+## Prior art (compressed)
 
-1. **The contract.** `everruns_core::capabilities::Capability` already
-   enumerates every contribution kind an extension could want: `tools`,
-   `system_prompt_contribution`, `config_schema`/`validate_config`,
-   `mcp_servers`, `commands`, `mounts`, `dependencies`, `features`,
-   pre/post tool hooks, tool-definition hooks, facts, message filters.
-   The extension mechanism's job is to let that contract be *fulfilled by an
-   installed artifact* instead of compiled code.
-2. **Harness composition.** `[[capabilities]]` overrides (ordered
-   remove/merge/append with JSON-schema validation, `set_config` tools,
-   catalog listing) already control *which* capabilities are active and how
-   they're configured. Extensions must plug into this, not add a parallel
-   enable/disable system.
-3. **Upstream plugins.** everruns-core ≥0.17 ships a plugin subsystem:
-   a plugin directory (Claude Code / Codex / Cursor-compatible `plugin.json`
-   dialect) compiles into a `DeclarativeCapabilityDefinition` — display
-   metadata, system prompt, skills, user-invocable commands, bundled files,
-   MCP servers, dependencies, risk level — registered as a `plugin:{name}`
-   capability ref. Critically, the definition travels *inside the capability
-   config*: the runtime hydrates `plugin:*` refs at collection time with no
-   compile-time registration. Prompt/skills/MCP contributions therefore
-   already flow through every existing path (prompt assembly, skill
-   discovery, scoped MCP merge, dependency resolution).
-4. **Scoped config surfaces.** Skills (workspace/global/system dirs), hooks
-   (`hooks.json` global/workspace → upstream `user_hooks`), MCP (`.mcp.json`
-   global/workspace), connectors (credential store) all follow one pattern:
-   *workspace overrides global; broken optional files warn, never sink
-   startup*. Extensions adopt the same pattern.
+Full survey history in the git log of this file. What bears on the protocol
+tier:
 
-What is missing in yolop: an install/discovery/trust layer for packages, and a
-way for an installed package to contribute **executable tool logic** — the
-part that makes the LSP case work.
+- Hosts without a dynamic language runtime (goose, Crush, Claude Code, Zed
+  for anything heavy) all converged on **subprocess + protocol**; in-process
+  breadth (pi's ~35-event TypeScript API, OpenCode's JS middleware) is a
+  property of having a scripting runtime, not a design yolop can copy.
+- **goose** proves "extension = MCP server" works but also shows its ceiling:
+  tools/resources/prompts only — no prompt shaping, no loop hooks, no config
+  schema. That ceiling is exactly the gap between MCP and the `Capability`
+  trait.
+- **Zed** shows the strongest versioning story (per-version WIT snapshots)
+  and the control-plane/data-plane split: extension logic decides, host- or
+  extension-spawned subprocesses do the heavy work.
+- **VS Code**'s durable lessons: static manifest so contributions are
+  inspectable without executing code; keep extension code off the
+  latency-critical path.
+- **pi**'s anti-MCP argument is really about context economics (tool schemas
+  burning 5–10% of the window). The antidote is declared tool policy, not a
+  different transport.
 
-## Prior art
+## Design decisions
 
-| Host | Unit & install | Code carrier | Contract breadth | Versioning |
-|---|---|---|---|---|
-| **pi** (Zechner) | TS files / npm / git packages, `pi install`, hot reload | in-process TypeScript via jiti, full trust | Maximal: ~35 loop events, tools, commands, **providers**, TUI renderers, flags | pre-1.0; pinning + compat shims |
-| **Zed** | git repo → curated registry, prebuilt `extension.wasm` | in-process WASM (WIT contract), sandboxed; heavy work (LSP servers) spawned by host | Language servers, slash commands, MCP wrappers, DAP, themes | best-in-class: `zed:api-version` + per-version WIT snapshots |
-| **goose** (Block) | config entry; any MCP server is an extension | stdio/HTTP MCP subprocess | Tools/resources/prompts only; no loop hooks, no prompt shaping | delegated to MCP negotiation |
-| **Claude Code** | plugin dir via marketplaces (git), copied to cache | none in-process: markdown + JSON registering subprocesses (MCP, hooks, **`.lsp.json`**, bin/) | skills, commands, agents, hooks, MCP, LSP servers, monitors | `version` field or commit SHA; marketplace pinning |
-| **OpenCode** | JS files / npm in config | in-process JS (Bun), full trust | tool intercept middleware, custom tools, events | npm semver of types package |
-| **VS Code** | VSIX marketplace | separate Node "extension host" process | manifest contribution points + lazy activation events | `engines.vscode` + append-only API |
+### D1 — The protocol is an MCP superset, not a second protocol
 
-Takeaways that shape this design:
+A capability server **is an MCP server** (JSON-RPC 2.0 over stdio) that
+additionally negotiates a `yolop` extension block. MCP explicitly reserves
+`experimental`/vendor capabilities and tolerates unknown methods, so this is
+sanctioned, not a fork.
 
-- **The in-process scripting model (pi, OpenCode) is a property of having a
-  dynamic runtime.** It buys maximal contract breadth and a trivial authoring
-  loop, at the price of zero isolation and single-language lock-in. A Rust
-  binary gets this only by embedding an engine (Lua/JS/WASM) — a deliberate
-  platform decision, not a default.
-- **Everyone with a Rust/Go host converged on subprocess + protocol** for
-  code-bearing extensions (goose, Crush, Claude Code, and Zed for anything
-  heavy). It is the LSP pattern itself: language-neutral, crash-isolated,
-  self-versioning via handshake.
-- **Zed's split is the architectural insight**: sandboxed logic as *control
-  plane*, host-spawned subprocesses as *data plane*. Its WIT snapshot
-  versioning is the strongest compat story surveyed — and also the highest
-  host-machinery cost.
-- **Claude Code proves declarative-plus-subprocess covers most real demand**
-  — including LSP servers via `.lsp.json` — with prompt-level contributions
-  (skills/agents) as first-class citizens. Upstream everruns already bet on
-  this dialect.
-- **pi's anti-MCP stance is a warning about context cost, not transport**:
-  many servers burn 5–10% of the context window on tool schemas before work
-  starts. Yolop already has the antidote (`tool_search` deferral +
-  never-defer allowlist); extensions must be able to *declare* their tool
-  economics rather than dump schemas.
+Why not bespoke LSP-style RPC: it would reimplement framing, handshake,
+lifecycle, and tool plumbing MCP already standardizes; it would orphan the
+SDK ecosystem extension authors get for free; and yolop would still need MCP
+alongside it for plain tool servers — two protocols forever. Why not plain
+MCP: the trait seams that make a capability a capability (config schema,
+prompt contribution, tool policy, hooks) have no MCP expression — goose's
+ceiling.
 
-## Design space: how does logic arrive after compile time?
+A capability server therefore degrades gracefully: in goose or Claude Code it
+is just an MCP tool server (prefixed names, no facets); under yolop it is a
+full capability. One binary, every host.
 
-| Option | Verdict | Why |
+Base-protocol versioning is MCP's own. The `yolop` block carries its own
+integer `protocolVersion`; yolop advertises the versions it supports in
+`initialize` and refuses (with a clear startup warning, never a crash) blocks
+it cannot speak.
+
+### D2 — Persistent processes (new transport mode)
+
+Today's stdio MCP transport spawns a process **per tool call** and tears it
+down (`everruns-mcp` D2: "per-invocation spawn keeps lifecycle trivial").
+That is fatal for the LSP class — warm state is the entire point (a
+rust-analyzer index takes tens of seconds to build).
+
+Capability servers get a **session-persistent connection**: spawned once per
+session, kept alive, `kill_on_drop`, restarted with backoff on crash (pending
+requests fail with a clear message; next call respawns — the exact policy
+`lsp/manager.rs` already implements for language servers). Spawn is eager at
+session start when the extension contributes prompt text or hooks (needed
+before the first turn), lazy on first tool call otherwise.
+
+This transport is useful beyond capability servers — stateful plain-MCP
+servers suffer under spawn-per-call too — so it lands as an opt-in
+(`"persistent": true`) for ordinary `.mcp.json` entries, with capability
+servers always persistent. Candidate for upstreaming into `everruns-mcp`.
+
+### D3 — Every trait seam gets one of three treatments
+
+The core of the design. The `Capability` trait's seams split by how hot their
+call path is:
+
+| Treatment | Seams | Mechanism |
 |---|---|---|
-| Rust `dylib` (`abi_stable`/`stabby`) | **Rejected** | No stable Rust ABI; per-platform artifacts; toolchain lockstep; no isolation. Unusable for third parties. |
-| In-process scripting (Lua exists upstream; JS/`rquickjs`) | **Deferred** | Single language, engine surface to maintain, sandbox liability for FS/process/net access — which is exactly what LSP-class extensions need. Revisit for tiny in-loop logic (custom guardrail predicates) if demand shows. |
-| WASM component (wasmtime + WIT, or Extism) | **Deferred** | The right *untrusted-marketplace* endgame, but heavy host machinery (WIT snapshots, bindgen per version), Rust-centric guest authoring, and WASI can't spawn/manage host processes — the LSP data plane still needs subprocesses. Adopt later as a control-plane tier if a public registry materializes. |
-| Subprocess + protocol (the LSP/MCP pattern) | **Chosen** | Matches yolop precedent (LSP servers, stdio MCP, hook executors are all subprocesses). Any language, crash-isolated, protocol-versioned. Trust model identical to `.mcp.json` today. |
-| Declarative-only bundle (Claude Code / everruns plugin) | **Chosen (base layer)** | Already implemented upstream; zero new runtime machinery; covers prompt/skills/commands/MCP/hooks. |
+| **Static** — declared, no RPC after startup | id/name/description/category, `config_schema`, static system prompt, tool policy (naming, never-defer, approval/risk hints, narration templates), commands, hook *subscriptions*, dependencies, features | Package manifest + `initialize` handshake; a generic yolop-side adapter answers the trait from this cache |
+| **RPC** — cold path, bounded, fallible | tool execution (`tools/call`), dynamic system prompt (`yolop/systemPrompt`, ≤1/turn, timeout + last-known-good fallback), hook firings (`yolop/hook`), user questions (MCP `elicitation` → `user_ask` bridge), config push (`yolop/configChanged`) | Requests over the persistent connection, each with a declared timeout and error policy |
+| **Excluded** from the wire (v1) | `facts`, `message_filter_provider`, `model_view_provider`, `tool_definition_hooks` | Per-request hot loop, documented "cheap and side-effect free" — a cross-process round-trip there is hostile to latency and prompt-cache stability. If real demand appears, this is the future WASM tier's job, not a protocol extension |
 
-The two chosen rows compose: **an extension is a declarative bundle that may
-carry subprocess servers as its code.** That is also exactly what upstream
-`plugin.json` + `mcpServers` already expresses.
+Hooks over RPC deserve the explicit precedent: `user_hooks` today spawns a
+**whole bash process per event**. A request to an already-warm process is
+strictly cheaper than the mechanism yolop already ships, so hook RPC is not a
+new class of cost — but it is bounded anyway: subscriptions are static
+(event + tool-name matcher + `timeout_ms` + `on_error: warn|block`), a
+match-all matcher must be spelled `"*"` and is called out at approval time,
+and per-extension subscription count is capped.
 
-## Proposal A (recommended) — extension packages on existing seams
+### D4 — The manifest is the approval boundary; the handshake may only narrow it
 
-### The unit
+Static facets live in **both** the package manifest and the handshake, with a
+strict relationship:
 
-An extension is a directory (installed from git, a local path, or later a
-registry) in the upstream plugin dialect, with yolop-specific facets under a
-single namespaced key so the package remains loadable by other hosts
-(upstream parsing tolerates unknown fields):
+- The **manifest** (`plugin.json` + `yolop` facet block) is what the user
+  approves at install time — it must be inspectable *without executing the
+  binary* (the VS Code lesson). It declares the server command and the upper
+  bound of everything: tool names, never-defer list, hook subscriptions,
+  prompt size, config schema.
+- The **handshake** is the runtime truth, **clamped by the manifest**: a
+  server may declare fewer tools or hooks than approved (feature-gated
+  builds), but anything not in the approved manifest is refused and logged.
+  A server that tries to widen its grant after installation is the exact
+  attack the clamp exists for.
 
-```
-my-ext/
-  plugin.json            # upstream dialect + optional "yolop" facet block
-  skills/<name>/SKILL.md # → declarative skills
-  commands/*.md          # → user-invocable skills (slash commands)
-  agents/*.md            # → system-prompt contribution
-  .mcp.json              # → MCP servers (stdio/http), ${VAR} expansion
-  hooks/hooks.json       # → user_hooks contributions (yolop facet)
-```
+Content-hash approval (workspace packages inert until approved per hash,
+recorded in user state, re-prompt on change) makes the boundary durable.
 
-Identity: capability ref `plugin:<name>` (upstream namespace, ≤43 bytes).
-One extension ⇒ one capability ref, so enable/disable/configure rides the
-existing `[[capabilities]]` machinery and `set_config` tools unchanged.
+### D5 — Config rides the existing capability machinery
 
-### Contribution mapping
+An enabled extension is one harness entry — `[[capabilities]]
+ref = "ext:<name>"` — so enable/disable/configure/validate ride the existing
+overrides, catalog, and `set_config` tools unchanged. The declared
+`config_schema` plugs into `CapabilityCatalog` validation exactly like a
+built-in's.
 
-| Facet | Carried by | Runtime seam (exists today) |
-|---|---|---|
-| System prompt | `agents/*.md` | `DeclarativeCapabilityDefinition.system_prompt` |
-| Skills | `skills/` | declarative skills → scoped skills discovery |
-| Slash commands | `commands/` | declarative user-invocable skills (`/name`) |
-| Tools (code!) | `.mcp.json` stdio/http servers | scoped-MCP merge → runtime MCP client |
-| Bundled files | `files` | capability mounts |
-| Hooks | `hooks/hooks.json` (yolop facet) | `user_hooks` capability-contributed specs; mutable via `disabled_contributions` |
-| Config schema | `yolop.config_schema` in manifest (yolop facet) | capability catalog validation + `set_config` |
-| Tool policy | `yolop.tools` in manifest (yolop facet) | tool-search never-defer list, naming, approval hints |
-| Dependencies | manifest `dependencies` | capability dependency resolution |
+Delivery: validated config is passed in `initialize` params
+(`yolop.config`), and pushed on change as `yolop/configChanged`; the server
+answers `ok` or `restart-required` (yolop restarts it — the same
+"rebuild manager on config change" semantics `LspCapability` has today).
+Secrets stay in env (`${VAR}` expansion in the server spec, as `.mcp.json`
+does now); config is for structure, not credentials.
 
-The first five rows are **pure reuse** of the upstream plugin compiler. The
-yolop facets are the new work, and they are thin:
+### D6 — Tool policy is part of the contract, not a courtesy
 
-**Tool policy** (`yolop.tools`). MCP tools normally surface as
-`mcp_<server>__<tool>` and may be deferred behind `tool_search`. The LSP eval
-showed both matter enormously: stub schemas behind `tool_search` drove
-adoption to ~zero, and prompt guidance names exact tools. So an extension can
-declare, per tool: a **canonical name** (unprefixed alias; registered only if
-it doesn't collide with a built-in or another extension — collision falls back
-to the prefixed form with a startup warning), **`never_defer`** (schema always
-loaded — budgeted, e.g. ≤8 tools per extension, so one package can't blow the
-context), and approval/risk hints consumed by the approval capability.
+The LSP eval produced two hard facts: tools deferred behind `tool_search`
+stubs get ~zero adoption, and prompt guidance names exact tool names. So the
+manifest declares, per tool:
 
-**Config schema** (`yolop.config_schema`). JSON Schema for the extension's
-`[[capabilities]]` config, exposed through the catalog like any built-in.
-The config is delivered to the extension's servers as env
-(`YOLOP_EXT_CONFIG` JSON) and/or `${config.*}` substitution in `.mcp.json` —
-the same expansion mechanism `${VAR}` uses today. This gives an extension
-exactly what `lsp` has: validated, discoverable, self-configurable settings.
+- **canonical name** — surfaced unprefixed (`lsp_definition`, not
+  `mcp_lsp__lsp_definition`). Registered only if it collides with nothing
+  built-in or already-installed; on collision, fall back to the prefixed form
+  with a startup warning.
+- **`never_defer`** — schema always loaded, budgeted (≤8 per extension) so
+  one package cannot blow the context window. Everything else defers behind
+  `tool_search` as usual — this is the answer to pi's context-cost critique.
+- **approval/risk hints** consumed by the approval capability, and optional
+  narration templates (static templates beat narration RPC).
 
-**Hooks** (`hooks/hooks.json`). Same envelope as the existing hooks spec;
-entries are namespaced `plugin:<name>:<hook_id>` and merged as
-capability-contributed hooks, so users mute them with the existing
-`disabled_contributions` list rather than editing the package.
-
-### Discovery, install, trust
-
-Scopes mirror skills/hooks/mcp exactly:
-
-- **Workspace**: `<workspace>/.agents/extensions/<name>/` — ships with the
-  repo.
-- **Global**: `<config_dir>/yolop/extensions/<name>/` — per user.
-
-Workspace overrides global by name. Malformed packages warn and are skipped.
-Enablement: installing does **not** activate. An extension activates the same
-way `lsp` does today — `[[capabilities]] ref = "plugin:<name>"` (written by
-`/extensions enable`, `set_config`, or by hand). A manifest may declare
-`yolop.default_enabled = true`, honored only for *global* installs (an act of
-explicit user consent).
-
-Install verbs (System commands + capability tools, so both the user and the
-model can drive them):
+### The wire, end to end
 
 ```
-/extensions install <git-url>[@rev] | <path>   # clone/copy into global scope
-/extensions list | update [<name>] | remove <name>
-/extensions enable|disable <name>
+yolop                                   capability server (ext:lsp)
+  |-- spawn (session start; prompt facet present)
+  |-- initialize { capabilities.experimental.yolop:
+  |                { protocolVersions: [1], config: {...} } }
+  |<- result { instructions: "<static prompt>",      # standard MCP field
+  |            capabilities.experimental.yolop:
+  |              { protocolVersion: 1,
+  |                tools:  { canonical: true, neverDefer: [...] },
+  |                hooks:  [ {event, matcher, timeoutMs, onError} ],
+  |                dynamicSystemPrompt: false } }    # clamped vs manifest
+  |-- notifications/initialized
+  |-- tools/list                        -> seven lsp_* tools
+  |   ... agent turn ...
+  |-- tools/call lsp_definition         -> (server keeps rust-analyzer warm)
+  |-- yolop/hook {event: post_tool_use, tool: edit_file, ...}   # if subscribed
+  |   ... user edits settings ...
+  |-- yolop/configChanged {config}      <- "restart-required" -> respawn
+  |   ... session end ...
+  |-- shutdown / SIGKILL (kill_on_drop)
 ```
 
-Git installs are pinned: `extensions.lock` (beside `settings.toml`) records
-source URL, resolved commit, and a content hash; `update` is explicit.
-Local-path installs are referenced, not copied (dev loop), and marked as such.
+The yolop side is one generic `ExtensionCapability` adapter implementing
+`Capability`: static answers from the clamped handshake cache; `tools()`
+proxied from `tools/list` with policy applied; `pre/post_tool_exec_hooks()`
+manufactured from subscriptions; `system_prompt_contribution()` from
+`instructions` (or the RPC when declared dynamic). Registered per
+installed+enabled extension at startup — `CapabilityRegistry::register`
+takes `Arc<dyn Capability>` at runtime, so no upstream change is needed to
+register; only the facets that touch collection (config schema exposure)
+need small hooks.
 
-Trust model, in line with `.mcp.json` precedent but stricter for the new
-attack path:
+Note the deliberate reuse of MCP's standard `instructions` field for the
+static prompt: even a plain MCP host that ignores every `yolop/*` method
+still gets the guidance text.
 
-- **Global install = consent.** The user ran the install command; stdio
-  servers and hook executors run with user privileges, same as `.mcp.json`
-  today. `/extensions install` prints what the package will contribute
-  (servers, hooks, prompt size, tool names) before confirming.
-- **Workspace extensions arrive with someone else's repo.** They are
-  discovered but **inert until approved once per content-hash**: first
-  activation shows the contribution summary and records the approved hash in
-  user-level state (not the repo). A changed package re-prompts. This is the
-  VS Code workspace-trust lesson applied at package granularity.
-- Hooks and prompt contributions are the sharpest edges (silent policy or
-  instruction injection), which is why approval summarizes them explicitly.
-- No sandbox is claimed. Sandboxing is what the WASM tier is *for*, later.
+## Packaging, install, trust
 
-### Versioning and compatibility
-
-- Manifest `version` (semver) + `engines.yolop = ">=0.6"`; incompatible
-  packages load nothing and warn.
-- The tool wire protocol is MCP — self-versioned by its own handshake, SDKs
-  in every language, zero yolop-owned protocol surface.
-- Yolop facets are versioned by the manifest schema; unknown facet keys warn
-  and are ignored (tolerant, like upstream).
-- No hot reload in v1: changes apply on next session (matches how
-  `[[capabilities]]` config behaves today).
-
-### Illustration: `lsp` as an extension
-
-The existing capability decomposes cleanly:
-
-- **Data plane** (already subprocesses): rust-analyzer, gopls, … unchanged.
-- **Control plane** (today ~3.4k lines of in-tree Rust): becomes `yolop-lsp`,
-  a standalone binary speaking MCP over stdio — the LSP client, server
-  lifecycle manager, position-encoding conversion, workspace-edit safety
-  checks move there verbatim. It exposes the seven `lsp_*` tools.
-- **Everything else** becomes the package:
+The package is the everruns plugin directory — the declarative layer arrives
+upstream; yolop adds one facet:
 
 ```json
 {
   "name": "lsp",
-  "description": "Semantic code intelligence from real language servers.",
   "version": "0.1.0",
+  "description": "Semantic code intelligence from real language servers.",
   "engines": { "yolop": ">=0.6" },
-  "mcpServers": { "lsp": { "type": "stdio", "command": "yolop-lsp",
-                            "env": { "YOLOP_EXT_CONFIG": "${config}" } } },
   "yolop": {
+    "protocolVersion": 1,
+    "capabilityServer": { "command": "yolop-lsp", "args": [] },
     "config_schema": { "$ref": "./config.schema.json" },
     "tools": {
       "canonical_names": true,
       "never_defer": ["lsp_definition", "lsp_references", "lsp_hover",
                        "lsp_diagnostics", "lsp_rename", "lsp_symbols",
                        "lsp_code_actions"]
-    }
+    },
+    "hooks": []
   }
 }
 ```
 
-plus `agents/lsp.md` carrying the directive "call `lsp_*` FIRST for
-symbol-level questions" prompt (verbatim from today's capability — the eval
-showed the wording is load-bearing), and the same config schema
-(`servers.<key>.command/args/extensions`, timeouts).
+- **Scopes** mirror skills/hooks/mcp: workspace
+  `<workspace>/.agents/extensions/<name>/` and global
+  `<config_dir>/yolop/extensions/<name>/`; workspace overrides global by
+  name; malformed packages warn, never sink startup.
+- **Install**: `/extensions install <git-url>[@rev] | <path>`, plus
+  `list | update | remove | enable | disable` — System commands *and*
+  capability tools, so both the user and the model can drive setup.
+  Git installs are pinned in `extensions.lock` (source, commit, content
+  hash); `update` is explicit. Path installs are referenced, not copied
+  (dev loop). Binaries: the manifest names the command; resolution is PATH
+  plus the package's own `bin/`; a missing binary is a call-time tool error
+  with install guidance, exactly like a missing `rust-analyzer` today.
+- **Trust**: a global install is consent by action (same stance as authoring
+  `.mcp.json`), preceded by a printed contribution summary (servers, hooks,
+  prompt size, tool names). Workspace packages arrive with someone else's
+  repo: discovered but **inert until approved once per content-hash**,
+  approval recorded in user state, changed package re-prompts. Hooks and
+  prompt text are the sharpest injection edges and are named explicitly in
+  the summary. No sandbox is claimed in v1.
 
-What this buys: a new language ecosystem integration (say, a JVM-heavy shop
-wrapping jdtls with warmup quirks) is a package on a git URL, not a PR to
-yolop. What it costs: MCP round-trip per tool call (noise against LSP server
-latencies) and cross-process config delivery.
+## Illustration: `lsp` as a capability server
 
-Migration policy: the built-in `lsp` capability **stays** until the extension
-packaging reaches parity on `evals/lsp_integration` (pass rate, `lsp_*`
-adoption, tokens). The eval is the gate; the extension is the dogfood that
-proves the mechanism. If parity holds, the in-tree capability retires and the
-binary shrinks — the mechanism pays for itself.
+Decomposition of the existing capability:
 
-### Future facets (design now, build later)
+- **Data plane** — rust-analyzer, gopls, pyright, … : already subprocesses;
+  now spawned and kept warm by the extension process instead of by yolop.
+- **Control plane** — `yolop-lsp`, a standalone binary: the transport-generic
+  LSP client, server lifecycle manager, position-encoding conversion, and
+  workspace-edit safety checks move there ~verbatim (`client.rs` is already
+  transport-generic; only `manager.rs` knows processes). It exposes the seven
+  `lsp_*` tools over MCP.
+- **Package** — manifest above + the directive prompt text (verbatim: the
+  eval showed the "call `lsp_*` FIRST" wording is load-bearing) + the same
+  config schema (`servers.<key>.command/args/extensions`, timeouts). Config
+  changes to the servers map answer `restart-required`, matching today's
+  "rebuild manager, killing old servers" behavior.
 
-- **LLM providers.** Two tiers. (1) *Declarative descriptors*: most
-  OpenAI-compatible endpoints (Groq, Mistral, gateways) need only
-  `base_url + auth env + model list + profiles` — a manifest facet feeding
-  the existing `Custom`/Completions path. Prerequisite refactor: `Provider`
-  moves from a closed enum to the catalog pattern the codebase already
-  prefers. (2) *Provider proxies*: exotic protocols ship a subprocess
-  exposing an OpenAI-compatible endpoint on a local socket (the pattern
-  Ollama/llama.cpp normalized; `codex_driver`'s `DriverId::external` shows
-  the driver-side seam). Native in-process drivers stay compiled-in.
-- **UI features.** Extensions never run code in the TUI. Near-term surface:
-  slash commands, config UI schema (`config_ui_schema` exists on the trait),
-  and `user_ask`-style forms. If richer needs appear, upstream already has
-  declarative UI precedent (`a2ui`/`openui`): extensions would emit
-  component *trees*, yolop renders them with its own widgets. pi's
-  TypeScript renderers are the counterexample that doesn't translate to a
-  Rust host.
-- **everruns plugin convergence.** The package format *is* the upstream
-  plugin format plus a tolerated `yolop` facet. Anything installable in the
-  hosted everruns product should load in yolop unchanged; yolop facets
-  upstream one by one when the hosted product wants them (config schema and
-  tool policy are obvious candidates). Keep in lockstep per the friendly-fork
-  rule.
-- **Registry.** Out of scope for v1 (git URLs suffice). If added: a curated
-  index file in a git repo (Claude Code marketplace / Zed extensions-repo
-  shape), commit-pinned entries.
+Workspace-root delivery uses MCP `roots`; out-of-root edit rejection stays in
+the extension (it owns the `WorkspaceEdit` application), while yolop's
+approval hooks still see every write the tools perform.
 
-## Proposal B (deferred) — a full capability wire protocol
+Migration gate: the built-in stays until the extension reaches parity on
+`evals/lsp_integration` (pass rate, `lsp_*` adoption, turns, tokens, plus
+tool-call latency overhead measured). Parity → retire the in-tree capability;
+the eval is the gate, the extension is the dogfood.
 
-Mirror the entire `Capability` trait over stdio JSON-RPC ("everything MCP
-can't express"): dynamic prompt contributions, facts, message filters,
-model-view providers, tool-definition hooks, narration. Rejected for now:
+## Future facets on the same protocol
 
-- The uncovered seams are the **hot loop**. Facts and message filters run per
-  request and are documented as "cheap and side-effect free" — a cross-process
-  round-trip in prompt assembly on every turn is hostile to latency and
-  cache-friendliness. In-loop transformation is precisely where in-process
-  execution (WASM tier, or upstream Rust) is the right tool.
-- It creates a yolop-owned protocol with a versioning burden Zed needed WIT
-  snapshots to manage — for demand that is, today, hypothetical.
-- Static-but-per-session needs (prompt text chosen by config) are already
-  covered by manifest + config substitution.
+- **LLM providers.** Tier 1 is declarative (OpenAI-compatible descriptor:
+  base_url, auth env, model list/profiles) once `Provider` moves from a
+  closed enum to a catalog. Tier 2 rides *this* mechanism: the capability
+  server exposes an OpenAI-compatible endpoint on a local socket and
+  announces it in the handshake (`yolop.provider: { baseUrl, models }`) —
+  the pattern Ollama normalized, and `codex_driver`'s `DriverId::external`
+  already shows the driver-side seam. Native drivers stay compiled in.
+- **UI features.** Extensions never run TUI code. The protocol path is
+  declarative: `elicitation` already bridges to `user_ask` forms; if richer
+  needs appear, handshake-declared component *trees* (upstream `a2ui`/
+  `openui` precedent) rendered by yolop's own widgets.
+- **everruns plugins.** A yolop extension without the `yolop` facet *is* an
+  everruns plugin; hosts that grow capability-server support can adopt the
+  `yolop` block as-is — it is a candidate for upstreaming under a neutral
+  name once proven here.
 
-Revisit trigger: a concrete extension that cannot be expressed as
-manifest + MCP (e.g. a community progress-guard variant needing message
-filtering). Then prefer *narrow* extension methods negotiated on top of the
-existing MCP connection (`experimental`/`yolop/*` namespaced) over a second
-protocol.
+## Alternatives considered
 
-## Proposal C (deferred) — WASM control-plane tier
-
-wasmtime + WIT (or Extism) hosting sandboxed extension logic in-process, with
-host functions for spawn-subprocess/read-workspace/HTTP mirroring Zed's
-capability declarations. This is the only path to *untrusted* third-party
-code and to in-loop hooks without RPC latency. Costs: WIT snapshot
-versioning machinery, guest-language friction, and a second execution model
-to support forever. Adopt only alongside a public registry where untrusted
-authorship is the norm, and keep Proposal A's manifest as the outer package
-format (a WASM module becomes one more facet, not a new unit).
+- **Rust dylibs** (`abi_stable`/`stabby`) — rejected: no stable ABI,
+  toolchain lockstep, per-platform artifacts, no isolation.
+- **In-process scripting** (pi/OpenCode model; upstream `lua` exists) —
+  deferred: single language, engine surface, and a sandbox liability for
+  exactly the FS/process access the LSP class needs.
+- **WASM components** (wasmtime + WIT / Extism) — deferred, and *scoped*: it
+  is the untrusted-marketplace endgame and the only honest home for the
+  excluded hot-loop seams (D3), but WASI cannot spawn the data plane, and the
+  host machinery (per-version WIT snapshots) is Zed-scale. When it comes, a
+  WASM module is one more facet in this same package format, not a new unit.
+- **Bespoke JSON-RPC protocol** — rejected in D1.
+- **Pure MCP with no extension block** — rejected as the ceiling goose
+  already demonstrates; it cannot express config schema, prompt policy,
+  tool economics, or hooks.
 
 ## Rollout
 
-1. **Loader + declarative facets.** Discover both scopes, compile via the
-   upstream plugin compiler, inject `plugin:<name>` configs into the harness,
-   workspace trust gate, `/extensions` list/enable/disable. Exit: a
-   prompt+skills+MCP package (e.g. a docs-search extension) works end to end.
-2. **Yolop facets.** `config_schema` into the catalog + config delivery to
-   servers; tool policy (canonical names, `never_defer` budget, approval
-   hints); hooks contributions; `extensions.lock` + install/update/remove
-   from git. Exit: facets exercised by a reference extension in CI.
-3. **`yolop-lsp` dogfood.** Extract the LSP control plane into an MCP binary
-   packaged as an extension; run `evals/lsp_integration` against
-   built-in vs extension. Exit: parity → retire the in-tree capability.
-4. **Providers, then UI.** Declarative provider descriptors (after the
-   Provider-catalog refactor); provider proxies and declarative UI on demand.
+1. **Persistent MCP transport.** Session-lifetime stdio connections with
+   crash/respawn policy behind `"persistent": true` in `.mcp.json`; measure
+   against spawn-per-call. Independently valuable; candidate upstream PR.
+2. **Handshake + adapter.** `yolop` extension block (protocolVersion, tool
+   policy, static prompt via `instructions`, config in `initialize`),
+   `ExtensionCapability` adapter, config-schema wiring into the catalog.
+   Exit: a hand-built capability server exercises every static facet in CI.
+3. **Packaging + trust.** `.agents/extensions/` + global scope discovery,
+   `extensions.lock`, `/extensions` verbs, manifest-clamps-handshake
+   enforcement, workspace content-hash approval. Exit: install from a git
+   URL to working tools in one command.
+4. **Hooks + dynamic prompt RPC.** `yolop/hook`, `yolop/systemPrompt`,
+   `yolop/configChanged`, elicitation bridge. Exit: a guardrail-style
+   reference extension (block writes to generated files) works.
+5. **`yolop-lsp` dogfood.** Extract the control plane; A/B on
+   `evals/lsp_integration`; parity retires the built-in.
+6. **Providers.** Descriptor tier after the Provider-catalog refactor;
+   provider-proxy handshake facet after.
 
 ## Non-goals
 
-- No in-process native code (dylibs) — ever, per the ABI analysis.
-- No arbitrary TUI code from extensions.
-- No hot reload, no central registry, no sandbox claims in v1.
-- No second hook engine, skill format, MCP config shape, or enable/disable
-  surface — every facet lands on an existing seam.
+- No in-process native code, ever (ABI analysis above).
+- No TUI code from extensions.
+- No hot-loop seams over the wire (facts, message filters, model views,
+  tool-definition transforms) — see D3.
+- No hot reload, central registry, or sandbox claims in v1.
+- No second hook engine, skills format, or enable/disable surface — every
+  facet lands on an existing seam.
 
 ## Open questions
 
-- Config delivery to servers: env blob vs `${config.*}` substitution vs both;
-  restart-on-config-change semantics for long-lived stdio servers.
-- `never_defer` budget size and whether the allowlist should be
-  model-adaptive (mirrors `auto_tool_search`).
-- Whether workspace-scope extensions may contribute hooks at all, or only
-  with a separate per-hook approval step.
-- Naming: `.agents/extensions/` (host-neutral, matches `.agents/skills/`)
-  vs `.yolop/extensions/`.
+- Namespace: `ext:<name>` vs reusing upstream `plugin:<name>` for
+  capability-server extensions. `ext:` keeps "hydrates from serialized
+  config" (upstream plugin semantics) distinct from "proxied live process",
+  at the cost of a second prefix; decide when the loader lands.
+- Should the persistent transport multiplex several sessions over one
+  process (LSP servers are expensive to duplicate) or stay
+  process-per-session (simpler isolation)? Yolop is effectively
+  single-session per TUI today; background sessions may force the choice.
+- `never_defer` budget size, and whether it should be model-adaptive
+  (mirroring `auto_tool_search`).
+- Hook RPC while the extension process is crashed: fail-open with warning
+  (availability) vs fail-closed per `on_error` (integrity). Leaning: honor
+  the subscription's declared `on_error`, same as hook timeouts.
+- Whether workspace-scope packages may subscribe hooks at all, or only with
+  per-hook approval.

--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -51,6 +51,14 @@ tier:
 - **pi**'s anti-MCP argument is really about context economics (tool schemas
   burning 5–10% of the window). The antidote is declared tool policy, not a
   particular transport.
+- **mira** (sibling project; its eval protocol is ACP-inspired) is the
+  in-house existence proof for building a protocol of exactly this shape:
+  stdio ndjson JSON-RPC dialect, field-classified messages, capability
+  tokens + `capability_params`, `MAJOR.MINOR` with hard forward-compat
+  rules, schema generated from Rust types with CI drift guards, native
+  zero-dependency SDKs generated from the schema, and staged unstable
+  additions. YEP adopts these conventions wholesale (see "Protocol
+  construction") rather than rediscovering them.
 
 ## Design decisions
 
@@ -99,13 +107,12 @@ already use. Division of labor:
   owns the process, so state survives) since yolop's stdio MCP transport is
   spawn-per-call today.
 
-The cost of a bespoke protocol is the missing SDK ecosystem. Mitigations,
-owned by this repo: the protocol surface is deliberately small (a dozen
-methods over ndjson JSON-RPC — an afternoon in any language); a reference
-Rust SDK crate (`yolop-extension`) that `yolop-lsp` dogfoods; and a
-conformance harness (`/extensions doctor <cmd>` drives a server through
-handshake, tool call, streaming, cancellation, config push and reports what
-it got).
+The cost of a bespoke protocol is the missing SDK ecosystem. The mitigation
+is not hand-waving — it is the pattern [mira](https://github.com/everruns/mira)
+already ships for its eval protocol (itself an ACP-inspired stdio dialect;
+YEP joins the same family and follows `mira/docs/protocol.md` as its style
+template): a schema-first contract with generated, native SDKs and a
+conformance harness. See "Protocol construction" below.
 
 ### D2 — Persistent, session-scoped processes
 
@@ -195,19 +202,66 @@ yolop-owned protocol this is native — each declared tool carries:
 
 ## The protocol surface
 
-Envelope: JSON-RPC 2.0, newline-delimited JSON over stdio. Integer
-`protocolVersion`, negotiated at `initialize`; yolop advertises the versions
-it supports and refuses (with a startup warning, never a crash) servers it
-cannot speak.
+### Wire model (mira conventions, adopted)
+
+YEP's wire model is lifted from the mira eval protocol — the ACP-inspired
+stdio dialect this codebase's sibling already specifies, generates, and
+tests — rather than invented fresh:
+
+- **Transport & framing.** Child-process stdio; newline-delimited JSON, one
+  UTF-8 object per line, blank lines ignored. `stdout` carries **only**
+  protocol JSON; `stderr` is free for the server's logs and is never parsed.
+  EOF on stdin signals clean exit (then `kill_on_drop` after grace).
+- **Field-based message classification.** A line bearing `method` is a
+  request (with `id`) or notification (without); only a `method`-less line
+  is a response. Classification is by fields, not by direction or pipe.
+- **Bidirectional from day one, with mira's reserved-seam invariants made
+  live**: independent `id` spaces per direction (a response matches pending
+  requests *on the same side* only), and each direction's optional methods
+  are capability-negotiated — a peer never emits a method the other side
+  did not advertise. YEP needs the reverse direction immediately
+  (`ui/ask`, `status/changed`, `log`), so these invariants are v1 behavior,
+  not a reservation.
+- **Correlated notifications.** A notification cannot carry the envelope
+  `id` (that would classify it as a response), so streamed `tool/update`
+  events correlate to their in-flight call via `request_id` in the payload —
+  the same demultiplexing key mira uses, which is what lets many tool calls
+  (and their update streams) multiplex over the single pipe.
+- **Errors are JSON-RPC-shaped and defaulted**: `code` (JSON-RPC
+  conventions, `0` = unclassified), required `message`, optional
+  `retryable` hint and structured `data`. A bare `{"message": …}` parses.
+- **Cancellation by request id.** `cancel {id}` is a generic method
+  addressing any in-flight request (mira semantics): best-effort, `false`
+  is benign, and the cancelled call itself resolves promptly with error
+  `cancelled` instead of hanging. This is the lever for user interrupts and
+  turn aborts.
+- **Multiplexing.** Yolop may keep many requests in flight; responses
+  correlate by `id` and arrive in any order. Parallel tool calls in one
+  turn ride this directly.
+
+### Versioning (mira rules, verbatim)
+
+`MAJOR.MINOR`, negotiated at `initialize`; v1 ships as `1.0`. Majors must
+match — yolop refuses a mismatched server with a startup warning, never a
+crash. Minors are additive. Forward compatibility is a hard requirement on
+both sides: **ignore unknown fields** (no deny-unknown-fields on the wire),
+**default missing fields**, and **feature-detect via capability tokens, not
+version sniffing**. The handshake's contribution facets are capability
+tokens with structured `capability_params` (open vocabulary, carried
+verbatim when unrecognized): `tools`, `streaming`, `hooks`, `prompt`,
+`dynamic_prompt`, `mcp_servers`, `commands`, `ui_ask`, `cancel`,
+`provider` (future). A server advertising only `tools` is fully conforming.
+
+### Methods
 
 | Direction | Method | Kind | Purpose |
 |---|---|---|---|
 | →server | `initialize` | req | protocol version, session id, workspace root, locale, validated config, host feature set |
 | ←server | (result) | — | identity, contributions (prompt, tools, hooks, MCP servers, commands), clamped by manifest |
 | →server | `initialized` | ntf | handshake complete |
-| →server | `tool/call` | req | `{toolCallId, name, args}`; response is the final `ToolExecutionResult`-shaped payload |
-| ←server | `tool/update` | ntf | streamed progress/partial output for a running `toolCallId` |
-| →server | `tool/cancel` | ntf | cancel a running call (user interrupt, turn abort) |
+| →server | `tool/call` | req | `{tool_call_id, name, args}`; response is the final `ToolExecutionResult`-shaped payload |
+| ←server | `tool/update` | ntf | streamed progress/partial output; correlates via `request_id` in the payload |
+| →server | `cancel` | req | `{id}` — abort any in-flight request (mira semantics: best-effort, aborted call resolves with error `cancelled`) |
 | →server | `prompt/contribution` | req | dynamic system prompt (only if declared `dynamic`); timeout + last-known-good |
 | →server | `hook/fire` | req | `{event, toolName, payload}` → decision per subscription (`allow/block/mutate`) |
 | →server | `config/changed` | req | new validated config → `ok` \| `restart-required` |
@@ -220,25 +274,70 @@ cannot speak.
 ```
 yolop                                   capability server (ext:lsp)
   |-- spawn (session start; prompt facet present)
-  |-- initialize {protocolVersions:[1], sessionId, workspaceRoot,
-  |               config:{...}, host:{streaming:true, hooks:true}}
-  |<- result {name:"lsp", prompt:{static:"<directive text>"},
-  |           tools:[{name:"lsp_definition", schema:{...},
-  |                   never_defer:true, streaming:false}, ...x7],
-  |           mcpServers:[], hooks:[], commands:[]}     # clamped vs manifest
+  |-- initialize {protocol_version:"1.0", session_id, workspace_root,
+  |               config:{...},
+  |               capabilities:["streaming","hooks","ui_ask","cancel"]}
+  |<- result {protocol_version:"1.0", name:"lsp",
+  |           capabilities:["tools","streaming","prompt"],
+  |           capability_params:{
+  |             prompt:{static:"<directive text>"},
+  |             tools:[{name:"lsp_definition", schema:{...},
+  |                     never_defer:true, streaming:false}, ...x7]}}
+  |                                     # ^ clamped vs manifest (D4)
   |-- initialized
   |   ... agent turn ...
-  |-- tool/call {toolCallId:"t1", name:"lsp_definition", args:{...}}
-  |<-   (server keeps rust-analyzer warm across calls)
-  |   ... long-running tool elsewhere ...
-  |-- tool/call {toolCallId:"t2", name:"lsp_rename", args:{...}}
-  |<- tool/update {toolCallId:"t2", output:"3/14 files patched"}
-  |<- (result t2)
+  |-- {id:1} tool/call {tool_call_id:"t1", name:"lsp_definition", args:{...}}
+  |<- {id:1} (result)                   # server keeps rust-analyzer warm
+  |-- {id:2} tool/call {tool_call_id:"t2", name:"lsp_rename", args:{...}}
+  |<- tool/update {request_id:2, output:"3/14 files patched"}
+  |<- {id:2} (result)
+  |-- {id:3} cancel {id:2}              # had it still been running:
+  |<- {id:3} {cancelled:true}           #   ...and id:2 resolves error "cancelled"
   |   ... user edits settings ...
   |-- config/changed {config}          <- "restart-required" -> respawn
   |   ... session end ...
-  |-- shutdown / exit                   (SIGKILL after grace; kill_on_drop)
+  |-- (close stdin) / shutdown          # EOF => exit; SIGKILL after grace
 ```
+
+### Protocol construction (the mira pattern)
+
+How the contract is defined, published, and kept honest — adopted wholesale
+from mira, which has already proven each piece for a protocol of this exact
+shape:
+
+- **Rust types are the source of truth; the schema is generated.** Wire
+  types live in one `yolop::yep` module; a schema-gen binary emits
+  `schema/yep/v1/schema.json` (JSON Schema 2020-12, root `anyOf` over the
+  three envelopes, every payload under `$defs`) and `meta.json` (protocol
+  version, method list, capability tokens, event vocabularies). The
+  directory is versioned by protocol **major**. CI runs the generator with
+  `--check` so a wire change cannot merge without a matching schema update;
+  a test suite validates real serialized messages against the committed
+  schema, and a conformance corpus lives beside it (`schema/yep/v1/
+  conformance/`).
+- **SDKs are native, zero-dependency libraries, never FFI bindings.** The
+  protocol is the seam by design; bindings would re-couple what the wire
+  decouples. Each SDK ships a small codegen with its own `--check` drift
+  mode that generates wire types from `schema.json` and protocol metadata
+  from `meta.json` — the version string and method/capability vocabulary
+  are generated, not hardcoded — plus a hand-written ergonomic layer: a
+  `serve()` stdio loop and tool/hook registration helpers. Rust
+  (`yolop-extension`, dogfooded by `yolop-lsp`) first; TypeScript and
+  Python when demand shows, following `mira/specs/sdks.md` including its
+  drift-guard table (handled-methods ⊇ meta methods, advertised
+  capabilities ⊆ meta tokens, emitted messages validate against schema).
+- **Unstable staging.** New wire *structure* develops behind a
+  `yep-unstable` cargo feature; the schema generator builds without it, so
+  the committed schema describes only the stable protocol and an addition
+  reaches the artifact (and a minor bump) only when promoted. Open
+  vocabularies (capability tokens, `capability_params`, metadata maps)
+  extend without any bump at all.
+- **Conformance harness in the product**: `/extensions doctor <cmd>` drives
+  a server through handshake, tool call, streaming, cancellation, and
+  config push, validating every message against the committed schema — the
+  runtime dual of the CI guards, pointed at third-party servers.
+
+### The adapter
 
 The yolop side is one generic `ExtensionCapability` adapter implementing
 `Capability`: static answers from the clamped handshake cache; `tools()`
@@ -262,7 +361,7 @@ upstream; yolop adds one facet:
   "description": "Semantic code intelligence from real language servers.",
   "engines": { "yolop": ">=0.6" },
   "yolop": {
-    "protocolVersion": 1,
+    "protocol_version": "1.0",
     "capabilityServer": { "command": "yolop-lsp", "args": [] },
     "config_schema": { "$ref": "./config.schema.json" },
     "tools": [
@@ -368,11 +467,12 @@ the protocol and the SDK.
 
 ## Rollout
 
-1. **Protocol core + SDK + conformance.** `initialize`/`initialized`,
-   `tool/call` + `tool/update` + `tool/cancel`, `shutdown`/`exit`; the
-   `ExtensionCapability` adapter; the `yolop-extension` reference crate;
-   `/extensions doctor`. Exit: a hand-built server passes conformance and
-   its tools stream in the TUI.
+1. **Protocol core + schema + SDK.** `initialize`/`initialized`,
+   `tool/call` + `tool/update` + `cancel`, `shutdown`; wire types +
+   schema-gen + `schema/yep/v1/` with CI `--check` and a conformance
+   corpus; the `ExtensionCapability` adapter; the `yolop-extension`
+   reference crate; `/extensions doctor`. Exit: a hand-built server passes
+   conformance and its tools stream in the TUI.
 2. **Packaging + trust.** `.agents/extensions/` + global scope discovery,
    `extensions.lock`, `/extensions` verbs, manifest-clamps-handshake
    enforcement, workspace content-hash approval, config schema into the
@@ -409,7 +509,8 @@ the protocol and the SDK.
 - Multiplex several sessions over one server process (LSP servers are
   expensive to duplicate) vs process-per-session (simpler isolation)? Yolop
   is effectively single-session per TUI today; background sessions may force
-  the choice. The protocol reserves `sessionId` on every request either way.
+  the choice. The protocol reserves `session_id` on every request either
+  way.
 - `never_defer` budget size, and whether it should be model-adaptive
   (mirroring `auto_tool_search`).
 - Hook RPC while the server is crashed: fail-open with warning

--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -166,8 +166,9 @@ a strict relationship:
   servers are clamped by *name and transport shape* — an approved stdio
   command cannot silently become a remote URL.
 
-Content-hash approval (workspace packages inert until approved per hash,
-recorded in user state, re-prompt on change) makes the boundary durable.
+The lockfile's content hash makes the boundary durable: what was approved
+is pinned, and an `update` whose manifest widens the grant re-asks with a
+contribution diff before anything runs.
 
 ### D5 — Config rides the existing capability machinery
 
@@ -379,25 +380,45 @@ upstream; yolop adds one facet:
 }
 ```
 
-- **Scopes** mirror skills/hooks/mcp: workspace
-  `<workspace>/.agents/extensions/<name>/` and global
-  `<config_dir>/yolop/extensions/<name>/`; workspace overrides global by
-  name; malformed packages warn, never sink startup.
-- **Install**: `/extensions install <git-url>[@rev] | <path>`, plus
+- **One scope: global.** Packages live in
+  `<config_dir>/yolop/extensions/<name>/`, installed per user; malformed
+  packages warn, never sink startup. There is deliberately **no workspace
+  scope** (no `.agents/extensions/` discovered from repos): a repository
+  must not carry agent-specific machinery — committing yolop extensions to
+  a repo would quietly couple that project to one agent. Projects keep
+  using the agent-neutral surfaces they already have (`.mcp.json`,
+  `.agents/skills/`, `.agents/hooks.json`); a project README may *recommend*
+  extensions, and the user installs them once, globally, by choice.
+- **Install**: `/extensions install <source>`, plus
   `list | update | remove | enable | disable | doctor` — System commands
   *and* capability tools, so both the user and the model can drive setup.
-  Git installs are pinned in `extensions.lock` (source, commit, content
-  hash); `update` is explicit. Path installs are referenced, not copied
-  (dev loop). Binaries: the manifest names the command; resolution is PATH
-  plus the package's own `bin/`; a missing binary is a call-time tool error
-  with install guidance, exactly like a missing `rust-analyzer` today.
-- **Trust**: a global install is consent by action (same stance as authoring
+  Sources, all pinned in `extensions.lock` and updated only explicitly:
+  - `<git-url>[@rev]` — cloned into the global dir; lock records source,
+    resolved commit, content hash. Carries the package; the server binary
+    must already be resolvable (PATH or the package's `bin/`) — a missing
+    binary is a call-time tool error with install guidance, exactly like a
+    missing `rust-analyzer` today.
+  - `crates.io:<crate>[@version]` — the Rust-native path that provisions
+    package *and binary* in one step. Yolop downloads the `.crate` tarball
+    (checksummed via the registry index) and reads the extension manifest
+    from it — `plugin.json` at the crate root or
+    `[package.metadata.yolop]` in `Cargo.toml` — **without executing
+    anything**, preserving the D4 invariant; after consent it runs
+    `cargo install <crate> --version <v> --locked --root
+    <config_dir>/yolop/extensions/<name>/` so the binary lands inside the
+    package dir, not in the user's cargo bin. Lock records crate, version,
+    and registry checksum (a stronger supply-chain pin than a git rev).
+    Requires a Rust toolchain — acceptable for yolop's audience; prebuilt
+    binaries (`cargo binstall`-style) are a deferred optimization.
+  - `<path>` — referenced in place, not copied (dev loop).
+- **Trust**: install is consent by action (same stance as authoring
   `.mcp.json`), preceded by a printed contribution summary (server command,
-  tools, hooks, MCP servers, prompt size). Workspace packages arrive with
-  someone else's repo: discovered but **inert until approved once per
-  content-hash**, approval recorded in user state, changed package
-  re-prompts. Hooks and prompt text are the sharpest injection edges and are
-  named explicitly in the summary. No sandbox is claimed in v1.
+  tools, hooks, MCP servers, prompt size) — readable straight from the
+  manifest, without executing the binary. `update` shows a **contribution
+  diff** against the approved manifest and re-asks when the grant widened
+  (new tools, new hooks, a changed server command); a hash-identical update
+  is silent. Hooks and prompt text are the sharpest injection edges and are
+  named explicitly in both summaries. No sandbox is claimed in v1.
 
 ## Illustration: `lsp` as a capability server
 
@@ -473,11 +494,11 @@ the protocol and the SDK.
    corpus; the `ExtensionCapability` adapter; the `yolop-extension`
    reference crate; `/extensions doctor`. Exit: a hand-built server passes
    conformance and its tools stream in the TUI.
-2. **Packaging + trust.** `.agents/extensions/` + global scope discovery,
-   `extensions.lock`, `/extensions` verbs, manifest-clamps-handshake
-   enforcement, workspace content-hash approval, config schema into the
-   catalog + `config/changed`. Exit: install from a git URL to working
-   tools in one command.
+2. **Packaging + trust.** Global-scope discovery, `extensions.lock`,
+   `/extensions` verbs, manifest-clamps-handshake enforcement,
+   update-time contribution diffs, config schema into the catalog +
+   `config/changed`. Exit: install from a git URL to working tools in one
+   command.
 3. **Contributed MCP servers.** Handshake `mcpServers` merged into scoped
    MCP config through the existing client; name/transport clamping. Exit: an
    extension wrapping a third-party MCP server (credentials + lifecycle)
@@ -496,6 +517,8 @@ the protocol and the SDK.
 - No TUI code from extensions.
 - No hot-loop seams over the wire (facts, message filters, model views,
   tool-definition transforms) — see D3.
+- No workspace scope — repos never carry (or auto-discover) yolop
+  extensions; projects stay agent-neutral.
 - No hot reload, central registry, or sandbox claims in v1.
 - No second hook engine, skills format, or enable/disable surface — every
   facet lands on an existing seam.
@@ -516,8 +539,6 @@ the protocol and the SDK.
 - Hook RPC while the server is crashed: fail-open with warning
   (availability) vs fail-closed per `on_error` (integrity). Leaning: honor
   the subscription's declared `on_error`, same as hook timeouts.
-- Whether workspace-scope packages may subscribe hooks at all, or only with
-  per-hook approval.
 - Whether contributed *stdio* MCP servers should get a persistent connection
   mode (today's transport is spawn-per-call), or whether stateful cases
   should always be extension-hosted HTTP endpoints.

--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -1,4 +1,4 @@
-# Extensions — capability servers over a subprocess protocol
+# Extensions — capability servers over the yolop extension protocol
 
 Status: **proposal** (design record, nothing implemented).
 
@@ -19,14 +19,15 @@ recompilation. Near-term: tools + prompt + config + hooks (the LSP class).
 Later: LLM providers, UI features, everruns plugins.
 
 **Scoping decision.** Declarative contributions (prompt text, skills,
-commands, plain MCP server registrations) are arriving upstream as **everruns
-plugins**: a plugin directory (Claude Code–compatible `plugin.json` dialect)
-compiles to a `DeclarativeCapabilityDefinition` carried *inside* the
-`plugin:{name}` capability config and hydrated at collection time. Yolop
-inherits that layer by staying in lockstep; this spec does not redesign it.
-What yolop must own is the tier upstream does not have: **executable,
-stateful, capability-level logic in a subprocess** — the *capability server*
-— and the protocol between yolop and it. That is the subject of this spec.
+commands, static MCP server registrations) are arriving upstream as
+**everruns plugins**: a plugin directory (Claude Code–compatible
+`plugin.json` dialect) compiles to a `DeclarativeCapabilityDefinition`
+carried *inside* the `plugin:{name}` capability config and hydrated at
+collection time. Yolop inherits that layer by staying in lockstep; this spec
+does not redesign it. What yolop must own is the tier upstream does not
+have: **executable, stateful, capability-level logic in a subprocess** — the
+*capability server* — and the protocol between yolop and it: the **yolop
+extension protocol (YEP)**.
 
 ## Prior art (compressed)
 
@@ -39,8 +40,8 @@ tier:
   property of having a scripting runtime, not a design yolop can copy.
 - **goose** proves "extension = MCP server" works but also shows its ceiling:
   tools/resources/prompts only — no prompt shaping, no loop hooks, no config
-  schema. That ceiling is exactly the gap between MCP and the `Capability`
-  trait.
+  schema, no streaming tool output. That ceiling is exactly the gap between
+  MCP and the `Capability` trait.
 - **Zed** shows the strongest versioning story (per-version WIT snapshots)
   and the control-plane/data-plane split: extension logic decides, host- or
   extension-spawned subprocesses do the heavy work.
@@ -49,87 +50,114 @@ tier:
   latency-critical path.
 - **pi**'s anti-MCP argument is really about context economics (tool schemas
   burning 5–10% of the window). The antidote is declared tool policy, not a
-  different transport.
+  particular transport.
 
 ## Design decisions
 
-### D1 — The protocol is an MCP superset, not a second protocol
+### D1 — YEP is its own protocol; MCP is a *contribution*, not the base
 
-A capability server **is an MCP server** (JSON-RPC 2.0 over stdio) that
-additionally negotiates a `yolop` extension block. MCP explicitly reserves
-`experimental`/vendor capabilities and tolerates unknown methods, so this is
-sanctioned, not a fork.
+A capability server speaks **YEP**: yolop-owned methods and lifecycle,
+JSON-RPC 2.0 as the message envelope (the same envelope LSP, DAP, and MCP
+use — it is framing, not semantics) over stdio, newline-delimited. The
+protocol mirrors the `Capability` trait directly instead of bending the
+contract to fit another protocol's shape.
 
-Why not bespoke LSP-style RPC: it would reimplement framing, handshake,
-lifecycle, and tool plumbing MCP already standardizes; it would orphan the
-SDK ecosystem extension authors get for free; and yolop would still need MCP
-alongside it for plain tool servers — two protocols forever. Why not plain
-MCP: the trait seams that make a capability a capability (config schema,
-prompt contribution, tool policy, hooks) have no MCP expression — goose's
-ceiling.
+Why not an MCP superset (the previous revision of this spec recommended one;
+recorded here as rejected):
 
-A capability server therefore degrades gracefully: in goose or Claude Code it
-is just an MCP tool server (prefixed names, no facets); under yolop it is a
-full capability. One binary, every host.
+- **The contract should evolve with the trait, not with MCP.** Tool policy,
+  hooks, prompt contributions, config push, streaming tool output — none of
+  these exist in MCP; a superset means forever expressing yolop semantics
+  through someone else's extension escape hatch and tracking their spec's
+  churn underneath.
+- **Tool calls need a richer lifecycle than MCP offers**: streamed
+  progress/partial output while a tool runs (yolop's TUI already renders
+  streaming `bash` output; extension tools must not regress to
+  spinner-until-done), cancellation, and structured result payloads aligned
+  with `ToolExecutionResult` — native YEP messages rather than bolted-on
+  progress notifications.
+- **The cross-host argument inverts.** The superset's main selling point was
+  "the same binary also works in goose/Claude Code." Composition achieves
+  that better: an extension that wants cross-host reach *provides an MCP
+  server* (next paragraph) and keeps the yolop-specific surface in YEP.
 
-Base-protocol versioning is MCP's own. The `yolop` block carries its own
-integer `protocolVersion`; yolop advertises the versions it supports in
-`initialize` and refuses (with a clear startup warning, never a crash) blocks
-it cannot speak.
+**MCP as a contribution.** An extension can announce, in its handshake:
+*"I provide these MCP servers"* — each entry a name plus transport (a stdio
+command, or an HTTP URL, typically `localhost` served by the extension
+process itself). Yolop merges them into scoped MCP config and consumes them
+through its **existing MCP client path**, exactly as if they came from
+`.mcp.json`. This is not a new seam: it is the wire form of
+`Capability::mcp_servers_with_config()`, which compiled-in capabilities
+already use. Division of labor:
 
-### D2 — Persistent processes (new transport mode)
+- **Native YEP tools** — streaming, stateful, policy-rich, session-scoped;
+  the LSP class.
+- **Contributed MCP servers** — wrapping/bundling the existing MCP
+  ecosystem: an extension can manage credentials, config, or lifecycle for a
+  third-party MCP server and hand yolop the endpoint. Stateful contributed
+  servers should prefer an extension-hosted HTTP endpoint (the extension
+  owns the process, so state survives) since yolop's stdio MCP transport is
+  spawn-per-call today.
 
-Today's stdio MCP transport spawns a process **per tool call** and tears it
-down (`everruns-mcp` D2: "per-invocation spawn keeps lifecycle trivial").
-That is fatal for the LSP class — warm state is the entire point (a
-rust-analyzer index takes tens of seconds to build).
+The cost of a bespoke protocol is the missing SDK ecosystem. Mitigations,
+owned by this repo: the protocol surface is deliberately small (a dozen
+methods over ndjson JSON-RPC — an afternoon in any language); a reference
+Rust SDK crate (`yolop-extension`) that `yolop-lsp` dogfoods; and a
+conformance harness (`/extensions doctor <cmd>` drives a server through
+handshake, tool call, streaming, cancellation, config push and reports what
+it got).
 
-Capability servers get a **session-persistent connection**: spawned once per
-session, kept alive, `kill_on_drop`, restarted with backoff on crash (pending
-requests fail with a clear message; next call respawns — the exact policy
-`lsp/manager.rs` already implements for language servers). Spawn is eager at
-session start when the extension contributes prompt text or hooks (needed
-before the first turn), lazy on first tool call otherwise.
+### D2 — Persistent, session-scoped processes
 
-This transport is useful beyond capability servers — stateful plain-MCP
-servers suffer under spawn-per-call too — so it lands as an opt-in
-(`"persistent": true`) for ordinary `.mcp.json` entries, with capability
-servers always persistent. Candidate for upstreaming into `everruns-mcp`.
+A capability server is spawned once per session and lives for it —
+persistence is intrinsic to YEP, not an option. Spawn is eager at session
+start when the extension contributes prompt text or hooks (needed before the
+first turn), lazy on first tool call otherwise. `kill_on_drop`; crash fails
+pending requests with a clear message and the next call respawns with
+backoff — the policy `lsp/manager.rs` already implements for language
+servers. Graceful path: `shutdown` request, then `exit` notification,
+SIGKILL after a grace window.
+
+The worktree caveat is first-class: yolop can repoint the active workspace
+mid-session (`WorkspaceHost`), so the workspace root arrives in `initialize`
+**and** changes arrive as `workspace/changed` notifications; servers that
+cache roots (the LSP class) must handle it.
 
 ### D3 — Every trait seam gets one of three treatments
 
-The core of the design. The `Capability` trait's seams split by how hot their
-call path is:
+The core of the design. The `Capability` trait's seams split by how hot
+their call path is:
 
 | Treatment | Seams | Mechanism |
 |---|---|---|
-| **Static** — declared, no RPC after startup | id/name/description/category, `config_schema`, static system prompt, tool policy (naming, never-defer, approval/risk hints, narration templates), commands, hook *subscriptions*, dependencies, features | Package manifest + `initialize` handshake; a generic yolop-side adapter answers the trait from this cache |
-| **RPC** — cold path, bounded, fallible | tool execution (`tools/call`), dynamic system prompt (`yolop/systemPrompt`, ≤1/turn, timeout + last-known-good fallback), hook firings (`yolop/hook`), user questions (MCP `elicitation` → `user_ask` bridge), config push (`yolop/configChanged`) | Requests over the persistent connection, each with a declared timeout and error policy |
+| **Static** — declared, no RPC after startup | id/name/description/category, `config_schema`, static system prompt, tool definitions + policy (naming, never-defer, approval/risk hints, narration templates), **provided MCP servers**, commands, hook *subscriptions*, dependencies, features | Package manifest + `initialize` handshake; a generic yolop-side adapter answers the trait from this cache |
+| **RPC** — cold path, bounded, fallible | tool execution (streamed), dynamic system prompt (≤1/turn, timeout + last-known-good fallback), hook firings, user questions, config push, workspace change | YEP requests/notifications over the persistent connection, each with a declared timeout and error policy |
 | **Excluded** from the wire (v1) | `facts`, `message_filter_provider`, `model_view_provider`, `tool_definition_hooks` | Per-request hot loop, documented "cheap and side-effect free" — a cross-process round-trip there is hostile to latency and prompt-cache stability. If real demand appears, this is the future WASM tier's job, not a protocol extension |
 
 Hooks over RPC deserve the explicit precedent: `user_hooks` today spawns a
 **whole bash process per event**. A request to an already-warm process is
-strictly cheaper than the mechanism yolop already ships, so hook RPC is not a
-new class of cost — but it is bounded anyway: subscriptions are static
-(event + tool-name matcher + `timeout_ms` + `on_error: warn|block`), a
-match-all matcher must be spelled `"*"` and is called out at approval time,
-and per-extension subscription count is capped.
+strictly cheaper than the mechanism yolop already ships — but bounded
+anyway: subscriptions are static (event + tool-name matcher + `timeout_ms` +
+`on_error: warn|block`), a match-all matcher must be spelled `"*"` and is
+called out at approval time, and per-extension subscription count is capped.
 
 ### D4 — The manifest is the approval boundary; the handshake may only narrow it
 
-Static facets live in **both** the package manifest and the handshake, with a
-strict relationship:
+Static facets live in **both** the package manifest and the handshake, with
+a strict relationship:
 
 - The **manifest** (`plugin.json` + `yolop` facet block) is what the user
   approves at install time — it must be inspectable *without executing the
   binary* (the VS Code lesson). It declares the server command and the upper
   bound of everything: tool names, never-defer list, hook subscriptions,
-  prompt size, config schema.
+  provided MCP servers, prompt size, config schema.
 - The **handshake** is the runtime truth, **clamped by the manifest**: a
-  server may declare fewer tools or hooks than approved (feature-gated
-  builds), but anything not in the approved manifest is refused and logged.
-  A server that tries to widen its grant after installation is the exact
-  attack the clamp exists for.
+  server may declare fewer tools, hooks, or MCP servers than approved
+  (feature-gated builds), but anything not in the approved manifest is
+  refused and logged. A server that tries to widen its grant after
+  installation is the exact attack the clamp exists for. Provided MCP
+  servers are clamped by *name and transport shape* — an approved stdio
+  command cannot silently become a remote URL.
 
 Content-hash approval (workspace packages inert until approved per hash,
 recorded in user state, re-prompt on change) makes the boundary durable.
@@ -142,66 +170,85 @@ overrides, catalog, and `set_config` tools unchanged. The declared
 `config_schema` plugs into `CapabilityCatalog` validation exactly like a
 built-in's.
 
-Delivery: validated config is passed in `initialize` params
-(`yolop.config`), and pushed on change as `yolop/configChanged`; the server
-answers `ok` or `restart-required` (yolop restarts it — the same
-"rebuild manager on config change" semantics `LspCapability` has today).
-Secrets stay in env (`${VAR}` expansion in the server spec, as `.mcp.json`
-does now); config is for structure, not credentials.
+Delivery: validated config is passed in `initialize` params, and pushed on
+change as `config/changed`; the server answers `ok` or `restart-required`
+(yolop restarts it — the same "rebuild manager on config change" semantics
+`LspCapability` has today). Secrets stay in env (`${VAR}` expansion in the
+server spec, as `.mcp.json` does now); config is for structure, not
+credentials.
 
-### D6 — Tool policy is part of the contract, not a courtesy
+### D6 — Tool policy is part of the tool definition
 
 The LSP eval produced two hard facts: tools deferred behind `tool_search`
-stubs get ~zero adoption, and prompt guidance names exact tool names. So the
-manifest declares, per tool:
+stubs get ~zero adoption, and prompt guidance names exact tool names. In a
+yolop-owned protocol this is native — each declared tool carries:
 
-- **canonical name** — surfaced unprefixed (`lsp_definition`, not
-  `mcp_lsp__lsp_definition`). Registered only if it collides with nothing
-  built-in or already-installed; on collision, fall back to the prefixed form
-  with a startup warning.
-- **`never_defer`** — schema always loaded, budgeted (≤8 per extension) so
-  one package cannot blow the context window. Everything else defers behind
-  `tool_search` as usual — this is the answer to pi's context-cost critique.
-- **approval/risk hints** consumed by the approval capability, and optional
-  narration templates (static templates beat narration RPC).
+- its **real name** (`lsp_definition` — no forced prefix; registered only if
+  it collides with nothing built-in or already installed; on collision, the
+  extension-qualified form with a startup warning),
+- **`never_defer`** (schema always loaded, budgeted: ≤8 per extension so one
+  package cannot blow the context window; everything else defers behind
+  `tool_search` — the answer to pi's context-cost critique),
+- **approval/risk hints** consumed by the approval capability, and an
+  optional **narration template** (static templates beat narration RPC),
+- **`streaming`** — whether the tool emits `tool/update` progress.
 
-### The wire, end to end
+## The protocol surface
+
+Envelope: JSON-RPC 2.0, newline-delimited JSON over stdio. Integer
+`protocolVersion`, negotiated at `initialize`; yolop advertises the versions
+it supports and refuses (with a startup warning, never a crash) servers it
+cannot speak.
+
+| Direction | Method | Kind | Purpose |
+|---|---|---|---|
+| →server | `initialize` | req | protocol version, session id, workspace root, locale, validated config, host feature set |
+| ←server | (result) | — | identity, contributions (prompt, tools, hooks, MCP servers, commands), clamped by manifest |
+| →server | `initialized` | ntf | handshake complete |
+| →server | `tool/call` | req | `{toolCallId, name, args}`; response is the final `ToolExecutionResult`-shaped payload |
+| ←server | `tool/update` | ntf | streamed progress/partial output for a running `toolCallId` |
+| →server | `tool/cancel` | ntf | cancel a running call (user interrupt, turn abort) |
+| →server | `prompt/contribution` | req | dynamic system prompt (only if declared `dynamic`); timeout + last-known-good |
+| →server | `hook/fire` | req | `{event, toolName, payload}` → decision per subscription (`allow/block/mutate`) |
+| →server | `config/changed` | req | new validated config → `ok` \| `restart-required` |
+| →server | `workspace/changed` | ntf | active worktree/root repointed |
+| ←server | `ui/ask` | req | user question/form — bridged to the `user_ask` capability |
+| ←server | `status/changed` | ntf | capability status (e.g. `degraded: rust-analyzer not found`) surfaced in `/extensions list` |
+| ←server | `log` | ntf | structured logs → yolop's tracing layer (`RUST_LOG` honored) |
+| →server | `shutdown` / `exit` | req/ntf | graceful stop before `kill_on_drop` |
 
 ```
 yolop                                   capability server (ext:lsp)
   |-- spawn (session start; prompt facet present)
-  |-- initialize { capabilities.experimental.yolop:
-  |                { protocolVersions: [1], config: {...} } }
-  |<- result { instructions: "<static prompt>",      # standard MCP field
-  |            capabilities.experimental.yolop:
-  |              { protocolVersion: 1,
-  |                tools:  { canonical: true, neverDefer: [...] },
-  |                hooks:  [ {event, matcher, timeoutMs, onError} ],
-  |                dynamicSystemPrompt: false } }    # clamped vs manifest
-  |-- notifications/initialized
-  |-- tools/list                        -> seven lsp_* tools
+  |-- initialize {protocolVersions:[1], sessionId, workspaceRoot,
+  |               config:{...}, host:{streaming:true, hooks:true}}
+  |<- result {name:"lsp", prompt:{static:"<directive text>"},
+  |           tools:[{name:"lsp_definition", schema:{...},
+  |                   never_defer:true, streaming:false}, ...x7],
+  |           mcpServers:[], hooks:[], commands:[]}     # clamped vs manifest
+  |-- initialized
   |   ... agent turn ...
-  |-- tools/call lsp_definition         -> (server keeps rust-analyzer warm)
-  |-- yolop/hook {event: post_tool_use, tool: edit_file, ...}   # if subscribed
+  |-- tool/call {toolCallId:"t1", name:"lsp_definition", args:{...}}
+  |<-   (server keeps rust-analyzer warm across calls)
+  |   ... long-running tool elsewhere ...
+  |-- tool/call {toolCallId:"t2", name:"lsp_rename", args:{...}}
+  |<- tool/update {toolCallId:"t2", output:"3/14 files patched"}
+  |<- (result t2)
   |   ... user edits settings ...
-  |-- yolop/configChanged {config}      <- "restart-required" -> respawn
+  |-- config/changed {config}          <- "restart-required" -> respawn
   |   ... session end ...
-  |-- shutdown / SIGKILL (kill_on_drop)
+  |-- shutdown / exit                   (SIGKILL after grace; kill_on_drop)
 ```
 
 The yolop side is one generic `ExtensionCapability` adapter implementing
 `Capability`: static answers from the clamped handshake cache; `tools()`
-proxied from `tools/list` with policy applied; `pre/post_tool_exec_hooks()`
-manufactured from subscriptions; `system_prompt_contribution()` from
-`instructions` (or the RPC when declared dynamic). Registered per
-installed+enabled extension at startup — `CapabilityRegistry::register`
-takes `Arc<dyn Capability>` at runtime, so no upstream change is needed to
-register; only the facets that touch collection (config schema exposure)
-need small hooks.
-
-Note the deliberate reuse of MCP's standard `instructions` field for the
-static prompt: even a plain MCP host that ignores every `yolop/*` method
-still gets the guidance text.
+manufactured from declared tools (calls proxied as `tool/call`, updates
+streamed to the TUI); `mcp_servers_with_config()` returns the contributed
+endpoints for the runtime's scoped-MCP merge; `pre/post_tool_exec_hooks()`
+manufactured from subscriptions; `system_prompt_contribution()` from the
+static text or the RPC. Registered per installed+enabled extension at
+startup — `CapabilityRegistry::register` takes `Arc<dyn Capability>` at
+runtime, so registration needs no upstream change.
 
 ## Packaging, install, trust
 
@@ -218,12 +265,16 @@ upstream; yolop adds one facet:
     "protocolVersion": 1,
     "capabilityServer": { "command": "yolop-lsp", "args": [] },
     "config_schema": { "$ref": "./config.schema.json" },
-    "tools": {
-      "canonical_names": true,
-      "never_defer": ["lsp_definition", "lsp_references", "lsp_hover",
-                       "lsp_diagnostics", "lsp_rename", "lsp_symbols",
-                       "lsp_code_actions"]
-    },
+    "tools": [
+      { "name": "lsp_definition", "never_defer": true },
+      { "name": "lsp_references", "never_defer": true },
+      { "name": "lsp_hover",      "never_defer": true },
+      { "name": "lsp_diagnostics","never_defer": true },
+      { "name": "lsp_rename",     "never_defer": true, "streaming": true },
+      { "name": "lsp_symbols",    "never_defer": true },
+      { "name": "lsp_code_actions","never_defer": true }
+    ],
+    "mcpServers": [],
     "hooks": []
   }
 }
@@ -234,20 +285,20 @@ upstream; yolop adds one facet:
   `<config_dir>/yolop/extensions/<name>/`; workspace overrides global by
   name; malformed packages warn, never sink startup.
 - **Install**: `/extensions install <git-url>[@rev] | <path>`, plus
-  `list | update | remove | enable | disable` — System commands *and*
-  capability tools, so both the user and the model can drive setup.
+  `list | update | remove | enable | disable | doctor` — System commands
+  *and* capability tools, so both the user and the model can drive setup.
   Git installs are pinned in `extensions.lock` (source, commit, content
   hash); `update` is explicit. Path installs are referenced, not copied
   (dev loop). Binaries: the manifest names the command; resolution is PATH
   plus the package's own `bin/`; a missing binary is a call-time tool error
   with install guidance, exactly like a missing `rust-analyzer` today.
 - **Trust**: a global install is consent by action (same stance as authoring
-  `.mcp.json`), preceded by a printed contribution summary (servers, hooks,
-  prompt size, tool names). Workspace packages arrive with someone else's
-  repo: discovered but **inert until approved once per content-hash**,
-  approval recorded in user state, changed package re-prompts. Hooks and
-  prompt text are the sharpest injection edges and are named explicitly in
-  the summary. No sandbox is claimed in v1.
+  `.mcp.json`), preceded by a printed contribution summary (server command,
+  tools, hooks, MCP servers, prompt size). Workspace packages arrive with
+  someone else's repo: discovered but **inert until approved once per
+  content-hash**, approval recorded in user state, changed package
+  re-prompts. Hooks and prompt text are the sharpest injection edges and are
+  named explicitly in the summary. No sandbox is claimed in v1.
 
 ## Illustration: `lsp` as a capability server
 
@@ -255,46 +306,54 @@ Decomposition of the existing capability:
 
 - **Data plane** — rust-analyzer, gopls, pyright, … : already subprocesses;
   now spawned and kept warm by the extension process instead of by yolop.
-- **Control plane** — `yolop-lsp`, a standalone binary: the transport-generic
-  LSP client, server lifecycle manager, position-encoding conversion, and
-  workspace-edit safety checks move there ~verbatim (`client.rs` is already
-  transport-generic; only `manager.rs` knows processes). It exposes the seven
-  `lsp_*` tools over MCP.
+- **Control plane** — `yolop-lsp`, a standalone binary on the reference SDK:
+  the transport-generic LSP client, server lifecycle manager,
+  position-encoding conversion, and workspace-edit safety checks move there
+  ~verbatim (`client.rs` is already transport-generic; only `manager.rs`
+  knows processes). It exposes the seven `lsp_*` tools natively over YEP —
+  streaming suits `lsp_rename` (per-file progress on large workspaces).
 - **Package** — manifest above + the directive prompt text (verbatim: the
   eval showed the "call `lsp_*` FIRST" wording is load-bearing) + the same
   config schema (`servers.<key>.command/args/extensions`, timeouts). Config
   changes to the servers map answer `restart-required`, matching today's
-  "rebuild manager, killing old servers" behavior.
-
-Workspace-root delivery uses MCP `roots`; out-of-root edit rejection stays in
-the extension (it owns the `WorkspaceEdit` application), while yolop's
-approval hooks still see every write the tools perform.
+  "rebuild manager, killing old servers" behavior. `workspace/changed`
+  re-roots the client, matching today's `WorkspaceHost` repointing.
 
 Migration gate: the built-in stays until the extension reaches parity on
 `evals/lsp_integration` (pass rate, `lsp_*` adoption, turns, tokens, plus
-tool-call latency overhead measured). Parity → retire the in-tree capability;
-the eval is the gate, the extension is the dogfood.
+tool-call latency overhead measured). Parity → retire the in-tree
+capability; the eval is the gate, the extension is the dogfood — for both
+the protocol and the SDK.
 
 ## Future facets on the same protocol
 
 - **LLM providers.** Tier 1 is declarative (OpenAI-compatible descriptor:
   base_url, auth env, model list/profiles) once `Provider` moves from a
-  closed enum to a catalog. Tier 2 rides *this* mechanism: the capability
-  server exposes an OpenAI-compatible endpoint on a local socket and
-  announces it in the handshake (`yolop.provider: { baseUrl, models }`) —
-  the pattern Ollama normalized, and `codex_driver`'s `DriverId::external`
-  already shows the driver-side seam. Native drivers stay compiled in.
-- **UI features.** Extensions never run TUI code. The protocol path is
-  declarative: `elicitation` already bridges to `user_ask` forms; if richer
-  needs appear, handshake-declared component *trees* (upstream `a2ui`/
-  `openui` precedent) rendered by yolop's own widgets.
-- **everruns plugins.** A yolop extension without the `yolop` facet *is* an
-  everruns plugin; hosts that grow capability-server support can adopt the
-  `yolop` block as-is — it is a candidate for upstreaming under a neutral
-  name once proven here.
+  closed enum to a catalog. Tier 2 rides the handshake: the server announces
+  `provider: { baseUrl: "http://127.0.0.1:<port>/v1", models: [...] }` — an
+  OpenAI-compatible endpoint it hosts (the pattern Ollama normalized;
+  `codex_driver`'s `DriverId::external` shows the driver-side seam). Native
+  drivers stay compiled in.
+- **UI features.** Extensions never run TUI code. `ui/ask` bridges to
+  `user_ask` forms now; if richer needs appear, handshake-declared component
+  *trees* (upstream `a2ui`/`openui` precedent) rendered by yolop's own
+  widgets.
+- **everruns plugins.** A package without the `yolop` facet *is* an everruns
+  plugin and loads through the upstream declarative path; the facet is
+  additive. If upstream grows capability-server support, YEP is the candidate
+  to upstream under a neutral name once proven here.
 
 ## Alternatives considered
 
+- **MCP superset** (previous revision's recommendation) — rejected: the
+  contract would be shaped by, and forever versioned under, a protocol that
+  lacks tool streaming, hooks, prompt policy, and config semantics; the
+  cross-host benefit is achieved better by composition — extensions
+  *provide* MCP servers through the handshake instead of *being* one.
+- **Pure MCP with no extension surface** — rejected as the ceiling goose
+  already demonstrates: tools only, no capability-level contract. Still
+  fully supported for plain tool servers via `.mcp.json` and via
+  extension-provided MCP servers.
 - **Rust dylibs** (`abi_stable`/`stabby`) — rejected: no stable ABI,
   toolchain lockstep, per-platform artifacts, no isolation.
 - **In-process scripting** (pi/OpenCode model; upstream `lua` exists) —
@@ -302,34 +361,34 @@ the eval is the gate, the extension is the dogfood.
   exactly the FS/process access the LSP class needs.
 - **WASM components** (wasmtime + WIT / Extism) — deferred, and *scoped*: it
   is the untrusted-marketplace endgame and the only honest home for the
-  excluded hot-loop seams (D3), but WASI cannot spawn the data plane, and the
-  host machinery (per-version WIT snapshots) is Zed-scale. When it comes, a
-  WASM module is one more facet in this same package format, not a new unit.
-- **Bespoke JSON-RPC protocol** — rejected in D1.
-- **Pure MCP with no extension block** — rejected as the ceiling goose
-  already demonstrates; it cannot express config schema, prompt policy,
-  tool economics, or hooks.
+  excluded hot-loop seams (D3), but WASI cannot spawn the data plane, and
+  the host machinery (per-version WIT snapshots) is Zed-scale. When it
+  comes, a WASM module is one more facet in this same package format, not a
+  new unit.
 
 ## Rollout
 
-1. **Persistent MCP transport.** Session-lifetime stdio connections with
-   crash/respawn policy behind `"persistent": true` in `.mcp.json`; measure
-   against spawn-per-call. Independently valuable; candidate upstream PR.
-2. **Handshake + adapter.** `yolop` extension block (protocolVersion, tool
-   policy, static prompt via `instructions`, config in `initialize`),
-   `ExtensionCapability` adapter, config-schema wiring into the catalog.
-   Exit: a hand-built capability server exercises every static facet in CI.
-3. **Packaging + trust.** `.agents/extensions/` + global scope discovery,
+1. **Protocol core + SDK + conformance.** `initialize`/`initialized`,
+   `tool/call` + `tool/update` + `tool/cancel`, `shutdown`/`exit`; the
+   `ExtensionCapability` adapter; the `yolop-extension` reference crate;
+   `/extensions doctor`. Exit: a hand-built server passes conformance and
+   its tools stream in the TUI.
+2. **Packaging + trust.** `.agents/extensions/` + global scope discovery,
    `extensions.lock`, `/extensions` verbs, manifest-clamps-handshake
-   enforcement, workspace content-hash approval. Exit: install from a git
-   URL to working tools in one command.
-4. **Hooks + dynamic prompt RPC.** `yolop/hook`, `yolop/systemPrompt`,
-   `yolop/configChanged`, elicitation bridge. Exit: a guardrail-style
-   reference extension (block writes to generated files) works.
-5. **`yolop-lsp` dogfood.** Extract the control plane; A/B on
+   enforcement, workspace content-hash approval, config schema into the
+   catalog + `config/changed`. Exit: install from a git URL to working
+   tools in one command.
+3. **Contributed MCP servers.** Handshake `mcpServers` merged into scoped
+   MCP config through the existing client; name/transport clamping. Exit: an
+   extension wrapping a third-party MCP server (credentials + lifecycle)
+   works end to end.
+4. **Hooks + dynamic prompt + ui/ask.** `hook/fire`, `prompt/contribution`,
+   `ui/ask`, `workspace/changed`. Exit: a guardrail-style reference
+   extension (block writes to generated files) works.
+5. **`yolop-lsp` dogfood.** Extract the control plane onto the SDK; A/B on
    `evals/lsp_integration`; parity retires the built-in.
 6. **Providers.** Descriptor tier after the Provider-catalog refactor;
-   provider-proxy handshake facet after.
+   provider handshake facet after.
 
 ## Non-goals
 
@@ -343,18 +402,21 @@ the eval is the gate, the extension is the dogfood.
 
 ## Open questions
 
-- Namespace: `ext:<name>` vs reusing upstream `plugin:<name>` for
-  capability-server extensions. `ext:` keeps "hydrates from serialized
-  config" (upstream plugin semantics) distinct from "proxied live process",
-  at the cost of a second prefix; decide when the loader lands.
-- Should the persistent transport multiplex several sessions over one
-  process (LSP servers are expensive to duplicate) or stay
-  process-per-session (simpler isolation)? Yolop is effectively
-  single-session per TUI today; background sessions may force the choice.
+- Namespace: `ext:<name>` vs reusing upstream `plugin:<name>`. `ext:` keeps
+  "hydrates from serialized config" (upstream plugin semantics) distinct
+  from "proxied live process", at the cost of a second prefix; decide when
+  the loader lands.
+- Multiplex several sessions over one server process (LSP servers are
+  expensive to duplicate) vs process-per-session (simpler isolation)? Yolop
+  is effectively single-session per TUI today; background sessions may force
+  the choice. The protocol reserves `sessionId` on every request either way.
 - `never_defer` budget size, and whether it should be model-adaptive
   (mirroring `auto_tool_search`).
-- Hook RPC while the extension process is crashed: fail-open with warning
+- Hook RPC while the server is crashed: fail-open with warning
   (availability) vs fail-closed per `on_error` (integrity). Leaning: honor
   the subscription's declared `on_error`, same as hook timeouts.
 - Whether workspace-scope packages may subscribe hooks at all, or only with
   per-hook approval.
+- Whether contributed *stdio* MCP servers should get a persistent connection
+  mode (today's transport is spawn-per-call), or whether stateful cases
+  should always be extension-hosted HTTP endpoints.


### PR DESCRIPTION
## What changed

Adds `specs/extensions.md`: the design record for yolop's extensions mechanism. An extension delivers a **capability** (the everruns `Capability` contract) as an installed artifact — no recompilation. The spec defines:

- **Capability servers over YEP** (yolop extension protocol): a yolop-owned stdio ndjson JSON-RPC dialect mirroring the `Capability` trait — streaming tool calls with cancellation, hooks, prompt contribution, config push. MCP is a *contribution* an extension can provide (announced in the handshake, consumed through yolop's existing MCP client path), not the base wire.
- **Wire model and construction adopted from mira's eval protocol** (ACP lineage): field-classified messages, per-direction id spaces, capability tokens + `capability_params`, `MAJOR.MINOR` with hard forward-compat rules, schema generated from Rust types with CI drift guards, native zero-dependency SDKs, staged unstable additions.
- **Trait seams split into three treatments**: static (manifest + handshake, no RPC after startup), cold-path RPC (tools, hooks, dynamic prompt), and excluded hot-loop seams (facts, message filters — reserved for a future WASM tier).
- **Trust model**: the manifest is the approval boundary, inspectable without executing the binary; the handshake may only narrow it. One global install scope — repos never carry yolop extensions (projects stay agent-neutral).
- **Distribution**: `yolop-extension-<name>` naming convention on crates.io; toolchain-free installs (sparse index + checksummed `.crate` read natively; prebuilt per-target artifacts primary, `cargo install` secondary fallback).
- **Rollout in six phases**, dogfooded by extracting the `lsp` capability into `yolop-extension-lsp`, gated on `evals/lsp_integration` parity.

Prior-art survey (pi, Zed, goose, Claude Code, OpenCode, VS Code, WASM/WIT) and rejected alternatives (MCP superset, pure MCP, dylibs, in-process scripting) are recorded with reasoning.

## Why

Every capability is compiled into the binary today; the `lsp` capability (#236) — ~3.4k lines most users keep off — is the canonical example. Community-authored tooling (language servers, providers, MCP bundles) has no path in at all. The declarative layer is arriving upstream as everruns plugins; this spec owns the tier upstream doesn't have: executable, stateful, capability-level logic in a subprocess.

## Before / After

Docs-only: no observable behavior change. Before: no extensions design existed. After: `specs/extensions.md` is the durable decision record for the mechanism, its protocol, packaging, and rollout.

## Risk

- Low
- No code paths touched; the only risk is design-level (decisions recorded here shape future implementation). Contested calls are captured in "Alternatives considered" and "Open questions" so they can be revisited cheaply.

## Security

No security-relevant code changes — the diff is a single new spec document. The spec itself *defines* the future trust model (manifest-as-approval-boundary, handshake clamping, checksummed installs), which will get its own review when implemented.

## Checklist

- [ ] Tests added or updated — not applicable: docs-only change with no behavior to exercise (exemption per `specs/shipping.md` outcome 3); relevant CI is the source of truth.
- [x] Backward compatibility considered — n/a for a new spec document; the spec itself mandates forward-compat rules for the future wire format.

## Follow-ups

- Draft `schema/yep/v1/meta.json` (method list + capability tokens) as the first implementation artifact to force precision on the method set.
- Decide the `ext:` vs `plugin:` capability-ref namespace when the loader lands (tracked in Open questions).
- `yolop-extension-lsp` should publish per-target prebuilt artifacts from its first release so the primary install path is exercised by the dogfood extension.

---
_Generated by [Claude Code](https://claude.ai/code/session_017d7odSAD8o79pUrd31dpDb)_