### PR TITLE
fix(background): clarify task status and timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   to a session-file log, writes a `result.json`, and tracks a background session
   task. Inspect and control them with `list_tasks`, `get_task`, and
   `cancel_task` (the `/background` command and the `Ctrl+B` panel list them). A
-  task's result survives a restart. `spawn_background` can also schedule a
+  task's result survives a restart. Detached shell commands may run for up to
+  24 hours (foreground `bash` remains limited to 120 seconds).
+  `spawn_background` can also schedule a
   one-shot or recurring monitor; yolop executes due schedules while the TUI or
   ACP session is running and recovers overdue schedules after restart. When a
   schedule fires or a task finishes while the session is idle, yolop

--- a/specs/background.md
+++ b/specs/background.md
@@ -37,6 +37,9 @@ The run executes on a detached task, streams to a session-file log
 (`/.background/<run_id>/output.log`), writes a `result.json`, and mirrors its
 lifecycle onto a `background_tool` session task (`Running` → `Succeeded` /
 `Failed` / `Canceled`). `signal_on_completion` defaults to `true`.
+Foreground shell calls retain the short interactive deadline; detached shell
+runs use a separate 24-hour wall-clock limit so CI watches can outlive a turn
+without becoming unbounded host processes.
 
 For delayed or recurring work, `spawn_background` accepts a `schedule` instead
 of starting the wrapped tool immediately. Everruns persists the monitor and its
@@ -81,7 +84,9 @@ The Everruns `session_tasks` capability exposes the model-facing tools:
 with the file tools), `cancel_task`, `message_task`, and `wait_task`. Yolop adds
 one host-facing surface: the `/background` command (and the `Ctrl+B` TUI panel /
 status-bar count) lists the session's tasks via
-`session_tasks_view::render_task_list`.
+`session_tasks_view::render_task_list`. Status counts distinguish executing
+tools from scheduled monitors so an armed schedule is not presented as a
+running command.
 
 ### Proactive wake (the callback)
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -443,7 +443,7 @@ impl App {
         Some(format!("? ask ({turns})"))
     }
 
-    fn background_counts(&self) -> Option<(usize, usize)> {
+    fn background_counts(&self) -> Option<crate::session_tasks_view::BackgroundCounts> {
         crate::session_tasks_view::counts(&self.session_tasks)
     }
 
@@ -3181,7 +3181,11 @@ mod tests {
         let state = ViewState {
             presentation: PresentationState {
                 status_layout: StatusLayout::Expanded,
-                background: Some((1, 2)),
+                background: Some(crate::session_tasks_view::BackgroundCounts {
+                    running: 1,
+                    scheduled: 0,
+                    total: 2,
+                }),
                 ..presentation_state_idle()
             },
             ..view_state_idle()
@@ -3192,8 +3196,8 @@ mod tests {
             "status should show bg segment: {lines}"
         );
         assert!(
-            lines.contains("1▸/2"),
-            "status should show running/total: {lines}"
+            lines.contains("1 running · 0 scheduled · 2 total"),
+            "status should distinguish running, scheduled, and total: {lines}"
         );
     }
 
@@ -3454,11 +3458,18 @@ mod tests {
         app.refresh_session_tasks().await;
         app.background_panel = Some(0);
 
-        assert_eq!(app.presentation_state().background, Some((1, 1)));
+        assert_eq!(
+            app.presentation_state().background,
+            Some(crate::session_tasks_view::BackgroundCounts {
+                running: 1,
+                scheduled: 0,
+                total: 1,
+            })
+        );
         let lines = render_app_lines(app, 120, 20).join("\n");
         assert!(lines.contains("Background tasks"), "panel header: {lines}");
         assert!(
-            lines.contains("background task(s), 1 active"),
+            lines.contains("background task(s): 1 running, 0 scheduled"),
             "panel should summarize session tasks: {lines}"
         );
         assert!(

--- a/src/capabilities/background.rs
+++ b/src/capabilities/background.rs
@@ -36,7 +36,9 @@ const BACKGROUND_SYSTEM_PROMPT: &str = "<capability id=\"background\">\n\
     or `until <check>; do sleep 30; done`), say what you are waiting for, and end \
     the turn: completion wakes you with the result. You can keep working on other \
     steps while it runs. In one-shot (`-p`) runs there is no wake — block on the \
-    spawned task with `wait_task` instead of ending the turn.\n\
+    spawned task with `wait_task` instead of ending the turn. To inspect background \
+    state, call `list_tasks` once without kind or state filters; scheduled work is a \
+    `monitor`, not a `background_tool`.\n\
     </capability>";
 
 pub(crate) struct BackgroundCapability {

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -6,6 +6,7 @@
 //! dependency so transcript wording and status values can be tested without a
 //! terminal buffer.
 
+use crate::session_tasks_view::BackgroundCounts;
 use crate::transcript::{Author, ChatLine, StreamKind, StreamPreview};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -29,7 +30,7 @@ pub(crate) struct PresentationState {
     pub status_layout: StatusLayout,
     pub hooks_summary: String,
     pub approval_mode: String,
-    pub background: Option<(usize, usize)>,
+    pub background: Option<BackgroundCounts>,
     pub goal_indicator: Option<String>,
     pub ask_indicator: Option<String>,
     pub worktree_compact: Option<String>,
@@ -142,7 +143,7 @@ fn expanded_status_lines(state: &PresentationState) -> Vec<StatusLine> {
         status_value(message_count_label(state.lines_count)),
         status_field("tokens", token_label(state.session_tokens)),
     ];
-    if let Some(bg) = background_label(state.background) {
+    if let Some(bg) = background_label(state.background, false) {
         counts.push(status_field("bg", bg));
     }
 
@@ -185,7 +186,7 @@ fn status_contributions(state: &PresentationState) -> Vec<Vec<StatusField>> {
         StatusLayout::Expanded => "[collapse ↑]",
     };
     let mut counts = vec![status_value(message_count_label(state.lines_count))];
-    if let Some(bg) = background_label(state.background) {
+    if let Some(bg) = background_label(state.background, true) {
         counts.push(status_field("bg", bg));
     }
     if let Some(wt) = &state.worktree_compact {
@@ -217,12 +218,22 @@ fn ask_label(state: &PresentationState) -> String {
     state.ask_indicator.clone().unwrap_or_else(|| "—".into())
 }
 
-fn background_label(counts: Option<(usize, usize)>) -> Option<String> {
-    let (running, total) = counts?;
-    if total == 0 {
+fn background_label(counts: Option<BackgroundCounts>, compact: bool) -> Option<String> {
+    let counts = counts?;
+    if counts.total == 0 {
         return None;
     }
-    Some(format!("{running}▸/{total}"))
+    if compact {
+        Some(format!(
+            "{} run/{} sched/{}",
+            counts.running, counts.scheduled, counts.total
+        ))
+    } else {
+        Some(format!(
+            "{} running · {} scheduled · {} total",
+            counts.running, counts.scheduled, counts.total
+        ))
+    }
 }
 
 fn status_value(value: impl Into<String>) -> StatusField {
@@ -346,7 +357,11 @@ mod tests {
     fn status_model_exposes_expanded_background_and_session_values() {
         let model = PresentationState {
             status_layout: StatusLayout::Expanded,
-            background: Some((2, 5)),
+            background: Some(BackgroundCounts {
+                running: 2,
+                scheduled: 1,
+                total: 5,
+            }),
             ..state()
         };
 
@@ -356,7 +371,10 @@ mod tests {
         assert_eq!(lines[0].fields[1].label, Some("provider"));
         assert_eq!(lines[0].fields[1].value, "openai");
         assert_eq!(lines[2].fields[2].label, Some("bg"));
-        assert_eq!(lines[2].fields[2].value, "2▸/5");
+        assert_eq!(
+            lines[2].fields[2].value,
+            "2 running · 1 scheduled · 5 total"
+        );
         assert_eq!(lines[3].fields[0].label, Some("session"));
         assert_eq!(lines[3].fields[0].value, "sess_123");
     }

--- a/src/session_tasks_view.rs
+++ b/src/session_tasks_view.rs
@@ -1,14 +1,30 @@
 use everruns_core::SessionTask;
+use everruns_core::session_task::TASK_KIND_MONITOR;
 
-/// `(active, total)` counts for the status bar, or `None` when there are no
-/// tasks. Active = non-terminal.
-pub(crate) fn counts(tasks: &[SessionTask]) -> Option<(usize, usize)> {
-    let active = tasks
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct BackgroundCounts {
+    pub(crate) running: usize,
+    pub(crate) scheduled: usize,
+    pub(crate) total: usize,
+}
+
+/// Running tools, scheduled monitors, and total history for the status bar.
+/// Returns `None` when the session has no tasks.
+pub(crate) fn counts(tasks: &[SessionTask]) -> Option<BackgroundCounts> {
+    let scheduled = tasks
         .iter()
-        .filter(|task| !task.state.is_terminal())
+        .filter(|task| task.kind == TASK_KIND_MONITOR && !task.state.is_terminal())
+        .count();
+    let running = tasks
+        .iter()
+        .filter(|task| task.kind != TASK_KIND_MONITOR && !task.state.is_terminal())
         .count();
     let total = tasks.len();
-    (total > 0).then_some((active, total))
+    (total > 0).then_some(BackgroundCounts {
+        running,
+        scheduled,
+        total,
+    })
 }
 
 /// Human-readable list of the session's everruns tasks for the `/background`
@@ -25,11 +41,11 @@ pub(crate) fn render_task_list(tasks: &[SessionTask], task_error: Option<&str>) 
         return "No background tasks in this session.".to_string();
     }
 
-    let active = tasks
-        .iter()
-        .filter(|task| !task.state.is_terminal())
-        .count();
-    let mut out = format!("{} background task(s), {} active:\n", tasks.len(), active);
+    let counts = counts(tasks).expect("non-empty task list has counts");
+    let mut out = format!(
+        "{} background task(s): {} running, {} scheduled:\n",
+        counts.total, counts.running, counts.scheduled
+    );
     let mut sorted = tasks.to_vec();
     sorted.sort_by(|a, b| {
         b.updated_at
@@ -41,7 +57,12 @@ pub(crate) fn render_task_list(tasks: &[SessionTask], task_error: Option<&str>) 
             "- [{}] {} {}: {}",
             task.id, task.kind, task.state, task.display_name
         ));
-        if let Some(detail) = task.state_detail.as_deref() {
+        if task.state.is_terminal()
+            && let Some(summary) = task.summary.as_deref()
+        {
+            out.push_str(" -- ");
+            out.push_str(summary);
+        } else if let Some(detail) = task.state_detail.as_deref() {
             out.push_str(" -- ");
             out.push_str(detail);
         } else if let Some(summary) = task.summary.as_deref() {
@@ -65,17 +86,21 @@ mod tests {
     use super::*;
     use chrono::Utc;
     use everruns_core::session_task::{
-        SessionTaskState, TASK_KIND_BACKGROUND_TOOL, new_session_task,
+        SessionTaskState, TASK_KIND_BACKGROUND_TOOL, TASK_KIND_MONITOR, new_session_task,
     };
     use everruns_core::{CreateSessionTask, SessionId};
     use serde_json::json;
 
     fn task(id: &str, state: SessionTaskState, name: &str) -> SessionTask {
+        task_with_kind(id, TASK_KIND_BACKGROUND_TOOL, state, name)
+    }
+
+    fn task_with_kind(id: &str, kind: &str, state: SessionTaskState, name: &str) -> SessionTask {
         let mut task = new_session_task(
             CreateSessionTask {
                 session_id: SessionId::from_seed(42),
                 id: Some(id.to_string()),
-                kind: TASK_KIND_BACKGROUND_TOOL.to_string(),
+                kind: kind.to_string(),
                 display_name: name.to_string(),
                 spec: json!({}),
                 state,
@@ -92,10 +117,23 @@ mod tests {
     fn counts_reflect_active_and_total_session_tasks() {
         let tasks = vec![
             task("task_a", SessionTaskState::Running, "run"),
+            task_with_kind(
+                "task_monitor",
+                TASK_KIND_MONITOR,
+                SessionTaskState::Running,
+                "scheduled review",
+            ),
             task("task_b", SessionTaskState::Succeeded, "done"),
         ];
 
-        assert_eq!(counts(&tasks), Some((1, 2)));
+        assert_eq!(
+            counts(&tasks),
+            Some(BackgroundCounts {
+                running: 1,
+                scheduled: 1,
+                total: 3,
+            })
+        );
         assert_eq!(counts(&[]), None);
     }
 
@@ -104,7 +142,7 @@ mod tests {
         let tasks = vec![task("task_a", SessionTaskState::Succeeded, "write marker")];
         let rendered = render_task_list(&tasks, None);
 
-        assert!(rendered.contains("1 background task(s), 0 active"));
+        assert!(rendered.contains("1 background task(s): 0 running, 0 scheduled"));
         assert!(rendered.contains("[task_a] background_tool succeeded: write marker"));
         assert!(rendered.contains("cancel with cancel_task"));
     }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -47,7 +47,8 @@ impl Workspace {
 
 pub struct BashTool {
     ws: Workspace,
-    timeout_secs: u64,
+    foreground_timeout_secs: u64,
+    background_timeout_secs: u64,
     max_output_bytes: usize,
 }
 
@@ -73,8 +74,17 @@ impl BashTool {
     pub fn new(ws: Workspace) -> Self {
         Self {
             ws,
-            timeout_secs: 120,
+            foreground_timeout_secs: 120,
+            background_timeout_secs: 24 * 60 * 60,
             max_output_bytes: 1024 * 1024,
+        }
+    }
+
+    fn timeout_secs(&self, background: bool) -> u64 {
+        if background {
+            self.background_timeout_secs
+        } else {
+            self.foreground_timeout_secs
         }
     }
 
@@ -89,7 +99,8 @@ impl BashTool {
                 return Err(ToolExecutionResult::tool_error(message));
             }
         };
-        let timeout = Duration::from_secs(self.timeout_secs);
+        let timeout_secs = self.timeout_secs(sink.is_some());
+        let timeout = Duration::from_secs(timeout_secs);
         let max_bytes = self.max_output_bytes;
 
         if let Some(sink) = &sink {
@@ -178,7 +189,7 @@ impl BashTool {
                          event (CI run, deploy, long build), re-run it detached via \
                          spawn_background and end the turn — completion wakes the agent \
                          (in one-shot mode, block on the task with wait_task instead).",
-                        self.timeout_secs
+                        timeout_secs
                     )));
                 }
             };
@@ -475,7 +486,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bash_background_executable_streams_and_returns_success_outcome() {
+    async fn bash_background_executable_uses_detached_timeout_and_streams_output() {
         #[derive(Default)]
         struct RecordingSink {
             output: Mutex<Vec<(String, String)>>,
@@ -503,13 +514,16 @@ mod tests {
         }
 
         let dir = tempfile::tempdir().unwrap();
-        let tool = BashTool::new(Workspace::from_path(dir.path().to_path_buf()));
+        let mut tool = BashTool::new(Workspace::from_path(dir.path().to_path_buf()));
+        // A zero foreground timeout proves the background entry point selects
+        // its independent deadline instead of inheriting the interactive one.
+        tool.foreground_timeout_secs = 0;
         let sink = Arc::new(RecordingSink::default());
         let outcome = tool
             .as_background_executable()
             .expect("background executor")
             .execute_background(
-                json!({ "command": "printf stdout-line; printf stderr-line >&2" }),
+                json!({ "command": "sleep 0.05; printf stdout-line; printf stderr-line >&2" }),
                 ToolContext::new(SessionId::new()),
                 sink.clone(),
             )


### PR DESCRIPTION
## What changed

- Distinguish executing background tools, scheduled monitors, and total task history in the status model, status bar, and background panel.
- Prefer terminal summaries over stale in-progress detail when rendering completed tasks.
- Give detached bash work a separate 24-hour deadline while retaining the 120-second foreground deadline.
- Tell the agent to inspect background state with one unfiltered `list_tasks` call so monitors are not hidden and state-specific calls are not duplicated.

## Why

Session `session_019f4dd5594f71418e3ba5eae3a4a055` showed `bg 1▸/14` while filtered `background_tool` queries reported nothing active. The missing record was a scheduled `monitor`, and repeated 120-second detached CI timeouts had inflated task history.

## Before / After

Before: `bg 1▸/14`, with scheduled monitors visually indistinguishable from running commands. Detached CI watches inherited the foreground 120-second timeout.

After (expanded): `bg 1 running · 1 scheduled · 14 total`; compact status uses `1 run/1 sched/14`. Detached bash may run for up to 24 hours while retaining output caps and kill-on-drop.

Live OpenAI smoke:
```text
The background task succeeded. Exact output:
background-smoke-ok
```

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (646 passed, 2 ignored; integration 34 passed, 1 ignored)
- `cargo build --release`
- `./target/release/yolop --provider llmsim -p "hi"`
- `doppler run --project yolop --config ci -- ./target/release/yolop --provider openai -p "Use spawn_background ... then wait_task ..."`

## Security

- TM-BASH: detached execution remains bounded by a 24-hour wall clock, 1 MiB per-stream caps, and process kill-on-drop; foreground remains 120 seconds.
- TM-FS: no filesystem boundary changes; the existing write blocklist remains intact.
- TM-LLM: prompt guidance contains no user data or credentials; secret handling is unchanged.
- TM-TOOL: no new capabilities or elevated access.
- TM-DEP: no dependency changes.

## Risk

- Low. Presentation wording changes and long-running detached commands consume host resources longer by design, but remain bounded.

## Follow-ups

- everruns/everruns#2719: scope local schedule claims to active sessions or add retry backoff. Smoke testing showed inactive-session schedules currently produce claim/release warning churn; suppressing it in yolop would risk losing one-shot schedules.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0 presentation wording intentionally changed)
