### PR TITLE
fix(acp): reconstruct tool calls on session replay

### DIFF
--- a/src/acp/bridge.rs
+++ b/src/acp/bridge.rs
@@ -36,11 +36,15 @@ pub struct Translator {
     /// event across the live broadcast and the catch-up drain; dedup keeps
     /// the client from seeing doubles.
     seen: HashSet<String>,
+    /// Tool calls already introduced to the client. Persisted history keeps
+    /// completed assistant messages and tool completions, but not the
+    /// transient `tool.started` events used by the live bridge.
+    started_tool_calls: HashSet<String>,
     /// Replay mode is used only for `session/load`, where ACP requires the
     /// agent to stream the historical user turns back to the client. Live
     /// `session/prompt` handling leaves this off because the client already
     /// has the prompt it just sent.
-    replay_input_messages: bool,
+    replay_history: bool,
 }
 
 impl Translator {
@@ -50,7 +54,7 @@ impl Translator {
 
     pub fn for_replay() -> Self {
         Self {
-            replay_input_messages: true,
+            replay_history: true,
             ..Self::default()
         }
     }
@@ -63,7 +67,7 @@ impl Translator {
         }
         match &event.data {
             EventData::InputMessage(data) => {
-                if !self.replay_input_messages {
+                if !self.replay_history {
                     return Vec::new();
                 }
                 if data.message.role != MessageRole::User {
@@ -93,8 +97,34 @@ impl Translator {
                 if self.current_message_streamed {
                     return Vec::new();
                 }
-                if data.message.role != MessageRole::Agent || data.message.has_tool_calls() {
+                if data.message.role != MessageRole::Agent {
                     return Vec::new();
+                }
+                if data.message.has_tool_calls() {
+                    if !self.replay_history {
+                        return Vec::new();
+                    }
+                    return data
+                        .message
+                        .content
+                        .iter()
+                        .filter_map(|part| match part {
+                            ContentPart::ToolCall(call) if call.name == WRITE_TODOS => {
+                                plan_from_value(&call.arguments)
+                                    .map(|entries| SessionUpdate::Plan(Plan::new(entries)))
+                            }
+                            ContentPart::ToolCall(call)
+                                if self.started_tool_calls.insert(call.id.clone()) =>
+                            {
+                                Some(SessionUpdate::ToolCall(
+                                    ToolCall::new(call.id.clone(), call.name.clone())
+                                        .status(ToolCallStatus::InProgress)
+                                        .raw_input(non_null(call.arguments.clone())),
+                                ))
+                            }
+                            _ => None,
+                        })
+                        .collect();
                 }
                 match data.message.text().map(str::trim) {
                     Some(text) if !text.is_empty() => {
@@ -127,6 +157,9 @@ impl Translator {
                         .map(|entries| vec![SessionUpdate::Plan(Plan::new(entries))])
                         .unwrap_or_default();
                 }
+                if !self.started_tool_calls.insert(data.tool_call.id.clone()) {
+                    return Vec::new();
+                }
                 let title = data
                     .narration
                     .as_deref()
@@ -158,10 +191,29 @@ impl Translator {
                 let content = tool_result_content(data)
                     .map(|block| vec![ToolCallContent::Content(protocol::Content::new(block))])
                     .unwrap_or_default();
-                vec![SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+                let title = data
+                    .narration
+                    .as_deref()
+                    .or(data.display_name.as_deref())
+                    .unwrap_or(&data.tool_name)
+                    .to_string();
+                let mut updates = Vec::new();
+                if self.replay_history && self.started_tool_calls.insert(data.tool_call_id.clone())
+                {
+                    updates.push(SessionUpdate::ToolCall(
+                        ToolCall::new(data.tool_call_id.clone(), title.clone())
+                            .status(ToolCallStatus::InProgress),
+                    ));
+                }
+                let mut fields = ToolCallUpdateFields::new().status(status).content(content);
+                if self.replay_history {
+                    fields = fields.title(title);
+                }
+                updates.push(SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
                     data.tool_call_id.clone(),
-                    ToolCallUpdateFields::new().status(status).content(content),
-                ))]
+                    fields,
+                )));
+                updates
             }
             _ => Vec::new(),
         }
@@ -486,6 +538,100 @@ mod tests {
                 "prior prompt"
             ))]
         );
+    }
+
+    #[test]
+    fn replay_mode_reconstructs_tool_calls_from_completed_agent_messages() {
+        let mut t = Translator::for_replay();
+        let message = Message::assistant_with_tools(
+            "",
+            vec![ToolCall {
+                id: "call_1".into(),
+                name: "bash".into(),
+                arguments: json!({ "command": "ls" }),
+            }],
+        );
+
+        let updates = t.on_event(&event(EventData::OutputMessageCompleted(
+            OutputMessageCompletedData {
+                message,
+                metadata: None,
+                usage: None,
+                error_code: None,
+                error_fields: None,
+                error_disclosure: None,
+            },
+        )));
+
+        assert_eq!(
+            updates,
+            vec![SessionUpdate::ToolCall(
+                protocol::ToolCall::new("call_1", "bash")
+                    .status(ToolCallStatus::InProgress)
+                    .raw_input(json!({ "command": "ls" })),
+            )]
+        );
+    }
+
+    #[test]
+    fn replay_mode_does_not_duplicate_a_reconstructed_tool_start() {
+        let mut t = Translator::for_replay();
+        let call = ToolCall {
+            id: "call_1".into(),
+            name: "bash".into(),
+            arguments: json!({ "command": "ls" }),
+        };
+        let completed = event(EventData::OutputMessageCompleted(
+            OutputMessageCompletedData {
+                message: Message::assistant_with_tools("", vec![call.clone()]),
+                metadata: None,
+                usage: None,
+                error_code: None,
+                error_fields: None,
+                error_disclosure: None,
+            },
+        ));
+        let started = event(EventData::ToolStarted(ToolStartedData {
+            tool_call: call,
+            tool_call_fingerprint: None,
+            display_name: Some("Bash".into()),
+            narration: Some("Listing files".into()),
+        }));
+
+        assert_eq!(t.on_event(&completed).len(), 1);
+        assert!(t.on_event(&started).is_empty());
+    }
+
+    #[test]
+    fn replay_mode_never_emits_an_orphaned_tool_completion() {
+        let mut t = Translator::for_replay();
+        let updates = t.on_event(&event(EventData::ToolCompleted(ToolCompletedData {
+            tool_call_id: "call_1".into(),
+            tool_name: "bash".into(),
+            tool_call_fingerprint: None,
+            tool_result_fingerprint: None,
+            display_name: Some("Bash".into()),
+            success: true,
+            status: "success".into(),
+            result: None,
+            error: None,
+            duration_ms: None,
+            capability_id: None,
+            capability_name: None,
+            narration: Some("Listed files".into()),
+        })));
+
+        assert_eq!(updates.len(), 2);
+        match (&updates[0], &updates[1]) {
+            (SessionUpdate::ToolCall(call), SessionUpdate::ToolCallUpdate(update)) => {
+                assert_eq!(call.tool_call_id.to_string(), "call_1");
+                assert_eq!(call.title, "Listed files");
+                assert_eq!(update.tool_call_id.to_string(), "call_1");
+                assert_eq!(update.fields.title.as_deref(), Some("Listed files"));
+                assert_eq!(update.fields.status, Some(ToolCallStatus::Completed));
+            }
+            other => panic!("expected tool call followed by completion, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -376,9 +376,17 @@ mod tests {
         let sessions = tempfile::tempdir().expect("sessions tempdir");
         let sessions_dir = sessions.path().to_path_buf();
         let cwd = tempfile::tempdir().expect("cwd tempdir").keep();
+        let first_config = LlmSimConfig::scripted(vec![
+            SimTurn::ToolCalls(vec![SimToolCall {
+                name: "bash".to_string(),
+                arguments: json!({ "command": "printf replayed-tool" }),
+                id: Some("call_replayed".to_string()),
+            }]),
+            SimTurn::Assistant("first answer".to_string()),
+        ]);
 
         let (mut first_w, mut first_reader, first_server) =
-            start_raw_server(fixed("first answer"), sessions_dir.clone());
+            start_raw_server(first_config, sessions_dir.clone());
         send_json(
             &mut first_w,
             json!({ "jsonrpc": "2.0", "id": 0, "method": "initialize", "params": { "protocolVersion": 1 } }),
@@ -459,6 +467,29 @@ mod tests {
                 .iter()
                 .any(|text| text.contains("first answer")),
             "expected replayed agent message, got: {replay_updates:?}"
+        );
+        let replayed_tool_updates = |kind: &str| {
+            replay_updates
+                .iter()
+                .filter_map(|message| message.get("params")?.get("update")?.as_object())
+                .filter(|update| update.get("sessionUpdate").and_then(Value::as_str) == Some(kind))
+                .collect::<Vec<_>>()
+        };
+        assert!(
+            replayed_tool_updates("tool_call").iter().any(|update| {
+                update.get("toolCallId").and_then(Value::as_str) == Some("call_replayed")
+                    && update["rawInput"]["command"] == "printf replayed-tool"
+            }),
+            "expected reconstructed tool call before completion: {replay_updates:?}"
+        );
+        assert!(
+            replayed_tool_updates("tool_call_update")
+                .iter()
+                .any(|update| {
+                    update.get("toolCallId").and_then(Value::as_str) == Some("call_replayed")
+                        && update["status"] == "completed"
+                }),
+            "expected replayed tool completion: {replay_updates:?}"
         );
 
         send_json(


### PR DESCRIPTION
## What changed

ACP session replay now reconstructs each persisted tool call before applying its completion update. Resumed Paseo/Zed sessions retain the tool title, arguments, status, and result instead of rendering orphaned `Call <id>` placeholders.

Replay also deduplicates reconstructed starts when a durable start exists and synthesizes a minimal start for legacy histories containing only a completion.

## Why

Yolop session logs durably store completed assistant messages and tool completions, but transient `tool.started` events are not persisted. `session/load` previously replayed the completion updates without introducing their tool-call IDs first.

## Before / After

Before, the affected session contained 134 `tool.completed` events and zero `tool.started` events. ACP replay began with updates such as a completion for `call_ZEEJvpZOdJYvX0G5CVEVpjn4`, leaving clients to render an ID-based placeholder.

After, replay of that same session emits:

```text
tool_call        call_ZEEJ...  repo_map  in_progress
tool_call_update call_ZEEJ...  Build repo map: /workspace  completed
```

The full ACP `session/new` → tool turn → server restart → `session/load` flow is covered by an automated regression test.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- Manual ACP replay of the affected persisted session completed successfully with paired starts/completions
- Local Doppler live smoke was unavailable because this environment has no Doppler project/token; GitHub Actions owns the credential-backed live smoke

## Risk

- Low
- Limited to ACP replay translation; live tool-call behavior is unchanged
- Replay retains one bounded set entry per historical tool-call ID to prevent duplicate starts

## Security

Reviewed TM-FS, TM-BASH, TM-LLM, TM-TOOL, and TM-DEP. No filesystem permissions, shell execution, prompt/API-key handling, capability registration, or dependencies changed. Persisted tool names and arguments were already sent live over ACP; replay now restores the same data. No new injection or data-exposure boundary is introduced.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
