### PR TITLE
chore(release): prepare v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,53 @@ mechanical `### What's Changed` list of merged PRs.
 Releases are cut via [`/release`](./.agents/skills/release/SKILL.md), which
 tags the version and publishes to crates.io and the Homebrew tap.
 
+## [0.7.0] - 2026-07-14
+
+### Highlights
+
+- **YEP capability servers (extensions phase 1).** A new extensions
+  mechanism lets capability servers plug into yolop, landing the first phase
+  of the YEP (Yolop Extension Proposal) design.
+- **Free web search tool.** A built-in web search tool is now available to
+  the agent, no external provider key required.
+- **Authenticated MCP server management.** First-class tooling to add and
+  manage authenticated MCP servers, with bearer auth supplied from the
+  environment and the groundwork for MCP OAuth.
+- **Richer session and client context.** Sessions expose list-friendly
+  metadata and the active client UI, and workspace paths now resolve to
+  their real locations.
+- **More reliable background execution.** Scheduled monitors run locally,
+  obsolete monitors are disarmed, and task status and timeout reporting are
+  clearer.
+
+### What's Changed
+
+* fix(background): disarm obsolete scheduled monitors ([#274](https://github.com/everruns/yolop/pull/274)) by @chaliy
+* feat(extensions): YEP capability servers (phase 1) ([#275](https://github.com/everruns/yolop/pull/275)) by @chaliy
+* test(evals): cover stale history grounding ([#268](https://github.com/everruns/yolop/pull/268)) by @chaliy
+* fix(codex): preserve structured stream errors ([#273](https://github.com/everruns/yolop/pull/273)) by @chaliy
+* fix(acp): reconstruct tool calls on session replay ([#272](https://github.com/everruns/yolop/pull/272)) by @chaliy
+* fix(background): clarify task status and timeout ([#271](https://github.com/everruns/yolop/pull/271)) by @chaliy
+* chore(specs): add extensions mechanism proposal (YEP) ([#270](https://github.com/everruns/yolop/pull/270)) by @chaliy
+* fix(ci): update Node 24 workflow actions ([#269](https://github.com/everruns/yolop/pull/269)) by @chaliy
+* fix(runtime): keep activate skill schema visible ([#267](https://github.com/everruns/yolop/pull/267)) by @chaliy
+* feat(session): add list-friendly metadata ([#266](https://github.com/everruns/yolop/pull/266)) by @chaliy
+* fix(mcp): supply bearer auth from environment ([#265](https://github.com/everruns/yolop/pull/265)) by @chaliy
+* feat(context): expose active client UI ([#264](https://github.com/everruns/yolop/pull/264)) by @chaliy
+* fix(background): execute local scheduled monitors ([#263](https://github.com/everruns/yolop/pull/263)) by @chaliy
+* feat(auth): prepare MCP OAuth foundation ([#262](https://github.com/everruns/yolop/pull/262)) by @chaliy
+* fix(codex): strip empty HTML-comment reasoning summary placeholders ([#261](https://github.com/everruns/yolop/pull/261)) by @chaliy
+* fix(agent): improve search efficiency ([#260](https://github.com/everruns/yolop/pull/260)) by @chaliy
+* fix(tui): mirror session system notices above composer ([#259](https://github.com/everruns/yolop/pull/259)) by @chaliy
+* fix(paths): expose real workspace paths ([#258](https://github.com/everruns/yolop/pull/258)) by @chaliy
+* chore(deps): bump everruns to 0.17.7 ([#257](https://github.com/everruns/yolop/pull/257)) by @chaliy
+* fix(acp): avoid duplicated command hints ([#256](https://github.com/everruns/yolop/pull/256)) by @chaliy
+* chore(runtime): update default provider models to latest catalog ([#255](https://github.com/everruns/yolop/pull/255)) by @chaliy
+* feat(tools): add free web search ([#253](https://github.com/everruns/yolop/pull/253)) by @chaliy
+* feat(mcp): add authenticated server management ([#254](https://github.com/everruns/yolop/pull/254)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/yolop/compare/v0.6.0...v0.7.0
+
 ## [0.6.0] - 2026-07-11
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6560,7 +6560,7 @@ dependencies = [
 
 [[package]]
 name = "yolop"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yolop"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 authors = ["Everruns <support@everruns.com>"]
 license = "MIT"


### PR DESCRIPTION
## What changed

Cuts the **v0.7.0** release: bumps `Cargo.toml` / `Cargo.lock` from `0.6.0` to
`0.7.0` and adds the `## [0.7.0]` section to `CHANGELOG.md`. Merging this on
`main` triggers `release.yml` to tag `v0.7.0` and publish to crates.io and the
`everruns/homebrew-tap` Homebrew tap.

23 commits since v0.6.0 (all by @chaliy), no breaking changes. Headline
user-visible changes:

- **YEP capability servers (extensions phase 1)** ([#275](https://github.com/everruns/yolop/pull/275), spec [#270](https://github.com/everruns/yolop/pull/270)) — a new extensions mechanism for plugging capability servers into yolop.
- **Free web search tool** ([#253](https://github.com/everruns/yolop/pull/253)) — built-in web search, no external provider key required.
- **Authenticated MCP server management** ([#254](https://github.com/everruns/yolop/pull/254)) with bearer auth from the environment ([#265](https://github.com/everruns/yolop/pull/265)) and the **MCP OAuth foundation** ([#262](https://github.com/everruns/yolop/pull/262)).
- **Richer session/client context** — list-friendly session metadata ([#266](https://github.com/everruns/yolop/pull/266)), active client UI ([#264](https://github.com/everruns/yolop/pull/264)), real workspace paths ([#258](https://github.com/everruns/yolop/pull/258)).
- **More reliable background execution** — local scheduled monitors ([#263](https://github.com/everruns/yolop/pull/263)), disarm obsolete monitors ([#274](https://github.com/everruns/yolop/pull/274)), clearer task status/timeout ([#271](https://github.com/everruns/yolop/pull/271)).

## Why

Release the accumulated feature and fix work landed since v0.6.0 to crates.io
and Homebrew users.

## Before / After

**Before:** `Cargo.toml` version `0.6.0`; crates.io serves `0.6.0`; latest tag `v0.6.0`.

**After (once merged + published):** `0.7.0` on crates.io and the Homebrew tap.

```
$ grep '^version' Cargo.toml
version = "0.7.0"
$ curl -sSL https://index.crates.io/yo/lo/yolop | tail -1 | jq -r .vers
0.6.0            # current published — publishing 0.7.0

$ cargo publish --dry-run --allow-dirty -p yolop
    Finished `dev` profile ... target(s)
   Uploading yolop v0.7.0
warning: aborting upload due to dry run          # dry-run OK
```

## Risk

- **Low** — version bump + changelog only, no source changes. `cargo publish
  --dry-run` succeeds, so the packaging boundary is proven.
- What can break: publish-time registry/network transients; Homebrew tap
  propagation lag (minutes, not a failure). Rolls forward via a hotfix if a
  workflow fails.

## Checklist

- [x] Tests added or updated (release chore — no source change; full suite passes)
- [x] Backward compatibility considered (no breaking changes; pre-1.0)

---

## [0.7.0] - 2026-07-14

### Highlights

- **YEP capability servers (extensions phase 1).** A new extensions mechanism lets capability servers plug into yolop, landing the first phase of the YEP (Yolop Extension Proposal) design.
- **Free web search tool.** A built-in web search tool is now available to the agent, no external provider key required.
- **Authenticated MCP server management.** First-class tooling to add and manage authenticated MCP servers, with bearer auth supplied from the environment and the groundwork for MCP OAuth.
- **Richer session and client context.** Sessions expose list-friendly metadata and the active client UI, and workspace paths now resolve to their real locations.
- **More reliable background execution.** Scheduled monitors run locally, obsolete monitors are disarmed, and task status and timeout reporting are clearer.

### What's Changed

* fix(background): disarm obsolete scheduled monitors ([#274](https://github.com/everruns/yolop/pull/274)) by @chaliy
* feat(extensions): YEP capability servers (phase 1) ([#275](https://github.com/everruns/yolop/pull/275)) by @chaliy
* test(evals): cover stale history grounding ([#268](https://github.com/everruns/yolop/pull/268)) by @chaliy
* fix(codex): preserve structured stream errors ([#273](https://github.com/everruns/yolop/pull/273)) by @chaliy
* fix(acp): reconstruct tool calls on session replay ([#272](https://github.com/everruns/yolop/pull/272)) by @chaliy
* fix(background): clarify task status and timeout ([#271](https://github.com/everruns/yolop/pull/271)) by @chaliy
* chore(specs): add extensions mechanism proposal (YEP) ([#270](https://github.com/everruns/yolop/pull/270)) by @chaliy
* fix(ci): update Node 24 workflow actions ([#269](https://github.com/everruns/yolop/pull/269)) by @chaliy
* fix(runtime): keep activate skill schema visible ([#267](https://github.com/everruns/yolop/pull/267)) by @chaliy
* feat(session): add list-friendly metadata ([#266](https://github.com/everruns/yolop/pull/266)) by @chaliy
* fix(mcp): supply bearer auth from environment ([#265](https://github.com/everruns/yolop/pull/265)) by @chaliy
* feat(context): expose active client UI ([#264](https://github.com/everruns/yolop/pull/264)) by @chaliy
* fix(background): execute local scheduled monitors ([#263](https://github.com/everruns/yolop/pull/263)) by @chaliy
* feat(auth): prepare MCP OAuth foundation ([#262](https://github.com/everruns/yolop/pull/262)) by @chaliy
* fix(codex): strip empty HTML-comment reasoning summary placeholders ([#261](https://github.com/everruns/yolop/pull/261)) by @chaliy
* fix(agent): improve search efficiency ([#260](https://github.com/everruns/yolop/pull/260)) by @chaliy
* fix(tui): mirror session system notices above composer ([#259](https://github.com/everruns/yolop/pull/259)) by @chaliy
* fix(paths): expose real workspace paths ([#258](https://github.com/everruns/yolop/pull/258)) by @chaliy
* chore(deps): bump everruns to 0.17.7 ([#257](https://github.com/everruns/yolop/pull/257)) by @chaliy
* fix(acp): avoid duplicated command hints ([#256](https://github.com/everruns/yolop/pull/256)) by @chaliy
* chore(runtime): update default provider models to latest catalog ([#255](https://github.com/everruns/yolop/pull/255)) by @chaliy
* feat(tools): add free web search ([#253](https://github.com/everruns/yolop/pull/253)) by @chaliy
* feat(mcp): add authenticated server management ([#254](https://github.com/everruns/yolop/pull/254)) by @chaliy

**Full Changelog**: https://github.com/everruns/yolop/compare/v0.6.0...v0.7.0

---

## Publish-readiness

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` (34 + integration tests pass)
- [x] `cargo publish --dry-run -p yolop`
- [x] crates.io currently serves `0.6.0` → publishing `0.7.0`
- [x] `Cargo.toml` + `Cargo.lock` agree on `0.7.0`

## Post-merge verification

- [ ] `release.yml` created tag `v0.7.0` and the GitHub Release
- [ ] `publish.yml` finished green
- [ ] `cli-binaries.yml` finished green
- [ ] crates.io serves `0.7.0`
- [ ] Homebrew tap formula points at `v0.7.0`