### PR TITLE
feat(extensions): install/enable management surface (phase 2)

### DIFF
--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -1,16 +1,24 @@
 # Extensions — capability servers over the yolop extension protocol
 
-Status: **phase 1 implemented** in `src/extensions/` (protocol core,
-transport-generic client, persistent process manager, package discovery,
-`ExtensionCapability` adapter, `[[capabilities]]` enablement, manifest
-clamp, never-defer wiring). Later phases — install verbs and lockfile,
-contributed MCP servers, hooks, dynamic prompt, `ui/ask`, schema-gen +
-SDKs, `/extensions doctor`, providers — remain design-of-record below.
-Phase-1 deltas from the original sketch: tool *definitions* (description,
-schema, policy) live in the manifest, and the handshake's `tools` list
-carries only the served names it narrows to — keeping every contribution
-inspectable without executing the binary; `tool/update` progress surfaces
-through the tracing layer until the TUI grows a live seam.
+Status: **phases 1–2 implemented** in `src/extensions/`.
+Phase 1: protocol core, transport-generic client, persistent process
+manager, package discovery, `ExtensionCapability` adapter,
+`[[capabilities]]` enablement, manifest clamp, never-defer wiring.
+Phase 2: the always-on `extensions` capability with
+`install`/`list`/`enable`/`disable`/`remove` tools, `extensions.lock`
+content-hash pinning, install from git URL and local path, and the
+`ext:<name>` enable/disable write path.
+Later phases — contributed MCP servers, hooks, dynamic prompt, `ui/ask`,
+schema-gen + SDKs, `/extensions doctor`, providers — remain
+design-of-record below. Not yet wired within phase 2 (tracked as
+follow-ups): the toolchain-free crates.io source (native sparse-index +
+tarball fetch), full JSON-Schema config validation, and `config/changed`
+restart. Phase-1 deltas from the original sketch: tool *definitions*
+(description, schema, policy) live in the manifest, and the handshake's
+`tools` list carries only the served names it narrows to — keeping every
+contribution inspectable without executing the binary; `tool/update`
+progress surfaces through the tracing layer until the TUI grows a live
+seam.
 
 ## Why
 

--- a/src/capability_settings.rs
+++ b/src/capability_settings.rs
@@ -76,6 +76,16 @@ pub struct CapabilityOverride {
 }
 
 impl CapabilityOverride {
+    /// A plain enabling override (`[[capabilities]] ref = "<id>"`), no config.
+    pub fn enable(capability_ref: impl Into<String>) -> Self {
+        Self {
+            capability_ref: capability_ref.into(),
+            enabled: None,
+            append: false,
+            config: Value::Null,
+        }
+    }
+
     pub fn remove(capability_ref: impl Into<String>) -> Self {
         Self {
             capability_ref: capability_ref.into(),

--- a/src/extensions/manage.rs
+++ b/src/extensions/manage.rs
@@ -1,0 +1,365 @@
+//! The `extensions` capability: the management surface for installing,
+//! listing, enabling, and removing extension packages. Distinct from the
+//! per-package `ext:<name>` capabilities — this one is always on the default
+//! harness (like `connectors`) and owns the verbs. Tools so both the user
+//! and the model can drive setup; a thin `/extensions` command mirrors them.
+
+use super::package::{discover_extensions, extension_capability_id};
+use super::store::{self, GitRunner, Source, SystemGit};
+use crate::settings::SettingsStore;
+use async_trait::async_trait;
+use everruns_core::capabilities::Capability;
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use serde_json::{Value, json};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+pub const EXTENSIONS_CAPABILITY_ID: &str = "extensions";
+
+pub struct ExtensionsCapability {
+    extensions_dir: PathBuf,
+    settings: Arc<SettingsStore>,
+    git: Arc<dyn GitRunner>,
+}
+
+impl ExtensionsCapability {
+    pub fn new(extensions_dir: PathBuf, settings: Arc<SettingsStore>) -> Self {
+        Self {
+            extensions_dir,
+            settings,
+            git: Arc::new(SystemGit),
+        }
+    }
+}
+
+#[async_trait]
+impl Capability for ExtensionsCapability {
+    fn id(&self) -> &str {
+        EXTENSIONS_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Extensions"
+    }
+
+    fn description(&self) -> &str {
+        "Install, list, enable, and remove yolop extensions — capability-level \
+         packages served over the extension protocol."
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Extensions")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(
+            "Extensions are installable capability packages. Use `list_extensions` to see what is \
+             installed and enabled, `install_extension` for a git URL or local path, \
+             `enable_extension`/`disable_extension` to toggle one in the harness (takes effect \
+             next session), and `remove_extension` to uninstall. Installing runs third-party \
+             code on the user's machine — confirm the source with the user first.",
+        )
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        let ctx = Arc::new(ManageCtx {
+            extensions_dir: self.extensions_dir.clone(),
+            settings: self.settings.clone(),
+            git: self.git.clone(),
+        });
+        vec![
+            Box::new(ManageTool::new(ctx.clone(), Verb::List)),
+            Box::new(ManageTool::new(ctx.clone(), Verb::Install)),
+            Box::new(ManageTool::new(ctx.clone(), Verb::Remove)),
+            Box::new(ManageTool::new(ctx.clone(), Verb::Enable)),
+            Box::new(ManageTool::new(ctx, Verb::Disable)),
+        ]
+    }
+}
+
+struct ManageCtx {
+    extensions_dir: PathBuf,
+    settings: Arc<SettingsStore>,
+    git: Arc<dyn GitRunner>,
+}
+
+#[derive(Clone, Copy)]
+enum Verb {
+    List,
+    Install,
+    Remove,
+    Enable,
+    Disable,
+}
+
+struct ManageTool {
+    ctx: Arc<ManageCtx>,
+    verb: Verb,
+}
+
+impl ManageTool {
+    fn new(ctx: Arc<ManageCtx>, verb: Verb) -> Self {
+        Self { ctx, verb }
+    }
+
+    fn list(&self) -> ToolExecutionResult {
+        let installed = discover_extensions(&self.ctx.extensions_dir);
+        let settings = self.ctx.settings.snapshot();
+        let items: Vec<Value> = installed
+            .iter()
+            .map(|pkg| {
+                let cap_id = extension_capability_id(&pkg.manifest.name);
+                let enabled = settings
+                    .capability_overrides_for(&cap_id)
+                    .iter()
+                    .any(|(_, entry)| !entry.is_remove());
+                json!({
+                    "name": pkg.manifest.name,
+                    "description": pkg.manifest.description,
+                    "version": pkg.manifest.version,
+                    "enabled": enabled,
+                    "capability_ref": cap_id,
+                    "tools": pkg.manifest.tools.iter().map(|t| &t.name).collect::<Vec<_>>(),
+                })
+            })
+            .collect();
+        ToolExecutionResult::Success(json!({ "extensions": items }))
+    }
+
+    fn install(&self, args: &Value) -> ToolExecutionResult {
+        let Some(spec) = args.get("source").and_then(Value::as_str) else {
+            return ToolExecutionResult::ToolError("`source` is required".into());
+        };
+        let source = match Source::parse(spec) {
+            Ok(source) => source,
+            Err(err) => return ToolExecutionResult::ToolError(err.to_string()),
+        };
+        match store::install(&self.ctx.extensions_dir, &source, self.ctx.git.as_ref()) {
+            Ok(installed) => {
+                let m = &installed.manifest;
+                ToolExecutionResult::Success(json!({
+                    "installed": m.name,
+                    "version": m.version,
+                    // The contribution summary the user consents to (D4).
+                    "contributes": {
+                        "server_command": m.capability_server.command,
+                        "tools": m.tools.iter().map(|t| &t.name).collect::<Vec<_>>(),
+                        "prompt": m.prompt,
+                    },
+                    "content_hash": installed.content_hash,
+                    "grant_changed": installed.previous_hash.is_some(),
+                    "note": format!(
+                        "Installed but not enabled. Run enable_extension name={} to add it to the harness.",
+                        m.name
+                    ),
+                }))
+            }
+            Err(err) => ToolExecutionResult::ToolError(format!("install failed: {err}")),
+        }
+    }
+
+    fn remove(&self, args: &Value) -> ToolExecutionResult {
+        let Some(name) = args.get("name").and_then(Value::as_str) else {
+            return ToolExecutionResult::ToolError("`name` is required".into());
+        };
+        // Also drop the enabling override so a reinstall starts clean.
+        let _ = self
+            .ctx
+            .settings
+            .set_capability_enabled(&extension_capability_id(name), false);
+        match store::remove(&self.ctx.extensions_dir, name) {
+            Ok(true) => ToolExecutionResult::Success(json!({ "removed": name })),
+            Ok(false) => ToolExecutionResult::ToolError(format!("no extension named `{name}`")),
+            Err(err) => ToolExecutionResult::ToolError(format!("remove failed: {err}")),
+        }
+    }
+
+    fn toggle(&self, args: &Value, enable: bool) -> ToolExecutionResult {
+        let Some(name) = args.get("name").and_then(Value::as_str) else {
+            return ToolExecutionResult::ToolError("`name` is required".into());
+        };
+        if enable
+            && !discover_extensions(&self.ctx.extensions_dir)
+                .iter()
+                .any(|pkg| pkg.manifest.name == name)
+        {
+            return ToolExecutionResult::ToolError(format!(
+                "no extension named `{name}` is installed; install_extension first"
+            ));
+        }
+        let cap_id = extension_capability_id(name);
+        match self.ctx.settings.set_capability_enabled(&cap_id, enable) {
+            Ok(changed) => ToolExecutionResult::Success(json!({
+                "name": name,
+                "enabled": enable,
+                "changed": changed,
+                "note": "Takes effect on the next session.",
+            })),
+            Err(err) => ToolExecutionResult::ToolError(format!("config write failed: {err}")),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for ManageTool {
+    fn name(&self) -> &str {
+        match self.verb {
+            Verb::List => "list_extensions",
+            Verb::Install => "install_extension",
+            Verb::Remove => "remove_extension",
+            Verb::Enable => "enable_extension",
+            Verb::Disable => "disable_extension",
+        }
+    }
+
+    fn description(&self) -> &str {
+        match self.verb {
+            Verb::List => "List installed extensions and whether each is enabled.",
+            Verb::Install => {
+                "Install an extension from a git URL (`https://…[@rev]`) or a local path. \
+                 Runs third-party code; confirm the source with the user. Does not enable it."
+            }
+            Verb::Remove => "Uninstall an extension by name and drop its enable override.",
+            Verb::Enable => {
+                "Enable an installed extension (adds `ext:<name>` to the harness). Effective next session."
+            }
+            Verb::Disable => {
+                "Disable an extension without uninstalling it. Effective next session."
+            }
+        }
+    }
+
+    fn parameters_schema(&self) -> Value {
+        match self.verb {
+            Verb::List => json!({ "type": "object", "properties": {} }),
+            Verb::Install => json!({
+                "type": "object",
+                "properties": {
+                    "source": { "type": "string",
+                        "description": "Git URL (optionally `@rev`) or a local directory path." }
+                },
+                "required": ["source"]
+            }),
+            _ => json!({
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string", "description": "Extension name." }
+                },
+                "required": ["name"]
+            }),
+        }
+    }
+
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        match self.verb {
+            Verb::List => self.list(),
+            Verb::Install => self.install(&arguments),
+            Verb::Remove => self.remove(&arguments),
+            Verb::Enable => self.toggle(&arguments, true),
+            Verb::Disable => self.toggle(&arguments, false),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extensions::package::MANIFEST_FILE;
+    use std::path::Path;
+
+    fn seed_package(dir: &Path, name: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(
+            dir.join(MANIFEST_FILE),
+            json!({
+                "name": name, "description": "T.",
+                "yolop": { "protocol_version": "1.0",
+                    "capabilityServer": { "command": "x" }, "tools": [{"name": "t"}] }
+            })
+            .to_string(),
+        )
+        .unwrap();
+    }
+
+    fn capability(tmp: &Path) -> (ExtensionsCapability, Arc<SettingsStore>, PathBuf) {
+        let ext_dir = tmp.join("extensions");
+        let settings = Arc::new(SettingsStore::open(tmp.join("settings.toml")));
+        let cap = ExtensionsCapability {
+            extensions_dir: ext_dir.clone(),
+            settings: settings.clone(),
+            git: Arc::new(crate::extensions::store::SystemGit),
+        };
+        (cap, settings, ext_dir)
+    }
+
+    #[tokio::test]
+    async fn install_list_enable_disable_remove_flow() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        seed_package(&src, "echo");
+        let (cap, settings, _ext_dir) = capability(tmp.path());
+        let tools = cap.tools();
+        let get = |name: &str| tools.iter().find(|t| t.name() == name).unwrap();
+
+        // install
+        let r = get("install_extension")
+            .execute(json!({ "source": src.to_str().unwrap() }))
+            .await;
+        assert!(matches!(r, ToolExecutionResult::Success(_)));
+
+        // list shows it, disabled
+        match get("list_extensions").execute(json!({})).await {
+            ToolExecutionResult::Success(v) => {
+                assert_eq!(v["extensions"][0]["name"], "echo");
+                assert_eq!(v["extensions"][0]["enabled"], false);
+            }
+            other => panic!("{other:?}"),
+        }
+
+        // enable writes the override
+        get("enable_extension")
+            .execute(json!({"name": "echo"}))
+            .await;
+        assert!(
+            settings
+                .snapshot()
+                .capability_overrides_for("ext:echo")
+                .iter()
+                .any(|(_, e)| !e.is_remove())
+        );
+        // list now enabled
+        match get("list_extensions").execute(json!({})).await {
+            ToolExecutionResult::Success(v) => assert_eq!(v["extensions"][0]["enabled"], true),
+            other => panic!("{other:?}"),
+        }
+
+        // disable drops it
+        get("disable_extension")
+            .execute(json!({"name": "echo"}))
+            .await;
+        assert!(
+            settings
+                .snapshot()
+                .capability_overrides_for("ext:echo")
+                .is_empty()
+        );
+
+        // enable on a missing extension errors
+        match get("enable_extension")
+            .execute(json!({"name": "ghost"}))
+            .await
+        {
+            ToolExecutionResult::ToolError(m) => assert!(m.contains("no extension")),
+            other => panic!("{other:?}"),
+        }
+
+        // remove
+        match get("remove_extension")
+            .execute(json!({"name": "echo"}))
+            .await
+        {
+            ToolExecutionResult::Success(v) => assert_eq!(v["removed"], "echo"),
+            other => panic!("{other:?}"),
+        }
+    }
+}

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -12,11 +12,14 @@
 
 pub(crate) mod capability;
 pub(crate) mod client;
+pub(crate) mod manage;
 pub(crate) mod manager;
 pub(crate) mod package;
 pub(crate) mod protocol;
+pub(crate) mod store;
 
 pub(crate) use capability::ExtensionCapability;
+pub(crate) use manage::ExtensionsCapability;
 pub(crate) use package::{discover_extensions, extensions_dir};
 
 #[cfg(test)]

--- a/src/extensions/store.rs
+++ b/src/extensions/store.rs
@@ -1,0 +1,482 @@
+//! Extension installation: sources, the `extensions.lock` pin file, and
+//! install/remove into the global extensions directory. See
+//! `specs/extensions.md`, "Packaging, install, trust".
+//!
+//! Trust: installing is consent by action (the user ran the install verb),
+//! mirroring how authoring `.mcp.json` consents to its stdio servers. The
+//! lockfile records what was approved (source, resolved commit, content
+//! hash) so `update` can show a contribution diff and re-ask on a widened
+//! grant. There is one scope — global — because repos never carry yolop
+//! extensions.
+
+use super::package::{ExtensionManifest, MANIFEST_FILE, parse_manifest};
+use anyhow::{Context, Result, anyhow, bail};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+pub const LOCKFILE: &str = "extensions.lock";
+
+/// Where an installed extension came from, as the user spelled it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+pub enum Source {
+    /// A git repository, pinned to the resolved commit.
+    Git { url: String, rev: String },
+    /// A local directory, referenced by absolute path (dev loop).
+    Path { path: String },
+    /// A crates.io crate (`yolop-extension-<name>`), pinned to a version.
+    Crate { crate_name: String, version: String },
+}
+
+impl Source {
+    /// Parse a user-supplied `<source>` argument.
+    ///
+    /// - `crates.io:<crate>[@ver]` or a bare `<name>` → crate
+    ///   (`<name>` expands to `yolop-extension-<name>`)
+    /// - `<git-url>[@rev]` (contains `://` or `git@`) → git
+    /// - anything else that exists on disk → path
+    pub fn parse(spec: &str) -> Result<Self> {
+        let spec = spec.trim();
+        if let Some(rest) = spec.strip_prefix("crates.io:") {
+            let (crate_name, version) = split_at_version(rest);
+            return Ok(Source::Crate {
+                crate_name: crate_name.to_string(),
+                version: version.unwrap_or_default().to_string(),
+            });
+        }
+        if spec.contains("://") || spec.starts_with("git@") {
+            let (url, rev) = split_at_version(spec);
+            return Ok(Source::Git {
+                url: url.to_string(),
+                rev: rev.unwrap_or_default().to_string(),
+            });
+        }
+        let path = Path::new(spec);
+        if path.exists() {
+            let absolute = std::fs::canonicalize(path)
+                .with_context(|| format!("resolving extension path {spec}"))?;
+            return Ok(Source::Path {
+                path: absolute.display().to_string(),
+            });
+        }
+        // Bare name shorthand: `lsp` → crate `yolop-extension-lsp`.
+        if spec
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        {
+            let (name, version) = split_at_version(spec);
+            return Ok(Source::Crate {
+                crate_name: format!("yolop-extension-{name}"),
+                version: version.unwrap_or_default().to_string(),
+            });
+        }
+        bail!("cannot interpret `{spec}` as a git URL, crate, or existing path")
+    }
+}
+
+fn split_at_version(spec: &str) -> (&str, Option<&str>) {
+    // Split on the LAST `@` so `git@host:org/repo@rev` keeps the scp-form
+    // user intact and only the trailing ref is taken.
+    match spec.rsplit_once('@') {
+        // `git@host:...` with no ref has its only `@` right after `git`.
+        Some((left, right)) if !right.contains('/') && !right.contains(':') => (left, Some(right)),
+        _ => (spec, None),
+    }
+}
+
+/// One `extensions.lock` entry: what was installed and the hash approved.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LockEntry {
+    pub name: String,
+    pub source: Source,
+    /// Content hash of the installed package tree at approval time.
+    pub content_hash: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Lockfile {
+    #[serde(default)]
+    pub extensions: Vec<LockEntry>,
+}
+
+impl Lockfile {
+    pub fn load(dir: &Path) -> Self {
+        let path = dir.join(LOCKFILE);
+        std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|raw| toml::from_str(&raw).ok())
+            .unwrap_or_default()
+    }
+
+    pub fn save(&self, dir: &Path) -> Result<()> {
+        std::fs::create_dir_all(dir)?;
+        let toml = toml::to_string_pretty(self).context("serializing extensions.lock")?;
+        std::fs::write(dir.join(LOCKFILE), toml).context("writing extensions.lock")?;
+        Ok(())
+    }
+
+    pub fn get(&self, name: &str) -> Option<&LockEntry> {
+        self.extensions.iter().find(|e| e.name == name)
+    }
+
+    fn upsert(&mut self, entry: LockEntry) {
+        match self.extensions.iter_mut().find(|e| e.name == entry.name) {
+            Some(existing) => *existing = entry,
+            None => self.extensions.push(entry),
+        }
+        self.extensions.sort_by(|a, b| a.name.cmp(&b.name));
+    }
+
+    fn remove(&mut self, name: &str) -> bool {
+        let before = self.extensions.len();
+        self.extensions.retain(|e| e.name != name);
+        self.extensions.len() != before
+    }
+}
+
+/// A stable content hash of a package tree: every file's relative path and
+/// bytes, order-independent. Used to pin what was approved and to detect a
+/// widened grant on update.
+pub fn hash_package_dir(dir: &Path) -> Result<String> {
+    use sha2::{Digest, Sha256};
+    let mut files: Vec<(String, Vec<u8>)> = Vec::new();
+    collect_files(dir, dir, &mut files)?;
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut hasher = Sha256::new();
+    for (rel, bytes) in files {
+        hasher.update(rel.as_bytes());
+        hasher.update([0u8]);
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update(&bytes);
+    }
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(7 + digest.len() * 2);
+    hex.push_str("sha256:");
+    for byte in digest {
+        use std::fmt::Write;
+        let _ = write!(hex, "{byte:02x}");
+    }
+    Ok(hex)
+}
+
+fn collect_files(root: &Path, dir: &Path, out: &mut Vec<(String, Vec<u8>)>) -> Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            // Skip VCS metadata so a git-cloned tree hashes to the same value
+            // a tarball would.
+            if entry.file_name() == ".git" {
+                continue;
+            }
+            collect_files(root, &path, out)?;
+        } else if file_type.is_file() {
+            let rel = path
+                .strip_prefix(root)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .replace('\\', "/");
+            out.push((rel, std::fs::read(&path)?));
+        }
+    }
+    Ok(())
+}
+
+/// Result of an install/update, for the caller to summarize to the user.
+#[derive(Debug, Clone)]
+pub struct Installed {
+    pub manifest: ExtensionManifest,
+    pub content_hash: String,
+    /// Present on an update: the previously approved hash, if the grant changed.
+    pub previous_hash: Option<String>,
+}
+
+/// Install (or update) an extension into `extensions_dir` from `source`.
+///
+/// Git and path sources are handled natively; crates.io is deferred (returns
+/// a clear error pointing at the follow-up) so this lands testable offline.
+/// The package is staged, its manifest parsed (approval boundary — no binary
+/// is executed), then swapped into place and pinned in the lockfile.
+pub fn install(extensions_dir: &Path, source: &Source, git: &dyn GitRunner) -> Result<Installed> {
+    std::fs::create_dir_all(extensions_dir)?;
+    let staging = extensions_dir.join(".staging");
+    let _ = std::fs::remove_dir_all(&staging);
+    std::fs::create_dir_all(&staging).context("creating staging dir")?;
+    let cleanup = StagingGuard(staging.clone());
+
+    let resolved_source = match source {
+        Source::Path { path } => {
+            copy_dir(Path::new(path), &staging)
+                .with_context(|| format!("copying extension from {path}"))?;
+            source.clone()
+        }
+        Source::Git { url, rev } => {
+            let resolved_rev = git.clone_into(url, rev.as_str_opt(), &staging)?;
+            Source::Git {
+                url: url.clone(),
+                rev: resolved_rev,
+            }
+        }
+        Source::Crate { .. } => {
+            bail!(
+                "crates.io installs are not yet wired (native sparse-index + tarball fetch is a \
+                 follow-up); install from a git URL or local path for now"
+            );
+        }
+    };
+
+    let manifest_raw = std::fs::read_to_string(staging.join(MANIFEST_FILE))
+        .with_context(|| format!("extension package has no {MANIFEST_FILE} at its root"))?;
+    let manifest = parse_manifest(&manifest_raw).map_err(|e| anyhow!(e))?;
+
+    let content_hash = hash_package_dir(&staging)?;
+    let dest = extensions_dir.join(&manifest.name);
+    let previous_hash = Lockfile::load(extensions_dir)
+        .get(&manifest.name)
+        .map(|e| e.content_hash.clone())
+        .filter(|prev| prev != &content_hash);
+
+    // Swap staging into place atomically-ish: remove old, rename new.
+    let _ = std::fs::remove_dir_all(&dest);
+    std::fs::rename(&staging, &dest)
+        .with_context(|| format!("installing into {}", dest.display()))?;
+    std::mem::forget(cleanup); // renamed away; nothing to clean.
+
+    let mut lock = Lockfile::load(extensions_dir);
+    lock.upsert(LockEntry {
+        name: manifest.name.clone(),
+        source: resolved_source,
+        content_hash: content_hash.clone(),
+        version: manifest.version.clone(),
+    });
+    lock.save(extensions_dir)?;
+
+    Ok(Installed {
+        manifest,
+        content_hash,
+        previous_hash,
+    })
+}
+
+/// Remove an installed extension and its lockfile pin. Returns whether it
+/// existed.
+pub fn remove(extensions_dir: &Path, name: &str) -> Result<bool> {
+    let dir = extensions_dir.join(name);
+    let existed = dir.is_dir();
+    if existed {
+        std::fs::remove_dir_all(&dir).with_context(|| format!("removing {}", dir.display()))?;
+    }
+    let mut lock = Lockfile::load(extensions_dir);
+    let unpinned = lock.remove(name);
+    if unpinned {
+        lock.save(extensions_dir)?;
+    }
+    Ok(existed || unpinned)
+}
+
+struct StagingGuard(PathBuf);
+impl Drop for StagingGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn copy_dir(src: &Path, dst: &Path) -> Result<()> {
+    if !src.is_dir() {
+        bail!("{} is not a directory", src.display());
+    }
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            if entry.file_name() == ".git" {
+                continue;
+            }
+            std::fs::create_dir_all(&to)?;
+            copy_dir(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
+}
+
+/// Seam for git operations, so install logic is testable without a network.
+pub trait GitRunner: Send + Sync {
+    /// Clone `url` (optionally at `rev`) into `dest`, returning the resolved
+    /// commit sha.
+    fn clone_into(&self, url: &str, rev: Option<&str>, dest: &Path) -> Result<String>;
+}
+
+/// Real git via the `git` binary (shallow clone, pinned checkout).
+pub struct SystemGit;
+
+impl GitRunner for SystemGit {
+    fn clone_into(&self, url: &str, rev: Option<&str>, dest: &Path) -> Result<String> {
+        use std::process::Command;
+        let run = |args: &[&str], cwd: Option<&Path>| -> Result<String> {
+            let mut cmd = Command::new("git");
+            cmd.args(args);
+            if let Some(cwd) = cwd {
+                cmd.current_dir(cwd);
+            }
+            let out = cmd.output().context("running git")?;
+            if !out.status.success() {
+                bail!(
+                    "git {} failed: {}",
+                    args.join(" "),
+                    String::from_utf8_lossy(&out.stderr).trim()
+                );
+            }
+            Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+        };
+        run(
+            &["clone", "--depth", "1", url, &dest.display().to_string()],
+            None,
+        )?;
+        if let Some(rev) = rev {
+            // Fetch and checkout the pinned ref; depth-1 clones don't have it.
+            let _ = run(&["fetch", "--depth", "1", "origin", rev], Some(dest));
+            run(&["checkout", rev], Some(dest))?;
+        }
+        run(&["rev-parse", "HEAD"], Some(dest))
+    }
+}
+
+trait RevOpt {
+    fn as_str_opt(&self) -> Option<&str>;
+}
+impl RevOpt for String {
+    fn as_str_opt(&self) -> Option<&str> {
+        (!self.is_empty()).then_some(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn write_pkg(dir: &Path, name: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(
+            dir.join(MANIFEST_FILE),
+            json!({
+                "name": name,
+                "description": "Test.",
+                "version": "0.1.0",
+                "yolop": {
+                    "protocol_version": "1.0",
+                    "capabilityServer": { "command": "yolop-extension-x" },
+                    "tools": [{ "name": "t" }]
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn source_parsing() {
+        assert_eq!(
+            Source::parse("crates.io:yolop-extension-lsp@0.1.0").unwrap(),
+            Source::Crate {
+                crate_name: "yolop-extension-lsp".into(),
+                version: "0.1.0".into()
+            }
+        );
+        assert_eq!(
+            Source::parse("lsp").unwrap(),
+            Source::Crate {
+                crate_name: "yolop-extension-lsp".into(),
+                version: String::new()
+            }
+        );
+        assert_eq!(
+            Source::parse("https://github.com/acme/x@v1").unwrap(),
+            Source::Git {
+                url: "https://github.com/acme/x".into(),
+                rev: "v1".into()
+            }
+        );
+    }
+
+    #[test]
+    fn install_from_path_pins_and_hashes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src-pkg");
+        write_pkg(&src, "echo");
+        let ext_dir = tmp.path().join("extensions");
+
+        let source = Source::parse(src.to_str().unwrap()).unwrap();
+        let installed = install(&ext_dir, &source, &SystemGit).unwrap();
+        assert_eq!(installed.manifest.name, "echo");
+        assert!(installed.content_hash.starts_with("sha256:"));
+        assert!(installed.previous_hash.is_none());
+        assert!(ext_dir.join("echo").join(MANIFEST_FILE).is_file());
+
+        let lock = Lockfile::load(&ext_dir);
+        assert_eq!(
+            lock.get("echo").unwrap().content_hash,
+            installed.content_hash
+        );
+
+        // Reinstall unchanged: no grant change.
+        let again = install(&ext_dir, &source, &SystemGit).unwrap();
+        assert!(again.previous_hash.is_none());
+
+        // Change a file, reinstall: previous hash surfaces.
+        std::fs::write(src.join("extra.txt"), "new").unwrap();
+        let changed = install(&ext_dir, &source, &SystemGit).unwrap();
+        assert!(changed.previous_hash.is_some());
+    }
+
+    #[test]
+    fn remove_deletes_dir_and_pin() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("p");
+        write_pkg(&src, "echo");
+        let ext_dir = tmp.path().join("extensions");
+        install(
+            &ext_dir,
+            &Source::parse(src.to_str().unwrap()).unwrap(),
+            &SystemGit,
+        )
+        .unwrap();
+
+        assert!(remove(&ext_dir, "echo").unwrap());
+        assert!(!ext_dir.join("echo").exists());
+        assert!(Lockfile::load(&ext_dir).get("echo").is_none());
+        assert!(!remove(&ext_dir, "echo").unwrap());
+    }
+
+    struct FakeGit;
+    impl GitRunner for FakeGit {
+        fn clone_into(&self, _url: &str, _rev: Option<&str>, dest: &Path) -> Result<String> {
+            write_pkg(dest, "gitext");
+            Ok("abc123".into())
+        }
+    }
+
+    #[test]
+    fn install_from_git_records_resolved_rev() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ext_dir = tmp.path().join("extensions");
+        let source = Source::parse("https://example.com/acme/gitext").unwrap();
+        let installed = install(&ext_dir, &source, &FakeGit).unwrap();
+        assert_eq!(installed.manifest.name, "gitext");
+        match Lockfile::load(&ext_dir)
+            .get("gitext")
+            .unwrap()
+            .source
+            .clone()
+        {
+            Source::Git { rev, .. } => assert_eq!(rev, "abc123"),
+            other => panic!("expected git source, got {other:?}"),
+        }
+    }
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1763,6 +1763,7 @@ fn default_coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabi
         AgentCapabilityConfig::new(SETUP_CAPABILITY_ID),
         AgentCapabilityConfig::new(CONFIG_CAPABILITY_ID),
         AgentCapabilityConfig::new(CONNECTORS_CAPABILITY_ID),
+        AgentCapabilityConfig::new(crate::extensions::manage::EXTENSIONS_CAPABILITY_ID),
         AgentCapabilityConfig::new(MEMORY_CAPABILITY_ID),
         AgentCapabilityConfig::new(HOOKS_CAPABILITY_ID),
         AgentCapabilityConfig::new(YOLOP_CAPABILITY_ID),
@@ -2324,13 +2325,18 @@ pub async fn build_with_options(
     // `[[capabilities]] ref = "ext:<name>"` in settings.toml, exactly like
     // `lsp`. See specs/extensions.md.
     let mut extension_never_defer: Vec<String> = Vec::new();
-    if let Some(extensions_dir) = crate::extensions::extensions_dir() {
-        for package in crate::extensions::discover_extensions(&extensions_dir) {
+    if let Some(ext_dir) = crate::extensions::extensions_dir() {
+        for package in crate::extensions::discover_extensions(&ext_dir) {
             let capability =
                 crate::extensions::ExtensionCapability::new(package, effective_root.clone());
             extension_never_defer.extend(capability.never_defer_tools());
             capabilities.register(capability);
         }
+        // The always-on management surface (install/list/enable/remove).
+        capabilities.register(crate::extensions::ExtensionsCapability::new(
+            ext_dir,
+            settings.clone(),
+        ));
     }
     capabilities.register(InfinityContextCapability);
     capabilities.register(CompactionCapability);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -618,6 +618,45 @@ impl SettingsStore {
         guard.capabilities.clear();
         save_to(&self.path, &guard)
     }
+
+    /// Enable or disable a capability by `ref`, idempotently. Enabling
+    /// appends a plain `[[capabilities]] ref = "<id>"` unless one is already
+    /// present; disabling drops every override with that `ref` (both the
+    /// enabling entry and any config/remove entries). Returns whether the
+    /// stored set changed. This is the write side of `/extensions
+    /// enable|disable` — a targeted alternative to hand-editing the ordered
+    /// override list.
+    pub fn set_capability_enabled(&self, capability_ref: &str, enabled: bool) -> Result<bool> {
+        let mut guard = self.inner.lock().expect("settings lock poisoned");
+        let already: Vec<usize> = guard
+            .capabilities
+            .iter()
+            .enumerate()
+            .filter(|(_, entry)| entry.capability_ref == capability_ref)
+            .map(|(index, _)| index)
+            .collect();
+        let changed = if enabled {
+            if already.iter().any(|&i| !guard.capabilities[i].is_remove()) {
+                false
+            } else {
+                guard
+                    .capabilities
+                    .push(CapabilityOverride::enable(capability_ref));
+                true
+            }
+        } else if already.is_empty() {
+            false
+        } else {
+            guard
+                .capabilities
+                .retain(|entry| entry.capability_ref != capability_ref);
+            true
+        };
+        if changed {
+            save_to(&self.path, &guard)?;
+        }
+        Ok(changed)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What changed

Phase 2 of the extensions mechanism (`specs/extensions.md`): the packaging + trust surface. Extensions can now be installed, listed, enabled, and removed — the milestone where an extension is usable without hand-editing files.

- **`store.rs`** — install engine: `Source::parse` (git URL `@rev`, local path, `crates.io:<crate>`, and bare-name → `yolop-extension-<name>` shorthand), install from **git** (shallow clone, pinned checkout, resolved-commit record) and **local path** (copy, dev loop), `remove`, and `extensions.lock` — a TOML pin file recording source, resolved rev, and a stable **content hash** (order-independent SHA-256 over the package tree, `.git` excluded) so an update can detect a widened grant. The manifest is parsed from the staged tree **before** anything runs (the D4 approval boundary). Git is behind a `GitRunner` trait so install logic tests offline.
- **`manage.rs`** — the always-on `extensions` capability (on the default harness, like `connectors`) with five tools: `list_extensions`, `install_extension`, `remove_extension`, `enable_extension`, `disable_extension`. Install returns the contribution summary the user consents to (server command, tool names, prompt flag). Both the user and the model can drive setup; installing does not auto-enable.
- **`settings.rs` / `capability_settings.rs`** — `SettingsStore::set_capability_enabled` + `CapabilityOverride::enable`: idempotent enable/disable that writes/removes `[[capabilities]] ref = "ext:<name>"`.

Install → enable → the phase-1 runtime spawns the extension's server next session; the loop is closed.

## Why

Phase 1 landed the runtime spine but nothing user-facing. This makes extensions installable and toggleable through tools, on the global scope only (repos never carry extensions).

## Before / After

**Before:** an extension worked only if you manually placed it in the extensions dir and hand-edited `settings.toml`.

**After** (unit-tested end to end in `manage.rs`): `install_extension {source: <git-url|path>}` → `enable_extension {name}` writes the `ext:<name>` override → `list_extensions` reports it enabled → `remove_extension` uninstalls and unpins. `extensions.lock` pins the approved content hash; a changed reinstall surfaces `grant_changed: true`.

## Risk

- Low–Medium. New default-harness capability, but it only reads/writes the user's own extensions dir and settings. Installing clones/copies into that dir; it does not execute the extension binary (that stays gated behind explicit enable + next session). Git failures surface as tool errors. No change to existing capabilities.

## Security

Reviewed against the ship threat model:

- **TM-BASH (process execution).** The only subprocess spawned here is `git` (clone/fetch/checkout/rev-parse) with user-supplied URL/rev passed as argv (no shell), invoked only when the user runs `install_extension`. The extension's own server is **not** run by this phase — install stops at parsing the manifest from the staged tree, preserving the "inspect without executing" boundary.
- **TM-FS.** All writes are confined to the global extensions dir and the settings file; the staging dir is swapped in via rename and cleaned on failure by a drop guard. Path installs canonicalize the source. Content hashing excludes `.git`. The write blocklist is untouched.
- **TM-TOOL.** Enable/disable only ever writes `ext:<name>` refs; it cannot enable arbitrary capabilities. `crates.io` installs are explicitly refused for now (returns a clear error) rather than silently doing nothing.
- **Data exposure.** Errors are surfaced as `ToolError` (safe for the model); no tokens or paths beyond the extension dir are logged.
- **TM-DEP.** No new dependencies — `sha2` and `toml` were already in the tree.

## Checklist

- [x] Tests added or updated — source parsing, install-from-path (pin + hash + grant-change detection), install-from-git (resolved-rev record, via a fake `GitRunner`), remove, and the full install→list→enable→disable→remove tool flow including the "enable a missing extension errors" negative path. `cargo fmt --check` + `clippy -D warnings` clean; full suite green.
- [x] Backward compatibility considered — additive: new default-harness capability + new opt-in `ext:<name>` refs; no existing behavior changes.

## Follow-ups

- **Toolchain-free crates.io source** (native sparse-index resolve + checksummed `.crate` fetch + prebuilt-artifact/`cargo install` binary provisioning) — the biggest remaining phase-2 piece; currently returns a clear "not yet wired" error.
- Full JSON-Schema validation of extension config (currently structural); wire `config/changed` restart.
- `/extensions` slash command mirroring the tools (tools work today; the command is a thin host-side alias).
- Update-time contribution **diff** UX (the hash + `grant_changed` signal is recorded; the interactive re-ask prompt is not built).
- `schema/yep/v1/` generation + `/extensions doctor` (carried from phase 1).

---
_Generated by [Claude Code](https://claude.ai/code/session_017d7odSAD8o79pUrd31dpDb)_