### PR TITLE
feat(extensions): contributed MCP servers (phase 3)

### DIFF
--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -1,6 +1,6 @@
 # Extensions — capability servers over the yolop extension protocol
 
-Status: **phases 1–2 implemented** in `src/extensions/`.
+Status: **phases 1–3 implemented** in `src/extensions/`.
 Phase 1: protocol core, transport-generic client, persistent process
 manager, package discovery, `ExtensionCapability` adapter,
 `[[capabilities]]` enablement, manifest clamp, never-defer wiring.
@@ -8,7 +8,12 @@ Phase 2: the always-on `extensions` capability with
 `install`/`list`/`enable`/`disable`/`remove` tools, `extensions.lock`
 content-hash pinning, install from git URL and local path, and the
 `ext:<name>` enable/disable write path.
-Later phases — contributed MCP servers, hooks, dynamic prompt, `ui/ask`,
+Phase 3: contributed MCP servers — a `yolop.mcpServers` manifest facet
+(stdio/http), surfaced through `Capability::mcp_servers()` and merged into
+scoped MCP config for enabled extensions, name-prefixed `<ext>__<server>`
+and consumed by yolop's own MCP client (workspace `.mcp.json` still
+overrides by name).
+Later phases — hooks, dynamic prompt, `ui/ask`,
 schema-gen + SDKs, `/extensions doctor`, providers — remain
 design-of-record below. Not yet wired within phase 2 (tracked as
 follow-ups): the toolchain-free crates.io source (native sparse-index +

--- a/src/extensions/capability.rs
+++ b/src/extensions/capability.rs
@@ -74,6 +74,36 @@ impl ExtensionCapability {
             .map(|tool| tool.name.clone())
             .collect()
     }
+
+    /// Manifest-declared MCP servers this extension contributes (D1: an
+    /// extension *provides* MCP servers, which yolop consumes through its own
+    /// client). Keyed `<extension>__<server>` so two extensions can't collide
+    /// on a logical server name and `/mcp` shows provenance. Manifest-declared
+    /// means the approved transport shape is exactly what runs.
+    pub fn contributed_mcp_servers(&self) -> everruns_core::ScopedMcpServers {
+        use super::package::McpTransport;
+        use everruns_core::mcp_server::{McpServerTransportType, ScopedMcpServer};
+        let mut servers = everruns_core::ScopedMcpServers::new();
+        for (name, spec) in &self.package.manifest.mcp_servers {
+            let scoped = match spec.transport {
+                McpTransport::Stdio => ScopedMcpServer {
+                    transport_type: McpServerTransportType::Stdio,
+                    command: spec.command.clone(),
+                    args: spec.args.clone(),
+                    env: spec.env.clone(),
+                    ..Default::default()
+                },
+                McpTransport::Http => ScopedMcpServer {
+                    transport_type: McpServerTransportType::Http,
+                    url: spec.url.clone().unwrap_or_default(),
+                    headers: spec.headers.clone(),
+                    ..Default::default()
+                },
+            };
+            servers.insert(format!("{}__{name}", self.package.manifest.name), scoped);
+        }
+        servers
+    }
 }
 
 #[async_trait]
@@ -109,6 +139,10 @@ impl Capability for ExtensionCapability {
                 self.id
             ))
         }
+    }
+
+    fn mcp_servers(&self) -> everruns_core::ScopedMcpServers {
+        self.contributed_mcp_servers()
     }
 
     async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
@@ -187,5 +221,49 @@ impl Tool for ExtensionTool {
             // no secrets: surface them as tool errors, not internal ones.
             Err(err) => ToolExecutionResult::ToolError(err.to_string()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extensions::package::ExtensionPackage;
+    use crate::extensions::package::parse_manifest;
+    use everruns_core::mcp_server::McpServerTransportType;
+    use serde_json::json;
+
+    #[test]
+    fn contributed_mcp_servers_are_prefixed_and_shaped() {
+        let manifest = parse_manifest(
+            &json!({
+                "name": "docs", "description": "Docs.",
+                "yolop": {
+                    "protocol_version": "1.0",
+                    "capabilityServer": { "command": "x" },
+                    "mcpServers": {
+                        "search": { "type": "http", "url": "https://d/mcp",
+                                    "headers": { "A": "b" } },
+                        "local": { "command": "svc", "args": ["--stdio"] }
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .expect("parse");
+        let cap = ExtensionCapability::new(
+            ExtensionPackage {
+                dir: std::env::temp_dir(),
+                manifest,
+            },
+            std::env::temp_dir(),
+        );
+        let servers = cap.contributed_mcp_servers();
+        // Prefixed with the extension name for provenance + collision safety.
+        let http = servers.get("docs__search").expect("http server");
+        assert_eq!(http.transport_type, McpServerTransportType::Http);
+        assert_eq!(http.url, "https://d/mcp");
+        let stdio = servers.get("docs__local").expect("stdio server");
+        assert_eq!(stdio.transport_type, McpServerTransportType::Stdio);
+        assert_eq!(stdio.command.as_deref(), Some("svc"));
     }
 }

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -20,7 +20,7 @@ pub(crate) mod store;
 
 pub(crate) use capability::ExtensionCapability;
 pub(crate) use manage::ExtensionsCapability;
-pub(crate) use package::{discover_extensions, extensions_dir};
+pub(crate) use package::{discover_extensions, extension_capability_id, extensions_dir};
 
 #[cfg(test)]
 mod spawn_tests {

--- a/src/extensions/package.rs
+++ b/src/extensions/package.rs
@@ -12,6 +12,7 @@
 
 use serde::Deserialize;
 use serde_json::Value;
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 pub const MANIFEST_FILE: &str = "plugin.json";
@@ -41,6 +42,11 @@ struct RawFacet {
     /// Permits a handshake system-prompt contribution.
     #[serde(default)]
     prompt: bool,
+    /// MCP servers the extension contributes; consumed by yolop's own MCP
+    /// client exactly as if listed in `.mcp.json` (D1: MCP is a
+    /// contribution, not the base wire). Keyed by logical server name.
+    #[serde(rename = "mcpServers", default)]
+    mcp_servers: BTreeMap<String, ContributedMcpServer>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -48,6 +54,39 @@ pub struct ServerSpec {
     pub command: String,
     #[serde(default)]
     pub args: Vec<String>,
+}
+
+/// A manifest-declared MCP server contribution. Manifest-declared (not
+/// handshake-negotiated) so it is inspectable at install without executing
+/// the binary, and clamped by construction — the approved transport shape
+/// (stdio command vs http url) is exactly what runs. `${VAR}` expansion in
+/// string fields is handled downstream by the runtime, as for `.mcp.json`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ContributedMcpServer {
+    /// `stdio` (default) or `http`.
+    #[serde(rename = "type", default)]
+    pub transport: McpTransport,
+    // stdio
+    #[serde(default)]
+    pub command: Option<String>,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub env: std::collections::HashMap<String, String>,
+    // http
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub headers: std::collections::HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum McpTransport {
+    #[default]
+    Stdio,
+    Http,
 }
 
 /// A manifest-declared tool: the full definition the LLM sees, plus policy.
@@ -76,6 +115,7 @@ pub struct ExtensionManifest {
     pub config_schema: Option<Value>,
     pub tools: Vec<ToolDefinition>,
     pub prompt: bool,
+    pub mcp_servers: BTreeMap<String, ContributedMcpServer>,
 }
 
 #[derive(Debug, Clone)]
@@ -113,8 +153,25 @@ pub fn parse_manifest(raw: &str) -> Result<ExtensionManifest, String> {
     if raw.yolop.capability_server.command.trim().is_empty() {
         return Err("yolop.capabilityServer.command must not be empty".into());
     }
-    if raw.yolop.tools.is_empty() && !raw.yolop.prompt {
-        return Err("extension declares no tools and no prompt; nothing to contribute".into());
+    if raw.yolop.tools.is_empty() && !raw.yolop.prompt && raw.yolop.mcp_servers.is_empty() {
+        return Err(
+            "extension declares no tools, prompt, or MCP servers; nothing to contribute".into(),
+        );
+    }
+    for (server_name, server) in &raw.yolop.mcp_servers {
+        match server.transport {
+            McpTransport::Stdio if server.command.as_deref().unwrap_or("").trim().is_empty() => {
+                return Err(format!(
+                    "mcpServers.{server_name}: stdio transport requires a non-empty `command`"
+                ));
+            }
+            McpTransport::Http if server.url.as_deref().unwrap_or("").trim().is_empty() => {
+                return Err(format!(
+                    "mcpServers.{server_name}: http transport requires a non-empty `url`"
+                ));
+            }
+            _ => {}
+        }
     }
     Ok(ExtensionManifest {
         name,
@@ -124,6 +181,7 @@ pub fn parse_manifest(raw: &str) -> Result<ExtensionManifest, String> {
         config_schema: raw.yolop.config_schema,
         tools: raw.yolop.tools,
         prompt: raw.yolop.prompt,
+        mcp_servers: raw.yolop.mcp_servers,
     })
 }
 
@@ -241,6 +299,56 @@ mod tests {
             parse_manifest(&empty.to_string())
                 .unwrap_err()
                 .contains("nothing to contribute")
+        );
+    }
+
+    #[test]
+    fn parses_contributed_mcp_servers() {
+        let mut m = manifest_json();
+        m["yolop"]["mcpServers"] = json!({
+            "docs": { "type": "http", "url": "https://example.com/mcp",
+                      "headers": { "Authorization": "Bearer ${DOCS_TOKEN}" } },
+            "fs": { "command": "mcp-fs", "args": ["/w"], "env": { "RUST_LOG": "info" } }
+        });
+        let manifest = parse_manifest(&m.to_string()).expect("parse");
+        assert_eq!(manifest.mcp_servers.len(), 2);
+        assert_eq!(manifest.mcp_servers["fs"].transport, McpTransport::Stdio);
+        assert_eq!(manifest.mcp_servers["docs"].transport, McpTransport::Http);
+        assert_eq!(
+            manifest.mcp_servers["docs"].url.as_deref(),
+            Some("https://example.com/mcp")
+        );
+    }
+
+    #[test]
+    fn mcp_only_extension_is_valid_and_transports_are_checked() {
+        // No tools, no prompt, but an MCP server — a valid contribution.
+        let mcp_only = json!({
+            "name": "wrap", "description": "Wrap an MCP server.",
+            "yolop": {
+                "protocol_version": "1.0",
+                "capabilityServer": { "command": "x" },
+                "mcpServers": { "svc": { "command": "svc-bin" } }
+            }
+        });
+        assert!(parse_manifest(&mcp_only.to_string()).is_ok());
+
+        // stdio without a command is rejected.
+        let mut bad = mcp_only.clone();
+        bad["yolop"]["mcpServers"]["svc"] = json!({ "type": "stdio" });
+        assert!(
+            parse_manifest(&bad.to_string())
+                .unwrap_err()
+                .contains("requires a non-empty `command`")
+        );
+
+        // http without a url is rejected.
+        let mut bad_http = mcp_only;
+        bad_http["yolop"]["mcpServers"]["svc"] = json!({ "type": "http" });
+        assert!(
+            parse_manifest(&bad_http.to_string())
+                .unwrap_err()
+                .contains("requires a non-empty `url`")
         );
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2172,9 +2172,7 @@ pub async fn build_with_options(
     // MCP servers from global settings and workspace `.mcp.json`, merged. Loading is
     // best-effort per scope: a malformed file is warned about and skipped, so
     // it never sinks the session or masks the other scope.
-    let mcp_servers: ScopedMcpServers = crate::mcp_config::load_mcp_servers(&canonical_root);
-    let mut mcp_server_names: Vec<String> = mcp_servers.keys().cloned().collect();
-    mcp_server_names.sort();
+    let mut mcp_servers: ScopedMcpServers = crate::mcp_config::load_mcp_servers(&canonical_root);
     let hooks_store = Arc::new(crate::hooks_config::HooksStore::beside_settings(
         &settings,
         canonical_root.clone(),
@@ -2326,9 +2324,29 @@ pub async fn build_with_options(
     // `lsp`. See specs/extensions.md.
     let mut extension_never_defer: Vec<String> = Vec::new();
     if let Some(ext_dir) = crate::extensions::extensions_dir() {
+        let settings_snapshot = settings.snapshot();
         for package in crate::extensions::discover_extensions(&ext_dir) {
+            // An extension's contributed MCP servers (D1) apply only when the
+            // extension is enabled in the harness — merged into scoped MCP
+            // config so the runtime's own client discovers them, exactly like
+            // `.mcp.json`. Workspace `.mcp.json` still overrides by name.
+            let enabled = settings_snapshot
+                .capability_overrides_for(&crate::extensions::extension_capability_id(
+                    &package.manifest.name,
+                ))
+                .iter()
+                .any(|(_, entry)| !entry.is_remove());
             let capability =
                 crate::extensions::ExtensionCapability::new(package, effective_root.clone());
+            if enabled {
+                let contributed = capability.contributed_mcp_servers();
+                if !contributed.is_empty() {
+                    mcp_servers = everruns_core::mcp_server::merge_scoped_mcp_servers(
+                        &contributed,
+                        &mcp_servers,
+                    );
+                }
+            }
             extension_never_defer.extend(capability.never_defer_tools());
             capabilities.register(capability);
         }
@@ -2338,6 +2356,10 @@ pub async fn build_with_options(
             settings.clone(),
         ));
     }
+    // Server name list for `/mcp` and StartupInfo, computed after extension
+    // contributions are merged so provider-provenance entries show up too.
+    let mut mcp_server_names: Vec<String> = mcp_servers.keys().cloned().collect();
+    mcp_server_names.sort();
     capabilities.register(InfinityContextCapability);
     capabilities.register(CompactionCapability);
     capabilities.register(StatelessTodoListCapability);


### PR DESCRIPTION
## What changed

Phase 3 of the extensions mechanism (`specs/extensions.md`): an extension can now **provide MCP servers**, which yolop consumes through its own MCP client — the composition path from decision D1 ("MCP is a contribution, not the base wire").

- **`package.rs`** — a `yolop.mcpServers` manifest facet: a name→server map, each `stdio` (command/args/env) or `http` (url/headers), validated at parse (stdio needs a command, http needs a url). An MCP-only extension (no tools, no prompt) is now a valid contribution.
- **`capability.rs`** — `ExtensionCapability::contributed_mcp_servers()` maps the facet to `ScopedMcpServer`s and `Capability::mcp_servers()` returns them. Entries are name-prefixed `<extension>__<server>` so two extensions can't collide on a logical server name and `/mcp` shows provenance.
- **`runtime.rs`** — the in-process runtime doesn't auto-collect capability-contributed MCP servers, so enabled extensions' contributions are merged into the session's scoped MCP config where `.mcp.json` is loaded. Workspace `.mcp.json` still overrides by name (it's layered last).

Because these become ordinary scoped MCP servers, everything downstream — discovery, `mcp_<server>__<tool>` naming, `${VAR}` expansion, the trust model — is the existing MCP path, unchanged.

## Why

The spec's division of labor: native YEP tools are streaming/stateful/policy-rich; **contributed MCP servers** let an extension wrap or bundle the existing MCP ecosystem (manage a third-party server's config/lifecycle and hand yolop the endpoint) without reimplementing anything. Manifest-declared (not handshake-negotiated) keeps them inspectable at install and clamped by construction.

## Before / After

**Before:** an extension could only contribute native YEP tools + prompt.

**After** (unit-tested): a manifest with `mcpServers: { docs: {type:http, url}, fs: {command} }` yields scoped servers `<ext>__docs` / `<ext>__fs` when the extension is enabled; only enabled extensions contribute; disabled ones don't reach the MCP config.

## Risk

- Low. Contributions are gated on the extension being enabled (an explicit `ext:<name>` override) and flow through the existing, hardened MCP path — no new execution surface beyond what `.mcp.json` already does. Manifest-declared transports are validated at parse.

## Security

- **TM-TOOL / TM-BASH.** Contributed stdio servers are spawned by the *existing* MCP client (same lifecycle, timeouts, and trust as `.mcp.json` stdio servers), and only for an enabled extension the user installed. The transport shape is fixed by the approved manifest — an http entry can't become stdio or vice versa at runtime (D4 clamp by construction, since there's no handshake step here).
- **TM-LLM.** Secrets stay in env: `${VAR}` expansion in server fields is handled by the same downstream path as `.mcp.json`; no tokens are embedded or logged.
- **Naming.** Servers are name-prefixed with the extension, preventing a malicious/careless extension from shadowing another extension's or the user's own `.mcp.json` server (the user's workspace file is layered last and still wins by name).
- **TM-DEP.** No new dependencies.

## Checklist

- [x] Tests added or updated — manifest parsing of stdio+http servers, transport validation (stdio-without-command, http-without-url), MCP-only extension validity, and `contributed_mcp_servers()` producing correctly-prefixed, correctly-typed `ScopedMcpServer`s. `fmt`/`clippy -D warnings` clean; full suite green (680).
- [x] Backward compatibility considered — additive manifest facet (absent = no contribution); existing extensions parse unchanged.

## Follow-ups

- Optional handshake-time narrowing of the manifest MCP set (today it's manifest-only, which is strictly the safer direction).
- Everything carried from earlier phases: toolchain-free crates.io source, full JSON-Schema config validation, `config/changed`, `/extensions` slash command, `schema/yep/v1/` + `/extensions doctor`.

---
_Generated by [Claude Code](https://claude.ai/code/session_017d7odSAD8o79pUrd31dpDb)_