### PR TITLE
feat(extensions): hook subscriptions and dynamic prompt (phase 4)

### DIFF
--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -13,9 +13,16 @@ Phase 3: contributed MCP servers — a `yolop.mcpServers` manifest facet
 scoped MCP config for enabled extensions, name-prefixed `<ext>__<server>`
 and consumed by yolop's own MCP client (workspace `.mcp.json` still
 overrides by name).
-Later phases — hooks, dynamic prompt, `ui/ask`,
-schema-gen + SDKs, `/extensions doctor`, providers — remain
-design-of-record below. Not yet wired within phase 2 (tracked as
+Phase 4: hook subscriptions (`yolop.hooks` — `pre_tool_use`/`post_tool_use`
+with a tool-name glob, `timeout_ms`, and `on_error`) fired on the warm
+server via `hook/fire`, and a `dynamic_prompt` facet recomputing the
+system-prompt contribution per turn via `prompt/contribution` (falling back
+to the static handshake prompt). Pre-hooks can block; per-hook timeout +
+`on_error` (warn/block) bound the cost; the whole-bash-per-event
+`user_hooks` precedent makes a warm-process RPC strictly cheaper.
+Later phases — `ui/ask` (needs the server→host reverse-request channel,
+still refused in phase 1), `workspace/changed`, schema-gen + SDKs,
+`/extensions doctor`, providers — remain design-of-record below. Not yet wired within phase 2 (tracked as
 follow-ups): the toolchain-free crates.io source (native sparse-index +
 tarball fetch), full JSON-Schema config validation, and `config/changed`
 restart. Phase-1 deltas from the original sketch: tool *definitions*

--- a/src/extensions/capability.rs
+++ b/src/extensions/capability.rs
@@ -155,16 +155,77 @@ impl Capability for ExtensionCapability {
         _ctx: &SystemPromptContext,
         config: &Value,
     ) -> Option<String> {
-        if !self.package.manifest.prompt {
+        let manifest = &self.package.manifest;
+        if !manifest.prompt && !manifest.dynamic_prompt {
             return None;
         }
         // Prompt facet ⇒ eager spawn: the contribution is needed before the
-        // first turn, so first prompt assembly starts the server.
-        let text = self.process_for(config).prompt_contribution().await?;
+        // first turn, so first prompt assembly starts the server. A dynamic
+        // prompt is recomputed per turn (`prompt/contribution`); it falls
+        // back to the static handshake prompt on failure.
+        let process = self.process_for(config);
+        let text = if manifest.dynamic_prompt {
+            match process.dynamic_prompt().await {
+                Some(text) => Some(text),
+                None => process.prompt_contribution().await,
+            }
+        } else {
+            process.prompt_contribution().await
+        }?;
         Some(format!(
             "<capability id=\"{}\">\n{}\n</capability>",
             self.id, text
         ))
+    }
+
+    fn pre_tool_use_hooks_with_config(
+        &self,
+        config: &Value,
+    ) -> Vec<Arc<dyn everruns_core::atoms::PreToolUseHook>> {
+        use super::hooks::ExtensionPreHook;
+        use super::package::HookEvent;
+        let manifest = &self.package.manifest;
+        if manifest.hooks.is_empty() {
+            return Vec::new();
+        }
+        let process = self.process_for(config);
+        manifest
+            .hooks
+            .iter()
+            .filter(|sub| sub.event == HookEvent::PreToolUse)
+            .map(|sub| {
+                Arc::new(ExtensionPreHook {
+                    ext_name: manifest.name.clone(),
+                    process: process.clone(),
+                    sub: sub.clone(),
+                }) as Arc<dyn everruns_core::atoms::PreToolUseHook>
+            })
+            .collect()
+    }
+
+    fn post_tool_exec_hooks_with_config(
+        &self,
+        config: &Value,
+    ) -> Vec<Arc<dyn everruns_core::atoms::PostToolExecHook>> {
+        use super::hooks::ExtensionPostHook;
+        use super::package::HookEvent;
+        let manifest = &self.package.manifest;
+        if manifest.hooks.is_empty() {
+            return Vec::new();
+        }
+        let process = self.process_for(config);
+        manifest
+            .hooks
+            .iter()
+            .filter(|sub| sub.event == HookEvent::PostToolUse)
+            .map(|sub| {
+                Arc::new(ExtensionPostHook {
+                    ext_name: manifest.name.clone(),
+                    process: process.clone(),
+                    sub: sub.clone(),
+                }) as Arc<dyn everruns_core::atoms::PostToolExecHook>
+            })
+            .collect()
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {

--- a/src/extensions/hooks.rs
+++ b/src/extensions/hooks.rs
@@ -1,0 +1,165 @@
+//! Hook adapters: turn an extension's manifest hook subscriptions into
+//! runtime `PreToolUseHook`/`PostToolExecHook`s that fire `hook/fire` on the
+//! extension's warm server. These run for *every* tool the agent calls, so
+//! each is gated by a tool-name glob and bounded by a per-hook timeout and an
+//! `on_error` policy. Precedent: `user_hooks` spawns a whole bash process per
+//! event; an RPC to an already-warm process is strictly cheaper.
+
+use super::manager::ExtensionProcess;
+use super::package::{HookEvent, HookOnError, HookSubscription};
+use async_trait::async_trait;
+use everruns_core::atoms::{PostToolExecHook, PostToolExecHookPriority};
+use everruns_core::atoms::{PreToolUseDecision, PreToolUseHook};
+use everruns_core::tool_types::{ToolCall, ToolDefinition, ToolResult};
+use everruns_core::traits::ToolContext;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Match a tool name against a manifest glob (`*` wildcards; `"*"` = all).
+fn glob_match(pattern: &str, name: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+    // Split on `*` and require the literal segments to appear in order,
+    // anchored at both ends. No escaping — tool names are `[a-z_]`-ish.
+    let parts: Vec<&str> = pattern.split('*').collect();
+    let mut cursor = 0usize;
+    for (i, part) in parts.iter().enumerate() {
+        if part.is_empty() {
+            continue;
+        }
+        match name[cursor..].find(part) {
+            Some(pos) => {
+                let abs = cursor + pos;
+                // First segment must anchor at the start (no leading `*`).
+                if i == 0 && abs != 0 {
+                    return false;
+                }
+                cursor = abs + part.len();
+            }
+            None => return false,
+        }
+    }
+    // Last segment must anchor at the end (no trailing `*`).
+    parts
+        .last()
+        .is_none_or(|last| last.is_empty() || name.ends_with(last))
+}
+
+pub struct ExtensionPreHook {
+    pub ext_name: String,
+    pub process: Arc<ExtensionProcess>,
+    pub sub: HookSubscription,
+}
+
+#[async_trait]
+impl PreToolUseHook for ExtensionPreHook {
+    async fn before_exec(
+        &self,
+        tool_call: ToolCall,
+        _tool_def: &ToolDefinition,
+        _context: &ToolContext,
+    ) -> PreToolUseDecision {
+        if self.sub.event != HookEvent::PreToolUse
+            || !glob_match(&self.sub.tool_name_glob, &tool_call.name)
+        {
+            return PreToolUseDecision::Continue(tool_call);
+        }
+        let fire = self
+            .process
+            .fire_hook("pre_tool_use", &tool_call.name, &tool_call.arguments);
+        // Reduce the timeout outcome to either a decision or a failure detail.
+        let result: Result<super::protocol::HookDecision, String> =
+            match tokio::time::timeout(Duration::from_millis(self.sub.timeout_ms), fire).await {
+                Ok(Ok(decision)) => Ok(decision),
+                Ok(Err(err)) => Err(err.to_string()),
+                Err(_) => Err("timed out".to_string()),
+            };
+        match result {
+            Ok(decision) if decision.block => PreToolUseDecision::Block {
+                reason: if decision.reason.is_empty() {
+                    format!("blocked by extension `{}`", self.ext_name)
+                } else {
+                    decision.reason
+                },
+                user_message: decision.user_message,
+                tool_call,
+            },
+            Ok(_) => PreToolUseDecision::Continue(tool_call),
+            Err(detail) => match self.sub.on_error {
+                HookOnError::Block => PreToolUseDecision::Block {
+                    reason: format!(
+                        "extension `{}` hook failed ({detail}); set to block on error",
+                        self.ext_name
+                    ),
+                    user_message: None,
+                    tool_call,
+                },
+                HookOnError::Warn => {
+                    tracing::warn!(
+                        target: "yolop::ext", ext = %self.ext_name,
+                        "pre_tool_use hook failed ({detail}); allowing (`on_error = warn`)"
+                    );
+                    PreToolUseDecision::Continue(tool_call)
+                }
+            },
+        }
+    }
+}
+
+pub struct ExtensionPostHook {
+    pub ext_name: String,
+    pub process: Arc<ExtensionProcess>,
+    pub sub: HookSubscription,
+}
+
+#[async_trait]
+impl PostToolExecHook for ExtensionPostHook {
+    fn priority(&self) -> PostToolExecHookPriority {
+        PostToolExecHookPriority::Normal
+    }
+
+    async fn after_exec(
+        &self,
+        tool_call: &ToolCall,
+        _tool_def: &ToolDefinition,
+        _result: &mut ToolResult,
+        _context: &ToolContext,
+    ) {
+        if self.sub.event != HookEvent::PostToolUse
+            || !glob_match(&self.sub.tool_name_glob, &tool_call.name)
+        {
+            return;
+        }
+        // Observe-only in this phase: the decision (result rewriting) is a
+        // later refinement; a post hook that errors is logged, never fatal.
+        let fire = self
+            .process
+            .fire_hook("post_tool_use", &tool_call.name, &tool_call.arguments);
+        if let Ok(Err(err)) =
+            tokio::time::timeout(Duration::from_millis(self.sub.timeout_ms), fire).await
+        {
+            tracing::warn!(
+                target: "yolop::ext", ext = %self.ext_name,
+                "post_tool_use hook failed: {err}"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn glob_matching() {
+        assert!(glob_match("*", "anything"));
+        assert!(glob_match("bash", "bash"));
+        assert!(!glob_match("bash", "bashx"));
+        assert!(glob_match("lsp_*", "lsp_rename"));
+        assert!(!glob_match("lsp_*", "grep_files"));
+        assert!(glob_match("*_file", "write_file"));
+        assert!(glob_match("edit*file", "edit_file"));
+        assert!(!glob_match("edit*file", "read_file"));
+    }
+}

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -101,6 +101,58 @@ impl ExtensionProcess {
         state.as_ref().and_then(|live| live.prompt.clone())
     }
 
+    /// A fresh dynamic system-prompt contribution (`prompt/contribution`),
+    /// recomputed per turn. Failure degrades to `None` (the caller falls back
+    /// to the static prompt / last-known-good).
+    pub async fn dynamic_prompt(&self) -> Option<String> {
+        let connection = {
+            let mut state = self.state.lock().await;
+            self.ensure_live(&mut state).await.ok()?;
+            state.as_ref().expect("ensured live").connection.clone()
+        };
+        match connection
+            .request("prompt/contribution", serde_json::Value::Null)
+            .await
+        {
+            Ok(value) => {
+                let contribution: super::protocol::PromptContribution =
+                    serde_json::from_value(value).unwrap_or_default();
+                let text = contribution.text.trim();
+                (!text.is_empty()).then(|| text.to_string())
+            }
+            Err(err) => {
+                tracing::warn!(
+                    target: "yolop::ext", ext = %self.name(),
+                    "dynamic prompt/contribution failed: {err}"
+                );
+                None
+            }
+        }
+    }
+
+    /// Fire one subscribed lifecycle hook (`hook/fire`) and return the
+    /// server's decision. `Err` is a transport/server failure the caller
+    /// resolves per the subscription's `on_error` policy.
+    pub async fn fire_hook(
+        &self,
+        event: &str,
+        tool_name: &str,
+        args: &serde_json::Value,
+    ) -> Result<super::protocol::HookDecision> {
+        let connection = {
+            let mut state = self.state.lock().await;
+            self.ensure_live(&mut state).await?;
+            state.as_ref().expect("ensured live").connection.clone()
+        };
+        let params = serde_json::to_value(super::protocol::HookFireParams {
+            event,
+            tool_name,
+            args,
+        })?;
+        let value = connection.request("hook/fire", params).await?;
+        Ok(serde_json::from_value(value).unwrap_or_default())
+    }
+
     async fn ensure_live(&self, state: &mut Option<Live>) -> Result<()> {
         if let Some(live) = state.as_ref()
             && !live.connection.is_closed()

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -1,8 +1,10 @@
 //! Extensions: installable capability-level packages served over YEP, the
-//! yolop extension protocol. Phase 1 of `specs/extensions.md`: package
-//! discovery, the protocol core, the persistent process manager, and the
-//! generic `ExtensionCapability` adapter. Install verbs, contributed MCP
-//! servers, hooks, and the dynamic-prompt RPC are later phases.
+//! yolop extension protocol. See `specs/extensions.md`. Implemented:
+//! the protocol core + persistent process manager + generic
+//! `ExtensionCapability` adapter (phase 1); install/enable management
+//! surface + lockfile (phase 2); contributed MCP servers (phase 3);
+//! hook subscriptions + dynamic prompt over RPC (phase 4). Later: `ui/ask`,
+//! `workspace/changed`, schema-gen + SDKs, `/extensions doctor`, providers.
 //!
 //! Registration: discovered packages are registered in the capability
 //! registry (so they appear in the catalog and validate config) but are
@@ -12,6 +14,7 @@
 
 pub(crate) mod capability;
 pub(crate) mod client;
+pub(crate) mod hooks;
 pub(crate) mod manage;
 pub(crate) mod manager;
 pub(crate) mod package;
@@ -136,5 +139,104 @@ mod spawn_tests {
             .expect("prompt facet");
         assert!(contribution.contains("<capability id=\"ext:echo\">"));
         assert!(contribution.contains("echo fixture prompt"));
+    }
+
+    /// A hook + dynamic-prompt manifest whose server is the same fixture.
+    fn hooks_package(python: &str) -> ExtensionPackage {
+        let server = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/yep_echo_server.py");
+        let manifest = parse_manifest(
+            &json!({
+                "name": "echo",
+                "description": "Echo fixture.",
+                "yolop": {
+                    "protocol_version": "1.0",
+                    "capabilityServer": { "command": python,
+                        "args": [server.display().to_string()] },
+                    "dynamic_prompt": true,
+                    "hooks": [
+                        { "event": "pre_tool_use", "tool_name_glob": "*",
+                          "timeout_ms": 5000, "on_error": "warn" }
+                    ]
+                }
+            })
+            .to_string(),
+        )
+        .expect("hooks manifest");
+        ExtensionPackage {
+            dir: std::env::temp_dir(),
+            manifest,
+        }
+    }
+
+    #[tokio::test]
+    async fn pre_tool_use_hook_blocks_via_server_decision() {
+        use everruns_core::atoms::PreToolUseDecision;
+        use everruns_core::tool_types::{BuiltinTool, ToolCall, ToolDefinition};
+        let Some(python) = python3() else {
+            eprintln!("skipping: python3 not available");
+            return;
+        };
+        let capability = ExtensionCapability::new(hooks_package(&python), std::env::temp_dir());
+        let hooks = capability.pre_tool_use_hooks_with_config(&json!(null));
+        assert_eq!(hooks.len(), 1);
+        let hook = &hooks[0];
+        let tool_def = ToolDefinition::Builtin(BuiltinTool {
+            name: "bash".into(),
+            display_name: None,
+            description: "run".into(),
+            parameters: json!({ "type": "object" }),
+            policy: Default::default(),
+            category: None,
+            deferrable: Default::default(),
+            hints: Default::default(),
+            full_parameters: None,
+        });
+        let ctx =
+            everruns_core::traits::ToolContext::new(everruns_core::typed_id::SessionId::new());
+
+        // Allowed call passes through.
+        let allow = ToolCall {
+            id: "1".into(),
+            name: "bash".into(),
+            arguments: json!({"command": "ls"}),
+        };
+        assert!(matches!(
+            hook.before_exec(allow, &tool_def, &ctx).await,
+            PreToolUseDecision::Continue(_)
+        ));
+
+        // Server blocks a call whose args carry {"forbidden": true}.
+        let deny = ToolCall {
+            id: "2".into(),
+            name: "bash".into(),
+            arguments: json!({"forbidden": true}),
+        };
+        match hook.before_exec(deny, &tool_def, &ctx).await {
+            PreToolUseDecision::Block { reason, .. } => {
+                assert!(reason.contains("forbidden"), "{reason}");
+            }
+            other => panic!("expected block, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn dynamic_prompt_is_served_per_turn() {
+        let Some(python) = python3() else {
+            eprintln!("skipping: python3 not available");
+            return;
+        };
+        let capability = ExtensionCapability::new(hooks_package(&python), std::env::temp_dir());
+        let ctx = everruns_core::capabilities::SystemPromptContext::without_file_store(
+            everruns_core::typed_id::SessionId::new(),
+        );
+        let contribution = capability
+            .system_prompt_contribution(&ctx)
+            .await
+            .expect("dynamic prompt");
+        assert!(
+            contribution.contains("dynamic echo prompt"),
+            "{contribution}"
+        );
     }
 }

--- a/src/extensions/package.rs
+++ b/src/extensions/package.rs
@@ -42,11 +42,64 @@ struct RawFacet {
     /// Permits a handshake system-prompt contribution.
     #[serde(default)]
     prompt: bool,
+    /// When true, the server serves a fresh `prompt/contribution` each turn
+    /// (in addition to / instead of the static handshake prompt).
+    #[serde(default)]
+    dynamic_prompt: bool,
     /// MCP servers the extension contributes; consumed by yolop's own MCP
     /// client exactly as if listed in `.mcp.json` (D1: MCP is a
     /// contribution, not the base wire). Keyed by logical server name.
     #[serde(rename = "mcpServers", default)]
     mcp_servers: BTreeMap<String, ContributedMcpServer>,
+    /// Lifecycle hook subscriptions the extension serves over `hook/fire`.
+    #[serde(default)]
+    hooks: Vec<HookSubscription>,
+}
+
+/// A manifest-declared hook subscription. Static (the approved upper bound):
+/// which event, which tools it fires for, how long it may take, and what
+/// happens if the server errors. A match-all glob must be spelled `"*"` and
+/// is surfaced at approval time.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HookSubscription {
+    /// `pre_tool_use` (may block/observe before a tool runs) or
+    /// `post_tool_use` (observe after).
+    pub event: HookEvent,
+    /// Glob over tool names this hook fires for (`"*"` = all). Matched with
+    /// simple `*` wildcards.
+    #[serde(default = "match_all_glob")]
+    pub tool_name_glob: String,
+    #[serde(default = "default_hook_timeout_ms")]
+    pub timeout_ms: u64,
+    #[serde(default)]
+    pub on_error: HookOnError,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HookEvent {
+    PreToolUse,
+    PostToolUse,
+}
+
+/// What to do when the extension server errors or times out on a hook.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HookOnError {
+    /// Log and allow the tool call (availability over integrity).
+    #[default]
+    Warn,
+    /// Block the tool call (integrity over availability).
+    Block,
+}
+
+fn match_all_glob() -> String {
+    "*".to_string()
+}
+
+fn default_hook_timeout_ms() -> u64 {
+    5_000
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -115,7 +168,9 @@ pub struct ExtensionManifest {
     pub config_schema: Option<Value>,
     pub tools: Vec<ToolDefinition>,
     pub prompt: bool,
+    pub dynamic_prompt: bool,
     pub mcp_servers: BTreeMap<String, ContributedMcpServer>,
+    pub hooks: Vec<HookSubscription>,
 }
 
 #[derive(Debug, Clone)]
@@ -153,10 +208,13 @@ pub fn parse_manifest(raw: &str) -> Result<ExtensionManifest, String> {
     if raw.yolop.capability_server.command.trim().is_empty() {
         return Err("yolop.capabilityServer.command must not be empty".into());
     }
-    if raw.yolop.tools.is_empty() && !raw.yolop.prompt && raw.yolop.mcp_servers.is_empty() {
-        return Err(
-            "extension declares no tools, prompt, or MCP servers; nothing to contribute".into(),
-        );
+    if raw.yolop.tools.is_empty()
+        && !raw.yolop.prompt
+        && !raw.yolop.dynamic_prompt
+        && raw.yolop.mcp_servers.is_empty()
+        && raw.yolop.hooks.is_empty()
+    {
+        return Err("extension declares no contributions; nothing to contribute".into());
     }
     for (server_name, server) in &raw.yolop.mcp_servers {
         match server.transport {
@@ -181,7 +239,9 @@ pub fn parse_manifest(raw: &str) -> Result<ExtensionManifest, String> {
         config_schema: raw.yolop.config_schema,
         tools: raw.yolop.tools,
         prompt: raw.yolop.prompt,
+        dynamic_prompt: raw.yolop.dynamic_prompt,
         mcp_servers: raw.yolop.mcp_servers,
+        hooks: raw.yolop.hooks,
     })
 }
 

--- a/src/extensions/protocol.rs
+++ b/src/extensions/protocol.rs
@@ -205,6 +205,46 @@ pub struct ToolUpdateParams {
     pub output: String,
 }
 
+// ---------------------------------------------------------------------------
+// hook/fire
+
+/// Host → server `hook/fire` params: a subscribed lifecycle event fired for
+/// one tool call (any tool, not just the extension's own).
+#[derive(Debug, Clone, Serialize)]
+pub struct HookFireParams<'a> {
+    /// `pre_tool_use` or `post_tool_use`.
+    pub event: &'a str,
+    pub tool_name: &'a str,
+    pub args: &'a Value,
+}
+
+/// Server → host `hook/fire` result. Lenient/defaulted: a bare `{}` means
+/// "allow, unchanged".
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct HookDecision {
+    /// `true` blocks the tool call (pre_tool_use only).
+    #[serde(default)]
+    pub block: bool,
+    /// Message shown to the model/audit log when blocking.
+    #[serde(default)]
+    pub reason: String,
+    /// Optional user-facing message when blocking.
+    #[serde(default)]
+    pub user_message: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// prompt/contribution
+
+/// Server → host `prompt/contribution` result: a dynamic system-prompt
+/// contribution recomputed per turn (only when the manifest declares
+/// `dynamic_prompt`).
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct PromptContribution {
+    #[serde(default)]
+    pub text: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/fixtures/yep_echo_server.py
+++ b/tests/fixtures/yep_echo_server.py
@@ -53,6 +53,17 @@ def main():
             })
             args = params.get("args") or {}
             send({"id": msg_id, "result": {"echoed": args.get("text", "")}})
+        elif method == "hook/fire":
+            params = msg.get("params") or {}
+            # Block any tool whose args carry {"forbidden": true}; else allow.
+            args = params.get("args") or {}
+            if args.get("forbidden") is True:
+                send({"id": msg_id, "result": {"block": True,
+                                               "reason": "forbidden by echo fixture"}})
+            else:
+                send({"id": msg_id, "result": {}})
+        elif method == "prompt/contribution":
+            send({"id": msg_id, "result": {"text": "dynamic echo prompt"}})
         elif method == "shutdown":
             send({"id": msg_id, "result": {}})
             return


### PR DESCRIPTION
## What changed

Phase 4 of the extensions mechanism (`specs/extensions.md`): the cold-path RPC facets — lifecycle **hooks** and a **dynamic system prompt** — served over the warm capability server.

- **`protocol.rs`** — `hook/fire` (host→server: `{event, tool_name, args}` → `{block, reason, user_message}`) and `prompt/contribution` (server→host result `{text}`). Both lenient/defaulted per the forward-compat rules.
- **`package.rs`** — two manifest facets: `yolop.hooks` (a list of `{event: pre_tool_use|post_tool_use, tool_name_glob, timeout_ms, on_error: warn|block}`) and `yolop.dynamic_prompt: bool`. An MCP-/hook-/prompt-only extension is a valid contribution.
- **`manager.rs`** — `fire_hook()` and `dynamic_prompt()` on the persistent process (spawns lazily, reuses the warm connection).
- **`hooks.rs`** — `ExtensionPreHook`/`ExtensionPostHook` adapters implementing the runtime hook traits. Each is gated by a tool-name glob (`*` wildcards, `"*"` = all), bounded by the subscription's `timeout_ms`, and on server error/timeout honors `on_error` (warn → allow, block → block). Pre-hooks can block a tool call; post-hooks observe.
- **`capability.rs`** — `pre_tool_use_hooks_with_config` / `post_tool_exec_hooks_with_config` build the adapters (the framework collects capability hooks via the `_with_config` variants); `system_prompt_contribution_with_config` recomputes via `prompt/contribution` when `dynamic_prompt` is set, falling back to the static handshake prompt.

Hooks fire for **every** tool the agent calls, so the glob + timeout + `on_error` bounds are load-bearing. Cost note: `user_hooks` already spawns a whole bash process per event; an RPC to an already-warm extension process is strictly cheaper.

## Why

These are the seams MCP can't express (D3's cold-path RPC tier): an extension can enforce policy (a guardrail that blocks writes to generated files) or inject fresh context each turn, without a second protocol or an always-on daemon.

## Before / After

**Before:** an extension could contribute tools, a static prompt, and MCP servers.

**After** (proven end to end against the Python fixture server): a `pre_tool_use` hook subscribed to `*` blocks a `bash` call whose args carry `{forbidden:true}` (server-decided) and passes a normal `ls`; a `dynamic_prompt` extension's system-prompt contribution is fetched per turn (`"dynamic echo prompt"`).

## Risk

- Medium. Pre-hooks can block tool calls and fire on every tool, so a slow/misbehaving extension adds latency — bounded by `timeout_ms` and a fail-open `on_error: warn` default. Only enabled extensions (explicit `ext:<name>`) contribute hooks. No change to existing capabilities' behavior.

## Security

- **TM-TOOL (policy surface).** Hooks are the sharpest injection edge (an extension can silently block or observe every tool call), which is exactly why they're manifest-declared (inspectable at install), gated by an explicit glob, and — for `on_error: block` — fail closed. A match-all hook must spell `"*"`; it's surfaced in the install contribution summary. The extension never sees tool *results* it isn't subscribed to (post-hooks are glob-gated too).
- **TM-BASH.** Hook firing is an RPC to the already-spawned extension server (no new process per event, unlike `user_hooks`); the server was already consented-to at enable time.
- **Fail modes.** Server crash/timeout during a hook resolves per `on_error`; the default (`warn`) preserves availability. Post-hook failures are logged, never fatal.
- **Data exposure.** Hook payloads carry the tool name + arguments to a server the user already trusts; nothing is logged beyond a warning on failure. Dynamic-prompt failures fall back to the static prompt.
- **TM-DEP.** No new dependencies.

## Checklist

- [x] Tests added or updated — glob matcher unit tests; end-to-end spawn tests (real Python server) for a pre-hook blocking via server decision + passing a normal call, and a per-turn dynamic prompt. `fmt`/`clippy -D warnings` clean; full suite green (683).
- [x] Backward compatibility considered — additive manifest facets (absent = no hooks, static prompt only); existing extensions unchanged. `hook/fire`/`prompt/contribution` results parse leniently.

## Follow-ups

- Post-hook **result rewriting** (today post-hooks are observe-only; the wire already carries a decision shape).
- `ui/ask` → `user_ask` bridge and `workspace/changed` — both deferred: `ui/ask` needs the server→host reverse-request channel still refused in phase 1.
- Wire the per-hook `timeout_ms` into `hook/fire`'s own request budget (currently enforced by an outer `tokio::timeout`).
- Carried: toolchain-free crates.io source, JSON-Schema config validation, `config/changed`, `/extensions` slash command, `schema/yep/v1/` + `/extensions doctor`.

---
_Generated by [Claude Code](https://claude.ai/code/session_017d7odSAD8o79pUrd31dpDb)_