### PR TITLE
feat(mcp): load/unload MCP servers live without restart

### DIFF
--- a/specs/mcp.md
+++ b/specs/mcp.md
@@ -33,6 +33,17 @@ path, so MCP tools flow through the same agent loop as the built-in tools.
   are prefixed (`mcp_<server>__<tool>`) by the runtime to avoid collisions.
 - **Visibility**: `/mcp` lists the configured servers; configured server names
   also appear in `StartupInfo`.
+- **Live reload**: server changes apply to the running session without a
+  restart. `/mcp enable|disable|remove` mutate config and immediately re-apply;
+  `/mcp reload` re-reads config from disk (picking up `yolop mcp add`, hand
+  edits, or the agent's own config tools). The runtime resolves a session's
+  scoped MCP servers per turn from `session.mcp_servers` and never negatively
+  caches a failed or empty discovery, so swapping that field
+  (`RuntimeHandles::reload_mcp_servers`) is enough: added servers are discovered
+  cold on the next turn and removed ones drop out of the tool set. A server
+  whose config changes but keeps the same name is served from the ≤1h discovery
+  cache until it revalidates (stale-while-revalidate) — enable/disable/add/
+  remove are unaffected.
 - **Execution model**: MCP tool calls run autonomously, like every other yolop
   tool — there is no per-call approval gate.
 
@@ -76,5 +87,6 @@ Config shape:
 |---------|----------|
 | Config loading (scopes, merge, `${VAR}`) | `src/mcp_config.rs` |
 | Wiring into the session | `src/runtime.rs` (`session_mcp_servers`, `StartupInfo.mcp_server_names`) |
-| `/mcp` command | `src/capabilities/client_commands.rs`, `src/host_ui.rs`, `src/app.rs` |
+| `/mcp` command (list/reload/enable/disable/remove) | `src/capabilities/client_commands.rs`, `src/host_ui.rs`, `src/app/mod.rs` |
+| Live reload seam | `src/runtime.rs` (`RuntimeHandles::reload_mcp_servers`), `src/session.rs` |
 | Client / transports / executor | upstream `everruns-mcp`, `everruns-runtime` (`mcp-stdio` feature) |

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -678,7 +678,7 @@ impl App {
         // flush/draw per command, matching the test dispatch helper.
         let mut applied_ui_command = false;
         while let Ok(command) = self.ui_rx.try_recv() {
-            self.apply_ui_command(command);
+            self.apply_ui_command(command).await;
             applied_ui_command = true;
         }
         if applied_ui_command {
@@ -1126,13 +1126,13 @@ impl App {
     /// Apply a terminal-side command emitted by a capability. This is the only
     /// place the host interprets the `UiCommand` vocabulary; capabilities
     /// declare commands and request effects, the host performs them.
-    fn apply_ui_command(&mut self, command: UiCommand) {
+    async fn apply_ui_command(&mut self, command: UiCommand) {
         match command {
             UiCommand::ShowHelp => self.show_help(),
             UiCommand::ShowTools => {
                 self.push_system(format!("tools: {}", self.startup.tool_names.join(", ")));
             }
-            UiCommand::ManageMcp { arg } => self.manage_mcp_command(arg.as_deref()),
+            UiCommand::ManageMcp { arg } => self.manage_mcp_command(arg.as_deref()).await,
             UiCommand::ShowCwd => {
                 self.push_system(format!(
                     "workspace root: {}",
@@ -1159,7 +1159,10 @@ impl App {
         }
     }
 
-    fn manage_mcp_command(&mut self, raw: Option<&str>) {
+    const MCP_USAGE: &'static str =
+        "usage: /mcp [reload | enable|disable|remove <name> [global|workspace]]";
+
+    async fn manage_mcp_command(&mut self, raw: Option<&str>) {
         let Some(raw) = raw.map(str::trim).filter(|s| !s.is_empty()) else {
             if self.startup.mcp_server_names.is_empty() {
                 let global = crate::mcp_config::global_mcp_config_path()
@@ -1170,39 +1173,43 @@ impl App {
                 ));
             } else {
                 self.push_system(format!(
-                    "MCP servers: {}",
+                    "active MCP servers: {}",
                     self.startup.mcp_server_names.join(", ")
                 ));
             }
-            self.push_system(
-                "usage: /mcp [enable|disable|remove <name> [global|workspace]]".into(),
-            );
+            self.push_system(Self::MCP_USAGE.into());
             return;
         };
 
         let mut parts = raw.split_whitespace();
         let action = parts.next().unwrap_or_default();
+
+        // `reload` re-reads config from disk (picking up `yolop mcp add`,
+        // hand edits, or the agent's own config tools) and applies it live.
+        if action == "reload" {
+            if parts.next().is_some() {
+                self.push_system(Self::MCP_USAGE.into());
+                return;
+            }
+            self.reload_mcp_and_report(None).await;
+            return;
+        }
+
         let name = parts.next();
         let scope = match parts.next() {
             None | Some("global") => crate::mcp_config::McpConfigScope::Global,
             Some("workspace") => crate::mcp_config::McpConfigScope::Workspace,
             Some(other) => {
-                self.push_system(format!(
-                    "usage: /mcp [enable|disable|remove <name> [global|workspace]] (unknown scope: {other})"
-                ));
+                self.push_system(format!("{} (unknown scope: {other})", Self::MCP_USAGE));
                 return;
             }
         };
         if parts.next().is_some() {
-            self.push_system(
-                "usage: /mcp [enable|disable|remove <name> [global|workspace]]".into(),
-            );
+            self.push_system(Self::MCP_USAGE.into());
             return;
         }
         let Some(name) = name else {
-            self.push_system(
-                "usage: /mcp [enable|disable|remove <name> [global|workspace]]".into(),
-            );
+            self.push_system(Self::MCP_USAGE.into());
             return;
         };
 
@@ -1223,21 +1230,35 @@ impl App {
                 }
             }),
             other => {
-                self.push_system(format!(
-                    "usage: /mcp [enable|disable|remove <name> [global|workspace]] (unknown action: {other})"
-                ));
+                self.push_system(format!("{} (unknown action: {other})", Self::MCP_USAGE));
                 return;
             }
         };
         match result {
-            Ok(message) => {
-                self.push_system(message);
-                self.push_system(
-                    "restart or start a new yolop session for MCP connection changes to take effect"
-                        .into(),
-                );
-            }
+            Ok(message) => self.reload_mcp_and_report(Some(message)).await,
             Err(error) => self.push_system(format!("failed to update MCP config: {error}")),
+        }
+    }
+
+    /// Apply the on-disk MCP config to the live session and report the active
+    /// set. `prelude`, when set, is printed first (e.g. the mutation summary).
+    async fn reload_mcp_and_report(&mut self, prelude: Option<String>) {
+        if let Some(message) = prelude {
+            self.push_system(message);
+        }
+        match self.session.reload_mcp_servers().await {
+            Ok(names) => {
+                self.startup.mcp_server_names = names;
+                if self.startup.mcp_server_names.is_empty() {
+                    self.push_system("active MCP servers: none".into());
+                } else {
+                    self.push_system(format!(
+                        "active MCP servers: {}",
+                        self.startup.mcp_server_names.join(", ")
+                    ));
+                }
+            }
+            Err(error) => self.push_system(format!("failed to reload MCP servers: {error}")),
         }
     }
 
@@ -3499,12 +3520,12 @@ mod tests {
         /// `handle_command`.
         async fn dispatch_command_for_test(&mut self, cmd: &str) {
             self.handle_command(cmd).await;
-            self.pump_ui_commands_for_test();
+            self.pump_ui_commands_for_test().await;
         }
 
-        fn pump_ui_commands_for_test(&mut self) {
+        async fn pump_ui_commands_for_test(&mut self) {
             while let Ok(command) = self.ui_rx.try_recv() {
-                self.apply_ui_command(command);
+                self.apply_ui_command(command).await;
             }
         }
 
@@ -3615,7 +3636,7 @@ mod tests {
         );
 
         app.submit_input().await;
-        app.pump_ui_commands_for_test();
+        app.pump_ui_commands_for_test().await;
 
         assert!(
             app.busy,
@@ -3664,7 +3685,7 @@ mod tests {
         app.set_input_text("!printf bare-output".into());
 
         app.submit_input().await;
-        app.pump_ui_commands_for_test();
+        app.pump_ui_commands_for_test().await;
 
         assert!(app.busy, "! should run as a bounded background command");
         app.pump_turn_until_idle_for_test().await;
@@ -4550,6 +4571,60 @@ mod tests {
                 .iter()
                 .any(|line| line.text.contains("workspace root:") && line.text.contains(&root)),
             "cwd should print the workspace root: {:?}",
+            app.lines
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn mcp_reload_applies_config_live_without_restart() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+
+        // The workspace declares no servers at startup.
+        assert!(!app.startup.mcp_server_names.iter().any(|n| n == "docs"));
+
+        // Write a workspace `.mcp.json` after startup, then `/mcp reload`.
+        std::fs::write(
+            app.startup.workspace_root.join(".mcp.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "mcpServers": { "docs": { "type": "http", "url": "https://example.com/mcp" } }
+            }))
+            .unwrap(),
+        )
+        .expect("write .mcp.json");
+        app.lines.clear();
+        app.dispatch_command_for_test("mcp reload").await;
+
+        // The server is now live on the session and reported as active — and
+        // the old "restart required" guidance is gone.
+        assert!(app.startup.mcp_server_names.iter().any(|n| n == "docs"));
+        assert!(
+            app.lines
+                .iter()
+                .any(|line| line.text.contains("active MCP servers: docs")),
+            "reload should report the active set: {:?}",
+            app.lines
+        );
+        assert!(
+            !app.lines.iter().any(|line| line.text.contains("restart")),
+            "reload must not tell the user to restart: {:?}",
+            app.lines
+        );
+
+        // Disabling via `/mcp` also applies live: the server drops out.
+        app.lines.clear();
+        app.dispatch_command_for_test("mcp disable docs workspace")
+            .await;
+        assert!(
+            !app.startup.mcp_server_names.iter().any(|n| n == "docs"),
+            "disabling a server removes it from the live set: {:?}",
+            app.startup.mcp_server_names
+        );
+        assert!(
+            app.lines
+                .iter()
+                .any(|line| line.text.contains("active MCP servers")),
+            "disable should report the active set: {:?}",
             app.lines
         );
     }

--- a/src/capabilities/client_commands.rs
+++ b/src/capabilities/client_commands.rs
@@ -113,7 +113,11 @@ fn command_descriptors() -> Vec<CommandDescriptor> {
     vec![
         cmd("help", "show commands", &[]),
         cmd("tools", "list available tools", &[]),
-        cmd("mcp", "list configured MCP servers", &[]),
+        cmd(
+            "mcp",
+            "list, reload, or enable/disable/remove MCP servers live",
+            &[opt("action")],
+        ),
         cmd("cwd", "show workspace root", &[]),
         cmd(
             "status",

--- a/src/capabilities/mcp.rs
+++ b/src/capabilities/mcp.rs
@@ -38,8 +38,9 @@ impl Capability for McpCapability {
               Manage global and workspace MCP servers with `list_mcp_servers`, \
               `upsert_mcp_server`, `remove_mcp_server`, and `set_mcp_server_enabled`. \
               Global servers live in settings.toml under `[mcp.servers.<name>]`; workspace \
-              servers live in `.mcp.json` and override global servers by name. Server changes \
-              are picked up by new sessions; use `enabled=false` to deactivate without deleting.\n\
+              servers live in `.mcp.json` and override global servers by name. Config changes \
+              take effect on the next `/mcp reload` (or a new session); use `enabled=false` to \
+              deactivate without deleting.\n\
               </capability>"
                 .to_string(),
         )
@@ -129,7 +130,7 @@ impl Tool for UpsertMcpServerTool {
         Some("Upsert MCP server")
     }
     fn description(&self) -> &str {
-        "Create or replace one global or workspace MCP server. Changes apply to new sessions."
+        "Create or replace one global or workspace MCP server. Changes take effect on the next `/mcp reload` or a new session."
     }
     fn parameters_schema(&self) -> Value {
         json!({
@@ -252,7 +253,7 @@ impl Tool for SetMcpServerEnabledTool {
         Some("Set MCP server enabled")
     }
     fn description(&self) -> &str {
-        "Enable or disable one MCP server without deleting it. Changes apply to new sessions."
+        "Enable or disable one MCP server without deleting it. Changes take effect on the next `/mcp reload` or a new session."
     }
     fn parameters_schema(&self) -> Value {
         json!({

--- a/src/mcp_e2e_tests.rs
+++ b/src/mcp_e2e_tests.rs
@@ -71,13 +71,10 @@ fn script(tool: &str, message: &str) -> LlmSimConfig {
     ])
 }
 
-/// Build a runtime whose workspace `.mcp.json` points the `echo` server at the
-/// Python fixture, passing `marker_dir` so calls leave a filesystem trace.
-async fn build_runtime(config: LlmSimConfig, marker_dir: &Path, python: &Path) -> BuiltRuntime {
-    let workspace_root = tempfile::tempdir().expect("workspace").keep();
-    let sessions_root = tempfile::tempdir().expect("sessions").keep();
-
-    let mcp_json = json!({
+/// The `.mcp.json` value pointing the `echo` server at the Python fixture,
+/// passing `marker_dir` so calls leave a filesystem trace.
+fn echo_mcp_json(python: &Path, marker_dir: &Path) -> serde_json::Value {
+    json!({
         "mcpServers": {
             "echo": {
                 "type": "stdio",
@@ -88,12 +85,46 @@ async fn build_runtime(config: LlmSimConfig, marker_dir: &Path, python: &Path) -
                 ]
             }
         }
-    });
+    })
+}
+
+/// A `.mcp.json` with no servers configured.
+fn empty_mcp_json() -> serde_json::Value {
+    json!({ "mcpServers": {} })
+}
+
+fn write_mcp_json(workspace_root: &Path, value: &serde_json::Value) {
     std::fs::write(
         workspace_root.join(".mcp.json"),
-        serde_json::to_vec_pretty(&mcp_json).unwrap(),
+        serde_json::to_vec_pretty(value).unwrap(),
     )
     .expect("write .mcp.json");
+}
+
+/// Names of the MCP servers currently attached to the live session (i.e. what
+/// the next turn will resolve). Reads the stored session directly rather than
+/// the on-disk config, so it reflects reloads applied via
+/// `RuntimeHandles::reload_mcp_servers`.
+async fn live_mcp_server_names(runtime: &BuiltRuntime) -> Vec<String> {
+    use everruns_core::SessionStore;
+    let session = runtime
+        .handles
+        .session_store
+        .get_session(runtime.handles.session_id)
+        .await
+        .expect("get session")
+        .expect("session exists");
+    let mut names: Vec<String> = session.mcp_servers.keys().cloned().collect();
+    names.sort();
+    names
+}
+
+/// Build a runtime whose workspace `.mcp.json` is seeded with `mcp_json`.
+async fn build_runtime_with(config: LlmSimConfig, mcp_json: &serde_json::Value) -> BuiltRuntime {
+    let workspace_root = tempfile::tempdir().expect("workspace").keep();
+    let sessions_root = tempfile::tempdir().expect("sessions").keep();
+
+    write_mcp_json(&workspace_root, mcp_json);
 
     let settings = Arc::new(SettingsStore::open(sessions_root.join("settings.toml")));
     build_with_options(
@@ -109,6 +140,12 @@ async fn build_runtime(config: LlmSimConfig, marker_dir: &Path, python: &Path) -
     )
     .await
     .expect("build runtime")
+}
+
+/// Build a runtime whose workspace `.mcp.json` points the `echo` server at the
+/// Python fixture, passing `marker_dir` so calls leave a filesystem trace.
+async fn build_runtime(config: LlmSimConfig, marker_dir: &Path, python: &Path) -> BuiltRuntime {
+    build_runtime_with(config, &echo_mcp_json(python, marker_dir)).await
 }
 
 async fn run_turn(runtime: &BuiltRuntime, text: &str) -> everruns_runtime::TurnResult {
@@ -145,5 +182,142 @@ async fn mcp_tool_executes_over_real_stdio_server() {
     assert!(
         body.contains("hello-mcp"),
         "server should receive the call arguments: {body}"
+    );
+}
+
+/// The reload seam swaps the live session's scoped MCP servers so add / remove
+/// take effect without rebuilding the runtime. This assertion is config-only
+/// (an HTTP server that is never contacted), so it runs in CI without
+/// `python3`: proving the mechanism the TUI `/mcp` command and `/mcp reload`
+/// drive.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reload_swaps_live_session_mcp_servers() {
+    // Membership checks (not exact equality) so any ambient global MCP config
+    // on the developer's machine can't perturb the assertions.
+    let has = |names: &[String], name: &str| names.iter().any(|n| n == name);
+
+    // Start with the workspace declaring no servers.
+    let runtime = build_runtime_with(LlmSimConfig::fixed("hi"), &empty_mcp_json()).await;
+    assert!(
+        !has(&live_mcp_server_names(&runtime).await, "docs"),
+        "docs is absent before it is configured"
+    );
+
+    // Add a server on disk, reload, and observe it attached live.
+    write_mcp_json(
+        &runtime.startup.workspace_root,
+        &json!({ "mcpServers": { "docs": { "type": "http", "url": "https://example.com/mcp" } } }),
+    );
+    let names = runtime
+        .handles
+        .reload_mcp_servers()
+        .await
+        .expect("reload after add");
+    assert!(has(&names, "docs"), "reload reports the added server");
+    assert!(
+        has(&live_mcp_server_names(&runtime).await, "docs"),
+        "the live session now carries the added server"
+    );
+
+    // Remove it again and confirm the live session drops it.
+    write_mcp_json(&runtime.startup.workspace_root, &empty_mcp_json());
+    let names = runtime
+        .handles
+        .reload_mcp_servers()
+        .await
+        .expect("reload after remove");
+    assert!(!has(&names, "docs"), "reload drops the removed server");
+    assert!(
+        !has(&live_mcp_server_names(&runtime).await, "docs"),
+        "the live session drops the removed server"
+    );
+}
+
+/// A server added to `.mcp.json` after startup is discovered and executable on
+/// the next turn once reloaded — no restart. Proven end-to-end via the real
+/// stdio fixture writing its marker file.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reload_adds_mcp_server_and_executes_live() {
+    let Some(python) = require_python3("reload_adds_mcp_server_and_executes_live") else {
+        return;
+    };
+    let marker = tempfile::tempdir().expect("marker").keep();
+    let tool = mcp_tool("echo", "echo");
+
+    // No server at startup: the scripted echo call has nothing to run yet.
+    let runtime = build_runtime_with(script(&tool, "added-live"), &empty_mcp_json()).await;
+    assert!(
+        !live_mcp_server_names(&runtime)
+            .await
+            .iter()
+            .any(|n| n == "echo"),
+        "echo server is absent before reload"
+    );
+
+    // Add the server and reload the live session.
+    write_mcp_json(
+        &runtime.startup.workspace_root,
+        &echo_mcp_json(&python, &marker),
+    );
+    let names = runtime
+        .handles
+        .reload_mcp_servers()
+        .await
+        .expect("reload after add");
+    assert!(names.iter().any(|n| n == "echo"), "reload attaches echo");
+
+    // The next turn discovers and executes the freshly added server.
+    let result = run_turn(&runtime, "use the echo tool").await;
+    assert!(result.success, "turn must succeed: {result:?}");
+    assert_eq!(result.tool_calls_count, 1, "exactly one MCP call expected");
+    let called = marker.join("echo.called");
+    assert!(
+        called.exists(),
+        "the reloaded MCP server must have executed tools/call (marker missing)"
+    );
+}
+
+/// A server removed from `.mcp.json` after startup stops being executable once
+/// reloaded. Proven via the absence of the fixture's marker file after a turn
+/// that scripts the (now-removed) tool call.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reload_removes_mcp_server_live() {
+    let Some(python) = require_python3("reload_removes_mcp_server_live") else {
+        return;
+    };
+    let marker = tempfile::tempdir().expect("marker").keep();
+    let tool = mcp_tool("echo", "echo");
+
+    // Start with the echo server present.
+    let runtime = build_runtime_with(
+        script(&tool, "should-not-run"),
+        &echo_mcp_json(&python, &marker),
+    )
+    .await;
+    assert!(
+        live_mcp_server_names(&runtime)
+            .await
+            .iter()
+            .any(|n| n == "echo"),
+        "echo server is present at startup"
+    );
+
+    // Remove it and reload the live session.
+    write_mcp_json(&runtime.startup.workspace_root, &empty_mcp_json());
+    let names = runtime
+        .handles
+        .reload_mcp_servers()
+        .await
+        .expect("reload after remove");
+    assert!(
+        !names.iter().any(|n| n == "echo"),
+        "echo dropped after remove"
+    );
+
+    // The scripted tool call can no longer reach a server: no marker is written.
+    let _ = run_turn(&runtime, "use the echo tool").await;
+    assert!(
+        !marker.join("echo.called").exists(),
+        "the removed MCP server must not execute after reload"
     );
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -59,14 +59,16 @@ use everruns_core::{
     ReasoningConfig, ResolvedModel, ScopedMcpServers, SessionFileSystem, SessionFileSystemFactory,
     SessionFileSystemFactoryContext,
 };
-use everruns_core::{DriverId, ModelProfile, ReasoningEffortConfig, ReasoningEffortValue};
+use everruns_core::{
+    DriverId, ModelProfile, ReasoningEffortConfig, ReasoningEffortValue, SessionStore,
+};
 use everruns_integrations_daytona::DaytonaCapability;
 use everruns_integrations_duckduckgo::DuckDuckGoCapability;
 use everruns_local::{LocalBackends, LocalProfile, LocalScheduleRunnerHandle};
 use everruns_mcp::{McpAuthProvider, McpAuthRequest, McpCredential};
 use everruns_runtime::{
     AgentBuilder, HarnessBuilder, InProcessRuntime, InProcessRuntimeBuilder, RealDiskFileStore,
-    RuntimeBackends, SessionBuilder, WriteBlocklistFileStore,
+    RuntimeBackends, RuntimeSessionStore, SessionBuilder, WriteBlocklistFileStore,
 };
 
 use crate::session_log::{
@@ -1910,6 +1912,39 @@ pub struct RuntimeHandles {
     /// through the `EventBus` trait object; we keep a direct reference
     /// so the TUI can subscribe to the live broadcast for streaming.
     pub events: Arc<JsonlEventEmitter>,
+    /// The runtime's session store, retained so the host can mutate the
+    /// live session's scoped MCP servers without rebuilding the runtime.
+    /// See [`RuntimeHandles::reload_mcp_servers`].
+    pub session_store: Arc<dyn RuntimeSessionStore>,
+    /// Workspace root the session's MCP servers were loaded from. Reused
+    /// verbatim on reload so `.mcp.json` resolution stays identical to
+    /// startup.
+    pub workspace_root: PathBuf,
+}
+
+impl RuntimeHandles {
+    /// Re-read the merged MCP server config (global settings + workspace
+    /// `.mcp.json`) and swap it into the live session, so add / remove /
+    /// enable / disable take effect on the next turn without a restart.
+    ///
+    /// The runtime resolves a session's scoped MCP servers per turn from
+    /// `session.mcp_servers` and never negatively caches a failed or empty
+    /// discovery, so upserting the session here is enough: newly enabled
+    /// servers are discovered cold on the next turn and removed ones simply
+    /// drop out of the tool set. Returns the sorted names now active.
+    pub async fn reload_mcp_servers(&self) -> anyhow::Result<Vec<String>> {
+        let servers = crate::mcp_config::load_mcp_servers(&self.workspace_root);
+        let mut session = self
+            .session_store
+            .get_session(self.session_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("session {} not found", self.session_id))?;
+        let mut names: Vec<String> = servers.keys().cloned().collect();
+        names.sort();
+        session.mcp_servers = servers;
+        self.session_store.add_session(session).await?;
+        Ok(names)
+    }
 }
 
 pub struct StartupInfo {
@@ -2540,6 +2575,12 @@ pub async fn build_with_options(
         .tag("example")
         .tag("coding");
 
+    // Retain the session store so the host can hot-swap the live session's
+    // scoped MCP servers (`RuntimeHandles::reload_mcp_servers`) without
+    // rebuilding the runtime. Cloned before `backends` is moved into the
+    // builder below.
+    let session_store = backends.session_store.clone();
+
     let mut builder = InProcessRuntimeBuilder::new()
         .mcp_auth_provider(Arc::new(EnvMcpAuthProvider))
         .platform_definition(platform)
@@ -2574,6 +2615,8 @@ pub async fn build_with_options(
             runtime: Arc::new(runtime),
             session_id,
             events: event_bus_typed,
+            session_store,
+            workspace_root: canonical_root.clone(),
         },
         startup: StartupInfo {
             workspace_root: effective_root,

--- a/src/session.rs
+++ b/src/session.rs
@@ -59,6 +59,14 @@ impl Session {
         self.handles.session_id
     }
 
+    /// Re-read the merged MCP server config and swap it into the live session
+    /// so add / remove / enable / disable apply on the next turn without a
+    /// restart. Returns the sorted names now active. See
+    /// [`RuntimeHandles::reload_mcp_servers`](crate::runtime::RuntimeHandles::reload_mcp_servers).
+    pub async fn reload_mcp_servers(&self) -> Result<Vec<String>> {
+        self.handles.reload_mcp_servers().await
+    }
+
     /// Translate the prefix of persisted events that were replayed from disk
     /// into transcript lines (used to seed the transcript on resume).
     pub async fn replayed_lines(&self, count: usize) -> Result<Vec<ChatLine>> {


### PR DESCRIPTION
## What changed
MCP server config changes now apply to the **running** session — no restart. Previously `/mcp` wrote config and told the user to start a new session before anything took effect.

- `/mcp enable|disable|remove <name> [scope]` mutate config **and re-apply live**, then report the active set.
- New `/mcp reload` re-reads config from disk, picking up `yolop mcp add`, hand edits to `.mcp.json`/`settings.toml`, or the agent's own `upsert_mcp_server`/`remove_mcp_server` tools.
- The "restart required" guidance is gone; `/mcp` lists the live-active servers.

Under the hood: `RuntimeHandles::reload_mcp_servers` re-reads the merged config (global settings + workspace `.mcp.json`) and upserts the live session's `mcp_servers`. The runtime already resolves scoped servers per turn from that field and never negatively caches a failed/empty discovery, so an added server is discovered cold on the next turn and a removed one drops out of the tool set — no upstream change needed.

## Why
Dynamic load/unload of MCP servers. Editing the server catalog mid-session and having to restart to use it is friction the runtime doesn't actually require.

## Before / After
Adding a server after startup, then using it:

**Before**
```
> /mcp enable docs
enabled MCP server `docs`
restart or start a new yolop session for MCP connection changes to take effect
```

**After**
```
> /mcp reload
active MCP servers: docs
> (next turn) the docs tools are available and execute — no restart
```

Proven end-to-end in tests: a server added to `.mcp.json` after startup is discovered and its tool executes on the next turn (real stdio fixture writing a marker file); a removed server no longer executes.

## Risk
- Low
- A server whose config changes but keeps the **same name** is served from the runtime's ≤1h tool-discovery cache (stale-while-revalidate) until it revalidates. enable/disable/add/remove are unaffected (they change the set of names). Noted in `specs/mcp.md`.
- A reload applies on the next turn, not mid-turn — the in-flight turn already resolved its server set.

## Security
Reviewed. No change to the trust model: authoring config remains the consent act; reload only applies what the user (or the agent's config tools) already wrote. No filesystem write-blocklist change (TM-FS), no shell/bash change (TM-BASH), no key handling or logging change (TM-LLM), no new capability registration (TM-TOOL), no new dependencies (TM-DEP). HTTP SSRF protection and the stdio feature gate are unchanged (they live in the runtime discovery/executor path). Reload reads the same config paths as startup; server names are map keys, not used as filesystem paths.

## Automated tests
- `reload_swaps_live_session_mcp_servers` — config-only, runs in CI without `python3`: asserts the live session's server set changes on reload (add then remove).
- `reload_adds_mcp_server_and_executes_live` / `reload_removes_mcp_server_live` — real stdio fixture: a server added after startup executes on the next turn; a removed one does not (filesystem marker).
- `mcp_reload_applies_config_live_without_restart` — drives the TUI `/mcp reload` and `/mcp disable` end-to-end and asserts the "restart" guidance is gone.

## Follow-ups
- The agent-facing config tools (`upsert_mcp_server`, etc.) write config but do not themselves trigger a live reload; changes apply on the next `/mcp reload` or new session. Wiring an automatic in-turn reload for those is a candidate follow-up.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (yolop is pre-1.0; `/mcp` gains behavior, no config format change)

https://claude.ai/code/session_01VA8DyqLHN5KP75Zr7zNcay

---
_Generated by [Claude Code](https://claude.ai/code/session_01VA8DyqLHN5KP75Zr7zNcay)_