### PR TITLE
feat(extensions): generate schema/yep/v1/meta.json with drift guard

### DIFF
--- a/crates/yolop-yep/src/bin/schema-gen.rs
+++ b/crates/yolop-yep/src/bin/schema-gen.rs
@@ -1,0 +1,51 @@
+//! Emit the machine-readable protocol metadata to `schema/yep/v1/meta.json`.
+//!
+//! `cargo run -p yolop-yep --bin schema-gen` regenerates the file; pass
+//! `--check` to fail (non-zero) when the committed file is stale, which CI
+//! runs so a wire-vocabulary change can't merge without a matching artifact
+//! (the mira pattern). The path is relative to the repo root.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let check = std::env::args().any(|a| a == "--check");
+    let path = repo_root().join("schema/yep/v1/meta.json");
+    let expected = yolop_yep::meta_json();
+
+    if check {
+        let actual = std::fs::read_to_string(&path).unwrap_or_default();
+        if actual == expected {
+            eprintln!("schema/yep/v1/meta.json is up to date");
+            ExitCode::SUCCESS
+        } else {
+            eprintln!(
+                "schema/yep/v1/meta.json is STALE — run `cargo run -p yolop-yep --bin schema-gen`"
+            );
+            ExitCode::FAILURE
+        }
+    } else {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        match std::fs::write(&path, &expected) {
+            Ok(()) => {
+                eprintln!("wrote {}", path.display());
+                ExitCode::SUCCESS
+            }
+            Err(err) => {
+                eprintln!("failed to write {}: {err}", path.display());
+                ExitCode::FAILURE
+            }
+        }
+    }
+}
+
+/// The workspace root: this crate is at `<root>/crates/yolop-yep`.
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."))
+}

--- a/crates/yolop-yep/src/lib.rs
+++ b/crates/yolop-yep/src/lib.rs
@@ -25,8 +25,10 @@
 //!
 //! See `specs/extensions.md` in the yolop repo for the full protocol.
 
+pub mod meta;
 pub mod protocol;
 mod server;
 
+pub use meta::{Meta, meta, meta_json};
 pub use protocol::PROTOCOL_VERSION;
 pub use server::{HookResponse, Server, ToolResponse};

--- a/crates/yolop-yep/src/meta.rs
+++ b/crates/yolop-yep/src/meta.rs
@@ -1,0 +1,143 @@
+//! Protocol metadata: the method and capability-token vocabularies, as data.
+//!
+//! This is the machine-readable index emitted to `schema/yep/v1/meta.json`
+//! (the mira pattern) so a non-Rust extension author can discover the wire
+//! surface without reading these structs. It is generated from the constants
+//! here by the `schema-gen` binary, and a drift test keeps the committed file
+//! in lockstep — the vocabulary can't change without the artifact changing.
+
+use crate::protocol::PROTOCOL_VERSION;
+use serde::Serialize;
+
+/// Every method name in the protocol, tagged by direction.
+pub const METHODS: &[Method] = &[
+    Method::host(
+        "initialize",
+        "Handshake: negotiate version, pass config; server replies with contributions.",
+    ),
+    Method::host("initialized", "Notification: handshake complete."),
+    Method::host("tool/call", "Invoke a tool the server declared."),
+    Method::server(
+        "tool/update",
+        "Notification: streamed progress for an in-flight tool/call (correlated by request_id).",
+    ),
+    Method::host(
+        "hook/fire",
+        "Fire a subscribed lifecycle hook (pre_tool_use/post_tool_use).",
+    ),
+    Method::host(
+        "prompt/contribution",
+        "Request a fresh dynamic system-prompt contribution.",
+    ),
+    Method::host("config/changed", "Notify the server its config changed."),
+    Method::host("shutdown", "Request a graceful stop."),
+];
+
+/// Capability tokens a server may advertise in the `initialize` result.
+pub const CAPABILITY_TOKENS: &[&str] = &[
+    "tools",
+    "streaming",
+    "prompt",
+    "dynamic_prompt",
+    "hooks",
+    "mcp_servers",
+];
+
+/// Direction a method flows.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Direction {
+    /// host → server
+    Host,
+    /// server → host
+    Server,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Method {
+    pub name: &'static str,
+    pub direction: Direction,
+    pub description: &'static str,
+}
+
+impl Method {
+    const fn host(name: &'static str, description: &'static str) -> Self {
+        Self {
+            name,
+            direction: Direction::Host,
+            description,
+        }
+    }
+    const fn server(name: &'static str, description: &'static str) -> Self {
+        Self {
+            name,
+            direction: Direction::Server,
+            description,
+        }
+    }
+}
+
+/// The full protocol metadata index.
+#[derive(Debug, Clone, Serialize)]
+pub struct Meta {
+    pub version: &'static str,
+    /// Minimum protocol version this implementation interoperates with.
+    pub min_version: &'static str,
+    pub methods: &'static [Method],
+    pub capabilities: &'static [&'static str],
+}
+
+/// Build the metadata index for the current protocol version.
+pub fn meta() -> Meta {
+    Meta {
+        version: PROTOCOL_VERSION,
+        // Same major = compatible; `1.0` is the baseline.
+        min_version: "1.0",
+        methods: METHODS,
+        capabilities: CAPABILITY_TOKENS,
+    }
+}
+
+/// The canonical pretty-printed JSON for `schema/yep/v1/meta.json`, with a
+/// trailing newline. The generator writes this; the drift test compares.
+pub fn meta_json() -> String {
+    let mut json = serde_json::to_string_pretty(&meta()).expect("meta serializes");
+    json.push('\n');
+    json
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn meta_covers_the_protocol() {
+        let meta = meta();
+        assert_eq!(meta.version, "1.0");
+        assert!(meta.methods.iter().any(|m| m.name == "initialize"));
+        assert!(
+            meta.methods
+                .iter()
+                .any(|m| m.name == "tool/update" && m.direction == Direction::Server)
+        );
+        assert!(meta.capabilities.contains(&"tools"));
+        // Serializes to valid JSON.
+        assert!(meta_json().starts_with('{'));
+    }
+
+    /// Drift guard: the committed `schema/yep/v1/meta.json` must match what the
+    /// generator produces. This makes `cargo test` (i.e. CI) the enforcement —
+    /// a vocabulary change can't merge without regenerating the artifact.
+    /// Run `cargo run -p yolop-yep --bin schema-gen` to fix a failure here.
+    #[test]
+    fn committed_meta_json_is_up_to_date() {
+        let path =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../schema/yep/v1/meta.json");
+        let committed = std::fs::read_to_string(&path).unwrap_or_default();
+        assert_eq!(
+            committed,
+            meta_json(),
+            "schema/yep/v1/meta.json is stale — run `cargo run -p yolop-yep --bin schema-gen`"
+        );
+    }
+}

--- a/schema/yep/v1/meta.json
+++ b/schema/yep/v1/meta.json
@@ -1,0 +1,54 @@
+{
+  "version": "1.0",
+  "min_version": "1.0",
+  "methods": [
+    {
+      "name": "initialize",
+      "direction": "host",
+      "description": "Handshake: negotiate version, pass config; server replies with contributions."
+    },
+    {
+      "name": "initialized",
+      "direction": "host",
+      "description": "Notification: handshake complete."
+    },
+    {
+      "name": "tool/call",
+      "direction": "host",
+      "description": "Invoke a tool the server declared."
+    },
+    {
+      "name": "tool/update",
+      "direction": "server",
+      "description": "Notification: streamed progress for an in-flight tool/call (correlated by request_id)."
+    },
+    {
+      "name": "hook/fire",
+      "direction": "host",
+      "description": "Fire a subscribed lifecycle hook (pre_tool_use/post_tool_use)."
+    },
+    {
+      "name": "prompt/contribution",
+      "direction": "host",
+      "description": "Request a fresh dynamic system-prompt contribution."
+    },
+    {
+      "name": "config/changed",
+      "direction": "host",
+      "description": "Notify the server its config changed."
+    },
+    {
+      "name": "shutdown",
+      "direction": "host",
+      "description": "Request a graceful stop."
+    }
+  ],
+  "capabilities": [
+    "tools",
+    "streaming",
+    "prompt",
+    "dynamic_prompt",
+    "hooks",
+    "mcp_servers"
+  ]
+}

--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -27,10 +27,16 @@ handler-based server SDK (`Server::new().tool().on_hook().dynamic_prompt()
 JSON-RPC loop. A reference `echo` example server built on it is driven by
 yolop's own client in an integration test — the SDK's interop proof and the
 foundation a future `yolop-extension-lsp` builds on.
+Schema artifact: `schema/yep/v1/meta.json` is generated from the `yolop-yep`
+`meta` module by `cargo run -p yolop-yep --bin schema-gen` (the mira pattern);
+a `cargo test` drift guard fails CI if the committed file is stale, so the
+method + capability-token vocabulary can't change without the artifact
+changing. A non-Rust author reads it to discover the wire surface. (Full
+JSON-Schema of the payloads — `schema.json` — is still a follow-up.)
 Later — the full `yolop-extension-lsp` control-plane extraction (gated on
 `evals/lsp_integration` parity to retire the built-in), `ui/ask` (needs the
 server→host reverse-request channel, still refused in phase 1),
-`workspace/changed`, `schema/yep/v1/` generation, `/extensions doctor`,
+`workspace/changed`, payload `schema.json`, `/extensions doctor`,
 providers — remain design-of-record below. Not yet wired within phase 2 (tracked as
 follow-ups): the toolchain-free crates.io source (native sparse-index +
 tarball fetch), full JSON-Schema config validation, and `config/changed`


### PR DESCRIPTION
## What changed

Adds the machine-readable protocol metadata artifact and its CI drift guard (the mira pattern), completing the wire-contract story for the `yolop-yep` crate.

- **`crates/yolop-yep/src/meta.rs`** — the method and capability-token vocabularies as data (`METHODS` with host/server direction, `CAPABILITY_TOKENS`), plus `meta()` / `meta_json()` producing the canonical index.
- **`crates/yolop-yep/src/bin/schema-gen.rs`** — `cargo run -p yolop-yep --bin schema-gen` writes `schema/yep/v1/meta.json`; `--check` fails non-zero when it's stale.
- **`schema/yep/v1/meta.json`** — the committed artifact (version, min_version, methods, capability tokens).
- **Drift guard as a `cargo test`** (`committed_meta_json_is_up_to_date`): existing CI (`cargo test`) now fails if the committed file drifts from the generator, so the vocabulary can't change without regenerating the artifact — no CI-workflow edit needed.

## Why

A non-Rust extension author needs a language-neutral description of the wire surface (which methods exist, which capability tokens a server can advertise) without reading the Rust structs. The spec's phase-5 follow-up: "generate `schema/yep/v1/` from the types with a CI drift-check before external authors pin the wire."

## Before / After

**Before:** the protocol vocabulary lived only in Rust; nothing pinned it for other languages, and a method/token change had no artifact to update.

**After:** `schema/yep/v1/meta.json` exists and is enforced. `cargo run -p yolop-yep --bin schema-gen -- --check` reports "up to date"; a vocabulary change without regeneration turns `cargo test` red.

## Risk

- Low. Additive: a new module, a new bin, a generated data file, and one test. No runtime/host behavior touched.

## Security

- No security-relevant code changes — protocol metadata + a generator + a test. No new dependencies (serde/serde_json only).

## Checklist

- [x] Tests added or updated — `meta_covers_the_protocol` (vocabulary sanity) and `committed_meta_json_is_up_to_date` (drift guard); `--check` mode exercised manually. `fmt`/`clippy -D warnings` clean; full suite green (686).
- [x] Backward compatibility considered — additive; the artifact is versioned by protocol major (`v1`).

## Follow-ups

- Full payload **`schema.json`** (JSON Schema 2020-12 of each wire type) — needs `schemars` derives on the protocol structs; `meta.json` is the smaller, no-new-deps half.
- Still open from the plan: `yolop-extension-lsp` control-plane extraction (eval-parity-gated), providers (phase 6), `/extensions doctor`, `ui/ask`/`workspace/changed`, toolchain-free crates.io install, JSON-Schema config validation.

---
_Generated by [Claude Code](https://claude.ai/code/session_017d7odSAD8o79pUrd31dpDb)_