### PR TITLE
feat(tui): add human narration for task and related tools

### DIFF
--- a/src/capabilities/background.rs
+++ b/src/capabilities/background.rs
@@ -11,15 +11,26 @@
 // session's everruns tasks. The model inspects and controls them with the
 // everruns `list_tasks` / `get_task` / `cancel_task` tools (the `session_tasks`
 // capability). See specs/background.md.
+//
+// `NarratedBackgroundExecutionCapability` wraps upstream
+// `BackgroundExecutionCapability` so `spawn_background` gets human narration
+// instead of the generic "Running Spawn Background" fallback.
 
+use crate::capabilities::narration::narrate_spawn_background;
 use crate::session_tasks_view::render_task_list;
 use async_trait::async_trait;
-use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
+use everruns_core::capabilities::{
+    BackgroundExecutionCapability, Capability, CapabilityLocalization, CapabilityStatus,
+    SystemPromptContext,
+};
 use everruns_core::command::{
     CommandDescriptor, CommandExecutionContext, CommandResult, CommandSource, ExecuteCommandRequest,
 };
 use everruns_core::session_task::SessionTaskRegistry;
 use everruns_core::session_task::TASK_KIND_MONITOR;
+use everruns_core::tool_narration::ToolNarrationPhase;
+use everruns_core::tool_types::{ToolCall, ToolDefinition};
+use everruns_core::tools::Tool;
 use everruns_core::typed_id::SessionId;
 use std::sync::Arc;
 
@@ -137,6 +148,71 @@ impl Capability for BackgroundCapability {
     }
 }
 
+/// Upstream `spawn_background` without argument-aware narration. Yolop wraps it
+/// so transcript / ACP titles read "Spawn background: …" instead of
+/// "Running Spawn Background".
+pub(crate) struct NarratedBackgroundExecutionCapability {
+    inner: BackgroundExecutionCapability,
+}
+
+impl NarratedBackgroundExecutionCapability {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: BackgroundExecutionCapability,
+        }
+    }
+}
+
+#[async_trait]
+impl Capability for NarratedBackgroundExecutionCapability {
+    fn id(&self) -> &str {
+        self.inner.id()
+    }
+
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn description(&self) -> &str {
+        self.inner.description()
+    }
+
+    fn localizations(&self) -> Vec<CapabilityLocalization> {
+        self.inner.localizations()
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        self.inner.status()
+    }
+
+    fn icon(&self) -> Option<&str> {
+        self.inner.icon()
+    }
+
+    fn category(&self) -> Option<&str> {
+        self.inner.category()
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        self.inner.tools()
+    }
+
+    fn narrate(
+        &self,
+        _tool_def: Option<&ToolDefinition>,
+        tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        if tool_call.name == "spawn_background" {
+            Some(narrate_spawn_background(tool_call, phase))
+        } else {
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -144,6 +220,7 @@ mod tests {
         CreateSessionTask, NewTaskMessage, SessionTask, SessionTaskFilter, SessionTaskUpdate,
         TaskMessage,
     };
+    use serde_json::json;
 
     /// The prompt contribution tolerates an empty registry.
     struct StubRegistry {
@@ -254,5 +331,27 @@ mod tests {
         assert!(prompt.contains("Active scheduled monitor obligations"));
         assert!(prompt.contains("task_scheduled_check"));
         assert!(prompt.contains("Reconcile each"));
+    }
+
+    #[test]
+    fn spawn_background_capability_narrates_with_title() {
+        let capability = NarratedBackgroundExecutionCapability::new();
+        let call = ToolCall {
+            id: "call-1".to_owned(),
+            name: "spawn_background".to_owned(),
+            arguments: json!({
+                "tool": "bash",
+                "title": "Wait for CI",
+                "args": { "command": "gh pr checks --watch" }
+            }),
+        };
+        let narration = capability.narrate(
+            None,
+            &call,
+            ToolNarrationPhase::Started,
+            None,
+            everruns_core::tool_narration::ToolNarrationContext::default(),
+        );
+        assert_eq!(narration.as_deref(), Some("Spawn background: Wait for CI"));
     }
 }

--- a/src/capabilities/free_search.rs
+++ b/src/capabilities/free_search.rs
@@ -1,6 +1,9 @@
 use std::time::Duration;
 
+use crate::capabilities::narration::stable_labeled;
 use async_trait::async_trait;
+use everruns_core::tool_narration::{ToolNarrationPhase, arg_str, truncate};
+use everruns_core::tool_types::ToolCall;
 use everruns_core::{Tool, ToolExecutionResult, capabilities::Capability, tool_types::ToolHints};
 use html_escape::decode_html_entities;
 use regex::Regex;
@@ -284,6 +287,17 @@ impl Tool for FreeWebSearchTool {
 
     fn display_name(&self) -> Option<&str> {
         Some("Free Web Search")
+    }
+
+    fn narrate(
+        &self,
+        tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        let detail = arg_str(&tool_call.arguments, &["query"]).map(|query| truncate(query, 48));
+        Some(stable_labeled("Search web", detail, phase))
     }
 
     fn description(&self) -> &str {

--- a/src/capabilities/lsp/mod.rs
+++ b/src/capabilities/lsp/mod.rs
@@ -15,10 +15,13 @@
 mod client;
 mod manager;
 
+use crate::capabilities::narration::stable_labeled;
 use crate::workspace_host::WorkspaceHost;
 use anyhow::{Context, Result, anyhow, bail};
 use async_trait::async_trait;
 use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
+use everruns_core::tool_narration::{ToolNarrationPhase, arg_str, basename, truncate};
+use everruns_core::tool_types::ToolCall;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use manager::{
     DEFAULT_DIAGNOSTICS_WAIT_MS, DEFAULT_REQUEST_TIMEOUT_MS, LspManager, MAX_DIAGNOSTICS_WAIT_MS,
@@ -368,6 +371,20 @@ impl Tool for LspTool {
         })
     }
 
+    fn narrate(
+        &self,
+        tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        Some(stable_labeled(
+            self.display_name().unwrap_or(self.name()),
+            lsp_narration_detail(self.action, &tool_call.arguments),
+            phase,
+        ))
+    }
+
     fn description(&self) -> &str {
         match self.action {
             LspAction::Diagnostics => {
@@ -493,6 +510,31 @@ impl Tool for LspTool {
 
 // ---------------------------------------------------------------------------
 // Argument helpers
+
+fn lsp_narration_detail(action: LspAction, arguments: &Value) -> Option<String> {
+    match action {
+        LspAction::Symbols => {
+            if let Some(query) = arg_str(arguments, &["query"]) {
+                return Some(truncate(query, 48));
+            }
+            arg_str(arguments, &["path", "hint_path"]).map(|path| basename(path).to_string())
+        }
+        LspAction::Rename => {
+            let path = arg_str(arguments, &["path"]).map(|path| basename(path).to_string())?;
+            match arg_str(arguments, &["new_name"]) {
+                Some(name) => Some(format!("{path} → {}", truncate(name, 32))),
+                None => Some(path),
+            }
+        }
+        _ => {
+            let path = arg_str(arguments, &["path"]).map(|path| basename(path).to_string())?;
+            match arguments.get("line").and_then(Value::as_u64) {
+                Some(line) => Some(format!("{path}:{line}")),
+                None => Some(path),
+            }
+        }
+    }
+}
 
 fn required_str<'a>(arguments: &'a Value, key: &str) -> Result<&'a str> {
     arguments

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -34,7 +34,9 @@ pub(crate) use crate::user_ask::USER_ASK_CAPABILITY_ID;
 pub(crate) use approval::{APPROVAL_CAPABILITY_ID, ApprovalCapability};
 pub(crate) use ast_grep::{AST_GREP_CAPABILITY_ID, AstEditCapability, AstGrepCapability};
 pub(crate) use attribution::{ATTRIBUTION_CAPABILITY_ID, AttributionCapability};
-pub(crate) use background::{BACKGROUND_CAPABILITY_ID, BackgroundCapability};
+pub(crate) use background::{
+    BACKGROUND_CAPABILITY_ID, BackgroundCapability, NarratedBackgroundExecutionCapability,
+};
 pub(crate) use client_commands::{CLIENT_COMMANDS_CAPABILITY_ID, ClientCommandsCapability};
 pub(crate) use config::{CONFIG_CAPABILITY_ID, ConfigCapability};
 pub(crate) use free_search::FreeSearchCapability;

--- a/src/capabilities/narration.rs
+++ b/src/capabilities/narration.rs
@@ -25,6 +25,86 @@ pub fn narrate_set_config(tool_call: &ToolCall, phase: ToolNarrationPhase) -> St
     stable_labeled("Set config", set_config_detail(&tool_call.arguments), phase)
 }
 
+/// Everruns `session_tasks` tools otherwise fall back to "Running List Tasks".
+pub fn narrate_session_task_tool(
+    tool_call: &ToolCall,
+    phase: ToolNarrationPhase,
+) -> Option<String> {
+    match tool_call.name.as_str() {
+        "list_tasks" => Some(narrate_list_tasks(tool_call, phase)),
+        "get_task" => Some(narrate_get_task(tool_call, phase)),
+        "wait_task" => Some(narrate_wait_task(tool_call, phase)),
+        "message_task" => Some(narrate_message_task(tool_call, phase)),
+        "cancel_task" => Some(narrate_cancel_task(tool_call, phase)),
+        _ => None,
+    }
+}
+
+pub fn narrate_list_tasks(tool_call: &ToolCall, phase: ToolNarrationPhase) -> String {
+    let detail = list_tasks_detail(&tool_call.arguments);
+    stable_labeled("List tasks", detail, phase)
+}
+
+pub fn narrate_get_task(tool_call: &ToolCall, phase: ToolNarrationPhase) -> String {
+    let detail = arg_str(&tool_call.arguments, &["task_id"]).map(|id| truncate(id, 48));
+    stable_labeled("Get task", detail, phase)
+}
+
+pub fn narrate_wait_task(tool_call: &ToolCall, phase: ToolNarrationPhase) -> String {
+    let detail = arg_str(&tool_call.arguments, &["task_id"]).map(|id| truncate(id, 48));
+    stable_labeled("Wait for task", detail, phase)
+}
+
+pub fn narrate_message_task(tool_call: &ToolCall, phase: ToolNarrationPhase) -> String {
+    let detail = arg_str(&tool_call.arguments, &["task_id"]).map(|id| truncate(id, 48));
+    stable_labeled("Message task", detail, phase)
+}
+
+pub fn narrate_cancel_task(tool_call: &ToolCall, phase: ToolNarrationPhase) -> String {
+    let detail = arg_str(&tool_call.arguments, &["task_id"]).map(|id| truncate(id, 48));
+    stable_labeled("Cancel task", detail, phase)
+}
+
+/// Everruns `spawn_background` otherwise falls back to "Running Spawn Background".
+pub fn narrate_spawn_background(tool_call: &ToolCall, phase: ToolNarrationPhase) -> String {
+    stable_labeled(
+        "Spawn background",
+        spawn_background_detail(&tool_call.arguments),
+        phase,
+    )
+}
+
+fn list_tasks_detail(arguments: &Value) -> Option<String> {
+    let state = arg_str(arguments, &["state"]);
+    let kind = arg_str(arguments, &["kind"]);
+    match (state, kind) {
+        (Some(state), Some(kind)) => Some(format!("{state}, {kind}")),
+        (Some(state), None) => Some(state.to_string()),
+        (None, Some(kind)) => Some(kind.to_string()),
+        (None, None) => None,
+    }
+}
+
+fn spawn_background_detail(arguments: &Value) -> Option<String> {
+    if let Some(title) = arg_str(arguments, &["title"]) {
+        return Some(truncate(title, 48));
+    }
+    let tool = arg_str(arguments, &["tool"])?;
+    let scheduled = arguments
+        .get("schedule")
+        .is_some_and(|value| !value.is_null());
+    let command = arguments
+        .get("args")
+        .and_then(|args| arg_str(args, &["command", "commands"]))
+        .map(|command| truncate(command, 40));
+    match (scheduled, command) {
+        (true, Some(command)) => Some(format!("schedule {tool} `{command}`")),
+        (true, None) => Some(format!("schedule {tool}")),
+        (false, Some(command)) => Some(format!("{tool} `{command}`")),
+        (false, None) => Some(tool.to_string()),
+    }
+}
+
 fn set_config_detail(arguments: &Value) -> Option<String> {
     let key = arg_str(arguments, &["key"])?;
     if arguments.get("json").is_some_and(|v| !v.is_null()) {
@@ -103,5 +183,80 @@ mod tests {
             ),
             "Run command: /help"
         );
+    }
+
+    #[test]
+    fn wait_task_narration_uses_human_verb_and_task_id() {
+        let call = ToolCall {
+            id: "call-1".to_owned(),
+            name: "wait_task".to_owned(),
+            arguments: json!({ "task_id": "task_ci_watch" }),
+        };
+        assert_eq!(
+            narrate_wait_task(&call, ToolNarrationPhase::Started),
+            "Wait for task: task_ci_watch"
+        );
+    }
+
+    #[test]
+    fn list_tasks_narration_includes_filters() {
+        let call = ToolCall {
+            id: "call-1".to_owned(),
+            name: "list_tasks".to_owned(),
+            arguments: json!({ "state": "running", "kind": "background_tool" }),
+        };
+        assert_eq!(
+            narrate_list_tasks(&call, ToolNarrationPhase::Completed),
+            "List tasks: running, background_tool"
+        );
+    }
+
+    #[test]
+    fn spawn_background_narration_prefers_title_then_command() {
+        let titled = ToolCall {
+            id: "call-1".to_owned(),
+            name: "spawn_background".to_owned(),
+            arguments: json!({
+                "tool": "bash",
+                "title": "Wait for CI",
+                "args": { "command": "gh pr checks --watch" }
+            }),
+        };
+        assert_eq!(
+            narrate_spawn_background(&titled, ToolNarrationPhase::Started),
+            "Spawn background: Wait for CI"
+        );
+
+        let with_command = ToolCall {
+            id: "call-2".to_owned(),
+            name: "spawn_background".to_owned(),
+            arguments: json!({
+                "tool": "bash",
+                "args": { "command": "gh pr checks --watch" }
+            }),
+        };
+        assert_eq!(
+            narrate_spawn_background(&with_command, ToolNarrationPhase::Completed),
+            "Spawn background: bash `gh pr checks --watch`"
+        );
+    }
+
+    #[test]
+    fn session_task_dispatcher_covers_known_tools() {
+        let call = ToolCall {
+            id: "call-1".to_owned(),
+            name: "get_task".to_owned(),
+            arguments: json!({ "task_id": "task_1" }),
+        };
+        assert_eq!(
+            narrate_session_task_tool(&call, ToolNarrationPhase::Started).as_deref(),
+            Some("Get task: task_1")
+        );
+        let unknown = ToolCall {
+            id: "call-2".to_owned(),
+            name: "mystery".to_owned(),
+            arguments: json!({}),
+        };
+        assert!(narrate_session_task_tool(&unknown, ToolNarrationPhase::Started).is_none());
     }
 }

--- a/src/capabilities/session_tasks_override.rs
+++ b/src/capabilities/session_tasks_override.rs
@@ -6,13 +6,14 @@
 //! task surface, replacing only `cancel_task` until the runtime result contract
 //! exposes the post-cancellation state.
 
+use crate::capabilities::narration::narrate_session_task_tool;
 use async_trait::async_trait;
 use everruns_core::capabilities::{
     Capability, CapabilityLocalization, CapabilityStatus, SessionTasksCapability,
     SystemPromptContext,
 };
 use everruns_core::tool_narration::ToolNarrationPhase;
-use everruns_core::tool_types::{ToolCall, ToolHints, ToolPolicy};
+use everruns_core::tool_types::{ToolCall, ToolDefinition, ToolHints, ToolPolicy};
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
 use everruns_core::{ScheduleId, SessionTaskState, SessionTaskUpdate};
@@ -87,6 +88,17 @@ impl Capability for TruthfulSessionTasksCapability {
             })
             .collect()
     }
+
+    fn narrate(
+        &self,
+        _tool_def: Option<&ToolDefinition>,
+        tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        narrate_session_task_tool(tool_call, phase)
+    }
 }
 
 struct TruthfulCancelTaskTool {
@@ -127,10 +139,10 @@ impl Tool for TruthfulCancelTaskTool {
         &self,
         tool_call: &ToolCall,
         phase: ToolNarrationPhase,
-        locale: Option<&str>,
-        ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+        _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
-        self.inner.narrate(tool_call, phase, locale, ctx)
+        narrate_session_task_tool(tool_call, phase)
     }
 
     async fn execute(&self, arguments: Value) -> ToolExecutionResult {
@@ -369,6 +381,24 @@ mod tests {
             .await
             .expect("create monitor task");
         (session_id, schedule.id, registry, schedules)
+    }
+
+    #[test]
+    fn session_tasks_capability_narrates_wait_task() {
+        let capability = TruthfulSessionTasksCapability::new();
+        let call = ToolCall {
+            id: "call-1".to_owned(),
+            name: "wait_task".to_owned(),
+            arguments: json!({ "task_id": "task_ci_watch" }),
+        };
+        let narration = capability.narrate(
+            None,
+            &call,
+            ToolNarrationPhase::Started,
+            None,
+            everruns_core::tool_narration::ToolNarrationContext::default(),
+        );
+        assert_eq!(narration.as_deref(), Some("Wait for task: task_ci_watch"));
     }
 
     #[tokio::test]

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -335,6 +335,67 @@ mod tests {
     }
 
     #[test]
+    fn session_task_narration_is_visible_in_live_activity_and_transcript() {
+        use crate::capabilities::narration::{narrate_spawn_background, narrate_wait_task};
+        use crate::transcript::status_for_event;
+        use everruns_core::events::ToolStartedData;
+        use everruns_core::tool_narration::ToolNarrationPhase;
+        use everruns_core::tool_types::ToolCall;
+
+        let wait_call = ToolCall {
+            id: "call_wait".to_string(),
+            name: "wait_task".to_string(),
+            arguments: json!({ "task_id": "task_ci_watch" }),
+        };
+        let wait_narration = narrate_wait_task(&wait_call, ToolNarrationPhase::Started);
+        let started = RuntimeEvent::new(
+            SessionId::new(),
+            EventContext::empty(),
+            ToolStartedData {
+                tool_call: wait_call,
+                display_name: Some("Wait Task".to_string()),
+                narration: Some(wait_narration.clone()),
+                tool_call_fingerprint: None,
+            },
+        );
+        assert_eq!(
+            status_for_event(&started).map(|status| status.text),
+            Some("→ Wait for task: task_ci_watch".to_string()),
+            "live activity must prefer human narration over display_name"
+        );
+
+        let spawn_call = ToolCall {
+            id: "call_spawn".to_string(),
+            name: "spawn_background".to_string(),
+            arguments: json!({
+                "tool": "bash",
+                "title": "Wait for CI",
+                "args": { "command": "gh pr checks --watch" }
+            }),
+        };
+        let mut completed = ToolCompletedData::success(
+            "call_spawn".to_string(),
+            "spawn_background".to_string(),
+            vec![ContentPart::text(
+                json!({ "task_id": "task_ci_watch", "state": "running" }).to_string(),
+            )],
+            None,
+        );
+        completed.display_name = Some("Spawn Background".to_string());
+        completed.narration = Some(narrate_spawn_background(
+            &spawn_call,
+            ToolNarrationPhase::Completed,
+        ));
+        let event = RuntimeEvent::new(SessionId::new(), EventContext::empty(), completed);
+        let rendered = plain_transcript_line(&lines_for_event(&event)[0]);
+        assert_eq!(
+            rendered, "tool › ✓ Spawn background: Wait for CI",
+            "transcript must not fall back to 'Ran Spawn Background'"
+        );
+        assert_ne!(wait_narration, "Wait Task");
+    }
+
+    #[test]
     fn status_model_exposes_compact_status_values_without_terminal() {
         let lines = state().status_lines();
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -34,15 +34,14 @@ use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 use everruns_core::capabilities::{
     AGENT_INSTRUCTIONS_CAPABILITY_ID, AgentInstructionsCapability, BTW_CAPABILITY_ID,
-    BackgroundExecutionCapability, BtwCapability, COMPACTION_CAPABILITY_ID, CompactionCapability,
-    INFINITY_CONTEXT_CAPABILITY_ID, InfinityContextCapability, LOOP_DETECTION_CAPABILITY_ID,
-    LoopDetectionCapability, MessageMetadataCapability, PROMPT_CACHING_CAPABILITY_ID,
-    PromptCachingCapability, SESSION_FILE_SYSTEM_CAPABILITY_ID, SESSION_STORAGE_CAPABILITY_ID,
-    SESSION_TASKS_CAPABILITY_ID, SKILLS_CAPABILITY_ID, STATELESS_TODO_LIST_CAPABILITY_ID,
-    ScopedSkillsCapability, SessionStorageCapability, StatelessTodoListCapability,
-    TOOL_OUTPUT_PERSISTENCE_CAPABILITY_ID, TOOL_SEARCH_CAPABILITY_ID,
-    ToolOutputPersistenceCapability, ToolSearchCapability, USER_HOOKS_CAPABILITY_ID,
-    UserHooksCapability, WEB_FETCH_CAPABILITY_ID, WebFetchCapability,
+    BtwCapability, COMPACTION_CAPABILITY_ID, CompactionCapability, INFINITY_CONTEXT_CAPABILITY_ID,
+    InfinityContextCapability, LOOP_DETECTION_CAPABILITY_ID, LoopDetectionCapability,
+    MessageMetadataCapability, PROMPT_CACHING_CAPABILITY_ID, PromptCachingCapability,
+    SESSION_FILE_SYSTEM_CAPABILITY_ID, SESSION_STORAGE_CAPABILITY_ID, SESSION_TASKS_CAPABILITY_ID,
+    SKILLS_CAPABILITY_ID, STATELESS_TODO_LIST_CAPABILITY_ID, ScopedSkillsCapability,
+    SessionStorageCapability, StatelessTodoListCapability, TOOL_OUTPUT_PERSISTENCE_CAPABILITY_ID,
+    TOOL_SEARCH_CAPABILITY_ID, ToolOutputPersistenceCapability, ToolSearchCapability,
+    USER_HOOKS_CAPABILITY_ID, UserHooksCapability, WEB_FETCH_CAPABILITY_ID, WebFetchCapability,
 };
 use everruns_core::command::CommandDescriptor;
 use everruns_core::driver_registry::{DriverRegistry, ProviderMetadata};
@@ -2497,7 +2496,7 @@ pub async fn build_with_options(
     capabilities.register(
         crate::capabilities::session_tasks_override::TruthfulSessionTasksCapability::new(),
     );
-    capabilities.register(BackgroundExecutionCapability);
+    capabilities.register(crate::capabilities::NarratedBackgroundExecutionCapability::new());
     capabilities.register(SessionStorageCapability);
     capabilities.register(DaytonaCapability);
     capabilities.register(UserHooksCapability);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed
Transcript / ACP tool titles for background session tools no longer fall back to robotic everruns labels like `Running Get Task` or `Running Spawn Background`. They now use argument-aware human narration in the same style as other yolop tools (`Get config`, `Build repo map`, …).

Also covers other yolop-owned tools that were still on the generic fallback: `free_web_search` and the LSP tools.

## Why
`list_tasks` / `get_task` / `wait_task` / `message_task` / `cancel_task` and `spawn_background` live in everruns and do not implement `Tool::narrate`. Without a host override, the UI shows `Running {Display Name}`.

## Before / After
**Before**
- `Running Get Task`
- `Running List Tasks`
- `Running Wait Task`
- `Running Spawn Background`

**After**
- `Get task: task_ci_watch`
- `List tasks: running, background_tool`
- `Wait for task: task_ci_watch`
- `Spawn background: Wait for CI` (prefers `title`, else `tool` + short command)

## Testing
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- Offline smoke: `cargo run -- --provider llmsim -p "hi"`
- Presentation-model test: live activity `→ Wait for task: …` and transcript `tool › ✓ Spawn background: Wait for CI`
- CI Live Provider Smoke (Doppler) on the PR

## Security
Narration-only surface. No new capabilities, filesystem, shell, or provider-key paths. Details use existing `arg_str` / truncation helpers; spawn-background titles and command prefixes are truncated and do not introduce secret-bearing keys beyond the existing narration redaction helpers used elsewhere. TM-FS / TM-BASH / TM-LLM / TM-TOOL / TM-DEP: not implicated.

## Risk
- Low
- Narration-only; no execution / policy changes. `cancel_task` behavior wrapper is unchanged aside from narrate.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; narration strings may change in UI)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3235e2d9-8710-4360-a9a0-1dff2a8e588e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3235e2d9-8710-4360-a9a0-1dff2a8e588e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

