### PR TITLE
feat(mcp): interactive OAuth login for remote MCP servers

### DIFF
--- a/specs/mcp.md
+++ b/specs/mcp.md
@@ -62,20 +62,47 @@ Config shape:
 
 `type` defaults to `http`; for HTTP, `url` is required.
 
+## Authentication
+
+Credentials for a server are resolved per request by the runtime's
+`McpAuthProvider`, in this order:
+
+1. **User-scoped OAuth token** minted by `/mcp login <name>` and stored in the
+   connection store (`mcp-oauth:<provider>`). Tokens are refreshed
+   automatically when they near expiry.
+2. **Environment bearer** — `<PROVIDER>_ACCESS_TOKEN`/`_API_KEY`/`_TOKEN` (by
+   `oauth_provider_id`) or `MCP_<SERVER>_TOKEN` — for headless/CI use.
+3. Literal `headers` in the config (with `${VAR}` expansion), applied by the
+   transport regardless of the provider.
+
+**OAuth login** (`/mcp login <name>`, remote HTTP servers) is discovery-based:
+protected-resource metadata (RFC 9728) → authorization-server metadata
+(RFC 8414 / OpenID discovery) → dynamic client registration (RFC 7591) when the
+server offers it → authorization code + PKCE (RFC 7636) through the browser with
+a loopback redirect. The token endpoint and client id are persisted alongside
+the tokens so refresh is self-contained. Because credentials are resolved per
+turn, a fresh login takes effect on the next message — no restart (composes with
+live reload above).
+
 ## Trust model
 
 - **HTTP** keeps the runtime's DNS-pinned SSRF protection — no relaxation.
 - **stdio** spawns local processes the user explicitly listed in their own
   `.mcp.json`. Authoring that file is the act of consent, mirroring how other
   MCP clients treat a project-scoped server list.
+- **OAuth** discovery/token calls go to the authorization server advertised by
+  the (user-configured) MCP server. Discovered endpoints must be `https`
+  (loopback may use `http`), bounding downgrade to plaintext. The user
+  configuring the server URL is the act of consent; yolop is a local CLI on the
+  user's own network.
 - **No per-call approval**: MCP tools run autonomously like the rest of yolop's
   tools; the standing guardrail is the write blocklist on filesystem writes.
 
 ## Non-goals (for now)
 
-- OAuth (browser/device-code) for remote servers. API-key/bearer via `headers`
-  (with `${VAR}` expansion) covers the common case; the runtime exposes an
-  `mcp_auth_provider()` seam for a future env/device-code provider.
+- OAuth **device-code** flow (browser + loopback covers the CLI case); a
+  configured `client_id` for servers without dynamic registration (DCR-only for
+  now).
 - MCP **resources** and **prompts** (tools are the 90% case).
 - ACP MCP pass-through: `mcpServers` supplied by an ACP client is still
   accepted-and-ignored (see `src/acp/protocol.rs`); only yolop's own
@@ -89,4 +116,7 @@ Config shape:
 | Wiring into the session | `src/runtime.rs` (`session_mcp_servers`, `StartupInfo.mcp_server_names`) |
 | `/mcp` command (list/reload/enable/disable/remove) | `src/capabilities/client_commands.rs`, `src/host_ui.rs`, `src/app/mod.rs` |
 | Live reload seam | `src/runtime.rs` (`RuntimeHandles::reload_mcp_servers`), `src/session.rs` |
+| OAuth login (discovery, DCR, PKCE) | `src/mcp_oauth_login.rs` |
+| OAuth token storage | `src/mcp_oauth.rs` (connection store) |
+| Auth provider (stored token + refresh, env fallback) | `src/runtime.rs` (`StoredMcpAuthProvider`) |
 | Client / transports / executor | upstream `everruns-mcp`, `everruns-runtime` (`mcp-stdio` feature) |

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1160,7 +1160,7 @@ impl App {
     }
 
     const MCP_USAGE: &'static str =
-        "usage: /mcp [reload | enable|disable|remove <name> [global|workspace]]";
+        "usage: /mcp [reload | login <name> | enable|disable|remove <name> [global|workspace]]";
 
     async fn manage_mcp_command(&mut self, raw: Option<&str>) {
         let Some(raw) = raw.map(str::trim).filter(|s| !s.is_empty()) else {
@@ -1192,6 +1192,20 @@ impl App {
                 return;
             }
             self.reload_mcp_and_report(None).await;
+            return;
+        }
+
+        // `login <name>` runs the interactive OAuth flow for a remote server.
+        if action == "login" {
+            let name = parts.next();
+            if parts.next().is_some() {
+                self.push_system(Self::MCP_USAGE.into());
+                return;
+            }
+            match name {
+                Some(name) => self.mcp_login(name).await,
+                None => self.push_system(Self::MCP_USAGE.into()),
+            }
             return;
         }
 
@@ -1237,6 +1251,50 @@ impl App {
         match result {
             Ok(message) => self.reload_mcp_and_report(Some(message)).await,
             Err(error) => self.push_system(format!("failed to update MCP config: {error}")),
+        }
+    }
+
+    /// Run the interactive OAuth login flow for a remote MCP server and persist
+    /// the resulting tokens. Because the runtime resolves credentials per turn
+    /// through the shared auth provider, the token is used on the next turn with
+    /// no restart or reload needed.
+    async fn mcp_login(&mut self, name: &str) {
+        let servers = crate::mcp_config::load_mcp_servers(&self.startup.workspace_root);
+        let Some(server) = servers.get(name) else {
+            self.push_system(format!(
+                "MCP server `{name}` is not configured or is disabled; add it and run `/mcp reload` first"
+            ));
+            return;
+        };
+        if server.transport_type != everruns_core::McpServerTransportType::Http {
+            self.push_system(format!(
+                "`{name}` is a stdio server; OAuth login only applies to remote HTTP servers"
+            ));
+            return;
+        }
+        let url = server.url.clone();
+        let provider_key = server
+            .oauth_provider_id
+            .clone()
+            .unwrap_or_else(|| name.to_string());
+
+        self.push_system(format!("opening browser for `{name}` OAuth login…"));
+        match crate::mcp_oauth_login::login(&url, None, None).await {
+            Ok(tokens) => {
+                match crate::mcp_oauth::save_tokens(
+                    &self.session.connections(),
+                    &provider_key,
+                    tokens,
+                ) {
+                    Ok(()) => self.push_system(format!(
+                        "signed in to `{name}` — the token is active on your next message"
+                    )),
+                    Err(error) => self.push_system(format!(
+                        "saved login for `{name}` failed to persist: {error}"
+                    )),
+                }
+            }
+            Err(error) => self.push_system(format!("`{name}` OAuth login failed: {error}")),
         }
     }
 
@@ -4625,6 +4683,43 @@ mod tests {
                 .iter()
                 .any(|line| line.text.contains("active MCP servers")),
             "disable should report the active set: {:?}",
+            app.lines
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn mcp_login_rejects_unknown_and_stdio_servers() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+
+        // Unknown server: guidance to add it first, no browser attempt.
+        app.lines.clear();
+        app.dispatch_command_for_test("mcp login ghost").await;
+        assert!(
+            app.lines
+                .iter()
+                .any(|line| line.text.contains("`ghost` is not configured")),
+            "unknown server should be reported: {:?}",
+            app.lines
+        );
+
+        // A stdio server is not eligible for OAuth login.
+        std::fs::write(
+            app.startup.workspace_root.join(".mcp.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "mcpServers": { "fs": { "type": "stdio", "command": "true" } }
+            }))
+            .unwrap(),
+        )
+        .expect("write .mcp.json");
+        app.lines.clear();
+        app.dispatch_command_for_test("mcp login fs").await;
+        assert!(
+            app.lines
+                .iter()
+                .any(|line| line.text.contains("stdio server")
+                    && line.text.contains("OAuth login only applies")),
+            "stdio server should be rejected before any browser flow: {:?}",
             app.lines
         );
     }

--- a/src/capabilities/client_commands.rs
+++ b/src/capabilities/client_commands.rs
@@ -115,7 +115,7 @@ fn command_descriptors() -> Vec<CommandDescriptor> {
         cmd("tools", "list available tools", &[]),
         cmd(
             "mcp",
-            "list, reload, or enable/disable/remove MCP servers live",
+            "list/reload/login or enable/disable/remove MCP servers live",
             &[opt("action")],
         ),
         cmd("cwd", "show workspace root", &[]),

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod image_input;
 mod into;
 mod mcp_config;
 mod mcp_oauth;
+mod mcp_oauth_login;
 mod oauth_flow;
 mod paste_attachment;
 mod presentation;

--- a/src/mcp_oauth.rs
+++ b/src/mcp_oauth.rs
@@ -1,3 +1,12 @@
+//! Persistence for user-scoped MCP OAuth tokens.
+//!
+//! Tokens minted by the interactive login flow (`crate::mcp_oauth_login`) are
+//! stored in the shared [`ConnectionStore`] under a stable `mcp-oauth:<id>`
+//! connection id, alongside just enough of the authorization-server contract
+//! (`token_endpoint`, `client_id`, optional `client_secret`) to refresh the
+//! access token later without re-reading MCP config or re-running discovery.
+//! [`crate::runtime::StoredMcpAuthProvider`] reads them back per request.
+
 use crate::connectors::{ConnectionStore, StoredConnection};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -10,8 +19,10 @@ const REFRESH_TOKEN_FIELD: &str = "refresh_token";
 const TOKEN_TYPE_FIELD: &str = "token_type";
 const EXPIRES_AT_FIELD: &str = "expires_at";
 const SCOPE_FIELD: &str = "scope";
+const TOKEN_ENDPOINT_FIELD: &str = "token_endpoint";
+const CLIENT_ID_FIELD: &str = "client_id";
+const CLIENT_SECRET_FIELD: &str = "client_secret";
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct McpOAuthTokenSet {
     pub(crate) access_token: String,
@@ -20,12 +31,25 @@ pub(crate) struct McpOAuthTokenSet {
     pub(crate) token_type: String,
     pub(crate) expires_at: Option<DateTime<Utc>>,
     pub(crate) scope: Option<String>,
+    /// Authorization-server token endpoint, retained so a refresh is
+    /// self-contained (no config re-read / re-discovery).
+    pub(crate) token_endpoint: Option<String>,
+    /// OAuth client id used at login (from dynamic registration or config).
+    pub(crate) client_id: Option<String>,
+    /// Client secret, only for confidential clients that were issued one.
+    pub(crate) client_secret: Option<String>,
 }
 
 impl McpOAuthTokenSet {
-    #[allow(dead_code)]
+    /// True once `expires_at` has arrived. A `now` at or past the expiry is
+    /// treated as expired so we refresh before the token is rejected.
     pub(crate) fn is_expired(&self, now: DateTime<Utc>) -> bool {
         self.expires_at.is_some_and(|expires_at| expires_at <= now)
+    }
+
+    /// The `Authorization` header value this token set contributes.
+    pub(crate) fn authorization_value(&self) -> String {
+        format!("{} {}", self.token_type, self.access_token)
     }
 }
 
@@ -33,12 +57,10 @@ fn default_token_type() -> String {
     "Bearer".to_string()
 }
 
-#[allow(dead_code)]
 pub(crate) fn connection_id(provider_id: &str) -> String {
     format!("mcp-oauth:{provider_id}")
 }
 
-#[allow(dead_code)]
 pub(crate) fn save_tokens(
     store: &ConnectionStore,
     provider_id: &str,
@@ -47,7 +69,6 @@ pub(crate) fn save_tokens(
     store.save(&connection_id(provider_id), tokens.into())
 }
 
-#[allow(dead_code)]
 pub(crate) fn load_tokens(store: &ConnectionStore, provider_id: &str) -> Option<McpOAuthTokenSet> {
     store
         .get(&connection_id(provider_id))
@@ -69,6 +90,15 @@ impl From<McpOAuthTokenSet> for StoredConnection {
         if let Some(scope) = tokens.scope {
             fields.insert(SCOPE_FIELD.to_string(), scope);
         }
+        if let Some(token_endpoint) = tokens.token_endpoint {
+            fields.insert(TOKEN_ENDPOINT_FIELD.to_string(), token_endpoint);
+        }
+        if let Some(client_id) = tokens.client_id {
+            fields.insert(CLIENT_ID_FIELD.to_string(), client_id);
+        }
+        if let Some(client_secret) = tokens.client_secret {
+            fields.insert(CLIENT_SECRET_FIELD.to_string(), client_secret);
+        }
         StoredConnection {
             fields,
             metadata: None,
@@ -83,40 +113,30 @@ impl TryFrom<StoredConnection> for McpOAuthTokenSet {
         if connection.fields.get(KIND_FIELD).map(String::as_str) != Some(KIND_OAUTH) {
             return Err(());
         }
-        let access_token = connection
-            .fields
-            .get(ACCESS_TOKEN_FIELD)
-            .filter(|token| !token.trim().is_empty())
-            .cloned()
-            .ok_or(())?;
-        let refresh_token = connection
-            .fields
-            .get(REFRESH_TOKEN_FIELD)
-            .filter(|token| !token.trim().is_empty())
-            .cloned();
-        let token_type = connection
-            .fields
-            .get(TOKEN_TYPE_FIELD)
-            .filter(|token_type| !token_type.trim().is_empty())
-            .cloned()
-            .unwrap_or_else(default_token_type);
+        let non_empty = |field: &str| {
+            connection
+                .fields
+                .get(field)
+                .filter(|value| !value.trim().is_empty())
+                .cloned()
+        };
+        let access_token = non_empty(ACCESS_TOKEN_FIELD).ok_or(())?;
+        let token_type = non_empty(TOKEN_TYPE_FIELD).unwrap_or_else(default_token_type);
         let expires_at = connection
             .fields
             .get(EXPIRES_AT_FIELD)
             .map(|raw| DateTime::parse_from_rfc3339(raw).map(|dt| dt.with_timezone(&Utc)))
             .transpose()
             .map_err(|_| ())?;
-        let scope = connection
-            .fields
-            .get(SCOPE_FIELD)
-            .filter(|scope| !scope.trim().is_empty())
-            .cloned();
         Ok(Self {
             access_token,
-            refresh_token,
+            refresh_token: non_empty(REFRESH_TOKEN_FIELD),
             token_type,
             expires_at,
-            scope,
+            scope: non_empty(SCOPE_FIELD),
+            token_endpoint: non_empty(TOKEN_ENDPOINT_FIELD),
+            client_id: non_empty(CLIENT_ID_FIELD),
+            client_secret: non_empty(CLIENT_SECRET_FIELD),
         })
     }
 }
@@ -126,35 +146,40 @@ mod tests {
     use super::*;
     use chrono::TimeZone;
 
+    fn sample(expires_at: Option<DateTime<Utc>>) -> McpOAuthTokenSet {
+        McpOAuthTokenSet {
+            access_token: "access".to_string(),
+            refresh_token: Some("refresh".to_string()),
+            token_type: "Bearer".to_string(),
+            expires_at,
+            scope: Some("search".to_string()),
+            token_endpoint: Some("https://as.example/token".to_string()),
+            client_id: Some("client-123".to_string()),
+            client_secret: None,
+        }
+    }
+
     #[test]
-    fn stores_oauth_tokens_under_provider_connection_id() {
+    fn round_trips_oauth_tokens_with_refresh_metadata() {
         let tmp = tempfile::tempdir().expect("tmp");
         let store = ConnectionStore::open(tmp.path().join("connections.toml"));
         let expires_at = Utc.with_ymd_and_hms(2030, 1, 2, 3, 4, 5).unwrap();
-        save_tokens(
-            &store,
-            "parallel",
-            McpOAuthTokenSet {
-                access_token: "access".to_string(),
-                refresh_token: Some("refresh".to_string()),
-                token_type: "Bearer".to_string(),
-                expires_at: Some(expires_at),
-                scope: Some("search".to_string()),
-            },
-        )
-        .expect("save tokens");
+        save_tokens(&store, "parallel", sample(Some(expires_at))).expect("save tokens");
 
         let raw = store.get("mcp-oauth:parallel").expect("stored raw");
         assert_eq!(raw.fields.get("kind").map(String::as_str), Some("oauth"));
         assert_eq!(
-            raw.fields.get("refresh_token").map(String::as_str),
-            Some("refresh")
+            raw.fields.get("token_endpoint").map(String::as_str),
+            Some("https://as.example/token")
         );
+
         let loaded = load_tokens(&store, "parallel").expect("loaded tokens");
         assert_eq!(loaded.access_token, "access");
         assert_eq!(loaded.refresh_token.as_deref(), Some("refresh"));
         assert_eq!(loaded.expires_at, Some(expires_at));
         assert_eq!(loaded.scope.as_deref(), Some("search"));
+        assert_eq!(loaded.client_id.as_deref(), Some("client-123"));
+        assert_eq!(loaded.authorization_value(), "Bearer access");
     }
 
     #[test]
@@ -169,13 +194,7 @@ mod tests {
     #[test]
     fn detects_expired_tokens_at_boundary() {
         let expires_at = Utc.with_ymd_and_hms(2030, 1, 2, 3, 4, 5).unwrap();
-        let tokens = McpOAuthTokenSet {
-            access_token: "access".to_string(),
-            refresh_token: None,
-            token_type: "Bearer".to_string(),
-            expires_at: Some(expires_at),
-            scope: None,
-        };
+        let tokens = sample(Some(expires_at));
         assert!(!tokens.is_expired(expires_at - chrono::TimeDelta::seconds(1)));
         assert!(tokens.is_expired(expires_at));
     }

--- a/src/mcp_oauth_login.rs
+++ b/src/mcp_oauth_login.rs
@@ -1,0 +1,774 @@
+//! Interactive OAuth login for remote (HTTP) MCP servers.
+//!
+//! Implements the MCP authorization handshake against a server's own
+//! authorization server, discovered at runtime rather than hand-configured:
+//!
+//! 1. **Protected-resource metadata** (RFC 9728) at the server origin points to
+//!    its authorization server(s); we fall back to treating the server origin
+//!    as the issuer when the document is absent.
+//! 2. **Authorization-server metadata** (RFC 8414 / OpenID discovery) yields the
+//!    `authorization`/`token`/`registration` endpoints.
+//! 3. **Dynamic client registration** (RFC 7591) mints a public client when the
+//!    server advertises a registration endpoint and no `client_id` is
+//!    configured.
+//! 4. **Authorization code + PKCE** (RFC 7636) runs through the browser with a
+//!    loopback redirect (RFC 8252), and the code is exchanged for tokens.
+//!
+//! The resulting [`McpOAuthTokenSet`] carries the token endpoint and client id
+//! so [`refresh`] (and the runtime auth provider) can renew the access token
+//! without re-discovering anything.
+
+use crate::mcp_oauth::McpOAuthTokenSet;
+use crate::oauth_flow;
+use anyhow::{Context, Result, anyhow};
+use chrono::{Duration, Utc};
+use reqwest::Url;
+use serde::Deserialize;
+use std::collections::HashMap;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+const CALLBACK_PATH: &str = "/callback";
+const CLIENT_NAME: &str = "yolop";
+/// Refresh a little before the hard expiry so a token is renewed before the
+/// server would reject it.
+const REFRESH_SKEW: Duration = Duration::seconds(60);
+
+/// Authorization-server endpoints resolved via discovery.
+#[derive(Debug, Clone)]
+pub(crate) struct OAuthEndpoints {
+    pub authorization_endpoint: String,
+    pub token_endpoint: String,
+    pub registration_endpoint: Option<String>,
+    pub scopes_supported: Option<Vec<String>>,
+}
+
+/// The OAuth client used for a login — either configured or dynamically
+/// registered.
+#[derive(Debug, Clone)]
+struct OAuthClient {
+    client_id: String,
+    client_secret: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProtectedResourceMetadata {
+    #[serde(default)]
+    authorization_servers: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AuthServerMetadata {
+    authorization_endpoint: String,
+    token_endpoint: String,
+    #[serde(default)]
+    registration_endpoint: Option<String>,
+    #[serde(default)]
+    scopes_supported: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegistrationResponse {
+    client_id: String,
+    #[serde(default)]
+    client_secret: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    #[serde(default)]
+    refresh_token: Option<String>,
+    #[serde(default)]
+    token_type: Option<String>,
+    #[serde(default)]
+    expires_in: Option<i64>,
+    #[serde(default)]
+    scope: Option<String>,
+}
+
+fn http_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .context("build OAuth HTTP client")
+}
+
+/// Guard against pointing the browser / token calls at a plaintext or
+/// non-HTTP(S) endpoint. Loopback stays allowed over HTTP so a locally hosted
+/// authorization server (and the test suite) works without TLS.
+fn require_secure(url: &str, what: &str) -> Result<Url> {
+    let parsed = Url::parse(url).with_context(|| format!("parse {what} URL: {url}"))?;
+    let is_loopback = matches!(parsed.host_str(), Some("localhost" | "127.0.0.1" | "::1"));
+    match parsed.scheme() {
+        "https" => Ok(parsed),
+        "http" if is_loopback => Ok(parsed),
+        other => Err(anyhow!(
+            "{what} must use https (got {other} for a non-loopback host): {url}"
+        )),
+    }
+}
+
+/// Run the full interactive login for `mcp_url`, returning tokens ready to
+/// persist. `configured_client_id` skips dynamic registration when the caller
+/// already has a client; `scope` overrides the server-advertised scopes.
+pub(crate) async fn login(
+    mcp_url: &str,
+    configured_client_id: Option<&str>,
+    scope: Option<&str>,
+) -> Result<McpOAuthTokenSet> {
+    let client = http_client()?;
+    let endpoints = discover_endpoints(&client, mcp_url).await?;
+
+    // Bind the loopback callback first so its port is part of the redirect_uri
+    // we register and send to the authorization endpoint.
+    let listener = TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .context("bind loopback OAuth callback")?;
+    let port = listener
+        .local_addr()
+        .context("resolve callback port")?
+        .port();
+    let redirect_uri = format!("http://127.0.0.1:{port}{CALLBACK_PATH}");
+
+    let oauth_client = match configured_client_id {
+        Some(client_id) => OAuthClient {
+            client_id: client_id.to_string(),
+            client_secret: None,
+        },
+        None => register_client(&client, &endpoints, &redirect_uri).await?,
+    };
+
+    let verifier = oauth_flow::random_pkce_verifier();
+    let challenge = oauth_flow::pkce_challenge(&verifier);
+    let state = oauth_flow::random_token(32);
+    let scope = scope
+        .map(str::to_string)
+        .or_else(|| endpoints.scopes_supported.as_ref().map(|s| s.join(" ")));
+
+    let auth_url = authorize_url(
+        &endpoints,
+        &oauth_client.client_id,
+        &redirect_uri,
+        &challenge,
+        &state,
+        scope.as_deref(),
+    )?;
+    oauth_flow::open_browser(auth_url.as_str())?;
+
+    let code = wait_for_callback(listener, &state).await?;
+    exchange_code(
+        &client,
+        &endpoints,
+        &oauth_client,
+        &code,
+        &verifier,
+        &redirect_uri,
+        scope.as_deref(),
+    )
+    .await
+}
+
+/// Discover the authorization-server endpoints for an MCP server URL.
+pub(crate) async fn discover_endpoints(
+    client: &reqwest::Client,
+    mcp_url: &str,
+) -> Result<OAuthEndpoints> {
+    let server = require_secure(mcp_url, "MCP server")?;
+    let origin = origin_of(&server);
+
+    // RFC 9728: protected-resource metadata advertises the issuer(s).
+    let issuer = match fetch_json::<ProtectedResourceMetadata>(
+        client,
+        &join_well_known(&origin, "oauth-protected-resource"),
+    )
+    .await?
+    {
+        Some(prm) => prm
+            .authorization_servers
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| origin.clone()),
+        None => origin.clone(),
+    };
+    let issuer = require_secure(&issuer, "authorization server")?;
+    let issuer_origin = origin_of(&issuer);
+
+    // RFC 8414 first, then OpenID Connect discovery as a fallback.
+    for suffix in ["oauth-authorization-server", "openid-configuration"] {
+        if let Some(meta) =
+            fetch_json::<AuthServerMetadata>(client, &join_well_known(&issuer_origin, suffix))
+                .await?
+        {
+            // Validate the endpoints before handing them to the browser / token
+            // exchange so discovery can't downgrade us to plaintext.
+            require_secure(&meta.authorization_endpoint, "authorization endpoint")?;
+            require_secure(&meta.token_endpoint, "token endpoint")?;
+            if let Some(reg) = &meta.registration_endpoint {
+                require_secure(reg, "registration endpoint")?;
+            }
+            return Ok(OAuthEndpoints {
+                authorization_endpoint: meta.authorization_endpoint,
+                token_endpoint: meta.token_endpoint,
+                registration_endpoint: meta.registration_endpoint,
+                scopes_supported: meta.scopes_supported,
+            });
+        }
+    }
+
+    Err(anyhow!(
+        "no OAuth authorization-server metadata found for {issuer_origin} \
+         (looked under /.well-known/oauth-authorization-server and /openid-configuration)"
+    ))
+}
+
+/// Register a public client via RFC 7591 dynamic client registration.
+async fn register_client(
+    client: &reqwest::Client,
+    endpoints: &OAuthEndpoints,
+    redirect_uri: &str,
+) -> Result<OAuthClient> {
+    let registration_endpoint = endpoints.registration_endpoint.as_deref().ok_or_else(|| {
+        anyhow!(
+            "server does not support dynamic client registration; \
+             configure `oauth_client_id` for this MCP server"
+        )
+    })?;
+    let body = serde_json::json!({
+        "client_name": CLIENT_NAME,
+        "redirect_uris": [redirect_uri],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none",
+    });
+    let response = client
+        .post(registration_endpoint)
+        .json(&body)
+        .send()
+        .await
+        .context("register OAuth client")?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(anyhow!(
+            "dynamic client registration failed ({status}): {text}"
+        ));
+    }
+    let parsed: RegistrationResponse = response
+        .json()
+        .await
+        .context("parse client registration response")?;
+    Ok(OAuthClient {
+        client_id: parsed.client_id,
+        client_secret: parsed.client_secret,
+    })
+}
+
+fn authorize_url(
+    endpoints: &OAuthEndpoints,
+    client_id: &str,
+    redirect_uri: &str,
+    challenge: &str,
+    state: &str,
+    scope: Option<&str>,
+) -> Result<Url> {
+    let mut url =
+        Url::parse(&endpoints.authorization_endpoint).context("parse authorization endpoint")?;
+    url.query_pairs_mut()
+        .append_pair("response_type", "code")
+        .append_pair("client_id", client_id)
+        .append_pair("redirect_uri", redirect_uri)
+        .append_pair("code_challenge", challenge)
+        .append_pair("code_challenge_method", "S256")
+        .append_pair("state", state);
+    if let Some(scope) = scope {
+        url.query_pairs_mut().append_pair("scope", scope);
+    }
+    Ok(url)
+}
+
+/// Exchange an authorization code for tokens, folding in the refresh metadata.
+async fn exchange_code(
+    client: &reqwest::Client,
+    endpoints: &OAuthEndpoints,
+    oauth_client: &OAuthClient,
+    code: &str,
+    verifier: &str,
+    redirect_uri: &str,
+    scope: Option<&str>,
+) -> Result<McpOAuthTokenSet> {
+    let mut form = vec![
+        ("grant_type", "authorization_code"),
+        ("code", code),
+        ("redirect_uri", redirect_uri),
+        ("client_id", oauth_client.client_id.as_str()),
+        ("code_verifier", verifier),
+    ];
+    if let Some(secret) = &oauth_client.client_secret {
+        form.push(("client_secret", secret.as_str()));
+    }
+    let token: TokenResponse = post_token(client, &endpoints.token_endpoint, &form).await?;
+    Ok(token_set(
+        token,
+        &endpoints.token_endpoint,
+        oauth_client,
+        None,
+        scope,
+    ))
+}
+
+/// Renew an access token from a stored token set. Preserves the client id,
+/// token endpoint, and (when the server omits a rotated one) the refresh token.
+pub(crate) async fn refresh(tokens: &McpOAuthTokenSet) -> Result<McpOAuthTokenSet> {
+    let token_endpoint = tokens
+        .token_endpoint
+        .as_deref()
+        .ok_or_else(|| anyhow!("stored token has no token endpoint to refresh against"))?;
+    let refresh_token = tokens
+        .refresh_token
+        .as_deref()
+        .ok_or_else(|| anyhow!("stored token has no refresh token"))?;
+    let client_id = tokens
+        .client_id
+        .as_deref()
+        .ok_or_else(|| anyhow!("stored token has no client id to refresh with"))?;
+    require_secure(token_endpoint, "token endpoint")?;
+
+    let client = http_client()?;
+    let mut form = vec![
+        ("grant_type", "refresh_token"),
+        ("refresh_token", refresh_token),
+        ("client_id", client_id),
+    ];
+    if let Some(secret) = tokens.client_secret.as_deref() {
+        form.push(("client_secret", secret));
+    }
+    let token: TokenResponse = post_token(&client, token_endpoint, &form).await?;
+    let oauth_client = OAuthClient {
+        client_id: client_id.to_string(),
+        client_secret: tokens.client_secret.clone(),
+    };
+    Ok(token_set(
+        token,
+        token_endpoint,
+        &oauth_client,
+        tokens.refresh_token.clone(),
+        tokens.scope.as_deref(),
+    ))
+}
+
+/// Whether a token set should be refreshed before use (expired or within the
+/// refresh skew of expiry). A set without a refresh token is never eligible.
+pub(crate) fn needs_refresh(tokens: &McpOAuthTokenSet) -> bool {
+    tokens.refresh_token.is_some() && tokens.is_expired(Utc::now() + REFRESH_SKEW)
+}
+
+async fn post_token(
+    client: &reqwest::Client,
+    token_endpoint: &str,
+    form: &[(&str, &str)],
+) -> Result<TokenResponse> {
+    let response = client
+        .post(token_endpoint)
+        .form(form)
+        .send()
+        .await
+        .context("call token endpoint")?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(anyhow!("token endpoint returned {status}: {text}"));
+    }
+    response.json().await.context("parse token response")
+}
+
+fn token_set(
+    token: TokenResponse,
+    token_endpoint: &str,
+    oauth_client: &OAuthClient,
+    fallback_refresh: Option<String>,
+    fallback_scope: Option<&str>,
+) -> McpOAuthTokenSet {
+    let expires_at = token
+        .expires_in
+        .filter(|seconds| *seconds > 0)
+        .map(|seconds| Utc::now() + Duration::seconds(seconds));
+    McpOAuthTokenSet {
+        access_token: token.access_token,
+        refresh_token: token.refresh_token.or(fallback_refresh),
+        token_type: token.token_type.unwrap_or_else(|| "Bearer".to_string()),
+        expires_at,
+        scope: token.scope.or_else(|| fallback_scope.map(str::to_string)),
+        token_endpoint: Some(token_endpoint.to_string()),
+        client_id: Some(oauth_client.client_id.clone()),
+        client_secret: oauth_client.client_secret.clone(),
+    }
+}
+
+/// `scheme://host[:port]` of a URL (no path), used as the well-known base.
+fn origin_of(url: &Url) -> String {
+    let scheme = url.scheme();
+    let host = url.host_str().unwrap_or_default();
+    match url.port() {
+        Some(port) => format!("{scheme}://{host}:{port}"),
+        None => format!("{scheme}://{host}"),
+    }
+}
+
+fn join_well_known(origin: &str, suffix: &str) -> String {
+    format!("{origin}/.well-known/{suffix}")
+}
+
+/// GET a JSON document, returning `None` on 404 (metadata simply absent) and an
+/// error on transport failures or malformed JSON.
+async fn fetch_json<T: for<'de> Deserialize<'de>>(
+    client: &reqwest::Client,
+    url: &str,
+) -> Result<Option<T>> {
+    let response = client
+        .get(url)
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .with_context(|| format!("GET {url}"))?;
+    if response.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+    if !response.status().is_success() {
+        return Err(anyhow!("GET {url} returned {}", response.status()));
+    }
+    let parsed = response
+        .json::<T>()
+        .await
+        .with_context(|| format!("parse JSON from {url}"))?;
+    Ok(Some(parsed))
+}
+
+/// Serve the loopback redirect until the authorization server redirects back
+/// with a matching `state`, returning the authorization code. Rejects
+/// mismatched state and surfaces `error` responses.
+async fn wait_for_callback(listener: TcpListener, expected_state: &str) -> Result<String> {
+    loop {
+        let (mut socket, _) = listener.accept().await.context("accept OAuth callback")?;
+        let request = read_request_line(&mut socket).await?;
+        let path = request
+            .split_whitespace()
+            .nth(1)
+            .ok_or_else(|| anyhow!("invalid OAuth callback request"))?;
+        let parsed =
+            Url::parse(&format!("http://127.0.0.1{path}")).context("parse OAuth callback URL")?;
+        let params: HashMap<_, _> = parsed.query_pairs().into_owned().collect();
+
+        if parsed.path() != CALLBACK_PATH {
+            write_response(&mut socket, "404 Not Found", "Unexpected callback path.").await?;
+            continue;
+        }
+        if params.get("state").map(String::as_str) != Some(expected_state) {
+            write_response(
+                &mut socket,
+                "400 Bad Request",
+                "Login rejected: the state did not match.",
+            )
+            .await?;
+            return Err(anyhow!("OAuth callback state mismatch"));
+        }
+        if let Some(error) = params.get("error") {
+            let message = format!("Authorization failed: {error}.");
+            write_response(&mut socket, "400 Bad Request", &message).await?;
+            return Err(anyhow!("authorization server returned error: {error}"));
+        }
+        if let Some(code) = params.get("code") {
+            write_response(
+                &mut socket,
+                "200 OK",
+                "MCP login complete. You can return to the terminal.",
+            )
+            .await?;
+            return Ok(code.clone());
+        }
+        write_response(
+            &mut socket,
+            "400 Bad Request",
+            "Callback had no authorization code.",
+        )
+        .await?;
+        return Err(anyhow!("OAuth callback missing authorization code"));
+    }
+}
+
+async fn read_request_line(socket: &mut TcpStream) -> Result<String> {
+    let mut buffer = vec![0u8; 8192];
+    let n = socket
+        .read(&mut buffer)
+        .await
+        .context("read OAuth callback")?;
+    let request = String::from_utf8_lossy(&buffer[..n]);
+    Ok(request.lines().next().unwrap_or_default().to_string())
+}
+
+async fn write_response(socket: &mut TcpStream, status: &str, message: &str) -> Result<()> {
+    let body = format!(
+        "<!doctype html><meta charset=\"utf-8\"><title>Yolop MCP login</title>\
+         <body style=\"font:16px system-ui;margin:4rem auto;max-width:32rem\">\
+         <h1>{}</h1><p>{}</p></body>",
+        if status.starts_with("200") {
+            "Signed in"
+        } else {
+            "Login interrupted"
+        },
+        oauth_flow::html_escape(message),
+    );
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    socket
+        .write_all(response.as_bytes())
+        .await
+        .context("write OAuth callback response")
+}
+
+/// A hand-rolled loopback OAuth authorization server for tests: serves the
+/// discovery documents, dynamic client registration, and token endpoints so the
+/// non-browser parts of the login flow (and the runtime auth provider) can be
+/// exercised end-to-end without a real provider. Shared with `runtime`'s
+/// provider tests.
+#[cfg(test)]
+pub(crate) mod test_support {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    pub(crate) struct MockOAuthServer {
+        pub base: String,
+    }
+
+    impl MockOAuthServer {
+        /// Start the server on an ephemeral loopback port and spawn its accept
+        /// loop. The task runs until the process exits (fine for tests).
+        pub(crate) async fn start() -> Self {
+            let listener = TcpListener::bind(("127.0.0.1", 0))
+                .await
+                .expect("bind mock");
+            let port = listener.local_addr().expect("addr").port();
+            let base = format!("http://127.0.0.1:{port}");
+            let base_for_task = base.clone();
+            tokio::spawn(async move {
+                loop {
+                    let Ok((mut socket, _)) = listener.accept().await else {
+                        break;
+                    };
+                    let base = base_for_task.clone();
+                    tokio::spawn(async move {
+                        let mut buf = vec![0u8; 8192];
+                        let Ok(n) = socket.read(&mut buf).await else {
+                            return;
+                        };
+                        let request = String::from_utf8_lossy(&buf[..n]).to_string();
+                        let first = request.lines().next().unwrap_or_default();
+                        let mut it = first.split_whitespace();
+                        let method = it.next().unwrap_or_default();
+                        let path = it.next().unwrap_or_default();
+                        let body = request
+                            .split_once("\r\n\r\n")
+                            .map(|(_, b)| b.to_string())
+                            .unwrap_or_default();
+                        let json = route(method, path, &body, &base);
+                        let response = match json {
+                            Some(body) => format!(
+                                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                                body.len()
+                            ),
+                            None => {
+                                "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                                    .to_string()
+                            }
+                        };
+                        let _ = socket.write_all(response.as_bytes()).await;
+                    });
+                }
+            });
+            Self { base }
+        }
+    }
+
+    fn route(method: &str, path: &str, body: &str, base: &str) -> Option<String> {
+        match (method, path) {
+            ("GET", "/.well-known/oauth-protected-resource") => {
+                Some(format!(r#"{{"authorization_servers":["{base}"]}}"#))
+            }
+            ("GET", "/.well-known/oauth-authorization-server") => Some(format!(
+                r#"{{"authorization_endpoint":"{base}/authorize","token_endpoint":"{base}/token","registration_endpoint":"{base}/register","scopes_supported":["read"]}}"#
+            )),
+            ("POST", "/register") => Some(r#"{"client_id":"dcr-client-1"}"#.to_string()),
+            ("POST", "/token") => {
+                if body.contains("grant_type=refresh_token") {
+                    Some(
+                        r#"{"access_token":"access-2","refresh_token":"refresh-2","token_type":"Bearer","expires_in":3600}"#
+                            .to_string(),
+                    )
+                } else {
+                    Some(
+                        r#"{"access_token":"access-1","refresh_token":"refresh-1","token_type":"Bearer","expires_in":3600,"scope":"read"}"#
+                            .to_string(),
+                    )
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::MockOAuthServer;
+    use super::*;
+
+    #[tokio::test]
+    async fn discovers_endpoints_via_protected_resource_metadata() {
+        let server = MockOAuthServer::start().await;
+        let client = http_client().unwrap();
+        let endpoints = discover_endpoints(&client, &format!("{}/mcp", server.base))
+            .await
+            .expect("discover");
+        assert_eq!(
+            endpoints.authorization_endpoint,
+            format!("{}/authorize", server.base)
+        );
+        assert_eq!(endpoints.token_endpoint, format!("{}/token", server.base));
+        assert_eq!(
+            endpoints.registration_endpoint.as_deref(),
+            Some(format!("{}/register", server.base).as_str())
+        );
+        assert_eq!(
+            endpoints.scopes_supported.as_deref(),
+            Some(["read".to_string()].as_slice())
+        );
+    }
+
+    #[tokio::test]
+    async fn full_flow_minus_browser_registers_and_exchanges() {
+        let server = MockOAuthServer::start().await;
+        let client = http_client().unwrap();
+        let endpoints = discover_endpoints(&client, &format!("{}/mcp", server.base))
+            .await
+            .expect("discover");
+        let oauth_client = register_client(&client, &endpoints, "http://127.0.0.1:9/callback")
+            .await
+            .expect("register");
+        assert_eq!(oauth_client.client_id, "dcr-client-1");
+
+        let tokens = exchange_code(
+            &client,
+            &endpoints,
+            &oauth_client,
+            "auth-code",
+            "verifier",
+            "http://127.0.0.1:9/callback",
+            Some("read"),
+        )
+        .await
+        .expect("exchange");
+        assert_eq!(tokens.access_token, "access-1");
+        assert_eq!(tokens.refresh_token.as_deref(), Some("refresh-1"));
+        assert_eq!(
+            tokens.token_endpoint.as_deref(),
+            Some(format!("{}/token", server.base).as_str())
+        );
+        assert_eq!(tokens.client_id.as_deref(), Some("dcr-client-1"));
+        assert!(tokens.expires_at.is_some(), "expires_in yields an expiry");
+    }
+
+    #[tokio::test]
+    async fn refresh_mints_new_access_token_and_preserves_metadata() {
+        let server = MockOAuthServer::start().await;
+        let tokens = McpOAuthTokenSet {
+            access_token: "access-1".to_string(),
+            refresh_token: Some("refresh-1".to_string()),
+            token_type: "Bearer".to_string(),
+            expires_at: Some(Utc::now() - Duration::seconds(1)),
+            scope: Some("read".to_string()),
+            token_endpoint: Some(format!("{}/token", server.base)),
+            client_id: Some("dcr-client-1".to_string()),
+            client_secret: None,
+        };
+        let refreshed = refresh(&tokens).await.expect("refresh");
+        assert_eq!(refreshed.access_token, "access-2");
+        assert_eq!(refreshed.refresh_token.as_deref(), Some("refresh-2"));
+        assert_eq!(refreshed.client_id.as_deref(), Some("dcr-client-1"));
+        assert_eq!(
+            refreshed.token_endpoint.as_deref(),
+            Some(format!("{}/token", server.base).as_str())
+        );
+    }
+
+    #[test]
+    fn require_secure_allows_https_and_loopback_http() {
+        assert!(require_secure("https://mcp.example.com/mcp", "s").is_ok());
+        assert!(require_secure("http://127.0.0.1:8080/mcp", "s").is_ok());
+        assert!(require_secure("http://localhost/mcp", "s").is_ok());
+        assert!(require_secure("http://mcp.example.com/mcp", "s").is_err());
+        assert!(require_secure("ftp://mcp.example.com", "s").is_err());
+    }
+
+    #[test]
+    fn origin_strips_path_and_keeps_port() {
+        let url = Url::parse("https://as.example.com:8443/tenant/authorize").unwrap();
+        assert_eq!(origin_of(&url), "https://as.example.com:8443");
+        let url = Url::parse("https://as.example.com/authorize").unwrap();
+        assert_eq!(origin_of(&url), "https://as.example.com");
+    }
+
+    #[test]
+    fn authorize_url_carries_pkce_and_state() {
+        let endpoints = OAuthEndpoints {
+            authorization_endpoint: "https://as.example.com/authorize".to_string(),
+            token_endpoint: "https://as.example.com/token".to_string(),
+            registration_endpoint: None,
+            scopes_supported: None,
+        };
+        let url = authorize_url(
+            &endpoints,
+            "client-1",
+            "http://127.0.0.1:9999/callback",
+            "challenge-xyz",
+            "state-abc",
+            Some("read write"),
+        )
+        .unwrap();
+        let pairs: HashMap<_, _> = url.query_pairs().into_owned().collect();
+        assert_eq!(pairs.get("response_type").map(String::as_str), Some("code"));
+        assert_eq!(pairs.get("client_id").map(String::as_str), Some("client-1"));
+        assert_eq!(
+            pairs.get("code_challenge_method").map(String::as_str),
+            Some("S256")
+        );
+        assert_eq!(
+            pairs.get("code_challenge").map(String::as_str),
+            Some("challenge-xyz")
+        );
+        assert_eq!(pairs.get("state").map(String::as_str), Some("state-abc"));
+        assert_eq!(pairs.get("scope").map(String::as_str), Some("read write"));
+    }
+
+    #[test]
+    fn needs_refresh_only_when_expiring_with_refresh_token() {
+        let mut tokens = McpOAuthTokenSet {
+            access_token: "a".to_string(),
+            refresh_token: Some("r".to_string()),
+            token_type: "Bearer".to_string(),
+            expires_at: Some(Utc::now() + Duration::seconds(300)),
+            scope: None,
+            token_endpoint: Some("https://as.example/token".to_string()),
+            client_id: Some("c".to_string()),
+            client_secret: None,
+        };
+        assert!(!needs_refresh(&tokens), "fresh token is not refreshed");
+        tokens.expires_at = Some(Utc::now() + Duration::seconds(10));
+        assert!(needs_refresh(&tokens), "near-expiry token is refreshed");
+        tokens.refresh_token = None;
+        assert!(
+            !needs_refresh(&tokens),
+            "no refresh token -> cannot refresh"
+        );
+    }
+}

--- a/src/oauth_flow.rs
+++ b/src/oauth_flow.rs
@@ -1,6 +1,27 @@
+use anyhow::{Context, Result, anyhow};
 use base64::Engine as _;
 use rand::RngExt;
 use sha2::{Digest, Sha256};
+
+/// Open `url` in the user's default browser. Shared by the interactive OAuth
+/// login flows (Codex provider auth, MCP server auth).
+pub fn open_browser(url: &str) -> Result<()> {
+    let status = if cfg!(target_os = "macos") {
+        std::process::Command::new("open").arg(url).status()
+    } else if cfg!(target_os = "windows") {
+        std::process::Command::new("cmd")
+            .args(["/C", "start", "", url])
+            .status()
+    } else {
+        std::process::Command::new("xdg-open").arg(url).status()
+    }
+    .context("open browser for login")?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(anyhow!("browser opener exited with {status}"))
+    }
+}
 
 pub fn random_pkce_verifier() -> String {
     const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -142,6 +142,73 @@ fn env_key_prefix(value: &str) -> String {
         .join("_")
 }
 
+/// MCP auth provider that prefers user-scoped OAuth tokens minted by
+/// `/mcp login` (refreshing them when they near expiry) and falls back to
+/// environment-provided bearer credentials. The stored connection is keyed by
+/// the server's `oauth_provider_id` when set, otherwise its name.
+pub(crate) struct StoredMcpAuthProvider {
+    connections: Arc<ConnectionStore>,
+    env: EnvMcpAuthProvider,
+}
+
+impl StoredMcpAuthProvider {
+    pub(crate) fn new(connections: Arc<ConnectionStore>) -> Self {
+        Self {
+            connections,
+            env: EnvMcpAuthProvider,
+        }
+    }
+
+    fn provider_key<'a>(request: &'a McpAuthRequest<'a>) -> &'a str {
+        request.oauth_provider_id.unwrap_or(request.server_name)
+    }
+}
+
+#[async_trait]
+impl McpAuthProvider for StoredMcpAuthProvider {
+    async fn authorization(
+        &self,
+        request: &McpAuthRequest<'_>,
+    ) -> anyhow::Result<Option<McpCredential>> {
+        let key = Self::provider_key(request);
+        let Some(tokens) = crate::mcp_oauth::load_tokens(&self.connections, key) else {
+            // No stored OAuth token for this server: fall back to env vars.
+            return self.env.authorization(request).await;
+        };
+
+        let tokens = if crate::mcp_oauth_login::needs_refresh(&tokens) {
+            match crate::mcp_oauth_login::refresh(&tokens).await {
+                Ok(refreshed) => {
+                    if let Err(err) =
+                        crate::mcp_oauth::save_tokens(&self.connections, key, refreshed.clone())
+                    {
+                        tracing::warn!(
+                            provider = key,
+                            %err,
+                            "failed to persist refreshed MCP OAuth token"
+                        );
+                    }
+                    refreshed
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        provider = key,
+                        %err,
+                        "MCP OAuth token refresh failed; using the existing token"
+                    );
+                    tokens
+                }
+            }
+        } else {
+            tokens
+        };
+
+        Ok(Some(McpCredential::authorization(
+            tokens.authorization_value(),
+        )))
+    }
+}
+
 const HARNESS_PROMPT: &str = "\
 You are an expert terminal coding agent. File tools write under the workspace
 root; `bash` runs on the host. There is no sandbox.
@@ -1923,6 +1990,11 @@ pub struct RuntimeHandles {
     /// verbatim on reload so `.mcp.json` resolution stays identical to
     /// startup.
     pub workspace_root: PathBuf,
+    /// Shared connection store backing MCP OAuth tokens. Saving through this
+    /// same instance is what lets the runtime's [`StoredMcpAuthProvider`] see a
+    /// freshly minted token (the store caches connections in memory per
+    /// handle), so `/mcp login` uses it rather than a separate handle.
+    pub connections: Arc<ConnectionStore>,
 }
 
 impl RuntimeHandles {
@@ -2479,7 +2551,7 @@ pub async fn build_with_options(
     // (see below).
     capabilities.register(ConnectorsCapability {
         catalog: connection_catalog,
-        store: connections,
+        store: connections.clone(),
     });
     // `memory` — global, durable, structured user memory. Its MEMORY.md lives
     // beside settings.toml in the yolop config dir, so a tempdir settings path
@@ -2637,7 +2709,7 @@ pub async fn build_with_options(
     let session_store = backends.session_store.clone();
 
     let mut builder = InProcessRuntimeBuilder::new()
-        .mcp_auth_provider(Arc::new(EnvMcpAuthProvider))
+        .mcp_auth_provider(Arc::new(StoredMcpAuthProvider::new(connections.clone())))
         .platform_definition(platform)
         .default_model(default_model)
         .backends(backends)
@@ -2672,6 +2744,7 @@ pub async fn build_with_options(
             events: event_bus_typed,
             session_store,
             workspace_root: canonical_root.clone(),
+            connections,
         },
         startup: StartupInfo {
             workspace_root: effective_root,
@@ -2766,6 +2839,101 @@ mod tests {
         unsafe {
             std::env::remove_var("LINEAR_ACCESS_TOKEN");
         }
+    }
+
+    fn oauth_request(server_name: &str) -> McpAuthRequest<'_> {
+        McpAuthRequest {
+            server_name,
+            auth_mode: McpServerAuthMode::OAuth,
+            oauth_provider_id: None,
+        }
+    }
+
+    fn stored_token(
+        token_endpoint: String,
+        expires_at: chrono::DateTime<chrono::Utc>,
+    ) -> crate::mcp_oauth::McpOAuthTokenSet {
+        crate::mcp_oauth::McpOAuthTokenSet {
+            access_token: "access-1".to_string(),
+            refresh_token: Some("refresh-1".to_string()),
+            token_type: "Bearer".to_string(),
+            expires_at: Some(expires_at),
+            scope: Some("read".to_string()),
+            token_endpoint: Some(token_endpoint),
+            client_id: Some("dcr-client-1".to_string()),
+            client_secret: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn stored_provider_refreshes_an_expired_token_and_persists_it() {
+        let server = crate::mcp_oauth_login::test_support::MockOAuthServer::start().await;
+        let tmp = tempfile::tempdir().expect("tmp");
+        let store = Arc::new(ConnectionStore::open(tmp.path().join("connections.toml")));
+        crate::mcp_oauth::save_tokens(
+            &store,
+            "docs",
+            stored_token(
+                format!("{}/token", server.base),
+                chrono::Utc::now() - chrono::Duration::seconds(1),
+            ),
+        )
+        .expect("seed token");
+
+        let provider = StoredMcpAuthProvider::new(store.clone());
+        let credential = provider
+            .authorization(&oauth_request("docs"))
+            .await
+            .expect("provider result")
+            .expect("credential");
+        assert_eq!(credential.authorization.as_deref(), Some("Bearer access-2"));
+
+        // The refreshed token is written back through the shared store, so the
+        // next request skips the refresh round-trip.
+        let saved = crate::mcp_oauth::load_tokens(&store, "docs").expect("persisted token");
+        assert_eq!(saved.access_token, "access-2");
+    }
+
+    #[tokio::test]
+    async fn stored_provider_uses_a_fresh_token_without_a_network_call() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let store = Arc::new(ConnectionStore::open(tmp.path().join("connections.toml")));
+        // Token endpoint points at a closed port: any refresh attempt would
+        // error, so a successful bearer proves no refresh was made.
+        crate::mcp_oauth::save_tokens(
+            &store,
+            "docs",
+            stored_token(
+                "http://127.0.0.1:1/token".to_string(),
+                chrono::Utc::now() + chrono::Duration::seconds(3600),
+            ),
+        )
+        .expect("seed token");
+
+        let provider = StoredMcpAuthProvider::new(store);
+        let credential = provider
+            .authorization(&oauth_request("docs"))
+            .await
+            .expect("provider result")
+            .expect("credential");
+        assert_eq!(credential.authorization.as_deref(), Some("Bearer access-1"));
+    }
+
+    #[tokio::test]
+    async fn stored_provider_without_token_or_env_returns_none() {
+        // Uses a server name no env credential can match, so it needs no
+        // ENV_LOCK (and holding a std mutex across await would be a lint error).
+        let tmp = tempfile::tempdir().expect("tmp");
+        let store = Arc::new(ConnectionStore::open(tmp.path().join("connections.toml")));
+        let provider = StoredMcpAuthProvider::new(store);
+        let credential = provider
+            .authorization(&oauth_request("yolop-test-unconfigured-server"))
+            .await
+            .expect("provider result");
+        assert!(
+            credential.is_none(),
+            "no stored token and no env var yields no credential"
+        );
     }
 
     fn test_file_store(

--- a/src/session.rs
+++ b/src/session.rs
@@ -67,6 +67,13 @@ impl Session {
         self.handles.reload_mcp_servers().await
     }
 
+    /// The shared connection store backing MCP OAuth tokens. `/mcp login` saves
+    /// through this so the runtime's auth provider (which holds the same handle)
+    /// sees the new token immediately.
+    pub fn connections(&self) -> Arc<crate::connectors::ConnectionStore> {
+        self.handles.connections.clone()
+    }
+
     /// Translate the prefix of persisted events that were replayed from disk
     /// into transcript lines (used to seed the transcript on resume).
     pub async fn replayed_lines(&self, count: usize) -> Result<Vec<ChatLine>> {


### PR DESCRIPTION
## What changed
Adds `/mcp login <name>` to authenticate a remote HTTP MCP server via OAuth — discovered at runtime, not hand-configured.

- **Discovery**: protected-resource metadata (RFC 9728) → authorization-server metadata (RFC 8414 / OpenID discovery) → dynamic client registration (RFC 7591) when the server offers it → authorization code + PKCE (RFC 7636) through the browser with a loopback redirect (RFC 8252).
- **Persistence**: tokens are stored in the connection store alongside the token endpoint and client id, so refresh is self-contained (no config re-read / re-discovery).
- **Runtime**: a new `StoredMcpAuthProvider` supplies stored tokens per request, refreshing them as they near expiry, and falls back to the existing environment-bearer resolution when no token is stored. Since credentials resolve per turn, a fresh login takes effect on the **next message** — no restart (composes with the live-reload change already on `main`).

The previously dead `mcp_oauth.rs` token storage is now wired end-to-end.

## Why
Dynamic OAuth for MCP servers from the TUI. API-key/bearer via headers or env only covers pre-provisioned secrets; many remote servers (Linear, etc.) require an interactive OAuth grant, and hand-configuring endpoints per server is friction the standard discovery documents remove.

## Before / After
**Before** — a remote server requiring OAuth had no in-app path to a token; you set an env var or a literal `Authorization` header.

**After**
```
> /mcp login docs
opening browser for `docs` OAuth login…
signed in to `docs` — the token is active on your next message
```
The token is refreshed automatically on later turns as it nears expiry.

## Risk
- Medium.
- **Egress for OAuth calls**: discovery/token/refresh requests use a direct HTTPS client (mirroring the existing Codex provider login), not the runtime's DNS-pinned SSRF egress. They target the authorization server advertised by the *user-configured* MCP server. Mitigations: discovered endpoints are required to be `https` (loopback may use `http`), so plaintext downgrade is blocked; the flow only runs on explicit user-initiated `/mcp login`; yolop is a local CLI on the user's own network. Routing these through the runtime's SSRF-validated egress is a candidate follow-up.
- Concurrent turns hitting an expired token could each refresh once (last write wins) — benign.

## Security
Reviewed against the yolop threat model:
- **TM-LLM / secrets**: tokens live in the connection store (`connections.toml`, same place as other provider credentials) and are never logged — refresh failures log the provider name and error only, never the token or bearer header.
- **CSRF / interception**: PKCE (S256) + a random `state` validated on the loopback callback; the callback binds `127.0.0.1` on an ephemeral port and serves only the redirect.
- **Downgrade**: `require_secure` enforces https for all non-loopback discovered endpoints before they are used.
- **TM-FS**: no write-blocklist change; no workspace writes (only the existing connection-store file).
- **TM-DEP**: no new dependencies (reqwest/chrono/base64/sha2/rand/serde already present).
- **Resource use**: 30s HTTP timeout; single-buffer callback read; refresh at most once per request when expired.

## Automated tests
Against a hand-rolled mock localhost authorization server (no real provider, no browser):
- `discovers_endpoints_via_protected_resource_metadata` — RFC 9728 → 8414 discovery.
- `full_flow_minus_browser_registers_and_exchanges` — DCR + authorization-code exchange.
- `refresh_mints_new_access_token_and_preserves_metadata` — refresh grant + metadata carry-over.
- `stored_provider_refreshes_an_expired_token_and_persists_it` / `…uses_a_fresh_token_without_a_network_call` / `…without_token_or_env_returns_none` — the provider's bearer injection, refresh-on-expiry, and env fallback.
- `mcp_login_rejects_unknown_and_stdio_servers` — the TUI command's early-exit paths.
- Plus storage round-trip and PKCE/URL-building unit tests.

## Follow-ups
- Support a configured `client_id` for servers without dynamic registration (currently DCR-only).
- Route OAuth discovery/token calls through the runtime's SSRF-validated egress.
- Device-code flow for headless environments.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; additive — env/header auth paths unchanged, new provider falls back to them)

https://claude.ai/code/session_01VA8DyqLHN5KP75Zr7zNcay

---
_Generated by [Claude Code](https://claude.ai/code/session_01VA8DyqLHN5KP75Zr7zNcay)_