### PR TITLE
fix(runtime): open setup when provider credentials missing

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1971,8 +1971,9 @@ pub struct StartupInfo {
     /// Zero for fresh sessions; used by the startup banner.
     pub replayed_events: usize,
     /// True when neither env vars nor saved settings provide a credential
-    /// for any real provider. The TUI auto-opens its setup wizard in this
-    /// case; `--print` mode ignores it.
+    /// for any real provider, or when the preferred provider cannot
+    /// authenticate. The TUI auto-opens its setup wizard in this case;
+    /// `--print` mode ignores the flag and surfaces a clear error instead.
     pub setup_recommended: bool,
     /// Names of MCP servers configured for this session from `.mcp.json`
     /// (global + workspace, merged). Source for the `/mcp` command and the
@@ -2548,7 +2549,7 @@ pub async fn build_with_options(
     everruns_openrouter::register_driver(&mut driver_registry);
     crate::codex_driver::register_driver(&mut driver_registry, settings.clone());
     let settings_snapshot = settings.snapshot();
-    let setup_recommended = SetupCapability::needs_onboarding(&settings_snapshot);
+    let mut setup_recommended = SetupCapability::needs_onboarding(&settings_snapshot);
     let default_model = match &provider {
         ProviderChoice::Anthropic { .. }
         | ProviderChoice::OpenAi { .. }
@@ -2558,8 +2559,24 @@ pub async fn build_with_options(
         | ProviderChoice::Ollama { .. }
         | ProviderChoice::Custom { .. } => match provider.model_with_provider(&settings_snapshot) {
             Ok(model) => model,
+            Err(err) if matches!(options.client_ui, ClientUiContext::Tui) => {
+                // Preferred provider is set but credentials are missing
+                // (e.g. Codex login cleared after refresh_token_reused).
+                // Interactive sessions open `/setup` instead of exiting.
+                tracing::warn!(
+                    error = %err,
+                    provider = provider.provider_name(),
+                    "provider credentials missing; opening setup"
+                );
+                setup_recommended = true;
+                provider.model_without_stored_key()
+            }
             Err(_) if setup_recommended => provider.model_without_stored_key(),
-            Err(err) => return Err(err),
+            Err(err) => {
+                return Err(err.context(
+                    "provider credentials missing; run `yolop` interactively and complete /setup",
+                ));
+            }
         },
         ProviderChoice::Sim => ResolvedModel {
             model: "llmsim-yolop".into(),
@@ -2822,6 +2839,102 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("offline llmsim only supports llmsim-yolop")
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[allow(clippy::await_holding_lock)]
+    async fn tui_build_opens_setup_when_codex_login_missing() {
+        // Reproduces: default_provider=codex with no CODEX_ACCESS_TOKEN and no
+        // [codex_auth] (e.g. after refresh_token_reused cleared login). Interactive
+        // startup must open /setup, not exit with "CODEX_ACCESS_TOKEN not set".
+        let _guard = crate::test_env::lock();
+        unsafe {
+            std::env::remove_var("CODEX_ACCESS_TOKEN");
+            std::env::remove_var("OPENAI_API_KEY");
+            std::env::remove_var("ANTHROPIC_API_KEY");
+        }
+
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+        settings
+            .set_default_provider(Some("codex".to_string()))
+            .expect("save provider");
+
+        let built = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Codex {
+                model: "gpt-5.5".to_string(),
+                reasoning_effort: None,
+            },
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            BuildOptions {
+                client_ui: ClientUiContext::Tui,
+                client_commands: true,
+                ..BuildOptions::default()
+            },
+        )
+        .await
+        .expect("TUI build must not crash when Codex login is missing");
+
+        assert!(
+            built.startup.setup_recommended,
+            "missing Codex login should recommend setup"
+        );
+        assert_eq!(built.model.provider_name(), "codex");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[allow(clippy::await_holding_lock)]
+    async fn print_build_errors_clearly_when_codex_login_missing() {
+        let _guard = crate::test_env::lock();
+        unsafe {
+            std::env::remove_var("CODEX_ACCESS_TOKEN");
+            std::env::remove_var("OPENAI_API_KEY");
+            std::env::remove_var("ANTHROPIC_API_KEY");
+        }
+
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+        // Saved preferred provider suppresses first-run onboarding, same as the
+        // TUI crash case — print mode must still fail clearly rather than hang
+        // with a keyless Codex driver.
+        settings
+            .set_default_provider(Some("codex".to_string()))
+            .expect("save provider");
+
+        let result = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Codex {
+                model: "gpt-5.5".to_string(),
+                reasoning_effort: None,
+            },
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            BuildOptions {
+                client_ui: ClientUiContext::Print,
+                ..BuildOptions::default()
+            },
+        )
+        .await;
+        let err = match result {
+            Ok(_) => panic!("print mode still needs credentials"),
+            Err(err) => err,
+        };
+
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("CODEX_ACCESS_TOKEN") || message.contains("Codex login"),
+            "got: {message}"
+        );
+        assert!(
+            message.contains("/setup") || message.contains("interactively"),
+            "got: {message}"
         );
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed
When the preferred provider cannot authenticate (e.g. `default_provider = "codex"` with no `CODEX_ACCESS_TOKEN` and no `[codex_auth]`), interactive `yolop` opens `/setup` instead of exiting with an error. `--print` / non-TUI hosts still fail, with a clearer hint to complete setup interactively.

## Why
After Codex login is cleared (including after `refresh_token_reused` recovery), the next `yolop` start crashed with `CODEX_ACCESS_TOKEN not set and no Codex login stored` because a saved provider suppressed first-run onboarding while credentials were gone.

## Before / After
**Before:**
```
$ yolop
Error: CODEX_ACCESS_TOKEN not set and no Codex login stored
```
exit 1

**After (TUI):** process starts and auto-opens the setup wizard (`setup_recommended = true`). Reproduced with `default_provider = "codex"` and no auth — process stayed alive (timeout exit 124) instead of immediate exit 1.

**After (`-p`):** 
```
Error: provider credentials missing; run `yolop` interactively and complete /setup
Caused by: CODEX_ACCESS_TOKEN not set and no Codex login stored
```

Tests: `tui_build_opens_setup_when_codex_login_missing`, `print_build_errors_clearly_when_codex_login_missing`.

**Validation:** `cargo fmt --check`, `clippy -D warnings`, `cargo test --all-features`, `llmsim -p hi`, `doppler … openai -p pong`.

## Risk
- Low — only changes credential-resolution failure handling at runtime build.
- TUI sessions with a broken preferred provider now land in setup rather than crashing.

## Security
- **TM-LLM**: No new credential storage or logging; setup still writes through existing settings paths.
- No changes to filesystem write blocklist, shell execution, or tool capability registration.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; interactive UX only)

## Follow-ups
- Optionally pre-select the preferred disconnected provider in the setup wizard when opening from this path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4b0bcf1-b06c-4b3d-bf93-442b082a0dad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4b0bcf1-b06c-4b3d-bf93-442b082a0dad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

