### PR TITLE
fix(auth): keep TUI responsive during Codex login

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -106,6 +106,12 @@ pub struct App {
     /// handling so provider, token, and model setup never echo through the
     /// normal chat composer.
     setup: Option<SetupStep>,
+    /// Codex login runs outside the terminal input handler. The task owns any
+    /// network wait; the event loop only polls its channel between frames.
+    codex_login: Option<PendingCodexLogin>,
+    codex_login_tx: mpsc::UnboundedSender<CodexLoginEvent>,
+    codex_login_rx: mpsc::UnboundedReceiver<CodexLoginEvent>,
+    next_codex_login_id: u64,
     status_layout: StatusLayout,
     session_tokens: Option<u64>,
     /// Terminal-side commands emitted by `ClientCommandsCapability` (via
@@ -192,6 +198,11 @@ pub(crate) enum SetupStep {
         selected: usize,
         error: Option<String>,
     },
+    CodexLogin {
+        selected: usize,
+        method: CodexLoginMethod,
+        device_code: Option<(String, String)>,
+    },
     TokenInput {
         provider: String,
         token: String,
@@ -206,6 +217,30 @@ pub(crate) enum SetupStep {
     PickEffort {
         selected: usize,
         error: Option<String>,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CodexLoginMethod {
+    Browser,
+    Device,
+}
+
+struct PendingCodexLogin {
+    id: u64,
+    task: tokio::task::JoinHandle<()>,
+}
+
+enum CodexLoginEvent {
+    DeviceCode {
+        id: u64,
+        verification_uri: String,
+        user_code: String,
+    },
+    Finished {
+        id: u64,
+        selected: usize,
+        result: Result<crate::settings::CodexAuth, String>,
     },
 }
 
@@ -315,6 +350,7 @@ impl App {
         let session_id = runtime.handles.session_id;
         let session = Session::new(runtime.handles, runtime.model.clone());
         let (models_tx, models_rx) = mpsc::unbounded_channel::<ModelDiscovery>();
+        let (codex_login_tx, codex_login_rx) = mpsc::unbounded_channel::<CodexLoginEvent>();
         let mut app = Self {
             session,
             startup: runtime.startup,
@@ -333,6 +369,10 @@ impl App {
             rx: None,
             turn_cancel: None,
             setup: None,
+            codex_login: None,
+            codex_login_tx,
+            codex_login_rx,
+            next_codex_login_id: 0,
             status_layout: StatusLayout::Compact,
             session_tokens: None,
             ui_rx: runtime.ui_rx,
@@ -695,6 +735,12 @@ impl App {
             return Ok(());
         }
 
+        // 3a) Codex login is intentionally a background operation so a browser
+        // close or an abandoned device flow cannot stop terminal input.
+        if self.apply_codex_login_events().await {
+            return Ok(());
+        }
+
         // 3b) proactive wake: when an everruns `spawn_background` task finishes
         // while the session is idle, auto-start a turn so the agent reacts
         // without a user prompt.
@@ -841,6 +887,7 @@ impl App {
                     return;
                 }
                 KeyCode::Char('d') => {
+                    self.abort_codex_login();
                     self.should_quit = true;
                     return;
                 }
@@ -1421,6 +1468,7 @@ impl App {
         }
 
         if self.ctrl_c_pending_exit() {
+            self.abort_codex_login();
             self.ctrl_c_exit = true;
             self.should_quit = true;
             return;
@@ -5128,6 +5176,32 @@ mod tests {
                 .iter()
                 .any(|line| line.contains("Use OPENAI_API_KEY from environment"))
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn setup_device_login_wait_can_be_cancelled() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        let task = tokio::spawn(std::future::pending());
+        app.codex_login = Some(PendingCodexLogin { id: 7, task });
+        app.setup = Some(SetupStep::CodexLogin {
+            selected: 1,
+            method: CodexLoginMethod::Device,
+            device_code: Some(("https://example.test/device".into(), "ABCD-EFGH".into())),
+        });
+
+        app.handle_setup_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
+            .await;
+
+        assert!(app.codex_login.is_none());
+        assert!(matches!(
+            app.setup,
+            Some(SetupStep::Credential {
+                ref provider,
+                selected: 1,
+                error: Some(ref error),
+            }) if provider == "codex" && error == "Codex sign-in canceled"
+        ));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -532,6 +532,35 @@ pub(crate) fn setup_overlay_content(app: &App) -> (Vec<Line<'static>>, Option<(u
             push_setup_error(&mut lines, error.as_deref());
             lines.push(setup_footer("Enter confirm · ↑/↓ move · Esc back"));
         }
+        Some(SetupStep::CodexLogin {
+            method,
+            device_code,
+            ..
+        }) => {
+            lines.push(setup_title("Sign in to Codex subscription"));
+            match method {
+                CodexLoginMethod::Browser => {
+                    lines.push(setup_hint(
+                        "Waiting for the browser to finish authentication.",
+                    ));
+                    lines.push(Line::from(""));
+                    lines.push(setup_hint(
+                        "If the browser was closed, cancel here and try again.",
+                    ));
+                }
+                CodexLoginMethod::Device => {
+                    if let Some((verification_uri, user_code)) = device_code {
+                        lines.push(setup_hint(&format!("Open {verification_uri}")));
+                        lines.push(Line::from(""));
+                        lines.push(setup_hint(&format!("Enter code: {user_code}")));
+                    } else {
+                        lines.push(setup_hint("Requesting a device code…"));
+                    }
+                }
+            }
+            lines.push(Line::from(""));
+            lines.push(setup_footer("Esc cancel · Ctrl+C twice exit"));
+        }
         Some(SetupStep::TokenInput {
             provider,
             token,

--- a/src/app/setup.rs
+++ b/src/app/setup.rs
@@ -599,6 +599,11 @@ impl App {
             } => {
                 self.handle_credential_key(key, provider, selected).await;
             }
+            SetupStep::CodexLogin { selected, .. } => {
+                if key.code == KeyCode::Esc {
+                    self.cancel_codex_login(selected);
+                }
+            }
             SetupStep::TokenInput {
                 provider, token, ..
             } => {
@@ -885,85 +890,13 @@ impl App {
                 if provider != "codex" {
                     return;
                 }
-                self.push_system("opening browser for Codex login...".into());
-                match crate::codex_auth::login_with_browser().await {
-                    Ok(auth) => {
-                        if let Err(error) = self.settings.set_codex_auth(auth) {
-                            self.setup = Some(SetupStep::Credential {
-                                provider,
-                                selected,
-                                error: Some(error.to_string()),
-                            });
-                            return;
-                        }
-                        if let Err(error) = self.run_setup_command(Some("provider codex")).await {
-                            self.setup = Some(SetupStep::Credential {
-                                provider,
-                                selected,
-                                error: Some(error),
-                            });
-                            return;
-                        }
-                        self.open_model_step("codex");
-                    }
-                    Err(error) => {
-                        self.setup = Some(SetupStep::Credential {
-                            provider,
-                            selected,
-                            error: Some(error.to_string()),
-                        });
-                    }
-                }
+                self.start_codex_login(CodexLoginMethod::Browser, selected);
             }
             CredentialAction::DeviceLogin => {
                 if provider != "codex" {
                     return;
                 }
-                match crate::codex_auth::start_device_login().await {
-                    Ok(login) => {
-                        self.push_system(format!(
-                            "Codex device login: open {} and enter code {}",
-                            login.verification_uri, login.user_code
-                        ));
-                        match crate::codex_auth::complete_device_login(login).await {
-                            Ok(auth) => {
-                                if let Err(error) = self.settings.set_codex_auth(auth) {
-                                    self.setup = Some(SetupStep::Credential {
-                                        provider,
-                                        selected,
-                                        error: Some(error.to_string()),
-                                    });
-                                    return;
-                                }
-                                if let Err(error) =
-                                    self.run_setup_command(Some("provider codex")).await
-                                {
-                                    self.setup = Some(SetupStep::Credential {
-                                        provider,
-                                        selected,
-                                        error: Some(error),
-                                    });
-                                    return;
-                                }
-                                self.open_model_step("codex");
-                            }
-                            Err(error) => {
-                                self.setup = Some(SetupStep::Credential {
-                                    provider,
-                                    selected,
-                                    error: Some(error.to_string()),
-                                });
-                            }
-                        }
-                    }
-                    Err(error) => {
-                        self.setup = Some(SetupStep::Credential {
-                            provider,
-                            selected,
-                            error: Some(error.to_string()),
-                        });
-                    }
-                }
+                self.start_codex_login(CodexLoginMethod::Device, selected);
             }
             CredentialAction::PasteKey => {
                 self.setup = Some(SetupStep::TokenInput {
@@ -1013,6 +946,118 @@ impl App {
                 }
             }
         }
+    }
+
+    fn start_codex_login(&mut self, method: CodexLoginMethod, selected: usize) {
+        if self.codex_login.is_some() {
+            return;
+        }
+        self.next_codex_login_id = self.next_codex_login_id.wrapping_add(1);
+        let id = self.next_codex_login_id;
+        let tx = self.codex_login_tx.clone();
+        let task = tokio::spawn(async move {
+            let result = match method {
+                CodexLoginMethod::Browser => crate::codex_auth::login_with_browser()
+                    .await
+                    .map_err(|error| error.to_string()),
+                CodexLoginMethod::Device => match crate::codex_auth::start_device_login().await {
+                    Ok(login) => {
+                        let _ = tx.send(CodexLoginEvent::DeviceCode {
+                            id,
+                            verification_uri: login.verification_uri.clone(),
+                            user_code: login.user_code.clone(),
+                        });
+                        crate::codex_auth::complete_device_login(login)
+                            .await
+                            .map_err(|error| error.to_string())
+                    }
+                    Err(error) => Err(error.to_string()),
+                },
+            };
+            let _ = tx.send(CodexLoginEvent::Finished {
+                id,
+                selected,
+                result,
+            });
+        });
+        self.codex_login = Some(PendingCodexLogin { id, task });
+        self.setup = Some(SetupStep::CodexLogin {
+            selected,
+            method,
+            device_code: None,
+        });
+    }
+
+    fn cancel_codex_login(&mut self, selected: usize) {
+        self.abort_codex_login();
+        self.setup = Some(SetupStep::Credential {
+            provider: "codex".to_string(),
+            selected,
+            error: Some("Codex sign-in canceled".to_string()),
+        });
+    }
+
+    pub(crate) fn abort_codex_login(&mut self) {
+        if let Some(login) = self.codex_login.take() {
+            login.task.abort();
+        }
+    }
+
+    pub(crate) async fn apply_codex_login_events(&mut self) -> bool {
+        let mut applied = false;
+        while let Ok(event) = self.codex_login_rx.try_recv() {
+            let current_id = self.codex_login.as_ref().map(|login| login.id);
+            match event {
+                CodexLoginEvent::DeviceCode {
+                    id,
+                    verification_uri,
+                    user_code,
+                } if current_id == Some(id) => {
+                    if let Some(SetupStep::CodexLogin { device_code, .. }) = self.setup.as_mut() {
+                        *device_code = Some((verification_uri, user_code));
+                    }
+                    applied = true;
+                }
+                CodexLoginEvent::Finished {
+                    id,
+                    selected,
+                    result,
+                } if current_id == Some(id) => {
+                    self.codex_login = None;
+                    applied = true;
+                    match result {
+                        Ok(auth) => {
+                            if let Err(error) = self.settings.set_codex_auth(auth) {
+                                self.setup = Some(SetupStep::Credential {
+                                    provider: "codex".to_string(),
+                                    selected,
+                                    error: Some(error.to_string()),
+                                });
+                            } else if let Err(error) =
+                                self.run_setup_command(Some("provider codex")).await
+                            {
+                                self.setup = Some(SetupStep::Credential {
+                                    provider: "codex".to_string(),
+                                    selected,
+                                    error: Some(error),
+                                });
+                            } else {
+                                self.open_model_step("codex");
+                            }
+                        }
+                        Err(error) => {
+                            self.setup = Some(SetupStep::Credential {
+                                provider: "codex".to_string(),
+                                selected,
+                                error: Some(error),
+                            });
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        applied
     }
 
     pub(crate) async fn handle_token_key(

--- a/src/codex_auth.rs
+++ b/src/codex_auth.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result, anyhow};
 use reqwest::Url;
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -18,6 +19,8 @@ const DEVICE_USER_URL: &str = "https://auth.openai.com/codex/device";
 const SCOPE: &str = "openid profile email offline_access";
 const CALLBACK_PORT: u16 = 1455;
 const CALLBACK_PATH: &str = "/auth/callback";
+const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+const USER_AUTH_TIMEOUT: Duration = Duration::from_secs(10 * 60);
 
 #[derive(Debug, Clone)]
 pub struct DeviceLogin {
@@ -78,13 +81,15 @@ pub async fn login_with_browser() -> Result<CodexAuth> {
         .append_pair("codex_cli_simplified_flow", "true")
         .append_pair("originator", CODEX_ORIGINATOR);
 
-    open_browser(url.as_str())?;
-    let code = wait_for_callback(listener, &state).await?;
+    open_browser(url.as_str()).await?;
+    let code = tokio::time::timeout(USER_AUTH_TIMEOUT, wait_for_callback(listener, &state))
+        .await
+        .map_err(|_| anyhow!("Codex browser login timed out"))??;
     exchange_code(&code, &verifier, &redirect_uri).await
 }
 
 pub async fn start_device_login() -> Result<DeviceLogin> {
-    let client = reqwest::Client::new();
+    let client = auth_http_client()?;
     let response = client
         .post(DEVICE_USER_CODE_URL)
         .json(&serde_json::json!({ "client_id": CODEX_CLIENT_ID }))
@@ -111,7 +116,13 @@ pub async fn start_device_login() -> Result<DeviceLogin> {
 }
 
 pub async fn complete_device_login(login: DeviceLogin) -> Result<CodexAuth> {
-    let client = reqwest::Client::new();
+    tokio::time::timeout(USER_AUTH_TIMEOUT, complete_device_login_inner(login))
+        .await
+        .map_err(|_| anyhow!("Codex device login timed out before authorization completed"))?
+}
+
+async fn complete_device_login_inner(login: DeviceLogin) -> Result<CodexAuth> {
+    let client = auth_http_client()?;
     for _ in 0..120 {
         tokio::time::sleep(std::time::Duration::from_secs(login.interval_secs)).await;
         let response = client
@@ -151,7 +162,7 @@ pub async fn refresh_with_token(refresh_token: &str) -> Result<CodexAuth> {
 
 /// Refresh against an arbitrary token endpoint (tests inject a local mock).
 pub async fn refresh_with_token_at(token_url: &str, refresh_token: &str) -> Result<CodexAuth> {
-    let client = reqwest::Client::new();
+    let client = auth_http_client()?;
     let response = client
         .post(token_url)
         .form(&[
@@ -250,7 +261,7 @@ fn auth_from_token_response(token: TokenResponse) -> Result<CodexAuth> {
 }
 
 async fn exchange_code(code: &str, verifier: &str, redirect_uri: &str) -> Result<CodexAuth> {
-    let client = reqwest::Client::new();
+    let client = auth_http_client()?;
     let response = client
         .post(TOKEN_URL)
         .form(&[
@@ -270,6 +281,13 @@ async fn exchange_code(code: &str, verifier: &str, redirect_uri: &str) -> Result
     }
     let token: TokenResponse = response.json().await.context("parse Codex OAuth token")?;
     auth_from_token_response(token)
+}
+
+fn auth_http_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(HTTP_TIMEOUT)
+        .build()
+        .context("build Codex auth HTTP client")
 }
 
 async fn wait_for_callback(
@@ -479,17 +497,25 @@ fn callback_page(status: &str, message: &str) -> String {
     )
 }
 
-fn open_browser(url: &str) -> Result<()> {
-    let status = if cfg!(target_os = "macos") {
-        std::process::Command::new("open").arg(url).status()
+async fn open_browser(url: &str) -> Result<()> {
+    let mut command = if cfg!(target_os = "macos") {
+        let mut command = tokio::process::Command::new("open");
+        command.arg(url);
+        command
     } else if cfg!(target_os = "windows") {
-        std::process::Command::new("cmd")
-            .args(["/C", "start", "", url])
-            .status()
+        let mut command = tokio::process::Command::new("cmd");
+        command.args(["/C", "start", "", url]);
+        command
     } else {
-        std::process::Command::new("xdg-open").arg(url).status()
-    }
-    .context("open browser for Codex login")?;
+        let mut command = tokio::process::Command::new("xdg-open");
+        command.arg(url);
+        command
+    };
+    command.kill_on_drop(true);
+    let status = command
+        .status()
+        .await
+        .context("open browser for Codex login")?;
     if status.success() {
         Ok(())
     } else {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -22,6 +22,8 @@
 mod support;
 
 use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::mpsc::{self, Receiver};
@@ -858,6 +860,53 @@ fn tui_setup_overlay_renders_in_real_pty() {
         tui.wait_for_output("Esc cancel", Duration::from_secs(3)),
         "/setup footer should render without clipping: {}",
         tui.output_text()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn tui_browser_login_can_be_cancelled_after_browser_closes() {
+    let opener_dir = tempfile::tempdir().expect("browser opener tempdir");
+    for name in ["open", "xdg-open"] {
+        let path = opener_dir.path().join(name);
+        std::fs::write(&path, "#!/bin/sh\nexec sleep 30\n").expect("write mock browser opener");
+        let mut permissions = std::fs::metadata(&path)
+            .expect("mock opener metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(path, permissions).expect("make mock opener executable");
+    }
+
+    let mut tui = spawn_tui_llmsim_with(
+        &yolop_binary(),
+        TuiSpawnOptions {
+            path_prefix: Some(opener_dir.path().to_path_buf()),
+            ..TuiSpawnOptions::default()
+        },
+    );
+    assert!(tui.wait_for_output("type /help", Duration::from_secs(3)));
+
+    tui.write_input(b"/setup\r2");
+    assert!(tui.wait_for_output("Sign in with browser", Duration::from_secs(3)));
+    tui.write_input(b"1");
+    thread::sleep(Duration::from_millis(200));
+    tui.write_input(b"\x1b");
+
+    assert!(
+        tui.wait_for_output("Codex sign-in canceled", Duration::from_secs(3)),
+        "Esc should cancel browser login and restore the credential picker: {}",
+        tui.output_text()
+    );
+
+    // Starting again proves cancellation released the fixed localhost callback
+    // port. Exit keys must also work while the replacement attempt is waiting.
+    tui.clear_output();
+    tui.write_input(b"1");
+    assert!(tui.wait_for_output("Waiting for the browser", Duration::from_secs(3)));
+    tui.write_input(b"\x03\x03");
+    assert!(
+        tui.wait_or_kill(Duration::from_secs(3)).success(),
+        "TUI should remain responsive after cancel"
     );
 }
 

--- a/tests/support/tui_harness.rs
+++ b/tests/support/tui_harness.rs
@@ -21,7 +21,7 @@ pub struct TuiHarness {
     _home: tempfile::TempDir,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct TuiSpawnOptions {
     pub rows: u16,
     pub cols: u16,
@@ -30,6 +30,8 @@ pub struct TuiSpawnOptions {
     /// going silent, emulating an emulator that stops replying mid-session.
     /// `usize::MAX` (the default) answers every query like a real terminal.
     pub cursor_reply_budget: usize,
+    /// Directory prepended to `PATH` for subprocess lookup in the spawned TUI.
+    pub path_prefix: Option<PathBuf>,
 }
 
 impl Default for TuiSpawnOptions {
@@ -39,6 +41,7 @@ impl Default for TuiSpawnOptions {
             cols: 80,
             cursor_row: 1,
             cursor_reply_budget: usize::MAX,
+            path_prefix: None,
         }
     }
 }
@@ -170,6 +173,13 @@ pub fn spawn_tui_llmsim_with_settings(
     cmd.env("XDG_CONFIG_HOME", home.path().join(".config"));
     cmd.env("XDG_DATA_HOME", home.path().join(".local/share"));
     cmd.env("TERM", "xterm-256color");
+    if let Some(prefix) = options.path_prefix {
+        let inherited = std::env::var_os("PATH").unwrap_or_default();
+        let path =
+            std::env::join_paths(std::iter::once(prefix).chain(std::env::split_paths(&inherited)))
+                .expect("join PATH for TUI");
+        cmd.env("PATH", path);
+    }
     cmd.env_remove("OPENAI_API_KEY");
     cmd.env_remove("ANTHROPIC_API_KEY");
     cmd.env_remove("OPENROUTER_API_KEY");


### PR DESCRIPTION
## What changed

Codex browser and device-code sign-in now run outside the terminal key handler. The setup overlay stays responsive while authentication waits, and users can cancel with Esc or exit with Ctrl+C/Ctrl+D. Cancellation also stops a hanging browser opener and releases the fixed OAuth callback port immediately.

Auth HTTP requests now have a 30-second bound, and abandoned user-auth flows time out after 10 minutes.

## Why

Closing the browser during Codex sign-in left the TUI awaiting the OAuth callback inside its key handler. Because that same handler owned Esc and Ctrl+C processing, the screen could not recover without external intervention. Device-code sign-in had the same architecture and could block input for roughly ten minutes.

## Before / After

Before: the real PTY remained alive but ignored Esc and two Ctrl+C presses after the browser opener returned without an OAuth callback.

After: the PTY regression drives /setup → Codex subscription → browser sign-in with a deliberately hanging opener, cancels with Esc, starts sign-in again to prove port 1455 was released, then exits with Ctrl+C while authentication is still pending.

Validation:

- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features (707 unit, 35 integration, 1 parallel integration passed; 3 credential-gated tests ignored)
- cargo build --release
- cargo run -- --provider llmsim -p "hi"
- Doppler-backed OpenAI smoke returned exactly AUTH-SMOKE-OK

## Risk

- Low
- The changed surface is limited to Codex login lifecycle and setup rendering. Successful auth still persists through the existing settings and provider-switch path.

## Security

- TM-LLM: OAuth tokens remain off the transcript and are persisted only through the existing settings store. No secrets are added to logs or process arguments.
- Resource exhaustion: per-request and overall auth timeouts are explicit; canceled tasks, browser children, and the localhost listener are dropped.
- Injection: the OAuth URL is passed directly as one subprocess argument without a shell.
- TM-FS, TM-BASH, TM-TOOL: no permission, filesystem, shell-tool, or capability-registration behavior changed.
- TM-DEP: no dependencies added or changed.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
