### PR TITLE
fix(evals): restore standalone Cargo workspaces

### DIFF
--- a/evals/harness_basic/Cargo.toml
+++ b/evals/harness_basic/Cargo.toml
@@ -7,6 +7,8 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
+[workspace]
+
 [dependencies]
 mira-eval = "0.3"
 serde_json = "1.0"

--- a/evals/lsp_integration/Cargo.toml
+++ b/evals/lsp_integration/Cargo.toml
@@ -7,6 +7,8 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
+[workspace]
+
 [dependencies]
 mira-eval = "0.3"
 serde_json = "1.0"


### PR DESCRIPTION
## What changed
Restore `harness_basic` and `lsp_integration` as standalone Cargo workspaces so their Cargo and Mira entry points run after the root workspace was introduced.

## Why
The root workspace made both eval packages believe they belonged to it, but neither package is a member. Cargo rejected every eval launcher before the study could start.

## Before / After
Before: `mira list` failed with `current package believes it is in a workspace when it is not`.

After: both studies compile independently; `mira list` launches each study successfully.

## Risk
- Low
- This only changes Cargo workspace discovery for two non-shipping eval packages.

## Security
No security-relevant code changes. No runtime, dependency, filesystem permission, shell, prompt, or credential behavior changes.

## Follow-ups
No follow-ups.

## Checklist
- [x] Config behavior validated through both real Mira entry points and package test suites
- [x] Backward compatibility considered