### PR TITLE
feat(tui): show version in status

### DIFF
--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -8,6 +8,7 @@
 
 use crate::session_tasks_view::BackgroundCounts;
 use crate::transcript::{Author, ChatLine, StreamKind, StreamPreview};
+use crate::version::VERSION_DETAILS;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct PresentedTranscriptLine {
@@ -166,7 +167,10 @@ fn expanded_status_lines(state: &PresentationState) -> Vec<StatusLine> {
         },
         StatusLine { fields: counts },
         StatusLine {
-            fields: vec![status_field("session", state.session_id.clone())],
+            fields: vec![
+                status_field("session", state.session_id.clone()),
+                status_field("version", VERSION_DETAILS),
+            ],
         },
     ];
     if let Some((branch, path)) = &state.worktree_expanded {
@@ -438,5 +442,7 @@ mod tests {
         );
         assert_eq!(lines[3].fields[0].label, Some("session"));
         assert_eq!(lines[3].fields[0].value, "sess_123");
+        assert_eq!(lines[3].fields[1].label, Some("version"));
+        assert_eq!(lines[3].fields[1].value, VERSION_DETAILS);
     }
 }


### PR DESCRIPTION
## Summary

- show the running yolop version in the existing expanded `/status` view
- reuse the canonical build/version details rather than introducing a separate TUI command
- assert the terminal-independent status presentation model exposes the exact version value

## Before / After

**Before:** `/status` showed the session ID but not the running yolop version.

**After:** the session row includes `version: <version details>` alongside the session ID.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features presentation::tests::status_model_exposes_expanded_background_and_session_values`
- retried both transiently failing PTY integration tests individually; both passed
- `cargo run -- --provider llmsim -p "hi"`

Full `cargo test --all-features` had two timing-sensitive PTY failures (`tui_alt_enter_sequence_submits_like_enter` and `tui_bang_shell_runs_shell_without_model_turn`); both passed when rerun individually and are unrelated to the presentation-only delta.

## Security

Reviewed TM-FS, TM-BASH, TM-LLM, TM-TOOL, and TM-DEP. The change only reads a compile-time version constant into the in-memory status presentation model. It adds no filesystem or shell access, trust boundary, secret handling, capability, dependency, or unbounded work.

## Follow-ups

No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
