### PR TITLE
feat(acp): support per-session model selection

### DIFF
--- a/specs/acp.md
+++ b/specs/acp.md
@@ -41,6 +41,26 @@ replay path as CLI `--session`: prior user and assistant messages are streamed
 back to the editor before the response, and the loaded runtime then continues
 appending to the same session folder.
 
+### Per-session model selection
+
+ACP clients may select the provider, model, and reasoning effort for a new Yolop session. Yolop advertises this extension in the `initialize` response under `_meta["yolop.dev/acp"].modelSelection`. Clients send the selection in `session/new` metadata:
+
+```json
+{
+  "_meta": {
+    "yolop.dev/acp": {
+      "selectedModel": {
+        "provider": "openai",
+        "model": "gpt-5.2",
+        "reasoningEffort": "high"
+      }
+    }
+  }
+}
+```
+
+`provider` is required when `selectedModel` is present. `model` and `reasoningEffort` are optional and use the selected provider's defaults when omitted. Yolop validates all supplied values before creating the runtime and returns ACP `InvalidParams` for unsupported selections. Requests without `selectedModel` keep Yolop's configured defaults.
+
 ### Streaming a turn
 
 While a turn runs, runtime events are translated into `session/update`

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -53,6 +53,7 @@ impl RuntimeFactory for ConfigRuntimeFactory {
         &self,
         cwd: PathBuf,
         resume_session_id: Option<RuntimeSessionId>,
+        model_selection: Option<ProviderChoice>,
     ) -> Result<BuiltRuntime> {
         build_with_options(
             cwd,
@@ -62,6 +63,7 @@ impl RuntimeFactory for ConfigRuntimeFactory {
             self.settings.clone(),
             BuildOptions {
                 client_ui: ClientUiContext::Acp,
+                provider_model: model_selection,
                 ..BuildOptions::default()
             },
         )
@@ -125,6 +127,7 @@ mod tests {
             &self,
             cwd: PathBuf,
             resume_session_id: Option<RuntimeSessionId>,
+            model_selection: Option<ProviderChoice>,
         ) -> Result<BuiltRuntime> {
             build_with_options(
                 cwd,
@@ -135,6 +138,7 @@ mod tests {
                 BuildOptions {
                     llmsim_override: Some(self.config.clone().with_model("llmsim-yolop")),
                     client_ui: ClientUiContext::Acp,
+                    provider_model: model_selection,
                     ..BuildOptions::default()
                 },
             )

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -28,6 +28,7 @@ use everruns_core::command::{CommandDescriptor, CommandSource, ExecuteCommandReq
 use everruns_core::message::{ContentPart, ImageContentPart};
 use everruns_core::typed_id::SessionId as RuntimeSessionId;
 use futures::{AsyncBufReadExt, AsyncWriteExt, StreamExt};
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{oneshot, watch};
@@ -35,7 +36,7 @@ use tokio::task::JoinHandle;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use crate::background_wake::{WakeReceiver, frame_wake_prompt};
-use crate::runtime::{BuiltRuntime, ModelState, RuntimeHandles};
+use crate::runtime::{BuiltRuntime, ModelState, ProviderChoice, RuntimeHandles};
 use crate::settings::SettingsStore;
 use crate::worktree::WorktreeManager;
 
@@ -62,7 +63,73 @@ pub trait RuntimeFactory: Send + Sync + 'static {
         &self,
         cwd: PathBuf,
         resume_session_id: Option<RuntimeSessionId>,
+        model_selection: Option<ProviderChoice>,
     ) -> Result<BuiltRuntime>;
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcpSelectedModel {
+    #[serde(default)]
+    pub provider: Option<String>,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub reasoning_effort: Option<String>,
+}
+
+impl AcpSelectedModel {
+    fn is_empty(&self) -> bool {
+        self.provider.as_deref().is_none_or(str::is_empty)
+            && self.model.as_deref().is_none_or(str::is_empty)
+            && self.reasoning_effort.as_deref().is_none_or(str::is_empty)
+    }
+}
+
+fn selected_model_from_new_session(
+    params: &NewSessionParams,
+) -> Result<Option<ProviderChoice>, agent_client_protocol::Error> {
+    let meta = params.meta.as_ref().map(|meta| Value::Object(meta.clone()));
+    selected_model_from_meta(meta.as_ref())
+}
+
+fn selected_model_from_meta(
+    meta: Option<&Value>,
+) -> Result<Option<ProviderChoice>, agent_client_protocol::Error> {
+    let Some(yolop_meta) = meta.and_then(|meta| meta.get("yolop.dev/acp")) else {
+        return Ok(None);
+    };
+    let Some(model_meta) = yolop_meta
+        .get("model")
+        .or_else(|| yolop_meta.get("selectedModel"))
+    else {
+        return Ok(None);
+    };
+
+    let selected: AcpSelectedModel = serde_json::from_value(model_meta.clone())
+        .map_err(|err| invalid_params(format!("invalid yolop model selection metadata: {err}")))?;
+    if selected.is_empty() {
+        return Ok(None);
+    }
+    let provider = selected
+        .provider
+        .as_deref()
+        .ok_or_else(|| invalid_params("model selection requires `provider`"))
+        .and_then(|provider| {
+            ProviderChoice::default_for_provider_name(provider)
+                .map_err(|err| invalid_params(err.to_string()))
+        })?;
+    let model = selected
+        .model
+        .unwrap_or_else(|| provider.model_id().to_string());
+    let spec = match selected.reasoning_effort {
+        Some(effort) => format!("{model} {effort}"),
+        None => model,
+    };
+    provider
+        .resolve_model_spec(&spec)
+        .map(Some)
+        .map_err(|err| invalid_params(err.to_string()))
 }
 
 /// SDK connection wrapper plus yolop-local ids for synthetic command tool calls.
@@ -341,7 +408,11 @@ fn handle_initialize(params: InitializeParams) -> InitializeResult {
                 "yolop.dev/acp": {
                     "commandMetadata": true,
                     "commandArgSuggestions": true,
-                    "commandToolLifecycle": true
+                    "commandToolLifecycle": true,
+                    "modelSelection": {
+                        "requestMetaKey": "selectedModel",
+                        "supportsReasoningEffort": true
+                    }
                 }
             }))),
     )
@@ -352,11 +423,12 @@ async fn handle_new_session<F: RuntimeFactory>(
     peer: &Arc<Peer>,
     params: NewSessionParams,
 ) -> std::result::Result<NewSessionResult, agent_client_protocol::Error> {
+    let model_selection = selected_model_from_new_session(&params)?;
     let cwd = params.cwd;
 
     let built = server
         .factory
-        .build(cwd, None)
+        .build(cwd, None, model_selection)
         .await
         .map_err(|e| internal_error(format!("build runtime: {e}")))?;
 
@@ -385,7 +457,7 @@ async fn handle_load_session<F: RuntimeFactory>(
             }
             let built = server
                 .factory
-                .build(params.cwd, Some(resume_session_id))
+                .build(params.cwd, Some(resume_session_id), None)
                 .await
                 .map_err(|e| internal_error(format!("load runtime: {e}")))?;
             let acp_id = register_session(server, peer, built);
@@ -959,5 +1031,58 @@ mod tests {
         ))];
 
         assert!(prompt_image_parts(&blocks).is_empty());
+    }
+    #[test]
+    fn new_session_request_selects_model() {
+        let params: NewSessionParams = serde_json::from_value(json!({
+            "cwd": "/tmp",
+            "mcpServers": [],
+            "_meta": {
+                "yolop.dev/acp": {
+                    "selectedModel": {
+                        "provider": "openai",
+                        "model": "gpt-5.2",
+                        "reasoningEffort": "high"
+                    }
+                }
+            }
+        }))
+        .expect("valid ACP new-session request");
+
+        let selected = selected_model_from_new_session(&params)
+            .expect("valid selection")
+            .expect("selection present");
+
+        assert_eq!(selected.provider_name(), "openai");
+        assert_eq!(selected.model_id(), "gpt-5.2");
+        assert_eq!(selected.reasoning_effort(), Some("high"));
+    }
+
+    #[test]
+    fn rejects_selected_model_without_provider() {
+        let meta = json!({
+            "yolop.dev/acp": {
+                "selectedModel": { "model": "gpt-5.2" }
+            }
+        });
+
+        let error = selected_model_from_meta(Some(&meta))
+            .expect_err("provider-less selection must be rejected");
+
+        assert_eq!(error.code, agent_client_protocol::ErrorCode::InvalidParams);
+    }
+
+    #[test]
+    fn rejects_unknown_selected_model_provider() {
+        let meta = json!({
+            "yolop.dev/acp": {
+                "model": { "provider": "unknown-provider", "model": "x" }
+            }
+        });
+
+        let error =
+            selected_model_from_meta(Some(&meta)).expect_err("unknown provider must be rejected");
+
+        assert_eq!(error.code, agent_client_protocol::ErrorCode::InvalidParams);
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2178,6 +2178,7 @@ impl ModelState {
 /// existing behavior.
 pub struct BuildOptions {
     pub llmsim_override: Option<LlmSimConfig>,
+    pub(crate) provider_model: Option<ProviderChoice>,
     pub session_kind: SessionKind,
     pub initial_prompt: Option<String>,
     /// Register [`ClientCommandsCapability`], which contributes the
@@ -2193,6 +2194,7 @@ impl Default for BuildOptions {
     fn default() -> Self {
         Self {
             llmsim_override: None,
+            provider_model: None,
             session_kind: SessionKind::Interactive,
             initial_prompt: None,
             client_commands: false,
@@ -2209,6 +2211,7 @@ pub async fn build_with_options(
     settings: Arc<SettingsStore>,
     options: BuildOptions,
 ) -> Result<BuiltRuntime> {
+    let provider = options.provider_model.clone().unwrap_or(provider);
     let canonical_root = std::fs::canonicalize(&workspace_root)
         .with_context(|| format!("canonicalize workspace: {}", workspace_root.display()))?;
 


### PR DESCRIPTION
## Summary

- advertise a Yolop ACP extension for per-session model selection
- accept and validate provider, model, and reasoning effort on `session/new`
- apply the validated selection only to the new ACP runtime
- document the metadata contract for ACP clients such as Paseo

## Before / After

**Before:** ACP clients could only use Yolop's configured default provider and model when creating a session.

**After:** An ACP client can send:

```json
{
  "_meta": {
    "yolop.dev/acp": {
      "selectedModel": {
        "provider": "openai",
        "model": "gpt-5.2",
        "reasoningEffort": "high"
      }
    }
  }
}
```

Yolop validates the selection before runtime construction and returns ACP `InvalidParams` for unsupported or incomplete values. Sessions without selection metadata keep configured defaults.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features -- --test-threads=1`
- `cargo test -q acp:: --all-features` after rebasing onto current `origin/main`
- `cargo run --quiet -- --provider llmsim -p "Reply with exactly: model selection smoke ok"`

## Security

- TM-LLM: ACP metadata is deserialized into a bounded typed structure and routed through the existing provider/model/reasoning validators before runtime creation.
- TM-FS/TM-BASH/TM-TOOL/TM-DEP: no filesystem, shell, capability-registration, secret-handling, or dependency changes.
- Invalid providers, models, reasoning levels, malformed metadata, and selections without a provider fail with ACP `InvalidParams`; no untrusted value is executed or used as a path.

## Follow-ups

No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
