### PR TITLE
test(evals): stabilize search efficiency regression gate

### DIFF
--- a/.github/workflows/search-efficiency-eval.yml
+++ b/.github/workflows/search-efficiency-eval.yml
@@ -1,0 +1,146 @@
+name: Search Efficiency Eval
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "23 6 * * *"
+
+concurrency:
+  group: search-efficiency-eval
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  RUST_BACKTRACE: 1
+
+jobs:
+  regression:
+    name: Preserved-baseline regression
+    if: github.repository == 'everruns/yolop'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+      HARNESS_BASIC_BASELINE_BIN: ${{ github.workspace }}/target/yolop-eval-bin/baseline/yolop
+      HARNESS_BASIC_CANDIDATE_BIN: ${{ github.workspace }}/target/yolop-eval-bin/candidate/yolop
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The monitor builds the immutable pre-fix revision recorded in the
+          # baseline manifest as well as the triggering candidate revision.
+          fetch-depth: 0
+
+      - name: Verify Doppler access
+        run: |
+          if [ -z "${DOPPLER_TOKEN}" ]; then
+            echo "::error::DOPPLER_TOKEN is required for the search-efficiency eval."
+            exit 1
+          fi
+
+      - name: Read regression baseline
+        run: |
+          manifest="evals/harness_basic/search_efficiency_baseline.json"
+          baseline_commit="$(jq -er '.baseline.git_commit | select(test("^[0-9a-f]{40}$"))' "${manifest}")"
+          focused_preset="$(jq -er '.monitor.focused_preset | select(test("^[a-z0-9-]+$"))' "${manifest}")"
+          focused_trials="$(jq -er '.monitor.focused_trials | select(type == "number" and . > 0)' "${manifest}")"
+          control_preset="$(jq -er '.monitor.control_preset | select(test("^[a-z0-9-]+$"))' "${manifest}")"
+          control_trials="$(jq -er '.monitor.control_trials | select(type == "number" and . > 0)' "${manifest}")"
+          analyzer="$(jq -er '.monitor.analyzer | select(test("^[a-z0-9_-]+\\.py$"))' "${manifest}")"
+          {
+            echo "BASELINE_COMMIT=${baseline_commit}"
+            echo "FOCUSED_PRESET=${focused_preset}"
+            echo "FOCUSED_TRIALS=${focused_trials}"
+            echo "CONTROL_PRESET=${control_preset}"
+            echo "CONTROL_TRIALS=${control_trials}"
+            echo "SEARCH_EFFICIENCY_ANALYZER=${analyzer}"
+          } >> "${GITHUB_ENV}"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "search-efficiency-eval"
+
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@v4
+
+      - name: Install pinned Mira CLI
+        run: cargo install mira-cli --version 0.3.0 --locked
+
+      - name: Build candidate and preserved baseline
+        run: |
+          mkdir -p "$(dirname "${HARNESS_BASIC_CANDIDATE_BIN}")" "$(dirname "${HARNESS_BASIC_BASELINE_BIN}")"
+
+          cargo build --release --locked --bin yolop
+          cp target/release/yolop "${HARNESS_BASIC_CANDIDATE_BIN}"
+
+          baseline_worktree="${RUNNER_TEMP}/yolop-search-baseline"
+          git worktree add --detach "${baseline_worktree}" "${BASELINE_COMMIT}"
+          cargo build \
+            --release \
+            --locked \
+            --bin yolop \
+            --manifest-path "${baseline_worktree}/Cargo.toml" \
+            --target-dir "${GITHUB_WORKSPACE}/target/search-efficiency-baseline"
+          cp "${GITHUB_WORKSPACE}/target/search-efficiency-baseline/release/yolop" "${HARNESS_BASIC_BASELINE_BIN}"
+
+      - name: Run focused search cases
+        working-directory: evals/harness_basic
+        run: |
+          mira_status=0
+          doppler run -- mira run \
+            --preset "${FOCUSED_PRESET}" \
+            --trials "${FOCUSED_TRIALS}" \
+            --group-by binary \
+            --max-concurrent 4 \
+            --provider-concurrency openai=4 \
+            --out "${RUNNER_TEMP}/search-efficiency-focused.json" \
+            --format json || mira_status=$?
+          if [ ! -s "${RUNNER_TEMP}/search-efficiency-focused.json" ]; then
+            echo "::error::Mira did not produce the focused report (exit ${mira_status})."
+            exit 1
+          fi
+          echo "Mira focused exit: ${mira_status}; the distribution analyzer decides the regression gate."
+
+      - name: Run ordinary controls
+        working-directory: evals/harness_basic
+        run: |
+          mira_status=0
+          doppler run -- mira run \
+            --preset "${CONTROL_PRESET}" \
+            --trials "${CONTROL_TRIALS}" \
+            --group-by binary \
+            --max-concurrent 4 \
+            --provider-concurrency openai=4 \
+            --out "${RUNNER_TEMP}/search-efficiency-controls.json" \
+            --format json || mira_status=$?
+          if [ ! -s "${RUNNER_TEMP}/search-efficiency-controls.json" ]; then
+            echo "::error::Mira did not produce the control report (exit ${mira_status})."
+            exit 1
+          fi
+          echo "Mira controls exit: ${mira_status}; the distribution analyzer decides the regression gate."
+
+      - name: Gate trial distributions
+        working-directory: evals/harness_basic
+        run: |
+          python3 "${SEARCH_EFFICIENCY_ANALYZER}" \
+            "${RUNNER_TEMP}/search-efficiency-focused.json" \
+            "${RUNNER_TEMP}/search-efficiency-controls.json"
+
+      - name: Upload eval reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: search-efficiency-${{ github.run_id }}
+          path: |
+            evals/harness_basic/results/
+            ${{ runner.temp }}/search-efficiency-focused.json
+            ${{ runner.temp }}/search-efficiency-controls.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/evals/harness_basic/README.md
+++ b/evals/harness_basic/README.md
@@ -50,7 +50,7 @@ search/refactor, and read-only code navigation.
 | `grep-files-nested-glob` [`search-efficiency`] | Nested Rust source plus decoys | Search through `src/**/*.rs` | response finds the nested code through `grep_files` | path glob contract |
 | `missing-rg-recovery` [`search-efficiency`] | Restricted PATH without ripgrep | Recover after the required `rg` call fails | response finds the code via an available path | command-not-found guidance |
 | `zero-result-search-recovery` [`search-efficiency`] | Three absent terms plus a real target | Recover after repeated empty searches | response finds the target and records a progress warning | result-aware progress guard |
-| `repo-map-bounded` [`search-efficiency`] | Rust file with 260+ symbols | Use an unqueried repo map | answer is found and repo-map output stays bounded | output-size discipline |
+| `repo-map-bounded` [`search-efficiency`] | Rust file with 260+ symbols | Use an unqueried repo map | answer is found, output stays bounded, and truncation is followed by a targeted map or grep | output-size and recovery discipline |
 | `normal-output-preserves-head` [`search-efficiency`] | leading match followed by 600 `Error` lines | Run one bash search with explicit `output: normal` | leading match remains visible without reading persisted output | successful-output compaction |
 | `replace-console-log` [`ast-edit`] | TS: `api.ts`/`worker.ts` call `console.log`; `logger.ts` exports `logger.info` | Replace every `console.log(...)` with `logger.info(...)` | both TS files use `logger.info`, no `console.log` | multi-file shape rewrite (`console.log` → `logger.info`) |
 | `strip-print-debug` [`ast-edit`] | Python `app.py`/`helpers.py` with standalone `print(...)` debug lines | Remove every standalone `print(...)` statement | neither file contains `print(` | bulk statement removal across files |
@@ -117,7 +117,8 @@ cost, `llm_calls`, `turns`, `tool_calls_failed`, `agent_reported_ms`,
 `exploration_tools_before_first_mutation`, `max_exploration_tools_without_progress`,
 `progress_guard_warnings`, `calls_after_progress_warning`, structured inner
 `tool_calls_failed`, duplicate exploration, total/maximum tool-result bytes,
-repo-map narrowing, session-search ordering, `ast_edit_tool_calls`, and
+repo-map narrowing and targeted recovery (a narrower map or `grep_files` fallback),
+session-search ordering, `ast_edit_tool_calls`, and
 `ast_edit_tool_calls_failed`
 — plus metadata (`provider`, `model`, `effort`,
 `reasoning_effort_applied`, `harness`, `stop_reason`) for `--group-by`.
@@ -153,13 +154,21 @@ doppler run -- mira run --preset harness-compare --group-by harness
 # Focused guardrail proof: default vs no-progress-guard on the long-read trap.
 doppler run -- mira run --preset progress-guard --group-by harness
 
-# Focused baseline/candidate proof, three trials per case.
+# Focused baseline/candidate proof, three trials per search case.
 HARNESS_BASIC_BASELINE_BIN=/path/to/main/yolop \
 HARNESS_BASIC_CANDIDATE_BIN=/path/to/change/yolop \
   doppler run -- mira run --preset search-efficiency --trials 3 --group-by binary
 
-# Gate the saved trial distributions, not only aggregate pass count.
-python3 analyze_search_efficiency.py results/<run_id>/report.json
+# Use five trials for ordinary controls so one stochastic trajectory does not
+# dominate a small median.
+HARNESS_BASIC_BASELINE_BIN=/path/to/main/yolop \
+HARNESS_BASIC_CANDIDATE_BIN=/path/to/change/yolop \
+  doppler run -- mira run --preset search-controls --trials 5 --group-by binary
+
+# Gate both saved trial distributions, not only aggregate pass count.
+python3 analyze_search_efficiency.py \
+  results/<focused_run_id>/report.json \
+  results/<control_run_id>/report.json
 
 # Isolate output persistence from other yolop/runtime changes.
 HARNESS_BASIC_DEPENDENCY_BASELINE_BIN=/path/to/yolop-with-everruns-main \
@@ -184,7 +193,8 @@ doppler run -- mira run --targets 'anthropic/*' --axis harness=no-ast-grep --sam
 | `smoke` | cheap candidate sanity check | tag `smoke` | claude-sonnet-4-5 | candidate, effort=default, all harness |
 | `harness-compare` | **A/B yolop configurations** | all | claude-sonnet-4-5 | candidate, effort=default, all harness |
 | `progress-guard` | focused warning-behavior check | tag `progress-guard` | claude-sonnet-4-5 | candidate, effort=default, default vs no-progress-guard |
-| `search-efficiency` | baseline/candidate session/search proof, 3 trials | 5 focused cases + `add-fn`/`find-constant` controls | gpt-5.5 | baseline + candidate, harness=default, effort=default |
+| `search-efficiency` | baseline/candidate session/search proof, 3 trials | 5 focused cases | gpt-5.5 | baseline + candidate, harness=default, effort=default |
+| `search-controls` | ordinary regression controls, 5 trials | `add-fn`, `find-constant` | gpt-5.5 | baseline + candidate, harness=default, effort=default |
 | `output-persistence` | dependency-isolated output proof, 3 trials | `normal-output-preserves-head` | gpt-5.5 | dependency baseline + candidate |
 | `ast-edit-compare` | **A/B ast_edit capability** | tag `ast-edit` | claude-sonnet-4-5 | candidate, effort=default, default vs with-ast-edit |
 | `effort-compare` | effort sweep | all | gpt-5.5 | candidate, harness=default, all efforts |
@@ -201,9 +211,17 @@ For search-efficiency, compare correctness first, then medians and the worst
 trial for tool/LLM calls, failures, bytes, tokens, cost, and duration. Focused
 checks reject the known inefficient trajectories: session search after source
 exploration, `git grep` in a non-repository, unchanged repo-map retries,
-continued exploration after a warning, and persisted-output rereads. The two
-ordinary controls expose global prompt/tool-surface regressions. A candidate is
-not an improvement merely because its aggregate pass count is higher.
+continued exploration after a warning, and persisted-output rereads. The
+separate five-trial controls expose global prompt/tool-surface regressions with
+a less noisy median. A candidate is not an improvement merely because its
+aggregate pass count is higher.
+
+The manual/nightly [Search Efficiency Eval](../../.github/workflows/search-efficiency-eval.yml)
+builds both the triggering revision and the immutable pre-fix commit recorded
+in [`search_efficiency_baseline.json`](search_efficiency_baseline.json), runs
+the focused and control presets, gates both reports, and uploads the complete
+Mira run archives. It is intentionally excluded from pull-request CI because
+it is a live-model regression monitor, not a deterministic unit test.
 
 Verified: with the `no-ast-grep` settings applied, the `ast_grep` tool is
 absent from yolop's registered toolset (and each case's input tokens drop by
@@ -216,6 +234,7 @@ evals/harness_basic/
   src/main.rs   # the whole study: matrix, samples + declarative checks,
                 #   yolop subject (spawn + events.jsonl mining), unit tests
   analyze_search_efficiency.py  # baseline/candidate distribution gates
+  search_efficiency_baseline.json  # immutable pre-fix revision + evidence
   tests/         # analyzer unit tests
   Cargo.toml    # standalone crate (outside the yolop package), mira-eval SDK
   mira.toml     # host config: launcher, ./results, presets

--- a/evals/harness_basic/analyze_search_efficiency.py
+++ b/evals/harness_basic/analyze_search_efficiency.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Compare baseline/candidate trials from a harness_basic report.json."""
+"""Compare baseline/candidate trials from harness_basic report.json files."""
 
 from __future__ import annotations
 
@@ -11,6 +11,16 @@ from collections import defaultdict
 from pathlib import Path
 
 CONTROLS = {"add-fn", "find-constant"}
+FOCUSED = {
+    "prior-session-reference",
+    "grep-files-nested-glob",
+    "missing-rg-recovery",
+    "zero-result-search-recovery",
+    "repo-map-bounded",
+}
+EXPECTED_SAMPLES = FOCUSED | CONTROLS
+FOCUSED_TRIALS = 3
+CONTROL_TRIALS = 5
 METRICS = (
     "tool_calls",
     "llm_calls",
@@ -33,14 +43,17 @@ def value(case: dict, metric: str) -> float:
     return float(transcript.get("metrics", {}).get(metric, 0))
 
 
-def analyze(report: dict) -> tuple[list[str], list[str]]:
+def analyze_reports(reports: list[dict]) -> tuple[list[str], list[str]]:
     grouped: dict[tuple[str, str], list[dict]] = defaultdict(list)
-    for case in report.get("cases", []):
-        binary = case.get("params", {}).get("binary")
-        if binary in {"baseline", "candidate"} and not case.get("skipped", False):
-            grouped[(case["sample"], binary)].append(case)
+    for report in reports:
+        for case in report.get("cases", []):
+            binary = case.get("params", {}).get("binary")
+            if binary in {"baseline", "candidate"} and not case.get(
+                "skipped", False
+            ):
+                grouped[(case["sample"], binary)].append(case)
 
-    samples = sorted({sample for sample, _ in grouped})
+    samples = sorted(EXPECTED_SAMPLES)
     failures: list[str] = []
     rows: list[str] = []
     improved = 0
@@ -50,9 +63,10 @@ def analyze(report: dict) -> tuple[list[str], list[str]]:
         if not baseline or not candidate:
             failures.append(f"{sample}: missing baseline or candidate trials")
             continue
-        if len(baseline) != 3 or len(candidate) != 3:
+        expected_trials = CONTROL_TRIALS if sample in CONTROLS else FOCUSED_TRIALS
+        if len(baseline) != expected_trials or len(candidate) != expected_trials:
             failures.append(
-                f"{sample}: expected 3 trials per binary, got "
+                f"{sample}: expected {expected_trials} trials per binary, got "
                 f"{len(baseline)} baseline / {len(candidate)} candidate"
             )
         base_pass = sum(bool(case.get("passed")) for case in baseline) / len(baseline)
@@ -61,9 +75,9 @@ def analyze(report: dict) -> tuple[list[str], list[str]]:
             failures.append(
                 f"{sample}: correctness regressed {base_pass:.0%} -> {cand_pass:.0%}"
             )
-        if sample not in CONTROLS and cand_pass < 2 / 3:
+        if sample in FOCUSED and cand_pass < 2 / 3:
             failures.append(f"{sample}: candidate focused pass rate {cand_pass:.0%} < 67%")
-        if sample not in CONTROLS and cand_pass > base_pass:
+        if sample in FOCUSED and cand_pass > base_pass:
             improved += 1
 
         medians = {}
@@ -99,18 +113,28 @@ def analyze(report: dict) -> tuple[list[str], list[str]]:
             f"bytes {medians[('baseline', 'total_tool_result_bytes')]:g}->"
             f"{medians[('candidate', 'total_tool_result_bytes')]:g}"
         )
-    if samples and improved == 0:
+    if improved == 0:
         failures.append("no focused case improved over baseline")
-    if not samples:
-        failures.append("report contains no comparable baseline/candidate cases")
     return rows, failures
+
+
+def analyze(report: dict) -> tuple[list[str], list[str]]:
+    """Analyze one report; retained for callers with a combined report."""
+    return analyze_reports([report])
 
 
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("report", type=Path)
+    parser.add_argument(
+        "reports",
+        type=Path,
+        nargs="+",
+        help="focused 3-trial and control 5-trial report.json files",
+    )
     args = parser.parse_args()
-    rows, failures = analyze(json.loads(args.report.read_text()))
+    rows, failures = analyze_reports(
+        [json.loads(report.read_text()) for report in args.reports]
+    )
     print("\n".join(rows))
     if failures:
         print("\nRegression gates:", file=sys.stderr)

--- a/evals/harness_basic/mira.toml
+++ b/evals/harness_basic/mira.toml
@@ -48,12 +48,21 @@ axes = { binary = ["candidate"], effort = ["default"], harness = ["default", "no
 # SEARCH-EFFICIENCY — regressions from a real failed session: prior-session
 # discovery, nested grep globs, bounded repo maps, missing-rg recovery, and
 # warnings after repeated zero-result searches.
-# Two ordinary controls catch prompt/tool-surface regressions. Three trials make
-# trajectory variance visible without turning the focused run into a full suite.
+# Three trials make trajectory variance visible without turning the focused run
+# into a full suite.
 # Requires HARNESS_BASIC_BASELINE_BIN and HARNESS_BASIC_CANDIDATE_BIN.
 #   doppler run -- mira run --preset search-efficiency --trials 3 --group-by binary
 [presets.search-efficiency]
-samples = ["prior-session-reference", "grep-files-nested-glob", "missing-rg-recovery", "zero-result-search-recovery", "repo-map-bounded", "add-fn", "find-constant"]
+samples = ["prior-session-reference", "grep-files-nested-glob", "missing-rg-recovery", "zero-result-search-recovery", "repo-map-bounded"]
+targets = ["openai/gpt-5.5"]
+axes = { binary = ["baseline", "candidate"], effort = ["default"], harness = ["default"] }
+
+# SEARCH-CONTROLS — ordinary tasks that detect global prompt/tool-surface
+# regressions. Five trials reduce false alarms from ordinary model variance.
+# Requires HARNESS_BASIC_BASELINE_BIN and HARNESS_BASIC_CANDIDATE_BIN.
+#   doppler run -- mira run --preset search-controls --trials 5 --group-by binary
+[presets.search-controls]
+samples = ["add-fn", "find-constant"]
 targets = ["openai/gpt-5.5"]
 axes = { binary = ["baseline", "candidate"], effort = ["default"], harness = ["default"] }
 

--- a/evals/harness_basic/search_efficiency_baseline.json
+++ b/evals/harness_basic/search_efficiency_baseline.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "baseline": {
+    "git_commit": "67e3d798240111614ca8051594caf8376753542f",
+    "everruns_runtime_version": "0.17.7",
+    "description": "Preserved pre-fix yolop revision that reproduced the session/search inefficiencies."
+  },
+  "monitor": {
+    "focused_preset": "search-efficiency",
+    "focused_trials": 3,
+    "control_preset": "search-controls",
+    "control_trials": 5,
+    "analyzer": "analyze_search_efficiency.py"
+  },
+  "reference_evidence": [
+    {
+      "run_id": "20260714T174054Z-14aa",
+      "scope": "focused-and-controls",
+      "trials": 3,
+      "baseline_passed": 11,
+      "candidate_passed": 20,
+      "cases_per_binary": 21
+    },
+    {
+      "run_id": "20260714T174418Z-6c54",
+      "scope": "add-fn-control-confirmation",
+      "trials": 5,
+      "baseline_passed": 5,
+      "candidate_passed": 5,
+      "cases_per_binary": 5
+    }
+  ]
+}

--- a/evals/harness_basic/src/main.rs
+++ b/evals/harness_basic/src/main.rs
@@ -482,7 +482,7 @@ fn bounded_repo_map_sample() -> Sample {
             "metric_at_most": {"repo_map_max_result_bytes": 20000.0},
         }, {
             "when_binary": "candidate",
-            "metric_at_least": {"repo_map_narrowed_after_truncation": 1.0},
+            "metric_at_least": {"repo_map_targeted_recovery_after_truncation": 1.0},
             "metric_at_most": {
                 "tool_calls": 3.0,
                 "llm_calls": 4.0,
@@ -1004,6 +1004,7 @@ struct Mined {
     total_tool_result_bytes: u64,
     repo_map_max_result_bytes: u64,
     repo_map_narrowed_after_truncation: u64,
+    repo_map_targeted_recovery_after_truncation: u64,
     search_sessions_tool_calls: u64,
     search_sessions_first_exploration: u64,
     duplicate_exploration_calls: u64,
@@ -1071,10 +1072,35 @@ fn result_is_truncated(data: &Value) -> bool {
 }
 
 fn result_has_query(data: &Value) -> bool {
+    result_has_nonempty_string(data, "query")
+}
+
+fn result_has_nonempty_string(data: &Value, key: &str) -> bool {
     tool_result_value(data)
-        .and_then(|result| result.get("query").cloned())
-        .and_then(|query| query.as_str().map(str::to_owned))
-        .is_some_and(|query| !query.trim().is_empty())
+        .and_then(|result| result.get(key).cloned())
+        .and_then(|value| value.as_str().map(str::to_owned))
+        .is_some_and(|value| !value.trim().is_empty())
+}
+
+fn result_has_positive_u64(data: &Value, key: &str) -> bool {
+    tool_result_value(data)
+        .and_then(|result| result.get(key).cloned())
+        .and_then(|value| value.as_u64())
+        .is_some_and(|value| value > 0)
+}
+
+fn is_targeted_repo_map_recovery(tool_name: &str, data: &Value) -> bool {
+    if data.get("success").and_then(Value::as_bool) != Some(true) {
+        return false;
+    }
+    match tool_name {
+        "repo_map" => result_has_query(data),
+        "grep_files" => {
+            result_has_nonempty_string(data, "pattern")
+                && result_has_positive_u64(data, "match_count")
+        }
+        _ => false,
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -1180,6 +1206,7 @@ fn parse_events(jsonl: &str) -> Mined {
     let mut saw_exploration = false;
     let mut saw_progress_warning = false;
     let mut saw_truncated_repo_map = false;
+    let mut repo_map_recovery_pending = false;
     let mut exploration_fingerprints = BTreeSet::new();
     for line in jsonl.lines() {
         let line = line.trim();
@@ -1247,12 +1274,19 @@ fn parse_events(jsonl: &str) -> Mined {
                     .unwrap_or_default();
                 m.max_tool_result_bytes = m.max_tool_result_bytes.max(result_bytes);
                 m.total_tool_result_bytes += result_bytes;
+                if repo_map_recovery_pending && is_targeted_repo_map_recovery(name, &data) {
+                    m.repo_map_targeted_recovery_after_truncation += 1;
+                    repo_map_recovery_pending = false;
+                }
                 if name == "repo_map" {
                     m.repo_map_max_result_bytes = m.repo_map_max_result_bytes.max(result_bytes);
                     if saw_truncated_repo_map && result_has_query(&data) {
                         m.repo_map_narrowed_after_truncation += 1;
                     }
-                    saw_truncated_repo_map |= result_is_truncated(&data);
+                    if result_is_truncated(&data) {
+                        saw_truncated_repo_map = true;
+                        repo_map_recovery_pending = true;
+                    }
                 }
                 if name == "search_sessions" {
                     m.search_sessions_tool_calls += 1;
@@ -1632,6 +1666,10 @@ async fn run_yolop(sample: Sample, cx: RunCx) -> Transcript {
         mined.repo_map_narrowed_after_truncation as f64,
     );
     t.metrics.insert(
+        "repo_map_targeted_recovery_after_truncation".into(),
+        mined.repo_map_targeted_recovery_after_truncation as f64,
+    );
+    t.metrics.insert(
         "search_sessions_tool_calls".into(),
         mined.search_sessions_tool_calls as f64,
     );
@@ -1858,6 +1896,7 @@ mod tests {
         assert_eq!(m.search_sessions_first_exploration, 1);
         assert_eq!(m.duplicate_exploration_calls, 1);
         assert_eq!(m.repo_map_narrowed_after_truncation, 1);
+        assert_eq!(m.repo_map_targeted_recovery_after_truncation, 1);
         assert_eq!(m.progress_guard_warnings, 1);
         assert_eq!(m.calls_after_progress_warning, 3);
         assert_eq!(m.inner_tool_failures, 1);
@@ -1866,6 +1905,19 @@ mod tests {
         assert_eq!(m.read_file_tool_calls, 1);
         assert_eq!(m.leading_marker_in_bash_result, 1);
         assert!(m.total_tool_result_bytes >= m.max_tool_result_bytes);
+    }
+
+    #[test]
+    fn parse_events_counts_targeted_grep_as_repo_map_recovery() {
+        let jsonl = r#"
+{"type":"tool.completed","data":{"tool_name":"repo_map","success":true,"result":[{"type":"text","text":"{\"query\":null,\"truncated\":true}"}]}}
+{"type":"tool.completed","data":{"tool_name":"grep_files","success":false,"result":[{"type":"text","text":"{\"pattern\":\"bounded_map_answer\",\"match_count\":1}"}]}}
+{"type":"tool.completed","data":{"tool_name":"grep_files","success":true,"result":[{"type":"text","text":"{\"pattern\":\"wrong_name\",\"match_count\":0,\"matches\":[]}"}]}}
+{"type":"tool.completed","data":{"tool_name":"grep_files","success":true,"result":[{"type":"text","text":"{\"pattern\":\"bounded_map_answer\",\"match_count\":1,\"matches\":[{\"path\":\"src/lib.rs\",\"line_number\":76}]}"}]}}
+"#;
+        let m = parse_events(jsonl);
+        assert_eq!(m.repo_map_narrowed_after_truncation, 0);
+        assert_eq!(m.repo_map_targeted_recovery_after_truncation, 1);
     }
 
     #[tokio::test]
@@ -1975,7 +2027,7 @@ mod tests {
             .split("[presets.search-efficiency]")
             .nth(1)
             .expect("search-efficiency preset")
-            .split("[presets.output-persistence]")
+            .split("[presets.search-controls]")
             .next()
             .unwrap();
         assert!(section.contains("binary = [\"baseline\", \"candidate\"]"));
@@ -1983,8 +2035,20 @@ mod tests {
             !section.contains("trials ="),
             "Mira presets do not select trial count; invoke this preset with --trials 3"
         );
-        assert!(section.contains("\"add-fn\""));
+        assert!(!section.contains("\"add-fn\""));
         assert!(!section.contains("\"normal-output-preserves-head\""));
+
+        let controls_section = config
+            .split("[presets.search-controls]")
+            .nth(1)
+            .expect("search-controls preset")
+            .split("[presets.output-persistence]")
+            .next()
+            .unwrap();
+        assert!(controls_section.contains("binary = [\"baseline\", \"candidate\"]"));
+        assert!(controls_section.contains("\"add-fn\""));
+        assert!(controls_section.contains("\"find-constant\""));
+        assert!(!controls_section.contains("trials ="));
 
         let output_section = config
             .split("[presets.output-persistence]")

--- a/evals/harness_basic/tests/test_analyze_search_efficiency.py
+++ b/evals/harness_basic/tests/test_analyze_search_efficiency.py
@@ -26,29 +26,60 @@ def case(sample, binary, passed, tools=1, tokens=100, failures=0):
     }
 
 
-class AnalyzeTests(unittest.TestCase):
-    def test_accepts_improvement_without_control_regression(self):
-        cases = []
+def focused_cases():
+    cases = []
+    for sample in sorted(analyzer.FOCUSED):
         for _ in range(3):
             cases += [
-                case("add-fn", "baseline", True),
-                case("add-fn", "candidate", True),
-                case("focused", "baseline", False, tools=4),
-                case("focused", "candidate", True, tools=2),
+                case(sample, "baseline", False, tools=4),
+                case(sample, "candidate", True, tools=2),
             ]
-        _, failures = analyzer.analyze({"cases": cases})
+    return cases
+
+
+def control_cases(candidate_passed=True, candidate_tokens=100, trials=5):
+    cases = []
+    for sample in sorted(analyzer.CONTROLS):
+        for _ in range(trials):
+            cases += [
+                case(sample, "baseline", True, tokens=100),
+                case(
+                    sample,
+                    "candidate",
+                    candidate_passed,
+                    tokens=candidate_tokens,
+                ),
+            ]
+    return cases
+
+
+class AnalyzeTests(unittest.TestCase):
+    def test_accepts_split_reports_with_stable_five_trial_controls(self):
+        _, failures = analyzer.analyze_reports(
+            [{"cases": focused_cases()}, {"cases": control_cases()}]
+        )
         self.assertEqual(failures, [])
 
     def test_rejects_control_cost_and_correctness_regression(self):
-        cases = [
-            case("add-fn", "baseline", True, tokens=100),
-            case("add-fn", "candidate", False, tokens=120),
-            case("focused", "baseline", False),
-            case("focused", "candidate", True),
-        ]
+        cases = focused_cases() + control_cases(
+            candidate_passed=False, candidate_tokens=120
+        )
         _, failures = analyzer.analyze({"cases": cases})
         self.assertTrue(any("correctness regressed" in failure for failure in failures))
         self.assertTrue(any("input_tokens regressed" in failure for failure in failures))
+
+    def test_rejects_three_trial_controls(self):
+        cases = focused_cases() + control_cases(trials=3)
+        _, failures = analyzer.analyze({"cases": cases})
+        self.assertTrue(
+            any("add-fn: expected 5 trials per binary" in failure for failure in failures)
+        )
+
+    def test_rejects_missing_preset_report(self):
+        _, failures = analyzer.analyze({"cases": focused_cases()})
+        self.assertTrue(
+            any("add-fn: missing baseline or candidate trials" in failure for failure in failures)
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

Search-efficiency regression monitoring now separates the five focused search cases from two ordinary controls. Focused cases run three trials; controls run five. The analyzer requires both reports and enforces the correct trial count per binary.

A targeted, successful grep_files call with at least one match now counts as valid recovery from a truncated repo map. The narrower-repo-map metric remains available for historical diagnostics.

A manual/nightly workflow compares the triggering revision with the immutable pre-fix baseline, analyzes both trial distributions, and uploads the Mira reports.

## Why

The original combined three-trial run made ordinary controls too sensitive to model variance, rejected the efficient repo_map to grep_files trajectory observed in the live eval, and left regression evidence as a one-off local report.

## Before / After

Before:
- Ordinary controls used three trials and a single outlier could move the median.
- Only a second narrowed repo_map satisfied the bounded-map recovery scorer.
- Regression reports were run and interpreted manually.

After:
- Focused cases use 3 trials and controls use 5; missing either report fails the analyzer.
- Successful positive targeted grep recovery is accepted; failed and zero-match greps are rejected.
- The preserved 0.17.7 baseline is rebuilt and compared on a nightly or manual schedule.

Proof:
- harness_basic: 15 tests passed; clippy clean.
- analyzer: 4 tests passed.
- full workspace: 718 unit tests, 35 integration tests, and 1 parallel integration test passed; expected live/LSP tests ignored.
- workflow actionlint, manifest JSON validation, and diff checks passed.
- the preserved baseline commit built successfully with its locked dependencies.

## Risk

- Medium: the scheduled live-model monitor consumes provider capacity and can surface genuine model variance.
- The 5-trial controls and distribution-aware gates reduce false alarms; adaptive provider throttling remains enabled.
- Existing per-trial focused thresholds and the historical repo-map metric are retained.

## Security

- Reviewed the final diff for workflow and secret exposure.
- The live workflow has contents: read only, no pull_request trigger, and runs only in everruns/yolop.
- DOPPLER_TOKEN is validated and used only for the live Mira commands.
- Baseline manifest fields are validated before use, and the pinned commit was built locally.

## Follow-ups

None required for this change. Nightly artifacts provide the continuing regression record.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered