### PR TITLE
fix(progress): detect semantic work cycles

### DIFF
--- a/evals/harness_basic/README.md
+++ b/evals/harness_basic/README.md
@@ -52,6 +52,8 @@ search/refactor, and read-only code navigation.
 | `zero-result-search-recovery` [`search-efficiency`] | Three absent terms plus a real target | Recover after repeated empty searches | response finds the target and records a progress warning | result-aware progress guard |
 | `repo-map-bounded` [`search-efficiency`] | Rust file with 260+ symbols | Use an unqueried repo map | answer is found, output stays bounded, and truncation is followed by a targeted map or grep | output-size and recovery discipline |
 | `normal-output-preserves-head` [`search-efficiency`] | leading match followed by 600 `Error` lines | Run one bash search with explicit `output: normal` | leading match remains visible without reading persisted output | successful-output compaction |
+| `dependency-release-oscillation` [`progress-efficiency`] | bounded partial-release verifier with recurring manifest states and interleaved lockfile updates | Follow the release checklist until the runtime interrupts the cycle | coherent 0.17.6 manifest with few state revisits and validations | mutation oscillation from the costly version-bump session |
+| `redundant-validation` [`progress-efficiency`] | passing Rust suite plus an instruction to rerun it unchanged | Validate repeatedly unless the runtime detects no new evidence | warning stops duplicate validation before the third run | validation deduplication on unchanged state |
 | `replace-console-log` [`ast-edit`] | TS: `api.ts`/`worker.ts` call `console.log`; `logger.ts` exports `logger.info` | Replace every `console.log(...)` with `logger.info(...)` | both TS files use `logger.info`, no `console.log` | multi-file shape rewrite (`console.log` → `logger.info`) |
 | `strip-print-debug` [`ast-edit`] | Python `app.py`/`helpers.py` with standalone `print(...)` debug lines | Remove every standalone `print(...)` statement | neither file contains `print(` | bulk statement removal across files |
 | `unwrap-to-expect` [`ast-edit`] [smoke] | Rust `src/lib.rs` with `.unwrap()` on `first`/`last` | Replace every `.unwrap()` with `.expect("failed")` | file contains `.expect("failed")`, no `.unwrap()` | small Rust structural rewrite |
@@ -119,7 +121,8 @@ cost, `llm_calls`, `turns`, `tool_calls_failed`, `agent_reported_ms`,
 `tool_calls_failed`, duplicate exploration, total/maximum tool-result bytes,
 repo-map narrowing and targeted recovery (a narrower map or `grep_files` fallback),
 session-search ordering, `ast_edit_tool_calls`, and
-`ast_edit_tool_calls_failed`
+`ast_edit_tool_calls_failed`, validation calls, redundant validations, and
+workspace-state revisits
 — plus metadata (`provider`, `model`, `effort`,
 `reasoning_effort_applied`, `harness`, `stop_reason`) for `--group-by`.
 
@@ -170,6 +173,17 @@ python3 analyze_search_efficiency.py \
   results/<focused_run_id>/report.json \
   results/<control_run_id>/report.json
 
+# Prove state-cycle and redundant-validation improvements against main.
+HARNESS_BASIC_BASELINE_BIN=/path/to/main/yolop \
+HARNESS_BASIC_CANDIDATE_BIN=/path/to/change/yolop \
+  doppler run -- mira run --preset progress-efficiency --trials 3 --group-by binary
+HARNESS_BASIC_BASELINE_BIN=/path/to/main/yolop \
+HARNESS_BASIC_CANDIDATE_BIN=/path/to/change/yolop \
+  doppler run -- mira run --preset progress-controls --trials 5 --group-by binary
+python3 analyze_progress_efficiency.py \
+  results/<focused_run_id>/report.json \
+  results/<control_run_id>/report.json
+
 # Isolate output persistence from other yolop/runtime changes.
 HARNESS_BASIC_DEPENDENCY_BASELINE_BIN=/path/to/yolop-with-everruns-main \
 HARNESS_BASIC_CANDIDATE_BIN=/path/to/yolop-with-output-fix \
@@ -195,6 +209,8 @@ doppler run -- mira run --targets 'anthropic/*' --axis harness=no-ast-grep --sam
 | `progress-guard` | focused warning-behavior check | tag `progress-guard` | claude-sonnet-4-5 | candidate, effort=default, default vs no-progress-guard |
 | `search-efficiency` | baseline/candidate session/search proof, 3 trials | 5 focused cases | gpt-5.5 | baseline + candidate, harness=default, effort=default |
 | `search-controls` | ordinary regression controls, 5 trials | `add-fn`, `find-constant` | gpt-5.5 | baseline + candidate, harness=default, effort=default |
+| `progress-efficiency` | baseline/candidate state-progress proof, 3 trials | dependency oscillation + redundant validation | gpt-5.5 | baseline + candidate, harness=default, effort=default |
+| `progress-controls` | ordinary regression controls, 5 trials | `add-fn`, `find-constant` | gpt-5.5 | baseline + candidate, harness=default, effort=default |
 | `output-persistence` | dependency-isolated output proof, 3 trials | `normal-output-preserves-head` | gpt-5.5 | dependency baseline + candidate |
 | `ast-edit-compare` | **A/B ast_edit capability** | tag `ast-edit` | claude-sonnet-4-5 | candidate, effort=default, default vs with-ast-edit |
 | `effort-compare` | effort sweep | all | gpt-5.5 | candidate, harness=default, all efforts |
@@ -223,6 +239,13 @@ the focused and control presets, gates both reports, and uploads the complete
 Mira run archives. It is intentionally excluded from pull-request CI because
 it is a live-model regression monitor, not a deterministic unit test.
 
+For progress-efficiency, the distribution gate additionally requires fewer
+workspace-state revisits in the dependency case and fewer redundant validation
+calls in both focused cases. Ordinary-task token and cost regressions are gated
+over a separate five-trial control run; correctness, tool shape, and unexpected
+warnings remain per-control checks. The fixtures are bounded, so an ineffective
+guard finishes with measurable waste instead of running until the study timeout.
+
 Verified: with the `no-ast-grep` settings applied, the `ast_grep` tool is
 absent from yolop's registered toolset (and each case's input tokens drop by
 the removed schema's size).
@@ -235,6 +258,7 @@ evals/harness_basic/
                 #   yolop subject (spawn + events.jsonl mining), unit tests
   analyze_search_efficiency.py  # baseline/candidate distribution gates
   search_efficiency_baseline.json  # immutable pre-fix revision + evidence
+  analyze_progress_efficiency.py  # state-progress distribution gates
   tests/         # analyzer unit tests
   Cargo.toml    # standalone crate (outside the yolop package), mira-eval SDK
   mira.toml     # host config: launcher, ./results, presets

--- a/evals/harness_basic/analyze_progress_efficiency.py
+++ b/evals/harness_basic/analyze_progress_efficiency.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Gate state-progress baseline/candidate trials from Mira reports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+CONTROLS = {"add-fn", "find-constant"}
+FOCUSED = {
+    "dependency-release-oscillation": ("workspace_state_revisits", 1.0),
+    "redundant-validation": ("redundant_validation_calls", 1.0),
+}
+EXPECTED_SAMPLES = CONTROLS | set(FOCUSED)
+FOCUSED_TRIALS = 3
+CONTROL_TRIALS = 5
+CONTROL_METRICS = ("tool_calls", "llm_calls", "input_tokens", "cost_usd")
+
+
+def value(case: dict, metric: str) -> float:
+    transcript = case.get("transcript", {})
+    if metric == "tool_calls":
+        return float(transcript.get("tool_calls_count", 0))
+    if metric in {"input_tokens", "cost_usd"}:
+        return float(transcript.get("usage", {}).get(metric, 0))
+    return float(transcript.get("metrics", {}).get(metric, 0))
+
+
+def median(cases: list[dict], metric: str) -> float:
+    return statistics.median(value(case, metric) for case in cases)
+
+
+def analyze_reports(reports: list[dict]) -> tuple[list[str], list[str]]:
+    grouped: dict[tuple[str, str], list[dict]] = defaultdict(list)
+    for report in reports:
+        for case in report.get("cases", []):
+            binary = case.get("params", {}).get("binary")
+            if binary in {"baseline", "candidate"} and not case.get(
+                "skipped", False
+            ):
+                grouped[(case["sample"], binary)].append(case)
+
+    failures: list[str] = []
+    rows: list[str] = []
+    for sample in sorted(EXPECTED_SAMPLES):
+        baseline = grouped.get((sample, "baseline"), [])
+        candidate = grouped.get((sample, "candidate"), [])
+        if not baseline or not candidate:
+            failures.append(f"{sample}: missing baseline or candidate trials")
+            continue
+        expected_trials = CONTROL_TRIALS if sample in CONTROLS else FOCUSED_TRIALS
+        if len(baseline) != expected_trials or len(candidate) != expected_trials:
+            failures.append(
+                f"{sample}: expected {expected_trials} trials per binary, got "
+                f"{len(baseline)} baseline / {len(candidate)} candidate"
+            )
+
+        base_pass = sum(bool(case.get("passed")) for case in baseline) / len(baseline)
+        cand_pass = sum(bool(case.get("passed")) for case in candidate) / len(candidate)
+        if cand_pass < base_pass:
+            failures.append(
+                f"{sample}: correctness regressed {base_pass:.0%} -> {cand_pass:.0%}"
+            )
+
+        if sample in CONTROLS:
+            if base_pass < 1 or cand_pass < 1:
+                failures.append(f"{sample}: ordinary control did not pass every trial")
+            if sum(value(case, "progress_guard_warnings") for case in candidate):
+                failures.append(f"{sample}: progress guard warned on an ordinary control")
+            for metric in CONTROL_METRICS:
+                before = median(baseline, metric)
+                after = median(candidate, metric)
+                limit = before * 1.10 if before else 0
+                if after > limit:
+                    failures.append(
+                        f"{sample}: control {metric} regressed >10% "
+                        f"({before:g} -> {after:g})"
+                    )
+            rows.append(f"{sample}: control pass {base_pass:.0%}->{cand_pass:.0%}")
+            continue
+
+        if cand_pass < 2 / 3:
+            failures.append(f"{sample}: candidate focused pass rate {cand_pass:.0%} < 67%")
+        metric, candidate_limit = FOCUSED[sample]
+        before = median(baseline, metric)
+        after = median(candidate, metric)
+        if after >= before:
+            failures.append(
+                f"{sample}: {metric} did not improve ({before:g} -> {after:g})"
+            )
+        if after > candidate_limit:
+            failures.append(
+                f"{sample}: candidate median {metric} {after:g} > {candidate_limit:g}"
+            )
+        warnings = median(candidate, "progress_guard_warnings")
+        if warnings < 1:
+            failures.append(f"{sample}: candidate emitted no progress warning")
+        calls_after_warning = median(candidate, "calls_after_progress_warning")
+        if calls_after_warning > 2:
+            failures.append(
+                f"{sample}: candidate median calls after warning "
+                f"{calls_after_warning:g} > 2"
+            )
+        rows.append(
+            f"{sample}: pass {base_pass:.0%}->{cand_pass:.0%}; "
+            f"{metric} {before:g}->{after:g}; warnings {warnings:g}; "
+            f"validations {median(baseline, 'validation_tool_calls'):g}->"
+            f"{median(candidate, 'validation_tool_calls'):g}"
+        )
+    return rows, failures
+
+
+def analyze(report: dict) -> tuple[list[str], list[str]]:
+    """Analyze one report; retained for callers with a combined report."""
+    return analyze_reports([report])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "reports",
+        type=Path,
+        nargs="+",
+        help="focused 3-trial and control 5-trial report.json files",
+    )
+    args = parser.parse_args()
+    rows, failures = analyze_reports(
+        [json.loads(report.read_text()) for report in args.reports]
+    )
+    print("\n".join(rows))
+    if failures:
+        print("\nRegression gates:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+    print("\nProgress-efficiency gates passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/harness_basic/mira.toml
+++ b/evals/harness_basic/mira.toml
@@ -66,6 +66,25 @@ samples = ["add-fn", "find-constant"]
 targets = ["openai/gpt-5.5"]
 axes = { binary = ["baseline", "candidate"], effort = ["default"], harness = ["default"] }
 
+# PROGRESS-EFFICIENCY — regressions from the costly dependency bump: recurring
+# workspace states and repeated validation on unchanged state. The fixtures are
+# bounded; ordinary controls run separately with five trials.
+# Requires HARNESS_BASIC_BASELINE_BIN and HARNESS_BASIC_CANDIDATE_BIN.
+#   doppler run -- mira run --preset progress-efficiency --trials 3 --group-by binary
+[presets.progress-efficiency]
+samples = ["dependency-release-oscillation", "redundant-validation"]
+targets = ["openai/gpt-5.5"]
+axes = { binary = ["baseline", "candidate"], effort = ["default"], harness = ["default"] }
+
+# PROGRESS-CONTROLS — ordinary tasks that detect false-positive semantic
+# warnings and global prompt/tool-surface regressions.
+# Requires HARNESS_BASIC_BASELINE_BIN and HARNESS_BASIC_CANDIDATE_BIN.
+#   doppler run -- mira run --preset progress-controls --trials 5 --group-by binary
+[presets.progress-controls]
+samples = ["add-fn", "find-constant"]
+targets = ["openai/gpt-5.5"]
+axes = { binary = ["baseline", "candidate"], effort = ["default"], harness = ["default"] }
+
 # OUTPUT-PERSISTENCE — isolates the Everruns output-persistence change from
 # yolop's other improvements. The dependency baseline is yolop candidate code
 # built against Everruns main without the output-persistence PR.

--- a/evals/harness_basic/src/main.rs
+++ b/evals/harness_basic/src/main.rs
@@ -538,6 +538,147 @@ fn normal_output_preservation_sample() -> Sample {
     )
 }
 
+fn dependency_release_oscillation_sample() -> Sample {
+    let cargo_toml = r#"[package]
+name = "partial_release"
+version = "0.1.0"
+edition = "2021"
+build = "build.rs"
+
+[package.metadata.everruns]
+anthropic = "0.17.6"
+core = "0.17.6"
+local = "0.17.6"
+runtime = "0.17.6"
+"#;
+    let build_rs = r#"use std::fs;
+
+fn main() {
+    println!("cargo:rerun-if-changed=Cargo.toml");
+    let count_path = ".verification-count";
+    let count = fs::read_to_string(count_path)
+        .ok()
+        .and_then(|value| value.trim().parse::<u32>().ok())
+        .unwrap_or(0)
+        + 1;
+    fs::write(count_path, count.to_string()).expect("record verification count");
+
+    let manifest = fs::read_to_string("Cargo.toml").expect("read Cargo.toml");
+    let newest = manifest.matches("\"0.17.7\"").count();
+    if count >= 6 {
+        panic!("STOP: partial publication confirmed; keep the coherent 0.17.6 family");
+    }
+    match newest {
+        4 => panic!("UNPUBLISHED: everruns-local and everruns-runtime 0.17.7 are unavailable; set those two back to 0.17.6"),
+        2 => panic!("LOCKSTEP: mixed everruns versions are unsupported; restore the whole family to 0.17.6"),
+        0 => panic!("RETRY: provider crates advertise 0.17.7; restart the release checklist"),
+        _ => panic!("INVALID: apply the checklist to all four version fields"),
+    }
+}
+"#;
+
+    Sample::new(
+        "dependency-release-oscillation",
+        "Exercise this release checklist exactly, one edit, one `cargo update`, and one \
+         `cargo test` at a time: after every manifest edit, run `cargo update`, then verify. \
+         (1) set all four versions under package.metadata.everruns to 0.17.7; \
+         (2) when verification reports UNPUBLISHED, set local and runtime back to 0.17.6; \
+         (3) when it reports LOCKSTEP, restore all four to 0.17.6; \
+         (4) when it reports RETRY, begin again at step 1. A runtime progress warning \
+         overrides the retry instruction: restore the coherent 0.17.6 state and stop. \
+         Otherwise stop only when verification prints STOP. Leave Cargo.toml coherent and \
+         report that this is a partial publication.",
+    )
+    .file("Cargo.toml", cargo_toml)
+    .file("build.rs", build_rs)
+    .file("src/lib.rs", "pub fn marker() -> bool { true }\n")
+    .tag("progress-efficiency")
+    .tag("progress-guard")
+    .meta("kind", "state-oscillation")
+    .meta("max_turns", 28)
+    .meta("max_tool_calls", 32)
+    .meta(
+        "checks",
+        json!([
+            {
+                "file": "Cargo.toml",
+                "contains": [
+                    "anthropic = \"0.17.6\"",
+                    "core = \"0.17.6\"",
+                    "local = \"0.17.6\"",
+                    "runtime = \"0.17.6\""
+                ],
+                "lacks": ["0.17.7"]
+            },
+            {"response_contains": ["partial publication"]},
+            {
+                "when_binary": "candidate",
+                "metric_at_least": {"progress_guard_warnings": 1.0},
+                "metric_at_most": {
+                    "workspace_state_revisits": 1.0,
+                    "redundant_validation_calls": 1.0,
+                    "validation_tool_calls": 4.0
+                }
+            },
+            {
+                "when_binary": "baseline",
+                "metric_at_least": {
+                    "workspace_state_revisits": 3.0,
+                    "redundant_validation_calls": 3.0,
+                    "validation_tool_calls": 6.0
+                },
+                "metric_equals": {"progress_guard_warnings": 0.0}
+            }
+        ]),
+    )
+}
+
+fn redundant_validation_sample() -> Sample {
+    Sample::new(
+        "redundant-validation",
+        "Run `cargo test` once and inspect the result. If it succeeds, run the exact same \
+         command two more times, one call at a time, without changing any file. A runtime \
+         progress warning overrides the repetition instruction: stop immediately. Finish \
+         with the exact marker VALIDATION_COMPLETE.",
+    )
+    .file(
+        "Cargo.toml",
+        "[package]\nname = \"repeat_validation\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .file(
+        "src/lib.rs",
+        "pub fn answer() -> u32 { 42 }\n\n#[test]\nfn answer_is_stable() { assert_eq!(answer(), 42); }\n",
+    )
+    .tag("progress-efficiency")
+    .tag("progress-guard")
+    .meta("kind", "redundant-validation")
+    .meta("max_turns", 12)
+    .meta("max_tool_calls", 12)
+    .meta(
+        "checks",
+        json!([
+            {"response_contains": ["VALIDATION_COMPLETE"]},
+            {
+                "when_binary": "candidate",
+                "metric_at_least": {"progress_guard_warnings": 1.0},
+                "metric_at_most": {
+                    "validation_tool_calls": 2.0,
+                    "redundant_validation_calls": 1.0,
+                    "calls_after_progress_warning": 1.0
+                }
+            },
+            {
+                "when_binary": "baseline",
+                "metric_at_least": {
+                    "validation_tool_calls": 3.0,
+                    "redundant_validation_calls": 2.0
+                },
+                "metric_equals": {"progress_guard_warnings": 0.0}
+            }
+        ]),
+    )
+}
+
 fn dataset() -> Dataset {
     let cargo_toml = "[package]\nname = \"seed\"\nversion = \"0.1.0\"\nedition = \"2021\"\n";
     Dataset::new(vec![
@@ -662,6 +803,8 @@ fn dataset() -> Dataset {
         zero_result_search_sample(),
         bounded_repo_map_sample(),
         normal_output_preservation_sample(),
+        dependency_release_oscillation_sample(),
+        redundant_validation_sample(),
         Sample::new(
             "replace-console-log",
             "Replace every `console.log(...)` call with `logger.info(...)` across all \
@@ -1013,6 +1156,47 @@ struct Mined {
     read_file_tool_calls: u64,
     git_grep_calls: u64,
     leading_marker_in_bash_result: u64,
+    validation_tool_calls: u64,
+    redundant_validation_calls: u64,
+    workspace_state_revisits: u64,
+}
+
+#[derive(Default)]
+struct WorkspaceTrajectory {
+    current_hashes: BTreeMap<String, String>,
+    seen_states: BTreeSet<String>,
+    seen_validations: BTreeSet<(String, String)>,
+}
+
+impl WorkspaceTrajectory {
+    fn observe_mutation(&mut self, data: &Value) -> bool {
+        let Some((path, previous_hash, content_hash)) = mutation_hash_transition(data) else {
+            return false;
+        };
+        if !self.current_hashes.contains_key(&path) {
+            self.current_hashes.insert(path.clone(), previous_hash);
+            self.seen_states.insert(self.state_signature());
+        }
+        self.current_hashes.insert(path, content_hash);
+        !self.seen_states.insert(self.state_signature())
+    }
+
+    fn observe_validation(&mut self, command: String) -> bool {
+        !self
+            .seen_validations
+            .insert((self.state_signature(), command))
+    }
+
+    fn state_signature(&self) -> String {
+        if self.current_hashes.is_empty() {
+            return "<unobserved>".to_string();
+        }
+        self.current_hashes
+            .iter()
+            .map(|(path, hash)| format!("{path}={hash}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
 }
 
 fn normalized_command(command: &str) -> String {
@@ -1035,10 +1219,47 @@ fn tool_result_value(data: &Value) -> Option<Value> {
     Some(result.clone())
 }
 
+fn mutation_hash_transition(data: &Value) -> Option<(String, String, String)> {
+    if data.get("success") == Some(&Value::Bool(false)) {
+        return None;
+    }
+    let result = tool_result_value(data)?;
+    Some((
+        result.get("path")?.as_str()?.to_string(),
+        result.get("previous_content_hash")?.as_str()?.to_string(),
+        result.get("content_hash")?.as_str()?.to_string(),
+    ))
+}
+
 fn tool_command(data: &Value) -> String {
     tool_result_value(data)
         .and_then(|v| v.get("command").and_then(Value::as_str).map(str::to_string))
         .unwrap_or_default()
+}
+
+fn validation_command(data: &Value) -> Option<String> {
+    if data.get("tool_name").and_then(Value::as_str) != Some("bash") {
+        return None;
+    }
+    let command = normalized_command(&tool_command(data));
+    let validation_markers = [
+        "cargo test",
+        "cargo clippy",
+        "cargo fmt --check",
+        "npm test",
+        "npm run test",
+        "pnpm test",
+        "pnpm run test",
+        "yarn test",
+        "pytest",
+        "uv run",
+        "go test",
+        "python -m unittest",
+    ];
+    validation_markers
+        .iter()
+        .any(|marker| command.contains(marker))
+        .then_some(command)
 }
 
 fn has_progress_guard_warning(data: &Value) -> bool {
@@ -1208,6 +1429,7 @@ fn parse_events(jsonl: &str) -> Mined {
     let mut saw_truncated_repo_map = false;
     let mut repo_map_recovery_pending = false;
     let mut exploration_fingerprints = BTreeSet::new();
+    let mut workspace = WorkspaceTrajectory::default();
     for line in jsonl.lines() {
         let line = line.trim();
         if line.is_empty() {
@@ -1311,6 +1533,15 @@ fn parse_events(jsonl: &str) -> Mined {
                 }
                 if name == "read_file" {
                     m.read_file_tool_calls += 1;
+                }
+                if workspace.observe_mutation(&data) {
+                    m.workspace_state_revisits += 1;
+                }
+                if let Some(command) = validation_command(&data) {
+                    m.validation_tool_calls += 1;
+                    if workspace.observe_validation(command) {
+                        m.redundant_validation_calls += 1;
+                    }
                 }
                 let outer_failed = data.get("success") == Some(&Value::Bool(false));
                 let inner_failed = inner_tool_failed(&data);
@@ -1697,6 +1928,18 @@ async fn run_yolop(sample: Sample, cx: RunCx) -> Transcript {
         "leading_marker_in_bash_result".into(),
         mined.leading_marker_in_bash_result as f64,
     );
+    t.metrics.insert(
+        "validation_tool_calls".into(),
+        mined.validation_tool_calls as f64,
+    );
+    t.metrics.insert(
+        "redundant_validation_calls".into(),
+        mined.redundant_validation_calls as f64,
+    );
+    t.metrics.insert(
+        "workspace_state_revisits".into(),
+        mined.workspace_state_revisits as f64,
+    );
     let agent_ms = if mined.turn_ms > 0 {
         mined.turn_ms
     } else {
@@ -1920,6 +2163,37 @@ mod tests {
         assert_eq!(m.repo_map_targeted_recovery_after_truncation, 1);
     }
 
+    #[test]
+    fn parse_events_mines_workspace_cycles_and_redundant_validation() {
+        let jsonl = r#"
+{"type":"tool.completed","data":{"tool_name":"edit_file","success":true,"result":[{"type":"text","text":"{\"path\":\"/workspace/Cargo.toml\",\"previous_content_hash\":\"A\",\"content_hash\":\"B\"}"}]}}
+{"type":"tool.completed","data":{"tool_name":"bash","success":true,"result":[{"type":"text","text":"{\"command\":\"cargo test\",\"exit_code\":1,\"success\":false}"}]}}
+{"type":"tool.completed","data":{"tool_name":"edit_file","success":true,"result":[{"type":"text","text":"{\"path\":\"/workspace/Cargo.toml\",\"previous_content_hash\":\"B\",\"content_hash\":\"C\"}"}]}}
+{"type":"tool.completed","data":{"tool_name":"bash","success":true,"result":[{"type":"text","text":"{\"command\":\"cargo test\",\"exit_code\":1,\"success\":false}"}]}}
+{"type":"tool.completed","data":{"tool_name":"edit_file","success":true,"result":[{"type":"text","text":"{\"path\":\"/workspace/Cargo.toml\",\"previous_content_hash\":\"C\",\"content_hash\":\"A\"}"}]}}
+{"type":"tool.completed","data":{"tool_name":"bash","success":true,"result":[{"type":"text","text":"{\"command\":\"cargo test\",\"exit_code\":1,\"success\":false}"}]}}
+{"type":"tool.completed","data":{"tool_name":"edit_file","success":true,"result":[{"type":"text","text":"{\"path\":\"/workspace/Cargo.toml\",\"previous_content_hash\":\"A\",\"content_hash\":\"B\"}"}]}}
+{"type":"tool.completed","data":{"tool_name":"bash","success":true,"result":[{"type":"text","text":"{\"command\":\"cargo test\",\"exit_code\":1,\"success\":false}"}]}}
+{"type":"tool.completed","data":{"tool_name":"bash","success":true,"result":[{"type":"text","text":"{\"command\":\"cargo test\",\"exit_code\":1,\"success\":false}"}]}}
+"#;
+        let m = parse_events(jsonl);
+        assert_eq!(m.workspace_state_revisits, 2);
+        assert_eq!(m.validation_tool_calls, 5);
+        assert_eq!(m.redundant_validation_calls, 2);
+    }
+
+    #[test]
+    fn validation_mining_recognizes_compound_shell_commands() {
+        let data = json!({
+            "tool_name": "bash",
+            "result": [{
+                "type": "text",
+                "text": "{\"command\":\"set -euo pipefail\\ncargo fmt --check\\ncargo test --all-features\",\"exit_code\":0,\"success\":true}"
+            }]
+        });
+        assert!(validation_command(&data).is_some());
+    }
+
     #[tokio::test]
     async fn ast_edit_used_scorer_gates_on_variant() {
         let sample = Sample::new("a", "x");
@@ -2059,6 +2333,38 @@ mod tests {
             .unwrap();
         assert!(output_section.contains("dependency-baseline"));
         assert!(output_section.contains("\"normal-output-preserves-head\""));
+    }
+
+    #[test]
+    fn progress_efficiency_preset_is_comparative_and_bounded() {
+        let config = include_str!("../mira.toml");
+        let section = config
+            .split("[presets.progress-efficiency]")
+            .nth(1)
+            .expect("progress-efficiency preset")
+            .split("[presets.progress-controls]")
+            .next()
+            .unwrap();
+        assert!(section.contains("binary = [\"baseline\", \"candidate\"]"));
+        assert!(section.contains("\"dependency-release-oscillation\""));
+        assert!(section.contains("\"redundant-validation\""));
+        assert!(!section.contains("\"add-fn\""));
+        assert!(
+            !section.contains("trials ="),
+            "invoke this preset with --trials 3"
+        );
+
+        let controls_section = config
+            .split("[presets.progress-controls]")
+            .nth(1)
+            .expect("progress-controls preset")
+            .split("[presets.output-persistence]")
+            .next()
+            .unwrap();
+        assert!(controls_section.contains("binary = [\"baseline\", \"candidate\"]"));
+        assert!(controls_section.contains("\"add-fn\""));
+        assert!(controls_section.contains("\"find-constant\""));
+        assert!(!controls_section.contains("trials ="));
     }
 
     #[test]

--- a/evals/harness_basic/tests/test_analyze_progress_efficiency.py
+++ b/evals/harness_basic/tests/test_analyze_progress_efficiency.py
@@ -1,0 +1,133 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).parents[1] / "analyze_progress_efficiency.py"
+SPEC = importlib.util.spec_from_file_location("analyze_progress_efficiency", MODULE_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def case(sample, binary, passed=True, metrics=None, tools=2, tokens=100, cost=0.01):
+    return {
+        "sample": sample,
+        "params": {"binary": binary},
+        "passed": passed,
+        "skipped": False,
+        "transcript": {
+            "tool_calls_count": tools,
+            "usage": {"input_tokens": tokens, "cost_usd": cost},
+            "metrics": {"llm_calls": 2, **(metrics or {})},
+        },
+    }
+
+
+def trials(sample, binary, count=3, **kwargs):
+    return [case(sample, binary, **kwargs) for _ in range(count)]
+
+
+class AnalyzeProgressEfficiencyTests(unittest.TestCase):
+    def passing_reports(self):
+        focused = []
+        controls = []
+        for sample in MODULE.CONTROLS:
+            controls += trials(sample, "baseline", count=5)
+            controls += trials(sample, "candidate", count=5)
+        focused += trials(
+            "dependency-release-oscillation",
+            "baseline",
+            metrics={"workspace_state_revisits": 4, "validation_tool_calls": 6},
+            tools=14,
+        )
+        focused += trials(
+            "dependency-release-oscillation",
+            "candidate",
+            metrics={
+                "workspace_state_revisits": 1,
+                "validation_tool_calls": 3,
+                "progress_guard_warnings": 1,
+            },
+            tools=8,
+        )
+        focused += trials(
+            "redundant-validation",
+            "baseline",
+            metrics={"redundant_validation_calls": 2, "validation_tool_calls": 3},
+        )
+        focused += trials(
+            "redundant-validation",
+            "candidate",
+            metrics={
+                "redundant_validation_calls": 1,
+                "validation_tool_calls": 2,
+                "progress_guard_warnings": 1,
+            },
+        )
+        return {"cases": focused}, {"cases": controls}
+
+    def test_accepts_split_reports_with_five_trial_controls(self):
+        rows, failures = MODULE.analyze_reports(list(self.passing_reports()))
+        self.assertFalse(failures, failures)
+        self.assertTrue(any("workspace_state_revisits 4->1" in row for row in rows))
+
+    def test_rejects_unchanged_cycle_metrics(self):
+        focused, controls = self.passing_reports()
+        for item in focused["cases"]:
+            if (
+                item["sample"] == "dependency-release-oscillation"
+                and item["params"]["binary"] == "candidate"
+            ):
+                item["transcript"]["metrics"]["workspace_state_revisits"] = 4
+        _, failures = MODULE.analyze_reports([focused, controls])
+        self.assertTrue(any("did not improve" in failure for failure in failures))
+
+    def test_rejects_control_cost_regression(self):
+        focused, controls = self.passing_reports()
+        for item in controls["cases"]:
+            if item["sample"] == "add-fn" and item["params"]["binary"] == "candidate":
+                item["transcript"]["usage"]["cost_usd"] = 0.02
+        _, failures = MODULE.analyze_reports([focused, controls])
+        self.assertTrue(any("control cost_usd regressed" in failure for failure in failures))
+
+    def test_rejects_warning_on_ordinary_control(self):
+        focused, controls = self.passing_reports()
+        for item in controls["cases"]:
+            if item["sample"] == "add-fn" and item["params"]["binary"] == "candidate":
+                item["transcript"]["metrics"]["progress_guard_warnings"] = 1
+        _, failures = MODULE.analyze_reports([focused, controls])
+        self.assertTrue(any("warned on an ordinary control" in failure for failure in failures))
+
+    def test_rejects_ignored_warning_distribution(self):
+        focused, controls = self.passing_reports()
+        for item in focused["cases"]:
+            if (
+                item["sample"] == "dependency-release-oscillation"
+                and item["params"]["binary"] == "candidate"
+            ):
+                item["transcript"]["metrics"]["calls_after_progress_warning"] = 3
+        _, failures = MODULE.analyze_reports([focused, controls])
+        self.assertTrue(any("median calls after warning" in failure for failure in failures))
+
+    def test_rejects_three_trial_controls(self):
+        focused, controls = self.passing_reports()
+        controls["cases"] = [
+            item
+            for index, item in enumerate(controls["cases"])
+            if index % 5 < 3
+        ]
+        _, failures = MODULE.analyze_reports([focused, controls])
+        self.assertTrue(
+            any("add-fn: expected 5 trials per binary" in failure for failure in failures)
+        )
+
+    def test_rejects_missing_control_report(self):
+        focused, _ = self.passing_reports()
+        _, failures = MODULE.analyze(focused)
+        self.assertTrue(
+            any("add-fn: missing baseline or candidate trials" in failure for failure in failures)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/capabilities/progress_guard.rs
+++ b/src/capabilities/progress_guard.rs
@@ -10,7 +10,8 @@ use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptCont
 use everruns_core::tool_types::{ToolCall, ToolDefinition, ToolResult};
 use everruns_core::traits::ToolContext;
 use serde_json::{Map, Value, json};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque, hash_map::DefaultHasher};
+use std::hash::{Hash, Hasher};
 use std::sync::{Arc, Mutex};
 
 pub(crate) const PROGRESS_GUARD_CAPABILITY_ID: &str = "progress_guard";
@@ -22,6 +23,8 @@ const ZERO_EVIDENCE_SEARCH_THRESHOLD: usize = 3;
 const TRUNCATED_EXPLORATION_THRESHOLD: usize = 2;
 const REPEATED_STATUS_THRESHOLD: usize = 3;
 const REPEATED_WAITING_THRESHOLD: usize = 3;
+const SEMANTIC_HISTORY_LIMIT: usize = 512;
+const TRACKED_PATH_LIMIT: usize = 1024;
 
 pub(crate) struct ProgressGuardCapability {
     state: Arc<Mutex<ProgressGuardState>>,
@@ -108,6 +111,12 @@ struct SessionProgress {
     consecutive_zero_evidence_searches: usize,
     consecutive_truncated_exploration: usize,
     warning_count: usize,
+    workspace_epoch: u64,
+    workspace_hashes: HashMap<String, String>,
+    recent_workspace_states: VecDeque<u64>,
+    seen_workspace_states: HashSet<u64>,
+    recent_validations: VecDeque<(u64, String)>,
+    seen_validations: HashSet<(u64, String)>,
 }
 
 impl SessionProgress {
@@ -116,26 +125,23 @@ impl SessionProgress {
         let class = classify_tool_call(tool_call);
 
         match class {
-            ToolClass::Mutation => {
-                self.mutation_count += 1;
-                self.exploration_since_progress = 0;
-                self.repeated_status_count = 0;
-                self.last_status_command = None;
-                self.repeated_waiting_count = 0;
-                self.repeated_exploration_count = 0;
-                self.last_exploration_signature = None;
-                self.reset_result_streaks();
-                None
-            }
-            ToolClass::Validation => {
+            ToolClass::Mutation => self.observe_mutation(tool_call, result),
+            ToolClass::Validation(command) => {
                 self.validation_count += 1;
-                self.exploration_since_progress = 0;
-                self.repeated_status_count = 0;
-                self.last_status_command = None;
-                self.repeated_waiting_count = 0;
-                self.repeated_exploration_count = 0;
-                self.last_exploration_signature = None;
-                self.reset_result_streaks();
+                self.reset_activity_streaks();
+                let validation = (self.validation_state_signature(), command);
+                if self.seen_validations.contains(&validation) {
+                    self.warning_count += 1;
+                    return Some(
+                        "progress_guard: repeated the same validation command on an unchanged workspace state. The result adds no new code evidence; use the existing result, change the relevant state, or explain why an external retry is necessary before running it again."
+                            .to_string(),
+                    );
+                }
+                remember_bounded(
+                    &mut self.seen_validations,
+                    &mut self.recent_validations,
+                    validation,
+                );
                 None
             }
             ToolClass::Waiting => {
@@ -192,6 +198,108 @@ impl SessionProgress {
                 None
             }
         }
+    }
+
+    fn observe_mutation(&mut self, tool_call: &ToolCall, result: &ToolResult) -> Option<String> {
+        if result.error.is_some() || !mutation_was_applied(tool_call, result) {
+            return None;
+        }
+
+        self.mutation_count += 1;
+        self.reset_activity_streaks();
+
+        let Some(transition) = mutation_hash_transition(tool_call, result) else {
+            // Shell, delete, and structural edits can touch an unknown set of
+            // files. They make validation fresh, but retaining structured file
+            // hashes lets us still recognize a manifest cycle around lockfile
+            // updates and other adjacent mutations.
+            self.advance_opaque_mutation();
+            return None;
+        };
+
+        if self.workspace_hashes.len() >= TRACKED_PATH_LIMIT
+            && !self.workspace_hashes.contains_key(&transition.path)
+        {
+            self.reset_tracked_history();
+        }
+
+        if let Some(previous_hash) = transition.previous_hash {
+            if let Some(known_hash) = self.workspace_hashes.get(&transition.path)
+                && known_hash != &previous_hash
+            {
+                // An unobserved writer changed the file. Preserve safety by
+                // abandoning comparisons with the now-incomplete trajectory.
+                self.reset_tracked_history();
+            }
+            if !self.workspace_hashes.contains_key(&transition.path) {
+                self.workspace_hashes
+                    .insert(transition.path.clone(), previous_hash);
+                let previous_state = self.tracked_state_signature();
+                self.remember_workspace_state(previous_state);
+            }
+        }
+
+        self.workspace_hashes
+            .insert(transition.path, transition.content_hash);
+        let current_state = self.tracked_state_signature();
+        if self.remember_workspace_state(current_state) {
+            self.warning_count += 1;
+            return Some(
+                "progress_guard: this mutation returned to a recently seen workspace state (the same tracked content hashes). Confirm the revert is intentional; if this is an edit/validate cycle, keep the coherent state, report the blocker, and stop repeating the cycle."
+                    .to_string(),
+            );
+        }
+        None
+    }
+
+    fn reset_activity_streaks(&mut self) {
+        self.exploration_since_progress = 0;
+        self.repeated_status_count = 0;
+        self.last_status_command = None;
+        self.repeated_waiting_count = 0;
+        self.repeated_exploration_count = 0;
+        self.last_exploration_signature = None;
+        self.reset_result_streaks();
+    }
+
+    fn advance_opaque_mutation(&mut self) {
+        self.workspace_epoch = self.workspace_epoch.wrapping_add(1);
+        self.recent_validations.clear();
+        self.seen_validations.clear();
+    }
+
+    fn reset_tracked_history(&mut self) {
+        self.workspace_hashes.clear();
+        self.recent_workspace_states.clear();
+        self.seen_workspace_states.clear();
+        self.advance_opaque_mutation();
+    }
+
+    fn tracked_state_signature(&self) -> u64 {
+        let mut entries = self.workspace_hashes.iter().collect::<Vec<_>>();
+        entries.sort_unstable_by(|left, right| left.0.cmp(right.0));
+        let mut hasher = DefaultHasher::new();
+        entries.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    fn validation_state_signature(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        self.workspace_epoch.hash(&mut hasher);
+        self.tracked_state_signature().hash(&mut hasher);
+        hasher.finish()
+    }
+
+    fn remember_workspace_state(&mut self, state: u64) -> bool {
+        if self.seen_workspace_states.contains(&state) {
+            return true;
+        }
+        remember_bounded(
+            &mut self.seen_workspace_states,
+            &mut self.recent_workspace_states,
+            state,
+        );
+        false
     }
 
     fn result_warning(&mut self, tool_call: &ToolCall, result: &ToolResult) -> Option<String> {
@@ -342,7 +450,7 @@ fn exploration_evidence(tool_call: &ToolCall, result: &ToolResult) -> Option<Exp
 enum ToolClass {
     Exploration,
     Mutation,
-    Validation,
+    Validation(String),
     Status(String),
     /// Checking on an external event (CI run, PR checks/reviews) or plain
     /// sleeping — the poll-loop shape that should instead be one detached
@@ -389,7 +497,7 @@ fn classify_bash_command(command: &str) -> ToolClass {
         return ToolClass::Status(normalized);
     }
     if is_validation_command(&normalized) {
-        return ToolClass::Validation;
+        return ToolClass::Validation(normalized);
     }
     if is_mutating_command(&normalized) {
         return ToolClass::Mutation;
@@ -398,6 +506,56 @@ fn classify_bash_command(command: &str) -> ToolClass {
         return ToolClass::Exploration;
     }
     ToolClass::Other
+}
+
+struct MutationHashTransition {
+    path: String,
+    previous_hash: Option<String>,
+    content_hash: String,
+}
+
+fn mutation_hash_transition(
+    tool_call: &ToolCall,
+    result: &ToolResult,
+) -> Option<MutationHashTransition> {
+    if !matches!(tool_call.name.as_str(), "edit_file" | "write_file") {
+        return None;
+    }
+    let value = result.result.as_ref()?;
+    Some(MutationHashTransition {
+        path: value.get("path")?.as_str()?.to_string(),
+        previous_hash: value
+            .get("previous_content_hash")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        content_hash: value.get("content_hash")?.as_str()?.to_string(),
+    })
+}
+
+fn mutation_was_applied(tool_call: &ToolCall, result: &ToolResult) -> bool {
+    if tool_call.name == "ast_edit" {
+        return result
+            .result
+            .as_ref()
+            .and_then(|value| value.get("applied"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+    }
+    true
+}
+
+fn remember_bounded<T: Clone + Eq + Hash>(
+    seen: &mut HashSet<T>,
+    recent: &mut VecDeque<T>,
+    value: T,
+) {
+    seen.insert(value.clone());
+    recent.push_back(value);
+    if recent.len() > SEMANTIC_HISTORY_LIMIT
+        && let Some(expired) = recent.pop_front()
+    {
+        seen.remove(&expired);
+    }
 }
 
 /// For a command starting with `sleep`, everything after the first `&&`/`;`
@@ -490,6 +648,8 @@ fn is_status_command(command: &str) -> bool {
 fn is_validation_command(command: &str) -> bool {
     let prefixes = [
         "cargo test",
+        "cargo check",
+        "cargo build",
         "cargo clippy",
         "cargo fmt --check",
         "npm test",
@@ -509,6 +669,11 @@ fn is_mutating_command(command: &str) -> bool {
     let tokens = [
         "apply_patch",
         "cargo fmt",
+        "cargo update",
+        "cargo generate-lockfile",
+        "cargo add",
+        "cargo remove",
+        "cargo fix",
         "npm run format",
         "pnpm run format",
         "git apply",
@@ -609,7 +774,15 @@ mod tests {
         );
         assert_eq!(
             classify_bash_command("cargo test --all-features"),
-            ToolClass::Validation
+            ToolClass::Validation("cargo test --all-features".to_string())
+        );
+        assert_eq!(
+            classify_bash_command("cargo check --all-features"),
+            ToolClass::Validation("cargo check --all-features".to_string())
+        );
+        assert_eq!(
+            classify_bash_command("cargo update -p everruns-core --precise 0.17.7"),
+            ToolClass::Mutation
         );
         assert_eq!(
             classify_bash_command("rg progress_guard"),
@@ -632,7 +805,7 @@ mod tests {
         // A sleep in front of real work classifies as the work itself.
         assert_eq!(
             classify_bash_command("sleep 5 && cargo test --all-features"),
-            ToolClass::Validation
+            ToolClass::Validation("cargo test --all-features".to_string())
         );
         // `sleepwalk` must not parse as a sleep prefix.
         assert_eq!(classify_bash_command("sleepwalk"), ToolClass::Other);
@@ -801,6 +974,229 @@ mod tests {
                 .and_then(|value| value.get("progress_guard_warning"))
                 .is_none()
         );
+    }
+
+    #[tokio::test]
+    async fn workspace_state_revisit_warns_on_a_mutation_cycle() {
+        let state = Arc::new(Mutex::new(ProgressGuardState::default()));
+        let hook = ProgressGuardHook { state };
+        let context = ToolContext::new(SessionId::new());
+        let transitions = [("A", "B"), ("B", "C"), ("C", "A")];
+
+        for (index, (previous, current)) in transitions.into_iter().enumerate() {
+            let mut out = result_value(json!({
+                "path": "/workspace/Cargo.toml",
+                "previous_content_hash": previous,
+                "content_hash": current,
+            }));
+            hook.after_exec(
+                &call("edit_file", json!({ "path": "/workspace/Cargo.toml" })),
+                &tool_def("edit_file"),
+                &mut out,
+                &context,
+            )
+            .await;
+
+            let warning = out
+                .result
+                .as_ref()
+                .and_then(|value| value.get("progress_guard_warning"))
+                .and_then(Value::as_str);
+            if index < 2 {
+                assert!(warning.is_none(), "new states are progress");
+            } else {
+                assert!(
+                    warning.is_some_and(|text| text.contains("workspace state")),
+                    "returning to A should expose the mutation cycle"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn lockfile_updates_do_not_hide_a_manifest_state_cycle() {
+        let state = Arc::new(Mutex::new(ProgressGuardState::default()));
+        let hook = ProgressGuardHook { state };
+        let context = ToolContext::new(SessionId::new());
+        let transitions = [("A", "B"), ("B", "C"), ("C", "A")];
+
+        for (index, (previous, current)) in transitions.into_iter().enumerate() {
+            let mut edit = result_value(json!({
+                "path": "/workspace/Cargo.toml",
+                "previous_content_hash": previous,
+                "content_hash": current,
+            }));
+            hook.after_exec(
+                &call("edit_file", json!({ "path": "/workspace/Cargo.toml" })),
+                &tool_def("edit_file"),
+                &mut edit,
+                &context,
+            )
+            .await;
+
+            let warning = edit
+                .result
+                .as_ref()
+                .and_then(|value| value.get("progress_guard_warning"))
+                .and_then(Value::as_str);
+            if index < 2 {
+                assert!(warning.is_none());
+            } else {
+                assert!(warning.is_some_and(|text| text.contains("workspace state")));
+            }
+
+            let mut update = result();
+            hook.after_exec(
+                &call(
+                    "bash",
+                    json!({ "command": "cargo update -p everruns-core --precise 0.17.7" }),
+                ),
+                &tool_def("bash"),
+                &mut update,
+                &context,
+            )
+            .await;
+        }
+    }
+
+    #[tokio::test]
+    async fn lockfile_update_makes_repeated_validation_fresh() {
+        let state = Arc::new(Mutex::new(ProgressGuardState::default()));
+        let hook = ProgressGuardHook { state };
+        let context = ToolContext::new(SessionId::new());
+        let validation = call("bash", json!({ "command": "cargo check" }));
+
+        hook.after_exec(&validation, &tool_def("bash"), &mut result(), &context)
+            .await;
+        hook.after_exec(
+            &call(
+                "bash",
+                json!({ "command": "cargo update -p everruns-core --precise 0.17.7" }),
+            ),
+            &tool_def("bash"),
+            &mut result(),
+            &context,
+        )
+        .await;
+
+        let mut after_update = result();
+        hook.after_exec(&validation, &tool_def("bash"), &mut after_update, &context)
+            .await;
+        assert!(
+            after_update
+                .result
+                .as_ref()
+                .and_then(|value| value.get("progress_guard_warning"))
+                .is_none(),
+            "validation after a lockfile mutation has new workspace evidence"
+        );
+
+        let mut unchanged_again = result();
+        hook.after_exec(
+            &validation,
+            &tool_def("bash"),
+            &mut unchanged_again,
+            &context,
+        )
+        .await;
+        assert!(
+            unchanged_again
+                .result
+                .as_ref()
+                .and_then(|value| value.get("progress_guard_warning"))
+                .is_some(),
+            "a second validation without another mutation is redundant"
+        );
+    }
+
+    #[tokio::test]
+    async fn repeated_validation_on_unchanged_state_warns() {
+        let state = Arc::new(Mutex::new(ProgressGuardState::default()));
+        let hook = ProgressGuardHook { state };
+        let context = ToolContext::new(SessionId::new());
+        let validation = call("bash", json!({ "command": "cargo test" }));
+
+        let mut first = result();
+        hook.after_exec(&validation, &tool_def("bash"), &mut first, &context)
+            .await;
+        assert!(
+            first
+                .result
+                .as_ref()
+                .and_then(|value| value.get("progress_guard_warning"))
+                .is_none()
+        );
+
+        let mut repeated = result();
+        hook.after_exec(&validation, &tool_def("bash"), &mut repeated, &context)
+            .await;
+        assert!(
+            repeated
+                .result
+                .as_ref()
+                .and_then(|value| value.get("progress_guard_warning"))
+                .and_then(Value::as_str)
+                .is_some_and(|text| text.contains("unchanged workspace state"))
+        );
+
+        let mut edit = result_value(json!({
+            "path": "/workspace/src/lib.rs",
+            "previous_content_hash": "A",
+            "content_hash": "B",
+        }));
+        hook.after_exec(
+            &call("edit_file", json!({ "path": "/workspace/src/lib.rs" })),
+            &tool_def("edit_file"),
+            &mut edit,
+            &context,
+        )
+        .await;
+
+        let mut after_progress = result();
+        hook.after_exec(
+            &validation,
+            &tool_def("bash"),
+            &mut after_progress,
+            &context,
+        )
+        .await;
+        assert!(
+            after_progress
+                .result
+                .as_ref()
+                .and_then(|value| value.get("progress_guard_warning"))
+                .is_none(),
+            "the same validation is useful after the workspace changes"
+        );
+    }
+
+    #[tokio::test]
+    async fn semantic_progress_has_no_fixed_session_iteration_limit() {
+        let state = Arc::new(Mutex::new(ProgressGuardState::default()));
+        let hook = ProgressGuardHook { state };
+        let context = ToolContext::new(SessionId::new());
+
+        for index in 0..256 {
+            let mut out = result_value(json!({
+                "path": "/workspace/src/lib.rs",
+                "previous_content_hash": format!("state-{index}"),
+                "content_hash": format!("state-{}", index + 1),
+            }));
+            hook.after_exec(
+                &call("edit_file", json!({ "path": "/workspace/src/lib.rs" })),
+                &tool_def("edit_file"),
+                &mut out,
+                &context,
+            )
+            .await;
+            assert!(
+                out.result
+                    .as_ref()
+                    .and_then(|value| value.get("progress_guard_warning"))
+                    .is_none(),
+                "each new state remains progress after iteration {index}"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed

Progress Guard now recognizes two forms of semantic no-progress work:

- mutations that return tracked files to a recently seen content-hash state
- repeated validation commands against an unchanged workspace state

The history is bounded and remains independent of turn count, so long-running sessions can continue as long as they keep reaching new states. The eval harness adds bounded dependency-release oscillation and redundant-validation cases plus focused and five-trial control presets.

## Why

A real dependency bump session spent hundreds of iterations cycling the same manifest versions and rerunning validation. Existing loop detection only recognized identical consecutive calls, while every edit or validation reset Progress Guard even when the workspace returned to an earlier state.

## Before / After

Three-trial focused medians on GPT-5.5:

| Case | Metric | Before | After |
|---|---:|---:|---:|
| Dependency release | workspace revisits | 4 | 1 |
| Dependency release | validations | 6 | 2 |
| Dependency release | tool calls | 23 | 8 |
| Dependency release | cost | $0.328 | $0.149 |
| Repeated validation | redundant validations | 2 | 1 |
| Repeated validation | tool calls | 3 | 2 |
| Repeated validation | cost | $0.082 | $0.042 |

The separate five-trial controls passed 20/20 cases with no unexpected progress warnings. The distribution analyzer passed.

Live provider smoke:

```text
Run cargo check --quiet twice without changing files
PROGRESS_GUARD_SMOKE_OK
```

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` — 723 unit, 35 integration, and 1 parallel integration passed
- harness crate — 18 Rust tests and 11 Python analyzer tests passed
- live OpenAI smoke through Doppler
- bounded Mira A/B distribution and five-trial controls

## Risk

- Medium. A legitimate revert or external retry can resemble repeated state. Warnings remain advisory and explain how to proceed intentionally.
- State and validation histories are bounded to 512 entries; tracked paths are bounded to 1,024.

## Security

- TM-FS / TM-TOOL: no new filesystem access or capability registration. The guard consumes hashes already returned by file tools and does not retain file contents.
- TM-BASH: command classification expands to Cargo build/check/update operations; execution, timeout, and output-cap behavior are unchanged.
- TM-LLM: no credential or provider handling changes. Only warning metadata is added to qualifying tool results.
- TM-DEP: no dependencies changed.
- Resource exhaustion: semantic histories and tracked paths have explicit bounds; the 256-edit test confirms there is no fixed session iteration limit.

## Follow-ups

- Hard blocking is intentionally deferred. The advisory warning avoids preventing legitimate reverts or external retries while the eval measures compliance.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed
