### PR TITLE
chore(release): make yolop-yep publish-clean, document two-crate publish

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -148,14 +148,28 @@ This is the step that catches what local tests don't — the `cargo publish`
 packaging boundary, missing files referenced by `Cargo.toml`, version drift:
 
 ```bash
-cargo publish --dry-run -p yolop
+cargo publish --dry-run -p yolop-yep   # the SDK crate; publishes first
 cargo search yolop --limit 1     # confirm CURRENT crates.io version < X.Y.Z
 grep '^version' Cargo.toml       # confirm reads X.Y.Z
 grep '"yolop"' Cargo.lock | head -1  # confirm reads X.Y.Z
 ```
 
-If `cargo publish --dry-run` fails, fix the root cause and re-run. Do **not**
-open a release PR with a known-broken publish path.
+**Two-crate workspace.** The repo publishes two crates: the `yolop-yep` SDK
+(separately versioned — bump it only when its API or the wire protocol
+changes) and the `yolop` binary, which depends on `yolop-yep` by version.
+crates.io requires `yolop-yep` to be published **before** `yolop`, so CI
+(`publish.yml`) publishes `yolop-yep` first, then `yolop` (each skipped if its
+version is already live). A consequence for this step: **`cargo publish
+--dry-run -p yolop` fails locally** with *"no matching package named
+`yolop-yep` found"* whenever the in-tree `yolop-yep` version isn't yet on
+crates.io — that is expected, not a broken release. Dry-run `yolop-yep`
+instead (above); `yolop`'s own publish is validated in CI after `yolop-yep`
+goes live. When bumping `yolop-yep`, update its version in
+`crates/yolop-yep/Cargo.toml` **and** the `yolop-yep = { version = … }`
+requirement in the root `Cargo.toml`.
+
+If `cargo publish --dry-run -p yolop-yep` fails, fix the root cause and re-run.
+Do **not** open a release PR with a known-broken publish path.
 
 ### 6. Commit and push
 

--- a/crates/yolop-yep/Cargo.toml
+++ b/crates/yolop-yep/Cargo.toml
@@ -10,6 +10,10 @@ repository = "https://github.com/everruns/yolop"
 readme = "README.md"
 keywords = ["yolop", "yolop-extension", "agent", "protocol", "plugin"]
 categories = ["development-tools", "api-bindings"]
+# `schema-gen` is a repo-only tool (regenerates schema/yep/v1/meta.json at the
+# repo root); it has no use for a downstream consumer, so keep it out of the
+# published package. The library + `echo` example are what authors need.
+exclude = ["src/bin"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/yolop-yep/src/meta.rs
+++ b/crates/yolop-yep/src/meta.rs
@@ -129,11 +129,18 @@ mod tests {
     /// generator produces. This makes `cargo test` (i.e. CI) the enforcement —
     /// a vocabulary change can't merge without regenerating the artifact.
     /// Run `cargo run -p yolop-yep --bin schema-gen` to fix a failure here.
+    ///
+    /// The schema file lives at the repo root, outside the crate, so it is
+    /// absent when the published crate is built/tested standalone (e.g. a
+    /// downstream `cargo test`). In that case the guard is a no-op — it only
+    /// enforces in-repo, which is where drift can be introduced.
     #[test]
     fn committed_meta_json_is_up_to_date() {
         let path =
             std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../schema/yep/v1/meta.json");
-        let committed = std::fs::read_to_string(&path).unwrap_or_default();
+        let Ok(committed) = std::fs::read_to_string(&path) else {
+            return; // not in the repo tree; nothing to guard
+        };
         assert_eq!(
             committed,
             meta_json(),

--- a/specs/release.md
+++ b/specs/release.md
@@ -83,7 +83,10 @@ When asked to release, the agent:
    `### Breaking Changes` block with before/after migration snippets.
 
 3. **Bump the version** in `Cargo.toml` and regenerate `Cargo.lock`
-   (`cargo update -p yolop`).
+   (`cargo update -p yolop`). The `yolop-yep` SDK crate under `crates/` is
+   **versioned separately** — bump it only when its API or the wire protocol
+   changes, and when you do, update both `crates/yolop-yep/Cargo.toml` and the
+   `yolop-yep = { version = … }` requirement in the root `Cargo.toml`.
 
 4. **Run local verification:**
    - `cargo fmt --check`
@@ -92,12 +95,21 @@ When asked to release, the agent:
 
 5. **Verify publish-readiness** (catches what local tests don't — the
    `cargo publish` packaging step, missing files, version drift):
-   - `cargo publish --dry-run -p yolop` must succeed.
+   - `cargo publish --dry-run -p yolop-yep` must succeed.
    - Confirm `Cargo.toml` and `Cargo.lock` agree on `X.Y.Z`.
    - Confirm `X.Y.Z` is greater than the latest published version on
      crates.io (`cargo search yolop --limit 1`).
    - If any check fails, fix the root cause and re-run before opening the
      PR. **Do not** merge a release PR with a known-broken publish path.
+
+   **Two crates, ordered publish.** crates.io requires `yolop-yep` to be
+   published before `yolop` (which depends on it by version), so
+   `publish.yml` publishes `yolop-yep` first, then `yolop` (each skipped when
+   already live). Because of that ordering, `cargo publish --dry-run -p yolop`
+   **fails locally** — *"no matching package named `yolop-yep` found"* —
+   until the in-tree `yolop-yep` version is on crates.io. That is expected,
+   not a broken release; dry-run `yolop-yep` and rely on CI to validate
+   `yolop` after `yolop-yep` goes live.
 
 6. **Commit and push** the changes on a feature branch with message
    `chore(release): prepare vX.Y.Z`.


### PR DESCRIPTION
## What changed

Release-readiness for the two-crate workspace (`yolop` + the new `yolop-yep` SDK), so the pending **v0.8.0** release publishes both cleanly.

- **`crates/yolop-yep/Cargo.toml`** — `exclude = ["src/bin"]` so the repo-only `schema-gen` generator isn't shipped in the published crate (a `cargo install yolop-yep` shouldn't drop a `schema-gen` binary; the library + `echo` example are what authors need).
- **`crates/yolop-yep/src/meta.rs`** — the drift-guard test now no-ops when the repo-root `schema/yep/v1/meta.json` is absent (i.e. the crate built/tested standalone downstream), instead of failing. It still enforces in-repo, where drift is actually introduced.
- **`.agents/skills/release/SKILL.md` + `specs/release.md`** — document the two-crate publish: `yolop-yep` is **versioned separately** (bump only on API/wire changes; update both its `Cargo.toml` and the root `version` requirement) and is published **before** `yolop`. Crucially, note that `cargo publish --dry-run -p yolop` **fails locally** ("no matching package named `yolop-yep` found") until `yolop-yep` is on crates.io — that's expected ordering, not a broken release — so the readiness check dry-runs `yolop-yep` and lets CI validate `yolop` after `yolop-yep` goes live.

## Why

`yolop` now depends on `yolop-yep` by version, so crates.io rejects publishing `yolop` unless `yolop-yep` is published first. CI (`publish.yml`) already handles the ordering (`publish_if_missing yolop-yep` then `yolop`), but: (1) the release **docs** still told a release agent to dry-run `yolop` and treat its failure as a blocker — which would now mislead them into thinking a healthy release is broken (as I initially read it); and (2) `yolop-yep`'s first publish had two quality warts (a stray dev bin, and a test that fails on a downstream `cargo test`). This fixes all three so the 0.8.0 release — the first to publish `yolop-yep` — goes out clean.

## Before / After

**Before:** `cargo publish --dry-run -p yolop` fails cryptically; the published `yolop-yep` would carry a useless `schema-gen` bin and fail `cargo test` for downstream users; release docs point the agent at the wrong (failing) dry-run.

**After:** `cargo publish --dry-run -p yolop-yep` succeeds and packages only the library + example (verified: `schema-gen` no longer in `cargo package --list`); `cargo test -p yolop-yep` passes standalone and in-repo; release docs describe the real ordered two-crate publish. No version bump — 0.8.0 stands (prepared, not yet tagged; already credits the extensions platform + `yolop-yep`).

## Risk

- Low. Packaging metadata + one test made tolerant + release docs. No runtime behavior; the `schema-gen` bin still builds in-repo (exclude only affects the published tarball), and the drift guard still enforces in CI.

## Security

- No security-relevant code changes — packaging/test/docs only. No new dependencies.

## Checklist

- [x] Tests added or updated — drift-guard test hardened for the standalone-crate case; full workspace suite green (724 + 35), `fmt`/`clippy -D warnings` clean. Verified `cargo package --list -p yolop-yep` excludes `schema-gen` and `cargo publish --dry-run -p yolop-yep` succeeds.
- [x] Backward compatibility considered — additive/metadata only.

## Notes on "cutting a new version"

Rebased on latest `main`: `yolop` is already at **0.8.0** (prepared via #300, **not yet tagged/released** — latest tag is `v0.7.0`, crates.io serves `0.7.0`), and its CHANGELOG already credits the extension platform and `yolop-yep`. There are no unreleased commits to justify bumping past 0.8.0, so this PR does not bump the version — it makes 0.8.0 actually publishable. `yolop-yep` keeps its own `0.1.0` line (its inaugural crates.io version).

**The actual release** (tag `v0.8.0` → `publish.yml` publishes `yolop-yep` 0.1.0 then `yolop` 0.8.0 → Homebrew) is an irreversible, outward step I've left for explicit go-ahead. Say the word and I'll drive `/release` (or hand you the exact tag command).

## Follow-ups

- Perform the v0.8.0 release once approved (first publish of `yolop-yep`).
- Simplify `docs/extensions.md` authoring step to `cargo add yolop-yep` after that publish lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_017d7odSAD8o79pUrd31dpDb)_