### PR TITLE
fix(release): allow crates.io registry checks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,14 +60,16 @@ jobs:
             version=$(cargo metadata --no-deps --format-version 1 \
               | jq -r --arg crate "$crate" '.packages[] | select(.name == $crate) | .version')
 
-            if curl --fail --silent "https://crates.io/api/v1/crates/$crate/$version" >/dev/null; then
+            if curl --fail --silent --user-agent "yolop-release-workflow (https://github.com/everruns/yolop)" \
+              "https://crates.io/api/v1/crates/$crate/$version" >/dev/null; then
               echo "$crate $version is already published"
               return
             fi
 
             cargo publish --locked -p "$crate"
             for _ in {1..30}; do
-              if curl --fail --silent "https://crates.io/api/v1/crates/$crate/$version" >/dev/null; then
+              if curl --fail --silent --user-agent "yolop-release-workflow (https://github.com/everruns/yolop)" \
+              "https://crates.io/api/v1/crates/$crate/$version" >/dev/null; then
                 return
               fi
               sleep 10


### PR DESCRIPTION
## Summary

- send an explicit crates.io-compliant User-Agent during registry propagation checks
- keep the manual publish workflow available for release recovery

## Before / After

Before, `yolop-yep 0.1.0` published successfully but the propagation check received HTTP 403 from crates.io and timed out. After, both registry checks identify the release workflow as required by crates.io policy.

## Verification

- [x] workflow YAML parses
- [x] both crates.io checks include the explicit User-Agent
- [x] the published `yolop-yep 0.1.0` endpoint returns HTTP 200 with that User-Agent

Produced by [yolop](https://everruns.com/yolop)
