### PR TITLE
chore(release): yolop-yep 0.1.1 (clean packaging) + docs use cargo add

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6634,7 +6634,7 @@ dependencies = [
 
 [[package]]
 name = "yolop-yep"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ serde_json = "1.0"
 # The extension protocol wire types + server SDK live in their own crate so
 # extension authors can depend on them from crates.io; the host shares the
 # same source of truth (see specs/extensions.md).
-yolop-yep = { version = "0.1.0", path = "crates/yolop-yep" }
+yolop-yep = { version = "0.1.1", path = "crates/yolop-yep" }
 sha2 = "0.11"
 toml = "1"
 textwrap = "0.16"

--- a/crates/yolop-yep/Cargo.toml
+++ b/crates/yolop-yep/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yolop-yep"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 authors = ["Everruns <support@everruns.com>"]
 license = "MIT"

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -68,10 +68,7 @@ owns the wire protocol:
 
 ```bash
 cargo new --bin yolop-extension-hello && cd yolop-extension-hello
-cargo add serde_json
-# yolop-yep is not yet published; depend on it from git until it is:
-#   cargo add yolop-yep --git https://github.com/everruns/yolop
-# (once published: cargo add yolop-yep)
+cargo add yolop-yep serde_json
 ```
 
 ```rust
@@ -153,7 +150,6 @@ servers in other languages — YEP is just newline-delimited JSON-RPC over stdio
 so any language works (see [`specs/extensions.md`](../specs/extensions.md)).
 
 > **Status.** The mechanism is implemented through hooks and the `yolop-yep`
-> SDK. Not yet shipped: publishing `yolop-yep` to crates.io (depend on it via
-> git for now), a one-command `crates.io` extension install, a payload JSON
-> Schema, and an `/extensions doctor` conformance check — see the spec's
-> follow-ups.
+> SDK, [published on crates.io](https://crates.io/crates/yolop-yep). Not yet
+> shipped: a one-command `crates.io` extension install, a payload JSON Schema,
+> and an `/extensions doctor` conformance check — see the spec's follow-ups.


### PR DESCRIPTION
## What changed

`yolop-yep` and `yolop 0.8.0` are now **live on crates.io** (verified: both un-yanked, on the sparse index, `yolop 0.8.0` → `yolop-yep ^0.1.0`). But the published `yolop-yep 0.1.0` was cut from the `v0.8.0` tag (`7f5cbd5`), which predates the #301 packaging fixes — so `0.1.0` shipped the two warts #301 addressed:

- `src/bin/schema-gen.rs` (a repo-only dev tool) is in the published crate — a `cargo install yolop-yep` would drop a `schema-gen` binary.
- the drift-guard test reads a repo-root file absent in the vendored crate, so `cargo test -p yolop-yep` fails for a downstream consumer.

`0.1.0` is immutable and works fine as a dependency, so this bumps to **`yolop-yep 0.1.1`** (the clean, #301-based packaging already on `main`) to supersede it, and updates the docs now that the crate is published.

- **`crates/yolop-yep/Cargo.toml`** — `version = "0.1.1"`.
- **`Cargo.toml`** — root dependency requirement `yolop-yep = { version = "0.1.1", … }` (separate-versioning hygiene: bump the crate *and* the requirement together).
- **`Cargo.lock`** — regenerated.
- **`docs/extensions.md`** — authoring step is now `cargo add yolop-yep` (dropped the "not yet published / depend via git" caveat); the status note links the published crate.

## Why

Clean first impression for a public SDK: `0.1.1` packages only the library + `echo` example, and `cargo test -p yolop-yep` passes standalone. The docs no longer tell authors to use a git dependency.

## Before / After

**Before:** published `yolop-yep 0.1.0` contains `src/bin/schema-gen.rs` and fails downstream `cargo test`; docs say "not yet published, use git."

**After:** `cargo publish --dry-run -p yolop-yep` for `0.1.1` packages 10 files with `schema-gen` excluded (`warning: ignoring binary schema-gen … not included in the published package`); docs use `cargo add yolop-yep`.

## Risk

- Low. Version-metadata bump + docs. No runtime behavior; `yolop 0.8.0` already depends on `^0.1.0`, satisfied by `0.1.1`.

## Security

- No security-relevant code changes — version metadata + docs. No new dependencies.

## Checklist

- [x] Tests added or updated — n/a (version/docs); `cargo test -p yolop-yep` green, `fmt`/`clippy -D warnings` clean, `cargo publish --dry-run -p yolop-yep` clean.
- [x] Backward compatibility considered — `0.1.1` is API-identical to `0.1.0` (packaging-only); `^0.1.0` consumers pick it up.

## Follow-ups

- Publish `yolop-yep 0.1.1` (picked up by `publish_if_missing yolop-yep` on the next release tag, or on demand). `0.1.0` can stay published (it works) or be yanked in favor of `0.1.1` — your call.
- The one-command crates.io extension install, payload `schema.json`, and `/extensions doctor` remain on the roadmap.

---
_Generated by [Claude Code](https://claude.ai/code/session_017d7odSAD8o79pUrd31dpDb)_