### PR TITLE
fix(tui): stabilize resize and overlay rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -910,7 +916,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -3312,7 +3318,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad5fd71b79026fb918650dde6d125000a233764f1c2f1659a1c71118e33ea08f"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -4047,7 +4053,7 @@ dependencies = [
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -4103,7 +4109,7 @@ dependencies = [
  "ratatui-crossterm",
  "ratatui-widgets",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -4123,7 +4129,7 @@ dependencies = [
  "strum",
  "time",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -5100,7 +5106,7 @@ checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "smawk",
  "unicode-linebreak",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -5803,8 +5809,14 @@ checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -5897,6 +5909,39 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vt100"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84cd863bf0db7e392ba3bd04994be3473491b31e66340672af5d11943c6274de"
+dependencies = [
+ "itoa",
+ "log",
+ "unicode-width 0.1.14",
+ "vte",
+]
+
+[[package]]
+name = "vte"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+dependencies = [
+ "arrayvec",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "vtparse"
@@ -6629,6 +6674,7 @@ dependencies = [
  "tree-sitter-typescript",
  "tree-sitter-zig",
  "urlencoding",
+ "vt100",
  "yolop-yep",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ inventory = "0.3"
 portable-pty = "0.9.0"
 tempfile = "3"
 tiny_http = "0.12"
+vt100 = "0.15"
 
 [profile.release]
 lto = "thin"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -158,9 +158,6 @@ pub struct App {
     workspace_host: Arc<crate::workspace_host::WorkspaceHost>,
     /// Images from `--image` / `-i` on the CLI, consumed on the first turn.
     pending_images: Vec<ContentPart>,
-    /// Skip bottom re-anchoring for a few frames after a terminal resize so
-    /// crossterm observes the new PTY dimensions before we jump the cursor.
-    reanchor_cooldown: u8,
     /// Large paste placeholders mapped to their full clipboard/terminal payloads.
     pending_pastes: Vec<(String, String)>,
 }
@@ -396,7 +393,6 @@ impl App {
             workspace_host: runtime.workspace_host,
             pending_images,
             pending_pastes: Vec::new(),
-            reanchor_cooldown: 0,
         };
         app.emit_system_banner();
         if should_setup {
@@ -649,27 +645,11 @@ impl App {
     {
         self.flush_transcript(terminal)?;
         self.refresh_session_tasks_if_due().await;
-        // Ratatui keeps the inline viewport row fixed across vertical grows and
-        // resets it to the top on horizontal shrinks. Re-anchor before each draw
-        // so the composer stays pinned to the terminal bottom after resize.
-        let before = terminal.size()?;
+        // Ratatui keeps an inline viewport's cursor offset across resizes and
+        // resets its origin on horizontal shrinks. Normalize the viewport to
+        // the terminal bottom before every draw.
         terminal.autoresize()?;
-        let after = terminal.size()?;
-        if before != after {
-            // Horizontal shrinks reset the inline viewport to the top and need
-            // an immediate bottom re-anchor. Vertical resizes need a short
-            // cooldown so crossterm observes the new PTY height first.
-            if before.width != after.width && before.height == after.height {
-                self.reanchor_cooldown = 0;
-            } else {
-                self.reanchor_cooldown = 2;
-            }
-        }
-        if self.reanchor_cooldown > 0 {
-            self.reanchor_cooldown -= 1;
-        } else {
-            maybe_reanchor_inline_viewport(terminal)?;
-        }
+        maybe_reanchor_inline_viewport(terminal)?;
         terminal.draw(|f| draw(f, self))?;
 
         // 1) drain background turn events
@@ -5132,6 +5112,14 @@ mod tests {
         assert!(
             rows.iter().any(|line| line.contains("Esc cancel")),
             "footer should not be clipped: {rows:?}"
+        );
+        assert!(
+            !rows.iter().any(|line| line.contains("Enter to send")),
+            "the composer must not render through the setup sheet: {rows:?}"
+        );
+        assert!(
+            rows.first().is_some_and(String::is_empty) && rows.last().is_some_and(String::is_empty),
+            "the centered panel should have clean margins without underlying chrome: {rows:?}"
         );
     }
 

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -33,6 +33,18 @@ impl StreamKind {
 
 pub(crate) fn draw(f: &mut ratatui::Frame, app: &mut App) {
     let area = f.area();
+    // Inline viewports cannot place a true full-screen modal above terminal
+    // scrollback. Treat overlays as sheets that own this complete viewport so
+    // the composer and status chrome never bleed through around their edges.
+    if app.setup.is_some() {
+        draw_setup_overlay(f, area, app);
+        return;
+    }
+    if app.background_panel.is_some() {
+        draw_background_panel(f, area, app);
+        return;
+    }
+
     // Match `draw_input`: the `> ` prompt consumes two columns.
     let input_width = area.width.saturating_sub(2);
     let desired_input_height = app.input_height(input_width);
@@ -50,8 +62,6 @@ pub(crate) fn draw(f: &mut ratatui::Frame, app: &mut App) {
     draw_recent_transcript(f, layout.transcript, app);
     draw_chrome_layout(f, layout.chrome, &state);
     draw_input(f, layout.chrome.input, app);
-    draw_setup_overlay(f, area, app);
-    draw_background_panel(f, area, app);
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -358,6 +368,7 @@ pub(crate) fn draw_setup_overlay(f: &mut ratatui::Frame, area: Rect, app: &App) 
     if panel.width == 0 || panel.height == 0 {
         return;
     }
+    f.render_widget(Clear, area);
     f.render_widget(Clear, panel);
     let block = Block::default()
         .borders(Borders::ALL)
@@ -403,6 +414,7 @@ pub(crate) fn draw_background_panel(f: &mut ratatui::Frame, area: Rect, app: &Ap
     if panel.width == 0 || panel.height == 0 {
         return;
     }
+    f.render_widget(Clear, area);
     f.render_widget(Clear, panel);
     let block = Block::default()
         .borders(Borders::ALL)

--- a/src/app/viewport.rs
+++ b/src/app/viewport.rs
@@ -41,8 +41,16 @@ where
         return Ok(());
     }
 
-    // Recompute the inline origin from a bottom-row cursor. Blank scrollback
-    // lines would leave a visible gap above the composer.
+    // Ratatui preserves `last_known_cursor_pos`'s offset within the old
+    // viewport when resizing. Normalize that offset to the viewport's last
+    // row, then move only the backend cursor to the terminal bottom. This
+    // makes the new viewport end exactly at the bottom regardless of whether
+    // the input or an overlay placed the visible cursor near the top.
+    let viewport_last_row = viewport_area.bottom().saturating_sub(1);
+    terminal.set_cursor_position(Position {
+        x: 0,
+        y: viewport_last_row,
+    })?;
     let bottom_row = terminal_size.height.saturating_sub(1);
     terminal.backend_mut().set_cursor_position(Position {
         x: 0,
@@ -228,5 +236,65 @@ mod tests {
 
         maybe_reanchor_inline_viewport(&mut terminal).expect("re-anchor after shrink");
         assert_eq!(viewport_bottom(&mut terminal), 24);
+    }
+
+    #[test]
+    fn reanchor_after_combined_resize_moves_viewport_to_new_bottom() {
+        let mut backend = TestBackend::new(100, 24);
+        backend
+            .set_cursor_position(Position { x: 0, y: 1 })
+            .unwrap();
+        let mut terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Inline(18),
+            },
+        )
+        .unwrap();
+
+        maybe_reanchor_inline_viewport(&mut terminal).expect("initial anchor");
+        terminal.backend_mut().resize(60, 40);
+        terminal.autoresize().expect("autoresize width and height");
+        maybe_reanchor_inline_viewport(&mut terminal).expect("re-anchor combined resize");
+
+        let viewport = terminal.get_frame().area();
+        assert_eq!(viewport.width, 60);
+        assert_eq!(viewport_bottom(&mut terminal), 40);
+    }
+
+    #[test]
+    fn reanchor_after_grow_ignores_overlay_cursor_row() {
+        let mut backend = TestBackend::new(80, 24);
+        backend
+            .set_cursor_position(Position { x: 0, y: 1 })
+            .unwrap();
+        let mut terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Inline(18),
+            },
+        )
+        .unwrap();
+
+        maybe_reanchor_inline_viewport(&mut terminal).expect("initial anchor");
+        let viewport_top = terminal.get_frame().area().y;
+        terminal
+            .draw(|frame| {
+                frame.set_cursor_position(Position {
+                    x: 4,
+                    y: viewport_top.saturating_add(3),
+                });
+            })
+            .expect("draw overlay-style cursor");
+
+        terminal.backend_mut().resize(100, 40);
+        terminal.autoresize().expect("autoresize grow");
+        maybe_reanchor_inline_viewport(&mut terminal).expect("re-anchor after grow");
+
+        assert_eq!(
+            viewport_bottom(&mut terminal),
+            40,
+            "an overlay cursor near the top must not push the inline viewport past the screen"
+        );
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -679,6 +679,39 @@ fn tui_resize_shrink_width_reanchors_composer_to_bottom() {
     );
 }
 
+#[test]
+fn tui_combined_resize_reconstructs_composer_at_screen_bottom() {
+    let mut tui = spawn_tui_llmsim(&yolop_binary());
+    assert!(tui.wait_for_output("type /help", Duration::from_secs(3)));
+
+    tui.clear_output();
+    tui.resize(60, 40);
+    tui.write_input(b" ");
+    assert!(
+        tui.wait_for_output("[expand", Duration::from_secs(3)),
+        "TUI did not redraw after combined resize: {}",
+        tui.output_text()
+    );
+
+    let screen = tui.screen_lines();
+    assert_eq!(
+        screen.len(),
+        40,
+        "expected a complete 60x40 screen: {screen:?}"
+    );
+    assert!(
+        screen.last().is_some_and(|row| row.contains("llmsim")),
+        "status row should be the final visible row after resize: {screen:?}"
+    );
+    assert!(
+        screen.iter().any(|row| row.contains("Enter to send")),
+        "composer separator should remain visible after resize: {screen:?}"
+    );
+
+    tui.write_input(b"\x03\x03");
+    assert!(tui.wait_or_kill(Duration::from_secs(5)).success());
+}
+
 // ratatui 0.30.1 `Terminal::clear` snapshots the cursor with a blocking
 // `CSI 6n` query, and the inline viewport calls `clear` inside
 // `insert_before` — so viewport anchoring, every transcript flush, and exit
@@ -850,6 +883,7 @@ fn tui_setup_overlay_renders_in_real_pty() {
         tui.output_text()
     );
 
+    tui.clear_output();
     tui.write_input(b"/setup\r");
     assert!(
         tui.wait_for_output("Set Up Yolop", Duration::from_secs(3)),
@@ -860,6 +894,31 @@ fn tui_setup_overlay_renders_in_real_pty() {
         tui.wait_for_output("Esc cancel", Duration::from_secs(3)),
         "/setup footer should render without clipping: {}",
         tui.output_text()
+    );
+
+    let screen = tui.screen_lines();
+    let sheet: Vec<_> = screen
+        .iter()
+        .filter(|row| row.contains('│') || row.contains('┌') || row.contains('└'))
+        .collect();
+    assert_eq!(
+        sheet.len(),
+        16,
+        "setup panel should retain its centered height: {screen:?}"
+    );
+    assert!(
+        sheet
+            .first()
+            .is_some_and(|row| row.trim_start().starts_with('┌'))
+    );
+    assert!(
+        sheet
+            .last()
+            .is_some_and(|row| row.trim_start().starts_with('└'))
+    );
+    assert!(
+        !screen.iter().any(|row| row.contains("Enter to send")),
+        "composer chrome must not bleed through the setup sheet: {screen:?}"
     );
 }
 

--- a/tests/support/tui_harness.rs
+++ b/tests/support/tui_harness.rs
@@ -16,6 +16,8 @@ pub struct TuiHarness {
     writer: Arc<Mutex<Box<dyn Write + Send>>>,
     output_rx: Receiver<Vec<u8>>,
     output: Vec<u8>,
+    rows: u16,
+    cols: u16,
     answer_cursor_queries: Arc<AtomicBool>,
     _session_dir: tempfile::TempDir,
     _home: tempfile::TempDir,
@@ -82,6 +84,8 @@ impl TuiHarness {
                 pixel_height: 0,
             })
             .expect("resize pty");
+        self.cols = cols;
+        self.rows = rows;
     }
 
     pub fn wait_for_output(&mut self, needle: &str, timeout: Duration) -> bool {
@@ -112,6 +116,21 @@ impl TuiHarness {
     pub fn output_text(&mut self) -> String {
         self.drain_output();
         String::from_utf8_lossy(&self.output).into_owned()
+    }
+
+    /// Reconstruct the visible terminal grid after applying all captured ANSI
+    /// control sequences. Use `clear_output` immediately before the action
+    /// under test when that action follows a PTY resize.
+    pub fn screen_lines(&mut self) -> Vec<String> {
+        self.drain_output();
+        let mut parser = vt100::Parser::new(self.rows, self.cols, 0);
+        parser.process(&self.output);
+        parser
+            .screen()
+            .contents()
+            .lines()
+            .map(ToOwned::to_owned)
+            .collect()
     }
 
     pub fn clear_output(&mut self) {
@@ -147,6 +166,8 @@ pub fn spawn_tui_llmsim_with_settings(
     options: TuiSpawnOptions,
     settings_toml: &str,
 ) -> TuiHarness {
+    let rows = options.rows;
+    let cols = options.cols;
     let session_dir = tempfile::tempdir().expect("session tempdir");
     let home = tempfile::tempdir().expect("home tempdir");
     for settings_dir in [
@@ -264,6 +285,8 @@ pub fn spawn_tui_llmsim_with_settings(
         writer,
         output_rx,
         output: Vec::new(),
+        rows,
+        cols,
         answer_cursor_queries,
         _session_dir: session_dir,
         _home: home,


### PR DESCRIPTION
## What changed
Yolop now keeps its inline composer pinned to the terminal bottom across combined width/height resizes and renders setup/background overlays on a clean inline surface. Centered panels no longer expose composer separators, input, or status content around their edges.

The PTY harness now reconstructs the final visible terminal grid with the dev-only `vt100` crate, so resize and overlay tests assert screen geometry instead of searching raw ANSI bytes.

## Why
Ratatui preserves its internally tracked cursor offset when resizing an inline viewport. Yolop moved only the backend cursor, so an overlay cursor near the top could produce an invalid viewport origin after a resize. The resize cooldown also compared two already-current backend sizes and never observed a transition.

## Before / After
Before: resizing in Ghostty could leave the composer above the terminal bottom, and centered overlays left fragments of the composer/status chrome visible around the panel.

After: tested in Ghostty 1.3.1 at 180 columns and after a combined resize to 117 columns with a taller window. The setup panel remained centered, fully visible, and bottom-anchored with clean margins and no chrome bleed-through.

## Risk
- Low to medium: changes inline viewport cursor normalization and overlay draw ordering.
- The new dependency is dev-only and does not enter the shipped binary. It is purpose-built to replay ANSI output into a terminal grid for integration assertions.

## Security
- Reviewed TM-FS, TM-BASH, TM-LLM, and TM-TOOL: no filesystem, shell execution, prompt/key handling, or capability registration paths changed.
- TM-DEP: `vt100` and its small parser dependency chain are test-only; captured output is limited to the existing short-lived PTY fixtures.
- `cargo audit` reports two existing `quick-xml 0.39.4` advisories and one existing unmaintained `rustls-pemfile` warning already present on `origin/main`; this change does not add or alter those dependency paths.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` — 762 passed, 3 intentionally ignored
- `cargo fetch --locked`
- Real Ghostty 1.3.1 setup-overlay and combined-resize smoke
- Offline binary smoke: `cargo run -- --provider llmsim -p "Reply with exactly: ghostty smoke ok"`
- Local live-provider smoke was unavailable because this worktree has no Doppler project/fallback and no `OPENAI_API_KEY`; CI live-provider checks remain required before merge.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered — pre-1.0 UI behavior; no public API change
- [x] Security review performed
- [x] All review comments addressed
