### PR TITLE
feat(herdr): add native session integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,16 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   system (`disclosed_titles`, `recall_limit`, `soft_cap`). See
   [`specs/memory.md`](./specs/memory.md).
 - **Skills** — `SKILL.md` files discovered from workspace
-  (`.agents/skills/`), global (`<config_dir>/yolop/skills/`), and system
-  (bundled) scopes, exposed via `list_skills`, `read_skill`, `write_skill`,
-  and `activate_skill`. Workspace/global skills installed after startup are
+  (`.agents/skills/`), global (`<config_dir>/yolop/skills/`), ephemeral
+  environment integrations, and system (bundled) scopes, exposed via
+  `list_skills`, `read_skill`, `write_skill`, and `activate_skill`.
+  Workspace/global skills installed after startup are
   available immediately; the bundled `skill-management` skill covers search,
   npx-style imports, and upgrades. See [`specs/skills.md`](./specs/skills.md).
+- **Herdr-aware sessions** — when launched in a Herdr pane, Yolop reports
+  `working`, `idle`, and explicit `blocked` lifecycle states and exposes
+  read-only Herdr operating guidance without installing a global skill. See
+  [`specs/herdr.md`](./specs/herdr.md).
 - **Infinity context** — older history is trimmed out of the live prompt but
   stays queryable via `query_history`, so long sessions don't hit the wall.
 - **Tool search** — provider-agnostic deferred tool loading: core file/shell

--- a/specs/herdr.md
+++ b/specs/herdr.md
@@ -1,0 +1,62 @@
+# Herdr integration
+
+## Purpose
+
+Yolop should behave as a first-class process when launched inside
+[Herdr](https://herdr.dev/) without requiring users to install hooks or copy a
+skill into every project.
+
+## Environment contract
+
+The integration activates only when all of these inherited variables are
+present and valid:
+
+- `HERDR_ENV=1`
+- `HERDR_PANE_ID`
+- `HERDR_SOCKET_PATH`
+
+`HERDR_BIN_PATH` selects the CLI binary when present; otherwise Yolop invokes
+`herdr` from `PATH`. Commands are executed directly, never through a shell.
+Missing or incompatible Herdr installations are non-fatal.
+
+## Lifecycle reporting
+
+Yolop reports to the current pane with source `yolop:lifecycle` and agent label
+`yolop`:
+
+- initial state and completed, failed, or cancelled turns: `idle`
+- a started turn: `working`
+- an explicit user-ask evaluation that needs user input: `blocked`
+
+Reports include Yolop's session id and a process-independent monotonic sequence.
+They are best-effort, bounded by a short timeout, and never delay or fail a
+model turn. Herdr's attention layer may display a completed background `idle`
+transition as `done`.
+
+When the last reporter owner is dropped, Yolop directly spawns Herdr's
+`release-agent` command for its own source and label. This exit-safe cleanup
+uses the next sequence value, and does not remove or alter reports owned by
+other integrations.
+
+Yolop does not infer `blocked` from prose. Soft-approval questions therefore
+still need Herdr screen detection until Yolop gains a structured question
+lifecycle.
+
+## Conditional skill
+
+Inside Herdr, the capability mounts a read-only `herdr` skill under a
+session-local environment-skill VFS. It is visible through the normal skills
+capability and follows normal precedence, so a workspace or global `herdr`
+skill can override it. The mount is
+in memory for the session: Yolop does not fetch instructions at startup or
+write `.agents/skills` or a global skill directory.
+
+Outside Herdr, the capability contributes no mount and performs no reporting.
+
+## Ownership
+
+- `capabilities::herdr` owns environment validation, reports, and the skill mount.
+- The runtime event bus drives cross-host lifecycle transitions for TUI,
+  `--print`, and ACP turns.
+- `ScopedSkillsCapability` owns discovery and activation of the mounted
+  environment scope.

--- a/specs/skills.md
+++ b/specs/skills.md
@@ -12,16 +12,18 @@ That capability owns discovery, precedence, the skills tools (`list_skills`,
 substitution — all driven strictly through the session `SessionFileSystem`. yolop
 supplies only the embedder-specific glue (`crate::capabilities::skills`):
 
-1. **The scope set and writability** — workspace, global, system (below), passed
-   as `SkillScope`s with labeled **VFS roots** (never host paths).
+1. **The scope set and writability** — workspace, global, environment, and
+   system (below), passed as `SkillScope`s with labeled **VFS roots** (never
+   host paths).
 2. **A host-path `SkillDirResolver`** — so `${SKILL_DIR}` and the displayed paths
    expand to real on-disk paths the host `bash` tool can read. (The core default
    keeps them in the VFS, which is correct only when the shell shares that
    namespace; yolop's `bash` runs on the host.)
 3. **Bundled system skills** — pre-packed in the binary and materialized once.
 4. **File-store routing** — `CodingCliSessionFileStore` maps each scope's VFS root
-   onto the real directory below, so the capability reaches global/system skills
-   through the VFS without ever being handed a host path.
+   onto the real directory or ephemeral store below, so the capability reaches
+   global/environment/system skills through the VFS without ever being handed a
+   host path.
 
 This spec owns the scope set and the yolop wiring; the capability contract and
 `SKILL.md` format are owned upstream (see `everruns` `specs/skills-registry.md`).
@@ -44,7 +46,11 @@ a labeled VFS root that yolop's file store maps to a **real on-disk directory**:
    `~/.config/yolop/skills/` on Linux; VFS `/.yolop/global-skills`), installed
    once per user and shared across every workspace. Writable. Overridable with
    `YOLOP_GLOBAL_SKILLS_DIR`.
-3. **System** — pre-packed inside the yolop binary and materialized once to
+3. **Environment** — optional, integration-owned skills mounted into the
+   session-only VFS (VFS `/.yolop/environment-skills`). Always read-only and
+   never materialized on disk. Herdr currently contributes this scope when its
+   inherited environment contract is valid.
+4. **System** — pre-packed inside the yolop binary and materialized once to
    `<data_dir>/yolop/system-skills/<name>/` (VFS `/.yolop/system-skills`). Always
    available, **read-only**. Overridable with `YOLOP_SYSTEM_SKILLS_DIR` (used
    verbatim, no materialization).
@@ -52,14 +58,15 @@ a labeled VFS root that yolop's file store maps to a **real on-disk directory**:
 ## Required Behavior
 
 1. **Merge.** `list_skills` and the system-prompt listing see skills from all
-   three scopes as one set; each entry is tagged with its scope.
+   active scopes as one set; each entry is tagged with its scope.
 2. **Precedence.** When the same skill directory name exists in more than one
-   scope, the most specific wins: workspace shadows global shadows system.
+   scope, the most specific wins: workspace shadows global, which shadows
+   environment, which shadows system.
    Discovery de-duplicates by directory name in that order; `activate_skill`
    resolves the same way.
-3. **Real paths.** Because every scope is a real directory, `${SKILL_DIR}` in an
-   activated skill expands to a path the host `bash` tool can read, so bundled
-   files work for all scopes.
+3. **Usable paths.** Disk-backed scopes expand `${SKILL_DIR}` to paths the host
+   `bash` tool can read, so bundled files work. Environment skills remain
+   VFS-only and must not advertise shell-side assets.
 4. **No command execution on activation.** The `!`cmd`` substitution is never
    expanded — activating a skill must not spawn a shell on the host (mirrors the
    upstream trust gate; see `everruns-core` skills / EVE-388).
@@ -97,6 +104,11 @@ a labeled VFS root that yolop's file store maps to a **real on-disk directory**:
     keyboard shortcuts, CLI flags, and session controls. `/help` in the TUI
     summarizes the live command registry and shortcuts; the skill carries the
     full guide for conversational help.
+13. **Environment skills are ephemeral.** An environment integration may mount
+    a read-only, VFS-only skill scope for the current session. Herdr does this
+    only when its inherited pane/socket contract is present. Precedence is
+    workspace, global, environment, then system; the mount never writes any
+    skill directory.
 
 ## Ownership Boundary
 

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -950,6 +950,7 @@ async fn run_prompt(
         // report cancelled. The runtime may finish in the background but its
         // remaining events are ignored.
         turn.abort();
+        handles.report_herdr_state(crate::capabilities::herdr::HerdrState::Idle);
         return StopReason::Cancelled;
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -8,7 +8,7 @@ use crate::host_ui::UiCommand;
 use crate::runtime::{BuiltRuntime, ModelState, StartupInfo};
 use crate::session::Session;
 use crate::user_ask::{
-    USER_ASK_EVALUATE_ARG, UserAskStore, evaluation_status_message,
+    AskOutcome, USER_ASK_EVALUATE_ARG, UserAskStore, evaluation_status_message,
     parse_evaluation_response as parse_user_ask_evaluation,
 };
 use crate::worktree::WorktreeManager;
@@ -1580,6 +1580,10 @@ impl App {
                 return;
             }
         };
+        if evaluation.outcome == AskOutcome::Blocked {
+            self.session
+                .report_herdr_state(crate::capabilities::herdr::HerdrState::Blocked);
+        }
         self.push_system(evaluation_status_message(&evaluation));
     }
 

--- a/src/capabilities/herdr.rs
+++ b/src/capabilities/herdr.rs
@@ -1,0 +1,525 @@
+//! Herdr environment integration.
+//!
+//! Herdr injects a local socket path and stable pane id into every managed
+//! process. When that contract is present, yolop reports its turn lifecycle and
+//! exposes a read-only Herdr skill through the existing skills capability. The
+//! integration never fetches instructions or writes a user skill directory.
+
+use async_trait::async_trait;
+use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
+use everruns_core::{Event, TURN_CANCELLED, TURN_COMPLETED, TURN_FAILED, TURN_STARTED};
+use std::ffi::OsString;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::sync::broadcast;
+
+pub(crate) const HERDR_CAPABILITY_ID: &str = "herdr";
+const HERDR_SOURCE: &str = "yolop:lifecycle";
+const REPORT_TIMEOUT: Duration = Duration::from_secs(2);
+
+const HERDR_SKILL_MD: &str = r#"---
+name: herdr
+description: Control the current Herdr terminal session when the user explicitly asks to inspect or operate Herdr panes, tabs, workspaces, or agents.
+---
+
+# Herdr
+
+This yolop process is running inside a Herdr-managed pane. Use Herdr only when
+the user explicitly asks for Herdr coordination or inspection; do not introduce
+extra panes or agents merely because parallel work is possible.
+
+The installed `herdr` binary is the authority for syntax. Inspect a command
+group such as `herdr pane`, `herdr agent`, `herdr workspace`, `herdr tab`, or
+`herdr wait`; do not run bare `herdr` for discovery because it attaches the UI.
+
+Use `$HERDR_PANE_ID` or `--current` for this pane. Treat all returned IDs as
+opaque and read them from command JSON. For background work, preserve the
+user's focus with `--no-focus`. Read current output before waiting for future
+output. Never stop the Herdr server, close resources you did not create, or
+kill another pane's process unless the user explicitly requests it.
+"#;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum HerdrState {
+    Idle,
+    Working,
+    Blocked,
+}
+
+impl HerdrState {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Idle => "idle",
+            Self::Working => "working",
+            Self::Blocked => "blocked",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct HerdrContext {
+    bin: OsString,
+    pane_id: String,
+    socket_path: OsString,
+    agent_session_id: String,
+    sequence: AtomicU64,
+    release_on_drop: bool,
+}
+
+impl HerdrContext {
+    fn from_lookup(
+        agent_session_id: String,
+        release_on_drop: bool,
+        mut get: impl FnMut(&str) -> Option<OsString>,
+    ) -> Option<Self> {
+        if get("HERDR_ENV").as_deref() != Some(std::ffi::OsStr::new("1")) {
+            return None;
+        }
+        let pane_id = get("HERDR_PANE_ID")?.into_string().ok()?;
+        if pane_id.trim().is_empty() {
+            return None;
+        }
+        let socket_path = get("HERDR_SOCKET_PATH")?;
+        if socket_path.is_empty() {
+            return None;
+        }
+        let bin = get("HERDR_BIN_PATH")
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| OsString::from("herdr"));
+        Some(Self {
+            bin,
+            pane_id,
+            socket_path,
+            agent_session_id,
+            sequence: AtomicU64::new(
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_micros()
+                    .min(u64::MAX as u128) as u64,
+            ),
+            release_on_drop,
+        })
+    }
+
+    fn command_args(&self, state: HerdrState, sequence: u64) -> Vec<OsString> {
+        [
+            "pane".into(),
+            "report-agent".into(),
+            self.pane_id.clone().into(),
+            "--source".into(),
+            HERDR_SOURCE.into(),
+            "--agent".into(),
+            "yolop".into(),
+            "--state".into(),
+            state.as_str().into(),
+            "--seq".into(),
+            sequence.to_string().into(),
+            "--agent-session-id".into(),
+            self.agent_session_id.clone().into(),
+        ]
+        .into()
+    }
+
+    fn release_args(&self, sequence: u64) -> Vec<OsString> {
+        [
+            "pane".into(),
+            "release-agent".into(),
+            self.pane_id.clone().into(),
+            "--source".into(),
+            HERDR_SOURCE.into(),
+            "--agent".into(),
+            "yolop".into(),
+            "--seq".into(),
+            sequence.to_string().into(),
+        ]
+        .into()
+    }
+}
+
+impl Drop for HerdrContext {
+    fn drop(&mut self) {
+        if !self.release_on_drop {
+            return;
+        }
+        // This is the last reporter owner and may run while Tokio itself is
+        // shutting down. Spawn the direct CLI command instead of depending on
+        // an async task that the runtime could cancel before it reaches Herdr.
+        let sequence = self.sequence.fetch_add(1, Ordering::Relaxed);
+        match std::process::Command::new(&self.bin)
+            .args(self.release_args(sequence))
+            .env("HERDR_ENV", "1")
+            .env("HERDR_PANE_ID", &self.pane_id)
+            .env("HERDR_SOCKET_PATH", &self.socket_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+        {
+            Ok(mut child) => {
+                std::thread::spawn(move || {
+                    let deadline = std::time::Instant::now() + REPORT_TIMEOUT;
+                    loop {
+                        match child.try_wait() {
+                            Ok(Some(_)) => break,
+                            Ok(None) if std::time::Instant::now() < deadline => {
+                                std::thread::sleep(Duration::from_millis(10));
+                            }
+                            Ok(None) => {
+                                let _ = child.kill();
+                                let _ = child.wait();
+                                break;
+                            }
+                            Err(error) => {
+                                tracing::debug!(%error, "Herdr agent release wait failed");
+                                break;
+                            }
+                        }
+                    }
+                });
+            }
+            Err(error) => tracing::debug!(%error, "Herdr agent release failed"),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct HerdrReporter {
+    context: Option<Arc<HerdrContext>>,
+}
+
+impl HerdrReporter {
+    pub(crate) fn from_env(agent_session_id: impl Into<String>) -> Self {
+        Self::from_lookup_inner(agent_session_id.into(), true, |key| std::env::var_os(key))
+    }
+
+    #[cfg(test)]
+    fn from_lookup(agent_session_id: String, get: impl FnMut(&str) -> Option<OsString>) -> Self {
+        Self::from_lookup_inner(agent_session_id, false, get)
+    }
+
+    fn from_lookup_inner(
+        agent_session_id: String,
+        release_on_drop: bool,
+        get: impl FnMut(&str) -> Option<OsString>,
+    ) -> Self {
+        Self {
+            context: HerdrContext::from_lookup(agent_session_id, release_on_drop, get)
+                .map(Arc::new),
+        }
+    }
+
+    pub(crate) fn is_active(&self) -> bool {
+        self.context.is_some()
+    }
+
+    pub(crate) fn report_background(&self, state: HerdrState) {
+        if self.context.is_none() {
+            return;
+        }
+        let reporter = self.clone();
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            runtime.spawn(async move { reporter.report(state).await });
+        }
+    }
+
+    async fn report(&self, state: HerdrState) {
+        let Some(context) = self.context.clone() else {
+            return;
+        };
+        let sequence = context.sequence.fetch_add(1, Ordering::Relaxed);
+        let mut command = tokio::process::Command::new(&context.bin);
+        command
+            .args(context.command_args(state, sequence))
+            .env("HERDR_ENV", "1")
+            .env("HERDR_PANE_ID", &context.pane_id)
+            .env("HERDR_SOCKET_PATH", &context.socket_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .kill_on_drop(true);
+        match tokio::time::timeout(REPORT_TIMEOUT, command.status()).await {
+            Ok(Ok(status)) if status.success() => {}
+            Ok(Ok(status)) => tracing::debug!(%status, ?state, "Herdr state report failed"),
+            Ok(Err(error)) => tracing::debug!(%error, ?state, "Herdr state report failed"),
+            Err(_) => tracing::debug!(?state, "Herdr state report timed out"),
+        }
+    }
+
+    pub(crate) fn start_monitor(
+        &self,
+        session_id: everruns_core::typed_id::SessionId,
+        mut events: broadcast::Receiver<Event>,
+    ) {
+        if self.context.is_none() {
+            return;
+        }
+        let reporter = self.clone();
+        tokio::spawn(async move {
+            reporter.report(HerdrState::Idle).await;
+            loop {
+                match events.recv().await {
+                    Ok(event) if event.session_id == session_id => {
+                        match event.event_type.as_str() {
+                            TURN_STARTED => reporter.report(HerdrState::Working).await,
+                            TURN_COMPLETED | TURN_FAILED | TURN_CANCELLED => {
+                                reporter.report(HerdrState::Idle).await
+                            }
+                            _ => {}
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(broadcast::error::RecvError::Lagged(_)) => {}
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+    }
+}
+
+pub(crate) struct HerdrCapability {
+    active: bool,
+}
+
+impl HerdrCapability {
+    pub(crate) fn new(active: bool) -> Self {
+        Self { active }
+    }
+
+    pub(crate) fn skill_content(active: bool) -> Option<&'static str> {
+        active.then_some(HERDR_SKILL_MD)
+    }
+}
+
+#[async_trait]
+impl Capability for HerdrCapability {
+    fn id(&self) -> &str {
+        HERDR_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Herdr environment"
+    }
+
+    fn description(&self) -> &str {
+        "Reports Yolop lifecycle state and mounts Herdr operating guidance inside Herdr panes."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Integrations")
+    }
+
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        self.active.then(|| {
+            "<capability id=\"herdr\">\nThis process is inside Herdr. A read-only `herdr` \
+             skill is available; activate it only when the user explicitly asks to inspect or \
+             control Herdr.\n</capability>"
+                .to_string()
+        })
+    }
+
+    fn dependencies(&self) -> Vec<&'static str> {
+        vec![everruns_core::capabilities::SESSION_FILE_SYSTEM_CAPABILITY_ID]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn reporter(vars: &[(&str, &str)]) -> HerdrReporter {
+        let vars: HashMap<&str, OsString> = vars
+            .iter()
+            .map(|(key, value)| (*key, OsString::from(value)))
+            .collect();
+        HerdrReporter::from_lookup("session_test".into(), |key| vars.get(key).cloned())
+    }
+
+    #[test]
+    fn requires_complete_herdr_environment_contract() {
+        assert!(!reporter(&[]).is_active());
+        assert!(!reporter(&[("HERDR_ENV", "1")]).is_active());
+        assert!(
+            reporter(&[
+                ("HERDR_ENV", "1"),
+                ("HERDR_PANE_ID", "w1:p2"),
+                ("HERDR_SOCKET_PATH", "/tmp/herdr.sock"),
+            ])
+            .is_active()
+        );
+    }
+
+    #[test]
+    fn state_report_is_a_direct_cli_invocation_with_session_identity() {
+        let reporter = reporter(&[
+            ("HERDR_ENV", "1"),
+            ("HERDR_PANE_ID", "w1:p2"),
+            ("HERDR_SOCKET_PATH", "/tmp/herdr.sock"),
+        ]);
+        let context = reporter.context.expect("active context");
+        let args = context.command_args(HerdrState::Blocked, 42);
+        let args: Vec<String> = args
+            .into_iter()
+            .map(|arg| arg.into_string().expect("utf-8 test argument"))
+            .collect();
+
+        assert_eq!(
+            args,
+            vec![
+                "pane",
+                "report-agent",
+                "w1:p2",
+                "--source",
+                "yolop:lifecycle",
+                "--agent",
+                "yolop",
+                "--state",
+                "blocked",
+                "--seq",
+                "42",
+                "--agent-session-id",
+                "session_test",
+            ]
+        );
+    }
+
+    #[test]
+    fn release_targets_only_yolops_own_agent_source() {
+        let reporter = reporter(&[
+            ("HERDR_ENV", "1"),
+            ("HERDR_PANE_ID", "w1:p2"),
+            ("HERDR_SOCKET_PATH", "/tmp/herdr.sock"),
+        ]);
+        let context = reporter.context.as_ref().expect("active context");
+        let args: Vec<String> = context
+            .release_args(43)
+            .into_iter()
+            .map(|arg| arg.into_string().expect("utf-8 test argument"))
+            .collect();
+
+        assert_eq!(
+            args,
+            vec![
+                "pane",
+                "release-agent",
+                "w1:p2",
+                "--source",
+                "yolop:lifecycle",
+                "--agent",
+                "yolop",
+                "--seq",
+                "43",
+            ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn monitor_reports_turn_lifecycle_and_releases_the_agent() {
+        use everruns_core::events::{EventContext, TurnCompletedData, TurnStartedData};
+        use everruns_core::typed_id::{MessageId, TurnId};
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let cli = temp.path().join("herdr-test");
+        let calls = temp.path().join("herdr-test.calls");
+        std::fs::write(&cli, "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"${0}.calls\"\n")
+            .expect("write fake Herdr CLI");
+        let mut permissions = std::fs::metadata(&cli).expect("CLI metadata").permissions();
+        permissions.set_mode(0o700);
+        std::fs::set_permissions(&cli, permissions).expect("make CLI executable");
+
+        let vars = HashMap::from([
+            ("HERDR_ENV", OsString::from("1")),
+            ("HERDR_PANE_ID", OsString::from("w1:p2")),
+            ("HERDR_SOCKET_PATH", OsString::from("/tmp/herdr.sock")),
+            ("HERDR_BIN_PATH", cli.as_os_str().to_os_string()),
+        ]);
+        let reporter = HerdrReporter::from_lookup_inner("session_test".into(), true, |key| {
+            vars.get(key).cloned()
+        });
+        let session_id = everruns_core::typed_id::SessionId::from_seed(91);
+        let turn_id = TurnId::from_seed(92);
+        let (events, receiver) = broadcast::channel(8);
+        reporter.start_monitor(session_id, receiver);
+        events
+            .send(Event::new(
+                session_id,
+                EventContext::default(),
+                TurnStartedData {
+                    turn_id,
+                    input_message_id: MessageId::from_seed(93),
+                    input_content: Some("test".to_string()),
+                },
+            ))
+            .expect("send turn started");
+        events
+            .send(Event::new(
+                session_id,
+                EventContext::default(),
+                TurnCompletedData {
+                    turn_id,
+                    iterations: 1,
+                    duration_ms: Some(1),
+                    usage: None,
+                    input_content: Some("test".to_string()),
+                    final_message_id: None,
+                    final_answer_preview: None,
+                    time_to_first_token_ms: None,
+                    tool_call_count: Some(0),
+                    llm_call_count: Some(1),
+                    status: Some("completed".to_string()),
+                },
+            ))
+            .expect("send turn completed");
+        drop(events);
+        drop(reporter);
+
+        let output = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if let Ok(output) = std::fs::read_to_string(&calls)
+                    && output.lines().count() >= 4
+                {
+                    break output;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("lifecycle reports and release should finish");
+        let lines: Vec<&str> = output.lines().collect();
+
+        assert!(lines[0].contains("--state idle"));
+        assert!(lines[1].contains("--state working"));
+        assert!(lines[2].contains("--state idle"));
+        assert!(lines[3].contains("pane release-agent w1:p2"));
+        let sequences: Vec<u64> = lines
+            .iter()
+            .map(|line| {
+                let words: Vec<&str> = line.split_whitespace().collect();
+                words
+                    .windows(2)
+                    .find_map(|pair| (pair[0] == "--seq").then_some(pair[1]))
+                    .expect("sequence argument")
+                    .parse()
+                    .expect("numeric sequence")
+            })
+            .collect();
+        assert!(sequences.windows(2).all(|pair| pair[0] < pair[1]));
+    }
+
+    #[test]
+    fn skill_content_is_conditional() {
+        assert!(HerdrCapability::skill_content(false).is_none());
+        let skill = HerdrCapability::skill_content(true).expect("active skill");
+        assert!(skill.contains("name: herdr"));
+        assert!(skill.contains("$HERDR_PANE_ID"));
+    }
+}

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod config;
 pub(crate) mod edit_file_override;
 pub(crate) mod free_search;
 pub(crate) mod goal;
+pub(crate) mod herdr;
 pub(crate) mod hooks;
 mod host;
 pub(crate) mod lsp;
@@ -41,6 +42,7 @@ pub(crate) use client_commands::{CLIENT_COMMANDS_CAPABILITY_ID, ClientCommandsCa
 pub(crate) use config::{CONFIG_CAPABILITY_ID, ConfigCapability};
 pub(crate) use free_search::FreeSearchCapability;
 pub(crate) use goal::GoalCapability;
+pub(crate) use herdr::{HERDR_CAPABILITY_ID, HerdrCapability};
 pub(crate) use hooks::{HOOKS_CAPABILITY_ID, HooksCapability};
 pub(crate) use host::{
     CODING_BASH_CAPABILITY_ID, ClientUiContext, CodingBashCapability,

--- a/src/capabilities/skills.rs
+++ b/src/capabilities/skills.rs
@@ -50,6 +50,10 @@ pub const GLOBAL_SKILLS_VFS: &str = "/.yolop/global-skills";
 /// Synthetic VFS root for the system scope, routed by the file store to the
 /// materialized system skills directory.
 pub const SYSTEM_SKILLS_VFS: &str = "/.yolop/system-skills";
+/// Read-only, session-local skills contributed by the active host environment.
+/// Unlike global/system skills this root has no disk backing; a capability
+/// mount (currently Herdr) serves it through `MountFs`.
+pub const ENVIRONMENT_SKILLS_VFS: &str = "/.yolop/environment-skills";
 
 /// System skills shipped inside the binary. Keep the source tree away from
 /// well-known skill discovery paths so it cannot be mistaken for a writable
@@ -90,13 +94,20 @@ pub fn relative_under(path: &str, root: &str) -> Option<String> {
 }
 
 /// Build the `ScopedSkillsCapability` configuration for these directories.
-/// Only scopes whose directory resolved are included; the system scope is
-/// read-only, the others writable. `${SKILL_DIR}` and display paths resolve to
-/// real host paths via [`HostSkillDirResolver`].
-pub fn skills_config(dirs: &SkillDirs) -> SkillsConfig {
+/// Only disk-backed scopes whose directory resolved are included. System and
+/// environment scopes are read-only; workspace/global are writable.
+/// `${SKILL_DIR}` and display paths resolve through [`HostSkillDirResolver`].
+pub fn skills_config(dirs: &SkillDirs, environment_active: bool) -> SkillsConfig {
     let mut scopes = vec![SkillScope::new("workspace", WORKSPACE_SKILLS_VFS, true)];
     if dirs.global.is_some() {
         scopes.push(SkillScope::new("global", GLOBAL_SKILLS_VFS, true));
+    }
+    if environment_active {
+        scopes.push(SkillScope::new(
+            "environment",
+            ENVIRONMENT_SKILLS_VFS,
+            false,
+        ));
     }
     if dirs.system.is_some() {
         scopes.push(SkillScope::new("system", SYSTEM_SKILLS_VFS, false));
@@ -120,6 +131,10 @@ impl HostSkillDirResolver {
     fn base_for(&self, label: &str) -> PathBuf {
         match label {
             "global" => self.dirs.global.clone(),
+            // Environment skills are VFS-only and contain no shell-side assets.
+            // Keep their display/substitution path honest instead of pretending
+            // they exist in a writable workspace or global directory.
+            "environment" => Some(PathBuf::from(ENVIRONMENT_SKILLS_VFS)),
             "system" => self.dirs.system.clone(),
             _ => Some(self.dirs.workspace.clone()),
         }
@@ -471,7 +486,7 @@ mod tests {
             global: None,
             system: Some(PathBuf::from("/data/sys")),
         };
-        let cfg = skills_config(&dirs);
+        let cfg = skills_config(&dirs, false);
         let labels: Vec<&str> = cfg.scopes.iter().map(|s| s.label.as_str()).collect();
         assert_eq!(labels, vec!["workspace", "system"]);
         assert!(cfg.manage_tools);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1162,7 +1162,11 @@ async fn run_print_mode(
             )
             .await?;
         if evaluation.success {
-            let _ = user_ask::parse_evaluation_response(&evaluation.message);
+            if let Ok(parsed) = user_ask::parse_evaluation_response(&evaluation.message)
+                && parsed.outcome == user_ask::AskOutcome::Blocked
+            {
+                handles.report_herdr_state(capabilities::herdr::HerdrState::Blocked);
+            }
         } else {
             eprintln!("user ask evaluation failed: {}", evaluation.message);
         }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -13,9 +13,9 @@ use crate::capabilities::{
     BackgroundCapability, CLIENT_COMMANDS_CAPABILITY_ID, CODING_BASH_CAPABILITY_ID,
     CONFIG_CAPABILITY_ID, ClientCommandsCapability, ClientUiContext, CodingBashCapability,
     CodingCliEnvironmentCapability, ConfigCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID,
-    GOAL_CAPABILITY_ID, GoalCapability, HOOKS_CAPABILITY_ID, HooksCapability, LspCapability,
-    PROGRESS_GUARD_CAPABILITY_ID, ProgressGuardCapability, REPO_MAP_CAPABILITY_ID,
-    RepoMapCapability, SESSION_HISTORY_CAPABILITY_ID, SETUP_CAPABILITY_ID,
+    GOAL_CAPABILITY_ID, GoalCapability, HERDR_CAPABILITY_ID, HOOKS_CAPABILITY_ID, HerdrCapability,
+    HooksCapability, LspCapability, PROGRESS_GUARD_CAPABILITY_ID, ProgressGuardCapability,
+    REPO_MAP_CAPABILITY_ID, RepoMapCapability, SESSION_HISTORY_CAPABILITY_ID, SETUP_CAPABILITY_ID,
     SessionHistoryCapability, SetupCapability, USER_ASK_CAPABILITY_ID, UserAskCapability,
     WorktreeCapability,
 };
@@ -66,8 +66,9 @@ use everruns_integrations_duckduckgo::DuckDuckGoCapability;
 use everruns_local::{LocalBackends, LocalProfile, LocalScheduleRunnerHandle};
 use everruns_mcp::{McpAuthProvider, McpAuthRequest, McpCredential};
 use everruns_runtime::{
-    AgentBuilder, HarnessBuilder, InProcessRuntime, InProcessRuntimeBuilder, RealDiskFileStore,
-    RuntimeBackends, RuntimeSessionStore, SessionBuilder, WriteBlocklistFileStore,
+    AgentBuilder, HarnessBuilder, InMemorySessionFileStore, InProcessRuntime,
+    InProcessRuntimeBuilder, RealDiskFileStore, RuntimeBackends, RuntimeSessionStore,
+    SessionBuilder, WriteBlocklistFileStore,
 };
 
 use crate::session_log::{
@@ -266,8 +267,10 @@ const AGENT_PROMPT: &str = "Investigate before editing. Cite paths and line numb
 struct CodingCliSessionFileSystemFactory {
     workspace: Arc<WorkspaceHost>,
     session_dir: PathBuf,
+    session_id: SessionId,
     skill_global: Option<PathBuf>,
     skill_system: Option<PathBuf>,
+    environment_skill: Option<&'static str>,
 }
 
 #[async_trait]
@@ -303,7 +306,27 @@ impl SessionFileSystemFactory for CodingCliSessionFileSystemFactory {
             self.skill_global.clone(),
             self.skill_system.clone(),
         )?);
-        let mounted = MountFs::wrap(composite);
+        let mut mounted = MountFs::new(composite);
+        if let Some(skill) = self.environment_skill {
+            let environment = Arc::new(InMemorySessionFileStore::new());
+            environment
+                .seed_initial_file(
+                    self.session_id,
+                    &InitialFile {
+                        path: "/herdr/SKILL.md".to_string(),
+                        content: skill.to_string(),
+                        encoding: "text".to_string(),
+                        is_readonly: true,
+                    },
+                )
+                .await?;
+            mounted = mounted.with_mount(
+                crate::capabilities::skills::ENVIRONMENT_SKILLS_VFS,
+                environment,
+                "/",
+            );
+        }
+        let mounted: Arc<dyn SessionFileSystem> = Arc::new(mounted);
         Ok(Arc::new(WriteBlocklistFileStore::new(mounted)))
     }
 }
@@ -1793,6 +1816,7 @@ fn default_coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabi
     caps.extend([
         AgentCapabilityConfig::new(SESSION_FILE_SYSTEM_CAPABILITY_ID),
         AgentCapabilityConfig::new(SKILLS_CAPABILITY_ID),
+        AgentCapabilityConfig::new(HERDR_CAPABILITY_ID),
         AgentCapabilityConfig::new(REPO_MAP_CAPABILITY_ID),
         AgentCapabilityConfig::new(SESSION_HISTORY_CAPABILITY_ID),
         AgentCapabilityConfig::new(AST_GREP_CAPABILITY_ID),
@@ -1994,9 +2018,15 @@ pub struct RuntimeHandles {
     /// freshly minted token (the store caches connections in memory per
     /// handle), so `/mcp login` uses it rather than a separate handle.
     pub connections: Arc<ConnectionStore>,
+    /// Best-effort local lifecycle bridge when this process runs in Herdr.
+    pub(crate) herdr: crate::capabilities::herdr::HerdrReporter,
 }
 
 impl RuntimeHandles {
+    pub(crate) fn report_herdr_state(&self, state: crate::capabilities::herdr::HerdrState) {
+        self.herdr.report_background(state);
+    }
+
     /// Re-read the merged MCP server config (global settings + workspace
     /// `.mcp.json`) and swap it into the live session, so add / remove /
     /// enable / disable take effect on the next turn without a restart.
@@ -2274,7 +2304,10 @@ pub async fn build_with_options(
     let workspace = Workspace::new(workspace_host.clone());
     let effective_root = worktree.active_root();
 
-    // Resolve the workspace/global/system skill directories once (this also
+    let herdr = crate::capabilities::herdr::HerdrReporter::from_env(session_id.to_string());
+
+    // Resolve the disk-backed workspace/global/system skill directories once
+    // (this also
     // materializes the embedded system skills). Shared by the skills capability
     // config and the file-store factory's scope routing.
     let skill_dirs = crate::capabilities::skills::SkillDirs::resolve(&effective_root);
@@ -2371,7 +2404,7 @@ pub async fn build_with_options(
     //
     // Skills (upstream `ScopedSkillsCapability`, wired in `crate::capabilities::skills`):
     //   * skills               — discovers SKILL.md across workspace / global /
-    //                            system scopes via the session file store;
+    //                            environment / system scopes via the session file store;
     //                            list_skills + activate_skill + read/write_skill
     //
     // Non-filesystem, but useful for a coding agent:
@@ -2399,12 +2432,15 @@ pub async fn build_with_options(
     capabilities
         .register(crate::capabilities::edit_file_override::EditsOnlyFileSystemCapability::new());
     // Upstream multi-scope skills capability (everruns-core 0.12.0+),
-    // configured with yolop's workspace/global/system scopes and a host-path
+    // configured with yolop's workspace/global/environment/system scopes and a host-path
     // resolver so `${SKILL_DIR}` reaches real files. The file store maps the
     // scope VFS roots onto disk (see `capabilities::skills`).
     capabilities.register(ScopedSkillsCapability::new(
-        crate::capabilities::skills::skills_config(&skill_dirs),
+        crate::capabilities::skills::skills_config(&skill_dirs, herdr.is_active()),
     ));
+    // Herdr contributes a conditional, read-only skill mount. Outside a Herdr
+    // pane it has no mounts and the reporter is inert.
+    capabilities.register(HerdrCapability::new(herdr.is_active()));
     // yolop-owned skill uninstall (`delete_skill`); the upstream capability has
     // no removal. Shares the same resolved scope directories.
     capabilities.register(crate::capabilities::skills::SkillManagementCapability::new(
@@ -2668,8 +2704,10 @@ pub async fn build_with_options(
         .session_file_system_factory(Arc::new(CodingCliSessionFileSystemFactory {
             workspace: workspace_host.clone(),
             session_dir: session_dir.clone(),
+            session_id,
             skill_global: skill_dirs.global.clone(),
             skill_system: skill_dirs.system.clone(),
+            environment_skill: HerdrCapability::skill_content(herdr.is_active()),
         }))
         .build();
 
@@ -2756,6 +2794,8 @@ pub async fn build_with_options(
         .collect();
     let capability_commands = runtime.list_commands(session_id).await?;
 
+    herdr.start_monitor(session_id, event_bus_typed.subscribe());
+
     Ok(BuiltRuntime {
         handles: RuntimeHandles {
             runtime: Arc::new(runtime),
@@ -2764,6 +2804,7 @@ pub async fn build_with_options(
             session_store,
             workspace_root: canonical_root.clone(),
             connections,
+            herdr,
         },
         startup: StartupInfo {
             workspace_root: effective_root,
@@ -5007,7 +5048,7 @@ mod tests {
             )
             .expect("store"),
         );
-        let cap = ScopedSkillsCapability::new(skills_config(&dirs));
+        let cap = ScopedSkillsCapability::new(skills_config(&dirs, false));
         let tools = cap.tools();
         let list = tools
             .iter()
@@ -5035,6 +5076,66 @@ mod tests {
             }
             other => panic!("expected success, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn herdr_skill_is_visible_from_the_ephemeral_environment_scope() {
+        use crate::capabilities::herdr::HerdrCapability;
+        use crate::capabilities::skills::ENVIRONMENT_SKILLS_VFS;
+
+        let workspace = tempfile::tempdir().expect("workspace");
+        let session = tempfile::tempdir().expect("session");
+        let session_id = SessionId::from_seed(81);
+        let host = Arc::new(
+            WorkspaceHost::new(
+                Arc::new(RwLock::new(workspace.path().to_path_buf())),
+                workspace.path().to_path_buf(),
+            )
+            .expect("host"),
+        );
+        let factory = CodingCliSessionFileSystemFactory {
+            workspace: host,
+            session_dir: session.path().to_path_buf(),
+            session_id,
+            skill_global: None,
+            skill_system: None,
+            environment_skill: HerdrCapability::skill_content(true),
+        };
+
+        let store = factory
+            .create_session_file_system(SessionFileSystemFactoryContext::default())
+            .await
+            .expect("session file system");
+        let entries = store
+            .list_directory(session_id, ENVIRONMENT_SKILLS_VFS)
+            .await
+            .expect("list environment skills");
+        assert!(
+            entries
+                .iter()
+                .any(|entry| entry.is_directory && entry.name == "herdr")
+        );
+        let skill = store
+            .read_file(
+                session_id,
+                &format!("{ENVIRONMENT_SKILLS_VFS}/herdr/SKILL.md"),
+            )
+            .await
+            .expect("read environment skill")
+            .expect("Herdr skill exists");
+        assert!(skill.content.as_deref().unwrap().contains("name: herdr"));
+        assert!(
+            store
+                .write_file(
+                    session_id,
+                    &format!("{ENVIRONMENT_SKILLS_VFS}/herdr/SKILL.md"),
+                    "changed",
+                    "text",
+                )
+                .await
+                .is_err(),
+            "environment skill must remain read-only"
+        );
     }
 
     #[cfg(unix)]

--- a/src/session.rs
+++ b/src/session.rs
@@ -59,6 +59,10 @@ impl Session {
         self.handles.session_id
     }
 
+    pub(crate) fn report_herdr_state(&self, state: crate::capabilities::herdr::HerdrState) {
+        self.handles.report_herdr_state(state);
+    }
+
     /// Re-read the merged MCP server config and swap it into the live session
     /// so add / remove / enable / disable apply on the next turn without a
     /// restart. Returns the sorted names now active. See
@@ -199,6 +203,7 @@ impl Session {
             }
 
             if cancelled {
+                handles.report_herdr_state(crate::capabilities::herdr::HerdrState::Idle);
                 let _ = tx.send(TurnEvent::Stream(None));
                 let _ = tx.send(TurnEvent::Lines(vec![ChatLine {
                     author: Author::System,


### PR DESCRIPTION
## What changed
- Detect Herdr-managed sessions from the inherited pane and socket contract.
- Report Yolop lifecycle state as working, idle, or structured blocked, then release the marker on exit.
- Mount read-only Herdr operating guidance in a session-local environment skill scope without installing files globally.
- Apply the integration consistently to TUI, print, and ACP hosts.

## Why
Yolop previously ran as an opaque terminal process inside Herdr. Users had no native agent status and had to install Herdr guidance manually. This makes Yolop a well-behaved Herdr guest while keeping the integration best-effort and local.

## Before / After
Before: Herdr could not identify Yolop lifecycle state, and Yolop had no Herdr skill unless the user installed one.

After: a live OpenAI smoke inside an unfocused Herdr workspace called `list_skills` and returned `HERDR_SKILL_PRESENT`. Herdr displayed the Yolop agent during the run and returned the pane to `unknown` after process exit. The disposable workspace and session were removed afterward.

## Risk
- Medium: capability registration and the session filesystem factory change for every runtime host.
- Outside Herdr the reporter is inert and no environment skill scope is configured.
- Herdr CLI failures and timeouts are debug-only and cannot fail a model turn.

## Security
- TM-FS: the conditional skill is seeded read-only in memory and mounted beneath a fixed VFS root; workspace write blocklisting remains unchanged.
- TM-BASH: Herdr commands use direct process invocation, never a shell. Reports and exit cleanup are bounded to two seconds with null stdio.
- TM-LLM: only fixed operating guidance enters the prompt. No API keys, prompt contents, or model output are sent to Herdr.
- TM-TOOL: the new capability depends on the existing session filesystem and exposes no write tool. Workspace/global skills retain precedence.
- TM-DEP: no dependencies were added.
- Trust boundaries reviewed for command injection, path traversal, data exposure, and resource exhaustion; no unresolved findings.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` — 731 unit, 36 integration, and 1 parallel integration test passed
- `cargo build --release`
- Automated fake-CLI lifecycle test covers initial idle, working, completed idle, monotonic sequences, and exit release.
- Automated session-filesystem test covers environment skill visibility and read-only enforcement.
- Live OpenAI smoke through Doppler inside Herdr returned `HERDR_SKILL_PRESENT`; exit cleanup returned agent status to `unknown`.

## Follow-ups
- Structured `blocked` reporting for prose-based soft approvals is deferred until Yolop exposes a question lifecycle event; Herdr screen detection remains the fallback.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed
- [x] Documentation and specs updated