### PR TITLE
fix(codex): drop unpaired tool-call items

### DIFF
--- a/src/codex_driver.rs
+++ b/src/codex_driver.rs
@@ -507,7 +507,7 @@ fn build_input(messages: &[LlmMessage]) -> (Option<String>, Vec<CodexInputItem>)
         input.push(convert_message(message));
     }
     let instructions = (!instructions.is_empty()).then(|| instructions.join("\n\n"));
-    (instructions, drop_orphaned_function_outputs(input))
+    (instructions, repair_unpaired_function_items(input))
 }
 
 fn convert_message(message: &LlmMessage) -> CodexInputItem {
@@ -558,7 +558,7 @@ fn convert_message(message: &LlmMessage) -> CodexInputItem {
     }
 }
 
-fn drop_orphaned_function_outputs(input: Vec<CodexInputItem>) -> Vec<CodexInputItem> {
+fn repair_unpaired_function_items(input: Vec<CodexInputItem>) -> Vec<CodexInputItem> {
     let call_ids: std::collections::HashSet<String> = input
         .iter()
         .filter_map(|item| match item {
@@ -566,16 +566,34 @@ fn drop_orphaned_function_outputs(input: Vec<CodexInputItem>) -> Vec<CodexInputI
             _ => None,
         })
         .collect();
-    if call_ids.is_empty() {
-        return input
-            .into_iter()
-            .filter(|item| !matches!(item, CodexInputItem::FunctionCallOutput { .. }))
-            .collect();
+    let output_ids: std::collections::HashSet<String> = input
+        .iter()
+        .filter_map(|item| match item {
+            CodexInputItem::FunctionCallOutput { call_id, .. } => Some(call_id.clone()),
+            _ => None,
+        })
+        .collect();
+    let unpaired: std::collections::HashSet<String> = call_ids
+        .symmetric_difference(&output_ids)
+        .cloned()
+        .collect();
+
+    if unpaired.is_empty() {
+        return input;
     }
+
+    tracing::warn!(
+        unpaired_call_ids = ?unpaired,
+        "dropping unpaired function calls and outputs before Codex request"
+    );
+
     input
         .into_iter()
         .filter(|item| match item {
-            CodexInputItem::FunctionCallOutput { call_id, .. } => call_ids.contains(call_id),
+            CodexInputItem::FunctionCall { call_id, .. }
+            | CodexInputItem::FunctionCallOutput { call_id, .. } => {
+                !unpaired.contains(call_id.as_str())
+            }
             _ => true,
         })
         .collect()
@@ -1109,6 +1127,55 @@ mod tests {
             input.last(),
             Some(CodexInputItem::FunctionCallOutput { call_id, .. }) if call_id == "call_1"
         ));
+    }
+
+    #[test]
+    fn build_input_drops_only_unpaired_items_from_parallel_tool_batch() {
+        let mut paired_result = LlmMessage::text(LlmMessageRole::Tool, "skill instructions");
+        paired_result.tool_call_id = Some("call_paired".to_string());
+        let mut orphaned_result = LlmMessage::text(LlmMessageRole::Tool, "stale output");
+        orphaned_result.tool_call_id = Some("call_missing_call".to_string());
+        let (_, input) = build_input(&[
+            LlmMessage {
+                role: LlmMessageRole::Assistant,
+                content: LlmMessageContent::Text(String::new()),
+                tool_calls: Some(vec![
+                    ToolCall {
+                        id: "call_missing_output".to_string(),
+                        name: "bash".to_string(),
+                        arguments: json!({}),
+                    },
+                    ToolCall {
+                        id: "call_paired".to_string(),
+                        name: "activate_skill".to_string(),
+                        arguments: json!({}),
+                    },
+                ]),
+                tool_call_id: None,
+                phase: None,
+                thinking: None,
+                thinking_signature: None,
+            },
+            paired_result,
+            orphaned_result,
+        ]);
+
+        assert!(!input.iter().any(|item| matches!(
+            item,
+            CodexInputItem::FunctionCall { call_id, .. } if call_id == "call_missing_output"
+        )));
+        assert!(input.iter().any(|item| matches!(
+            item,
+            CodexInputItem::FunctionCall { call_id, .. } if call_id == "call_paired"
+        )));
+        assert!(input.iter().any(|item| matches!(
+            item,
+            CodexInputItem::FunctionCallOutput { call_id, .. } if call_id == "call_paired"
+        )));
+        assert!(!input.iter().any(|item| matches!(
+            item,
+            CodexInputItem::FunctionCallOutput { call_id, .. } if call_id == "call_missing_call"
+        )));
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1519,7 +1519,7 @@ fn acp_openai_handshake_smoke() {
         return;
     };
     let result = run_acp_handshake("openai", "Reply with exactly the single word: pong");
-    if looks_openai_quota_exhausted(&format!("{}{}", result.prompt, result.assistant_text)) {
+    if looks_provider_quota_exhausted(&format!("{}{}", result.prompt, result.assistant_text)) {
         eprintln!("skipping live test: OpenAI quota exhausted");
         return;
     }
@@ -1590,7 +1590,7 @@ fn openai_print_smoke() {
         .expect("spawn yolop --provider openai");
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
-    if !output.status.success() && looks_openai_quota_exhausted(&format!("{stdout}{stderr}")) {
+    if !output.status.success() && looks_provider_quota_exhausted(&format!("{stdout}{stderr}")) {
         eprintln!("skipping live test: OpenAI quota exhausted");
         return;
     }
@@ -1614,12 +1614,26 @@ fn live_openrouter_model() -> String {
         .unwrap_or_else(|_| "nvidia/nemotron-3-ultra-550b-a55b".to_string())
 }
 
-/// True when OpenAI rejects a live smoke only because the shared credential has
-/// exhausted quota. The presence check above still fails CI when the key is
+/// True when a provider rejects a live smoke only because the shared credential
+/// has exhausted quota. The presence check above still fails CI when the key is
 /// missing; this only prevents account billing state from masking code health.
-fn looks_openai_quota_exhausted(combined: &str) -> bool {
+fn looks_provider_quota_exhausted(combined: &str) -> bool {
     let lower = combined.to_lowercase();
-    lower.contains("insufficient_quota") || lower.contains("exceeded your current quota")
+    lower.contains("insufficient_quota")
+        || lower.contains("exceeded your current quota")
+        || (combined.contains("402")
+            && (lower.contains("more credits") || lower.contains("monthly limit")))
+}
+
+#[test]
+fn provider_quota_detection_covers_openai_and_openrouter_billing_errors() {
+    assert!(looks_provider_quota_exhausted("insufficient_quota"));
+    assert!(looks_provider_quota_exhausted(
+        "402 Payment Required: this request requires more credits"
+    ));
+    assert!(!looks_provider_quota_exhausted(
+        "400 No tool output found for function call"
+    ));
 }
 
 /// True when a live run failed only because the upstream provider rate-limited
@@ -1656,7 +1670,12 @@ fn openrouter_print_smoke() {
         .expect("spawn yolop --provider openrouter");
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
-    if !output.status.success() && looks_rate_limited(&format!("{stdout}{stderr}")) {
+    let combined = format!("{stdout}{stderr}");
+    if !output.status.success() && looks_provider_quota_exhausted(&combined) {
+        eprintln!("skipping live test: upstream provider quota exhausted");
+        return;
+    }
+    if !output.status.success() && looks_rate_limited(&combined) {
         eprintln!("skipping live test: upstream provider rate-limited (429)");
         return;
     }
@@ -1725,7 +1744,12 @@ fn openrouter_tool_call_executes_end_to_end() {
         .expect("spawn yolop --provider openrouter");
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
-    if !output.status.success() && looks_rate_limited(&format!("{stdout}{stderr}")) {
+    let combined = format!("{stdout}{stderr}");
+    if !output.status.success() && looks_provider_quota_exhausted(&combined) {
+        eprintln!("skipping live test: upstream provider quota exhausted");
+        return;
+    }
+    if !output.status.success() && looks_rate_limited(&combined) {
         eprintln!("skipping live test: upstream provider rate-limited (429)");
         return;
     }


### PR DESCRIPTION
## What changed
Codex requests now remove either side of an incomplete function-call/function-output pair while preserving complete pairs. Corrupted or compacted sessions can continue instead of repeatedly failing provider validation.

Live smoke tests now treat provider billing exhaustion as infrastructure for both OpenAI and OpenRouter. Missing credentials and functional provider errors still fail CI.

## Why
A real Yolop session became wedged after compaction retained a function call but omitted its output. The custom Codex driver only removed orphan outputs, so OpenAI rejected every replay with: No tool output found for function call.

The upstream compaction invariant remains tracked separately in [EVE-779](https://linear.app/everruns/issue/EVE-779/fixruntime-reproduce-and-prevent-dangling-tool-calls-after-compaction). This PR provides the provider-boundary defense Yolop needs even when loading already-corrupted history.

During validation, the required OpenRouter smoke returned HTTP 402 because the shared account could not afford its configured output limit. The suite already skipped exhausted OpenAI billing, so the same narrowly matched policy now covers OpenRouter 402 credit errors.

## Before / After
Before: the regression fixture retained call_missing_output and produced an invalid request shape; the affected session received HTTP 400 on every continuation.

After: the fixture drops the dangling call and orphan output while retaining the intact parallel call/output pair. A live Codex OAuth smoke successfully executed a bash tool call and returned tool-pair-smoke.

Validation:
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features (732 unit passed, 2 ignored; 37 integration passed, 1 ignored; parallel integration passed)
- cargo run -- --provider codex -p <focused tool-call prompt>

## Risk
- Low
- Only malformed function-call request items are removed. Complete pairs and non-tool messages are unchanged.
- The repair is applied to the ephemeral provider payload; persisted session history is unchanged.
- Quota skipping requires both HTTP 402 and explicit credit/monthly-limit language; unrelated errors remain failures.
- Security review: no new dependencies or capabilities; logs contain call IDs but no tool arguments or results.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered