### PR TITLE
feat(extensions): add doctor_extension conformance probe

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -34,9 +34,9 @@ config dir — so a repository never carries agent-specific machinery:
 - Override for testing: `YOLOP_EXTENSIONS_DIR`
 
 **1. Install** — put the package in that directory. You can also ask yolop to
-do it: it has `install_extension` / `list_extensions` / `enable_extension`
-tools, so "install and enable the extension at `<path>`" works
-conversationally.
+do it: it has `install_extension` / `list_extensions` / `enable_extension` /
+`doctor_extension` tools, so "install and enable the extension at `<path>`"
+works conversationally.
 
 **2. Enable** — installing does not activate. Turn an extension on by adding it
 to your harness in `~/.config/yolop/settings.toml`:
@@ -149,7 +149,9 @@ at [`schema/yep/v1/meta.json`](../schema/yep/v1/meta.json) for authors writing
 servers in other languages — YEP is just newline-delimited JSON-RPC over stdio,
 so any language works (see [`specs/extensions.md`](../specs/extensions.md)).
 
-> **Status.** The mechanism is implemented through hooks and the `yolop-yep`
-> SDK, [published on crates.io](https://crates.io/crates/yolop-yep). Not yet
-> shipped: a one-command `crates.io` extension install, a payload JSON Schema,
-> and an `/extensions doctor` conformance check — see the spec's follow-ups.
+> **Status.** The mechanism is implemented through hooks, the `yolop-yep`
+> SDK ([published on crates.io](https://crates.io/crates/yolop-yep)), and a
+> `doctor_extension` conformance check — spawn an installed extension's
+> server, handshake it, and grade its tools/prompt against the manifest
+> (`"doctor the echo extension"`). Not yet shipped: a one-command `crates.io`
+> extension install and a payload JSON Schema — see the spec's follow-ups.

--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -33,10 +33,17 @@ a `cargo test` drift guard fails CI if the committed file is stale, so the
 method + capability-token vocabulary can't change without the artifact
 changing. A non-Rust author reads it to discover the wire surface. (Full
 JSON-Schema of the payloads — `schema.json` — is still a follow-up.)
+Conformance: `doctor_extension` (surfaced as `/extensions doctor`) spawns an
+installed extension's server, runs the `initialize` handshake, and grades it
+against the manifest — protocol-version compatibility, the D4 tool clamp
+(a widened tool is a hard fail; an unserved manifest tool a warning), and
+prompt-facet consistency — returning per-check pass/warn/fail. It is the
+runtime dual of the CI schema/drift guards: authors validate a server before
+shipping without booting a whole session.
 Later — the full `yolop-extension-lsp` control-plane extraction (gated on
 `evals/lsp_integration` parity to retire the built-in), `ui/ask` (needs the
 server→host reverse-request channel, still refused in phase 1),
-`workspace/changed`, payload `schema.json`, `/extensions doctor`,
+`workspace/changed`, payload `schema.json`,
 providers — remain design-of-record below. Not yet wired within phase 2 (tracked as
 follow-ups): the toolchain-free crates.io source (native sparse-index +
 tarball fetch), full JSON-Schema config validation, and `config/changed`

--- a/src/extensions/doctor.rs
+++ b/src/extensions/doctor.rs
@@ -1,0 +1,434 @@
+//! `doctor` — a conformance probe for an extension's capability server.
+//!
+//! Spawns the server, runs the YEP `initialize` handshake, and checks the
+//! result against the package manifest and the protocol: version
+//! compatibility, that the server only *narrows* the manifest's tool/prompt
+//! grant (the D4 clamp), and that its declared facets line up. It is a
+//! diagnostic — a one-shot spawn that shuts the server down again — so
+//! authors can validate a server before shipping it (`/extensions doctor`),
+//! and the runtime dual of the CI schema/drift guards.
+
+use super::client::YepConnection;
+use super::package::ExtensionManifest;
+use super::protocol::{InitializeParams, InitializeResult, PROTOCOL_VERSION, version_compatible};
+use serde::Serialize;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+use tokio::process::Command;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Status {
+    Pass,
+    Warn,
+    Fail,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Check {
+    pub name: &'static str,
+    pub status: Status,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Report {
+    /// `true` when no check failed (warnings are allowed).
+    pub ok: bool,
+    pub checks: Vec<Check>,
+}
+
+impl Report {
+    fn from(checks: Vec<Check>) -> Self {
+        let ok = !checks.iter().any(|c| c.status == Status::Fail);
+        Self { ok, checks }
+    }
+
+    /// A report where spawning/handshake failed outright — a single failed
+    /// check, since nothing else could run.
+    fn fatal(name: &'static str, detail: impl Into<String>) -> Self {
+        Self::from(vec![Check {
+            name,
+            status: Status::Fail,
+            detail: detail.into(),
+        }])
+    }
+}
+
+fn pass(name: &'static str, detail: impl Into<String>) -> Check {
+    Check {
+        name,
+        status: Status::Pass,
+        detail: detail.into(),
+    }
+}
+fn warn(name: &'static str, detail: impl Into<String>) -> Check {
+    Check {
+        name,
+        status: Status::Warn,
+        detail: detail.into(),
+    }
+}
+
+/// Probe one extension server described by `manifest`, spawning its command
+/// with `package_dir`'s `bin/` on `PATH` (as the runtime does). Never panics;
+/// a spawn/handshake failure becomes a `Fail` check rather than an error.
+pub async fn doctor(
+    manifest: &ExtensionManifest,
+    package_dir: &Path,
+    workspace_root: &Path,
+    timeout: Duration,
+) -> Report {
+    let server = &manifest.capability_server;
+    let mut command = Command::new(&server.command);
+    command
+        .args(&server.args)
+        .current_dir(workspace_root)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .kill_on_drop(true);
+    let bin_dir = package_dir.join("bin");
+    if bin_dir.is_dir()
+        && let Some(path) = std::env::var_os("PATH")
+    {
+        let mut paths: Vec<PathBuf> = vec![bin_dir];
+        paths.extend(std::env::split_paths(&path));
+        if let Ok(joined) = std::env::join_paths(paths) {
+            command.env("PATH", joined);
+        }
+    }
+
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(err) => {
+            return Report::fatal(
+                "spawn",
+                format!(
+                    "cannot spawn `{}`: {err} (is it installed / on PATH?)",
+                    server.command
+                ),
+            );
+        }
+    };
+    let (Some(stdout), Some(stdin)) = (child.stdout.take(), child.stdin.take()) else {
+        return Report::fatal("spawn", "server has no stdio pipes");
+    };
+
+    let init = InitializeParams {
+        protocol_version: PROTOCOL_VERSION.to_string(),
+        session_id: "doctor".into(),
+        workspace_root: workspace_root.display().to_string(),
+        config: serde_json::Value::Null,
+        capabilities: vec!["cancel".into(), "streaming".into()],
+    };
+    let handshake = match YepConnection::connect(stdout, stdin, &manifest.name, init, timeout).await
+    {
+        Ok((connection, handshake)) => {
+            connection.notify("shutdown", serde_json::Value::Null);
+            handshake
+        }
+        Err(err) => {
+            return Report::fatal("handshake", format!("initialize failed: {err}"));
+        }
+    };
+
+    Report::from(evaluate(manifest, &handshake))
+}
+
+/// The manifest-vs-handshake checks (pure; unit-tested without a process).
+pub fn evaluate(manifest: &ExtensionManifest, handshake: &InitializeResult) -> Vec<Check> {
+    let mut checks = vec![
+        pass("spawn", "server started"),
+        pass("handshake", "initialize ok"),
+    ];
+
+    // Protocol version.
+    checks.push(if handshake.protocol_version.is_empty() {
+        warn(
+            "protocol_version",
+            "server did not report a protocol_version",
+        )
+    } else if version_compatible(&handshake.protocol_version) {
+        pass(
+            "protocol_version",
+            format!("{} (compatible)", handshake.protocol_version),
+        )
+    } else {
+        Check {
+            name: "protocol_version",
+            status: Status::Fail,
+            detail: format!(
+                "server speaks YEP {} — incompatible with {PROTOCOL_VERSION}",
+                handshake.protocol_version
+            ),
+        }
+    });
+
+    // Identity.
+    if !handshake.name.is_empty() && handshake.name != manifest.name {
+        checks.push(warn(
+            "name",
+            format!(
+                "server introduced itself as `{}`; manifest name `{}` wins",
+                handshake.name, manifest.name
+            ),
+        ));
+    }
+
+    // Tool clamp (D4): the handshake may only narrow the manifest's tools.
+    let approved: HashSet<&str> = manifest.tools.iter().map(|t| t.name.as_str()).collect();
+    let served: HashSet<&str> = handshake
+        .capability_params
+        .tools
+        .iter()
+        .map(|t| t.name.as_str())
+        .collect();
+    let widened: Vec<&str> = served.difference(&approved).copied().collect();
+    let unserved: Vec<&str> = approved.difference(&served).copied().collect();
+    checks.push(if !widened.is_empty() {
+        Check {
+            name: "tools",
+            status: Status::Fail,
+            detail: format!(
+                "server advertises tool(s) not in the manifest: {} — this would be refused at runtime",
+                widened.join(", ")
+            ),
+        }
+    } else if !unserved.is_empty() {
+        warn(
+            "tools",
+            format!(
+                "manifest declares {} tool(s) the server did not serve: {}",
+                unserved.len(),
+                unserved.join(", ")
+            ),
+        )
+    } else if approved.is_empty() {
+        pass("tools", "no tools declared")
+    } else {
+        pass("tools", format!("{} tool(s), all served", approved.len()))
+    });
+
+    // Prompt facet consistency.
+    let server_prompt = handshake.capability_params.prompt.is_some()
+        || handshake.capabilities.iter().any(|c| c == "dynamic_prompt");
+    let manifest_prompt = manifest.prompt || manifest.dynamic_prompt;
+    if server_prompt && !manifest_prompt {
+        checks.push(warn(
+            "prompt",
+            "server offers a prompt contribution but the manifest declares neither `prompt` nor `dynamic_prompt` — it will be ignored",
+        ));
+    } else if manifest.prompt
+        && handshake.capability_params.prompt.is_none()
+        && !manifest.dynamic_prompt
+    {
+        checks.push(warn(
+            "prompt",
+            "manifest declares `prompt: true` but the server sent no static prompt",
+        ));
+    } else if manifest_prompt {
+        checks.push(pass("prompt", "prompt facet present"));
+    }
+
+    checks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extensions::package::parse_manifest;
+    use serde_json::json;
+
+    fn manifest(tools: &[&str], prompt: bool) -> ExtensionManifest {
+        parse_manifest(
+            &json!({
+                "name": "echo", "description": "t",
+                "yolop": {
+                    "protocol_version": "1.0",
+                    "capabilityServer": { "command": "x" },
+                    "tools": tools.iter().map(|n| json!({"name": n})).collect::<Vec<_>>(),
+                    "prompt": prompt,
+                }
+            })
+            .to_string(),
+        )
+        .unwrap()
+    }
+
+    fn handshake(version: &str, tools: &[&str], prompt: bool) -> InitializeResult {
+        serde_json::from_value(json!({
+            "protocol_version": version,
+            "name": "echo",
+            "capabilities": if prompt { vec!["tools","prompt"] } else { vec!["tools"] },
+            "capability_params": {
+                "tools": tools.iter().map(|n| json!({"name": n})).collect::<Vec<_>>(),
+                "prompt": if prompt { json!({"static": "hi"}) } else { json!(null) },
+            }
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn clean_server_passes() {
+        let checks = evaluate(
+            &manifest(&["echo"], true),
+            &handshake("1.0", &["echo"], true),
+        );
+        assert!(Report::from(checks.clone()).ok, "{checks:?}");
+        assert!(checks.iter().all(|c| c.status == Status::Pass));
+    }
+
+    #[test]
+    fn widened_tools_fail() {
+        // Server advertises a tool not in the manifest → hard fail (would be refused).
+        let checks = evaluate(
+            &manifest(&["echo"], false),
+            &handshake("1.0", &["echo", "sneaky"], false),
+        );
+        let report = Report::from(checks);
+        assert!(!report.ok);
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.name == "tools" && c.status == Status::Fail)
+        );
+    }
+
+    #[test]
+    fn incompatible_version_fails() {
+        let report = Report::from(evaluate(
+            &manifest(&["echo"], false),
+            &handshake("2.0", &["echo"], false),
+        ));
+        assert!(!report.ok);
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.name == "protocol_version" && c.status == Status::Fail)
+        );
+    }
+
+    #[test]
+    fn unserved_manifest_tool_warns_but_passes() {
+        let report = Report::from(evaluate(
+            &manifest(&["echo", "extra"], false),
+            &handshake("1.0", &["echo"], false),
+        ));
+        assert!(report.ok); // warnings don't fail
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.name == "tools" && c.status == Status::Warn)
+        );
+    }
+
+    fn python3() -> Option<String> {
+        for candidate in ["python3", "python"] {
+            if std::process::Command::new(candidate)
+                .arg("--version")
+                .output()
+                .is_ok_and(|out| out.status.success())
+            {
+                return Some(candidate.to_string());
+            }
+        }
+        None
+    }
+
+    /// End-to-end: spawn the real Python fixture server, handshake, and grade
+    /// it. The fixture serves `echo` but not the manifest-approved `unserved`,
+    /// so a clean run reports `ok` with a warn on the unserved tool — the same
+    /// shape `/extensions doctor` surfaces to an author.
+    #[tokio::test]
+    async fn doctor_probes_the_real_fixture_server() {
+        let Some(python) = python3() else {
+            eprintln!("skipping: python3 not available");
+            return;
+        };
+        let server = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/yep_echo_server.py");
+        let manifest = parse_manifest(
+            &json!({
+                "name": "echo", "description": "Echo fixture.",
+                "yolop": {
+                    "protocol_version": "1.0",
+                    "capabilityServer": { "command": python,
+                        "args": [server.display().to_string()] },
+                    "tools": [
+                        { "name": "echo", "description": "Echo text." },
+                        { "name": "unserved", "description": "Never served." }
+                    ],
+                    "prompt": true
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let report = super::doctor(
+            &manifest,
+            &std::env::temp_dir(),
+            &std::env::temp_dir(),
+            Duration::from_secs(20),
+        )
+        .await;
+
+        assert!(report.ok, "clean fixture should pass: {:?}", report.checks);
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.name == "spawn" && c.status == Status::Pass)
+        );
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.name == "handshake" && c.status == Status::Pass)
+        );
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.name == "tools" && c.status == Status::Warn),
+            "unserved manifest tool should warn: {:?}",
+            report.checks
+        );
+    }
+
+    #[tokio::test]
+    async fn doctor_reports_spawn_failure_without_panicking() {
+        let manifest = parse_manifest(
+            &json!({
+                "name": "nope", "description": "missing binary",
+                "yolop": {
+                    "protocol_version": "1.0",
+                    "capabilityServer": { "command": "yolop-definitely-not-a-real-binary-xyz" },
+                    "tools": [{ "name": "noop", "description": "n" }]
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let report = super::doctor(
+            &manifest,
+            &std::env::temp_dir(),
+            &std::env::temp_dir(),
+            Duration::from_secs(5),
+        )
+        .await;
+        assert!(!report.ok);
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.name == "spawn" && c.status == Status::Fail)
+        );
+    }
+}

--- a/src/extensions/manage.rs
+++ b/src/extensions/manage.rs
@@ -18,14 +18,20 @@ pub const EXTENSIONS_CAPABILITY_ID: &str = "extensions";
 
 pub struct ExtensionsCapability {
     extensions_dir: PathBuf,
+    workspace_root: PathBuf,
     settings: Arc<SettingsStore>,
     git: Arc<dyn GitRunner>,
 }
 
 impl ExtensionsCapability {
-    pub fn new(extensions_dir: PathBuf, settings: Arc<SettingsStore>) -> Self {
+    pub fn new(
+        extensions_dir: PathBuf,
+        workspace_root: PathBuf,
+        settings: Arc<SettingsStore>,
+    ) -> Self {
         Self {
             extensions_dir,
+            workspace_root,
             settings,
             git: Arc::new(SystemGit),
         }
@@ -64,6 +70,7 @@ impl Capability for ExtensionsCapability {
     fn tools(&self) -> Vec<Box<dyn Tool>> {
         let ctx = Arc::new(ManageCtx {
             extensions_dir: self.extensions_dir.clone(),
+            workspace_root: self.workspace_root.clone(),
             settings: self.settings.clone(),
             git: self.git.clone(),
         });
@@ -72,13 +79,15 @@ impl Capability for ExtensionsCapability {
             Box::new(ManageTool::new(ctx.clone(), Verb::Install)),
             Box::new(ManageTool::new(ctx.clone(), Verb::Remove)),
             Box::new(ManageTool::new(ctx.clone(), Verb::Enable)),
-            Box::new(ManageTool::new(ctx, Verb::Disable)),
+            Box::new(ManageTool::new(ctx.clone(), Verb::Disable)),
+            Box::new(ManageTool::new(ctx, Verb::Doctor)),
         ]
     }
 }
 
 struct ManageCtx {
     extensions_dir: PathBuf,
+    workspace_root: PathBuf,
     settings: Arc<SettingsStore>,
     git: Arc<dyn GitRunner>,
 }
@@ -90,6 +99,7 @@ enum Verb {
     Remove,
     Enable,
     Disable,
+    Doctor,
 }
 
 struct ManageTool {
@@ -198,6 +208,31 @@ impl ManageTool {
             Err(err) => ToolExecutionResult::ToolError(format!("config write failed: {err}")),
         }
     }
+
+    async fn doctor(&self, args: &Value) -> ToolExecutionResult {
+        let Some(name) = args.get("name").and_then(Value::as_str) else {
+            return ToolExecutionResult::ToolError("`name` is required".into());
+        };
+        let Some(pkg) = discover_extensions(&self.ctx.extensions_dir)
+            .into_iter()
+            .find(|pkg| pkg.manifest.name == name)
+        else {
+            return ToolExecutionResult::ToolError(format!(
+                "no extension named `{name}` is installed"
+            ));
+        };
+        // Bounded probe: spawn the server, handshake, check, shut down.
+        let report = super::doctor::doctor(
+            &pkg.manifest,
+            &pkg.dir,
+            &self.ctx.workspace_root,
+            std::time::Duration::from_secs(20),
+        )
+        .await;
+        ToolExecutionResult::Success(
+            json!({ "name": name, "ok": report.ok, "checks": report.checks }),
+        )
+    }
 }
 
 #[async_trait]
@@ -209,6 +244,7 @@ impl Tool for ManageTool {
             Verb::Remove => "remove_extension",
             Verb::Enable => "enable_extension",
             Verb::Disable => "disable_extension",
+            Verb::Doctor => "doctor_extension",
         }
     }
 
@@ -225,6 +261,12 @@ impl Tool for ManageTool {
             }
             Verb::Disable => {
                 "Disable an extension without uninstalling it. Effective next session."
+            }
+            Verb::Doctor => {
+                "Conformance-check an installed extension: spawn its server, run the \
+                 protocol handshake, and verify its tools/prompt against the manifest. \
+                 Returns per-check pass/warn/fail. Use to diagnose why an extension \
+                 isn't working."
             }
         }
     }
@@ -257,6 +299,7 @@ impl Tool for ManageTool {
             Verb::Remove => self.remove(&arguments),
             Verb::Enable => self.toggle(&arguments, true),
             Verb::Disable => self.toggle(&arguments, false),
+            Verb::Doctor => self.doctor(&arguments).await,
         }
     }
 }
@@ -286,6 +329,7 @@ mod tests {
         let settings = Arc::new(SettingsStore::open(tmp.join("settings.toml")));
         let cap = ExtensionsCapability {
             extensions_dir: ext_dir.clone(),
+            workspace_root: tmp.to_path_buf(),
             settings: settings.clone(),
             git: Arc::new(crate::extensions::store::SystemGit),
         };

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -3,8 +3,9 @@
 //! the protocol core + persistent process manager + generic
 //! `ExtensionCapability` adapter (phase 1); install/enable management
 //! surface + lockfile (phase 2); contributed MCP servers (phase 3);
-//! hook subscriptions + dynamic prompt over RPC (phase 4). Later: `ui/ask`,
-//! `workspace/changed`, schema-gen + SDKs, `/extensions doctor`, providers.
+//! hook subscriptions + dynamic prompt over RPC (phase 4); the
+//! `doctor_extension` conformance probe (`doctor` module). Later: `ui/ask`,
+//! `workspace/changed`, `crates.io` install, providers.
 //!
 //! Registration: discovered packages are registered in the capability
 //! registry (so they appear in the catalog and validate config) but are
@@ -14,6 +15,7 @@
 
 pub(crate) mod capability;
 pub(crate) mod client;
+pub(crate) mod doctor;
 pub(crate) mod hooks;
 pub(crate) mod manage;
 pub(crate) mod manager;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2463,6 +2463,7 @@ pub async fn build_with_options(
         // The always-on management surface (install/list/enable/remove).
         capabilities.register(crate::extensions::ExtensionsCapability::new(
             ext_dir,
+            effective_root.clone(),
             settings.clone(),
         ));
     }


### PR DESCRIPTION
## What changed

Adds `doctor_extension` — a conformance probe for an installed extension's
capability server, exposed as the sixth tool on the always-on extensions
capability (drive it conversationally: *"doctor the echo extension"*).

Given an installed extension name it spawns the server, runs the YEP
`initialize` handshake, shuts it down, and grades the result against the
package manifest:

- **protocol_version** — server's YEP version is major-compatible with the host
- **tools (D4 clamp)** — the handshake may only *narrow* the manifest's tool
  grant. A tool the server advertises but the manifest doesn't declare is a
  hard **fail** (it would be refused at runtime); a manifest tool the server
  never serves is a **warn**.
- **prompt** — prompt / dynamic_prompt facets are consistent between manifest
  and server.

It returns per-check `pass` / `warn` / `fail` and an overall `ok` (warnings
don't fail). Authors get to validate a server before shipping it without
booting a whole session — the runtime dual of the existing CI schema/drift
guards.

Small structural note: `ExtensionsCapability` now carries `workspace_root`
(threaded from `runtime.rs`) so the probe runs the server with the same cwd
the real harness would.

## Why

Until now the only way to find out why an extension wasn't working was to
enable it and start a session. The clamp, version, and facet rules that govern
whether a server loads were only enforced deep in the runtime. `doctor`
surfaces exactly those rules as an upfront, one-shot diagnostic — the last
open item on the extensions roadmap.

## Before / After

**Before** — no way to check an extension short of enabling it and reading
`RUST_LOG=yolop::ext=debug` from a live session.

**After** — `doctor_extension name=<x>` returns a graded report, e.g. against
the test fixture (serves `echo`, manifest also declares an unserved `unserved`):

```json
{
  "name": "echo",
  "ok": true,
  "checks": [
    { "name": "spawn",            "status": "pass", "detail": "server started" },
    { "name": "handshake",        "status": "pass", "detail": "initialize ok" },
    { "name": "protocol_version", "status": "pass", "detail": "1.0 (compatible)" },
    { "name": "tools",            "status": "warn", "detail": "manifest declares 1 tool(s) the server did not serve: unserved" },
    { "name": "prompt",           "status": "pass", "detail": "prompt facet present" }
  ]
}
```

A missing binary or a widened/incompatible server yields `ok: false` with the
failing check named — never a panic.

## Risk

- Low
- New, additive tool; no existing path changes behavior. The one cross-cutting
  edit is the `ExtensionsCapability::new` signature (added `workspace_root`),
  updated at its single call site in `runtime.rs`.

## Checklist
- [x] Tests added or updated — pure `evaluate()` unit tests (clean / widened /
  incompatible / unserved) plus end-to-end tests spawning the real Python
  fixture server (clean probe + missing-binary spawn failure)
- [x] Backward compatibility considered — pre-1.0; additive tool, no wire change

https://claude.ai/code/session_017d7odSAD8o79pUrd31dpDb

---
_Generated by [Claude Code](https://claude.ai/code/session_017d7odSAD8o79pUrd31dpDb)_