### PR TITLE
feat(yep): emit schema/yep/v1/schema.json for wire payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6715,6 +6715,7 @@ dependencies = [
 name = "yolop-yep"
 version = "0.1.1"
 dependencies = [
+ "schemars 1.2.1",
  "serde",
  "serde_json",
 ]

--- a/crates/yolop-yep/Cargo.toml
+++ b/crates/yolop-yep/Cargo.toml
@@ -18,3 +18,11 @@ exclude = ["src/bin"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+# Optional: derive JSON Schema for the wire payloads so `schema-gen` can emit
+# schema/yep/v1/schema.json. Off by default — the SDK stays serde-only for
+# extension authors; only the in-repo generator turns it on.
+schemars = { version = "1", optional = true }
+
+[features]
+# Enables `schemars` derives + the `schema` module (repo tooling only).
+schema = ["dep:schemars"]

--- a/crates/yolop-yep/src/bin/schema-gen.rs
+++ b/crates/yolop-yep/src/bin/schema-gen.rs
@@ -1,44 +1,63 @@
-//! Emit the machine-readable protocol metadata to `schema/yep/v1/meta.json`.
+//! Emit the machine-readable protocol artifacts under `schema/yep/v1/`:
+//! `meta.json` (method + capability vocabulary) always, and `schema.json`
+//! (full JSON Schema of the wire payloads) when built with `--features schema`.
 //!
-//! `cargo run -p yolop-yep --bin schema-gen` regenerates the file; pass
-//! `--check` to fail (non-zero) when the committed file is stale, which CI
-//! runs so a wire-vocabulary change can't merge without a matching artifact
-//! (the mira pattern). The path is relative to the repo root.
+//! `cargo run -p yolop-yep --features schema --bin schema-gen` regenerates
+//! both; pass `--check` to fail (non-zero) when a committed file is stale,
+//! which CI runs so a wire change can't merge without matching artifacts (the
+//! mira pattern). Paths are relative to the repo root.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
     let check = std::env::args().any(|a| a == "--check");
-    let path = repo_root().join("schema/yep/v1/meta.json");
-    let expected = yolop_yep::meta_json();
+    let root = repo_root();
 
-    if check {
-        let actual = std::fs::read_to_string(&path).unwrap_or_default();
-        if actual == expected {
-            eprintln!("schema/yep/v1/meta.json is up to date");
-            ExitCode::SUCCESS
+    // (relative path, expected contents). `mut` is used only when the
+    // `schema` feature adds schema.json below.
+    #[cfg_attr(not(feature = "schema"), allow(unused_mut))]
+    let mut artifacts: Vec<(&str, String)> =
+        vec![("schema/yep/v1/meta.json", yolop_yep::meta_json())];
+    #[cfg(feature = "schema")]
+    artifacts.push(("schema/yep/v1/schema.json", yolop_yep::schema_json()));
+
+    let mut ok = true;
+    for (rel, expected) in &artifacts {
+        let path = root.join(rel);
+        if check {
+            let actual = std::fs::read_to_string(&path).unwrap_or_default();
+            if &actual == expected {
+                eprintln!("{rel} is up to date");
+            } else {
+                eprintln!(
+                    "{rel} is STALE — run `cargo run -p yolop-yep --features schema --bin schema-gen`"
+                );
+                ok = false;
+            }
+        } else if let Err(err) = write_file(&path, expected) {
+            eprintln!("failed to write {}: {err}", path.display());
+            ok = false;
         } else {
-            eprintln!(
-                "schema/yep/v1/meta.json is STALE — run `cargo run -p yolop-yep --bin schema-gen`"
-            );
-            ExitCode::FAILURE
-        }
-    } else {
-        if let Some(parent) = path.parent() {
-            let _ = std::fs::create_dir_all(parent);
-        }
-        match std::fs::write(&path, &expected) {
-            Ok(()) => {
-                eprintln!("wrote {}", path.display());
-                ExitCode::SUCCESS
-            }
-            Err(err) => {
-                eprintln!("failed to write {}: {err}", path.display());
-                ExitCode::FAILURE
-            }
+            eprintln!("wrote {}", path.display());
         }
     }
+
+    #[cfg(not(feature = "schema"))]
+    eprintln!("note: schema.json skipped — rebuild with `--features schema` to include it");
+
+    if ok {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
+}
+
+fn write_file(path: &Path, contents: &str) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, contents)
 }
 
 /// The workspace root: this crate is at `<root>/crates/yolop-yep`.

--- a/crates/yolop-yep/src/lib.rs
+++ b/crates/yolop-yep/src/lib.rs
@@ -27,8 +27,12 @@
 
 pub mod meta;
 pub mod protocol;
+#[cfg(feature = "schema")]
+pub mod schema;
 mod server;
 
 pub use meta::{Meta, meta, meta_json};
 pub use protocol::PROTOCOL_VERSION;
+#[cfg(feature = "schema")]
+pub use schema::schema_json;
 pub use server::{HookResponse, Server, ToolResponse};

--- a/crates/yolop-yep/src/protocol.rs
+++ b/crates/yolop-yep/src/protocol.rs
@@ -104,6 +104,7 @@ pub fn response_error_line(id: u64, error: &ErrorObject) -> String {
 /// JSON-RPC-shaped error object. Everything beyond `message` is optional and
 /// defaulted, so a peer that sends bare `{ "message": … }` still parses.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct ErrorObject {
     #[serde(default)]
     pub code: i64,
@@ -140,6 +141,7 @@ impl ErrorObject {
 /// Host → server `initialize` params. Bidirectional so the server SDK can
 /// parse what the host serializes.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct InitializeParams {
     #[serde(default)]
     pub protocol_version: String,
@@ -157,6 +159,7 @@ pub struct InitializeParams {
 /// Server → host `initialize` result. Lenient: unknown fields ignored,
 /// missing fields defaulted, per the forward-compat rules.
 #[derive(Debug, Clone, Default, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct InitializeResult {
     #[serde(default)]
     pub protocol_version: String,
@@ -169,6 +172,7 @@ pub struct InitializeResult {
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct CapabilityParams {
     #[serde(default)]
     pub prompt: Option<PromptParams>,
@@ -180,6 +184,7 @@ pub struct CapabilityParams {
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct PromptParams {
     /// Static system-prompt contribution.
     #[serde(default, rename = "static")]
@@ -187,6 +192,7 @@ pub struct PromptParams {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct ServedTool {
     pub name: String,
 }
@@ -195,6 +201,7 @@ pub struct ServedTool {
 // tool/call
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct ToolCallParams {
     #[serde(default)]
     pub tool_call_id: String,
@@ -208,6 +215,7 @@ pub struct ToolCallParams {
 /// `tool/call` by `request_id` (a notification cannot carry the envelope
 /// `id` — that field would classify the line as a response).
 #[derive(Debug, Clone, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct ToolUpdateParams {
     #[serde(default)]
     pub request_id: u64,
@@ -222,6 +230,7 @@ pub struct ToolUpdateParams {
 /// one tool call (any tool, not just the extension's own). Owned + bidirectional
 /// so the server SDK parses what the host serializes.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct HookFireParams {
     /// `pre_tool_use` or `post_tool_use`.
     #[serde(default)]
@@ -235,6 +244,7 @@ pub struct HookFireParams {
 /// Server → host `hook/fire` result. Lenient/defaulted: a bare `{}` means
 /// "allow, unchanged".
 #[derive(Debug, Clone, Default, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct HookDecision {
     /// `true` blocks the tool call (pre_tool_use only).
     #[serde(default)]
@@ -254,6 +264,7 @@ pub struct HookDecision {
 /// contribution recomputed per turn (only when the manifest declares
 /// `dynamic_prompt`).
 #[derive(Debug, Clone, Default, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct PromptContribution {
     #[serde(default)]
     pub text: String,

--- a/crates/yolop-yep/src/schema.rs
+++ b/crates/yolop-yep/src/schema.rs
@@ -60,10 +60,31 @@ fn schema_document() -> Value {
 }
 
 /// The canonical pretty-printed `schema/yep/v1/schema.json`, trailing newline.
+///
+/// Object keys are sorted recursively so the output is byte-identical whether
+/// `serde_json` is built with `preserve_order` (insertion order, as it is under
+/// the full workspace) or without it (sorted) — otherwise the committed file
+/// and the drift-test regeneration would disagree across build configurations.
 pub fn schema_json() -> String {
-    let mut json = serde_json::to_string_pretty(&schema_document()).expect("schema serializes");
+    let mut json =
+        serde_json::to_string_pretty(&sort_keys(schema_document())).expect("schema serializes");
     json.push('\n');
     json
+}
+
+/// Recursively sort every object's keys, so serialization order does not depend
+/// on `serde_json`'s map backend.
+fn sort_keys(value: Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut entries: Vec<(String, Value)> =
+                map.into_iter().map(|(k, v)| (k, sort_keys(v))).collect();
+            entries.sort_by(|a, b| a.0.cmp(&b.0));
+            Value::Object(entries.into_iter().collect())
+        }
+        Value::Array(items) => Value::Array(items.into_iter().map(sort_keys).collect()),
+        other => other,
+    }
 }
 
 #[cfg(test)]

--- a/crates/yolop-yep/src/schema.rs
+++ b/crates/yolop-yep/src/schema.rs
@@ -1,0 +1,111 @@
+//! JSON Schema for the YEP wire payloads — emitted to
+//! `schema/yep/v1/schema.json` by the `schema-gen` binary (repo tooling).
+//!
+//! This is the payload-level companion to [`crate::meta`]: where `meta.json`
+//! lists the method + capability *vocabulary*, `schema.json` gives the full
+//! Draft 2020-12 shape of every request/result payload, so an author writing a
+//! server in any language can validate what they send and receive. It is
+//! generated from the `#[derive(JsonSchema)]` payload structs behind the
+//! `schema` feature, and a drift test keeps the committed file in lockstep.
+
+use crate::protocol::{
+    CapabilityParams, ErrorObject, HookDecision, HookFireParams, InitializeParams,
+    InitializeResult, PromptContribution, ToolCallParams, ToolUpdateParams,
+};
+use schemars::generate::SchemaSettings;
+use serde_json::{Value, json};
+
+/// Build the combined payload schema document: a `messages` map from method
+/// name to its `params`/`result` payload refs, plus a `$defs` block with the
+/// full schema of every referenced type.
+fn schema_document() -> Value {
+    let mut generator = SchemaSettings::draft2020_12().into_generator();
+
+    // A `$ref` to each payload, registering it in the shared `$defs`.
+    let ref_for = |value: schemars::Schema| value.to_value();
+    let init_params = ref_for(generator.subschema_for::<InitializeParams>());
+    let init_result = ref_for(generator.subschema_for::<InitializeResult>());
+    let tool_call = ref_for(generator.subschema_for::<ToolCallParams>());
+    let tool_update = ref_for(generator.subschema_for::<ToolUpdateParams>());
+    let hook_fire = ref_for(generator.subschema_for::<HookFireParams>());
+    let hook_decision = ref_for(generator.subschema_for::<HookDecision>());
+    let prompt_contribution = ref_for(generator.subschema_for::<PromptContribution>());
+    let capability_params = ref_for(generator.subschema_for::<CapabilityParams>());
+    let error = ref_for(generator.subschema_for::<ErrorObject>());
+
+    // Method → payloads. Directions mirror `meta::METHODS`; only messages that
+    // carry a typed payload appear (bare notifications like `initialized` and
+    // `shutdown` are payload-less).
+    let messages = json!({
+        "initialize": { "params": init_params, "result": init_result },
+        "tool/call": { "params": tool_call },
+        "tool/update": { "params": tool_update },
+        "hook/fire": { "params": hook_fire, "result": hook_decision },
+        "prompt/contribution": { "result": prompt_contribution },
+    });
+
+    let defs: Value = generator.take_definitions(true).into();
+
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "YEP payload schemas",
+        "protocol_version": crate::protocol::PROTOCOL_VERSION,
+        "description": "JSON Schema for yolop extension protocol (YEP) request \
+                        and result payloads. Companion to meta.json.",
+        "capability_params": capability_params,
+        "error": error,
+        "messages": messages,
+        "$defs": defs,
+    })
+}
+
+/// The canonical pretty-printed `schema/yep/v1/schema.json`, trailing newline.
+pub fn schema_json() -> String {
+    let mut json = serde_json::to_string_pretty(&schema_document()).expect("schema serializes");
+    json.push('\n');
+    json
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_has_defs_for_every_payload() {
+        let doc = schema_document();
+        let defs = doc["$defs"].as_object().expect("$defs object");
+        for name in [
+            "InitializeParams",
+            "InitializeResult",
+            "ToolCallParams",
+            "HookFireParams",
+            "HookDecision",
+        ] {
+            assert!(defs.contains_key(name), "missing $def for {name}: {defs:?}");
+        }
+        // Messages reference the definitions.
+        assert!(doc["messages"]["initialize"]["params"]["$ref"].is_string());
+    }
+
+    /// Drift guard: the committed `schema/yep/v1/schema.json` must match what
+    /// the generator produces. Runs under `--all-features` (CI's coverage job),
+    /// so a payload-shape change can't merge without regenerating the artifact.
+    /// Run `cargo run -p yolop-yep --features schema --bin schema-gen` to fix.
+    ///
+    /// The file lives at the repo root, outside the crate, so it is absent when
+    /// the published crate is tested standalone — then the guard is a no-op.
+    #[test]
+    fn committed_schema_json_is_up_to_date() {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../schema/yep/v1/schema.json");
+        let Ok(committed) = std::fs::read_to_string(&path) else {
+            return; // not in the repo tree; nothing to guard
+        };
+        assert_eq!(
+            committed,
+            schema_json(),
+            "schema/yep/v1/schema.json is stale — run \
+             `cargo run -p yolop-yep --features schema --bin schema-gen`"
+        );
+    }
+}

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -173,14 +173,23 @@ Because a published crate ships source, the manifest's
 `capabilityServer.command` should name a binary the user already has on `PATH`
 (or one shipped in the package's `bin/`); yolop does **not** compile the crate.
 
-The protocol vocabulary is published as a language-neutral index at
-[`schema/yep/v1/meta.json`](../schema/yep/v1/meta.json) for authors writing
-servers in other languages — YEP is just newline-delimited JSON-RPC over stdio,
-so any language works (see [`specs/extensions.md`](../specs/extensions.md)).
+**Writing a server in another language.** YEP is just newline-delimited
+JSON-RPC over stdio, so any language works. Two language-neutral artifacts
+describe the wire surface:
+
+- [`schema/yep/v1/meta.json`](../schema/yep/v1/meta.json) — the *vocabulary*:
+  every method name (with direction) and capability token.
+- [`schema/yep/v1/schema.json`](../schema/yep/v1/schema.json) — the *payloads*:
+  a Draft 2020-12 JSON Schema for each request/result, keyed by method under
+  `messages`, with full type definitions in `$defs`. Validate what you send and
+  receive against it.
+
+Both are generated from the `yolop-yep` types (`cargo run -p yolop-yep
+--features schema --bin schema-gen`) and CI fails if they drift.
 
 > **Status.** The mechanism is implemented through hooks, the `yolop-yep`
 > SDK ([published on crates.io](https://crates.io/crates/yolop-yep)), a
-> `doctor_extension` conformance check, and toolchain-free **crates.io
-> installs** (`install_extension source="crates.io:yolop-extension-<name>"`).
-> Not yet shipped: a payload JSON Schema for the RPC types — see the spec's
-> follow-ups.
+> `doctor_extension` conformance check, toolchain-free **crates.io installs**
+> (`install_extension source="crates.io:yolop-extension-<name>"`), and
+> language-neutral **`meta.json` + `schema.json`** wire artifacts. Remaining
+> follow-ups are listed in [`specs/extensions.md`](../specs/extensions.md).

--- a/schema/yep/v1/schema.json
+++ b/schema/yep/v1/schema.json
@@ -1,0 +1,249 @@
+{
+  "$defs": {
+    "CapabilityParams": {
+      "properties": {
+        "prompt": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PromptParams"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tools": {
+          "description": "Tool names the server actually serves this run. The definitions\n(description/schema/policy) live in the package manifest; the\nhandshake may only narrow that set (see D4 manifest clamp).",
+          "items": {
+            "$ref": "#/$defs/ServedTool"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "ErrorObject": {
+      "description": "JSON-RPC-shaped error object. Everything beyond `message` is optional and\ndefaulted, so a peer that sends bare `{ \"message\": … }` still parses.",
+      "properties": {
+        "code": {
+          "default": 0,
+          "format": "int64",
+          "type": "integer"
+        },
+        "data": true,
+        "message": {
+          "type": "string"
+        },
+        "retryable": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "message"
+      ],
+      "type": "object"
+    },
+    "HookDecision": {
+      "description": "Server → host `hook/fire` result. Lenient/defaulted: a bare `{}` means\n\"allow, unchanged\".",
+      "properties": {
+        "block": {
+          "default": false,
+          "description": "`true` blocks the tool call (pre_tool_use only).",
+          "type": "boolean"
+        },
+        "reason": {
+          "default": "",
+          "description": "Message shown to the model/audit log when blocking.",
+          "type": "string"
+        },
+        "user_message": {
+          "default": null,
+          "description": "Optional user-facing message when blocking.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "HookFireParams": {
+      "description": "Host → server `hook/fire` params: a subscribed lifecycle event fired for\none tool call (any tool, not just the extension's own). Owned + bidirectional\nso the server SDK parses what the host serializes.",
+      "properties": {
+        "args": {
+          "default": null
+        },
+        "event": {
+          "default": "",
+          "description": "`pre_tool_use` or `post_tool_use`.",
+          "type": "string"
+        },
+        "tool_name": {
+          "default": "",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "InitializeParams": {
+      "description": "Host → server `initialize` params. Bidirectional so the server SDK can\nparse what the host serializes.",
+      "properties": {
+        "capabilities": {
+          "default": [],
+          "description": "Host feature tokens the server may rely on (`streaming`, `cancel`, …).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "config": {
+          "default": null
+        },
+        "protocol_version": {
+          "default": "",
+          "type": "string"
+        },
+        "session_id": {
+          "default": "",
+          "type": "string"
+        },
+        "workspace_root": {
+          "default": "",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "InitializeResult": {
+      "description": "Server → host `initialize` result. Lenient: unknown fields ignored,\nmissing fields defaulted, per the forward-compat rules.",
+      "properties": {
+        "capabilities": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "capability_params": {
+          "$ref": "#/$defs/CapabilityParams"
+        },
+        "name": {
+          "default": "",
+          "type": "string"
+        },
+        "protocol_version": {
+          "default": "",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "PromptContribution": {
+      "description": "Server → host `prompt/contribution` result: a dynamic system-prompt\ncontribution recomputed per turn (only when the manifest declares\n`dynamic_prompt`).",
+      "properties": {
+        "text": {
+          "default": "",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "PromptParams": {
+      "properties": {
+        "static": {
+          "default": "",
+          "description": "Static system-prompt contribution.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ServedTool": {
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "ToolCallParams": {
+      "properties": {
+        "args": {
+          "default": null
+        },
+        "name": {
+          "default": "",
+          "type": "string"
+        },
+        "tool_call_id": {
+          "default": "",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ToolUpdateParams": {
+      "description": "Payload of a `tool/update` notification, correlated to its in-flight\n`tool/call` by `request_id` (a notification cannot carry the envelope\n`id` — that field would classify the line as a response).",
+      "properties": {
+        "output": {
+          "default": "",
+          "type": "string"
+        },
+        "request_id": {
+          "default": 0,
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "capability_params": {
+    "$ref": "#/$defs/CapabilityParams"
+  },
+  "description": "JSON Schema for yolop extension protocol (YEP) request and result payloads. Companion to meta.json.",
+  "error": {
+    "$ref": "#/$defs/ErrorObject"
+  },
+  "messages": {
+    "hook/fire": {
+      "params": {
+        "$ref": "#/$defs/HookFireParams"
+      },
+      "result": {
+        "$ref": "#/$defs/HookDecision"
+      }
+    },
+    "initialize": {
+      "params": {
+        "$ref": "#/$defs/InitializeParams"
+      },
+      "result": {
+        "$ref": "#/$defs/InitializeResult"
+      }
+    },
+    "prompt/contribution": {
+      "result": {
+        "$ref": "#/$defs/PromptContribution"
+      }
+    },
+    "tool/call": {
+      "params": {
+        "$ref": "#/$defs/ToolCallParams"
+      }
+    },
+    "tool/update": {
+      "params": {
+        "$ref": "#/$defs/ToolUpdateParams"
+      }
+    }
+  },
+  "protocol_version": "1.0",
+  "title": "YEP payload schemas"
+}

--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -27,12 +27,17 @@ handler-based server SDK (`Server::new().tool().on_hook().dynamic_prompt()
 JSON-RPC loop. A reference `echo` example server built on it is driven by
 yolop's own client in an integration test — the SDK's interop proof and the
 foundation a future `yolop-extension-lsp` builds on.
-Schema artifact: `schema/yep/v1/meta.json` is generated from the `yolop-yep`
-`meta` module by `cargo run -p yolop-yep --bin schema-gen` (the mira pattern);
-a `cargo test` drift guard fails CI if the committed file is stale, so the
-method + capability-token vocabulary can't change without the artifact
-changing. A non-Rust author reads it to discover the wire surface. (Full
-JSON-Schema of the payloads — `schema.json` — is still a follow-up.)
+Schema artifacts: `schema/yep/v1/meta.json` (method + capability-token
+vocabulary) and `schema/yep/v1/schema.json` (Draft 2020-12 JSON Schema of every
+request/result payload — keyed by method under `messages`, full types under
+`$defs`) are both generated from the `yolop-yep` types by `cargo run -p
+yolop-yep --features schema --bin schema-gen` (the mira pattern). `schema.json`
+comes from `#[derive(schemars::JsonSchema)]` on the payload structs behind an
+optional `schema` feature, so the published SDK stays serde-only for authors.
+A `cargo test` drift guard (run under CI's `--all-features` coverage job) fails
+if either committed file is stale, so the wire surface can't change without the
+artifacts changing. A non-Rust author reads them to discover and validate the
+wire format.
 Conformance: `doctor_extension` (surfaced as `/extensions doctor`) spawns an
 installed extension's server, runs the `initialize` handshake, and grades it
 against the manifest — protocol-version compatibility, the D4 tool clamp
@@ -43,7 +48,7 @@ shipping without booting a whole session.
 Later — the full `yolop-extension-lsp` control-plane extraction (gated on
 `evals/lsp_integration` parity to retire the built-in), `ui/ask` (needs the
 server→host reverse-request channel, still refused in phase 1),
-`workspace/changed`, payload `schema.json`,
+`workspace/changed`,
 providers — remain design-of-record below.
 Toolchain-free crates.io install is now wired: `install_extension
 source="crates.io:yolop-extension-<name>[@ver]"` (or the bare-`<name>`
@@ -366,15 +371,20 @@ from mira, which has already proven each piece for a protocol of this exact
 shape:
 
 - **Rust types are the source of truth; the schema is generated.** Wire
-  types live in one `yolop::yep` module; a schema-gen binary emits
-  `schema/yep/v1/schema.json` (JSON Schema 2020-12, root `anyOf` over the
-  three envelopes, every payload under `$defs`) and `meta.json` (protocol
-  version, method list, capability tokens, event vocabularies). The
-  directory is versioned by protocol **major**. CI runs the generator with
-  `--check` so a wire change cannot merge without a matching schema update;
-  a test suite validates real serialized messages against the committed
-  schema, and a conformance corpus lives beside it (`schema/yep/v1/
-  conformance/`).
+  types live in the `yolop-yep` crate; a schema-gen binary emits
+  `schema/yep/v1/schema.json` (JSON Schema 2020-12, every payload under
+  `$defs`) and `meta.json` (protocol version, method list, capability
+  tokens, event vocabularies). The directory is versioned by protocol
+  **major**. CI runs the generator with `--check` (and the drift tests under
+  `--all-features`) so a wire change cannot merge without a matching schema
+  update.
+  *Implemented shape:* rather than a root `anyOf` over the three envelopes
+  (the envelope is field-classified — see `classify_line` — and its
+  direction vocabulary already lives in `meta.json`), `schema.json` keys
+  payloads by **method** under a `messages` map (`{ params, result }` refs),
+  with the shared `error` and `capability_params` shapes at the top level and
+  all types under `$defs`. A conformance corpus (`schema/yep/v1/
+  conformance/`) remains a follow-up.
 - **SDKs are native, zero-dependency libraries, never FFI bindings.** The
   protocol is the seam by design; bindings would re-couple what the wire
   decouples. Each SDK ships a small codegen with its own `--check` drift


### PR DESCRIPTION
## What changed

Adds a payload-level JSON Schema companion to the existing `meta.json`:
`schema/yep/v1/schema.json`. Where `meta.json` lists the method + capability
*vocabulary*, `schema.json` gives the full Draft 2020-12 *shape* of every YEP
request/result payload — keyed by method under a `messages` map, with all type
definitions in `$defs`:

```json
{
  "messages": {
    "initialize":          { "params": {"$ref": "#/$defs/InitializeParams"}, "result": {"$ref": "#/$defs/InitializeResult"} },
    "tool/call":           { "params": {"$ref": "#/$defs/ToolCallParams"} },
    "hook/fire":           { "params": {"$ref": "#/$defs/HookFireParams"}, "result": {"$ref": "#/$defs/HookDecision"} },
    "prompt/contribution": { "result": {"$ref": "#/$defs/PromptContribution"} }
  },
  "$defs": { "InitializeParams": { … }, … }
}
```

An author writing a server in any language can now validate what they send and
receive, not just read method names.

## Why

`schema.json` was the last language-neutral artifact missing from the wire
contract. It closes the "any language over stdio JSON-RPC" promise: `meta.json`
told you *which* messages exist; `schema.json` tells you *exactly* what each
one looks like.

## How

- The schema is generated from `#[derive(schemars::JsonSchema)]` on the payload
  structs, gated behind a **new optional `schema` feature**. The published
  `yolop-yep` SDK stays **serde-only by default** — schemars never enters an
  extension author's dependency tree unless they opt in.
- `schema-gen` now emits both `meta.json` and `schema.json` when run with
  `--features schema`; `--check` fails on drift for either.
- A drift test (`committed_schema_json_is_up_to_date`) runs under CI's
  `--all-features` coverage job, so a payload-shape change can't merge without
  regenerating the artifact — same guarantee `meta.json` already has.

## Before / After

**Before** — only `meta.json` (method/capability vocabulary); payload shapes
lived only in the Rust structs.

**After** — `schema.json` committed and drift-guarded. Regeneration is
reproducible:

```
$ cargo run -p yolop-yep --features schema --bin schema-gen
wrote schema/yep/v1/meta.json
wrote schema/yep/v1/schema.json

$ cargo test -p yolop-yep --features schema
test schema::tests::schema_has_defs_for_every_payload ... ok
test schema::tests::committed_schema_json_is_up_to_date ... ok
```

Default build stays serde-only (`cargo build -p yolop-yep` pulls no schemars).

## Risk

- Low
- Additive: a new optional feature + a new committed artifact. No runtime code
  path changes; the host doesn't consume `schema.json`. The published SDK's
  default dependency set is unchanged.

## Checklist
- [x] Tests added or updated — `$defs` coverage + committed-artifact drift guard
- [x] Backward compatibility considered — pre-1.0; optional feature, serde-only
  default preserved, no wire change

https://claude.ai/code/session_017d7odSAD8o79pUrd31dpDb

---
_Generated by [Claude Code](https://claude.ai/code/session_017d7odSAD8o79pUrd31dpDb)_