### PR TITLE
fix(ci): raise search-efficiency-eval timeout for slow provider days

### DIFF
--- a/.github/workflows/search-efficiency-eval.yml
+++ b/.github/workflows/search-efficiency-eval.yml
@@ -22,7 +22,11 @@ jobs:
     name: Preserved-baseline regression
     if: github.repository == 'everruns/yolop'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # Live-provider latency is variable: focused cases alone have taken
+    # 43+ minutes in observed runs. 60 minutes left no room for the control
+    # trials and cut the 2026-07-16 nightly off mid-step (cancelled, not
+    # a real regression). 120 minutes gives headroom for slow provider days.
+    timeout-minutes: 120
     env:
       DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
       HARNESS_BASIC_BASELINE_BIN: ${{ github.workspace }}/target/yolop-eval-bin/baseline/yolop


### PR DESCRIPTION
## What changed
Raises the `Search Efficiency Eval` nightly job's `timeout-minutes` from 60 to 120.

## Why
The 2026-07-16 nightly run ([run 29479066126](https://github.com/everruns/yolop/actions/runs/29479066126)) was cancelled, not failed on the merits: `Run focused search cases` alone took 43 minutes (07:17–08:00 UTC), leaving only ~11 of the 60-minute job budget for `Run ordinary controls`, which GitHub cut off mid-step before the regression gate could even run. The prior nightly (run 2, 2026-07-15) completed the full job in ~10 minutes, so live-provider latency is the variable here, not the codebase. 60 minutes doesn't leave enough headroom for slower provider days.

## Before / After
Before: job `timeout-minutes: 60` — cancelled on 2026-07-16 mid "Run ordinary controls" step, gate skipped.
After: job `timeout-minutes: 120` — same steps get room to finish even when focused-case trials run long.

No code paths change; this is a CI configuration adjustment only.

## Risk
- Low
- Worst case: a genuinely hung job now takes up to 120 minutes to be killed instead of 60. The job is `schedule`/`workflow_dispatch` only (no PR-blocking dependency), so this doesn't slow down PR merges.

## Checklist
- [ ] Tests added or updated — not applicable, CI config only
- [x] Backward compatibility considered — no behavior change, pre-1.0


---
_Generated by [Claude Code](https://claude.ai/code/session_011hFMjinefTcH5AR9ZNqK3B)_