### PR TITLE
feat(tui): experimental full-screen renderer (tuika) behind --fullscreen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6706,6 +6706,7 @@ dependencies = [
  "tree-sitter-sequel",
  "tree-sitter-typescript",
  "tree-sitter-zig",
+ "unicode-width 0.2.2",
  "urlencoding",
  "vt100",
  "yolop-yep",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ yolop-yep = { version = "0.1.1", path = "crates/yolop-yep" }
 sha2 = "0.11"
 toml = "1"
 textwrap = "0.16"
+unicode-width = "0.2"
 tokio = { version = "1.52", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tree-sitter = "0.26"

--- a/src/app/fullscreen.rs
+++ b/src/app/fullscreen.rs
@@ -1,0 +1,151 @@
+//! Experimental full-screen renderer (opt-in via `--fullscreen`).
+//!
+//! Where the inline renderer (`super::render::draw`) pushes the transcript into
+//! native terminal scrollback and owns only a bottom composer, this path owns
+//! the whole alternate screen and rebuilds the frame from `App` state every
+//! draw through the [`crate::tuika`] toolkit: a scrollable transcript, a
+//! bordered composer, and a status bar, with setup rendered as a centered
+//! overlay. The transcript lives in `App::lines` and is windowed by
+//! `App::scroll` rather than handed to the terminal — the deliberate trade for
+//! clean overlays and resize behavior.
+//!
+//! This is intentionally a subset of the inline renderer's affordances; it is
+//! the foundation for the full-screen mode, not yet at parity.
+
+use ratatui::Frame;
+use ratatui::layout::Position;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+
+use crate::tuika::{
+    self, Boxed, Flex, Overlay, OverlaySpec, Paragraph, Scroll, StatusBar, Text, Theme, element,
+};
+
+use super::App;
+
+/// Border (2) + horizontal padding (2) a [`Boxed`] adds around its child.
+const BOX_H_CHROME: u16 = 4;
+/// Border rows (top + bottom) a [`Boxed`] adds around its child.
+const BOX_V_CHROME: u16 = 2;
+const STATUS_ROWS: u16 = 1;
+/// Cap the composer so a huge paste cannot swallow the transcript.
+const MAX_COMPOSER_ROWS: u16 = 10;
+
+pub(crate) fn draw(f: &mut Frame, app: &mut App) {
+    let area = f.area();
+    let theme = Theme::default();
+    if area.width < 4 || area.height < 6 {
+        return;
+    }
+
+    let transcript_inner_w = area.width.saturating_sub(BOX_H_CHROME).max(1);
+
+    // Whole transcript, wrapped through the shared presenter so full-screen and
+    // inline render identical line content.
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    for chat in &app.lines {
+        super::append_chat_lines(&mut lines, chat, transcript_inner_w as usize);
+    }
+    let content_h = lines.len() as u16;
+
+    // Composer geometry.
+    let composer_text = app.input.lines().join("\n");
+    let composer_rows = (app.input.lines().len() as u16).clamp(1, MAX_COMPOSER_ROWS);
+    let composer_box_h = composer_rows + BOX_V_CHROME;
+
+    // Transcript box gets whatever height is left after the composer + status.
+    let transcript_box_h = area
+        .height
+        .saturating_sub(STATUS_ROWS + composer_box_h)
+        .max(BOX_V_CHROME + 1);
+    let transcript_inner_h = transcript_box_h.saturating_sub(BOX_V_CHROME).max(1);
+
+    // Reconcile scroll with the freshly measured content, and record metrics so
+    // the mouse-wheel handler can scroll without re-laying out.
+    app.scroll.clamp(content_h, transcript_inner_h);
+    app.scroll_metrics = (content_h, transcript_inner_h);
+    let scroll_state = app.scroll;
+
+    // Status bar segments.
+    let ps = app.presentation_state();
+    let mut left = vec![
+        Span::styled(
+            format!(" {} ", ps.model_id),
+            Style::default()
+                .fg(theme.accent)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(format!("· {} ", ps.provider_name), theme.muted_style()),
+    ];
+    if app.busy {
+        left.push(Span::styled("· working…", theme.muted_style()));
+    }
+    let mut right = Vec::new();
+    if let Some(tokens) = ps.session_tokens {
+        right.push(Span::styled(format!("{tokens} tok  "), theme.muted_style()));
+    }
+    right.push(Span::styled(
+        format!("{}  ", ps.approval_mode),
+        Style::default().fg(theme.accent_alt),
+    ));
+
+    // Compose the base tree.
+    let transcript = Boxed::new(element(Scroll::new(lines, &scroll_state))).title(Line::from(
+        Span::styled(" transcript ", theme.accent_style()),
+    ));
+    let composer_title = if scroll_state.is_stuck_to_bottom() {
+        " message "
+    } else {
+        " message · scrolled up (End to resume) "
+    };
+    let composer = Boxed::new(element(Paragraph::new(composer_text, theme.text_style()))).title(
+        Line::from(Span::styled(composer_title, theme.muted_style())),
+    );
+    let status = StatusBar::new()
+        .left(left)
+        .right(right)
+        .background(Style::default().bg(theme.surface));
+
+    let root = Flex::column()
+        .grow(1, element(transcript))
+        .fixed(composer_box_h, element(composer))
+        .fixed(STATUS_ROWS, element(status));
+
+    // Setup renders as a centered overlay; declared before `overlays` so it
+    // outlives the borrow held in the `Overlay`.
+    let setup_view = if app.setup.is_some() {
+        let (setup_lines, _cursor) = super::setup_overlay_content(app);
+        Some(
+            Boxed::new(element(Text::new(setup_lines)))
+                .title(Line::from(Span::styled(" setup ", theme.accent_style()))),
+        )
+    } else {
+        None
+    };
+    let mut overlays: Vec<Overlay> = Vec::new();
+    if let Some(view) = setup_view.as_ref() {
+        let rect = OverlaySpec::centered(60, 60).min_size(32, 8).resolve(area);
+        overlays.push(Overlay {
+            area: rect,
+            view,
+            clear: true,
+        });
+    }
+
+    tuika::paint(f.buffer_mut(), area, &theme, &root, &overlays);
+
+    // Park the terminal cursor in the composer (only when no overlay owns input).
+    if app.setup.is_none() {
+        let cursor = app.input.cursor();
+        let (crow, ccol) = (cursor.0, cursor.1);
+        let inner_x = area.x + 2; // border + left pad
+        let inner_y = area.y + transcript_box_h + 1; // composer border top
+        let cursor_x = (inner_x + ccol as u16).min(area.right().saturating_sub(1));
+        let max_y = inner_y + composer_rows.saturating_sub(1);
+        let cursor_y = (inner_y + crow as u16).min(max_y);
+        f.set_cursor_position(Position {
+            x: cursor_x,
+            y: cursor_y,
+        });
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -34,6 +34,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, oneshot};
 
+mod fullscreen;
 mod markdown_table;
 mod render;
 mod setup;
@@ -160,6 +161,31 @@ pub struct App {
     pending_images: Vec<ContentPart>,
     /// Large paste placeholders mapped to their full clipboard/terminal payloads.
     pending_pastes: Vec<(String, String)>,
+    /// Which renderer this session drives. `Inline` is the default
+    /// scrollback-native composer; `Fullscreen` is the experimental
+    /// alternate-screen `tuika` renderer (`--fullscreen`).
+    render_mode: RenderMode,
+    /// Full-screen transcript scroll position (unused in inline mode).
+    scroll: crate::tuika::ScrollState,
+    /// Last (content_height, viewport_height) the full-screen transcript drew,
+    /// so mouse/paging handlers can clamp scrolling without re-laying out.
+    scroll_metrics: (u16, u16),
+}
+
+/// The renderer backing a TUI session.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum RenderMode {
+    /// Scrollback-native inline composer (default).
+    #[default]
+    Inline,
+    /// Experimental full-screen alternate-screen renderer (`tuika`).
+    Fullscreen,
+}
+
+impl RenderMode {
+    pub(crate) fn is_fullscreen(self) -> bool {
+        matches!(self, RenderMode::Fullscreen)
+    }
 }
 
 /// Result of one background models API fetch. `Ok(None)` means the provider
@@ -393,6 +419,9 @@ impl App {
             workspace_host: runtime.workspace_host,
             pending_images,
             pending_pastes: Vec::new(),
+            render_mode: RenderMode::default(),
+            scroll: crate::tuika::ScrollState::new(),
+            scroll_metrics: (0, 0),
         };
         app.emit_system_banner();
         if should_setup {
@@ -411,6 +440,12 @@ impl App {
             app.start_turn(condition);
         }
         app
+    }
+
+    /// Switch this session to the experimental full-screen renderer. Called by
+    /// `run_tui` before the loop when `--fullscreen` is set.
+    pub(crate) fn set_render_mode(&mut self, mode: RenderMode) {
+        self.render_mode = mode;
     }
 
     pub fn should_show_resume_hint(&self) -> bool {
@@ -643,13 +678,21 @@ impl App {
         B: Backend,
         B::Error: std::error::Error + Send + Sync + 'static,
     {
-        self.flush_transcript(terminal)?;
+        // Inline mode streams finalized lines into native scrollback via
+        // `insert_before`; full-screen keeps the whole transcript in `lines`
+        // and redraws it into the alternate screen each frame, so it skips both
+        // the flush and the inline-viewport re-anchoring.
+        if !self.render_mode.is_fullscreen() {
+            self.flush_transcript(terminal)?;
+        }
         self.refresh_session_tasks_if_due().await;
-        // Ratatui keeps an inline viewport's cursor offset across resizes and
-        // resets its origin on horizontal shrinks. Normalize the viewport to
-        // the terminal bottom before every draw.
         terminal.autoresize()?;
-        maybe_reanchor_inline_viewport(terminal)?;
+        if !self.render_mode.is_fullscreen() {
+            // Ratatui keeps an inline viewport's cursor offset across resizes
+            // and resets its origin on horizontal shrinks. Normalize the
+            // viewport to the terminal bottom before every draw.
+            maybe_reanchor_inline_viewport(terminal)?;
+        }
         terminal.draw(|f| draw(f, self))?;
 
         // 1) drain background turn events
@@ -756,6 +799,10 @@ impl App {
                     self.handle_key(key).await;
                 }
                 CrosstermEvent::Mouse(mouse) => {
+                    if self.render_mode.is_fullscreen() && self.handle_fullscreen_scroll(mouse.kind)
+                    {
+                        continue;
+                    }
                     let area = terminal.get_frame().area();
                     if self.handle_mouse(mouse, area) {
                         return Ok(());
@@ -1392,6 +1439,24 @@ impl App {
             StatusLayout::Compact => StatusLayout::Expanded,
             StatusLayout::Expanded => StatusLayout::Compact,
         };
+    }
+
+    /// Route a mouse-wheel event to the full-screen transcript scroll. Returns
+    /// true when consumed. Uses the metrics recorded by the last full-screen
+    /// draw so it need not re-run layout.
+    fn handle_fullscreen_scroll(&mut self, kind: MouseEventKind) -> bool {
+        let tuika_kind = match kind {
+            MouseEventKind::ScrollUp => crate::tuika::MouseKind::ScrollUp,
+            MouseEventKind::ScrollDown => crate::tuika::MouseKind::ScrollDown,
+            _ => return false,
+        };
+        let (content_h, viewport_h) = self.scroll_metrics;
+        let event = crate::tuika::Event::Mouse(crate::tuika::Mouse {
+            kind: tuika_kind,
+            column: 0,
+            row: 0,
+        });
+        self.scroll.handle(&event, content_h, viewport_h).consumed()
     }
 
     fn handle_mouse(&mut self, mouse: MouseEvent, terminal_area: Rect) -> bool {
@@ -3378,6 +3443,54 @@ mod tests {
                 row.trim_end().to_string()
             })
             .collect()
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fullscreen_renders_transcript_composer_and_status() {
+        let mut test = app_with_llmsim().await;
+        test.app.set_render_mode(RenderMode::Fullscreen);
+        // Dismiss the first-run setup overlay so the base transcript is visible;
+        // overlay compositing is covered by the tuika suite.
+        test.app.setup = None;
+        test.app.push_user("hello from user".to_string());
+        test.app.input.insert_str("draft reply");
+
+        // `Terminal::new` (used by `render_app_lines`) defaults to a full
+        // viewport, matching the `--fullscreen` runtime path.
+        let rows = render_app_lines(&mut test.app, 60, 20);
+        let joined = rows.join("\n");
+
+        assert!(
+            joined.contains("hello from user"),
+            "transcript should render in the full-screen body: {joined}"
+        );
+        assert!(
+            joined.contains("draft reply"),
+            "composer text should render in the full-screen composer: {joined}"
+        );
+        assert!(
+            joined.contains("llmsim"),
+            "status bar should surface the provider: {joined}"
+        );
+        assert!(
+            joined.contains('╭'),
+            "full-screen chrome should draw rounded tuika borders: {joined}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fullscreen_scroll_wheel_unsticks_from_bottom() {
+        let mut test = app_with_llmsim().await;
+        test.app.set_render_mode(RenderMode::Fullscreen);
+        for i in 0..80 {
+            test.app.push_user(format!("line {i}"));
+        }
+        // Draw once so scroll metrics reflect the tall transcript.
+        let _ = render_app_lines(&mut test.app, 40, 12);
+        assert!(test.app.scroll.is_stuck_to_bottom());
+        // A wheel-up should be consumed and detach from the bottom.
+        assert!(test.app.handle_fullscreen_scroll(MouseEventKind::ScrollUp));
+        assert!(!test.app.scroll.is_stuck_to_bottom());
     }
 
     fn setup_overlay_text(app: &App) -> Vec<String> {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -32,6 +32,10 @@ impl StreamKind {
 }
 
 pub(crate) fn draw(f: &mut ratatui::Frame, app: &mut App) {
+    if app.render_mode.is_fullscreen() {
+        super::fullscreen::draw(f, app);
+        return;
+    }
     let area = f.area();
     // Inline viewports cannot place a true full-screen modal above terminal
     // scrollback. Treat overlays as sheets that own this complete viewport so

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ mod settings;
 mod test_env;
 mod tools;
 mod transcript;
+mod tuika;
 mod user_ask;
 mod version;
 mod workspace_host;
@@ -146,6 +147,13 @@ struct Cli {
     /// `specs/trajectory.md`.
     #[arg(long, value_name = "PATH")]
     trajectory_out: Option<PathBuf>,
+
+    /// EXPERIMENTAL: render the interactive TUI full-screen on the alternate
+    /// screen (via the `tuika` toolkit) instead of the default inline
+    /// scrollback composer. Overlays and scrolling are owned in-app; native
+    /// terminal scrollback is unavailable in this mode.
+    #[arg(long)]
+    fullscreen: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -558,7 +566,7 @@ async fn main() -> Result<()> {
         return run_print_mode(runtime, prompt, image_parts, cli.trajectory_out).await;
     }
     let pending_images = image_input::load_image_parts(&cli.images)?;
-    run_tui(runtime, pending_images, cli.trajectory_out).await
+    run_tui(runtime, pending_images, cli.trajectory_out, cli.fullscreen).await
 }
 
 fn resolve_workspace_root(
@@ -896,6 +904,7 @@ async fn run_tui(
     runtime: BuiltRuntime,
     pending_images: Vec<ContentPart>,
     trajectory_out: Option<PathBuf>,
+    fullscreen: bool,
 ) -> Result<()> {
     // Cheap Arc clones taken before `App` consumes the runtime, so the
     // trajectory can be exported after the TUI loop ends.
@@ -904,23 +913,35 @@ async fn run_tui(
     let mut raw_mode = RawModeGuard::new()?;
     let mut keyboard_enhancements = KeyboardEnhancementGuard::new();
     let mut bracketed_paste = BracketedPasteGuard::new();
+    // In full-screen mode `tuika` owns the alternate screen + mouse capture via
+    // an RAII guard that restores them on drop. The viewport becomes the whole
+    // terminal instead of a short inline strip.
+    let alt_screen = if fullscreen {
+        Some(tuika::AltScreen::enter()?)
+    } else {
+        None
+    };
     let stdout = io::stdout();
     let backend = CrosstermBackend::new(stdout);
-    let mut terminal = Terminal::with_options(
-        backend,
-        TerminalOptions {
-            viewport: Viewport::Inline(COMPOSER_VIEWPORT_HEIGHT),
-        },
-    )?;
-    // Anchoring is cosmetic. Since ratatui 0.30.1 `insert_before` snapshots
-    // the cursor (via `Terminal::clear`) with a blocking `CSI 6n` query that
-    // slow emulators (ttyd / xterm.js) may not answer before crossterm's ~2s
-    // timeout. Start unanchored rather than dying.
-    if let Err(err) = maybe_reanchor_inline_viewport(&mut terminal) {
+    let viewport = if fullscreen {
+        Viewport::Fullscreen
+    } else {
+        Viewport::Inline(COMPOSER_VIEWPORT_HEIGHT)
+    };
+    let mut terminal = Terminal::with_options(backend, TerminalOptions { viewport })?;
+    // Anchoring is cosmetic and inline-only. Since ratatui 0.30.1
+    // `insert_before` snapshots the cursor (via `Terminal::clear`) with a
+    // blocking `CSI 6n` query that slow emulators (ttyd / xterm.js) may not
+    // answer before crossterm's ~2s timeout. Start unanchored rather than
+    // dying.
+    if !fullscreen && let Err(err) = maybe_reanchor_inline_viewport(&mut terminal) {
         tracing::warn!("inline viewport anchoring failed, starting unanchored: {err:#}");
     }
 
     let mut app = App::new(runtime, pending_images);
+    if fullscreen {
+        app.set_render_mode(app::RenderMode::Fullscreen);
+    }
     let result = app.run(&mut terminal).await;
     let show_resume_hint = app.should_show_resume_hint();
     let session_id = app.session_id();
@@ -938,6 +959,11 @@ async fn run_tui(
         tracing::warn!("cursor restore failed: {err:#}");
     }
     drop(terminal);
+    // Leave the alternate screen before any post-loop stdout (resume hint) so
+    // it lands on the user's normal screen, not the one about to be torn down.
+    if let Some(mut alt) = alt_screen {
+        alt.leave();
+    }
     bracketed_paste.disable();
     keyboard_enhancements.disable();
     raw_mode.disable()?;
@@ -1333,6 +1359,7 @@ mod tests {
             session: None,
             session_dir: None,
             trajectory_out: None,
+            fullscreen: false,
         }
     }
 
@@ -1389,6 +1416,7 @@ mod tests {
             session: None,
             session_dir: None,
             trajectory_out: None,
+            fullscreen: false,
         };
 
         let (provider, _notes) = pick_provider(&cli, &settings);

--- a/src/tuika/components/boxed.rs
+++ b/src/tuika/components/boxed.rs
@@ -1,0 +1,126 @@
+//! Bordered box — a single-child container with border, padding, background,
+//! and an optional title. Focus-aware: its border recolors when the render
+//! context reports focus. This is `tuika`'s framing primitive (Pi's
+//! `DynamicBorder` / `Box`).
+
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use ratatui::text::Line;
+
+use crate::tuika::geometry::{Padding, Size};
+use crate::tuika::style::BorderStyle;
+use crate::tuika::surface::Surface;
+use crate::tuika::view::{Element, RenderCtx, View};
+
+use super::text::line_width;
+
+/// A bordered, padded container wrapping one child.
+pub struct Boxed {
+    child: Element,
+    border: BorderStyle,
+    padding: Padding,
+    title: Option<Line<'static>>,
+    background: Option<Style>,
+}
+
+impl Boxed {
+    pub fn new(child: Element) -> Self {
+        Self {
+            child,
+            border: BorderStyle::Rounded,
+            padding: Padding::symmetric(1, 0),
+            title: None,
+            background: None,
+        }
+    }
+
+    pub fn border(mut self, border: BorderStyle) -> Self {
+        self.border = border;
+        self
+    }
+
+    pub fn padding(mut self, padding: Padding) -> Self {
+        self.padding = padding;
+        self
+    }
+
+    pub fn title(mut self, title: impl Into<Line<'static>>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    pub fn background(mut self, style: Style) -> Self {
+        self.background = Some(style);
+        self
+    }
+
+    fn has_border(&self) -> bool {
+        !matches!(self.border, BorderStyle::None)
+    }
+
+    /// Interior rect available to the child after border + padding.
+    fn inner(&self, area: Rect) -> Rect {
+        let bordered = if self.has_border() {
+            Rect {
+                x: area.x.saturating_add(1),
+                y: area.y.saturating_add(1),
+                width: area.width.saturating_sub(2),
+                height: area.height.saturating_sub(2),
+            }
+        } else {
+            area
+        };
+        self.padding.inner(bordered)
+    }
+
+    fn chrome(&self) -> Size {
+        let border = if self.has_border() { 2 } else { 0 };
+        Size::new(
+            self.padding.horizontal().saturating_add(border),
+            self.padding.vertical().saturating_add(border),
+        )
+    }
+}
+
+impl View for Boxed {
+    fn measure(&self, available: Size) -> Size {
+        let chrome = self.chrome();
+        let inner_avail = Size::new(
+            available.width.saturating_sub(chrome.width),
+            available.height.saturating_sub(chrome.height),
+        );
+        let content = self.child.measure(inner_avail);
+        Size::new(
+            content.width.saturating_add(chrome.width),
+            content.height.saturating_add(chrome.height),
+        )
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        if let Some(bg) = self.background {
+            let mut fill = surface.child(area);
+            fill.fill(bg);
+        }
+        if self.has_border() {
+            let border_style = Style::default().fg(ctx.theme.border_color(ctx.focused));
+            surface.draw_border(area, self.border.glyphs(), border_style);
+            if let Some(title) = &self.title {
+                // Title sits on the top border, one cell in, clipped to fit
+                // between the corners.
+                let max = area.width.saturating_sub(4);
+                let mut x = area.x.saturating_add(2);
+                if line_width(title) <= max {
+                    for span in &title.spans {
+                        x = surface.set_string(x, area.y, span.content.as_ref(), span.style);
+                    }
+                }
+            }
+        }
+        let inner = self.inner(area);
+        let mut inner_surface = surface.child(inner);
+        self.child.render(inner, &mut inner_surface, ctx);
+    }
+}

--- a/src/tuika/components/flex.rs
+++ b/src/tuika/components/flex.rs
@@ -1,0 +1,122 @@
+//! Flex container — the composition primitive.
+//!
+//! Holds a [`LayoutStyle`] and a list of children, each tagged with a
+//! [`Dimension`] for its main-axis sizing. Delegates rect assignment to the
+//! [`solve`](crate::tuika::layout::solve) flexbox solver, then renders each
+//! child into its rect through a clipped child surface. Nesting `Flex`es is how
+//! every screen is built.
+
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+
+use crate::tuika::geometry::Size;
+use crate::tuika::layout::{Dimension, Item, LayoutStyle, solve};
+use crate::tuika::surface::Surface;
+use crate::tuika::view::{Element, RenderCtx, View};
+
+struct Child {
+    view: Element,
+    dimension: Dimension,
+}
+
+/// A flexbox container of child views.
+pub struct Flex {
+    style: LayoutStyle,
+    children: Vec<Child>,
+    background: Option<Style>,
+}
+
+impl Flex {
+    pub fn new(style: LayoutStyle) -> Self {
+        Self {
+            style,
+            children: Vec::new(),
+            background: None,
+        }
+    }
+
+    pub fn row() -> Self {
+        Self::new(LayoutStyle::row())
+    }
+
+    pub fn column() -> Self {
+        Self::new(LayoutStyle::column())
+    }
+
+    /// Fill the container area with `style` before drawing children.
+    pub fn background(mut self, style: Style) -> Self {
+        self.background = Some(style);
+        self
+    }
+
+    /// Add a child with an explicit main-axis dimension.
+    pub fn child(mut self, dimension: Dimension, view: Element) -> Self {
+        self.children.push(Child { view, dimension });
+        self
+    }
+
+    /// Add an auto-sized child (sizes to its measured content).
+    pub fn auto(self, view: Element) -> Self {
+        self.child(Dimension::Auto, view)
+    }
+
+    /// Add a flexible child that grows to share leftover space.
+    pub fn grow(self, weight: u16, view: Element) -> Self {
+        self.child(Dimension::Flex(weight), view)
+    }
+
+    /// Add a fixed-size child.
+    pub fn fixed(self, cells: u16, view: Element) -> Self {
+        self.child(Dimension::Fixed(cells), view)
+    }
+
+    fn items(&self, available: Size) -> Vec<Item> {
+        self.children
+            .iter()
+            .map(|c| Item::new(c.dimension, c.view.measure(available)))
+            .collect()
+    }
+}
+
+impl View for Flex {
+    fn measure(&self, available: Size) -> Size {
+        // Sum children on the main axis, max on the cross axis, plus gaps and
+        // padding. Used when this Flex is itself an Auto child.
+        let axis = self.style.direction.axis();
+        let inner = self
+            .style
+            .padding
+            .inner(Rect::new(0, 0, available.width, available.height));
+        let inner_avail = Size::from(inner);
+        let mut main_total: u16 = 0;
+        let mut cross_max: u16 = 0;
+        for (i, c) in self.children.iter().enumerate() {
+            let sz = c.view.measure(inner_avail);
+            main_total = main_total.saturating_add(axis.main(sz));
+            if i > 0 {
+                main_total = main_total.saturating_add(self.style.gap);
+            }
+            cross_max = cross_max.max(axis.cross(sz));
+        }
+        let content = axis.size(main_total, cross_max);
+        Size::new(
+            content
+                .width
+                .saturating_add(self.style.padding.horizontal()),
+            content.height.saturating_add(self.style.padding.vertical()),
+        )
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+        if let Some(bg) = self.background {
+            let mut fill = surface.child(area);
+            fill.fill(bg);
+        }
+        let items = self.items(Size::from(area));
+        let rects = solve(area, &self.style, &items);
+        for (child, rect) in self.children.iter().zip(rects) {
+            let mut child_surface = surface.child(rect);
+            child.view.render(rect, &mut child_surface, ctx);
+        }
+    }
+}

--- a/src/tuika/components/mod.rs
+++ b/src/tuika/components/mod.rs
@@ -1,0 +1,24 @@
+//! Component library.
+//!
+//! Every component implements [`View`](crate::tuika::view::View). Layout
+//! containers ([`Flex`], [`Boxed`]) nest children; leaves ([`Text`],
+//! [`Paragraph`], [`SelectList`], [`Scroll`], [`StatusBar`], [`Spacer`]) paint
+//! content. Interactive leaves pair with a persisted `*State` (see
+//! [`ScrollState`], [`SelectState`]) held by the host. To add a component, drop
+//! a new module here and implement `View`; nothing else needs to change.
+
+mod boxed;
+mod flex;
+mod scroll;
+mod select;
+mod spacer;
+mod status_bar;
+mod text;
+
+pub use boxed::Boxed;
+pub use flex::Flex;
+pub use scroll::{Scroll, ScrollState};
+pub use select::{SelectList, SelectOutcome, SelectState};
+pub use spacer::Spacer;
+pub use status_bar::StatusBar;
+pub use text::{Paragraph, Text, line_width};

--- a/src/tuika/components/scroll.rs
+++ b/src/tuika/components/scroll.rs
@@ -1,0 +1,212 @@
+//! Vertical scroll viewport with a scrollbar.
+//!
+//! This is the primitive that replaces native terminal scrollback in the
+//! full-screen renderer: content taller than the viewport is windowed by a
+//! persisted [`ScrollState`], and the state handles wheel/paging events. The
+//! offset is measured in content rows from the top; a "stick to bottom" flag
+//! keeps a live transcript pinned to the newest line until the user scrolls up.
+
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use ratatui::text::Line;
+
+use crate::tuika::event::{Event, EventFlow, KeyCode, MouseKind};
+use crate::tuika::geometry::Size;
+use crate::tuika::surface::Surface;
+use crate::tuika::view::{RenderCtx, View};
+
+/// Persisted scroll position for one scroll region.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ScrollState {
+    /// Top visible content row.
+    offset: u16,
+    /// When true, `clamp` snaps to the bottom on content growth so new
+    /// transcript output stays visible.
+    stick_to_bottom: bool,
+}
+
+impl ScrollState {
+    pub fn new() -> Self {
+        Self {
+            offset: 0,
+            stick_to_bottom: true,
+        }
+    }
+
+    pub fn offset(&self) -> u16 {
+        self.offset
+    }
+
+    pub fn is_stuck_to_bottom(&self) -> bool {
+        self.stick_to_bottom
+    }
+
+    fn max_offset(content_h: u16, viewport_h: u16) -> u16 {
+        content_h.saturating_sub(viewport_h)
+    }
+
+    /// Reconcile the offset with current content/viewport dimensions, honoring
+    /// the stick-to-bottom flag. Call once per frame before rendering.
+    pub fn clamp(&mut self, content_h: u16, viewport_h: u16) {
+        let max = Self::max_offset(content_h, viewport_h);
+        if self.stick_to_bottom {
+            self.offset = max;
+        } else {
+            self.offset = self.offset.min(max);
+        }
+    }
+
+    fn scroll_up(&mut self, lines: u16) {
+        self.offset = self.offset.saturating_sub(lines);
+        self.stick_to_bottom = false;
+    }
+
+    fn scroll_down(&mut self, lines: u16, content_h: u16, viewport_h: u16) {
+        let max = Self::max_offset(content_h, viewport_h);
+        self.offset = self.offset.saturating_add(lines).min(max);
+        // Re-arm bottom-stick once the user scrolls back to the end.
+        self.stick_to_bottom = self.offset >= max;
+    }
+
+    /// Jump to the newest content and re-enable bottom-stick.
+    pub fn jump_to_bottom(&mut self, content_h: u16, viewport_h: u16) {
+        self.offset = Self::max_offset(content_h, viewport_h);
+        self.stick_to_bottom = true;
+    }
+
+    /// Jump to the top.
+    pub fn jump_to_top(&mut self) {
+        self.offset = 0;
+        self.stick_to_bottom = false;
+    }
+
+    /// Handle a scroll/paging event against the given dimensions.
+    pub fn handle(&mut self, event: &Event, content_h: u16, viewport_h: u16) -> EventFlow {
+        let page = viewport_h.saturating_sub(1).max(1);
+        match event {
+            Event::Mouse(m) => match m.kind {
+                MouseKind::ScrollUp => {
+                    self.scroll_up(3);
+                    EventFlow::Consumed
+                }
+                MouseKind::ScrollDown => {
+                    self.scroll_down(3, content_h, viewport_h);
+                    EventFlow::Consumed
+                }
+                _ => EventFlow::Ignored,
+            },
+            Event::Key(k) if k.plain() => match k.code {
+                KeyCode::PageUp => {
+                    self.scroll_up(page);
+                    EventFlow::Consumed
+                }
+                KeyCode::PageDown => {
+                    self.scroll_down(page, content_h, viewport_h);
+                    EventFlow::Consumed
+                }
+                KeyCode::Home => {
+                    self.jump_to_top();
+                    EventFlow::Consumed
+                }
+                KeyCode::End => {
+                    self.jump_to_bottom(content_h, viewport_h);
+                    EventFlow::Consumed
+                }
+                _ => EventFlow::Ignored,
+            },
+            _ => EventFlow::Ignored,
+        }
+    }
+}
+
+/// A windowed view of `lines`, showing the slice at `offset` and a scrollbar
+/// when content overflows.
+pub struct Scroll {
+    lines: Vec<Line<'static>>,
+    offset: u16,
+    scrollbar: bool,
+}
+
+impl Scroll {
+    pub fn new(lines: Vec<Line<'static>>, state: &ScrollState) -> Self {
+        Self {
+            lines,
+            offset: state.offset(),
+            scrollbar: true,
+        }
+    }
+
+    pub fn scrollbar(mut self, show: bool) -> Self {
+        self.scrollbar = show;
+        self
+    }
+
+    pub fn content_height(&self) -> u16 {
+        self.lines.len() as u16
+    }
+}
+
+impl View for Scroll {
+    fn measure(&self, available: Size) -> Size {
+        Size::new(available.width, self.content_height())
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        let content_h = self.content_height();
+        let overflow = content_h > area.height;
+        let text_width = if overflow && self.scrollbar {
+            area.width.saturating_sub(1)
+        } else {
+            area.width
+        };
+
+        let start = self.offset as usize;
+        for row in 0..area.height {
+            let idx = start + row as usize;
+            let Some(line) = self.lines.get(idx) else {
+                break;
+            };
+            let y = area.y + row;
+            let mut clip = surface.child(Rect::new(area.x, y, text_width, 1));
+            let mut x = area.x;
+            for span in &line.spans {
+                if x >= area.x + text_width {
+                    break;
+                }
+                x = clip.set_string(x, y, span.content.as_ref(), span.style);
+            }
+        }
+
+        if overflow && self.scrollbar && text_width < area.width {
+            self.draw_scrollbar(area, content_h, surface, ctx);
+        }
+    }
+}
+
+impl Scroll {
+    fn draw_scrollbar(&self, area: Rect, content_h: u16, surface: &mut Surface, ctx: &RenderCtx) {
+        let track_x = area.right() - 1;
+        let track_h = area.height;
+        let max_offset = content_h.saturating_sub(area.height).max(1);
+        // Thumb size proportional to the visible fraction, at least one cell.
+        let thumb_h = ((track_h as u32 * track_h as u32) / content_h as u32).max(1) as u16;
+        let thumb_h = thumb_h.min(track_h);
+        let travel = track_h.saturating_sub(thumb_h);
+        let thumb_y = area.y + ((self.offset as u32 * travel as u32) / max_offset as u32) as u16;
+        let track_style = Style::default().fg(ctx.theme.dim);
+        let thumb_style = Style::default().fg(ctx.theme.muted);
+        for row in 0..track_h {
+            let y = area.y + row;
+            let within = y >= thumb_y && y < thumb_y.saturating_add(thumb_h);
+            let (glyph, style) = if within {
+                ('█', thumb_style)
+            } else {
+                ('│', track_style)
+            };
+            surface.set(track_x, y, glyph, style);
+        }
+    }
+}

--- a/src/tuika/components/select.rs
+++ b/src/tuika/components/select.rs
@@ -1,0 +1,141 @@
+//! Selectable list (Pi's `SelectList`).
+//!
+//! [`SelectState`] persists the highlighted index and handles up/down/wrap
+//! navigation; [`SelectList`] renders the options, marking the current one with
+//! the theme selection style and a caret. Enter is surfaced to the host via
+//! [`SelectOutcome`] so the caller decides what "confirm" means.
+
+use ratatui::layout::Rect;
+use ratatui::text::Line;
+
+use crate::tuika::event::{Event, EventFlow, KeyCode};
+use crate::tuika::geometry::Size;
+use crate::tuika::surface::Surface;
+use crate::tuika::view::{RenderCtx, View};
+
+/// Result of feeding an event to a [`SelectState`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SelectOutcome {
+    /// Highlight moved or nothing happened; event consumed status in `.1`.
+    Moved(EventFlow),
+    /// Enter pressed on the given index.
+    Confirmed(usize),
+    /// Esc pressed.
+    Cancelled,
+}
+
+/// Persisted selection index for one list.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SelectState {
+    selected: usize,
+}
+
+impl SelectState {
+    pub fn new() -> Self {
+        Self { selected: 0 }
+    }
+
+    pub fn selected(&self) -> usize {
+        self.selected
+    }
+
+    /// Keep the index in range as the list length changes.
+    pub fn clamp(&mut self, len: usize) {
+        if len == 0 {
+            self.selected = 0;
+        } else if self.selected >= len {
+            self.selected = len - 1;
+        }
+    }
+
+    /// Navigate with arrow keys (wrapping), confirm with Enter, cancel on Esc.
+    pub fn handle(&mut self, event: &Event, len: usize) -> SelectOutcome {
+        if len == 0 {
+            return SelectOutcome::Moved(EventFlow::Ignored);
+        }
+        let Event::Key(k) = event else {
+            return SelectOutcome::Moved(EventFlow::Ignored);
+        };
+        if !k.plain() {
+            return SelectOutcome::Moved(EventFlow::Ignored);
+        }
+        match k.code {
+            KeyCode::Up => {
+                self.selected = if self.selected == 0 {
+                    len - 1
+                } else {
+                    self.selected - 1
+                };
+                SelectOutcome::Moved(EventFlow::Consumed)
+            }
+            KeyCode::Down => {
+                self.selected = (self.selected + 1) % len;
+                SelectOutcome::Moved(EventFlow::Consumed)
+            }
+            KeyCode::Enter => SelectOutcome::Confirmed(self.selected),
+            KeyCode::Esc => SelectOutcome::Cancelled,
+            _ => SelectOutcome::Moved(EventFlow::Ignored),
+        }
+    }
+}
+
+/// Renders `items` with the selected row highlighted.
+pub struct SelectList {
+    items: Vec<Line<'static>>,
+    selected: usize,
+}
+
+impl SelectList {
+    pub fn new(items: Vec<Line<'static>>, state: &SelectState) -> Self {
+        Self {
+            items,
+            selected: state.selected(),
+        }
+    }
+}
+
+impl View for SelectList {
+    fn measure(&self, available: Size) -> Size {
+        let width = self
+            .items
+            .iter()
+            .map(super::text::line_width)
+            .max()
+            .unwrap_or(0)
+            .saturating_add(2); // caret + space
+        Size::new(width.min(available.width), self.items.len() as u16)
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+        for (row, item) in self.items.iter().enumerate() {
+            let y = area.y.saturating_add(row as u16);
+            if y >= area.bottom() {
+                break;
+            }
+            let selected = row == self.selected;
+            if selected {
+                let mut line = surface.child(Rect::new(area.x, y, area.width, 1));
+                line.fill(ctx.theme.selection_style());
+            }
+            let caret = if selected { '›' } else { ' ' };
+            let caret_style = if selected {
+                ctx.theme.selection_style()
+            } else {
+                ctx.theme.muted_style()
+            };
+            surface.set(area.x, y, caret, caret_style);
+            let mut x = area.x.saturating_add(2);
+            for span in &item.spans {
+                if x >= area.right() {
+                    break;
+                }
+                let style = if selected {
+                    span.style.patch(ctx.theme.selection_style())
+                } else {
+                    span.style
+                };
+                x = surface.set_string(x, y, span.content.as_ref(), style);
+            }
+        }
+    }
+}

--- a/src/tuika/components/spacer.rs
+++ b/src/tuika/components/spacer.rs
@@ -1,0 +1,18 @@
+//! Spacer — empty, flexible filler. Paints nothing; useful as a
+//! `Dimension::Flex` child to push siblings apart, or fixed to insert a gap.
+
+use ratatui::layout::Rect;
+
+use crate::tuika::geometry::Size;
+use crate::tuika::surface::Surface;
+use crate::tuika::view::{RenderCtx, View};
+
+pub struct Spacer;
+
+impl View for Spacer {
+    fn measure(&self, _available: Size) -> Size {
+        Size::ZERO
+    }
+
+    fn render(&self, _area: Rect, _surface: &mut Surface, _ctx: &RenderCtx) {}
+}

--- a/src/tuika/components/status_bar.rs
+++ b/src/tuika/components/status_bar.rs
@@ -1,0 +1,96 @@
+//! Status bar — a single-row strip of left/right aligned segments over a
+//! surface-colored background. Used for the full-screen renderer's model /
+//! mode / token line, mirroring yolop's inline status chrome.
+
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use ratatui::text::Span;
+
+use crate::tuika::geometry::Size;
+use crate::tuika::surface::Surface;
+use crate::tuika::view::{RenderCtx, View};
+
+/// A one-line status bar with left- and right-anchored segment groups.
+pub struct StatusBar {
+    left: Vec<Span<'static>>,
+    right: Vec<Span<'static>>,
+    background: Option<Style>,
+}
+
+impl StatusBar {
+    pub fn new() -> Self {
+        Self {
+            left: Vec::new(),
+            right: Vec::new(),
+            background: None,
+        }
+    }
+
+    pub fn left(mut self, spans: Vec<Span<'static>>) -> Self {
+        self.left = spans;
+        self
+    }
+
+    pub fn right(mut self, spans: Vec<Span<'static>>) -> Self {
+        self.right = spans;
+        self
+    }
+
+    pub fn background(mut self, style: Style) -> Self {
+        self.background = Some(style);
+        self
+    }
+}
+
+impl Default for StatusBar {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn spans_width(spans: &[Span]) -> u16 {
+    use unicode_width::UnicodeWidthStr;
+    spans
+        .iter()
+        .map(|s| UnicodeWidthStr::width(s.content.as_ref()) as u16)
+        .fold(0, u16::saturating_add)
+}
+
+impl View for StatusBar {
+    fn measure(&self, available: Size) -> Size {
+        Size::new(available.width, 1)
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+        if area.height == 0 {
+            return;
+        }
+        let bg = self
+            .background
+            .unwrap_or_else(|| Style::default().bg(ctx.theme.surface));
+        let row = Rect::new(area.x, area.y, area.width, 1);
+        {
+            let mut fill = surface.child(row);
+            fill.fill(bg);
+        }
+        // Left group from the left edge.
+        let mut x = area.x;
+        for span in &self.left {
+            if x >= area.right() {
+                break;
+            }
+            x = surface.set_string(x, area.y, span.content.as_ref(), span.style.patch(bg));
+        }
+        // Right group anchored to the right edge, if it fits past the left.
+        let right_w = spans_width(&self.right);
+        let mut rx = area.right().saturating_sub(right_w);
+        if rx > x {
+            for span in &self.right {
+                if rx >= area.right() {
+                    break;
+                }
+                rx = surface.set_string(rx, area.y, span.content.as_ref(), span.style.patch(bg));
+            }
+        }
+    }
+}

--- a/src/tuika/components/text.rs
+++ b/src/tuika/components/text.rs
@@ -1,0 +1,116 @@
+//! Text and paragraph components.
+//!
+//! [`Text`] draws pre-styled ratatui [`Line`]s faithfully (mixed styles per
+//! line preserved), clipping to its area. [`Paragraph`] takes a plain string
+//! plus one style and word-wraps it to the available width. Callers that need
+//! wrapped *and* multi-styled text should wrap upstream and feed [`Text`].
+
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use ratatui::text::Line;
+use unicode_width::UnicodeWidthStr;
+
+use crate::tuika::geometry::Size;
+use crate::tuika::surface::Surface;
+use crate::tuika::view::{RenderCtx, View};
+
+/// Display width of a styled line (sum of span widths).
+pub fn line_width(line: &Line) -> u16 {
+    line.spans
+        .iter()
+        .map(|s| UnicodeWidthStr::width(s.content.as_ref()) as u16)
+        .fold(0, u16::saturating_add)
+}
+
+/// A block of pre-styled lines, drawn top-down and clipped.
+pub struct Text {
+    lines: Vec<Line<'static>>,
+}
+
+impl Text {
+    pub fn new(lines: Vec<Line<'static>>) -> Self {
+        Self { lines }
+    }
+
+    /// A single unstyled line from a string.
+    pub fn raw(text: impl Into<String>) -> Self {
+        Self::new(vec![Line::from(text.into())])
+    }
+}
+
+impl View for Text {
+    fn measure(&self, _available: Size) -> Size {
+        let width = self.lines.iter().map(line_width).max().unwrap_or(0);
+        Size::new(width, self.lines.len() as u16)
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, _ctx: &RenderCtx) {
+        for (row, line) in self.lines.iter().enumerate() {
+            let y = area.y.saturating_add(row as u16);
+            if y >= area.bottom() {
+                break;
+            }
+            let mut x = area.x;
+            for span in &line.spans {
+                if x >= area.right() {
+                    break;
+                }
+                x = surface.set_string(x, y, span.content.as_ref(), span.style);
+            }
+        }
+    }
+}
+
+/// Plain text word-wrapped to the render width in one style.
+pub struct Paragraph {
+    text: String,
+    style: Style,
+}
+
+impl Paragraph {
+    pub fn new(text: impl Into<String>, style: Style) -> Self {
+        Self {
+            text: text.into(),
+            style,
+        }
+    }
+
+    fn wrap(&self, width: u16) -> Vec<String> {
+        if width == 0 {
+            return Vec::new();
+        }
+        self.text
+            .split('\n')
+            .flat_map(|para| {
+                let wrapped = textwrap::wrap(para, width as usize);
+                if wrapped.is_empty() {
+                    vec![String::new()]
+                } else {
+                    wrapped.into_iter().map(|c| c.into_owned()).collect()
+                }
+            })
+            .collect()
+    }
+}
+
+impl View for Paragraph {
+    fn measure(&self, available: Size) -> Size {
+        let lines = self.wrap(available.width);
+        let width = lines
+            .iter()
+            .map(|l| UnicodeWidthStr::width(l.as_str()) as u16)
+            .max()
+            .unwrap_or(0);
+        Size::new(width, lines.len() as u16)
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, _ctx: &RenderCtx) {
+        for (row, line) in self.wrap(area.width).into_iter().enumerate() {
+            let y = area.y.saturating_add(row as u16);
+            if y >= area.bottom() {
+                break;
+            }
+            surface.set_string(area.x, y, &line, self.style);
+        }
+    }
+}

--- a/src/tuika/event.rs
+++ b/src/tuika/event.rs
@@ -1,0 +1,92 @@
+//! Input events, decoupled from crossterm.
+//!
+//! Components handle `tuika` events, not raw crossterm events, so the widget
+//! layer stays testable without a terminal. The host ([`super::host`])
+//! translates crossterm into these. This mirrors Codex's event-stream input
+//! model: a small, explicit event enum flowing to focused components.
+
+/// A translated input event.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Event {
+    Key(Key),
+    Mouse(Mouse),
+    /// Bracketed-paste payload.
+    Paste(String),
+    Resize {
+        width: u16,
+        height: u16,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Key {
+    pub code: KeyCode,
+    pub ctrl: bool,
+    pub alt: bool,
+    pub shift: bool,
+}
+
+impl Key {
+    pub fn new(code: KeyCode) -> Self {
+        Self {
+            code,
+            ctrl: false,
+            alt: false,
+            shift: false,
+        }
+    }
+
+    pub fn plain(&self) -> bool {
+        !self.ctrl && !self.alt
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum KeyCode {
+    Char(char),
+    Enter,
+    Esc,
+    Backspace,
+    Delete,
+    Tab,
+    BackTab,
+    Up,
+    Down,
+    Left,
+    Right,
+    Home,
+    End,
+    PageUp,
+    PageDown,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Mouse {
+    pub kind: MouseKind,
+    pub column: u16,
+    pub row: u16,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MouseKind {
+    Down,
+    Up,
+    ScrollUp,
+    ScrollDown,
+    Moved,
+}
+
+/// Whether a component consumed an event or let it bubble.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EventFlow {
+    /// The event was handled; stop propagating.
+    Consumed,
+    /// The event was not handled; keep bubbling.
+    Ignored,
+}
+
+impl EventFlow {
+    pub fn consumed(self) -> bool {
+        matches!(self, EventFlow::Consumed)
+    }
+}

--- a/src/tuika/focus.rs
+++ b/src/tuika/focus.rs
@@ -1,0 +1,100 @@
+//! Focus registry and input ownership.
+//!
+//! Focusable regions register a stable string id each frame. The registry
+//! tracks which id currently holds focus and cycles through them with
+//! Tab/BackTab. Overlays claim *input ownership*: while an overlay is open, the
+//! registry reports its id as focused and the host routes events there,
+//! regardless of the base tree's focus ring — the missing "input ownership
+//! across overlay and non-overlay components" piece from Pi.
+
+use super::event::{Event, EventFlow, KeyCode};
+
+/// Tracks the focus ring and the currently focused region.
+#[derive(Clone, Debug, Default)]
+pub struct FocusRegistry {
+    order: Vec<String>,
+    focused: Option<String>,
+    /// When set, this id owns all input (an open overlay).
+    owner: Option<String>,
+}
+
+impl FocusRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Begin a frame: clear the per-frame focus ring. Registrations follow.
+    pub fn begin_frame(&mut self) {
+        self.order.clear();
+    }
+
+    /// Register a focusable region for this frame, in tab order.
+    pub fn register(&mut self, id: impl Into<String>) {
+        let id = id.into();
+        if self.focused.is_none() {
+            self.focused = Some(id.clone());
+        }
+        self.order.push(id);
+    }
+
+    /// Give exclusive input ownership to `id` (e.g. an overlay) until cleared.
+    pub fn set_owner(&mut self, id: impl Into<String>) {
+        self.owner = Some(id.into());
+    }
+
+    /// Release input ownership.
+    pub fn clear_owner(&mut self) {
+        self.owner = None;
+    }
+
+    /// The id that should receive input: the owner if any, else the focused id.
+    pub fn active(&self) -> Option<&str> {
+        self.owner.as_deref().or(self.focused.as_deref())
+    }
+
+    /// Whether `id` is the active input target.
+    pub fn is_active(&self, id: &str) -> bool {
+        self.active() == Some(id)
+    }
+
+    /// Whether `id` holds focus in the base ring (ignores overlay ownership).
+    pub fn is_focused(&self, id: &str) -> bool {
+        self.focused.as_deref() == Some(id)
+    }
+
+    fn advance(&mut self, delta: isize) {
+        if self.order.is_empty() {
+            return;
+        }
+        let len = self.order.len() as isize;
+        let current = self
+            .focused
+            .as_ref()
+            .and_then(|f| self.order.iter().position(|id| id == f))
+            .map(|p| p as isize)
+            .unwrap_or(0);
+        let next = ((current + delta) % len + len) % len;
+        self.focused = Some(self.order[next as usize].clone());
+    }
+
+    /// Route Tab/BackTab to move focus. Ignored while an overlay owns input.
+    pub fn handle(&mut self, event: &Event) -> EventFlow {
+        if self.owner.is_some() {
+            return EventFlow::Ignored;
+        }
+        let Event::Key(k) = event else {
+            return EventFlow::Ignored;
+        };
+        match k.code {
+            KeyCode::Tab if k.plain() => {
+                self.advance(1);
+                EventFlow::Consumed
+            }
+            KeyCode::BackTab => {
+                self.advance(-1);
+                EventFlow::Consumed
+            }
+            _ => EventFlow::Ignored,
+        }
+    }
+}

--- a/src/tuika/geometry.rs
+++ b/src/tuika/geometry.rs
@@ -1,0 +1,154 @@
+//! Geometry helpers shared across `tuika`.
+//!
+//! `tuika` reuses ratatui's [`Rect`] as its area type so the compositor can
+//! draw straight into a ratatui [`Buffer`](ratatui::buffer::Buffer), but the
+//! layout solver reasons about a direction-agnostic main/cross axis. The
+//! helpers here bridge the two: an [`Axis`] projects a `Rect` onto its main or
+//! cross extent so the flex solver can be written once for rows and columns.
+
+use ratatui::layout::Rect;
+
+/// An intrinsic size in terminal cells.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Size {
+    pub width: u16,
+    pub height: u16,
+}
+
+impl Size {
+    pub const ZERO: Size = Size {
+        width: 0,
+        height: 0,
+    };
+
+    pub fn new(width: u16, height: u16) -> Self {
+        Self { width, height }
+    }
+
+    /// Clamp both extents so the size fits inside `bounds`.
+    pub fn clamp_to(self, bounds: Size) -> Size {
+        Size {
+            width: self.width.min(bounds.width),
+            height: self.height.min(bounds.height),
+        }
+    }
+}
+
+impl From<Rect> for Size {
+    fn from(rect: Rect) -> Self {
+        Size {
+            width: rect.width,
+            height: rect.height,
+        }
+    }
+}
+
+/// The layout axis a flex container distributes children along.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Axis {
+    Horizontal,
+    Vertical,
+}
+
+impl Axis {
+    /// Extent of `size` along this axis (the "main" extent).
+    pub fn main(self, size: Size) -> u16 {
+        match self {
+            Axis::Horizontal => size.width,
+            Axis::Vertical => size.height,
+        }
+    }
+
+    /// Extent of `size` across this axis (the "cross" extent).
+    pub fn cross(self, size: Size) -> u16 {
+        match self {
+            Axis::Horizontal => size.height,
+            Axis::Vertical => size.width,
+        }
+    }
+
+    /// Build a `Size` from main/cross extents on this axis.
+    pub fn size(self, main: u16, cross: u16) -> Size {
+        match self {
+            Axis::Horizontal => Size::new(main, cross),
+            Axis::Vertical => Size::new(cross, main),
+        }
+    }
+
+    /// Place a child rect at `main`/`cross` offsets with `main_len`/`cross_len`
+    /// extents, relative to `origin`.
+    pub fn place(self, origin: Rect, main: u16, cross: u16, main_len: u16, cross_len: u16) -> Rect {
+        match self {
+            Axis::Horizontal => Rect {
+                x: origin.x.saturating_add(main),
+                y: origin.y.saturating_add(cross),
+                width: main_len,
+                height: cross_len,
+            },
+            Axis::Vertical => Rect {
+                x: origin.x.saturating_add(cross),
+                y: origin.y.saturating_add(main),
+                width: cross_len,
+                height: main_len,
+            },
+        }
+    }
+}
+
+/// Symmetric-per-edge padding, in cells.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Padding {
+    pub left: u16,
+    pub right: u16,
+    pub top: u16,
+    pub bottom: u16,
+}
+
+impl Padding {
+    pub const ZERO: Padding = Padding {
+        left: 0,
+        right: 0,
+        top: 0,
+        bottom: 0,
+    };
+
+    /// Uniform padding on every edge.
+    pub fn all(value: u16) -> Self {
+        Self {
+            left: value,
+            right: value,
+            top: value,
+            bottom: value,
+        }
+    }
+
+    /// Independent horizontal and vertical padding.
+    pub fn symmetric(horizontal: u16, vertical: u16) -> Self {
+        Self {
+            left: horizontal,
+            right: horizontal,
+            top: vertical,
+            bottom: vertical,
+        }
+    }
+
+    pub fn horizontal(self) -> u16 {
+        self.left.saturating_add(self.right)
+    }
+
+    pub fn vertical(self) -> u16 {
+        self.top.saturating_add(self.bottom)
+    }
+
+    /// Shrink `area` by this padding, saturating so it never inverts.
+    pub fn inner(self, area: Rect) -> Rect {
+        let width = area.width.saturating_sub(self.horizontal());
+        let height = area.height.saturating_sub(self.vertical());
+        Rect {
+            x: area.x.saturating_add(self.left),
+            y: area.y.saturating_add(self.top),
+            width,
+            height,
+        }
+    }
+}

--- a/src/tuika/host.rs
+++ b/src/tuika/host.rs
@@ -1,0 +1,150 @@
+//! Terminal host: alternate-screen lifecycle, event translation, compositor.
+//!
+//! This is the seam between `tuika` and a real terminal. [`AltScreen`] enters
+//! the alternate-screen buffer and mouse-capture on construction and restores
+//! them on drop (RAII, so a panic still cleans up) — the Codex-style
+//! full-screen entry. [`translate_event`] maps crossterm input to `tuika`
+//! [`Event`]s. [`paint`] composites a root view plus any overlays into the
+//! frame buffer: background fill, root, then each overlay last (clearing its
+//! rect first), which is why overlays never leak surrounding chrome here.
+
+use std::io::{self, Write};
+
+use crossterm::event::{
+    DisableMouseCapture, EnableMouseCapture, Event as CtEvent, KeyCode as CtKeyCode, KeyEventKind,
+    KeyModifiers, MouseEventKind as CtMouseKind,
+};
+use crossterm::execute;
+use crossterm::terminal::{EnterAlternateScreen, LeaveAlternateScreen};
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+
+use super::event::{Event, Key, KeyCode, Mouse, MouseKind};
+use super::style::Theme;
+use super::surface::Surface;
+use super::view::{RenderCtx, View};
+
+/// RAII guard for the alternate screen + mouse capture.
+pub struct AltScreen {
+    active: bool,
+}
+
+impl AltScreen {
+    /// Enter the alternate screen and enable mouse capture. Assumes raw mode is
+    /// already enabled by the caller.
+    pub fn enter() -> io::Result<Self> {
+        let mut out = io::stdout();
+        execute!(out, EnterAlternateScreen, EnableMouseCapture)?;
+        out.flush()?;
+        Ok(Self { active: true })
+    }
+
+    /// Explicitly leave (also runs on drop; idempotent).
+    pub fn leave(&mut self) {
+        if self.active {
+            let mut out = io::stdout();
+            let _ = execute!(out, DisableMouseCapture, LeaveAlternateScreen);
+            let _ = out.flush();
+            self.active = false;
+        }
+    }
+}
+
+impl Drop for AltScreen {
+    fn drop(&mut self) {
+        self.leave();
+    }
+}
+
+/// An overlay to composite over the base tree at a resolved rect.
+pub struct Overlay<'a> {
+    pub area: Rect,
+    pub view: &'a dyn View,
+    /// Clear the rect (fill with the theme background) before painting.
+    pub clear: bool,
+}
+
+/// Composite `root` and `overlays` into `buffer` over `area`.
+pub fn paint(
+    buffer: &mut Buffer,
+    area: Rect,
+    theme: &Theme,
+    root: &dyn View,
+    overlays: &[Overlay],
+) {
+    // Base background so the alternate screen is fully owned (no stale cells).
+    {
+        let mut surface = Surface::new(buffer, area);
+        surface.fill(Style::default().bg(theme.background));
+    }
+    let ctx = RenderCtx::new(theme);
+    {
+        let mut surface = Surface::new(buffer, area);
+        root.render(area, &mut surface, &ctx);
+    }
+    for overlay in overlays {
+        let mut surface = Surface::new(buffer, overlay.area);
+        if overlay.clear {
+            surface.fill(Style::default().bg(theme.surface));
+        }
+        // An open overlay owns input, so render it focused.
+        overlay
+            .view
+            .render(overlay.area, &mut surface, &ctx.with_focus(true));
+    }
+}
+
+/// Translate a crossterm event into a `tuika` event, dropping ones `tuika`
+/// does not model (key-release, unmapped codes).
+pub fn translate_event(event: CtEvent) -> Option<Event> {
+    match event {
+        CtEvent::Key(k) => {
+            if k.kind == KeyEventKind::Release {
+                return None;
+            }
+            let code = match k.code {
+                CtKeyCode::Char(c) => KeyCode::Char(c),
+                CtKeyCode::Enter => KeyCode::Enter,
+                CtKeyCode::Esc => KeyCode::Esc,
+                CtKeyCode::Backspace => KeyCode::Backspace,
+                CtKeyCode::Delete => KeyCode::Delete,
+                CtKeyCode::Tab => KeyCode::Tab,
+                CtKeyCode::BackTab => KeyCode::BackTab,
+                CtKeyCode::Up => KeyCode::Up,
+                CtKeyCode::Down => KeyCode::Down,
+                CtKeyCode::Left => KeyCode::Left,
+                CtKeyCode::Right => KeyCode::Right,
+                CtKeyCode::Home => KeyCode::Home,
+                CtKeyCode::End => KeyCode::End,
+                CtKeyCode::PageUp => KeyCode::PageUp,
+                CtKeyCode::PageDown => KeyCode::PageDown,
+                _ => return None,
+            };
+            Some(Event::Key(Key {
+                code,
+                ctrl: k.modifiers.contains(KeyModifiers::CONTROL),
+                alt: k.modifiers.contains(KeyModifiers::ALT),
+                shift: k.modifiers.contains(KeyModifiers::SHIFT),
+            }))
+        }
+        CtEvent::Mouse(m) => {
+            let kind = match m.kind {
+                CtMouseKind::Down(_) => MouseKind::Down,
+                CtMouseKind::Up(_) => MouseKind::Up,
+                CtMouseKind::ScrollUp => MouseKind::ScrollUp,
+                CtMouseKind::ScrollDown => MouseKind::ScrollDown,
+                CtMouseKind::Moved | CtMouseKind::Drag(_) => MouseKind::Moved,
+                _ => return None,
+            };
+            Some(Event::Mouse(Mouse {
+                kind,
+                column: m.column,
+                row: m.row,
+            }))
+        }
+        CtEvent::Paste(text) => Some(Event::Paste(text)),
+        CtEvent::Resize(width, height) => Some(Event::Resize { width, height }),
+        _ => None,
+    }
+}

--- a/src/tuika/layout.rs
+++ b/src/tuika/layout.rs
@@ -1,0 +1,241 @@
+//! Flexbox-style layout solver.
+//!
+//! This is the piece ratatui does not give you: a CSS-flexbox-shaped solver
+//! (borrowing OpenTUI's Yoga model and quench's declarative structure, but
+//! implemented as plain Rust — no reconciler). A [`Flex`](crate::tuika::components::Flex)
+//! container owns a [`LayoutStyle`] and children; [`solve`] resolves child
+//! rects for one axis. It is written once against a direction-agnostic
+//! [`Axis`] so rows and columns share the same code path.
+
+use ratatui::layout::Rect;
+
+use super::geometry::{Axis, Padding, Size};
+
+/// How a child sizes itself along the container's main axis.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Dimension {
+    /// Size to the child's intrinsic (measured) main extent.
+    #[default]
+    Auto,
+    /// Exactly this many cells.
+    Fixed(u16),
+    /// This percent (0–100) of the container's available main extent.
+    Percent(u16),
+    /// Grow to share leftover main space, weighted by this factor.
+    Flex(u16),
+}
+
+/// Cross-axis alignment of children within the container.
+///
+/// Defaults to [`Align::Stretch`], matching CSS flexbox and the common TUI case
+/// where a column's children should fill its width (and a row's its height).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Align {
+    Start,
+    Center,
+    End,
+    /// Fill the full cross extent.
+    #[default]
+    Stretch,
+}
+
+/// Main-axis distribution of leftover space when no child is [`Dimension::Flex`].
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Justify {
+    #[default]
+    Start,
+    Center,
+    End,
+    /// Even gaps between children, none at the ends.
+    SpaceBetween,
+}
+
+/// Direction a flex container stacks its children.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Direction {
+    Row,
+    #[default]
+    Column,
+}
+
+impl Direction {
+    pub fn axis(self) -> Axis {
+        match self {
+            Direction::Row => Axis::Horizontal,
+            Direction::Column => Axis::Vertical,
+        }
+    }
+}
+
+/// Declarative layout properties for a flex container.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct LayoutStyle {
+    pub direction: Direction,
+    pub padding: Padding,
+    pub gap: u16,
+    pub align_items: Align,
+    pub justify: Justify,
+}
+
+impl LayoutStyle {
+    pub fn row() -> Self {
+        Self {
+            direction: Direction::Row,
+            ..Self::default()
+        }
+    }
+
+    pub fn column() -> Self {
+        Self {
+            direction: Direction::Column,
+            ..Self::default()
+        }
+    }
+
+    pub fn gap(mut self, gap: u16) -> Self {
+        self.gap = gap;
+        self
+    }
+
+    pub fn padding(mut self, padding: Padding) -> Self {
+        self.padding = padding;
+        self
+    }
+
+    pub fn align(mut self, align: Align) -> Self {
+        self.align_items = align;
+        self
+    }
+
+    pub fn justify(mut self, justify: Justify) -> Self {
+        self.justify = justify;
+        self
+    }
+}
+
+/// A child's layout request: its main-axis sizing rule and its intrinsic size.
+///
+/// `intrinsic` is what the child's `measure` reported for the content box; the
+/// solver uses it for [`Dimension::Auto`] main sizing and for non-stretch
+/// cross alignment.
+#[derive(Clone, Copy, Debug)]
+pub struct Item {
+    pub dimension: Dimension,
+    pub intrinsic: Size,
+}
+
+impl Item {
+    pub fn new(dimension: Dimension, intrinsic: Size) -> Self {
+        Self {
+            dimension,
+            intrinsic,
+        }
+    }
+}
+
+/// Resolve child rects inside `area` for a container with `style` and `items`.
+///
+/// Returns one `Rect` per item, in order. The algorithm mirrors flexbox on a
+/// single line: resolve fixed/percent/auto main sizes, distribute remaining
+/// main space to flex children (or to `justify` when there are none), then
+/// align each child on the cross axis.
+pub fn solve(area: Rect, style: &LayoutStyle, items: &[Item]) -> Vec<Rect> {
+    if items.is_empty() {
+        return Vec::new();
+    }
+
+    let axis = style.direction.axis();
+    let inner = style.padding.inner(area);
+    let inner_size = Size::from(inner);
+    let main_avail = axis.main(inner_size);
+    let cross_avail = axis.cross(inner_size);
+
+    let total_gap = style
+        .gap
+        .saturating_mul(items.len().saturating_sub(1) as u16);
+    let space_for_children = main_avail.saturating_sub(total_gap);
+
+    // Pass 1: resolve the main extent of every non-flex child and tally the
+    // flex weights.
+    let mut main_sizes: Vec<u16> = Vec::with_capacity(items.len());
+    let mut flex_weight_total: u32 = 0;
+    let mut consumed: u16 = 0;
+    for item in items {
+        let size = match item.dimension {
+            Dimension::Auto => axis.main(item.intrinsic).min(space_for_children),
+            Dimension::Fixed(n) => n.min(space_for_children),
+            Dimension::Percent(p) => {
+                let p = p.min(100) as u32;
+                ((space_for_children as u32 * p) / 100) as u16
+            }
+            Dimension::Flex(weight) => {
+                flex_weight_total += weight.max(1) as u32;
+                0 // resolved in pass 2
+            }
+        };
+        main_sizes.push(size);
+        consumed = consumed.saturating_add(size);
+    }
+
+    // Pass 2: distribute leftover main space to flex children by weight,
+    // handing the rounding remainder to the last flex child so the row fills
+    // exactly.
+    let leftover = space_for_children.saturating_sub(consumed);
+    if flex_weight_total > 0 {
+        let mut distributed: u16 = 0;
+        let flex_indices: Vec<usize> = items
+            .iter()
+            .enumerate()
+            .filter(|(_, it)| matches!(it.dimension, Dimension::Flex(_)))
+            .map(|(i, _)| i)
+            .collect();
+        for (nth, &i) in flex_indices.iter().enumerate() {
+            let weight = match items[i].dimension {
+                Dimension::Flex(w) => w.max(1) as u32,
+                _ => unreachable!(),
+            };
+            let size = if nth + 1 == flex_indices.len() {
+                leftover.saturating_sub(distributed)
+            } else {
+                (leftover as u32 * weight)
+                    .checked_div(flex_weight_total)
+                    .unwrap_or(0) as u16
+            };
+            distributed = distributed.saturating_add(size);
+            main_sizes[i] = size;
+        }
+    }
+
+    // Main-axis start offset from `justify` (only meaningful when there is
+    // leftover space and no flex child soaked it up).
+    let used_main: u16 = main_sizes.iter().copied().fold(0, u16::saturating_add);
+    let free = space_for_children.saturating_sub(used_main);
+    let (mut cursor, between_extra) = match style.justify {
+        Justify::Start => (0, 0),
+        Justify::Center => (free / 2, 0),
+        Justify::End => (free, 0),
+        Justify::SpaceBetween if items.len() > 1 => (0, free / (items.len() as u16 - 1)),
+        Justify::SpaceBetween => (0, 0),
+    };
+
+    // Place each child, aligning it on the cross axis.
+    let mut rects = Vec::with_capacity(items.len());
+    for (i, item) in items.iter().enumerate() {
+        let main_len = main_sizes[i];
+        let cross_len = match style.align_items {
+            Align::Stretch => cross_avail,
+            _ => axis.cross(item.intrinsic).min(cross_avail),
+        };
+        let cross_off = match style.align_items {
+            Align::Start | Align::Stretch => 0,
+            Align::Center => cross_avail.saturating_sub(cross_len) / 2,
+            Align::End => cross_avail.saturating_sub(cross_len),
+        };
+        rects.push(axis.place(inner, cursor, cross_off, main_len, cross_len));
+        cursor = cursor
+            .saturating_add(main_len)
+            .saturating_add(style.gap)
+            .saturating_add(between_extra);
+    }
+    rects
+}

--- a/src/tuika/mod.rs
+++ b/src/tuika/mod.rs
@@ -1,0 +1,73 @@
+//! `tuika` — a small retained-tree terminal UI toolkit.
+//!
+//! `tuika` is yolop's experimental full-screen renderer foundation. It is
+//! designed to graduate into a standalone crate, so it depends only on
+//! `ratatui`, `crossterm`, `textwrap`, and `unicode-width`, and knows nothing
+//! about yolop's `App`, runtime, or presentation model. Yolop drives it from
+//! `crate::app::fullscreen`; nothing here reaches back into the binary.
+//!
+//! # Why it exists
+//!
+//! yolop's default TUI is *inline*: the transcript lives in native terminal
+//! scrollback and ratatui owns only a bottom composer. That keeps scrollback
+//! and copy/paste native, but centered overlays and resize anchoring fight the
+//! inline viewport (see the inline path's re-anchoring logic). `tuika` is the
+//! opt-in *full-screen* alternative (`--fullscreen`): it owns the alternate
+//! screen, so overlays, focus, and scrolling compose cleanly at the cost of
+//! rebuilding scrollback in-app. This mirrors where Codex and Claude Code's
+//! full-screen renderer landed.
+//!
+//! # Model
+//!
+//! - **Views** ([`view::View`]) are ephemeral, rebuilt from application state
+//!   each frame; ratatui diffs the resulting cell buffer, so this is cheap.
+//! - **State** that must persist across frames ([`components::ScrollState`],
+//!   [`components::SelectState`], [`focus::FocusRegistry`]) lives in the host,
+//!   in the `StatefulWidget` idiom.
+//! - **Layout** is a flexbox subset ([`layout`]); **overlays** ([`overlay`])
+//!   anchor over the base tree; the **host** ([`host`]) owns the alternate
+//!   screen, translates crossterm input, and composites the frame.
+//!
+//! # Extending
+//!
+//! Add a component by implementing [`view::View`] in a new module under
+//! [`components`]. No registration step; containers accept any boxed `View`.
+
+// `tuika` is a self-contained toolkit staged for extraction into its own crate.
+// Its public API is deliberately broader than yolop's current full-screen host
+// consumes (Select, focus, overlays, alt themes, the full event enum), so the
+// binary build sees parts of the surface as dead. Allow it here rather than
+// trimming the API down to today's single call site.
+#![allow(dead_code, unused_imports)]
+
+pub mod components;
+pub mod event;
+pub mod focus;
+pub mod geometry;
+pub mod host;
+pub mod layout;
+pub mod overlay;
+pub mod style;
+pub mod surface;
+pub mod view;
+
+// Curated top-level re-exports so callers write `tuika::Flex`, `tuika::Theme`,
+// etc. for the common surface without deep paths. This is the toolkit's public
+// API; not every item is used by yolop's current full-screen host, but they are
+// part of the surface a future standalone crate exposes, so we keep them
+// exported rather than trimming to today's call sites.
+pub use components::{
+    Boxed, Flex, Paragraph, Scroll, ScrollState, SelectList, SelectOutcome, SelectState, Spacer,
+    StatusBar, Text,
+};
+pub use event::{Event, EventFlow, Key, KeyCode, Mouse, MouseKind};
+pub use focus::FocusRegistry;
+pub use geometry::{Padding, Size};
+pub use host::{AltScreen, Overlay, paint, translate_event};
+pub use layout::{Align, Dimension, Direction, Justify, LayoutStyle};
+pub use overlay::{Anchor, Extent, OverlaySpec};
+pub use style::{BorderStyle, Theme};
+pub use view::{Element, RenderCtx, View, element};
+
+#[cfg(test)]
+mod tests;

--- a/src/tuika/overlay.rs
+++ b/src/tuika/overlay.rs
@@ -1,0 +1,143 @@
+//! Overlay positioning (Pi's overlay model).
+//!
+//! An overlay is a view drawn on top of the base tree at an anchored, sized
+//! rect. Because the full-screen renderer owns the whole alternate-screen
+//! buffer, an overlay is just "paint this last, into this rect, after clearing
+//! it" — none of the inline-viewport chrome-bleed the inline path fights. The
+//! [`OverlaySpec`] resolves a target [`Rect`] from an [`Anchor`] plus size
+//! constraints relative to the screen.
+
+use ratatui::layout::Rect;
+
+use super::geometry::Size;
+
+/// Where an overlay sits relative to the screen.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Anchor {
+    #[default]
+    Center,
+    Top,
+    Bottom,
+    Left,
+    Right,
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    BottomRight,
+}
+
+/// A size request: an absolute cell count or a percentage of the screen extent,
+/// with optional min/max clamps.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Extent {
+    Cells(u16),
+    Percent(u16),
+}
+
+impl Extent {
+    fn resolve(self, available: u16) -> u16 {
+        match self {
+            Extent::Cells(n) => n,
+            Extent::Percent(p) => ((available as u32 * p.min(100) as u32) / 100) as u16,
+        }
+    }
+}
+
+/// Anchored, sized overlay placement relative to a screen rect.
+#[derive(Clone, Copy, Debug)]
+pub struct OverlaySpec {
+    pub anchor: Anchor,
+    pub width: Extent,
+    pub height: Extent,
+    pub min_width: u16,
+    pub min_height: u16,
+    pub max_width: u16,
+    pub max_height: u16,
+    pub margin: u16,
+}
+
+impl OverlaySpec {
+    /// A centered overlay sized as a percentage of the screen.
+    pub fn centered(width_pct: u16, height_pct: u16) -> Self {
+        Self {
+            anchor: Anchor::Center,
+            width: Extent::Percent(width_pct),
+            height: Extent::Percent(height_pct),
+            min_width: 0,
+            min_height: 0,
+            max_width: u16::MAX,
+            max_height: u16::MAX,
+            margin: 0,
+        }
+    }
+
+    pub fn anchor(mut self, anchor: Anchor) -> Self {
+        self.anchor = anchor;
+        self
+    }
+
+    pub fn min_size(mut self, width: u16, height: u16) -> Self {
+        self.min_width = width;
+        self.min_height = height;
+        self
+    }
+
+    pub fn max_size(mut self, width: u16, height: u16) -> Self {
+        self.max_width = width;
+        self.max_height = height;
+        self
+    }
+
+    pub fn margin(mut self, margin: u16) -> Self {
+        self.margin = margin;
+        self
+    }
+
+    /// Resolve the overlay rect within `screen`.
+    pub fn resolve(&self, screen: Rect) -> Rect {
+        let avail = Size::new(
+            screen.width.saturating_sub(self.margin.saturating_mul(2)),
+            screen.height.saturating_sub(self.margin.saturating_mul(2)),
+        );
+        let w = self.width.resolve(avail.width).clamp(
+            self.min_width.min(avail.width),
+            self.max_width.min(avail.width),
+        );
+        let h = self.height.resolve(avail.height).clamp(
+            self.min_height.min(avail.height),
+            self.max_height.min(avail.height),
+        );
+
+        let inner = Rect {
+            x: screen.x.saturating_add(self.margin),
+            y: screen.y.saturating_add(self.margin),
+            width: avail.width,
+            height: avail.height,
+        };
+        let (x, y) = self.position(inner, w, h);
+        Rect {
+            x,
+            y,
+            width: w,
+            height: h,
+        }
+    }
+
+    fn position(&self, inner: Rect, w: u16, h: u16) -> (u16, u16) {
+        let free_x = inner.width.saturating_sub(w);
+        let free_y = inner.height.saturating_sub(h);
+        let (left, mid_x, right) = (inner.x, inner.x + free_x / 2, inner.x + free_x);
+        let (top, mid_y, bottom) = (inner.y, inner.y + free_y / 2, inner.y + free_y);
+        match self.anchor {
+            Anchor::Center => (mid_x, mid_y),
+            Anchor::Top => (mid_x, top),
+            Anchor::Bottom => (mid_x, bottom),
+            Anchor::Left => (left, mid_y),
+            Anchor::Right => (right, mid_y),
+            Anchor::TopLeft => (left, top),
+            Anchor::TopRight => (right, top),
+            Anchor::BottomLeft => (left, bottom),
+            Anchor::BottomRight => (right, bottom),
+        }
+    }
+}

--- a/src/tuika/style.rs
+++ b/src/tuika/style.rs
@@ -1,0 +1,132 @@
+//! Styling and theming.
+//!
+//! `tuika` reuses ratatui's [`Style`], [`Color`], and [`Modifier`] rather than
+//! reinventing cell attributes, but components never hard-code colors: they
+//! pull from a [`Theme`] passed through the render context. Swapping the theme
+//! restyles every component at once, and downstream libraries can ship their
+//! own palette without touching component code.
+
+use ratatui::style::{Color, Modifier, Style};
+
+/// Line-drawing style for bordered components.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum BorderStyle {
+    #[default]
+    Rounded,
+    Plain,
+    Thick,
+    None,
+}
+
+impl BorderStyle {
+    /// (top_left, top_right, bottom_left, bottom_right, horizontal, vertical)
+    pub fn glyphs(self) -> BorderGlyphs {
+        match self {
+            BorderStyle::Rounded => BorderGlyphs::new('╭', '╮', '╰', '╯', '─', '│'),
+            BorderStyle::Plain => BorderGlyphs::new('┌', '┐', '└', '┘', '─', '│'),
+            BorderStyle::Thick => BorderGlyphs::new('┏', '┓', '┗', '┛', '━', '┃'),
+            BorderStyle::None => BorderGlyphs::new(' ', ' ', ' ', ' ', ' ', ' '),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BorderGlyphs {
+    pub top_left: char,
+    pub top_right: char,
+    pub bottom_left: char,
+    pub bottom_right: char,
+    pub horizontal: char,
+    pub vertical: char,
+}
+
+impl BorderGlyphs {
+    const fn new(
+        top_left: char,
+        top_right: char,
+        bottom_left: char,
+        bottom_right: char,
+        horizontal: char,
+        vertical: char,
+    ) -> Self {
+        Self {
+            top_left,
+            top_right,
+            bottom_left,
+            bottom_right,
+            horizontal,
+            vertical,
+        }
+    }
+}
+
+/// A named palette every component styles itself from.
+///
+/// The default mirrors yolop's existing inline palette so the full-screen
+/// renderer looks like the same product. A different host can construct its
+/// own `Theme` and the whole component tree follows.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Theme {
+    pub background: Color,
+    pub surface: Color,
+    pub text: Color,
+    pub muted: Color,
+    pub dim: Color,
+    pub accent: Color,
+    pub accent_alt: Color,
+    pub border: Color,
+    pub border_focused: Color,
+    pub selection_bg: Color,
+    pub selection_fg: Color,
+}
+
+impl Default for Theme {
+    fn default() -> Self {
+        // Kept in lockstep with the palette in `crate::app` so inline and
+        // full-screen share one look.
+        Theme {
+            background: Color::Rgb(18, 18, 22),
+            surface: Color::Rgb(28, 28, 34),
+            text: Color::Rgb(230, 230, 232),
+            muted: Color::Rgb(140, 140, 145),
+            dim: Color::Rgb(72, 72, 78),
+            accent: Color::Rgb(45, 91, 158),
+            accent_alt: Color::Rgb(126, 94, 19),
+            border: Color::Rgb(72, 72, 78),
+            border_focused: Color::Rgb(45, 91, 158),
+            selection_bg: Color::Rgb(45, 91, 158),
+            selection_fg: Color::Rgb(230, 230, 232),
+        }
+    }
+}
+
+impl Theme {
+    pub fn text_style(&self) -> Style {
+        Style::default().fg(self.text)
+    }
+
+    pub fn muted_style(&self) -> Style {
+        Style::default().fg(self.muted)
+    }
+
+    pub fn accent_style(&self) -> Style {
+        Style::default()
+            .fg(self.accent)
+            .add_modifier(Modifier::BOLD)
+    }
+
+    pub fn border_color(&self, focused: bool) -> Color {
+        if focused {
+            self.border_focused
+        } else {
+            self.border
+        }
+    }
+
+    pub fn selection_style(&self) -> Style {
+        Style::default()
+            .bg(self.selection_bg)
+            .fg(self.selection_fg)
+            .add_modifier(Modifier::BOLD)
+    }
+}

--- a/src/tuika/surface.rs
+++ b/src/tuika/surface.rs
@@ -1,0 +1,114 @@
+//! Clipped drawing surface over a ratatui [`Buffer`].
+//!
+//! Components paint through a [`Surface`], which owns a mutable borrow of the
+//! frame buffer plus a clip [`Rect`]. Every write is intersected with the clip
+//! region, so a child can never scribble outside the area the layout gave it —
+//! this is what makes scroll viewports and overlays safe to compose. ratatui
+//! still owns the shadow-buffer diff against the terminal, so `tuika` pays
+//! nothing extra for dirty-cell tracking.
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use unicode_width::UnicodeWidthChar;
+
+use super::style::BorderGlyphs;
+
+/// A clipped view into the frame buffer for one component.
+pub struct Surface<'a> {
+    buffer: &'a mut Buffer,
+    clip: Rect,
+}
+
+impl<'a> Surface<'a> {
+    /// Wrap `buffer`, clipping all writes to the intersection of `clip` and the
+    /// buffer's own area.
+    pub fn new(buffer: &'a mut Buffer, clip: Rect) -> Self {
+        let clip = clip.intersection(buffer.area);
+        Self { buffer, clip }
+    }
+
+    /// The region this surface may draw into.
+    pub fn area(&self) -> Rect {
+        self.clip
+    }
+
+    /// Re-borrow as a child surface clipped to `area` (further intersected with
+    /// the current clip). Used when a container hands a sub-rect to a child.
+    pub fn child(&mut self, area: Rect) -> Surface<'_> {
+        let clip = area.intersection(self.clip);
+        Surface {
+            buffer: self.buffer,
+            clip,
+        }
+    }
+
+    fn contains(&self, x: u16, y: u16) -> bool {
+        x >= self.clip.x && x < self.clip.right() && y >= self.clip.y && y < self.clip.bottom()
+    }
+
+    /// Paint every cell in the clip region with `style` (and a space glyph).
+    pub fn fill(&mut self, style: Style) {
+        for y in self.clip.y..self.clip.bottom() {
+            for x in self.clip.x..self.clip.right() {
+                let cell = &mut self.buffer[(x, y)];
+                cell.set_char(' ');
+                cell.set_style(style);
+            }
+        }
+    }
+
+    /// Set a single cell's symbol and style if it is inside the clip.
+    pub fn set(&mut self, x: u16, y: u16, ch: char, style: Style) {
+        if self.contains(x, y) {
+            let cell = &mut self.buffer[(x, y)];
+            cell.set_char(ch);
+            cell.set_style(style);
+        }
+    }
+
+    /// Draw `text` starting at (`x`, `y`), advancing by each glyph's display
+    /// width and stopping at the clip's right edge. Returns the exclusive end
+    /// column actually written.
+    pub fn set_string(&mut self, x: u16, y: u16, text: &str, style: Style) -> u16 {
+        let mut col = x;
+        for ch in text.chars() {
+            let w = UnicodeWidthChar::width(ch).unwrap_or(0) as u16;
+            if w == 0 {
+                continue;
+            }
+            if col >= self.clip.right() {
+                break;
+            }
+            self.set(col, y, ch, style);
+            // Blank the trailing cell of a wide glyph so stale content behind a
+            // double-width char never shows through.
+            if w == 2 && col + 1 < self.clip.right() {
+                self.set(col + 1, y, ' ', style);
+            }
+            col = col.saturating_add(w);
+        }
+        col
+    }
+
+    /// Draw a rectangular border with `glyphs` around `area`, styled `style`.
+    pub fn draw_border(&mut self, area: Rect, glyphs: BorderGlyphs, style: Style) {
+        if area.width < 2 || area.height < 2 {
+            return;
+        }
+        let right = area.right() - 1;
+        let bottom = area.bottom() - 1;
+        for x in area.x..area.right() {
+            self.set(x, area.y, glyphs.horizontal, style);
+            self.set(x, bottom, glyphs.horizontal, style);
+        }
+        for y in area.y..area.bottom() {
+            self.set(area.x, y, glyphs.vertical, style);
+            self.set(right, y, glyphs.vertical, style);
+        }
+        self.set(area.x, area.y, glyphs.top_left, style);
+        self.set(right, area.y, glyphs.top_right, style);
+        self.set(area.x, bottom, glyphs.bottom_left, style);
+        self.set(right, bottom, glyphs.bottom_right, style);
+    }
+}

--- a/src/tuika/tests.rs
+++ b/src/tuika/tests.rs
@@ -1,0 +1,379 @@
+//! Unit tests for the `tuika` toolkit. These exercise the layout math and
+//! interactive state directly, and the components/compositor by rendering into
+//! an in-memory ratatui [`Buffer`] and reading cells back — no real terminal.
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+
+use super::components::{
+    Paragraph, Scroll, ScrollState, SelectList, SelectOutcome, SelectState, Text,
+};
+use super::event::{Event, EventFlow, Key, KeyCode, Mouse, MouseKind};
+use super::focus::FocusRegistry;
+use super::geometry::{Padding, Size};
+use super::host::{self, Overlay};
+use super::layout::{Align, Dimension, Direction, Item, Justify, LayoutStyle, solve};
+use super::overlay::{Anchor, Extent, OverlaySpec};
+use super::style::Theme;
+use super::surface::Surface;
+use super::view::{RenderCtx, View, element};
+
+/// Read a buffer row into a trimmed string for assertions.
+fn row(buffer: &Buffer, y: u16) -> String {
+    let area = buffer.area;
+    let mut s = String::new();
+    for x in area.x..area.right() {
+        s.push_str(buffer[(x, y)].symbol());
+    }
+    s.trim_end().to_string()
+}
+
+fn buffer(width: u16, height: u16) -> Buffer {
+    Buffer::empty(Rect::new(0, 0, width, height))
+}
+
+fn item(dim: Dimension, w: u16, h: u16) -> Item {
+    Item::new(dim, Size::new(w, h))
+}
+
+// ---- layout solver -------------------------------------------------------
+
+#[test]
+fn flex_distributes_leftover_to_grow_children() {
+    let area = Rect::new(0, 0, 30, 1);
+    let style = LayoutStyle::row();
+    let items = [
+        item(Dimension::Fixed(10), 10, 1),
+        item(Dimension::Flex(1), 0, 1),
+        item(Dimension::Flex(1), 0, 1),
+    ];
+    let rects = solve(area, &style, &items);
+    assert_eq!(rects[0].width, 10);
+    // 20 leftover split evenly.
+    assert_eq!(rects[1].width, 10);
+    assert_eq!(rects[2].width, 10);
+    // Contiguous placement.
+    assert_eq!(rects[1].x, 10);
+    assert_eq!(rects[2].x, 20);
+}
+
+#[test]
+fn flex_grow_weights_and_remainder_fill_exactly() {
+    let area = Rect::new(0, 0, 10, 1);
+    let style = LayoutStyle::row();
+    let items = [
+        item(Dimension::Flex(1), 0, 1),
+        item(Dimension::Flex(2), 0, 1),
+    ];
+    let rects = solve(area, &style, &items);
+    // Weighted 1:2 across 10 cells; the last flex child absorbs the remainder.
+    assert_eq!(rects[0].width + rects[1].width, 10);
+    assert_eq!(rects[0].width, 3);
+    assert_eq!(rects[1].width, 7);
+}
+
+#[test]
+fn flex_percent_and_gap() {
+    let area = Rect::new(0, 0, 20, 1);
+    let style = LayoutStyle::row().gap(2);
+    let items = [
+        item(Dimension::Percent(50), 0, 1),
+        item(Dimension::Auto, 4, 1),
+    ];
+    let rects = solve(area, &style, &items);
+    // space_for_children = 20 - gap(2) = 18; 50% = 9.
+    assert_eq!(rects[0].width, 9);
+    assert_eq!(rects[1].x, rects[0].x + 9 + 2);
+}
+
+#[test]
+fn column_stretch_fills_cross_axis() {
+    let area = Rect::new(0, 0, 12, 6);
+    let style = LayoutStyle::column().align(Align::Stretch);
+    let items = [
+        item(Dimension::Fixed(2), 3, 2),
+        item(Dimension::Fixed(2), 5, 2),
+    ];
+    let rects = solve(area, &style, &items);
+    assert_eq!(rects[0].width, 12);
+    assert_eq!(rects[1].width, 12);
+    assert_eq!(rects[0].height, 2);
+    assert_eq!(rects[1].y, 2);
+}
+
+#[test]
+fn justify_center_and_end_offset_main_axis() {
+    let area = Rect::new(0, 0, 20, 1);
+    let items = [item(Dimension::Fixed(4), 4, 1)];
+    let center = solve(area, &LayoutStyle::row().justify(Justify::Center), &items);
+    assert_eq!(center[0].x, 8); // (20-4)/2
+    let end = solve(area, &LayoutStyle::row().justify(Justify::End), &items);
+    assert_eq!(end[0].x, 16);
+}
+
+#[test]
+fn padding_shrinks_layout_area() {
+    let area = Rect::new(0, 0, 20, 5);
+    let style = LayoutStyle::column().padding(Padding::all(1));
+    let items = [item(Dimension::Flex(1), 0, 0)];
+    let rects = solve(area, &style, &items);
+    assert_eq!(rects[0].x, 1);
+    assert_eq!(rects[0].y, 1);
+    assert_eq!(rects[0].width, 18);
+    assert_eq!(rects[0].height, 3);
+}
+
+// ---- text / paragraph ----------------------------------------------------
+
+#[test]
+fn text_renders_and_clips_to_width() {
+    let mut buf = buffer(6, 2);
+    let text = Text::new(vec![Line::from("hello world"), Line::from("hi")]);
+    let theme = Theme::default();
+    let ctx = RenderCtx::new(&theme);
+    let area = buf.area;
+    let mut surface = Surface::new(&mut buf, area);
+    text.render(area, &mut surface, &ctx);
+    // Clipped to 6 columns ("hello " with a trailing space, which `row` trims).
+    assert_eq!(row(&buf, 0), "hello");
+    assert_eq!(row(&buf, 1), "hi");
+}
+
+#[test]
+fn paragraph_wraps_to_width() {
+    let p = Paragraph::new("the quick brown fox", Style::default());
+    let size = p.measure(Size::new(10, 10));
+    assert!(size.height >= 2, "expected wrap, got {size:?}");
+    assert!(size.width <= 10);
+}
+
+// ---- scroll state --------------------------------------------------------
+
+#[test]
+fn scroll_sticks_to_bottom_until_scrolled_up() {
+    let mut s = ScrollState::new();
+    // content 100 rows, viewport 10 => bottom offset 90.
+    s.clamp(100, 10);
+    assert_eq!(s.offset(), 90);
+    assert!(s.is_stuck_to_bottom());
+
+    // Wheel up unsticks and moves up by 3.
+    let up = Event::Mouse(Mouse {
+        kind: MouseKind::ScrollUp,
+        column: 0,
+        row: 0,
+    });
+    assert_eq!(s.handle(&up, 100, 10), EventFlow::Consumed);
+    assert!(!s.is_stuck_to_bottom());
+    assert_eq!(s.offset(), 87);
+
+    // Growing content no longer drags the view down while unstuck.
+    s.clamp(200, 10);
+    assert_eq!(s.offset(), 87);
+}
+
+#[test]
+fn scroll_end_key_rearms_bottom_stick() {
+    let mut s = ScrollState::new();
+    s.clamp(100, 10);
+    s.jump_to_top();
+    assert_eq!(s.offset(), 0);
+    assert!(!s.is_stuck_to_bottom());
+    let end = Event::Key(Key::new(KeyCode::End));
+    assert_eq!(s.handle(&end, 100, 10), EventFlow::Consumed);
+    assert_eq!(s.offset(), 90);
+    assert!(s.is_stuck_to_bottom());
+}
+
+#[test]
+fn scroll_view_windows_content_and_draws_scrollbar() {
+    let lines: Vec<Line<'static>> = (0..20).map(|i| Line::from(format!("line{i}"))).collect();
+    let mut state = ScrollState::new();
+    state.clamp(20, 5); // stuck to bottom => offset 15
+    let scroll = Scroll::new(lines, &state);
+    let mut buf = buffer(10, 5);
+    let theme = Theme::default();
+    let ctx = RenderCtx::new(&theme);
+    let area = buf.area;
+    let mut surface = Surface::new(&mut buf, area);
+    scroll.render(area, &mut surface, &ctx);
+    // Bottom-stuck: shows the last five lines (15..20).
+    assert!(row(&buf, 0).starts_with("line15"));
+    assert!(row(&buf, 4).starts_with("line19"));
+    // Scrollbar drawn in the last column somewhere.
+    let has_bar = (0..5).any(|y| {
+        let c = buf[(9, y)].symbol().to_string();
+        c == "█" || c == "│"
+    });
+    assert!(has_bar, "expected a scrollbar in the right column");
+}
+
+// ---- select --------------------------------------------------------------
+
+#[test]
+fn select_navigation_wraps_and_confirms() {
+    let mut s = SelectState::new();
+    let down = Event::Key(Key::new(KeyCode::Down));
+    let up = Event::Key(Key::new(KeyCode::Up));
+    assert_eq!(s.handle(&up, 3), SelectOutcome::Moved(EventFlow::Consumed));
+    assert_eq!(s.selected(), 2); // wrapped from 0 to last
+    assert_eq!(
+        s.handle(&down, 3),
+        SelectOutcome::Moved(EventFlow::Consumed)
+    );
+    assert_eq!(s.selected(), 0); // wrapped back
+    let enter = Event::Key(Key::new(KeyCode::Enter));
+    assert_eq!(s.handle(&enter, 3), SelectOutcome::Confirmed(0));
+    let esc = Event::Key(Key::new(KeyCode::Esc));
+    assert_eq!(s.handle(&esc, 3), SelectOutcome::Cancelled);
+}
+
+#[test]
+fn select_highlights_current_row() {
+    let items = vec![Line::from("alpha"), Line::from("beta")];
+    let mut state = SelectState::new();
+    state.handle(&Event::Key(Key::new(KeyCode::Down)), 2); // select beta
+    let list = SelectList::new(items, &state);
+    let mut buf = buffer(10, 2);
+    let theme = Theme::default();
+    let ctx = RenderCtx::new(&theme);
+    let area = buf.area;
+    let mut surface = Surface::new(&mut buf, area);
+    list.render(area, &mut surface, &ctx);
+    assert!(row(&buf, 1).contains("beta"));
+    // Selected row carries the selection background.
+    assert_eq!(buf[(0, 1)].bg, theme.selection_bg);
+    assert_eq!(buf[(0, 0)].bg, ratatui::style::Color::Reset);
+}
+
+// ---- overlay -------------------------------------------------------------
+
+#[test]
+fn overlay_centered_percentage() {
+    let screen = Rect::new(0, 0, 100, 40);
+    let spec = OverlaySpec::centered(50, 50);
+    let rect = spec.resolve(screen);
+    assert_eq!(rect.width, 50);
+    assert_eq!(rect.height, 20);
+    assert_eq!(rect.x, 25);
+    assert_eq!(rect.y, 10);
+}
+
+#[test]
+fn overlay_anchors_to_corner_with_margin() {
+    let screen = Rect::new(0, 0, 100, 40);
+    let spec = OverlaySpec {
+        anchor: Anchor::BottomRight,
+        width: Extent::Cells(20),
+        height: Extent::Cells(10),
+        min_width: 0,
+        min_height: 0,
+        max_width: u16::MAX,
+        max_height: u16::MAX,
+        margin: 2,
+    };
+    let rect = spec.resolve(screen);
+    assert_eq!(rect.width, 20);
+    assert_eq!(rect.height, 10);
+    // Bottom-right inside a 2-cell margin: right edge at 98, bottom at 38.
+    assert_eq!(rect.right(), 98);
+    assert_eq!(rect.bottom(), 38);
+}
+
+#[test]
+fn overlay_clamps_to_max() {
+    let screen = Rect::new(0, 0, 100, 40);
+    let spec = OverlaySpec::centered(90, 90).max_size(40, 20);
+    let rect = spec.resolve(screen);
+    assert_eq!(rect.width, 40);
+    assert_eq!(rect.height, 20);
+}
+
+// ---- focus ---------------------------------------------------------------
+
+#[test]
+fn focus_tab_cycles_registered_regions() {
+    let mut f = FocusRegistry::new();
+    f.begin_frame();
+    f.register("a");
+    f.register("b");
+    f.register("c");
+    assert!(f.is_focused("a"));
+    let tab = Event::Key(Key::new(KeyCode::Tab));
+    assert_eq!(f.handle(&tab), EventFlow::Consumed);
+    assert!(f.is_focused("b"));
+    let back = Event::Key(Key::new(KeyCode::BackTab));
+    f.handle(&back);
+    assert!(f.is_focused("a"));
+    // Wrap backwards.
+    f.handle(&back);
+    assert!(f.is_focused("c"));
+}
+
+#[test]
+fn overlay_owner_takes_input_and_blocks_tab() {
+    let mut f = FocusRegistry::new();
+    f.begin_frame();
+    f.register("composer");
+    f.set_owner("dialog");
+    assert!(f.is_active("dialog"));
+    assert!(!f.is_active("composer"));
+    // Tab is swallowed while an overlay owns input.
+    let tab = Event::Key(Key::new(KeyCode::Tab));
+    assert_eq!(f.handle(&tab), EventFlow::Ignored);
+    f.clear_owner();
+    assert!(f.is_active("composer"));
+}
+
+// ---- compositor ----------------------------------------------------------
+
+#[test]
+fn paint_composites_background_root_and_overlay() {
+    let theme = Theme::default();
+    let mut buf = buffer(20, 5);
+    let area = buf.area;
+    let root = Text::new(vec![Line::from(Span::raw("base layer"))]);
+    let dialog = Text::new(vec![Line::from("MODAL")]);
+    let overlay_area = Rect::new(5, 2, 7, 1);
+    let overlays = [Overlay {
+        area: overlay_area,
+        view: &dialog,
+        clear: true,
+    }];
+    host::paint(&mut buf, area, &theme, &root, &overlays);
+    // Root text on the top row.
+    assert!(row(&buf, 0).starts_with("base layer"));
+    // Background fill applied everywhere.
+    assert_eq!(buf[(0, 0)].bg, theme.background);
+    // Overlay painted last on its row with a surface background.
+    assert!(row(&buf, 2).contains("MODAL"));
+    assert_eq!(buf[(5, 2)].bg, theme.surface);
+}
+
+// ---- a small end-to-end tree ---------------------------------------------
+
+#[test]
+fn nested_flex_tree_lays_out_status_and_body() {
+    use super::components::{Boxed, Flex, StatusBar};
+    let theme = Theme::default();
+    let mut buf = buffer(24, 6);
+    let area = buf.area;
+
+    let body = Boxed::new(element(Text::raw("hi"))).title("Body");
+    let status = StatusBar::new().left(vec![Span::raw("model: sim")]);
+    let tree = Flex::column()
+        .grow(1, element(body))
+        .fixed(1, element(status));
+
+    let ctx = RenderCtx::new(&theme);
+    let mut surface = Surface::new(&mut buf, area);
+    tree.render(area, &mut surface, &ctx);
+
+    // Status bar occupies the last row.
+    assert!(row(&buf, 5).starts_with("model: sim"));
+    // Body box drew a rounded border on the top row with its title.
+    assert!(row(&buf, 0).contains("Body"));
+    assert_eq!(buf[(0, 0)].symbol(), "╭");
+}

--- a/src/tuika/view.rs
+++ b/src/tuika/view.rs
@@ -1,0 +1,71 @@
+//! The `View` trait — the extensibility seam for components.
+//!
+//! Design note (why not a React-style reconciler): `tuika` rebuilds the view
+//! tree from application state every frame, which is cheap because ratatui
+//! already diffs the resulting cell buffer against the terminal. So views are
+//! ephemeral *render descriptions* (immediate-mode structure), while the
+//! interactive state that must survive across frames — scroll offset, current
+//! selection, editor cursor — lives in host-persisted `State` structs (the
+//! ratatui `StatefulWidget` idiom). Adding a component means implementing
+//! `View` for its render, and, if interactive, a small state struct with an
+//! event handler. No trait-object tree to reconcile.
+
+use ratatui::layout::Rect;
+
+use super::geometry::Size;
+use super::style::Theme;
+use super::surface::Surface;
+
+/// Context threaded to every `View::render`.
+pub struct RenderCtx<'a> {
+    pub theme: &'a Theme,
+    /// Whether the focused component of the frame is this one. Containers pass
+    /// this down unchanged; focus-aware leaves use it to highlight borders.
+    pub focused: bool,
+}
+
+impl<'a> RenderCtx<'a> {
+    pub fn new(theme: &'a Theme) -> Self {
+        Self {
+            theme,
+            focused: false,
+        }
+    }
+
+    /// A child context with an explicit focus flag.
+    pub fn with_focus(&self, focused: bool) -> RenderCtx<'a> {
+        RenderCtx {
+            theme: self.theme,
+            focused,
+        }
+    }
+}
+
+/// A drawable, measurable UI element.
+///
+/// `measure` reports the intrinsic content size the view would like given
+/// `available`; the flex solver uses it for `Dimension::Auto` sizing.
+/// `render` paints into the `area` the layout assigned, through the clipped
+/// `surface`.
+pub trait View {
+    fn measure(&self, available: Size) -> Size;
+    fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx);
+}
+
+/// Boxed view, the element type stored by containers.
+pub type Element = Box<dyn View>;
+
+impl View for Element {
+    fn measure(&self, available: Size) -> Size {
+        (**self).measure(available)
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+        (**self).render(area, surface, ctx)
+    }
+}
+
+/// Convenience to box any view into an [`Element`].
+pub fn element<V: View + 'static>(view: V) -> Element {
+    Box::new(view)
+}


### PR DESCRIPTION
## What changed

Adds an **opt-in full-screen TUI renderer** behind a new `--fullscreen` flag. When set, yolop draws on the terminal's **alternate screen** (like vim/htop) instead of the default inline scrollback composer: a scrollable transcript, a bordered composer, a status bar, and setup shown as a centered overlay. **Inline remains the default and is unchanged** — this is experimental and gated by the flag.

It also introduces **`tuika`** (`src/tuika/`), a small retained-tree terminal-UI toolkit that provides the layout/overlay/focus/component primitives ratatui lacks. It's self-contained (depends only on `ratatui`, `crossterm`, `textwrap`, `unicode-width`) and staged for extraction into its own crate — yolop only reaches into it from `src/app/fullscreen.rs`.

## Why

yolop's inline viewport keeps native scrollback but fights centered overlays and resize anchoring (see the inline re-anchor logic in `viewport.rs` and the recent resize/overlay stabilization work, #305). Full-screen owns the whole screen, so overlays, focus, and scrolling compose cleanly — the direction Codex (`--no-alt-screen` toggle) and Claude Code's full-screen renderer both took. This lands the foundation for that path without disturbing the inline default, so the two can be compared in practice.

`tuika` design: flexbox-subset layout solver over a direction-agnostic axis; a clipped `Surface` over ratatui's `Buffer` (cell-diffing stays free); a `View` trait using immediate structure + host-persisted state (the `StatefulWidget` idiom, no reconciler); components (Text, Paragraph, Flex, Boxed, Spacer, Scroll, SelectList, StatusBar); overlay anchor/size solver; a `FocusRegistry` with input ownership; and an RAII alt-screen host + crossterm→tuika event translation + compositor. Theme-driven, with a default palette in lockstep with the inline one.

## Before / After

**Before:** interactive TUI only ran inline (short composer + native scrollback); no full-screen option.

**After:** `yolop --fullscreen` renders full-screen. PTY smoke test (120×40) drives the real binary end-to-end:

```
exit_code= 0
entered_alt= True   left_alt= True
mouse_on= True      mouse_off= True
has_transcript= True   has_message= True   has_status_provider(llmsim)= True
```

Rendered frame (from the integration test buffer):

```
╭─ transcript ─────────────────────────────────────────────╮
│ system › <banner>                                        █│
│ you › hello from user                                    █│
╰──────────────────────────────────────────────────────────╯
╭─ message ────────────────────────────────────────────────╮
│ draft reply                                              │
╰──────────────────────────────────────────────────────────╯
 llmsim-yolop · llmsim                              normal
```

The alt screen is entered and **restored on exit** (mouse capture too); the resume hint prints on the normal screen afterward. Inline `-p` mode still starts normally.

## Validation

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all-features` — **804 passed**, 2 ignored. New: 20 `tuika` unit tests (layout math, text wrap, scroll stick/clamp, select nav, overlay anchoring, focus/input-ownership, compositor) + 2 yolop integration tests (`fullscreen_renders_transcript_composer_and_status`, `fullscreen_scroll_wheel_unsticks_from_bottom`).
- PTY smoke (above) — enter/leave alt screen, mouse capture, chrome rendered, clean exit.
- `cargo run -- --provider llmsim -p "hi"` — inline path unaffected.

## Security

Rendering-only change; the agent's trust boundaries are untouched.

- **TM-FS / TM-BASH / TM-LLM / TM-TOOL** — no filesystem write paths, shell execution, prompt/key handling, or capability registration changed. `tuika` only reads app state and paints cells.
- **TM-DEP** — one new crate, `unicode-width = "0.2"` (display width for correct wide-glyph rendering); already present transitively via ratatui, widely used. No `everruns-*` version changes.
- Resource use: the full-screen transcript is rebuilt from `App::lines` each frame (bounded by session length, same data the inline path holds); composer rows capped, scroll offset clamped, no unbounded loops. Per-frame rebuild for very long sessions is noted as a follow-up.

## Risk

- **Low.** New code is behind `--fullscreen`; the default inline renderer and its loop are unchanged except for guarding inline-only steps (`flush_transcript`, re-anchoring) behind the mode check.
- What could break: full-screen-specific rendering on unusual terminals — mitigated by the flag being opt-in and experimental.

## Follow-ups

- Show the live streaming preview in the full-screen transcript (currently finalized lines only).
- Route keyboard paging (PageUp/PageDown/Home/End) to the transcript scroll; today only mouse wheel scrolls.
- Drive model / reasoning-effort selection through the new `SelectList` instead of the read-only overlay content.
- Consider incremental transcript caching to avoid rebuilding all wrapped lines each frame on very long sessions.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (inline default unchanged; pre-1.0, flag-gated)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LksbgmgJfiGmNXXGZphgW6)_