### PR TITLE
feat(extensions): scaffold_extension for self-authored extensions

### DIFF
--- a/.agents/skills/author-extension/SKILL.md
+++ b/.agents/skills/author-extension/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: author-extension
+description: Write a new yolop extension end-to-end — scaffold, implement, install, verify, and enable it — when the user asks yolop to add a capability, integrate with something, or "build an extension" for a need that no installed extension covers.
+metadata:
+  internal: true
+user-invocable: true
+---
+
+# Author an extension
+
+Goal: turn a capability request ("integrate with X", "block Y", "add a tool
+that Z") into a working, installed yolop extension — built by yolop itself.
+
+An extension is a capability package served over YEP (the yolop extension
+protocol): a `plugin.json` manifest plus a capability server that speaks
+newline-delimited JSON-RPC over stdio. See [`specs/extensions.md`](../../../specs/extensions.md).
+
+## When to use
+
+Use this when the user wants a *new, persistent* capability and no installed
+extension provides it — something worth keeping across sessions, not a one-off
+shell command. Signals: "make yourself a tool for…", "add an extension that…",
+"integrate yolop with…", "from now on, block/allow…".
+
+If an installed extension already covers it, use that instead
+(`list_extensions`). If the need is a single throwaway action, just do it — do
+not author an extension for it.
+
+## What an extension can contribute
+
+Declare only what you need; a manifest must contribute at least one of:
+
+- **tools** — functions the model can call (the model sees name + schema).
+- **hooks** — `pre_tool_use` (can **block** a tool call, e.g. deny git) or
+  `post_tool_use` (observe-only).
+- **prompt** — a static system-prompt contribution.
+- **mcpServers** — contributed MCP servers (declare in the manifest directly).
+
+Not yet available: statusline/UI, providers, slash commands.
+
+## The loop
+
+1. **Scaffold.** `scaffold_extension name=<name> [description=…] [language=python]`
+   with the facets you need — `tools=[…]`, `hooks=[…]`, and/or `prompt=…`.
+   This writes a correct-by-construction package (manifest + a self-contained
+   server) that installs and passes `doctor` before you write a line of logic.
+   Python is the default and needs no build step.
+
+2. **Implement.** Open the generated server (the tool result prints its path)
+   and fill in the `handle_*` bodies:
+   - `handle_tool(name, args)` — return the tool result dict.
+   - `handle_hook(event, tool_name, args)` — return `{}` to allow, or
+     `{"block": True, "reason": "…"}` to deny (pre_tool_use only). The server
+     receives *every* subscribed tool call, so gate on `tool_name`/`args`.
+   - Keep stdout for protocol JSON only; log to stderr.
+   Edit only the marked handler bodies — leave the protocol plumbing alone.
+
+3. **Install.** `install_extension source=<package dir>` — copies the package
+   into the store and pins it. Installing runs third-party code; since *you*
+   authored it here, the sharp edge is enabling — see step 5.
+
+4. **Verify.** `doctor_extension name=<name>` — spawns the server, runs the
+   handshake, and checks the served tools/prompt against the manifest. Fix any
+   `fail`/`warn` before enabling. If the server won't spawn, check the shebang
+   and that the command is executable.
+
+5. **Enable (ask first).** Show the user the contribution summary and ask
+   before `enable_extension name=<name>` — enabling adds it to the harness and
+   runs its server every session. **Enabling takes effect on the next
+   session**, so tell the user to restart yolop to load it.
+
+## Acceptance check
+
+The loop is proven when yolop, unaided, produces an extension that actually
+works — e.g. a `pre_tool_use` hook that blocks any `git` command, or a tool
+that returns a computed value — installed, doctor-green, and effective after a
+restart. The end-to-end deny path is covered by
+`scaffolded_extension_blocks_git_end_to_end` in `src/extensions/mod.rs`.
+
+## Notes
+
+- Names: ascii letters, digits, `-`, `_`. The dir name must equal the manifest
+  `name`.
+- Do not hardcode absolute paths in the manifest — the package is copied on
+  install. The scaffold resolves the server via the package's `bin/` on PATH.
+- Iterate by editing the server and re-running `doctor_extension`; no reinstall
+  is needed while working from the scaffolded dir, but re-run `install_extension`
+  to pick up edits into the store.

--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -45,6 +45,22 @@ against the manifest — protocol-version compatibility, the D4 tool clamp
 prompt-facet consistency — returning per-check pass/warn/fail. It is the
 runtime dual of the CI schema/drift guards: authors validate a server before
 shipping without booting a whole session.
+Self-writing: `scaffold_extension` generates a ready-to-edit package — a
+`plugin.json` declaring the requested facets (`tools`, `hooks`, `prompt`) plus
+a self-contained capability server whose only author-editable seams are the
+`handle_*` bodies. The skeleton is correct by construction: it installs via
+`install_extension source=<dir>` and passes `doctor_extension` before any logic
+is written, so authoring collapses to filling in handlers. The server is a
+single executable under the package `bin/` (resolved via the `bin/`-on-PATH
+rule the runtime already uses; the exec bit survives the install copy), so no
+absolute paths leak into the manifest. Python is the first template because it
+is toolchain-free — the fastest, most reliable path for yolop to author an
+extension for itself (Rust via `yolop-yep` and TypeScript follow). The
+[`author-extension`](../.agents/skills/author-extension/SKILL.md) skill drives
+the loop (scaffold → implement → install → doctor → ask-to-enable); the
+end-to-end acceptance — a self-authored `pre_tool_use` hook that blocks `git`,
+spawned exactly as the runtime spawns it — is covered by
+`scaffolded_extension_blocks_git_end_to_end`.
 Later — the full `yolop-extension-lsp` control-plane extraction (gated on
 `evals/lsp_integration` parity to retire the built-in), `ui/ask` (needs the
 server→host reverse-request channel, still refused in phase 1),

--- a/src/extensions/manage.rs
+++ b/src/extensions/manage.rs
@@ -5,6 +5,7 @@
 //! and the model can drive setup; a thin `/extensions` command mirrors them.
 
 use super::package::{discover_extensions, extension_capability_id};
+use super::scaffold::{self, HookSpec, Language, ScaffoldRequest, ToolSpec};
 use super::store::{self, CrateFetcher, GitRunner, Source, SystemCrateFetcher, SystemGit};
 use crate::settings::SettingsStore;
 use async_trait::async_trait;
@@ -65,8 +66,13 @@ impl Capability for ExtensionsCapability {
              installed and enabled, `install_extension` for a crates.io crate \
              (`crates.io:yolop-extension-<name>`), git URL, or local path, \
              `enable_extension`/`disable_extension` to toggle one in the harness (takes effect \
-             next session), and `remove_extension` to uninstall. Installing runs third-party \
-             code on the user's machine — confirm the source with the user first.",
+             next session), and `remove_extension` to uninstall. To build a NEW extension \
+             yourself, `scaffold_extension` generates a ready-to-edit package (manifest + \
+             capability server) — declare what it contributes via `tools`, `hooks`, and/or \
+             `prompt` — then edit the generated `handle_*` bodies, `install_extension \
+             source=<dir>`, `doctor_extension` to verify, and `enable_extension`. Installing \
+             runs third-party code on the user's machine — confirm the source with the user \
+             first.",
         )
     }
 
@@ -79,6 +85,7 @@ impl Capability for ExtensionsCapability {
             crates: self.crates.clone(),
         });
         vec![
+            Box::new(ManageTool::new(ctx.clone(), Verb::Scaffold)),
             Box::new(ManageTool::new(ctx.clone(), Verb::List)),
             Box::new(ManageTool::new(ctx.clone(), Verb::Install)),
             Box::new(ManageTool::new(ctx.clone(), Verb::Remove)),
@@ -99,6 +106,7 @@ struct ManageCtx {
 
 #[derive(Clone, Copy)]
 enum Verb {
+    Scaffold,
     List,
     Install,
     Remove,
@@ -115,6 +123,102 @@ struct ManageTool {
 impl ManageTool {
     fn new(ctx: Arc<ManageCtx>, verb: Verb) -> Self {
         Self { ctx, verb }
+    }
+
+    fn scaffold(&self, args: &Value) -> ToolExecutionResult {
+        let Some(name) = args.get("name").and_then(Value::as_str) else {
+            return ToolExecutionResult::ToolError("`name` is required".into());
+        };
+        let language = match Language::parse(
+            args.get("language")
+                .and_then(Value::as_str)
+                .unwrap_or("python"),
+        ) {
+            Ok(lang) => lang,
+            Err(err) => return ToolExecutionResult::ToolError(err),
+        };
+        let tools = args
+            .get("tools")
+            .and_then(Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|t| {
+                        let name = t.get("name").and_then(Value::as_str)?.to_string();
+                        let description = t
+                            .get("description")
+                            .and_then(Value::as_str)
+                            .unwrap_or("")
+                            .to_string();
+                        Some(ToolSpec { name, description })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let hooks = args
+            .get("hooks")
+            .and_then(Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|h| {
+                        let event = h.get("event").and_then(Value::as_str)?.to_string();
+                        let tool_name_glob = h
+                            .get("tool_name_glob")
+                            .and_then(Value::as_str)
+                            .unwrap_or("*")
+                            .to_string();
+                        Some(HookSpec {
+                            event,
+                            tool_name_glob,
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let prompt = args
+            .get("prompt")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        // Default target: a sibling `scaffold/<name>` of the extensions dir, so
+        // authored packages sit next to where they install without cluttering
+        // the workspace. An explicit `dir` (a parent) overrides.
+        let dir = match args.get("dir").and_then(Value::as_str) {
+            Some(parent) => PathBuf::from(parent).join(name),
+            None => self
+                .ctx
+                .extensions_dir
+                .parent()
+                .unwrap_or(&self.ctx.extensions_dir)
+                .join("scaffold")
+                .join(name),
+        };
+        let req = ScaffoldRequest {
+            name: name.to_string(),
+            description: args
+                .get("description")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string(),
+            language,
+            tools,
+            hooks,
+            prompt,
+            dir,
+        };
+        match scaffold::scaffold(&req) {
+            Ok(out) => ToolExecutionResult::Success(json!({
+                "scaffolded": name,
+                "dir": out.dir.display().to_string(),
+                "server": out.server.display().to_string(),
+                "files": out.files,
+                "next": format!(
+                    "Edit the handle_* bodies in {}, then: install_extension source={} → \
+                     doctor_extension name={name} → enable_extension name={name} (next session).",
+                    out.server.display(),
+                    out.dir.display(),
+                ),
+            })),
+            Err(err) => ToolExecutionResult::ToolError(format!("scaffold failed: {err}")),
+        }
     }
 
     fn list(&self) -> ToolExecutionResult {
@@ -251,6 +355,7 @@ impl ManageTool {
 impl Tool for ManageTool {
     fn name(&self) -> &str {
         match self.verb {
+            Verb::Scaffold => "scaffold_extension",
             Verb::List => "list_extensions",
             Verb::Install => "install_extension",
             Verb::Remove => "remove_extension",
@@ -262,6 +367,15 @@ impl Tool for ManageTool {
 
     fn description(&self) -> &str {
         match self.verb {
+            Verb::Scaffold => {
+                "Scaffold a new, ready-to-edit extension package (manifest + a self-contained \
+                 capability server) so you can author an extension end-to-end. Generates a \
+                 correct-by-construction skeleton that installs and passes doctor out of the \
+                 box; you then fill in the `handle_*` bodies. Declare what it contributes via \
+                 `tools`, `hooks`, and/or `prompt`. After editing, install it with \
+                 `install_extension source=<dir>`, verify with `doctor_extension`, and turn it \
+                 on with `enable_extension` (effective next session)."
+            }
             Verb::List => "List installed extensions and whether each is enabled.",
             Verb::Install => {
                 "Install an extension from crates.io (`crates.io:yolop-extension-<name>[@ver]`, \
@@ -287,6 +401,37 @@ impl Tool for ManageTool {
 
     fn parameters_schema(&self) -> Value {
         match self.verb {
+            Verb::Scaffold => json!({
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string",
+                        "description": "Extension name (ascii letters, digits, `-`, `_`)." },
+                    "description": { "type": "string",
+                        "description": "One-line summary of what the extension does." },
+                    "language": { "type": "string", "enum": ["python"], "default": "python",
+                        "description": "Server language template. Python is toolchain-free." },
+                    "tools": { "type": "array", "description": "Tool contributions.",
+                        "items": { "type": "object", "properties": {
+                            "name": { "type": "string" },
+                            "description": { "type": "string" }
+                        }, "required": ["name"] } },
+                    "hooks": { "type": "array",
+                        "description": "Lifecycle hook subscriptions. A pre_tool_use hook can \
+                            block a tool call (e.g. deny git).",
+                        "items": { "type": "object", "properties": {
+                            "event": { "type": "string",
+                                "enum": ["pre_tool_use", "post_tool_use"] },
+                            "tool_name_glob": { "type": "string", "default": "*",
+                                "description": "Glob over tool names to fire for." }
+                        }, "required": ["event"] } },
+                    "prompt": { "type": "string",
+                        "description": "Static system-prompt contribution text, if any." },
+                    "dir": { "type": "string",
+                        "description": "Parent directory to create `<name>/` under. Defaults to \
+                            a `scaffold/` dir beside the extensions store." }
+                },
+                "required": ["name"]
+            }),
             Verb::List => json!({ "type": "object", "properties": {} }),
             Verb::Install => json!({
                 "type": "object",
@@ -310,6 +455,7 @@ impl Tool for ManageTool {
 
     async fn execute(&self, arguments: Value) -> ToolExecutionResult {
         match self.verb {
+            Verb::Scaffold => self.scaffold(&arguments),
             Verb::List => self.list(),
             Verb::Install => self.install(&arguments).await,
             Verb::Remove => self.remove(&arguments),
@@ -351,6 +497,61 @@ mod tests {
             crates: Arc::new(crate::extensions::store::SystemCrateFetcher::default()),
         };
         (cap, settings, ext_dir)
+    }
+
+    #[tokio::test]
+    async fn scaffold_then_install_flow() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (cap, _settings, _ext_dir) = capability(tmp.path());
+        let tools = cap.tools();
+        let get = |name: &str| tools.iter().find(|t| t.name() == name).unwrap();
+
+        // Scaffold a hook extension into an explicit parent dir.
+        let parent = tmp.path().join("authored");
+        let dir = match get("scaffold_extension")
+            .execute(json!({
+                "name": "git-guard",
+                "description": "Blocks git.",
+                "hooks": [{ "event": "pre_tool_use" }],
+                "dir": parent.to_str().unwrap(),
+            }))
+            .await
+        {
+            ToolExecutionResult::Success(v) => {
+                assert_eq!(v["scaffolded"], "git-guard");
+                assert!(parent.join("git-guard").join("plugin.json").exists());
+                v["dir"].as_str().unwrap().to_string()
+            }
+            other => panic!("{other:?}"),
+        };
+
+        // The scaffolded package installs (manifest parses, tree copied).
+        match get("install_extension")
+            .execute(json!({ "source": dir }))
+            .await
+        {
+            ToolExecutionResult::Success(v) => assert_eq!(v["installed"], "git-guard"),
+            other => panic!("{other:?}"),
+        }
+        match get("list_extensions").execute(json!({})).await {
+            ToolExecutionResult::Success(v) => assert_eq!(v["extensions"][0]["name"], "git-guard"),
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn scaffold_rejects_no_contributions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (cap, _s, _e) = capability(tmp.path());
+        let tools = cap.tools();
+        let scaffold = tools
+            .iter()
+            .find(|t| t.name() == "scaffold_extension")
+            .unwrap();
+        match scaffold.execute(json!({ "name": "empty" })).await {
+            ToolExecutionResult::ToolError(m) => assert!(m.contains("contribute"), "{m}"),
+            other => panic!("{other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -22,6 +22,7 @@ pub(crate) mod manage;
 pub(crate) mod manager;
 pub(crate) mod package;
 pub(crate) mod protocol;
+pub(crate) mod scaffold;
 pub(crate) mod store;
 
 pub(crate) use capability::ExtensionCapability;
@@ -318,6 +319,94 @@ mod spawn_tests {
             }
             other => panic!("expected block, got {other:?}"),
         }
+    }
+
+    /// The self-writing acceptance case: `scaffold_extension` produces a
+    /// package whose generated server, once the author fills in the hook body,
+    /// blocks a real tool call when spawned exactly as the runtime spawns it
+    /// (command resolved via the package's `bin/` on PATH — no absolute paths).
+    #[tokio::test]
+    async fn scaffolded_extension_blocks_git_end_to_end() {
+        use super::scaffold::{HookSpec, Language, ScaffoldRequest, scaffold};
+        use everruns_core::atoms::PreToolUseDecision;
+        use everruns_core::tool_types::{BuiltinTool, ToolCall, ToolDefinition};
+        if python3().is_none() {
+            eprintln!("skipping: python3 not available");
+            return;
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let out = scaffold(&ScaffoldRequest {
+            name: "git-guard".into(),
+            description: "Blocks git.".into(),
+            language: Language::Python,
+            tools: vec![],
+            hooks: vec![HookSpec {
+                event: "pre_tool_use".into(),
+                tool_name_glob: "*".into(),
+            }],
+            prompt: None,
+            dir: tmp.path().join("git-guard"),
+        })
+        .unwrap();
+
+        // Author step: fill in the hook body the scaffold left as a no-op.
+        let server = std::fs::read_to_string(&out.server).unwrap();
+        let filled = server.replace(
+            "\n    return {}\n\n\ndef handle_prompt",
+            "\n    command = (args or {}).get(\"command\", \"\")\n    \
+             if event == \"pre_tool_use\" and \"git\" in command.split():\n        \
+             return {\"block\": True, \"reason\": \"git is disabled by git-guard\"}\n    \
+             return {}\n\n\ndef handle_prompt",
+        );
+        assert_ne!(filled, server, "hook body anchor must match");
+        std::fs::write(&out.server, filled).unwrap();
+
+        let manifest =
+            parse_manifest(&std::fs::read_to_string(out.dir.join("plugin.json")).unwrap()).unwrap();
+        let capability = ExtensionCapability::new(
+            ExtensionPackage {
+                dir: out.dir.clone(),
+                manifest,
+            },
+            tmp.path().to_path_buf(),
+        );
+        let hooks = capability.pre_tool_use_hooks_with_config(&json!(null));
+        let hook = &hooks[0];
+        let tool_def = ToolDefinition::Builtin(BuiltinTool {
+            name: "bash".into(),
+            display_name: None,
+            description: "run".into(),
+            parameters: json!({ "type": "object" }),
+            policy: Default::default(),
+            category: None,
+            deferrable: Default::default(),
+            hints: Default::default(),
+            full_parameters: None,
+        });
+        let ctx =
+            everruns_core::traits::ToolContext::new(everruns_core::typed_id::SessionId::new());
+
+        // A git command is denied by the self-authored server.
+        let deny = ToolCall {
+            id: "1".into(),
+            name: "bash".into(),
+            arguments: json!({ "command": "git status" }),
+        };
+        match hook.before_exec(deny, &tool_def, &ctx).await {
+            PreToolUseDecision::Block { reason, .. } => assert!(reason.contains("git"), "{reason}"),
+            other => panic!("expected block, got {other:?}"),
+        }
+
+        // A non-git command passes through.
+        let allow = ToolCall {
+            id: "2".into(),
+            name: "bash".into(),
+            arguments: json!({ "command": "ls -la" }),
+        };
+        assert!(matches!(
+            hook.before_exec(allow, &tool_def, &ctx).await,
+            PreToolUseDecision::Continue(_)
+        ));
     }
 
     #[tokio::test]

--- a/src/extensions/scaffold.rs
+++ b/src/extensions/scaffold.rs
@@ -1,0 +1,474 @@
+//! Extension scaffolding: generate a ready-to-edit YEP extension package so
+//! the agent (or a human) can author an extension end-to-end without
+//! remembering the wire protocol or the package layout.
+//!
+//! The generated package is **correct by construction** — it installs via
+//! `install_extension source=<dir>` and passes `doctor_extension` out of the
+//! box — so authoring collapses to "fill in the handler bodies." The server is
+//! a single self-contained executable under `bin/`, which the runtime resolves
+//! by prepending `<package>/bin` to `PATH` (see `manager.rs`); the exec bit
+//! survives install because `store::copy_dir` uses `std::fs::copy`.
+//!
+//! Language templates are pluggable. Python lands first because it is
+//! toolchain-free (no build step), the fastest and most reliable path for a
+//! self-writing loop; Rust (`yolop-yep`) and TypeScript follow.
+
+use serde_json::{Value, json};
+use std::path::{Path, PathBuf};
+
+/// A tool contribution to scaffold: the definition the model will see.
+pub struct ToolSpec {
+    pub name: String,
+    pub description: String,
+}
+
+/// A hook subscription to scaffold.
+pub struct HookSpec {
+    /// `pre_tool_use` or `post_tool_use`.
+    pub event: String,
+    /// Glob over tool names the hook fires for (default `*`).
+    pub tool_name_glob: String,
+}
+
+/// Which language template to emit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Language {
+    Python,
+}
+
+impl Language {
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "python" | "py" => Ok(Self::Python),
+            "rust" | "rs" | "typescript" | "ts" | "javascript" | "js" | "node" => Err(format!(
+                "`{s}` templates are not available yet; use `python` (toolchain-free) for now"
+            )),
+            other => Err(format!("unknown language `{other}`; use `python`")),
+        }
+    }
+}
+
+/// A fully specified scaffold request.
+pub struct ScaffoldRequest {
+    pub name: String,
+    pub description: String,
+    pub language: Language,
+    pub tools: Vec<ToolSpec>,
+    pub hooks: Vec<HookSpec>,
+    pub prompt: Option<String>,
+    /// Absolute path of the package directory to create.
+    pub dir: PathBuf,
+}
+
+/// Outcome of a scaffold: what was written and where.
+#[derive(Debug)]
+pub struct Scaffolded {
+    pub dir: PathBuf,
+    pub server: PathBuf,
+    pub files: Vec<String>,
+}
+
+/// Validate the request the way `parse_manifest` will, so a scaffold never
+/// produces a package the installer would reject.
+fn validate(req: &ScaffoldRequest) -> Result<(), String> {
+    let name = req.name.trim();
+    if name.is_empty()
+        || !name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(format!(
+            "invalid extension name `{name}`: use ascii letters, digits, `-`, `_`"
+        ));
+    }
+    if req.tools.is_empty() && req.hooks.is_empty() && req.prompt.is_none() {
+        return Err(
+            "an extension must contribute something: pass at least one of `tools`, `hooks`, \
+             or `prompt`"
+                .into(),
+        );
+    }
+    for hook in &req.hooks {
+        if hook.event != "pre_tool_use" && hook.event != "post_tool_use" {
+            return Err(format!(
+                "invalid hook event `{}`: use `pre_tool_use` or `post_tool_use`",
+                hook.event
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Generate the package on disk. Refuses to clobber a non-empty directory so
+/// in-progress edits are never lost.
+pub fn scaffold(req: &ScaffoldRequest) -> Result<Scaffolded, String> {
+    validate(req)?;
+    if req.dir.is_dir()
+        && std::fs::read_dir(&req.dir)
+            .map(|mut d| d.next().is_some())
+            .unwrap_or(false)
+    {
+        return Err(format!(
+            "{} already exists and is not empty; pick a fresh `dir` or remove it",
+            req.dir.display()
+        ));
+    }
+    let bin_dir = req.dir.join("bin");
+    std::fs::create_dir_all(&bin_dir)
+        .map_err(|e| format!("creating {}: {e}", bin_dir.display()))?;
+
+    let manifest = manifest_json(req);
+    let manifest_path = req.dir.join("plugin.json");
+    write(&manifest_path, &format!("{manifest:#}\n"))?;
+
+    let server_name = format!("{}-server", req.name);
+    let server_path = bin_dir.join(&server_name);
+    match req.language {
+        Language::Python => write(&server_path, &python_server(req))?,
+    }
+    make_executable(&server_path)?;
+
+    let readme_path = req.dir.join("README.md");
+    write(&readme_path, &readme(req, &server_name))?;
+
+    Ok(Scaffolded {
+        dir: req.dir.clone(),
+        server: server_path,
+        files: vec![
+            "plugin.json".into(),
+            format!("bin/{server_name}"),
+            "README.md".into(),
+        ],
+    })
+}
+
+fn manifest_json(req: &ScaffoldRequest) -> Value {
+    let tools: Vec<Value> = req
+        .tools
+        .iter()
+        .map(|t| {
+            json!({
+                "name": t.name,
+                "description": t.description,
+                "schema": { "type": "object" },
+            })
+        })
+        .collect();
+    let hooks: Vec<Value> = req
+        .hooks
+        .iter()
+        .map(|h| json!({ "event": h.event, "tool_name_glob": h.tool_name_glob }))
+        .collect();
+    let mut yolop = json!({
+        "protocol_version": "1.0",
+        "capabilityServer": { "command": format!("{}-server", req.name) },
+    });
+    let obj = yolop.as_object_mut().expect("object");
+    if !tools.is_empty() {
+        obj.insert("tools".into(), Value::Array(tools));
+    }
+    if !hooks.is_empty() {
+        obj.insert("hooks".into(), Value::Array(hooks));
+    }
+    if req.prompt.is_some() {
+        obj.insert("prompt".into(), Value::Bool(true));
+    }
+    json!({
+        "name": req.name,
+        "description": req.description,
+        "version": "0.1.0",
+        "yolop": yolop,
+    })
+}
+
+/// The generated Python server: a data-driven YEP server whose only
+/// author-editable seams are the three `handle_*` bodies. Everything else is
+/// protocol plumbing that must not change.
+fn python_server(req: &ScaffoldRequest) -> String {
+    let tools_list = req
+        .tools
+        .iter()
+        .map(|t| format!("{:?}", t.name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let prompt_literal = match &req.prompt {
+        Some(text) => format!("{text:?}"),
+        None => "None".into(),
+    };
+    let has_hooks = !req.hooks.is_empty();
+    let hooks_cap = if has_hooks {
+        "\n            caps.append(\"hooks\")"
+    } else {
+        ""
+    };
+    format!(
+        r##"#!/usr/bin/env python3
+"""{name} — a yolop extension (YEP capability server).
+
+Speaks the yolop extension protocol: newline-delimited JSON-RPC over stdio.
+stdout carries ONLY protocol JSON — write any logs to stderr via log(). This
+file has no third-party dependencies.
+
+To author: edit the handle_* bodies below, then from yolop:
+  install_extension source=<this package directory>
+  doctor_extension  name={name}
+  enable_extension  name={name}    # takes effect on the next session
+"""
+
+import json
+import sys
+
+NAME = {name:?}
+# Tool names this server serves. MUST match plugin.json's yolop.tools.
+TOOLS = [{tools_list}]
+# Static system-prompt contribution, or None.
+PROMPT = {prompt_literal}
+
+
+def send(obj):
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+
+
+def log(msg):
+    sys.stderr.write(str(msg) + "\n")
+    sys.stderr.flush()
+
+
+# --- author-editable handlers -------------------------------------------------
+
+def handle_tool(name, args):
+    """Return the tool-result dict for a `tool/call`.
+
+    TODO: implement each tool in TOOLS. `args` is the model-supplied object.
+    """
+    return {{"ok": True, "tool": name, "args": args}}
+
+
+def handle_hook(event, tool_name, args):
+    """Decide a subscribed lifecycle event. Return {{}} to allow (unchanged),
+    or {{"block": True, "reason": "..."}} to deny (pre_tool_use only).
+
+    Example — block the shell tool when the command runs git:
+        if event == "pre_tool_use" and tool_name in ("bash", "shell"):
+            command = (args or {{}}).get("command", "")
+            if "git" in command.split():
+                return {{"block": True, "reason": "git is disabled by {name}"}}
+    """
+    return {{}}
+
+
+def handle_prompt():
+    """Dynamic system-prompt contribution (only if the manifest opts in)."""
+    return {{"text": PROMPT or ""}}
+
+
+# --- protocol plumbing (do not edit) -----------------------------------------
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        method = msg.get("method")
+        msg_id = msg.get("id")
+        if method == "initialize":
+            caps = ["tools", "streaming"]
+            params = {{"tools": [{{"name": t}} for t in TOOLS]}}
+            if PROMPT is not None:
+                caps.append("prompt")
+                params["prompt"] = {{"static": PROMPT}}{hooks_cap}
+            send({{"id": msg_id, "result": {{
+                "protocol_version": "1.0",
+                "name": NAME,
+                "capabilities": caps,
+                "capability_params": params,
+            }}}})
+        elif method == "initialized":
+            continue
+        elif method == "tool/call":
+            p = msg.get("params") or {{}}
+            name = p.get("name")
+            if name not in TOOLS:
+                send({{"id": msg_id, "error": {{"message": f"no such tool: {{name}}"}}}})
+                continue
+            try:
+                send({{"id": msg_id, "result": handle_tool(name, p.get("args") or {{}})}})
+            except Exception as exc:  # a tool error must not crash the server
+                send({{"id": msg_id, "error": {{"message": str(exc)}}}})
+        elif method == "hook/fire":
+            p = msg.get("params") or {{}}
+            try:
+                decision = handle_hook(
+                    p.get("event", ""), p.get("tool_name", ""), p.get("args") or {{}})
+                send({{"id": msg_id, "result": decision}})
+            except Exception as exc:
+                log(f"hook error: {{exc}}")
+                send({{"id": msg_id, "result": {{}}}})  # fail open
+        elif method == "prompt/contribution":
+            send({{"id": msg_id, "result": handle_prompt()}})
+        elif method == "shutdown":
+            send({{"id": msg_id, "result": {{}}}})
+            return
+        elif msg_id is not None:
+            send({{"id": msg_id, "error": {{
+                "code": -32601, "message": f"method not found: {{method}}"}}}})
+
+
+if __name__ == "__main__":
+    main()
+"##,
+        name = req.name,
+        tools_list = tools_list,
+        prompt_literal = prompt_literal,
+        hooks_cap = hooks_cap,
+    )
+}
+
+fn readme(req: &ScaffoldRequest, server_name: &str) -> String {
+    format!(
+        "# {name}\n\n\
+         {desc}\n\n\
+         A [yolop](https://crates.io/crates/yolop) extension (YEP capability server).\n\n\
+         ## Layout\n\n\
+         - `plugin.json` — the manifest: the contributions yolop approves at install.\n\
+         - `bin/{server}` — the capability server (stdio JSON-RPC). yolop puts `bin/` on\n  \
+         `PATH`, so `capabilityServer.command` resolves here.\n\n\
+         ## Author\n\n\
+         Edit the `handle_*` bodies in `bin/{server}`, then from yolop:\n\n\
+         ```\n\
+         install_extension source=<this directory>\n\
+         doctor_extension  name={name}\n\
+         enable_extension  name={name}\n\
+         ```\n\n\
+         Enabling takes effect on the next session.\n",
+        name = req.name,
+        desc = req.description,
+        server = server_name,
+    )
+}
+
+fn write(path: &Path, contents: &str) -> Result<(), String> {
+    std::fs::write(path, contents).map_err(|e| format!("writing {}: {e}", path.display()))
+}
+
+#[cfg(unix)]
+fn make_executable(path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(path)
+        .map_err(|e| format!("stat {}: {e}", path.display()))?
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms).map_err(|e| format!("chmod {}: {e}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn make_executable(_path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extensions::package::parse_manifest;
+
+    fn req(dir: PathBuf) -> ScaffoldRequest {
+        ScaffoldRequest {
+            name: "git-guard".into(),
+            description: "Blocks git.".into(),
+            language: Language::Python,
+            tools: vec![ToolSpec {
+                name: "note".into(),
+                description: "Record a note.".into(),
+            }],
+            hooks: vec![HookSpec {
+                event: "pre_tool_use".into(),
+                tool_name_glob: "*".into(),
+            }],
+            prompt: Some("Guarding git.".into()),
+            dir,
+        }
+    }
+
+    #[test]
+    fn generates_a_package_the_installer_accepts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let out = scaffold(&req(tmp.path().join("git-guard"))).unwrap();
+
+        // Manifest parses under the real installer path, with the declared
+        // contributions clamped in.
+        let manifest_src = std::fs::read_to_string(out.dir.join("plugin.json")).unwrap();
+        let manifest = parse_manifest(&manifest_src).expect("manifest parses");
+        assert_eq!(manifest.name, "git-guard");
+        assert_eq!(manifest.capability_server.command, "git-guard-server");
+        assert_eq!(manifest.tools.len(), 1);
+        assert_eq!(manifest.hooks.len(), 1);
+        assert!(manifest.prompt);
+
+        // Server exists, carries the shebang, and serves exactly the tool.
+        let server = std::fs::read_to_string(&out.server).unwrap();
+        assert!(server.starts_with("#!/usr/bin/env python3"));
+        assert!(server.contains(r#"TOOLS = ["note"]"#));
+        assert_eq!(out.files.len(), 3);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn server_is_executable() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let out = scaffold(&req(tmp.path().join("git-guard"))).unwrap();
+        let mode = std::fs::metadata(&out.server).unwrap().permissions().mode();
+        assert_eq!(mode & 0o111, 0o111, "server must be executable");
+    }
+
+    #[test]
+    fn refuses_empty_contributions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut r = req(tmp.path().join("x"));
+        r.tools.clear();
+        r.hooks.clear();
+        r.prompt = None;
+        assert!(scaffold(&r).unwrap_err().contains("contribute"));
+    }
+
+    #[test]
+    fn refuses_bad_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut r = req(tmp.path().join("x"));
+        r.name = "bad name!".into();
+        assert!(scaffold(&r).unwrap_err().contains("invalid extension name"));
+    }
+
+    #[test]
+    fn wont_clobber_a_nonempty_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("git-guard");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("keep.txt"), "mine").unwrap();
+        assert!(scaffold(&req(dir)).unwrap_err().contains("not empty"));
+    }
+
+    #[test]
+    fn unbuilt_languages_report_clearly() {
+        assert!(
+            Language::parse("rust")
+                .unwrap_err()
+                .contains("not available yet")
+        );
+        assert!(
+            Language::parse("typescript")
+                .unwrap_err()
+                .contains("not available yet")
+        );
+        assert!(
+            Language::parse("cobol")
+                .unwrap_err()
+                .contains("unknown language")
+        );
+    }
+}

--- a/src/extensions/scaffold.rs
+++ b/src/extensions/scaffold.rs
@@ -185,14 +185,14 @@ fn manifest_json(req: &ScaffoldRequest) -> Value {
 /// author-editable seams are the three `handle_*` bodies. Everything else is
 /// protocol plumbing that must not change.
 fn python_server(req: &ScaffoldRequest) -> String {
-    let tools_list = req
-        .tools
-        .iter()
-        .map(|t| format!("{:?}", t.name))
-        .collect::<Vec<_>>()
-        .join(", ");
+    // A JSON array/string literal is also a valid Python literal, so serialize
+    // through serde_json rather than Rust's `{:?}` (whose `\u{..}` escapes are
+    // not valid Python) — this stays correct for arbitrary tool names / prompt.
+    let names: Vec<&String> = req.tools.iter().map(|t| &t.name).collect();
+    let tools_list = serde_json::to_string(&names).unwrap_or_else(|_| "[]".into());
+    let name_literal = serde_json::to_string(&req.name).unwrap_or_else(|_| "\"\"".into());
     let prompt_literal = match &req.prompt {
-        Some(text) => format!("{text:?}"),
+        Some(text) => serde_json::to_string(text).unwrap_or_else(|_| "\"\"".into()),
         None => "None".into(),
     };
     let has_hooks = !req.hooks.is_empty();
@@ -218,9 +218,9 @@ To author: edit the handle_* bodies below, then from yolop:
 import json
 import sys
 
-NAME = {name:?}
+NAME = {name_literal}
 # Tool names this server serves. MUST match plugin.json's yolop.tools.
-TOOLS = [{tools_list}]
+TOOLS = {tools_list}
 # Static system-prompt contribution, or None.
 PROMPT = {prompt_literal}
 
@@ -323,6 +323,7 @@ if __name__ == "__main__":
     main()
 "##,
         name = req.name,
+        name_literal = name_literal,
         tools_list = tools_list,
         prompt_literal = prompt_literal,
         hooks_cap = hooks_cap,


### PR DESCRIPTION
## What changed

yolop can now build its own extensions. A new `scaffold_extension` agent tool generates a ready-to-edit YEP package — a `plugin.json` declaring the requested facets (`tools`, `hooks`, and/or `prompt`) plus a self-contained capability server whose only author-editable seams are the `handle_*` bodies. The generated skeleton is **correct by construction**: it installs via `install_extension source=<dir>` and passes `doctor_extension` before any logic is written, so authoring an extension collapses to filling in handlers.

A companion `author-extension` skill drives the end-to-end loop: **scaffold → implement → install → doctor → ask-before-enable**. The Extensions capability's system prompt now points the model at `scaffold_extension` so it reaches for it when asked to add a capability no installed extension covers.

Server mechanics: the generated server is a single executable under the package `bin/`, resolved via the `bin/`-on-PATH rule the runtime already uses (`manager.rs`). The exec bit survives the install copy (`std::fs::copy`), so no absolute paths leak into the manifest — the package is location-independent after install. Python is the first language template because it is toolchain-free (no build step); Rust (`yolop-yep`) and TypeScript templates are the planned follow-up, at which point a single-file NDJSON server per language *is* the author-facing SDK.

## Why

The extension mechanism had install/enable/doctor/remove but no way to *create* an extension — authoring meant hand-writing a manifest and a protocol server from memory, which drifts from the manifest (exactly what `doctor` flags). This closes the loop so a request like "integrate with X" or "block all git calls" can be answered by yolop authoring, validating, and installing a persistent extension for itself, rather than a one-off action.

## Before / After

**Before:** no scaffold affordance. To add an extension the agent hand-authored `plugin.json` + a stdio JSON-RPC server, with no guarantee the two agreed.

**After:** `scaffold_extension name=git-guard hooks=[{event: pre_tool_use}]` writes:

```
git-guard/
  plugin.json          # manifest: capabilityServer + declared hooks
  bin/git-guard-server # executable; #!/usr/bin/env python3 YEP server, handle_* stubs
  README.md
```

The author fills in `handle_hook`, and the server denies matching calls. Proven by `scaffolded_extension_blocks_git_end_to_end`, which scaffolds a `pre_tool_use` hook, fills in a git-block body, and spawns the generated server exactly as the runtime does:

```
test extensions::scaffold::tests::generates_a_package_the_installer_accepts ... ok
test extensions::scaffold::tests::server_is_executable ... ok
test extensions::manage::tests::scaffold_then_install_flow ... ok
test extensions::spawn_tests::scaffolded_extension_blocks_git_end_to_end ... ok
test result: ok. 10 passed; 0 failed
```

`cargo fmt --check` and `cargo clippy --all-features -D warnings` are clean.

## Risk

- **Low.** Additive — a new tool verb, a new module, and a skill; no existing behavior changes. Scaffolding only writes files; it never executes generated code. Install/enable keep the existing D4 approval boundary (the skill asks before enabling), and the generated server fails open on hook errors.
- Windows: the launcher relies on a shebang/exec bit; the Python template targets unix (matches the current runtime posture). Non-Python templates are follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (additive; yolop is pre-1.0)

https://claude.ai/code/session_017d7odSAD8o79pUrd31dpDb

---
_Generated by [Claude Code](https://claude.ai/code/session_017d7odSAD8o79pUrd31dpDb)_