### PR TITLE
feat(tui): tuika motion module — spinner, progress, native OSC 9;4

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -170,6 +170,12 @@ pub struct App {
     /// Last (content_height, viewport_height) the full-screen transcript drew,
     /// so mouse/paging handlers can clamp scrolling without re-laying out.
     scroll_metrics: (u16, u16),
+    /// Drives the terminal's native OSC 9;4 progress indicator (Ghostty top
+    /// bar / taskbar) while a turn runs. Works in both renderers. Enabled only
+    /// for real TUI sessions via [`App::enable_native_progress`] so tests and
+    /// non-terminal hosts emit no escape sequences.
+    term_progress: crate::tuika::TerminalProgress,
+    native_progress: bool,
 }
 
 /// The renderer backing a TUI session.
@@ -422,6 +428,8 @@ impl App {
             render_mode: RenderMode::default(),
             scroll: crate::tuika::ScrollState::new(),
             scroll_metrics: (0, 0),
+            term_progress: crate::tuika::TerminalProgress::new(),
+            native_progress: false,
         };
         app.emit_system_banner();
         if should_setup {
@@ -446,6 +454,12 @@ impl App {
     /// `run_tui` before the loop when `--fullscreen` is set.
     pub(crate) fn set_render_mode(&mut self, mode: RenderMode) {
         self.render_mode = mode;
+    }
+
+    /// Enable the terminal's native OSC 9;4 progress indicator for this session.
+    /// Called by `run_tui`; left off for tests and non-terminal hosts.
+    pub(crate) fn enable_native_progress(&mut self) {
+        self.native_progress = true;
     }
 
     pub fn should_show_resume_hint(&self) -> bool {
@@ -1558,6 +1572,9 @@ impl App {
         self.stream_preview = None;
         self.rx = None;
         self.turn_cancel = None;
+        if self.native_progress {
+            self.term_progress.clear();
+        }
         self.esc_pending_cancel = false;
     }
 
@@ -1736,6 +1753,11 @@ impl App {
         self.busy = true;
         self.turn_activity = activity;
         self.stream_preview = None;
+        if self.native_progress {
+            // Turn length is unknown, so show the terminal's busy/indeterminate
+            // indicator until the turn completes.
+            self.term_progress.indeterminate();
+        }
     }
 
     fn start_turn(&mut self, prompt: String) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,6 +166,10 @@ enum Commands {
     Worktree(WorktreeArgs),
     /// Manage MCP servers in global settings or workspace `.mcp.json`.
     Mcp(McpArgs),
+    /// Live demo of the experimental `tuika` TUI toolkit (spinners, progress
+    /// bars, loader). Press `q` or `Esc` to quit. Hidden dev helper.
+    #[command(hide = true)]
+    TuikaGallery,
 }
 
 #[derive(Args, Debug)]
@@ -826,6 +830,7 @@ fn run_command(command: Commands) -> Result<()> {
         }
         Commands::Worktree(args) => run_worktree_command(args.command),
         Commands::Mcp(args) => run_mcp_command(args.command),
+        Commands::TuikaGallery => run_tuika_gallery(),
         Commands::Into(into) => match into.target {
             IntoTarget::Paseo(args) => {
                 let command = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("yolop"));
@@ -900,6 +905,106 @@ fn run_command(command: Commands) -> Result<()> {
     }
 }
 
+/// Live demo of the `tuika` motion components. Renders spinners, progress bars,
+/// and a loader on the alternate screen, and drives the terminal's native
+/// OSC 9;4 progress indicator while running. Quits on `q`/`Esc`/`Ctrl-C`.
+fn run_tuika_gallery() -> Result<()> {
+    use crossterm::event::{self, Event as CtEvent, KeyCode as CtKeyCode, KeyEventKind};
+    use std::time::Duration;
+
+    let mut raw = RawModeGuard::new()?;
+    let mut alt = tuika::AltScreen::enter()?;
+    let backend = CrosstermBackend::new(io::stdout());
+    let mut terminal = Terminal::with_options(
+        backend,
+        TerminalOptions {
+            viewport: Viewport::Fullscreen,
+        },
+    )?;
+    let theme = tuika::Theme::default();
+    let mut progress = tuika::TerminalProgress::new();
+    progress.indeterminate();
+
+    let mut frame: u64 = 0;
+    loop {
+        terminal.draw(|f| {
+            let area = f.area();
+            let root = build_gallery(frame, &theme);
+            tuika::paint(f.buffer_mut(), area, &theme, root.as_ref(), &[]);
+        })?;
+
+        if event::poll(Duration::from_millis(80))?
+            && let CtEvent::Key(key) = event::read()?
+            && key.kind != KeyEventKind::Release
+            && matches!(key.code, CtKeyCode::Char('q') | CtKeyCode::Esc)
+        {
+            break;
+        }
+        frame = frame.wrapping_add(1);
+    }
+
+    progress.clear();
+    let _ = terminal.clear();
+    drop(terminal);
+    alt.leave();
+    raw.disable()?;
+    Ok(())
+}
+
+/// Build the gallery view tree for `frame`, using [`ratatui::text`] helpers via
+/// `tuika` components.
+fn build_gallery(frame: u64, theme: &tuika::Theme) -> tuika::Element {
+    use ratatui::text::{Line, Span};
+    use tuika::{Boxed, Flex, Loader, ProgressBar, Spinner, SpinnerStyle, Text, element};
+
+    let labeled_spinner = |style: SpinnerStyle, label: &str| -> tuika::Element {
+        element(
+            Flex::row()
+                .gap(1)
+                .fixed(1, element(Spinner::new(frame).style(style)))
+                .auto(element(Text::raw(label.to_string()))),
+        )
+    };
+
+    let spinners = Boxed::new(element(
+        Flex::column()
+            .fixed(1, labeled_spinner(SpinnerStyle::Braille, "Braille"))
+            .fixed(1, labeled_spinner(SpinnerStyle::Line, "Line"))
+            .fixed(1, labeled_spinner(SpinnerStyle::Dots, "Dots")),
+    ))
+    .title(Line::from(Span::styled(" spinners ", theme.accent_style())));
+
+    let animated = tuika::anim::ping_pong(frame, 120);
+    let bars = Boxed::new(element(
+        Flex::column()
+            .fixed(1, element(ProgressBar::determinate(0.25).percent(true)))
+            .fixed(1, element(ProgressBar::determinate(0.60).percent(true)))
+            .fixed(1, element(ProgressBar::determinate(animated).percent(true)))
+            .fixed(1, element(ProgressBar::indeterminate(frame))),
+    ))
+    .title(Line::from(Span::styled(" progress ", theme.accent_style())));
+
+    let loader = Boxed::new(element(Loader::new(frame, "working…").hint("esc to quit")))
+        .title(Line::from(Span::styled(" loader ", theme.accent_style())));
+
+    let footer = Text::new(vec![Line::from(Span::styled(
+        "tuika gallery — native progress is live in the taskbar/top bar · press q to quit",
+        theme.muted_style(),
+    ))]);
+
+    element(
+        Flex::column()
+            .background(ratatui::style::Style::default().bg(theme.background))
+            .padding(tuika::Padding::all(1))
+            .gap(1)
+            .fixed(5, element(spinners))
+            .fixed(6, element(bars))
+            .fixed(3, element(loader))
+            .grow(1, element(tuika::Spacer))
+            .fixed(1, element(footer)),
+    )
+}
+
 async fn run_tui(
     runtime: BuiltRuntime,
     pending_images: Vec<ContentPart>,
@@ -939,6 +1044,7 @@ async fn run_tui(
     }
 
     let mut app = App::new(runtime, pending_images);
+    app.enable_native_progress();
     if fullscreen {
         app.set_render_mode(app::RenderMode::Fullscreen);
     }

--- a/src/tuika/README.md
+++ b/src/tuika/README.md
@@ -1,0 +1,79 @@
+# tuika
+
+A small retained-tree terminal UI toolkit. `tuika` provides the layout,
+overlay, focus, and component primitives that `ratatui` leaves to you, while
+letting `ratatui` keep ownership of the cell buffer and its diff against the
+terminal.
+
+It is self-contained — it depends only on `ratatui`, `crossterm`, `textwrap`,
+and `unicode-width`, and knows nothing about yolop — and is staged for
+extraction into its own crate. Today yolop drives it from
+`src/app/fullscreen.rs` (the `--fullscreen` renderer) and `src/main.rs` (the
+`tuika-gallery` demo).
+
+## Model
+
+- **Views** (`view::View`) are rebuilt from application state every frame. This
+  is cheap because `ratatui` diffs the resulting cell buffer, so there is no
+  reconciler.
+- **State** that must survive across frames — scroll offset, selection index,
+  focus — lives in host-persisted `*State` structs (the `StatefulWidget`
+  idiom), not in the view tree.
+- **Layout** is a flexbox subset (`layout`): `Dimension` (`Auto`/`Fixed`/
+  `Percent`/`Flex`), `Align`, `Justify`, `Direction`, over a direction-agnostic
+  axis so rows and columns share one solver.
+- **Overlays** (`overlay`) anchor a view over the base tree; the **host**
+  (`host`) owns the alternate screen, translates crossterm input, and
+  composites the frame.
+- **Motion** (`anim`, `components::{Spinner, ProgressBar, Loader}`,
+  `native::TerminalProgress`) animates from a host-supplied frame counter and
+  can drive the terminal's own OSC 9;4 progress indicator.
+
+## Components
+
+| Component | Purpose |
+| --- | --- |
+| `Text` / `Paragraph` | Styled lines / word-wrapped text |
+| `Flex` | Flexbox container (the composition primitive) |
+| `Boxed` | Border + padding + title, focus-aware |
+| `Spacer` | Flexible filler |
+| `Scroll` (+ `ScrollState`) | Vertical scroll viewport + scrollbar |
+| `SelectList` (+ `SelectState`) | Selectable list |
+| `StatusBar` | One-row left/right status segments |
+| `Spinner` | Frame-cycled activity glyph |
+| `ProgressBar` | Determinate (sub-cell) / indeterminate bar |
+| `Loader` | Spinner + message + hint row |
+
+## Example
+
+```rust
+use crate::tuika::{self, Boxed, Flex, ProgressBar, Spinner, Text, element};
+
+let theme = tuika::Theme::default();
+let root = Flex::column()
+    .gap(1)
+    .fixed(1, element(Spinner::new(frame)))
+    .fixed(1, element(ProgressBar::determinate(0.6).percent(true)))
+    .grow(1, element(Text::raw("body")));
+
+// In a `terminal.draw(|f| ...)` closure:
+tuika::paint(f.buffer_mut(), f.area(), &theme, root.as_ref(), &[]);
+```
+
+Run the live demo: `cargo run -- tuika-gallery` (press `q` to quit).
+
+## Native terminal progress
+
+`native::TerminalProgress` emits the OSC 9;4 sequence, which drives the
+terminal's own progress indicator — a bar across the top of the window in
+Ghostty, the taskbar in Windows Terminal / ConEmu, and similar in
+WezTerm / Konsole / mintty. It is out-of-band (no cursor movement, no cells),
+so it works in both the inline and full-screen renderers; terminals that don't
+understand it ignore the sequence. yolop shows it (indeterminate) while a turn
+runs and clears it when idle.
+
+## Extending
+
+Add a component by implementing `view::View` in a new module under
+`components/`. There is no registration step — containers accept any boxed
+`View`.

--- a/src/tuika/anim.rs
+++ b/src/tuika/anim.rs
@@ -1,0 +1,61 @@
+//! Animation helpers: easing curves and a frame phase.
+//!
+//! `tuika` has no internal clock — the host owns time and passes a monotonically
+//! increasing frame counter (yolop uses `App::busy_frame`) into animated
+//! components. This module turns that counter into normalized progress and
+//! shapes it with easing curves, the minimal analog of OpenTUI's Timeline API
+//! without a scheduler or reconciler.
+
+/// Normalized time in `0.0..=1.0`.
+pub type Phase = f32;
+
+/// Linear identity curve.
+pub fn linear(t: Phase) -> Phase {
+    t.clamp(0.0, 1.0)
+}
+
+/// Quadratic ease-in (slow start).
+pub fn ease_in(t: Phase) -> Phase {
+    let t = t.clamp(0.0, 1.0);
+    t * t
+}
+
+/// Quadratic ease-out (slow end).
+pub fn ease_out(t: Phase) -> Phase {
+    let t = t.clamp(0.0, 1.0);
+    1.0 - (1.0 - t) * (1.0 - t)
+}
+
+/// Cubic ease-in-out (slow start and end).
+pub fn ease_in_out(t: Phase) -> Phase {
+    let t = t.clamp(0.0, 1.0);
+    if t < 0.5 {
+        4.0 * t * t * t
+    } else {
+        let f = -2.0 * t + 2.0;
+        1.0 - f * f * f / 2.0
+    }
+}
+
+/// Triangle wave in `0.0..=1.0..=0.0` over one period, for ping-pong motion.
+///
+/// `frame` is the host's counter, `period` the number of frames for a full
+/// there-and-back cycle.
+pub fn ping_pong(frame: u64, period: u64) -> Phase {
+    if period == 0 {
+        return 0.0;
+    }
+    let pos = frame % period;
+    let half = period as f32 / 2.0;
+    let up = pos as f32 / half;
+    if up <= 1.0 { up } else { 2.0 - up }
+}
+
+/// Sawtooth wave in `0.0..1.0`, wrapping every `period` frames, for looping
+/// motion like an indeterminate marquee.
+pub fn sawtooth(frame: u64, period: u64) -> Phase {
+    if period == 0 {
+        return 0.0;
+    }
+    (frame % period) as f32 / period as f32
+}

--- a/src/tuika/components/flex.rs
+++ b/src/tuika/components/flex.rs
@@ -49,6 +49,30 @@ impl Flex {
         self
     }
 
+    /// Set the gap between children (passthrough to the layout style).
+    pub fn gap(mut self, gap: u16) -> Self {
+        self.style.gap = gap;
+        self
+    }
+
+    /// Set padding inside the container (passthrough to the layout style).
+    pub fn padding(mut self, padding: crate::tuika::geometry::Padding) -> Self {
+        self.style.padding = padding;
+        self
+    }
+
+    /// Set cross-axis alignment (passthrough to the layout style).
+    pub fn align(mut self, align: crate::tuika::layout::Align) -> Self {
+        self.style.align_items = align;
+        self
+    }
+
+    /// Set main-axis distribution (passthrough to the layout style).
+    pub fn justify(mut self, justify: crate::tuika::layout::Justify) -> Self {
+        self.style.justify = justify;
+        self
+    }
+
     /// Add a child with an explicit main-axis dimension.
     pub fn child(mut self, dimension: Dimension, view: Element) -> Self {
         self.children.push(Child { view, dimension });

--- a/src/tuika/components/loader.rs
+++ b/src/tuika/components/loader.rs
@@ -1,0 +1,75 @@
+//! Loader — spinner + message + optional cancel hint on one row.
+//!
+//! Pi's `BorderedLoader` analog. Kept borderless so callers compose it with
+//! [`Boxed`](super::Boxed) when they want a frame; on its own it fits inline in
+//! a status row or overlay.
+
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+
+use crate::tuika::geometry::Size;
+use crate::tuika::surface::Surface;
+use crate::tuika::view::{RenderCtx, View};
+
+use super::spinner::{Spinner, SpinnerStyle};
+
+/// An animated loading row.
+pub struct Loader {
+    frame: u64,
+    message: String,
+    hint: Option<String>,
+    spinner_style: SpinnerStyle,
+}
+
+impl Loader {
+    pub fn new(frame: u64, message: impl Into<String>) -> Self {
+        Self {
+            frame,
+            message: message.into(),
+            hint: None,
+            spinner_style: SpinnerStyle::default(),
+        }
+    }
+
+    /// A trailing dim hint, e.g. "esc to cancel".
+    pub fn hint(mut self, hint: impl Into<String>) -> Self {
+        self.hint = Some(hint.into());
+        self
+    }
+
+    pub fn spinner_style(mut self, style: SpinnerStyle) -> Self {
+        self.spinner_style = style;
+        self
+    }
+}
+
+impl View for Loader {
+    fn measure(&self, available: Size) -> Size {
+        Size::new(available.width, 1)
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        // Spinner in the first cell.
+        Spinner::new(self.frame).style(self.spinner_style).render(
+            Rect::new(area.x, area.y, 1, 1),
+            surface,
+            ctx,
+        );
+
+        let mut x = area.x.saturating_add(2);
+        x = surface.set_string(x, area.y, &self.message, ctx.theme.text_style());
+
+        if let Some(hint) = &self.hint {
+            let hint = format!("  {hint}");
+            let hint_w = hint.len() as u16;
+            // Right-align the hint if it fits past the message.
+            let hx = area.right().saturating_sub(hint_w);
+            if hx > x {
+                surface.set_string(hx, area.y, &hint, ctx.theme.muted_style());
+            }
+        }
+    }
+}

--- a/src/tuika/components/mod.rs
+++ b/src/tuika/components/mod.rs
@@ -9,16 +9,22 @@
 
 mod boxed;
 mod flex;
+mod loader;
+mod progress_bar;
 mod scroll;
 mod select;
 mod spacer;
+mod spinner;
 mod status_bar;
 mod text;
 
 pub use boxed::Boxed;
 pub use flex::Flex;
+pub use loader::Loader;
+pub use progress_bar::ProgressBar;
 pub use scroll::{Scroll, ScrollState};
 pub use select::{SelectList, SelectOutcome, SelectState};
 pub use spacer::Spacer;
+pub use spinner::{Spinner, SpinnerStyle};
 pub use status_bar::StatusBar;
 pub use text::{Paragraph, Text, line_width};

--- a/src/tuika/components/progress_bar.rs
+++ b/src/tuika/components/progress_bar.rs
@@ -1,0 +1,161 @@
+//! Progress bar — determinate (sub-cell precision) or indeterminate (marquee).
+//!
+//! Determinate bars fill by eighths using partial block glyphs, so a 20-cell
+//! bar shows 160 distinct levels. Indeterminate bars slide a bright segment
+//! across a dim track, driven by the host frame counter (see [`crate::tuika::anim`]).
+
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+
+use crate::tuika::anim;
+use crate::tuika::geometry::Size;
+use crate::tuika::surface::Surface;
+use crate::tuika::view::{RenderCtx, View};
+
+/// Left-to-right eighth-block fill glyphs, index 0 = empty .. 8 = full.
+const EIGHTHS: [char; 9] = [' ', '▏', '▎', '▍', '▌', '▋', '▊', '▉', '█'];
+
+/// A single-row progress bar.
+pub struct ProgressBar {
+    /// `Some(0.0..=1.0)` for a determinate bar; `None` for indeterminate.
+    fraction: Option<f32>,
+    /// Host frame counter, used to animate the indeterminate marquee.
+    frame: u64,
+    /// Append a right-aligned `NN%` label to a determinate bar.
+    show_percent: bool,
+    filled: Option<ratatui::style::Color>,
+    track: Option<ratatui::style::Color>,
+}
+
+impl ProgressBar {
+    /// A determinate bar filled to `fraction` (clamped to `0.0..=1.0`).
+    pub fn determinate(fraction: f32) -> Self {
+        Self {
+            fraction: Some(fraction.clamp(0.0, 1.0)),
+            frame: 0,
+            show_percent: false,
+            filled: None,
+            track: None,
+        }
+    }
+
+    /// An indeterminate bar whose marquee position follows `frame`.
+    pub fn indeterminate(frame: u64) -> Self {
+        Self {
+            fraction: None,
+            frame,
+            show_percent: false,
+            filled: None,
+            track: None,
+        }
+    }
+
+    /// Show a trailing `NN%` (determinate bars only).
+    pub fn percent(mut self, show: bool) -> Self {
+        self.show_percent = show;
+        self
+    }
+
+    pub fn colors(mut self, filled: ratatui::style::Color, track: ratatui::style::Color) -> Self {
+        self.filled = Some(filled);
+        self.track = Some(track);
+        self
+    }
+
+    /// Percent integer for the current fraction, or `None` when indeterminate.
+    pub fn percent_value(&self) -> Option<u8> {
+        self.fraction.map(|f| (f * 100.0).round() as u8)
+    }
+
+    fn render_determinate(
+        &self,
+        area: Rect,
+        surface: &mut Surface,
+        ctx: &RenderCtx,
+        fraction: f32,
+    ) {
+        let filled = self.filled.unwrap_or(ctx.theme.accent);
+        let track = self.track.unwrap_or(ctx.theme.dim);
+
+        // Reserve space for a " 100%" suffix when requested.
+        let suffix = if self.show_percent {
+            Some(format!(" {:>3}%", (fraction * 100.0).round() as u16))
+        } else {
+            None
+        };
+        let suffix_w = suffix.as_ref().map(|s| s.len() as u16).unwrap_or(0);
+        let bar_w = area.width.saturating_sub(suffix_w);
+        if bar_w == 0 {
+            return;
+        }
+
+        // Total fill measured in eighths of a cell across the bar width.
+        let total_eighths = (fraction * bar_w as f32 * 8.0).round() as u32;
+        let full = (total_eighths / 8) as u16;
+        let remainder = (total_eighths % 8) as usize;
+
+        for i in 0..bar_w {
+            let x = area.x + i;
+            if i < full {
+                surface.set(x, area.y, '█', Style::default().fg(filled));
+            } else if i == full && remainder > 0 {
+                // Partial cell: the fractional glyph is the "filled" color on
+                // the track background so it reads as a leading edge.
+                surface.set(
+                    x,
+                    area.y,
+                    EIGHTHS[remainder],
+                    Style::default().fg(filled).bg(track),
+                );
+            } else {
+                surface.set(x, area.y, ' ', Style::default().bg(track));
+            }
+        }
+
+        if let Some(suffix) = suffix {
+            surface.set_string(
+                area.x + bar_w,
+                area.y,
+                &suffix,
+                Style::default().fg(ctx.theme.muted),
+            );
+        }
+    }
+
+    fn render_indeterminate(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+        let filled = self.filled.unwrap_or(ctx.theme.accent);
+        let track = self.track.unwrap_or(ctx.theme.dim);
+        let w = area.width;
+        // A segment roughly one-third of the bar bounces back and forth.
+        let seg = (w / 3).max(1);
+        let travel = w.saturating_sub(seg);
+        let pos = (anim::ping_pong(self.frame, 60) * travel as f32).round() as u16;
+
+        for i in 0..w {
+            let x = area.x + i;
+            let within = i >= pos && i < pos.saturating_add(seg);
+            if within {
+                surface.set(x, area.y, '█', Style::default().fg(filled));
+            } else {
+                surface.set(x, area.y, '░', Style::default().fg(track));
+            }
+        }
+    }
+}
+
+impl View for ProgressBar {
+    fn measure(&self, available: Size) -> Size {
+        Size::new(available.width, 1)
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        let row = Rect::new(area.x, area.y, area.width, 1);
+        match self.fraction {
+            Some(fraction) => self.render_determinate(row, surface, ctx, fraction),
+            None => self.render_indeterminate(row, surface, ctx),
+        }
+    }
+}

--- a/src/tuika/components/spinner.rs
+++ b/src/tuika/components/spinner.rs
@@ -1,0 +1,82 @@
+//! Spinner — a frame-cycled activity indicator.
+//!
+//! Stateless: the host passes its frame counter and the spinner picks the glyph
+//! for that frame. Pair with a steady tick (yolop advances `busy_frame` every
+//! loop iteration while a turn runs) for smooth motion.
+
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+
+use crate::tuika::geometry::Size;
+use crate::tuika::surface::Surface;
+use crate::tuika::view::{RenderCtx, View};
+
+/// A named set of spinner frames.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum SpinnerStyle {
+    /// Braille dots — the smooth default.
+    #[default]
+    Braille,
+    /// ASCII line spinner (`| / - \`), for terminals without Braille.
+    Line,
+    /// Bouncing dots.
+    Dots,
+}
+
+impl SpinnerStyle {
+    pub fn frames(self) -> &'static [&'static str] {
+        match self {
+            SpinnerStyle::Braille => &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"],
+            SpinnerStyle::Line => &["|", "/", "-", "\\"],
+            SpinnerStyle::Dots => &["⠂", "⠒", "⠐", "⠰", "⠠", "⠤", "⠄", "⠆"],
+        }
+    }
+}
+
+/// An animated spinner glyph.
+pub struct Spinner {
+    style: SpinnerStyle,
+    frame: u64,
+    color: Option<ratatui::style::Color>,
+}
+
+impl Spinner {
+    /// A spinner showing the glyph for `frame`.
+    pub fn new(frame: u64) -> Self {
+        Self {
+            style: SpinnerStyle::default(),
+            frame,
+            color: None,
+        }
+    }
+
+    pub fn style(mut self, style: SpinnerStyle) -> Self {
+        self.style = style;
+        self
+    }
+
+    pub fn color(mut self, color: ratatui::style::Color) -> Self {
+        self.color = Some(color);
+        self
+    }
+
+    /// The glyph this spinner draws for its current frame.
+    pub fn glyph(&self) -> &'static str {
+        let frames = self.style.frames();
+        frames[(self.frame as usize) % frames.len()]
+    }
+}
+
+impl View for Spinner {
+    fn measure(&self, _available: Size) -> Size {
+        Size::new(1, 1)
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        let color = self.color.unwrap_or(ctx.theme.accent);
+        surface.set_string(area.x, area.y, self.glyph(), Style::default().fg(color));
+    }
+}

--- a/src/tuika/mod.rs
+++ b/src/tuika/mod.rs
@@ -40,12 +40,14 @@
 // trimming the API down to today's single call site.
 #![allow(dead_code, unused_imports)]
 
+pub mod anim;
 pub mod components;
 pub mod event;
 pub mod focus;
 pub mod geometry;
 pub mod host;
 pub mod layout;
+pub mod native;
 pub mod overlay;
 pub mod style;
 pub mod surface;
@@ -57,14 +59,15 @@ pub mod view;
 // part of the surface a future standalone crate exposes, so we keep them
 // exported rather than trimming to today's call sites.
 pub use components::{
-    Boxed, Flex, Paragraph, Scroll, ScrollState, SelectList, SelectOutcome, SelectState, Spacer,
-    StatusBar, Text,
+    Boxed, Flex, Loader, Paragraph, ProgressBar, Scroll, ScrollState, SelectList, SelectOutcome,
+    SelectState, Spacer, Spinner, SpinnerStyle, StatusBar, Text,
 };
 pub use event::{Event, EventFlow, Key, KeyCode, Mouse, MouseKind};
 pub use focus::FocusRegistry;
 pub use geometry::{Padding, Size};
 pub use host::{AltScreen, Overlay, paint, translate_event};
 pub use layout::{Align, Dimension, Direction, Justify, LayoutStyle};
+pub use native::{ProgressState, TerminalProgress};
 pub use overlay::{Anchor, Extent, OverlaySpec};
 pub use style::{BorderStyle, Theme};
 pub use view::{Element, RenderCtx, View, element};

--- a/src/tuika/native.rs
+++ b/src/tuika/native.rs
@@ -1,0 +1,107 @@
+//! Native terminal progress via the OSC 9;4 sequence.
+//!
+//! OSC 9;4 (originated by ConEmu) drives the terminal's *own* progress
+//! indicator — Ghostty renders a bar across the top of the window, Windows
+//! Terminal and ConEmu light the taskbar, WezTerm/Konsole/mintty support it
+//! too. It is out-of-band: it moves no cursor and paints no cells, so it works
+//! in both the inline and full-screen renderers, and terminals that don't
+//! understand it silently swallow the unknown OSC.
+//!
+//! Sequence: `ESC ] 9 ; 4 ; <state> ; <progress> BEL`, where `progress` is
+//! 0–100 and `state` is one of [`ProgressState`].
+
+use std::io::{self, Write};
+
+/// OSC 9;4 progress states.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProgressState {
+    /// Hide the indicator (progress ignored).
+    Clear,
+    /// Normal determinate progress at the given percent.
+    Normal,
+    /// Error state (typically red), at the given percent.
+    Error,
+    /// Indeterminate / busy (percent ignored).
+    Indeterminate,
+    /// Warning state (typically yellow), at the given percent.
+    Warning,
+}
+
+impl ProgressState {
+    fn code(self) -> u8 {
+        match self {
+            ProgressState::Clear => 0,
+            ProgressState::Normal => 1,
+            ProgressState::Error => 2,
+            ProgressState::Indeterminate => 3,
+            ProgressState::Warning => 4,
+        }
+    }
+}
+
+/// Encode an OSC 9;4 progress sequence. Pure and unit-testable — no I/O.
+pub fn encode(state: ProgressState, percent: u8) -> String {
+    format!("\x1b]9;4;{};{}\x07", state.code(), percent.min(100))
+}
+
+/// Drives the terminal's native progress indicator, clearing it on drop so a
+/// dropped or panicking session never leaves a stuck bar in the taskbar.
+pub struct TerminalProgress {
+    /// Tracks whether an indicator is currently shown, to avoid redundant
+    /// writes and to know whether `Drop` must clear.
+    active: bool,
+}
+
+impl TerminalProgress {
+    pub fn new() -> Self {
+        Self { active: false }
+    }
+
+    fn write(&mut self, state: ProgressState, percent: u8) {
+        // Best-effort: a failed progress write must never disrupt the session.
+        let mut out = io::stdout();
+        if out.write_all(encode(state, percent).as_bytes()).is_ok() {
+            let _ = out.flush();
+        }
+        self.active = state != ProgressState::Clear;
+    }
+
+    /// Show the busy/indeterminate indicator.
+    pub fn indeterminate(&mut self) {
+        self.write(ProgressState::Indeterminate, 0);
+    }
+
+    /// Show determinate progress at `percent` (0–100).
+    pub fn percent(&mut self, percent: u8) {
+        self.write(ProgressState::Normal, percent);
+    }
+
+    /// Show the error indicator at `percent`.
+    pub fn error(&mut self, percent: u8) {
+        self.write(ProgressState::Error, percent);
+    }
+
+    /// Hide the indicator. Idempotent.
+    pub fn clear(&mut self) {
+        if self.active {
+            self.write(ProgressState::Clear, 0);
+        }
+    }
+
+    /// Whether an indicator is currently shown.
+    pub fn is_active(&self) -> bool {
+        self.active
+    }
+}
+
+impl Default for TerminalProgress {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for TerminalProgress {
+    fn drop(&mut self) {
+        self.clear();
+    }
+}

--- a/src/tuika/tests.rs
+++ b/src/tuika/tests.rs
@@ -7,14 +7,17 @@ use ratatui::layout::Rect;
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 
+use super::anim;
 use super::components::{
-    Paragraph, Scroll, ScrollState, SelectList, SelectOutcome, SelectState, Text,
+    Loader, Paragraph, ProgressBar, Scroll, ScrollState, SelectList, SelectOutcome, SelectState,
+    Spinner, Text,
 };
 use super::event::{Event, EventFlow, Key, KeyCode, Mouse, MouseKind};
 use super::focus::FocusRegistry;
 use super::geometry::{Padding, Size};
 use super::host::{self, Overlay};
 use super::layout::{Align, Dimension, Direction, Item, Justify, LayoutStyle, solve};
+use super::native::{self, ProgressState};
 use super::overlay::{Anchor, Extent, OverlaySpec};
 use super::style::Theme;
 use super::surface::Surface;
@@ -350,6 +353,128 @@ fn paint_composites_background_root_and_overlay() {
     // Overlay painted last on its row with a surface background.
     assert!(row(&buf, 2).contains("MODAL"));
     assert_eq!(buf[(5, 2)].bg, theme.surface);
+}
+
+// ---- animation / progress ------------------------------------------------
+
+#[test]
+fn easing_endpoints_and_midpoints() {
+    for f in [
+        anim::linear,
+        anim::ease_in,
+        anim::ease_out,
+        anim::ease_in_out,
+    ] {
+        assert!((f(0.0) - 0.0).abs() < 1e-6);
+        assert!((f(1.0) - 1.0).abs() < 1e-6);
+    }
+    // Cubic ease-in-out is symmetric about 0.5.
+    assert!((anim::ease_in_out(0.5) - 0.5).abs() < 1e-6);
+    // Clamps out-of-range input.
+    assert_eq!(anim::linear(2.0), 1.0);
+    assert_eq!(anim::ease_out(-1.0), 0.0);
+}
+
+#[test]
+fn ping_pong_and_sawtooth_shapes() {
+    assert!((anim::ping_pong(0, 60) - 0.0).abs() < 1e-6);
+    assert!((anim::ping_pong(30, 60) - 1.0).abs() < 1e-6); // peak at half period
+    assert!((anim::ping_pong(60, 60) - 0.0).abs() < 1e-6); // back to start
+    assert!((anim::sawtooth(0, 10) - 0.0).abs() < 1e-6);
+    assert!((anim::sawtooth(5, 10) - 0.5).abs() < 1e-6);
+    assert!((anim::sawtooth(10, 10) - 0.0).abs() < 1e-6); // wraps
+}
+
+#[test]
+fn spinner_cycles_frames() {
+    let frames = super::components::SpinnerStyle::Braille.frames();
+    assert_eq!(Spinner::new(0).glyph(), frames[0]);
+    assert_eq!(Spinner::new(1).glyph(), frames[1]);
+    // Wraps at the end of the frame set.
+    assert_eq!(Spinner::new(frames.len() as u64).glyph(), frames[0]);
+}
+
+#[test]
+fn progress_bar_determinate_fills_by_fraction() {
+    let bar = ProgressBar::determinate(0.5);
+    assert_eq!(bar.percent_value(), Some(50));
+    let mut buf = buffer(10, 1);
+    let theme = Theme::default();
+    let ctx = RenderCtx::new(&theme);
+    let area = buf.area;
+    let mut surface = Surface::new(&mut buf, area);
+    bar.render(area, &mut surface, &ctx);
+    // Half of 10 cells fully filled.
+    let full = (0..10).filter(|&x| buf[(x, 0)].symbol() == "█").count();
+    assert_eq!(full, 5);
+}
+
+#[test]
+fn progress_bar_full_and_percent_label() {
+    let bar = ProgressBar::determinate(1.0).percent(true);
+    let mut buf = buffer(20, 1);
+    let theme = Theme::default();
+    let ctx = RenderCtx::new(&theme);
+    let area = buf.area;
+    let mut surface = Surface::new(&mut buf, area);
+    bar.render(area, &mut surface, &ctx);
+    assert!(row(&buf, 0).contains("100%"));
+    // Bar area (minus the " 100%" suffix = 5 cols) is fully filled.
+    let full = (0..15).filter(|&x| buf[(x, 0)].symbol() == "█").count();
+    assert_eq!(full, 15);
+}
+
+#[test]
+fn progress_bar_indeterminate_has_segment_and_track() {
+    let bar = ProgressBar::indeterminate(0);
+    let mut buf = buffer(12, 1);
+    let theme = Theme::default();
+    let ctx = RenderCtx::new(&theme);
+    let area = buf.area;
+    let mut surface = Surface::new(&mut buf, area);
+    bar.render(area, &mut surface, &ctx);
+    let seg = (0..12).filter(|&x| buf[(x, 0)].symbol() == "█").count();
+    let track = (0..12).filter(|&x| buf[(x, 0)].symbol() == "░").count();
+    assert!(seg > 0, "expected a bright segment");
+    assert!(track > 0, "expected a dim track");
+    assert_eq!(seg + track, 12);
+}
+
+#[test]
+fn loader_renders_spinner_and_message() {
+    let loader = Loader::new(0, "thinking").hint("esc to cancel");
+    let mut buf = buffer(30, 1);
+    let theme = Theme::default();
+    let ctx = RenderCtx::new(&theme);
+    let area = buf.area;
+    let mut surface = Surface::new(&mut buf, area);
+    loader.render(area, &mut surface, &ctx);
+    let line = row(&buf, 0);
+    assert!(line.contains("thinking"), "{line}");
+    assert!(line.contains("esc to cancel"), "{line}");
+}
+
+#[test]
+fn osc_progress_encoding() {
+    // ESC ] 9 ; 4 ; state ; percent BEL
+    assert_eq!(
+        native::encode(ProgressState::Indeterminate, 0),
+        "\x1b]9;4;3;0\x07"
+    );
+    assert_eq!(
+        native::encode(ProgressState::Normal, 50),
+        "\x1b]9;4;1;50\x07"
+    );
+    assert_eq!(native::encode(ProgressState::Clear, 0), "\x1b]9;4;0;0\x07");
+    assert_eq!(
+        native::encode(ProgressState::Error, 12),
+        "\x1b]9;4;2;12\x07"
+    );
+    // Percent is clamped to 100.
+    assert_eq!(
+        native::encode(ProgressState::Normal, 200),
+        "\x1b]9;4;1;100\x07"
+    );
 }
 
 // ---- a small end-to-end tree ---------------------------------------------


### PR DESCRIPTION
## What changed

Adds animated **motion primitives** to the `tuika` toolkit and wires yolop to drive the terminal's **native progress indicator** while a turn runs.

New components:
- **`Spinner`** — frame-cycled activity glyph (Braille / Line / Dots).
- **`ProgressBar`** — determinate with **sub-cell (eighth-block) precision** and optional `NN%` label, or **indeterminate marquee**.
- **`Loader`** — spinner + message + hint row (Pi's `BorderedLoader` analog).

Supporting:
- **`anim`** — easing curves (`linear`/`ease_in`/`ease_out`/`ease_in_out`) and `ping_pong` / `sawtooth` phases driven by a host frame counter. The minimal Timeline analog — no scheduler, no reconciler.
- **`native::TerminalProgress`** — emits **OSC 9;4**, driving the terminal's own progress indicator: a bar across the top of the window in **Ghostty**, the taskbar in **Windows Terminal / ConEmu**, and similar in **WezTerm / Konsole / mintty**. It's out-of-band (no cursor moves, no cells), so it works in **both** the inline and full-screen renderers; terminals that don't understand it ignore the sequence. RAII-clears on drop so a dropped/panicking session never leaves a stuck bar.
- `Flex` gains `gap`/`padding`/`align`/`justify` builder passthroughs.

yolop integration: a running turn shows the native **indeterminate** indicator and clears it when idle — in both renderers, enabled only for real TUI sessions so tests and non-terminal hosts emit nothing.

DX: a hidden **`yolop tuika-gallery`** subcommand renders the motion components live (press `q` to quit), and **`src/tuika/README.md`** documents the toolkit.

## Why

The toolkit had layout/overlay/focus/host parity with OpenTUI/Pi but no motion. Progress + spinners are the highest-visibility, lowest-risk gap, and OSC 9;4 gives a genuinely native touch (Ghostty's top bar / the taskbar) that benefits the default inline renderer too, not just `--fullscreen`.

## Before / After

**Before:** no spinner/progress components; no native terminal progress.

**After:** PTY smoke of `yolop tuika-gallery` (100×30) drives the real binary:

```
exit_code= 0
osc_indeterminate_start= True   (ESC ]9;4;3;0 BEL emitted on start)
osc_clear_on_exit=      True    (ESC ]9;4;0;0 BEL emitted on quit)
entered_alt= True
has_spinners_box= True   has_progress_box= True   has_loader_box= True   has_percent= True
```

In yolop proper, a turn now lights the terminal's native progress indicator (indeterminate) while running and clears it on completion, in both inline and full-screen modes.

## Validation

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` (Rust 1.97) — clean
- `cargo test --all-features` — **774 passed**, 2 ignored (+8 new motion tests: easing endpoints, ping_pong/sawtooth, spinner cycling, determinate/indeterminate/percent bars, loader, OSC 9;4 encoder)
- PTY smoke of `tuika-gallery` (above) — components render, OSC 9;4 fires and clears, clean exit.

## Security

Rendering + one out-of-band escape sequence; no trust boundaries touched.

- **TM-FS / TM-BASH / TM-LLM / TM-TOOL** — no filesystem, shell, prompt/key, or capability changes.
- **TM-DEP** — no new dependencies.
- OSC 9;4 is a fixed, numeric-only sequence (`ESC ]9;4;<state>;<percent> BEL`, percent clamped 0–100); no user data is interpolated into it. Unsupported terminals discard unknown OSC. Emission is gated to real TUI sessions.

## Risk

- **Low.** New components are additive; the only behavior change to existing flows is emitting an ignorable OSC sequence during turns (gated to TUI sessions, RAII-cleared).
- What could break: a terminal that mis-parses unknown OSC could show stray bytes — rare; mitigated by the sequence being standard and widely supported.

## Follow-ups

- Show a determinate bar for known-length work (multi-file edits, downloads) instead of only indeterminate.
- Grapheme-cluster width in `Surface::set_string` (currently per-`char`).
- Mouse hit-testing (click-to-focus / click-to-select).
- Extract `tuika` to a workspace crate to unlock `examples/` + doctests (would replace the hidden gallery subcommand with a real example).

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (additive; pre-1.0)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LksbgmgJfiGmNXXGZphgW6)_