### PR TITLE
feat(extensions): TypeScript (Node.js) scaffold template

### DIFF
--- a/.agents/skills/author-extension/SKILL.md
+++ b/.agents/skills/author-extension/SKILL.md
@@ -40,11 +40,13 @@ Not yet available: statusline/UI, providers, slash commands.
 
 ## The loop
 
-1. **Scaffold.** `scaffold_extension name=<name> [description=…] [language=python]`
+1. **Scaffold.** `scaffold_extension name=<name> [description=…] [language=python|typescript]`
    with the facets you need — `tools=[…]`, `hooks=[…]`, and/or `prompt=…`.
    This writes a correct-by-construction package (manifest + a self-contained
    server) that installs and passes `doctor` before you write a line of logic.
-   Python is the default and needs no build step.
+   Both `python` and `typescript` (a dependency-free Node.js server) need no
+   build step; pick the one whose runtime the environment has. Python is the
+   default.
 
 2. **Implement.** Open the generated server (the tool result prints its path)
    and fill in the `handle_*` bodies:

--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -53,9 +53,10 @@ a self-contained capability server whose only author-editable seams are the
 is written, so authoring collapses to filling in handlers. The server is a
 single executable under the package `bin/` (resolved via the `bin/`-on-PATH
 rule the runtime already uses; the exec bit survives the install copy), so no
-absolute paths leak into the manifest. Python is the first template because it
-is toolchain-free — the fastest, most reliable path for yolop to author an
-extension for itself (Rust via `yolop-yep` and TypeScript follow). The
+absolute paths leak into the manifest. The `python` and `typescript`
+(dependency-free Node.js) templates are both single-file and toolchain-free —
+the fastest, most reliable path for yolop to author an extension for itself; a
+compiled Rust/`yolop-yep` template (binary built before it runs) follows. The
 [`author-extension`](../.agents/skills/author-extension/SKILL.md) skill drives
 the loop (scaffold → implement → install → doctor → ask-to-enable); the
 end-to-end acceptance — a self-authored `pre_tool_use` hook that blocks `git`,

--- a/src/extensions/manage.rs
+++ b/src/extensions/manage.rs
@@ -408,8 +408,11 @@ impl Tool for ManageTool {
                         "description": "Extension name (ascii letters, digits, `-`, `_`)." },
                     "description": { "type": "string",
                         "description": "One-line summary of what the extension does." },
-                    "language": { "type": "string", "enum": ["python"], "default": "python",
-                        "description": "Server language template. Python is toolchain-free." },
+                    "language": { "type": "string", "enum": ["python", "typescript"],
+                        "default": "python",
+                        "description": "Server language template. Both are single-file and \
+                            toolchain-free (no build step); `typescript` emits a dependency-free \
+                            Node.js server." },
                     "tools": { "type": "array", "description": "Tool contributions.",
                         "items": { "type": "object", "properties": {
                             "name": { "type": "string" },

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -321,24 +321,25 @@ mod spawn_tests {
         }
     }
 
-    /// The self-writing acceptance case: `scaffold_extension` produces a
-    /// package whose generated server, once the author fills in the hook body,
-    /// blocks a real tool call when spawned exactly as the runtime spawns it
-    /// (command resolved via the package's `bin/` on PATH — no absolute paths).
-    #[tokio::test]
-    async fn scaffolded_extension_blocks_git_end_to_end() {
-        use super::scaffold::{HookSpec, Language, ScaffoldRequest, scaffold};
+    /// The self-writing acceptance case, run for one language template:
+    /// `scaffold_extension` produces a package whose generated server, once the
+    /// author fills in the hook body, blocks a real tool call when spawned
+    /// exactly as the runtime spawns it (command resolved via the package's
+    /// `bin/` on PATH — no absolute paths, no build step).
+    async fn assert_scaffolded_git_block(language: super::scaffold::Language) {
+        use super::scaffold::{HookSpec, ScaffoldRequest, scaffold};
         use everruns_core::atoms::PreToolUseDecision;
         use everruns_core::tool_types::{BuiltinTool, ToolCall, ToolDefinition};
-        if python3().is_none() {
-            eprintln!("skipping: python3 not available");
+
+        if which_python(&[language.interpreter()]).is_none() {
+            eprintln!("skipping: {} not available", language.interpreter());
             return;
         }
         let tmp = tempfile::tempdir().unwrap();
         let out = scaffold(&ScaffoldRequest {
             name: "git-guard".into(),
             description: "Blocks git.".into(),
-            language: Language::Python,
+            language,
             tools: vec![],
             hooks: vec![HookSpec {
                 event: "pre_tool_use".into(),
@@ -351,13 +352,22 @@ mod spawn_tests {
 
         // Author step: fill in the hook body the scaffold left as a no-op.
         let server = std::fs::read_to_string(&out.server).unwrap();
-        let filled = server.replace(
-            "\n    return {}\n\n\ndef handle_prompt",
-            "\n    command = (args or {}).get(\"command\", \"\")\n    \
-             if event == \"pre_tool_use\" and \"git\" in command.split():\n        \
-             return {\"block\": True, \"reason\": \"git is disabled by git-guard\"}\n    \
-             return {}\n\n\ndef handle_prompt",
-        );
+        let filled = match language {
+            super::scaffold::Language::Python => server.replace(
+                "\n    return {}\n\n\ndef handle_prompt",
+                "\n    command = (args or {}).get(\"command\", \"\")\n    \
+                 if event == \"pre_tool_use\" and \"git\" in command.split():\n        \
+                 return {\"block\": True, \"reason\": \"git is disabled by git-guard\"}\n    \
+                 return {}\n\n\ndef handle_prompt",
+            ),
+            super::scaffold::Language::Node => server.replace(
+                "\n  return {};\n}\n\nfunction handlePrompt",
+                "\n  const command = (args || {}).command || \"\";\n  \
+                 if (event === \"pre_tool_use\" && command.split(/\\s+/).includes(\"git\")) {\n    \
+                 return { block: true, reason: \"git is disabled by git-guard\" };\n  }\n  \
+                 return {};\n}\n\nfunction handlePrompt",
+            ),
+        };
         assert_ne!(filled, server, "hook body anchor must match");
         std::fs::write(&out.server, filled).unwrap();
 
@@ -407,6 +417,16 @@ mod spawn_tests {
             hook.before_exec(allow, &tool_def, &ctx).await,
             PreToolUseDecision::Continue(_)
         ));
+    }
+
+    #[tokio::test]
+    async fn scaffolded_python_extension_blocks_git_end_to_end() {
+        assert_scaffolded_git_block(super::scaffold::Language::Python).await;
+    }
+
+    #[tokio::test]
+    async fn scaffolded_node_extension_blocks_git_end_to_end() {
+        assert_scaffolded_git_block(super::scaffold::Language::Node).await;
     }
 
     #[tokio::test]

--- a/src/extensions/scaffold.rs
+++ b/src/extensions/scaffold.rs
@@ -30,20 +30,41 @@ pub struct HookSpec {
     pub tool_name_glob: String,
 }
 
-/// Which language template to emit.
+/// Which language template to emit. Both current templates are single-file,
+/// dependency-free, and need no build step — the fastest path for a
+/// self-writing loop. (A compiled Rust/`yolop-yep` template is a follow-up; it
+/// has a distinct flow because the binary must be built before it can run.)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Language {
+    /// A `#!/usr/bin/env python3` server.
     Python,
+    /// A dependency-free Node.js (`#!/usr/bin/env node`) server — the
+    /// toolchain-free path for the TypeScript/JavaScript ecosystem.
+    Node,
 }
 
 impl Language {
     pub fn parse(s: &str) -> Result<Self, String> {
         match s.trim().to_ascii_lowercase().as_str() {
             "python" | "py" => Ok(Self::Python),
-            "rust" | "rs" | "typescript" | "ts" | "javascript" | "js" | "node" => Err(format!(
-                "`{s}` templates are not available yet; use `python` (toolchain-free) for now"
+            "typescript" | "ts" | "javascript" | "js" | "node" => Ok(Self::Node),
+            "rust" | "rs" => Err(format!(
+                "`{s}` needs a compiled template (build before run); use `python` or \
+                 `typescript` for the toolchain-free path for now"
             )),
-            other => Err(format!("unknown language `{other}`; use `python`")),
+            other => Err(format!(
+                "unknown language `{other}`; use `python` or `typescript`"
+            )),
+        }
+    }
+
+    /// The interpreter the generated launcher shebang invokes — used to skip
+    /// tests when the runtime isn't installed.
+    #[cfg(test)]
+    pub fn interpreter(self) -> &'static str {
+        match self {
+            Self::Python => "python3",
+            Self::Node => "node",
         }
     }
 }
@@ -125,6 +146,7 @@ pub fn scaffold(req: &ScaffoldRequest) -> Result<Scaffolded, String> {
     let server_path = bin_dir.join(&server_name);
     match req.language {
         Language::Python => write(&server_path, &python_server(req))?,
+        Language::Node => write(&server_path, &node_server(req))?,
     }
     make_executable(&server_path)?;
 
@@ -330,6 +352,145 @@ if __name__ == "__main__":
     )
 }
 
+/// The generated Node.js server: the JavaScript twin of `python_server`.
+/// Dependency-free (only the `readline` builtin) and runs on any Node with no
+/// build step. Author-editable seams are the three `handle*` bodies.
+fn node_server(req: &ScaffoldRequest) -> String {
+    // JSON literals are valid JavaScript literals, so serde_json output drops
+    // straight into the source.
+    let names: Vec<&String> = req.tools.iter().map(|t| &t.name).collect();
+    let tools_list = serde_json::to_string(&names).unwrap_or_else(|_| "[]".into());
+    let name_literal = serde_json::to_string(&req.name).unwrap_or_else(|_| "\"\"".into());
+    let prompt_literal = match &req.prompt {
+        Some(text) => serde_json::to_string(text).unwrap_or_else(|_| "null".into()),
+        None => "null".into(),
+    };
+    let hooks_cap = if req.hooks.is_empty() {
+        ""
+    } else {
+        "\n    caps.push(\"hooks\");"
+    };
+    format!(
+        r##"#!/usr/bin/env node
+// {name} — a yolop extension (YEP capability server).
+//
+// Speaks the yolop extension protocol: newline-delimited JSON-RPC over stdio.
+// stdout carries ONLY protocol JSON — write any logs to stderr via log(). No
+// third-party dependencies.
+//
+// To author: edit the handle* bodies below, then from yolop:
+//   install_extension source=<this package directory>
+//   doctor_extension  name={name}
+//   enable_extension  name={name}    // takes effect on the next session
+
+const readline = require("readline");
+
+const NAME = {name_literal};
+// Tool names this server serves. MUST match plugin.json's yolop.tools.
+const TOOLS = {tools_list};
+// Static system-prompt contribution, or null.
+const PROMPT = {prompt_literal};
+
+function send(obj) {{
+  process.stdout.write(JSON.stringify(obj) + "\n");
+}}
+
+function log(msg) {{
+  process.stderr.write(String(msg) + "\n");
+}}
+
+// --- author-editable handlers ------------------------------------------------
+
+function handleTool(name, args) {{
+  // TODO: implement each tool in TOOLS. `args` is the model-supplied object.
+  return {{ ok: true, tool: name, args: args }};
+}}
+
+function handleHook(event, toolName, args) {{
+  // Return {{}} to allow (unchanged), or {{ block: true, reason: "..." }} to deny
+  // (pre_tool_use only). The server sees every subscribed tool call.
+  //
+  // Example — block the shell tool when the command runs git:
+  //   if (event === "pre_tool_use" && (toolName === "bash" || toolName === "shell")) {{
+  //     const command = (args || {{}}).command || "";
+  //     if (command.split(/\s+/).includes("git")) {{
+  //       return {{ block: true, reason: "git is disabled by {name}" }};
+  //     }}
+  //   }}
+  return {{}};
+}}
+
+function handlePrompt() {{
+  return {{ text: PROMPT || "" }};
+}}
+
+// --- protocol plumbing (do not edit) -----------------------------------------
+
+const rl = readline.createInterface({{ input: process.stdin }});
+rl.on("line", (raw) => {{
+  const line = raw.trim();
+  if (!line) return;
+  let msg;
+  try {{
+    msg = JSON.parse(line);
+  }} catch (_e) {{
+    return;
+  }}
+  const method = msg.method;
+  const id = msg.id;
+  if (method === "initialize") {{
+    const caps = ["tools", "streaming"];
+    const params = {{ tools: TOOLS.map((t) => ({{ name: t }})) }};
+    if (PROMPT !== null) {{
+      caps.push("prompt");
+      params.prompt = {{ static: PROMPT }};
+    }}{hooks_cap}
+    send({{ id: id, result: {{
+      protocol_version: "1.0",
+      name: NAME,
+      capabilities: caps,
+      capability_params: params,
+    }} }});
+  }} else if (method === "initialized") {{
+    // no-op
+  }} else if (method === "tool/call") {{
+    const p = msg.params || {{}};
+    if (!TOOLS.includes(p.name)) {{
+      send({{ id: id, error: {{ message: "no such tool: " + p.name }} }});
+      return;
+    }}
+    try {{
+      send({{ id: id, result: handleTool(p.name, p.args || {{}}) }});
+    }} catch (e) {{
+      send({{ id: id, error: {{ message: String(e) }} }});
+    }}
+  }} else if (method === "hook/fire") {{
+    const p = msg.params || {{}};
+    try {{
+      send({{ id: id, result: handleHook(p.event || "", p.tool_name || "", p.args || {{}}) }});
+    }} catch (e) {{
+      log("hook error: " + e);
+      send({{ id: id, result: {{}} }});  // fail open
+    }}
+  }} else if (method === "prompt/contribution") {{
+    send({{ id: id, result: handlePrompt() }});
+  }} else if (method === "shutdown") {{
+    send({{ id: id, result: {{}} }});
+    rl.close();
+    process.exit(0);
+  }} else if (id !== undefined && id !== null) {{
+    send({{ id: id, error: {{ code: -32601, message: "method not found: " + method }} }});
+  }}
+}});
+"##,
+        name = req.name,
+        name_literal = name_literal,
+        tools_list = tools_list,
+        prompt_literal = prompt_literal,
+        hooks_cap = hooks_cap,
+    )
+}
+
 fn readme(req: &ScaffoldRequest, server_name: &str) -> String {
     format!(
         "# {name}\n\n\
@@ -455,21 +616,37 @@ mod tests {
     }
 
     #[test]
-    fn unbuilt_languages_report_clearly() {
+    fn language_parsing() {
+        assert_eq!(Language::parse("python").unwrap(), Language::Python);
+        assert_eq!(Language::parse("py").unwrap(), Language::Python);
+        assert_eq!(Language::parse("typescript").unwrap(), Language::Node);
+        assert_eq!(Language::parse("ts").unwrap(), Language::Node);
+        assert_eq!(Language::parse("node").unwrap(), Language::Node);
         assert!(
             Language::parse("rust")
                 .unwrap_err()
-                .contains("not available yet")
-        );
-        assert!(
-            Language::parse("typescript")
-                .unwrap_err()
-                .contains("not available yet")
+                .contains("compiled template")
         );
         assert!(
             Language::parse("cobol")
                 .unwrap_err()
                 .contains("unknown language")
         );
+    }
+
+    #[test]
+    fn generates_a_node_package_the_installer_accepts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut r = req(tmp.path().join("git-guard"));
+        r.language = Language::Node;
+        let out = scaffold(&r).unwrap();
+
+        let manifest_src = std::fs::read_to_string(out.dir.join("plugin.json")).unwrap();
+        parse_manifest(&manifest_src).expect("manifest parses");
+
+        let server = std::fs::read_to_string(&out.server).unwrap();
+        assert!(server.starts_with("#!/usr/bin/env node"));
+        assert!(server.contains(r#"const TOOLS = ["note"];"#));
+        assert!(server.contains("function handleHook"));
     }
 }


### PR DESCRIPTION
## What changed

`scaffold_extension` gains a second language template: a **dependency-free Node.js server** — the toolchain-free path for the TypeScript/JavaScript ecosystem, and the JS twin of the Python template. Like Python it is single-file, needs no build step, and installs + passes `doctor` out of the box. The `language` argument now accepts `python` | `typescript` (aliases `py`, `ts`, `js`, `node`); Rust is reported as needing a compiled template (a planned follow-up with a build-before-run flow) rather than an unknown language.

Embedded literals (tool names, extension name, prompt text) are serialized through `serde_json`, whose output is a valid literal in both JavaScript and Python, so a generated server stays correct for arbitrary inputs.

## Why

The self-writing goal is that yolop can author an extension in whatever language fits — "we need the case for all of them." Python landed first (#313); this adds the JS/TS ecosystem's zero-build path so yolop can scaffold a working extension for either runtime, picking whichever the environment already has.

## Before / After

**Before:** `scaffold_extension` emitted only Python; `language=typescript` was rejected.

**After:** `scaffold_extension name=git-guard language=typescript hooks=[{event: pre_tool_use}]` writes `bin/git-guard-server` as a `#!/usr/bin/env node` YEP server with `handle*` stubs. The end-to-end git-block acceptance is now run for **both** templates — each scaffolds a hook, fills in the git-block body, and spawns the generated server exactly as the runtime does:

```
test extensions::scaffold::tests::generates_a_node_package_the_installer_accepts ... ok
test extensions::scaffold::tests::language_parsing ... ok
test extensions::spawn_tests::scaffolded_python_extension_blocks_git_end_to_end ... ok
test extensions::spawn_tests::scaffolded_node_extension_blocks_git_end_to_end ... ok
test result: ok. 11 passed; 0 failed
```

`cargo fmt --check` and `cargo clippy --all-features -D warnings` are clean.

## Risk

- **Low.** Additive — a new `Language::Node` variant and generator; the Python path is unchanged. Scaffolding only writes files; it never executes generated code. The Node acceptance test self-skips when `node` is absent (mirrors the existing `python3` guards), so CI stays green regardless of runner tooling.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (additive; yolop is pre-1.0)

https://claude.ai/code/session_017d7odSAD8o79pUrd31dpDb

---
_Generated by [Claude Code](https://claude.ai/code/session_017d7odSAD8o79pUrd31dpDb)_