### PR TITLE
feat(tui): declarative view! macro over the tuika builder API

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -955,54 +955,61 @@ fn run_tuika_gallery() -> Result<()> {
 /// `tuika` components.
 fn build_gallery(frame: u64, theme: &tuika::Theme) -> tuika::Element {
     use ratatui::text::{Line, Span};
-    use tuika::{Boxed, Flex, Loader, ProgressBar, Spinner, SpinnerStyle, Text, element};
+    use tuika::{Loader, ProgressBar, Spinner, SpinnerStyle, Text};
 
+    // The whole demo is expressed with the declarative `view!` DSL. Leaf and
+    // third-party components (Spinner, ProgressBar, Loader, Text) enter through
+    // `node(expr)`; layout is the `col`/`row`/`boxed`/`fixed`/`grow` sugar.
     let labeled_spinner = |style: SpinnerStyle, label: &str| -> tuika::Element {
-        element(
-            Flex::row()
-                .gap(1)
-                .fixed(1, element(Spinner::new(frame).style(style)))
-                .auto(element(Text::raw(label.to_string()))),
-        )
+        crate::view! {
+            row(gap = 1) {
+                fixed(1) { node(Spinner::new(frame).style(style)) }
+                text(label.to_string())
+            }
+        }
     };
 
-    let spinners = Boxed::new(element(
-        Flex::column()
-            .fixed(1, labeled_spinner(SpinnerStyle::Braille, "Braille"))
-            .fixed(1, labeled_spinner(SpinnerStyle::Line, "Line"))
-            .fixed(1, labeled_spinner(SpinnerStyle::Dots, "Dots")),
-    ))
-    .title(Line::from(Span::styled(" spinners ", theme.accent_style())));
-
     let animated = tuika::anim::ping_pong(frame, 120);
-    let bars = Boxed::new(element(
-        Flex::column()
-            .fixed(1, element(ProgressBar::determinate(0.25).percent(true)))
-            .fixed(1, element(ProgressBar::determinate(0.60).percent(true)))
-            .fixed(1, element(ProgressBar::determinate(animated).percent(true)))
-            .fixed(1, element(ProgressBar::indeterminate(frame))),
-    ))
-    .title(Line::from(Span::styled(" progress ", theme.accent_style())));
 
-    let loader = Boxed::new(element(Loader::new(frame, "working…").hint("esc to quit")))
-        .title(Line::from(Span::styled(" loader ", theme.accent_style())));
-
-    let footer = Text::new(vec![Line::from(Span::styled(
-        "tuika gallery — native progress is live in the taskbar/top bar · press q to quit",
-        theme.muted_style(),
-    ))]);
-
-    element(
-        Flex::column()
-            .background(ratatui::style::Style::default().bg(theme.background))
-            .padding(tuika::Padding::all(1))
-            .gap(1)
-            .fixed(5, element(spinners))
-            .fixed(6, element(bars))
-            .fixed(3, element(loader))
-            .grow(1, element(tuika::Spacer))
-            .fixed(1, element(footer)),
-    )
+    crate::view! {
+        col(
+            background = ratatui::style::Style::default().bg(theme.background),
+            padding = tuika::Padding::all(1),
+            gap = 1
+        ) {
+            fixed(5) {
+                boxed(title = Line::from(Span::styled(" spinners ", theme.accent_style()))) {
+                    col {
+                        fixed(1) { node(labeled_spinner(SpinnerStyle::Braille, "Braille")) }
+                        fixed(1) { node(labeled_spinner(SpinnerStyle::Line, "Line")) }
+                        fixed(1) { node(labeled_spinner(SpinnerStyle::Dots, "Dots")) }
+                    }
+                }
+            }
+            fixed(6) {
+                boxed(title = Line::from(Span::styled(" progress ", theme.accent_style()))) {
+                    col {
+                        fixed(1) { node(ProgressBar::determinate(0.25).percent(true)) }
+                        fixed(1) { node(ProgressBar::determinate(0.60).percent(true)) }
+                        fixed(1) { node(ProgressBar::determinate(animated).percent(true)) }
+                        fixed(1) { node(ProgressBar::indeterminate(frame)) }
+                    }
+                }
+            }
+            fixed(3) {
+                boxed(title = Line::from(Span::styled(" loader ", theme.accent_style()))) {
+                    node(Loader::new(frame, "working…").hint("esc to quit"))
+                }
+            }
+            grow(1) { spacer() }
+            fixed(1) {
+                node(Text::new(vec![Line::from(Span::styled(
+                    "tuika gallery — native progress is live in the taskbar/top bar · press q to quit",
+                    theme.muted_style(),
+                ))]))
+            }
+        }
+    }
 }
 
 async fn run_tui(

--- a/src/tuika/README.md
+++ b/src/tuika/README.md
@@ -62,6 +62,44 @@ tuika::paint(f.buffer_mut(), f.area(), &theme, root.as_ref(), &[]);
 
 Run the live demo: `cargo run -- tuika-gallery` (press `q` to quit).
 
+## Declarative DSL (`view!`)
+
+`view!` is optional sugar over the builders — it expands to the exact same
+`Flex`/`Boxed`/`element(...)` calls, so there is no runtime cost and nothing new
+in the model. It just makes nested layout read top-down:
+
+```rust
+let root = crate::view! {
+    col(gap = 1, padding = tuika::Padding::all(1)) {
+        boxed(title = " body ") { text("hello") }
+        grow(1) { spacer() }
+        node(status_bar)          // any expression that is `impl View`
+    }
+};
+```
+
+Grammar (each keyword consumes exactly one node):
+
+- `col(attrs) { … }` / `row(attrs) { … }` — flex containers. Attrs (all
+  optional): `gap`, `padding`, `align`, `justify`, `background`.
+- `boxed(attrs) { child }` — bordered container. Attrs: `title`, `border`,
+  `padding`, `background`.
+- `text(expr)`, `spacer()` — leaves.
+- `grow(n) { node }` / `fixed(n) { node }` — set a child's main-axis size
+  (default auto).
+- **`node(expr)`** — splice any `impl View`. This is the escape hatch, and how
+  a component **from another crate** participates in the DSL:
+
+  ```rust
+  use other_crate::Sparkline;
+  crate::view! { col { node(Sparkline::new(&data)) } };
+  ```
+
+First-class `Sparkline { … }` syntax for external components (with their own
+constructors and named attrs) needs a proc-macro; that lands when `tuika`
+becomes its own crate. Until then, `node(...)` covers every third-party
+component. The `tuika-gallery` demo is built entirely with `view!`.
+
 ## Native terminal progress
 
 `native::TerminalProgress` emits the OSC 9;4 sequence, which drives the

--- a/src/tuika/macros.rs
+++ b/src/tuika/macros.rs
@@ -1,0 +1,129 @@
+//! `view!` — a declarative macro layer over the `tuika` builder API.
+//!
+//! `view!` is pure sugar: every rule expands to the same `Flex`/`Boxed`/
+//! `element(...)` calls you would write by hand, so there is no runtime cost,
+//! no reconciler, and nothing new to learn about the model. It exists to make
+//! nested layouts read top-down instead of inside-out.
+//!
+//! ```ignore
+//! let root = view! {
+//!     col(gap = 1, padding = tuika::Padding::all(1)) {
+//!         boxed(title = " body ") { text("hello") }
+//!         grow(1) { spacer() }
+//!         node(my_status_bar)      // any expression that is `impl View`
+//!     }
+//! };
+//! ```
+//!
+//! Grammar (each keyword consumes exactly one node):
+//! - `col( attrs ) { children }` / `row( attrs ) { children }` — flex containers.
+//!   Attrs: `gap = e`, `padding = e`, `align = e`, `justify = e` (comma-separated,
+//!   all optional; the whole `( … )` may be omitted).
+//! - `boxed( attrs ) { child }` — bordered container of one child.
+//!   Attrs: `title = e`, `border = e`, `padding = e`, `background = e`.
+//! - `text( expr )` — a `Text::raw` line. `spacer()` — a `Spacer`.
+//! - `grow(n) { node }` / `fixed(n) { node }` — set a child's main-axis size
+//!   (default is auto).
+//! - `node( expr )` — **escape hatch**: splice any `impl View`, including a
+//!   component defined in another crate. This is how third-party components
+//!   plug into the DSL today.
+//!
+//! Cross-crate note: the macro emits `$crate::tuika::…` paths, so it works
+//! anywhere in this binary without imports. When `tuika` graduates to its own
+//! crate, this becomes a `#[macro_export]` in that crate and a proc-macro can
+//! add first-class `MyWidget { … }` syntax for external components.
+
+#[macro_export]
+macro_rules! view {
+    // ---- public entry: a single node -> Element -----------------------------
+    (col $($rest:tt)*) => { $crate::view!(@one col $($rest)*) };
+    (row $($rest:tt)*) => { $crate::view!(@one row $($rest)*) };
+    (boxed $($rest:tt)*) => { $crate::view!(@one boxed $($rest)*) };
+    (text $($rest:tt)*) => { $crate::view!(@one text $($rest)*) };
+    (spacer $($rest:tt)*) => { $crate::view!(@one spacer $($rest)*) };
+    (node $($rest:tt)*) => { $crate::view!(@one node $($rest)*) };
+
+    // ---- @one: parse one node into an Element -------------------------------
+    (@one col $(( $($attr:tt)* ))? { $($kids:tt)* }) => {{
+        let __flex = $crate::tuika::Flex::column();
+        let __flex = $crate::view!(@attrs __flex; $($($attr)*)?);
+        let __flex = $crate::view!(@kids __flex; $($kids)*);
+        $crate::tuika::element(__flex)
+    }};
+    (@one row $(( $($attr:tt)* ))? { $($kids:tt)* }) => {{
+        let __flex = $crate::tuika::Flex::row();
+        let __flex = $crate::view!(@attrs __flex; $($($attr)*)?);
+        let __flex = $crate::view!(@kids __flex; $($kids)*);
+        $crate::tuika::element(__flex)
+    }};
+    (@one boxed $(( $($attr:tt)* ))? { $($kids:tt)* }) => {{
+        let __boxed = $crate::tuika::Boxed::new($crate::view!(@one $($kids)*));
+        let __boxed = $crate::view!(@boxattrs __boxed; $($($attr)*)?);
+        $crate::tuika::element(__boxed)
+    }};
+    (@one text ( $e:expr )) => {
+        $crate::tuika::element($crate::tuika::Text::raw($e))
+    };
+    (@one spacer ()) => { $crate::tuika::element($crate::tuika::Spacer) };
+    (@one node ( $e:expr )) => { $crate::tuika::element($e) };
+
+    // ---- @kids: fold children onto a Flex builder ---------------------------
+    (@kids $b:expr; ) => { $b };
+    (@kids $b:expr; grow ( $n:expr ) { $($node:tt)* } $($rest:tt)*) => {
+        $crate::view!(@kids $b.grow($n, $crate::view!(@one $($node)*)); $($rest)*)
+    };
+    (@kids $b:expr; fixed ( $n:expr ) { $($node:tt)* } $($rest:tt)*) => {
+        $crate::view!(@kids $b.fixed($n, $crate::view!(@one $($node)*)); $($rest)*)
+    };
+    (@kids $b:expr; col $(( $($a:tt)* ))? { $($k:tt)* } $($rest:tt)*) => {
+        $crate::view!(@kids $b.auto($crate::view!(@one col $(($($a)*))? { $($k)* })); $($rest)*)
+    };
+    (@kids $b:expr; row $(( $($a:tt)* ))? { $($k:tt)* } $($rest:tt)*) => {
+        $crate::view!(@kids $b.auto($crate::view!(@one row $(($($a)*))? { $($k)* })); $($rest)*)
+    };
+    (@kids $b:expr; boxed $(( $($a:tt)* ))? { $($k:tt)* } $($rest:tt)*) => {
+        $crate::view!(@kids $b.auto($crate::view!(@one boxed $(($($a)*))? { $($k)* })); $($rest)*)
+    };
+    (@kids $b:expr; text ( $e:expr ) $($rest:tt)*) => {
+        $crate::view!(@kids $b.auto($crate::tuika::element($crate::tuika::Text::raw($e))); $($rest)*)
+    };
+    (@kids $b:expr; spacer () $($rest:tt)*) => {
+        $crate::view!(@kids $b.auto($crate::tuika::element($crate::tuika::Spacer)); $($rest)*)
+    };
+    (@kids $b:expr; node ( $e:expr ) $($rest:tt)*) => {
+        $crate::view!(@kids $b.auto($crate::tuika::element($e)); $($rest)*)
+    };
+
+    // ---- @attrs: fold flex layout attributes --------------------------------
+    (@attrs $b:expr; ) => { $b };
+    (@attrs $b:expr; gap = $e:expr $(, $($rest:tt)*)?) => {
+        $crate::view!(@attrs $b.gap($e); $($($rest)*)?)
+    };
+    (@attrs $b:expr; padding = $e:expr $(, $($rest:tt)*)?) => {
+        $crate::view!(@attrs $b.padding($e); $($($rest)*)?)
+    };
+    (@attrs $b:expr; align = $e:expr $(, $($rest:tt)*)?) => {
+        $crate::view!(@attrs $b.align($e); $($($rest)*)?)
+    };
+    (@attrs $b:expr; justify = $e:expr $(, $($rest:tt)*)?) => {
+        $crate::view!(@attrs $b.justify($e); $($($rest)*)?)
+    };
+    (@attrs $b:expr; background = $e:expr $(, $($rest:tt)*)?) => {
+        $crate::view!(@attrs $b.background($e); $($($rest)*)?)
+    };
+
+    // ---- @boxattrs: fold boxed attributes -----------------------------------
+    (@boxattrs $b:expr; ) => { $b };
+    (@boxattrs $b:expr; title = $e:expr $(, $($rest:tt)*)?) => {
+        $crate::view!(@boxattrs $b.title($e); $($($rest)*)?)
+    };
+    (@boxattrs $b:expr; border = $e:expr $(, $($rest:tt)*)?) => {
+        $crate::view!(@boxattrs $b.border($e); $($($rest)*)?)
+    };
+    (@boxattrs $b:expr; padding = $e:expr $(, $($rest:tt)*)?) => {
+        $crate::view!(@boxattrs $b.padding($e); $($($rest)*)?)
+    };
+    (@boxattrs $b:expr; background = $e:expr $(, $($rest:tt)*)?) => {
+        $crate::view!(@boxattrs $b.background($e); $($($rest)*)?)
+    };
+}

--- a/src/tuika/mod.rs
+++ b/src/tuika/mod.rs
@@ -43,6 +43,8 @@
 pub mod anim;
 pub mod components;
 pub mod event;
+#[macro_use]
+mod macros;
 pub mod focus;
 pub mod geometry;
 pub mod host;

--- a/src/tuika/tests.rs
+++ b/src/tuika/tests.rs
@@ -477,6 +477,68 @@ fn osc_progress_encoding() {
     );
 }
 
+// ---- view! macro ---------------------------------------------------------
+
+fn render_el(el: &super::view::Element, w: u16, h: u16) -> Vec<String> {
+    let theme = Theme::default();
+    let mut buf = buffer(w, h);
+    let area = buf.area;
+    let ctx = RenderCtx::new(&theme);
+    let mut surface = Surface::new(&mut buf, area);
+    el.render(area, &mut surface, &ctx);
+    (0..h).map(|y| row(&buf, y)).collect()
+}
+
+#[test]
+fn view_macro_matches_builder() {
+    use super::components::{Boxed, Flex, Spacer, Text};
+
+    // Hand-written builder tree.
+    let built: super::view::Element = element(
+        Flex::column()
+            .gap(1)
+            .auto(element(Boxed::new(element(Text::raw("hi"))).title(" t ")))
+            .grow(1, element(Spacer)),
+    );
+
+    // The same tree via the declarative macro.
+    let macroed: super::view::Element = crate::view! {
+        col(gap = 1) {
+            boxed(title = " t ") { text("hi") }
+            grow(1) { spacer() }
+        }
+    };
+
+    let a = render_el(&built, 20, 5);
+    let b = render_el(&macroed, 20, 5);
+    assert_eq!(a, b, "view! must render identically to the builder form");
+    assert!(b.iter().any(|l| l.contains('t')), "{b:?}");
+}
+
+/// A `View` standing in for a component defined in some other crate.
+struct Star;
+impl super::view::View for Star {
+    fn measure(&self, _available: Size) -> Size {
+        Size::new(1, 1)
+    }
+    fn render(&self, area: Rect, surface: &mut Surface, _ctx: &RenderCtx) {
+        surface.set(area.x, area.y, '★', Style::default());
+    }
+}
+
+#[test]
+fn view_macro_accepts_foreign_view_via_node() {
+    // `node(expr)` splices any `impl View` — this is how a component from
+    // another crate participates in the DSL.
+    let tree: super::view::Element = crate::view! {
+        col {
+            node(Star)
+        }
+    };
+    let out = render_el(&tree, 5, 2);
+    assert!(out[0].contains('★'), "foreign view should render: {out:?}");
+}
+
 // ---- a small end-to-end tree ---------------------------------------------
 
 #[test]


### PR DESCRIPTION
## What changed

Adds a **`view!` declarative macro** over the `tuika` builder API, so nested layouts read top-down instead of inside-out. It's `macro_rules` sugar that expands to the *exact* `Flex`/`Boxed`/`element(...)` calls — no runtime cost, no reconciler, nothing new in the model.

```rust
crate::view! {
    col(gap = 1, padding = tuika::Padding::all(1)) {
        boxed(title = " body ") { text("hello") }
        grow(1) { spacer() }
        node(status_bar)          // any impl View, incl. from another crate
    }
}
```

**Grammar** (each keyword consumes one node): `col`/`row` (flex, attrs `gap`/`padding`/`align`/`justify`/`background`), `boxed` (attrs `title`/`border`/`padding`/`background`), `text`/`spacer` leaves, `grow(n)`/`fixed(n)` layout hints, and **`node(expr)`** — the escape hatch that splices any `impl View`.

The hidden **`tuika-gallery`** demo is rewritten entirely with `view!`, so yolop drives the DSL end-to-end.

## Why

Follows up the toolkit with the declarative layer people expect from OpenTUI/quench, while keeping tuika's "no reconciler" design. Two questions this answers concretely:
- **Can yolop use it?** Yes — `build_gallery` is now pure `view!`.
- **Can components live in other crates?** Yes — `node(expr)` accepts any `impl View`, so a widget from any crate drops in. (First-class `Widget { … }` syntax for external components needs a proc-macro; that's the extraction follow-up. `node(...)` covers it today.)

## Before / After

**Before:** layouts were built with nested builder calls (`Flex::column().fixed(…, element(Boxed::new(element(…))…))`).

**After:** the same trees can be written declaratively. Proven equivalent by a test that renders `view!` and the hand-written builder tree into a buffer and asserts they're byte-identical, and by the gallery PTY smoke (unchanged output):

```
exit= 0
osc_start= True   osc_clear= True
spinners=True  progress=True  loader=True  Braille=True  %=True
```

## Validation

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` (Rust 1.97) — clean
- `cargo test --all-features` — **789 passed**, 2 ignored (+2 new: `view_macro_matches_builder`, `view_macro_accepts_foreign_view_via_node`)
- `yolop tuika-gallery` PTY smoke — renders identically, OSC 9;4 fires/clears, exit 0

## Security

- No new dependencies, no runtime behavior change — the macro expands to existing builder calls.
- **TM-FS / TM-BASH / TM-LLM / TM-TOOL** — untouched.

## Risk

- **Low.** Pure sugar; the only non-test production change is rewriting the hidden gallery demo with the macro (output verified identical).

## Follow-ups

- Proc-macro `view!` (when `tuika` is extracted to a crate) for near-JSX syntax and first-class external-component nodes with named attrs.
- Optional `if`/`for` control-flow sugar inside `view!` bodies.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (additive sugar; pre-1.0)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LksbgmgJfiGmNXXGZphgW6)_