### PR TITLE
fix(acp): route reasoning summaries as thoughts

### DIFF
--- a/specs/acp.md
+++ b/specs/acp.md
@@ -72,7 +72,7 @@ notifications. The mapping is a pure, per-turn state machine
 | assistant text delta | `agent_message_chunk` (incremental) |
 | completed assistant message, when no deltas streamed | `agent_message_chunk` (whole text) — covers providers that don't stream |
 | extended-thinking delta | `agent_thought_chunk` |
-| provider-curated reasoning summary | `agent_message_chunk` (public narration; segments separated by blank lines) |
+| provider-curated reasoning summary | `agent_thought_chunk` (displayable reasoning; segments separated by blank lines) |
 | completed assistant commentary with tool calls, when no deltas streamed | `agent_message_chunk` before the tool activity |
 | tool started | `tool_call` (`status: in_progress`, `rawInput`, semantic `kind`) |
 | tool completed | `tool_call_update` (`status: completed`/`failed`, summary `content`) |

--- a/src/acp/bridge.rs
+++ b/src/acp/bridge.rs
@@ -143,21 +143,20 @@ impl Translator {
                 ))]
             }
             EventData::ReasonItem(data) => {
-                // Provider-curated summaries are safe public narration, unlike
-                // plaintext extended thinking. ACP has no commentary update,
-                // so match the terminal projection and use an agent message.
-                let narration = data
+                // Provider-curated summaries are displayable reasoning, while
+                // opaque continuation content remains private.
+                let summary = data
                     .summary
                     .iter()
                     .map(|segment| segment.trim())
                     .filter(|segment| !segment.is_empty())
                     .collect::<Vec<_>>()
                     .join("\n\n");
-                if narration.is_empty() {
+                if summary.is_empty() {
                     Vec::new()
                 } else {
-                    vec![SessionUpdate::AgentMessageChunk(protocol::text_chunk(
-                        narration,
+                    vec![SessionUpdate::AgentThoughtChunk(protocol::text_chunk(
+                        summary,
                     ))]
                 }
             }
@@ -452,7 +451,7 @@ mod tests {
     }
 
     #[test]
-    fn reasoning_summaries_render_as_public_narration() {
+    fn reasoning_summaries_render_as_thought_chunks() {
         let mut t = Translator::new();
         let updates = t.on_event(&event(EventData::ReasonItem(ReasonItemData {
             turn_id: TurnId::new(),
@@ -469,7 +468,7 @@ mod tests {
 
         assert_eq!(
             updates,
-            vec![SessionUpdate::AgentMessageChunk(protocol::text_chunk(
+            vec![SessionUpdate::AgentThoughtChunk(protocol::text_chunk(
                 "**Investigating event semantics**\n\n**Comparing ACP projections**"
             ))]
         );


### PR DESCRIPTION
## What changed
Provider-curated reasoning summaries now stream over ACP as `agent_thought_chunk`. Deliberate commentary and final answers remain `agent_message_chunk`.

The ACP specification now documents the same channel mapping as Everruns EVE-775.

## Why
Yolop's quick commentary fix classified safe provider reasoning summaries as public assistant narration. Everruns subsequently finalized the cross-protocol contract: summaries are displayable reasoning, while commentary is ordinary assistant text. Keeping these distinct prevents provider reasoning summaries from becoming transcript answers.

## Before / After
Before:
```
reason.item.summary → agent_message_chunk
```

After:
```
reason.item.summary → agent_thought_chunk
assistant commentary → agent_message_chunk
```

Automated proof:
- The regression test failed before the implementation with `AgentMessageChunk` vs expected `AgentThoughtChunk`.
- The updated ACP bridge suite passes all 18 translation tests.

## Risk
- Low.
- The visible location of provider-curated summaries changes in ACP clients, typically into a collapsible reasoning section.
- Empty summaries remain suppressed and opaque/encrypted continuation content remains excluded.

## Security
- Reviewed TM-DATA/LLM exposure. Only provider-curated displayable summary text is emitted; encrypted/opaque reasoning is never placed on the ACP wire, covered by the exact-output regression assertion.
- TM-FS, TM-BASH, TM-TOOL, and TM-DEP are unaffected: no filesystem, shell, capability, prompt, secret, or dependency changes.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` — 804 unit, 37 integration, 1 parallel integration passed
- Live ACP/OpenAI handshake through Doppler passed

## Follow-ups
- Adopt per-`message_id` ACP streaming state after Everruns EVE-772 is implemented and released; the required runtime field is not available yet.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed
- [x] All review comments addressed
