### PR TITLE
feat(extensions): extension-contributed status bar (status/changed)

### DIFF
--- a/.agents/skills/author-extension/SKILL.md
+++ b/.agents/skills/author-extension/SKILL.md
@@ -35,8 +35,12 @@ Declare only what you need; a manifest must contribute at least one of:
   `post_tool_use` (observe-only).
 - **prompt** — a static system-prompt contribution.
 - **mcpServers** — contributed MCP servers (declare in the manifest directly).
+- **status** — a status-bar field the server updates live by pushing
+  `status/changed` (e.g. a counter). Scaffold with `status: true`; the generated
+  server gets an `emit_status(text)` helper (empty text clears the field). Shows
+  in the inline and full-screen TUIs; a no-op in `--print`/ACP.
 
-Not yet available: statusline/UI, providers, slash commands.
+Not yet available: providers, slash commands.
 
 ## The loop
 

--- a/crates/yolop-yep/src/meta.rs
+++ b/crates/yolop-yep/src/meta.rs
@@ -21,6 +21,11 @@ pub const METHODS: &[Method] = &[
         "tool/update",
         "Notification: streamed progress for an in-flight tool/call (correlated by request_id).",
     ),
+    Method::server(
+        "status/changed",
+        "Notification: a short capability status the host surfaces in its status bar \
+         (empty status clears it).",
+    ),
     Method::host(
         "hook/fire",
         "Fire a subscribed lifecycle hook (pre_tool_use/post_tool_use).",
@@ -41,6 +46,7 @@ pub const CAPABILITY_TOKENS: &[&str] = &[
     "dynamic_prompt",
     "hooks",
     "mcp_servers",
+    "status",
 ];
 
 /// Direction a method flows.

--- a/crates/yolop-yep/src/protocol.rs
+++ b/crates/yolop-yep/src/protocol.rs
@@ -270,6 +270,39 @@ pub struct PromptContribution {
     pub text: String,
 }
 
+// ---------------------------------------------------------------------------
+// status/changed
+
+/// Severity of a `status/changed` update. Purely presentational; the host may
+/// tint the field. Open/defaulted so an unknown level parses as `ok`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum StatusLevel {
+    #[default]
+    Ok,
+    Warn,
+    Error,
+}
+
+/// Server → host `status/changed` params: a short capability status the host
+/// surfaces in its status bar (and, longer-form, in `/extensions list`). Sent
+/// at will as a notification — e.g. an LSP extension reporting `rust-analyzer
+/// ready`, or a counter ticking. An empty `status` clears the field. Owned +
+/// bidirectional so the server SDK serializes what the host parses.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct StatusChangedParams {
+    /// Short text for the status bar. Empty clears the extension's field.
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub level: StatusLevel,
+    /// Optional long form for `/extensions list`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/yolop-yep/src/schema.rs
+++ b/crates/yolop-yep/src/schema.rs
@@ -10,7 +10,7 @@
 
 use crate::protocol::{
     CapabilityParams, ErrorObject, HookDecision, HookFireParams, InitializeParams,
-    InitializeResult, PromptContribution, ToolCallParams, ToolUpdateParams,
+    InitializeResult, PromptContribution, StatusChangedParams, ToolCallParams, ToolUpdateParams,
 };
 use schemars::generate::SchemaSettings;
 use serde_json::{Value, json};
@@ -30,6 +30,7 @@ fn schema_document() -> Value {
     let hook_fire = ref_for(generator.subschema_for::<HookFireParams>());
     let hook_decision = ref_for(generator.subschema_for::<HookDecision>());
     let prompt_contribution = ref_for(generator.subschema_for::<PromptContribution>());
+    let status_changed = ref_for(generator.subschema_for::<StatusChangedParams>());
     let capability_params = ref_for(generator.subschema_for::<CapabilityParams>());
     let error = ref_for(generator.subschema_for::<ErrorObject>());
 
@@ -40,6 +41,7 @@ fn schema_document() -> Value {
         "initialize": { "params": init_params, "result": init_result },
         "tool/call": { "params": tool_call },
         "tool/update": { "params": tool_update },
+        "status/changed": { "params": status_changed },
         "hook/fire": { "params": hook_fire, "result": hook_decision },
         "prompt/contribution": { "result": prompt_contribution },
     });

--- a/schema/yep/v1/meta.json
+++ b/schema/yep/v1/meta.json
@@ -23,6 +23,11 @@
       "description": "Notification: streamed progress for an in-flight tool/call (correlated by request_id)."
     },
     {
+      "name": "status/changed",
+      "direction": "server",
+      "description": "Notification: a short capability status the host surfaces in its status bar (empty status clears it)."
+    },
+    {
       "name": "hook/fire",
       "direction": "host",
       "description": "Fire a subscribed lifecycle hook (pre_tool_use/post_tool_use)."
@@ -49,6 +54,7 @@
     "prompt",
     "dynamic_prompt",
     "hooks",
-    "mcp_servers"
+    "mcp_servers",
+    "status"
   ]
 }

--- a/schema/yep/v1/schema.json
+++ b/schema/yep/v1/schema.json
@@ -170,6 +170,37 @@
       ],
       "type": "object"
     },
+    "StatusChangedParams": {
+      "description": "Server → host `status/changed` params: a short capability status the host\nsurfaces in its status bar (and, longer-form, in `/extensions list`). Sent\nat will as a notification — e.g. an LSP extension reporting `rust-analyzer\nready`, or a counter ticking. An empty `status` clears the field. Owned +\nbidirectional so the server SDK serializes what the host parses.",
+      "properties": {
+        "detail": {
+          "description": "Optional long form for `/extensions list`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "level": {
+          "$ref": "#/$defs/StatusLevel",
+          "default": "ok"
+        },
+        "status": {
+          "default": "",
+          "description": "Short text for the status bar. Empty clears the extension's field.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "StatusLevel": {
+      "description": "Severity of a `status/changed` update. Purely presentational; the host may\ntint the field. Open/defaulted so an unknown level parses as `ok`.",
+      "enum": [
+        "ok",
+        "warn",
+        "error"
+      ],
+      "type": "string"
+    },
     "ToolCallParams": {
       "properties": {
         "args": {
@@ -231,6 +262,11 @@
     "prompt/contribution": {
       "result": {
         "$ref": "#/$defs/PromptContribution"
+      }
+    },
+    "status/changed": {
+      "params": {
+        "$ref": "#/$defs/StatusChangedParams"
       }
     },
     "tool/call": {

--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -65,6 +65,18 @@ the loop (scaffold → implement → install → doctor → ask-to-enable); the
 end-to-end acceptance — a self-authored `pre_tool_use` hook that blocks `git`,
 spawned exactly as the runtime spawns it — is covered by
 `scaffolded_extension_blocks_git_end_to_end`.
+Status bar: an extension that declares `status` in its manifest (the D4 opt-in)
+may push `status/changed` notifications carrying a short string the host shows
+in its status bar (empty clears it). The wire type is `StatusChangedParams`; the
+notification routes through an optional `StatusSink` created in `runtime.rs`
+into a `SetExtensionStatus` `UiCommand`, then `App.extension_status`, then
+`PresentationState`. It renders in the inline TUI (`status_contributions` /
+`expanded_status_lines`) and the full-screen renderer (`app/fullscreen.rs`); it
+is a no-op in `--print`/ACP, where the sink is `None` and the push only logs.
+`scaffold_extension status=true` emits an `emit_status(text)` helper; the
+acceptance — a self-authored char-counter that pushes to the sink — is covered
+by `scaffolded_status_extension_pushes_to_the_sink`. ACP has no status surface
+today, so extension status is intentionally TUI-only for now.
 Later — the full `yolop-extension-lsp` control-plane extraction (gated on
 `evals/lsp_integration` parity to retire the built-in), `ui/ask` (needs the
 server→host reverse-request channel, still refused in phase 1),

--- a/src/app/fullscreen.rs
+++ b/src/app/fullscreen.rs
@@ -80,6 +80,14 @@ pub(crate) fn draw(f: &mut Frame, app: &mut App) {
     if app.busy {
         left.push(Span::styled("· working…", theme.muted_style()));
     }
+    // Extension-pushed status (status/changed) — the same data the inline TUI
+    // renders, shown left after the model/provider segment.
+    for (name, status) in &ps.extension_status {
+        left.push(Span::styled(
+            format!("· {name}: {status} "),
+            theme.muted_style(),
+        ));
+    }
     let mut right = Vec::new();
     if let Some(tokens) = ps.session_tokens {
         right.push(Span::styled(format!("{tokens} tok  "), theme.muted_style()));

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -119,6 +119,10 @@ pub struct App {
     /// `runtime.execute_command`). Drained in the event loop; see
     /// [`App::apply_ui_command`].
     ui_rx: mpsc::UnboundedReceiver<UiCommand>,
+    /// Live status-bar text per extension (`ext:<name>` → status), pushed by
+    /// extension servers over `status/changed`. Rendered in the status bar via
+    /// [`App::presentation_state`].
+    extension_status: std::collections::BTreeMap<String, String>,
     /// Settings store shared with the runtime (same instance
     /// `SetupCapability` writes). Used to resolve credentials when querying
     /// provider models APIs and to show per-provider connection status in
@@ -405,6 +409,7 @@ impl App {
             status_layout: StatusLayout::Compact,
             session_tokens: None,
             ui_rx: runtime.ui_rx,
+            extension_status: std::collections::BTreeMap::new(),
             settings: runtime.settings,
             model_catalog: HashMap::new(),
             model_fetches_in_flight: HashSet::new(),
@@ -509,6 +514,15 @@ impl App {
             ask_indicator: self.ask_indicator(),
             worktree_compact: self.worktree.status_bar_compact(),
             worktree_expanded: self.worktree.status_bar_expanded(),
+            extension_status: self
+                .extension_status
+                .iter()
+                .map(|(ext, status)| {
+                    // `ext:<name>` → `<name>` for a compact status-bar label.
+                    let label = ext.strip_prefix("ext:").unwrap_or(ext).to_string();
+                    (label, status.clone())
+                })
+                .collect(),
         }
     }
 
@@ -1243,6 +1257,14 @@ impl App {
             },
             UiCommand::OpenEffortOverlay { arg } => {
                 self.start_effort_setup(arg.as_deref().unwrap_or(""))
+            }
+            UiCommand::SetExtensionStatus { ext, status } => {
+                // Empty status clears the field; a live value replaces it.
+                if status.trim().is_empty() {
+                    self.extension_status.remove(&ext);
+                } else {
+                    self.extension_status.insert(ext, status);
+                }
             }
         }
     }
@@ -3363,6 +3385,7 @@ mod tests {
             ask_indicator: None,
             worktree_compact: None,
             worktree_expanded: None,
+            extension_status: Vec::new(),
         }
     }
 

--- a/src/extensions/capability.rs
+++ b/src/extensions/capability.rs
@@ -4,6 +4,7 @@
 //! manifest; execution and the prompt contribution are proxied to the
 //! package's capability server over YEP (see `manager.rs`).
 
+use super::client::StatusSink;
 use super::manager::{DEFAULT_REQUEST_TIMEOUT_MS, ExtensionProcess, ExtensionProcessSpec};
 use super::package::{ExtensionPackage, ToolDefinition, extension_capability_id};
 use async_trait::async_trait;
@@ -22,6 +23,9 @@ pub struct ExtensionCapability {
     id: String,
     package: ExtensionPackage,
     workspace_root: PathBuf,
+    /// Where the server's `status/changed` pushes go. Forwarded to the process
+    /// only when the manifest declares `status` (the D4 opt-in).
+    status_sink: Option<StatusSink>,
     /// Process shared by all tool instances so the server persists across
     /// turns; rebuilt (killing the old server) when the config changes —
     /// the same cache-by-config pattern as `LspCapability::manager_for`.
@@ -34,8 +38,17 @@ impl ExtensionCapability {
             id: extension_capability_id(&package.manifest.name),
             package,
             workspace_root,
+            status_sink: None,
             process: Mutex::new(None),
         }
+    }
+
+    /// Wire a status-bar sink. The sink is used only if the manifest declares
+    /// `status`; a non-declaring extension can never write the status bar even
+    /// if given a sink.
+    pub fn with_status_sink(mut self, sink: Option<StatusSink>) -> Self {
+        self.status_sink = sink;
+        self
     }
 
     fn process_for(&self, config: &Value) -> Arc<ExtensionProcess> {
@@ -56,6 +69,12 @@ impl ExtensionCapability {
             workspace_root: self.workspace_root.clone(),
             config: config.clone(),
             request_timeout: Duration::from_millis(timeout_ms),
+            status_sink: self
+                .package
+                .manifest
+                .status
+                .then(|| self.status_sink.clone())
+                .flatten(),
         }));
         *slot = Some((config.clone(), process.clone()));
         process

--- a/src/extensions/client.rs
+++ b/src/extensions/client.rs
@@ -4,8 +4,9 @@
 //! (the same seam split as `capabilities/lsp/client.rs`).
 
 use super::protocol::{
-    ErrorObject, Incoming, InitializeParams, InitializeResult, ToolUpdateParams, classify_line,
-    notification_line, request_line, response_error_line, version_compatible,
+    ErrorObject, Incoming, InitializeParams, InitializeResult, StatusChangedParams,
+    ToolUpdateParams, classify_line, notification_line, request_line, response_error_line,
+    version_compatible,
 };
 use anyhow::{Result, anyhow};
 use serde_json::Value;
@@ -16,6 +17,13 @@ use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::sync::{mpsc, oneshot};
 
+/// Sink for `status/changed` notifications: called with the extension name and
+/// the parsed status each time a server pushes one. The host wires this to its
+/// status bar (see `runtime.rs`); `None` in headless/ACP modes, where it just
+/// logs. Kept as an opaque callback so `src/extensions/` stays decoupled from
+/// the app/UI layer.
+pub type StatusSink = Arc<dyn Fn(&str, StatusChangedParams) + Send + Sync>;
+
 /// Pending host-originated requests, keyed by id. Host and server id spaces
 /// are independent per direction; only `method`-less lines land here.
 type PendingMap = Arc<Mutex<Option<HashMap<u64, oneshot::Sender<Result<Value, ErrorObject>>>>>>;
@@ -25,8 +33,10 @@ pub struct YepConnection {
     pending: PendingMap,
     next_id: AtomicU64,
     request_timeout: Duration,
-    /// Extension name, for log targets only.
+    /// Extension name, for log targets and status attribution.
     name: String,
+    /// Where `status/changed` notifications go; `None` logs only.
+    status_sink: Option<StatusSink>,
 }
 
 impl YepConnection {
@@ -38,6 +48,7 @@ impl YepConnection {
         name: &str,
         init: InitializeParams,
         request_timeout: Duration,
+        status_sink: Option<StatusSink>,
     ) -> Result<(Arc<Self>, InitializeResult)>
     where
         R: AsyncRead + Unpin + Send + 'static,
@@ -63,6 +74,7 @@ impl YepConnection {
             next_id: AtomicU64::new(1),
             request_timeout,
             name: name.to_string(),
+            status_sink,
         });
 
         let read_conn = connection.clone();
@@ -168,7 +180,15 @@ impl YepConnection {
                 tracing::info!(target: "yolop::ext", ext = %self.name, "{message}");
             }
             "status/changed" => {
-                tracing::warn!(target: "yolop::ext", ext = %self.name, status = %params, "status changed");
+                let status: StatusChangedParams =
+                    serde_json::from_value(params).unwrap_or_default();
+                match &self.status_sink {
+                    Some(sink) => sink(&self.name, status),
+                    None => tracing::info!(
+                        target: "yolop::ext", ext = %self.name,
+                        "status: {}", status.status
+                    ),
+                }
             }
             // Unknown notification kinds are carried through the log, never a
             // failure — open vocabulary per the forward-compat rules.
@@ -310,6 +330,7 @@ mod tests {
             "fake",
             init_params(),
             Duration::from_secs(5),
+            None,
         )
         .await
         .expect("handshake");
@@ -327,6 +348,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn status_changed_reaches_the_sink() {
+        use crate::extensions::protocol::StatusChangedParams;
+        let recorded: Arc<Mutex<Vec<(String, String)>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink: super::StatusSink = {
+            let recorded = recorded.clone();
+            Arc::new(move |ext: &str, params: StatusChangedParams| {
+                recorded
+                    .lock()
+                    .unwrap()
+                    .push((ext.to_string(), params.status));
+            })
+        };
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        // On the tool/call, the server first pushes a status update, then the
+        // result — so once the call resolves the notification is already routed.
+        tokio::spawn(fake_server(server_io, handshake_json(), |id, _, _| {
+            vec![
+                json!({"method": "status/changed", "params": {"status": "42 chars"}}).to_string(),
+                json!({"id": id, "result": {}}).to_string(),
+            ]
+        }));
+        let (read_half, write_half) = tokio::io::split(client_io);
+        let (conn, _) = YepConnection::connect(
+            read_half,
+            write_half,
+            "counter",
+            init_params(),
+            Duration::from_secs(5),
+            Some(sink),
+        )
+        .await
+        .expect("handshake");
+        conn.request("tool/call", json!({"name": "echo"}))
+            .await
+            .expect("tool call");
+        let recorded = recorded.lock().unwrap();
+        assert_eq!(
+            recorded.as_slice(),
+            &[("counter".to_string(), "42 chars".to_string())]
+        );
+    }
+
+    #[tokio::test]
     async fn error_response_maps_to_message() {
         let (client_io, server_io) = tokio::io::duplex(64 * 1024);
         tokio::spawn(fake_server(server_io, handshake_json(), |id, _, _| {
@@ -339,6 +403,7 @@ mod tests {
             "fake",
             init_params(),
             Duration::from_secs(5),
+            None,
         )
         .await
         .expect("handshake");
@@ -363,6 +428,7 @@ mod tests {
             "fake",
             init_params(),
             Duration::from_millis(200),
+            None,
         )
         .await
         .expect("handshake");
@@ -389,6 +455,7 @@ mod tests {
             "future",
             init_params(),
             Duration::from_secs(5),
+            None,
         )
         .await
         {
@@ -446,6 +513,7 @@ mod tests {
             "fake",
             init_params(),
             Duration::from_secs(5),
+            None,
         )
         .await
         .expect("handshake");

--- a/src/extensions/doctor.rs
+++ b/src/extensions/doctor.rs
@@ -124,16 +124,16 @@ pub async fn doctor(
         config: serde_json::Value::Null,
         capabilities: vec!["cancel".into(), "streaming".into()],
     };
-    let handshake = match YepConnection::connect(stdout, stdin, &manifest.name, init, timeout).await
-    {
-        Ok((connection, handshake)) => {
-            connection.notify("shutdown", serde_json::Value::Null);
-            handshake
-        }
-        Err(err) => {
-            return Report::fatal("handshake", format!("initialize failed: {err}"));
-        }
-    };
+    let handshake =
+        match YepConnection::connect(stdout, stdin, &manifest.name, init, timeout, None).await {
+            Ok((connection, handshake)) => {
+                connection.notify("shutdown", serde_json::Value::Null);
+                handshake
+            }
+            Err(err) => {
+                return Report::fatal("handshake", format!("initialize failed: {err}"));
+            }
+        };
 
     Report::from(evaluate(manifest, &handshake))
 }

--- a/src/extensions/manage.rs
+++ b/src/extensions/manage.rs
@@ -178,6 +178,7 @@ impl ManageTool {
             .get("prompt")
             .and_then(Value::as_str)
             .map(str::to_string);
+        let status = args.get("status").and_then(Value::as_bool).unwrap_or(false);
         // Default target: a sibling `scaffold/<name>` of the extensions dir, so
         // authored packages sit next to where they install without cluttering
         // the workspace. An explicit `dir` (a parent) overrides.
@@ -202,6 +203,7 @@ impl ManageTool {
             tools,
             hooks,
             prompt,
+            status,
             dir,
         };
         match scaffold::scaffold(&req) {
@@ -440,6 +442,9 @@ impl Tool for ManageTool {
                         }, "required": ["event"] } },
                     "prompt": { "type": "string",
                         "description": "Static system-prompt contribution text, if any." },
+                    "status": { "type": "boolean",
+                        "description": "Contribute a status-bar field the server updates by \
+                            pushing status/changed (e.g. a live counter)." },
                     "dir": { "type": "string",
                         "description": "Parent directory to create `<name>/` under. Defaults to \
                             a `scaffold/` dir beside the extensions store." }

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -5,7 +5,7 @@
 //! to language servers. Only this module knows about processes; everything
 //! else drives the transport-generic `YepConnection`.
 
-use super::client::YepConnection;
+use super::client::{StatusSink, YepConnection};
 use super::package::ExtensionManifest;
 use super::protocol::{InitializeParams, InitializeResult, PROTOCOL_VERSION};
 use anyhow::{Context, Result, anyhow};
@@ -28,6 +28,10 @@ pub struct ExtensionProcessSpec {
     pub workspace_root: PathBuf,
     pub config: Value,
     pub request_timeout: Duration,
+    /// Where the server's `status/changed` notifications go (status bar).
+    /// Only wired when the extension declares `status` and the host has a
+    /// status bar; `None` otherwise.
+    pub status_sink: Option<StatusSink>,
 }
 
 /// A live (or lazily spawned) capability server.
@@ -209,9 +213,15 @@ impl ExtensionProcess {
             config: self.spec.config.clone(),
             capabilities: vec!["cancel".into(), "streaming".into()],
         };
-        let (connection, handshake) =
-            YepConnection::connect(stdout, stdin, self.name(), init, self.spec.request_timeout)
-                .await?;
+        let (connection, handshake) = YepConnection::connect(
+            stdout,
+            stdin,
+            self.name(),
+            init,
+            self.spec.request_timeout,
+            self.spec.status_sink.clone(),
+        )
+        .await?;
 
         if !handshake.name.is_empty() && handshake.name != self.spec.manifest.name {
             tracing::warn!(

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -26,6 +26,7 @@ pub(crate) mod scaffold;
 pub(crate) mod store;
 
 pub(crate) use capability::ExtensionCapability;
+pub(crate) use client::StatusSink;
 pub(crate) use manage::ExtensionsCapability;
 pub(crate) use package::{discover_extensions, extension_capability_id, extensions_dir};
 
@@ -346,6 +347,7 @@ mod spawn_tests {
                 tool_name_glob: "*".into(),
             }],
             prompt: None,
+            status: false,
             dir: tmp.path().join("git-guard"),
         })
         .unwrap();
@@ -460,6 +462,103 @@ mod spawn_tests {
     #[tokio::test]
     async fn scaffolded_rust_extension_blocks_git_end_to_end() {
         assert_scaffolded_git_block(super::scaffold::Language::Rust).await;
+    }
+
+    /// The status-bar acceptance case: `scaffold_extension` with `status` yields
+    /// a package whose server, after the author fills the hook to count and
+    /// `emit_status`, pushes `status/changed` — and the host routes it to the
+    /// status-bar sink, attributed to the extension.
+    #[tokio::test]
+    async fn scaffolded_status_extension_pushes_to_the_sink() {
+        use super::client::StatusSink;
+        use super::scaffold::{HookSpec, Language, ScaffoldRequest, scaffold};
+        use everruns_core::atoms::PreToolUseDecision;
+        use everruns_core::tool_types::{BuiltinTool, ToolCall, ToolDefinition};
+        use std::sync::{Arc, Mutex};
+
+        if python3().is_none() {
+            eprintln!("skipping: python3 not available");
+            return;
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let out = scaffold(&ScaffoldRequest {
+            name: "char-counter".into(),
+            description: "Counts characters seen in tool calls.".into(),
+            language: Language::Python,
+            tools: vec![],
+            hooks: vec![HookSpec {
+                event: "pre_tool_use".into(),
+                tool_name_glob: "*".into(),
+            }],
+            prompt: None,
+            status: true,
+            dir: tmp.path().join("char-counter"),
+        })
+        .unwrap();
+
+        // Author step: count characters across observed tool-call args and push
+        // the running total to the status bar via the generated emit_status().
+        let server = std::fs::read_to_string(&out.edit).unwrap();
+        let filled = server.replace(
+            "\n    return {}\n\n\ndef handle_prompt",
+            "\n    handle_hook.total = getattr(handle_hook, \"total\", 0) + len(json.dumps(args))\n    \
+             emit_status(str(handle_hook.total) + \" chars\")\n    return {}\n\n\ndef handle_prompt",
+        );
+        assert_ne!(filled, server, "hook body anchor must match");
+        std::fs::write(&out.edit, filled).unwrap();
+
+        let recorded: Arc<Mutex<Vec<(String, String)>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink: StatusSink = {
+            let recorded = recorded.clone();
+            Arc::new(move |ext: &str, p: super::protocol::StatusChangedParams| {
+                recorded.lock().unwrap().push((ext.to_string(), p.status));
+            })
+        };
+        let manifest =
+            parse_manifest(&std::fs::read_to_string(out.dir.join("plugin.json")).unwrap()).unwrap();
+        assert!(manifest.status, "manifest must declare the status facet");
+        let capability = ExtensionCapability::new(
+            ExtensionPackage {
+                dir: out.dir.clone(),
+                manifest,
+            },
+            tmp.path().to_path_buf(),
+        )
+        .with_status_sink(Some(sink));
+
+        let hooks = capability.pre_tool_use_hooks_with_config(&json!(null));
+        let tool_def = ToolDefinition::Builtin(BuiltinTool {
+            name: "bash".into(),
+            display_name: None,
+            description: "run".into(),
+            parameters: json!({ "type": "object" }),
+            policy: Default::default(),
+            category: None,
+            deferrable: Default::default(),
+            hints: Default::default(),
+            full_parameters: None,
+        });
+        let ctx =
+            everruns_core::traits::ToolContext::new(everruns_core::typed_id::SessionId::new());
+        let call = ToolCall {
+            id: "1".into(),
+            name: "bash".into(),
+            arguments: json!({ "command": "git status" }),
+        };
+        // The hook allows the call (it only counts) and pushes a status first.
+        assert!(matches!(
+            hooks[0].before_exec(call, &tool_def, &ctx).await,
+            PreToolUseDecision::Continue(_)
+        ));
+
+        let recorded = recorded.lock().unwrap();
+        assert_eq!(recorded.len(), 1, "one status push expected: {recorded:?}");
+        assert_eq!(recorded[0].0, "char-counter");
+        assert!(
+            recorded[0].1.ends_with("chars"),
+            "status should be the char counter: {:?}",
+            recorded[0].1
+        );
     }
 
     #[tokio::test]

--- a/src/extensions/package.rs
+++ b/src/extensions/package.rs
@@ -54,6 +54,11 @@ struct RawFacet {
     /// Lifecycle hook subscriptions the extension serves over `hook/fire`.
     #[serde(default)]
     hooks: Vec<HookSubscription>,
+    /// Permits the server to push `status/changed` notifications into the host
+    /// status bar (D4: the approval boundary — a non-declaring extension can
+    /// never write the status bar).
+    #[serde(default)]
+    status: bool,
 }
 
 /// A manifest-declared hook subscription. Static (the approved upper bound):
@@ -171,6 +176,7 @@ pub struct ExtensionManifest {
     pub dynamic_prompt: bool,
     pub mcp_servers: BTreeMap<String, ContributedMcpServer>,
     pub hooks: Vec<HookSubscription>,
+    pub status: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -213,6 +219,7 @@ pub fn parse_manifest(raw: &str) -> Result<ExtensionManifest, String> {
         && !raw.yolop.dynamic_prompt
         && raw.yolop.mcp_servers.is_empty()
         && raw.yolop.hooks.is_empty()
+        && !raw.yolop.status
     {
         return Err("extension declares no contributions; nothing to contribute".into());
     }
@@ -242,6 +249,7 @@ pub fn parse_manifest(raw: &str) -> Result<ExtensionManifest, String> {
         dynamic_prompt: raw.yolop.dynamic_prompt,
         mcp_servers: raw.yolop.mcp_servers,
         hooks: raw.yolop.hooks,
+        status: raw.yolop.status,
     })
 }
 

--- a/src/extensions/scaffold.rs
+++ b/src/extensions/scaffold.rs
@@ -81,6 +81,8 @@ pub struct ScaffoldRequest {
     pub tools: Vec<ToolSpec>,
     pub hooks: Vec<HookSpec>,
     pub prompt: Option<String>,
+    /// Contribute a status-bar field (the server may push `status/changed`).
+    pub status: bool,
     /// Absolute path of the package directory to create.
     pub dir: PathBuf,
 }
@@ -111,10 +113,10 @@ fn validate(req: &ScaffoldRequest) -> Result<(), String> {
             "invalid extension name `{name}`: use ascii letters, digits, `-`, `_`"
         ));
     }
-    if req.tools.is_empty() && req.hooks.is_empty() && req.prompt.is_none() {
+    if req.tools.is_empty() && req.hooks.is_empty() && req.prompt.is_none() && !req.status {
         return Err(
             "an extension must contribute something: pass at least one of `tools`, `hooks`, \
-             or `prompt`"
+             `prompt`, or `status`"
                 .into(),
         );
     }
@@ -235,6 +237,9 @@ fn manifest_json(req: &ScaffoldRequest) -> Value {
     if req.prompt.is_some() {
         obj.insert("prompt".into(), Value::Bool(true));
     }
+    if req.status {
+        obj.insert("status".into(), Value::Bool(true));
+    }
     json!({
         "name": req.name,
         "description": req.description,
@@ -257,9 +262,13 @@ fn python_server(req: &ScaffoldRequest) -> String {
         Some(text) => serde_json::to_string(text).unwrap_or_else(|_| "\"\"".into()),
         None => "None".into(),
     };
-    let has_hooks = !req.hooks.is_empty();
-    let hooks_cap = if has_hooks {
+    let hooks_cap = if req.hooks.is_empty() {
+        ""
+    } else {
         "\n            caps.append(\"hooks\")"
+    };
+    let status_cap = if req.status {
+        "\n            caps.append(\"status\")"
     } else {
         ""
     };
@@ -295,6 +304,12 @@ def send(obj):
 def log(msg):
     sys.stderr.write(str(msg) + "\n")
     sys.stderr.flush()
+
+
+def emit_status(text):
+    # Push a status-bar update to the host (requires "status" in plugin.json).
+    # An empty string clears this extension's field.
+    send({{"method": "status/changed", "params": {{"status": text}}}})
 
 
 # --- author-editable handlers -------------------------------------------------
@@ -343,7 +358,7 @@ def main():
             params = {{"tools": [{{"name": t}} for t in TOOLS]}}
             if PROMPT is not None:
                 caps.append("prompt")
-                params["prompt"] = {{"static": PROMPT}}{hooks_cap}
+                params["prompt"] = {{"static": PROMPT}}{hooks_cap}{status_cap}
             send({{"id": msg_id, "result": {{
                 "protocol_version": "1.0",
                 "name": NAME,
@@ -389,6 +404,7 @@ if __name__ == "__main__":
         tools_list = tools_list,
         prompt_literal = prompt_literal,
         hooks_cap = hooks_cap,
+        status_cap = status_cap,
     )
 }
 
@@ -409,6 +425,11 @@ fn node_server(req: &ScaffoldRequest) -> String {
         ""
     } else {
         "\n    caps.push(\"hooks\");"
+    };
+    let status_cap = if req.status {
+        "\n    caps.push(\"status\");"
+    } else {
+        ""
     };
     format!(
         r##"#!/usr/bin/env node
@@ -437,6 +458,12 @@ function send(obj) {{
 
 function log(msg) {{
   process.stderr.write(String(msg) + "\n");
+}}
+
+function emitStatus(text) {{
+  // Push a status-bar update to the host (requires "status" in plugin.json).
+  // An empty string clears this extension's field.
+  send({{ method: "status/changed", params: {{ status: text }} }});
 }}
 
 // --- author-editable handlers ------------------------------------------------
@@ -484,7 +511,7 @@ rl.on("line", (raw) => {{
     if (PROMPT !== null) {{
       caps.push("prompt");
       params.prompt = {{ static: PROMPT }};
-    }}{hooks_cap}
+    }}{hooks_cap}{status_cap}
     send({{ id: id, result: {{
       protocol_version: "1.0",
       name: NAME,
@@ -528,6 +555,7 @@ rl.on("line", (raw) => {{
         tools_list = tools_list,
         prompt_literal = prompt_literal,
         hooks_cap = hooks_cap,
+        status_cap = status_cap,
     )
 }
 
@@ -775,6 +803,7 @@ mod tests {
                 tool_name_glob: "*".into(),
             }],
             prompt: Some("Guarding git.".into()),
+            status: false,
             dir,
         }
     }
@@ -849,6 +878,36 @@ mod tests {
         r.hooks.clear();
         r.prompt = None;
         assert!(scaffold(&r).unwrap_err().contains("contribute"));
+    }
+
+    #[test]
+    fn status_facet_scaffolds_manifest_flag_and_helper() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut r = req(tmp.path().join("counter"));
+        r.status = true;
+        let out = scaffold(&r).unwrap();
+
+        let manifest =
+            parse_manifest(&std::fs::read_to_string(out.dir.join("plugin.json")).unwrap()).unwrap();
+        assert!(manifest.status, "manifest declares the status facet");
+
+        let server = std::fs::read_to_string(&out.edit).unwrap();
+        assert!(
+            server.contains("def emit_status"),
+            "emit_status helper present"
+        );
+        assert!(server.contains(r#"caps.append("status")"#));
+    }
+
+    #[test]
+    fn status_alone_is_a_valid_contribution() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut r = req(tmp.path().join("s"));
+        r.tools.clear();
+        r.hooks.clear();
+        r.prompt = None;
+        r.status = true;
+        assert!(scaffold(&r).is_ok());
     }
 
     #[test]

--- a/src/host_ui.rs
+++ b/src/host_ui.rs
@@ -36,6 +36,9 @@ pub enum UiCommand {
     OpenModelOverlay { arg: Option<String> },
     /// Open the interactive reasoning-effort picker. `arg` pre-seeds it.
     OpenEffortOverlay { arg: Option<String> },
+    /// Set (or, when `status` is empty, clear) an extension's status-bar field.
+    /// Pushed by an extension server's `status/changed` notification.
+    SetExtensionStatus { ext: String, status: String },
 }
 
 /// What a client-executed command can ask the host UI to do. Implemented per

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -36,6 +36,9 @@ pub(crate) struct PresentationState {
     pub ask_indicator: Option<String>,
     pub worktree_compact: Option<String>,
     pub worktree_expanded: Option<(String, String)>,
+    /// Live status pushed by extensions over `status/changed`, as
+    /// `(extension_name, status_text)` pairs. Rendered as its own status field.
+    pub extension_status: Vec<(String, String)>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -147,6 +150,9 @@ fn expanded_status_lines(state: &PresentationState) -> Vec<StatusLine> {
     if let Some(bg) = background_label(state.background, false) {
         counts.push(status_field("bg", bg));
     }
+    // Extension-pushed status shares the counts row so the expanded layout's
+    // fixed row budget is unchanged.
+    counts.extend(extension_status_fields(state));
 
     let mut lines = vec![
         StatusLine {
@@ -196,7 +202,7 @@ fn status_contributions(state: &PresentationState) -> Vec<Vec<StatusField>> {
     if let Some(wt) = &state.worktree_compact {
         counts.push(status_field("wt", wt.clone()));
     }
-    vec![
+    let mut groups = vec![
         vec![
             status_value(toggle_label),
             status_value(state.provider_name.clone()),
@@ -211,7 +217,22 @@ fn status_contributions(state: &PresentationState) -> Vec<Vec<StatusField>> {
             status_field("ask", ask_label(state)),
         ],
         counts,
-    ]
+    ];
+    let ext = extension_status_fields(state);
+    if !ext.is_empty() {
+        groups.push(ext);
+    }
+    groups
+}
+
+/// One status field per extension that pushed a `status/changed`, labelled with
+/// the extension name (e.g. `git-guard › 1423 chars`).
+fn extension_status_fields(state: &PresentationState) -> Vec<StatusField> {
+    state
+        .extension_status
+        .iter()
+        .map(|(name, status)| status_value(format!("{name}: {status}")))
+        .collect()
 }
 
 fn goal_label(state: &PresentationState) -> String {
@@ -299,7 +320,38 @@ mod tests {
             ask_indicator: None,
             worktree_compact: None,
             worktree_expanded: None,
+            extension_status: Vec::new(),
         }
+    }
+
+    #[test]
+    fn extension_status_renders_in_both_layouts() {
+        let flatten = |lines: Vec<StatusLine>| -> String {
+            lines
+                .iter()
+                .flat_map(|l| l.fields.iter())
+                .map(|f| f.value.clone())
+                .collect::<Vec<_>>()
+                .join(" · ")
+        };
+        let mut s = state();
+        s.extension_status = vec![("git-guard".to_string(), "1423 chars".to_string())];
+
+        s.status_layout = StatusLayout::Compact;
+        assert!(
+            flatten(s.status_lines()).contains("git-guard: 1423 chars"),
+            "compact layout must show the extension status"
+        );
+
+        s.status_layout = StatusLayout::Expanded;
+        assert!(
+            flatten(s.status_lines()).contains("git-guard: 1423 chars"),
+            "expanded layout must show the extension status"
+        );
+
+        // No extensions → no stray field.
+        s.extension_status.clear();
+        assert!(!flatten(s.status_lines()).contains("git-guard"));
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2468,6 +2468,26 @@ pub async fn build_with_options(
     // but never on the default harness: enable with
     // `[[capabilities]] ref = "ext:<name>"` in settings.toml, exactly like
     // `lsp`. See specs/extensions.md.
+    // Terminal-side command channel. Created here (before extensions register)
+    // so extension `status/changed` pushes and `ClientCommandsCapability` share
+    // one `UiCommand` stream that the `App` event loop drains.
+    let (ui_tx, ui_rx) = mpsc::unbounded_channel::<UiCommand>();
+    // Status-bar sink for extensions, only when the host has a status bar (the
+    // TUI). Maps a server's `status/changed` into a `SetExtensionStatus`
+    // command; `None` in `--print`/ACP, where it logs instead.
+    let status_sink: Option<crate::extensions::StatusSink> =
+        matches!(options.client_ui, ClientUiContext::Tui).then(|| {
+            let tx = ui_tx.clone();
+            Arc::new(
+                move |ext: &str, params: crate::extensions::protocol::StatusChangedParams| {
+                    let _ = tx.send(UiCommand::SetExtensionStatus {
+                        ext: ext.to_string(),
+                        status: params.status,
+                    });
+                },
+            ) as crate::extensions::StatusSink
+        });
+
     let mut extension_never_defer: Vec<String> = Vec::new();
     if let Some(ext_dir) = crate::extensions::extensions_dir() {
         let settings_snapshot = settings.snapshot();
@@ -2483,7 +2503,8 @@ pub async fn build_with_options(
                 .iter()
                 .any(|(_, entry)| !entry.is_remove());
             let capability =
-                crate::extensions::ExtensionCapability::new(package, effective_root.clone());
+                crate::extensions::ExtensionCapability::new(package, effective_root.clone())
+                    .with_status_sink(status_sink.clone());
             if enabled {
                 let contributed = capability.contributed_mcp_servers();
                 if !contributed.is_empty() {
@@ -2632,11 +2653,11 @@ pub async fn build_with_options(
         session_id,
         task_registry: task_registry.clone(),
     });
-    // Terminal-side commands. Registered only when the host can apply
-    // their effects (the TUI). The capability declares help/tools/mcp/cwd/model/
+    // Terminal-side commands. Registered only when the host can apply their
+    // effects (the TUI). The capability declares help/tools/mcp/cwd/model/
     // effort/clear/shell/quit and forwards each invocation as a `UiCommand` down
-    // `ui_tx`; the `App` event loop drains `ui_rx` and performs the effect.
-    let (ui_tx, ui_rx) = mpsc::unbounded_channel::<UiCommand>();
+    // `ui_tx` (created above, shared with extension status); the `App` event
+    // loop drains `ui_rx` and performs the effect.
     if options.client_commands {
         let ui: Arc<dyn HostUi> = Arc::new(TuiHandle::new(ui_tx));
         capabilities.register(ClientCommandsCapability::new(ui));


### PR DESCRIPTION
## What changed

Extensions can now push live text into yolop's **status bar**. An extension that declares `status` in its manifest (the D4 approval boundary) may send `status/changed` notifications carrying a short string — a health line, a live counter, whatever — and an empty string clears its field. This is the first server→host contribution that renders in the app chrome rather than the transcript.

**Wire** (`yolop-yep`): new `StatusChangedParams` + `StatusLevel`, the `status/changed` server→host method, and a `status` capability token — all emitted into the drift-guarded `meta.json` / `schema.json`.

**Host path**: the YEP read loop routes `status/changed` through an optional `StatusSink` (kept opaque so `src/extensions/` stays decoupled from the UI layer). The sink is created in `runtime.rs` **only for the TUI**, mapping each push to a `SetExtensionStatus` `UiCommand` on the existing `HostUi` channel; the `App` stores it per-extension and folds it into `PresentationState`.

**Three frontends, honestly:**
- **Inline TUI** — renders automatically via `status_contributions` / `expanded_status_lines`.
- **Full-screen (tuika)** — an explicit line in `app/fullscreen.rs` (it hand-builds its status spans).
- **ACP / `--print`** — the sink is `None`, so the push only logs. ACP has no status surface today, so extension status is intentionally TUI-only for now (per the agreed scope).

**Self-authoring**: `scaffold_extension status=true` adds the facet to the Python and Node templates, generating an `emit_status()` helper so a self-written extension can drive the bar.

## Why

Completes the status-bar half of the self-writing story (the other acceptance example alongside the git-block hook). It gives extensions a live, ambient surface — the LSP dogfood can show `rust-analyzer ready`, a counter can tick — closing the last "extensions can contribute UI" gap short of full panels.

## Before / After

**Before:** `status/changed` was a recognized method name that only logged to tracing; no extension could affect the UI chrome.

**After:** a `status`-declaring server's push appears as `git-guard: 1423 chars` in the status bar. Proven end to end — a scaffolded Python status extension counts characters across tool-call args and pushes the running total, which the host routes to a recording sink:

```
test extensions::client::tests::status_changed_reaches_the_sink ... ok
test presentation::tests::extension_status_renders_in_both_layouts ... ok
test extensions::scaffold::tests::status_facet_scaffolds_manifest_flag_and_helper ... ok
test extensions::spawn_tests::scaffolded_status_extension_pushes_to_the_sink ... ok
test result: ok. 56 passed; 0 failed   (extensions)   |   139 passed (app)
```

`cargo fmt --check` and `cargo clippy --all-features -D warnings` clean; the `meta.json`/`schema.json` drift guard passes with the regenerated artifacts.

## Risk

- **Medium** — touches the app event loop and adds protocol surface. Mitigated by: the `Option<StatusSink>` design (headless/ACP get `None`, so their behavior is unchanged), reuse of the established `HostUi`/`UiCommand` seam, and the manifest opt-in (a non-declaring extension can never write the bar even if handed a sink). The expanded layout reuses the counts row, so status rows aren't re-accounted.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (additive; wire is forward-compatible — unknown `level`/`detail` default)

https://claude.ai/code/session_017d7odSAD8o79pUrd31dpDb

---
_Generated by [Claude Code](https://claude.ai/code/session_017d7odSAD8o79pUrd31dpDb)_