### PR TITLE
test(tui): proptest layout/overlay invariants + fix two bounds bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2722,7 +2722,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
  "byteorder-lite",
- "quick-error",
+ "quick-error 2.0.1",
 ]
 
 [[package]]
@@ -4138,6 +4138,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags 2.13.0",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4279,6 +4298,12 @@ name = "pxfm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-error"
@@ -4470,6 +4495,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4986,6 +5020,18 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -5850,7 +5896,7 @@ dependencies = [
  "fax",
  "flate2",
  "half",
- "quick-error",
+ "quick-error 2.0.1",
  "weezl",
  "zune-jpeg",
 ]
@@ -6478,6 +6524,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6701,6 +6753,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -7441,6 +7502,7 @@ dependencies = [
  "include_dir",
  "inventory",
  "portable-pty",
+ "proptest",
  "rand 0.10.2",
  "ratatui",
  "ratatui-textarea",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,7 @@ comfy-table = { version = "7.2.2", default-features = false }
 [dev-dependencies]
 inventory = "0.3"
 portable-pty = "0.9.0"
+proptest = "1"
 tempfile = "3"
 tiny_http = "0.12"
 vt100 = "0.15"

--- a/proptest-regressions/tuika/proptests.txt
+++ b/proptest-regressions/tuika/proptests.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 7070aa7d00c56db90bf9087e68dadd3450e1abf26314e81a36cfc4e181fc6f18 # shrinks to w = 0, h = 0, items = [Item { dimension: Auto, intrinsic: Size { width: 0, height: 0 } }], gap = 0, pad = 1, dir = Row, align = Start, justify = Start

--- a/src/tuika/geometry.rs
+++ b/src/tuika/geometry.rs
@@ -140,13 +140,16 @@ impl Padding {
         self.top.saturating_add(self.bottom)
     }
 
-    /// Shrink `area` by this padding, saturating so it never inverts.
+    /// Shrink `area` by this padding, saturating so it never inverts. The
+    /// origin offset is clamped to the area's extent so an area smaller than
+    /// its padding stays inside `area` (a zero-size box at the edge) instead of
+    /// pushing the inner rect past the right/bottom edge.
     pub fn inner(self, area: Rect) -> Rect {
         let width = area.width.saturating_sub(self.horizontal());
         let height = area.height.saturating_sub(self.vertical());
         Rect {
-            x: area.x.saturating_add(self.left),
-            y: area.y.saturating_add(self.top),
+            x: area.x.saturating_add(self.left.min(area.width)),
+            y: area.y.saturating_add(self.top.min(area.height)),
             width,
             height,
         }

--- a/src/tuika/mod.rs
+++ b/src/tuika/mod.rs
@@ -75,4 +75,6 @@ pub use style::{BorderStyle, Theme};
 pub use view::{Element, RenderCtx, View, element};
 
 #[cfg(test)]
+mod proptests;
+#[cfg(test)]
 mod tests;

--- a/src/tuika/overlay.rs
+++ b/src/tuika/overlay.rs
@@ -115,6 +115,10 @@ impl OverlaySpec {
             height: avail.height,
         };
         let (x, y) = self.position(inner, w, h);
+        // Clamp into the screen: a margin wider than the screen would otherwise
+        // place `inner` (and the overlay) past the edge.
+        let x = x.min(screen.right().saturating_sub(w)).max(screen.x);
+        let y = y.min(screen.bottom().saturating_sub(h)).max(screen.y);
         Rect {
             x,
             y,

--- a/src/tuika/proptests.rs
+++ b/src/tuika/proptests.rs
@@ -1,0 +1,164 @@
+//! Property-based tests for the layout solver and overlay resolver.
+//!
+//! Example-based tests pin down specific cases; these assert *invariants* that
+//! must hold for every input, which is how the flexbox solver's arithmetic
+//! edge cases get shaken out (the out-of-bounds-placement bug fixed alongside
+//! the resize suite is exactly the kind proptest finds automatically).
+
+use proptest::prelude::*;
+use ratatui::layout::Rect;
+
+use super::geometry::{Axis, Padding, Size};
+use super::layout::{Align, Dimension, Direction, Item, Justify, LayoutStyle, solve};
+use super::overlay::{Anchor, Extent, OverlaySpec};
+
+fn dimension_strategy() -> impl Strategy<Value = Dimension> {
+    prop_oneof![
+        Just(Dimension::Auto),
+        (0u16..60).prop_map(Dimension::Fixed),
+        (0u16..=100).prop_map(Dimension::Percent),
+        (1u16..6).prop_map(Dimension::Flex),
+    ]
+}
+
+fn item_strategy() -> impl Strategy<Value = Item> {
+    (dimension_strategy(), 0u16..60, 0u16..30).prop_map(|(d, w, h)| Item::new(d, Size::new(w, h)))
+}
+
+fn align_strategy() -> impl Strategy<Value = Align> {
+    prop_oneof![
+        Just(Align::Start),
+        Just(Align::Center),
+        Just(Align::End),
+        Just(Align::Stretch),
+    ]
+}
+
+fn justify_strategy() -> impl Strategy<Value = Justify> {
+    prop_oneof![
+        Just(Justify::Start),
+        Just(Justify::Center),
+        Just(Justify::End),
+        Just(Justify::SpaceBetween),
+    ]
+}
+
+fn direction_strategy() -> impl Strategy<Value = Direction> {
+    prop_oneof![Just(Direction::Row), Just(Direction::Column)]
+}
+
+proptest! {
+    /// For ANY area, item set, gap, padding, alignment and justification: every
+    /// child rect stays inside the area, the rect count matches, and children
+    /// are placed in non-decreasing main-axis order (never overlapping backward).
+    #[test]
+    fn solved_children_stay_within_area(
+        w in 0u16..300,
+        h in 0u16..120,
+        items in proptest::collection::vec(item_strategy(), 1..8),
+        gap in 0u16..30,
+        pad in 0u16..6,
+        dir in direction_strategy(),
+        align in align_strategy(),
+        justify in justify_strategy(),
+    ) {
+        let area = Rect::new(0, 0, w, h);
+        let style = LayoutStyle {
+            direction: dir,
+            padding: Padding::all(pad),
+            gap,
+            align_items: align,
+            justify,
+        };
+        let rects = solve(area, &style, &items);
+        prop_assert_eq!(rects.len(), items.len());
+
+        let axis = dir.axis();
+        let mut last_main = 0u16;
+        for r in &rects {
+            prop_assert!(
+                r.x >= area.x && r.right() <= area.right(),
+                "x out of bounds: {:?} in {:?}",
+                r,
+                area
+            );
+            prop_assert!(
+                r.y >= area.y && r.bottom() <= area.bottom(),
+                "y out of bounds: {:?} in {:?}",
+                r,
+                area
+            );
+            let main = match axis {
+                Axis::Horizontal => r.x,
+                Axis::Vertical => r.y,
+            };
+            prop_assert!(main >= last_main, "children placed out of order: {:?}", rects);
+            last_main = main;
+        }
+    }
+
+    /// N equal-weight flex children with no gap or padding fill the main axis
+    /// exactly — no cell lost to rounding, none double-counted.
+    #[test]
+    fn flex_children_fill_main_axis_exactly(w in 0u16..500, n in 1usize..8) {
+        let items: Vec<Item> = (0..n)
+            .map(|_| Item::new(Dimension::Flex(1), Size::ZERO))
+            .collect();
+        let rects = solve(Rect::new(0, 0, w, 1), &LayoutStyle::row(), &items);
+        let total: u16 = rects.iter().map(|r| r.width).fold(0, u16::saturating_add);
+        prop_assert_eq!(total, w, "flex children must fill width exactly");
+    }
+
+    /// An overlay always lands inside its screen and never exceeds its max
+    /// clamp — for any anchor, size request, and margin (including a margin
+    /// larger than the screen).
+    #[test]
+    fn overlay_stays_within_screen(
+        w in 0u16..300,
+        h in 0u16..120,
+        pct_w in 0u16..=100,
+        pct_h in 0u16..=100,
+        margin in 0u16..12,
+        anchor_i in 0usize..9,
+        max_w in 1u16..300,
+        max_h in 1u16..120,
+    ) {
+        let anchors = [
+            Anchor::Center,
+            Anchor::Top,
+            Anchor::Bottom,
+            Anchor::Left,
+            Anchor::Right,
+            Anchor::TopLeft,
+            Anchor::TopRight,
+            Anchor::BottomLeft,
+            Anchor::BottomRight,
+        ];
+        let screen = Rect::new(0, 0, w, h);
+        let spec = OverlaySpec {
+            anchor: anchors[anchor_i],
+            width: Extent::Percent(pct_w),
+            height: Extent::Percent(pct_h),
+            min_width: 0,
+            min_height: 0,
+            max_width: max_w,
+            max_height: max_h,
+            margin,
+        };
+        let r = spec.resolve(screen);
+        prop_assert!(
+            r.x >= screen.x && r.right() <= screen.right(),
+            "overlay x out of bounds: {:?} in {:?}",
+            r,
+            screen
+        );
+        prop_assert!(
+            r.y >= screen.y && r.bottom() <= screen.bottom(),
+            "overlay y out of bounds: {:?} in {:?}",
+            r,
+            screen
+        );
+        prop_assert!(r.width <= max_w, "width exceeds max");
+        prop_assert!(r.height <= max_h, "height exceeds max");
+    }
+}


### PR DESCRIPTION
## What changed

Adds **property-based tests** (`proptest` dev-dependency) for `tuika`'s layout solver and overlay resolver (PR 3 of 5), and **fixes two real out-of-bounds bugs they immediately found**.

The properties hold for *every* input, not just chosen examples:
- **`solve()`** — for any area, item set, gap, padding, alignment, and justification: every child rect stays inside the area, the rect count matches the item count, and children are placed in non-decreasing main-axis order.
- **Flex fill** — N equal-weight flex children with no gap/padding fill the main axis *exactly* (no cell lost to rounding, none double-counted).
- **`OverlaySpec::resolve()`** — for any anchor / size request / margin (including a margin larger than the screen): the rect stays inside the screen and never exceeds its max clamp.

**Two bugs found & fixed** (this is the payoff — proptest would have caught PR2's bug automatically too):
1. `Padding::inner` pushed the inner origin past the edge when the area was smaller than its padding (it added `left`/`top` with no room to give). Now clamps the offset, so a too-small area yields a zero-size box *at* the edge instead of outside it.
2. `OverlaySpec::resolve` could place an overlay past the screen when the margin exceeded the screen size. Now clamps the resolved rect into the screen.

## Why

Example tests can't cover the combinatorial space of a flexbox solver; the arithmetic edge cases (saturating subtraction, zero/tiny areas, oversized gaps/margins/padding) are exactly where bounds bugs hide. proptest explores that space and shrinks failures to a minimal case.

## Before / After

Before: `Padding::inner` and `OverlaySpec::resolve` could return out-of-bounds rects on degenerate inputs (hidden by the `Surface` clip at render time). After: both clamp; **+3 property tests**; `cargo test --all-features` = **808 passed**.

## Security

Test-only plus two bounds-tightening one-liners. **TM-DEP:** one new dev-dependency, `proptest = "1"` (test-only, widely used; not in the shipped binary). No runtime deps added.

## Risk

- **Low.** The two fixes only tighten bounds on degenerate inputs; all existing tests pass unchanged.

## Follow-ups

- PR4: golden snapshot harness. PR5: terminal-variance CI PTY smoke + manual matrix.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered

---
_Generated by [Claude Code](https://claude.ai/code/session_01LksbgmgJfiGmNXXGZphgW6)_