### PR TITLE
test(tui): terminal-variance PTY smoke + manual matrix for tuika

### DIFF
--- a/src/tuika/README.md
+++ b/src/tuika/README.md
@@ -110,6 +110,49 @@ so it works in both the inline and full-screen renderers; terminals that don't
 understand it ignore the sequence. yolop shows it (indeterminate) while a turn
 runs and clears it when idle.
 
+## Testing
+
+Layout and rendering are tested hermetically by rendering into an in-memory
+ratatui `Buffer` and reading cells back — no real terminal:
+
+- **Unit tests** (`src/tuika/tests.rs`) — layout math, component rendering,
+  interactive state (scroll/select/focus), compositor, easing, OSC encoder,
+  and palette (every themed cell pinned to its `Theme` slot).
+- **Property tests** (`src/tuika/proptests.rs`, `proptest`) — solver and overlay
+  invariants for *any* input (children stay in bounds, flex fills exactly).
+- **Golden snapshots** (`src/tuika/snapshots.rs`) — whole screens diffed against
+  checked-in glyph grids; refresh with `UPDATE_SNAPSHOTS=1`.
+- **Resize / degenerate sizes** — a size sweep from `0×0` up asserts no panic
+  and no out-of-clip writes.
+- **PTY smoke** (`tests/tuika_pty.rs`) — drives the real binary under a
+  pseudo-terminal and asserts the terminal-facing protocol: alternate-screen
+  enter/leave, OSC 9;4 progress, resize survival, clean exit.
+
+### Manual terminal matrix
+
+The automated tests cover the *protocol* a terminal receives; they cannot
+verify how a specific emulator actually paints it. This is a **checklist to run
+before a release**, not a record of verified results — tick a box only after
+confirming it yourself. Run `cargo run -- tuika-gallery` in each terminal and
+check alt-screen enter/exit, Braille/wide glyphs, truecolor, and mouse-wheel
+scroll:
+
+- [ ] Ghostty
+- [ ] iTerm2
+- [ ] WezTerm
+- [ ] Kitty
+- [ ] Windows Terminal
+- [ ] Konsole
+- [ ] tmux (truecolor needs `Tc`/`RGB` in `terminal-overrides`)
+
+**Native OSC 9;4 progress** support is a fixed property of each terminal (not
+something to re-verify per release). Terminals that render it: **Ghostty**
+(bar at top of window), **Windows Terminal** and **ConEmu** (taskbar),
+**WezTerm**, **Konsole**, **mintty**. Others (e.g. **iTerm2**, **Kitty**)
+silently ignore the unknown OSC, so emitting it is safe everywhere — the
+in-terminal UI is unaffected. See the OSC 9;4 references linked from the
+motion-module PR.
+
 ## Extending
 
 Add a component by implementing `view::View` in a new module under

--- a/tests/tuika_pty.rs
+++ b/tests/tuika_pty.rs
@@ -1,0 +1,198 @@
+//! Terminal-variance smoke for the `tuika` full-screen renderer.
+//!
+//! Unit and snapshot tests render into an in-memory buffer — they never touch a
+//! real terminal. This drives the actual `yolop` binary under a pseudo-terminal
+//! (`portable-pty`) and asserts the terminal-facing behavior the buffer tests
+//! can't see: entering/leaving the alternate screen, driving the native OSC 9;4
+//! progress indicator, surviving a resize, and exiting cleanly. It exercises
+//! the hidden `tuika-gallery` demo, which has no provider/network dependencies.
+//!
+//! This covers the *protocol* a terminal receives; genuinely terminal-specific
+//! rendering (does Ghostty draw the Braille, does the taskbar light up) is the
+//! manual matrix documented in `src/tuika/README.md`.
+#![cfg(unix)]
+
+use std::io::{Read, Write};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
+
+const BIN: &str = env!("CARGO_BIN_EXE_yolop");
+
+struct GalleryRun {
+    output: Vec<u8>,
+    exited_ok: bool,
+}
+
+/// Spawn `yolop tuika-gallery` under a pty of the given size, optionally resize
+/// mid-run, then send `q` and collect everything the terminal received.
+fn run_gallery(rows: u16, cols: u16, resize_to: Option<(u16, u16)>) -> GalleryRun {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let pty = NativePtySystem::default();
+    let pair = pty
+        .openpty(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .expect("open pty");
+
+    let mut cmd = CommandBuilder::new(BIN);
+    cmd.arg("tuika-gallery");
+    cmd.env("TERM", "xterm-256color");
+    cmd.env("HOME", home.path());
+    cmd.env("XDG_CONFIG_HOME", home.path().join(".config"));
+    cmd.env("XDG_DATA_HOME", home.path().join(".local/share"));
+
+    let mut child = pair.slave.spawn_command(cmd).expect("spawn gallery");
+    drop(pair.slave);
+
+    // Reader thread accumulates all bytes until the pty closes (child exit).
+    let reader = pair.master.try_clone_reader().expect("clone reader");
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let reader_buffer = Arc::clone(&buffer);
+    let reader_handle = thread::spawn(move || {
+        let mut reader = reader;
+        let mut chunk = [0u8; 8192];
+        while let Ok(n) = reader.read(&mut chunk) {
+            if n == 0 {
+                break;
+            }
+            reader_buffer
+                .lock()
+                .expect("lock read buffer")
+                .extend_from_slice(&chunk[..n]);
+        }
+    });
+
+    // Let it paint a few frames.
+    thread::sleep(Duration::from_millis(1500));
+    if let Some((c, r)) = resize_to {
+        pair.master
+            .resize(PtySize {
+                rows: r,
+                cols: c,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("resize pty");
+        thread::sleep(Duration::from_millis(800));
+    }
+
+    // Quit.
+    {
+        let mut writer = pair.master.take_writer().expect("pty writer");
+        writer.write_all(b"q").expect("send q");
+        writer.flush().expect("flush q");
+    }
+
+    // Wait for a clean exit.
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let mut exited_ok = false;
+    loop {
+        match child.try_wait().expect("poll child") {
+            Some(status) => {
+                exited_ok = status.success();
+                break;
+            }
+            None if Instant::now() > deadline => {
+                let _ = child.kill();
+                break;
+            }
+            None => thread::sleep(Duration::from_millis(100)),
+        }
+    }
+
+    // The child has exited, so the reader hits EOF; join it and take the bytes.
+    drop(pair.master);
+    let _ = reader_handle.join();
+    let output = Arc::try_unwrap(buffer)
+        .expect("reader thread finished")
+        .into_inner()
+        .expect("read buffer");
+    GalleryRun { output, exited_ok }
+}
+
+fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+/// Strip CSI sequences so we can look for rendered text.
+fn visible_text(bytes: &[u8]) -> String {
+    let text = String::from_utf8_lossy(bytes);
+    let mut out = String::new();
+    let mut chars = text.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\u{1b}' {
+            // Skip an escape sequence: ESC [ ... <final>, or ESC ] ... BEL.
+            match chars.next() {
+                Some('[') => {
+                    for e in chars.by_ref() {
+                        if e.is_ascii_alphabetic() || e == '~' {
+                            break;
+                        }
+                    }
+                }
+                Some(']') => {
+                    for e in chars.by_ref() {
+                        if e == '\u{7}' {
+                            break;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+#[test]
+fn gallery_drives_altscreen_and_native_progress() {
+    let run = run_gallery(24, 80, None);
+    let out = &run.output;
+
+    assert!(run.exited_ok, "gallery should exit cleanly on `q`");
+    assert!(
+        contains(out, b"\x1b[?1049h"),
+        "should enter the alternate screen"
+    );
+    assert!(
+        contains(out, b"\x1b[?1049l"),
+        "should restore the main screen on exit"
+    );
+    // OSC 9;4: indeterminate on start, cleared on exit.
+    assert!(
+        contains(out, b"\x1b]9;4;3"),
+        "should emit the native indeterminate progress sequence"
+    );
+    assert!(
+        contains(out, b"\x1b]9;4;0"),
+        "should clear the native progress indicator on exit"
+    );
+
+    let text = visible_text(out);
+    assert!(
+        text.contains("spinners") && text.contains("progress"),
+        "gallery chrome should render: {text:?}"
+    );
+}
+
+#[test]
+fn gallery_survives_resize() {
+    // Start wide, shrink to a small size mid-run.
+    let run = run_gallery(24, 100, Some((40, 12)));
+    assert!(
+        run.exited_ok,
+        "gallery should survive a resize and exit cleanly"
+    );
+    assert!(
+        contains(&run.output, b"\x1b[?1049l"),
+        "should still restore the screen after a resize"
+    );
+}


### PR DESCRIPTION
## What changed

Adds the terminal-variance layer of `tuika`'s tests (PR 5 of 5) — the part the in-memory buffer tests can't reach.

- **CI PTY smoke** (`tests/tuika_pty.rs`) — drives the *real* `yolop` binary under a pseudo-terminal (`portable-pty`, already a dev-dep) and asserts the terminal-facing protocol: enters and **leaves** the alternate screen, emits **and clears** the native OSC 9;4 progress sequence, **survives a mid-run resize**, and exits cleanly. It exercises the hidden `tuika-gallery` demo (no provider/network), so it runs in CI on every push.
- **Manual terminal matrix** (`src/tuika/README.md`) — a pre-release checklist to run the gallery in Ghostty / iTerm2 / WezTerm / Kitty / Windows Terminal / Konsole / tmux (the automated tests cover the *protocol*, not how a given emulator *paints* it), plus the factual list of terminals that render OSC 9;4 natively. Framed as a checklist to tick after verifying — not a record of results I didn't personally gather.
- Documents the full `tuika` test strategy (unit, proptest, golden snapshots, resize sweep, PTY smoke).

## Why

Everything before this rendered into a `Buffer` and never touched a terminal. This closes the loop by asserting the escape-sequence protocol a real terminal receives, and honestly scopes the one thing that can't be automated (per-emulator painting) into a documented manual pass.

## Before / After

Before: no test drove the actual binary against a terminal. After: **+2 PTY integration tests** (both pass locally under a pty in ~4s), run in CI.

```
gallery_drives_altscreen_and_native_progress ... ok   (enter/leave alt, OSC 9;4 fire/clear, chrome rendered)
gallery_survives_resize ... ok                         (wide→small mid-run, clean exit + screen restored)
```

## Security

Test + docs only. No new dependencies (`portable-pty`/`tempfile` already dev-deps). The test spawns only the workspace binary with a scrubbed `HOME`/XDG env in a tempdir. TM-* untouched.

## Risk

- **Low.** PTY tests are `#[cfg(unix)]` with generous timeouts; they spawn the local binary and quit it deterministically.

## Follow-ups

- PR6: extract `tuika` into its own workspace crate with independent versioning (unlocks `examples/`, doctests, and external reuse).

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered

---
_Generated by [Claude Code](https://claude.ai/code/session_01LksbgmgJfiGmNXXGZphgW6)_