### PR TITLE
ci(release): publish the tuika crate before yolop

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -33,8 +33,11 @@ change), use [`/ship`](../ship/SKILL.md) instead.
    `X.Y.Z`. `X.Y.Z` is strictly greater than the latest version on crates.io.
 2. **The changelog is honest.** `CHANGELOG.md` lists every commit landed
    since the previous tag, in descending order, with PR numbers and authors.
-3. **Publish-readiness is proven before merge.** `cargo publish --dry-run -p
-   yolop` succeeds. The PR body includes a publish-readiness report.
+3. **Publish-readiness is proven before merge.** The library dry-runs
+   (`cargo publish --dry-run -p yolop-yep` and `-p tuika`) succeed; `yolop`'s
+   own publish is validated in CI once the libraries are live (dry-running it
+   locally fails until then — see step 5). The PR body includes a
+   publish-readiness report.
 4. **Post-merge verification is a hard gate.** After the release PR merges,
    the agent must monitor CI and independently confirm that crates.io serves
    `X.Y.Z` and the Homebrew tap formula points at `vX.Y.Z`. A "release" is
@@ -148,28 +151,29 @@ This is the step that catches what local tests don't — the `cargo publish`
 packaging boundary, missing files referenced by `Cargo.toml`, version drift:
 
 ```bash
-cargo publish --dry-run -p yolop-yep   # the SDK crate; publishes first
+cargo publish --dry-run -p yolop-yep   # SDK library; publishes first
+cargo publish --dry-run -p tuika       # TUI toolkit library; publishes first
 cargo search yolop --limit 1     # confirm CURRENT crates.io version < X.Y.Z
 grep '^version' Cargo.toml       # confirm reads X.Y.Z
 grep '"yolop"' Cargo.lock | head -1  # confirm reads X.Y.Z
 ```
 
-**Two-crate workspace.** The repo publishes two crates: the `yolop-yep` SDK
-(separately versioned — bump it only when its API or the wire protocol
-changes) and the `yolop` binary, which depends on `yolop-yep` by version.
-crates.io requires `yolop-yep` to be published **before** `yolop`, so CI
-(`publish.yml`) publishes `yolop-yep` first, then `yolop` (each skipped if its
-version is already live). A consequence for this step: **`cargo publish
---dry-run -p yolop` fails locally** with *"no matching package named
-`yolop-yep` found"* whenever the in-tree `yolop-yep` version isn't yet on
-crates.io — that is expected, not a broken release. Dry-run `yolop-yep`
-instead (above); `yolop`'s own publish is validated in CI after `yolop-yep`
-goes live. When bumping `yolop-yep`, update its version in
-`crates/yolop-yep/Cargo.toml` **and** the `yolop-yep = { version = … }`
-requirement in the root `Cargo.toml`.
+**Three-crate workspace.** The repo publishes three crates: two libraries —
+the `yolop-yep` SDK and the `tuika` TUI toolkit (each separately versioned;
+bump one only when its own API changes, and for `yolop-yep` the wire protocol)
+— and the `yolop` binary, which depends on **both** by version. crates.io
+requires the libraries live **before** `yolop`, so CI (`publish.yml`) publishes
+`yolop-yep`, then `tuika`, then `yolop` (each skipped if its version is already
+live). A consequence for this step: **`cargo publish --dry-run -p yolop` fails
+locally** with *"no matching package named `tuika` found"* (or `yolop-yep`)
+whenever an in-tree library version isn't yet on crates.io — that is expected,
+not a broken release. Dry-run the two libraries instead (above); `yolop`'s own
+publish is validated in CI after they go live. When bumping a library, update
+its version in `crates/<crate>/Cargo.toml` **and** the
+`<crate> = { version = … }` requirement in the root `Cargo.toml`.
 
-If `cargo publish --dry-run -p yolop-yep` fails, fix the root cause and re-run.
-Do **not** open a release PR with a known-broken publish path.
+If either library dry-run fails, fix the root cause and re-run. Do **not** open
+a release PR with a known-broken publish path.
 
 ### 6. Commit and push
 
@@ -196,7 +200,8 @@ Body must include:
   - [x] `cargo fmt --check`
   - [x] `cargo clippy --all-targets --all-features -- -D warnings`
   - [x] `cargo test --all-features`
-  - [x] `cargo publish --dry-run -p yolop`
+  - [x] `cargo publish --dry-run -p yolop-yep` and `-p tuika` (the libraries;
+        `-p yolop` is validated in CI after they publish)
   - [x] crates.io currently serves `A.B.C` → publishing `X.Y.Z`
   - [x] `Cargo.toml` + `Cargo.lock` agree on `X.Y.Z`
   ```

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,7 +78,10 @@ jobs:
             return 1
           }
 
+          # yolop depends on both library crates by version, so crates.io
+          # requires them live before yolop. Order: leaf deps first, binary last.
           publish_if_missing yolop-yep
+          publish_if_missing tuika
           publish_if_missing yolop
 
   verify-publish:

--- a/crates/tuika/src/macros.rs
+++ b/crates/tuika/src/macros.rs
@@ -28,10 +28,11 @@
 //!   component defined in another crate. This is how third-party components
 //!   plug into the DSL today.
 //!
-//! Cross-crate note: the macro emits `$crate::…` paths, so it works
-//! anywhere in this binary without imports. When `tuika` graduates to its own
-//! crate, this becomes a `#[macro_export]` in that crate and a proc-macro can
-//! add first-class `MyWidget { … }` syntax for external components.
+//! Cross-crate note: the macro emits `$crate::…` paths and is
+//! `#[macro_export]`ed, so downstream crates use it as `tuika::view!` without
+//! importing the referenced types. A future proc-macro could add first-class
+//! `MyWidget { … }` syntax for external components; the `node(expr)` escape
+//! hatch covers that case today.
 
 #[macro_export]
 macro_rules! view {

--- a/specs/release.md
+++ b/specs/release.md
@@ -28,8 +28,13 @@ Every yolop release ships to:
 | Target          | Surface                                  | How users install                       |
 |-----------------|------------------------------------------|-----------------------------------------|
 | GitHub Release  | tag `vX.Y.Z`, source archive, binaries   | `gh release download vX.Y.Z`            |
-| crates.io       | `yolop` crate                            | `cargo install yolop --locked`          |
+| crates.io       | `yolop` binary + `yolop-yep` & `tuika` libs | `cargo install yolop --locked`       |
 | Homebrew tap    | formula at `everruns/homebrew-tap`       | `brew install everruns/tap/yolop`       |
+
+The two library crates (`yolop-yep`, `tuika`) are versioned independently of
+`yolop` and are published as a side effect of a `yolop` release only when their
+in-tree version isn't already on crates.io (see § `publish.yml`). They can also
+be consumed on their own (`cargo add tuika`).
 
 Prebuilt CLI binaries are produced for:
 
@@ -83,10 +88,11 @@ When asked to release, the agent:
    `### Breaking Changes` block with before/after migration snippets.
 
 3. **Bump the version** in `Cargo.toml` and regenerate `Cargo.lock`
-   (`cargo update -p yolop`). The `yolop-yep` SDK crate under `crates/` is
-   **versioned separately** — bump it only when its API or the wire protocol
-   changes, and when you do, update both `crates/yolop-yep/Cargo.toml` and the
-   `yolop-yep = { version = … }` requirement in the root `Cargo.toml`.
+   (`cargo update -p yolop`). The library crates under `crates/` — the
+   `yolop-yep` SDK and the `tuika` TUI toolkit — are **versioned separately**:
+   bump one only when its own API changes (for `yolop-yep`, also the wire
+   protocol), and when you do, update both `crates/<crate>/Cargo.toml` and the
+   matching `<crate> = { version = … }` requirement in the root `Cargo.toml`.
 
 4. **Run local verification:**
    - `cargo fmt --check`
@@ -102,14 +108,14 @@ When asked to release, the agent:
    - If any check fails, fix the root cause and re-run before opening the
      PR. **Do not** merge a release PR with a known-broken publish path.
 
-   **Two crates, ordered publish.** crates.io requires `yolop-yep` to be
-   published before `yolop` (which depends on it by version), so
-   `publish.yml` publishes `yolop-yep` first, then `yolop` (each skipped when
-   already live). Because of that ordering, `cargo publish --dry-run -p yolop`
-   **fails locally** — *"no matching package named `yolop-yep` found"* —
-   until the in-tree `yolop-yep` version is on crates.io. That is expected,
-   not a broken release; dry-run `yolop-yep` and rely on CI to validate
-   `yolop` after `yolop-yep` goes live.
+   **Three crates, ordered publish.** `yolop` depends on both `yolop-yep` and
+   `tuika` by version, so crates.io requires both live first. `publish.yml`
+   publishes `yolop-yep`, then `tuika`, then `yolop` (each skipped when already
+   live). Because of that ordering, `cargo publish --dry-run -p yolop`
+   **fails locally** — *"no matching package named `tuika` found"* (or
+   `yolop-yep`) — until both in-tree library versions are on crates.io. That
+   is expected, not a broken release; dry-run the two library crates and rely
+   on CI to validate `yolop` after they go live.
 
 6. **Commit and push** the changes on a feature branch with message
    `chore(release): prepare vX.Y.Z`.


### PR DESCRIPTION
## What changed

Wires the new `tuika` crate into the release/publish path so a `yolop` release actually publishes.

**Why this is a blocker, not a nice-to-have:** after #328, yolop depends on `tuika` by version (`tuika = { version = "0.1.0", path = … }`). crates.io rejects `cargo publish -p yolop` with *"no matching package named `tuika` found"* until tuika is live — the exact constraint the spec already documents for `yolop-yep`. Before this PR, a release would tag successfully via `release.yml` and then **fail at the crates.io publish step**, leaving a half-shipped release.

The fix mirrors the existing `yolop-yep` ordered-publish pattern one-for-one:

- **`publish.yml`** — `publish_if_missing tuika` between `yolop-yep` and `yolop`. Both leaf libraries publish first (each skipped when its version is already live), binary last.
- **`specs/release.md`** + **release skill** — document three published crates (the `yolop-yep` and `tuika` libraries + the `yolop` binary), add the `tuika` dry-run to the publish-readiness step, and note that `cargo publish --dry-run -p yolop` fails locally until both libraries are on crates.io (expected; validated in CI). Corrected Required Outcome #3, which claimed the yolop dry-run succeeds locally.
- Refreshed the now-stale "when tuika graduates to its own crate…" note in tuika's macro docs (it has, and the macro is `#[macro_export]`ed as `tuika::view!`).

## Verification

- `cargo publish --dry-run -p tuika` → **Packaged 38 files (189 KiB), verified build** — packages cleanly, valid metadata (license/readme/repository/keywords/categories all set).
- `publish.yml` is valid YAML; `cargo fmt --check`, `cargo build -p tuika` clean.
- No code behavior change — CI + docs + one doc comment.

## Effect on releases

Once merged, the normal `/release` flow carries tuika automatically: on the first release after this, `publish.yml` publishes `tuika 0.1.0`, then `yolop`. Future tuika changes need a manual version bump in `crates/tuika/Cargo.toml` + the root `tuika = { version = … }` requirement, same as `yolop-yep`.

## Risk

- **Low.** The publish step is idempotent (`publish_if_missing` no-ops when the version is already live), so re-runs are safe. Worst case if something's off: the tuika publish is skipped and the yolop publish fails exactly as it does today — no worse than the pre-PR state.

## Checklist

- [x] Tests added or updated (n/a — CI/docs)
- [x] Backward compatibility considered

---
_Generated by [Claude Code](https://claude.ai/code/session_01LksbgmgJfiGmNXXGZphgW6)_