### PR TITLE
feat(extensions): extension-contributed skills

### DIFF
--- a/.agents/skills/author-extension/SKILL.md
+++ b/.agents/skills/author-extension/SKILL.md
@@ -39,8 +39,11 @@ Declare only what you need; a manifest must contribute at least one of:
   `status/changed` (e.g. a counter). Scaffold with `status: true`; the generated
   server gets an `emit_status(text)` helper (empty text clears the field). Shows
   in the inline and full-screen TUIs; a no-op in `--print`/ACP.
+- **skills** — a `skills/` directory of `SKILL.md` files, mounted read-only for
+  the enabled extension (same discovery as workspace/global skills). Scaffold
+  with `skills: true` to get a starter `skills/<name>/SKILL.md`.
 
-Not yet available: providers, slash commands.
+Not yet available: providers, slash commands, `ui/ask`.
 
 ## The loop
 

--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -77,6 +77,16 @@ is a no-op in `--print`/ACP, where the sink is `None` and the push only logs.
 acceptance — a self-authored char-counter that pushes to the sink — is covered
 by `scaffolded_status_extension_pushes_to_the_sink`. ACP has no status surface
 today, so extension status is intentionally TUI-only for now.
+Skills: an extension that declares `skills` and ships a `skills/` directory
+contributes its `SKILL.md` files read-only, discovered by the same
+`ScopedSkillsCapability` scan as workspace/global/system skills. Each enabled,
+declaring extension's `skills/` is seeded into a read-only in-memory mount at
+`extension_skills_vfs(<name>)` (so an installed extension's skills can't be
+mutated through the VFS) and added as a read-only `SkillScope` (label
+`ext:<name>`) in `skills_config`. Loading follows the MCP-contribution rule
+(enabled extensions only) and is host-side — no server or wire involvement.
+`scaffold_extension skills=true` writes a starter `skills/<name>/SKILL.md`;
+`extension_contributed_skill_is_visible_and_read_only` covers the mount.
 Later — the full `yolop-extension-lsp` control-plane extraction (gated on
 `evals/lsp_integration` parity to retire the built-in), `ui/ask` (needs the
 server→host reverse-request channel, still refused in phase 1),

--- a/src/capabilities/skills.rs
+++ b/src/capabilities/skills.rs
@@ -54,6 +54,20 @@ pub const SYSTEM_SKILLS_VFS: &str = "/.yolop/system-skills";
 /// Unlike global/system skills this root has no disk backing; a capability
 /// mount (currently Herdr) serves it through `MountFs`.
 pub const ENVIRONMENT_SKILLS_VFS: &str = "/.yolop/environment-skills";
+/// VFS prefix for read-only skills contributed by installed extensions. Each
+/// enabled extension declaring `skills` mounts its `skills/` dir at
+/// `<prefix>/<name>`, served from real disk (like global/system).
+pub const EXTENSION_SKILLS_VFS_PREFIX: &str = "/.yolop/extension-skills";
+
+/// VFS root for one extension's contributed skills.
+pub fn extension_skills_vfs(name: &str) -> String {
+    format!("{EXTENSION_SKILLS_VFS_PREFIX}/{name}")
+}
+
+/// Scope label for one extension's contributed skills.
+pub fn extension_skills_label(name: &str) -> String {
+    format!("ext:{name}")
+}
 
 /// System skills shipped inside the binary. Keep the source tree away from
 /// well-known skill discovery paths so it cannot be mistaken for a writable
@@ -97,7 +111,11 @@ pub fn relative_under(path: &str, root: &str) -> Option<String> {
 /// Only disk-backed scopes whose directory resolved are included. System and
 /// environment scopes are read-only; workspace/global are writable.
 /// `${SKILL_DIR}` and display paths resolve through [`HostSkillDirResolver`].
-pub fn skills_config(dirs: &SkillDirs, environment_active: bool) -> SkillsConfig {
+pub fn skills_config(
+    dirs: &SkillDirs,
+    environment_active: bool,
+    extensions: &[(String, PathBuf)],
+) -> SkillsConfig {
     let mut scopes = vec![SkillScope::new("workspace", WORKSPACE_SKILLS_VFS, true)];
     if dirs.global.is_some() {
         scopes.push(SkillScope::new("global", GLOBAL_SKILLS_VFS, true));
@@ -112,9 +130,23 @@ pub fn skills_config(dirs: &SkillDirs, environment_active: bool) -> SkillsConfig
     if dirs.system.is_some() {
         scopes.push(SkillScope::new("system", SYSTEM_SKILLS_VFS, false));
     }
+    // Read-only skills contributed by enabled extensions.
+    for (name, _dir) in extensions {
+        scopes.push(SkillScope::new(
+            extension_skills_label(name),
+            extension_skills_vfs(name),
+            false,
+        ));
+    }
     SkillsConfig {
         scopes,
-        resolver: Arc::new(HostSkillDirResolver { dirs: dirs.clone() }),
+        resolver: Arc::new(HostSkillDirResolver {
+            dirs: dirs.clone(),
+            extensions: extensions
+                .iter()
+                .map(|(name, dir)| (extension_skills_label(name), dir.clone()))
+                .collect(),
+        }),
         manage_tools: true,
     }
 }
@@ -125,10 +157,15 @@ pub fn skills_config(dirs: &SkillDirs, environment_active: bool) -> SkillsConfig
 /// paths.
 struct HostSkillDirResolver {
     dirs: SkillDirs,
+    /// Extension scope label (`ext:<name>`) → its on-disk `skills/` directory.
+    extensions: std::collections::BTreeMap<String, PathBuf>,
 }
 
 impl HostSkillDirResolver {
     fn base_for(&self, label: &str) -> PathBuf {
+        if let Some(dir) = self.extensions.get(label) {
+            return dir.clone();
+        }
         match label {
             "global" => self.dirs.global.clone(),
             // Environment skills are VFS-only and contain no shell-side assets.
@@ -486,7 +523,7 @@ mod tests {
             global: None,
             system: Some(PathBuf::from("/data/sys")),
         };
-        let cfg = skills_config(&dirs, false);
+        let cfg = skills_config(&dirs, false, &[]);
         let labels: Vec<&str> = cfg.scopes.iter().map(|s| s.label.as_str()).collect();
         assert_eq!(labels, vec!["workspace", "system"]);
         assert!(cfg.manage_tools);
@@ -508,13 +545,42 @@ mod tests {
     }
 
     #[test]
+    fn extension_scopes_are_read_only_and_routed() {
+        let dirs = SkillDirs {
+            workspace: PathBuf::from("/ws/.agents/skills"),
+            global: None,
+            system: None,
+        };
+        let ext = vec![(
+            "git-guard".to_string(),
+            PathBuf::from("/ext/git-guard/skills"),
+        )];
+        let cfg = skills_config(&dirs, false, &ext);
+        let scope = cfg
+            .scopes
+            .iter()
+            .find(|s| s.label == "ext:git-guard")
+            .expect("extension scope present");
+        assert!(!scope.writable, "extension skills are read-only");
+        assert_eq!(scope.vfs_root, extension_skills_vfs("git-guard"));
+        // The resolver maps the scope back to the real on-disk dir.
+        assert_eq!(
+            cfg.resolver.skill_dir(scope, "my-skill"),
+            "/ext/git-guard/skills/my-skill"
+        );
+    }
+
+    #[test]
     fn resolver_returns_real_host_paths() {
         let dirs = SkillDirs {
             workspace: PathBuf::from("/ws/.agents/skills"),
             global: Some(PathBuf::from("/cfg/yolop/skills")),
             system: Some(PathBuf::from("/data/sys")),
         };
-        let r = HostSkillDirResolver { dirs };
+        let r = HostSkillDirResolver {
+            dirs,
+            extensions: Default::default(),
+        };
         // Compare as paths so separators are platform-correct.
         assert_eq!(
             PathBuf::from(r.skill_dir(&SkillScope::new("global", GLOBAL_SKILLS_VFS, true), "foo")),

--- a/src/extensions/manage.rs
+++ b/src/extensions/manage.rs
@@ -179,6 +179,7 @@ impl ManageTool {
             .and_then(Value::as_str)
             .map(str::to_string);
         let status = args.get("status").and_then(Value::as_bool).unwrap_or(false);
+        let skills = args.get("skills").and_then(Value::as_bool).unwrap_or(false);
         // Default target: a sibling `scaffold/<name>` of the extensions dir, so
         // authored packages sit next to where they install without cluttering
         // the workspace. An explicit `dir` (a parent) overrides.
@@ -204,6 +205,7 @@ impl ManageTool {
             hooks,
             prompt,
             status,
+            skills,
             dir,
         };
         match scaffold::scaffold(&req) {
@@ -445,6 +447,9 @@ impl Tool for ManageTool {
                     "status": { "type": "boolean",
                         "description": "Contribute a status-bar field the server updates by \
                             pushing status/changed (e.g. a live counter)." },
+                    "skills": { "type": "boolean",
+                        "description": "Contribute a skills/ directory (a starter SKILL.md is \
+                            generated); loaded read-only for the enabled extension." },
                     "dir": { "type": "string",
                         "description": "Parent directory to create `<name>/` under. Defaults to \
                             a `scaffold/` dir beside the extensions store." }

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -28,7 +28,9 @@ pub(crate) mod store;
 pub(crate) use capability::ExtensionCapability;
 pub(crate) use client::StatusSink;
 pub(crate) use manage::ExtensionsCapability;
-pub(crate) use package::{discover_extensions, extension_capability_id, extensions_dir};
+pub(crate) use package::{
+    discover_extensions, extension_capability_id, extension_skill_scopes, extensions_dir,
+};
 
 #[cfg(test)]
 mod spawn_tests {
@@ -348,6 +350,7 @@ mod spawn_tests {
             }],
             prompt: None,
             status: false,
+            skills: false,
             dir: tmp.path().join("git-guard"),
         })
         .unwrap();
@@ -492,6 +495,7 @@ mod spawn_tests {
             }],
             prompt: None,
             status: true,
+            skills: false,
             dir: tmp.path().join("char-counter"),
         })
         .unwrap();

--- a/src/extensions/package.rs
+++ b/src/extensions/package.rs
@@ -59,6 +59,11 @@ struct RawFacet {
     /// never write the status bar).
     #[serde(default)]
     status: bool,
+    /// Contributes the package's `skills/` directory as read-only skills (D4:
+    /// only a declaring, enabled extension's skills load). Static markdown, so
+    /// no server is involved.
+    #[serde(default)]
+    skills: bool,
 }
 
 /// A manifest-declared hook subscription. Static (the approved upper bound):
@@ -177,6 +182,7 @@ pub struct ExtensionManifest {
     pub mcp_servers: BTreeMap<String, ContributedMcpServer>,
     pub hooks: Vec<HookSubscription>,
     pub status: bool,
+    pub skills: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -188,6 +194,26 @@ pub struct ExtensionPackage {
 /// Capability ref for an extension: `ext:<name>`.
 pub fn extension_capability_id(name: &str) -> String {
     format!("ext:{name}")
+}
+
+/// `(name, skills_dir)` for every enabled extension that declares `skills` and
+/// actually ships a `skills/` directory. Read-only skill scopes are built from
+/// this (see `capabilities::skills`). Skills load only for enabled extensions,
+/// matching the MCP-contribution rule.
+pub fn extension_skill_scopes(
+    packages: &[ExtensionPackage],
+    is_enabled: impl Fn(&str) -> bool,
+) -> Vec<(String, PathBuf)> {
+    packages
+        .iter()
+        .filter_map(|pkg| {
+            if !pkg.manifest.skills || !is_enabled(&pkg.manifest.name) {
+                return None;
+            }
+            let dir = pkg.dir.join("skills");
+            dir.is_dir().then(|| (pkg.manifest.name.clone(), dir))
+        })
+        .collect()
 }
 
 pub fn parse_manifest(raw: &str) -> Result<ExtensionManifest, String> {
@@ -220,6 +246,7 @@ pub fn parse_manifest(raw: &str) -> Result<ExtensionManifest, String> {
         && raw.yolop.mcp_servers.is_empty()
         && raw.yolop.hooks.is_empty()
         && !raw.yolop.status
+        && !raw.yolop.skills
     {
         return Err("extension declares no contributions; nothing to contribute".into());
     }
@@ -250,6 +277,7 @@ pub fn parse_manifest(raw: &str) -> Result<ExtensionManifest, String> {
         mcp_servers: raw.yolop.mcp_servers,
         hooks: raw.yolop.hooks,
         status: raw.yolop.status,
+        skills: raw.yolop.skills,
     })
 }
 
@@ -439,5 +467,38 @@ mod tests {
         let found = discover_extensions(tmp.path());
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].manifest.name, "echo");
+    }
+
+    #[test]
+    fn extension_skill_scopes_needs_flag_enabled_and_a_skills_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mk = |name: &str, declares: bool, has_dir: bool| -> ExtensionPackage {
+            let dir = tmp.path().join(name);
+            std::fs::create_dir_all(&dir).unwrap();
+            if has_dir {
+                std::fs::create_dir_all(dir.join("skills")).unwrap();
+            }
+            let manifest = parse_manifest(
+                &json!({
+                    "name": name, "description": "t",
+                    "yolop": { "protocol_version": "1.0",
+                        "capabilityServer": { "command": "x" },
+                        "tools": [{ "name": "t" }], "skills": declares }
+                })
+                .to_string(),
+            )
+            .unwrap();
+            ExtensionPackage { dir, manifest }
+        };
+        let packages = vec![
+            mk("has-skills", true, true), // declares + dir + enabled → included
+            mk("no-flag", false, true),   // no `skills` flag → excluded
+            mk("no-dir", true, false),    // flag but no skills/ dir → excluded
+            mk("disabled", true, true),   // flag + dir but disabled → excluded
+        ];
+        let scopes = extension_skill_scopes(&packages, |name| name != "disabled");
+        assert_eq!(scopes.len(), 1, "{scopes:?}");
+        assert_eq!(scopes[0].0, "has-skills");
+        assert!(scopes[0].1.ends_with("skills"));
     }
 }

--- a/src/extensions/scaffold.rs
+++ b/src/extensions/scaffold.rs
@@ -83,6 +83,8 @@ pub struct ScaffoldRequest {
     pub prompt: Option<String>,
     /// Contribute a status-bar field (the server may push `status/changed`).
     pub status: bool,
+    /// Contribute a `skills/` directory (a starter `SKILL.md` is generated).
+    pub skills: bool,
     /// Absolute path of the package directory to create.
     pub dir: PathBuf,
 }
@@ -113,10 +115,15 @@ fn validate(req: &ScaffoldRequest) -> Result<(), String> {
             "invalid extension name `{name}`: use ascii letters, digits, `-`, `_`"
         ));
     }
-    if req.tools.is_empty() && req.hooks.is_empty() && req.prompt.is_none() && !req.status {
+    if req.tools.is_empty()
+        && req.hooks.is_empty()
+        && req.prompt.is_none()
+        && !req.status
+        && !req.skills
+    {
         return Err(
             "an extension must contribute something: pass at least one of `tools`, `hooks`, \
-             `prompt`, or `status`"
+             `prompt`, `status`, or `skills`"
                 .into(),
         );
     }
@@ -198,12 +205,37 @@ pub fn scaffold(req: &ScaffoldRequest) -> Result<Scaffolded, String> {
         &readme(req, &server_name, &build),
     )?;
 
+    if req.skills {
+        // A starter skill under skills/<name>/SKILL.md. The host mounts the
+        // whole skills/ dir read-only for an enabled, declaring extension.
+        let skill_dir = req.dir.join("skills").join(&req.name);
+        std::fs::create_dir_all(&skill_dir)
+            .map_err(|e| format!("creating {}: {e}", skill_dir.display()))?;
+        write(&skill_dir.join("SKILL.md"), &starter_skill(req))?;
+        files.push(format!("skills/{}/SKILL.md", req.name));
+    }
+
     Ok(Scaffolded {
         dir: req.dir.clone(),
         edit,
         files,
         build,
     })
+}
+
+fn starter_skill(req: &ScaffoldRequest) -> String {
+    let desc = if req.description.is_empty() {
+        "What this skill helps with (one line, used for matching)."
+    } else {
+        &req.description
+    };
+    format!(
+        "---\nname: {name}\ndescription: {desc}\n---\n\n# {name}\n\n\
+         TODO: write the instructions the agent should follow when this skill is \
+         active.\n",
+        name = req.name,
+        desc = desc,
+    )
 }
 
 fn manifest_json(req: &ScaffoldRequest) -> Value {
@@ -239,6 +271,9 @@ fn manifest_json(req: &ScaffoldRequest) -> Value {
     }
     if req.status {
         obj.insert("status".into(), Value::Bool(true));
+    }
+    if req.skills {
+        obj.insert("skills".into(), Value::Bool(true));
     }
     json!({
         "name": req.name,
@@ -804,6 +839,7 @@ mod tests {
             }],
             prompt: Some("Guarding git.".into()),
             status: false,
+            skills: false,
             dir,
         }
     }
@@ -907,6 +943,33 @@ mod tests {
         r.hooks.clear();
         r.prompt = None;
         r.status = true;
+        assert!(scaffold(&r).is_ok());
+    }
+
+    #[test]
+    fn skills_facet_scaffolds_manifest_flag_and_starter_skill() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut r = req(tmp.path().join("git-guard"));
+        r.skills = true;
+        let out = scaffold(&r).unwrap();
+
+        let manifest =
+            parse_manifest(&std::fs::read_to_string(out.dir.join("plugin.json")).unwrap()).unwrap();
+        assert!(manifest.skills, "manifest declares the skills facet");
+
+        let skill = std::fs::read_to_string(out.dir.join("skills/git-guard/SKILL.md")).unwrap();
+        assert!(skill.contains("name: git-guard"));
+        assert!(out.files.iter().any(|f| f.contains("SKILL.md")));
+    }
+
+    #[test]
+    fn skills_alone_is_a_valid_contribution() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut r = req(tmp.path().join("packof"));
+        r.tools.clear();
+        r.hooks.clear();
+        r.prompt = None;
+        r.skills = true;
         assert!(scaffold(&r).is_ok());
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -271,6 +271,9 @@ struct CodingCliSessionFileSystemFactory {
     skill_global: Option<PathBuf>,
     skill_system: Option<PathBuf>,
     environment_skill: Option<&'static str>,
+    /// `(name, skills_dir)` for enabled extensions contributing skills; each is
+    /// mounted read-only at its `extension_skills_vfs(name)` root.
+    extension_skills: Vec<(String, PathBuf)>,
 }
 
 #[async_trait]
@@ -331,9 +334,65 @@ impl SessionFileSystemFactory for CodingCliSessionFileSystemFactory {
                 "/",
             );
         }
+        // Mount each contributing extension's `skills/` dir read-only. Seeded
+        // into an in-memory store (which honors `is_readonly`) rather than a
+        // live-disk mount, so an installed extension's skills can't be mutated
+        // through the VFS — the same read-only guarantee as environment skills.
+        for (name, dir) in &self.extension_skills {
+            let store = InMemorySessionFileStore::new();
+            if let Err(err) = seed_readonly_dir(&store, self.session_id, dir).await {
+                tracing::warn!(
+                    target: "yolop::ext",
+                    "skipping skills for extension `{name}`: {err}"
+                );
+                continue;
+            }
+            mounted = mounted.with_mount(
+                crate::capabilities::skills::extension_skills_vfs(name),
+                Arc::new(store),
+                "/",
+            );
+        }
         let mounted: Arc<dyn SessionFileSystem> = Arc::new(mounted);
         Ok(Arc::new(WriteBlocklistFileStore::new(mounted)))
     }
+}
+
+/// Seed every UTF-8 file under `root` into `store` read-only, keyed by its path
+/// relative to `root`. Used to mount an extension's on-disk `skills/` dir as a
+/// read-only VFS source. Non-UTF-8 files (rare in skills) are skipped.
+async fn seed_readonly_dir(
+    store: &InMemorySessionFileStore,
+    session_id: SessionId,
+    root: &std::path::Path,
+) -> everruns_core::Result<()> {
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = std::fs::read_dir(&dir)
+            .map_err(|e| AgentLoopError::config(format!("read {}: {e}", dir.display())))?;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if let Ok(text) = std::fs::read_to_string(&path)
+                && let Ok(rel) = path.strip_prefix(root)
+            {
+                let vfs = format!("/{}", rel.to_string_lossy().replace('\\', "/"));
+                store
+                    .seed_initial_file(
+                        session_id,
+                        &InitialFile {
+                            path: vfs,
+                            content: text,
+                            encoding: "text".to_string(),
+                            is_readonly: true,
+                        },
+                    )
+                    .await?;
+            }
+        }
+    }
+    Ok(())
 }
 
 struct CodingCliSessionFileStore {
@@ -2317,6 +2376,22 @@ pub async fn build_with_options(
     // config and the file-store factory's scope routing.
     let skill_dirs = crate::capabilities::skills::SkillDirs::resolve(&effective_root);
 
+    // Read-only skills contributed by enabled extensions (D4: only a declaring,
+    // enabled extension's `skills/` loads). Computed here so it feeds both the
+    // skills capability config and the file-store mounts below.
+    let extension_skill_scopes = crate::extensions::extensions_dir()
+        .map(|ext_dir| {
+            let snapshot = settings.snapshot();
+            let packages = crate::extensions::discover_extensions(&ext_dir);
+            crate::extensions::extension_skill_scopes(&packages, |name| {
+                snapshot
+                    .capability_overrides_for(&crate::extensions::extension_capability_id(name))
+                    .iter()
+                    .any(|(_, entry)| !entry.is_remove())
+            })
+        })
+        .unwrap_or_default();
+
     // MCP servers from global settings and workspace `.mcp.json`, merged. Loading is
     // best-effort per scope: a malformed file is warned about and skipped, so
     // it never sinks the session or masks the other scope.
@@ -2441,7 +2516,11 @@ pub async fn build_with_options(
     // resolver so `${SKILL_DIR}` reaches real files. The file store maps the
     // scope VFS roots onto disk (see `capabilities::skills`).
     capabilities.register(ScopedSkillsCapability::new(
-        crate::capabilities::skills::skills_config(&skill_dirs, herdr.is_active()),
+        crate::capabilities::skills::skills_config(
+            &skill_dirs,
+            herdr.is_active(),
+            &extension_skill_scopes,
+        ),
     ));
     // Herdr contributes a conditional, read-only skill mount. Outside a Herdr
     // pane it has no mounts and the reporter is inert.
@@ -2735,6 +2814,7 @@ pub async fn build_with_options(
             skill_global: skill_dirs.global.clone(),
             skill_system: skill_dirs.system.clone(),
             environment_skill: HerdrCapability::skill_content(herdr.is_active()),
+            extension_skills: extension_skill_scopes.clone(),
         }))
         .build();
 
@@ -5080,7 +5160,7 @@ mod tests {
             )
             .expect("store"),
         );
-        let cap = ScopedSkillsCapability::new(skills_config(&dirs, false));
+        let cap = ScopedSkillsCapability::new(skills_config(&dirs, false, &[]));
         let tools = cap.tools();
         let list = tools
             .iter()
@@ -5132,6 +5212,7 @@ mod tests {
             skill_global: None,
             skill_system: None,
             environment_skill: HerdrCapability::skill_content(true),
+            extension_skills: Vec::new(),
         };
 
         let store = factory
@@ -5167,6 +5248,70 @@ mod tests {
                 .await
                 .is_err(),
             "environment skill must remain read-only"
+        );
+    }
+
+    #[tokio::test]
+    async fn extension_contributed_skill_is_visible_and_read_only() {
+        use crate::capabilities::skills::extension_skills_vfs;
+
+        let workspace = tempfile::tempdir().expect("workspace");
+        let session = tempfile::tempdir().expect("session");
+        let ext = tempfile::tempdir().expect("extension");
+        let session_id = SessionId::from_seed(82);
+
+        // An installed extension ships skills/greet/SKILL.md.
+        let skills_dir = ext.path().join("skills");
+        std::fs::create_dir_all(skills_dir.join("greet")).unwrap();
+        std::fs::write(
+            skills_dir.join("greet/SKILL.md"),
+            "---\nname: greet\ndescription: Say hi\n---\nBe warm.",
+        )
+        .unwrap();
+
+        let host = Arc::new(
+            WorkspaceHost::new(
+                Arc::new(RwLock::new(workspace.path().to_path_buf())),
+                workspace.path().to_path_buf(),
+            )
+            .expect("host"),
+        );
+        let factory = CodingCliSessionFileSystemFactory {
+            workspace: host,
+            session_dir: session.path().to_path_buf(),
+            session_id,
+            skill_global: None,
+            skill_system: None,
+            environment_skill: None,
+            extension_skills: vec![("demo".to_string(), skills_dir.clone())],
+        };
+        let store = factory
+            .create_session_file_system(SessionFileSystemFactoryContext::default())
+            .await
+            .expect("session file system");
+
+        let vfs = extension_skills_vfs("demo");
+        let entries = store
+            .list_directory(session_id, &vfs)
+            .await
+            .expect("list extension skills");
+        assert!(
+            entries.iter().any(|e| e.is_directory && e.name == "greet"),
+            "extension skill dir should be listed: {entries:?}"
+        );
+        let skill = store
+            .read_file(session_id, &format!("{vfs}/greet/SKILL.md"))
+            .await
+            .expect("read")
+            .expect("skill exists");
+        assert!(skill.content.as_deref().unwrap().contains("name: greet"));
+        // Contributed skills are read-only.
+        assert!(
+            store
+                .write_file(session_id, &format!("{vfs}/greet/SKILL.md"), "x", "text")
+                .await
+                .is_err(),
+            "extension skills must be read-only"
         );
     }
 


### PR DESCRIPTION
## What changed

An installed extension can now **ship skills**. An extension that declares `skills` in its manifest (the D4 opt-in) and includes a `skills/` directory contributes its `SKILL.md` files — discovered by the very same `ScopedSkillsCapability` scan that already handles workspace/global/system skills. No server, no wire involvement; skills are static markdown.

**Mechanism:** each enabled, declaring extension's `skills/` is seeded into a **read-only in-memory mount** at `extension_skills_vfs(<name>)` (so an installed extension's skills can't be mutated through the VFS — same guarantee as environment skills) and added as a read-only `SkillScope` (label `ext:<name>`) to `skills_config`. The host resolver maps `${SKILL_DIR}` to the real on-disk path so the `bash` tool can still read a skill's bundled assets. Loading follows the MCP-contribution rule (**enabled extensions only**), computed once at session build and threaded into both the skills config and the file-store factory.

**Self-authoring:** `scaffold_extension skills=true` writes a starter `skills/<name>/SKILL.md` and sets the manifest facet; `skills` alone is a valid contribution.

## Why

Completes the "extensions contribute skills" ask. Skills are the one facet that isn't served over YEP — they're files — so this rides the file-store/skill-scope machinery rather than the protocol, keeping the change host-side and additive.

## Before / After

**Before:** an extension's `skills/` directory was ignored; only workspace/global/system/environment scopes were scanned.

**After:** `~/.config/yolop/extensions/<name>/skills/greet/SKILL.md` (for an enabled extension declaring `skills`) shows up in `list_skills` under scope `ext:<name>`, read-only. Proven end to end:

```
test extensions::package::tests::extension_skill_scopes_needs_flag_enabled_and_a_skills_dir ... ok
test capabilities::skills::tests::extension_scopes_are_read_only_and_routed ... ok
test extensions::scaffold::tests::skills_facet_scaffolds_manifest_flag_and_starter_skill ... ok
test runtime::tests::extension_contributed_skill_is_visible_and_read_only ... ok
68 passed (extensions+skills) · 238 passed (app+runtime)
```

`cargo fmt --check` and `cargo clippy --all-features -D warnings` clean; yep drift guard passes (no wire change).

## Risk

- **Low–medium.** Additive — new manifest facet + read-only mounts + scopes; no protocol change, no effect on non-declaring or disabled extensions. Skills are seeded read-only, so an extension can't be mutated via the VFS. Non-UTF-8 files under `skills/` are skipped (rare). Scoped to the file-store factory + skills config; existing skill scopes are untouched.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (additive; yolop is pre-1.0)

https://claude.ai/code/session_017d7odSAD8o79pUrd31dpDb

---
_Generated by [Claude Code](https://claude.ai/code/session_017d7odSAD8o79pUrd31dpDb)_