### PR TITLE
docs(tuika): add interactive select + overlay examples

### DIFF
--- a/crates/tuika/README.md
+++ b/crates/tuika/README.md
@@ -47,9 +47,9 @@ extraction into its own crate. Today yolop drives it from
 ## Example
 
 ```rust
-use crate::tuika::{self, Boxed, Flex, ProgressBar, Spinner, Text, element};
+use tuika::{Flex, ProgressBar, Spinner, Text, Theme, element, paint};
 
-let theme = tuika::Theme::default();
+let theme = Theme::default();
 let root = Flex::column()
     .gap(1)
     .fixed(1, element(Spinner::new(frame)))
@@ -57,10 +57,20 @@ let root = Flex::column()
     .grow(1, element(Text::raw("body")));
 
 // In a `terminal.draw(|f| ...)` closure:
-tuika::paint(f.buffer_mut(), f.area(), &theme, root.as_ref(), &[]);
+paint(f.buffer_mut(), f.area(), &theme, root.as_ref(), &[]);
 ```
 
-Run the live demo: `cargo run -- tuika-gallery` (press `q` to quit).
+### Runnable examples
+
+Each enters the alternate screen; press `q` (or `esc`) to quit.
+
+| Example    | Command                                   | Shows                                              |
+| ---------- | ----------------------------------------- | -------------------------------------------------- |
+| `gallery`  | `cargo run -p tuika --example gallery`    | motion components + native OSC 9;4 progress        |
+| `select`   | `cargo run -p tuika --example select`     | `SelectState` + `SelectList` (stateful-widget idiom) |
+| `overlay`  | `cargo run -p tuika --example overlay`    | `OverlaySpec` centered dialog + input routing      |
+
+(Embedded in yolop, the gallery is also reachable as `yolop tuika-gallery`.)
 
 ## Declarative DSL (`view!`)
 

--- a/crates/tuika/examples/overlay.rs
+++ b/crates/tuika/examples/overlay.rs
@@ -1,0 +1,122 @@
+//! Overlay compositing + input routing. Run with
+//! `cargo run -p tuika --example overlay` (o open · enter/esc close · q quit).
+//!
+//! Demonstrates [`OverlaySpec`] anchoring a centered dialog over the base tree
+//! and [`paint`] compositing it last (clearing its rect first, so base content
+//! leaks around a clean-bordered panel). While the dialog is open it owns
+//! input — the same key means different things depending on overlay state.
+
+use std::io;
+use std::time::Duration;
+
+use crossterm::event::{self};
+use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
+use ratatui::backend::CrosstermBackend;
+use ratatui::text::{Line, Span};
+use ratatui::{Terminal, TerminalOptions, Viewport};
+
+use tuika::{
+    AltScreen, Element, Event, KeyCode, Overlay, OverlaySpec, Padding, Text, Theme, paint,
+    translate_event, view,
+};
+
+fn main() -> io::Result<()> {
+    let mut open = false;
+    let mut confirmed = 0u32;
+
+    enable_raw_mode()?;
+    let mut alt = AltScreen::enter()?;
+    let mut terminal = Terminal::with_options(
+        CrosstermBackend::new(io::stdout()),
+        TerminalOptions {
+            viewport: Viewport::Fullscreen,
+        },
+    )?;
+    let theme = Theme::default();
+
+    loop {
+        terminal.draw(|f| {
+            let area = f.area();
+            let hint = if open {
+                "dialog open — enter = confirm · esc = dismiss"
+            } else {
+                "o open dialog · q quit"
+            };
+            let base = view! {
+                col(padding = Padding::all(1), gap = 1) {
+                    node(Text::new(vec![Line::from(Span::styled(
+                        "tuika overlay demo",
+                        theme.accent_style(),
+                    ))]))
+                    fixed(4) {
+                        boxed(title = Line::from(" base layer ")) {
+                            node(Text::raw(format!(
+                                "confirmed {confirmed} time(s) — base content stays visible around the panel"
+                            )))
+                        }
+                    }
+                    grow(1) { spacer() }
+                    fixed(1) {
+                        node(Text::new(vec![Line::from(Span::styled(hint, theme.muted_style()))]))
+                    }
+                }
+            };
+
+            // The dialog Element must outlive the `paint` borrow below.
+            let dialog: Option<Element> = open.then(|| {
+                view! {
+                    boxed(
+                        title = Line::from(Span::styled(" confirm ", theme.accent_style())),
+                        padding = Padding::all(1)
+                    ) {
+                        col(gap = 1) {
+                            node(Text::raw("Proceed with the action?"))
+                            node(Text::new(vec![Line::from(Span::styled(
+                                "enter = yes · esc = no",
+                                theme.muted_style(),
+                            ))]))
+                        }
+                    }
+                }
+            });
+            let mut overlays: Vec<Overlay> = Vec::new();
+            if let Some(d) = &dialog {
+                let rect = OverlaySpec::centered(50, 40)
+                    .min_size(34, 7)
+                    .resolve(area);
+                overlays.push(Overlay {
+                    area: rect,
+                    view: d.as_ref(),
+                    clear: true,
+                });
+            }
+            paint(f.buffer_mut(), area, &theme, base.as_ref(), &overlays);
+        })?;
+
+        if !event::poll(Duration::from_millis(150))? {
+            continue;
+        }
+        let Some(Event::Key(k)) = translate_event(event::read()?) else {
+            continue;
+        };
+        if !k.plain() {
+            continue;
+        }
+        match (open, k.code) {
+            (false, KeyCode::Char('q')) => break,
+            (false, KeyCode::Char('o')) => open = true,
+            (true, KeyCode::Enter) => {
+                confirmed += 1;
+                open = false;
+            }
+            (true, KeyCode::Esc) => open = false,
+            _ => {}
+        }
+    }
+
+    let _ = terminal.clear();
+    drop(terminal);
+    alt.leave();
+    disable_raw_mode()?;
+    Ok(())
+}

--- a/crates/tuika/examples/select.rs
+++ b/crates/tuika/examples/select.rs
@@ -1,0 +1,99 @@
+//! Interactive select list. Run with `cargo run -p tuika --example select`
+//! (↑/↓ move · enter choose · q or esc quit).
+//!
+//! Demonstrates the stateful-widget idiom: [`SelectState`] persists the
+//! highlighted index across frames while [`SelectList`] is rebuilt each frame,
+//! and [`translate_event`] feeds real terminal input to the widget.
+
+use std::io;
+use std::time::Duration;
+
+use crossterm::event::{self};
+use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
+use ratatui::backend::CrosstermBackend;
+use ratatui::text::{Line, Span};
+use ratatui::{Terminal, TerminalOptions, Viewport};
+
+use tuika::{
+    AltScreen, Event, KeyCode, Padding, SelectList, SelectOutcome, SelectState, Text, Theme, paint,
+    translate_event, view,
+};
+
+const FRUITS: [&str; 8] = [
+    "Apple",
+    "Blueberry",
+    "Cherry",
+    "Date",
+    "Elderberry",
+    "Fig",
+    "Grape",
+    "Honeydew",
+];
+
+fn main() -> io::Result<()> {
+    let mut state = SelectState::new();
+    let mut chosen: Option<usize> = None;
+
+    enable_raw_mode()?;
+    let mut alt = AltScreen::enter()?;
+    let mut terminal = Terminal::with_options(
+        CrosstermBackend::new(io::stdout()),
+        TerminalOptions {
+            viewport: Viewport::Fullscreen,
+        },
+    )?;
+    let theme = Theme::default();
+
+    loop {
+        terminal.draw(|f| {
+            let area = f.area();
+            let items: Vec<Line> = FRUITS.iter().map(|s| Line::from(*s)).collect();
+            let list = SelectList::new(items, &state);
+            let status = match chosen {
+                Some(i) => format!("chose: {}", FRUITS[i]),
+                None => "↑/↓ move · enter choose · q quit".to_string(),
+            };
+            let root = view! {
+                col(padding = Padding::all(1), gap = 1) {
+                    fixed(FRUITS.len() as u16 + 2) {
+                        boxed(title = Line::from(Span::styled(" fruit ", theme.accent_style()))) {
+                            node(list)
+                        }
+                    }
+                    fixed(1) {
+                        node(Text::new(vec![Line::from(Span::styled(
+                            status,
+                            theme.muted_style(),
+                        ))]))
+                    }
+                }
+            };
+            paint(f.buffer_mut(), area, &theme, root.as_ref(), &[]);
+        })?;
+
+        if !event::poll(Duration::from_millis(150))? {
+            continue;
+        }
+        let Some(ev) = translate_event(event::read()?) else {
+            continue;
+        };
+        // `q` quits globally; the list itself only cares about arrows/enter/esc.
+        if let Event::Key(k) = &ev
+            && k.plain()
+            && matches!(k.code, KeyCode::Char('q'))
+        {
+            break;
+        }
+        match state.handle(&ev, FRUITS.len()) {
+            SelectOutcome::Confirmed(i) => chosen = Some(i),
+            SelectOutcome::Cancelled => break,
+            SelectOutcome::Moved(_) => {}
+        }
+    }
+
+    let _ = terminal.clear();
+    drop(terminal);
+    alt.leave();
+    disable_raw_mode()?;
+    Ok(())
+}


### PR DESCRIPTION
## What changed

Adds two runnable examples for tuika's **interactive** surface — the `gallery` example only shows the passive/motion side. Both drive real terminal input through `translate_event`, so they double as usage references for the input seam.

| Example   | Command                                | Demonstrates |
| --------- | -------------------------------------- | ------------ |
| `select`  | `cargo run -p tuika --example select`  | the **stateful-widget idiom** — `SelectState` persists the highlighted index across frames while `SelectList` is rebuilt each frame; ↑/↓ navigate, enter confirms |
| `overlay` | `cargo run -p tuika --example overlay` | `OverlaySpec` anchoring a **centered dialog** composited by `paint` (base content leaks around a clean-bordered panel), and **input routing** — while the dialog is open it owns input, so the same key means different things by overlay state |

Also fixes the README's stale `use crate::tuika::{self, …}` import (a pre-extraction leftover — the crate is now consumed as `use tuika::…`) and adds a runnable-examples table.

## Why

Extraction into a crate (#328) unlocked `examples/`. `gallery` covered spinners/progress; these cover the parts a real app actually wires up — selection state and modal overlays with input ownership. They give newcomers a copy-pasteable event loop for each.

## Verification

- `cargo clippy -p tuika --example select --example overlay` — clean.
- Both built and **driven under a pseudo-terminal**: each enters the alternate screen (`\x1b[?1049h`), processes navigation/confirm input, and exits cleanly (`exit=0`) restoring the screen (`\x1b[?1049l`).

## Risk

- **Low.** Example code only; not part of the published library surface or the binary. No changes to `src/`.

## Checklist

- [x] Tests added or updated (n/a — examples; both pty-smoked)
- [x] Backward compatibility considered

---
_Generated by [Claude Code](https://claude.ai/code/session_01LksbgmgJfiGmNXXGZphgW6)_