### PR TITLE
fix(ci): initialize extension skills in runtime test

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -5243,6 +5243,7 @@ mod tests {
             skill_global: None,
             skill_system: None,
             environment_skill: None,
+            extension_skills: Vec::new(),
         };
         let store = factory
             .create_session_file_system(SessionFileSystemFactoryContext::default())


### PR DESCRIPTION
## What changed
Complete the runtime filesystem factory test fixture with an empty extension-skill set, restoring compilation for test targets.

## Why
The extension-contributed skills change added a required factory field but missed one test-only initializer. `cargo build --locked --all-targets` and Clippy therefore failed on `main`; coverage uploads then failed because no report was produced.

## Before / After
Before: CI failed with `E0063: missing field extension_skills` in `src/runtime.rs`.

After:
- `cargo fmt --check` passes.
- `cargo build --locked --all-targets` passes.
- `cargo clippy --all-targets --all-features -- -D warnings` passes.
- `cargo test --all-features` passes: 809 passed, 0 failed, 3 expected ignores across all test binaries.
- `cargo run -- --provider llmsim -p "hi"` exits successfully.

## Risk
- Low.
- Test-fixture-only initialization; no production behavior changes.

## Security
No security-relevant code changes. Reviewed TM-FS, TM-BASH, TM-LLM, TM-TOOL, and TM-DEP; the patch only supplies an empty collection to an existing test factory and does not alter filesystem access, shell execution, prompts/keys, capabilities, or dependencies.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
