### PR TITLE
feat(extensions): extension-contributed slash commands

### DIFF
--- a/.agents/skills/author-extension/SKILL.md
+++ b/.agents/skills/author-extension/SKILL.md
@@ -42,8 +42,12 @@ Declare only what you need; a manifest must contribute at least one of:
 - **skills** — a `skills/` directory of `SKILL.md` files, mounted read-only for
   the enabled extension (same discovery as workspace/global skills). Scaffold
   with `skills: true` to get a starter `skills/<name>/SKILL.md`.
+- **commands** — slash commands, registered namespaced as `/<ext>:<cmd>` in the
+  palette and dispatched to the server over `command/execute` (the result
+  message is shown to the user). Scaffold with `commands: ["name", …]`; the
+  generated server gets a `handle_command(name, arguments)` seam.
 
-Not yet available: providers, slash commands, `ui/ask`.
+Not yet available: providers, `ui/ask`.
 
 ## The loop
 

--- a/crates/yolop-yep/src/meta.rs
+++ b/crates/yolop-yep/src/meta.rs
@@ -34,6 +34,10 @@ pub const METHODS: &[Method] = &[
         "prompt/contribution",
         "Request a fresh dynamic system-prompt contribution.",
     ),
+    Method::host(
+        "command/execute",
+        "Run a manifest-declared slash command; the result message is shown to the user.",
+    ),
     Method::host("config/changed", "Notify the server its config changed."),
     Method::host("shutdown", "Request a graceful stop."),
 ];
@@ -47,6 +51,7 @@ pub const CAPABILITY_TOKENS: &[&str] = &[
     "hooks",
     "mcp_servers",
     "status",
+    "commands",
 ];
 
 /// Direction a method flows.

--- a/crates/yolop-yep/src/protocol.rs
+++ b/crates/yolop-yep/src/protocol.rs
@@ -271,6 +271,37 @@ pub struct PromptContribution {
 }
 
 // ---------------------------------------------------------------------------
+// command/execute
+
+/// Host → server `command/execute` params: run a manifest-declared slash
+/// command. `name` is the command's own name (the host strips any `<ext>:`
+/// namespace prefix before sending); `arguments` is the raw text after the
+/// command token.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct CommandExecuteParams {
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub arguments: String,
+}
+
+/// Server → host `command/execute` result: a message the host shows to the
+/// user. Lenient/defaulted — a bare `{}` means "succeeded, no message".
+#[derive(Debug, Clone, Default, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct CommandExecuteResult {
+    #[serde(default = "default_true")]
+    pub success: bool,
+    #[serde(default)]
+    pub message: String,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+// ---------------------------------------------------------------------------
 // status/changed
 
 /// Severity of a `status/changed` update. Purely presentational; the host may

--- a/crates/yolop-yep/src/schema.rs
+++ b/crates/yolop-yep/src/schema.rs
@@ -9,8 +9,9 @@
 //! `schema` feature, and a drift test keeps the committed file in lockstep.
 
 use crate::protocol::{
-    CapabilityParams, ErrorObject, HookDecision, HookFireParams, InitializeParams,
-    InitializeResult, PromptContribution, StatusChangedParams, ToolCallParams, ToolUpdateParams,
+    CapabilityParams, CommandExecuteParams, CommandExecuteResult, ErrorObject, HookDecision,
+    HookFireParams, InitializeParams, InitializeResult, PromptContribution, StatusChangedParams,
+    ToolCallParams, ToolUpdateParams,
 };
 use schemars::generate::SchemaSettings;
 use serde_json::{Value, json};
@@ -30,6 +31,8 @@ fn schema_document() -> Value {
     let hook_fire = ref_for(generator.subschema_for::<HookFireParams>());
     let hook_decision = ref_for(generator.subschema_for::<HookDecision>());
     let prompt_contribution = ref_for(generator.subschema_for::<PromptContribution>());
+    let command_params = ref_for(generator.subschema_for::<CommandExecuteParams>());
+    let command_result = ref_for(generator.subschema_for::<CommandExecuteResult>());
     let status_changed = ref_for(generator.subschema_for::<StatusChangedParams>());
     let capability_params = ref_for(generator.subschema_for::<CapabilityParams>());
     let error = ref_for(generator.subschema_for::<ErrorObject>());
@@ -44,6 +47,7 @@ fn schema_document() -> Value {
         "status/changed": { "params": status_changed },
         "hook/fire": { "params": hook_fire, "result": hook_decision },
         "prompt/contribution": { "result": prompt_contribution },
+        "command/execute": { "params": command_params, "result": command_result },
     });
 
     let defs: Value = generator.take_definitions(true).into();

--- a/schema/yep/v1/meta.json
+++ b/schema/yep/v1/meta.json
@@ -38,6 +38,11 @@
       "description": "Request a fresh dynamic system-prompt contribution."
     },
     {
+      "name": "command/execute",
+      "direction": "host",
+      "description": "Run a manifest-declared slash command; the result message is shown to the user."
+    },
+    {
       "name": "config/changed",
       "direction": "host",
       "description": "Notify the server its config changed."
@@ -55,6 +60,7 @@
     "dynamic_prompt",
     "hooks",
     "mcp_servers",
-    "status"
+    "status",
+    "commands"
   ]
 }

--- a/schema/yep/v1/schema.json
+++ b/schema/yep/v1/schema.json
@@ -22,6 +22,34 @@
       },
       "type": "object"
     },
+    "CommandExecuteParams": {
+      "description": "Host → server `command/execute` params: run a manifest-declared slash\ncommand. `name` is the command's own name (the host strips any `<ext>:`\nnamespace prefix before sending); `arguments` is the raw text after the\ncommand token.",
+      "properties": {
+        "arguments": {
+          "default": "",
+          "type": "string"
+        },
+        "name": {
+          "default": "",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "CommandExecuteResult": {
+      "description": "Server → host `command/execute` result: a message the host shows to the\nuser. Lenient/defaulted — a bare `{}` means \"succeeded, no message\".",
+      "properties": {
+        "message": {
+          "default": "",
+          "type": "string"
+        },
+        "success": {
+          "default": true,
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
     "ErrorObject": {
       "description": "JSON-RPC-shaped error object. Everything beyond `message` is optional and\ndefaulted, so a peer that sends bare `{ \"message\": … }` still parses.",
       "properties": {
@@ -243,6 +271,14 @@
     "$ref": "#/$defs/ErrorObject"
   },
   "messages": {
+    "command/execute": {
+      "params": {
+        "$ref": "#/$defs/CommandExecuteParams"
+      },
+      "result": {
+        "$ref": "#/$defs/CommandExecuteResult"
+      }
+    },
     "hook/fire": {
       "params": {
         "$ref": "#/$defs/HookFireParams"

--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -87,6 +87,15 @@ mutated through the VFS) and added as a read-only `SkillScope` (label
 (enabled extensions only) and is host-side — no server or wire involvement.
 `scaffold_extension skills=true` writes a starter `skills/<name>/SKILL.md`;
 `extension_contributed_skill_is_visible_and_read_only` covers the mount.
+Slash commands: an extension declares `commands` in its manifest; `ExtensionCapability`
+implements the `Capability` `commands()`/`execute_command()` seams, so the
+commands flow into `runtime.list_commands` → the palette automatically. Each is
+registered namespaced (`<ext>:<name>`) so it can never shadow a built-in, and
+invoking it sends `command/execute` (host→server) with `{name, arguments}`; the
+server's `CommandExecuteResult { success, message }` becomes the `CommandResult`
+shown to the user. `scaffold_extension commands=[…]` generates a
+`handle_command` seam in all three templates. Covered by
+`scaffolded_extension_serves_a_slash_command`.
 Later — the full `yolop-extension-lsp` control-plane extraction (gated on
 `evals/lsp_integration` parity to retire the built-in), `ui/ask` (needs the
 server→host reverse-request channel, still refused in phase 1),

--- a/src/extensions/capability.rs
+++ b/src/extensions/capability.rs
@@ -9,6 +9,10 @@ use super::manager::{DEFAULT_REQUEST_TIMEOUT_MS, ExtensionProcess, ExtensionProc
 use super::package::{ExtensionPackage, ToolDefinition, extension_capability_id};
 use async_trait::async_trait;
 use everruns_core::capabilities::{Capability, SystemPromptContext};
+use everruns_core::command::{
+    CommandArg, CommandDescriptor, CommandExecutionContext, CommandResult, CommandSource,
+    ExecuteCommandRequest,
+};
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use serde_json::Value;
 use std::path::PathBuf;
@@ -245,6 +249,73 @@ impl Capability for ExtensionCapability {
                 }) as Arc<dyn everruns_core::atoms::PostToolExecHook>
             })
             .collect()
+    }
+
+    fn commands(&self) -> Vec<CommandDescriptor> {
+        let ext = &self.package.manifest.name;
+        self.package
+            .manifest
+            .commands
+            .iter()
+            .map(|c| CommandDescriptor {
+                // Namespaced `<ext>:<name>` so extension commands can never
+                // collide with or shadow built-in slash commands.
+                name: format!("{ext}:{}", c.name),
+                description: c.description.clone(),
+                source: CommandSource::System,
+                args: c
+                    .args
+                    .iter()
+                    .map(|a| CommandArg {
+                        name: a.name.clone(),
+                        description: if a.description.is_empty() {
+                            a.name.clone()
+                        } else {
+                            a.description.clone()
+                        },
+                        required: a.required,
+                        suggestions: Vec::new(),
+                    })
+                    .collect(),
+            })
+            .collect()
+    }
+
+    async fn execute_command(
+        &self,
+        request: &ExecuteCommandRequest,
+        _ctx: &CommandExecutionContext,
+    ) -> everruns_core::Result<CommandResult> {
+        let prefix = format!("{}:", self.package.manifest.name);
+        let name = request.name.strip_prefix(&prefix).unwrap_or(&request.name);
+        if !self
+            .package
+            .manifest
+            .commands
+            .iter()
+            .any(|c| c.name == name)
+        {
+            return Err(everruns_core::AgentLoopError::config(format!(
+                "extension `{}` does not provide command `{name}`",
+                self.package.manifest.name
+            )));
+        }
+        let arguments = request.arguments.as_deref().unwrap_or("");
+        let process = self.process_for(&Value::Null);
+        Ok(match process.execute_command(name, arguments).await {
+            Ok(result) => CommandResult {
+                success: result.success,
+                message: result.message,
+                error_code: None,
+                error_fields: None,
+            },
+            Err(err) => CommandResult {
+                success: false,
+                message: format!("command failed: {err}"),
+                error_code: None,
+                error_fields: None,
+            },
+        })
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {

--- a/src/extensions/manage.rs
+++ b/src/extensions/manage.rs
@@ -180,6 +180,15 @@ impl ManageTool {
             .map(str::to_string);
         let status = args.get("status").and_then(Value::as_bool).unwrap_or(false);
         let skills = args.get("skills").and_then(Value::as_bool).unwrap_or(false);
+        let commands = args
+            .get("commands")
+            .and_then(Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|c| c.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default();
         // Default target: a sibling `scaffold/<name>` of the extensions dir, so
         // authored packages sit next to where they install without cluttering
         // the workspace. An explicit `dir` (a parent) overrides.
@@ -203,6 +212,7 @@ impl ManageTool {
             language,
             tools,
             hooks,
+            commands,
             prompt,
             status,
             skills,
@@ -442,6 +452,10 @@ impl Tool for ManageTool {
                             "tool_name_glob": { "type": "string", "default": "*",
                                 "description": "Glob over tool names to fire for." }
                         }, "required": ["event"] } },
+                    "commands": { "type": "array",
+                        "description": "Slash-command names the extension contributes; each is \
+                            registered as /<name>:<command> and dispatched to the server.",
+                        "items": { "type": "string" } },
                     "prompt": { "type": "string",
                         "description": "Static system-prompt contribution text, if any." },
                     "status": { "type": "boolean",

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -90,6 +90,30 @@ impl ExtensionProcess {
         result
     }
 
+    /// Run a manifest-declared slash command on the server (`command/execute`).
+    /// Spawns the server if needed. `name` is the command's own name (no
+    /// namespace prefix).
+    pub async fn execute_command(
+        &self,
+        name: &str,
+        arguments: &str,
+    ) -> Result<super::protocol::CommandExecuteResult> {
+        let connection = {
+            let mut state = self.state.lock().await;
+            self.ensure_live(&mut state).await?;
+            state.as_ref().expect("ensured live").connection.clone()
+        };
+        let params = serde_json::to_value(super::protocol::CommandExecuteParams {
+            name: name.to_string(),
+            arguments: arguments.to_string(),
+        })?;
+        let result = connection.request("command/execute", params).await;
+        if connection.is_closed() {
+            *self.state.lock().await = None;
+        }
+        Ok(serde_json::from_value(result?).unwrap_or_default())
+    }
+
     /// The server's static system-prompt contribution, from the handshake.
     /// Spawns the server if needed; a failure is a warning, never a session
     /// sink — the prompt facet degrades to absent.

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -348,6 +348,7 @@ mod spawn_tests {
                 event: "pre_tool_use".into(),
                 tool_name_glob: "*".into(),
             }],
+            commands: Vec::new(),
             prompt: None,
             status: false,
             skills: false,
@@ -467,6 +468,71 @@ mod spawn_tests {
         assert_scaffolded_git_block(super::scaffold::Language::Rust).await;
     }
 
+    /// Slash-command acceptance: a scaffolded extension declaring a command
+    /// exposes it namespaced (`<ext>:<cmd>`) via `commands()`, and invoking it
+    /// routes `command/execute` to the server, whose message comes back.
+    #[tokio::test]
+    async fn scaffolded_extension_serves_a_slash_command() {
+        use super::scaffold::{Language, ScaffoldRequest, scaffold};
+        use everruns_core::capabilities::Capability;
+        use everruns_core::command::{CommandExecutionContext, ExecuteCommandRequest};
+
+        if python3().is_none() {
+            eprintln!("skipping: python3 not available");
+            return;
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let out = scaffold(&ScaffoldRequest {
+            name: "greeter".into(),
+            description: "Greets.".into(),
+            language: Language::Python,
+            tools: vec![],
+            hooks: vec![],
+            commands: vec!["hello".into()],
+            prompt: None,
+            status: false,
+            skills: false,
+            dir: tmp.path().join("greeter"),
+        })
+        .unwrap();
+
+        let manifest =
+            parse_manifest(&std::fs::read_to_string(out.dir.join("plugin.json")).unwrap()).unwrap();
+        assert_eq!(manifest.commands.len(), 1);
+        let capability = ExtensionCapability::new(
+            ExtensionPackage {
+                dir: out.dir.clone(),
+                manifest,
+            },
+            tmp.path().to_path_buf(),
+        );
+
+        // The command is exposed namespaced so it can't shadow a built-in.
+        let commands = capability.commands();
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].name, "greeter:hello");
+
+        // Invoking it round-trips to the server (default handler echoes args).
+        let request = ExecuteCommandRequest {
+            name: "greeter:hello".into(),
+            arguments: Some("world".into()),
+            controls: None,
+        };
+        let result = capability
+            .execute_command(
+                &request,
+                &CommandExecutionContext::without_host(everruns_core::typed_id::SessionId::new()),
+            )
+            .await
+            .expect("command executes");
+        assert!(result.success, "{result:?}");
+        assert!(
+            result.message.contains("greeter:hello") && result.message.contains("world"),
+            "server message should echo the command + args: {:?}",
+            result.message
+        );
+    }
+
     /// The status-bar acceptance case: `scaffold_extension` with `status` yields
     /// a package whose server, after the author fills the hook to count and
     /// `emit_status`, pushes `status/changed` — and the host routes it to the
@@ -493,6 +559,7 @@ mod spawn_tests {
                 event: "pre_tool_use".into(),
                 tool_name_glob: "*".into(),
             }],
+            commands: Vec::new(),
             prompt: None,
             status: true,
             skills: false,

--- a/src/extensions/package.rs
+++ b/src/extensions/package.rs
@@ -54,6 +54,10 @@ struct RawFacet {
     /// Lifecycle hook subscriptions the extension serves over `hook/fire`.
     #[serde(default)]
     hooks: Vec<HookSubscription>,
+    /// Slash commands the extension contributes (dispatched to the server over
+    /// `command/execute`).
+    #[serde(default)]
+    commands: Vec<CommandDef>,
     /// Permits the server to push `status/changed` notifications into the host
     /// status bar (D4: the approval boundary — a non-declaring extension can
     /// never write the status bar).
@@ -169,6 +173,28 @@ fn default_schema() -> Value {
     serde_json::json!({ "type": "object" })
 }
 
+/// A manifest-declared slash command. Registered (namespaced `<ext>:<name>`) in
+/// the host command palette; invoking it sends `command/execute` to the server.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CommandDef {
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub args: Vec<CommandArgDef>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CommandArgDef {
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub required: bool,
+}
+
 #[derive(Debug, Clone)]
 pub struct ExtensionManifest {
     pub name: String,
@@ -181,6 +207,7 @@ pub struct ExtensionManifest {
     pub dynamic_prompt: bool,
     pub mcp_servers: BTreeMap<String, ContributedMcpServer>,
     pub hooks: Vec<HookSubscription>,
+    pub commands: Vec<CommandDef>,
     pub status: bool,
     pub skills: bool,
 }
@@ -245,10 +272,24 @@ pub fn parse_manifest(raw: &str) -> Result<ExtensionManifest, String> {
         && !raw.yolop.dynamic_prompt
         && raw.yolop.mcp_servers.is_empty()
         && raw.yolop.hooks.is_empty()
+        && raw.yolop.commands.is_empty()
         && !raw.yolop.status
         && !raw.yolop.skills
     {
         return Err("extension declares no contributions; nothing to contribute".into());
+    }
+    for command in &raw.yolop.commands {
+        if command.name.trim().is_empty()
+            || !command
+                .name
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        {
+            return Err(format!(
+                "invalid command name `{}`: use ascii letters, digits, `-`, `_`",
+                command.name
+            ));
+        }
     }
     for (server_name, server) in &raw.yolop.mcp_servers {
         match server.transport {
@@ -276,6 +317,7 @@ pub fn parse_manifest(raw: &str) -> Result<ExtensionManifest, String> {
         dynamic_prompt: raw.yolop.dynamic_prompt,
         mcp_servers: raw.yolop.mcp_servers,
         hooks: raw.yolop.hooks,
+        commands: raw.yolop.commands,
         status: raw.yolop.status,
         skills: raw.yolop.skills,
     })
@@ -467,6 +509,31 @@ mod tests {
         let found = discover_extensions(tmp.path());
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].manifest.name, "echo");
+    }
+
+    #[test]
+    fn parses_commands_and_rejects_bad_names() {
+        let ok = json!({
+            "name": "greeter", "description": "t",
+            "yolop": { "protocol_version": "1.0",
+                "capabilityServer": { "command": "x" },
+                "commands": [{ "name": "hello", "description": "Say hi",
+                    "args": [{ "name": "who", "required": true }] }] }
+        });
+        let manifest = parse_manifest(&ok.to_string()).expect("commands parse");
+        assert_eq!(manifest.commands.len(), 1);
+        assert_eq!(manifest.commands[0].name, "hello");
+        assert_eq!(manifest.commands[0].args[0].name, "who");
+        assert!(manifest.commands[0].args[0].required);
+
+        // A command name with a space/slash is rejected.
+        let mut bad = ok;
+        bad["yolop"]["commands"][0]["name"] = json!("bad name");
+        assert!(
+            parse_manifest(&bad.to_string())
+                .unwrap_err()
+                .contains("invalid command name")
+        );
     }
 
     #[test]

--- a/src/extensions/scaffold.rs
+++ b/src/extensions/scaffold.rs
@@ -80,6 +80,8 @@ pub struct ScaffoldRequest {
     pub language: Language,
     pub tools: Vec<ToolSpec>,
     pub hooks: Vec<HookSpec>,
+    /// Slash-command names the extension contributes (dispatched to the server).
+    pub commands: Vec<String>,
     pub prompt: Option<String>,
     /// Contribute a status-bar field (the server may push `status/changed`).
     pub status: bool,
@@ -117,13 +119,14 @@ fn validate(req: &ScaffoldRequest) -> Result<(), String> {
     }
     if req.tools.is_empty()
         && req.hooks.is_empty()
+        && req.commands.is_empty()
         && req.prompt.is_none()
         && !req.status
         && !req.skills
     {
         return Err(
             "an extension must contribute something: pass at least one of `tools`, `hooks`, \
-             `prompt`, `status`, or `skills`"
+             `commands`, `prompt`, `status`, or `skills`"
                 .into(),
         );
     }
@@ -266,6 +269,14 @@ fn manifest_json(req: &ScaffoldRequest) -> Value {
     if !hooks.is_empty() {
         obj.insert("hooks".into(), Value::Array(hooks));
     }
+    if !req.commands.is_empty() {
+        let commands: Vec<Value> = req
+            .commands
+            .iter()
+            .map(|name| json!({ "name": name, "description": format!("The {name} command.") }))
+            .collect();
+        obj.insert("commands".into(), Value::Array(commands));
+    }
     if req.prompt.is_some() {
         obj.insert("prompt".into(), Value::Bool(true));
     }
@@ -292,6 +303,7 @@ fn python_server(req: &ScaffoldRequest) -> String {
     // not valid Python) — this stays correct for arbitrary tool names / prompt.
     let names: Vec<&String> = req.tools.iter().map(|t| &t.name).collect();
     let tools_list = serde_json::to_string(&names).unwrap_or_else(|_| "[]".into());
+    let commands_list = serde_json::to_string(&req.commands).unwrap_or_else(|_| "[]".into());
     let name_literal = serde_json::to_string(&req.name).unwrap_or_else(|_| "\"\"".into());
     let prompt_literal = match &req.prompt {
         Some(text) => serde_json::to_string(text).unwrap_or_else(|_| "\"\"".into()),
@@ -306,6 +318,11 @@ fn python_server(req: &ScaffoldRequest) -> String {
         "\n            caps.append(\"status\")"
     } else {
         ""
+    };
+    let commands_cap = if req.commands.is_empty() {
+        ""
+    } else {
+        "\n            caps.append(\"commands\")"
     };
     format!(
         r##"#!/usr/bin/env python3
@@ -327,6 +344,8 @@ import sys
 NAME = {name_literal}
 # Tool names this server serves. MUST match plugin.json's yolop.tools.
 TOOLS = {tools_list}
+# Slash-command names this server serves. MUST match plugin.json's yolop.commands.
+COMMANDS = {commands_list}
 # Static system-prompt contribution, or None.
 PROMPT = {prompt_literal}
 
@@ -375,6 +394,15 @@ def handle_prompt():
     return {{"text": PROMPT or ""}}
 
 
+def handle_command(name, arguments):
+    """Run a slash command. Return {{"message": "..."}} to show the user (and
+    optionally "success": false). `arguments` is the raw text after the command.
+
+    TODO: implement each command in COMMANDS.
+    """
+    return {{"message": f"{{NAME}}:{{name}} ran with args: {{arguments!r}}"}}
+
+
 # --- protocol plumbing (do not edit) -----------------------------------------
 
 def main():
@@ -393,7 +421,7 @@ def main():
             params = {{"tools": [{{"name": t}} for t in TOOLS]}}
             if PROMPT is not None:
                 caps.append("prompt")
-                params["prompt"] = {{"static": PROMPT}}{hooks_cap}{status_cap}
+                params["prompt"] = {{"static": PROMPT}}{hooks_cap}{status_cap}{commands_cap}
             send({{"id": msg_id, "result": {{
                 "protocol_version": "1.0",
                 "name": NAME,
@@ -423,6 +451,13 @@ def main():
                 send({{"id": msg_id, "result": {{}}}})  # fail open
         elif method == "prompt/contribution":
             send({{"id": msg_id, "result": handle_prompt()}})
+        elif method == "command/execute":
+            p = msg.get("params") or {{}}
+            try:
+                result = handle_command(p.get("name", ""), p.get("arguments", ""))
+                send({{"id": msg_id, "result": result}})
+            except Exception as exc:
+                send({{"id": msg_id, "result": {{"success": False, "message": str(exc)}}}})
         elif method == "shutdown":
             send({{"id": msg_id, "result": {{}}}})
             return
@@ -451,6 +486,7 @@ fn node_server(req: &ScaffoldRequest) -> String {
     // straight into the source.
     let names: Vec<&String> = req.tools.iter().map(|t| &t.name).collect();
     let tools_list = serde_json::to_string(&names).unwrap_or_else(|_| "[]".into());
+    let commands_list = serde_json::to_string(&req.commands).unwrap_or_else(|_| "[]".into());
     let name_literal = serde_json::to_string(&req.name).unwrap_or_else(|_| "\"\"".into());
     let prompt_literal = match &req.prompt {
         Some(text) => serde_json::to_string(text).unwrap_or_else(|_| "null".into()),
@@ -465,6 +501,11 @@ fn node_server(req: &ScaffoldRequest) -> String {
         "\n    caps.push(\"status\");"
     } else {
         ""
+    };
+    let commands_cap = if req.commands.is_empty() {
+        ""
+    } else {
+        "\n    caps.push(\"commands\");"
     };
     format!(
         r##"#!/usr/bin/env node
@@ -484,6 +525,8 @@ const readline = require("readline");
 const NAME = {name_literal};
 // Tool names this server serves. MUST match plugin.json's yolop.tools.
 const TOOLS = {tools_list};
+// Slash-command names this server serves. MUST match plugin.json's yolop.commands.
+const COMMANDS = {commands_list};
 // Static system-prompt contribution, or null.
 const PROMPT = {prompt_literal};
 
@@ -526,6 +569,12 @@ function handlePrompt() {{
   return {{ text: PROMPT || "" }};
 }}
 
+function handleCommand(name, args) {{
+  // Run a slash command. Return {{ message: "..." }} to show the user (and
+  // optionally success: false). `args` is the raw text after the command.
+  return {{ message: NAME + ":" + name + " ran with args: " + JSON.stringify(args) }};
+}}
+
 // --- protocol plumbing (do not edit) -----------------------------------------
 
 const rl = readline.createInterface({{ input: process.stdin }});
@@ -546,7 +595,7 @@ rl.on("line", (raw) => {{
     if (PROMPT !== null) {{
       caps.push("prompt");
       params.prompt = {{ static: PROMPT }};
-    }}{hooks_cap}{status_cap}
+    }}{hooks_cap}{status_cap}{commands_cap}
     send({{ id: id, result: {{
       protocol_version: "1.0",
       name: NAME,
@@ -576,6 +625,13 @@ rl.on("line", (raw) => {{
     }}
   }} else if (method === "prompt/contribution") {{
     send({{ id: id, result: handlePrompt() }});
+  }} else if (method === "command/execute") {{
+    const p = msg.params || {{}};
+    try {{
+      send({{ id: id, result: handleCommand(p.name || "", p.arguments || "") }});
+    }} catch (e) {{
+      send({{ id: id, result: {{ success: false, message: String(e) }} }});
+    }}
   }} else if (method === "shutdown") {{
     send({{ id: id, result: {{}} }});
     rl.close();
@@ -588,9 +644,11 @@ rl.on("line", (raw) => {{
         name = req.name,
         name_literal = name_literal,
         tools_list = tools_list,
+        commands_list = commands_list,
         prompt_literal = prompt_literal,
         hooks_cap = hooks_cap,
         status_cap = status_cap,
+        commands_cap = commands_cap,
     )
 }
 
@@ -664,6 +722,12 @@ fn rust_main(req: &ScaffoldRequest) -> String {
         .map(|n| format!("{n:?}"))
         .collect::<Vec<_>>()
         .join(", ");
+    let commands_list = req
+        .commands
+        .iter()
+        .map(|n| format!("{n:?}"))
+        .collect::<Vec<_>>()
+        .join(", ");
     let name_literal = format!("{:?}", req.name);
     let prompt_literal = match &req.prompt {
         Some(text) => format!("Some({text:?})"),
@@ -673,6 +737,11 @@ fn rust_main(req: &ScaffoldRequest) -> String {
         ""
     } else {
         "\n            caps.push(json!(\"hooks\"));"
+    };
+    let commands_cap = if req.commands.is_empty() {
+        ""
+    } else {
+        "\n            caps.push(json!(\"commands\"));"
     };
     format!(
         r##"//! {name} — a yolop extension (YEP capability server).
@@ -693,6 +762,8 @@ use std::io::{{BufRead, Write}};
 const NAME: &str = {name_literal};
 // Tool names this server serves. MUST match plugin.json's yolop.tools.
 const TOOLS: &[&str] = &[{tools_list}];
+// Slash-command names this server serves. MUST match plugin.json's yolop.commands.
+const COMMANDS: &[&str] = &[{commands_list}];
 // Static system-prompt contribution, or None.
 const PROMPT: Option<&str> = {prompt_literal};
 
@@ -728,6 +799,13 @@ fn handle_prompt() -> Value {{
     json!({{ "text": PROMPT.unwrap_or("") }})
 }}
 
+fn handle_command(name: &str, arguments: &str) -> Value {{
+    // Run a slash command. Return {{"message": "..."}} to show the user (and
+    // optionally "success": false). `arguments` is the raw text after the command.
+    let _ = COMMANDS;
+    json!({{ "message": format!("{{NAME}}:{{name}} ran with args: {{arguments:?}}") }})
+}}
+
 // --- protocol plumbing (do not edit) ----------------------------------------
 
 fn main() {{
@@ -751,7 +829,7 @@ fn main() {{
                 if let Some(p) = PROMPT {{
                     caps.push(json!("prompt"));
                     params["prompt"] = json!({{ "static": p }});
-                }}{hooks_cap}
+                }}{hooks_cap}{commands_cap}
                 send(&json!({{ "id": id, "result": {{
                     "protocol_version": "1.0",
                     "name": NAME,
@@ -778,6 +856,12 @@ fn main() {{
                 send(&json!({{ "id": id, "result": handle_hook(event, tool_name, &args) }}));
             }}
             "prompt/contribution" => send(&json!({{ "id": id, "result": handle_prompt() }})),
+            "command/execute" => {{
+                let p = msg.get("params").cloned().unwrap_or_else(|| json!({{}}));
+                let name = p.get("name").and_then(Value::as_str).unwrap_or("");
+                let arguments = p.get("arguments").and_then(Value::as_str).unwrap_or("");
+                send(&json!({{ "id": id, "result": handle_command(name, arguments) }}));
+            }}
             "shutdown" => {{
                 send(&json!({{ "id": id, "result": {{}} }}));
                 return;
@@ -795,8 +879,10 @@ fn main() {{
         name = req.name,
         name_literal = name_literal,
         tools_list = tools_list,
+        commands_list = commands_list,
         prompt_literal = prompt_literal,
         hooks_cap = hooks_cap,
+        commands_cap = commands_cap,
     )
 }
 
@@ -837,6 +923,7 @@ mod tests {
                 event: "pre_tool_use".into(),
                 tool_name_glob: "*".into(),
             }],
+            commands: Vec::new(),
             prompt: Some("Guarding git.".into()),
             status: false,
             skills: false,
@@ -971,6 +1058,37 @@ mod tests {
         r.prompt = None;
         r.skills = true;
         assert!(scaffold(&r).is_ok());
+    }
+
+    #[test]
+    fn commands_facet_scaffolds_manifest_and_dispatch() {
+        for (lang, needle) in [
+            (Language::Python, "def handle_command"),
+            (Language::Node, "function handleCommand"),
+            (Language::Rust, "fn handle_command"),
+        ] {
+            let tmp = tempfile::tempdir().unwrap();
+            let mut r = req(tmp.path().join("git-guard"));
+            r.language = lang;
+            r.commands = vec!["review".into()];
+            let out = scaffold(&r).unwrap();
+
+            let manifest =
+                parse_manifest(&std::fs::read_to_string(out.dir.join("plugin.json")).unwrap())
+                    .unwrap();
+            assert_eq!(manifest.commands.len(), 1, "{lang:?}");
+            assert_eq!(manifest.commands[0].name, "review");
+
+            let server = std::fs::read_to_string(&out.edit).unwrap();
+            assert!(
+                server.contains(needle),
+                "{lang:?} missing handler: {needle}"
+            );
+            assert!(
+                server.contains("command/execute"),
+                "{lang:?} missing dispatch"
+            );
+        }
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -5243,6 +5243,7 @@ mod tests {
             skill_global: None,
             skill_system: None,
             environment_skill: None,
+            extension_skills: Vec::new(),
         };
         let store = factory
             .create_session_file_system(SessionFileSystemFactoryContext::default())


### PR DESCRIPTION
## What changed

An extension can now contribute **slash commands**. It declares `commands` in its manifest; `ExtensionCapability` implements the `Capability` `commands()` / `execute_command()` seams, so the commands flow into `runtime.list_commands` and the `/` palette **automatically** (same aggregation as built-ins). Each command is registered **namespaced** — `/<ext>:<name>` — so it can never shadow or collide with a built-in slash command. Invoking one sends the new host→server `command/execute` (`{name, arguments}`); the server's `CommandExecuteResult { success, message }` becomes the `CommandResult` shown to the user.

**Wire** (`yolop-yep`): new `CommandExecuteParams` / `CommandExecuteResult`, the `command/execute` method, and a `commands` capability token — emitted into the drift-guarded `meta.json` / `schema.json`. `ExtensionProcess` gains an `execute_command` proxy next to `call_tool`.

**Self-authoring:** `scaffold_extension commands=[…]` generates a `handle_command` seam and the `command/execute` dispatch in **all three** templates (Python, Node, Rust).

## ⚠️ Also fixes a broken `main`

`cargo test` on `main` (7ad08a6) currently **does not compile**: the test factory literal added by **#329** predates the `extension_skills` struct field added by **#331**, and the two merged in an order where neither PR's CI saw the collision. The one-line addition in `src/runtime.rs` (`extension_skills: Vec::new()` in `production_file_store_forwards_contextual_grep_through_write_blocklist`) restores the test build. Flagging in case you want a standalone hotfix instead — but it's folded in here so this branch is green.

## Before / After

**Before:** an extension's `commands` were ignored (`ExtensionCapability` inherited the empty `commands()` default); no `command/execute` wire method existed.

**After:** a manifest with `commands: [{name: "hello"}]` surfaces `/greeter:hello` in the palette; running it dispatches to the server. Proven end to end — a scaffolded Python command extension exposes `greeter:hello` and round-trips `command/execute`:

```
test extensions::package::tests::parses_commands_and_rejects_bad_names ... ok
test extensions::scaffold::tests::commands_facet_scaffolds_manifest_and_dispatch ... ok   (python/node/rust)
test extensions::spawn_tests::scaffolded_extension_serves_a_slash_command ... ok
56 passed (extensions) · runtime tests green (incl. the #329/#331 fix)
```

`cargo fmt --check` and `cargo clippy --all-features -D warnings` clean; yep drift guard passes with regenerated artifacts.

## Risk

- **Low–medium.** Additive facet + one new wire method (forward-compatible; unknown fields default). Namespacing prevents command collisions. No effect on extensions that don't declare `commands`. The `main` build-fix is a test-only one-liner.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (additive; yolop is pre-1.0)

https://claude.ai/code/session_017d7odSAD8o79pUrd31dpDb

---
_Generated by [Claude Code](https://claude.ai/code/session_017d7odSAD8o79pUrd31dpDb)_