### PR TITLE
feat(extensions): ui/ask reverse-request channel

### DIFF
--- a/.agents/skills/author-extension/SKILL.md
+++ b/.agents/skills/author-extension/SKILL.md
@@ -46,8 +46,13 @@ Declare only what you need; a manifest must contribute at least one of:
   palette and dispatched to the server over `command/execute` (the result
   message is shown to the user). Scaffold with `commands: ["name", …]`; the
   generated server gets a `handle_command(name, arguments)` seam.
+- **ui_ask** — declare `ui_ask: true`, then the server may send a `ui/ask`
+  request (`{prompt, placeholder?}`) to prompt the user for a typed answer
+  mid-turn; the TUI shows an overlay and returns `{answer, cancelled}`. Refused
+  in `--print`/ACP. (No scaffold-template helper yet — send the request by hand
+  from your server.)
 
-Not yet available: providers, `ui/ask`.
+Not yet available: providers.
 
 ## The loop
 

--- a/crates/yolop-yep/src/meta.rs
+++ b/crates/yolop-yep/src/meta.rs
@@ -38,6 +38,10 @@ pub const METHODS: &[Method] = &[
         "command/execute",
         "Run a manifest-declared slash command; the result message is shown to the user.",
     ),
+    Method::server(
+        "ui/ask",
+        "Ask the user a question and wait for a typed answer (TUI hosts only).",
+    ),
     Method::host("config/changed", "Notify the server its config changed."),
     Method::host("shutdown", "Request a graceful stop."),
 ];
@@ -52,6 +56,7 @@ pub const CAPABILITY_TOKENS: &[&str] = &[
     "mcp_servers",
     "status",
     "commands",
+    "ui_ask",
 ];
 
 /// Direction a method flows.

--- a/crates/yolop-yep/src/protocol.rs
+++ b/crates/yolop-yep/src/protocol.rs
@@ -101,6 +101,15 @@ pub fn response_error_line(id: u64, error: &ErrorObject) -> String {
     json!({ "id": id, "error": error }).to_string()
 }
 
+/// Response to a server→host request (e.g. `ui/ask`), keyed by the server's own
+/// request id.
+pub fn response_result_line(id: u64, result: &Value) -> String {
+    let mut obj = Map::new();
+    obj.insert("id".into(), json!(id));
+    obj.insert("result".into(), result.clone());
+    Value::Object(obj).to_string()
+}
+
 /// JSON-RPC-shaped error object. Everything beyond `message` is optional and
 /// defaulted, so a peer that sends bare `{ "message": … }` still parses.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -268,6 +277,34 @@ pub struct HookDecision {
 pub struct PromptContribution {
     #[serde(default)]
     pub text: String,
+}
+
+// ---------------------------------------------------------------------------
+// ui/ask (server → host request)
+
+/// Server → host `ui/ask` params: ask the user a question and wait for a typed
+/// answer. The host prompts interactively (TUI); in headless/ACP hosts with no
+/// prompt surface the request is refused.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct UiAskParams {
+    /// The question shown to the user.
+    #[serde(default)]
+    pub prompt: String,
+    /// Optional placeholder / hint for the input field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placeholder: Option<String>,
+}
+
+/// Host → server `ui/ask` result: the user's answer (empty + `cancelled` when
+/// they dismiss the prompt).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct UiAskResult {
+    #[serde(default)]
+    pub answer: String,
+    #[serde(default)]
+    pub cancelled: bool,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/yolop-yep/src/schema.rs
+++ b/crates/yolop-yep/src/schema.rs
@@ -11,7 +11,7 @@
 use crate::protocol::{
     CapabilityParams, CommandExecuteParams, CommandExecuteResult, ErrorObject, HookDecision,
     HookFireParams, InitializeParams, InitializeResult, PromptContribution, StatusChangedParams,
-    ToolCallParams, ToolUpdateParams,
+    ToolCallParams, ToolUpdateParams, UiAskParams, UiAskResult,
 };
 use schemars::generate::SchemaSettings;
 use serde_json::{Value, json};
@@ -33,6 +33,8 @@ fn schema_document() -> Value {
     let prompt_contribution = ref_for(generator.subschema_for::<PromptContribution>());
     let command_params = ref_for(generator.subschema_for::<CommandExecuteParams>());
     let command_result = ref_for(generator.subschema_for::<CommandExecuteResult>());
+    let ui_ask_params = ref_for(generator.subschema_for::<UiAskParams>());
+    let ui_ask_result = ref_for(generator.subschema_for::<UiAskResult>());
     let status_changed = ref_for(generator.subschema_for::<StatusChangedParams>());
     let capability_params = ref_for(generator.subschema_for::<CapabilityParams>());
     let error = ref_for(generator.subschema_for::<ErrorObject>());
@@ -48,6 +50,7 @@ fn schema_document() -> Value {
         "hook/fire": { "params": hook_fire, "result": hook_decision },
         "prompt/contribution": { "result": prompt_contribution },
         "command/execute": { "params": command_params, "result": command_result },
+        "ui/ask": { "params": ui_ask_params, "result": ui_ask_result },
     });
 
     let defs: Value = generator.take_definitions(true).into();

--- a/schema/yep/v1/meta.json
+++ b/schema/yep/v1/meta.json
@@ -43,6 +43,11 @@
       "description": "Run a manifest-declared slash command; the result message is shown to the user."
     },
     {
+      "name": "ui/ask",
+      "direction": "server",
+      "description": "Ask the user a question and wait for a typed answer (TUI hosts only)."
+    },
+    {
       "name": "config/changed",
       "direction": "host",
       "description": "Notify the server its config changed."
@@ -61,6 +66,7 @@
     "hooks",
     "mcp_servers",
     "status",
-    "commands"
+    "commands",
+    "ui_ask"
   ]
 }

--- a/schema/yep/v1/schema.json
+++ b/schema/yep/v1/schema.json
@@ -260,6 +260,38 @@
         }
       },
       "type": "object"
+    },
+    "UiAskParams": {
+      "description": "Server → host `ui/ask` params: ask the user a question and wait for a typed\nanswer. The host prompts interactively (TUI); in headless/ACP hosts with no\nprompt surface the request is refused.",
+      "properties": {
+        "placeholder": {
+          "description": "Optional placeholder / hint for the input field.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "prompt": {
+          "default": "",
+          "description": "The question shown to the user.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "UiAskResult": {
+      "description": "Host → server `ui/ask` result: the user's answer (empty + `cancelled` when\nthey dismiss the prompt).",
+      "properties": {
+        "answer": {
+          "default": "",
+          "type": "string"
+        },
+        "cancelled": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "type": "object"
     }
   },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -313,6 +345,14 @@
     "tool/update": {
       "params": {
         "$ref": "#/$defs/ToolUpdateParams"
+      }
+    },
+    "ui/ask": {
+      "params": {
+        "$ref": "#/$defs/UiAskParams"
+      },
+      "result": {
+        "$ref": "#/$defs/UiAskResult"
       }
     }
   },

--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -96,9 +96,20 @@ server's `CommandExecuteResult { success, message }` becomes the `CommandResult`
 shown to the user. `scaffold_extension commands=[…]` generates a
 `handle_command` seam in all three templates. Covered by
 `scaffolded_extension_serves_a_slash_command`.
+ui/ask: an extension that declares `ui_ask` (the D4 opt-in) may send a `ui/ask`
+*request* (server→host, the reverse-request direction) carrying
+`UiAskParams { prompt, placeholder? }`; the host prompts the user and answers
+with `UiAskResult { answer, cancelled }`. The client routes the request to an
+`AskSink` (built in `runtime.rs`, gated on the TUI client) that pushes an
+`AskRequest` onto a dedicated channel; `App` shows a single-line overlay
+(`draw_ask_overlay`) that captures keys *before* the busy check so it works
+mid-turn, then resolves the request's oneshot with the typed answer (or
+`cancelled` on Esc). Only one prompt is live at a time; a request arriving while
+another is pending is answered `cancelled`. Refused (`cancelled`) with no sink,
+so `--print`/ACP never blocks on it. Covered by
+`ui_ask_reverse_request_is_answered_by_the_sink`.
 Later — the full `yolop-extension-lsp` control-plane extraction (gated on
-`evals/lsp_integration` parity to retire the built-in), `ui/ask` (needs the
-server→host reverse-request channel, still refused in phase 1),
+`evals/lsp_integration` parity to retire the built-in),
 `workspace/changed`,
 providers — remain design-of-record below.
 Toolchain-free crates.io install is now wired: `install_extension

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -123,6 +123,12 @@ pub struct App {
     /// extension servers over `status/changed`. Rendered in the status bar via
     /// [`App::presentation_state`].
     extension_status: std::collections::BTreeMap<String, String>,
+    /// Incoming extension `ui/ask` requests; each is prompted one at a time via
+    /// [`App::pending_ask`].
+    ask_rx: mpsc::UnboundedReceiver<crate::host_ui::AskRequest>,
+    /// The `ui/ask` prompt currently shown, if any. Owns the keyboard (even
+    /// mid-turn) until the user answers or dismisses it.
+    pending_ask: Option<PendingAsk>,
     /// Settings store shared with the runtime (same instance
     /// `SetupCapability` writes). Used to resolve credentials when querying
     /// provider models APIs and to show per-provider connection status in
@@ -262,6 +268,15 @@ pub(crate) enum CodexLoginMethod {
 struct PendingCodexLogin {
     id: u64,
     task: tokio::task::JoinHandle<()>,
+}
+
+/// An in-flight extension `ui/ask`: the prompt shown, the answer being typed,
+/// and the oneshot that delivers it back to the extension server.
+struct PendingAsk {
+    prompt: String,
+    placeholder: Option<String>,
+    value: String,
+    reply: Option<oneshot::Sender<crate::host_ui::AskAnswer>>,
 }
 
 enum CodexLoginEvent {
@@ -410,6 +425,8 @@ impl App {
             session_tokens: None,
             ui_rx: runtime.ui_rx,
             extension_status: std::collections::BTreeMap::new(),
+            ask_rx: runtime.ask_rx,
+            pending_ask: None,
             settings: runtime.settings,
             model_catalog: HashMap::new(),
             model_fetches_in_flight: HashSet::new(),
@@ -772,6 +789,25 @@ impl App {
             self.apply_ui_command(command).await;
             applied_ui_command = true;
         }
+        // Extension `ui/ask` prompts. One at a time; a request arriving while a
+        // prompt is open is answered "cancelled" rather than stacking overlays.
+        while let Ok(request) = self.ask_rx.try_recv() {
+            if self.pending_ask.is_some() {
+                let _ = request.reply.send(crate::host_ui::AskAnswer {
+                    answer: String::new(),
+                    cancelled: true,
+                });
+                continue;
+            }
+            self.push_system(format!("extension asks: {}", request.prompt));
+            self.pending_ask = Some(PendingAsk {
+                prompt: request.prompt,
+                placeholder: request.placeholder,
+                value: String::new(),
+                reply: Some(request.reply),
+            });
+            applied_ui_command = true;
+        }
         if applied_ui_command {
             return Ok(());
         }
@@ -970,6 +1006,13 @@ impl App {
             return;
         }
 
+        // An extension `ui/ask` prompt owns the keyboard even mid-turn, since
+        // the server typically asks while a tool is running.
+        if self.pending_ask.is_some() {
+            self.handle_ask_key(key);
+            return;
+        }
+
         if self.busy {
             // Block only input editing while a turn is running.
             self.handle_busy_key(key);
@@ -1083,6 +1126,51 @@ impl App {
                 tracing::debug!("clipboard image paste failed: {err}");
                 self.push_system(format!("clipboard image paste failed: {err}"));
             }
+        }
+    }
+
+    /// Keyboard handling while an extension `ui/ask` prompt is open: edit the
+    /// answer, Enter to submit, Esc to cancel.
+    fn handle_ask_key(&mut self, key: KeyEvent) {
+        let Some(ask) = self.pending_ask.as_mut() else {
+            return;
+        };
+        match key.code {
+            KeyCode::Enter => {
+                let answer = ask.value.clone();
+                self.resolve_ask(crate::host_ui::AskAnswer {
+                    answer,
+                    cancelled: false,
+                });
+            }
+            KeyCode::Esc => {
+                self.resolve_ask(crate::host_ui::AskAnswer {
+                    answer: String::new(),
+                    cancelled: true,
+                });
+            }
+            KeyCode::Backspace => {
+                ask.value.pop();
+            }
+            KeyCode::Char(c) => {
+                ask.value.push(c);
+            }
+            _ => {}
+        }
+    }
+
+    /// Deliver an answer to the extension and close the prompt.
+    fn resolve_ask(&mut self, answer: crate::host_ui::AskAnswer) {
+        if let Some(mut ask) = self.pending_ask.take() {
+            let shown = if answer.cancelled {
+                "(cancelled)".to_string()
+            } else {
+                answer.answer.clone()
+            };
+            if let Some(reply) = ask.reply.take() {
+                let _ = reply.send(answer);
+            }
+            self.push_system(format!("answered: {shown}"));
         }
     }
 

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -40,6 +40,10 @@ pub(crate) fn draw(f: &mut ratatui::Frame, app: &mut App) {
     // Inline viewports cannot place a true full-screen modal above terminal
     // scrollback. Treat overlays as sheets that own this complete viewport so
     // the composer and status chrome never bleed through around their edges.
+    if app.pending_ask.is_some() {
+        draw_ask_overlay(f, area, app);
+        return;
+    }
     if app.setup.is_some() {
         draw_setup_overlay(f, area, app);
         return;
@@ -400,6 +404,72 @@ pub(crate) fn draw_setup_overlay(f: &mut ratatui::Frame, area: Rect, app: &App) 
             inner
                 .y
                 .saturating_add((row as u16).min(inner.height.saturating_sub(1))),
+        ));
+    }
+}
+
+/// Overlay for an extension `ui/ask` prompt: the question plus a live echo of
+/// the answer being typed. Owns the viewport like the setup overlay.
+pub(crate) fn draw_ask_overlay(f: &mut ratatui::Frame, area: Rect, app: &App) {
+    let Some(ask) = app.pending_ask.as_ref() else {
+        return;
+    };
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let panel = setup_panel_rect(area);
+    if panel.width == 0 || panel.height == 0 {
+        return;
+    }
+    f.render_widget(Clear, area);
+    f.render_widget(Clear, panel);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .style(Style::default().bg(PANEL_BG).fg(TEXT_PRIMARY));
+    f.render_widget(block, panel);
+    let inner = Rect {
+        x: panel.x.saturating_add(2),
+        y: panel.y.saturating_add(1),
+        width: panel.width.saturating_sub(4),
+        height: panel.height.saturating_sub(2),
+    };
+    let field = if ask.value.is_empty() {
+        ask.placeholder
+            .as_ref()
+            .map(|p| format!("({p})"))
+            .unwrap_or_default()
+    } else {
+        ask.value.clone()
+    };
+    let lines = vec![
+        Line::from(Span::styled(
+            "An extension is asking:",
+            Style::default()
+                .fg(TEXT_PRIMARY)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(ask.prompt.clone()),
+        Line::from(""),
+        Line::from(format!("> {field}")),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Enter to answer · Esc to cancel",
+            Style::default().add_modifier(Modifier::DIM),
+        )),
+    ];
+    f.render_widget(
+        Paragraph::new(lines).style(Style::default().bg(PANEL_BG)),
+        inner,
+    );
+    // Park the cursor after the typed value.
+    let col = "> ".len() + ask.value.chars().count();
+    if inner.width > 0 && inner.height > 4 {
+        f.set_cursor_position((
+            inner
+                .x
+                .saturating_add((col as u16).min(inner.width.saturating_sub(1))),
+            inner.y.saturating_add(4),
         ));
     }
 }

--- a/src/extensions/capability.rs
+++ b/src/extensions/capability.rs
@@ -4,7 +4,7 @@
 //! manifest; execution and the prompt contribution are proxied to the
 //! package's capability server over YEP (see `manager.rs`).
 
-use super::client::StatusSink;
+use super::client::{AskSink, StatusSink};
 use super::manager::{DEFAULT_REQUEST_TIMEOUT_MS, ExtensionProcess, ExtensionProcessSpec};
 use super::package::{ExtensionPackage, ToolDefinition, extension_capability_id};
 use async_trait::async_trait;
@@ -30,6 +30,9 @@ pub struct ExtensionCapability {
     /// Where the server's `status/changed` pushes go. Forwarded to the process
     /// only when the manifest declares `status` (the D4 opt-in).
     status_sink: Option<StatusSink>,
+    /// Handles the server's `ui/ask` requests. Forwarded to the process only
+    /// when the manifest declares `ui_ask` (the D4 opt-in).
+    ask_sink: Option<AskSink>,
     /// Process shared by all tool instances so the server persists across
     /// turns; rebuilt (killing the old server) when the config changes —
     /// the same cache-by-config pattern as `LspCapability::manager_for`.
@@ -43,6 +46,7 @@ impl ExtensionCapability {
             package,
             workspace_root,
             status_sink: None,
+            ask_sink: None,
             process: Mutex::new(None),
         }
     }
@@ -52,6 +56,12 @@ impl ExtensionCapability {
     /// if given a sink.
     pub fn with_status_sink(mut self, sink: Option<StatusSink>) -> Self {
         self.status_sink = sink;
+        self
+    }
+
+    /// Wire a `ui/ask` handler. Used only if the manifest declares `ui_ask`.
+    pub fn with_ask_sink(mut self, sink: Option<AskSink>) -> Self {
+        self.ask_sink = sink;
         self
     }
 
@@ -78,6 +88,12 @@ impl ExtensionCapability {
                 .manifest
                 .status
                 .then(|| self.status_sink.clone())
+                .flatten(),
+            ask_sink: self
+                .package
+                .manifest
+                .ui_ask
+                .then(|| self.ask_sink.clone())
                 .flatten(),
         }));
         *slot = Some((config.clone(), process.clone()));

--- a/src/extensions/client.rs
+++ b/src/extensions/client.rs
@@ -5,12 +5,14 @@
 
 use super::protocol::{
     ErrorObject, Incoming, InitializeParams, InitializeResult, StatusChangedParams,
-    ToolUpdateParams, classify_line, notification_line, request_line, response_error_line,
-    version_compatible,
+    ToolUpdateParams, UiAskParams, UiAskResult, classify_line, notification_line, request_line,
+    response_error_line, response_result_line, version_compatible,
 };
 use anyhow::{Result, anyhow};
 use serde_json::Value;
 use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -23,6 +25,13 @@ use tokio::sync::{mpsc, oneshot};
 /// logs. Kept as an opaque callback so `src/extensions/` stays decoupled from
 /// the app/UI layer.
 pub type StatusSink = Arc<dyn Fn(&str, StatusChangedParams) + Send + Sync>;
+
+/// Async handler for a server→host `ui/ask` request: prompts the user and
+/// resolves to their answer. `None` in hosts with no prompt surface
+/// (headless/ACP), where `ui/ask` is refused. Opaque so `src/extensions/` stays
+/// decoupled from the app/UI layer.
+pub type AskSink =
+    Arc<dyn Fn(UiAskParams) -> Pin<Box<dyn Future<Output = UiAskResult> + Send>> + Send + Sync>;
 
 /// Pending host-originated requests, keyed by id. Host and server id spaces
 /// are independent per direction; only `method`-less lines land here.
@@ -37,6 +46,8 @@ pub struct YepConnection {
     name: String,
     /// Where `status/changed` notifications go; `None` logs only.
     status_sink: Option<StatusSink>,
+    /// Handles `ui/ask` requests; `None` refuses them.
+    ask_sink: Option<AskSink>,
 }
 
 impl YepConnection {
@@ -49,6 +60,7 @@ impl YepConnection {
         init: InitializeParams,
         request_timeout: Duration,
         status_sink: Option<StatusSink>,
+        ask_sink: Option<AskSink>,
     ) -> Result<(Arc<Self>, InitializeResult)>
     where
         R: AsyncRead + Unpin + Send + 'static,
@@ -75,6 +87,7 @@ impl YepConnection {
             request_timeout,
             name: name.to_string(),
             status_sink,
+            ask_sink,
         });
 
         let read_conn = connection.clone();
@@ -142,8 +155,22 @@ impl YepConnection {
             }
             Incoming::Notification { method, params } => self.handle_notification(&method, params),
             Incoming::Request { id, method, params } => {
-                // Server→host requests (ui/ask, …) arrive in a later phase.
-                // Refuse them cleanly instead of corrupting our own routing.
+                if method == "ui/ask"
+                    && let Some(sink) = self.ask_sink.clone()
+                {
+                    // Prompt the user off the read loop, then answer on the
+                    // server's own id space when they respond.
+                    let ask: UiAskParams = serde_json::from_value(params).unwrap_or_default();
+                    let writer_tx = self.writer_tx.clone();
+                    tokio::spawn(async move {
+                        let result = sink(ask).await;
+                        let value = serde_json::to_value(&result).unwrap_or(Value::Null);
+                        let _ = writer_tx.send(response_result_line(id, &value));
+                    });
+                    return;
+                }
+                // Any other server→host request (or `ui/ask` with no prompt
+                // surface) is refused cleanly instead of corrupting our routing.
                 tracing::debug!(
                     target: "yolop::ext", ext = %self.name,
                     has_params = !params.is_null(),
@@ -331,6 +358,7 @@ mod tests {
             init_params(),
             Duration::from_secs(5),
             None,
+            None,
         )
         .await
         .expect("handshake");
@@ -377,6 +405,7 @@ mod tests {
             init_params(),
             Duration::from_secs(5),
             Some(sink),
+            None,
         )
         .await
         .expect("handshake");
@@ -404,6 +433,7 @@ mod tests {
             init_params(),
             Duration::from_secs(5),
             None,
+            None,
         )
         .await
         .expect("handshake");
@@ -428,6 +458,7 @@ mod tests {
             "fake",
             init_params(),
             Duration::from_millis(200),
+            None,
             None,
         )
         .await
@@ -455,6 +486,7 @@ mod tests {
             "future",
             init_params(),
             Duration::from_secs(5),
+            None,
             None,
         )
         .await
@@ -514,6 +546,7 @@ mod tests {
             init_params(),
             Duration::from_secs(5),
             None,
+            None,
         )
         .await
         .expect("handshake");
@@ -522,5 +555,74 @@ mod tests {
             .await
             .expect("tool call resolves after reverse-request refusal");
         assert_eq!(result["refused_code"], -32601);
+    }
+
+    #[tokio::test]
+    async fn ui_ask_reverse_request_is_answered_by_the_sink() {
+        use crate::extensions::protocol::{UiAskParams, UiAskResult};
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        // Server sends a `ui/ask` after initialize, then resolves the pending
+        // tool call with whatever answer the host sends back.
+        tokio::spawn(async move {
+            let (read_half, mut write_half) = tokio::io::split(server_io);
+            let mut lines = BufReader::new(read_half).lines();
+            let mut tool_call_id = None;
+            while let Ok(Some(line)) = lines.next_line().await {
+                let value: Value = serde_json::from_str(&line).unwrap_or(Value::Null);
+                match value["method"].as_str() {
+                    Some("initialize") => {
+                        let reply =
+                            json!({"id": value["id"], "result": handshake_json()}).to_string();
+                        let _ = write_half.write_all(reply.as_bytes()).await;
+                        let _ = write_half.write_all(b"\n").await;
+                    }
+                    Some("initialized") => {
+                        let ask = json!({"id": 7, "method": "ui/ask",
+                            "params": {"prompt": "proceed?"}})
+                        .to_string();
+                        let _ = write_half.write_all(ask.as_bytes()).await;
+                        let _ = write_half.write_all(b"\n").await;
+                    }
+                    Some("tool/call") => tool_call_id = value["id"].as_u64(),
+                    None if value["id"] == json!(7) && value.get("result").is_some() => {
+                        if let Some(id) = tool_call_id {
+                            let reply = json!({"id": id, "result": {
+                                "got": value["result"]["answer"].clone()
+                            }})
+                            .to_string();
+                            let _ = write_half.write_all(reply.as_bytes()).await;
+                            let _ = write_half.write_all(b"\n").await;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        });
+        let ask_sink: super::AskSink = Arc::new(|params: UiAskParams| {
+            Box::pin(async move {
+                UiAskResult {
+                    answer: format!("answered:{}", params.prompt),
+                    cancelled: false,
+                }
+            }) as Pin<Box<dyn Future<Output = UiAskResult> + Send>>
+        });
+        let (read_half, write_half) = tokio::io::split(client_io);
+        let (conn, _) = YepConnection::connect(
+            read_half,
+            write_half,
+            "fake",
+            init_params(),
+            Duration::from_secs(5),
+            None,
+            Some(ask_sink),
+        )
+        .await
+        .expect("handshake");
+        let result = conn
+            .request("tool/call", json!({"name": "echo"}))
+            .await
+            .expect("tool call resolves after ui/ask answer");
+        assert_eq!(result["got"], "answered:proceed?");
     }
 }

--- a/src/extensions/doctor.rs
+++ b/src/extensions/doctor.rs
@@ -124,16 +124,25 @@ pub async fn doctor(
         config: serde_json::Value::Null,
         capabilities: vec!["cancel".into(), "streaming".into()],
     };
-    let handshake =
-        match YepConnection::connect(stdout, stdin, &manifest.name, init, timeout, None).await {
-            Ok((connection, handshake)) => {
-                connection.notify("shutdown", serde_json::Value::Null);
-                handshake
-            }
-            Err(err) => {
-                return Report::fatal("handshake", format!("initialize failed: {err}"));
-            }
-        };
+    let handshake = match YepConnection::connect(
+        stdout,
+        stdin,
+        &manifest.name,
+        init,
+        timeout,
+        None,
+        None,
+    )
+    .await
+    {
+        Ok((connection, handshake)) => {
+            connection.notify("shutdown", serde_json::Value::Null);
+            handshake
+        }
+        Err(err) => {
+            return Report::fatal("handshake", format!("initialize failed: {err}"));
+        }
+    };
 
     Report::from(evaluate(manifest, &handshake))
 }

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -5,7 +5,7 @@
 //! to language servers. Only this module knows about processes; everything
 //! else drives the transport-generic `YepConnection`.
 
-use super::client::{StatusSink, YepConnection};
+use super::client::{AskSink, StatusSink, YepConnection};
 use super::package::ExtensionManifest;
 use super::protocol::{InitializeParams, InitializeResult, PROTOCOL_VERSION};
 use anyhow::{Context, Result, anyhow};
@@ -32,6 +32,9 @@ pub struct ExtensionProcessSpec {
     /// Only wired when the extension declares `status` and the host has a
     /// status bar; `None` otherwise.
     pub status_sink: Option<StatusSink>,
+    /// Handles the server's `ui/ask` requests. Only wired when the extension
+    /// declares `ui_ask` and the host has a prompt surface; `None` otherwise.
+    pub ask_sink: Option<AskSink>,
 }
 
 /// A live (or lazily spawned) capability server.
@@ -244,6 +247,7 @@ impl ExtensionProcess {
             init,
             self.spec.request_timeout,
             self.spec.status_sink.clone(),
+            self.spec.ask_sink.clone(),
         )
         .await?;
 

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -26,7 +26,7 @@ pub(crate) mod scaffold;
 pub(crate) mod store;
 
 pub(crate) use capability::ExtensionCapability;
-pub(crate) use client::StatusSink;
+pub(crate) use client::{AskSink, StatusSink};
 pub(crate) use manage::ExtensionsCapability;
 pub(crate) use package::{
     discover_extensions, extension_capability_id, extension_skill_scopes, extensions_dir,

--- a/src/extensions/package.rs
+++ b/src/extensions/package.rs
@@ -68,6 +68,10 @@ struct RawFacet {
     /// no server is involved.
     #[serde(default)]
     skills: bool,
+    /// Permits the server to send `ui/ask` requests (prompt the user for a typed
+    /// answer). D4 opt-in — a non-declaring extension's `ui/ask` is refused.
+    #[serde(default)]
+    ui_ask: bool,
 }
 
 /// A manifest-declared hook subscription. Static (the approved upper bound):
@@ -210,6 +214,7 @@ pub struct ExtensionManifest {
     pub commands: Vec<CommandDef>,
     pub status: bool,
     pub skills: bool,
+    pub ui_ask: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -320,6 +325,7 @@ pub fn parse_manifest(raw: &str) -> Result<ExtensionManifest, String> {
         commands: raw.yolop.commands,
         status: raw.yolop.status,
         skills: raw.yolop.skills,
+        ui_ask: raw.yolop.ui_ask,
     })
 }
 
@@ -509,6 +515,30 @@ mod tests {
         let found = discover_extensions(tmp.path());
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].manifest.name, "echo");
+    }
+
+    #[test]
+    fn ui_ask_parses_but_is_not_a_standalone_contribution() {
+        // ui_ask alongside a tool: opt-in is recorded.
+        let with_tool = json!({
+            "name": "asker", "description": "t",
+            "yolop": { "protocol_version": "1.0",
+                "capabilityServer": { "command": "x" },
+                "tools": [{ "name": "t" }], "ui_ask": true }
+        });
+        assert!(parse_manifest(&with_tool.to_string()).unwrap().ui_ask);
+
+        // ui_ask alone can't be triggered, so it's not a contribution by itself.
+        let alone = json!({
+            "name": "asker", "description": "t",
+            "yolop": { "protocol_version": "1.0",
+                "capabilityServer": { "command": "x" }, "ui_ask": true }
+        });
+        assert!(
+            parse_manifest(&alone.to_string())
+                .unwrap_err()
+                .contains("nothing to contribute")
+        );
     }
 
     #[test]

--- a/src/host_ui.rs
+++ b/src/host_ui.rs
@@ -10,7 +10,23 @@
 //! forwards a typed [`UiCommand`] to the terminal event loop over a channel.
 //! The loop is the only thing that can perform the effect, so it applies it.
 
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
+
+/// A server→host `ui/ask`: prompt the user and deliver their answer via
+/// `reply`. Carried on its own channel rather than as a [`UiCommand`] variant
+/// because the oneshot sender can't derive `Clone`/`Eq`.
+pub struct AskRequest {
+    pub prompt: String,
+    pub placeholder: Option<String>,
+    pub reply: oneshot::Sender<AskAnswer>,
+}
+
+/// The user's answer to a [`AskRequest`] (empty + `cancelled` on dismiss).
+#[derive(Clone, Debug, Default)]
+pub struct AskAnswer {
+    pub answer: String,
+    pub cancelled: bool,
+}
 
 /// A request from a client-executed capability command to the terminal host.
 /// Variants name *what* should happen; the host decides *how* to render it.

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2215,6 +2215,9 @@ pub struct BuiltRuntime {
     /// other hosts ignore it. Empty/never-written when
     /// [`BuildOptions::client_commands`] is `false`.
     pub ui_rx: mpsc::UnboundedReceiver<UiCommand>,
+    /// Receiver for extension `ui/ask` requests; the TUI prompts the user and
+    /// answers each via its oneshot. Empty/never-written outside the TUI.
+    pub ask_rx: mpsc::UnboundedReceiver<crate::host_ui::AskRequest>,
     /// Receiver for everruns background-task completion signals, delivered via
     /// the wake seam (`background_wake`). The host (TUI/ACP) drains it and runs
     /// a streamed turn so the agent reacts to finished `spawn_background` work.
@@ -2741,6 +2744,42 @@ pub async fn build_with_options(
                 },
             ) as crate::extensions::StatusSink
         });
+    // `ui/ask` handler channel: an extension's request rides `ask_tx` to the
+    // App, which prompts the user and answers via a per-request oneshot. Only
+    // wired for the TUI; `None` elsewhere refuses `ui/ask`.
+    let (ask_tx, ask_rx) = mpsc::unbounded_channel::<crate::host_ui::AskRequest>();
+    let ask_sink: Option<crate::extensions::AskSink> =
+        matches!(options.client_ui, ClientUiContext::Tui).then(|| {
+            let ask_tx = ask_tx.clone();
+            Arc::new(move |params: crate::extensions::protocol::UiAskParams| {
+                let ask_tx = ask_tx.clone();
+                Box::pin(async move {
+                    let (reply, answer) = tokio::sync::oneshot::channel();
+                    let _ = ask_tx.send(crate::host_ui::AskRequest {
+                        prompt: params.prompt,
+                        placeholder: params.placeholder,
+                        reply,
+                    });
+                    match answer.await {
+                        Ok(a) => crate::extensions::protocol::UiAskResult {
+                            answer: a.answer,
+                            cancelled: a.cancelled,
+                        },
+                        Err(_) => crate::extensions::protocol::UiAskResult {
+                            answer: String::new(),
+                            cancelled: true,
+                        },
+                    }
+                })
+                    as std::pin::Pin<
+                        Box<
+                            dyn std::future::Future<
+                                    Output = crate::extensions::protocol::UiAskResult,
+                                > + Send,
+                        >,
+                    >
+            }) as crate::extensions::AskSink
+        });
 
     let mut extension_never_defer: Vec<String> = Vec::new();
     if let Some(ext_dir) = crate::extensions::extensions_dir() {
@@ -2758,7 +2797,8 @@ pub async fn build_with_options(
                 .any(|(_, entry)| !entry.is_remove());
             let capability =
                 crate::extensions::ExtensionCapability::new(package, effective_root.clone())
-                    .with_status_sink(status_sink.clone());
+                    .with_status_sink(status_sink.clone())
+                    .with_ask_sink(ask_sink.clone());
             if enabled {
                 let contributed = capability.contributed_mcp_servers();
                 if !contributed.is_empty() {
@@ -3100,6 +3140,7 @@ pub async fn build_with_options(
         model: ModelState::new(provider_state),
         settings,
         ui_rx,
+        ask_rx,
         background_wake: background_wake_rx,
         schedule_runner,
         workspace_host,


### PR DESCRIPTION
## What changed

Extensions can now ask the user a question mid-turn. An extension that declares
`ui_ask` in its manifest may send a `ui/ask` request (server→host — the
reverse-request direction) carrying `{prompt, placeholder?}`; the TUI shows a
single-line overlay and returns the typed answer as `{answer, cancelled}`.

- New wire types `UiAskParams`/`UiAskResult` and a `response_result_line`
  helper for answering server→host requests; `ui/ask` method + `ui_ask`
  capability token in the protocol metadata; regenerated `meta.json`/`schema.json`.
- The client routes an inbound `ui/ask` request to an `AskSink` (built in
  `runtime.rs`, gated on the TUI client) instead of refusing it; the sink pushes
  an `AskRequest` onto a dedicated channel. With no sink the request is answered
  `cancelled`, so `--print`/ACP never blocks.
- `App` drains the ask channel and shows an overlay (`draw_ask_overlay`) that
  captures keys **before** the busy check, so the prompt works while a turn is
  in flight; Enter resolves with the typed answer, Esc resolves `cancelled`.
- Only one prompt is live at a time; a request arriving while another is pending
  is answered `cancelled`.
- `ui_ask` is a manifest opt-in (the D4 approval boundary) but is not a
  standalone contribution — it can't be triggered on its own.
- Spec + `author-extension` skill updated to document the facet.

Third and final facet from the recent batch (skills #331, slash commands #334,
ui/ask here).

## Why

Extensions could contribute tools, hooks, prompt, MCP servers, status, skills,
and commands, but had no way to collect input from the user during a turn — e.g.
an integration that needs a confirmation, a missing value, or a choice before it
can proceed. `ui/ask` closes that gap over the same protocol.

## Before / After

**Before:** an inbound `ui/ask` request was refused with `method_not_found`
(`-32601`); an extension could never prompt the user.

**After:** the request reaches the host, the user sees an overlay, and the typed
answer flows back to the server. Covered end-to-end by
`extensions::client::tests::ui_ask_reverse_request_is_answered_by_the_sink`; the
no-sink path still returns `cancelled` (`server_request_gets_method_not_found`
remains green for genuinely unknown methods), and
`ui_ask_parses_but_is_not_a_standalone_contribution` covers the manifest rule.

```
$ cargo test --bin yolop -- extensions::   # 58 passed
$ cargo test --bin yolop -- app::tests     # 139 passed
$ cargo test -p yolop-yep --all-features   # 12 passed (drift guards green)
$ cargo clippy --all-targets --all-features -- -D warnings   # clean
```

## Risk

- Low
- New reverse-request path in the client; guarded so absence of a sink answers
  `cancelled` rather than hanging. UI overlay is additive and gated on the TUI
  client, so `--print`/ACP behavior is unchanged.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; forward-compatible wire — unknown fields ignored, missing defaulted)