### PR TITLE
fix(evals): don't count a no-match search as a tool failure

### DIFF
--- a/evals/harness_basic/src/main.rs
+++ b/evals/harness_basic/src/main.rs
@@ -1400,7 +1400,34 @@ fn has_progress_guard_warning(data: &Value) -> bool {
     }
 }
 
+/// `grep`/`rg`/`git grep` exit with code 1 when they find no matches. That is a
+/// normal outcome of exploratory search — the model is probing for the right
+/// name and a miss is information, not a broken tool call — so it must not count
+/// toward `tool_calls_failed`. Only exit codes >= 2 (a real usage/IO error)
+/// remain failures. See issue #324: this benign miss was inflating the
+/// `candidate introduced command/tool failures` gate with sampling noise.
+fn is_benign_search_miss(data: &Value) -> bool {
+    if data.get("tool_name").and_then(Value::as_str) != Some("bash") {
+        return false;
+    }
+    let Some(result) = tool_result_value(data) else {
+        return false;
+    };
+    // A no-match search reports exit_code 1 (and, downstream, success=false);
+    // exit_code 2+ is a genuine error and stays a failure.
+    if result.get("exit_code").and_then(Value::as_i64) != Some(1) {
+        return false;
+    }
+    let command = normalized_command(&tool_command(data));
+    ["rg ", "grep ", "egrep ", "fgrep ", "git grep "]
+        .iter()
+        .any(|prefix| command.starts_with(prefix))
+}
+
 fn inner_tool_failed(data: &Value) -> bool {
+    if is_benign_search_miss(data) {
+        return false;
+    }
     tool_result_value(data).is_some_and(|result| {
         result.get("success") == Some(&Value::Bool(false))
             || result
@@ -2299,6 +2326,27 @@ mod tests {
         assert_eq!(m.read_file_tool_calls, 1);
         assert_eq!(m.leading_marker_in_bash_result, 1);
         assert!(m.total_tool_result_bytes >= m.max_tool_result_bytes);
+    }
+
+    #[test]
+    fn parse_events_ignores_benign_search_miss() {
+        // A `grep`/`rg`/`git grep` that finds nothing exits with code 1. That is a
+        // normal exploratory-search outcome (issue #324), not a broken tool call,
+        // so it must not count toward tool_calls_failed / inner_tool_failures.
+        // Exit code 2+ (real error) and a non-search command's exit 1 still count.
+        let jsonl = r#"
+{"type":"tool.completed","data":{"tool_name":"bash","success":true,"result":[{"type":"text","text":"{\"command\":\"grep -rn MISSING_NAME src\",\"exit_code\":1,\"success\":false,\"stdout\":\"\"}"}]}}
+{"type":"tool.completed","data":{"tool_name":"bash","success":true,"result":[{"type":"text","text":"{\"command\":\"rg MISSING_NAME\",\"exit_code\":1,\"success\":false,\"stdout\":\"\"}"}]}}
+{"type":"tool.completed","data":{"tool_name":"bash","success":true,"result":[{"type":"text","text":"{\"command\":\"git grep MISSING_NAME\",\"exit_code\":1,\"success\":false,\"stdout\":\"\"}"}]}}
+{"type":"tool.completed","data":{"tool_name":"bash","success":true,"result":[{"type":"text","text":"{\"command\":\"grep --bogus-flag foo\",\"exit_code\":2,\"success\":false,\"stderr\":\"grep: unknown option\"}"}]}}
+{"type":"tool.completed","data":{"tool_name":"bash","success":true,"result":[{"type":"text","text":"{\"command\":\"cargo test\",\"exit_code\":1,\"success\":false,\"stdout\":\"FAILED\"}"}]}}
+"#;
+        let m = parse_events(jsonl);
+        assert_eq!(m.bash_tool_calls, 5);
+        // Three benign misses are excluded; the grep usage error (exit 2) and the
+        // failing `cargo test` (non-search exit 1) are the only real failures.
+        assert_eq!(m.inner_tool_failures, 2);
+        assert_eq!(m.tool_calls_failed, 2);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

The `harness_basic` metric miner no longer counts a no-match `grep`/`rg`/`git grep` as a tool failure. A search that finds nothing exits with code `1` — a normal, expected outcome of exploratory search, not a broken tool call. Previously *any* non-zero bash exit incremented `tool_calls_failed` / `inner_tool_failures`, which fed the search-efficiency eval's `candidate introduced command/tool failures` gate and let ordinary sampling noise trip it.

Scope is deliberately narrow: only exit code `1` for `grep`/`rg`/`egrep`/`fgrep`/`git grep` is exempted. Exit code `2+` (a genuine usage/IO error) and any non-search command still count as failures.

## Why

Issue #324: the 2026-07-18 nightly search-efficiency eval went red twice on the same `main` commit with a *different, overlapping* set of gates each run — the signature of live-model sampling noise, not a code regression (correctness stayed 100%, no relevant source changed). One contributing factor was a real bug in the metric miner: `inner_tool_failed` (`evals/harness_basic/src/main.rs`) treated a benign exploratory-search miss as a broken tool call, inflating the very gate that flipped between the two runs. This fixes that miscount without touching any `repo_map`/search product code, for which there is no evidence of a defect.

## Before / After

Metric-mining behavior on a trajectory containing exploratory-search misses:

- **Before:** `grep MISSING_NAME` (exit 1, no match) → counted as a tool failure → `tool_calls_failed += 1`.
- **After:** the same no-match search is not counted; only real failures (exit `2+`, or non-search commands like a failing `cargo test`) count.

New unit test `parse_events_ignores_benign_search_miss` drives `parse_events` over five bash calls — three no-match searches (`grep`/`rg`/`git grep`, exit 1), one grep usage error (exit 2), and one failing `cargo test` (non-search, exit 1) — and asserts `inner_tool_failures == 2` and `tool_calls_failed == 2`. The existing `missing-rg-recovery` sample (command-not-found, exit `127`) and the `parse_events_mines_search_efficiency_trajectory` test (exit `127`) still expect the failure to be counted, confirming no regression.

Validation (in `evals/harness_basic/`, after rebasing onto latest `origin/main`):

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — 20 passed, 0 failed (includes the new test, the offline end-to-end harness test, and the unchanged exit-127 expectations)

## Risk

- **Low.** Change is confined to eval metric-mining in the `harness_basic` crate, which is outside the Cargo workspace and has no `yolop` runtime, agent-loop, or host surface. It makes an existing gate less noisy; it cannot affect product behavior or correctness scoring (pass/fail is unchanged — only the failure *count* metric).
- Once merged, the next scheduled nightly search-efficiency eval picks up the corrected counting automatically.

## Security

No security-relevant code changes. The diff touches only eval metric-mining logic (JSON field inspection over recorded event fixtures) — no filesystem/shell/capability surface, no key handling, and no new dependencies (TM-FS / TM-BASH / TM-LLM / TM-TOOL / TM-DEP all unaffected).

## Smoke test

Not applicable to the `yolop` binary — no runtime/agent-loop path changed. The impacted functionality (the metric miner) is exercised directly by `parse_events` unit tests over realistic `events.jsonl` fixtures, plus the offline end-to-end `run_yolop_end_to_end_offline` harness test, all green.

## Follow-ups

- **Deferred (Option 1 from #324):** raising `FOCUSED_TRIALS` so a single bad `repo-map-bounded` trial can't flip that separate, historically-borderline gate. That is genuine model variance untouched by this fix; left as a maintainer call rather than bundled here.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered

Closes #324

https://claude.ai/code/session_01HTonSBAHx89AdWfUU6yud8

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTonSBAHx89AdWfUU6yud8)_