### PR TITLE
feat(extensions): live reload for enabled extension servers

### DIFF
--- a/.agents/skills/author-extension/SKILL.md
+++ b/.agents/skills/author-extension/SKILL.md
@@ -90,6 +90,15 @@ Not yet available: providers.
    runs its server every session. **Enabling takes effect on the next
    session**, so tell the user to restart yolop to load it.
 
+6. **Iterate live (already-enabled extensions).** Once an extension is enabled
+   and its server has run this session, `reload_extension name=<name>` restarts
+   that server in place so edits to its *implementation* take effect
+   immediately — no yolop restart. This is the fast inner loop for fixing a
+   handler you authored: edit the server, `reload_extension`, call the tool
+   again. The manifest is the session's approval boundary, so a *surface*
+   change (adding a tool, changing a schema) still needs a restart, and reload
+   can never widen the grant.
+
 ## Acceptance check
 
 The loop is proven when yolop, unaided, produces an extension that actually

--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -108,6 +108,21 @@ mid-turn, then resolves the request's oneshot with the typed answer (or
 another is pending is answered `cancelled`. Refused (`cancelled`) with no sink,
 so `--print`/ACP never blocks on it. Covered by
 `ui_ask_reverse_request_is_answered_by_the_sink`.
+Live reload: `reload_extension name=<name>` restarts an already-enabled
+extension's *server process* in place, so implementation edits take effect
+mid-session without a yolop restart — the self-writing inner loop. Each
+`ExtensionCapability` publishes its live `ExtensionProcess` into a shared
+`LiveProcessRegistry` (a `Weak` map, so the registry never keeps a server alive
+past its owning capability's cache); the management capability holds the same
+registry and `reload()` upgrades the handle and drops the running child
+(`kill_on_drop`), so the next tool/hook/command call respawns with a fresh
+handshake. Crucially the *approved surface* is the session snapshot: the
+manifest (tool names, schemas, prompt opt-in) was read at build and the harness
+tool set is frozen there, so reload re-runs the binary within the same D4 grant
+and can never widen it. A manifest change (a new tool, a changed schema) still
+requires a restart — the enabled-capability set is fixed for the session
+because `everruns-core` builds the harness once with no live-reconfigure seam.
+Covered by `reload_respawns_the_server_with_edited_code`.
 Later — the full `yolop-extension-lsp` control-plane extraction (gated on
 `evals/lsp_integration` parity to retire the built-in),
 `workspace/changed`,

--- a/src/extensions/capability.rs
+++ b/src/extensions/capability.rs
@@ -5,7 +5,9 @@
 //! package's capability server over YEP (see `manager.rs`).
 
 use super::client::{AskSink, StatusSink};
-use super::manager::{DEFAULT_REQUEST_TIMEOUT_MS, ExtensionProcess, ExtensionProcessSpec};
+use super::manager::{
+    DEFAULT_REQUEST_TIMEOUT_MS, ExtensionProcess, ExtensionProcessSpec, LiveProcessRegistry,
+};
 use super::package::{ExtensionPackage, ToolDefinition, extension_capability_id};
 use async_trait::async_trait;
 use everruns_core::capabilities::{Capability, SystemPromptContext};
@@ -33,6 +35,9 @@ pub struct ExtensionCapability {
     /// Handles the server's `ui/ask` requests. Forwarded to the process only
     /// when the manifest declares `ui_ask` (the D4 opt-in).
     ask_sink: Option<AskSink>,
+    /// Shared live-process registry so `reload_extension` can restart this
+    /// extension's server mid-session; `None` outside the runtime (tests).
+    live_processes: Option<LiveProcessRegistry>,
     /// Process shared by all tool instances so the server persists across
     /// turns; rebuilt (killing the old server) when the config changes —
     /// the same cache-by-config pattern as `LspCapability::manager_for`.
@@ -47,8 +52,16 @@ impl ExtensionCapability {
             workspace_root,
             status_sink: None,
             ask_sink: None,
+            live_processes: None,
             process: Mutex::new(None),
         }
+    }
+
+    /// Wire the shared live-process registry so this extension's server can be
+    /// reloaded mid-session via `reload_extension`.
+    pub fn with_process_registry(mut self, registry: LiveProcessRegistry) -> Self {
+        self.live_processes = Some(registry);
+        self
     }
 
     /// Wire a status-bar sink. The sink is used only if the manifest declares
@@ -96,6 +109,10 @@ impl ExtensionCapability {
                 .then(|| self.ask_sink.clone())
                 .flatten(),
         }));
+        // Publish the live handle so `reload_extension` can reach this server.
+        if let Some(registry) = &self.live_processes {
+            registry.register(&self.package.manifest.name, &process);
+        }
         *slot = Some((config.clone(), process.clone()));
         process
     }

--- a/src/extensions/manage.rs
+++ b/src/extensions/manage.rs
@@ -4,6 +4,7 @@
 //! harness (like `connectors`) and owns the verbs. Tools so both the user
 //! and the model can drive setup; a thin `/extensions` command mirrors them.
 
+use super::manager::LiveProcessRegistry;
 use super::package::{discover_extensions, extension_capability_id};
 use super::scaffold::{self, HookSpec, Language, ScaffoldRequest, ToolSpec};
 use super::store::{self, CrateFetcher, GitRunner, Source, SystemCrateFetcher, SystemGit};
@@ -23,6 +24,8 @@ pub struct ExtensionsCapability {
     settings: Arc<SettingsStore>,
     git: Arc<dyn GitRunner>,
     crates: Arc<dyn CrateFetcher>,
+    /// Live server processes, so `reload_extension` can restart one in place.
+    live_processes: LiveProcessRegistry,
 }
 
 impl ExtensionsCapability {
@@ -30,6 +33,7 @@ impl ExtensionsCapability {
         extensions_dir: PathBuf,
         workspace_root: PathBuf,
         settings: Arc<SettingsStore>,
+        live_processes: LiveProcessRegistry,
     ) -> Self {
         Self {
             extensions_dir,
@@ -37,6 +41,7 @@ impl ExtensionsCapability {
             settings,
             git: Arc::new(SystemGit),
             crates: Arc::new(SystemCrateFetcher::default()),
+            live_processes,
         }
     }
 }
@@ -66,7 +71,9 @@ impl Capability for ExtensionsCapability {
              installed and enabled, `install_extension` for a crates.io crate \
              (`crates.io:yolop-extension-<name>`), git URL, or local path, \
              `enable_extension`/`disable_extension` to toggle one in the harness (takes effect \
-             next session), and `remove_extension` to uninstall. To build a NEW extension \
+             next session), `reload_extension` to restart an enabled extension's server in \
+             place after editing its code (effective immediately, this session), and \
+             `remove_extension` to uninstall. To build a NEW extension \
              yourself, `scaffold_extension` generates a ready-to-edit package (manifest + \
              capability server) — declare what it contributes via `tools`, `hooks`, and/or \
              `prompt` — then edit the generated `handle_*` bodies, `install_extension \
@@ -83,6 +90,7 @@ impl Capability for ExtensionsCapability {
             settings: self.settings.clone(),
             git: self.git.clone(),
             crates: self.crates.clone(),
+            live_processes: self.live_processes.clone(),
         });
         vec![
             Box::new(ManageTool::new(ctx.clone(), Verb::Scaffold)),
@@ -91,6 +99,7 @@ impl Capability for ExtensionsCapability {
             Box::new(ManageTool::new(ctx.clone(), Verb::Remove)),
             Box::new(ManageTool::new(ctx.clone(), Verb::Enable)),
             Box::new(ManageTool::new(ctx.clone(), Verb::Disable)),
+            Box::new(ManageTool::new(ctx.clone(), Verb::Reload)),
             Box::new(ManageTool::new(ctx, Verb::Doctor)),
         ]
     }
@@ -102,6 +111,7 @@ struct ManageCtx {
     settings: Arc<SettingsStore>,
     git: Arc<dyn GitRunner>,
     crates: Arc<dyn CrateFetcher>,
+    live_processes: LiveProcessRegistry,
 }
 
 #[derive(Clone, Copy)]
@@ -112,6 +122,7 @@ enum Verb {
     Remove,
     Enable,
     Disable,
+    Reload,
     Doctor,
 }
 
@@ -349,6 +360,41 @@ impl ManageTool {
         }
     }
 
+    async fn reload(&self, args: &Value) -> ToolExecutionResult {
+        let Some(name) = args.get("name").and_then(Value::as_str) else {
+            return ToolExecutionResult::ToolError("`name` is required".into());
+        };
+        if !discover_extensions(&self.ctx.extensions_dir)
+            .iter()
+            .any(|pkg| pkg.manifest.name == name)
+        {
+            return ToolExecutionResult::ToolError(format!(
+                "no extension named `{name}` is installed"
+            ));
+        }
+        // Reload restarts the *running* server so implementation edits take
+        // effect. The approved surface (manifest tools/prompt) is fixed for the
+        // session, so a manifest change (a new tool) still needs a restart —
+        // and reload can never widen the grant.
+        match self.ctx.live_processes.reload(name).await {
+            Some(true) => ToolExecutionResult::Success(json!({
+                "name": name,
+                "reloaded": true,
+                "note": "Server restarted; the next call runs the current on-disk code. \
+                         Manifest changes (new tools) still need a session restart.",
+            })),
+            Some(false) => ToolExecutionResult::Success(json!({
+                "name": name,
+                "reloaded": false,
+                "note": "No server was running yet; the next call spawns the current code.",
+            })),
+            None => ToolExecutionResult::ToolError(format!(
+                "extension `{name}` is not enabled this session, so it has no running server to \
+                 reload; enable_extension name={name} and restart yolop to load it"
+            )),
+        }
+    }
+
     async fn doctor(&self, args: &Value) -> ToolExecutionResult {
         let Some(name) = args.get("name").and_then(Value::as_str) else {
             return ToolExecutionResult::ToolError("`name` is required".into());
@@ -385,6 +431,7 @@ impl Tool for ManageTool {
             Verb::Remove => "remove_extension",
             Verb::Enable => "enable_extension",
             Verb::Disable => "disable_extension",
+            Verb::Reload => "reload_extension",
             Verb::Doctor => "doctor_extension",
         }
     }
@@ -413,6 +460,13 @@ impl Tool for ManageTool {
             }
             Verb::Disable => {
                 "Disable an extension without uninstalling it. Effective next session."
+            }
+            Verb::Reload => {
+                "Reload an enabled extension's server in place so edits to its implementation \
+                 take effect this session (no yolop restart). Use after editing a running \
+                 extension's server code — e.g. while iterating on one you authored. Manifest \
+                 changes (adding a tool, changing a schema) still need a restart; reload never \
+                 changes the approved surface."
             }
             Verb::Doctor => {
                 "Conformance-check an installed extension: spawn its server, run the \
@@ -499,6 +553,7 @@ impl Tool for ManageTool {
             Verb::Remove => self.remove(&arguments),
             Verb::Enable => self.toggle(&arguments, true),
             Verb::Disable => self.toggle(&arguments, false),
+            Verb::Reload => self.reload(&arguments).await,
             Verb::Doctor => self.doctor(&arguments).await,
         }
     }
@@ -533,6 +588,7 @@ mod tests {
             settings: settings.clone(),
             git: Arc::new(crate::extensions::store::SystemGit),
             crates: Arc::new(crate::extensions::store::SystemCrateFetcher::default()),
+            live_processes: LiveProcessRegistry::default(),
         };
         (cap, settings, ext_dir)
     }
@@ -659,6 +715,39 @@ mod tests {
             .await
         {
             ToolExecutionResult::Success(v) => assert_eq!(v["removed"], "echo"),
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn reload_reports_when_nothing_is_live() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        seed_package(&src, "echo");
+        let (cap, _settings, _ext_dir) = capability(tmp.path());
+        let tools = cap.tools();
+        let get = |name: &str| tools.iter().find(|t| t.name() == name).unwrap();
+        get("install_extension")
+            .execute(json!({ "source": src.to_str().unwrap() }))
+            .await;
+
+        // Unknown extension is rejected outright.
+        match get("reload_extension")
+            .execute(json!({"name": "ghost"}))
+            .await
+        {
+            ToolExecutionResult::ToolError(m) => assert!(m.contains("no extension"), "{m}"),
+            other => panic!("{other:?}"),
+        }
+
+        // Installed but with no running server this session (the management
+        // capability's registry is empty in this unit test): reload explains
+        // it isn't live rather than silently succeeding.
+        match get("reload_extension")
+            .execute(json!({"name": "echo"}))
+            .await
+        {
+            ToolExecutionResult::ToolError(m) => assert!(m.contains("not enabled"), "{m}"),
             other => panic!("{other:?}"),
         }
     }

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -10,10 +10,10 @@ use super::package::ExtensionManifest;
 use super::protocol::{InitializeParams, InitializeResult, PROTOCOL_VERSION};
 use anyhow::{Context, Result, anyhow};
 use serde_json::Value;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::process::Stdio;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::time::Duration;
 use tokio::process::Command;
 use tokio::sync::Mutex;
@@ -184,6 +184,17 @@ impl ExtensionProcess {
         Ok(serde_json::from_value(value).unwrap_or_default())
     }
 
+    /// Drop the running server (if any) so the next call respawns it from
+    /// disk with a fresh handshake — the live-reload seam. Picks up edits to
+    /// the server *implementation*; the approved surface (manifest tools,
+    /// prompt) is the session snapshot, so reload can never widen the grant
+    /// (D4). Returns whether a live server was actually torn down.
+    pub async fn reload(&self) -> bool {
+        // Taking the `Live` drops its `_child` (`kill_on_drop`), ending the old
+        // process; `ensure_live` respawns on the next call.
+        self.state.lock().await.take().is_some()
+    }
+
     async fn ensure_live(&self, state: &mut Option<Live>) -> Result<()> {
         if let Some(live) = state.as_ref()
             && !live.connection.is_closed()
@@ -302,5 +313,41 @@ impl ExtensionProcess {
             None => None,
         };
         (served, prompt)
+    }
+}
+
+/// Shared handle to the live server processes, keyed by extension name. Each
+/// `ExtensionCapability` registers its process here on spawn; the management
+/// capability (`reload_extension`) looks one up to restart it mid-session
+/// without a yolop restart. Weak references so the registry never keeps a
+/// process alive past its owning capability's own cache.
+#[derive(Clone, Default)]
+pub struct LiveProcessRegistry {
+    processes: Arc<std::sync::Mutex<HashMap<String, Weak<ExtensionProcess>>>>,
+}
+
+impl LiveProcessRegistry {
+    /// Record the current process for `name`, replacing any prior entry (the
+    /// capability rebuilds its process when config changes).
+    pub fn register(&self, name: &str, process: &Arc<ExtensionProcess>) {
+        self.processes
+            .lock()
+            .expect("live-process registry lock")
+            .insert(name.to_string(), Arc::downgrade(process));
+    }
+
+    /// Reload the named extension's server. Returns `Some(true)` if a running
+    /// server was torn down (next call respawns), `Some(false)` if the
+    /// extension is registered but hasn't spawned a server yet (nothing to do
+    /// — the next call spawns current code anyway), and `None` if no such
+    /// extension is live in this session (not enabled, or unknown).
+    pub async fn reload(&self, name: &str) -> Option<bool> {
+        let process = self
+            .processes
+            .lock()
+            .expect("live-process registry lock")
+            .get(name)
+            .and_then(Weak::upgrade)?;
+        Some(process.reload().await)
     }
 }

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -28,6 +28,7 @@ pub(crate) mod store;
 pub(crate) use capability::ExtensionCapability;
 pub(crate) use client::{AskSink, StatusSink};
 pub(crate) use manage::ExtensionsCapability;
+pub(crate) use manager::LiveProcessRegistry;
 pub(crate) use package::{
     discover_extensions, extension_capability_id, extension_skill_scopes, extensions_dir,
 };
@@ -650,5 +651,105 @@ mod spawn_tests {
             contribution.contains("dynamic echo prompt"),
             "{contribution}"
         );
+    }
+
+    /// A minimal Python YEP server whose one tool returns `value` — baked into
+    /// the source and captured at process start, so the returned value only
+    /// changes when the *process* is respawned (not per call). Lets the reload
+    /// test distinguish "same process" from "fresh process".
+    fn write_versioned_echo_server(path: &std::path::Path, value: &str) {
+        let src = format!(
+            r#"import json, sys
+VALUE = {value:?}
+def send(o):
+    sys.stdout.write(json.dumps(o) + "\n"); sys.stdout.flush()
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    msg = json.loads(line)
+    method, msg_id = msg.get("method"), msg.get("id")
+    if method == "initialize":
+        send({{"id": msg_id, "result": {{"protocol_version": "1.0", "name": "reloadable",
+             "capabilities": ["tools"], "capability_params": {{"tools": [{{"name": "version"}}]}}}}}})
+    elif method == "tool/call":
+        send({{"id": msg_id, "result": {{"version": VALUE}}}})
+    elif msg_id is not None:
+        send({{"id": msg_id, "error": {{"code": -32601, "message": "nope"}}}})
+"#
+        );
+        std::fs::write(path, src).unwrap();
+    }
+
+    /// Live reload: after editing a running extension's server, `reload`
+    /// respawns it so the next call runs the new code — without rebuilding the
+    /// harness. The approved surface (the manifest) is untouched, so this is
+    /// the self-writing iteration seam, not a grant change.
+    #[tokio::test]
+    async fn reload_respawns_the_server_with_edited_code() {
+        let Some(python) = python3() else {
+            eprintln!("skipping: python3 not available");
+            return;
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let server = tmp.path().join("server.py");
+        write_versioned_echo_server(&server, "v1");
+
+        let manifest = parse_manifest(
+            &json!({
+                "name": "reloadable",
+                "description": "Reload fixture.",
+                "yolop": {
+                    "protocol_version": "1.0",
+                    "capabilityServer": {
+                        "command": python,
+                        "args": [server.display().to_string()]
+                    },
+                    "tools": [{ "name": "version", "description": "Report baked version." }]
+                }
+            })
+            .to_string(),
+        )
+        .expect("reload manifest");
+        let registry = super::LiveProcessRegistry::default();
+        let capability = ExtensionCapability::new(
+            ExtensionPackage {
+                dir: tmp.path().to_path_buf(),
+                manifest,
+            },
+            tmp.path().to_path_buf(),
+        )
+        .with_process_registry(registry.clone());
+
+        let call = || async {
+            let tools = capability.tools();
+            let tool = tools.iter().find(|t| t.name() == "version").unwrap();
+            match tool.execute(json!({})).await {
+                ToolExecutionResult::Success(v) => v["version"].as_str().unwrap().to_string(),
+                other => panic!("expected success, got {other:?}"),
+            }
+        };
+
+        // First call spawns the server; it reports the v1 code.
+        assert_eq!(call().await, "v1");
+
+        // Edit the server on disk. The running process still holds v1.
+        write_versioned_echo_server(&server, "v2");
+        assert_eq!(call().await, "v1", "running server should not see the edit");
+
+        // Reload tears the old server down; the next call respawns and runs v2.
+        assert_eq!(
+            registry.reload("reloadable").await,
+            Some(true),
+            "a live server should be reloaded"
+        );
+        assert_eq!(
+            call().await,
+            "v2",
+            "reloaded server should run the edited code"
+        );
+
+        // An extension with no live process in this session can't be reloaded.
+        assert_eq!(registry.reload("ghost").await, None);
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2781,6 +2781,10 @@ pub async fn build_with_options(
             }) as crate::extensions::AskSink
         });
 
+    // Shared handle to enabled extensions' live server processes, so
+    // `reload_extension` can restart one in place mid-session (self-writing
+    // iteration) without a yolop restart.
+    let live_processes = crate::extensions::LiveProcessRegistry::default();
     let mut extension_never_defer: Vec<String> = Vec::new();
     if let Some(ext_dir) = crate::extensions::extensions_dir() {
         let settings_snapshot = settings.snapshot();
@@ -2798,7 +2802,8 @@ pub async fn build_with_options(
             let capability =
                 crate::extensions::ExtensionCapability::new(package, effective_root.clone())
                     .with_status_sink(status_sink.clone())
-                    .with_ask_sink(ask_sink.clone());
+                    .with_ask_sink(ask_sink.clone())
+                    .with_process_registry(live_processes.clone());
             if enabled {
                 let contributed = capability.contributed_mcp_servers();
                 if !contributed.is_empty() {
@@ -2811,11 +2816,12 @@ pub async fn build_with_options(
             extension_never_defer.extend(capability.never_defer_tools());
             capabilities.register(capability);
         }
-        // The always-on management surface (install/list/enable/remove).
+        // The always-on management surface (install/list/enable/remove/reload).
         capabilities.register(crate::extensions::ExtensionsCapability::new(
             ext_dir,
             effective_root.clone(),
             settings.clone(),
+            live_processes.clone(),
         ));
     }
     // Server name list for `/mcp` and StartupInfo, computed after extension


### PR DESCRIPTION
## What changed

Adds `reload_extension name=NAME`: restart an already-enabled extension's
**server process** in place so edits to its *implementation* take effect
mid-session, without restarting yolop. This is the fast inner loop for the
self-writing flow — edit a handler you authored, `reload_extension`, call the
tool again.

- Each `ExtensionCapability` now publishes its live `ExtensionProcess` into a
  shared `LiveProcessRegistry` (a `Weak` map, so the registry never keeps a
  server alive past its owning capability's own cache).
- The management capability holds the same registry; `reload()` upgrades the
  handle and drops the running child (`kill_on_drop`), so the next
  tool/hook/command call respawns with a fresh handshake.
- `ExtensionProcess::reload()` takes the cached `Live` (ending the old process)
  so `ensure_live` respawns on the next call.
- Spec + `author-extension` skill document the verb, the iteration loop, and the
  boundary.

**The boundary (documented, not a bug):** the approved *surface* is the session
snapshot. The manifest (tool names, schemas, prompt opt-in) is read at harness
build and the harness tool set is frozen there, so reload re-runs the binary
**within the same D4 grant and can never widen it**. A manifest change (adding a
tool, changing a schema) still needs a restart, because `everruns-core` builds
the harness once with no live-reconfigure seam — enabling a brand-new extension
mid-session is not possible today regardless of this change.

## Why

Enabling an extension only took effect on the next session, and there was no way
to pick up edits to an already-running extension's server without a full
restart. That made iterating on an extension you just authored slow. Reload
closes the common self-writing case (fix the handler → reload → run) while
keeping the trust model intact — reload cannot change what an extension is
allowed to do.

## Before / After

**Before:** edit a running extension's server → no effect until you restart
yolop. No `reload` verb existed.

**After:** `reload_extension name=NAME` restarts the server in place; the next
call runs the new code. Unknown/not-enabled extensions get a clear error instead
of a silent no-op.

Proven by `reload_respawns_the_server_with_edited_code`: a real Python server
bakes a version into its source, captured at process start. The test calls the
tool (`v1`), edits the source to `v2`, calls again (still `v1` — process
persists), `reload()`s, then calls again and gets `v2` — the respawn ran the
edited code. `reload_reports_when_nothing_is_live` covers the verb's error paths
(unknown name; installed but no live server this session).

```
$ cargo test --bin yolop -- extensions::   # 60 passed (was 58; +2 reload)
$ cargo clippy --all-targets --all-features -- -D warnings   # clean
$ cargo fmt --check   # clean
```

## Risk

- Low
- Additive: a new management verb + a `Weak`-backed registry. Reload only ever
  drops a process so the existing respawn-on-next-call path runs; it cannot
  widen the D4 grant (surface is the session snapshot). The registry holds weak
  refs, so it can't leak or extend a process's lifetime.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; purely additive verb + wiring)