### PR TITLE
chore(deps): bump everruns to 0.17.13, pin Rust 1.96.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: rustfmt, clippy
 
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -117,7 +117,7 @@ jobs:
         uses: dopplerhq/cli-action@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -37,7 +37,7 @@ jobs:
           ref: ${{ inputs.tag }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Verify version matches tag
         env:

--- a/.github/workflows/search-efficiency-eval.yml
+++ b/.github/workflows/search-efficiency-eval.yml
@@ -64,7 +64,7 @@ jobs:
           } >> "${GITHUB_ENV}"
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,14 +1649,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.12"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4084ce7e22d0d1941d6155984463054a2bc0846a0eed4edba299f30d05832b1"
+checksum = "f70350aa81c2b499171e882079cc4221a7c0f26fd179bff8e797623567b29b09"
 dependencies = [
  "async-trait",
  "chrono",
  "eventsource-stream",
- "everruns-core",
+ "everruns-provider",
  "futures",
  "reqwest 0.13.4",
  "serde",
@@ -1667,9 +1667,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.12"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b81bec27dc6339717f81aec2ab1094c21626bac0a137963fe9931adef829d4d3"
+checksum = "74cd3b2eeea2cbaf4ddc292e50caca8ae5a56cd5756bfde816fc30bfea484b75"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -1682,6 +1682,7 @@ dependencies = [
  "cron",
  "ed25519-dalek 3.0.0",
  "eventsource-stream",
+ "everruns-provider",
  "fetchkit",
  "futures",
  "globset",
@@ -1713,9 +1714,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.12"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b78955cb07738e8a117732656042d8566197b009e327184a7aeb9185d69dd26b"
+checksum = "6bcb221b38574945bbd88774a6ab454d887f1b66c9ffab09ca60e56c82b633ff"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1730,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.12"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d4507be08ffe8e8b11873daaebde005f70bb5afbe7471bbacd5bd4f399686"
+checksum = "3c37ded4e03ef15de0a250783498a92e49a74733cc6de32568b45dc8ccedefb5"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1746,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.12"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426f50d4ec2318b8d7e86516148aefa2e91d395d7380322b3dabc707fb0195e4"
+checksum = "8d83e6a3d9b8c77929648f0732f21bf20034a04fba33c190a996744f6c6526db"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1760,9 +1761,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.12"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ecd5fb994a723339a31ca251bffd60caacd224c1114a9ff0d5af63d2489d393"
+checksum = "63cf2b6eecc1d4f3099de9ee8074d76d15d41f3b2a86e4ad070699727539db2c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1784,9 +1785,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.12"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a232f8288712c43664b030a4c3f94d247460f3e4850b09e15a05bba4f40c8b6c"
+checksum = "1e1d0a9d7630728a28f8d0f5ba7883c483c14ff75d96b903e5d3d1088777f7c9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1799,18 +1800,13 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.12"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c12c0d81aa61bc4bcf501371ff2415392773f9c1ef754abff472704fb85890d5"
+checksum = "aa6babfe5e823f4ab1f1945a4cb3aef168a46796b4918021d41ecd4d3310b5cc"
 dependencies = [
- "anyhow",
  "async-trait",
- "base64",
  "chrono",
- "eventsource-stream",
- "everruns-core",
- "futures",
- "inventory",
+ "everruns-provider",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
@@ -1820,23 +1816,51 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.12"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef4f2b7438ed2d431af2872c54b153b3606ad4a75a93489ab0ce0926d27de52"
+checksum = "99cfb6f029111f9dbc1be4430ad1822f4676dee8a0dde3cdbd91e10d9a81d959"
 dependencies = [
  "async-trait",
  "chrono",
- "everruns-core",
+ "everruns-provider",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
 ]
 
 [[package]]
-name = "everruns-runtime"
-version = "0.17.12"
+name = "everruns-provider"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa65e0efe7ee5b8530fc749172860c7b7138785cec0ade8524a7ea6c70265adf"
+checksum = "de551f9084b3eca0d5c44a78967be46845f7b937f64fab39478c0a3edb1de7d3"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "eventsource-stream",
+ "futures",
+ "hex",
+ "http",
+ "rand 0.10.2",
+ "regex",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "everruns-runtime"
+version = "0.17.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "861e56333e028eed3ea84441fc141fc2e7f6d2f51279a5aa413b7a244a0fd76c"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,20 +90,20 @@ tree-sitter-zig = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-everruns-anthropic = "0.17.12"
-everruns-core = "0.17.12"
-everruns-openai = "0.17.12"
+everruns-anthropic = "0.17.13"
+everruns-core = "0.17.13"
+everruns-openai = "0.17.13"
 # OpenRouter's first-class driver was split out of everruns-openai into its own
 # crate in 0.13.0; register it alongside openai to keep DriverId::OpenRouter.
-everruns-openrouter = "0.17.12"
-everruns-local = "0.17.12"
-everruns-mcp = "0.17.12"
+everruns-openrouter = "0.17.13"
+everruns-local = "0.17.13"
+everruns-mcp = "0.17.13"
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (specs/mcp.md, upstream runtime-mcp.md D2).
-everruns-runtime = { version = "0.17.12", features = ["mcp-stdio"] }
-everruns-integrations-duckduckgo = "0.17.12"
-everruns-integrations-parallel = "0.17.12"
-everruns-integrations-daytona = "0.17.12"
+everruns-runtime = { version = "0.17.13", features = ["mcp-stdio"] }
+everruns-integrations-duckduckgo = "0.17.13"
+everruns-integrations-parallel = "0.17.13"
+everruns-integrations-daytona = "0.17.13"
 arboard = { version = "3", features = ["wayland-data-control"] }
 futures = "0.3"
 html-escape = "0.2"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,5 @@
+# Pinned to 1.96.0: everruns-core 0.17.13 uses `if let` match guards, which
+# stabilized in Rust 1.96.0. Older stable toolchains fail with E0658.
 [toolchain]
-channel = "stable"
+channel = "1.96.0"
 components = ["rustfmt", "clippy"]

--- a/src/acp/bridge.rs
+++ b/src/acp/bridge.rs
@@ -335,7 +335,7 @@ mod tests {
     };
     use everruns_core::message::{ExecutionPhase, Message};
     use everruns_core::tool_types::ToolCall;
-    use everruns_core::typed_id::{EventId, SessionId, TurnId};
+    use everruns_core::typed_id::{EventId, MessageId, SessionId, TurnId};
     use serde_json::json;
 
     fn event(data: EventData) -> Event {
@@ -358,6 +358,7 @@ mod tests {
         let updates = t.on_event(&event(EventData::OutputMessageDelta(
             OutputMessageDeltaData {
                 turn_id: TurnId::new(),
+                message_id: MessageId::new(),
                 delta: "Hel".into(),
                 accumulated: "Hel".into(),
                 phase: None,
@@ -377,6 +378,7 @@ mod tests {
         let _ = t.on_event(&event(EventData::OutputMessageDelta(
             OutputMessageDeltaData {
                 turn_id: TurnId::new(),
+                message_id: MessageId::new(),
                 delta: "Hi".into(),
                 accumulated: "Hi".into(),
                 phase: None,
@@ -665,6 +667,7 @@ mod tests {
         let mut t = Translator::new();
         let ev = event(EventData::OutputMessageDelta(OutputMessageDeltaData {
             turn_id: TurnId::new(),
+            message_id: MessageId::new(),
             delta: "x".into(),
             accumulated: "x".into(),
             phase: None,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2132,7 +2132,7 @@ mod tests {
         CreateSessionTask, SessionTaskState, TASK_KIND_BACKGROUND_TOOL,
     };
     use everruns_core::tool_types::ToolCall;
-    use everruns_core::{SessionId, TurnId};
+    use everruns_core::{MessageId, SessionId, TurnId};
 
     use everruns_core::command::{CommandArg, CommandDescriptor, CommandSource};
 
@@ -2579,6 +2579,7 @@ mod tests {
             EventContext::empty(),
             OutputMessageStartedData {
                 turn_id: TurnId::new(),
+                message_id: MessageId::new(),
                 model: None,
                 iteration: Some(3),
                 phase: None,
@@ -2871,12 +2872,14 @@ mod tests {
         let mut emitted = HashSet::new();
         let mut router = DeltaRouter::default();
         let turn_id = TurnId::new();
+        let message_id = MessageId::new();
 
         let delta_event = RuntimeEvent::new(
             SessionId::new(),
             EventContext::empty(),
             OutputMessageDeltaData {
                 turn_id,
+                message_id,
                 delta: "Hel".to_string(),
                 accumulated: "Hel".to_string(),
                 phase: None,
@@ -2889,6 +2892,7 @@ mod tests {
             EventContext::empty(),
             OutputMessageDeltaData {
                 turn_id,
+                message_id,
                 delta: "lo, world".to_string(),
                 accumulated: "Hello, world".to_string(),
                 phase: None,

--- a/src/session_log.rs
+++ b/src/session_log.rs
@@ -1136,7 +1136,7 @@ mod tests {
         use everruns_core::events::{
             OUTPUT_MESSAGE_DELTA, OutputMessageDeltaData, TOOL_OUTPUT_DELTA, ToolOutputDeltaData,
         };
-        use everruns_core::typed_id::TurnId;
+        use everruns_core::typed_id::{MessageId, TurnId};
 
         let dir = tempfile::tempdir().expect("tempdir");
         let session_id = SessionId::from_seed(99);
@@ -1152,6 +1152,7 @@ mod tests {
             EventContext::default(),
             OutputMessageDeltaData {
                 turn_id,
+                message_id: MessageId::new(),
                 delta: "hello".to_string(),
                 accumulated: "hello".to_string(),
                 phase: None,


### PR DESCRIPTION
## What changed
Bumps all `everruns-*` runtime crates from `0.17.12` to `0.17.13` (kept in
lockstep), pinning them to the latest published release. Two things fall out of
that bump:

- **Toolchain pinned to Rust 1.96.0.** `everruns-core` 0.17.13 uses `if let`
  match guards, which stabilized in Rust 1.96.0. On any older stable toolchain
  the dependency fails to compile with `E0658`. `rust-toolchain.toml` and the CI
  `dtolnay/rust-toolchain@…` steps now name `1.96.0` explicitly.
- **`message_id` added to two event types.** The 0.17.13 event API adds a stable
  `message_id: MessageId` to `OutputMessageStartedData` and
  `OutputMessageDeltaData` (the same id carried on the completed message). yolop
  only *consumes* these events in production; the only code touched is the
  test-construction sites, which now populate the field (deltas of one streamed
  message share a single id).

No runtime behavior changes — this is a dependency/toolchain update plus test
fixture updates. The bump also pulls in the new first-party `everruns-provider`
transitive crate from the upstream driver/provider split.

## Why
Keep the public runtime crate versions in lockstep with what is published on
crates.io (per `AGENTS.md` → Upstream relationship). 0.17.13 is the latest
release.

## Before / After
No user-visible behavior change. Evidence that the toolchain + bump build and
pass clean:

**Before** (on stable 1.94.1, after only the version bump):
```
error[E0658]: `if let` guards are experimental
  --> everruns-core-0.17.13/src/capabilities/a2a_delegation.rs:1430:25
error: could not compile `everruns-core` (lib) due to 3 previous errors
```

**After** (Rust 1.96.0, full bump):
```
cargo fmt --all --check            # clean
cargo clippy --all-targets --all-features -- -D warnings   # clean
cargo test --all-features          # ok. 816 passed; 0 failed
cargo run -- --provider llmsim -p "say hi in three words"  # binary starts, runs a turn
```

## Risk
- **Low**
- The main risk is the toolchain floor moving to 1.96.0; contributors and CI now
  need that compiler (rustup auto-installs it from the pin). No behavioral risk —
  source changes are test-only.

## Security
No security-relevant runtime code changes (TM-DEP only). `everruns-*` bumped
together in lockstep; new transitive crate `everruns-provider` is first-party.
No changes to `tools.rs`, the filesystem write blocklist, bash execution, or
LLM/key handling — no injection, data-exposure, or new-capability surface.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (event-construction test fixtures carry the new `message_id`)
- [x] Backward compatibility considered (pre-1.0; toolchain floor raised to 1.96.0, documented in `rust-toolchain.toml`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSgUPWaC7soWRNYDaeEkwu)_