### PR TITLE
feat(tui): Codex-inspired composer, highlighting, and status features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6387,6 +6387,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-highlight"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7a0c48d503cf4e0a57a2453424eaef2fce4b4269f13e3579e52f0d0c9e5cc8"
+dependencies = [
+ "regex",
+ "streaming-iterator",
+ "thiserror 2.0.18",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-html"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7562,6 +7574,7 @@ dependencies = [
  "tree-sitter-cpp",
  "tree-sitter-css",
  "tree-sitter-go",
+ "tree-sitter-highlight",
  "tree-sitter-html",
  "tree-sitter-java",
  "tree-sitter-javascript",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ tuika = { version = "0.1.0", path = "crates/tuika" }
 tokio = { version = "1.52", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tree-sitter = "0.26"
+tree-sitter-highlight = "0.26"
 tree-sitter-bash = "0.25"
 tree-sitter-c = "0.24"
 tree-sitter-c-sharp = "0.23"

--- a/README.md
+++ b/README.md
@@ -67,13 +67,15 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   paranoia level (`protective` / `normal` / `off`) is shown in the status bar
   and set with `/setup approval <level>` (or just by telling yolop to be more
   or less careful). See [Soft approval](#soft-approval) below.
-- **TUI chat** (ratatui): scrolling transcript, multiline composer, status
+- **TUI chat** (ratatui): scrolling transcript with language-aware syntax
+  highlighting of fenced code blocks (tree-sitter), multiline composer, status
   bar (with a `bg` count whenever the session has background tasks), slash commands
   (`/help`, `/tools`, `/mcp`, `/cwd`, `/setup`, `/model`, `/effort`, `/goal`,
   `/shell`, `/background`, `/clear`, `/quit`), a read-only background-tasks panel
   toggled with `Ctrl+B`, `!<command>` as a direct shell shortcut, shell-style
-  `↑`/`↓` recall of previously submitted prompts (persisted across sessions), and
-  natural-language requests for terminal actions such as "exit" or "clear the screen".
+  `↑`/`↓` recall and `Ctrl+R` reverse search of previously submitted prompts
+  (persisted across sessions), and natural-language requests for terminal
+  actions such as "exit" or "clear the screen".
 - **Side questions** — `/btw <question>` answers a question about the current
   session out-of-band: same context as the main task, no tools, and nothing
   added to the conversation history.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   bar (with a `bg` count whenever the session has background tasks), slash commands
   (`/help`, `/tools`, `/mcp`, `/cwd`, `/setup`, `/model`, `/effort`, `/goal`,
   `/shell`, `/background`, `/clear`, `/quit`), a read-only background-tasks panel
-  toggled with `Ctrl+B`, `!<command>` as a direct shell shortcut, and
+  toggled with `Ctrl+B`, `!<command>` as a direct shell shortcut, shell-style
+  `↑`/`↓` recall of previously submitted prompts (persisted across sessions), and
   natural-language requests for terminal actions such as "exit" or "clear the screen".
 - **Side questions** — `/btw <question>` answers a question about the current
   session out-of-band: same context as the main task, no tools, and nothing

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   and set with `/setup approval <level>` (or just by telling yolop to be more
   or less careful). See [Soft approval](#soft-approval) below.
 - **TUI chat** (ratatui): scrolling transcript with language-aware syntax
-  highlighting of fenced code blocks (tree-sitter), multiline composer, a busy
+  highlighting of fenced code blocks (tree-sitter) and styled `http(s)` links,
+  multiline composer, a busy
   indicator with a live elapsed timer while a turn runs, status
   bar (with a `bg` count whenever the session has background tasks), slash commands
   (`/help`, `/tools`, `/mcp`, `/cwd`, `/setup`, `/model`, `/effort`, `/goal`,

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   bar (with a `bg` count whenever the session has background tasks), slash commands
   (`/help`, `/tools`, `/mcp`, `/cwd`, `/setup`, `/model`, `/effort`, `/goal`,
   `/shell`, `/background`, `/clear`, `/quit`), a read-only background-tasks panel
-  toggled with `Ctrl+B`, `!<command>` as a direct shell shortcut, shell-style
-  `↑`/`↓` recall and `Ctrl+R` reverse search of previously submitted prompts
-  (persisted across sessions), and natural-language requests for terminal
-  actions such as "exit" or "clear the screen".
+  toggled with `Ctrl+B`, `!<command>` as a direct shell shortcut, `@`-triggered
+  file-path completion, shell-style `↑`/`↓` recall and `Ctrl+R` reverse search of
+  previously submitted prompts (persisted across sessions), and natural-language
+  requests for terminal actions such as "exit" or "clear the screen".
 - **Side questions** — `/btw <question>` answers a question about the current
   session out-of-band: same context as the main task, no tools, and nothing
   added to the conversation history.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   and set with `/setup approval <level>` (or just by telling yolop to be more
   or less careful). See [Soft approval](#soft-approval) below.
 - **TUI chat** (ratatui): scrolling transcript with language-aware syntax
-  highlighting of fenced code blocks (tree-sitter), multiline composer, status
+  highlighting of fenced code blocks (tree-sitter), multiline composer, a busy
+  indicator with a live elapsed timer while a turn runs, status
   bar (with a `bg` count whenever the session has background tasks), slash commands
   (`/help`, `/tools`, `/mcp`, `/cwd`, `/setup`, `/model`, `/effort`, `/goal`,
   `/shell`, `/background`, `/clear`, `/quit`), a read-only background-tasks panel

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   highlighting of fenced code blocks (tree-sitter) and styled `http(s)` links,
   multiline composer, a busy
   indicator with a live elapsed timer while a turn runs, status
-  bar (with a `bg` count whenever the session has background tasks), slash commands
+  bar (with a `bg` count whenever the session has background tasks and a `ctx`
+  context-window gauge once the model reports usage), slash commands
   (`/help`, `/tools`, `/mcp`, `/cwd`, `/setup`, `/model`, `/effort`, `/goal`,
   `/shell`, `/background`, `/clear`, `/quit`), a read-only background-tasks panel
   toggled with `Ctrl+B`, `!<command>` as a direct shell shortcut, `@`-triggered

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -189,6 +189,20 @@ pub struct App {
     /// Shell-style Up/Down recall of previously submitted composer prompts,
     /// persisted across sessions. See [`crate::prompt_history`].
     history: crate::prompt_history::PromptHistory,
+    /// Active Ctrl+R reverse-history search, if any. While set it owns the
+    /// keyboard and the composer previews the current match.
+    history_search: Option<HistorySearch>,
+}
+
+/// In-progress Ctrl+R reverse search over [`App::history`].
+#[derive(Clone, Debug)]
+pub(crate) struct HistorySearch {
+    /// The incremental search query typed so far.
+    query: String,
+    /// Index of the entry currently matched, or `None` when nothing matches.
+    match_index: Option<usize>,
+    /// The composer rows captured on entry, restored if the search is cancelled.
+    saved_lines: Vec<String>,
 }
 
 /// The renderer backing a TUI session.
@@ -383,7 +397,17 @@ pub(crate) struct ModelOption {
 pub(crate) struct ViewState {
     pub presentation: PresentationState,
     pub command_suggestions: Vec<CommandSuggestion>,
+    /// Active Ctrl+R reverse-search prompt, if any. Takes over the chrome
+    /// preview row and suppresses command suggestions.
+    pub history_search: Option<HistorySearchView>,
     pub busy_frame: u64,
+}
+
+/// Render-facing view of an active reverse-history search.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct HistorySearchView {
+    pub query: String,
+    pub matched: bool,
 }
 
 impl ViewState {
@@ -462,6 +486,7 @@ impl App {
             } else {
                 crate::prompt_history::PromptHistory::load()
             },
+            history_search: None,
         };
         app.emit_system_banner();
         if should_setup {
@@ -506,12 +531,19 @@ impl App {
     /// once per frame; the clones are dominated by small `String`s.
     pub(crate) fn view_state(&self) -> ViewState {
         let presentation = self.presentation_state();
+        let history_search = self.history_search_view();
         ViewState {
-            command_suggestions: if !presentation.busy && self.setup.is_none() {
+            // The search prompt owns the chrome row while active, so suppress
+            // command suggestions to avoid two things fighting for it.
+            command_suggestions: if history_search.is_none()
+                && !presentation.busy
+                && self.setup.is_none()
+            {
                 self.suggestions()
             } else {
                 Vec::new()
             },
+            history_search,
             busy_frame: self.busy_frame,
             presentation,
         }
@@ -981,6 +1013,17 @@ impl App {
     }
 
     async fn handle_key(&mut self, key: KeyEvent) {
+        // Reverse-history search owns the keyboard while active (even Ctrl+C,
+        // which cancels the search rather than arming exit).
+        if self.history_search.is_some() {
+            self.handle_search_key(key);
+            return;
+        }
+        // Ctrl+R opens reverse-history search from the idle composer.
+        if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('r')) {
+            self.history_search_start();
+            return;
+        }
         if key.modifiers.contains(KeyModifiers::CONTROL) {
             match key.code {
                 KeyCode::Char('c') => {
@@ -1112,6 +1155,146 @@ impl App {
         true
     }
 
+    /// Open Ctrl+R reverse-history search from the idle composer. No-op while a
+    /// turn or overlay owns the keyboard, or when there is no history to search.
+    fn history_search_start(&mut self) {
+        if self.busy
+            || self.setup.is_some()
+            || self.background_panel.is_some()
+            || self.pending_ask.is_some()
+            || self.history.is_empty()
+        {
+            return;
+        }
+        self.history.reset_navigation();
+        self.history_search = Some(HistorySearch {
+            query: String::new(),
+            match_index: None,
+            saved_lines: self.input.lines().to_vec(),
+        });
+        // An empty query lands on the newest entry, so Ctrl+R immediately
+        // previews the last prompt — like a shell.
+        self.history_search_refresh();
+    }
+
+    /// Keyboard handling while reverse search owns the composer.
+    fn handle_search_key(&mut self, key: KeyEvent) {
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        match key.code {
+            KeyCode::Char('r') if ctrl => self.history_search_cycle(),
+            // Ctrl+C / Ctrl+G / Esc abandon the search and restore the draft.
+            KeyCode::Char('c' | 'g') if ctrl => self.history_search_cancel(),
+            KeyCode::Esc => self.history_search_cancel(),
+            KeyCode::Enter => self.history_search_accept(),
+            KeyCode::Backspace => {
+                if let Some(search) = self.history_search.as_mut() {
+                    search.query.pop();
+                }
+                self.history_search_refresh();
+            }
+            KeyCode::Char(c) if !ctrl => {
+                if let Some(search) = self.history_search.as_mut() {
+                    search.query.push(c);
+                }
+                self.history_search_refresh();
+            }
+            // Ignore anything else so stray keys don't leak into the composer.
+            _ => {}
+        }
+    }
+
+    /// Recompute the match from the newest entry for the current query and
+    /// preview it in the composer. Called after every query edit.
+    fn history_search_refresh(&mut self) {
+        let Some(search) = self.history_search.as_ref() else {
+            return;
+        };
+        let Some(newest) = self.history.newest_index() else {
+            return;
+        };
+        let hit = self.history.reverse_search(&search.query, newest);
+        self.apply_search_hit(hit);
+    }
+
+    /// Advance to the next older match for the current query (repeated Ctrl+R).
+    /// Holds on the current match when nothing older matches.
+    fn history_search_cycle(&mut self) {
+        let Some(search) = self.history_search.as_ref() else {
+            return;
+        };
+        let query = search.query.clone();
+        let start = match search.match_index {
+            Some(0) => return, // already at the oldest match
+            Some(i) => i - 1,
+            None => match self.history.newest_index() {
+                Some(n) => n,
+                None => return,
+            },
+        };
+        if let Some(hit) = self.history.reverse_search(&query, start) {
+            self.apply_search_hit(Some(hit));
+        }
+    }
+
+    /// Store the resolved match and mirror it into the composer (or clear the
+    /// composer when nothing matches).
+    fn apply_search_hit(&mut self, hit: Option<(usize, String)>) {
+        let Some(search) = self.history_search.as_mut() else {
+            return;
+        };
+        match hit {
+            Some((index, entry)) => {
+                search.match_index = Some(index);
+                self.set_input_text(entry);
+            }
+            None => {
+                search.match_index = None;
+                self.input = new_input_area(vec![String::new()]);
+            }
+        }
+    }
+
+    /// Accept the current match: keep it in the composer and leave search mode
+    /// so the user can edit or submit. With no match, restore the saved draft.
+    fn history_search_accept(&mut self) {
+        let Some(search) = self.history_search.take() else {
+            return;
+        };
+        match search.match_index.and_then(|i| self.history.entry_at(i)) {
+            Some(entry) => {
+                let entry = entry.to_string();
+                self.set_input_text(entry);
+            }
+            None => self.restore_saved_input(search.saved_lines),
+        }
+    }
+
+    /// Abandon the search and restore the composer to its pre-search contents.
+    fn history_search_cancel(&mut self) {
+        if let Some(search) = self.history_search.take() {
+            self.restore_saved_input(search.saved_lines);
+        }
+    }
+
+    fn restore_saved_input(&mut self, lines: Vec<String>) {
+        self.input = new_input_area(if lines.is_empty() {
+            vec![String::new()]
+        } else {
+            lines
+        });
+        self.input.move_cursor(CursorMove::End);
+    }
+
+    /// Snapshot of the active reverse search for rendering, if any.
+    pub(crate) fn history_search_view(&self) -> Option<HistorySearchView> {
+        self.history_search
+            .as_ref()
+            .map(|search| HistorySearchView {
+                query: search.query.clone(),
+                matched: search.match_index.is_some(),
+            })
+    }
+
     fn suggestions(&self) -> Vec<CommandSuggestion> {
         command_suggestions(self.suggestion_input(), &self.startup.capability_commands)
     }
@@ -1129,7 +1312,14 @@ impl App {
     }
 
     fn set_input_text(&mut self, text: String) {
-        self.input = new_input_area(vec![text]);
+        // Split on newlines so a recalled multi-line prompt restores as multiple
+        // composer rows rather than one row with embedded control characters.
+        let lines: Vec<String> = text.split('\n').map(str::to_string).collect();
+        self.input = new_input_area(if lines.is_empty() {
+            vec![String::new()]
+        } else {
+            lines
+        });
         self.input.move_cursor(CursorMove::End);
     }
 
@@ -2087,7 +2277,7 @@ fn help_command_line(descriptor: &CommandDescriptor) -> String {
 
 fn help_shortcut_lines() -> [&'static str; 5] {
     [
-        "  Enter send · Shift-Enter newline · Tab complete · ←/→ edit · ↑/↓ history",
+        "  Enter send · Shift-Enter newline · Tab complete · ↑/↓ history · Ctrl+R search",
         "  Ctrl+V paste image/text · Ctrl+B background tasks · !<cmd> shell alias",
         "  exit: Ctrl-C twice / Ctrl-D",
         "  cancel turn: Esc twice (while model is busy)",
@@ -2293,6 +2483,25 @@ mod tests {
 
         assert!(rendered.starts_with("Tab /help"));
         assert!(rendered.ends_with('…'));
+    }
+
+    #[test]
+    fn history_search_preview_line_shows_query_and_no_match_flag() {
+        let matched = HistorySearchView {
+            query: "deploy".to_string(),
+            matched: true,
+        };
+        let rendered = line_text(&history_search_preview_line(&matched, 96));
+        assert!(rendered.starts_with("(reverse-search) 'deploy'"));
+        assert!(!rendered.contains("no match"));
+
+        let missed = HistorySearchView {
+            query: "zzz".to_string(),
+            matched: false,
+        };
+        let rendered = line_text(&history_search_preview_line(&missed, 96));
+        assert!(rendered.contains("'zzz'"));
+        assert!(rendered.contains("no match"));
     }
 
     #[test]
@@ -3562,6 +3771,7 @@ mod tests {
         ViewState {
             presentation: presentation_state_idle(),
             command_suggestions: Vec::new(),
+            history_search: None,
             busy_frame: 0,
         }
     }
@@ -5315,6 +5525,98 @@ mod tests {
         app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::empty()))
             .await;
         assert_eq!(app.input_text(), "/cwd");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ctrl_r_reverse_search_matches_narrows_and_accepts() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+        for entry in ["deploy staging", "run tests", "deploy prod"] {
+            app.history.record(entry);
+        }
+
+        // Ctrl+R opens search and previews the newest entry.
+        app.handle_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL))
+            .await;
+        assert!(app.history_search.is_some());
+        assert_eq!(app.input_text(), "deploy prod");
+
+        // Typing narrows to the newest entry containing the query.
+        for ch in ['t', 'e', 's', 't'] {
+            app.handle_key(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::empty()))
+                .await;
+        }
+        assert_eq!(app.input_text(), "run tests");
+        let view = app.history_search_view().expect("search active");
+        assert_eq!(view.query, "test");
+        assert!(view.matched);
+
+        // Enter accepts the match into the composer and leaves search mode.
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()))
+            .await;
+        assert!(app.history_search.is_none());
+        assert_eq!(app.input_text(), "run tests");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ctrl_r_cycles_older_matches_then_reports_no_match() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+        for entry in ["deploy staging", "run tests", "deploy prod"] {
+            app.history.record(entry);
+        }
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL))
+            .await;
+        for ch in ['d', 'e', 'p', 'l', 'o', 'y'] {
+            app.handle_key(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::empty()))
+                .await;
+        }
+        // Newest "deploy" match first.
+        assert_eq!(app.input_text(), "deploy prod");
+        // Ctrl+R again cycles to the older "deploy" entry.
+        app.handle_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL))
+            .await;
+        assert_eq!(app.input_text(), "deploy staging");
+
+        // A query with no match clears the preview and flags it in the view.
+        app.handle_key(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::empty()))
+            .await;
+        assert_eq!(app.input_text(), "");
+        assert!(!app.history_search_view().unwrap().matched);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn esc_cancels_reverse_search_and_restores_draft() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+        app.history.record("some old prompt");
+
+        // Type a draft, then search, then cancel — the draft must come back.
+        for ch in ['d', 'r', 'a', 'f', 't'] {
+            app.handle_key(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::empty()))
+                .await;
+        }
+        app.handle_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL))
+            .await;
+        assert_eq!(app.input_text(), "some old prompt");
+        app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
+            .await;
+        assert!(app.history_search.is_none());
+        assert_eq!(app.input_text(), "draft");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ctrl_r_with_empty_history_is_a_no_op() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+        app.handle_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL))
+            .await;
+        assert!(app.history_search.is_none());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -30,6 +30,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget};
 use ratatui_textarea::{CursorMove, TextArea, WrapMode};
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, oneshot};
@@ -1302,6 +1303,16 @@ impl App {
     }
 
     fn suggestions(&self) -> Vec<CommandSuggestion> {
+        // `@`-triggered file-path completion takes over the suggestion row when
+        // the word being typed starts with `@`. Restricted to single-line input
+        // so completion can safely rebuild the whole line (matching how slash
+        // completion works).
+        if self.input.lines().len() == 1
+            && let Some(file) =
+                file_path_suggestions(self.suggestion_input(), &self.startup.workspace_root)
+        {
+            return file;
+        }
         command_suggestions(self.suggestion_input(), &self.startup.capability_commands)
     }
 
@@ -2263,6 +2274,82 @@ fn bang_command_suggestions(
     }]
 }
 
+/// Maximum `@file` completions surfaced at once.
+const FILE_SUGGESTION_LIMIT: usize = 12;
+
+/// File-path completions for an `@`-prefixed token in the composer, mirroring
+/// the Codex `@file` mention. Returns `None` when the word being typed is not an
+/// `@` mention (so command completion can take over). The returned `completion`
+/// rebuilds the whole single-line input with the mention replaced, matching how
+/// the Tab handler applies suggestions.
+fn file_path_suggestions(line: &str, workspace_root: &Path) -> Option<Vec<CommandSuggestion>> {
+    let (head, token) = split_trailing_token(line);
+    let path_prefix = token.strip_prefix('@')?;
+    let matches = list_path_completions(workspace_root, path_prefix, FILE_SUGGESTION_LIMIT);
+    if matches.is_empty() {
+        return None;
+    }
+    Some(
+        matches
+            .into_iter()
+            .map(|rel| CommandSuggestion {
+                completion: format!("{head}@{rel}"),
+                label: format!("@{rel}"),
+            })
+            .collect(),
+    )
+}
+
+/// Split a line into `(everything up to and including the last whitespace, last
+/// token)`. For `"explain @src/ma"` this yields `("explain ", "@src/ma")`.
+fn split_trailing_token(line: &str) -> (&str, &str) {
+    match line.rfind(char::is_whitespace) {
+        Some(idx) => line.split_at(idx + 1),
+        None => ("", line),
+    }
+}
+
+/// List workspace entries matching `prefix` (a path relative to the workspace
+/// root, `/`-separated). Directories get a trailing `/` so the user can keep
+/// descending. Hidden entries and `.git` are skipped unless explicitly typed.
+fn list_path_completions(workspace_root: &Path, prefix: &str, limit: usize) -> Vec<String> {
+    // Split the prefix into its directory part (already-typed dirs) and the
+    // final filename fragment we match against.
+    let (dir_part, frag) = match prefix.rfind('/') {
+        Some(idx) => (&prefix[..idx + 1], &prefix[idx + 1..]),
+        None => ("", prefix),
+    };
+    let scan_dir = workspace_root.join(dir_part);
+    let Ok(entries) = std::fs::read_dir(&scan_dir) else {
+        return Vec::new();
+    };
+    let want_hidden = frag.starts_with('.');
+    let mut names: Vec<String> = Vec::new();
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name == ".git" {
+            continue;
+        }
+        if name.starts_with('.') && !want_hidden {
+            continue;
+        }
+        if !name.starts_with(frag) {
+            continue;
+        }
+        let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+        let suffix = if is_dir { "/" } else { "" };
+        names.push(format!("{dir_part}{name}{suffix}"));
+    }
+    // Directories first, then files, each alphabetical — a predictable order.
+    names.sort_by(|a, b| {
+        let a_dir = a.ends_with('/');
+        let b_dir = b.ends_with('/');
+        b_dir.cmp(&a_dir).then_with(|| a.cmp(b))
+    });
+    names.truncate(limit);
+    names
+}
+
 fn capability_command_display_usage(descriptor: &CommandDescriptor) -> String {
     capability_command_usage_with_prefix(
         descriptor,
@@ -2285,7 +2372,7 @@ fn help_command_line(descriptor: &CommandDescriptor) -> String {
 
 fn help_shortcut_lines() -> [&'static str; 5] {
     [
-        "  Enter send · Shift-Enter newline · Tab complete · ↑/↓ history · Ctrl+R search",
+        "  Enter send · Shift-Enter newline · Tab complete (cmds, @files) · ↑/↓ history · Ctrl+R search",
         "  Ctrl+V paste image/text · Ctrl+B background tasks · !<cmd> shell alias",
         "  exit: Ctrl-C twice / Ctrl-D",
         "  cancel turn: Esc twice (while model is busy)",
@@ -2579,6 +2666,63 @@ mod tests {
 
         let suggestions = command_suggestions("/echo hello", &caps);
         assert!(suggestions.is_empty(), "got: {suggestions:?}");
+    }
+
+    #[test]
+    fn split_trailing_token_isolates_the_last_word() {
+        assert_eq!(
+            split_trailing_token("explain @src/ma"),
+            ("explain ", "@src/ma")
+        );
+        assert_eq!(split_trailing_token("@src"), ("", "@src"));
+        assert_eq!(split_trailing_token(""), ("", ""));
+    }
+
+    #[test]
+    fn list_path_completions_scopes_by_prefix_and_hides_dotfiles() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::create_dir(root.join("src")).unwrap();
+        std::fs::create_dir(root.join(".git")).unwrap();
+        std::fs::write(root.join("src/main.rs"), b"").unwrap();
+        std::fs::write(root.join("src/lib.rs"), b"").unwrap();
+        std::fs::write(root.join("README.md"), b"").unwrap();
+        std::fs::write(root.join(".env"), b"").unwrap();
+
+        // Bare prefix: directories first, dotfiles and .git hidden.
+        let top = list_path_completions(root, "", 12);
+        assert_eq!(top, vec!["src/".to_string(), "README.md".to_string()]);
+
+        // Into a directory.
+        let inside = list_path_completions(root, "src/", 12);
+        assert_eq!(
+            inside,
+            vec!["src/lib.rs".to_string(), "src/main.rs".to_string()]
+        );
+
+        // Filename fragment filters within a directory.
+        let filtered = list_path_completions(root, "src/ma", 12);
+        assert_eq!(filtered, vec!["src/main.rs".to_string()]);
+
+        // Explicitly typing a dot reveals dotfiles.
+        let dotted = list_path_completions(root, ".e", 12);
+        assert_eq!(dotted, vec![".env".to_string()]);
+    }
+
+    #[test]
+    fn file_path_suggestions_only_fire_on_at_mentions() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::write(root.join("hello.txt"), b"").unwrap();
+
+        assert!(file_path_suggestions("no mention here", root).is_none());
+
+        let suggestions =
+            file_path_suggestions("please read @hel", root).expect("mention suggestions");
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].label, "@hello.txt");
+        // The completion rebuilds the whole line with the mention replaced.
+        assert_eq!(suggestions[0].completion, "please read @hello.txt");
     }
 
     #[test]
@@ -5565,6 +5709,31 @@ mod tests {
         app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::empty()))
             .await;
         assert_eq!(app.input_text(), "/cwd");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn at_mention_completes_workspace_files() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+        let root = app.startup.workspace_root.clone();
+        std::fs::write(root.join("hello.txt"), b"hi").expect("write file");
+
+        // Type "@hel" — the suggestion row should offer the matching file.
+        for ch in ['@', 'h', 'e', 'l'] {
+            app.handle_key(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::empty()))
+                .await;
+        }
+        let suggestions = app.suggestions();
+        assert!(
+            suggestions.iter().any(|s| s.label == "@hello.txt"),
+            "expected @hello.txt among {suggestions:?}"
+        );
+
+        // Tab accepts the first suggestion, completing the mention in place.
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::empty()))
+            .await;
+        assert_eq!(app.input_text(), "@hello.txt");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -186,6 +186,9 @@ pub struct App {
     /// non-terminal hosts emit no escape sequences.
     term_progress: tuika::TerminalProgress,
     native_progress: bool,
+    /// Shell-style Up/Down recall of previously submitted composer prompts,
+    /// persisted across sessions. See [`crate::prompt_history`].
+    history: crate::prompt_history::PromptHistory,
 }
 
 /// The renderer backing a TUI session.
@@ -452,6 +455,13 @@ impl App {
             scroll_metrics: (0, 0),
             term_progress: tuika::TerminalProgress::new(),
             native_progress: false,
+            // Tests run in-memory so recall never reads or appends to the real
+            // per-user history file.
+            history: if cfg!(test) {
+                crate::prompt_history::PromptHistory::in_memory()
+            } else {
+                crate::prompt_history::PromptHistory::load()
+            },
         };
         app.emit_system_banner();
         if should_setup {
@@ -1036,10 +1046,70 @@ impl App {
                     let _ = self.input.input(key);
                 }
             }
+            KeyCode::Up if self.try_history_prev() => {}
+            KeyCode::Down if self.try_history_next() => {}
             _ => {
                 let _ = self.input.input(normalize_printable_key(key));
             }
         }
+    }
+
+    /// Whether pressing Up should recall an older prompt rather than move the
+    /// composer cursor. Recall only kicks in when the composer is empty, or when
+    /// an unmodified recalled entry is showing and the cursor sits on the first
+    /// line — so editing a multi-line prompt (or a fresh draft) never loses text
+    /// to an accidental recall. Mirrors Codex's line-boundary gating.
+    fn history_recall_prev_allowed(&self) -> bool {
+        let text = self.input_text();
+        if text.is_empty() {
+            return true;
+        }
+        match self.history.current_entry() {
+            Some(entry) if entry == text => self.input.cursor().0 == 0,
+            _ => false,
+        }
+    }
+
+    /// Handle Up as history recall. Returns `true` when the key was consumed
+    /// (recall began, moved, or is parked at the oldest entry), `false` to let
+    /// the textarea move the cursor normally.
+    fn try_history_prev(&mut self) -> bool {
+        if !self.history_recall_prev_allowed() {
+            return false;
+        }
+        let current = self.input_text();
+        if let Some(entry) = self.history.navigate_up(&current) {
+            self.set_input_text(entry);
+            true
+        } else {
+            // No entries at all → let the textarea handle Up. Already browsing at
+            // the oldest entry → swallow the key so it doesn't move the cursor.
+            self.history.is_browsing()
+        }
+    }
+
+    /// Handle Down as history recall. Only active while browsing an unmodified
+    /// recalled entry with the cursor on the last line; otherwise the textarea
+    /// moves the cursor.
+    fn try_history_next(&mut self) -> bool {
+        if !self.history.is_browsing() {
+            return false;
+        }
+        let current = self.input_text();
+        match self.history.current_entry() {
+            Some(entry) if entry == current => {
+                let last_row = self.input.lines().len().saturating_sub(1);
+                if self.input.cursor().0 != last_row {
+                    return false;
+                }
+            }
+            // The user edited the recalled entry; treat Down as normal movement.
+            _ => return false,
+        }
+        if let Some(text) = self.history.navigate_down(&current) {
+            self.set_input_text(text);
+        }
+        true
     }
 
     fn suggestions(&self) -> Vec<CommandSuggestion> {
@@ -1182,6 +1252,10 @@ impl App {
         self.reset_input();
         let text = expanded.trim().to_string();
         let display_text = raw.trim().to_string();
+        // Record what the user typed (including slash/bang commands) for
+        // shell-style Up/Down recall. Uses the pre-expansion display text so
+        // paste placeholders recall as the user saw them.
+        self.history.record(&display_text);
         if let Some(command) = parse_bang_shell_command(&text) {
             if command.is_empty() {
                 self.push_system("usage: !<command>".into());
@@ -2013,7 +2087,7 @@ fn help_command_line(descriptor: &CommandDescriptor) -> String {
 
 fn help_shortcut_lines() -> [&'static str; 5] {
     [
-        "  Enter send · Shift-Enter newline · Tab complete slash command · ←/→ edit",
+        "  Enter send · Shift-Enter newline · Tab complete · ←/→ edit · ↑/↓ history",
         "  Ctrl+V paste image/text · Ctrl+B background tasks · !<cmd> shell alias",
         "  exit: Ctrl-C twice / Ctrl-D",
         "  cancel turn: Esc twice (while model is busy)",
@@ -5174,6 +5248,73 @@ mod tests {
             "Shift-Enter should edit the composer, not submit: {:?}",
             app.lines
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn up_down_recall_previous_prompts() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+        app.history.record("first");
+        app.history.record("second");
+
+        let up = || KeyEvent::new(KeyCode::Up, KeyModifiers::empty());
+        let down = || KeyEvent::new(KeyCode::Down, KeyModifiers::empty());
+
+        // Up from an empty composer recalls newest-first.
+        app.handle_key(up()).await;
+        assert_eq!(app.input_text(), "second");
+        app.handle_key(up()).await;
+        assert_eq!(app.input_text(), "first");
+        // Already at the oldest entry: Up holds instead of clearing.
+        app.handle_key(up()).await;
+        assert_eq!(app.input_text(), "first");
+
+        // Down walks back toward newer, then restores the (empty) draft.
+        app.handle_key(down()).await;
+        assert_eq!(app.input_text(), "second");
+        app.handle_key(down()).await;
+        assert_eq!(app.input_text(), "");
+        assert!(!app.history.is_browsing());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn up_does_not_recall_over_an_unsent_draft() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+        app.history.record("old prompt");
+
+        // A non-empty, freshly-typed draft must not be clobbered by recall.
+        for ch in ['h', 'i'] {
+            app.handle_key(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::empty()))
+                .await;
+        }
+        app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::empty()))
+            .await;
+        assert_eq!(app.input_text(), "hi");
+        assert!(!app.history.is_browsing());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submitting_a_prompt_records_it_for_recall() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+
+        // `/cwd` is a client command: it records into history but starts no turn,
+        // so the app stays idle and recall stays reachable.
+        for ch in ['/', 'c', 'w', 'd'] {
+            app.handle_key(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::empty()))
+                .await;
+        }
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()))
+            .await;
+
+        assert_eq!(app.input_text(), "");
+        app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::empty()))
+            .await;
+        assert_eq!(app.input_text(), "/cwd");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -38,6 +38,7 @@ mod fullscreen;
 mod markdown_table;
 mod render;
 mod setup;
+mod syntax;
 mod viewport;
 
 // Re-export the moved free items so the rest of the crate (and the test module)
@@ -2483,6 +2484,37 @@ mod tests {
 
         assert!(rendered.starts_with("Tab /help"));
         assert!(rendered.ends_with('…'));
+    }
+
+    #[test]
+    fn code_fence_gets_language_aware_highlighting() {
+        let mut lines: Vec<Line> = Vec::new();
+        append_markdown_lines(
+            &mut lines,
+            "",
+            Style::default(),
+            "```rust\nfn demo() {}\n```",
+            80,
+        );
+        let text: String = lines
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .map(|span| span.content.as_ref())
+            .collect();
+        assert!(
+            text.contains("fn demo() {}"),
+            "code content should render: {text:?}"
+        );
+        // Tree-sitter highlighting must color at least one token gold (keyword),
+        // proving the language-aware path ran rather than the flat fallback.
+        let has_keyword_color = lines
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .any(|span| span.style.fg == Some(ACCENT_GOLD));
+        assert!(
+            has_keyword_color,
+            "rust fence should be syntax-highlighted: {lines:?}"
+        );
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -197,6 +197,9 @@ pub struct App {
     /// When the active turn began, for the live elapsed timer on the busy
     /// indicator. `None` while idle.
     turn_started_at: Option<Instant>,
+    /// Prompt tokens the most recent LLM generation consumed — the current fill
+    /// of the model's context window. `None` until the first generation.
+    context_used_tokens: Option<u32>,
 }
 
 /// In-progress Ctrl+R reverse search over [`App::history`].
@@ -493,6 +496,7 @@ impl App {
             },
             history_search: None,
             turn_started_at: None,
+            context_used_tokens: None,
         };
         app.emit_system_banner();
         if should_setup {
@@ -555,6 +559,16 @@ impl App {
         }
     }
 
+    /// The active model's context-window size in tokens, from its static
+    /// profile. `None` for models without a profile (e.g. the `llmsim` sim), in
+    /// which case no context gauge is shown.
+    fn context_window_tokens(&self) -> Option<u32> {
+        let driver =
+            crate::runtime::Provider::from_name(&self.model.provider_name())?.driver_id()?;
+        let profile = everruns_core::get_model_profile(&driver, &self.model.model_id())?;
+        u32::try_from(profile.limits?.context).ok()
+    }
+
     pub(crate) fn presentation_state(&self) -> PresentationState {
         PresentationState {
             stream_preview: self.stream_preview.clone(),
@@ -567,6 +581,8 @@ impl App {
             lines_count: self.lines.len(),
             session_tokens: self.session_tokens,
             turn_elapsed_secs: self.turn_started_at.map(|start| start.elapsed().as_secs()),
+            context_used_tokens: self.context_used_tokens,
+            context_window_tokens: self.context_window_tokens(),
             status_layout: self.status_layout,
             hooks_summary: self.startup.hook_summary(),
             approval_mode: self
@@ -809,6 +825,10 @@ impl App {
                 Ok(TurnEvent::Tokens(tokens)) => {
                     self.session_tokens =
                         Some(self.session_tokens.unwrap_or(0).saturating_add(tokens));
+                    return Ok(());
+                }
+                Ok(TurnEvent::ContextUsed(used)) => {
+                    self.context_used_tokens = Some(used);
                     return Ok(());
                 }
                 Ok(TurnEvent::Done) => {
@@ -3981,6 +4001,8 @@ mod tests {
             lines_count: 3,
             session_tokens: None,
             turn_elapsed_secs: None,
+            context_used_tokens: None,
+            context_window_tokens: None,
             status_layout: StatusLayout::Compact,
             hooks_summary: "none".to_string(),
             approval_mode: "normal".to_string(),
@@ -4395,6 +4417,9 @@ mod tests {
                         Ok(TurnEvent::Tokens(tokens)) => {
                             self.session_tokens =
                                 Some(self.session_tokens.unwrap_or(0).saturating_add(tokens));
+                        }
+                        Ok(TurnEvent::ContextUsed(used)) => {
+                            self.context_used_tokens = Some(used);
                         }
                         Ok(TurnEvent::Done) => {
                             self.finish_busy();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -5779,6 +5779,43 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fullscreen_renders_at_mention_suggestions() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+        app.set_render_mode(RenderMode::Fullscreen);
+        let root = app.startup.workspace_root.clone();
+        std::fs::write(root.join("hello.txt"), b"hi").expect("write file");
+
+        for ch in ['@', 'h', 'e', 'l'] {
+            app.handle_key(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::empty()))
+                .await;
+        }
+        let rows = render_app_lines(app, 100, 24);
+        assert!(
+            rows.iter().any(|row| row.contains("@hello.txt")),
+            "fullscreen should render the @file hint row: {rows:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fullscreen_renders_reverse_search_prompt() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+        app.set_render_mode(RenderMode::Fullscreen);
+        app.history.record("deploy prod");
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL))
+            .await;
+        let rows = render_app_lines(app, 100, 24);
+        assert!(
+            rows.iter().any(|row| row.contains("reverse-search")),
+            "fullscreen should render the Ctrl+R search prompt: {rows:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn at_mention_completes_workspace_files() {
         let mut fixture = app_with_llmsim().await;
         let app = &mut fixture.app;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -193,6 +193,9 @@ pub struct App {
     /// Active Ctrl+R reverse-history search, if any. While set it owns the
     /// keyboard and the composer previews the current match.
     history_search: Option<HistorySearch>,
+    /// When the active turn began, for the live elapsed timer on the busy
+    /// indicator. `None` while idle.
+    turn_started_at: Option<Instant>,
 }
 
 /// In-progress Ctrl+R reverse search over [`App::history`].
@@ -488,6 +491,7 @@ impl App {
                 crate::prompt_history::PromptHistory::load()
             },
             history_search: None,
+            turn_started_at: None,
         };
         app.emit_system_banner();
         if should_setup {
@@ -561,6 +565,7 @@ impl App {
             session_id: self.session.session_id().to_string(),
             lines_count: self.lines.len(),
             session_tokens: self.session_tokens,
+            turn_elapsed_secs: self.turn_started_at.map(|start| start.elapsed().as_secs()),
             status_layout: self.status_layout,
             hooks_summary: self.startup.hook_summary(),
             approval_mode: self
@@ -1944,6 +1949,7 @@ impl App {
         self.busy = false;
         self.busy_frame = 0;
         self.turn_activity = None;
+        self.turn_started_at = None;
         self.stream_preview = None;
         self.rx = None;
         self.turn_cancel = None;
@@ -2127,6 +2133,7 @@ impl App {
         self.esc_pending_cancel = false;
         self.busy = true;
         self.turn_activity = activity;
+        self.turn_started_at = Some(Instant::now());
         self.stream_preview = None;
         if self.native_progress {
             // Turn length is unknown, so show the terminal's busy/indeterminate
@@ -3787,6 +3794,7 @@ mod tests {
             session_id: SessionId::from_seed(770001).to_string(),
             lines_count: 3,
             session_tokens: None,
+            turn_elapsed_secs: None,
             status_layout: StatusLayout::Compact,
             hooks_summary: "none".to_string(),
             approval_mode: "normal".to_string(),
@@ -6728,6 +6736,33 @@ mod tests {
             "busy separator should signal input is disabled: {}",
             rows[0]
         );
+    }
+
+    #[test]
+    fn chrome_busy_shows_live_elapsed_timer() {
+        let state = ViewState {
+            presentation: PresentationState {
+                busy: true,
+                turn_activity: Some("reading files".to_string()),
+                turn_elapsed_secs: Some(75),
+                ..presentation_state_idle()
+            },
+            busy_frame: 4,
+            ..view_state_idle()
+        };
+        let rows = render_chrome_lines(&state, 80, 4);
+        assert!(
+            rows[0].contains("1m15s"),
+            "busy separator should show the elapsed timer: {}",
+            rows[0]
+        );
+    }
+
+    #[test]
+    fn format_elapsed_is_compact() {
+        assert_eq!(format_elapsed(8), "8s");
+        assert_eq!(format_elapsed(75), "1m15s");
+        assert_eq!(format_elapsed(3725), "1h02m");
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2612,6 +2612,48 @@ mod tests {
     }
 
     #[test]
+    fn linkify_styles_urls_and_trims_trailing_punctuation() {
+        let spans = linkify("see https://example.com/docs, then stop");
+        let url = spans
+            .iter()
+            .find(|s| s.content.as_ref() == "https://example.com/docs")
+            .expect("url span present");
+        assert_eq!(url.style.fg, Some(ACCENT_BLUE));
+        assert!(url.style.add_modifier.contains(Modifier::UNDERLINED));
+        // The trailing comma stays as plain text, not part of the link.
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(text, "see https://example.com/docs, then stop");
+    }
+
+    #[test]
+    fn linkify_leaves_plain_text_untouched() {
+        let spans = linkify("no links here");
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].style.fg, None);
+        assert_eq!(spans[0].content.as_ref(), "no links here");
+    }
+
+    #[test]
+    fn transcript_paragraph_links_urls() {
+        let mut lines: Vec<Line> = Vec::new();
+        append_markdown_lines(
+            &mut lines,
+            "",
+            Style::default(),
+            "Visit https://rust-lang.org for docs",
+            120,
+        );
+        let has_link = lines.iter().flat_map(|line| line.spans.iter()).any(|span| {
+            span.content.as_ref() == "https://rust-lang.org"
+                && span.style.add_modifier.contains(Modifier::UNDERLINED)
+        });
+        assert!(
+            has_link,
+            "paragraph URL should be styled as a link: {lines:?}"
+        );
+    }
+
+    #[test]
     fn history_search_preview_line_shows_query_and_no_match_flag() {
         let matched = HistorySearchView {
             query: "deploy".to_string(),

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -4,6 +4,7 @@
 //! mutation lives elsewhere.
 
 use super::*;
+use std::collections::HashMap;
 
 // Color presentation for the transcript view-model types defined in
 // `crate::transcript`. Labels and status semantics live in `crate::presentation`
@@ -1252,6 +1253,48 @@ pub(crate) fn diff_line_style(line: &str) -> Style {
     Style::default().fg(color)
 }
 
+/// Parse each fenced code block as a whole and return per-source-line highlight
+/// spans, keyed by line index. Only lines inside a block whose language we
+/// support get an entry; everything else is absent and rendered by the
+/// lightweight fallback highlighter. The stored spans are over each line's
+/// `trim_end`ed text so they line up with the render loop's `trimmed`.
+fn precompute_code_highlights(source_lines: &[&str]) -> HashMap<usize, Vec<Span<'static>>> {
+    let mut map = HashMap::new();
+    let mut index = 0;
+    while index < source_lines.len() {
+        let trimmed = source_lines[index].trim_end();
+        let Some(info) = trimmed.trim_start().strip_prefix("```") else {
+            index += 1;
+            continue;
+        };
+        // Opening fence: collect the block body up to the closing fence (or EOF).
+        let lang = info.trim();
+        let body_start = index + 1;
+        let mut body_end = body_start;
+        while body_end < source_lines.len()
+            && !source_lines[body_end].trim_start().starts_with("```")
+        {
+            body_end += 1;
+        }
+        let body: Vec<&str> = source_lines[body_start..body_end]
+            .iter()
+            .map(|line| line.trim_end())
+            .collect();
+        if let Some(highlighted) = super::syntax::highlight_lines(lang, &body) {
+            for (offset, spans) in highlighted.into_iter().enumerate() {
+                map.insert(body_start + offset, spans);
+            }
+        }
+        // Resume after the closing fence (or at EOF when unterminated).
+        index = if body_end < source_lines.len() {
+            body_end + 1
+        } else {
+            body_end
+        };
+    }
+    map
+}
+
 pub(crate) fn append_markdown_lines<'a>(
     lines: &mut Vec<Line<'a>>,
     first_prefix: &str,
@@ -1266,6 +1309,10 @@ pub(crate) fn append_markdown_lines<'a>(
     let mut first = true;
     let mut in_code = false;
     let source_lines = text.lines().collect::<Vec<_>>();
+    // Language-aware highlights for fenced blocks, keyed by source-line index.
+    // Whole blocks are parsed at once (tree-sitter needs full context); lines
+    // without an entry fall back to the lightweight keyword highlighter.
+    let code_highlights = precompute_code_highlights(&source_lines);
     let mut index = 0;
 
     while index < source_lines.len() {
@@ -1316,7 +1363,10 @@ pub(crate) fn append_markdown_lines<'a>(
         }
 
         let content_spans = if in_code {
-            markdown_code_spans(trimmed)
+            code_highlights
+                .get(&index)
+                .cloned()
+                .unwrap_or_else(|| markdown_code_spans(trimmed))
         } else {
             markdown_text_spans(trimmed)
         };

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1768,7 +1768,11 @@ pub(crate) fn draw_input_cursor(f: &mut ratatui::Frame, area: Rect, app: &App) {
 
 pub(crate) fn message_separator_title(state: &ViewState) -> Line<'static> {
     if let Some(activity) = state.presentation.activity_text() {
-        return thinking_title(state.busy_frame, activity);
+        return thinking_title(
+            state.busy_frame,
+            activity,
+            state.presentation.turn_elapsed_secs,
+        );
     }
     Line::from(vec![
         Span::styled("─── ", Style::default().fg(ACCENT_BLUE)),
@@ -1783,19 +1787,44 @@ pub(crate) fn newline_shortcut_hint() -> &'static str {
     "Shift-Enter"
 }
 
-pub(crate) fn thinking_title(frame: u64, activity: &str) -> Line<'static> {
+pub(crate) fn thinking_title(
+    frame: u64,
+    activity: &str,
+    elapsed_secs: Option<u64>,
+) -> Line<'static> {
     const SPINNER: [&str; 4] = ["-", "\\", "|", "/"];
     let spinner = SPINNER[((frame / 2) as usize) % SPINNER.len()];
     let text = format!("{activity}...");
     let text_style = Style::default().fg(TEXT_MUTED).add_modifier(Modifier::BOLD);
-    let spans = vec![
+    let mut spans = vec![
         Span::styled("─── ", Style::default().fg(ACCENT_BLUE)),
         Span::styled(spinner.to_string(), Style::default().fg(ACCENT_GOLD)),
         Span::raw(" "),
         Span::styled(text, text_style),
-        Span::styled(" (input disabled) ", Style::default().fg(TEXT_DIM)),
     ];
+    // Live elapsed timer, like Codex's working indicator.
+    if let Some(secs) = elapsed_secs {
+        spans.push(Span::styled(
+            format!(" {}", format_elapsed(secs)),
+            Style::default().fg(TEXT_DIM),
+        ));
+    }
+    spans.push(Span::styled(
+        " (input disabled) ",
+        Style::default().fg(TEXT_DIM),
+    ));
     Line::from(spans)
+}
+
+/// Compact wall-clock formatting for the busy timer: `8s`, `1m03s`, `1h02m`.
+pub(crate) fn format_elapsed(secs: u64) -> String {
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3600 {
+        format!("{}m{:02}s", secs / 60, secs % 60)
+    } else {
+        format!("{}h{:02}m", secs / 3600, (secs % 3600) / 60)
+    }
 }
 
 pub(crate) fn draw_message_separator(f: &mut ratatui::Frame, area: Rect, state: &ViewState) {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -358,11 +358,15 @@ pub(crate) fn draw_chrome(
 }
 
 pub(crate) fn chrome_preview_visible(state: &ViewState) -> bool {
-    state.presentation.stream_preview.is_some() || !state.command_suggestions.is_empty()
+    state.history_search.is_some()
+        || state.presentation.stream_preview.is_some()
+        || !state.command_suggestions.is_empty()
 }
 
 pub(crate) fn draw_chrome_layout(f: &mut ratatui::Frame, layout: ChromeLayout, state: &ViewState) {
-    if state.command_suggestions.is_empty() {
+    if let Some(search) = &state.history_search {
+        draw_history_search(f, layout.preview, search);
+    } else if state.command_suggestions.is_empty() {
         draw_stream_preview(f, layout.preview, state);
     } else {
         draw_suggestions(f, layout.preview, &state.command_suggestions);
@@ -884,6 +888,45 @@ pub(crate) fn draw_suggestions(
         Paragraph::new(suggestion_preview_line(suggestions, area.width)),
         area,
     );
+}
+
+pub(crate) fn draw_history_search(f: &mut ratatui::Frame, area: Rect, search: &HistorySearchView) {
+    if area.height == 0 || area.width == 0 {
+        return;
+    }
+    f.render_widget(
+        Paragraph::new(history_search_preview_line(search, area.width)),
+        area,
+    );
+}
+
+/// The chrome row for an active reverse search: `(reverse-search)'query'` plus a
+/// `no match` marker when nothing matched. The matched entry itself previews in
+/// the composer below.
+pub(crate) fn history_search_preview_line(search: &HistorySearchView, width: u16) -> Line<'static> {
+    let prefix = "(reverse-search) ";
+    let query = format!("'{}'", search.query);
+    // Flag a non-empty query that matched nothing; a bare prompt stays quiet.
+    let suffix = if !search.matched && !search.query.is_empty() {
+        "  no match".to_string()
+    } else {
+        String::new()
+    };
+    let budget = (width as usize).saturating_sub(prefix.chars().count() + 1);
+    let query = truncate_end_chars(&query, budget.max(4));
+    let mut spans = vec![
+        Span::styled(
+            prefix,
+            Style::default()
+                .fg(ACCENT_BLUE)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(query, Style::default().fg(TEXT_PRIMARY)),
+    ];
+    if !suffix.is_empty() {
+        spans.push(Span::styled(suffix, Style::default().fg(DIFF_DELETE)));
+    }
+    Line::from(spans)
 }
 
 pub(crate) fn suggestion_preview_line(

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1444,16 +1444,14 @@ pub(crate) fn markdown_text_spans(text: &str) -> Vec<Span<'static>> {
         .strip_prefix("- ")
         .or_else(|| trimmed.strip_prefix("* "))
     {
-        return vec![
-            Span::styled("- ", Style::default().fg(ACCENT_GOLD)),
-            Span::raw(rest.to_string()),
-        ];
+        let mut spans = vec![Span::styled("- ", Style::default().fg(ACCENT_GOLD))];
+        spans.extend(linkify(rest));
+        return spans;
     }
     if let Some((marker, rest)) = numbered_marker(trimmed) {
-        return vec![
-            Span::styled(marker, Style::default().fg(ACCENT_GOLD)),
-            Span::raw(rest.to_string()),
-        ];
+        let mut spans = vec![Span::styled(marker, Style::default().fg(ACCENT_GOLD))];
+        spans.extend(linkify(rest));
+        return spans;
     }
     inline_code_spans(text)
 }
@@ -1467,10 +1465,9 @@ pub(crate) fn markdown_code_spans(text: &str) -> Vec<Span<'static>> {
 pub(crate) fn inline_code_spans(text: &str) -> Vec<Span<'static>> {
     let mut spans = Vec::new();
     let mut rest = text;
-    let mut code = false;
     while let Some((before, after_tick)) = rest.split_once('`') {
         if !before.is_empty() {
-            spans.push(Span::raw(before.to_string()));
+            spans.extend(linkify(before));
         }
         if let Some((inside, after)) = after_tick.split_once('`') {
             spans.push(Span::styled(
@@ -1478,7 +1475,6 @@ pub(crate) fn inline_code_spans(text: &str) -> Vec<Span<'static>> {
                 Style::default().fg(TEXT_PRIMARY).bg(CODE_BG),
             ));
             rest = after;
-            code = true;
         } else {
             spans.push(Span::raw("`".to_string()));
             rest = after_tick;
@@ -1486,13 +1482,72 @@ pub(crate) fn inline_code_spans(text: &str) -> Vec<Span<'static>> {
         }
     }
     if !rest.is_empty() {
-        spans.push(Span::raw(rest.to_string()));
+        spans.extend(linkify(rest));
     }
-    if spans.is_empty() || !code {
+    if spans.is_empty() {
         vec![Span::raw(text.to_string())]
     } else {
         spans
     }
+}
+
+/// Split plain text into spans, styling any `http(s)://` URL as a link
+/// (accent + underline). ratatui 0.30 can't emit OSC 8 hyperlink escapes
+/// through its cell buffer, but styling the raw URL keeps it visually distinct
+/// and — because the literal URL stays in the terminal scrollback — modern
+/// emulators still auto-linkify it for click/⌘-click.
+pub(crate) fn linkify(text: &str) -> Vec<Span<'static>> {
+    if text.is_empty() {
+        return Vec::new();
+    }
+    let mut spans = Vec::new();
+    let mut rest = text;
+    while let Some(start) = next_url_start(rest) {
+        let (before, from) = rest.split_at(start);
+        if !before.is_empty() {
+            spans.push(Span::raw(before.to_string()));
+        }
+        let end = url_end(from);
+        let (url, after) = from.split_at(end);
+        spans.push(Span::styled(
+            url.to_string(),
+            Style::default()
+                .fg(ACCENT_BLUE)
+                .add_modifier(Modifier::UNDERLINED),
+        ));
+        rest = after;
+    }
+    if !rest.is_empty() {
+        spans.push(Span::raw(rest.to_string()));
+    }
+    if spans.is_empty() {
+        spans.push(Span::raw(text.to_string()));
+    }
+    spans
+}
+
+/// Byte offset of the next `http://` or `https://` in `s`, if any.
+fn next_url_start(s: &str) -> Option<usize> {
+    match (s.find("https://"), s.find("http://")) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (Some(a), None) => Some(a),
+        (None, b) => b,
+    }
+}
+
+/// Byte length of the URL at the start of `from`: up to the next whitespace,
+/// with trailing sentence punctuation trimmed so `(see https://x.dev).` links
+/// just the URL.
+fn url_end(from: &str) -> usize {
+    let raw_end = from.find(char::is_whitespace).unwrap_or(from.len());
+    from[..raw_end]
+        .trim_end_matches(|c| {
+            matches!(
+                c,
+                '.' | ',' | ';' | ':' | '!' | '?' | ')' | ']' | '}' | '\'' | '"'
+            )
+        })
+        .len()
 }
 
 pub(crate) fn simple_code_highlight(text: &str) -> Vec<Span<'static>> {

--- a/src/app/syntax.rs
+++ b/src/app/syntax.rs
@@ -1,0 +1,297 @@
+//! Language-aware syntax highlighting for fenced code blocks, using the
+//! tree-sitter grammars yolop already bundles (the same ones `repo_map` and
+//! `ast_grep` parse with) plus `tree-sitter-highlight`.
+//!
+//! [`highlight_lines`] takes a fence's language tag and its body lines and
+//! returns per-line styled spans, or `None` when the language is unsupported or
+//! the source fails to parse — in which case the caller falls back to the
+//! lightweight keyword highlighter. Highlight configurations are built once per
+//! language and cached on the rendering thread.
+
+use super::{ACCENT_BLUE, ACCENT_GOLD, DIFF_ADD, TEXT_DIM, TEXT_MUTED, TEXT_PRIMARY};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::Span;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+use tree_sitter_highlight::{Highlight, HighlightConfiguration, HighlightEvent, Highlighter};
+
+/// Muted teal for type names; amber for numbers/constants. Chosen to sit
+/// alongside the existing accent palette without shouting.
+const SYNTAX_TYPE: Color = Color::Rgb(126, 170, 176);
+const SYNTAX_CONST: Color = Color::Rgb(184, 152, 120);
+
+/// Highlight capture names we recognize, longest-specific first so
+/// tree-sitter-highlight resolves the most precise style. Kept in sync with
+/// [`style_for_name`].
+const HIGHLIGHT_NAMES: &[&str] = &[
+    "keyword",
+    "function.builtin",
+    "function.method",
+    "function",
+    "constructor",
+    "type.builtin",
+    "type",
+    "constant.builtin",
+    "constant.numeric",
+    "constant",
+    "number",
+    "string.special",
+    "string",
+    "escape",
+    "comment",
+    "operator",
+    "punctuation.bracket",
+    "punctuation.delimiter",
+    "punctuation.special",
+    "punctuation",
+    "property",
+    "attribute",
+    "tag",
+    "label",
+    "variable.builtin",
+    "variable.parameter",
+    "variable",
+];
+
+fn style_for_name(name: &str) -> Style {
+    let base = Style::default();
+    match name {
+        "keyword" => base.fg(ACCENT_GOLD).add_modifier(Modifier::BOLD),
+        "function" | "function.builtin" | "function.method" | "constructor" | "label" => {
+            base.fg(ACCENT_BLUE)
+        }
+        "type" | "type.builtin" => base.fg(SYNTAX_TYPE),
+        "constant" | "constant.builtin" | "constant.numeric" | "number" | "variable.builtin" => {
+            base.fg(SYNTAX_CONST)
+        }
+        "string" | "string.special" | "escape" => base.fg(DIFF_ADD),
+        "comment" => base.fg(TEXT_MUTED).add_modifier(Modifier::ITALIC),
+        "operator"
+        | "punctuation"
+        | "punctuation.bracket"
+        | "punctuation.delimiter"
+        | "punctuation.special" => base.fg(TEXT_DIM),
+        "attribute" | "tag" => base.fg(ACCENT_GOLD),
+        _ => base.fg(TEXT_PRIMARY),
+    }
+}
+
+fn default_style() -> Style {
+    Style::default().fg(TEXT_PRIMARY)
+}
+
+/// Map a fence info string (e.g. `rust`, `py`, `ts`, `c#`) to the canonical
+/// grammar key, or `None` when we don't highlight that language.
+fn canonical_language(lang: &str) -> Option<&'static str> {
+    let lang = lang.trim().to_ascii_lowercase();
+    let key = match lang.as_str() {
+        "rust" | "rs" => "rust",
+        "python" | "py" => "python",
+        // The TypeScript grammar is a superset that parses plain JS cleanly.
+        "typescript" | "ts" | "javascript" | "js" | "mjs" | "cjs" => "typescript",
+        "tsx" | "jsx" => "tsx",
+        "go" | "golang" => "go",
+        "java" => "java",
+        "ruby" | "rb" => "ruby",
+        "css" => "css",
+        "html" | "htm" => "html",
+        "c#" | "cs" | "csharp" | "c_sharp" => "csharp",
+        "php" => "php",
+        "zig" => "zig",
+        "scala" => "scala",
+        "sql" => "sql",
+        _ => return None,
+    };
+    Some(key)
+}
+
+fn build_configuration(key: &str) -> Option<HighlightConfiguration> {
+    let (language, query): (tree_sitter::Language, &str) = match key {
+        "rust" => (
+            tree_sitter_rust::LANGUAGE.into(),
+            tree_sitter_rust::HIGHLIGHTS_QUERY,
+        ),
+        "python" => (
+            tree_sitter_python::LANGUAGE.into(),
+            tree_sitter_python::HIGHLIGHTS_QUERY,
+        ),
+        "typescript" => (
+            tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+            tree_sitter_typescript::HIGHLIGHTS_QUERY,
+        ),
+        "tsx" => (
+            tree_sitter_typescript::LANGUAGE_TSX.into(),
+            tree_sitter_typescript::HIGHLIGHTS_QUERY,
+        ),
+        "go" => (
+            tree_sitter_go::LANGUAGE.into(),
+            tree_sitter_go::HIGHLIGHTS_QUERY,
+        ),
+        "java" => (
+            tree_sitter_java::LANGUAGE.into(),
+            tree_sitter_java::HIGHLIGHTS_QUERY,
+        ),
+        "ruby" => (
+            tree_sitter_ruby::LANGUAGE.into(),
+            tree_sitter_ruby::HIGHLIGHTS_QUERY,
+        ),
+        "css" => (
+            tree_sitter_css::LANGUAGE.into(),
+            tree_sitter_css::HIGHLIGHTS_QUERY,
+        ),
+        "html" => (
+            tree_sitter_html::LANGUAGE.into(),
+            tree_sitter_html::HIGHLIGHTS_QUERY,
+        ),
+        "csharp" => (
+            tree_sitter_c_sharp::LANGUAGE.into(),
+            tree_sitter_c_sharp::HIGHLIGHTS_QUERY,
+        ),
+        "php" => (
+            tree_sitter_php::LANGUAGE_PHP.into(),
+            tree_sitter_php::HIGHLIGHTS_QUERY,
+        ),
+        "zig" => (
+            tree_sitter_zig::LANGUAGE.into(),
+            tree_sitter_zig::HIGHLIGHTS_QUERY,
+        ),
+        "scala" => (
+            tree_sitter_scala::LANGUAGE.into(),
+            tree_sitter_scala::HIGHLIGHTS_QUERY,
+        ),
+        "sql" => (
+            tree_sitter_sequel::LANGUAGE.into(),
+            tree_sitter_sequel::HIGHLIGHTS_QUERY,
+        ),
+        _ => return None,
+    };
+    let mut config = HighlightConfiguration::new(language, key, query, "", "").ok()?;
+    let names: Vec<String> = HIGHLIGHT_NAMES.iter().map(|n| n.to_string()).collect();
+    config.configure(&names);
+    Some(config)
+}
+
+thread_local! {
+    /// Per-language highlight configs, built on first use. `None` marks a
+    /// language whose config failed to build so we don't retry it every render.
+    static CONFIGS: RefCell<HashMap<&'static str, Option<Rc<HighlightConfiguration>>>> =
+        RefCell::new(HashMap::new());
+}
+
+fn config_for(key: &'static str) -> Option<Rc<HighlightConfiguration>> {
+    CONFIGS.with(|configs| {
+        configs
+            .borrow_mut()
+            .entry(key)
+            .or_insert_with(|| build_configuration(key).map(Rc::new))
+            .clone()
+    })
+}
+
+/// Highlight a fenced code block, returning one span vector per input line.
+/// Returns `None` for unsupported languages or on any parse failure so callers
+/// can fall back to the lightweight highlighter.
+pub(crate) fn highlight_lines(lang: &str, lines: &[&str]) -> Option<Vec<Vec<Span<'static>>>> {
+    if lines.is_empty() {
+        return None;
+    }
+    let key = canonical_language(lang)?;
+    let config = config_for(key)?;
+    let source = lines.join("\n");
+
+    let mut highlighter = Highlighter::new();
+    let events = highlighter
+        .highlight(&config, source.as_bytes(), None, |_| None)
+        .ok()?;
+
+    let mut style_stack: Vec<Style> = Vec::new();
+    let mut out: Vec<Vec<Span<'static>>> = vec![Vec::new()];
+    for event in events {
+        match event.ok()? {
+            HighlightEvent::HighlightStart(Highlight(index)) => {
+                let style = HIGHLIGHT_NAMES
+                    .get(index)
+                    .map(|name| style_for_name(name))
+                    .unwrap_or_else(default_style);
+                style_stack.push(style);
+            }
+            HighlightEvent::HighlightEnd => {
+                style_stack.pop();
+            }
+            HighlightEvent::Source { start, end } => {
+                let style = style_stack.last().copied().unwrap_or_else(default_style);
+                let text = source.get(start..end)?;
+                let mut segments = text.split('\n');
+                if let Some(first) = segments.next()
+                    && !first.is_empty()
+                {
+                    out.last_mut()?.push(Span::styled(first.to_string(), style));
+                }
+                for segment in segments {
+                    out.push(Vec::new());
+                    if !segment.is_empty() {
+                        out.last_mut()?
+                            .push(Span::styled(segment.to_string(), style));
+                    }
+                }
+            }
+        }
+    }
+
+    // The event stream must reproduce exactly one output line per source line;
+    // if it doesn't (unexpected), bail so the caller falls back deterministically.
+    if out.len() == lines.len() {
+        Some(out)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn plain(spans: &[Span<'static>]) -> String {
+        spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    #[test]
+    fn highlights_rust_keywords_distinctly() {
+        let lines = vec!["fn main() {", "    let x = 1;", "}"];
+        let out = highlight_lines("rust", &lines).expect("rust highlights");
+        assert_eq!(out.len(), 3);
+        // Each output line reconstructs its source exactly.
+        for (rendered, source) in out.iter().zip(lines.iter()) {
+            assert_eq!(&plain(rendered), source);
+        }
+        // `fn` is a keyword and must carry the keyword color, not the default.
+        let fn_span = out[0]
+            .iter()
+            .find(|s| s.content.as_ref() == "fn")
+            .expect("fn span present");
+        assert_eq!(fn_span.style.fg, Some(ACCENT_GOLD));
+    }
+
+    #[test]
+    fn aliases_resolve_and_js_uses_typescript_grammar() {
+        assert_eq!(canonical_language("py"), Some("python"));
+        assert_eq!(canonical_language("js"), Some("typescript"));
+        assert_eq!(canonical_language("c#"), Some("csharp"));
+        assert!(highlight_lines("js", &["const x = 1;"]).is_some());
+    }
+
+    #[test]
+    fn unsupported_language_returns_none() {
+        assert!(highlight_lines("brainfuck", &["+++"]).is_none());
+        assert_eq!(canonical_language("whatever"), None);
+    }
+
+    #[test]
+    fn blank_lines_inside_a_block_are_preserved() {
+        let lines = vec!["x = 1", "", "y = 2"];
+        let out = highlight_lines("python", &lines).expect("python highlights");
+        assert_eq!(out.len(), 3);
+        assert_eq!(plain(&out[1]), "");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ mod mcp_oauth_login;
 mod oauth_flow;
 mod paste_attachment;
 mod presentation;
+mod prompt_history;
 mod runtime;
 mod session;
 mod session_log;

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -31,6 +31,10 @@ pub(crate) struct PresentationState {
     /// Wall-clock seconds since the active turn began, or `None` when idle.
     /// Drives the live elapsed timer on the busy indicator.
     pub turn_elapsed_secs: Option<u64>,
+    /// Prompt tokens the most recent generation consumed (context-window fill).
+    pub context_used_tokens: Option<u32>,
+    /// The active model's context-window size, when known.
+    pub context_window_tokens: Option<u32>,
     pub status_layout: StatusLayout,
     pub hooks_summary: String,
     pub approval_mode: String,
@@ -150,6 +154,9 @@ fn expanded_status_lines(state: &PresentationState) -> Vec<StatusLine> {
         status_value(message_count_label(state.lines_count)),
         status_field("tokens", token_label(state.session_tokens)),
     ];
+    if let Some(ctx) = context_label(state.context_used_tokens, state.context_window_tokens) {
+        counts.push(status_field("ctx", ctx));
+    }
     if let Some(bg) = background_label(state.background, false) {
         counts.push(status_field("bg", bg));
     }
@@ -199,6 +206,9 @@ fn status_contributions(state: &PresentationState) -> Vec<Vec<StatusField>> {
         StatusLayout::Expanded => "[collapse ↑]",
     };
     let mut counts = vec![status_value(message_count_label(state.lines_count))];
+    if let Some(ctx) = context_label(state.context_used_tokens, state.context_window_tokens) {
+        counts.push(status_field("ctx", ctx));
+    }
     if let Some(bg) = background_label(state.background, true) {
         counts.push(status_field("bg", bg));
     }
@@ -295,6 +305,30 @@ fn message_count_label(count: usize) -> String {
     format!("{count} msgs")
 }
 
+/// Context-window fill as `pct% (used/total)`, e.g. `45% (90k/200k)`. `None`
+/// until we have both a usage sample and a known window size.
+pub(crate) fn context_label(used: Option<u32>, window: Option<u32>) -> Option<String> {
+    let (used, window) = (used?, window?);
+    if window == 0 {
+        return None;
+    }
+    let pct = ((u64::from(used) * 100) / u64::from(window)).min(100);
+    Some(format!(
+        "{pct}% ({}/{})",
+        compact_token_count(used),
+        compact_token_count(window)
+    ))
+}
+
+/// Render a token count compactly: `900`, `90k`, `1.2M`.
+fn compact_token_count(tokens: u32) -> String {
+    match tokens {
+        n if n < 1_000 => n.to_string(),
+        n if n < 1_000_000 => format!("{}k", n / 1_000),
+        n => format!("{:.1}M", n as f64 / 1_000_000.0),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -316,6 +350,8 @@ mod tests {
             lines_count: 3,
             session_tokens: Some(42),
             turn_elapsed_secs: None,
+            context_used_tokens: None,
+            context_window_tokens: None,
             status_layout: StatusLayout::Compact,
             hooks_summary: "none".to_string(),
             approval_mode: "normal".to_string(),
@@ -472,6 +508,47 @@ mod tests {
         assert!(values.contains(&(Some("approval"), "normal")));
         assert!(values.contains(&(Some("goal"), "—")));
         assert!(values.contains(&(None, "3 msgs")));
+    }
+
+    #[test]
+    fn context_label_formats_percentage_and_compact_counts() {
+        assert_eq!(
+            context_label(Some(90_000), Some(200_000)).as_deref(),
+            Some("45% (90k/200k)")
+        );
+        assert_eq!(
+            context_label(Some(1_500_000), Some(2_000_000)).as_deref(),
+            Some("75% (1.5M/2.0M)")
+        );
+        // Clamped to 100% and safe against a zero/absent window.
+        assert_eq!(
+            context_label(Some(300), Some(200)).as_deref(),
+            Some("100% (300/200)")
+        );
+        assert_eq!(context_label(Some(10), None), None);
+        assert_eq!(context_label(None, Some(200_000)), None);
+        assert_eq!(context_label(Some(10), Some(0)), None);
+    }
+
+    #[test]
+    fn status_shows_context_gauge_when_known() {
+        let model = PresentationState {
+            context_used_tokens: Some(50_000),
+            context_window_tokens: Some(200_000),
+            ..state()
+        };
+        let values = model
+            .status_lines()
+            .into_iter()
+            .flat_map(|line| line.fields)
+            .map(|field| (field.label, field.value))
+            .collect::<Vec<_>>();
+        assert!(
+            values
+                .iter()
+                .any(|(label, value)| *label == Some("ctx") && value == "25% (50k/200k)"),
+            "expected a ctx gauge in {values:?}"
+        );
     }
 
     #[test]

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -28,6 +28,9 @@ pub(crate) struct PresentationState {
     pub session_id: String,
     pub lines_count: usize,
     pub session_tokens: Option<u64>,
+    /// Wall-clock seconds since the active turn began, or `None` when idle.
+    /// Drives the live elapsed timer on the busy indicator.
+    pub turn_elapsed_secs: Option<u64>,
     pub status_layout: StatusLayout,
     pub hooks_summary: String,
     pub approval_mode: String,
@@ -312,6 +315,7 @@ mod tests {
             session_id: "sess_123".to_string(),
             lines_count: 3,
             session_tokens: Some(42),
+            turn_elapsed_secs: None,
             status_layout: StatusLayout::Compact,
             hooks_summary: "none".to_string(),
             approval_mode: "normal".to_string(),

--- a/src/prompt_history.rs
+++ b/src/prompt_history.rs
@@ -1,0 +1,281 @@
+//! Composer prompt history: shell-style Up/Down recall of previously submitted
+//! prompts, mirroring the chat-composer history in OpenAI's Codex CLI.
+//!
+//! Entries persist across sessions in a JSONL file under the platform data dir
+//! (next to the session logs), so recall survives restarts. The file is a
+//! plain append log of `{"text": "..."}` lines; on startup we read the tail and
+//! keep the most recent [`MAX_ENTRIES`]. Persistence is best-effort — any I/O
+//! error degrades to in-memory-only history rather than surfacing to the user,
+//! because losing composer recall must never block a turn.
+//!
+//! Navigation model (matches Codex): a single cursor walks the entry list from
+//! newest to oldest. The in-progress draft is saved when browsing begins and
+//! restored when the user pages back past the newest entry. The host gates when
+//! Up/Down recall (vs. move the cursor within a multi-line composer) — see
+//! `App::try_history_prev`/`try_history_next`.
+
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+
+/// Keep recall bounded so a long-lived history file never grows without limit
+/// or slows startup. The newest entries are the ones worth recalling.
+const MAX_ENTRIES: usize = 1000;
+
+/// Recall store for previously submitted composer prompts.
+pub(crate) struct PromptHistory {
+    /// Submitted prompts, oldest first, with consecutive duplicates collapsed.
+    entries: Vec<String>,
+    /// Index into `entries` currently being viewed, or `None` when not browsing.
+    cursor: Option<usize>,
+    /// The composer text captured when browsing began, restored on page-past.
+    draft: Option<String>,
+    /// Persistence target; `None` disables the append log (tests, or when the
+    /// platform data dir can't be resolved).
+    path: Option<PathBuf>,
+}
+
+impl PromptHistory {
+    /// In-memory-only history (no persistence). Used by tests and any host
+    /// without a resolvable data dir.
+    pub(crate) fn in_memory() -> Self {
+        Self {
+            entries: Vec::new(),
+            cursor: None,
+            draft: None,
+            path: None,
+        }
+    }
+
+    /// Load persisted history from the default data-dir path, seeding recall
+    /// with prior sessions' prompts. Falls back to in-memory-only if the path
+    /// can't be resolved or read.
+    pub(crate) fn load() -> Self {
+        let Some(path) = default_history_path() else {
+            return Self::in_memory();
+        };
+        let mut entries = read_entries(&path);
+        // Trim to the most recent MAX_ENTRIES; older lines stay on disk but are
+        // not loaded into recall.
+        if entries.len() > MAX_ENTRIES {
+            entries.drain(0..entries.len() - MAX_ENTRIES);
+        }
+        Self {
+            entries,
+            cursor: None,
+            draft: None,
+            path: Some(path),
+        }
+    }
+
+    /// Record a submitted prompt. Empty text and consecutive duplicates are
+    /// ignored (recalling the same line twice is noise). Resets any in-progress
+    /// browse so the next Up starts from the newest entry. Appends to the
+    /// persistence log on a best-effort basis.
+    pub(crate) fn record(&mut self, text: &str) {
+        self.reset_navigation();
+        let text = text.trim();
+        if text.is_empty() {
+            return;
+        }
+        if self.entries.last().map(String::as_str) == Some(text) {
+            return;
+        }
+        self.entries.push(text.to_string());
+        if self.entries.len() > MAX_ENTRIES {
+            self.entries.remove(0);
+        }
+        self.append_to_log(text);
+    }
+
+    /// Abandon any in-progress browse without touching the composer. Called on
+    /// submit so a fresh Up begins from the newest entry.
+    pub(crate) fn reset_navigation(&mut self) {
+        self.cursor = None;
+        self.draft = None;
+    }
+
+    /// Whether a browse is currently in progress (cursor parked on an entry).
+    pub(crate) fn is_browsing(&self) -> bool {
+        self.cursor.is_some()
+    }
+
+    /// The entry currently being viewed, if browsing. The host compares this to
+    /// the live composer text to tell an unmodified recall from a user edit.
+    pub(crate) fn current_entry(&self) -> Option<&str> {
+        self.cursor.map(|i| self.entries[i].as_str())
+    }
+
+    /// Move to the previous (older) entry, saving `current` as the draft on the
+    /// first step. Returns the entry to place in the composer, or `None` when
+    /// there is nothing older (history empty, or already at the oldest entry).
+    pub(crate) fn navigate_up(&mut self, current: &str) -> Option<String> {
+        match self.cursor {
+            None => {
+                let last = self.entries.len().checked_sub(1)?;
+                self.draft = Some(current.to_string());
+                self.cursor = Some(last);
+                Some(self.entries[last].clone())
+            }
+            Some(0) => None,
+            Some(i) => {
+                self.cursor = Some(i - 1);
+                Some(self.entries[i - 1].clone())
+            }
+        }
+    }
+
+    /// Move to the next (newer) entry. Paging past the newest entry ends the
+    /// browse and restores the saved draft. Returns the text to place in the
+    /// composer, or `None` when not browsing.
+    pub(crate) fn navigate_down(&mut self, _current: &str) -> Option<String> {
+        let i = self.cursor?;
+        if i + 1 < self.entries.len() {
+            self.cursor = Some(i + 1);
+            Some(self.entries[i + 1].clone())
+        } else {
+            self.cursor = None;
+            Some(self.draft.take().unwrap_or_default())
+        }
+    }
+
+    fn append_to_log(&self, text: &str) {
+        let Some(path) = &self.path else {
+            return;
+        };
+        // Best-effort: create the parent dir and append one JSON line. Any error
+        // is swallowed — recall still works for the rest of this session.
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let line = serde_json::json!({ "text": text }).to_string();
+        if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
+            let _ = writeln!(file, "{line}");
+        }
+    }
+}
+
+/// Default persistence path: `<data_dir>/yolop/prompt_history.jsonl`, alongside
+/// the per-session logs. Mirrors [`crate::session_log::default_sessions_dir`]'s
+/// use of the platform data dir.
+fn default_history_path() -> Option<PathBuf> {
+    dirs::data_dir().map(|p| p.join("yolop").join("prompt_history.jsonl"))
+}
+
+/// Read `{"text": "..."}` lines from the log, skipping blank or malformed lines.
+fn read_entries(path: &PathBuf) -> Vec<String> {
+    let Ok(file) = File::open(path) else {
+        return Vec::new();
+    };
+    let mut entries = Vec::new();
+    for line in BufReader::new(file).lines().map_while(Result::ok) {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Ok(serde_json::Value::Object(obj)) = serde_json::from_str::<serde_json::Value>(line)
+            && let Some(serde_json::Value::String(text)) = obj.get("text")
+            && !text.is_empty()
+        {
+            entries.push(text.clone());
+        }
+    }
+    entries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn seeded(entries: &[&str]) -> PromptHistory {
+        let mut h = PromptHistory::in_memory();
+        for e in entries {
+            h.record(e);
+        }
+        h
+    }
+
+    #[test]
+    fn record_skips_empty_and_consecutive_duplicates() {
+        let mut h = PromptHistory::in_memory();
+        h.record("hello");
+        h.record("hello"); // dup
+        h.record("   "); // blank
+        h.record("world");
+        h.record("hello"); // non-consecutive dup is kept
+        assert_eq!(h.entries, vec!["hello", "world", "hello"]);
+    }
+
+    #[test]
+    fn record_trims_surrounding_whitespace() {
+        let mut h = PromptHistory::in_memory();
+        h.record("  spaced  ");
+        assert_eq!(h.entries, vec!["spaced"]);
+    }
+
+    #[test]
+    fn up_walks_from_newest_to_oldest_then_stops() {
+        let mut h = seeded(&["one", "two", "three"]);
+        assert_eq!(h.navigate_up(""), Some("three".to_string()));
+        assert_eq!(h.navigate_up("three"), Some("two".to_string()));
+        assert_eq!(h.navigate_up("two"), Some("one".to_string()));
+        // At the oldest entry, further Up is a no-op.
+        assert_eq!(h.navigate_up("one"), None);
+        assert_eq!(h.current_entry(), Some("one"));
+    }
+
+    #[test]
+    fn down_restores_draft_after_paging_past_newest() {
+        let mut h = seeded(&["one", "two"]);
+        assert_eq!(h.navigate_up("draft"), Some("two".to_string()));
+        assert_eq!(h.navigate_up("two"), Some("one".to_string()));
+        // Page back down: one -> two -> draft.
+        assert_eq!(h.navigate_down("one"), Some("two".to_string()));
+        assert_eq!(h.navigate_down("two"), Some("draft".to_string()));
+        assert!(!h.is_browsing());
+    }
+
+    #[test]
+    fn down_without_browsing_is_a_no_op() {
+        let mut h = seeded(&["one"]);
+        assert_eq!(h.navigate_down("whatever"), None);
+    }
+
+    #[test]
+    fn up_on_empty_history_does_not_begin_browsing() {
+        let mut h = PromptHistory::in_memory();
+        assert_eq!(h.navigate_up("draft"), None);
+        assert!(!h.is_browsing());
+    }
+
+    #[test]
+    fn record_resets_an_in_progress_browse() {
+        let mut h = seeded(&["one", "two"]);
+        assert_eq!(h.navigate_up(""), Some("two".to_string()));
+        assert!(h.is_browsing());
+        h.record("three");
+        assert!(!h.is_browsing());
+        // The next Up starts from the newest (freshly recorded) entry.
+        assert_eq!(h.navigate_up(""), Some("three".to_string()));
+    }
+
+    #[test]
+    fn persistence_round_trips_through_the_log_file() {
+        let dir = std::env::temp_dir().join(format!("yolop-hist-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let path = dir.join("prompt_history.jsonl");
+
+        let mut h = PromptHistory {
+            entries: Vec::new(),
+            cursor: None,
+            draft: None,
+            path: Some(path.clone()),
+        };
+        h.record("first");
+        h.record("second\nwith newline");
+
+        let reloaded = read_entries(&path);
+        assert_eq!(reloaded, vec!["first", "second\nwith newline"]);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/prompt_history.rs
+++ b/src/prompt_history.rs
@@ -106,6 +106,38 @@ impl PromptHistory {
         self.cursor.map(|i| self.entries[i].as_str())
     }
 
+    /// Whether there is anything to recall or search.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// The entry at `index`, if it exists.
+    pub(crate) fn entry_at(&self, index: usize) -> Option<&str> {
+        self.entries.get(index).map(String::as_str)
+    }
+
+    /// Reverse (newest-first) case-insensitive substring search for the most
+    /// recent entry at or below `start_at` that contains `query`. An empty query
+    /// matches every entry, so a bare Ctrl+R walks straight back through history.
+    /// Returns the matched `(index, entry)`.
+    pub(crate) fn reverse_search(&self, query: &str, start_at: usize) -> Option<(usize, String)> {
+        if self.entries.is_empty() {
+            return None;
+        }
+        let start = start_at.min(self.entries.len() - 1);
+        let needle = query.to_lowercase();
+        (0..=start)
+            .rev()
+            .find(|&i| self.entries[i].to_lowercase().contains(&needle))
+            .map(|i| (i, self.entries[i].clone()))
+    }
+
+    /// The newest entry's index, if any — the natural starting point for a fresh
+    /// reverse search.
+    pub(crate) fn newest_index(&self) -> Option<usize> {
+        self.entries.len().checked_sub(1)
+    }
+
     /// Move to the previous (older) entry, saving `current` as the draft on the
     /// first step. Returns the entry to place in the composer, or `None` when
     /// there is nothing older (history empty, or already at the oldest entry).
@@ -257,6 +289,35 @@ mod tests {
         assert!(!h.is_browsing());
         // The next Up starts from the newest (freshly recorded) entry.
         assert_eq!(h.navigate_up(""), Some("three".to_string()));
+    }
+
+    #[test]
+    fn reverse_search_finds_newest_match_and_cycles_older() {
+        let h = seeded(&["deploy staging", "run tests", "deploy prod", "run lint"]);
+        let newest = h.newest_index().unwrap();
+        // From the newest, "deploy" matches "deploy prod" (index 2) first.
+        let (i, entry) = h.reverse_search("deploy", newest).unwrap();
+        assert_eq!((i, entry.as_str()), (2, "deploy prod"));
+        // Cycling older (search below index 2) reaches "deploy staging".
+        let (i, entry) = h.reverse_search("deploy", i - 1).unwrap();
+        assert_eq!((i, entry.as_str()), (0, "deploy staging"));
+        // A query absent from index 0 (and below) yields no match there.
+        assert_eq!(h.reverse_search("prod", 0), None);
+    }
+
+    #[test]
+    fn reverse_search_is_case_insensitive_and_empty_matches_newest() {
+        let h = seeded(&["First", "SECOND"]);
+        assert_eq!(h.reverse_search("second", 1).unwrap().1, "SECOND");
+        // Empty query matches the newest entry.
+        assert_eq!(h.reverse_search("", 1).unwrap(), (1, "SECOND".to_string()));
+    }
+
+    #[test]
+    fn reverse_search_on_empty_history_is_none() {
+        let h = PromptHistory::in_memory();
+        assert!(h.newest_index().is_none());
+        assert_eq!(h.reverse_search("x", 0), None);
     }
 
     #[test]

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -64,6 +64,9 @@ pub(crate) enum TurnEvent {
     /// `None` clears the preview.
     Stream(Option<StreamPreview>),
     Tokens(u64),
+    /// Prompt tokens the latest LLM generation consumed — the current fill of
+    /// the model's context window. Replaces (not accumulates) the prior value.
+    ContextUsed(u32),
     Done,
     Failed(String),
 }
@@ -131,6 +134,9 @@ pub(crate) fn handle_live_event(
     if let Some(tokens) = tokens_for_event(event) {
         let _ = tx.send(TurnEvent::Tokens(tokens));
     }
+    if let Some(context) = context_tokens_for_event(event) {
+        let _ = tx.send(TurnEvent::ContextUsed(context));
+    }
     remember_write_todos_args(event, router);
     if let Some(activity) = status_for_event(event) {
         let _ = tx.send(TurnEvent::Activity(activity));
@@ -156,6 +162,23 @@ pub(crate) fn tokens_for_event(event: &RuntimeEvent) -> Option<u64> {
         EventData::ReasonItem(data) => data.token_count.map(u64::from),
         _ => None,
     }
+}
+
+/// Prompt-side token count for an LLM generation — the full context sent to the
+/// model (non-cached input plus both cache buckets, which are disjoint from
+/// `input_tokens`). This is the current context-window fill, taken from the most
+/// recent generation rather than accumulated across the turn.
+pub(crate) fn context_tokens_for_event(event: &RuntimeEvent) -> Option<u32> {
+    let EventData::LlmGeneration(data) = &event.data else {
+        return None;
+    };
+    let usage = data.metadata.usage.as_ref()?;
+    Some(
+        usage
+            .input_tokens
+            .saturating_add(usage.cache_read_tokens.unwrap_or(0))
+            .saturating_add(usage.cache_creation_tokens.unwrap_or(0)),
+    )
 }
 
 pub(crate) fn lines_for_event_with_router(


### PR DESCRIPTION
## What changed

Brings a set of terminal-UI affordances from OpenAI's Codex CLI to yolop's TUI. Eight self-contained features, each usable in both the inline and `--fullscreen` renderers (fullscreen shares the inline renderer as of #340):

- **Prompt history recall** — `↑`/`↓` cycle previously submitted prompts, persisted across sessions in `<data_dir>/yolop/prompt_history.jsonl`. Draft-preserving; consecutive duplicates collapsed.
- **Reverse history search** — `Ctrl+R` opens incremental search; typing narrows, repeated `Ctrl+R` cycles older, `Enter` accepts, `Esc`/`Ctrl+C` cancels and restores the draft. Shows `(reverse-search) 'query'` with a `no match` marker.
- **Language-aware syntax highlighting** — fenced code blocks are highlighted per language with tree-sitter (the grammars already bundled for repo_map/ast_grep) plus `tree-sitter-highlight`. Covers rust, python, ts/js, tsx, go, java, ruby, css, html, c#, php, zig, scala, sql; unknown languages and parse failures fall back to the previous lightweight highlighter.
- **`@file` path completion** — typing `@` offers matching workspace paths in the suggestion row; `Tab` completes in place. Directories first (with trailing `/` to descend), dotfiles/`.git` hidden unless typed.
- **`http(s)` link styling** — URLs in transcript prose/list items are accent-colored and underlined (trailing punctuation excluded), keeping them visually distinct and terminal-clickable via native URL detection.
- **Live elapsed timer** — the busy indicator shows turn duration (`reading files... 1m15s`).
- **Context-window gauge** — a `ctx 45% (90k/200k)` status field, from per-generation prompt tokens (`TokenUsage`) and the model's profile context window (`get_model_profile`). Hidden when the model has no profile (e.g. `llmsim`).

## Why

yolop's composer and transcript lagged Codex on everyday ergonomics — no history recall/search, keyword-only highlighting regardless of language, no file-mention completion, no at-a-glance sense of turn duration or context fill. These are high-frequency, low-risk quality-of-life wins that reuse infrastructure already in the tree (tree-sitter grammars, the suggestion row, everruns-core model profiles).

## Before / After

Terminal UI; described with representative output (no screenshot capture available in this environment).

**Composer hint row**
- Before: `Tab /help  …` (slash commands only)
- After (typing `@src/ma`): `Tab @src/main.rs  @src/markdown.rs`
- After (`Ctrl+R`, typed `test`): `(reverse-search) 'test'` with the match previewed in the composer

**Busy indicator**
- Before: `─── / reading files... (input disabled)`
- After: `─── / reading files... 1m15s (input disabled)`

**Status bar**
- Before: `… 3 msgs · tokens 1240`
- After: `… 3 msgs · tokens 1240 · ctx 45% (90k/200k)`

**Code fence** — a ```rust block now renders `fn`/`let`/`struct` in the keyword color, strings/comments/types/numbers distinctly, instead of a flat keyword-only pass.

## Risk

- **Low.** All additions are render-side or composer-input logic behind existing seams; unknown languages and parse failures fall back cleanly, and the context gauge is omitted when unavailable. No changes to agent/runtime behavior.
- Possible surface: syntax highlighting adds a `tree-sitter-highlight` dependency and parses each fenced block once per transcript build (cached highlight configs per language).

## Checklist

- [x] Tests added or updated — unit + render-integration + key-path tests for every feature (854 tests pass; `fmt` and `clippy -D warnings` clean)
- [x] Backward compatibility considered — pre-1.0; no config or on-disk format changes beyond the additive prompt-history log

---

Follow-up (separate PR, by request): real OSC 8 hyperlinks via a custom scrollback writer — ratatui 0.30's `insert_before` has no hyperlink seam, so it needs a dedicated writer with manual multi-terminal verification.

https://claude.ai/code/session_01NF3QQPUybLPR6rGMmnHUHC

---
_Generated by [Claude Code](https://claude.ai/code/session_01NF3QQPUybLPR6rGMmnHUHC)_