### PR TITLE
fix(tools): honor /workspace alias in host-path scope resolution

### DIFF
--- a/src/capabilities/ast_grep.rs
+++ b/src/capabilities/ast_grep.rs
@@ -686,7 +686,7 @@ fn ast_grep(workspace_root: &Path, options: AstGrepOptions) -> Result<AstGrepRep
     let mut files = Vec::new();
     let mut skipped_unsupported_files = 0;
     collect_supported_files(
-        &scope,
+        scope.as_path(),
         language_filter,
         &mut files,
         &mut skipped_unsupported_files,
@@ -802,7 +802,7 @@ fn ast_edit(workspace_root: &Path, options: AstEditOptions) -> Result<AstEditRep
     let mut files = Vec::new();
     let mut skipped_unsupported_files = 0;
     collect_supported_files(
-        &scope,
+        scope.as_path(),
         language_filter,
         &mut files,
         &mut skipped_unsupported_files,
@@ -1285,6 +1285,36 @@ mod tests {
         assert_eq!(value["matches"][0]["path"], json!("src/lib.rs"));
         assert_eq!(value["matches"][0]["captures"][0]["name"], json!("NAME"));
         assert_eq!(value["matches"][0]["captures"][0]["text"], json!("target"));
+    }
+
+    #[tokio::test]
+    async fn ast_grep_tool_accepts_workspace_alias_scope() {
+        // Like repo_map, ast_grep resolves its `path` through resolve_host_scope,
+        // so the `/workspace` display alias must scope correctly here too.
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(&dir.path().join("src/lib.rs"), "fn target() {}\n");
+        write(&dir.path().join("other/lib.rs"), "fn other() {}\n");
+
+        let capability = AstGrepCapability::new(host(dir.path()));
+        let tools = capability.tools();
+        let tool = tools
+            .iter()
+            .find(|tool| tool.name() == "ast_grep")
+            .expect("ast_grep tool");
+        let result = tool
+            .execute(json!({
+                "pattern": "fn $NAME() {}",
+                "language": "rust",
+                "path": "/workspace/src",
+                "limit": 10
+            }))
+            .await;
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("expected success, got {result:?}");
+        };
+
+        assert_eq!(value["count"], json!(1));
+        assert_eq!(value["matches"][0]["path"], json!("src/lib.rs"));
     }
 
     #[test]

--- a/src/capabilities/lsp/manager.rs
+++ b/src/capabilities/lsp/manager.rs
@@ -188,7 +188,7 @@ impl LspManager {
                     self.spec_summary()
                 )
             })?;
-        Ok((file, spec))
+        Ok((file.into_path_buf(), spec))
     }
 
     fn spec_summary(&self) -> String {

--- a/src/capabilities/repo_map.rs
+++ b/src/capabilities/repo_map.rs
@@ -407,7 +407,7 @@ fn collect_repo_symbols(
     let mut files = Vec::new();
     let mut skipped_unsupported_files = 0;
     collect_supported_files(
-        &scope,
+        scope.as_path(),
         language_filter.as_deref(),
         &mut files,
         &mut skipped_unsupported_files,
@@ -424,7 +424,7 @@ fn collect_repo_symbols(
         MAX_CANDIDATES
     };
     let mut report = SymbolScanReport {
-        path: relative_path(&root, &scope),
+        path: relative_path(&root, scope.as_path()),
         query: options.query,
         languages: Vec::new(),
         scanned_files: 0,

--- a/src/capabilities/repo_map.rs
+++ b/src/capabilities/repo_map.rs
@@ -1921,6 +1921,45 @@ trait Named {
         assert!(report.symbols.iter().any(|s| s.name == "inside_fn"));
     }
 
+    #[tokio::test]
+    async fn repo_map_tool_accepts_workspace_alias_scope() {
+        // The model often passes the `/workspace` display alias as `path`; the
+        // file tools honor it via MountFs, so repo_map must resolve it to the
+        // workspace root instead of erroring with "path not found: /workspace".
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(&dir.path().join("pkg/inside.rs"), "pub fn pkg_fn() {}\n");
+        write(
+            &dir.path().join("other/elsewhere.rs"),
+            "pub fn other_fn() {}\n",
+        );
+
+        let capability = RepoMapCapability::new(host(dir.path()));
+        let tools = capability.tools();
+        let tool = tools
+            .iter()
+            .find(|tool| tool.name() == "repo_map")
+            .expect("repo_map tool");
+
+        // Alias root scans the whole workspace.
+        let ToolExecutionResult::Success(root) = tool
+            .execute(json!({ "path": "/workspace", "language": "rust" }))
+            .await
+        else {
+            panic!("expected success scanning /workspace");
+        };
+        assert_eq!(root["count"], json!(2));
+
+        // Alias subpath scopes to just that directory.
+        let ToolExecutionResult::Success(sub) = tool
+            .execute(json!({ "path": "/workspace/pkg", "language": "rust" }))
+            .await
+        else {
+            panic!("expected success scanning /workspace/pkg");
+        };
+        assert_eq!(sub["count"], json!(1));
+        assert_eq!(sub["files"][0]["symbols"][0]["name"], json!("pkg_fn"));
+    }
+
     #[test]
     fn accepts_host_absolute_subpath() {
         let dir = tempfile::tempdir().expect("tempdir");

--- a/src/workspace_host.rs
+++ b/src/workspace_host.rs
@@ -5,7 +5,9 @@
 // repointable disk handle synced from the worktree's active-root lock.
 
 use anyhow::{Context, Result, bail};
+use everruns_core::session_path::to_session_path;
 use everruns_runtime::RealDiskFileStore;
+use std::ops::Deref;
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, Mutex, RwLock};
 
@@ -73,46 +75,86 @@ impl WorkspaceHost {
     }
 }
 
-/// The model-facing display alias for the workspace root. everruns' `MountFs`
-/// routes `/workspace/...` to the host root for the file tools (read/grep/edit);
-/// `repo_map` / `repo_symbols` resolve host paths here directly, bypassing
-/// `MountFs`, so they must honor the same alias.
-const WORKSPACE_ALIAS: &str = "/workspace";
+/// A disk path proven to live inside the workspace root.
+///
+/// The only way to obtain one from model-supplied input is [`resolve_host_scope`],
+/// which normalizes the `/workspace` display alias and enforces containment. The
+/// disk-scanning capabilities (`repo_map`, `repo_symbols`, `ast_grep`, `lsp`)
+/// resolve model paths through it, so a resolved scope is a *distinct type* from
+/// a bare `PathBuf` a tool might build by hand — a new tool that skips
+/// normalization can't produce a `HostPath` without going through the resolver.
+/// `Deref<Target = Path>` keeps it ergonomic at the call sites.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HostPath(PathBuf);
+
+impl HostPath {
+    /// Borrow the contained, containment-checked host path.
+    pub fn as_path(&self) -> &Path {
+        &self.0
+    }
+
+    /// Consume into the owned host path.
+    pub fn into_path_buf(self) -> PathBuf {
+        self.0
+    }
+}
+
+impl Deref for HostPath {
+    type Target = Path;
+
+    fn deref(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for HostPath {
+    fn as_ref(&self) -> &Path {
+        &self.0
+    }
+}
 
 /// Map a model-facing path to a canonical host directory under `root`.
-pub fn resolve_host_scope(root: &Path, path: Option<&str>) -> Result<PathBuf> {
+///
+/// yolop presents the model its **real** host checkout path (#258), yet models
+/// still emit the `/workspace` alias from cloud-agent priors — so both spellings
+/// must resolve, on every path surface, forever. A real host-absolute path is
+/// honored directly (with a containment check); everything else — the
+/// `/workspace` alias, a session-absolute `/src`, a bare relative `src` — is
+/// funneled through everruns' `to_session_path`, the *same* normalizer the file
+/// tools reach via `MountFs`. That shared normalizer is the point: `repo_map` /
+/// `repo_symbols` / `ast_grep` / `lsp` now accept exactly what `read` / `grep` /
+/// `edit` accept, and the two can't drift because there is one algorithm.
+pub fn resolve_host_scope(root: &Path, path: Option<&str>) -> Result<HostPath> {
     let Some(path) = path else {
-        return Ok(root.to_path_buf());
+        return Ok(HostPath(root.to_path_buf()));
     };
     let trimmed = path.trim();
 
-    // The model frequently addresses scopes through the `/workspace` alias — a
-    // strong cloud-agent prior, and the route everruns' `MountFs` already
-    // accepts for the file tools. Strip it to a workspace-relative path so
-    // `repo_map`/`repo_symbols` don't 404 with "path not found: /workspace" on a
-    // scope that read/grep/edit resolve fine. Mirrors the alias handling in
-    // `everruns_core::session_path::to_session_path`.
-    if let Some(rest) = strip_workspace_alias(trimmed) {
-        return resolve_relative_scope(root, rest.trim_start_matches('/'), path);
-    }
-
+    // A real host-absolute path (what yolop actually shows the model): accept it
+    // when it resolves inside the workspace, reject it when it resolves outside.
+    // If it does not resolve as a real path it is almost certainly a session
+    // spelling (`/workspace/...`, `/src`), so fall through to the normalizer.
     let candidate = Path::new(trimmed);
-    if candidate.is_absolute() {
-        let canonical = candidate
-            .canonicalize()
-            .with_context(|| format!("path not found: {path}"))?;
-        if !canonical.starts_with(root) {
-            bail!("`path` must stay inside the workspace");
+    if candidate.is_absolute()
+        && let Ok(canonical) = candidate.canonicalize()
+    {
+        if canonical.starts_with(root) {
+            return Ok(HostPath(canonical));
         }
-        return Ok(canonical);
+        bail!("`path` must stay inside the workspace");
     }
 
-    resolve_relative_scope(root, trimmed, path)
+    // Alias / session-absolute / relative all normalize through the one shared
+    // normalizer (which strips `/workspace`, collapses slashes, and canonicalizes
+    // the spelling), then resolve relative to the real root.
+    let session = to_session_path(trimmed);
+    resolve_relative_scope(root, session.trim_start_matches('/'), path).map(HostPath)
 }
 
-/// Resolve a workspace-relative scope (already stripped of any `/workspace`
-/// alias) against `root`, rejecting traversal and enforcing containment.
-/// `original` is the caller-supplied spelling, used only for error messages.
+/// Resolve a workspace-relative scope (already normalized to a session path and
+/// stripped of its leading slash) against `root`, rejecting traversal and
+/// enforcing containment. `original` is the caller-supplied spelling, used only
+/// for error messages.
 fn resolve_relative_scope(root: &Path, relative: &str, original: &str) -> Result<PathBuf> {
     if relative.is_empty() || relative == "." {
         return Ok(root.to_path_buf());
@@ -134,17 +176,6 @@ fn resolve_relative_scope(root: &Path, relative: &str, original: &str) -> Result
         bail!("`path` must stay inside the workspace");
     }
     Ok(canonical)
-}
-
-/// Strip the `/workspace` display alias, returning the remainder for an exact
-/// match (`""`) or a `/workspace/<sub>` prefix. Returns `None` for unrelated
-/// paths, including near-misses like `/workspacefoo` that only share the prefix
-/// without the segment boundary.
-fn strip_workspace_alias(path: &str) -> Option<&str> {
-    if path == WORKSPACE_ALIAS {
-        return Some("");
-    }
-    path.strip_prefix("/workspace/")
 }
 
 /// Validate that `root` contains no traversal components (for tests/helpers).
@@ -174,50 +205,64 @@ mod tests {
 
         let host_path = root.join("pkg");
         let scope = resolve_host_scope(&root, host_path.to_str()).expect("host subpath");
-        assert_eq!(scope, root.join("pkg"));
+        assert_eq!(scope, HostPath(root.join("pkg")));
 
         let root_scope = resolve_host_scope(&root, root.to_str()).expect("host root");
-        assert_eq!(root_scope, root);
+        assert_eq!(root_scope, HostPath(root.clone()));
 
         let relative = resolve_host_scope(&root, Some("pkg")).expect("relative subpath");
-        assert_eq!(relative, root.join("pkg"));
+        assert_eq!(relative, HostPath(root.join("pkg")));
     }
 
+    // Every spelling a model might reach for — the `/workspace` alias, a
+    // session-absolute `/pkg`, the real host-absolute path, a bare relative, and
+    // their slash/​trailing-slash variants — must resolve to the *same* host path
+    // as the file tools' MountFs route. This table is the cross-cutting guard the
+    // per-tool suites never had: it fails the moment any spelling drifts.
     #[test]
-    fn resolve_host_scope_accepts_workspace_alias() {
+    fn resolve_host_scope_spelling_table_is_consistent() {
         let dir = tempfile::tempdir().expect("tempdir");
         fs::create_dir_all(dir.path().join("pkg")).expect("pkg dir");
         let root = fs::canonicalize(dir.path()).expect("canonical root");
 
-        // `/workspace` is the model-facing alias for the root; the file tools
-        // accept it via MountFs, so repo_map/repo_symbols must too.
-        assert_eq!(
-            resolve_host_scope(&root, Some("/workspace")).expect("alias root"),
-            root
-        );
-        assert_eq!(
-            resolve_host_scope(&root, Some("/workspace/pkg")).expect("alias subpath"),
-            root.join("pkg")
-        );
-        // Trailing/duplicate slashes still land on the alias target.
-        assert_eq!(
-            resolve_host_scope(&root, Some("/workspace/")).expect("alias root slash"),
-            root
-        );
-    }
+        let root_spellings = [
+            None,
+            Some(".".to_string()),
+            Some("/workspace".to_string()),
+            Some("/workspace/".to_string()),
+            Some("//workspace//".to_string()),
+            Some(root.to_str().expect("root utf8").to_string()),
+        ];
+        for spelling in root_spellings {
+            let scope = resolve_host_scope(&root, spelling.as_deref())
+                .unwrap_or_else(|e| panic!("root spelling {spelling:?}: {e}"));
+            assert_eq!(scope.as_path(), root, "root spelling {spelling:?}");
+        }
 
-    #[test]
-    fn resolve_host_scope_alias_rejects_escape_and_near_miss() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let root = fs::canonicalize(dir.path()).expect("canonical root");
+        let pkg = root.join("pkg");
+        let pkg_spellings = [
+            "pkg",
+            "/pkg",                          // session-absolute
+            "/workspace/pkg",                // display alias
+            "//workspace//pkg",              // alias with redundant slashes
+            pkg.to_str().expect("pkg utf8"), // real host-absolute
+        ];
+        for spelling in pkg_spellings {
+            let scope = resolve_host_scope(&root, Some(spelling))
+                .unwrap_or_else(|e| panic!("pkg spelling {spelling:?}: {e}"));
+            assert_eq!(scope.as_path(), pkg, "pkg spelling {spelling:?}");
+        }
 
-        // Traversal dressed up with the alias prefix must not escape the root.
-        let err =
-            resolve_host_scope(&root, Some("/workspace/../outside")).expect_err("alias escape");
-        assert!(err.to_string().contains("inside the workspace"));
+        // Escapes are rejected no matter how they are dressed up.
+        for escape in ["/workspace/../outside", "../outside", "//workspace//../x"] {
+            assert!(
+                resolve_host_scope(&root, Some(escape)).is_err(),
+                "escape {escape:?} must be rejected"
+            );
+        }
 
         // `/workspacefoo` shares the prefix but is not the `/workspace` segment,
-        // so it is treated as a real absolute path (which does not exist here).
+        // so it is a real absolute path that does not exist here — not the alias.
         let err = resolve_host_scope(&root, Some("/workspacefoo")).expect_err("near miss");
         assert!(err.to_string().contains("path not found"));
     }

--- a/src/workspace_host.rs
+++ b/src/workspace_host.rs
@@ -73,12 +73,29 @@ impl WorkspaceHost {
     }
 }
 
+/// The model-facing display alias for the workspace root. everruns' `MountFs`
+/// routes `/workspace/...` to the host root for the file tools (read/grep/edit);
+/// `repo_map` / `repo_symbols` resolve host paths here directly, bypassing
+/// `MountFs`, so they must honor the same alias.
+const WORKSPACE_ALIAS: &str = "/workspace";
+
 /// Map a model-facing path to a canonical host directory under `root`.
 pub fn resolve_host_scope(root: &Path, path: Option<&str>) -> Result<PathBuf> {
     let Some(path) = path else {
         return Ok(root.to_path_buf());
     };
     let trimmed = path.trim();
+
+    // The model frequently addresses scopes through the `/workspace` alias — a
+    // strong cloud-agent prior, and the route everruns' `MountFs` already
+    // accepts for the file tools. Strip it to a workspace-relative path so
+    // `repo_map`/`repo_symbols` don't 404 with "path not found: /workspace" on a
+    // scope that read/grep/edit resolve fine. Mirrors the alias handling in
+    // `everruns_core::session_path::to_session_path`.
+    if let Some(rest) = strip_workspace_alias(trimmed) {
+        return resolve_relative_scope(root, rest.trim_start_matches('/'), path);
+    }
+
     let candidate = Path::new(trimmed);
     if candidate.is_absolute() {
         let canonical = candidate
@@ -90,9 +107,17 @@ pub fn resolve_host_scope(root: &Path, path: Option<&str>) -> Result<PathBuf> {
         return Ok(canonical);
     }
 
-    if trimmed.is_empty() || trimmed == "." {
+    resolve_relative_scope(root, trimmed, path)
+}
+
+/// Resolve a workspace-relative scope (already stripped of any `/workspace`
+/// alias) against `root`, rejecting traversal and enforcing containment.
+/// `original` is the caller-supplied spelling, used only for error messages.
+fn resolve_relative_scope(root: &Path, relative: &str, original: &str) -> Result<PathBuf> {
+    if relative.is_empty() || relative == "." {
         return Ok(root.to_path_buf());
     }
+    let candidate = Path::new(relative);
     if candidate.components().any(|component| {
         matches!(
             component,
@@ -104,11 +129,22 @@ pub fn resolve_host_scope(root: &Path, path: Option<&str>) -> Result<PathBuf> {
     let scope = root.join(candidate);
     let canonical = scope
         .canonicalize()
-        .with_context(|| format!("path not found: {path}"))?;
+        .with_context(|| format!("path not found: {original}"))?;
     if !canonical.starts_with(root) {
         bail!("`path` must stay inside the workspace");
     }
     Ok(canonical)
+}
+
+/// Strip the `/workspace` display alias, returning the remainder for an exact
+/// match (`""`) or a `/workspace/<sub>` prefix. Returns `None` for unrelated
+/// paths, including near-misses like `/workspacefoo` that only share the prefix
+/// without the segment boundary.
+fn strip_workspace_alias(path: &str) -> Option<&str> {
+    if path == WORKSPACE_ALIAS {
+        return Some("");
+    }
+    path.strip_prefix("/workspace/")
 }
 
 /// Validate that `root` contains no traversal components (for tests/helpers).
@@ -145,6 +181,45 @@ mod tests {
 
         let relative = resolve_host_scope(&root, Some("pkg")).expect("relative subpath");
         assert_eq!(relative, root.join("pkg"));
+    }
+
+    #[test]
+    fn resolve_host_scope_accepts_workspace_alias() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::create_dir_all(dir.path().join("pkg")).expect("pkg dir");
+        let root = fs::canonicalize(dir.path()).expect("canonical root");
+
+        // `/workspace` is the model-facing alias for the root; the file tools
+        // accept it via MountFs, so repo_map/repo_symbols must too.
+        assert_eq!(
+            resolve_host_scope(&root, Some("/workspace")).expect("alias root"),
+            root
+        );
+        assert_eq!(
+            resolve_host_scope(&root, Some("/workspace/pkg")).expect("alias subpath"),
+            root.join("pkg")
+        );
+        // Trailing/duplicate slashes still land on the alias target.
+        assert_eq!(
+            resolve_host_scope(&root, Some("/workspace/")).expect("alias root slash"),
+            root
+        );
+    }
+
+    #[test]
+    fn resolve_host_scope_alias_rejects_escape_and_near_miss() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = fs::canonicalize(dir.path()).expect("canonical root");
+
+        // Traversal dressed up with the alias prefix must not escape the root.
+        let err =
+            resolve_host_scope(&root, Some("/workspace/../outside")).expect_err("alias escape");
+        assert!(err.to_string().contains("inside the workspace"));
+
+        // `/workspacefoo` shares the prefix but is not the `/workspace` segment,
+        // so it is treated as a real absolute path (which does not exist here).
+        let err = resolve_host_scope(&root, Some("/workspacefoo")).expect_err("near miss");
+        assert!(err.to_string().contains("path not found"));
     }
 
     #[test]


### PR DESCRIPTION
## What changed

`repo_map`, `repo_symbols`, `ast_grep`, and `lsp` now accept the `/workspace`
path spelling the model actually emits. Previously these tools rejected a
`/workspace` or `/workspace/sub` scope with `path not found: /workspace`, even
though `read`/`grep`/`edit` resolve the very same path fine. All host-touching
tools now agree on what a model-facing path means: the `/workspace` display
alias, a session-absolute `/src`, the real host-absolute path, and a bare
relative `src` all resolve to the same location.

Under the hood this replaces yolop's hand-rolled path normalization in
`resolve_host_scope` with a delegation to everruns' `to_session_path` — the same
normalizer the file tools reach through `MountFs` — so the two can no longer
drift. The resolver now returns a `HostPath` newtype whose only constructor from
model input is the resolver itself, making "a resolved scope" a distinct type
from a path a tool builds by hand.

## Why

`/workspace` is unavoidable on every path surface, forever: it is burned into
model priors (DevContainers/Codespaces/cloud defaults) independent of what yolop
displays, and #258 additionally shows the model real host paths — so both
spellings must resolve. The bug recurred because path resolution existed in
**two** implementations — everruns' `MountFs`/`to_session_path` (file tools) and
yolop's separate `resolve_host_scope` (repo_map/ast_grep/lsp) — and only the
second one forgot the alias. Each side's tests were green while the seam between
them was broken, so "tons of tests on both sides" never caught it. Collapsing to
one normalizer + one typed funnel + one cross-cutting test makes honoring the
alias structural rather than per-tool vigilance.

## Before / After

Scope argument `/workspace` (and `/workspace/<sub>`) to `repo_map`:

**Before** — `repo_map { path: "/workspace" }` → tool error:
```
Could not build repo map: … error: path not found: /workspace
```

**After** — resolves to the workspace root and scans normally; `/workspace/pkg`
scopes to that subdirectory. Proven by tool-level tests that drive `execute()`
with the alias:
- `repo_map::tests::repo_map_tool_accepts_workspace_alias_scope`
- `ast_grep::tests::ast_grep_tool_accepts_workspace_alias_scope`
- `workspace_host::tests::resolve_host_scope_spelling_table_is_consistent`
  (asserts every spelling of the same scope resolves identically, and that
  `/workspace/../outside`, `../outside`, `//workspace//../x` stay rejected)

Full suite green on the rebased base (Rust 1.96.0, everruns 0.17.13):
`cargo test --all-features` → 0 failed; `cargo fmt --check` and
`cargo clippy --all-targets --all-features -- -D warnings` clean; offline smoke
`yolop --provider llmsim -p "hi"` boots and completes a turn.

## Risk

- **Low.** Behavior-preserving for every spelling that already worked; it only
  *adds* acceptance of `/workspace`/session-absolute forms that previously
  errored. Containment is unchanged — real host-absolute paths are still
  rejected when they resolve outside the root, and `..`/symlink escapes are
  still caught by `canonicalize` + `starts_with(root)`.
- What could break: nothing observable removed. The one deliberate difference is
  that a `/workspace/...` scope now succeeds instead of erroring.

## Security

Reviewed **TM-FS** (the only relevant category — this is pure workspace
path-scope resolution; no bash, LLM, tool-registration, or dependency surface).

- **Path traversal / containment:** preserved. `resolve_relative_scope` still
  rejects `ParentDir`/`RootDir`/`Prefix` components and re-checks
  `canonical.starts_with(root)`; the host-absolute branch rejects anything that
  canonicalizes outside the root. Alias-dressed traversal
  (`/workspace/../outside`) and symlink escapes remain rejected — covered by the
  spelling-table test and the existing `absolute_host_path_does_not_bypass_containment`
  / `skips_symlinked_directories_during_recursive_scan` tests.
- **Input validation:** the newly delegated normalizer (`to_session_path`) is
  everruns' existing, already-trusted normalizer used by the file tools; no new
  parsing surface.
- No new dependencies. No key/secret handling. No write-blocklist change.

## Follow-ups

- **Multi-root host scopes (Zed ACP + general).** everruns already has a richer
  resolver — `WorkspaceRootSet::parse_host_scope` — that resolves *named*
  multiple roots with symlink-escape rejection. yolop's `resolve_host_scope` is
  single-root. Unifying yolop onto that (a cross-repo change) is the path toward
  multi-root support; being analyzed separately, not required for this fix.
- **Fully sealing `WorkspaceHost::host_root()`** so a future tool cannot
  `host_root().join(model_str)` and bypass normalization would make the funnel
  compiler-proof rather than typed-and-greppable. Deferred: it means splitting
  "raw root for cwd" from "resolve a model path" on `WorkspaceHost`, larger than
  this change warrants.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; behavior-preserving + additive)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQWhnyfPHhBx3n31hzFrjb)_