### PR TITLE
chore(deps): bump everruns to 0.17.14, unpin Rust to 1.94.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@1.94.0
         with:
           components: rustfmt, clippy
 
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@1.94.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -117,7 +117,7 @@ jobs:
         uses: dopplerhq/cli-action@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@1.94.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -37,7 +37,7 @@ jobs:
           ref: ${{ inputs.tag }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@1.94.0
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@1.94.0
 
       - name: Verify version matches tag
         env:

--- a/.github/workflows/search-efficiency-eval.yml
+++ b/.github/workflows/search-efficiency-eval.yml
@@ -64,7 +64,7 @@ jobs:
           } >> "${GITHUB_ENV}"
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@1.94.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,9 +1649,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.13"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f70350aa81c2b499171e882079cc4221a7c0f26fd179bff8e797623567b29b09"
+checksum = "bddb1b4a80d530a61f41be8273a0b811aeae3f4fa12b5633e79563158a1b0fe9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1667,9 +1667,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.13"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74cd3b2eeea2cbaf4ddc292e50caca8ae5a56cd5756bfde816fc30bfea484b75"
+checksum = "ec9a796e6b9a9726c896ec55d93de3bca81335075998196bddabc0d1911aeba8"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -1714,9 +1714,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.13"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bcb221b38574945bbd88774a6ab454d887f1b66c9ffab09ca60e56c82b633ff"
+checksum = "548a625db33dd0ffbe01ffb1020950c3466e17820ce67b172ddc697c7c4a875c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1731,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.13"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c37ded4e03ef15de0a250783498a92e49a74733cc6de32568b45dc8ccedefb5"
+checksum = "5d6f029448ea5dfa421025abbcb62489bb86127a6a5cf4519b1c05bc2455bbab"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1747,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.13"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d83e6a3d9b8c77929648f0732f21bf20034a04fba33c190a996744f6c6526db"
+checksum = "74cf7213e3f490dcd276ae03ced1b79555f364599445ef0d0e7543681eecae87"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1761,9 +1761,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.13"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63cf2b6eecc1d4f3099de9ee8074d76d15d41f3b2a86e4ad070699727539db2c"
+checksum = "97bfd2bde84eac980dc85e3f874c920e8322b5a8c2bdd7c9370350c04d4deea0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1785,9 +1785,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.13"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e1d0a9d7630728a28f8d0f5ba7883c483c14ff75d96b903e5d3d1088777f7c9"
+checksum = "77b0d856cfe0f0dc205a75fe7cfd1112239c1832d23c838a2e3fe2bd4db6d3ff"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1800,9 +1800,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.13"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa6babfe5e823f4ab1f1945a4cb3aef168a46796b4918021d41ecd4d3310b5cc"
+checksum = "c609f4dd02e9606d6a34d8b071466997b7334b54df112a8044a0fa708e63221d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1816,9 +1816,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.13"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99cfb6f029111f9dbc1be4430ad1822f4676dee8a0dde3cdbd91e10d9a81d959"
+checksum = "b706b46ed0f46d0abc83f4bdb6ef41196d281afbc1ea2f1c6dd7562914337683"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1830,9 +1830,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-provider"
-version = "0.17.13"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de551f9084b3eca0d5c44a78967be46845f7b937f64fab39478c0a3edb1de7d3"
+checksum = "6164497db9e942643c85e1e68e43f205f444f27fb85b4a3639ac431a18bd3e98"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1858,9 +1858,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.13"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "861e56333e028eed3ea84441fc141fc2e7f6d2f51279a5aa413b7a244a0fd76c"
+checksum = "3972f38e9563683919d33ed1096011b53c53a986f409a0509d184e61b8bf99bd"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,20 +91,20 @@ tree-sitter-zig = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-everruns-anthropic = "0.17.13"
-everruns-core = "0.17.13"
-everruns-openai = "0.17.13"
+everruns-anthropic = "0.17.14"
+everruns-core = "0.17.14"
+everruns-openai = "0.17.14"
 # OpenRouter's first-class driver was split out of everruns-openai into its own
 # crate in 0.13.0; register it alongside openai to keep DriverId::OpenRouter.
-everruns-openrouter = "0.17.13"
-everruns-local = "0.17.13"
-everruns-mcp = "0.17.13"
+everruns-openrouter = "0.17.14"
+everruns-local = "0.17.14"
+everruns-mcp = "0.17.14"
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (specs/mcp.md, upstream runtime-mcp.md D2).
-everruns-runtime = { version = "0.17.13", features = ["mcp-stdio"] }
-everruns-integrations-duckduckgo = "0.17.13"
-everruns-integrations-parallel = "0.17.13"
-everruns-integrations-daytona = "0.17.13"
+everruns-runtime = { version = "0.17.14", features = ["mcp-stdio"] }
+everruns-integrations-duckduckgo = "0.17.14"
+everruns-integrations-parallel = "0.17.14"
+everruns-integrations-daytona = "0.17.14"
 arboard = { version = "3", features = ["wayland-data-control"] }
 futures = "0.3"
 html-escape = "0.2"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,6 @@
-# Pinned to 1.96.0: everruns-core 0.17.14 uses `if let` match guards, which
-# stabilized in Rust 1.96.0. Older stable toolchains fail with E0658.
+# Pinned to everruns' declared MSRV (rust-version = 1.94.0). everruns-core
+# 0.17.13 briefly required 1.96.0 for `if let` match guards; 0.17.14 dropped
+# them, restoring 1.94.0 compatibility. Keep in sync with the everruns-* MSRV.
 [toolchain]
-channel = "1.96.0"
+channel = "1.94.0"
 components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
-# Pinned to 1.96.0: everruns-core 0.17.13 uses `if let` match guards, which
+# Pinned to 1.96.0: everruns-core 0.17.14 uses `if let` match guards, which
 # stabilized in Rust 1.96.0. Older stable toolchains fail with E0658.
 [toolchain]
 channel = "1.96.0"


### PR DESCRIPTION
## What changed

- Bumps all `everruns-*` crates from 0.17.13 to 0.17.14, in lockstep (`Cargo.toml` + `Cargo.lock`, including the transitive `everruns-provider`).
- Lowers the Rust toolchain pin from 1.96.0 back to **1.94.0** — `rust-toolchain.toml` and all six CI toolchain references (`ci.yml`, `publish.yml`, `cli-binaries.yml`, `search-efficiency-eval.yml`).

Functionally there is no change to yolop's own behavior. everruns-provider 0.17.14 adds a Kimi K3 model profile, which yolop picks up automatically through the model-profile registry — no wiring needed.

## Why

The 0.17.13 bump had to pin the toolchain to 1.96.0 because everruns-core used `if let` match guards (stabilized in 1.96.0), even though the crates declared `rust-version = 1.94.0` — the source violated its own MSRV.

everruns-core 0.17.14 rewrites those three capability sites (`a2a_delegation`, `agent_handoff`, `subagents`) to use nested `match` instead of `if let` guards, dropping the 1.96.0 requirement and restoring genuine 1.94.0 compatibility. No `if let` match guards remain anywhere in the 0.17.14 dependency sources. This lets us drop the pin back to everruns' declared MSRV, which also matches the default `stable` toolchain shipped in our build environment (1.94.1).

## Before / After

Pure dependency + build-config change; no observable runtime behavior change. Toolchain floor:

- **Before:** `channel = "1.96.0"` (ahead of the env's default stable; required a separate toolchain install)
- **After:** `channel = "1.94.0"` (matches everruns' MSRV and the env default stable)

Offline smoke test (binary still starts on the 1.94.0 pin):

```
$ cargo run -- --provider llmsim -p "hi"
I'm running in offline mode (llmsim — no API key set). Set ANTHROPIC_API_KEY or OPENAI_API_KEY for real responses.
```

Validation on a freshly installed **Rust 1.94.0** toolchain:

- `cargo check --all-targets --all-features` — clean
- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all-features` — all suites pass
- `cargo fetch --locked` — lockfile consistent

## Risk

- **Low.** Patch-level dependency bump with no yolop source changes, plus a toolchain-floor reduction that is verified to compile/test/lint cleanly on the lower version. Lowering (not raising) an MSRV cannot break consumers on newer toolchains.

## Security

Dependency-only change (TM-DEP). All `everruns-*` versions bumped together — no mismatched versions or soft API break. No new crates introduced. No changes to `tools.rs`, the filesystem write blocklist, shell execution, or API-key handling. No security-relevant code changes in yolop.

## Follow-ups

No follow-ups.

## Checklist
- [x] Tests added or updated — N/A: dependency + build-config change with no yolop behavior change; validated via the full existing suite (build/fmt/clippy/test) on the new 1.94.0 pin plus an offline smoke test. The added Kimi K3 profile is covered by everruns-provider's own tests.
- [x] Backward compatibility considered — lowering the MSRV floor is backward compatible; everruns pre-1.0 with all crates in lockstep.

---
_Generated by [Claude Code](https://claude.ai/code/session_0121mGqRebmyFTpyYd4xXAdU)_