### PR TITLE
feat(extensions): hot-enable an extension on the live session

### DIFF
--- a/.agents/skills/author-extension/SKILL.md
+++ b/.agents/skills/author-extension/SKILL.md
@@ -87,8 +87,11 @@ Not yet available: providers.
 
 5. **Enable (ask first).** Show the user the contribution summary and ask
    before `enable_extension name=<name>` — enabling adds it to the harness and
-   runs its server every session. **Enabling takes effect on the next
-   session**, so tell the user to restart yolop to load it.
+   runs its server every session. In the interactive TUI it is **applied to the
+   running session immediately** (activated on the live agent), so its
+   tools/prompt/hooks are available on the **next turn** — no restart — and it's
+   persisted for future sessions. In `--print`/ACP there's no live session to
+   mutate, so it only takes effect next run.
 
 6. **Iterate live (already-enabled extensions).** Once an extension is enabled
    and its server has run this session, `reload_extension name=<name>` restarts

--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -123,6 +123,22 @@ and can never widen it. A manifest change (a new tool, a changed schema) still
 requires a restart — the enabled-capability set is fixed for the session
 because `everruns-core` builds the harness once with no live-reconfigure seam.
 Covered by `reload_respawns_the_server_with_edited_code`.
+Hot-enable: `everruns-runtime` grew a live-reconfigure seam
+(`InProcessRuntime::activate_capability`/`deactivate_capability` →
+`CapabilityDelta`, EVE-795), so enabling a *new* extension no longer waits for
+the next session. `enable_extension`/`disable_extension` still persist the
+`ext:<name>` override to settings, and in the TUI they also push a
+`SetExtensionActive` `UiCommand`; the `App` answers it by calling
+`Session::activate_capability`/`deactivate_capability`, which mutate the
+session-scoped capability overlay. The runtime reassembles prompt, tools, hooks,
+commands, and contributed MCP servers from that overlay on the next reason/act
+boundary, so the extension is live on the **next turn** — no restart. The
+capability lands on the session overlay (distinct from the harness layer a
+startup-enabled extension rides), so it can be live-deactivated too; disabling
+one that was active from session start rides the harness layer and only settings
+can drop it (next session). Refused with no live session (`--print`/ACP), where
+enable/disable persist for the next run. Covered by
+`enable_disable_emit_live_activation_when_wired`.
 Later — the full `yolop-extension-lsp` control-plane extraction (gated on
 `evals/lsp_integration` parity to retire the built-in),
 `workspace/changed`,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1655,6 +1655,37 @@ impl App {
                     self.extension_status.insert(ext, status);
                 }
             }
+            UiCommand::SetExtensionActive {
+                capability_id,
+                name,
+                activate,
+            } => {
+                // enable_extension/disable_extension already persisted the
+                // setting; here we apply it to the running session so it takes
+                // effect on the next turn (EVE-795) rather than only next start.
+                let result = if activate {
+                    self.session.activate_capability(&capability_id).await
+                } else {
+                    self.session.deactivate_capability(&capability_id).await
+                };
+                match result {
+                    Ok(delta) if delta.changed => self.push_system(format!(
+                        "extension `{name}` {} for this session; effective on the next turn.",
+                        if activate { "enabled" } else { "disabled" }
+                    )),
+                    // No overlay change: already in the desired state, or (on
+                    // disable) it rides the harness layer from startup and only
+                    // settings can drop it — which happens next session.
+                    Ok(_) if !activate => self.push_system(format!(
+                        "extension `{name}` will be disabled on the next session."
+                    )),
+                    Ok(_) => {}
+                    Err(err) => self.push_system(format!(
+                        "extension `{name}` saved, but applying it to this session failed: {err}. \
+                         It will load on the next session."
+                    )),
+                }
+            }
         }
     }
 

--- a/src/extensions/manage.rs
+++ b/src/extensions/manage.rs
@@ -8,6 +8,7 @@ use super::manager::LiveProcessRegistry;
 use super::package::{discover_extensions, extension_capability_id};
 use super::scaffold::{self, HookSpec, Language, ScaffoldRequest, ToolSpec};
 use super::store::{self, CrateFetcher, GitRunner, Source, SystemCrateFetcher, SystemGit};
+use crate::host_ui::UiCommand;
 use crate::settings::SettingsStore;
 use async_trait::async_trait;
 use everruns_core::capabilities::Capability;
@@ -15,6 +16,7 @@ use everruns_core::tools::{Tool, ToolExecutionResult};
 use serde_json::{Value, json};
 use std::path::PathBuf;
 use std::sync::Arc;
+use tokio::sync::mpsc::UnboundedSender;
 
 pub const EXTENSIONS_CAPABILITY_ID: &str = "extensions";
 
@@ -26,6 +28,10 @@ pub struct ExtensionsCapability {
     crates: Arc<dyn CrateFetcher>,
     /// Live server processes, so `reload_extension` can restart one in place.
     live_processes: LiveProcessRegistry,
+    /// UI-command sink (the TUI's `ui_rx`) used to activate/deactivate an
+    /// extension on the live session after enable/disable; `None` in
+    /// `--print`/ACP, where enable/disable only persists for the next session.
+    ui_tx: Option<UnboundedSender<UiCommand>>,
 }
 
 impl ExtensionsCapability {
@@ -34,6 +40,7 @@ impl ExtensionsCapability {
         workspace_root: PathBuf,
         settings: Arc<SettingsStore>,
         live_processes: LiveProcessRegistry,
+        ui_tx: Option<UnboundedSender<UiCommand>>,
     ) -> Self {
         Self {
             extensions_dir,
@@ -42,6 +49,7 @@ impl ExtensionsCapability {
             git: Arc::new(SystemGit),
             crates: Arc::new(SystemCrateFetcher::default()),
             live_processes,
+            ui_tx,
         }
     }
 }
@@ -70,10 +78,10 @@ impl Capability for ExtensionsCapability {
             "Extensions are installable capability packages. Use `list_extensions` to see what is \
              installed and enabled, `install_extension` for a crates.io crate \
              (`crates.io:yolop-extension-<name>`), git URL, or local path, \
-             `enable_extension`/`disable_extension` to toggle one in the harness (takes effect \
-             next session), `reload_extension` to restart an enabled extension's server in \
-             place after editing its code (effective immediately, this session), and \
-             `remove_extension` to uninstall. To build a NEW extension \
+             `enable_extension`/`disable_extension` to toggle one (applied to the running \
+             session immediately in the TUI — effective on the next turn — and persisted for \
+             future sessions), `reload_extension` to restart an enabled extension's server in \
+             place after editing its code, and `remove_extension` to uninstall. To build a NEW \
              yourself, `scaffold_extension` generates a ready-to-edit package (manifest + \
              capability server) — declare what it contributes via `tools`, `hooks`, and/or \
              `prompt` — then edit the generated `handle_*` bodies, `install_extension \
@@ -91,6 +99,7 @@ impl Capability for ExtensionsCapability {
             git: self.git.clone(),
             crates: self.crates.clone(),
             live_processes: self.live_processes.clone(),
+            ui_tx: self.ui_tx.clone(),
         });
         vec![
             Box::new(ManageTool::new(ctx.clone(), Verb::Scaffold)),
@@ -112,6 +121,7 @@ struct ManageCtx {
     git: Arc<dyn GitRunner>,
     crates: Arc<dyn CrateFetcher>,
     live_processes: LiveProcessRegistry,
+    ui_tx: Option<UnboundedSender<UiCommand>>,
 }
 
 #[derive(Clone, Copy)]
@@ -350,12 +360,38 @@ impl ManageTool {
         }
         let cap_id = extension_capability_id(name);
         match self.ctx.settings.set_capability_enabled(&cap_id, enable) {
-            Ok(changed) => ToolExecutionResult::Success(json!({
-                "name": name,
-                "enabled": enable,
-                "changed": changed,
-                "note": "Takes effect on the next session.",
-            })),
+            Ok(changed) => {
+                // Persisted for next session; also apply live if the host has a
+                // session to mutate (the TUI). The App answers on `ui_rx` by
+                // calling activate/deactivate_capability, so the extension's
+                // tools/prompt/hooks land on the next turn — no restart.
+                let live = self
+                    .ctx
+                    .ui_tx
+                    .as_ref()
+                    .map(|tx| {
+                        tx.send(UiCommand::SetExtensionActive {
+                            capability_id: cap_id.clone(),
+                            name: name.to_string(),
+                            activate: enable,
+                        })
+                        .is_ok()
+                    })
+                    .unwrap_or(false);
+                let note = if live {
+                    "Applying to the running session now; effective on the next turn (and \
+                     persisted for future sessions)."
+                } else {
+                    "Takes effect on the next session."
+                };
+                ToolExecutionResult::Success(json!({
+                    "name": name,
+                    "enabled": enable,
+                    "changed": changed,
+                    "live": live,
+                    "note": note,
+                }))
+            }
             Err(err) => ToolExecutionResult::ToolError(format!("config write failed: {err}")),
         }
     }
@@ -456,10 +492,14 @@ impl Tool for ManageTool {
             }
             Verb::Remove => "Uninstall an extension by name and drop its enable override.",
             Verb::Enable => {
-                "Enable an installed extension (adds `ext:<name>` to the harness). Effective next session."
+                "Enable an installed extension (adds `ext:<name>` to the harness). In the TUI it \
+                 is also applied to the running session immediately — its tools/prompt/hooks are \
+                 live on the next turn — and persisted for future sessions."
             }
             Verb::Disable => {
-                "Disable an extension without uninstalling it. Effective next session."
+                "Disable an extension without uninstalling it. Applied to the running session \
+                 immediately in the TUI (if it was enabled this session) and persisted for \
+                 future sessions."
             }
             Verb::Reload => {
                 "Reload an enabled extension's server in place so edits to its implementation \
@@ -589,6 +629,7 @@ mod tests {
             git: Arc::new(crate::extensions::store::SystemGit),
             crates: Arc::new(crate::extensions::store::SystemCrateFetcher::default()),
             live_processes: LiveProcessRegistry::default(),
+            ui_tx: None,
         };
         (cap, settings, ext_dir)
     }
@@ -750,5 +791,59 @@ mod tests {
             ToolExecutionResult::ToolError(m) => assert!(m.contains("not enabled"), "{m}"),
             other => panic!("{other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn enable_disable_emit_live_activation_when_wired() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        seed_package(&src, "echo");
+        let ext_dir = tmp.path().join("extensions");
+        let settings = Arc::new(SettingsStore::open(tmp.path().join("settings.toml")));
+        let (ui_tx, mut ui_rx) = tokio::sync::mpsc::unbounded_channel::<UiCommand>();
+        let cap = ExtensionsCapability {
+            extensions_dir: ext_dir,
+            workspace_root: tmp.path().to_path_buf(),
+            settings,
+            git: Arc::new(crate::extensions::store::SystemGit),
+            crates: Arc::new(crate::extensions::store::SystemCrateFetcher::default()),
+            live_processes: LiveProcessRegistry::default(),
+            ui_tx: Some(ui_tx),
+        };
+        let tools = cap.tools();
+        let get = |name: &str| tools.iter().find(|t| t.name() == name).unwrap();
+        get("install_extension")
+            .execute(json!({ "source": src.to_str().unwrap() }))
+            .await;
+
+        // enable persists AND signals live activation on the UI channel.
+        match get("enable_extension")
+            .execute(json!({"name": "echo"}))
+            .await
+        {
+            ToolExecutionResult::Success(v) => assert_eq!(v["live"], true),
+            other => panic!("{other:?}"),
+        }
+        assert_eq!(
+            ui_rx.try_recv().unwrap(),
+            UiCommand::SetExtensionActive {
+                capability_id: "ext:echo".into(),
+                name: "echo".into(),
+                activate: true,
+            }
+        );
+
+        // disable signals deactivation.
+        get("disable_extension")
+            .execute(json!({"name": "echo"}))
+            .await;
+        assert_eq!(
+            ui_rx.try_recv().unwrap(),
+            UiCommand::SetExtensionActive {
+                capability_id: "ext:echo".into(),
+                name: "echo".into(),
+                activate: false,
+            }
+        );
     }
 }

--- a/src/host_ui.rs
+++ b/src/host_ui.rs
@@ -55,6 +55,14 @@ pub enum UiCommand {
     /// Set (or, when `status` is empty, clear) an extension's status-bar field.
     /// Pushed by an extension server's `status/changed` notification.
     SetExtensionStatus { ext: String, status: String },
+    /// Activate (`activate = true`) or deactivate an extension capability on the
+    /// live session so it takes effect this session, not just next. Pushed by
+    /// `enable_extension`/`disable_extension` after the settings write.
+    SetExtensionActive {
+        capability_id: String,
+        name: String,
+        activate: bool,
+    },
 }
 
 /// What a client-executed command can ask the host UI to do. Implemented per

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -68,7 +68,7 @@ use everruns_integrations_duckduckgo::DuckDuckGoCapability;
 use everruns_local::{LocalBackends, LocalProfile, LocalScheduleRunnerHandle};
 use everruns_mcp::{McpAuthProvider, McpAuthRequest, McpCredential};
 use everruns_runtime::{
-    AgentBuilder, HarnessBuilder, InMemorySessionFileStore, InProcessRuntime,
+    AgentBuilder, CapabilityDelta, HarnessBuilder, InMemorySessionFileStore, InProcessRuntime,
     InProcessRuntimeBuilder, RealDiskFileStore, RuntimeBackends, RuntimeSessionStore,
     SessionBuilder, WriteBlocklistFileStore,
 };
@@ -2286,6 +2286,35 @@ impl RuntimeHandles {
         self.session_store.add_session(session).await?;
         Ok(names)
     }
+
+    /// Activate a registered `ext:<name>` capability on the live session so its
+    /// tools, prompt, hooks, commands, and contributed MCP servers appear on
+    /// the next turn — the hot-enable seam (EVE-795). The capability lands on
+    /// the session overlay (distinct from the harness layer a startup-enabled
+    /// extension rides), so it can also be live-deactivated.
+    pub async fn activate_capability(
+        &self,
+        capability_id: &str,
+    ) -> anyhow::Result<CapabilityDelta> {
+        Ok(self
+            .runtime
+            .activate_capability(self.session_id, AgentCapabilityConfig::new(capability_id))
+            .await?)
+    }
+
+    /// Deactivate a capability from the live session overlay. Succeeds only for
+    /// one activated *this session*; an extension enabled at startup rides the
+    /// harness layer and cannot be removed by a session-scoped op (its disable
+    /// takes effect next session via settings).
+    pub async fn deactivate_capability(
+        &self,
+        capability_id: &str,
+    ) -> anyhow::Result<CapabilityDelta> {
+        Ok(self
+            .runtime
+            .deactivate_capability(self.session_id, capability_id)
+            .await?)
+    }
 }
 
 pub struct StartupInfo {
@@ -2817,11 +2846,15 @@ pub async fn build_with_options(
             capabilities.register(capability);
         }
         // The always-on management surface (install/list/enable/remove/reload).
+        // Hand it the UI-command sink so enable/disable can activate the
+        // capability on the live session (TUI only); `None` elsewhere.
+        let manage_ui_tx = matches!(options.client_ui, ClientUiContext::Tui).then(|| ui_tx.clone());
         capabilities.register(crate::extensions::ExtensionsCapability::new(
             ext_dir,
             effective_root.clone(),
             settings.clone(),
             live_processes.clone(),
+            manage_ui_tx,
         ));
     }
     // Server name list for `/mcp` and StartupInfo, computed after extension

--- a/src/session.rs
+++ b/src/session.rs
@@ -78,6 +78,25 @@ impl Session {
         self.handles.connections.clone()
     }
 
+    /// Activate a registered `ext:<name>` capability on the live session so its
+    /// tools/prompt/hooks/commands/MCP appear on the next turn (hot-enable). See
+    /// [`RuntimeHandles::activate_capability`](crate::runtime::RuntimeHandles::activate_capability).
+    pub async fn activate_capability(
+        &self,
+        capability_id: &str,
+    ) -> Result<everruns_runtime::CapabilityDelta> {
+        self.handles.activate_capability(capability_id).await
+    }
+
+    /// Deactivate a session-activated capability. See
+    /// [`RuntimeHandles::deactivate_capability`](crate::runtime::RuntimeHandles::deactivate_capability).
+    pub async fn deactivate_capability(
+        &self,
+        capability_id: &str,
+    ) -> Result<everruns_runtime::CapabilityDelta> {
+        self.handles.deactivate_capability(capability_id).await
+    }
+
     /// Translate the prefix of persisted events that were replayed from disk
     /// into transcript lines (used to seed the transcript on resume).
     pub async fn replayed_lines(&self, count: usize) -> Result<Vec<ChatLine>> {


### PR DESCRIPTION
## What changed

Enabling a new extension no longer waits for the next session. `enable_extension`
now applies to the **running** session immediately (in the TUI) — the extension's
tools, prompt, hooks, commands, and contributed MCP servers are live on the
**next turn**, no restart — while still persisting for future sessions.
`disable_extension` is symmetric.

This lands the last mile of the self-writing loop: scaffold → install → enable →
use, all in one session.

- Uses the runtime's live-reconfigure seam that shipped upstream in
  `everruns-runtime` (`InProcessRuntime::activate_capability` /
  `deactivate_capability` → `CapabilityDelta`, EVE-795 —
  everruns/everruns#2844).
- `enable_extension`/`disable_extension` still persist the `ext:NAME` override
  to settings, and in the TUI now also push a `SetExtensionActive` `UiCommand`.
  The `App` answers it via new `Session::activate_capability` /
  `deactivate_capability` facades (over `RuntimeHandles`), which mutate the
  session-scoped capability overlay. The runtime reassembles surfaces from that
  overlay on the next reason/act boundary.
- `--print`/ACP have no live session to mutate, so enable/disable there persist
  for the next run (the tool result's `live` flag reflects which path ran).
- Spec + `author-extension` skill updated (the "restart to load" guidance is
  gone for the TUI).

## Why

Extensions could be authored, installed, and enabled mid-session, but enabling
only took effect on the **next** session — so an extension yolop just wrote for
itself couldn't be used until a restart. The upstream runtime grew a
live-reconfigure API (EVE-795, which this repo's earlier reload work motivated);
this wires yolop's enable/disable to it.

## The layering (documented)

Extensions enabled at **startup** ride the harness layer (fixed for the
session). Extensions enabled **mid-session** land on the **session overlay** —
which is what `activate_capability` mutates and `deactivate_capability` can
remove. Consequence: you can live-disable an extension you enabled this session;
disabling one that was active from session start is persisted but only drops on
the next session (the harness layer can't be mutated by a session-scoped op).
The App surfaces exactly which happened via the `CapabilityDelta`.

## Before / After

**Before:** `enable_extension` → "Takes effect on the next session." The model's
tool list did not change until restart.

**After:** in the TUI, `enable_extension` → "Applying to the running session now;
effective on the next turn." The extension's tools appear on the next turn.

```
$ cargo test --bin yolop -- extensions:: app::tests   # 220 passed
$ cargo test --bin yolop                              # 778 passed
$ cargo clippy --all-targets --all-features -- -D warnings   # clean
$ cargo fmt --check                                          # clean
```

`enable_disable_emit_live_activation_when_wired` proves the management verbs emit
the `SetExtensionActive` activate/deactivate signal (and set `live: true`) when a
UI sink is wired, and don't when it isn't. The activation/deactivation semantics
themselves are covered upstream in `everruns-runtime` (EVE-795 AC #11).

## Risk

- Low
- Additive: a new `UiCommand` variant + two `Session`/`RuntimeHandles` facades +
  a signal from the management verbs. The trust model is unchanged — enabling
  already required user confirmation, and this only changes *when* it takes
  effect, not *what* is granted. No live session → the prior persist-only
  behavior.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; additive; `everruns-runtime`
      0.17.14 already the workspace pin)