### PR TITLE
fix(tui): stop leaked subprocess output from corrupting the TUI

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4184,6 +4184,111 @@ mod tests {
         assert!(!test.app.scroll.is_stuck_to_bottom());
     }
 
+    /// Render the same app state in regular and full-screen mode and return
+    /// `(fullscreen_rows, regular_rows)`. Full-screen now routes through the
+    /// shared presentation renderer (`render::draw_shared`), so the buffers
+    /// must be byte-for-byte identical — this is the helper the
+    /// unified-presentation parity tests build on.
+    fn render_regular_and_fullscreen(
+        app: &mut App,
+        width: u16,
+        height: u16,
+    ) -> (Vec<String>, Vec<String>) {
+        app.set_render_mode(RenderMode::Inline);
+        let regular = render_app_lines(app, width, height);
+        app.set_render_mode(RenderMode::Fullscreen);
+        let fullscreen = render_app_lines(app, width, height);
+        (fullscreen, regular)
+    }
+
+    /// `fullscreen_matches_regular_presentation` pins parity for the base
+    /// transcript state; this widens that guard to the states most likely to
+    /// tempt a mode-specific rendering fork — a busy turn with a token count, an
+    /// extension-pushed status segment, an open setup overlay, an overflowing
+    /// transcript, and an oversized paste in the composer. If any of these ever
+    /// diverges between the two modes, the unified-presentation invariant has
+    /// regressed.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fullscreen_shares_regular_presentation_across_states() {
+        type Mutate = fn(&mut App);
+        // (name, state mutation, a substring the frame must contain — empty to
+        // skip the content check, e.g. for the overlay case whose exact copy
+        // lives elsewhere).
+        let cases: &[(&str, Mutate, &str)] = &[
+            (
+                "busy turn with tokens",
+                |app| {
+                    app.busy = true;
+                    app.session_tokens = Some(4096);
+                    app.push_user("hello from user".to_string());
+                },
+                "hello from user",
+            ),
+            (
+                "extension status segment",
+                |app| {
+                    app.extension_status
+                        .insert("ext:lsp".to_string(), "indexing".to_string());
+                    app.push_user("hello from user".to_string());
+                },
+                "hello from user",
+            ),
+            (
+                "open setup overlay",
+                |app| {
+                    app.setup = Some(SetupStep::Provider { selected: 0 });
+                },
+                "",
+            ),
+            (
+                "transcript taller than the viewport",
+                |app| {
+                    for i in 0..80 {
+                        app.push_user(format!("line {i}"));
+                    }
+                },
+                "",
+            ),
+            (
+                "oversized paste in the composer",
+                |app| {
+                    let paste = (0..40)
+                        .map(|i| format!("pasteline{i}"))
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    app.input.insert_str(paste);
+                },
+                "",
+            ),
+        ];
+
+        for (name, mutate, needle) in cases {
+            let mut test = app_with_llmsim().await;
+            // Start from a dismissed first-run overlay; cases that want it re-open
+            // it themselves.
+            test.app.setup = None;
+            mutate(&mut test.app);
+
+            let (fullscreen, regular) = render_regular_and_fullscreen(&mut test.app, 60, 20);
+
+            assert_eq!(
+                fullscreen, regular,
+                "full-screen must match regular presentation for state: {name}"
+            );
+            assert!(
+                fullscreen.iter().any(|row| !row.is_empty()),
+                "state {name} should render a non-blank frame (parity must not be vacuous)"
+            );
+            if !needle.is_empty() {
+                let joined = fullscreen.join("\n");
+                assert!(
+                    joined.contains(needle),
+                    "state {name} should render {needle:?}: {joined}"
+                );
+            }
+        }
+    }
+
     fn setup_overlay_text(app: &App) -> Vec<String> {
         setup_overlay_content(app)
             .0

--- a/src/codex_auth.rs
+++ b/src/codex_auth.rs
@@ -512,6 +512,12 @@ async fn open_browser(url: &str) -> Result<()> {
         command
     };
     command.kill_on_drop(true);
+    // Detach stdio so a chatty browser launcher can't print onto the TUI frame
+    // (mirrors `crate::proc::detach_stdio`, which is for std `Command`).
+    command
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
     let status = command
         .status()
         .await

--- a/src/extensions/doctor.rs
+++ b/src/extensions/doctor.rs
@@ -88,7 +88,10 @@ pub async fn doctor(
         .current_dir(workspace_root)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
+        // Pipe (and drain to tracing below) rather than inherit: inheriting the
+        // probed server's stderr writes it onto the terminal, corrupting the TUI
+        // frame. See `extensions::manager` and `crate::proc`.
+        .stderr(Stdio::piped())
         .kill_on_drop(true);
     let bin_dir = package_dir.join("bin");
     if bin_dir.is_dir()
@@ -116,6 +119,17 @@ pub async fn doctor(
     let (Some(stdout), Some(stdin)) = (child.stdout.take(), child.stdin.take()) else {
         return Report::fatal("spawn", "server has no stdio pipes");
     };
+    // Keep the probed server's stderr off the terminal; surface it via tracing.
+    if let Some(stderr) = child.stderr.take() {
+        let name = manifest.name.clone();
+        tokio::spawn(async move {
+            use tokio::io::{AsyncBufReadExt, BufReader};
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                tracing::debug!(target: "yolop::ext", ext = %name, "{line}");
+            }
+        });
+    }
 
     let init = InitializeParams {
         protocol_version: PROTOCOL_VERSION.to_string(),

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -213,9 +213,13 @@ impl ExtensionProcess {
             .current_dir(&self.spec.workspace_root)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            // stderr is the server's free log channel, never parsed; inherit
-            // so `RUST_LOG`-style server logs land with yolop's own stderr.
-            .stderr(Stdio::inherit())
+            // stderr is the server's free log channel, never parsed. Pipe it and
+            // drain to tracing rather than inherit: inheriting writes the
+            // server's logs straight onto the terminal, which corrupts the TUI
+            // frame (most visibly the `--fullscreen` alternate screen). Routed to
+            // tracing, the logs still surface via `RUST_LOG` — just never on the
+            // raw screen.
+            .stderr(Stdio::piped())
             .kill_on_drop(true);
         // Resolve the command against the package's own `bin/` first.
         let bin_dir = self.spec.package_dir.join("bin");
@@ -243,6 +247,19 @@ impl ExtensionProcess {
             .stdin
             .take()
             .ok_or_else(|| anyhow!("extension server has no stdin"))?;
+        // Drain the server's stderr into tracing so its logs never touch the
+        // terminal the TUI owns. The task ends when the child exits and stderr
+        // hits EOF.
+        if let Some(stderr) = child.stderr.take() {
+            let ext = self.name().to_string();
+            tokio::spawn(async move {
+                use tokio::io::{AsyncBufReadExt, BufReader};
+                let mut lines = BufReader::new(stderr).lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    tracing::debug!(target: "yolop::ext", ext = %ext, "{line}");
+                }
+            });
+        }
 
         let init = InitializeParams {
             protocol_version: PROTOCOL_VERSION.to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ mod mcp_oauth_login;
 mod oauth_flow;
 mod paste_attachment;
 mod presentation;
+mod proc;
 mod prompt_history;
 mod runtime;
 mod session;

--- a/src/oauth_flow.rs
+++ b/src/oauth_flow.rs
@@ -6,16 +6,24 @@ use sha2::{Digest, Sha256};
 /// Open `url` in the user's default browser. Shared by the interactive OAuth
 /// login flows (Codex provider auth, MCP server auth).
 pub fn open_browser(url: &str) -> Result<()> {
-    let status = if cfg!(target_os = "macos") {
-        std::process::Command::new("open").arg(url).status()
+    // Detach the opener's stdio: a browser launcher that prints to the inherited
+    // terminal (some `xdg-open` shims are chatty) would corrupt the TUI frame.
+    let mut command = if cfg!(target_os = "macos") {
+        let mut c = std::process::Command::new("open");
+        c.arg(url);
+        c
     } else if cfg!(target_os = "windows") {
-        std::process::Command::new("cmd")
-            .args(["/C", "start", "", url])
-            .status()
+        let mut c = std::process::Command::new("cmd");
+        c.args(["/C", "start", "", url]);
+        c
     } else {
-        std::process::Command::new("xdg-open").arg(url).status()
-    }
-    .context("open browser for login")?;
+        let mut c = std::process::Command::new("xdg-open");
+        c.arg(url);
+        c
+    };
+    let status = crate::proc::detach_stdio(&mut command)
+        .status()
+        .context("open browser for login")?;
     if status.success() {
         Ok(())
     } else {

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -1,0 +1,86 @@
+//! Subprocess execution that never corrupts the terminal the TUI owns.
+//!
+//! yolop's renderer owns stdout, and in `--fullscreen` the whole alternate
+//! screen — which, unlike the inline viewport, has no scrollback to absorb
+//! stray writes. Any child process that *inherits* our stdout/stderr therefore
+//! prints straight onto the live frame: the `Preparing worktree …` /
+//! `HEAD is now at …` / `From github.com…` corruption of the composer and
+//! status bar.
+//!
+//! The fix is a policy, not a per-call-site patch: **internal subprocesses must
+//! keep their output off the terminal.** This module is the single blessed way
+//! to spawn them, so the rule is enforceable by "route it through `proc`"
+//! instead of remembered (and forgotten) at each `Command`. Prefer these over a
+//! bare `Command::status()`/`spawn()`, both of which inherit our stdio.
+//!
+//! Two shapes cover the internal cases:
+//! - [`capture`] — run a one-shot command to completion with its output
+//!   captured (git, cargo, …); the caller inspects status/stdout/stderr.
+//! - [`detach_stdio`] — point a child's three streams at the null device for
+//!   fire-and-forget launches (opening a browser) we neither read nor want on
+//!   the frame.
+//!
+//! Long-running servers that speak a protocol over piped stdin/stdout (the
+//! extension host, language servers) are already safe for those two streams;
+//! the trap there is *stderr*, which must be piped-and-drained or nulled rather
+//! than inherited (see `extensions::manager`).
+
+use std::io;
+use std::process::{Command, Output, Stdio};
+
+/// Run `cmd` to completion with stdin detached and stdout/stderr **captured**
+/// into the returned [`Output`], never inherited from the parent.
+///
+/// Use for one-shot internal commands whose output must stay off the terminal
+/// but whose exit status or captured streams the caller needs (e.g. surfacing
+/// stderr in an error message).
+pub fn capture(cmd: &mut Command) -> io::Result<Output> {
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+}
+
+/// Point a child's stdin, stdout, and stderr at the null device so nothing it
+/// writes can reach the terminal. Returns the same `cmd` for chaining with
+/// `.status()`/`.spawn()`.
+///
+/// Use for fire-and-forget launches (opening a URL in a browser) where we do
+/// not consume the child's output.
+pub fn detach_stdio(cmd: &mut Command) -> &mut Command {
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capture_pipes_stdout_instead_of_inheriting_terminal() {
+        // If `capture` inherited our stdio (as `Command::status()` does), the
+        // returned stdout would be empty and the text would land on the
+        // terminal — the exact leak that corrupts the --fullscreen frame.
+        let mut cmd = Command::new("echo");
+        cmd.arg("captured-not-leaked");
+        let output = capture(&mut cmd).expect("run echo");
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "captured-not-leaked"
+        );
+    }
+
+    #[test]
+    fn capture_also_captures_stderr() {
+        // A command that writes only to stderr must still be captured, never
+        // inherited — stderr is the stream git/cargo use for progress.
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "echo to-stderr 1>&2"]);
+        let output = capture(&mut cmd).expect("run sh");
+        assert!(output.status.success());
+        assert!(output.stdout.is_empty());
+        assert_eq!(String::from_utf8_lossy(&output.stderr).trim(), "to-stderr");
+    }
+}

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -658,22 +658,18 @@ fn git_output(repo_root: &Path, args: &[&str]) -> Option<String> {
     if text.is_empty() { None } else { Some(text) }
 }
 
-/// Run a mutating git subcommand with stdout/stderr **captured**, never
-/// inherited from the parent process.
+/// Run a mutating git subcommand with its output **captured**, never inherited.
 ///
 /// Worktree management runs while the TUI owns the terminal — most visibly the
 /// `--fullscreen` alternate screen, which has no scrollback to absorb stray
-/// output. A bare `Command::status()` inherits our stdio, so git's progress
-/// (`Preparing worktree …`, `From github.com…`, `HEAD is now at …`) prints
-/// straight onto the frame and corrupts the composer and status bar. Routing
-/// every worktree git call through `.output()` keeps that noise off the screen
-/// while still exposing the exit status and captured stderr for diagnostics.
+/// output — so git's progress (`Preparing worktree …`, `HEAD is now at …`)
+/// must not reach the frame. Goes through [`crate::proc::capture`], the shared
+/// choke point for terminal-safe subprocesses, and returns the completed
+/// `Output` so callers can gate on `status.success()` and surface stderr.
 fn git_run(repo_root: &Path, args: &[&str]) -> std::io::Result<std::process::Output> {
-    Command::new("git")
-        .arg("-C")
-        .arg(repo_root)
-        .args(args)
-        .output()
+    let mut cmd = Command::new("git");
+    cmd.arg("-C").arg(repo_root).args(args);
+    crate::proc::capture(&mut cmd)
 }
 
 pub fn restore_worktree_from_metadata(metadata: &SessionWorkspaceMetadata) -> Option<WorktreeInfo> {
@@ -880,8 +876,12 @@ mod tests {
             .output()
             .expect("git init");
 
-        let output = git_run(repo.path(), &["rev-parse", "--is-inside-work-tree"]).expect("git_run");
-        assert!(output.status.success(), "rev-parse should succeed in a repo");
+        let output =
+            git_run(repo.path(), &["rev-parse", "--is-inside-work-tree"]).expect("git_run");
+        assert!(
+            output.status.success(),
+            "rev-parse should succeed in a repo"
+        );
         assert_eq!(
             String::from_utf8_lossy(&output.stdout).trim(),
             "true",

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -449,32 +449,22 @@ fn create_worktree(repo_root: &Path, path: &Path, branch: &str, base_ref: &str) 
     // Best-effort fetch so origin/main is current when used as the base.
     if base_ref.starts_with("origin/") {
         let remote_branch = base_ref.strip_prefix("origin/").unwrap_or(base_ref);
-        let _ = Command::new("git")
-            .arg("-C")
-            .arg(repo_root)
-            .args(["fetch", "origin", remote_branch])
-            .status();
+        let _ = git_run(repo_root, &["fetch", "origin", remote_branch]);
     }
-    let status = Command::new("git")
-        .arg("-C")
-        .arg(repo_root)
-        .args([
-            "worktree",
-            "add",
-            "-B",
-            branch,
-            &path.display().to_string(),
-            base_ref,
-        ])
-        .status()
-        .with_context(|| format!("git worktree add for {}", path.display()))?;
-    if status.success() {
+    let path_str = path.display().to_string();
+    let output = git_run(
+        repo_root,
+        &["worktree", "add", "-B", branch, &path_str, base_ref],
+    )
+    .with_context(|| format!("git worktree add for {}", path.display()))?;
+    if output.status.success() {
         copy_worktree_includes(repo_root, path);
         return Ok(());
     }
     bail!(
-        "git worktree add -B {branch} {} {base_ref} failed",
-        path.display()
+        "git worktree add -B {branch} {} {base_ref} failed: {}",
+        path.display(),
+        String::from_utf8_lossy(&output.stderr).trim()
     );
 }
 
@@ -600,19 +590,16 @@ fn recreate_worktree(repo_root: &Path, saved: &WorktreeMetadata) -> Result<Workt
         let _ = std::fs::remove_dir_all(&path);
     }
     if branch_exists(repo_root, &saved.branch) {
-        let status = Command::new("git")
-            .arg("-C")
-            .arg(repo_root)
-            .args([
-                "worktree",
-                "add",
-                &path.display().to_string(),
-                &saved.branch,
-            ])
-            .status()
+        let path_str = path.display().to_string();
+        let output = git_run(repo_root, &["worktree", "add", &path_str, &saved.branch])
             .with_context(|| format!("reattach worktree branch {}", saved.branch))?;
-        if !status.success() {
-            bail!("git worktree add {} {}", path.display(), saved.branch);
+        if !output.status.success() {
+            bail!(
+                "git worktree add {} {}: {}",
+                path.display(),
+                saved.branch,
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
         }
         copy_worktree_includes(repo_root, &path);
     } else {
@@ -669,6 +656,24 @@ fn git_output(repo_root: &Path, args: &[&str]) -> Option<String> {
     }
     let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
     if text.is_empty() { None } else { Some(text) }
+}
+
+/// Run a mutating git subcommand with stdout/stderr **captured**, never
+/// inherited from the parent process.
+///
+/// Worktree management runs while the TUI owns the terminal — most visibly the
+/// `--fullscreen` alternate screen, which has no scrollback to absorb stray
+/// output. A bare `Command::status()` inherits our stdio, so git's progress
+/// (`Preparing worktree …`, `From github.com…`, `HEAD is now at …`) prints
+/// straight onto the frame and corrupts the composer and status bar. Routing
+/// every worktree git call through `.output()` keeps that noise off the screen
+/// while still exposing the exit status and captured stderr for diagnostics.
+fn git_run(repo_root: &Path, args: &[&str]) -> std::io::Result<std::process::Output> {
+    Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(args)
+        .output()
 }
 
 pub fn restore_worktree_from_metadata(metadata: &SessionWorkspaceMetadata) -> Option<WorktreeInfo> {
@@ -783,13 +788,10 @@ fn main_repo_for_worktree(worktree_path: &Path) -> Option<PathBuf> {
 
 pub fn remove_worktree_path(path: &Path) -> Result<()> {
     if let Some(repo_root) = main_repo_for_worktree(path) {
-        let status = Command::new("git")
-            .arg("-C")
-            .arg(&repo_root)
-            .args(["worktree", "remove", "--force", &path.display().to_string()])
-            .status()
+        let path_str = path.display().to_string();
+        let output = git_run(&repo_root, &["worktree", "remove", "--force", &path_str])
             .with_context(|| format!("git worktree remove {}", path.display()))?;
-        if status.success() {
+        if output.status.success() {
             return Ok(());
         }
     }
@@ -861,6 +863,30 @@ mod tests {
         assert!(truncated.starts_with('…'));
         assert!(truncated.contains("session_019ee6c2"));
         assert!(truncated.chars().count() <= 40);
+    }
+
+    #[test]
+    fn git_run_captures_output_instead_of_inheriting_terminal() {
+        // Regression guard for the `--fullscreen` status-bar corruption: worktree
+        // git commands must capture their stdout/stderr rather than inherit the
+        // TUI's terminal. `git_run` uses `Command::output()`, so a command that
+        // writes to stdout must come back captured. If a caller ever reverts to
+        // `Command::status()` (terminal-inherited), the output would splatter the
+        // alternate screen — the exact leak seen with `Preparing worktree …`.
+        let repo = tempfile::tempdir().expect("repo");
+        std::process::Command::new("git")
+            .args(["init", "-b", "main"])
+            .current_dir(repo.path())
+            .output()
+            .expect("git init");
+
+        let output = git_run(repo.path(), &["rev-parse", "--is-inside-work-tree"]).expect("git_run");
+        assert!(output.status.success(), "rev-parse should succeed in a repo");
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "true",
+            "git_run must capture stdout so worktree git output never reaches the TUI frame"
+        );
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -463,6 +463,80 @@ fn tui_escape_does_not_exit_and_ctrl_c_exits() {
 }
 
 #[test]
+fn tui_default_renders_and_responds_smoke() {
+    tui_smoke(false);
+}
+
+#[test]
+fn tui_fullscreen_renders_and_responds_smoke() {
+    tui_smoke(true);
+}
+
+/// End-to-end smoke for both TUI renderers: start the TUI, drive one llmsim
+/// turn, and assert the rendered grid shows the composer and provider status
+/// bar with no subprocess output leaked onto the frame (the corruption this
+/// change fixes), then exit cleanly.
+fn tui_smoke(fullscreen: bool) {
+    let mode = if fullscreen { "fullscreen" } else { "default" };
+    let mut tui = spawn_tui_llmsim_with(
+        &yolop_binary(),
+        TuiSpawnOptions {
+            fullscreen,
+            ..TuiSpawnOptions::default()
+        },
+    );
+    // Wait on the composer hint from the shared chrome, which both renderers
+    // draw (unlike the startup banner, which inline flushes to scrollback that
+    // the fullscreen alternate screen does not have).
+    assert!(
+        tui.wait_for_output("Enter to send", Duration::from_secs(5)),
+        "{mode}: composer never rendered: {}",
+        tui.output_text()
+    );
+
+    // Drive a turn end-to-end; llmsim's offline reply is deterministic. Match
+    // its tail, which stays on-screen at the bottom of the transcript (the
+    // "offline mode" head can scroll above the fullscreen window).
+    tui.write_input(b"hi\r");
+    assert!(
+        tui.wait_for_output("real responses", Duration::from_secs(10)),
+        "{mode}: llmsim response never rendered after a prompt: {}",
+        tui.output_text()
+    );
+
+    // Assert on the reconstructed grid (post-ANSI), which is what the user sees.
+    let screen = tui.screen_lines().join("\n");
+    assert!(
+        screen.contains("llmsim"),
+        "{mode}: provider status bar should be on-screen:\n{screen}"
+    );
+    // The frame must not carry leaked child-process output. These are the git
+    // progress lines that corrupted the --fullscreen status bar before the
+    // subprocess output was captured/detached.
+    for leak in ["Preparing worktree", "HEAD is now at", "From github.com"] {
+        assert!(
+            !screen.contains(leak),
+            "{mode}: subprocess output leaked onto the frame ({leak:?}):\n{screen}"
+        );
+    }
+
+    // Clean shutdown via Ctrl-C twice.
+    tui.write_input(b"\x03");
+    assert!(
+        tui.wait_for_output("Press Ctrl+C again to exit", Duration::from_secs(5)),
+        "{mode}: first Ctrl-C should invite a second press: {}",
+        tui.output_text()
+    );
+    tui.write_input(b"\x03");
+    let status = tui.wait_or_kill(Duration::from_secs(5));
+    assert!(
+        status.success(),
+        "{mode}: second Ctrl-C should exit cleanly, got {status:?}: {}",
+        tui.output_text()
+    );
+}
+
+#[test]
 fn tui_alt_enter_sequence_submits_like_enter() {
     let mut tui = spawn_tui_llmsim(&yolop_binary());
     assert!(

--- a/tests/support/tui_harness.rs
+++ b/tests/support/tui_harness.rs
@@ -34,6 +34,9 @@ pub struct TuiSpawnOptions {
     pub cursor_reply_budget: usize,
     /// Directory prepended to `PATH` for subprocess lookup in the spawned TUI.
     pub path_prefix: Option<PathBuf>,
+    /// Launch the alternate-screen renderer (`--fullscreen`) instead of the
+    /// default inline TUI.
+    pub fullscreen: bool,
 }
 
 impl Default for TuiSpawnOptions {
@@ -44,6 +47,7 @@ impl Default for TuiSpawnOptions {
             cursor_row: 1,
             cursor_reply_budget: usize::MAX,
             path_prefix: None,
+            fullscreen: false,
         }
     }
 }
@@ -190,6 +194,9 @@ pub fn spawn_tui_llmsim_with_settings(
     let mut cmd = CommandBuilder::new(binary);
     cmd.args(["--provider", "llmsim", "--session-dir"]);
     cmd.arg(session_dir.path());
+    if options.fullscreen {
+        cmd.arg("--fullscreen");
+    }
     cmd.env("HOME", home.path());
     cmd.env("XDG_CONFIG_HOME", home.path().join(".config"));
     cmd.env("XDG_DATA_HOME", home.path().join(".local/share"));


### PR DESCRIPTION
## What changed

`yolop --fullscreen` could have its status bar and composer clobbered by raw
git output after an internal worktree operation. The cause was general, not
worktree-specific: several internal helpers ran child processes that **inherited
the TUI's stdout/stderr**, so the child's output printed straight onto the live
frame. The alternate screen has no scrollback to absorb stray writes, which is
why it showed there most visibly (the inline TUI shared the same latent hazard).

Now every internal subprocess keeps its output off the terminal, funneled
through a single choke point (`crate::proc`) instead of each call site
remembering the right stdio:

- `proc::capture()` — one-shot commands (git worktree/fetch/remove) run with
  output captured; failures surface the captured stderr.
- `proc::detach_stdio()` — fire-and-forget launches (OAuth/Codex browser
  openers) send their streams to the null device.
- The extension host and `doctor` now pipe the server's stderr and drain it to
  `tracing` rather than inheriting it onto the terminal — still visible via
  `RUST_LOG`, never on the raw screen.

Also widens `--fullscreen` test coverage: parity assertions that fullscreen and
regular mode render identically across busy/tokens, extension-status, setup
overlay, overflowing transcript, and oversized-paste states.

## Why

A user on `--fullscreen` saw the status bar interleaved with `From github.com…`,
`Preparing worktree (new branch …)`, `branch … set up to track 'origin/main'`,
and `HEAD is now at …` after the `ship` skill created a worktree — git's own
progress, printed over the TUI because the spawn inherited our terminal.

## Before / After

- **Before:** git progress from `Command::status()` (inherited stdio) splattered
  the composer and status bar in the alternate screen.
- **After:** a PTY smoke test drives one llmsim turn in **both** the default and
  `--fullscreen` renderers and asserts the composer + provider status render with
  **no** leaked subprocess strings (`Preparing worktree`, `HEAD is now at`,
  `From github.com`) on the frame. Unit tests assert `proc::capture` captures
  stdout/stderr rather than inheriting. Full suite, `fmt`, and
  `clippy -D warnings` are green.

## Risk

- **Low.** The change only redirects child stdio (capture / null / drain to
  tracing); it does not alter command arguments or control flow. One observable
  behavior change: extension-server stderr now lands in `tracing`/`RUST_LOG`
  instead of the raw terminal — intended, since inheriting it is the bug.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; extension stderr now via tracing)

https://claude.ai/code/session_01Jtcm51unYZqhTTsSZY9oXF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jtcm51unYZqhTTsSZY9oXF)_