### PR TITLE
feat(session): add checkpoint rewind and undo

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
 - **Sessions** — every run writes a durable per-session event log; resume any
   conversation with `--session <id>` (see
   [Session persistence](#session-persistence)).
+- **Checkpoint rewind** — every turn gets a durable conversation checkpoint and,
+  in Yolop-owned Git worktrees, an exact workspace snapshot. `/undo`, `/redo`,
+  and `/rewind` preview and restore either axis without changing `HEAD` or the
+  real Git index. See [`specs/checkpointing.md`](specs/checkpointing.md).
 - **Session search** — `search_sessions` finds recent local sessions by a
   distinctive user/assistant phrase, or lists recent sessions when no query is
   supplied. This keeps investigations of prior or crashed runs grounded in the
@@ -478,6 +482,16 @@ workspace.
 
 `--session-dir <PATH>` overrides the parent storage location (useful for
 keeping per-workspace session histories in `<workspace>/.yolop/sessions/`).
+
+Interactive sessions create a checkpoint before every turn. `/undo` previews a
+restore to before the latest turn; `/rewind` lists earlier checkpoints and
+`/rewind <id> [conversation|workspace|both]` previews one explicitly. `/redo`
+previews the last abandoned branch. Every restore returns a confirmation token;
+confirm with the same command followed by `confirm <token>`. Conversation
+restore removes abandoned turns from model-visible history and returns the
+original prompt to the composer. Workspace restore is available only in a
+Yolop-owned worktree and never changes the branch, `HEAD`, commits, or real
+index.
 
 **Treat session logs as you would shell history.** They contain every prompt
 you typed, every string passed to `bash` / `write_file` / `web_fetch`, tool

--- a/specs/checkpointing.md
+++ b/specs/checkpointing.md
@@ -1,0 +1,292 @@
+# Session checkpointing and rewind
+
+Status: implemented (v1).
+
+## Why
+
+Yolop persists a resumable conversation and normally gives implementation
+sessions an isolated Git worktree. Neither property is an undo mechanism. A bad
+turn remains in the model's context, and its filesystem changes remain in the
+worktree. Asking the model to reverse itself is lossy because it depends on the
+same context that may be wrong and cannot reliably reconstruct deleted or
+overwritten content.
+
+Checkpointing makes every user-turn boundary a durable recovery point. A user
+can discard an unproductive conversational branch, restore the corresponding
+workspace, or do both, then edit and resend the original prompt.
+
+## Product model
+
+A checkpoint is the state immediately **before** a user or automatic turn:
+
+- the active conversation head;
+- an exact sequence boundary in the append-only session log;
+- a workspace snapshot when the session owns an active Git worktree;
+- the prompt that is about to run, for list labels and input restoration;
+- enough metadata to preview and validate a restore.
+
+Checkpoints are automatic. They are not commits in the user's branch and are
+not a replacement for Git history.
+
+### User actions
+
+- `/rewind` lists checkpoints newest first. `/rewind <id> [mode]` previews:
+  - **Conversation and workspace** (default when a complete workspace snapshot
+    is available);
+  - **Conversation only**;
+  - **Workspace only**;
+  - cancellation by simply not confirming.
+- `/undo` is a shortcut for rewinding both states to before the most recent
+  completed turn. It still shows a destructive preview when files would change.
+- `/redo` restores the branch most recently abandoned by `/undo` or `/rewind`.
+  It is available until a new turn starts. Starting a new turn clears the redo
+  shortcut but does not delete the abandoned branch.
+- Natural-language requests such as "undo the last turn" use the same controller
+  through a model-facing tool. The tool may request a preview, but it must not
+  bypass the same safety checks as the slash command.
+
+After conversation rewind, the selected turn's original prompt is placed in the
+input editor but is not submitted. The user may edit, discard, or resend it.
+The active transcript is replaced with the selected branch and a restore notice.
+Inline mode cannot erase bytes already emitted to the terminal's scrollback,
+but subsequent rendering and model context use only the selected branch.
+`/clear` remains display-only and is unrelated to rewind.
+
+## Semantics
+
+Conversation and workspace are independent axes. Restoring one never silently
+implies the other. The UI always names the state it will change.
+
+| Action | Model-visible history | Transcript | Workspace files |
+|---|---|---|---|
+| Conversation only | selected ancestor branch | selected ancestor branch | unchanged |
+| Workspace only | unchanged | unchanged plus restore notice | selected snapshot |
+| Both | selected ancestor branch | selected ancestor branch | selected snapshot |
+
+Rewind does not delete history. It moves the active head to an ancestor and
+preserves the abandoned suffix as a branch. This makes redo and crash-safe
+resume possible without rewriting `events.jsonl`.
+
+Workspace restore means file contents, paths, executable bits, and symlinks in
+the captured worktree. It deliberately does **not** rewrite the worktree branch,
+`HEAD`, commits, user refs, reflogs, submodule repositories, ignored files,
+write-blocklisted build/dependency directories, or external
+side effects such as databases, services, deployed resources, and commands run
+outside the active root. Empty directories are not captured. These exclusions
+are a stable part of the workspace snapshot contract.
+
+If commits were created after a checkpoint, restoring files leaves those commits
+intact and produces ordinary working-tree differences against the current
+`HEAD`. The user can recover either state with Git or `/redo`.
+
+## Storage
+
+The existing per-session directory gains:
+
+```text
+<session>/
+  events.jsonl                 # immutable event payloads, as today
+  timeline.jsonl               # append-only checkpoint/head/restore records
+  workspace.json               # existing session/worktree metadata
+```
+
+Workspace snapshots use Git objects in the session worktree's repository,
+anchored by private refs:
+
+```text
+refs/yolop/checkpoints/<session-id>/<checkpoint-id>
+```
+
+Creating a snapshot uses a temporary index and plumbing commands (`add -A`,
+`write-tree`, `update-ref`). It does not change the real index, working tree,
+current branch, or `HEAD`. Each checkpoint ref points directly to a tree object;
+Git's object store deduplicates content. Ordinary Git machinery calculates
+previews. Untracked non-ignored files are included; ignored and write-blocklisted
+paths are not. Checkpoint refs are removed when their worktree is pruned, leaving
+normal Git GC to reclaim unreachable objects.
+
+Each timeline record is JSONL and owner-only. Relevant record types are:
+
+- `checkpoint.created`: checkpoint id, parent checkpoint, event sequence before
+  the turn, prompt, snapshot tree/ref, and any capture error;
+- `turn.completed`: checkpoint id and final event sequence/status;
+- `head.moved`: old head, new head, abandoned head, and recovery snapshot;
+- `redo.cleared`: the abandoned head is no longer the implicit redo target.
+
+The journal is append-only and flushed before the turn begins or a restore is
+reported successful. A compact derived index may be added later, but it is never
+the source of truth.
+
+## Conversation replay
+
+`events.jsonl` remains the durable event payload store. `timeline.jsonl`
+describes which event ranges form the active branch.
+
+On a new turn, Yolop:
+
+1. creates and flushes the checkpoint;
+2. records its parent as the current conversation head;
+3. runs the turn and appends events normally;
+4. records the turn's final sequence and status;
+5. advances the active head.
+
+On resume, Yolop validates the timeline, walks parents from the active head, and
+replays only those event ranges into the event bus, message store, and transcript.
+Abandoned events remain in the raw session log and therefore remain discoverable
+through session search, but never enter model context unless that branch is
+restored.
+
+The live runtime retains the concrete in-memory message store handle. A
+conversation restore reseeds it from the materialized branch and replaces the
+host's active transcript from the same event set. No process restart is
+required. The event sequence remains globally monotonic across all branches.
+
+Compaction and opaque provider reasoning artifacts belong to their turn range.
+Rolling back past them removes them from active replay; Yolop must not reuse a
+provider continuation id whose ancestor messages are no longer active. The next
+turn starts a fresh provider continuation from the materialized messages.
+
+## Workspace restore
+
+Restore is a small transaction coordinated by a session-scoped lock:
+
+1. Refuse while a foreground turn, shell command, scheduled wake, or background
+   task can still write the workspace. The user may cancel those tasks first.
+2. Capture the current workspace as a durable recovery checkpoint. If this
+   fails, make no changes.
+3. Compare current files with the target snapshot and show the paths that will
+   change. Confirmation is required for every restore.
+4. After confirmation, materialize through a private Git index and replace or
+   delete captured paths under the active root. Reject path traversal and
+   write-blocklisted paths.
+5. Verify the resulting captured tree id. Only then append `head.moved` and
+   update the conversation head when the selected mode includes conversation.
+6. On failure, attempt to restore the recovery checkpoint and keep the journal
+   head unchanged.
+
+The preview and token confirmation are mandatory, including for a no-op restore.
+The model-facing tool can only queue confirmation; mutation occurs after its
+current turn has completed.
+
+### Ownership boundary
+
+Version 1 offers workspace snapshots only for a Yolop-owned worktree. This is
+the key safety boundary: restoring the whole captured state cannot erase edits
+from the user's primary checkout or another session.
+
+When worktrees are off, checkpoint listings label entries conversation-only and
+workspace restore explains why it is unavailable. A later version may add a shadow repository
+and three-way conflict handling for shared or non-Git directories, but it must
+not weaken version 1's guarantee or silently restore only edit-tool changes.
+
+## Partial and failed checkpoints
+
+A turn is allowed to continue when workspace capture fails, but its checkpoint
+is labeled `conversation only` with the reason. Typical reasons include a missing
+Git repository, repository lock, unsupported path encoding, or unreadable file.
+Yolop never presents a partial snapshot as an exact workspace restore.
+
+Interrupted/failed turns still have checkpoints and are rewindable. If a crash
+occurs after the workspace snapshot but before the turn-completion record, resume
+closes the turn as interrupted at the last persisted event sequence. If a crash
+occurs during restore, the absence of `head.moved` leaves the prior conversation
+head authoritative and the private recovery ref available for manual recovery.
+
+Malformed timeline records are skipped only at the corrupt tail. Corruption in
+the committed prefix disables mutation and leaves session replay read-only until
+the user repairs or forks the session; silently guessing a branch is unsafe.
+
+## Retention and privacy
+
+- Version 1 retains automatic checkpoints for the life of the session worktree.
+  `yolop worktree prune` removes their private refs; Git object cleanup follows
+  repository GC policy.
+- Prompts remain in the existing private event log and timeline, both protected
+  with owner-only permissions on Unix.
+- Snapshotting honors Git ignores. Yolop does not force-add ignored secrets.
+- `yolop worktree prune --dry-run` reports checkpoint refs it would detach.
+
+## Host surface
+
+The controller is host-independent; presentation is not:
+
+- TUI: `/rewind`, `/undo`, and `/redo` produce textual previews and confirmation
+  tokens; a conversation restore puts the original prompt back in the composer.
+- ACP: advertise system commands through the existing
+  `available_commands_update` path. Because ACP has no Yolop-specific rewind
+  picker, restoration is a two-step command: the first invocation returns a
+  preview plus a confirmation token; the second supplies that token.
+  Do not expose TUI-only effects over ACP.
+- `--print`: the same model-facing tool is available. A restore still requires
+  the explicit preview/confirmation sequence and is applied only after the turn.
+
+The command palette remains sourced from capability descriptors. All front-ends
+and the model-facing tool call one `CheckpointController`; restore logic must not
+be duplicated in the UI.
+
+## Fit with the current architecture
+
+Version 1 is implemented inside Yolop without an Everruns protocol change:
+
+- `src/session_log.rs` already owns append-only event persistence, replay
+  filtering, sequence continuity, private permissions, tail repair, and the
+  single-writer file lock. Timeline materialization belongs beside it.
+- Runtime construction already creates a concrete `InMemoryMessageRetriever`
+  and seeds it on resume. Retaining its `Arc` in `RuntimeHandles` is sufficient
+  to clear/reseed live model history after rewind; no new message-store trait
+  method is required.
+- `App` owns the mutable transcript vector and replaces it from the active event
+  set after a restore.
+- `WorktreeManager::worktree_info()` identifies an active session worktree and
+  exposes its path. Snapshot creation can use ordinary Git plumbing against that
+  path without changing the runtime file-store abstraction.
+- TUI and ACP foreground turns are serialized at host boundaries. The retained
+  `SessionTaskRegistry` rejects restore while descendant tasks are active, and
+  stale-preview verification rejects external edits made before confirmation.
+- ACP already advertises and dispatches capability commands. Preview/confirm can
+  therefore be expressed as command results without extending ACP.
+
+The main implementation is Yolop state coordination, not a missing platform
+capability. A future shared-checkout/non-Git restore mode may justify a shadow
+repository, and richer native ACP UI would require ACP support.
+
+## Acceptance criteria
+
+- After three turns, rewinding to turn one and resuming sends the model no
+  messages, tool results, or reasoning artifacts from turns two and three.
+- Resume after process restart materializes the same active branch.
+- Combined rewind restores tracked and untracked non-ignored,
+  non-write-blocklisted files exactly,
+  including creations, deletions, renames, binary content, symlinks, and modes,
+  even when the changes came from shell commands.
+- Restore never changes `HEAD`, branch refs, commits, or the user's real index.
+- A recovery checkpoint makes every successful restore redoable.
+- Workspace restore is unavailable outside the session-owned worktree in v1.
+- Active writers block restore; a failed capture or preview causes no mutation.
+- Abandoned branches remain durable but absent from model context.
+- Session and worktree pruning remove checkpoint refs without touching user refs.
+
+## Prior art
+
+- [Claude Code checkpointing](https://code.claude.com/docs/en/checkpointing)
+  exposes separate conversation/code/both restores, but documents that shell and
+  external changes are not tracked.
+- [Gemini CLI checkpointing](https://google-gemini.github.io/gemini-cli/docs/cli/checkpointing.html)
+  stores a Git snapshot, conversation, and pending tool call in a shadow repo.
+- [Cline checkpoints](https://www.mintlify.com/cline/cline/core-workflows/checkpoints)
+  use shadow Git and expose files/task/both restore modes.
+- [Cursor checkpoints](https://docs.cursor.com/en/agent/chat/checkpoints) are
+  local, automatic snapshots of agent changes and explicitly not version control.
+- [Aider Git integration](https://aider.chat/docs/git.html) auto-commits agent
+  changes and implements `/undo` through Git history.
+- [Codex app-server `thread/rollback`](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md)
+  records a rollback marker and prunes model-visible turns without deleting the
+  rollout; its documented endpoint is deprecated and does not restore files.
+
+## Related
+
+- [`session-history.md`](./session-history.md) — local session discovery.
+- [`worktrees.md`](./worktrees.md) — session-owned workspace isolation.
+- [`commands.md`](./commands.md) — command registry and host routing.
+- [`conversational-control.md`](./conversational-control.md) — natural-language
+  access to user-facing controls.

--- a/specs/commands.md
+++ b/specs/commands.md
@@ -27,7 +27,8 @@ top of the runtime's two, not a separate `CommandSource` variant.
 1. **System** — the **runtime** executes it via `runtime.execute_command`,
    returning a `CommandResult { success, message }` the host renders inline.
    Example: `/setup` and its subcommands mutate provider/model/token settings;
-   `/shell <command>` runs the existing bounded bash tool; `/goal <condition>`
+   `/shell <command>` runs the existing bounded bash tool; `/undo`, `/redo`, and
+   `/rewind` preview and confirm durable session restores; `/goal <condition>`
    starts an autonomous completion loop (see [`goal.md`](./goal.md)).
 
 2. **Skill** — the **LLM** executes it. The literal `/name args` text is

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -563,6 +563,12 @@ mod tests {
             commands.iter().any(|c| c["name"] == "shell"),
             "expected /shell to be advertised, got: {commands:?}"
         );
+        for name in ["rewind", "undo", "redo"] {
+            assert!(
+                commands.iter().any(|command| command["name"] == name),
+                "expected /{name} to be advertised, got: {commands:?}"
+            );
+        }
         let setup = commands
             .iter()
             .find(|c| c["name"] == "setup")

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -903,8 +903,9 @@ async fn run_prompt(
     if let Err(err) = session.worktree.ensure_before_turn(&prompt) {
         tracing::warn!(%err, "acp: worktree activation failed");
     }
-    let runtime = handles.runtime.clone();
-    let turn = tokio::spawn(async move { runtime.run_turn(session_id, input).await });
+    let turn_handles = handles.clone();
+    let turn =
+        tokio::spawn(async move { turn_handles.run_checkpointed_turn(&prompt, input).await });
 
     let mut translator = Translator::new();
     let mut cancel_rx = session.arm_cancel();
@@ -954,7 +955,14 @@ async fn run_prompt(
         return StopReason::Cancelled;
     }
 
-    match turn.await {
+    let outcome = turn.await;
+    if let Some(notice) = handles.checkpoints.take_notice() {
+        peer.session_update(
+            &acp_id,
+            SessionUpdate::AgentMessageChunk(protocol::text_chunk(notice)),
+        );
+    }
+    match outcome {
         Ok(Ok(result)) if result.success => StopReason::EndTurn,
         Ok(Ok(result)) => {
             if let Some(error) = result.error {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -833,6 +833,10 @@ impl App {
                 }
                 Ok(TurnEvent::Done) => {
                     self.finish_busy();
+                    if let Some(notice) = self.session.take_checkpoint_notice() {
+                        self.refresh_after_checkpoint_restore(notice).await;
+                        return Ok(());
+                    }
                     self.after_turn_goal_check().await;
                     self.after_turn_user_ask_check().await;
                     return Ok(());
@@ -1001,6 +1005,20 @@ impl App {
         {
             Ok(replayed_lines) => self.lines.extend(replayed_lines),
             Err(err) => self.push_system(format!("load replayed transcript: {err}")),
+        }
+    }
+
+    async fn refresh_after_checkpoint_restore(&mut self, notice: String) {
+        match self.session.active_lines().await {
+            Ok(lines) => {
+                self.lines = lines;
+                self.printed_lines = 0;
+            }
+            Err(error) => self.push_system(format!("refresh restored transcript: {error}")),
+        }
+        self.push_system(notice);
+        if let Some(prompt) = self.session.take_restored_prompt() {
+            self.set_input_text(prompt);
         }
     }
 
@@ -2157,7 +2175,12 @@ impl App {
                         // Client-executed commands (help/clear/model/…) apply
                         // their effect via a `UiCommand` and return an empty
                         // message; don't render a blank line for those.
-                        if !result.message.is_empty() {
+                        if result.success
+                            && matches!(descriptor.name.as_str(), "rewind" | "undo" | "redo")
+                            && result.message.starts_with("restored ")
+                        {
+                            self.refresh_after_checkpoint_restore(result.message).await;
+                        } else if !result.message.is_empty() {
                             let prefix = if result.success { "" } else { "error: " };
                             self.push_system(format!("{prefix}{}", result.message));
                         }
@@ -4520,6 +4543,79 @@ mod tests {
         );
         assert!(!app.busy);
         assert!(app.stream_preview.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn undo_command_refreshes_visible_branch_and_restores_prompt() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+        app.lines.clear();
+
+        for prompt in ["first turn", "second turn"] {
+            app.set_input_text(prompt.to_string());
+            app.submit_input().await;
+            app.pump_turn_until_idle_for_test().await;
+        }
+
+        let preview = app
+            .session
+            .execute_command("undo", None)
+            .await
+            .expect("preview undo");
+        let token = preview
+            .message
+            .lines()
+            .last()
+            .and_then(|line| line.split('`').nth(1))
+            .expect("confirmation token");
+        let restored = app
+            .session
+            .execute_command("undo", Some(format!("confirm {token}")))
+            .await
+            .expect("confirm undo");
+        app.refresh_after_checkpoint_restore(restored.message).await;
+
+        assert!(
+            app.lines
+                .iter()
+                .any(|line| { matches!(line.author, Author::User) && line.text == "first turn" })
+        );
+        assert!(
+            !app.lines
+                .iter()
+                .any(|line| { matches!(line.author, Author::User) && line.text == "second turn" })
+        );
+        assert_eq!(app.input_text(), "second turn");
+
+        let session_id = fixture.app.session.session_id();
+        let workspace_root = fixture._workspace.path().to_path_buf();
+        let sessions_root = fixture._sessions.path().to_path_buf();
+        drop(fixture.app);
+        let settings = std::sync::Arc::new(crate::settings::SettingsStore::open(
+            sessions_root.join("settings.toml"),
+        ));
+        let resumed = crate::runtime::build_with_options(
+            workspace_root,
+            crate::runtime::ProviderChoice::Sim,
+            Some(session_id),
+            sessions_root,
+            settings,
+            crate::runtime::BuildOptions::default(),
+        )
+        .await
+        .expect("resume rewound session");
+        let resumed_text = resumed
+            .handles
+            .runtime
+            .messages(session_id)
+            .await
+            .expect("resumed messages")
+            .into_iter()
+            .filter_map(|message| message.text().map(str::to_string))
+            .collect::<Vec<_>>();
+        assert!(resumed_text.iter().any(|text| text == "first turn"));
+        assert!(!resumed_text.iter().any(|text| text == "second turn"));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/capabilities/checkpoint.rs
+++ b/src/capabilities/checkpoint.rs
@@ -1,0 +1,314 @@
+//! Session checkpoint commands and the conversational restore tool.
+
+use crate::checkpoint::{CheckpointManager, RestoreMode, safe_display};
+use async_trait::async_trait;
+use everruns_core::capabilities::{Capability, CapabilityStatus};
+use everruns_core::command::{
+    CommandArg, CommandDescriptor, CommandExecutionContext, CommandResult, CommandSource,
+    ExecuteCommandRequest,
+};
+use everruns_core::tool_types::{ToolCall, ToolHints};
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use serde_json::{Value, json};
+use std::sync::Arc;
+
+pub(crate) const CHECKPOINT_CAPABILITY_ID: &str = "yolop_checkpoint";
+
+pub(crate) struct CheckpointCapability {
+    pub(crate) manager: Arc<CheckpointManager>,
+}
+
+#[async_trait]
+impl Capability for CheckpointCapability {
+    fn id(&self) -> &str {
+        CHECKPOINT_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Session Checkpoints"
+    }
+
+    fn description(&self) -> &str {
+        "List, preview, confirm, undo, redo, or rewind durable session checkpoints."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Sessions")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(
+            "<capability id=\"yolop_checkpoint\">\n\
+             When the user asks to undo, redo, rewind, or roll back this Yolop session, use \
+             `manage_checkpoint`. First request a preview. Describe it and ask for confirmation; \
+             only queue the returned token after the user confirms. Workspace restore is available \
+             only in a Yolop-owned worktree.\n\
+             </capability>",
+        )
+    }
+
+    fn commands(&self) -> Vec<CommandDescriptor> {
+        vec![
+            command("rewind", "list or restore an earlier turn"),
+            command("undo", "restore the state before the latest turn"),
+            command("redo", "restore the most recently abandoned branch"),
+        ]
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![Box::new(ManageCheckpointTool {
+            manager: self.manager.clone(),
+        })]
+    }
+
+    async fn execute_command(
+        &self,
+        request: &ExecuteCommandRequest,
+        _ctx: &CommandExecutionContext,
+    ) -> everruns_core::Result<CommandResult> {
+        let result = execute_command(&self.manager, &request.name, request.arguments.as_deref())
+            .await
+            .map_err(|error| {
+                everruns_core::AgentLoopError::config(safe_display(&format!("{error:#}")))
+            })?;
+        Ok(CommandResult {
+            success: true,
+            message: result,
+            error_code: None,
+            error_fields: None,
+        })
+    }
+}
+
+fn command(name: &str, description: &str) -> CommandDescriptor {
+    CommandDescriptor {
+        name: name.to_string(),
+        description: description.to_string(),
+        source: CommandSource::System,
+        args: vec![CommandArg {
+            name: "checkpoint, mode, or confirmation token".to_string(),
+            description:
+                "Modes: conversation, workspace, both. Use `confirm <token>` after preview."
+                    .to_string(),
+            required: false,
+            suggestions: vec![
+                "conversation".to_string(),
+                "workspace".to_string(),
+                "both".to_string(),
+            ],
+        }],
+    }
+}
+
+async fn execute_command(
+    manager: &CheckpointManager,
+    name: &str,
+    arguments: Option<&str>,
+) -> anyhow::Result<String> {
+    let words = arguments
+        .unwrap_or_default()
+        .split_whitespace()
+        .collect::<Vec<_>>();
+    if words.first().is_some_and(|word| *word == "confirm") {
+        let token = words
+            .get(1)
+            .ok_or_else(|| anyhow::anyhow!("confirmation token is required"))?;
+        return manager.confirm(token).await;
+    }
+    match name {
+        "rewind" if words.is_empty() => Ok(render_checkpoints(manager)),
+        "rewind" => {
+            let checkpoint = words[0];
+            let mode = match words.get(1).copied() {
+                Some(mode) => RestoreMode::parse(Some(mode))?,
+                None => manager.default_rewind_mode(checkpoint),
+            };
+            Ok(manager.prepare_rewind(checkpoint, mode)?.render())
+        }
+        "undo" => {
+            let mode = match words.first().copied() {
+                Some(mode) => RestoreMode::parse(Some(mode))?,
+                None => manager.default_undo_mode(),
+            };
+            Ok(manager.prepare_undo(mode)?.render())
+        }
+        "redo" => {
+            let mode = match words.first().copied() {
+                Some(mode) => RestoreMode::parse(Some(mode))?,
+                None => manager.default_redo_mode(),
+            };
+            Ok(manager.prepare_redo(mode)?.render())
+        }
+        _ => anyhow::bail!("unknown checkpoint command `/{name}`"),
+    }
+}
+
+fn render_checkpoints(manager: &CheckpointManager) -> String {
+    let checkpoints = manager.list();
+    if checkpoints.is_empty() {
+        return "no checkpoints yet".to_string();
+    }
+    let mut lines = vec!["checkpoints (newest first):".to_string()];
+    lines.extend(checkpoints.into_iter().map(|checkpoint| {
+        let workspace = if checkpoint.workspace_available {
+            "conversation + workspace"
+        } else {
+            "conversation only"
+        };
+        let reason = checkpoint
+            .workspace_error
+            .map(|error| format!(" ({error})"))
+            .unwrap_or_default();
+        format!(
+            "  {} · {}{} · {}",
+            checkpoint.id, workspace, reason, checkpoint.prompt
+        )
+    }));
+    lines.push("preview with `/rewind <id> [conversation|workspace|both]`".to_string());
+    lines.join("\n")
+}
+
+struct ManageCheckpointTool {
+    manager: Arc<CheckpointManager>,
+}
+
+#[async_trait]
+impl Tool for ManageCheckpointTool {
+    fn name(&self) -> &str {
+        "manage_checkpoint"
+    }
+
+    fn description(&self) -> &str {
+        "List or preview session undo/redo/rewind. Preview returns a confirmation token. Only use \
+         operation=confirm after the user explicitly confirms; confirmation is queued until the \
+         current turn ends so model history is never mutated mid-turn."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": ["list", "undo", "redo", "rewind", "confirm"]
+                },
+                "checkpoint_id": { "type": "string" },
+                "mode": {
+                    "type": "string",
+                    "enum": ["conversation", "workspace", "both"]
+                },
+                "token": { "type": "string" }
+            },
+            "required": ["operation"],
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default().with_idempotent(false)
+    }
+
+    fn narrate(
+        &self,
+        tool_call: &ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
+        _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        let operation = tool_call
+            .arguments
+            .get("operation")
+            .and_then(Value::as_str)
+            .unwrap_or("checkpoint");
+        Some(match phase {
+            everruns_core::tool_narration::ToolNarrationPhase::Started => {
+                format!("Checkpoint · {operation}")
+            }
+            _ => format!("Checkpoint · {operation} complete"),
+        })
+    }
+
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let result = (|| -> anyhow::Result<Value> {
+            let operation = arguments
+                .get("operation")
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow::anyhow!("operation is required"))?;
+            if operation == "list" {
+                return Ok(json!({ "message": render_checkpoints(&self.manager) }));
+            }
+            if operation == "confirm" {
+                let token = arguments
+                    .get("token")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow::anyhow!("token is required"))?;
+                self.manager.queue_confirmation(token)?;
+                return Ok(json!({
+                    "queued": true,
+                    "message": "restore queued for after this turn"
+                }));
+            }
+            let preview = match operation {
+                "undo" => {
+                    let mode = arguments
+                        .get("mode")
+                        .and_then(Value::as_str)
+                        .map(|mode| RestoreMode::parse(Some(mode)))
+                        .transpose()?
+                        .unwrap_or_else(|| self.manager.default_undo_mode());
+                    self.manager.prepare_undo(mode)?
+                }
+                "redo" => {
+                    let mode = arguments
+                        .get("mode")
+                        .and_then(Value::as_str)
+                        .map(|mode| RestoreMode::parse(Some(mode)))
+                        .transpose()?
+                        .unwrap_or_else(|| self.manager.default_redo_mode());
+                    self.manager.prepare_redo(mode)?
+                }
+                "rewind" => {
+                    let checkpoint = arguments
+                        .get("checkpoint_id")
+                        .and_then(Value::as_str)
+                        .ok_or_else(|| anyhow::anyhow!("checkpoint_id is required"))?;
+                    let mode = arguments
+                        .get("mode")
+                        .and_then(Value::as_str)
+                        .map(|mode| RestoreMode::parse(Some(mode)))
+                        .transpose()?
+                        .unwrap_or_else(|| self.manager.default_rewind_mode(checkpoint));
+                    self.manager.prepare_rewind(checkpoint, mode)?
+                }
+                other => anyhow::bail!("unknown operation `{other}`"),
+            };
+            Ok(json!({
+                "token": preview.token,
+                "checkpoint_id": preview.checkpoint_id,
+                "mode": format!("{:?}", preview.mode).to_lowercase(),
+                "changed_paths": preview.changed_paths,
+                "message": preview.render()
+            }))
+        })();
+        match result {
+            Ok(value) => ToolExecutionResult::success(value),
+            Err(error) => ToolExecutionResult::tool_error(safe_display(&format!("{error:#}"))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_descriptors_expose_restore_modes() {
+        let descriptor = command("undo", "undo");
+        assert_eq!(descriptor.source, CommandSource::System);
+        assert!(descriptor.args[0].suggestions.contains(&"both".to_string()));
+    }
+}

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod approval;
 pub(crate) mod ast_grep;
 pub(crate) mod attribution;
 pub(crate) mod background;
+pub(crate) mod checkpoint;
 pub(crate) mod client_commands;
 pub(crate) mod config;
 pub(crate) mod edit_file_override;
@@ -38,6 +39,7 @@ pub(crate) use attribution::{ATTRIBUTION_CAPABILITY_ID, AttributionCapability};
 pub(crate) use background::{
     BACKGROUND_CAPABILITY_ID, BackgroundCapability, NarratedBackgroundExecutionCapability,
 };
+pub(crate) use checkpoint::{CHECKPOINT_CAPABILITY_ID, CheckpointCapability};
 pub(crate) use client_commands::{CLIENT_COMMANDS_CAPABILITY_ID, ClientCommandsCapability};
 pub(crate) use config::{CONFIG_CAPABILITY_ID, ConfigCapability};
 pub(crate) use free_search::FreeSearchCapability;

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -1,0 +1,1435 @@
+//! Durable turn checkpoints and branch-aware session rewind.
+//!
+//! Conversation events remain append-only in `events.jsonl`. This module keeps
+//! a small append-only timeline that selects the active event ranges and stores
+//! pre-turn workspace trees in private Git refs. Restores never rewrite the
+//! user's branch, HEAD, or index.
+
+use crate::session_log::{JsonlEventEmitter, messages_from_events, replay};
+use crate::worktree::WorktreeManager;
+use anyhow::{Context, Result, anyhow, bail};
+use chrono::{DateTime, Utc};
+use everruns_core::events::Event;
+use everruns_core::in_memory::InMemoryMessageRetriever;
+use everruns_core::session_task::SessionTaskRegistry;
+use everruns_core::typed_id::SessionId;
+use everruns_runtime::DEFAULT_WRITE_BLOCKLIST;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
+
+const TIMELINE_FILE: &str = "timeline.jsonl";
+const MAX_PROMPT_PREVIEW_CHARS: usize = 120;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RestoreMode {
+    Conversation,
+    Workspace,
+    Both,
+}
+
+impl RestoreMode {
+    pub fn parse(value: Option<&str>) -> Result<Self> {
+        match value.unwrap_or("both") {
+            "conversation" | "chat" => Ok(Self::Conversation),
+            "workspace" | "files" | "code" => Ok(Self::Workspace),
+            "both" | "all" => Ok(Self::Both),
+            other => bail!("unknown restore mode `{other}`; use conversation, workspace, or both"),
+        }
+    }
+
+    fn includes_conversation(self) -> bool {
+        matches!(self, Self::Conversation | Self::Both)
+    }
+
+    fn includes_workspace(self) -> bool {
+        matches!(self, Self::Workspace | Self::Both)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct WorkspaceSnapshot {
+    tree: String,
+    reference: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+struct CheckpointNode {
+    id: String,
+    parent: Option<String>,
+    prompt: String,
+    event_start: i32,
+    event_end: Option<i32>,
+    snapshot: Option<WorkspaceSnapshot>,
+    snapshot_error: Option<String>,
+    created_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug)]
+struct RedoState {
+    head: Option<String>,
+    snapshot: Option<WorkspaceSnapshot>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct TimelineState {
+    baseline_end: i32,
+    nodes: BTreeMap<String, CheckpointNode>,
+    head: Option<String>,
+    pending: Option<String>,
+    redo: Option<RedoState>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum TimelineRecord {
+    Initialized {
+        baseline_end: i32,
+        created_at: DateTime<Utc>,
+    },
+    CheckpointCreated {
+        id: String,
+        parent: Option<String>,
+        prompt: String,
+        event_start: i32,
+        snapshot: Option<WorkspaceSnapshot>,
+        snapshot_error: Option<String>,
+        created_at: DateTime<Utc>,
+    },
+    TurnCompleted {
+        checkpoint_id: String,
+        event_end: i32,
+        success: bool,
+        completed_at: DateTime<Utc>,
+    },
+    HeadMoved {
+        from: Option<String>,
+        to: Option<String>,
+        redo_head: Option<String>,
+        redo_snapshot: Option<WorkspaceSnapshot>,
+        moved_at: DateTime<Utc>,
+    },
+    RedoCleared {
+        cleared_at: DateTime<Utc>,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CheckpointSummary {
+    pub id: String,
+    pub prompt: String,
+    pub workspace_available: bool,
+    pub workspace_error: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug)]
+enum RestoreTarget {
+    Rewind { checkpoint_id: String },
+    Redo,
+}
+
+#[derive(Clone, Debug)]
+struct PreparedRestore {
+    token: String,
+    target: RestoreTarget,
+    mode: RestoreMode,
+    conversation_head: Option<String>,
+    workspace_target: Option<WorkspaceSnapshot>,
+    recovery_snapshot: Option<WorkspaceSnapshot>,
+    changed_paths: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RestorePreview {
+    pub token: String,
+    pub checkpoint_id: Option<String>,
+    pub prompt: Option<String>,
+    pub mode: RestoreMode,
+    pub changed_paths: Vec<String>,
+}
+
+impl RestorePreview {
+    pub fn render(&self) -> String {
+        let mut lines = vec![match (&self.checkpoint_id, &self.prompt) {
+            (Some(id), Some(prompt)) => format!("restore `{id}` before: {prompt}"),
+            _ => "restore the most recently abandoned branch".to_string(),
+        }];
+        if self.mode.includes_workspace() {
+            if self.changed_paths.is_empty() {
+                lines.push("workspace: no captured file changes".to_string());
+            } else {
+                lines.push(format!(
+                    "workspace: {} path(s) will change",
+                    self.changed_paths.len()
+                ));
+                lines.extend(
+                    self.changed_paths
+                        .iter()
+                        .take(20)
+                        .map(|path| format!("  {}", safe_display(path))),
+                );
+                if self.changed_paths.len() > 20 {
+                    lines.push(format!("  … and {} more", self.changed_paths.len() - 20));
+                }
+            }
+        }
+        lines.push(format!("confirm with token `{}`", self.token));
+        lines.join("\n")
+    }
+}
+
+pub struct CheckpointManager {
+    session_id: SessionId,
+    session_dir: PathBuf,
+    log_path: PathBuf,
+    timeline_path: PathBuf,
+    worktree: Arc<WorktreeManager>,
+    events: Arc<JsonlEventEmitter>,
+    messages: Arc<InMemoryMessageRetriever>,
+    state: Mutex<TimelineState>,
+    prepared: Mutex<Option<PreparedRestore>>,
+    queued_confirmation: Mutex<Option<String>>,
+    notice: Mutex<Option<String>>,
+    restored_prompt: Mutex<Option<String>>,
+    task_registry: RwLock<Option<Arc<dyn SessionTaskRegistry>>>,
+    snapshot_nonce: AtomicU64,
+}
+
+pub struct TurnCheckpoint {
+    manager: Arc<CheckpointManager>,
+    id: String,
+    finished: bool,
+}
+
+impl TurnCheckpoint {
+    pub fn finish(mut self, success: bool) -> Result<()> {
+        self.manager.finish_turn(&self.id, success)?;
+        self.finished = true;
+        Ok(())
+    }
+}
+
+impl Drop for TurnCheckpoint {
+    fn drop(&mut self) {
+        if !self.finished
+            && let Err(error) = self.manager.finish_turn(&self.id, false)
+        {
+            tracing::warn!(%error, checkpoint = %self.id, "close interrupted checkpoint");
+        }
+    }
+}
+
+impl CheckpointManager {
+    pub fn open(
+        session_id: SessionId,
+        session_dir: PathBuf,
+        log_path: PathBuf,
+        worktree: Arc<WorktreeManager>,
+        events: Arc<JsonlEventEmitter>,
+        messages: Arc<InMemoryMessageRetriever>,
+        max_sequence: i32,
+    ) -> Result<Self> {
+        let timeline_path = session_dir.join(TIMELINE_FILE);
+        let mut state = load_timeline(&timeline_path)?;
+        if !timeline_path.exists() {
+            append_record(
+                &timeline_path,
+                &TimelineRecord::Initialized {
+                    baseline_end: max_sequence,
+                    created_at: Utc::now(),
+                },
+            )?;
+            state.baseline_end = max_sequence;
+        } else if state.nodes.is_empty() && max_sequence > state.baseline_end {
+            // Older/internal callers can write a turn through the raw runtime
+            // before checkpointing owns the first boundary. Preserve that
+            // legacy prefix instead of hiding it on the next resume.
+            let record = TimelineRecord::Initialized {
+                baseline_end: max_sequence,
+                created_at: Utc::now(),
+            };
+            append_record(&timeline_path, &record)?;
+            apply_record(&mut state, record);
+        }
+        let manager = Self {
+            session_id,
+            session_dir,
+            log_path,
+            timeline_path,
+            worktree,
+            events,
+            messages,
+            state: Mutex::new(state),
+            prepared: Mutex::new(None),
+            queued_confirmation: Mutex::new(None),
+            notice: Mutex::new(None),
+            restored_prompt: Mutex::new(None),
+            task_registry: RwLock::new(None),
+            snapshot_nonce: AtomicU64::new(0),
+        };
+        manager.close_interrupted_turn()?;
+        Ok(manager)
+    }
+
+    pub fn filter_active_events(&self, events: Vec<Event>) -> Vec<Event> {
+        let state = self.state.lock().expect("checkpoint state lock");
+        filter_active_events(&state, events)
+    }
+
+    pub fn begin_turn(&self, prompt: &str) -> Result<String> {
+        self.close_interrupted_turn()?;
+        if let Some(prepared) = self.prepared.lock().expect("prepared restore lock").take() {
+            self.delete_snapshot_ref(prepared.recovery_snapshot.as_ref());
+        }
+        let mut state = self.state.lock().expect("checkpoint state lock");
+        let persisted_sequence = self.events.last_sequence();
+        if state.nodes.is_empty() && persisted_sequence > state.baseline_end {
+            let record = TimelineRecord::Initialized {
+                baseline_end: persisted_sequence,
+                created_at: Utc::now(),
+            };
+            append_record(&self.timeline_path, &record)?;
+            apply_record(&mut state, record);
+        }
+        if let Some(redo) = state.redo.take() {
+            append_record(
+                &self.timeline_path,
+                &TimelineRecord::RedoCleared {
+                    cleared_at: Utc::now(),
+                },
+            )?;
+            self.delete_snapshot_ref(redo.snapshot.as_ref());
+        }
+        let event_start = persisted_sequence.saturating_add(1);
+        let id = format!("cp_{event_start}_{}", state.nodes.len() + 1);
+        let (snapshot, snapshot_error) = match self.capture_workspace(&id, true) {
+            Ok(snapshot) => (snapshot, None),
+            Err(error) => (None, Some(error.to_string())),
+        };
+        let record = TimelineRecord::CheckpointCreated {
+            id: id.clone(),
+            parent: state.head.clone(),
+            prompt: prompt.to_string(),
+            event_start,
+            snapshot: snapshot.clone(),
+            snapshot_error: snapshot_error.clone(),
+            created_at: Utc::now(),
+        };
+        append_record(&self.timeline_path, &record)?;
+        apply_record(&mut state, record);
+        Ok(id)
+    }
+
+    pub fn start_turn(self: &Arc<Self>, prompt: &str) -> Result<TurnCheckpoint> {
+        Ok(TurnCheckpoint {
+            manager: self.clone(),
+            id: self.begin_turn(prompt)?,
+            finished: false,
+        })
+    }
+
+    pub fn finish_turn(&self, checkpoint_id: &str, success: bool) -> Result<()> {
+        let record = TimelineRecord::TurnCompleted {
+            checkpoint_id: checkpoint_id.to_string(),
+            event_end: self.events.last_sequence(),
+            success,
+            completed_at: Utc::now(),
+        };
+        append_record(&self.timeline_path, &record)?;
+        apply_record(
+            &mut self.state.lock().expect("checkpoint state lock"),
+            record,
+        );
+        Ok(())
+    }
+
+    pub fn list(&self) -> Vec<CheckpointSummary> {
+        let state = self.state.lock().expect("checkpoint state lock");
+        active_path(&state)
+            .into_iter()
+            .rev()
+            .filter_map(|id| state.nodes.get(&id))
+            .map(|node| CheckpointSummary {
+                id: node.id.clone(),
+                prompt: prompt_preview(&node.prompt),
+                workspace_available: node.snapshot.is_some(),
+                workspace_error: node.snapshot_error.as_deref().map(safe_display),
+                created_at: node.created_at,
+            })
+            .collect()
+    }
+
+    pub fn prepare_undo(&self, mode: RestoreMode) -> Result<RestorePreview> {
+        let checkpoint_id = self
+            .state
+            .lock()
+            .expect("checkpoint state lock")
+            .head
+            .clone()
+            .ok_or_else(|| anyhow!("nothing to undo"))?;
+        self.prepare_rewind(&checkpoint_id, mode)
+    }
+
+    pub fn default_undo_mode(&self) -> RestoreMode {
+        let state = self.state.lock().expect("checkpoint state lock");
+        state
+            .head
+            .as_ref()
+            .and_then(|head| state.nodes.get(head))
+            .map_or(RestoreMode::Conversation, |node| {
+                if node.snapshot.is_some() {
+                    RestoreMode::Both
+                } else {
+                    RestoreMode::Conversation
+                }
+            })
+    }
+
+    pub fn default_rewind_mode(&self, checkpoint_id: &str) -> RestoreMode {
+        self.state
+            .lock()
+            .expect("checkpoint state lock")
+            .nodes
+            .get(checkpoint_id)
+            .map_or(RestoreMode::Conversation, |node| {
+                if node.snapshot.is_some() {
+                    RestoreMode::Both
+                } else {
+                    RestoreMode::Conversation
+                }
+            })
+    }
+
+    pub fn default_redo_mode(&self) -> RestoreMode {
+        if self
+            .state
+            .lock()
+            .expect("checkpoint state lock")
+            .redo
+            .as_ref()
+            .and_then(|redo| redo.snapshot.as_ref())
+            .is_some()
+        {
+            RestoreMode::Both
+        } else {
+            RestoreMode::Conversation
+        }
+    }
+
+    pub fn prepare_rewind(&self, checkpoint_id: &str, mode: RestoreMode) -> Result<RestorePreview> {
+        let (node, conversation_head) = {
+            let state = self.state.lock().expect("checkpoint state lock");
+            let active = active_path(&state);
+            if !active.iter().any(|id| id == checkpoint_id) {
+                bail!("checkpoint `{checkpoint_id}` is not on the active branch");
+            }
+            let node = state
+                .nodes
+                .get(checkpoint_id)
+                .cloned()
+                .ok_or_else(|| anyhow!("checkpoint `{checkpoint_id}` not found"))?;
+            (node.clone(), node.parent.clone())
+        };
+        let (recovery_snapshot, changed_paths) = self.prepare_workspace(
+            mode,
+            node.snapshot.as_ref(),
+            &format!("recovery_{}", self.events.last_sequence()),
+        )?;
+        let token = confirmation_token(self.events.last_sequence());
+        self.set_prepared(PreparedRestore {
+            token: token.clone(),
+            target: RestoreTarget::Rewind {
+                checkpoint_id: node.id.clone(),
+            },
+            mode,
+            conversation_head,
+            workspace_target: node.snapshot.clone(),
+            recovery_snapshot,
+            changed_paths: changed_paths.clone(),
+        });
+        Ok(RestorePreview {
+            token,
+            checkpoint_id: Some(node.id),
+            prompt: Some(prompt_preview(&node.prompt)),
+            mode,
+            changed_paths,
+        })
+    }
+
+    pub fn prepare_redo(&self, mode: RestoreMode) -> Result<RestorePreview> {
+        let redo = self
+            .state
+            .lock()
+            .expect("checkpoint state lock")
+            .redo
+            .clone()
+            .ok_or_else(|| anyhow!("nothing to redo"))?;
+        let (recovery_snapshot, changed_paths) = self.prepare_workspace(
+            mode,
+            redo.snapshot.as_ref(),
+            &format!("recovery_{}", self.events.last_sequence()),
+        )?;
+        let token = confirmation_token(self.events.last_sequence());
+        self.set_prepared(PreparedRestore {
+            token: token.clone(),
+            target: RestoreTarget::Redo,
+            mode,
+            conversation_head: redo.head,
+            workspace_target: redo.snapshot,
+            recovery_snapshot,
+            changed_paths: changed_paths.clone(),
+        });
+        Ok(RestorePreview {
+            token,
+            checkpoint_id: None,
+            prompt: None,
+            mode,
+            changed_paths,
+        })
+    }
+
+    pub async fn confirm(&self, token: &str) -> Result<String> {
+        self.ensure_no_active_tasks().await?;
+        let prepared = self
+            .prepared
+            .lock()
+            .expect("prepared restore lock")
+            .take()
+            .ok_or_else(|| anyhow!("no restore is awaiting confirmation"))?;
+        if prepared.token != token {
+            *self.prepared.lock().expect("prepared restore lock") = Some(prepared);
+            bail!("confirmation token does not match the pending restore");
+        }
+        let is_redo = matches!(&prepared.target, RestoreTarget::Redo);
+
+        let restored_prompt = match &prepared.target {
+            RestoreTarget::Rewind { checkpoint_id } if prepared.mode.includes_conversation() => {
+                self.active_prompt_for(checkpoint_id)
+            }
+            _ => None,
+        };
+
+        if prepared.mode.includes_workspace() {
+            let current = self
+                .capture_workspace(&format!("verify_{}", self.events.last_sequence()), false)?
+                .ok_or_else(|| anyhow!("workspace restore is unavailable"))?;
+            let recovery = prepared
+                .recovery_snapshot
+                .as_ref()
+                .ok_or_else(|| anyhow!("recovery snapshot is missing"))?;
+            if current.tree != recovery.tree {
+                self.delete_snapshot_ref(prepared.recovery_snapshot.as_ref());
+                bail!("workspace changed after preview; request a fresh restore preview");
+            }
+            let target = prepared
+                .workspace_target
+                .as_ref()
+                .ok_or_else(|| anyhow!("selected checkpoint has no workspace snapshot"))?;
+            if let Err(error) = self.restore_workspace(target) {
+                let _ = self.restore_workspace(recovery);
+                return Err(error.context("restore workspace"));
+            }
+        }
+
+        {
+            let mut state = self.state.lock().expect("checkpoint state lock");
+            let from = state.head.clone();
+            let to = if prepared.mode.includes_conversation() {
+                prepared.conversation_head.clone()
+            } else {
+                from.clone()
+            };
+            let record = TimelineRecord::HeadMoved {
+                from: from.clone(),
+                to,
+                redo_head: from,
+                redo_snapshot: prepared.recovery_snapshot.clone(),
+                moved_at: Utc::now(),
+            };
+            append_record(&self.timeline_path, &record)?;
+            apply_record(&mut state, record);
+            if is_redo {
+                let cleared = TimelineRecord::RedoCleared {
+                    cleared_at: Utc::now(),
+                };
+                append_record(&self.timeline_path, &cleared)?;
+                apply_record(&mut state, cleared);
+            }
+        }
+
+        if prepared.mode.includes_conversation() {
+            self.reseed_active_conversation().await?;
+            *self.restored_prompt.lock().expect("restored prompt lock") = restored_prompt;
+        }
+        let action = match prepared.target {
+            RestoreTarget::Rewind { checkpoint_id } => format!("restored `{checkpoint_id}`"),
+            RestoreTarget::Redo => "restored the abandoned branch".to_string(),
+        };
+        if is_redo {
+            self.delete_snapshot_ref(prepared.workspace_target.as_ref());
+            self.delete_snapshot_ref(prepared.recovery_snapshot.as_ref());
+        }
+        Ok(format!(
+            "{action} ({:?}; {} workspace path(s))",
+            prepared.mode,
+            prepared.changed_paths.len()
+        ))
+    }
+
+    pub fn queue_confirmation(&self, token: &str) -> Result<()> {
+        let prepared = self.prepared.lock().expect("prepared restore lock");
+        let Some(prepared) = prepared.as_ref() else {
+            bail!("no restore is awaiting confirmation");
+        };
+        if prepared.token != token {
+            bail!("confirmation token does not match the pending restore");
+        }
+        *self
+            .queued_confirmation
+            .lock()
+            .expect("queued confirmation lock") = Some(token.to_string());
+        Ok(())
+    }
+
+    pub async fn apply_queued_confirmation(&self) {
+        let token = self
+            .queued_confirmation
+            .lock()
+            .expect("queued confirmation lock")
+            .take();
+        let Some(token) = token else {
+            return;
+        };
+        let notice = match self.confirm(&token).await {
+            Ok(message) => message,
+            Err(error) => format!(
+                "checkpoint restore failed: {}",
+                safe_display(&format!("{error:#}"))
+            ),
+        };
+        *self.notice.lock().expect("checkpoint notice lock") = Some(notice);
+    }
+
+    pub fn take_notice(&self) -> Option<String> {
+        self.notice.lock().ok()?.take()
+    }
+
+    pub fn take_restored_prompt(&self) -> Option<String> {
+        self.restored_prompt.lock().ok()?.take()
+    }
+
+    pub fn attach_task_registry(&self, registry: Arc<dyn SessionTaskRegistry>) {
+        if let Ok(mut slot) = self.task_registry.write() {
+            *slot = Some(registry);
+        }
+    }
+
+    pub fn active_prompt_for(&self, checkpoint_id: &str) -> Option<String> {
+        self.state
+            .lock()
+            .ok()?
+            .nodes
+            .get(checkpoint_id)
+            .map(|node| node.prompt.clone())
+    }
+
+    async fn reseed_active_conversation(&self) -> Result<()> {
+        let replayed = replay(&self.log_path, self.session_id)?;
+        let active = self.filter_active_events(replayed.events);
+        let messages = messages_from_events(&active);
+        self.events.replace_collected_events(active).await;
+        self.messages.seed(self.session_id, messages).await;
+        Ok(())
+    }
+
+    async fn ensure_no_active_tasks(&self) -> Result<()> {
+        let registry = self
+            .task_registry
+            .read()
+            .ok()
+            .and_then(|registry| registry.clone());
+        let Some(registry) = registry else {
+            return Ok(());
+        };
+        let active = registry
+            .list(self.session_id, None)
+            .await?
+            .into_iter()
+            .filter(|task| !task.state.is_terminal())
+            .map(|task| task.id)
+            .collect::<Vec<_>>();
+        if !active.is_empty() {
+            bail!(
+                "cannot restore while session tasks are active: {}",
+                active.join(", ")
+            );
+        }
+        Ok(())
+    }
+
+    fn close_interrupted_turn(&self) -> Result<()> {
+        let pending = self
+            .state
+            .lock()
+            .expect("checkpoint state lock")
+            .pending
+            .clone();
+        if let Some(id) = pending {
+            self.finish_turn(&id, false)?;
+        }
+        Ok(())
+    }
+
+    fn prepare_workspace(
+        &self,
+        mode: RestoreMode,
+        target: Option<&WorkspaceSnapshot>,
+        recovery_name: &str,
+    ) -> Result<(Option<WorkspaceSnapshot>, Vec<String>)> {
+        if !mode.includes_workspace() {
+            return Ok((None, Vec::new()));
+        }
+        let target =
+            target.ok_or_else(|| anyhow!("selected checkpoint has no workspace snapshot"))?;
+        let nonce = self.snapshot_nonce.fetch_add(1, Ordering::Relaxed);
+        let recovery_name = format!("{recovery_name}_{nonce}");
+        let recovery = self
+            .capture_workspace(&recovery_name, true)?
+            .ok_or_else(|| anyhow!("workspace restore is available only in a Yolop worktree"))?;
+        let changed = self.diff_trees(&recovery.tree, &target.tree)?;
+        Ok((Some(recovery), changed))
+    }
+
+    fn capture_workspace(&self, name: &str, anchor: bool) -> Result<Option<WorkspaceSnapshot>> {
+        let Some(info) = self.worktree.owned_worktree_info() else {
+            return Ok(None);
+        };
+        let index = self.session_dir.join(format!("checkpoint-{name}.index"));
+        let _ = std::fs::remove_file(&index);
+        let result = (|| {
+            run_git(
+                git_command(&info.path, Some(&index)).args(["read-tree", "HEAD"]),
+                "initialize checkpoint index",
+            )?;
+            let mut add = git_command(&info.path, Some(&index));
+            add.args(["add", "-A", "--", "."]);
+            for blocked in DEFAULT_WRITE_BLOCKLIST {
+                add.arg(format!(":(exclude,glob)**/{blocked}/**"));
+                add.arg(format!(":(exclude,glob){blocked}/**"));
+            }
+            run_git(&mut add, "snapshot workspace")?;
+            let mut remove_blocked = git_command(&info.path, Some(&index));
+            remove_blocked.args(["rm", "-r", "-f", "--cached", "--ignore-unmatch", "--"]);
+            for blocked in DEFAULT_WRITE_BLOCKLIST {
+                remove_blocked.arg(format!(":(glob)**/{blocked}/**"));
+                remove_blocked.arg(format!(":(glob){blocked}/**"));
+            }
+            run_git(&mut remove_blocked, "exclude protected checkpoint paths")?;
+            let entries = git_output_bytes(
+                git_command(&info.path, Some(&index)).args(["ls-files", "--stage", "-z"]),
+                "validate checkpoint paths",
+            )?;
+            for entry in entries
+                .split(|byte| *byte == 0)
+                .filter(|entry| !entry.is_empty())
+            {
+                let separator = entry
+                    .iter()
+                    .position(|byte| *byte == b'\t')
+                    .ok_or_else(|| anyhow!("invalid Git index entry"))?;
+                let (metadata, path_with_separator) = entry.split_at(separator);
+                let path = &path_with_separator[1..];
+                std::str::from_utf8(path)
+                    .context("checkpoint restore does not support non-UTF-8 paths")?;
+                if metadata.starts_with(b"160000 ") {
+                    bail!("checkpoint restore does not support submodules");
+                }
+            }
+            let tree = git_output(
+                git_command(&info.path, Some(&index)).args(["write-tree"]),
+                "write checkpoint tree",
+            )?;
+            let reference =
+                anchor.then(|| format!("refs/yolop/checkpoints/{}/{name}", self.session_id));
+            if let Some(reference) = &reference {
+                run_git(
+                    git_command(&info.path, None).args(["update-ref", reference, &tree]),
+                    "anchor checkpoint tree",
+                )?;
+            }
+            Ok(WorkspaceSnapshot { tree, reference })
+        })();
+        let _ = std::fs::remove_file(index);
+        result.map(Some)
+    }
+
+    fn delete_snapshot_ref(&self, snapshot: Option<&WorkspaceSnapshot>) {
+        let Some(reference) = snapshot.and_then(|snapshot| snapshot.reference.as_deref()) else {
+            return;
+        };
+        let Some(info) = self.worktree.owned_worktree_info() else {
+            return;
+        };
+        let _ = run_git(
+            git_command(&info.path, None).args(["update-ref", "-d", reference]),
+            "delete checkpoint ref",
+        );
+    }
+
+    fn set_prepared(&self, prepared: PreparedRestore) {
+        let replaced = self
+            .prepared
+            .lock()
+            .expect("prepared restore lock")
+            .replace(prepared);
+        if let Some(replaced) = replaced {
+            self.delete_snapshot_ref(replaced.recovery_snapshot.as_ref());
+        }
+    }
+
+    fn diff_trees(&self, current: &str, target: &str) -> Result<Vec<String>> {
+        let info = self
+            .worktree
+            .owned_worktree_info()
+            .ok_or_else(|| anyhow!("workspace restore is unavailable"))?;
+        let output = git_output_bytes(
+            git_command(&info.path, None).args([
+                "diff",
+                "--name-status",
+                "-z",
+                "--no-renames",
+                current,
+                target,
+            ]),
+            "preview checkpoint restore",
+        )?;
+        let fields: Vec<&[u8]> = output
+            .split(|byte| *byte == 0)
+            .filter(|field| !field.is_empty())
+            .collect();
+        if !fields.len().is_multiple_of(2) {
+            bail!("invalid Git name-status output");
+        }
+        fields
+            .chunks_exact(2)
+            .map(|pair| {
+                String::from_utf8(pair[1].to_vec())
+                    .context("checkpoint restore does not support non-UTF-8 paths")
+            })
+            .collect()
+    }
+
+    fn restore_workspace(&self, target: &WorkspaceSnapshot) -> Result<()> {
+        let info = self
+            .worktree
+            .owned_worktree_info()
+            .ok_or_else(|| anyhow!("workspace restore is unavailable"))?;
+        let current = self
+            .capture_workspace(
+                &format!("restore_current_{}", self.events.last_sequence()),
+                false,
+            )?
+            .ok_or_else(|| anyhow!("workspace restore is unavailable"))?;
+        let current_paths = tree_paths(&info.path, &current.tree)?;
+        let target_paths = tree_paths(&info.path, &target.tree)?;
+        let removable = current_paths
+            .difference(&target_paths)
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        for path in &target_paths {
+            validate_restore_path(&info.path, path, &removable)?;
+        }
+        for path in &removable {
+            remove_captured_path(&info.path, path)?;
+        }
+
+        let index = self.session_dir.join("checkpoint-restore.index");
+        let _ = std::fs::remove_file(&index);
+        run_git(
+            git_command(&info.path, Some(&index)).args(["read-tree", &target.tree]),
+            "load checkpoint tree",
+        )?;
+        run_git(
+            git_command(&info.path, Some(&index)).args(["checkout-index", "-a", "-f"]),
+            "materialize checkpoint tree",
+        )?;
+        let _ = std::fs::remove_file(index);
+
+        let verified = self
+            .capture_workspace(&format!("restored_{}", self.events.last_sequence()), false)?
+            .ok_or_else(|| anyhow!("workspace restore verification unavailable"))?;
+        if verified.tree != target.tree {
+            bail!("workspace restore verification failed");
+        }
+        Ok(())
+    }
+}
+
+fn filter_active_events(state: &TimelineState, events: Vec<Event>) -> Vec<Event> {
+    let mut ranges = vec![(i32::MIN, state.baseline_end)];
+    for id in active_path(state) {
+        if let Some(node) = state.nodes.get(&id)
+            && let Some(end) = node.event_end
+        {
+            ranges.push((node.event_start, end));
+        }
+    }
+    events
+        .into_iter()
+        .filter(|event| {
+            event.sequence.is_none_or(|sequence| {
+                ranges
+                    .iter()
+                    .any(|(start, end)| sequence >= *start && sequence <= *end)
+            })
+        })
+        .collect()
+}
+
+fn active_path(state: &TimelineState) -> Vec<String> {
+    let mut reversed = Vec::new();
+    let mut cursor = state.head.clone();
+    let mut seen = BTreeSet::new();
+    while let Some(id) = cursor {
+        if !seen.insert(id.clone()) {
+            break;
+        }
+        let Some(node) = state.nodes.get(&id) else {
+            break;
+        };
+        reversed.push(id);
+        cursor = node.parent.clone();
+    }
+    reversed.reverse();
+    reversed
+}
+
+fn load_timeline(path: &Path) -> Result<TimelineState> {
+    if !path.exists() {
+        return Ok(TimelineState::default());
+    }
+    let mut file = File::open(path).with_context(|| format!("open timeline {}", path.display()))?;
+    let mut contents = Vec::new();
+    file.read_to_end(&mut contents)
+        .with_context(|| format!("read timeline {}", path.display()))?;
+    let lines: Vec<&[u8]> = contents.split(|byte| *byte == b'\n').collect();
+    let last_nonempty = lines
+        .iter()
+        .rposition(|line| !line.iter().all(u8::is_ascii_whitespace));
+    let mut state = TimelineState::default();
+    for (index, line) in lines.into_iter().enumerate() {
+        if line.iter().all(u8::is_ascii_whitespace) {
+            continue;
+        }
+        let record: TimelineRecord = match serde_json::from_slice(line) {
+            Ok(record) => record,
+            Err(_) if Some(index) == last_nonempty => break,
+            Err(error) => {
+                return Err(error).with_context(|| format!("parse timeline line {}", index + 1));
+            }
+        };
+        apply_record(&mut state, record);
+    }
+    Ok(state)
+}
+
+fn apply_record(state: &mut TimelineState, record: TimelineRecord) {
+    match record {
+        TimelineRecord::Initialized { baseline_end, .. } => state.baseline_end = baseline_end,
+        TimelineRecord::CheckpointCreated {
+            id,
+            parent,
+            prompt,
+            event_start,
+            snapshot,
+            snapshot_error,
+            created_at,
+        } => {
+            state.pending = Some(id.clone());
+            state.nodes.insert(
+                id.clone(),
+                CheckpointNode {
+                    id,
+                    parent,
+                    prompt,
+                    event_start,
+                    event_end: None,
+                    snapshot,
+                    snapshot_error,
+                    created_at,
+                },
+            );
+        }
+        TimelineRecord::TurnCompleted {
+            checkpoint_id,
+            event_end,
+            ..
+        } => {
+            if let Some(node) = state.nodes.get_mut(&checkpoint_id) {
+                node.event_end = Some(event_end);
+                state.head = Some(checkpoint_id.clone());
+            }
+            if state.pending.as_deref() == Some(&checkpoint_id) {
+                state.pending = None;
+            }
+        }
+        TimelineRecord::HeadMoved {
+            to,
+            redo_head,
+            redo_snapshot,
+            ..
+        } => {
+            state.head = to;
+            state.redo = Some(RedoState {
+                head: redo_head,
+                snapshot: redo_snapshot,
+            });
+        }
+        TimelineRecord::RedoCleared { .. } => state.redo = None,
+    }
+}
+
+fn append_record(path: &Path, record: &TimelineRecord) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))?;
+        }
+    }
+    let mut options = OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    serde_json::to_writer(&mut file, record)?;
+    file.write_all(b"\n")?;
+    file.flush()?;
+    file.sync_data()?;
+    Ok(())
+}
+
+fn git_command(worktree: &Path, index: Option<&Path>) -> Command {
+    let mut command = Command::new("git");
+    command.arg("-C").arg(worktree);
+    if let Some(index) = index {
+        command.env("GIT_INDEX_FILE", index);
+    }
+    command
+}
+
+fn run_git(command: &mut Command, label: &str) -> Result<()> {
+    let output = command.output().with_context(|| label.to_string())?;
+    if output.status.success() {
+        return Ok(());
+    }
+    bail!(
+        "{label}: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    )
+}
+
+fn git_output(command: &mut Command, label: &str) -> Result<String> {
+    Ok(String::from_utf8(git_output_bytes(command, label)?)?
+        .trim()
+        .to_string())
+}
+
+fn git_output_bytes(command: &mut Command, label: &str) -> Result<Vec<u8>> {
+    let output = command.output().with_context(|| label.to_string())?;
+    if !output.status.success() {
+        bail!(
+            "{label}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(output.stdout)
+}
+
+fn tree_paths(worktree: &Path, tree: &str) -> Result<BTreeSet<String>> {
+    let output = git_output_bytes(
+        git_command(worktree, None).args(["ls-tree", "-rz", "--name-only", tree]),
+        "list checkpoint tree",
+    )?;
+    output
+        .split(|byte| *byte == 0)
+        .filter(|field| !field.is_empty())
+        .map(|field| {
+            String::from_utf8(field.to_vec())
+                .context("checkpoint restore does not support non-UTF-8 paths")
+        })
+        .collect()
+}
+
+fn remove_captured_path(root: &Path, relative: &str) -> Result<()> {
+    validate_relative_path(relative)?;
+    let path = Path::new(relative);
+    let absolute = root.join(path);
+    match std::fs::symlink_metadata(&absolute) {
+        Ok(metadata) if metadata.file_type().is_dir() => std::fs::remove_dir(&absolute)?,
+        Ok(_) => std::fs::remove_file(&absolute)?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    let mut parent = absolute.parent();
+    while let Some(directory) = parent {
+        if directory == root {
+            break;
+        }
+        match std::fs::remove_dir(directory) {
+            Ok(()) => parent = directory.parent(),
+            Err(error) if error.kind() == std::io::ErrorKind::DirectoryNotEmpty => break,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                parent = directory.parent()
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(())
+}
+
+fn validate_relative_path(relative: &str) -> Result<()> {
+    let path = Path::new(relative);
+    if path.is_absolute()
+        || path.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        })
+        || path.components().any(|component| {
+            matches!(component, Component::Normal(name) if DEFAULT_WRITE_BLOCKLIST.iter().any(|blocked| name == std::ffi::OsStr::new(blocked)))
+        })
+    {
+        bail!("unsafe checkpoint path `{relative}`");
+    }
+    Ok(())
+}
+
+fn validate_restore_path(root: &Path, relative: &str, removable: &BTreeSet<String>) -> Result<()> {
+    validate_relative_path(relative)?;
+    let path = Path::new(relative);
+    let mut current = root.to_path_buf();
+    let mut current_relative = PathBuf::new();
+    let parent = path.parent().unwrap_or_else(|| Path::new(""));
+    for component in parent.components() {
+        if let Component::Normal(name) = component {
+            current.push(name);
+            current_relative.push(name);
+            let is_removable = current_relative
+                .to_str()
+                .is_some_and(|path| removable.contains(path));
+            match std::fs::symlink_metadata(&current) {
+                Ok(metadata) if metadata.file_type().is_symlink() && !is_removable => {
+                    bail!("checkpoint path crosses symlink `{}`", current.display());
+                }
+                Ok(metadata) if !metadata.is_dir() && !is_removable => {
+                    bail!(
+                        "checkpoint path parent is not a directory `{}`",
+                        current.display()
+                    );
+                }
+                Ok(_) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error.into()),
+            }
+        }
+    }
+    Ok(())
+}
+
+fn confirmation_token(sequence: i32) -> String {
+    format!("restore-{sequence}-{}", Utc::now().timestamp_millis())
+}
+
+fn prompt_preview(prompt: &str) -> String {
+    let collapsed = prompt.split_whitespace().collect::<Vec<_>>().join(" ");
+    let mut chars = collapsed.chars();
+    let preview: String = chars.by_ref().take(MAX_PROMPT_PREVIEW_CHARS).collect();
+    let preview = safe_display(&preview);
+    if chars.next().is_some() {
+        format!("{preview}…")
+    } else {
+        preview
+    }
+}
+
+pub(crate) fn safe_display(value: &str) -> String {
+    value.chars().flat_map(char::escape_default).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session_log::{JsonlEventEmitter, session_log_path};
+    use crate::settings::WorktreesMode;
+    use everruns_core::events::{EventContext, EventRequest, InputMessageData};
+    use everruns_core::message::Message;
+    use everruns_core::traits::EventEmitter;
+    use everruns_runtime::EventBus;
+    use tempfile::TempDir;
+
+    fn git(path: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(path)
+            .args(args)
+            .output()
+            .expect("git command");
+        assert!(
+            output.status.success(),
+            "git {:?}: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    async fn manager() -> (TempDir, TempDir, Arc<CheckpointManager>) {
+        let root = tempfile::tempdir().expect("root");
+        git(root.path(), &["init", "-q"]);
+        git(root.path(), &["config", "user.name", "Test User"]);
+        git(root.path(), &["config", "user.email", "test@example.com"]);
+        std::fs::write(root.path().join("tracked.txt"), "base\n").expect("base file");
+        git(root.path(), &["add", "tracked.txt"]);
+        git(root.path(), &["commit", "-qm", "base"]);
+
+        let session_id = SessionId::new();
+        let session = tempfile::tempdir().expect("session");
+        let session_dir = session.path().to_path_buf();
+        let log_path = session_log_path(&session_dir);
+        let events = Arc::new(JsonlEventEmitter::open(&log_path, 1).expect("event emitter"));
+        let messages = Arc::new(InMemoryMessageRetriever::new());
+        let info = crate::worktree::WorktreeInfo {
+            path: root.path().to_path_buf(),
+            branch: "master".to_string(),
+            base_ref: "HEAD".to_string(),
+            slug: "test".to_string(),
+        };
+        let worktree = Arc::new(WorktreeManager::new(
+            WorktreesMode::Always,
+            Some(root.path().join("main-checkout")),
+            root.path().to_path_buf(),
+            session_id,
+            session_dir.clone(),
+            Some(info),
+        ));
+        let manager = Arc::new(
+            CheckpointManager::open(
+                session_id,
+                session_dir,
+                log_path,
+                worktree,
+                events,
+                messages,
+                0,
+            )
+            .expect("checkpoint manager"),
+        );
+        (root, session, manager)
+    }
+
+    async fn emit_user(manager: &CheckpointManager, text: &str) {
+        manager
+            .events
+            .emit(EventRequest::new(
+                manager.session_id,
+                EventContext::empty(),
+                InputMessageData::new(Message::user(text)),
+            ))
+            .await
+            .expect("emit user");
+    }
+
+    #[tokio::test]
+    async fn rewind_filters_abandoned_events_and_restores_files() {
+        let (root, _session, manager) = manager().await;
+        let first = manager
+            .begin_turn("first prompt")
+            .expect("first checkpoint");
+        std::fs::write(root.path().join("tracked.txt"), "first\n").expect("first edit");
+        std::fs::write(root.path().join("new.txt"), "new\n").expect("new file");
+        emit_user(&manager, "first prompt").await;
+        manager.finish_turn(&first, true).expect("finish first");
+
+        let second = manager
+            .begin_turn("second prompt")
+            .expect("second checkpoint");
+        std::fs::write(root.path().join("tracked.txt"), "second\n").expect("second edit");
+        emit_user(&manager, "second prompt").await;
+        manager.finish_turn(&second, true).expect("finish second");
+
+        let preview = manager
+            .prepare_rewind(&second, RestoreMode::Both)
+            .expect("preview rewind");
+        assert!(preview.changed_paths.contains(&"tracked.txt".to_string()));
+        manager
+            .confirm(&preview.token)
+            .await
+            .expect("confirm rewind");
+
+        assert_eq!(
+            std::fs::read_to_string(root.path().join("tracked.txt")).expect("tracked"),
+            "first\n"
+        );
+        assert!(root.path().join("new.txt").exists());
+        let active = manager.events.collected_events().await;
+        let texts = messages_from_events(&active)
+            .into_iter()
+            .filter_map(|message| message.text().map(str::to_string))
+            .collect::<Vec<_>>();
+        assert_eq!(texts, vec!["first prompt"]);
+
+        let redo = manager
+            .prepare_redo(RestoreMode::Both)
+            .expect("preview redo");
+        manager.confirm(&redo.token).await.expect("confirm redo");
+        assert_eq!(
+            std::fs::read_to_string(root.path().join("tracked.txt")).expect("tracked"),
+            "second\n"
+        );
+        let active = manager.events.collected_events().await;
+        let texts = messages_from_events(&active)
+            .into_iter()
+            .filter_map(|message| message.text().map(str::to_string))
+            .collect::<Vec<_>>();
+        assert_eq!(texts, vec!["first prompt", "second prompt"]);
+        assert!(manager.prepare_redo(RestoreMode::Both).is_err());
+    }
+
+    #[tokio::test]
+    async fn stale_preview_refuses_to_overwrite_new_changes() {
+        let (root, _session, manager) = manager().await;
+        let first = manager.begin_turn("first").expect("checkpoint");
+        std::fs::write(root.path().join("tracked.txt"), "changed\n").expect("edit");
+        emit_user(&manager, "first").await;
+        manager.finish_turn(&first, true).expect("finish");
+
+        let preview = manager
+            .prepare_undo(RestoreMode::Both)
+            .expect("prepare undo");
+        std::fs::write(root.path().join("tracked.txt"), "manual\n").expect("manual edit");
+        let error = manager
+            .confirm(&preview.token)
+            .await
+            .expect_err("stale preview must fail");
+        assert!(
+            error
+                .to_string()
+                .contains("workspace changed after preview")
+        );
+        assert_eq!(
+            std::fs::read_to_string(root.path().join("tracked.txt")).expect("tracked"),
+            "manual\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn checkpoint_ids_stay_unique_when_turn_emits_no_events() {
+        let (_root, _session, manager) = manager().await;
+        let first = manager.begin_turn("first").expect("first checkpoint");
+        manager.finish_turn(&first, false).expect("finish first");
+        let second = manager.begin_turn("second").expect("second checkpoint");
+        assert_ne!(first, second);
+    }
+
+    #[tokio::test]
+    async fn restore_handles_paths_containing_newlines() {
+        let (root, _session, manager) = manager().await;
+        let checkpoint = manager.begin_turn("create file").expect("checkpoint");
+        let unusual = "line\nbreak.txt";
+        std::fs::write(root.path().join(unusual), "content").expect("unusual file");
+        emit_user(&manager, "create file").await;
+        manager.finish_turn(&checkpoint, true).expect("finish");
+
+        let preview = manager
+            .prepare_undo(RestoreMode::Both)
+            .expect("preview undo");
+        assert!(preview.changed_paths.contains(&unusual.to_string()));
+        manager.confirm(&preview.token).await.expect("confirm undo");
+        assert!(!root.path().join(unusual).exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn restore_refuses_to_cross_an_ignored_symlink() {
+        let (root, _session, manager) = manager().await;
+        std::fs::create_dir(root.path().join("dir")).expect("tracked dir");
+        std::fs::write(root.path().join("dir/file.txt"), "inside").expect("tracked child");
+        std::fs::write(root.path().join(".gitignore"), "dir\n").expect("gitignore");
+        git(root.path(), &["add", ".gitignore"]);
+        git(root.path(), &["add", "-f", "dir/file.txt"]);
+        git(root.path(), &["commit", "-qm", "tracked child"]);
+
+        let checkpoint = manager.begin_turn("replace dir").expect("checkpoint");
+        std::fs::remove_dir_all(root.path().join("dir")).expect("remove tracked dir");
+        let outside = tempfile::tempdir().expect("outside");
+        std::os::unix::fs::symlink(outside.path(), root.path().join("dir"))
+            .expect("ignored symlink");
+        emit_user(&manager, "replace dir").await;
+        manager.finish_turn(&checkpoint, true).expect("finish");
+
+        let preview = manager
+            .prepare_undo(RestoreMode::Both)
+            .expect("preview undo");
+        let error = manager
+            .confirm(&preview.token)
+            .await
+            .expect_err("symlink escape must fail");
+        let error_chain = format!("{error:#}");
+        assert!(
+            error_chain.contains("crosses symlink"),
+            "unexpected restore error: {error_chain}"
+        );
+        assert!(root.path().join("dir").is_symlink());
+        assert!(
+            std::fs::read_dir(outside.path())
+                .expect("outside contents")
+                .next()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn timeline_ignores_only_a_corrupt_tail() {
+        let dir = tempfile::tempdir().expect("timeline dir");
+        let path = dir.path().join(TIMELINE_FILE);
+        let initialized = TimelineRecord::Initialized {
+            baseline_end: 7,
+            created_at: Utc::now(),
+        };
+        std::fs::write(
+            &path,
+            format!(
+                "{}\n{{partial",
+                serde_json::to_string(&initialized).unwrap()
+            ),
+        )
+        .expect("write timeline");
+        assert_eq!(load_timeline(&path).expect("load tail").baseline_end, 7);
+
+        std::fs::write(
+            &path,
+            format!(
+                "{{broken}}\n{}\n",
+                serde_json::to_string(&initialized).unwrap()
+            ),
+        )
+        .expect("write corrupt prefix");
+        assert!(load_timeline(&path).is_err());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod atif;
 mod background_wake;
 mod capabilities;
 mod capability_settings;
+mod checkpoint;
 mod clipboard_paste;
 mod codex_auth;
 mod codex_driver;
@@ -805,6 +806,10 @@ fn run_worktree_command(command: WorktreeCommand) -> Result<()> {
             for path in &report.removed {
                 println!("{action}: {}", path.display());
             }
+            let ref_action = if dry_run { "would detach" } else { "detached" };
+            for reference in &report.checkpoint_refs {
+                println!("{ref_action} checkpoint ref: {reference}");
+            }
             println!(
                 "kept {} referenced worktree(s); {} orphan(s) {action}",
                 report.kept,
@@ -1411,7 +1416,10 @@ async fn collect_print_turn(
         .unwrap_or(0);
 
     let input = model.input_message_with_images(prompt, images);
-    let result = handles.runtime.run_turn(handles.session_id, input).await?;
+    let result = handles.run_checkpointed_turn(prompt, input).await?;
+    if let Some(notice) = handles.checkpoints.take_notice() {
+        eprintln!("{notice}");
+    }
     let messages = handles
         .runtime
         .messages(handles.session_id)

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -10,8 +10,9 @@ use crate::capabilities::yolop::{YOLOP_CAPABILITY_ID, YolopCapability};
 use crate::capabilities::{
     APPROVAL_CAPABILITY_ID, AST_GREP_CAPABILITY_ID, ATTRIBUTION_CAPABILITY_ID, ApprovalCapability,
     AstEditCapability, AstGrepCapability, AttributionCapability, BACKGROUND_CAPABILITY_ID,
-    BackgroundCapability, CLIENT_COMMANDS_CAPABILITY_ID, CODING_BASH_CAPABILITY_ID,
-    CONFIG_CAPABILITY_ID, ClientCommandsCapability, ClientUiContext, CodingBashCapability,
+    BackgroundCapability, CHECKPOINT_CAPABILITY_ID, CLIENT_COMMANDS_CAPABILITY_ID,
+    CODING_BASH_CAPABILITY_ID, CONFIG_CAPABILITY_ID, CheckpointCapability,
+    ClientCommandsCapability, ClientUiContext, CodingBashCapability,
     CodingCliEnvironmentCapability, ConfigCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID,
     GOAL_CAPABILITY_ID, GoalCapability, HERDR_CAPABILITY_ID, HOOKS_CAPABILITY_ID, HerdrCapability,
     HooksCapability, LspCapability, PROGRESS_GUARD_CAPABILITY_ID, ProgressGuardCapability,
@@ -20,6 +21,7 @@ use crate::capabilities::{
     WorktreeCapability,
 };
 use crate::capability_settings::{CapabilityCatalog, apply_capability_settings};
+use crate::checkpoint::CheckpointManager;
 use crate::connectors::{
     CONNECTORS_CAPABILITY_ID, ConnectionCatalog, ConnectionStore, ConnectorsCapability,
     YolopConnectionResolver, default_connections_path,
@@ -2053,6 +2055,7 @@ fn default_coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabi
         AgentCapabilityConfig::new(HERDR_CAPABILITY_ID),
         AgentCapabilityConfig::new(REPO_MAP_CAPABILITY_ID),
         AgentCapabilityConfig::new(SESSION_HISTORY_CAPABILITY_ID),
+        AgentCapabilityConfig::new(CHECKPOINT_CAPABILITY_ID),
         AgentCapabilityConfig::new(AST_GREP_CAPABILITY_ID),
         AgentCapabilityConfig::new(INFINITY_CONTEXT_CAPABILITY_ID),
         AgentCapabilityConfig::with_config(
@@ -2242,6 +2245,9 @@ pub struct RuntimeHandles {
     /// through the `EventBus` trait object; we keep a direct reference
     /// so the TUI can subscribe to the live broadcast for streaming.
     pub events: Arc<JsonlEventEmitter>,
+    /// Durable conversation/workspace checkpoint controller shared by every
+    /// host path that can start a turn or restore a branch.
+    pub checkpoints: Arc<CheckpointManager>,
     /// The runtime's session store, retained so the host can mutate the
     /// live session's scoped MCP servers without rebuilding the runtime.
     /// See [`RuntimeHandles::reload_mcp_servers`].
@@ -2262,6 +2268,19 @@ pub struct RuntimeHandles {
 impl RuntimeHandles {
     pub(crate) fn report_herdr_state(&self, state: crate::capabilities::herdr::HerdrState) {
         self.herdr.report_background(state);
+    }
+
+    pub async fn run_checkpointed_turn(
+        &self,
+        prompt: &str,
+        input: InputMessage,
+    ) -> anyhow::Result<everruns_runtime::TurnResult> {
+        let checkpoint = self.checkpoints.start_turn(prompt)?;
+        let result = self.runtime.run_turn(self.session_id, input).await;
+        let success = result.as_ref().is_ok_and(|turn| turn.success);
+        checkpoint.finish(success)?;
+        self.checkpoints.apply_queued_confirmation().await;
+        Ok(result?)
     }
 
     /// Re-read the merged MCP server config (global settings + workspace
@@ -2618,7 +2637,6 @@ pub async fn build_with_options(
     // Pass `session_id` so events for any other session get skipped
     // rather than seeded — defends against mixed/copied logs.
     let replayed = replay(&log_path, session_id)?;
-    let replayed_events_count = replayed.events.len();
     let next_sequence = replayed.max_sequence.map(|m| m + 1).unwrap_or(1);
 
     // JsonlEventEmitter is the EventBus: emits to memory + appends
@@ -2626,21 +2644,27 @@ pub async fn build_with_options(
     // carries the sequence counter across resumes so `Event.sequence`
     // stays monotonic within a session.
     let event_bus_typed = Arc::new(JsonlEventEmitter::open(&log_path, next_sequence)?);
-    let event_bus: Arc<dyn everruns_runtime::EventBus> = event_bus_typed.clone();
-    // Seed the in-memory event vec with what we just read off disk so
-    // `runtime.events()` after resume returns the full history — not
-    // just events emitted during the resumed run. Does not re-persist;
-    // these lines are already in the JSONL file. Move (not clone): the
-    // replay buffer isn't used again after this and the seeded vec can
-    // get large on long-lived sessions.
-    event_bus_typed.seed_replayed(replayed.events).await;
-
-    // Pre-seed the message store with anything reconstructed from disk
-    // so the agent sees prior conversation in its first context assembly.
     let message_store = Arc::new(InMemoryMessageRetriever::new());
-    if !replayed.messages.is_empty() {
-        message_store.seed(session_id, replayed.messages).await;
+    let checkpoints = Arc::new(CheckpointManager::open(
+        session_id,
+        session_dir.clone(),
+        log_path.clone(),
+        worktree.clone(),
+        event_bus_typed.clone(),
+        message_store.clone(),
+        replayed.max_sequence.unwrap_or(0),
+    )?);
+    let active_events = checkpoints.filter_active_events(replayed.events);
+    let replayed_events_count = active_events.len();
+    let active_messages = crate::session_log::messages_from_events(&active_events);
+
+    // Only the selected timeline branch enters the live stores. Abandoned
+    // suffixes remain in events.jsonl for redo and local history inspection.
+    event_bus_typed.seed_replayed(active_events).await;
+    if !active_messages.is_empty() {
+        message_store.seed(session_id, active_messages).await;
     }
+    let event_bus: Arc<dyn everruns_runtime::EventBus> = event_bus_typed.clone();
 
     // Start from the in-memory backend bundle, preserving Yolop's durable
     // event bus and replay-seeded message store, then let everruns-local attach
@@ -2654,6 +2678,7 @@ pub async fn build_with_options(
     let local_backends = LocalBackends::new(local_profile, base_backends)
         .context("initialize everruns-local backend stores")?;
     let task_registry: Arc<dyn SessionTaskRegistry> = local_backends.task_registry.clone();
+    checkpoints.attach_task_registry(task_registry.clone());
     // Install the wake seam: a `LocalPlatformStore` whose `send_message`
     // enqueues everruns background-task completion signals onto `background_wake`
     // for the host to run as a streamed turn (see `background_wake` and
@@ -2930,6 +2955,9 @@ pub async fn build_with_options(
     capabilities.register(WorktreeCapability {
         manager: worktree.clone(),
     });
+    capabilities.register(CheckpointCapability {
+        manager: checkpoints.clone(),
+    });
     // `/setup` (below) is the capability-sourced slash command. It implements
     // `Capability::execute_command` end to end.
     capabilities.register(SetupCapability {
@@ -3157,6 +3185,7 @@ pub async fn build_with_options(
             runtime: Arc::new(runtime),
             session_id,
             events: event_bus_typed,
+            checkpoints,
             session_store,
             workspace_root: canonical_root.clone(),
             connections,

--- a/src/session.rs
+++ b/src/session.rs
@@ -108,6 +108,25 @@ impl Session {
             .collect())
     }
 
+    pub async fn active_lines(&self) -> Result<Vec<ChatLine>> {
+        Ok(self
+            .handles
+            .runtime
+            .events()
+            .await?
+            .iter()
+            .flat_map(lines_for_replayed_event)
+            .collect())
+    }
+
+    pub fn take_checkpoint_notice(&self) -> Option<String> {
+        self.handles.checkpoints.take_notice()
+    }
+
+    pub fn take_restored_prompt(&self) -> Option<String> {
+        self.handles.checkpoints.take_restored_prompt()
+    }
+
     /// Execute a capability-provided command through the runtime, returning a
     /// host-facing [`CommandOutcome`].
     pub async fn execute_command(
@@ -160,9 +179,12 @@ impl Session {
                 Err(_) => 0,
             };
 
-            let input = model.input_message_with_images(prompt, images);
-            let runtime = handles.runtime.clone();
-            let mut turn = tokio::spawn(async move { runtime.run_turn(session_id, input).await });
+            let input = model.input_message_with_images(prompt.clone(), images);
+            let turn_handles = handles.clone();
+            let mut turn =
+                tokio::spawn(
+                    async move { turn_handles.run_checkpointed_turn(&prompt, input).await },
+                );
 
             let mut emitted_events = HashSet::new();
             let mut delta_router = DeltaRouter::default();

--- a/src/session_log.rs
+++ b/src/session_log.rs
@@ -70,6 +70,7 @@ use std::fs::{File, OpenOptions, TryLockError};
 use std::io::{BufRead, BufReader, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicI32, Ordering};
 use tokio::sync::{Mutex, RwLock, broadcast};
 
 /// Capacity of the live event broadcast. Sized to absorb a few hundred
@@ -431,7 +432,8 @@ fn is_replay_relevant(event_type: &str) -> bool {
 /// and producing non-monotonic per-session sequences).
 pub struct JsonlEventEmitter {
     events: Arc<RwLock<Vec<Event>>>,
-    sequence: Arc<RwLock<i32>>,
+    sequence: Arc<AtomicI32>,
+    persisted_sequence: Arc<AtomicI32>,
     file: Arc<Mutex<File>>,
     /// Live fan-out of every emitted event (including deltas) for in-process
     /// subscribers like the TUI's streaming renderer. Filesystem persistence
@@ -554,7 +556,8 @@ impl JsonlEventEmitter {
         let (live, _) = broadcast::channel(EVENT_BROADCAST_CAPACITY);
         Ok(Self {
             events: Arc::new(RwLock::new(Vec::new())),
-            sequence: Arc::new(RwLock::new(start_sequence.saturating_sub(1))),
+            sequence: Arc::new(AtomicI32::new(start_sequence.saturating_sub(1))),
+            persisted_sequence: Arc::new(AtomicI32::new(start_sequence.saturating_sub(1))),
             file: Arc::new(Mutex::new(file)),
             live,
         })
@@ -578,6 +581,20 @@ impl JsonlEventEmitter {
         }
         self.events.write().await.extend(events);
     }
+
+    /// Replace the model-visible branch after a conversation rewind. The
+    /// discarded suffix remains durable in `events.jsonl`; only the live view
+    /// queried by the runtime and transcript changes.
+    pub async fn replace_collected_events(&self, events: Vec<Event>) {
+        *self.events.write().await = events;
+    }
+
+    /// Highest sequence allocated in this session, including abandoned
+    /// branches. New branches continue from this value so event ordering stays
+    /// globally monotonic.
+    pub fn last_sequence(&self) -> i32 {
+        self.persisted_sequence.load(Ordering::Acquire)
+    }
 }
 
 #[async_trait]
@@ -585,10 +602,13 @@ impl EventEmitter for JsonlEventEmitter {
     async fn emit(&self, request: EventRequest) -> Result<Event> {
         // Assign id + sequence ourselves so we own the monotonic
         // sequence even across resumes.
-        let mut seq = self.sequence.write().await;
-        *seq = seq.saturating_add(1);
-        let seq_val = *seq;
-        drop(seq);
+        let previous = self
+            .sequence
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |sequence| {
+                Some(sequence.saturating_add(1))
+            })
+            .expect("sequence update closure always succeeds");
+        let seq_val = previous.saturating_add(1);
 
         let mut event = request.into_event(EventId::new(), seq_val);
         // `into_event` may have set its own timestamp; ensure we always
@@ -614,6 +634,7 @@ impl EventEmitter for JsonlEventEmitter {
                 .map_err(|e| AgentLoopError::config(format!("write session log line: {e}")))?;
             file.flush()
                 .map_err(|e| AgentLoopError::config(format!("flush session log: {e}")))?;
+            self.persisted_sequence.fetch_max(seq_val, Ordering::AcqRel);
         }
 
         // Fan out to live subscribers. `send` errors only when there are
@@ -648,6 +669,13 @@ fn message_from_event(data: &EventData) -> Option<Message> {
         EventData::ToolCompleted(d) => Some(tool_completed_to_message(d.clone())),
         _ => None,
     }
+}
+
+pub(crate) fn messages_from_events(events: &[Event]) -> Vec<Message> {
+    events
+        .iter()
+        .filter_map(|event| message_from_event(&event.data))
+        .collect()
 }
 
 fn tool_completed_to_message(data: everruns_core::events::ToolCompletedData) -> Message {

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -117,6 +117,18 @@ impl WorktreeManager {
         self.worktree.read().ok().and_then(|g| g.clone())
     }
 
+    /// Return the isolated worktree only when it is distinct from the main
+    /// checkout. Checkpoint restore uses this stricter ownership boundary so
+    /// corrupt or hand-edited metadata cannot turn the primary checkout into a
+    /// whole-workspace restore target.
+    pub fn owned_worktree_info(&self) -> Option<WorktreeInfo> {
+        let info = self.worktree_info()?;
+        let repo_root = self.repo_root.as_ref()?;
+        let worktree_path = std::fs::canonicalize(&info.path).unwrap_or_else(|_| info.path.clone());
+        let main_path = std::fs::canonicalize(repo_root).unwrap_or_else(|_| repo_root.clone());
+        (worktree_path != main_path).then_some(info)
+    }
+
     pub fn disable_auto(&self) {
         self.auto_disabled.store(true, Ordering::SeqCst);
     }
@@ -688,6 +700,7 @@ pub fn restore_worktree_from_metadata(metadata: &SessionWorkspaceMetadata) -> Op
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PruneReport {
     pub removed: Vec<PathBuf>,
+    pub checkpoint_refs: Vec<String>,
     pub kept: usize,
     pub errors: Vec<String>,
 }
@@ -800,10 +813,51 @@ pub fn remove_worktree_path(path: &Path) -> Result<()> {
     Ok(())
 }
 
+fn checkpoint_refs_for_worktree(path: &Path) -> Result<Vec<(PathBuf, String)>> {
+    let Some(repo_root) = main_repo_for_worktree(path) else {
+        return Ok(Vec::new());
+    };
+    let Some(session_id) = path.file_name().and_then(|name| name.to_str()) else {
+        return Ok(Vec::new());
+    };
+    let prefix = format!("refs/yolop/checkpoints/{session_id}/");
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(&repo_root)
+        .args(["for-each-ref", "--format=%(refname)", &prefix])
+        .output()
+        .context("list checkpoint refs")?;
+    if !output.status.success() {
+        bail!(
+            "list checkpoint refs: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8(output.stdout)?
+        .lines()
+        .filter(|reference| !reference.is_empty())
+        .map(|reference| (repo_root.clone(), reference.to_string()))
+        .collect())
+}
+
+fn delete_checkpoint_ref(repo_root: &Path, reference: &str) -> Result<()> {
+    let status = Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(["update-ref", "-d", reference])
+        .status()
+        .with_context(|| format!("delete checkpoint ref {reference}"))?;
+    if !status.success() {
+        bail!("delete checkpoint ref {reference}");
+    }
+    Ok(())
+}
+
 pub fn prune_orphan_worktrees(sessions_dir: &Path, dry_run: bool) -> Result<PruneReport> {
     let referenced = referenced_worktree_paths(sessions_dir)?;
     let mut report = PruneReport {
         removed: Vec::new(),
+        checkpoint_refs: Vec::new(),
         kept: 0,
         errors: Vec::new(),
     };
@@ -814,7 +868,33 @@ pub fn prune_orphan_worktrees(sessions_dir: &Path, dry_run: bool) -> Result<Prun
             continue;
         }
         if dry_run {
+            match checkpoint_refs_for_worktree(&path) {
+                Ok(refs) => report
+                    .checkpoint_refs
+                    .extend(refs.into_iter().map(|(_, reference)| reference)),
+                Err(err) => report.errors.push(format!("{}: {err}", path.display())),
+            }
             report.removed.push(path);
+            continue;
+        }
+        let refs = match checkpoint_refs_for_worktree(&path) {
+            Ok(refs) => refs,
+            Err(err) => {
+                report.errors.push(format!("{}: {err}", path.display()));
+                continue;
+            }
+        };
+        let mut ref_error = false;
+        for (repo_root, reference) in refs {
+            match delete_checkpoint_ref(&repo_root, &reference) {
+                Ok(()) => report.checkpoint_refs.push(reference),
+                Err(err) => {
+                    report.errors.push(err.to_string());
+                    ref_error = true;
+                }
+            }
+        }
+        if ref_error {
             continue;
         }
         match remove_worktree_path(&path) {
@@ -836,6 +916,27 @@ mod tests {
             slug_from_prompt("Please fix the auth bug in login"),
             "fix-auth-bug-login"
         );
+    }
+
+    #[test]
+    fn primary_checkout_is_not_treated_as_an_owned_worktree() {
+        let root = tempfile::tempdir().expect("root");
+        let session = tempfile::tempdir().expect("session");
+        let info = WorktreeInfo {
+            path: root.path().to_path_buf(),
+            branch: "main".to_string(),
+            base_ref: "HEAD".to_string(),
+            slug: "main".to_string(),
+        };
+        let manager = WorktreeManager::new(
+            WorktreesMode::Always,
+            Some(root.path().to_path_buf()),
+            root.path().to_path_buf(),
+            everruns_core::typed_id::SessionId::new(),
+            session.path().to_path_buf(),
+            Some(info),
+        );
+        assert!(manager.owned_worktree_info().is_none());
     }
 
     #[test]
@@ -1029,12 +1130,53 @@ mod tests {
             .join("worktrees")
             .join("abc12345")
             .join("orphan-session");
-        std::fs::create_dir_all(&orphan).expect("orphan");
+        let repo = tempfile::tempdir().expect("repo");
+        let run = |args: &[&str]| {
+            let output = Command::new("git")
+                .arg("-C")
+                .arg(repo.path())
+                .args(args)
+                .env("GIT_COMMITTER_NAME", "test")
+                .env("GIT_COMMITTER_EMAIL", "test@example.com")
+                .output()
+                .expect("git");
+            assert!(
+                output.status.success(),
+                "git {args:?}: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        };
+        run(&["init", "-q"]);
+        std::fs::write(repo.path().join("tracked.txt"), "base").expect("tracked");
+        run(&["add", "tracked.txt"]);
+        run(&[
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "-qm",
+            "base",
+            "--author",
+            "test <test@example.com>",
+        ]);
+        std::fs::create_dir_all(orphan.parent().expect("orphan parent")).expect("worktree parent");
+        run(&[
+            "worktree",
+            "add",
+            "-q",
+            "-b",
+            "orphan-session",
+            orphan.to_str().expect("utf8 path"),
+            "HEAD",
+        ]);
+        let checkpoint_ref = "refs/yolop/checkpoints/orphan-session/cp_1";
+        run(&["update-ref", checkpoint_ref, "HEAD"]);
 
         let report = prune_orphan_worktrees(sessions.path(), false).expect("prune");
         assert_eq!(report.kept, 0);
         assert_eq!(report.removed.len(), 1);
+        assert_eq!(report.checkpoint_refs, vec![checkpoint_ref]);
         assert!(!orphan.exists());
+        assert!(git_output(repo.path(), &["show-ref", checkpoint_ref]).is_none());
 
         // SAFETY: restore prior TMPDIR so later tests see a valid temp root.
         unsafe {


### PR DESCRIPTION
## What changed

Adds durable, automatic pre-turn checkpoints with branch-aware conversation rewind and exact Git-worktree restoration.

- `/undo`, `/redo`, and `/rewind` list or preview conversation/workspace restores and require a confirmation token before mutation.
- Abandoned conversation events remain append-only on disk but are removed from model-visible history and the active transcript, including after resume.
- Workspace snapshots include tracked and untracked non-ignored files without changing the real index, branch, or `HEAD`; restore uses recovery snapshots, stale-preview checks, protected-path/symlink validation, and active-task exclusion.
- TUI, ACP, print mode, and the model-facing `manage_checkpoint` tool share one controller. Conversation restore returns the original prompt to the TUI composer.
- Orphan worktree pruning also reports and detaches private checkpoint refs.

## Why

Persistent session logs and isolated worktrees made Yolop resumable and safer, but neither could undo a bad agent turn. Users had no reliable way to remove a wrong branch from model context or reconstruct files changed by shell commands.

## Before / After

Before:

```text
/undo
unknown command
```

After:

```text
/undo
restore `cp_…` before: <original prompt>
workspace: N path(s) will change
confirm with token `restore-…`

/undo confirm restore-…
restored `cp_…` (Both; N workspace path(s))
```

Proof:

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` — 825 unit tests passed, 37 integration tests passed, plus parallel and PTY suites; 3 provider-dependent tests ignored
- `cargo run -- --provider llmsim -p "Reply exactly: checkpoint-smoke-ok"` — completed successfully
- Real-provider smoke was attempted through Doppler, but this checkout has no Doppler project configuration. CI remains the source of truth for provider-backed checks.

## Risk

- Medium
- Restore intentionally mutates captured worktree files. The implementation limits this to a non-primary Yolop worktree, previews paths, requires confirmation, verifies stale state and the resulting tree, and attempts recovery on failure.
- Timeline filtering changes resume context for sessions that have used rewind. Legacy and unsequenced logs remain a preserved baseline.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
