### PR TITLE
feat(sandbox): contain shell execution by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Install Linux sandbox
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.94.0
 
@@ -106,6 +109,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Install Linux sandbox
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+
       - name: Verify DOPPLER_TOKEN is set
         run: |
           if [ -z "${DOPPLER_TOKEN}" ]; then
@@ -131,3 +137,29 @@ jobs:
         env:
           YOLOP_REQUIRE_LIVE_TESTS: "1"
         run: doppler run -- cargo test --test integration -- --nocapture
+
+  sandbox-contract:
+    name: Sandbox Contract (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Linux sandbox
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.94.0
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "sandbox-${{ runner.os }}"
+
+      - name: Run sandbox contract suite
+        run: cargo test sandbox -- --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install Linux sandbox
-        run: sudo apt-get update && sudo apt-get install -y bubblewrap
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.94.0
 
@@ -109,9 +106,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install Linux sandbox
-        run: sudo apt-get update && sudo apt-get install -y bubblewrap
-
       - name: Verify DOPPLER_TOKEN is set
         run: |
           if [ -z "${DOPPLER_TOKEN}" ]; then
@@ -148,10 +142,6 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v7
-
-      - name: Install Linux sandbox
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y bubblewrap
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.94.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,6 +1585,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.46",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3060,6 +3080,17 @@ name = "lab"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
+name = "landlock"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "635839550ae8b90d9fd2571460a6645dc0aec070225956ca7a2831ed31d2795d"
+dependencies = [
+ "enumflags2",
+ "libc",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "lazy_static"
@@ -5137,6 +5168,15 @@ dependencies = [
  "precomputed-hash",
  "selectors",
  "tendril 0.5.1",
+]
+
+[[package]]
+name = "seccompiler"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae55de56877481d112a559bbc12667635fdaf5e005712fd4e2b2fa50ffc884"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -7548,6 +7588,8 @@ dependencies = [
  "image",
  "include_dir",
  "inventory",
+ "landlock",
+ "libc",
  "portable-pty",
  "proptest",
  "rand 0.10.2",
@@ -7555,6 +7597,7 @@ dependencies = [
  "ratatui-textarea",
  "regex",
  "reqwest 0.13.4",
+ "seccompiler",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,13 @@ regex = "1"
 urlencoding = "2"
 comfy-table = { version = "7.2.2", default-features = false }
 
+# Linux's default local sandbox uses Landlock for filesystem rights and
+# seccomp-BPF for network denial. Both are pure-Rust wrappers over kernel APIs.
+[target.'cfg(target_os = "linux")'.dependencies]
+landlock = "0.4.4"
+libc = "0.2"
+seccompiler = "0.5.0"
+
 [dev-dependencies]
 inventory = "0.3"
 portable-pty = "0.9.0"

--- a/README.md
+++ b/README.md
@@ -62,11 +62,12 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   `.venv/`, `venv/`, `.tox/`, `.gradle/` at any depth; reads are unrestricted
   inside the workspace.
 - **Native shell sandbox by default** — every foreground, background, slash,
-  and direct shell command runs under Seatbelt on macOS or bubblewrap on Linux.
-  The active workspace is writable, `.git` is read-only, and network access is
-  denied. Linux requires `bwrap`. You can set `sandbox = "off"` only when yolop
-  already runs inside a trusted VM/container; Yolop marks that mode `UNSAFE
-  HOST` and warns that it exposes host files, processes, and network.
+  and direct shell command runs under Seatbelt on macOS or Landlock + seccomp
+  on Linux. The active workspace is writable, writes outside it and network
+  access are denied, and macOS also makes workspace `.git` metadata read-only.
+  You can set `sandbox = "off"` only when yolop already runs inside a trusted
+  VM/container; Yolop marks that mode `UNSAFE HOST` and warns that it exposes
+  host files, processes, and network.
 - **Soft approval** — an optional spoken-consent layer for critical actions.
   yolop batches the safe work and pauses to ask, in plain chat, only before
   destructive or outward-facing steps; you approve by replying "yes". The

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   into `.git/`, `node_modules/`, `target/`, `dist/`, `build/`, `.next/`,
   `.venv/`, `venv/`, `.tox/`, `.gradle/` at any depth; reads are unrestricted
   inside the workspace.
+- **Native shell sandbox by default** — every foreground, background, slash,
+  and direct shell command runs under Seatbelt on macOS or bubblewrap on Linux.
+  The active workspace is writable, `.git` is read-only, and network access is
+  denied. Linux requires `bwrap`. You can set `sandbox = "off"` only when yolop
+  already runs inside a trusted VM/container; Yolop marks that mode `UNSAFE
+  HOST` and warns that it exposes host files, processes, and network.
 - **Soft approval** — an optional spoken-consent layer for critical actions.
   yolop batches the safe work and pauses to ask, in plain chat, only before
   destructive or outward-facing steps; you approve by replying "yes". The
@@ -255,8 +261,9 @@ The current level is always shown in the status bar. Change it with
 less careful ("stop asking me", "yolo mode") — it switches the level itself.
 The setting is saved to `settings.toml`, so it persists across sessions.
 
-Soft approval is judgement, not a guarantee. For deterministic enforcement
-(hard-blocking a tool), use [hooks](specs/hooks.md); the two compose.
+Soft approval is judgement, not a guarantee. Native shell
+[sandboxing](specs/sandboxing.md) supplies the kernel boundary; deterministic
+hooks can additionally block specific operations. The controls compose.
 For the public user-facing details, see
 [Approvals](./docs/features/approvals.md).
 
@@ -389,8 +396,8 @@ tools. See [`specs/mcp.md`](specs/mcp.md).
 
 A small TOML settings file persists the preferred provider, per-provider
 model picks, custom endpoint base URLs, the soft-approval level
-(`approval_mode`), Codex subscription login metadata, and (optionally)
-provider API tokens across runs:
+(`approval_mode`), shell sandbox mode (`sandbox`, default `native`), Codex
+subscription login metadata, and (optionally) provider API tokens across runs:
 `<config_dir>/yolop/settings.toml` —
 `~/.config/yolop/settings.toml` on Linux,
 `~/Library/Application Support/yolop/settings.toml` on macOS,
@@ -403,6 +410,11 @@ connected (env key, saved key/login, or no key needed); selecting a connected on
 jumps straight to model selection, and `c` opens key/base-URL configuration
 for any provider. Provider, model, and custom base URL choices are written
 to this file.
+
+To disable kernel containment for an already isolated environment, add
+`sandbox = "off"` or ask yolop to set that config key. This is dangerous on a
+normal host: commands then have unrestricted host file, process, and network
+access. Clearing the key restores the native default.
 
 The model picker queries the provider's models API live (OpenAI, Anthropic,
 and OpenRouter via the everruns drivers; Ollama, Gemini, and other

--- a/specs/approval.md
+++ b/specs/approval.md
@@ -77,8 +77,8 @@ The paranoia level can be changed three ways, all writing the same setting:
 ## Non-goals
 
 - **Not a hard sandbox.** Soft approval cannot *prevent* a tool call; it asks
-  the model to. Hard enforcement belongs to hooks (see `specs/hooks.md`), which
-  can block a tool deterministically. The two compose: hooks for guarantees,
-  soft approval for judgement.
+  the model to. Deterministic hooks can reject known operations, while the
+  implemented [`sandboxing`](./sandboxing.md) boundary contains arbitrary shell
+  execution. These controls compose with soft approval; they do not replace it.
 - **No bespoke approval UI.** Consent is spoken in chat; there is deliberately
   no modal or button.

--- a/specs/background.md
+++ b/specs/background.md
@@ -152,7 +152,9 @@ from an interrupted runner become retryable after the upstream claim timeout.
 
 ## Safety
 
-`spawn_background{bash}` runs the same unsandboxed shell as the `bash` tool, so
-it inherits that tool's approval policy; there is no separate background approval
-gate. Concurrency is bounded by Everruns' per-worker / per-session background-run
-limits.
+`spawn_background{bash}` runs through the same sandbox provider as the `bash`
+tool, so it inherits both containment and approval policy; there is no separate
+background approval gate. The implemented [`sandboxing`](./sandboxing.md)
+boundary routes foreground, direct, and background shell execution through one
+environment so detached work cannot bypass isolation. Concurrency is bounded
+by Everruns' per-worker / per-session background-run limits.

--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -40,6 +40,8 @@ Keys are addressed the way a human would name them:
 | `approval_mode`           | text   | Soft-approval paranoia level (`protective` / `normal` / `off`). |
 | `attribution`             | bool   | Commit/PR attribution on/off.                                  |
 | `proactive_wake`          | bool   | Auto-start a turn when a background task finishes (TUI); on by default. |
+| `worktrees`               | text   | Worktree isolation (`auto` / `always` / `off`).             |
+| `sandbox`                 | text   | Shell containment (`native` by default; `off` is dangerous). |
 | `capabilities`            | list   | Ordered `[[capabilities]]` harness overrides; `capabilities.<ref>` for schema metadata. |
 
 `default_provider` is persisted under that name on disk; the legacy `provider`

--- a/specs/connectors.md
+++ b/specs/connectors.md
@@ -4,7 +4,7 @@ Status: v1 implemented (Daytona).
 
 ## Why
 
-Yolop runs unsandboxed on the user's host by default. Some tasks — untrusted
+Yolop sandboxes arbitrary local shell commands by default. Some tasks — untrusted
 code, heavy builds, network experiments — should run in an isolated remote
 environment instead. [Daytona](https://www.daytona.io/) provides cloud Linux
 sandboxes; upstream ships the integration as `everruns-integrations-daytona`.
@@ -89,5 +89,6 @@ docs for the full tool reference.
 ## See also
 
 - [`specs/configuration.md`](./configuration.md) — `[[capabilities]]` harness overrides
+- [`specs/sandboxing.md`](./sandboxing.md) — common execution-provider boundary
 - [`specs/maintenance.md`](./maintenance.md) — host threat surface
 - [Everruns Daytona integration](https://docs.everruns.com/integrations/daytona/)

--- a/specs/maintenance.md
+++ b/specs/maintenance.md
@@ -105,12 +105,19 @@ Before tagging a release:
 
 ## Security And Threat Posture
 
-Yolop runs unsandboxed on the user's host. The threat surface is concentrated:
+Yolop uses native containment for arbitrary shell commands by default. The
+remaining threat surface is concentrated:
 
-- **Filesystem** — the write blocklist in `runtime.rs` is the only thing preventing rewrites of `.git/`, dependency caches, and build artifacts. Maintenance must verify it is still wired through the real-disk file store.
-- **Shell** — the bash tool spawns a real subprocess on the host. Maintenance must verify the timeout and the per-stream output cap.
+- **Filesystem** — structured file tools still use the rooted real-disk broker
+  and protected-path checks. Maintenance must verify those mounts and checks
+  remain wired.
+- **Shell** — arbitrary commands spawn through the configured sandbox provider.
+  Maintenance must run the workspace-write, outside-write, network-denial,
+  worktree-switch, timeout, and output-cap tests on macOS and Linux.
 - **Session log** — JSONL session logs contain prompts, tool arguments, and tool output. They must be created with `0o600` on Unix.
 - **API keys** — provider keys must only be read from process env. They must never be written to the session log or echoed to tracing output.
+
+[`sandboxing.md`](./sandboxing.md) defines the implemented boundary and its known limitations.
 
 ## Spec Hygiene
 

--- a/specs/sandboxing.md
+++ b/specs/sandboxing.md
@@ -1,0 +1,182 @@
+# Sandboxed execution
+
+Status: implemented for arbitrary shell execution on macOS and Linux.
+
+## Purpose and boundary
+
+Yolop treats soft approval and sandboxing as separate controls. Approval asks
+whether an action is intended. The sandbox limits what arbitrary child
+processes can do even when the model is jailbroken, confused, or simply wrong.
+
+Every shell entry point uses one shared `SandboxProvider` boundary:
+
+- the model-facing `bash` tool;
+- `spawn_background` executions of that tool;
+- the `/shell` command; and
+- the TUI `!shell` shortcut.
+
+Structured file tools remain in Yolop's trusted host broker. They are rooted at
+the active `WorkspaceHost` and retain the existing protected-path checks. System,
+global, workspace, and extension skills also keep their existing read-only
+mounts. Model-provider credentials stay in the trusted parent process.
+
+This is intentionally a provider seam rather than Seatbelt/bubblewrap logic in
+the tool. A provider receives the canonical active workspace and script and
+returns the process to launch. Bashkit, agentOS, Daytona, Monty, or another
+backend can implement the same seam without changing tool schemas.
+
+## Default policy
+
+`sandbox = "native"` is the implicit default. It provides a live writable
+workspace, a private temporary directory, no network, and restrictions inherited
+by descendant processes. The provider is selected once when a runtime is built;
+each command resolves the current workspace again, so worktree activation is
+reflected on the next command.
+
+Native execution is fail closed. If the required OS primitive is unavailable,
+the command returns a sandbox-setup error and is not retried on the host.
+
+### macOS
+
+The native provider launches `/usr/bin/sandbox-exec` with a Seatbelt profile:
+
+- processes and host reads are allowed for compiler/SDK compatibility;
+- writes are allowed only below the active workspace and Yolop sandbox temp;
+- `.git` below the active workspace is read-only; and
+- all network access is denied.
+
+Host reads are deliberately allowed in this first version. Therefore it does
+not yet prevent a command from reading unrelated host files. It prevents writes
+and network exfiltration, and the limitation is part of the documented threat
+model rather than an implied guarantee.
+
+### Linux
+
+The native provider requires `bwrap` (bubblewrap). It creates a new session and
+network namespace, mounts `/` read-only, bind-mounts only the active workspace
+and private temp read-write, then overlays the workspace `.git` path read-only.
+Bubblewrap relies on kernel namespaces and capability dropping; unavailable
+`bwrap` is an error, never an unsandboxed fallback.
+
+## Unsafe opt-out
+
+Users already running Yolop inside a trusted VM/container may set:
+
+```toml
+sandbox = "off"
+```
+
+The same change is available through `set_config key=sandbox value=off`.
+Disabling applies on the next run. Yolop communicates the risk in three places:
+
+- `set_config` returns an explicit `DANGER` / `UNSAFE HOST` message;
+- startup writes the warning to stderr and the TUI transcript; and
+- the status bar appends `UNSAFE HOST` to its persistent approval indicator.
+
+Clearing the setting restores `native`. Yolop never writes the safe default to
+the file, so an `off` entry is conspicuous during review.
+
+## Provider contract and future composition
+
+The implemented host seam is deliberately small:
+
+```rust
+trait SandboxProvider: Send + Sync {
+    fn command(&self, cwd: &Path, script: &str) -> Result<tokio::process::Command>;
+}
+```
+
+The current registry contains `native` and the explicit `off` provider. A
+provider owns policy compilation and launch but not output collection,
+timeouts, cancellation, or background event streaming; those remain in the
+shared `BashTool` executor. That separation guarantees every entry point keeps
+the existing lifecycle semantics.
+
+The next protocol revision may expand this into a session-oriented interface
+for providers with virtual filesystems, snapshots, or remote lifecycle:
+
+```rust
+#[async_trait]
+trait SandboxSession: Send + Sync {
+    async fn execute(&self, request: ExecRequest, events: Arc<dyn ExecEventSink>)
+        -> Result<ExecOutcome>;
+    async fn snapshot(&self) -> Result<Option<OpaqueSnapshot>>;
+    async fn shutdown(&self) -> Result<()>;
+}
+```
+
+That extension must preserve strict event ordering (zero or more stream events,
+then exactly one terminal result), opaque provider state, fail-closed startup,
+and a provider-neutral policy description. It must not let model input choose a
+host executable or silently widen mounts/network.
+
+## Containment providers
+
+- **Native** is the default kernel-enforced local provider.
+- **Bashkit** is a containment provider in its own right: it interprets a bash
+  subset against a virtual filesystem and does not spawn arbitrary OS
+  processes. It would advertise different capabilities from native execution,
+  not masquerade as an equivalent shell.
+- **agentOS** and **Daytona** can provide VM/remote containment and lifecycle.
+- **Monty** is a restricted Python interpreter provider, not a general shell.
+- **Logfire Sandboxes** can be a remotely observed Python execution provider.
+
+Provider capabilities must be explicit so policy can require a kernel/VM
+boundary, virtual-runtime boundary, network denial, snapshots, or a full system
+shell without guessing from the provider name.
+
+### Monty protocol
+
+Monty's protobuf protocol is a useful precedent for restricted interpreters. It
+strictly alternates execution with typed host callbacks and represents
+continuations as opaque snapshots. A future Yolop adapter should map that state
+machine into the common executor rather than adopt Python-specific messages as
+the universal sandbox protocol. Monty has had sandbox-escape security work, so
+its interpreter boundary must not be described as equivalent to kernel/VM
+isolation.
+
+### Logfire Sandboxes
+
+Logfire's sandbox API combines Python execution with managed lifecycle and
+observability. It is a promising provider for Python-heavy tasks. Enforcement
+must remain independent of telemetry: Logfire/OpenTelemetry spans may record
+provider, execution, denial, and resource metadata, but code, tool arguments,
+filesystem contents, credentials, and callback values are omitted by default.
+
+## Worktrees and Git
+
+The active workspace is resolved immediately before each spawn. A worktree
+switch therefore changes the write boundary without rebuilding tool schemas or
+skill configuration. The worktree's `.git` indirection remains readable but is
+not writable from arbitrary shell commands. Git metadata mutation will require
+a future narrow Git broker or an explicit policy capability; it must not happen
+by weakening the entire shell boundary.
+
+## Validation
+
+The automated suite exercises the real `BashTool` launch path and asserts:
+
+- the safe default and sparse settings serialization;
+- explicit unsafe opt-out persistence and danger messaging;
+- writes inside the workspace succeed;
+- writes outside it fail;
+- network connections fail;
+- the active worktree is resolved per command;
+- foreground and background execution retain the shared executor; and
+- runtime construction still resolves system skills and automatic settings.
+
+Platform CI must run the black-box contract suite on both macOS and Linux. The
+Linux job must install bubblewrap. Release validation also includes the normal
+llmsim packaged-binary smoke and a live provider smoke.
+
+## Known limitations
+
+- macOS host reads are allowed in the first provider for toolchain
+  compatibility;
+- native policy is fixed to workspace-write/network-deny (no custom mounts or
+  network allowlist yet);
+- there is no typed Git mutation broker;
+- MCP/extension server processes are user-configured control-plane processes
+  and are not automatically moved into this shell sandbox; and
+- resource controls are the existing wall-clock/output limits, not yet cgroup
+  or VM quotas.

--- a/specs/sandboxing.md
+++ b/specs/sandboxing.md
@@ -20,7 +20,7 @@ the active `WorkspaceHost` and retain the existing protected-path checks. System
 global, workspace, and extension skills also keep their existing read-only
 mounts. Model-provider credentials stay in the trusted parent process.
 
-This is intentionally a provider seam rather than Seatbelt/bubblewrap logic in
+This is intentionally a provider seam rather than OS-specific policy logic in
 the tool. A provider receives the canonical active workspace and script and
 returns the process to launch. Bashkit, agentOS, Daytona, Monty, or another
 backend can implement the same seam without changing tool schemas.
@@ -52,11 +52,21 @@ model rather than an implied guarantee.
 
 ### Linux
 
-The native provider requires `bwrap` (bubblewrap). It creates a new session and
-network namespace, mounts `/` read-only, bind-mounts only the active workspace
-and private temp read-write, then overlays the workspace `.git` path read-only.
-Bubblewrap relies on kernel namespaces and capability dropping; unavailable
-`bwrap` is an error, never an unsandboxed fallback.
+The native provider re-executes Yolop as a small policy worker. The worker uses
+Landlock to grant host reads plus writes only below the active workspace and
+private temp, then installs a seccomp-BPF filter that denies internet and packet
+socket creation before replacing itself with bash. Restrictions are inherited
+by descendants. A kernel that cannot enforce Landlock is an error, never an
+unsandboxed fallback.
+
+The policy requires full Landlock ABI v3 enforcement (Linux 6.2 or a backport)
+so direct truncate operations cannot bypass the write boundary.
+
+Landlock path rules are additive: a writable workspace grant cannot subtract a
+writable `.git` subtree. Linux therefore permits Git metadata writes that live
+inside the active workspace. Linked-worktree metadata outside that boundary
+remains read-only. This is weaker than the macOS policy and is communicated as
+a known limit.
 
 ## Unsafe opt-out
 
@@ -147,10 +157,11 @@ filesystem contents, credentials, and callback values are omitted by default.
 
 The active workspace is resolved immediately before each spawn. A worktree
 switch therefore changes the write boundary without rebuilding tool schemas or
-skill configuration. The worktree's `.git` indirection remains readable but is
-not writable from arbitrary shell commands. Git metadata mutation will require
-a future narrow Git broker or an explicit policy capability; it must not happen
-by weakening the entire shell boundary.
+skill configuration. On macOS, the worktree's `.git` indirection remains
+readable but is not writable from arbitrary shell commands. Linux Landlock
+cannot subtract that path from a writable parent, so metadata paths below the
+workspace remain writable there; linked metadata outside it remains protected.
+The boundary still tracks the newly active worktree for every command.
 
 ## Validation
 
@@ -165,14 +176,16 @@ The automated suite exercises the real `BashTool` launch path and asserts:
 - foreground and background execution retain the shared executor; and
 - runtime construction still resolves system skills and automatic settings.
 
-Platform CI must run the black-box contract suite on both macOS and Linux. The
-Linux job must install bubblewrap. Release validation also includes the normal
-llmsim packaged-binary smoke and a live provider smoke.
+Platform CI runs the black-box contract suite on both macOS and Linux. Release
+validation also includes the normal llmsim packaged-binary smoke and a live
+provider smoke.
 
 ## Known limitations
 
 - macOS host reads are allowed in the first provider for toolchain
   compatibility;
+- Linux host reads and workspace `.git` writes are allowed in the first
+  provider for toolchain and worktree compatibility;
 - native policy is fixed to workspace-write/network-deny (no custom mounts or
   network allowlist yet);
 - there is no typed Git mutation broker;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -570,6 +570,12 @@ impl App {
     }
 
     pub(crate) fn presentation_state(&self) -> PresentationState {
+        let settings = self.settings.snapshot();
+        let approval_mode = if settings.sandbox_mode() == crate::settings::SandboxMode::Off {
+            format!("{} · UNSAFE HOST", settings.approval_mode().as_str())
+        } else {
+            settings.approval_mode().as_str().to_string()
+        };
         PresentationState {
             stream_preview: self.stream_preview.clone(),
             busy: self.busy,
@@ -585,12 +591,7 @@ impl App {
             context_window_tokens: self.context_window_tokens(),
             status_layout: self.status_layout,
             hooks_summary: self.startup.hook_summary(),
-            approval_mode: self
-                .settings
-                .snapshot()
-                .approval_mode()
-                .as_str()
-                .to_string(),
+            approval_mode,
             background: self.background_counts(),
             goal_indicator: self.goal_indicator(),
             ask_indicator: self.ask_indicator(),
@@ -686,6 +687,11 @@ impl App {
             self.startup.workspace_root.display()
         ));
         self.push_system(format!("model: {}", self.model.provider_label()));
+        let sandbox_mode = self.settings.snapshot().sandbox_mode();
+        self.push_system(format!("sandbox: {}", sandbox_mode.as_str()));
+        if let Some(warning) = crate::sandbox::danger_warning(sandbox_mode) {
+            self.push_system(warning.to_string());
+        }
         self.push_system(format!("tools: {}", self.startup.tool_names.join(", ")));
         if !self.startup.capability_commands.is_empty() {
             let names: Vec<String> = self

--- a/src/capabilities/config.rs
+++ b/src/capabilities/config.rs
@@ -516,6 +516,24 @@ impl SetConfigTool {
                     mode.as_str()
                 )))
             }
+            KeyTarget::Sandbox => {
+                if clearing {
+                    self.settings
+                        .set_sandbox_mode(crate::settings::SandboxMode::Native)
+                        .map_err(map_err)?;
+                    return Ok(saved(
+                        "cleared sandbox (default native); applies next run".to_string(),
+                    ));
+                }
+                let mode = crate::settings::SandboxMode::parse(value)
+                    .ok_or_else(|| "sandbox expects native or off".to_string())?;
+                self.settings.set_sandbox_mode(mode).map_err(map_err)?;
+                if mode == crate::settings::SandboxMode::Off {
+                    Ok(saved("sandbox = off; DANGER: next run uses UNSAFE HOST execution with unrestricted file, process, and network access".to_string()))
+                } else {
+                    Ok(saved("sandbox = native; applies next run".to_string()))
+                }
+            }
             KeyTarget::Model(provider) => {
                 if clearing {
                     let existed = self.settings.clear_model(provider).map_err(map_err)?;
@@ -775,6 +793,31 @@ mod tests {
             .execute(json!({ "key": "proactive_wake", "value": "maybe" }))
             .await;
         assert!(matches!(bad, ToolExecutionResult::ToolError(_)));
+    }
+
+    #[tokio::test]
+    async fn set_config_requires_explicit_unsafe_sandbox_opt_out_and_warns() {
+        let (_tmp, settings) = store();
+        let tool = set_config_tool(settings.clone());
+        let result = tool
+            .execute(json!({ "key": "sandbox", "value": "off" }))
+            .await;
+        let ToolExecutionResult::Success(message) = result else {
+            panic!("expected success");
+        };
+        assert!(message.to_string().contains("DANGER"), "{message}");
+        assert!(message.to_string().contains("UNSAFE HOST"), "{message}");
+        assert_eq!(
+            settings.snapshot().sandbox_mode(),
+            crate::settings::SandboxMode::Off
+        );
+
+        tool.execute(json!({ "key": "containment", "value": "clear" }))
+            .await;
+        assert_eq!(
+            settings.snapshot().sandbox_mode(),
+            crate::settings::SandboxMode::Native
+        );
     }
 
     #[tokio::test]

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -279,6 +279,7 @@ pub(crate) const CODING_BASH_CAPABILITY_ID: &str = "yolop_bash";
 
 pub(crate) struct CodingBashCapability {
     pub(crate) workspace: Workspace,
+    pub(crate) sandbox: Arc<dyn crate::sandbox::SandboxProvider>,
     pub(crate) expose_command: bool,
 }
 
@@ -306,7 +307,10 @@ impl Capability for CodingBashCapability {
         None
     }
     fn tools(&self) -> Vec<Box<dyn Tool>> {
-        vec![Box::new(BashTool::new(self.workspace.clone()))]
+        vec![Box::new(BashTool::with_sandbox(
+            self.workspace.clone(),
+            self.sandbox.clone(),
+        ))]
     }
     fn commands(&self) -> Vec<CommandDescriptor> {
         if !self.expose_command {
@@ -342,7 +346,7 @@ impl Capability for CodingBashCapability {
             .map(str::trim)
             .filter(|command| !command.is_empty())
             .ok_or_else(|| everruns_core::AgentLoopError::config("/shell requires: command"))?;
-        let result = BashTool::new(self.workspace.clone())
+        let result = BashTool::with_sandbox(self.workspace.clone(), self.sandbox.clone())
             .execute(json!({ "command": command, "output": "normal" }))
             .await;
         Ok(shell_command_result(result))

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -186,6 +186,16 @@ pub fn schema() -> &'static [ConfigField] {
             provider_scoped: false,
         },
         ConfigField {
+            key: "sandbox",
+            aliases: &["containment"],
+            title: "Shell sandbox",
+            description: "Kernel-enforced containment for every shell command. `native` is the safe default. `off` runs commands directly on the host and is dangerous; use it only when yolop itself already runs inside an isolated VM or container.",
+            kind: ValueKind::Text,
+            default: Some("native"),
+            examples: &["native", "off"],
+            provider_scoped: false,
+        },
+        ConfigField {
             key: "capabilities",
             aliases: &["capability"],
             title: "Harness capabilities",
@@ -235,6 +245,7 @@ pub enum KeyTarget {
     ApprovalMode,
     ProactiveWake,
     Worktrees,
+    Sandbox,
     /// Per-provider model spec, for the named provider.
     Model(String),
     /// Per-provider API token.
@@ -259,6 +270,7 @@ impl KeyTarget {
             KeyTarget::ApprovalMode => "approval_mode",
             KeyTarget::ProactiveWake => "proactive_wake",
             KeyTarget::Worktrees => "worktrees",
+            KeyTarget::Sandbox => "sandbox",
             KeyTarget::Model(_) => "models",
             KeyTarget::Token(_) => "tokens",
             KeyTarget::BaseUrl(_) => "base_urls",
@@ -312,6 +324,7 @@ pub fn parse_key(input: &str) -> Result<KeyTarget, String> {
         "approval_mode" | "approval" => scalar(KeyTarget::ApprovalMode),
         "proactive_wake" | "background_wake" | "wake" => scalar(KeyTarget::ProactiveWake),
         "worktrees" | "worktree" => scalar(KeyTarget::Worktrees),
+        "sandbox" | "containment" => scalar(KeyTarget::Sandbox),
         "models" | "model_for" => scoped(KeyTarget::Model),
         "tokens" | "token" => scoped(KeyTarget::Token),
         "base_urls" | "base_url" | "url" => scoped(KeyTarget::BaseUrl),

--- a/src/config_service.rs
+++ b/src/config_service.rs
@@ -73,6 +73,7 @@ pub(crate) fn current_value(settings: &Settings, target: &KeyTarget) -> Value {
         KeyTarget::ApprovalMode => Value::String(settings.approval_mode().as_str().to_string()),
         KeyTarget::ProactiveWake => Value::Bool(settings.proactive_wake_enabled()),
         KeyTarget::Worktrees => Value::String(settings.worktrees_mode().as_str().to_string()),
+        KeyTarget::Sandbox => Value::String(settings.sandbox_mode().as_str().to_string()),
         KeyTarget::Model(p) => settings
             .model_for(p)
             .map(|s| Value::String(s.to_string()))

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ mod presentation;
 mod proc;
 mod prompt_history;
 mod runtime;
+mod sandbox;
 mod session;
 mod session_log;
 mod session_tasks_view;
@@ -533,6 +534,9 @@ async fn main() -> Result<()> {
     // ACP mode builds runtimes per session (cwd arrives via `session/new`), so
     // it bypasses the up-front runtime build and the TUI.
     if cli.acp {
+        if let Some(warning) = sandbox::danger_warning(settings.snapshot().sandbox_mode()) {
+            eprintln!("yolop: {warning}");
+        }
         if cli.trajectory_out.is_some() {
             eprintln!("yolop: --trajectory-out is ignored in --acp mode");
         }
@@ -543,6 +547,9 @@ async fn main() -> Result<()> {
     // transcript clear, quit), so only it enables `ClientCommandsCapability`.
     // `--print` is one-shot and never dispatches them.
     let interactive = cli.print.is_none();
+    if let Some(warning) = sandbox::danger_warning(settings.snapshot().sandbox_mode()) {
+        eprintln!("yolop: {warning}");
+    }
     let runtime = runtime::build_with_options(
         cwd,
         provider,

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,6 +173,17 @@ enum Commands {
     /// bars, loader). Press `q` or `Esc` to quit. Hidden dev helper.
     #[command(hide = true)]
     TuikaGallery,
+    /// Internal Linux Landlock/seccomp worker. Not a user-facing command.
+    #[cfg(target_os = "linux")]
+    #[command(name = "__sandbox-exec", hide = true)]
+    SandboxExec {
+        #[arg(long)]
+        cwd: PathBuf,
+        #[arg(long)]
+        temp: PathBuf,
+        #[arg(long, allow_hyphen_values = true)]
+        script: String,
+    },
 }
 
 #[derive(Args, Debug)]
@@ -844,6 +855,10 @@ fn run_command(command: Commands) -> Result<()> {
         Commands::Worktree(args) => run_worktree_command(args.command),
         Commands::Mcp(args) => run_mcp_command(args.command),
         Commands::TuikaGallery => run_tuika_gallery(),
+        #[cfg(target_os = "linux")]
+        Commands::SandboxExec { cwd, temp, script } => {
+            sandbox::run_linux_worker(&cwd, &temp, &script)
+        }
         Commands::Into(into) => match into.target {
             IntoTarget::Paseo(args) => {
                 let command = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("yolop"));

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,8 +1,8 @@
 // Runtime construction: wires `InProcessRuntime` through a platform
 // `SessionFileSystemFactory` so the built-in `agent_instructions`,
 // `file_system`, and `skills` capabilities operate against the embedder's
-// actual workspace. Only the `bash` tool is custom — it shells out to the host
-// instead of running against the VFS.
+// actual workspace. Only the `bash` tool is custom — it executes through the
+// configured containment provider instead of running against the VFS.
 
 use crate::capabilities::mcp::McpCapability as YolopMcpCapability;
 use crate::capabilities::memory::{GlobalMemoryCapability, MEMORY_CAPABILITY_ID, MemoryStore};
@@ -29,6 +29,7 @@ use crate::connectors::{
 use crate::goal::GoalStore;
 use crate::host_ui::{HostUi, TuiHandle, UiCommand};
 use crate::mcp_config::McpConfigStore;
+use crate::sandbox::SandboxProvider;
 use crate::settings::{Settings, SettingsStore};
 use crate::tools::Workspace;
 use crate::user_ask::UserAskStore;
@@ -2261,6 +2262,8 @@ pub struct RuntimeHandles {
     /// freshly minted token (the store caches connections in memory per
     /// handle), so `/mcp login` uses it rather than a separate handle.
     pub connections: Arc<ConnectionStore>,
+    /// Shared containment provider for host-triggered shell commands.
+    pub(crate) sandbox: Arc<dyn SandboxProvider>,
     /// Best-effort local lifecycle bridge when this process runs in Herdr.
     pub(crate) herdr: crate::capabilities::herdr::HerdrReporter,
 }
@@ -2529,6 +2532,7 @@ pub async fn build_with_options(
     let provider = options.provider_model.clone().unwrap_or(provider);
     let canonical_root = std::fs::canonicalize(&workspace_root)
         .with_context(|| format!("canonicalize workspace: {}", workspace_root.display()))?;
+    let sandbox = crate::sandbox::provider(settings.snapshot().sandbox_mode());
 
     // Pin the SessionId so resume can re-attach to the same session folder
     // (directory name is the session id).
@@ -3004,6 +3008,7 @@ pub async fn build_with_options(
     });
     capabilities.register(CodingBashCapability {
         workspace: workspace.clone(),
+        sandbox: sandbox.clone(),
         expose_command: !options.client_commands,
     });
     // `background` — the `/background` command listing this session's everruns
@@ -3189,6 +3194,7 @@ pub async fn build_with_options(
             session_store,
             workspace_root: canonical_root.clone(),
             connections,
+            sandbox: sandbox.clone(),
             herdr,
         },
         startup: StartupInfo {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -216,9 +216,7 @@ impl McpAuthProvider for StoredMcpAuthProvider {
 
 const HARNESS_PROMPT: &str = "\
 You are an expert terminal coding agent. File tools write under the workspace
-root. Shell commands run in the configured containment provider, which defaults
-to a native workspace-write/network-deny sandbox. Do not assume they can write
-outside the active workspace or reach the network.
+root; shell is sandboxed to workspace writes and no network by default.
 
 ## Workflow
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -89,7 +89,7 @@ use tokio::sync::mpsc;
 
 // The harness prompt is the durable instruction surface — borrowed in shape
 // from `crates/server/src/harnesses/coding_container.rs` and trimmed for
-// yolop's single-level (no-sandbox) execution model and our specific tool
+// yolop's single-level execution model and our specific tool
 // names. The agent prompt below stays small on purpose; harness covers it.
 
 #[derive(Debug, Default)]
@@ -216,7 +216,9 @@ impl McpAuthProvider for StoredMcpAuthProvider {
 
 const HARNESS_PROMPT: &str = "\
 You are an expert terminal coding agent. File tools write under the workspace
-root; `bash` runs on the host. There is no sandbox.
+root. Shell commands run in the configured containment provider, which defaults
+to a native workspace-write/network-deny sandbox. Do not assume they can write
+outside the active workspace or reach the network.
 
 ## Workflow
 
@@ -2532,7 +2534,13 @@ pub async fn build_with_options(
     let provider = options.provider_model.clone().unwrap_or(provider);
     let canonical_root = std::fs::canonicalize(&workspace_root)
         .with_context(|| format!("canonicalize workspace: {}", workspace_root.display()))?;
-    let sandbox = crate::sandbox::provider(settings.snapshot().sandbox_mode());
+    // Unit-test binaries are libtest harnesses and cannot service the Linux
+    // worker subcommand. Real-binary coverage lives in tests/integration.rs.
+    #[cfg(all(test, target_os = "linux"))]
+    let sandbox_mode = crate::settings::SandboxMode::Off;
+    #[cfg(not(all(test, target_os = "linux")))]
+    let sandbox_mode = settings.snapshot().sandbox_mode();
+    let sandbox = crate::sandbox::provider(sandbox_mode);
 
     // Pin the SessionId so resume can re-attach to the same session folder
     // (directory name is the session id).

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -80,43 +80,92 @@ fn native_command(cwd: &Path, script: &str) -> Result<Command> {
 
 #[cfg(target_os = "linux")]
 fn native_command(cwd: &Path, script: &str) -> Result<Command> {
-    let bwrap = find_in_path("bwrap").ok_or_else(|| anyhow::anyhow!(
-        "native sandbox unavailable: bubblewrap (`bwrap`) is required on Linux; refusing to run unsandboxed. Install bubblewrap or set `sandbox = \"off\"` only inside an already isolated environment"
-    ))?;
     let temp = sandbox_temp_dir()?;
     let home = sandbox_home_dir(&temp)?;
-    let mut command = Command::new(bwrap);
+    let executable = std::env::current_exe().context("resolve yolop sandbox worker executable")?;
+    let mut command = Command::new(executable);
     command
-        // An explicit user namespace supplies the namespaced CAP_NET_ADMIN
-        // bubblewrap needs to initialize loopback after --unshare-net. Without
-        // it, setuid bwrap builds fail closed on hardened hosts such as GitHub
-        // runners before the payload starts.
-        .args([
-            "--die-with-parent",
-            "--new-session",
-            "--unshare-user",
-            "--uid",
-            "0",
-            "--gid",
-            "0",
-            "--unshare-net",
-        ])
-        .args(["--ro-bind", "/", "/"])
-        .arg("--bind")
+        .arg("__sandbox-exec")
+        .arg("--cwd")
         .arg(cwd)
-        .arg(cwd)
-        .arg("--bind")
+        .arg("--temp")
         .arg(&temp)
-        .arg(&temp)
-        .arg("--chdir")
-        .arg(cwd);
-    let dot_git = cwd.join(".git");
-    if dot_git.exists() {
-        command.arg("--ro-bind").arg(&dot_git).arg(&dot_git);
-    }
-    command.arg("/bin/bash").arg("-lc").arg(script);
+        .arg("--script")
+        .arg(script)
+        .current_dir(cwd);
     apply_native_environment(&mut command, &home, &temp);
     Ok(command)
+}
+
+/// Apply Linux kernel restrictions in a fresh helper process, then replace it
+/// with bash. Keeping this out of `pre_exec` avoids allocation and locking in a
+/// post-fork callback of Tokio's multi-threaded parent.
+#[cfg(target_os = "linux")]
+pub(crate) fn run_linux_worker(cwd: &Path, temp: &Path, script: &str) -> Result<()> {
+    use landlock::{
+        ABI, Access, AccessFs, PathBeneath, PathFd, Ruleset, RulesetAttr, RulesetCreatedAttr,
+        RulesetStatus,
+    };
+    use seccompiler::{
+        BpfProgram, SeccompAction, SeccompCmpArgLen, SeccompCmpOp, SeccompCondition, SeccompFilter,
+        SeccompRule,
+    };
+    use std::convert::TryInto;
+    use std::os::unix::process::CommandExt;
+
+    std::env::set_current_dir(cwd)
+        .with_context(|| format!("enter sandbox workspace: {}", cwd.display()))?;
+
+    // ABI V3 is the oldest policy that also mediates truncate(2); requiring
+    // full enforcement avoids silently weakening the write boundary.
+    let abi = ABI::V3;
+    let status = Ruleset::default()
+        .handle_access(AccessFs::from_all(abi))?
+        .create()?
+        .add_rule(PathBeneath::new(
+            PathFd::new("/")?,
+            AccessFs::from_read(abi),
+        ))?
+        .add_rule(PathBeneath::new(PathFd::new(cwd)?, AccessFs::from_all(abi)))?
+        .add_rule(PathBeneath::new(
+            PathFd::new(temp)?,
+            AccessFs::from_all(abi),
+        ))?
+        .restrict_self()?;
+    if status.ruleset != RulesetStatus::FullyEnforced || !status.no_new_privs {
+        anyhow::bail!(
+            "native sandbox unavailable: Landlock ABI v3 is not fully enforced by this Linux kernel; refusing to run unsandboxed. Set `sandbox = \"off\"` only inside an already isolated environment"
+        );
+    }
+
+    // Internet and packet sockets are denied. Unix sockets remain available
+    // for local toolchains and agents; the sanitized environment removes
+    // credential-bearing agent socket paths before this worker starts.
+    let socket_rules = [libc::AF_INET, libc::AF_INET6, libc::AF_PACKET]
+        .into_iter()
+        .map(|family| {
+            SeccompRule::new(vec![SeccompCondition::new(
+                0,
+                SeccompCmpArgLen::Dword,
+                SeccompCmpOp::Eq,
+                family as u64,
+            )?])
+        })
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let filter: BpfProgram = SeccompFilter::new(
+        [(libc::SYS_socket, socket_rules)].into_iter().collect(),
+        SeccompAction::Allow,
+        SeccompAction::Errno(libc::EACCES as u32),
+        std::env::consts::ARCH.try_into()?,
+    )?
+    .try_into()?;
+    seccompiler::apply_filter(&filter)?;
+
+    Err(std::process::Command::new("/bin/bash")
+        .arg("-lc")
+        .arg(script)
+        .exec()
+        .into())
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
@@ -181,15 +230,6 @@ fn seatbelt_escape(path: &Path) -> String {
     path.to_string_lossy()
         .replace('\\', "\\\\")
         .replace('"', "\\\"")
-}
-
-#[cfg(target_os = "linux")]
-fn find_in_path(name: &str) -> Option<PathBuf> {
-    std::env::var_os("PATH").and_then(|paths| {
-        std::env::split_paths(&paths)
-            .map(|path| path.join(name))
-            .find(|path| path.is_file())
-    })
 }
 
 pub(crate) fn configure_stdio(command: &mut Command) {

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,0 +1,235 @@
+//! Pluggable containment for arbitrary child-process execution.
+//!
+//! Structured filesystem tools remain in the trusted host broker. Every shell
+//! entry point receives one of these providers, so foreground, background and
+//! interactive commands share the same kernel boundary.
+
+use crate::settings::SandboxMode;
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use tokio::process::Command;
+
+pub(crate) trait SandboxProvider: Send + Sync {
+    fn command(&self, cwd: &Path, script: &str) -> Result<Command>;
+}
+
+pub(crate) fn provider(mode: SandboxMode) -> std::sync::Arc<dyn SandboxProvider> {
+    match mode {
+        SandboxMode::Native => std::sync::Arc::new(NativeSandbox),
+        SandboxMode::Off => std::sync::Arc::new(UnsafeHost),
+    }
+}
+
+pub(crate) fn danger_warning(mode: SandboxMode) -> Option<&'static str> {
+    (mode == SandboxMode::Off).then_some(
+        "DANGER: sandbox disabled (UNSAFE HOST) — shell commands can access and modify files, processes, and the network outside the workspace",
+    )
+}
+
+struct UnsafeHost;
+
+impl SandboxProvider for UnsafeHost {
+    fn command(&self, cwd: &Path, script: &str) -> Result<Command> {
+        let mut command = Command::new("bash");
+        command.arg("-lc").arg(script).current_dir(cwd);
+        Ok(command)
+    }
+}
+
+struct NativeSandbox;
+
+impl SandboxProvider for NativeSandbox {
+    fn command(&self, cwd: &Path, script: &str) -> Result<Command> {
+        native_command(cwd, script)
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn native_command(cwd: &Path, script: &str) -> Result<Command> {
+    let executable = Path::new("/usr/bin/sandbox-exec");
+    if !executable.is_file() {
+        anyhow::bail!(
+            "native sandbox unavailable: /usr/bin/sandbox-exec is missing; refusing to run unsandboxed. Set `sandbox = \"off\"` only inside an already isolated environment"
+        )
+    }
+
+    // Seatbelt denies network and all writes by default. Reads stay available
+    // so compilers, SDKs, package caches and system skills continue to work;
+    // only the active workspace and a private temporary directory are writable.
+    let temp = sandbox_temp_dir()?;
+    let home = sandbox_home_dir(&temp)?;
+    let profile = format!(
+        "(version 1)\n(deny default)\n(allow process*)\n(allow file-read*)\n(allow sysctl-read)\n(allow mach-lookup)\n(allow file-write* (subpath \"{}\") (subpath \"{}\"))\n(deny network*)\n(deny file-write* (literal \"{}\") (subpath \"{}\"))",
+        seatbelt_escape(cwd),
+        seatbelt_escape(&temp),
+        seatbelt_escape(&cwd.join(".git")),
+        seatbelt_escape(&cwd.join(".git")),
+    );
+    let mut command = Command::new(executable);
+    command
+        .arg("-p")
+        .arg(profile)
+        .arg("/bin/bash")
+        .arg("-lc")
+        .arg(script)
+        .current_dir(cwd);
+    apply_native_environment(&mut command, &home, &temp);
+    Ok(command)
+}
+
+#[cfg(target_os = "linux")]
+fn native_command(cwd: &Path, script: &str) -> Result<Command> {
+    let bwrap = find_in_path("bwrap").ok_or_else(|| anyhow::anyhow!(
+        "native sandbox unavailable: bubblewrap (`bwrap`) is required on Linux; refusing to run unsandboxed. Install bubblewrap or set `sandbox = \"off\"` only inside an already isolated environment"
+    ))?;
+    let temp = sandbox_temp_dir()?;
+    let home = sandbox_home_dir(&temp)?;
+    let mut command = Command::new(bwrap);
+    command
+        .args(["--die-with-parent", "--new-session", "--unshare-net"])
+        .args(["--ro-bind", "/", "/"])
+        .arg("--bind")
+        .arg(cwd)
+        .arg(cwd)
+        .arg("--bind")
+        .arg(&temp)
+        .arg(&temp)
+        .arg("--chdir")
+        .arg(cwd);
+    let dot_git = cwd.join(".git");
+    if dot_git.exists() {
+        command.arg("--ro-bind").arg(&dot_git).arg(&dot_git);
+    }
+    command.arg("/bin/bash").arg("-lc").arg(script);
+    apply_native_environment(&mut command, &home, &temp);
+    Ok(command)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn native_command(_cwd: &Path, _script: &str) -> Result<Command> {
+    anyhow::bail!(
+        "native sandbox is supported only on macOS and Linux; refusing to run unsandboxed. Set `sandbox = \"off\"` only inside an already isolated environment"
+    )
+}
+
+fn sandbox_temp_dir() -> Result<PathBuf> {
+    let path = std::env::temp_dir().join(format!("yolop-sandbox-{}", std::process::id()));
+    std::fs::create_dir_all(&path)
+        .with_context(|| format!("create sandbox temp directory: {}", path.display()))?;
+    Ok(path)
+}
+
+fn sandbox_home_dir(temp: &Path) -> Result<PathBuf> {
+    let path = temp.join("home");
+    std::fs::create_dir_all(&path)
+        .with_context(|| format!("create sandbox home directory: {}", path.display()))?;
+    Ok(path)
+}
+
+fn apply_native_environment(command: &mut Command, home: &Path, temp: &Path) {
+    command.env_clear();
+    for (key, value) in std::env::vars_os() {
+        if safe_environment_key(&key.to_string_lossy()) {
+            command.env(key, value);
+        }
+    }
+    command.env("HOME", home).env("TMPDIR", temp);
+}
+
+fn safe_environment_key(key: &str) -> bool {
+    matches!(
+        key,
+        "PATH"
+            | "LANG"
+            | "LC_ALL"
+            | "LC_CTYPE"
+            | "TERM"
+            | "COLORTERM"
+            | "NO_COLOR"
+            | "FORCE_COLOR"
+            | "CARGO_HOME"
+            | "RUSTUP_HOME"
+            | "SDKROOT"
+            | "DEVELOPER_DIR"
+            | "PKG_CONFIG_PATH"
+            | "CPATH"
+            | "LIBRARY_PATH"
+            | "C_INCLUDE_PATH"
+            | "CPLUS_INCLUDE_PATH"
+            | "JAVA_HOME"
+            | "GOPATH"
+            | "GOROOT"
+    ) || key.starts_with("LC_")
+}
+
+#[cfg(target_os = "macos")]
+fn seatbelt_escape(path: &Path) -> String {
+    path.to_string_lossy()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+}
+
+#[cfg(target_os = "linux")]
+fn find_in_path(name: &str) -> Option<PathBuf> {
+    std::env::var_os("PATH").and_then(|paths| {
+        std::env::split_paths(&paths)
+            .map(|path| path.join(name))
+            .find(|path| path.is_file())
+    })
+}
+
+pub(crate) fn configure_stdio(command: &mut Command) {
+    command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn seatbelt_paths_are_escaped() {
+        assert_eq!(
+            seatbelt_escape(Path::new("/tmp/a \\\"b")),
+            "/tmp/a \\\\\\\"b"
+        );
+    }
+
+    #[test]
+    fn native_is_the_safe_default_provider() {
+        assert!(danger_warning(SandboxMode::Native).is_none());
+        assert!(
+            danger_warning(SandboxMode::Off)
+                .unwrap()
+                .contains("UNSAFE HOST")
+        );
+    }
+
+    #[test]
+    fn native_environment_allowlist_excludes_credentials_and_agents() {
+        for key in [
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "DOPPLER_TOKEN",
+            "GITHUB_TOKEN",
+            "AWS_SECRET_ACCESS_KEY",
+            "SSH_AUTH_SOCK",
+            "GPG_AGENT_INFO",
+        ] {
+            assert!(!safe_environment_key(key), "unexpectedly allowed {key}");
+        }
+        for key in [
+            "PATH",
+            "CARGO_HOME",
+            "RUSTUP_HOME",
+            "SDKROOT",
+            "LC_MESSAGES",
+        ] {
+            assert!(safe_environment_key(key), "expected build env {key}");
+        }
+    }
+}

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -87,7 +87,20 @@ fn native_command(cwd: &Path, script: &str) -> Result<Command> {
     let home = sandbox_home_dir(&temp)?;
     let mut command = Command::new(bwrap);
     command
-        .args(["--die-with-parent", "--new-session", "--unshare-net"])
+        // An explicit user namespace supplies the namespaced CAP_NET_ADMIN
+        // bubblewrap needs to initialize loopback after --unshare-net. Without
+        // it, setuid bwrap builds fail closed on hardened hosts such as GitHub
+        // runners before the payload starts.
+        .args([
+            "--die-with-parent",
+            "--new-session",
+            "--unshare-user",
+            "--uid",
+            "0",
+            "--gid",
+            "0",
+            "--unshare-net",
+        ])
         .args(["--ro-bind", "/", "/"])
         .arg("--bind")
         .arg(cwd)

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -177,9 +177,36 @@ fn native_command(_cwd: &Path, _script: &str) -> Result<Command> {
 
 fn sandbox_temp_dir() -> Result<PathBuf> {
     let path = std::env::temp_dir().join(format!("yolop-sandbox-{}", std::process::id()));
-    std::fs::create_dir_all(&path)
-        .with_context(|| format!("create sandbox temp directory: {}", path.display()))?;
+    prepare_sandbox_temp(&path)?;
     Ok(path)
+}
+
+fn prepare_sandbox_temp(path: &Path) -> Result<()> {
+    use std::io::ErrorKind;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    match std::fs::create_dir(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+            let metadata = std::fs::symlink_metadata(path)
+                .with_context(|| format!("inspect sandbox temp directory: {}", path.display()))?;
+            if !metadata.file_type().is_dir() {
+                anyhow::bail!(
+                    "sandbox temp path is not a directory (possible path-alias attack): {}",
+                    path.display()
+                );
+            }
+        }
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("create sandbox temp directory: {}", path.display()));
+        }
+    }
+    #[cfg(unix)]
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+        .with_context(|| format!("secure sandbox temp directory: {}", path.display()))?;
+    Ok(())
 }
 
 fn sandbox_home_dir(temp: &Path) -> Result<PathBuf> {
@@ -242,6 +269,19 @@ pub(crate) fn configure_stdio(command: &mut Command) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn sandbox_temp_rejects_a_preexisting_symlink() {
+        let root = tempfile::tempdir().unwrap();
+        let target = root.path().join("target");
+        let alias = root.path().join("alias");
+        std::fs::create_dir(&target).unwrap();
+        std::os::unix::fs::symlink(&target, &alias).unwrap();
+
+        let error = prepare_sandbox_temp(&alias).unwrap_err().to_string();
+        assert!(error.contains("path-alias attack"), "{error}");
+    }
 
     #[cfg(target_os = "macos")]
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -331,9 +331,10 @@ impl Session {
     ) -> TurnHandle {
         let (tx, rx) = mpsc::unbounded_channel::<TurnEvent>();
         let (cancel_tx, mut cancel_rx) = oneshot::channel::<()>();
+        let sandbox = self.handles.sandbox.clone();
 
         tokio::spawn(async move {
-            let tool = BashTool::new(Workspace::new(workspace));
+            let tool = BashTool::with_sandbox(Workspace::new(workspace), sandbox);
             let run = tool.execute(serde_json::json!({
                 "command": command,
                 // Direct shell output is not persisted through a tool-call

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -72,6 +72,33 @@ impl std::fmt::Display for WorktreesMode {
     }
 }
 
+/// Kernel containment used for arbitrary shell commands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SandboxMode {
+    /// Seatbelt on macOS; bubblewrap namespaces on Linux.
+    #[default]
+    Native,
+    /// Explicitly run commands directly on the host. Dangerous.
+    Off,
+}
+
+impl SandboxMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Native => "native",
+            Self::Off => "off",
+        }
+    }
+
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "native" | "on" | "default" => Some(Self::Native),
+            "off" | "none" | "disabled" | "unsafe-host" => Some(Self::Off),
+            _ => None,
+        }
+    }
+}
+
 /// running critical actions. Soft approval is prompt-engineering, not a
 /// hard gate: the chosen level is injected into the system prompt so the
 /// model itself decides when to ask, batches safe calls, and the user
@@ -149,6 +176,8 @@ pub struct Settings {
     pub proactive_wake: bool,
     /// Git worktree isolation for code changes (`auto`, `always`, `off`).
     pub worktrees: WorktreesMode,
+    /// Kernel sandbox for arbitrary shell commands. Enabled by default.
+    pub sandbox: SandboxMode,
     /// Global MCP servers (`[mcp.servers.<name>]` in settings.toml). Repo `.mcp.json` entries override these by name.
     pub mcp: McpSettings,
     /// Ordered harness capability overrides (`[[capabilities]]` in settings.toml).
@@ -168,6 +197,7 @@ impl Default for Settings {
             approval_mode: ApprovalMode::Normal,
             proactive_wake: true,
             worktrees: WorktreesMode::Auto,
+            sandbox: SandboxMode::Native,
             mcp: McpSettings::default(),
             capabilities: Vec::new(),
         }
@@ -205,6 +235,11 @@ impl Settings {
             .and_then(Value::as_str)
             .and_then(WorktreesMode::parse)
             .unwrap_or_default();
+        let sandbox = table
+            .get("sandbox")
+            .and_then(Value::as_str)
+            .and_then(SandboxMode::parse)
+            .unwrap_or_default();
         let string_map = |key: &str| {
             let mut map = BTreeMap::new();
             if let Some(t) = table.get(key).and_then(Value::as_table) {
@@ -231,6 +266,7 @@ impl Settings {
             approval_mode,
             proactive_wake,
             worktrees,
+            sandbox,
             mcp: parse_mcp_settings(table),
             capabilities: parse_capabilities_table(table),
         }
@@ -263,6 +299,10 @@ impl Settings {
                 "worktrees".to_string(),
                 Value::String(self.worktrees.as_str().to_string()),
             );
+        }
+        // The safe default stays implicit; an unsafe host opt-out is conspicuous.
+        if self.sandbox == SandboxMode::Off {
+            table.insert("sandbox".to_string(), Value::String("off".to_string()));
         }
         let mut insert_map = |key: &str, map: &BTreeMap<String, String>| {
             if !map.is_empty() {
@@ -341,6 +381,10 @@ impl Settings {
 
     pub fn worktrees_mode(&self) -> WorktreesMode {
         self.worktrees
+    }
+
+    pub fn sandbox_mode(&self) -> SandboxMode {
+        self.sandbox
     }
 
     pub fn capability_overrides_for(&self, id: &str) -> Vec<(usize, &CapabilityOverride)> {
@@ -531,6 +575,12 @@ impl SettingsStore {
     pub fn set_worktrees_mode(&self, mode: WorktreesMode) -> Result<()> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
         guard.worktrees = mode;
+        save_to(&self.path, &guard)
+    }
+
+    pub fn set_sandbox_mode(&self, mode: SandboxMode) -> Result<()> {
+        let mut guard = self.inner.lock().expect("settings lock poisoned");
+        guard.sandbox = mode;
         save_to(&self.path, &guard)
     }
 
@@ -737,6 +787,27 @@ mod tests {
             !SettingsStore::open(path)
                 .snapshot()
                 .proactive_wake_enabled()
+        );
+    }
+
+    #[test]
+    fn sandbox_defaults_on_and_unsafe_opt_out_round_trips() {
+        let settings = Settings::from_table(&Table::new());
+        assert_eq!(settings.sandbox_mode(), SandboxMode::Native);
+        assert!(!settings.to_table().contains_key("sandbox"));
+
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join("settings.toml");
+        let store = SettingsStore::open(path.clone());
+        store.set_sandbox_mode(SandboxMode::Off).expect("save");
+        assert!(
+            std::fs::read_to_string(&path)
+                .expect("read")
+                .contains("sandbox = \"off\"")
+        );
+        assert_eq!(
+            SettingsStore::open(path).snapshot().sandbox_mode(),
+            SandboxMode::Off
         );
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -75,7 +75,7 @@ impl std::fmt::Display for WorktreesMode {
 /// Kernel containment used for arbitrary shell commands.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SandboxMode {
-    /// Seatbelt on macOS; bubblewrap namespaces on Linux.
+    /// Seatbelt on macOS; Landlock and seccomp on Linux.
     #[default]
     Native,
     /// Explicitly run commands directly on the host. Dangerous.

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -73,10 +73,15 @@ fn command_failure_hint(exit_code: i32, stderr: &str) -> Option<&'static str> {
 impl BashTool {
     #[cfg(test)]
     pub fn new(ws: Workspace) -> Self {
-        Self::with_sandbox(
-            ws,
-            crate::sandbox::provider(crate::settings::SandboxMode::Native),
-        )
+        // Linux's native provider re-execs the yolop binary. Unit tests run in
+        // the libtest harness, so its real-binary contract lives in
+        // tests/integration.rs instead.
+        let mode = if cfg!(target_os = "linux") {
+            crate::settings::SandboxMode::Off
+        } else {
+            crate::settings::SandboxMode::Native
+        };
+        Self::with_sandbox(ws, crate::sandbox::provider(mode))
     }
 
     pub fn with_sandbox(ws: Workspace, sandbox: Arc<dyn SandboxProvider>) -> Self {
@@ -454,7 +459,7 @@ mod tests {
         );
     }
 
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[cfg(target_os = "macos")]
     #[tokio::test]
     async fn native_sandbox_allows_workspace_writes_and_denies_outside_writes() {
         let parent = tempfile::tempdir().unwrap();
@@ -485,7 +490,7 @@ mod tests {
         assert!(!outside.exists(), "sandbox wrote outside the workspace");
     }
 
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[cfg(target_os = "macos")]
     #[tokio::test]
     async fn native_sandbox_denies_git_metadata_and_path_alias_escapes() {
         let parent = tempfile::tempdir().unwrap();
@@ -512,7 +517,7 @@ mod tests {
         assert_eq!(std::fs::read_to_string(&outside).unwrap(), "safe");
     }
 
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[cfg(target_os = "macos")]
     #[tokio::test]
     async fn native_sandbox_denies_network_connections() {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
@@ -527,7 +532,7 @@ mod tests {
         assert_ne!(result["exit_code"], 0, "{result}");
     }
 
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[cfg(target_os = "macos")]
     #[tokio::test]
     async fn native_sandbox_follows_active_worktree_per_command() {
         let parent = tempfile::tempdir().unwrap();

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -4,9 +4,10 @@
 // capability now that yolop selects `RealDiskFileStore` through its platform
 // filesystem factory. The bash tool stays custom because the built-in `virtual_bash`
 // runs commands against the VFS, not against the real workspace, and the
-// security model for unsandboxed shell-on-host needs yolop-specific policy
-// (timeout, output cap). See EVE-478 for the eventual runtime-side story.
+// security model for real child processes needs yolop-specific containment,
+// timeout, and output policy.
 
+use crate::sandbox::SandboxProvider;
 use crate::workspace_host::WorkspaceHost;
 use async_trait::async_trait;
 use everruns_core::exec_tool_result::ExecToolResultPayload;
@@ -18,11 +19,9 @@ use everruns_core::{
     ToolContext,
 };
 use serde_json::{Value, json};
-use std::process::Stdio;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::io::AsyncReadExt;
-use tokio::process::Command;
 
 /// Workspace context for the bash tool. The host disk repoints when a session
 /// worktree is activated mid-session (EVE-660).
@@ -47,6 +46,7 @@ impl Workspace {
 
 pub struct BashTool {
     ws: Workspace,
+    sandbox: Arc<dyn SandboxProvider>,
     foreground_timeout_secs: u64,
     background_timeout_secs: u64,
     max_output_bytes: usize,
@@ -71,9 +71,18 @@ fn command_failure_hint(exit_code: i32, stderr: &str) -> Option<&'static str> {
 }
 
 impl BashTool {
+    #[cfg(test)]
     pub fn new(ws: Workspace) -> Self {
+        Self::with_sandbox(
+            ws,
+            crate::sandbox::provider(crate::settings::SandboxMode::Native),
+        )
+    }
+
+    pub fn with_sandbox(ws: Workspace, sandbox: Arc<dyn SandboxProvider>) -> Self {
         Self {
             ws,
+            sandbox,
             foreground_timeout_secs: 120,
             background_timeout_secs: 24 * 60 * 60,
             max_output_bytes: 1024 * 1024,
@@ -109,13 +118,12 @@ impl BashTool {
 
         // kill_on_drop ensures a timed-out or canceled background command is
         // reaped when the owning future is dropped.
-        let mut child = Command::new("bash")
-            .arg("-lc")
-            .arg(command)
-            .current_dir(&cwd)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .kill_on_drop(true)
+        let mut process = self
+            .sandbox
+            .command(&cwd, command)
+            .map_err(|e| ToolExecutionResult::tool_error(format!("sandbox setup failed: {e:#}")))?;
+        crate::sandbox::configure_stdio(&mut process);
+        let mut child = process
             .spawn()
             .map_err(|e| ToolExecutionResult::tool_error(format!("spawn failed: {e}")))?;
         let mut stdout = child.stdout.take().unwrap();
@@ -443,6 +451,117 @@ mod tests {
             out.trim(),
             root_name,
             "cwd should reset to the workspace root between calls"
+        );
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[tokio::test]
+    async fn native_sandbox_allows_workspace_writes_and_denies_outside_writes() {
+        let parent = tempfile::tempdir().unwrap();
+        let workspace = parent.path().join("workspace");
+        std::fs::create_dir(&workspace).unwrap();
+        let outside = parent.path().join("outside.txt");
+        let tool = BashTool::new(Workspace::from_path(workspace.clone()));
+
+        let ToolExecutionResult::Success(inside) = tool
+            .execute(json!({ "command": "printf inside > allowed.txt" }))
+            .await
+        else {
+            panic!("expected structured result");
+        };
+        assert_eq!(inside["exit_code"], 0, "{inside}");
+        assert_eq!(
+            std::fs::read_to_string(workspace.join("allowed.txt")).unwrap(),
+            "inside"
+        );
+
+        let script = format!("printf escaped > '{}'", outside.display());
+        let ToolExecutionResult::Success(escaped) =
+            tool.execute(json!({ "command": script })).await
+        else {
+            panic!("expected structured result");
+        };
+        assert_ne!(escaped["exit_code"], 0, "{escaped}");
+        assert!(!outside.exists(), "sandbox wrote outside the workspace");
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[tokio::test]
+    async fn native_sandbox_denies_git_metadata_and_path_alias_escapes() {
+        let parent = tempfile::tempdir().unwrap();
+        let workspace = parent.path().join("workspace");
+        std::fs::create_dir(&workspace).unwrap();
+        std::fs::create_dir(workspace.join(".git")).unwrap();
+        let outside = parent.path().join("outside.txt");
+        std::fs::write(&outside, "safe").unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&outside, workspace.join("escape-link")).unwrap();
+        let tool = BashTool::new(Workspace::from_path(workspace.clone()));
+
+        let script = format!(
+            "if printf git > .git/config; then exit 91; fi; if printf symlink > escape-link; then exit 92; fi; if ln '{}' hard-link 2>/dev/null; then exit 93; fi; exit 0",
+            outside.display()
+        );
+        let ToolExecutionResult::Success(result) = tool.execute(json!({ "command": script })).await
+        else {
+            panic!("expected structured result");
+        };
+        assert_eq!(result["exit_code"], 0, "{result}");
+        assert!(!workspace.join(".git/config").exists());
+        assert!(!workspace.join("hard-link").exists());
+        assert_eq!(std::fs::read_to_string(&outside).unwrap(), "safe");
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[tokio::test]
+    async fn native_sandbox_denies_network_connections() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let workspace = tempfile::tempdir().unwrap();
+        let tool = BashTool::new(Workspace::from_path(workspace.path().to_path_buf()));
+        let script = format!("exec 3<>/dev/tcp/127.0.0.1/{port}");
+        let ToolExecutionResult::Success(result) = tool.execute(json!({ "command": script })).await
+        else {
+            panic!("expected structured result");
+        };
+        assert_ne!(result["exit_code"], 0, "{result}");
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[tokio::test]
+    async fn native_sandbox_follows_active_worktree_per_command() {
+        let parent = tempfile::tempdir().unwrap();
+        let root = parent.path().join("root");
+        let worktree = parent.path().join("worktree");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::create_dir(&worktree).unwrap();
+        let active = Arc::new(std::sync::RwLock::new(root.clone()));
+        let host = Arc::new(WorkspaceHost::new(active.clone(), root.clone()).expect("host"));
+        let tool = BashTool::new(Workspace::new(host));
+
+        let ToolExecutionResult::Success(first) = tool
+            .execute(json!({ "command": "printf root > marker" }))
+            .await
+        else {
+            panic!("expected root command result");
+        };
+        assert_eq!(first["exit_code"], 0, "{first}");
+
+        *active.write().expect("lock") = worktree.clone();
+        let ToolExecutionResult::Success(second) = tool
+            .execute(json!({ "command": "printf worktree > marker" }))
+            .await
+        else {
+            panic!("expected worktree command result");
+        };
+        assert_eq!(second["exit_code"], 0, "{second}");
+        assert_eq!(
+            std::fs::read_to_string(root.join("marker")).unwrap(),
+            "root"
+        );
+        assert_eq!(
+            std::fs::read_to_string(worktree.join("marker")).unwrap(),
+            "worktree"
         );
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -264,6 +264,64 @@ fn llmsim_print_smoke() {
 }
 
 #[test]
+fn unsafe_sandbox_opt_out_warns_from_the_real_binary() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config_root = tmp.path().join(".config");
+    let linux_settings = config_root.join("yolop/settings.toml");
+    std::fs::create_dir_all(linux_settings.parent().unwrap()).unwrap();
+    std::fs::write(&linux_settings, "sandbox = \"off\"\n").unwrap();
+    let mac_settings = tmp
+        .path()
+        .join("Library/Application Support/yolop/settings.toml");
+    std::fs::create_dir_all(mac_settings.parent().unwrap()).unwrap();
+    std::fs::write(&mac_settings, "sandbox = \"off\"\n").unwrap();
+
+    let output = Command::new(yolop_binary())
+        .args([
+            "--provider",
+            "llmsim",
+            "--session-dir",
+            tmp.path().to_str().unwrap(),
+            "-p",
+            "hi",
+        ])
+        .env("HOME", tmp.path())
+        .env("XDG_CONFIG_HOME", &config_root)
+        .output()
+        .expect("spawn yolop with sandbox disabled");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr={stderr}");
+    assert!(stderr.contains("DANGER"), "stderr={stderr}");
+    assert!(stderr.contains("UNSAFE HOST"), "stderr={stderr}");
+}
+
+#[test]
+fn unsafe_sandbox_opt_out_is_visible_in_tui_transcript_and_status() {
+    let mut tui = spawn_tui_llmsim_with_settings(
+        &yolop_binary(),
+        TuiSpawnOptions::default(),
+        "provider = \"llmsim\"\nsandbox = \"off\"\n",
+    );
+    assert!(
+        tui.wait_for_output("UNSAFE HOST", Duration::from_secs(3)),
+        "TUI did not show unsafe sandbox state: {}",
+        tui.output_text()
+    );
+    assert!(
+        tui.output_text().contains("DANGER"),
+        "{}",
+        tui.output_text()
+    );
+    assert!(
+        tui.wait_for_output("type /help", Duration::from_secs(3)),
+        "TUI did not finish startup: {}",
+        tui.output_text()
+    );
+    tui.write_input(b"\x03\x03");
+    assert!(tui.wait_or_kill(Duration::from_secs(10)).success());
+}
+
+#[test]
 fn llmsim_print_writes_atif_trajectory() {
     // End-to-end offline smoke for `--trajectory-out`: a one-shot llmsim run
     // must leave a parseable ATIF-v1.7 document with the user prompt and at

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -43,6 +43,88 @@ fn yolop_binary() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_yolop"))
 }
 
+#[cfg(target_os = "linux")]
+fn run_linux_sandbox_worker(cwd: &Path, temp: &Path, script: &str) -> std::process::Output {
+    Command::new(yolop_binary())
+        .arg("__sandbox-exec")
+        .arg("--cwd")
+        .arg(cwd)
+        .arg("--temp")
+        .arg(temp)
+        .arg("--script")
+        .arg(script)
+        .output()
+        .expect("spawn Linux sandbox worker")
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn linux_sandbox_worker_enforces_filesystem_and_network_contract() {
+    use std::net::TcpListener;
+
+    let root = tempfile::tempdir().expect("sandbox root");
+    let workspace = root.path().join("workspace");
+    let private_temp = root.path().join("private-temp");
+    let outside = root.path().join("outside.txt");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::create_dir_all(&private_temp).expect("private temp");
+    std::os::unix::fs::symlink(&outside, workspace.join("outside-link")).expect("outside symlink");
+
+    let script = format!(
+        "printf allowed > inside.txt && printf temp > {}/allowed.txt && \
+         ! printf denied > {} && ! printf denied > outside-link",
+        private_temp.display(),
+        outside.display(),
+    );
+    let output = run_linux_sandbox_worker(&workspace, &private_temp, &script);
+    assert!(
+        output.status.success(),
+        "filesystem policy failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        std::fs::read(workspace.join("inside.txt")).unwrap(),
+        b"allowed"
+    );
+    assert!(!outside.exists(), "sandbox wrote outside its workspace");
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind local listener");
+    let port = listener.local_addr().unwrap().port();
+    let output = run_linux_sandbox_worker(
+        &workspace,
+        &private_temp,
+        &format!(": > /dev/tcp/127.0.0.1/{port}"),
+    );
+    assert!(
+        !output.status.success(),
+        "sandbox unexpectedly created an IPv4 socket"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn linux_sandbox_worker_tracks_each_active_worktree() {
+    let root = tempfile::tempdir().expect("sandbox root");
+    let first = root.path().join("first");
+    let second = root.path().join("second");
+    let private_temp = root.path().join("private-temp");
+    for path in [&first, &second, &private_temp] {
+        std::fs::create_dir_all(path).unwrap();
+    }
+
+    for workspace in [&first, &second] {
+        let output = run_linux_sandbox_worker(workspace, &private_temp, "pwd > active.txt");
+        assert!(
+            output.status.success(),
+            "worker failed for {}",
+            workspace.display()
+        );
+        let recorded = std::fs::read_to_string(workspace.join("active.txt")).unwrap();
+        assert_eq!(recorded.trim(), workspace.to_str().unwrap());
+    }
+}
+
 fn session_ids(sessions_dir: &Path) -> Vec<String> {
     let mut ids: Vec<String> = std::fs::read_dir(sessions_dir)
         .expect("read sessions dir")


### PR DESCRIPTION
## What changed

Yolop now routes model bash, background bash, `/shell`, and TUI `!shell` through one pluggable containment provider. Native containment is the default: Seatbelt on macOS and Landlock + seccomp-BPF on Linux. The active workspace and isolated temp are writable, outside writes and network are denied, and ambient credentials/agent sockets are removed from the child environment. macOS additionally makes workspace `.git` read-only. Worktree changes are resolved per command; structured file tools and system/global/workspace skills keep their existing brokered mounts and automatic configuration.

Users already running Yolop inside a trusted VM/container can set `sandbox = "off"`. That opt-out applies next run and is labeled `DANGER` / `UNSAFE HOST` in config output, stderr, the TUI transcript, and the persistent status bar. Native setup failures never fall back to the host.

The provider seam is intentionally backend-neutral so Bashkit, agentOS, Daytona, Monty, or Logfire-backed execution can be added without changing shell tool schemas. Linux has no external executable dependency: Yolop re-execs a small worker that installs the kernel policy before replacing itself with bash.

## Why

The prior approval prompt and filesystem blocklist could not contain a jailbroken or confused model. Arbitrary shell commands executed directly on the user host, including child processes and background jobs.

## Before / After

Before: shell commands could write outside the workspace and open network connections.

After: platform contract tests prove workspace writes succeed; outside writes, path-alias escapes, and loopback connections fail. macOS also proves `.git` writes fail. Switching the active worktree changes the writable root on the next command. Linux tests invoke the real packaged worker path. The packaged release binary completes the llmsim smoke.

Unsafe opt-out evidence: the real print binary and PTY/TUI integration tests assert both `DANGER` and `UNSAFE HOST`.

## Risk

- High: this changes the default execution boundary for every shell entry point.
- Linux requires full Landlock ABI v3 enforcement (Linux 6.2 or a backport); unsupported kernels fail closed with remediation.
- Networked shell workflows are blocked by native policy.
- macOS intentionally permits host reads for compiler/SDK compatibility.
- Linux permits host reads and cannot subtract an in-workspace `.git` subtree from its writable workspace grant. Linked-worktree metadata outside the workspace remains protected.
- User-configured MCP/extension processes remain control-plane processes and are outside this shell boundary.

Security review: verified fail-closed selection, no host fallback, inherited child containment, environment credential removal, network denial, path-alias escape attempts, worktree rebinding, and visible unsafe-state messaging. The Linux policy requires full ABI v3 enforcement so `truncate(2)` cannot bypass the write boundary.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] `cargo build --release --locked`
- [x] Packaged llmsim smoke
- [ ] Doppler live-provider smoke (runs in required PR CI; local worktree has no Doppler project/token)
