### PR TITLE
feat: native Open Knowledge Format (OKF) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,13 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   Workspace/global skills installed after startup are
   available immediately; the bundled `skill-management` skill covers search,
   npx-style imports, and upgrades. See [`specs/skills.md`](./specs/skills.md).
+- **OKF knowledge** — native [Open Knowledge Format](https://okf.md/spec/)
+  support. The bundled `okf` skill teaches reading, authoring, and validating
+  OKF bundles (knowledge as a directory of markdown + YAML frontmatter), and the
+  default-on `okf` capability detects a bundle in the workspace and points the
+  agent at it — inert when none is present. Override the location with
+  `YOLOP_OKF_BUNDLE_DIR`; otherwise `.okf/` and `okf/` are auto-detected by
+  content signature. See [`specs/okf.md`](./specs/okf.md).
 - **Herdr-aware sessions** — when launched in a Herdr pane, Yolop reports
   `working`, `idle`, and explicit `blocked` lifecycle states and exposes
   read-only Herdr operating guidance without installing a global skill. See

--- a/specs/okf.md
+++ b/specs/okf.md
@@ -1,0 +1,73 @@
+# `okf` — native Open Knowledge Format support
+
+Status: implemented. Skill in `src/bundled/system-skills/okf/`; detection
+capability in `src/capabilities/okf.rs`. **On by default** (the capability is
+inert unless a bundle is present).
+
+## Why
+
+[OKF](https://okf.md/spec/) (Open Knowledge Format, Google Cloud, v0.1)
+represents a body of knowledge as a plain directory of markdown files with YAML
+frontmatter — no database, SDK, or runtime. It is the emerging portable format
+for the curated context agents need: architecture, data models, metrics,
+processes, conventions. Yolop should be able to **consume** such a bundle as
+high-signal context, and **author/validate/maintain** one on request, without
+the user having to explain the format each time.
+
+## What
+
+Two cooperating pieces:
+
+### A. The `okf` skill (bundled)
+
+A system skill compiled into the binary, so every session can read, author,
+convert to, and validate OKF regardless of network policy. Its `SKILL.md`
+carries the whole v0.1 mental model inline — bundle, concept, concept-id, links,
+the reserved `index.md`/`log.md`, the required `type` frontmatter field plus
+recommended fields, and the three conformance rules — and links the spec for
+edge cases. It ships a zero-dependency validator
+(`scripts/validate_okf.py`, `--strict` and `--check-links` modes).
+
+Because the skill teaches authoring, **producing** OKF needs no separate
+feature: a repository can instruct the agent (e.g. from `AGENTS.md`) to keep its
+bundle current, and the agent does so through the skill.
+
+### B. The `okf` detection capability
+
+A passive detector registered on the default harness. At session start it looks
+for a bundle and, **only when it confidently finds one**, contributes a short
+system-prompt note naming the bundle path and concept count and pointing the
+agent at the bundle's `index.md` and the `okf` skill. It exposes no tools —
+reading a bundle uses the ordinary file tools; the note simply makes the agent
+*aware* the bundle exists without the user prompting. When no bundle is present
+it contributes nothing, so non-OKF repositories are unaffected.
+
+## Detection — deliberately conservative
+
+OKF has **no canonical bundle marker**: the spec mandates only a per-file `type`
+field, with no required root manifest and no fixed directory name. So the
+detector never assumes `.okf/` exists or is authoritative. Resolution order:
+
+1. **Explicit override** — `YOLOP_OKF_BUNDLE_DIR` (workspace-relative or
+   absolute). Trusted when it resolves to a directory; the content signature is
+   not required because the user declared the location.
+2. **Conventional roots** — `.okf/` then `okf/`, each accepted **only** if it
+   passes a content signature: it contains an `index.md`, or at least one
+   non-reserved `.md` whose frontmatter carries a non-empty `type`. This keeps a
+   plain markdown directory (Jekyll, Obsidian, `docs/`) from being mistaken for
+   a bundle.
+3. **Otherwise nothing.**
+
+The candidate scan is bounded (build/dependency and nested hidden directories
+skipped; a hard file-count cap) so a mis-pointed large tree cannot stall
+startup. Detection runs once at construction; a bundle created mid-session is
+picked up on the next session.
+
+## Non-goals
+
+- No bundle-loading runtime, index, or database — OKF is "just markdown," and
+  the file tools already read it. Native support is awareness + know-how, not a
+  new storage engine.
+- No new authoring tools in the binary; authoring lives in the skill.
+- The conventional-root list stays short on purpose; broader or fuzzier
+  auto-detection would trade the adoption-safety guard for false positives.

--- a/src/bundled/system-skills/okf/SKILL.md
+++ b/src/bundled/system-skills/okf/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: okf
+description: Read, author, and validate Open Knowledge Format (OKF) bundles — knowledge represented as a directory of markdown files with YAML frontmatter. Use when a repo contains an OKF bundle (concept docs with a `type` field, an `index.md`/`log.md`), when the user mentions OKF or the Open Knowledge Format, or when asked to author, validate, convert to, or keep an OKF knowledge base current.
+user-invocable: true
+---
+
+# Open Knowledge Format (OKF)
+
+OKF is an open spec (Google Cloud, v0.1) for representing knowledge as a plain
+**directory of markdown files with YAML frontmatter** — no database, SDK, or
+runtime. If you can `cat` a file, you can read OKF. This skill carries the whole
+mental model inline so it works offline; consult the spec only for edge cases.
+
+Spec: <https://okf.md/spec/> · Overview: <https://okf.md/>
+
+## The model (all of it)
+
+- **Bundle** — a directory tree of markdown; the unit of distribution. There is
+  **no required root marker file** and no mandated directory name, so a bundle is
+  simply a directory someone declares to be OKF (often `.okf/`, `okf/`, or
+  `knowledge/`, but that is convention, not spec).
+- **Concept** — one `.md` file = one unit of knowledge: a table, an API, a
+  metric, a process, an idea.
+- **Concept-id** — the file path within the bundle minus `.md`
+  (`tables/users.md` → `tables/users`).
+- **Links** — plain markdown links between concepts turn the tree into a graph.
+  Prefer bundle-absolute paths starting with `/` (`[users](/tables/users)`).
+- **Reserved files** (both optional):
+  - `index.md` — a directory listing for **progressive disclosure**: read it
+    first to see what a bundle holds without opening every file.
+  - `log.md` — a chronological changelog, newest-relevant, dated ISO 8601.
+
+## Frontmatter
+
+Every concept file has YAML frontmatter. Only one field is **required**:
+
+- `type` (required) — a short producer-chosen string, e.g. `BigQuery Table`,
+  `Metric`, `Playbook`. Values are not centrally registered.
+
+Recommended optional fields: `title`, `description` (one sentence), `resource`
+(a URI for the underlying asset), `tags` (list), `timestamp` (ISO 8601 of last
+significant change). Producers may add more keys; **consumers must preserve
+unknown keys** and must not choke on them.
+
+```markdown
+---
+type: Module
+title: tuika
+description: Standalone terminal-UI toolkit powering the --fullscreen renderer.
+resource: file:///crates/tuika
+tags: [ui, ratatui, terminal]
+timestamp: 2026-07-19T10:30:00Z
+---
+
+# tuika
+
+Layout, overlays, focus, and components over ratatui.
+
+## Relationships
+- Consumed by the [yolop host](/modules/yolop-yep)
+```
+
+## Conformance (the only hard rules)
+
+A bundle conforms to OKF v0.1 if:
+
+1. Every non-reserved `.md` file has parseable YAML frontmatter.
+2. Every such frontmatter has a non-empty `type` field.
+3. Reserved files (`index.md`, `log.md`) follow their structure.
+
+Everything else is **soft guidance**. Do not reject a bundle for missing
+optional fields, unknown `type` values, broken links, or an absent `index.md` —
+the format is deliberately permissive. Validate with `scripts/validate_okf.py`
+under `${SKILL_DIR}` (no dependencies): `python3 ${SKILL_DIR}/scripts/validate_okf.py <bundle-dir>`.
+
+## Consuming a bundle
+
+When a repo contains an OKF bundle, treat it as curated, high-signal context:
+
+1. Read `index.md` at the bundle root first — it maps the territory cheaply.
+2. Open only the concept docs relevant to the task; follow links to related
+   concepts instead of grepping blindly.
+3. Check `log.md` when recency matters.
+
+## Authoring a concept
+
+1. Pick a stable concept-id (its path); group related concepts in subdirectories.
+2. Write frontmatter — always `type`; add `title`/`description`/`timestamp` for
+   anything others will read.
+3. Write the body as normal markdown; link related concepts with `/`-absolute
+   paths so links survive moves.
+4. Keep `index.md` and `log.md` current when you add or change concepts.
+
+## Producing / maintaining a bundle in this repo
+
+If this repo asks yolop to keep a knowledge bundle current (e.g. an `.okf/`
+directory referenced from `AGENTS.md`), after a change that alters durable facts
+about the codebase:
+
+- Add or update the affected concept file(s), bumping their `timestamp`.
+- Update `index.md` if the set of concepts changed.
+- Append a dated entry to `log.md`.
+
+Write down only durable, reusable knowledge — architecture, contracts,
+invariants, processes — not transient task notes. A bundle that rots into stale
+docs is worse than none; keep it accurate or leave it out.
+
+## Converting into OKF
+
+From a wiki, Notion export, Obsidian vault, or CSV: one source page/row → one
+concept file; choose a `type`; carry titles/descriptions into frontmatter;
+rewrite internal links as `/`-absolute concept links; add an `index.md`.

--- a/src/bundled/system-skills/okf/scripts/validate_okf.py
+++ b/src/bundled/system-skills/okf/scripts/validate_okf.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Validate an OKF v0.1 bundle. Zero dependencies (stdlib only).
+
+Hard conformance rules (a failure exits non-zero):
+  1. Every non-reserved `.md` file has a parseable YAML frontmatter block.
+  2. Every such frontmatter has a non-empty `type` field.
+  3. Reserved files (`index.md`, `log.md`) are exempt from the `type` rule.
+
+Optional modes:
+  --strict       also require `title`, `description`, and `timestamp`.
+  --check-links  report broken `/`-absolute intra-bundle links (informational;
+                 never fails the run — broken links are soft guidance in OKF).
+
+Usage: python3 validate_okf.py <bundle-dir> [--strict] [--check-links]
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+RESERVED = {"index.md", "log.md"}
+
+
+def parse_frontmatter(text: str):
+    """Return (frontmatter_dict, error). Only top-level `key: value` pairs are
+    read — enough for conformance without a YAML dependency. Nested structures
+    are ignored, not rejected."""
+    if not text.startswith("---"):
+        return None, "missing YAML frontmatter (file must start with `---`)"
+    # Split off the block between the first two `---` fences.
+    parts = text.split("\n")
+    if parts[0].strip() != "---":
+        return None, "frontmatter fence `---` must be on the first line"
+    fields: dict[str, str] = {}
+    closed = False
+    for line in parts[1:]:
+        if line.strip() == "---":
+            closed = True
+            break
+        m = re.match(r"^([A-Za-z0-9_-]+)\s*:\s*(.*)$", line)
+        if m:
+            fields[m.group(1)] = m.group(2).strip()
+    if not closed:
+        return None, "frontmatter block is not closed with a trailing `---`"
+    return fields, None
+
+
+def main() -> int:
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    flags = {a for a in sys.argv[1:] if a.startswith("--")}
+    if len(args) != 1:
+        print(__doc__)
+        return 2
+    root = Path(args[0])
+    if not root.is_dir():
+        print(f"error: {root} is not a directory")
+        return 2
+
+    strict = "--strict" in flags
+    check_links = "--check-links" in flags
+
+    md_files = sorted(root.rglob("*.md"))
+    ids = {f.relative_to(root).with_suffix("").as_posix() for f in md_files}
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    concepts = 0
+
+    for f in md_files:
+        rel = f.relative_to(root).as_posix()
+        reserved = f.name in RESERVED
+        text = f.read_text(encoding="utf-8", errors="replace")
+        fm, err = parse_frontmatter(text)
+        if reserved:
+            continue
+        if err:
+            errors.append(f"{rel}: {err}")
+            continue
+        concepts += 1
+        if not fm.get("type"):
+            errors.append(f"{rel}: frontmatter has no non-empty `type` field")
+        if strict:
+            for req in ("title", "description", "timestamp"):
+                if not fm.get(req):
+                    errors.append(f"{rel}: --strict requires `{req}`")
+        if check_links:
+            for target in re.findall(r"\]\((/[^)\s]+)\)", text):
+                cid = target.lstrip("/").removesuffix(".md")
+                if cid not in ids:
+                    warnings.append(f"{rel}: broken link -> {target}")
+
+    for w in warnings:
+        print(f"warn: {w}")
+    for e in errors:
+        print(f"FAIL: {e}")
+
+    print(
+        f"\n{concepts} concept(s) checked in {root} — "
+        f"{len(errors)} error(s), {len(warnings)} warning(s)"
+    )
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -22,6 +22,7 @@ pub(crate) mod memory;
 pub(crate) mod model_discovery;
 pub(crate) mod model_ranking;
 pub(crate) mod narration;
+pub(crate) mod okf;
 pub(crate) mod progress_guard;
 pub(crate) mod repo_map;
 pub(crate) mod session_history;
@@ -52,6 +53,7 @@ pub(crate) use host::{
     SetupCapability,
 };
 pub(crate) use lsp::LspCapability;
+pub(crate) use okf::{OKF_CAPABILITY_ID, OkfCapability};
 pub(crate) use progress_guard::{PROGRESS_GUARD_CAPABILITY_ID, ProgressGuardCapability};
 pub(crate) use repo_map::{REPO_MAP_CAPABILITY_ID, RepoMapCapability};
 pub(crate) use session_history::{SESSION_HISTORY_CAPABILITY_ID, SessionHistoryCapability};

--- a/src/capabilities/okf.rs
+++ b/src/capabilities/okf.rs
@@ -1,0 +1,411 @@
+//! Native awareness of an Open Knowledge Format (OKF) bundle in the workspace.
+//!
+//! OKF represents knowledge as a plain directory of markdown files with YAML
+//! frontmatter (spec: <https://okf.md/spec/>). This capability is a passive
+//! *detector*: at session start it looks for a bundle and, only when it finds
+//! one, contributes a short system-prompt note pointing the agent at the bundle
+//! and the bundled `okf` skill. When no bundle is present it is completely
+//! inert, so non-OKF repositories behave exactly as before.
+//!
+//! Detection is deliberately conservative because OKF has **no canonical bundle
+//! marker** — the spec mandates only a per-file `type` field, and neither a root
+//! manifest nor a fixed directory name. We therefore never assume `.okf/` exists
+//! or is authoritative. Resolution order:
+//!
+//!   1. An explicit override (`YOLOP_OKF_BUNDLE_DIR`, workspace-relative or
+//!      absolute) — trusted when it resolves to a directory.
+//!   2. Otherwise a short list of conventional roots (`.okf/`, `okf/`), each
+//!      accepted **only** if it passes a content signature: it contains an
+//!      `index.md`, or at least one non-reserved `.md` whose frontmatter carries
+//!      a non-empty `type`. This is what keeps a plain markdown directory
+//!      (Jekyll, Obsidian, docs/) from being mistaken for an OKF bundle.
+//!   3. Otherwise nothing.
+
+use crate::workspace_host::WorkspaceHost;
+use async_trait::async_trait;
+use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+pub(crate) const OKF_CAPABILITY_ID: &str = "okf";
+
+/// Env override naming the OKF bundle directory (workspace-relative or absolute).
+const OKF_BUNDLE_DIR_ENV: &str = "YOLOP_OKF_BUNDLE_DIR";
+
+/// Conventional bundle directory names, tried in order when no override is set.
+const CONVENTIONAL_ROOTS: &[&str] = &[".okf", "okf"];
+
+/// Reserved OKF filenames — not concept documents, and exempt from the `type`
+/// rule. `index.md` doubles as a strong presence signal.
+const RESERVED: &[&str] = &["index.md", "log.md"];
+
+/// Directory names never descended into while scanning a candidate bundle.
+const SKIP_DIRS: &[&str] = &["target", "node_modules", "dist", "build", "venv", ".git"];
+
+/// Upper bound on files inspected while validating/counting a candidate, so a
+/// mistakenly-pointed-at huge tree can't stall session startup.
+const MAX_SCAN_FILES: usize = 4000;
+
+/// A bundle the detector is confident about.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct DetectedBundle {
+    /// Workspace-relative path of the bundle root (forward-slashed).
+    rel_path: String,
+    /// Number of non-reserved `.md` concept documents found.
+    concept_count: usize,
+}
+
+#[derive(Clone)]
+pub(crate) struct OkfCapability {
+    bundle: Option<DetectedBundle>,
+}
+
+impl OkfCapability {
+    /// Detect a bundle for `workspace` at construction time. Reads the env
+    /// override once here; the detection logic itself is a pure function of
+    /// `(workspace_root, override)` so it can be unit-tested without env state.
+    pub(crate) fn new(workspace: Arc<WorkspaceHost>) -> Self {
+        let bundle = match workspace.host_root() {
+            Ok(root) => {
+                let override_dir = std::env::var(OKF_BUNDLE_DIR_ENV)
+                    .ok()
+                    .map(|value| value.trim().to_string())
+                    .filter(|value| !value.is_empty())
+                    .map(PathBuf::from);
+                detect_bundle(&root, override_dir.as_deref())
+            }
+            Err(_) => None,
+        };
+        Self { bundle }
+    }
+
+    fn prompt(&self) -> Option<String> {
+        let bundle = self.bundle.as_ref()?;
+        let concepts = if bundle.concept_count == 1 {
+            "1 concept document".to_string()
+        } else {
+            format!("{} concept documents", bundle.concept_count)
+        };
+        Some(format!(
+            "<capability id=\"okf\">\n\
+             This workspace contains an Open Knowledge Format (OKF) bundle at \
+             `{path}` ({concepts}) — curated, high-signal knowledge as markdown \
+             with YAML frontmatter. Before broad exploration for facts it may \
+             already cover (architecture, data models, processes, conventions), \
+             read `{path}/index.md` first, then follow its links into the \
+             relevant concept documents. Use the `okf` skill to read, author, \
+             validate, or maintain the bundle.\n\
+             </capability>",
+            path = bundle.rel_path,
+            concepts = concepts,
+        ))
+    }
+}
+
+#[async_trait]
+impl Capability for OkfCapability {
+    fn id(&self) -> &str {
+        OKF_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "OKF"
+    }
+
+    fn description(&self) -> &str {
+        "Detects an Open Knowledge Format bundle in the workspace and points the agent at it."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Knowledge")
+    }
+
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        self.prompt()
+    }
+
+    fn system_prompt_preview(&self) -> Option<String> {
+        self.prompt()
+    }
+}
+
+/// Resolve a bundle for `workspace_root`, honoring an optional explicit
+/// `override_dir` (workspace-relative or absolute). Returns `None` when no
+/// bundle is confidently identified.
+fn detect_bundle(workspace_root: &Path, override_dir: Option<&Path>) -> Option<DetectedBundle> {
+    if let Some(dir) = override_dir {
+        // An explicit pointer is trusted: resolve it, require a real directory,
+        // but do not demand the content signature — the user declared it OKF.
+        let abs = if dir.is_absolute() {
+            dir.to_path_buf()
+        } else {
+            workspace_root.join(dir)
+        };
+        if !abs.is_dir() {
+            return None;
+        }
+        let (concepts, _has_index) = scan_bundle(&abs);
+        return Some(DetectedBundle {
+            rel_path: rel_display(workspace_root, &abs),
+            concept_count: concepts,
+        });
+    }
+
+    // No override: try conventional roots, accepting one only on a content match.
+    for name in CONVENTIONAL_ROOTS {
+        let candidate = workspace_root.join(name);
+        if !candidate.is_dir() {
+            continue;
+        }
+        let (concepts, has_index) = scan_bundle(&candidate);
+        if has_index || concepts > 0 {
+            return Some(DetectedBundle {
+                rel_path: (*name).to_string(),
+                concept_count: concepts,
+            });
+        }
+    }
+    None
+}
+
+/// Scan a candidate bundle directory. Returns `(concept_count, has_index)` where
+/// `concept_count` is the number of non-reserved `.md` files whose frontmatter
+/// carries a non-empty `type`, and `has_index` is whether a root `index.md`
+/// exists. The walk is bounded by [`MAX_SCAN_FILES`].
+fn scan_bundle(root: &Path) -> (usize, bool) {
+    let has_index = root.join("index.md").is_file();
+    let mut concept_count = 0usize;
+    let mut budget = MAX_SCAN_FILES;
+    walk(root, &mut budget, &mut concept_count);
+    (concept_count, has_index)
+}
+
+fn walk(dir: &Path, budget: &mut usize, concept_count: &mut usize) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if *budget == 0 {
+            return;
+        }
+        let path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if file_type.is_dir() {
+            // Skip build/dep output and nested hidden directories; the bundle
+            // root itself may be hidden (`.okf`), but its subtree should not
+            // sprawl into `.git`/caches.
+            if SKIP_DIRS.contains(&name.as_ref()) || name.starts_with('.') {
+                continue;
+            }
+            walk(&path, budget, concept_count);
+        } else if file_type.is_file() {
+            *budget = budget.saturating_sub(1);
+            if !name.ends_with(".md") || RESERVED.contains(&name.as_ref()) {
+                continue;
+            }
+            if frontmatter_has_type(&path) {
+                *concept_count += 1;
+            }
+        }
+    }
+}
+
+/// Whether a markdown file opens with a YAML frontmatter block containing a
+/// non-empty top-level `type:` key. Only the frontmatter block is read; the rest
+/// of the file is ignored. Mirrors the conformance check in the `okf` skill's
+/// validator without pulling in a YAML dependency.
+fn frontmatter_has_type(path: &Path) -> bool {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let mut lines = text.lines();
+    if lines.next().map(str::trim) != Some("---") {
+        return false;
+    }
+    for line in lines {
+        let trimmed = line.trim();
+        if trimmed == "---" {
+            return false; // closed the block without a `type`
+        }
+        if let Some(rest) = trimmed.strip_prefix("type:") {
+            return !rest.trim().is_empty();
+        }
+    }
+    false
+}
+
+/// Forward-slashed workspace-relative display path (falls back to the absolute
+/// path when `path` is not under `root`).
+fn rel_display(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn write(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent");
+        }
+        fs::write(path, content).expect("write file");
+    }
+
+    #[test]
+    fn detects_dot_okf_bundle_with_index() {
+        let dir = tempfile::tempdir().unwrap();
+        write(&dir.path().join(".okf/index.md"), "# Index\n- users\n");
+        write(
+            &dir.path().join(".okf/tables/users.md"),
+            "---\ntype: Table\n---\n# users\n",
+        );
+
+        let bundle = detect_bundle(dir.path(), None).expect("bundle detected");
+        assert_eq!(bundle.rel_path, ".okf");
+        assert_eq!(bundle.concept_count, 1);
+    }
+
+    #[test]
+    fn detects_okf_bundle_by_typed_concept_without_index() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("okf/metrics/signups.md"),
+            "---\ntype: Metric\ntitle: Signups\n---\n# Signups\n",
+        );
+
+        let bundle = detect_bundle(dir.path(), None).expect("bundle detected");
+        assert_eq!(bundle.rel_path, "okf");
+        assert_eq!(bundle.concept_count, 1);
+    }
+
+    #[test]
+    fn ignores_plain_markdown_directory() {
+        // A conventional-looking dir with markdown but no `type` and no index
+        // must NOT be treated as a bundle — this is the adoption-safety guard.
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("okf/readme.md"),
+            "---\ntitle: not okf\n---\n# hi\n",
+        );
+        write(
+            &dir.path().join("okf/notes.md"),
+            "just prose, no frontmatter\n",
+        );
+
+        assert_eq!(detect_bundle(dir.path(), None), None);
+    }
+
+    #[test]
+    fn ignores_workspace_without_any_bundle() {
+        let dir = tempfile::tempdir().unwrap();
+        write(&dir.path().join("src/main.rs"), "fn main() {}\n");
+        assert_eq!(detect_bundle(dir.path(), None), None);
+    }
+
+    #[test]
+    fn override_points_at_custom_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("knowledge/api.md"),
+            "---\ntype: API\n---\n# API\n",
+        );
+        // Non-conventional location: only found because the override names it.
+        assert_eq!(detect_bundle(dir.path(), None), None);
+
+        let bundle = detect_bundle(dir.path(), Some(Path::new("knowledge")))
+            .expect("override bundle detected");
+        assert_eq!(bundle.rel_path, "knowledge");
+        assert_eq!(bundle.concept_count, 1);
+    }
+
+    #[test]
+    fn override_to_missing_directory_yields_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(detect_bundle(dir.path(), Some(Path::new("nope"))), None);
+    }
+
+    #[test]
+    fn prefers_dot_okf_over_okf() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join(".okf/a.md"),
+            "---\ntype: Concept\n---\n# a\n",
+        );
+        write(
+            &dir.path().join("okf/b.md"),
+            "---\ntype: Concept\n---\n# b\n",
+        );
+        let bundle = detect_bundle(dir.path(), None).unwrap();
+        assert_eq!(bundle.rel_path, ".okf");
+    }
+
+    #[test]
+    fn counts_multiple_concepts_and_excludes_reserved() {
+        let dir = tempfile::tempdir().unwrap();
+        write(&dir.path().join(".okf/index.md"), "# Index\n");
+        write(&dir.path().join(".okf/log.md"), "# Log\n");
+        write(&dir.path().join(".okf/a.md"), "---\ntype: X\n---\n");
+        write(&dir.path().join(".okf/sub/b.md"), "---\ntype: Y\n---\n");
+        write(&dir.path().join(".okf/notype.md"), "---\ntitle: z\n---\n");
+
+        let bundle = detect_bundle(dir.path(), None).unwrap();
+        // a.md + sub/b.md count; index.md, log.md, notype.md do not.
+        assert_eq!(bundle.concept_count, 2);
+    }
+
+    #[test]
+    fn frontmatter_type_detection_edges() {
+        let dir = tempfile::tempdir().unwrap();
+        let with_type = dir.path().join("t.md");
+        write(&with_type, "---\ntype:  Table \n---\nbody\n");
+        assert!(frontmatter_has_type(&with_type));
+
+        let empty_type = dir.path().join("e.md");
+        write(&empty_type, "---\ntype:\n---\n");
+        assert!(!frontmatter_has_type(&empty_type));
+
+        let no_fm = dir.path().join("n.md");
+        write(&no_fm, "# just a heading\n");
+        assert!(!frontmatter_has_type(&no_fm));
+    }
+
+    #[test]
+    fn contributes_prompt_only_when_bundle_present() {
+        let with = OkfCapability {
+            bundle: Some(DetectedBundle {
+                rel_path: ".okf".to_string(),
+                concept_count: 3,
+            }),
+        };
+        let prompt = with.prompt().expect("prompt when bundle present");
+        assert!(prompt.contains(".okf"));
+        assert!(prompt.contains("3 concept documents"));
+        assert!(prompt.contains("okf` skill"));
+
+        let without = OkfCapability { bundle: None };
+        assert!(without.prompt().is_none());
+    }
+
+    #[test]
+    fn prompt_uses_singular_for_one_concept() {
+        let cap = OkfCapability {
+            bundle: Some(DetectedBundle {
+                rel_path: ".okf".to_string(),
+                concept_count: 1,
+            }),
+        };
+        assert!(cap.prompt().unwrap().contains("(1 concept document)"));
+    }
+}

--- a/src/capabilities/okf.rs
+++ b/src/capabilities/okf.rs
@@ -408,4 +408,57 @@ mod tests {
         };
         assert!(cap.prompt().unwrap().contains("(1 concept document)"));
     }
+
+    /// End-to-end through the real entry point: build the capability from a
+    /// `WorkspaceHost` (exercising `new` → `host_root` → detection) and drive the
+    /// `Capability::system_prompt_contribution` trait method the harness calls.
+    #[tokio::test]
+    async fn new_over_bundle_workspace_emits_note_via_trait() {
+        let dir = tempfile::tempdir().unwrap();
+        write(&dir.path().join(".okf/index.md"), "# Index\n");
+        write(
+            &dir.path().join(".okf/tables/users.md"),
+            "---\ntype: Table\n---\n# users\n",
+        );
+        let host = Arc::new(
+            WorkspaceHost::new(
+                Arc::new(std::sync::RwLock::new(dir.path().to_path_buf())),
+                dir.path().to_path_buf(),
+            )
+            .expect("workspace host"),
+        );
+
+        let cap = OkfCapability::new(host);
+        let ctx =
+            SystemPromptContext::without_file_store(everruns_core::typed_id::SessionId::new());
+        let note = cap
+            .system_prompt_contribution(&ctx)
+            .await
+            .expect("bundle present → note contributed");
+
+        assert!(note.contains("id=\"okf\""));
+        assert!(note.contains(".okf"));
+        assert!(note.contains("1 concept document"));
+        assert!(note.contains("okf` skill"));
+    }
+
+    /// The mirror case: no bundle in the workspace → the harness entry point
+    /// contributes nothing, so non-OKF repos are unaffected.
+    #[tokio::test]
+    async fn new_over_plain_workspace_contributes_nothing_via_trait() {
+        let dir = tempfile::tempdir().unwrap();
+        write(&dir.path().join("src/main.rs"), "fn main() {}\n");
+        let host = Arc::new(
+            WorkspaceHost::new(
+                Arc::new(std::sync::RwLock::new(dir.path().to_path_buf())),
+                dir.path().to_path_buf(),
+            )
+            .expect("workspace host"),
+        );
+
+        let cap = OkfCapability::new(host);
+        let ctx =
+            SystemPromptContext::without_file_store(everruns_core::typed_id::SessionId::new());
+        assert!(cap.system_prompt_contribution(&ctx).await.is_none());
+    }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -15,10 +15,10 @@ use crate::capabilities::{
     ClientCommandsCapability, ClientUiContext, CodingBashCapability,
     CodingCliEnvironmentCapability, ConfigCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID,
     GOAL_CAPABILITY_ID, GoalCapability, HERDR_CAPABILITY_ID, HOOKS_CAPABILITY_ID, HerdrCapability,
-    HooksCapability, LspCapability, PROGRESS_GUARD_CAPABILITY_ID, ProgressGuardCapability,
-    REPO_MAP_CAPABILITY_ID, RepoMapCapability, SESSION_HISTORY_CAPABILITY_ID, SETUP_CAPABILITY_ID,
-    SessionHistoryCapability, SetupCapability, USER_ASK_CAPABILITY_ID, UserAskCapability,
-    WorktreeCapability,
+    HooksCapability, LspCapability, OKF_CAPABILITY_ID, OkfCapability, PROGRESS_GUARD_CAPABILITY_ID,
+    ProgressGuardCapability, REPO_MAP_CAPABILITY_ID, RepoMapCapability,
+    SESSION_HISTORY_CAPABILITY_ID, SETUP_CAPABILITY_ID, SessionHistoryCapability, SetupCapability,
+    USER_ASK_CAPABILITY_ID, UserAskCapability, WorktreeCapability,
 };
 use crate::capability_settings::{CapabilityCatalog, apply_capability_settings};
 use crate::checkpoint::CheckpointManager;
@@ -2054,6 +2054,7 @@ fn default_coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabi
         AgentCapabilityConfig::new(SKILLS_CAPABILITY_ID),
         AgentCapabilityConfig::new(HERDR_CAPABILITY_ID),
         AgentCapabilityConfig::new(REPO_MAP_CAPABILITY_ID),
+        AgentCapabilityConfig::new(OKF_CAPABILITY_ID),
         AgentCapabilityConfig::new(SESSION_HISTORY_CAPABILITY_ID),
         AgentCapabilityConfig::new(CHECKPOINT_CAPABILITY_ID),
         AgentCapabilityConfig::new(AST_GREP_CAPABILITY_ID),
@@ -2758,6 +2759,10 @@ pub async fn build_with_options(
         skill_dirs.clone(),
     ));
     capabilities.register(RepoMapCapability::new(workspace_host.clone()));
+    // Native OKF awareness: detects an Open Knowledge Format bundle in the
+    // workspace and, only when one is present, points the agent at it and the
+    // bundled `okf` skill. Inert otherwise. See specs/okf.md.
+    capabilities.register(OkfCapability::new(workspace_host.clone()));
     capabilities.register(SessionHistoryCapability::new(
         sessions_dir.clone(),
         session_id,


### PR DESCRIPTION
## What changed

Yolop now natively supports the [Open Knowledge Format](https://okf.md/spec/)
(OKF) — knowledge represented as a plain directory of markdown files with YAML
frontmatter. Two cooperating pieces:

- **Bundled `okf` skill** (`src/bundled/system-skills/okf/`) — compiled into the
  binary, so every session can read, author, convert to, and validate OKF
  regardless of network policy. `SKILL.md` carries the whole v0.1 mental model
  inline (bundle / concept / concept-id / links / reserved `index.md` &
  `log.md`, the required `type` frontmatter field plus recommended fields, the
  three conformance rules) and links the spec for depth. Ships a zero-dependency
  Python validator with `--strict` and `--check-links` modes.
- **`okf` detection capability** (`src/capabilities/okf.rs`), on the default
  harness — a passive detector. At session start it looks for an OKF bundle and,
  **only when it confidently finds one**, contributes a short system-prompt note
  naming the bundle path and concept count and pointing the agent at the
  bundle's `index.md` and the skill. It exposes no tools and is completely inert
  when no bundle is present, so non-OKF repositories are unaffected.

Because the skill teaches authoring, **producing/maintaining** a bundle needs no
separate feature: a repo can instruct the agent (e.g. from `AGENTS.md`) to keep
its bundle current, and the agent does so through the skill.

## Why

OKF is the emerging portable format for the curated context agents need
(architecture, data models, metrics, processes, conventions) — vendor-neutral,
just markdown, no SDK or runtime. Yolop should consume such a bundle as
high-signal context and author/validate one on request without the user having
to re-explain the format each session.

Detection is deliberately conservative because **OKF defines no canonical bundle
marker** (only a per-file `type` field; no root manifest, no fixed directory
name). Resolution order: an explicit `YOLOP_OKF_BUNDLE_DIR` override is trusted;
otherwise the conventional `.okf/` then `okf/` roots are accepted **only** when a
content signature holds (an `index.md`, or a non-reserved `.md` whose frontmatter
carries a non-empty `type`). A plain markdown/`docs/`/Obsidian directory is never
mistaken for a bundle. The candidate scan is bounded (build/dep and nested hidden
dirs skipped; hard file-count cap) so a mis-pointed tree cannot stall startup.

## Before / After

**Before:** yolop had no awareness of OKF; a checked-in knowledge bundle was just
undifferentiated markdown, and authoring/validating it required the user to
explain the format.

**After (offline smoke, `--provider llmsim`):** the binary starts cleanly both in
a workspace containing an `.okf/` bundle and in one without it. The detection
path is proven by an automated test that drives the real harness entry point
(`Capability::system_prompt_contribution`) — with a bundle it returns the note:

```
<capability id="okf">
This workspace contains an Open Knowledge Format (OKF) bundle at `.okf`
(1 concept document) — curated, high-signal knowledge as markdown with YAML
frontmatter. Before broad exploration for facts it may already cover ...
read `.okf/index.md` first ... Use the `okf` skill to read, author, validate,
or maintain the bundle.
</capability>
```

and without a bundle it returns `None` (nothing injected).

**Validation:**
- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all-features` — all green (13 new `okf` tests: full detection
  matrix — `.okf`/`okf`, index vs typed-concept signature, plain-markdown
  rejection, override to custom/missing dir, reserved-file exclusion, `.okf`
  precedence, frontmatter edges — plus two async tests driving the real trait
  entry point)
- Bundled-skill parse test (`name` matches directory) — green
- Offline `llmsim` smoke with and without a bundle — starts cleanly

Live-provider (Doppler) smoke was not run: Doppler/provider keys are not
available in this environment. Per `specs/shipping.md`, the offline `llmsim`
smoke plus the automated test that drives the real `system_prompt_contribution`
entry point stand in for it.

## Security

Structured review per the ship skill:

- **TM-FS** — the capability performs **no writes** (the write blocklist is
  untouched). Reads are bounded by a hard file-count cap and skip build/dep and
  nested hidden dirs; symlinked directories are not followed. Only a concept
  *count* and the bundle *path* reach the prompt — concept file contents are
  never read into it, so there is no prompt-injection surface from bundle
  contents via this capability. `YOLOP_OKF_BUNDLE_DIR` is operator-set process
  env (not untrusted content); an absolute/`..` override can read outside the
  workspace to count files, which is accepted for operator-provided config and
  exposes only the path/count.
- **TM-BASH** — no changes to `tools.rs`; bounded execution model unchanged.
- **TM-LLM** — no API-key handling; the prompt note contains only a path and a
  count, and nothing is logged.
- **TM-TOOL** — the new capability registers zero tools and only contributes a
  system-prompt string; write blocklist trivially respected.
- **TM-DEP** — no new crates.

## Risk

- **Low.** Additive and default-inert: no behavior change in repositories without
  an OKF bundle. The only always-on code path is a bounded, read-only directory
  probe at session start.

## Follow-ups

- A `settings.toml` field for the bundle path (today the override is the
  `YOLOP_OKF_BUNDLE_DIR` env var only). Deferred — env override covers the
  non-conventional-location case; a typed config field can follow if demand
  appears.
- Mid-session re-detection: a bundle created during a session is picked up on the
  next session, not the current one. Deferred — session start is the natural
  detection point and keeps the always-on cost to one probe.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (additive; pre-1.0, no compat surface)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTws11JdeEH1Cz8qTvRfCV)_