### PR TITLE
feat(tui): demo and end-to-end proof for OSC 8 hyperlinks

### DIFF
--- a/crates/tuika/README.md
+++ b/crates/tuika/README.md
@@ -143,8 +143,9 @@ The automated tests cover the *protocol* a terminal receives; they cannot
 verify how a specific emulator actually paints it. This is a **checklist to run
 before a release**, not a record of verified results — tick a box only after
 confirming it yourself. Run `cargo run -- tuika-gallery` in each terminal and
-check alt-screen enter/exit, Braille/wide glyphs, truecolor, and mouse-wheel
-scroll:
+check alt-screen enter/exit, Braille/wide glyphs, truecolor, mouse-wheel
+scroll, and — with `YOLOP_HYPERLINKS=1` — that the footer URL is a clickable
+OSC 8 link:
 
 - [ ] Ghostty
 - [ ] iTerm2
@@ -161,6 +162,16 @@ something to re-verify per release). Terminals that render it: **Ghostty**
 silently ignore the unknown OSC, so emitting it is safe everywhere — the
 in-terminal UI is unaffected. See the OSC 9;4 references linked from the
 motion-module PR.
+
+**OSC 8 hyperlinks** ([`HyperlinkBackend`](src/hyperlink.rs)) wrap `http(s)`
+URL runs so a supporting terminal makes them clickable: **Ghostty**, **iTerm2**,
+**WezTerm**, **Kitty**, **Konsole**, recent **GNOME Terminal / VTE**. Others
+ignore the escape and render the URL as plain (usually still auto-linkified)
+text, so emitting it is safe everywhere. Unlike OSC 9;4, this one *is* worth
+re-checking, because it writes styled spans straight to the terminal: confirm
+the link is clickable **and** that surrounding text, colors, and wrapping are
+undamaged. In yolop it is opt-in (`YOLOP_HYPERLINKS=1`), default-off until this
+matrix is walked — that is what the checkbox above verifies.
 
 ## Extending
 

--- a/crates/tuika/examples/gallery.rs
+++ b/crates/tuika/examples/gallery.rs
@@ -1,8 +1,9 @@
 //! Live component gallery. Run with `cargo run -p tuika --example gallery`
 //! (press `q` or `Esc` to quit).
 //!
-//! Demonstrates the declarative `view!` DSL, the motion components, and the
-//! native OSC 9;4 progress indicator — the same building blocks yolop's
+//! Demonstrates the declarative `view!` DSL, the motion components, the native
+//! OSC 9;4 progress indicator, and OSC 8 hyperlinks (the footer URL is
+//! clickable in a supporting terminal) — the same building blocks yolop's
 //! full-screen renderer uses, with no host application involved.
 
 use std::io;
@@ -10,11 +11,11 @@ use std::time::Duration;
 
 use crossterm::event::{self, Event as CtEvent, KeyCode, KeyEventKind};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
-use ratatui::backend::CrosstermBackend;
+use ratatui::style::Modifier;
 use ratatui::text::{Line, Span};
 use ratatui::{Terminal, TerminalOptions, Viewport};
 
-use tuika::{Loader, ProgressBar, Spinner, SpinnerStyle, Text, Theme, view};
+use tuika::{HyperlinkBackend, Loader, ProgressBar, Spinner, SpinnerStyle, Text, Theme, view};
 
 fn build(frame: u64, theme: &Theme) -> tuika::Element {
     let labeled = |style: SpinnerStyle, label: &str| -> tuika::Element {
@@ -56,10 +57,14 @@ fn build(frame: u64, theme: &Theme) -> tuika::Element {
             }
             grow(1) { spacer() }
             fixed(1) {
-                node(Text::new(vec![Line::from(Span::styled(
-                    "tuika gallery — native progress is live in the taskbar/top bar · press q to quit",
-                    theme.muted_style(),
-                ))]))
+                node(Text::new(vec![Line::from(vec![
+                    Span::styled("docs ", theme.muted_style()),
+                    Span::styled(
+                        "https://github.com/everruns/yolop",
+                        theme.accent_style().add_modifier(Modifier::UNDERLINED),
+                    ),
+                    Span::styled("  ·  press q to quit", theme.muted_style()),
+                ])]))
             }
         }
     }
@@ -68,8 +73,9 @@ fn build(frame: u64, theme: &Theme) -> tuika::Element {
 fn main() -> io::Result<()> {
     enable_raw_mode()?;
     let mut alt = tuika::AltScreen::enter()?;
+    // Hyperlinks enabled so the footer URL demos as a real OSC 8 link.
     let mut terminal = Terminal::with_options(
-        CrosstermBackend::new(io::stdout()),
+        HyperlinkBackend::new(io::stdout(), true),
         TerminalOptions {
             viewport: Viewport::Fullscreen,
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,6 @@ use everruns_core::command::ExecuteCommandRequest;
 use everruns_core::message::{ContentPart, MessageRole};
 use everruns_core::typed_id::SessionId;
 use mcp_config::{McpConfigScope, McpConfigStore};
-use ratatui::backend::CrosstermBackend;
 use ratatui::{Terminal, TerminalOptions, Viewport};
 use runtime::{BuiltRuntime, ProviderChoice, ResolvedProviderChoice, resolve_for_settings};
 use settings::SettingsStore;
@@ -911,6 +910,15 @@ fn run_command(command: Commands) -> Result<()> {
     }
 }
 
+/// Whether opt-in OSC 8 hyperlinks are enabled via `YOLOP_HYPERLINKS`
+/// (`1`/`true`/`on`). Default off until the rendering is verified across
+/// terminals; see `tuika::HyperlinkBackend` and the tuika README matrix.
+fn hyperlinks_enabled() -> bool {
+    std::env::var("YOLOP_HYPERLINKS")
+        .map(|v| matches!(v.as_str(), "1" | "true" | "on"))
+        .unwrap_or(false)
+}
+
 /// Live demo of the `tuika` motion components. Renders spinners, progress bars,
 /// and a loader on the alternate screen, and drives the terminal's native
 /// OSC 9;4 progress indicator while running. Quits on `q`/`Esc`/`Ctrl-C`.
@@ -920,7 +928,9 @@ fn run_tuika_gallery() -> Result<()> {
 
     let mut raw = RawModeGuard::new()?;
     let mut alt = tuika::AltScreen::enter()?;
-    let backend = CrosstermBackend::new(io::stdout());
+    // Route through the same hyperlink-aware backend as the main TUI so the
+    // demo's URL becomes a clickable OSC 8 link when YOLOP_HYPERLINKS is set.
+    let backend = tuika::HyperlinkBackend::new(io::stdout(), hyperlinks_enabled());
     let mut terminal = Terminal::with_options(
         backend,
         TerminalOptions {
@@ -960,6 +970,7 @@ fn run_tuika_gallery() -> Result<()> {
 /// Build the gallery view tree for `frame`, using [`ratatui::text`] helpers via
 /// `tuika` components.
 fn build_gallery(frame: u64, theme: &tuika::Theme) -> tuika::Element {
+    use ratatui::style::Modifier;
     use ratatui::text::{Line, Span};
     use tuika::{Loader, ProgressBar, Spinner, SpinnerStyle, Text};
 
@@ -1009,10 +1020,17 @@ fn build_gallery(frame: u64, theme: &tuika::Theme) -> tuika::Element {
             }
             grow(1) { spacer() }
             fixed(1) {
-                node(Text::new(vec![Line::from(Span::styled(
-                    "tuika gallery — native progress is live in the taskbar/top bar · press q to quit",
-                    theme.muted_style(),
-                ))]))
+                node(Text::new(vec![Line::from(vec![
+                    Span::styled("docs ", theme.muted_style()),
+                    Span::styled(
+                        "https://github.com/everruns/yolop",
+                        theme.accent_style().add_modifier(Modifier::UNDERLINED),
+                    ),
+                    Span::styled(
+                        "  ·  native progress is live · press q to quit",
+                        theme.muted_style(),
+                    ),
+                ])]))
             }
         }
     }
@@ -1043,10 +1061,7 @@ async fn run_tui(
     // Opt-in OSC 8 hyperlinks: wrap the crossterm backend so http(s) URLs in
     // rendered output become clickable. Default off (pure pass-through) until the
     // rendering is verified across terminals; enable with YOLOP_HYPERLINKS=1.
-    let hyperlinks = std::env::var("YOLOP_HYPERLINKS")
-        .map(|v| matches!(v.as_str(), "1" | "true" | "on"))
-        .unwrap_or(false);
-    let backend = tuika::HyperlinkBackend::new(stdout, hyperlinks);
+    let backend = tuika::HyperlinkBackend::new(stdout, hyperlinks_enabled());
     let viewport = if fullscreen {
         Viewport::Fullscreen
     } else {

--- a/tests/tuika_pty.rs
+++ b/tests/tuika_pty.rs
@@ -28,7 +28,12 @@ struct GalleryRun {
 
 /// Spawn `yolop tuika-gallery` under a pty of the given size, optionally resize
 /// mid-run, then send `q` and collect everything the terminal received.
-fn run_gallery(rows: u16, cols: u16, resize_to: Option<(u16, u16)>) -> GalleryRun {
+fn run_gallery(
+    rows: u16,
+    cols: u16,
+    resize_to: Option<(u16, u16)>,
+    hyperlinks: bool,
+) -> GalleryRun {
     let home = tempfile::tempdir().expect("home tempdir");
     let pty = NativePtySystem::default();
     let pair = pty
@@ -46,6 +51,8 @@ fn run_gallery(rows: u16, cols: u16, resize_to: Option<(u16, u16)>) -> GalleryRu
     cmd.env("HOME", home.path());
     cmd.env("XDG_CONFIG_HOME", home.path().join(".config"));
     cmd.env("XDG_DATA_HOME", home.path().join(".local/share"));
+    // Opt-in OSC 8 hyperlinks (the gallery honors this like the main TUI).
+    cmd.env("YOLOP_HYPERLINKS", if hyperlinks { "1" } else { "0" });
 
     let mut child = pair.slave.spawn_command(cmd).expect("spawn gallery");
     drop(pair.slave);
@@ -152,9 +159,13 @@ fn visible_text(bytes: &[u8]) -> String {
     out
 }
 
+/// The URL rendered in the gallery footer, emitted as an OSC 8 hyperlink target
+/// when `YOLOP_HYPERLINKS` is enabled.
+const GALLERY_URL: &str = "https://github.com/everruns/yolop";
+
 #[test]
 fn gallery_drives_altscreen_and_native_progress() {
-    let run = run_gallery(24, 80, None);
+    let run = run_gallery(24, 80, None, false);
     let out = &run.output;
 
     assert!(run.exited_ok, "gallery should exit cleanly on `q`");
@@ -186,7 +197,7 @@ fn gallery_drives_altscreen_and_native_progress() {
 #[test]
 fn gallery_survives_resize() {
     // Start wide, shrink to a small size mid-run.
-    let run = run_gallery(24, 100, Some((40, 12)));
+    let run = run_gallery(24, 100, Some((40, 12)), false);
     assert!(
         run.exited_ok,
         "gallery should survive a resize and exit cleanly"
@@ -194,5 +205,36 @@ fn gallery_survives_resize() {
     assert!(
         contains(&run.output, b"\x1b[?1049l"),
         "should still restore the screen after a resize"
+    );
+}
+
+#[test]
+fn gallery_emits_osc8_hyperlink_when_enabled() {
+    let run = run_gallery(24, 80, None, true);
+    assert!(run.exited_ok, "gallery should exit cleanly");
+    // With hyperlinks on, the footer URL is wrapped in an OSC 8 sequence
+    // (`ESC ] 8 ; ; <url> ST`) targeting itself — proven end-to-end through the
+    // real binary + HyperlinkBackend, not just the unit tests.
+    let osc8 = format!("\x1b]8;;{GALLERY_URL}\x1b\\");
+    assert!(
+        contains(&run.output, osc8.as_bytes()),
+        "expected OSC 8 hyperlink for {GALLERY_URL} when YOLOP_HYPERLINKS=1"
+    );
+}
+
+#[test]
+fn gallery_omits_osc8_hyperlink_when_disabled() {
+    let run = run_gallery(24, 80, None, false);
+    assert!(run.exited_ok, "gallery should exit cleanly");
+    // Default (disabled) backend is a pure pass-through: the URL still renders
+    // as visible text, but no OSC 8 escape is emitted.
+    assert!(
+        !contains(&run.output, b"\x1b]8;;"),
+        "no OSC 8 hyperlink should be emitted when hyperlinks are disabled"
+    );
+    let text = visible_text(&run.output);
+    assert!(
+        text.contains(GALLERY_URL),
+        "the URL should still be visible as text: {text:?}"
     );
 }


### PR DESCRIPTION
## What changed

Builds on #343 (which landed the OSC 8 primitive + `HyperlinkBackend`, wired opt-in via `YOLOP_HYPERLINKS`, **default-off pending cross-terminal verification**). #343's byte emission is unit-tested, but nothing exercised it through the real binary, and there was no checklist for the manual verification its default flip depends on. This adds a live demo, an end-to-end proof, and that checklist.

- **`tuika-gallery` now routes through `HyperlinkBackend`** (via a shared `hyperlinks_enabled()` helper; drops the now-unused direct `CrosstermBackend`) and renders a real footer URL — so the demo shows a clickable link when `YOLOP_HYPERLINKS=1`. The standalone `gallery` example does the same with hyperlinks always on.
- **`tests/tuika_pty.rs`: two end-to-end tests** drive the actual `yolop` binary under a pty and assert the OSC 8 sequence for the footer URL is **emitted when enabled** and **absent (pure pass-through, URL still visible as text) when disabled**. This is the real-binary proof the unit tests can't give.
- **tuika README manual matrix** now includes the OSC 8 hyperlink check and which terminals support it (Ghostty, iTerm2, WezTerm, Kitty, Konsole, recent VTE) — the verification that gates flipping the default on.

## Why

The feature is deliberately default-off "until the rendering is verified across terminals." This closes the automatable half of that gap (end-to-end escape emission through the wired backend) and writes down the manual half (the per-emulator visual check), so a future PR can flip the default with evidence rather than hope.

## Before / After

```
gallery_drives_altscreen_and_native_progress ... ok
gallery_survives_resize ... ok
gallery_emits_osc8_hyperlink_when_enabled ... ok      # ESC]8;;https://github.com/everruns/yolop ESC\ present
gallery_omits_osc8_hyperlink_when_disabled ... ok     # no ESC]8;; ; URL still visible as text
```

## Security

No new deps; test + demo + docs. The gallery URL is a fixed literal. `HyperlinkBackend`'s own URL sanitization (from #343) is unchanged.

## Risk

- **Low.** The demo/example gain a URL and route through the already-shipped backend; when hyperlinks are disabled (the default) the backend is a pure pass-through, so existing behavior is unchanged. Verified by the disabled-path test.

## Follow-up

Styled-span wrapping in tuika (the remaining toolkit gap) is the next PR.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered

---
_Generated by [Claude Code](https://claude.ai/code/session_01LksbgmgJfiGmNXXGZphgW6)_