### PR TITLE
feat(tuika): styled-span text wrapping (wrap_lines + Wrap)

### DIFF
--- a/crates/tuika/README.md
+++ b/crates/tuika/README.md
@@ -32,7 +32,8 @@ extraction into its own crate. Today yolop drives the component gallery from
 
 | Component | Purpose |
 | --- | --- |
-| `Text` / `Paragraph` | Styled lines / word-wrapped text |
+| `Text` / `Paragraph` | Styled lines / word-wrapped plain text |
+| `Wrap` | Word-wraps pre-styled lines, preserving per-span styles |
 | `Flex` | Flexbox container (the composition primitive) |
 | `Boxed` | Border + padding + title, focus-aware |
 | `Spacer` | Flexible filler |

--- a/crates/tuika/src/components/mod.rs
+++ b/crates/tuika/src/components/mod.rs
@@ -27,4 +27,4 @@ pub use select::{SelectList, SelectOutcome, SelectState};
 pub use spacer::Spacer;
 pub use spinner::{Spinner, SpinnerStyle};
 pub use status_bar::StatusBar;
-pub use text::{Paragraph, Text, line_width};
+pub use text::{Paragraph, Text, Wrap, line_width, wrap_lines};

--- a/crates/tuika/src/components/text.rs
+++ b/crates/tuika/src/components/text.rs
@@ -2,17 +2,36 @@
 //!
 //! [`Text`] draws pre-styled ratatui [`Line`]s faithfully (mixed styles per
 //! line preserved), clipping to its area. [`Paragraph`] takes a plain string
-//! plus one style and word-wraps it to the available width. Callers that need
-//! wrapped *and* multi-styled text should wrap upstream and feed [`Text`].
+//! plus one style and word-wraps it to the available width. [`Wrap`] is the
+//! styled counterpart to `Paragraph`: it word-wraps pre-styled `Line`s while
+//! preserving each span's style across the reflow (see [`wrap_lines`]).
 
 use ratatui::layout::Rect;
 use ratatui::style::Style;
-use ratatui::text::Line;
-use unicode_width::UnicodeWidthStr;
+use ratatui::text::{Line, Span};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::geometry::Size;
 use crate::surface::Surface;
 use crate::view::{RenderCtx, View};
+
+/// Draw pre-styled `lines` top-down from `area`'s origin, clipping to `area`.
+/// Shared by [`Text`] and [`Wrap`].
+fn draw_lines(lines: &[Line<'static>], area: Rect, surface: &mut Surface) {
+    for (row, line) in lines.iter().enumerate() {
+        let y = area.y.saturating_add(row as u16);
+        if y >= area.bottom() {
+            break;
+        }
+        let mut x = area.x;
+        for span in &line.spans {
+            if x >= area.right() {
+                break;
+            }
+            x = surface.set_string(x, y, span.content.as_ref(), span.style);
+        }
+    }
+}
 
 /// Display width of a styled line (sum of span widths).
 pub fn line_width(line: &Line) -> u16 {
@@ -45,19 +64,7 @@ impl View for Text {
     }
 
     fn render(&self, area: Rect, surface: &mut Surface, _ctx: &RenderCtx) {
-        for (row, line) in self.lines.iter().enumerate() {
-            let y = area.y.saturating_add(row as u16);
-            if y >= area.bottom() {
-                break;
-            }
-            let mut x = area.x;
-            for span in &line.spans {
-                if x >= area.right() {
-                    break;
-                }
-                x = surface.set_string(x, y, span.content.as_ref(), span.style);
-            }
-        }
+        draw_lines(&self.lines, area, surface);
     }
 }
 
@@ -112,5 +119,159 @@ impl View for Paragraph {
             }
             surface.set_string(area.x, y, &line, self.style);
         }
+    }
+}
+
+/// Display columns of a single char (0 for zero-width).
+fn char_cols(ch: char) -> u16 {
+    UnicodeWidthChar::width(ch).unwrap_or(0) as u16
+}
+
+/// Word-wrap pre-styled `lines` to `width` columns, preserving each span's
+/// style across the wrap.
+///
+/// Unlike [`Paragraph`] (single style, plain text), the input may be
+/// multi-styled — highlighted code, a linkified URL run, a diff line — and the
+/// per-span styling survives the reflow. Wrapping is greedy and word-oriented:
+/// runs of whitespace collapse to a single break opportunity, a word longer
+/// than `width` is hard-broken so no output line exceeds `width`, and a blank
+/// (empty or all-whitespace) input line stays exactly one blank output line.
+/// Widths are counted in display columns, so wide/CJK glyphs wrap correctly.
+/// A `width` of 0 returns the input unchanged.
+pub fn wrap_lines(lines: &[Line<'static>], width: u16) -> Vec<Line<'static>> {
+    if width == 0 {
+        return lines.to_vec();
+    }
+    let mut out = Vec::new();
+    for line in lines {
+        wrap_one(line, width, &mut out);
+    }
+    out
+}
+
+fn wrap_one(line: &Line<'static>, width: u16, out: &mut Vec<Line<'static>>) {
+    let cells: Vec<(char, Style)> = line
+        .spans
+        .iter()
+        .flat_map(|s| s.content.chars().map(move |c| (c, s.style)))
+        .collect();
+    let before = out.len();
+    let mut cur: Vec<(char, Style)> = Vec::new();
+    let mut cur_w = 0u16;
+    let mut i = 0;
+    let n = cells.len();
+    while i < n {
+        // Collapse a run of whitespace into a single break opportunity.
+        if cells[i].0.is_whitespace() {
+            i += 1;
+            continue;
+        }
+        // Gather one word (a maximal run of non-whitespace).
+        let start = i;
+        let mut word_w = 0u16;
+        while i < n && !cells[i].0.is_whitespace() {
+            word_w = word_w.saturating_add(char_cols(cells[i].0));
+            i += 1;
+        }
+        let word = &cells[start..i];
+        let sep = u16::from(!cur.is_empty());
+        if word_w <= width && cur_w + sep + word_w <= width {
+            // Fits on the current line (with a joining space if needed). The
+            // space inherits the preceding cell's style so a background run
+            // stays continuous across the join.
+            if sep == 1 {
+                let prev = cur.last().map(|c| c.1).unwrap_or_default();
+                cur.push((' ', prev));
+                cur_w += 1;
+            }
+            cur.extend_from_slice(word);
+            cur_w += word_w;
+        } else if word_w <= width {
+            // Doesn't fit; break to a new line, then place the word.
+            if !cur.is_empty() {
+                out.push(coalesce(&cur));
+                cur.clear();
+            }
+            cur.extend_from_slice(word);
+            cur_w = word_w;
+        } else {
+            // Word wider than the line: hard-break it across lines.
+            if !cur.is_empty() {
+                out.push(coalesce(&cur));
+                cur.clear();
+                cur_w = 0;
+            }
+            for &(ch, st) in word {
+                let w = char_cols(ch);
+                if cur_w + w > width && !cur.is_empty() {
+                    out.push(coalesce(&cur));
+                    cur.clear();
+                    cur_w = 0;
+                }
+                cur.push((ch, st));
+                cur_w += w;
+            }
+        }
+    }
+    if !cur.is_empty() {
+        out.push(coalesce(&cur));
+    }
+    // Preserve a blank (empty or all-whitespace) input line as one blank row.
+    if out.len() == before {
+        out.push(Line::default());
+    }
+}
+
+/// Merge a run of styled cells into a [`Line`], coalescing adjacent cells with
+/// equal style into one [`Span`].
+fn coalesce(cells: &[(char, Style)]) -> Line<'static> {
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    let mut buf = String::new();
+    let mut run: Option<Style> = None;
+    for &(ch, st) in cells {
+        match run {
+            Some(s) if s == st => buf.push(ch),
+            _ => {
+                if let Some(s) = run.take() {
+                    spans.push(Span::styled(std::mem::take(&mut buf), s));
+                }
+                run = Some(st);
+                buf.push(ch);
+            }
+        }
+    }
+    if let Some(s) = run {
+        spans.push(Span::styled(buf, s));
+    }
+    Line::from(spans)
+}
+
+/// Multi-styled text, word-wrapped to the render width with per-span styles
+/// preserved.
+///
+/// This is the styled counterpart to [`Paragraph`]: feed it the styled
+/// [`Line`]s a host already builds — syntax-highlighted code, linkified URLs, a
+/// colored diff — and it reflows them to the available width without flattening
+/// the styling (see [`wrap_lines`] for the exact wrapping rules).
+pub struct Wrap {
+    lines: Vec<Line<'static>>,
+}
+
+impl Wrap {
+    pub fn new(lines: Vec<Line<'static>>) -> Self {
+        Self { lines }
+    }
+}
+
+impl View for Wrap {
+    fn measure(&self, available: Size) -> Size {
+        let wrapped = wrap_lines(&self.lines, available.width);
+        let width = wrapped.iter().map(line_width).max().unwrap_or(0);
+        Size::new(width.min(available.width), wrapped.len() as u16)
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, _ctx: &RenderCtx) {
+        let wrapped = wrap_lines(&self.lines, area.width);
+        draw_lines(&wrapped, area, surface);
     }
 }

--- a/crates/tuika/src/lib.rs
+++ b/crates/tuika/src/lib.rs
@@ -48,7 +48,7 @@ pub mod view;
 // etc. for the common surface without deep paths.
 pub use components::{
     Boxed, Flex, Loader, Paragraph, ProgressBar, Scroll, ScrollState, SelectList, SelectOutcome,
-    SelectState, Spacer, Spinner, SpinnerStyle, StatusBar, Text,
+    SelectState, Spacer, Spinner, SpinnerStyle, StatusBar, Text, Wrap, wrap_lines,
 };
 pub use event::{Event, EventFlow, Key, KeyCode, Mouse, MouseKind};
 pub use focus::FocusRegistry;

--- a/crates/tuika/src/tests.rs
+++ b/crates/tuika/src/tests.rs
@@ -10,7 +10,7 @@ use ratatui::text::{Line, Span};
 use super::anim;
 use super::components::{
     Loader, Paragraph, ProgressBar, Scroll, ScrollState, SelectList, SelectOutcome, SelectState,
-    Spinner, Text,
+    Spinner, Text, Wrap, line_width, wrap_lines,
 };
 use super::event::{Event, EventFlow, Key, KeyCode, Mouse, MouseKind};
 use super::focus::FocusRegistry;
@@ -150,6 +150,129 @@ fn paragraph_wraps_to_width() {
     let size = p.measure(Size::new(10, 10));
     assert!(size.height >= 2, "expected wrap, got {size:?}");
     assert!(size.width <= 10);
+}
+
+// ---- styled wrapping (wrap_lines / Wrap) ---------------------------------
+
+/// Concatenated text of a line's spans.
+fn line_text(line: &Line) -> String {
+    line.spans.iter().map(|s| s.content.as_ref()).collect()
+}
+
+#[test]
+fn wrap_lines_breaks_on_word_boundaries() {
+    let out = wrap_lines(&[Line::from("the quick brown fox jumps")], 9);
+    assert!(
+        out.iter().all(|l| line_width(l) <= 9),
+        "no output line may exceed the width: {out:?}"
+    );
+    // Every word survives, in order, un-split.
+    let words: Vec<String> = out
+        .iter()
+        .flat_map(|l| {
+            line_text(l)
+                .split_whitespace()
+                .map(String::from)
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    assert_eq!(words, ["the", "quick", "brown", "fox", "jumps"]);
+}
+
+#[test]
+fn wrap_lines_preserves_span_styles() {
+    let red = Style::default().fg(Color::Red);
+    let blue = Style::default().fg(Color::Blue);
+    let line = Line::from(vec![
+        Span::styled("red", red),
+        Span::raw(" "),
+        Span::styled("blue", blue),
+    ]);
+    // Wide enough that nothing wraps.
+    let out = wrap_lines(&[line], 40);
+    assert_eq!(out.len(), 1);
+    let spans = &out[0].spans;
+    assert!(
+        spans
+            .iter()
+            .any(|s| s.content.starts_with("red") && s.style.fg == Some(Color::Red)),
+        "red run lost its style: {spans:?}"
+    );
+    assert!(
+        spans
+            .iter()
+            .any(|s| s.content.contains("blue") && s.style.fg == Some(Color::Blue)),
+        "blue run lost its style: {spans:?}"
+    );
+}
+
+#[test]
+fn wrap_lines_style_survives_a_break() {
+    let accent = Style::default()
+        .fg(Color::Blue)
+        .add_modifier(Modifier::UNDERLINED);
+    // "aaaa bbbb", all accent, width 4 -> two lines, both still accent.
+    let out = wrap_lines(&[Line::from(Span::styled("aaaa bbbb", accent))], 4);
+    assert_eq!(out.len(), 2, "{out:?}");
+    for l in &out {
+        assert!(
+            l.spans.iter().all(|s| s.style.fg == Some(Color::Blue)
+                && s.style.add_modifier.contains(Modifier::UNDERLINED)),
+            "wrapped line dropped styling: {l:?}"
+        );
+    }
+}
+
+#[test]
+fn wrap_lines_hard_breaks_overlong_word() {
+    let word = "x".repeat(20);
+    let out = wrap_lines(&[Line::from(word.clone())], 8);
+    assert!(out.len() >= 3, "a 20-col word at width 8 needs >=3 lines");
+    assert!(out.iter().all(|l| line_width(l) <= 8));
+    let joined: String = out.iter().map(|l| line_text(l)).collect();
+    assert_eq!(joined, word, "hard-break must not lose characters");
+}
+
+#[test]
+fn wrap_lines_counts_wide_glyphs() {
+    // Each CJK glyph is 2 columns; no whitespace, so it hard-breaks at width 4.
+    let out = wrap_lines(&[Line::from("你好世界")], 4);
+    assert!(out.iter().all(|l| line_width(l) <= 4), "{out:?}");
+    let joined: String = out.iter().map(|l| line_text(l)).collect();
+    assert_eq!(joined, "你好世界");
+}
+
+#[test]
+fn wrap_lines_keeps_blank_lines() {
+    let lines = vec![Line::from("a"), Line::from(""), Line::from("b")];
+    let out = wrap_lines(&lines, 10);
+    assert_eq!(
+        out.len(),
+        3,
+        "a blank line must stay one blank row: {out:?}"
+    );
+    assert_eq!(line_text(&out[1]), "");
+}
+
+#[test]
+fn wrap_lines_zero_width_is_identity() {
+    let out = wrap_lines(&[Line::from("hello world")], 0);
+    assert_eq!(out.len(), 1);
+    assert_eq!(line_text(&out[0]), "hello world");
+}
+
+#[test]
+fn wrap_component_renders_reflowed() {
+    // "aa bb cc" at width 5 wraps to "aa bb" / "cc".
+    let mut buf = buffer(5, 3);
+    let w = Wrap::new(vec![Line::from("aa bb cc")]);
+    let theme = Theme::default();
+    let ctx = RenderCtx::new(&theme);
+    let area = buf.area;
+    let mut surface = Surface::new(&mut buf, area);
+    w.render(area, &mut surface, &ctx);
+    assert_eq!(row(&buf, 0), "aa bb");
+    assert_eq!(row(&buf, 1), "cc");
 }
 
 // ---- scroll state --------------------------------------------------------


### PR DESCRIPTION
## What changed

Closes the remaining toolkit-level gap from the coverage audit: tuika's `Paragraph` word-wraps **single-style plain text only**. Wrapping *multi-styled* text — syntax-highlighted code, a linkified URL run, a colored diff line — had to be done upstream, which is exactly why yolop hand-rolls `append_wrapped_styled`/`append_wrapped_diff` in `render.rs` instead of using the toolkit.

Adds the missing capability:

- **`wrap_lines(lines, width) -> Vec<Line>`** — a pure, greedy, word-oriented wrap that **preserves each span's style across the break**. Whitespace runs collapse to a single break opportunity; an over-long word hard-breaks so no output line exceeds `width`; a blank (empty or all-whitespace) line stays exactly one blank row; widths are counted in **display columns** so wide/CJK glyphs wrap correctly; `width == 0` is identity.
- **`Wrap`** — the styled counterpart to `Paragraph`: a `View` that reflows pre-styled `Line`s to the render width. `Text` and `Wrap` now share a `draw_lines` helper.

Both are re-exported at the crate root (`tuika::Wrap`, `tuika::wrap_lines`).

## Why

It pairs directly with the just-merged hyperlinks work: a wrapped line keeps its underlined/accented URL spans intact instead of flattening to one style. More broadly it means a tuika consumer building a transcript no longer has to reimplement styled wrapping outside the toolkit — which was the one production-grade text feature tuika was missing.

## Before / After

```
wrap_lines_breaks_on_word_boundaries ... ok
wrap_lines_preserves_span_styles ... ok
wrap_lines_style_survives_a_break ... ok      # "aaaa bbbb" @4 -> both lines keep fg+underline
wrap_lines_hard_breaks_overlong_word ... ok   # 20-col word @8 -> 3 lines, no chars lost
wrap_lines_counts_wide_glyphs ... ok          # 你好世界 @4 -> 2 glyphs/line
wrap_lines_keeps_blank_lines ... ok
wrap_lines_zero_width_is_identity ... ok
wrap_component_renders_reflowed ... ok        # "aa bb cc" @5 -> "aa bb" / "cc"
```

Full tuika suite: **71 passed**; `fmt` + `clippy --all-targets -D warnings` clean.

## Follow-up (out of scope)

yolop's `render.rs` could later drop its bespoke `append_wrapped_styled` in favor of `tuika::wrap_lines`. Left for a separate change since it touches the transcript path and wants its own before/after verification.

## Risk

- **Low.** Pure additive library code (new function + component + re-exports); no existing API changed, no yolop consumer yet.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered

---
_Generated by [Claude Code](https://claude.ai/code/session_01LksbgmgJfiGmNXXGZphgW6)_