### PR TITLE
feat(tuika): add safe ratatui composition foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,24 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
+  tuika-msrv:
+    name: Tuika MSRV
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust 1.88
+        uses: dtolnay/rust-toolchain@1.88.0
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "tuika-msrv"
+
+      - name: Check Tuika
+        run: cargo check --locked -p tuika --all-targets
+
   lint:
     name: Format + Clippy
     runs-on: ubuntu-latest

--- a/crates/tuika/Cargo.toml
+++ b/crates/tuika/Cargo.toml
@@ -2,9 +2,10 @@
 name = "tuika"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.88"
 authors = ["Everruns <support@everruns.com>"]
 license = "MIT"
-description = "A small retained-tree terminal UI toolkit — flexbox layout, overlays, focus, and components over ratatui."
+description = "A composable terminal UI toolkit — flexbox layout, overlays, focus, and safe ratatui interoperability."
 homepage = "https://github.com/everruns/yolop"
 repository = "https://github.com/everruns/yolop"
 readme = "README.md"

--- a/crates/tuika/README.md
+++ b/crates/tuika/README.md
@@ -1,14 +1,13 @@
 # tuika
 
-A small retained-tree terminal UI toolkit. `tuika` provides the layout,
+A small composable terminal UI toolkit. `tuika` provides the layout,
 overlay, focus, and component primitives that `ratatui` leaves to you, while
 letting `ratatui` keep ownership of the cell buffer and its diff against the
 terminal.
 
-It is self-contained — it depends only on `ratatui`, `crossterm`, `textwrap`,
-and `unicode-width`, and knows nothing about yolop — and is staged for
-extraction into its own crate. Today yolop drives the component gallery from
-`src/main.rs` (`tuika-gallery`).
+It is a published, self-contained crate that depends only on `ratatui`,
+`crossterm`, `textwrap`, and `unicode-width`. It knows nothing about yolop;
+yolop is one production consumer.
 
 ## Model
 
@@ -18,6 +17,9 @@ extraction into its own crate. Today yolop drives the component gallery from
 - **State** that must survive across frames — scroll offset, selection index,
   focus — lives in host-persisted `*State` structs (the `StatefulWidget`
   idiom), not in the view tree.
+- **Live data** (`Live` / `LiveView`) is shared application state read at render
+  time. Updates request a redraw from the runner; Tuika does not spawn data
+  sources or reconcile a retained widget tree.
 - **Layout** is a flexbox subset (`layout`): `Dimension` (`Auto`/`Fixed`/
   `Percent`/`Flex`), `Align`, `Justify`, `Direction`, over a direction-agnostic
   axis so rows and columns share one solver.
@@ -35,11 +37,13 @@ extraction into its own crate. Today yolop drives the component gallery from
 | `Text` / `Paragraph` | Styled lines / word-wrapped plain text |
 | `Wrap` | Word-wraps pre-styled lines, preserving per-span styles |
 | `Flex` | Flexbox container (the composition primitive) |
+| `Responsive` / `Constrained` | Breakpoint selection and min/max measurement |
 | `Boxed` | Border + padding + title, focus-aware |
 | `Spacer` | Flexible filler |
 | `Scroll` (+ `ScrollState`) | Vertical scroll viewport + scrollbar |
 | `SelectList` (+ `SelectState`) | Selectable list |
 | `StatusBar` | One-row left/right status segments |
+| `Tabs` / `KeyHints` | Host-state tab navigation and command hints |
 | `Spinner` | Frame-cycled activity glyph |
 | `ProgressBar` | Determinate (sub-cell) / indeterminate bar |
 | `Loader` | Spinner + message + hint row |
@@ -69,6 +73,7 @@ Each enters the alternate screen; press `q` (or `esc`) to quit.
 | `gallery`  | `cargo run -p tuika --example gallery`    | motion components + native OSC 9;4 progress        |
 | `select`   | `cargo run -p tuika --example select`     | `SelectState` + `SelectList` (stateful-widget idiom) |
 | `overlay`  | `cargo run -p tuika --example overlay`    | `OverlaySpec` centered dialog + input routing      |
+| `ratatui_dashboard` | `cargo run -p tuika --example ratatui_dashboard` | mixed Ratatui widgets + responsive live data |
 
 (Embedded in yolop, the gallery is also reachable as `yolop tuika-gallery`.)
 
@@ -101,14 +106,60 @@ Grammar (each keyword consumes exactly one node):
   a component **from another crate** participates in the DSL:
 
   ```rust
-  use other_crate::Sparkline;
-  crate::view! { col { node(Sparkline::new(&data)) } };
+  use other_crate::CustomView;
+  crate::view! { col { node(CustomView::new(&data)) } };
   ```
 
-First-class `Sparkline { … }` syntax for external components (with their own
-constructors and named attrs) needs a proc-macro; that lands when `tuika`
-becomes its own crate. Until then, `node(...)` covers every third-party
-component. The `tuika-gallery` demo is built entirely with `view!`.
+`node(...)` accepts any type that already implements Tuika's `View`; it does
+not make a Ratatui `Widget` implement `View`. Use `RatatuiView` for Ratatui
+widgets. The `tuika-gallery` demo is built entirely with `view!`.
+
+## Ratatui interoperability
+
+Tuika deliberately does not duplicate Ratatui's widget catalog. Wrap existing
+widgets in `RatatuiView`; they render into an isolated buffer and only the
+assigned clip is composited into the frame:
+
+```rust
+use ratatui::widgets::{Sparkline, Widget};
+use tuika::{RatatuiView, Size};
+
+let values = vec![1, 4, 2, 8];
+let chart = RatatuiView::sized(Size::new(20, 4), move |area, buffer| {
+    Sparkline::default().data(&values).render(area, buffer);
+});
+```
+
+The closure form supports widgets that borrow captured data. Stateful widgets
+can capture host-owned synchronized state and call `StatefulWidget::render`
+inside the same closure. `Surface::render_ratatui` is the lower-level escape
+hatch for custom views that need several widgets. Neither API exposes the
+frame's mutable buffer.
+
+## Responsive and live views
+
+`Responsive` chooses complete compact/wide view trees from the current width;
+this supports row-to-column reflow and intentionally omitted secondary
+content. `Constrained` supplies min/max intrinsic measurements to flex layout.
+
+`Live<T>` is shared application data with a narrow read/update API. `LiveView`
+derives a fresh view from its current value each frame. Connect it to
+`Runner::redraw_handle()` when background producers should invalidate the
+screen. Producers retain ownership of their threads, tasks, retries, and
+lifecycle.
+
+## Terminal lifecycle and runner
+
+`TerminalSession` is the complete RAII guard: it owns raw mode, alternate
+screen, mouse capture, and cursor visibility, including rollback after partial
+initialization. It preserves raw mode when the caller had already enabled it.
+`AltScreen` remains available for hosts that intentionally own raw mode and
+cursor visibility themselves.
+
+`Runner` is an optional synchronous event loop for dashboards and small tools.
+It owns `TerminalSession`, frame scheduling, Crossterm event translation, and
+data-driven redraw checks. Async applications can keep their existing loop and
+call `paint` directly.
 
 ## Native terminal progress
 
@@ -137,6 +188,20 @@ ratatui `Buffer` and reading cells back — no real terminal:
 - **PTY smoke** (`tests/tuika_pty.rs`) — drives the real binary under a
   pseudo-terminal and asserts the terminal-facing protocol: alternate-screen
   enter/leave, OSC 9;4 progress, resize survival, clean exit.
+
+Downstream crates can use `tuika::testing::{render, render_sizes, grid}` for
+buffer assertions, resize sweeps, and stable glyph snapshots without a real
+terminal or `TestBackend` setup.
+
+## Compatibility
+
+- Minimum supported Rust version: **1.88**, declared as `rust-version` and
+  checked in CI.
+- Tuika 0.x follows Cargo semver: minor releases may make deliberate breaking
+  API changes; patch releases do not.
+- Ratatui and Crossterm are part of Tuika's public interoperability surface.
+  Tuika tracks compatible minor lines deliberately; applications should use
+  matching versions so Cargo can deduplicate them.
 
 ### Manual terminal matrix
 

--- a/crates/tuika/examples/gallery.rs
+++ b/crates/tuika/examples/gallery.rs
@@ -10,7 +10,6 @@ use std::io;
 use std::time::Duration;
 
 use crossterm::event::{self, Event as CtEvent, KeyCode, KeyEventKind};
-use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 use ratatui::style::Modifier;
 use ratatui::text::{Line, Span};
 use ratatui::{Terminal, TerminalOptions, Viewport};
@@ -71,8 +70,7 @@ fn build(frame: u64, theme: &Theme) -> tuika::Element {
 }
 
 fn main() -> io::Result<()> {
-    enable_raw_mode()?;
-    let mut alt = tuika::AltScreen::enter()?;
+    let _session = tuika::TerminalSession::enter()?;
     // Hyperlinks enabled so the footer URL demos as a real OSC 8 link.
     let mut terminal = Terminal::with_options(
         HyperlinkBackend::new(io::stdout(), true),
@@ -104,7 +102,5 @@ fn main() -> io::Result<()> {
     progress.clear();
     let _ = terminal.clear();
     drop(terminal);
-    alt.leave();
-    disable_raw_mode()?;
     Ok(())
 }

--- a/crates/tuika/examples/overlay.rs
+++ b/crates/tuika/examples/overlay.rs
@@ -10,13 +10,12 @@ use std::io;
 use std::time::Duration;
 
 use crossterm::event::{self};
-use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 use ratatui::backend::CrosstermBackend;
 use ratatui::text::{Line, Span};
 use ratatui::{Terminal, TerminalOptions, Viewport};
 
 use tuika::{
-    AltScreen, Element, Event, KeyCode, Overlay, OverlaySpec, Padding, Text, Theme, paint,
+    Element, Event, KeyCode, Overlay, OverlaySpec, Padding, TerminalSession, Text, Theme, paint,
     translate_event, view,
 };
 
@@ -24,8 +23,7 @@ fn main() -> io::Result<()> {
     let mut open = false;
     let mut confirmed = 0u32;
 
-    enable_raw_mode()?;
-    let mut alt = AltScreen::enter()?;
+    let _session = TerminalSession::enter()?;
     let mut terminal = Terminal::with_options(
         CrosstermBackend::new(io::stdout()),
         TerminalOptions {
@@ -116,7 +114,5 @@ fn main() -> io::Result<()> {
 
     let _ = terminal.clear();
     drop(terminal);
-    alt.leave();
-    disable_raw_mode()?;
     Ok(())
 }

--- a/crates/tuika/examples/ratatui_dashboard.rs
+++ b/crates/tuika/examples/ratatui_dashboard.rs
@@ -1,0 +1,137 @@
+//! Mixed Tuika/Ratatui dashboard.
+//!
+//! Demonstrates clipped widget adapters, responsive layouts, live data, the
+//! terminal runner, and semantic key hints. Run with:
+//! `cargo run -p tuika --example ratatui_dashboard`.
+
+use std::ops::ControlFlow;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::Duration;
+
+use ratatui::layout::Constraint;
+use ratatui::text::Line;
+use ratatui::widgets::{Bar, BarChart, BarGroup, Block, Borders, Row, Sparkline, Table, Widget};
+use tuika::{
+    Dimension, Element, Event, Flex, KeyCode, KeyHints, Live, LiveView, RatatuiView, Responsive,
+    Runner, RunnerConfig, Theme, element,
+};
+
+#[derive(Clone)]
+struct Metrics {
+    requests: u64,
+    errors: u64,
+    history: Vec<u64>,
+}
+
+fn table(metrics: Metrics) -> Element {
+    element(RatatuiView::fill(move |area, buffer| {
+        Table::new(
+            [
+                Row::new(["requests", &metrics.requests.to_string()]),
+                Row::new(["errors", &metrics.errors.to_string()]),
+            ],
+            [Constraint::Percentage(60), Constraint::Percentage(40)],
+        )
+        .block(Block::bordered().title(" Metrics "))
+        .render(area, buffer);
+    }))
+}
+
+fn sparkline(metrics: Metrics) -> Element {
+    element(RatatuiView::fill(move |area, buffer| {
+        Sparkline::default()
+            .data(&metrics.history)
+            .block(Block::bordered().title(" Requests "))
+            .render(area, buffer);
+    }))
+}
+
+fn bars(metrics: Metrics) -> Element {
+    element(RatatuiView::fill(move |area, buffer| {
+        let bars = [
+            Bar::default()
+                .value(metrics.requests)
+                .label(Line::from("ok")),
+            Bar::default()
+                .value(metrics.errors)
+                .label(Line::from("err")),
+        ];
+        BarChart::default()
+            .data(BarGroup::default().bars(&bars))
+            .block(Block::default().borders(Borders::ALL).title(" Totals "))
+            .render(area, buffer);
+    }))
+}
+
+fn dashboard(metrics: &Metrics) -> Element {
+    let compact = Flex::column()
+        .child(Dimension::Fixed(4), table(metrics.clone()))
+        .child(Dimension::Flex(1), sparkline(metrics.clone()));
+    let wide = Flex::row()
+        .gap(1)
+        .child(Dimension::Flex(1), table(metrics.clone()))
+        .child(Dimension::Flex(2), sparkline(metrics.clone()))
+        .child(Dimension::Flex(1), bars(metrics.clone()));
+
+    element(
+        Flex::column()
+            .gap(1)
+            .child(
+                Dimension::Flex(1),
+                element(Responsive::new(70, element(compact), element(wide))),
+            )
+            .child(
+                Dimension::Fixed(1),
+                element(KeyHints::new([("q", "quit"), ("resize", "reflow")])),
+            ),
+    )
+}
+
+fn main() -> std::io::Result<()> {
+    let runner = Runner::new(RunnerConfig::default());
+    let metrics = Live::with_redraw(
+        Metrics {
+            requests: 1,
+            errors: 0,
+            history: vec![1],
+        },
+        runner.redraw_handle(),
+    );
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let worker_stop = Arc::clone(&stop);
+    let worker_metrics = metrics.clone();
+    let worker = thread::spawn(move || {
+        while !worker_stop.load(Ordering::Acquire) {
+            thread::sleep(Duration::from_millis(500));
+            worker_metrics.update(|metrics| {
+                metrics.requests += 1;
+                metrics.errors = metrics.requests / 7;
+                metrics.history.push(metrics.requests % 20);
+                if metrics.history.len() > 40 {
+                    metrics.history.remove(0);
+                }
+            });
+        }
+    });
+
+    let live_view = metrics.clone();
+    let result = runner.run(
+        &Theme::default(),
+        move |_| element(LiveView::new(live_view.clone(), dashboard)),
+        |event| match event {
+            Event::Key(key)
+                if key.plain() && matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) =>
+            {
+                ControlFlow::Break(())
+            }
+            _ => ControlFlow::Continue(()),
+        },
+    );
+
+    stop.store(true, Ordering::Release);
+    let _ = worker.join();
+    result
+}

--- a/crates/tuika/examples/select.rs
+++ b/crates/tuika/examples/select.rs
@@ -9,14 +9,13 @@ use std::io;
 use std::time::Duration;
 
 use crossterm::event::{self};
-use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 use ratatui::backend::CrosstermBackend;
 use ratatui::text::{Line, Span};
 use ratatui::{Terminal, TerminalOptions, Viewport};
 
 use tuika::{
-    AltScreen, Event, KeyCode, Padding, SelectList, SelectOutcome, SelectState, Text, Theme, paint,
-    translate_event, view,
+    Event, KeyCode, Padding, SelectList, SelectOutcome, SelectState, TerminalSession, Text, Theme,
+    paint, translate_event, view,
 };
 
 const FRUITS: [&str; 8] = [
@@ -34,8 +33,7 @@ fn main() -> io::Result<()> {
     let mut state = SelectState::new();
     let mut chosen: Option<usize> = None;
 
-    enable_raw_mode()?;
-    let mut alt = AltScreen::enter()?;
+    let _session = TerminalSession::enter()?;
     let mut terminal = Terminal::with_options(
         CrosstermBackend::new(io::stdout()),
         TerminalOptions {
@@ -93,7 +91,5 @@ fn main() -> io::Result<()> {
 
     let _ = terminal.clear();
     drop(terminal);
-    alt.leave();
-    disable_raw_mode()?;
     Ok(())
 }

--- a/crates/tuika/src/components/constrained.rs
+++ b/crates/tuika/src/components/constrained.rs
@@ -1,0 +1,57 @@
+//! Intrinsic min/max sizing for responsive flex children.
+
+use ratatui::layout::Rect;
+
+use crate::{Element, RenderCtx, Size, Surface, View};
+
+/// Clamp a child's measured size without changing its rendering contract.
+pub struct Constrained {
+    child: Element,
+    min: Size,
+    max: Size,
+}
+
+impl Constrained {
+    /// Wrap `child` with unconstrained defaults.
+    pub fn new(child: Element) -> Self {
+        Self {
+            child,
+            min: Size::ZERO,
+            max: Size::new(u16::MAX, u16::MAX),
+        }
+    }
+
+    /// Set the minimum intrinsic width and height.
+    pub fn min_size(mut self, width: u16, height: u16) -> Self {
+        self.min = Size::new(width, height);
+        self
+    }
+
+    /// Set the maximum intrinsic width and height.
+    pub fn max_size(mut self, width: u16, height: u16) -> Self {
+        self.max = Size::new(width, height);
+        self
+    }
+}
+
+impl View for Constrained {
+    fn measure(&self, available: Size) -> Size {
+        let measured = self.child.measure(available);
+        Size::new(
+            measured
+                .width
+                .max(self.min.width)
+                .min(self.max.width)
+                .min(available.width),
+            measured
+                .height
+                .max(self.min.height)
+                .min(self.max.height)
+                .min(available.height),
+        )
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+        self.child.render(area, surface, ctx);
+    }
+}

--- a/crates/tuika/src/components/key_hints.rs
+++ b/crates/tuika/src/components/key_hints.rs
@@ -1,0 +1,63 @@
+//! Compact, responsive key/action hints.
+
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Style};
+use unicode_width::UnicodeWidthStr;
+
+use crate::{RenderCtx, Size, Surface, View};
+
+/// A one-line sequence of styled key and action labels.
+pub struct KeyHints {
+    hints: Vec<(String, String)>,
+}
+
+impl KeyHints {
+    /// Build hints from `(key, action)` pairs.
+    pub fn new<K, L>(hints: impl IntoIterator<Item = (K, L)>) -> Self
+    where
+        K: Into<String>,
+        L: Into<String>,
+    {
+        Self {
+            hints: hints
+                .into_iter()
+                .map(|(key, label)| (key.into(), label.into()))
+                .collect(),
+        }
+    }
+}
+
+impl View for KeyHints {
+    fn measure(&self, available: Size) -> Size {
+        let width = self
+            .hints
+            .iter()
+            .map(|(key, label)| key.width() + label.width() + 3)
+            .sum::<usize>()
+            .min(available.width as usize) as u16;
+        Size::new(width, u16::from(available.height > 0))
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+        if area.is_empty() {
+            return;
+        }
+        let mut x = area.x;
+        for (index, (key, label)) in self.hints.iter().enumerate() {
+            if index > 0 {
+                x = surface.set_string(x, area.y, "  ", ctx.theme.muted_style());
+            }
+            x = surface.set_string(
+                x,
+                area.y,
+                &format!(" {key} "),
+                Style::default().fg(Color::Black).bg(ctx.theme.accent),
+            );
+            x = surface.set_string(x, area.y, " ", ctx.theme.muted_style());
+            x = surface.set_string(x, area.y, label, ctx.theme.muted_style());
+            if x >= area.right() {
+                break;
+            }
+        }
+    }
+}

--- a/crates/tuika/src/components/mod.rs
+++ b/crates/tuika/src/components/mod.rs
@@ -8,23 +8,31 @@
 //! a new module here and implement `View`; nothing else needs to change.
 
 mod boxed;
+mod constrained;
 mod flex;
+mod key_hints;
 mod loader;
 mod progress_bar;
+mod responsive;
 mod scroll;
 mod select;
 mod spacer;
 mod spinner;
 mod status_bar;
+mod tabs;
 mod text;
 
 pub use boxed::Boxed;
+pub use constrained::Constrained;
 pub use flex::Flex;
+pub use key_hints::KeyHints;
 pub use loader::Loader;
 pub use progress_bar::ProgressBar;
+pub use responsive::Responsive;
 pub use scroll::{Scroll, ScrollState};
 pub use select::{SelectList, SelectOutcome, SelectState};
 pub use spacer::Spacer;
 pub use spinner::{Spinner, SpinnerStyle};
 pub use status_bar::StatusBar;
+pub use tabs::{Tabs, TabsState};
 pub use text::{Paragraph, Text, Wrap, line_width, wrap_lines};

--- a/crates/tuika/src/components/responsive.rs
+++ b/crates/tuika/src/components/responsive.rs
@@ -1,0 +1,45 @@
+//! Width-driven view selection for responsive terminal layouts.
+
+use ratatui::layout::Rect;
+
+use crate::{Element, RenderCtx, Size, Surface, View};
+
+/// Select between compact and wide layouts at a column breakpoint.
+///
+/// Each branch is a normal view tree, so an application can switch from a row
+/// to a column, omit secondary content, or choose a shorter status component
+/// without embedding breakpoint logic in individual leaves.
+pub struct Responsive {
+    breakpoint: u16,
+    compact: Element,
+    wide: Element,
+}
+
+impl Responsive {
+    /// Use `compact` below `breakpoint` columns and `wide` otherwise.
+    pub fn new(breakpoint: u16, compact: Element, wide: Element) -> Self {
+        Self {
+            breakpoint,
+            compact,
+            wide,
+        }
+    }
+
+    fn select(&self, width: u16) -> &Element {
+        if width < self.breakpoint {
+            &self.compact
+        } else {
+            &self.wide
+        }
+    }
+}
+
+impl View for Responsive {
+    fn measure(&self, available: Size) -> Size {
+        self.select(available.width).measure(available)
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+        self.select(area.width).render(area, surface, ctx);
+    }
+}

--- a/crates/tuika/src/components/tabs.rs
+++ b/crates/tuika/src/components/tabs.rs
@@ -1,0 +1,110 @@
+//! Focus-independent tab navigation with host-owned selection state.
+
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::Line;
+
+use crate::{Event, EventFlow, KeyCode, RenderCtx, Size, Surface, View};
+
+use super::text::line_width;
+
+#[derive(Clone, Debug, Default)]
+/// Host-owned selected-tab state.
+pub struct TabsState {
+    selected: usize,
+}
+
+impl TabsState {
+    /// Current selected tab index.
+    pub fn selected(&self) -> usize {
+        self.selected
+    }
+
+    /// Select an index, clamped to the available tab count.
+    pub fn select(&mut self, index: usize, len: usize) {
+        self.selected = index.min(len.saturating_sub(1));
+    }
+
+    /// Handle left/right and forward/backward tab navigation.
+    pub fn handle(&mut self, event: &Event, len: usize) -> EventFlow {
+        if len == 0 {
+            return EventFlow::Ignored;
+        }
+        let Event::Key(key) = event else {
+            return EventFlow::Ignored;
+        };
+        if !key.plain() {
+            return EventFlow::Ignored;
+        }
+        match key.code {
+            KeyCode::Left | KeyCode::BackTab => {
+                self.selected = self.selected.checked_sub(1).unwrap_or(len - 1);
+                EventFlow::Consumed
+            }
+            KeyCode::Right | KeyCode::Tab => {
+                self.selected = (self.selected + 1) % len;
+                EventFlow::Consumed
+            }
+            _ => EventFlow::Ignored,
+        }
+    }
+}
+
+/// A one-line tab strip derived from [`TabsState`].
+pub struct Tabs {
+    labels: Vec<Line<'static>>,
+    selected: usize,
+}
+
+impl Tabs {
+    /// Create a tab strip, snapshotting the selected index for this frame.
+    pub fn new(labels: Vec<Line<'static>>, state: &TabsState) -> Self {
+        Self {
+            labels,
+            selected: state.selected(),
+        }
+    }
+}
+
+impl View for Tabs {
+    fn measure(&self, available: Size) -> Size {
+        let labels = self
+            .labels
+            .iter()
+            .map(line_width)
+            .fold(0, u16::saturating_add);
+        let gaps = (self.labels.len().saturating_sub(1) as u16).saturating_mul(2);
+        Size::new(
+            labels.saturating_add(gaps).min(available.width),
+            u16::from(available.height > 0),
+        )
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+        if area.is_empty() {
+            return;
+        }
+        let mut x = area.x;
+        for (index, label) in self.labels.iter().enumerate() {
+            if index > 0 {
+                x = surface.set_string(x, area.y, "  ", ctx.theme.muted_style());
+            }
+            let selected = index == self.selected;
+            for span in &label.spans {
+                let style = if selected {
+                    span.style.patch(
+                        ctx.theme
+                            .accent_style()
+                            .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+                    )
+                } else {
+                    span.style.patch(Style::default().fg(ctx.theme.muted))
+                };
+                x = surface.set_string(x, area.y, span.content.as_ref(), style);
+            }
+            if x >= area.right() {
+                break;
+            }
+        }
+    }
+}

--- a/crates/tuika/src/host.rs
+++ b/crates/tuika/src/host.rs
@@ -1,21 +1,25 @@
 //! Terminal host: alternate-screen lifecycle, event translation, compositor.
 //!
-//! This is the seam between `tuika` and a real terminal. [`AltScreen`] enters
-//! the alternate-screen buffer and mouse-capture on construction and restores
-//! them on drop (RAII, so a panic still cleans up) — the Codex-style
-//! full-screen entry. [`translate_event`] maps crossterm input to `tuika`
-//! [`Event`]s. [`paint`] composites a root view plus any overlays into the
-//! frame buffer: background fill, root, then each overlay last (clearing its
-//! rect first), which is why overlays never leak surrounding chrome here.
+//! This is the seam between `tuika` and a real terminal. [`TerminalSession`]
+//! owns the complete full-screen lifecycle; [`AltScreen`] is the narrower
+//! guard for hosts that manage raw mode and cursor visibility themselves.
+//! [`translate_event`] maps crossterm input to `tuika` [`Event`]s. [`paint`]
+//! composites a root view plus any overlays into the frame buffer: background
+//! fill, root, then each overlay last (clearing its rect first), which is why
+//! overlays never leak surrounding chrome here.
 
 use std::io::{self, Write};
 
+use crossterm::cursor::{Hide, Show};
 use crossterm::event::{
     DisableMouseCapture, EnableMouseCapture, Event as CtEvent, KeyCode as CtKeyCode, KeyEventKind,
     KeyModifiers, MouseEventKind as CtMouseKind,
 };
 use crossterm::execute;
-use crossterm::terminal::{EnterAlternateScreen, LeaveAlternateScreen};
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+    is_raw_mode_enabled,
+};
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::Style;
@@ -52,6 +56,62 @@ impl AltScreen {
 }
 
 impl Drop for AltScreen {
+    fn drop(&mut self) {
+        self.leave();
+    }
+}
+
+/// Complete RAII ownership of a full-screen terminal session.
+///
+/// Construction enables raw mode, enters the alternate screen, enables mouse
+/// capture, and hides the cursor. Drop restores the terminal, including when
+/// unwinding from a panic. Pre-existing raw mode is preserved rather than
+/// disabled. If construction fails partway through, it performs the same
+/// best-effort rollback before returning.
+pub struct TerminalSession {
+    active: bool,
+    raw_mode_owned: bool,
+}
+
+impl TerminalSession {
+    /// Enter a full-screen terminal session, rolling back on failure.
+    pub fn enter() -> io::Result<Self> {
+        let raw_mode_owned = !is_raw_mode_enabled()?;
+        if raw_mode_owned {
+            enable_raw_mode()?;
+        }
+        let mut out = io::stdout();
+        if let Err(error) =
+            execute!(out, EnterAlternateScreen, EnableMouseCapture, Hide).and_then(|()| out.flush())
+        {
+            let _ = execute!(out, Show, DisableMouseCapture, LeaveAlternateScreen);
+            if raw_mode_owned {
+                let _ = disable_raw_mode();
+            }
+            return Err(error);
+        }
+        Ok(Self {
+            active: true,
+            raw_mode_owned,
+        })
+    }
+
+    /// Restore the terminal immediately. Calling this more than once is safe.
+    pub fn leave(&mut self) {
+        if !self.active {
+            return;
+        }
+        let mut out = io::stdout();
+        let _ = execute!(out, Show, DisableMouseCapture, LeaveAlternateScreen);
+        let _ = out.flush();
+        if self.raw_mode_owned {
+            let _ = disable_raw_mode();
+        }
+        self.active = false;
+    }
+}
+
+impl Drop for TerminalSession {
     fn drop(&mut self) {
         self.leave();
     }

--- a/crates/tuika/src/lib.rs
+++ b/crates/tuika/src/lib.rs
@@ -1,4 +1,4 @@
-//! `tuika` — a small retained-tree terminal UI toolkit over
+//! `tuika` — a small composable terminal UI toolkit over
 //! [`ratatui`](https://docs.rs/ratatui).
 //!
 //! `tuika` adds the pieces ratatui leaves to you — a flexbox-style layout
@@ -27,6 +27,10 @@
 //!
 //! Add a component by implementing [`view::View`] in a new module under
 //! [`components`]. No registration step; containers accept any boxed `View`.
+//!
+//! Existing ratatui widgets should normally be wrapped in [`RatatuiView`],
+//! which preserves Tuika clipping without exposing the frame buffer.
+//! [`TerminalSession`] and [`Runner`] are optional host-side lifecycle helpers.
 
 pub mod anim;
 pub mod components;
@@ -38,27 +42,36 @@ pub mod geometry;
 pub mod host;
 pub mod hyperlink;
 pub mod layout;
+pub mod live;
 pub mod native;
 pub mod overlay;
+pub mod ratatui_view;
+pub mod runner;
 pub mod style;
 pub mod surface;
+pub mod testing;
 pub mod view;
 
 // Curated top-level re-exports so callers write `tuika::Flex`, `tuika::Theme`,
 // etc. for the common surface without deep paths.
 pub use components::{
-    Boxed, Flex, Loader, Paragraph, ProgressBar, Scroll, ScrollState, SelectList, SelectOutcome,
-    SelectState, Spacer, Spinner, SpinnerStyle, StatusBar, Text, Wrap, wrap_lines,
+    Boxed, Constrained, Flex, KeyHints, Loader, Paragraph, ProgressBar, Responsive, Scroll,
+    ScrollState, SelectList, SelectOutcome, SelectState, Spacer, Spinner, SpinnerStyle, StatusBar,
+    Tabs, TabsState, Text, Wrap, wrap_lines,
 };
 pub use event::{Event, EventFlow, Key, KeyCode, Mouse, MouseKind};
 pub use focus::FocusRegistry;
 pub use geometry::{Padding, Size};
-pub use host::{AltScreen, Overlay, paint, translate_event};
+pub use host::{AltScreen, Overlay, TerminalSession, paint, translate_event};
 pub use hyperlink::{HyperlinkBackend, is_web_url, osc8, write_line};
 pub use layout::{Align, Dimension, Direction, Justify, LayoutStyle};
+pub use live::{Live, LiveView, RedrawHandle};
 pub use native::{ProgressState, TerminalProgress};
 pub use overlay::{Anchor, Extent, OverlaySpec};
+pub use ratatui_view::RatatuiView;
+pub use runner::{Runner, RunnerConfig};
 pub use style::{BorderStyle, Theme};
+pub use surface::Surface;
 pub use view::{Element, RenderCtx, View, element};
 
 #[cfg(test)]

--- a/crates/tuika/src/live.rs
+++ b/crates/tuika/src/live.rs
@@ -1,0 +1,122 @@
+//! Small observable values for data-driven views.
+//!
+//! `Live` is not a reconciler and does not spawn work. Producers own their
+//! threads or async tasks; updating a value requests a redraw from a connected
+//! [`Runner`](crate::Runner), and views read the latest value each frame.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, RwLock};
+
+use ratatui::layout::Rect;
+
+use crate::{Element, RenderCtx, Size, Surface, View};
+
+/// A thread-safe request for the terminal runner to redraw.
+#[derive(Clone, Default)]
+pub struct RedrawHandle {
+    requested: Arc<AtomicBool>,
+}
+
+impl RedrawHandle {
+    /// Mark the connected runner dirty.
+    pub fn request(&self) {
+        self.requested.store(true, Ordering::Release);
+    }
+
+    pub(crate) fn take(&self) -> bool {
+        self.requested.swap(false, Ordering::AcqRel)
+    }
+}
+
+/// Shared application data whose updates invalidate a connected runner.
+pub struct Live<T> {
+    value: Arc<RwLock<T>>,
+    redraw: Option<RedrawHandle>,
+}
+
+impl<T> Clone for Live<T> {
+    fn clone(&self) -> Self {
+        Self {
+            value: Arc::clone(&self.value),
+            redraw: self.redraw.clone(),
+        }
+    }
+}
+
+impl<T> Live<T> {
+    /// Create a value that is read live but does not notify a runner.
+    pub fn new(value: T) -> Self {
+        Self {
+            value: Arc::new(RwLock::new(value)),
+            redraw: None,
+        }
+    }
+
+    /// Create a value whose mutations request redraws through `redraw`.
+    pub fn with_redraw(value: T, redraw: RedrawHandle) -> Self {
+        Self {
+            value: Arc::new(RwLock::new(value)),
+            redraw: Some(redraw),
+        }
+    }
+
+    /// Read the current value without exposing the lock guard.
+    pub fn with<R>(&self, read: impl FnOnce(&T) -> R) -> R {
+        let value = self.value.read().unwrap_or_else(|error| error.into_inner());
+        read(&value)
+    }
+
+    /// Mutate the value and request a redraw after releasing the write lock.
+    pub fn update<R>(&self, update: impl FnOnce(&mut T) -> R) -> R {
+        let result = {
+            let mut value = self
+                .value
+                .write()
+                .unwrap_or_else(|error| error.into_inner());
+            update(&mut value)
+        };
+        if let Some(redraw) = &self.redraw {
+            redraw.request();
+        }
+        result
+    }
+
+    /// Replace the current value and request a redraw.
+    pub fn set(&self, value: T) {
+        self.update(|current| *current = value);
+    }
+}
+
+/// A view derived from the current value of a [`Live`] on every measurement
+/// and render pass.
+pub struct LiveView<T, F> {
+    value: Live<T>,
+    build: F,
+}
+
+impl<T, F> LiveView<T, F>
+where
+    F: Fn(&T) -> Element,
+{
+    /// Bind `value` to a view-building function.
+    pub fn new(value: Live<T>, build: F) -> Self {
+        Self { value, build }
+    }
+
+    fn current(&self) -> Element {
+        self.value.with(&self.build)
+    }
+}
+
+impl<T, F> View for LiveView<T, F>
+where
+    F: Fn(&T) -> Element,
+{
+    fn measure(&self, available: Size) -> Size {
+        self.current().measure(available)
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+        self.current().render(area, surface, ctx);
+    }
+}

--- a/crates/tuika/src/ratatui_view.rs
+++ b/crates/tuika/src/ratatui_view.rs
@@ -1,0 +1,75 @@
+//! Safe interoperability with ratatui widgets.
+//!
+//! [`RatatuiView`] participates in Tuika layout while rendering through
+//! [`Surface::render_ratatui`](crate::Surface::render_ratatui), so arbitrary
+//! widget code never receives the frame's underlying buffer.
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+
+use crate::{RenderCtx, Size, Surface, View};
+
+/// A Tuika view backed by a ratatui rendering closure.
+///
+/// The closure form is intentional: many ratatui widgets borrow their data.
+/// Captured owned data can be borrowed while constructing the widget inside
+/// the closure, without requiring a self-referential wrapper.
+pub struct RatatuiView<F> {
+    measure: Measure,
+    render: F,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Measure {
+    Fill,
+    Fixed(Size),
+}
+
+impl<F> RatatuiView<F>
+where
+    F: Fn(Rect, &mut Buffer),
+{
+    /// Create a view that requests all space offered by its parent.
+    ///
+    /// ```
+    /// use ratatui::widgets::{Block, Widget};
+    /// use tuika::RatatuiView;
+    ///
+    /// let view = RatatuiView::fill(|area, buffer| {
+    ///     Block::bordered().title(" ratatui ").render(area, buffer);
+    /// });
+    /// ```
+    pub fn fill(render: F) -> Self {
+        Self {
+            measure: Measure::Fill,
+            render,
+        }
+    }
+
+    /// Create a view with a fixed intrinsic size for `Dimension::Auto` layout.
+    pub fn sized(size: Size, render: F) -> Self {
+        Self {
+            measure: Measure::Fixed(size),
+            render,
+        }
+    }
+}
+
+impl<F> View for RatatuiView<F>
+where
+    F: Fn(Rect, &mut Buffer),
+{
+    fn measure(&self, available: Size) -> Size {
+        match self.measure {
+            Measure::Fill => available,
+            Measure::Fixed(size) => Size::new(
+                size.width.min(available.width),
+                size.height.min(available.height),
+            ),
+        }
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, _ctx: &RenderCtx) {
+        surface.render_ratatui(area, &self.render);
+    }
+}

--- a/crates/tuika/src/runner.rs
+++ b/crates/tuika/src/runner.rs
@@ -1,0 +1,132 @@
+//! A small synchronous full-screen runner.
+//!
+//! Applications with an existing async runtime can keep their own event loop
+//! and use [`paint`] directly. This runner is for conventional
+//! dashboards and tools that want lifecycle, redraw scheduling, and event
+//! translation in one place.
+
+use std::io;
+use std::ops::ControlFlow;
+use std::time::{Duration, Instant};
+
+use crossterm::event;
+use ratatui::backend::{Backend, CrosstermBackend};
+use ratatui::{Terminal, TerminalOptions, Viewport};
+
+use crate::{Element, Event, RedrawHandle, TerminalSession, Theme, paint, translate_event};
+
+#[derive(Clone, Copy, Debug)]
+/// Scheduling options for [`Runner`].
+pub struct RunnerConfig {
+    /// Maximum time between frames and data-driven redraw checks.
+    pub tick_rate: Duration,
+}
+
+impl Default for RunnerConfig {
+    fn default() -> Self {
+        Self {
+            tick_rate: Duration::from_millis(100),
+        }
+    }
+}
+
+/// A synchronous Crossterm event and rendering loop.
+pub struct Runner {
+    config: RunnerConfig,
+    redraw: RedrawHandle,
+}
+
+impl Runner {
+    /// Create a runner without touching the terminal.
+    pub fn new(mut config: RunnerConfig) -> Self {
+        // A zero interval would busy-spin even when the application has no
+        // events or updates. Keep the public config ergonomic while enforcing
+        // a safe scheduling floor at the boundary.
+        config.tick_rate = config.tick_rate.max(Duration::from_millis(1));
+        Self {
+            config,
+            redraw: RedrawHandle::default(),
+        }
+    }
+
+    /// Return a handle that background producers can use to request redraws.
+    pub fn redraw_handle(&self) -> RedrawHandle {
+        self.redraw.clone()
+    }
+
+    /// Run until `on_event` returns [`ControlFlow::Break`].
+    pub fn run(
+        &self,
+        theme: &Theme,
+        build: impl FnMut(u64) -> Element,
+        on_event: impl FnMut(Event) -> ControlFlow<()>,
+    ) -> io::Result<()> {
+        self.run_with_backend(theme, CrosstermBackend::new(io::stdout()), build, on_event)
+    }
+
+    /// Run with a caller-provided backend, such as
+    /// [`HyperlinkBackend`](crate::HyperlinkBackend).
+    pub fn run_with_backend<B>(
+        &self,
+        theme: &Theme,
+        backend: B,
+        mut build: impl FnMut(u64) -> Element,
+        mut on_event: impl FnMut(Event) -> ControlFlow<()>,
+    ) -> io::Result<()>
+    where
+        B: Backend<Error = io::Error>,
+    {
+        let _session = TerminalSession::enter()?;
+        let mut terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Fullscreen,
+            },
+        )?;
+        let mut frame = 0u64;
+        let mut last_draw = Instant::now();
+        self.redraw.request();
+
+        loop {
+            let due = last_draw.elapsed() >= self.config.tick_rate;
+            let requested = self.redraw.take();
+            if due || requested {
+                terminal.draw(|terminal_frame| {
+                    let area = terminal_frame.area();
+                    let root = build(frame);
+                    paint(terminal_frame.buffer_mut(), area, theme, root.as_ref(), &[]);
+                })?;
+                frame = frame.wrapping_add(1);
+                last_draw = Instant::now();
+            }
+
+            let timeout = self.config.tick_rate.saturating_sub(last_draw.elapsed());
+            if event::poll(timeout)?
+                && let Some(event) = translate_event(event::read()?)
+                && on_event(event).is_break()
+            {
+                break;
+            }
+        }
+
+        // Some terminal emulators do not answer the cursor-position query
+        // used by `clear`. Session restoration must still succeed and a
+        // cosmetic cleanup failure must not turn a completed run into an
+        // application error.
+        let _ = terminal.clear();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_tick_rate_is_clamped() {
+        let runner = Runner::new(RunnerConfig {
+            tick_rate: Duration::ZERO,
+        });
+        assert_eq!(runner.config.tick_rate, Duration::from_millis(1));
+    }
+}

--- a/crates/tuika/src/surface.rs
+++ b/crates/tuika/src/surface.rs
@@ -43,6 +43,57 @@ impl<'a> Surface<'a> {
         }
     }
 
+    /// Render one or more ratatui widgets without giving them unrestricted
+    /// access to the frame buffer.
+    ///
+    /// The callback receives a temporary [`Buffer`] covering `area`. Existing
+    /// cells are copied into it first, so widgets that only patch styles retain
+    /// the surrounding background. After the callback returns, only cells in
+    /// this surface's clip are composited back. A widget that writes outside
+    /// its assigned area therefore cannot overwrite a sibling or an overlay.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ratatui::widgets::{Sparkline, Widget};
+    /// use tuika::Surface;
+    ///
+    /// # fn draw(surface: &mut Surface<'_>) {
+    /// let values = [1, 4, 2, 8];
+    /// let area = surface.area();
+    /// surface.render_ratatui(area, |area, buffer| {
+    ///     Sparkline::default().data(&values).render(area, buffer);
+    /// });
+    /// # }
+    /// ```
+    pub fn render_ratatui(&mut self, area: Rect, render: impl FnOnce(Rect, &mut Buffer)) {
+        let render_area = area.intersection(self.buffer.area);
+        if render_area.is_empty() {
+            return;
+        }
+
+        // A custom View can pass any Rect. Restrict allocation to the actual
+        // frame while retaining the full assigned area for normal clipped
+        // composition inside that frame.
+        let mut scratch = Buffer::empty(render_area);
+        for y in render_area.y..render_area.bottom() {
+            for x in render_area.x..render_area.right() {
+                scratch[(x, y)] = self.buffer[(x, y)].clone();
+            }
+        }
+
+        render(render_area, &mut scratch);
+
+        let destination = render_area.intersection(self.clip);
+        for y in destination.y..destination.bottom() {
+            for x in destination.x..destination.right() {
+                if let Some(cell) = scratch.cell((x, y)) {
+                    self.buffer[(x, y)] = cell.clone();
+                }
+            }
+        }
+    }
+
     fn contains(&self, x: u16, y: u16) -> bool {
         x >= self.clip.x && x < self.clip.right() && y >= self.clip.y && y < self.clip.bottom()
     }

--- a/crates/tuika/src/testing.rs
+++ b/crates/tuika/src/testing.rs
@@ -1,0 +1,40 @@
+//! Public helpers for hermetic view and resize tests.
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+
+use crate::{Theme, View, paint};
+
+/// Render `view` into a zero-origin in-memory buffer.
+pub fn render(view: &dyn View, width: u16, height: u16, theme: &Theme) -> Buffer {
+    let area = Rect::new(0, 0, width, height);
+    let mut buffer = Buffer::empty(area);
+    paint(&mut buffer, area, theme, view, &[]);
+    buffer
+}
+
+/// Convert a buffer to a stable glyph grid suitable for snapshot assertions.
+pub fn grid(buffer: &Buffer) -> String {
+    let mut output = String::new();
+    for y in buffer.area.y..buffer.area.bottom() {
+        for x in buffer.area.x..buffer.area.right() {
+            output.push_str(buffer[(x, y)].symbol());
+        }
+        if y + 1 < buffer.area.bottom() {
+            output.push('\n');
+        }
+    }
+    output
+}
+
+/// Render the same view at several sizes, useful for resize and degenerate-size tests.
+pub fn render_sizes(
+    view: &dyn View,
+    sizes: impl IntoIterator<Item = (u16, u16)>,
+    theme: &Theme,
+) -> Vec<Buffer> {
+    sizes
+        .into_iter()
+        .map(|(width, height)| render(view, width, height, theme))
+        .collect()
+}

--- a/crates/tuika/src/tests.rs
+++ b/crates/tuika/src/tests.rs
@@ -23,6 +23,166 @@ use super::style::Theme;
 use super::surface::Surface;
 use super::view::{RenderCtx, View, element};
 
+// ---- ratatui interoperability -------------------------------------------
+
+#[test]
+fn ratatui_rendering_preserves_clip_even_if_buffer_expands() {
+    let mut buf = Buffer::filled(Rect::new(0, 0, 12, 3), ratatui::buffer::Cell::new("#"));
+    let clip = Rect::new(4, 1, 4, 1);
+    {
+        let mut surface = Surface::new(&mut buf, clip);
+        surface.render_ratatui(Rect::new(2, 0, 8, 3), |_area, scratch| {
+            let expanded = Buffer::filled(Rect::new(0, 0, 12, 3), ratatui::buffer::Cell::new("x"));
+            scratch.merge(&expanded);
+        });
+    }
+
+    for y in 0..3 {
+        for x in 0..12 {
+            let expected = if y == 1 && (4..8).contains(&x) {
+                "x"
+            } else {
+                "#"
+            };
+            assert_eq!(buf[(x, y)].symbol(), expected, "cell ({x}, {y})");
+        }
+    }
+}
+
+#[test]
+fn ratatui_rendering_starts_with_existing_cells() {
+    use ratatui::style::Color;
+
+    let mut cell = ratatui::buffer::Cell::new(".");
+    cell.set_bg(Color::Blue);
+    let mut buf = Buffer::filled(Rect::new(0, 0, 4, 1), cell);
+    let area = buf.area;
+    {
+        let mut surface = Surface::new(&mut buf, area);
+        surface.render_ratatui(area, |_area, scratch| {
+            scratch[(1, 0)].set_char('x');
+        });
+    }
+    assert_eq!(buf[(1, 0)].symbol(), "x");
+    assert_eq!(buf[(1, 0)].bg, Color::Blue);
+}
+
+#[test]
+fn ratatui_rendering_limits_scratch_to_the_frame() {
+    let mut buf = buffer(3, 2);
+    let area = buf.area;
+    let mut surface = Surface::new(&mut buf, area);
+    surface.render_ratatui(Rect::new(0, 0, u16::MAX, u16::MAX), |actual, _| {
+        assert_eq!(actual, Rect::new(0, 0, 3, 2));
+    });
+}
+
+#[test]
+fn ratatui_rendering_tolerates_a_callback_that_resizes_its_buffer() {
+    let mut buf = Buffer::filled(Rect::new(0, 0, 4, 1), ratatui::buffer::Cell::new("#"));
+    let area = buf.area;
+    let mut surface = Surface::new(&mut buf, area);
+    surface.render_ratatui(area, |_area, scratch| {
+        scratch.resize(Rect::new(0, 0, 1, 1));
+        scratch[(0, 0)].set_char('x');
+    });
+    assert_eq!(row(&buf, 0), "x###");
+}
+
+#[test]
+fn ratatui_view_renders_borrowing_widget_data() {
+    use ratatui::widgets::{Sparkline, Widget};
+
+    let data = vec![1, 2, 4, 8];
+    let view = crate::RatatuiView::fill(move |area, buffer| {
+        Sparkline::default().data(&data).render(area, buffer);
+    });
+    let theme = Theme::default();
+    let rendered = crate::testing::render(&view, 4, 1, &theme);
+    assert_ne!(row(&rendered, 0), "");
+}
+
+// ---- responsive and data-driven views ----------------------------------
+
+#[test]
+fn responsive_selects_layout_from_render_width() {
+    let view = crate::Responsive::new(
+        10,
+        element(Text::raw("compact")),
+        element(Text::raw("wide")),
+    );
+    let theme = Theme::default();
+    let compact = crate::testing::render(&view, 8, 1, &theme);
+    let wide = crate::testing::render(&view, 12, 1, &theme);
+    assert_eq!(row(&compact, 0), "compact");
+    assert_eq!(row(&wide, 0), "wide");
+}
+
+#[test]
+fn constrained_clamps_intrinsic_measurement() {
+    let constrained = crate::Constrained::new(element(Text::raw("long content")))
+        .min_size(4, 1)
+        .max_size(6, 2);
+    assert_eq!(constrained.measure(Size::new(20, 10)), Size::new(6, 1));
+    assert_eq!(constrained.measure(Size::new(3, 1)), Size::new(3, 1));
+}
+
+#[test]
+fn live_view_reads_updated_data_without_reconstruction() {
+    let redraw = crate::RedrawHandle::default();
+    let value = crate::Live::with_redraw(1u32, redraw.clone());
+    let view = crate::LiveView::new(value.clone(), |value| {
+        element(Text::raw(format!("count: {value}")))
+    });
+    let theme = Theme::default();
+    assert_eq!(
+        row(&crate::testing::render(&view, 12, 1, &theme), 0),
+        "count: 1"
+    );
+    value.set(2);
+    assert!(redraw.take());
+    assert_eq!(
+        row(&crate::testing::render(&view, 12, 1, &theme), 0),
+        "count: 2"
+    );
+}
+
+#[test]
+fn tabs_state_wraps_and_tabs_render_selection() {
+    let mut state = crate::TabsState::default();
+    assert_eq!(
+        state.handle(&Event::Key(Key::new(KeyCode::Left)), 3),
+        EventFlow::Consumed
+    );
+    assert_eq!(state.selected(), 2);
+
+    let tabs = crate::Tabs::new(
+        vec![Line::from("one"), Line::from("two"), Line::from("three")],
+        &state,
+    );
+    let theme = Theme::default();
+    let rendered = crate::testing::render(&tabs, 20, 1, &theme);
+    assert!(row(&rendered, 0).contains("one  two  three"));
+    assert!(
+        rendered[(10, 0)]
+            .modifier
+            .contains(ratatui::style::Modifier::UNDERLINED)
+    );
+}
+
+#[test]
+fn key_hints_measure_unicode_by_terminal_width() {
+    let hints = crate::KeyHints::new([("⌘", "開く")]);
+    assert_eq!(hints.measure(Size::new(20, 1)), Size::new(8, 1));
+}
+
+#[test]
+fn public_testing_grid_is_stable_and_rectangular() {
+    let theme = Theme::default();
+    let rendered = crate::testing::render(&Text::raw("hi"), 3, 2, &theme);
+    assert_eq!(crate::testing::grid(&rendered), "hi \n   ");
+}
+
 /// Read a buffer row into a trimmed string for assertions.
 fn row(buffer: &Buffer, y: u16) -> String {
     let area = buffer.area;

--- a/src/main.rs
+++ b/src/main.rs
@@ -945,47 +945,33 @@ fn hyperlinks_enabled() -> bool {
 /// and a loader on the alternate screen, and drives the terminal's native
 /// OSC 9;4 progress indicator while running. Quits on `q`/`Esc`/`Ctrl-C`.
 fn run_tuika_gallery() -> Result<()> {
-    use crossterm::event::{self, Event as CtEvent, KeyCode as CtKeyCode, KeyEventKind};
+    use std::ops::ControlFlow;
     use std::time::Duration;
 
-    let mut raw = RawModeGuard::new()?;
-    let mut alt = tuika::AltScreen::enter()?;
     // Route through the same hyperlink-aware backend as the main TUI so the
     // demo's URL becomes a clickable OSC 8 link when YOLOP_HYPERLINKS is set.
     let backend = tuika::HyperlinkBackend::new(io::stdout(), hyperlinks_enabled());
-    let mut terminal = Terminal::with_options(
-        backend,
-        TerminalOptions {
-            viewport: Viewport::Fullscreen,
-        },
-    )?;
     let theme = tuika::Theme::default();
     let mut progress = tuika::TerminalProgress::new();
     progress.indeterminate();
-
-    let mut frame: u64 = 0;
-    loop {
-        terminal.draw(|f| {
-            let area = f.area();
-            let root = build_gallery(frame, &theme);
-            tuika::paint(f.buffer_mut(), area, &theme, root.as_ref(), &[]);
-        })?;
-
-        if event::poll(Duration::from_millis(80))?
-            && let CtEvent::Key(key) = event::read()?
-            && key.kind != KeyEventKind::Release
-            && matches!(key.code, CtKeyCode::Char('q') | CtKeyCode::Esc)
-        {
-            break;
-        }
-        frame = frame.wrapping_add(1);
-    }
-
+    let runner = tuika::Runner::new(tuika::RunnerConfig {
+        tick_rate: Duration::from_millis(80),
+    });
+    runner.run_with_backend(
+        &theme,
+        backend,
+        |frame| build_gallery(frame, &theme),
+        |event| match event {
+            tuika::Event::Key(key)
+                if matches!(key.code, tuika::KeyCode::Esc | tuika::KeyCode::Char('q'))
+                    || (key.ctrl && matches!(key.code, tuika::KeyCode::Char('c'))) =>
+            {
+                ControlFlow::Break(())
+            }
+            _ => ControlFlow::Continue(()),
+        },
+    )?;
     progress.clear();
-    let _ = terminal.clear();
-    drop(terminal);
-    alt.leave();
-    raw.disable()?;
     Ok(())
 }
 

--- a/tests/tuika_pty.rs
+++ b/tests/tuika_pty.rs
@@ -168,7 +168,11 @@ fn gallery_drives_altscreen_and_native_progress() {
     let run = run_gallery(24, 80, None, false);
     let out = &run.output;
 
-    assert!(run.exited_ok, "gallery should exit cleanly on `q`");
+    assert!(
+        run.exited_ok,
+        "gallery should exit cleanly on `q`: {}",
+        visible_text(out)
+    );
     assert!(
         contains(out, b"\x1b[?1049h"),
         "should enter the alternate screen"
@@ -176,6 +180,16 @@ fn gallery_drives_altscreen_and_native_progress() {
     assert!(
         contains(out, b"\x1b[?1049l"),
         "should restore the main screen on exit"
+    );
+    assert!(contains(out, b"\x1b[?25l"), "should hide the cursor");
+    assert!(
+        contains(out, b"\x1b[?25h"),
+        "should restore the cursor on exit"
+    );
+    assert!(contains(out, b"\x1b[?1000h"), "should enable mouse capture");
+    assert!(
+        contains(out, b"\x1b[?1000l"),
+        "should disable mouse capture on exit"
     );
     // OSC 9;4: indeterminate on start, cleared on exit.
     assert!(
@@ -200,7 +214,8 @@ fn gallery_survives_resize() {
     let run = run_gallery(24, 100, Some((40, 12)), false);
     assert!(
         run.exited_ok,
-        "gallery should survive a resize and exit cleanly"
+        "gallery should survive a resize and exit cleanly: {}",
+        visible_text(&run.output)
     );
     assert!(
         contains(&run.output, b"\x1b[?1049l"),


### PR DESCRIPTION
## What changed
Tuika can now safely compose arbitrary Ratatui widgets through a clipped adapter while preserving Tuika layout and view ownership. It also gains retained live data bindings, complete terminal-session RAII, a small configurable runner, responsive and semantic components, and public rendering test helpers.

The public contract now declares Rust 1.88 as the MSRV and documents direct Ratatui/Crossterm interoperability with a mixed dashboard example.

## Why
Dashboard adopters should be able to reuse Ratatui tables, charts, and other mature widgets without unrestricted access to the terminal buffer or reimplementing the widget catalog. Terminal setup, teardown, event-loop behavior, testing, and compatibility also need stable foundations before Tuika expands its visual API.

## Before / After
Before: the private Surface buffer prevented straightforward reuse of Ratatui Table, Sparkline, and BarChart widgets; applications owned fragmented terminal lifecycle and event-loop code; Tuika had no declared MSRV or public snapshot helpers.

After: Ratatui widgets render into a clipped scratch buffer and are copied only into their assigned area; terminal lifecycle is PTY-tested for cursor and mouse restoration; live views, responsive components, testing helpers, compatibility docs, and a mixed dashboard example are available.

Evidence:
- Tuika unit tests: 83 passed
- Workspace tests: 853 passed, 2 ignored; integration tests 41 passed, 1 ignored; Tuika PTY tests 4 passed
- Rust 1.88 locked check passed
- Clippy with all targets/features and warnings denied passed
- Rustdoc warnings denied passed
- Release build and Tuika package verification passed
- Live OpenAI smoke test returned tuika-smoke-ok

## Risk
- Medium
- This adds public APIs around rendering and terminal lifecycle.
- Adapted Ratatui widgets allocate and copy a scratch buffer per render, favoring isolation and correctness over zero-copy performance.
- Live data producers remain application-owned and must manage their own shutdown.

## Security
- No new dependencies, filesystem access, shell execution, credentials, prompts, or tool capabilities.
- Widget writes are clipped to the assigned rectangle before entering the destination surface.
- Runner tick intervals are clamped to prevent a zero-duration busy loop.
- Terminal escape sequences are fixed constants rather than user-controlled content.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review completed
