### PR TITLE
docs: add user-facing OKF feature doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,8 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   default-on `okf` capability detects a bundle in the workspace and points the
   agent at it — inert when none is present. Override the location with
   `YOLOP_OKF_BUNDLE_DIR`; otherwise `.okf/` and `okf/` are auto-detected by
-  content signature. See [`specs/okf.md`](./specs/okf.md).
+  content signature. See [OKF](./docs/features/okf.md) and
+  [`specs/okf.md`](./specs/okf.md).
 - **Herdr-aware sessions** — when launched in a Herdr pane, Yolop reports
   `working`, `idle`, and explicit `blocked` lifecycle states and exposes
   read-only Herdr operating guidance without installing a global skill. See

--- a/docs/features/okf.md
+++ b/docs/features/okf.md
@@ -1,0 +1,137 @@
+---
+title: OKF
+description: Native Open Knowledge Format support — read, author, and validate markdown knowledge bundles, and have Yolop notice one in your workspace automatically.
+---
+
+The [Open Knowledge Format](https://okf.md/spec/) (OKF, an open specification
+from Google Cloud) represents a body of knowledge as a plain **directory of
+markdown files with YAML frontmatter** — no database, SDK, or runtime. It is a
+portable way to hand an agent the curated context it needs: architecture notes,
+data models, metrics, processes, conventions. If you can `cat` a file, you can
+read OKF.
+
+Yolop supports OKF with two cooperating pieces: a bundled **`okf` skill** that
+teaches reading, authoring, and validating bundles, and an always-on **`okf`
+capability** that detects a bundle in your workspace and points the agent at it.
+Neither requires configuration, and both are inert in repositories that have no
+bundle.
+
+## How it works
+
+```mermaid
+flowchart LR
+  Start["Session start"] --> Detect["okf capability: detect bundle"]
+  Detect -->|none found| Inert["stay silent (no change)"]
+  Detect -->|bundle found| Note["contribute system-prompt note:<br/>path + concept count"]
+  Note --> Agent["Agent reads bundle/index.md,<br/>follows links to concepts"]
+  Agent --> Skill["okf skill: author / validate / maintain"]
+```
+
+At session start the capability looks for a bundle. When it confidently finds
+one it adds a short note to the system prompt naming the bundle path and how many
+concept documents it holds, so the agent knows to consult the bundle **before**
+exploring the repo file-by-file. When no bundle is present it contributes
+nothing.
+
+## What a bundle looks like
+
+A bundle is just a directory tree of markdown. The unit of knowledge is a
+**concept** — one markdown file — identified by its path minus `.md` (its
+*concept-id*). Concepts link to each other with ordinary markdown links, turning
+the directory into a graph.
+
+```
+.okf/
+├── index.md            # directory listing (read first)
+├── log.md              # dated changelog
+├── modules/
+│   └── auth.md         # a concept document
+└── metrics/
+    └── signups.md
+```
+
+Every concept file carries YAML frontmatter. Only `type` is required:
+
+```markdown
+---
+type: Module
+title: Auth
+description: Session and credential handling for the API.
+resource: file:///src/auth
+tags: [security, api]
+timestamp: 2026-07-20T10:30:00Z
+---
+
+# Auth
+
+Handles login, tokens, and session lifecycle.
+
+## Relationships
+- Emits the [signups metric](/metrics/signups)
+```
+
+`index.md` and `log.md` are **reserved** files (both optional): `index.md` is a
+listing for cheap orientation, `log.md` is a chronological changelog. A bundle
+conforms to OKF v0.1 when every non-reserved `.md` file has parseable
+frontmatter with a non-empty `type`; everything else is soft guidance.
+
+## Detection
+
+OKF defines **no canonical bundle marker** — no required root manifest and no
+fixed directory name — so Yolop never assumes one is present. It resolves a
+bundle in this order:
+
+| Order | Source | Accepted when |
+|---|---|---|
+| 1 | `YOLOP_OKF_BUNDLE_DIR` (workspace-relative or absolute) | it resolves to a directory (trusted — you declared it) |
+| 2 | Conventional roots `.okf/` then `okf/` | a content signature holds: an `index.md`, or a non-reserved `.md` whose frontmatter has a non-empty `type` |
+| 3 | — | nothing detected; the capability stays silent |
+
+The content signature is what keeps a plain markdown directory (a Jekyll site,
+an Obsidian vault, `docs/`) from being mistaken for a bundle. Detection runs once
+at session start and the candidate scan is bounded, so a mis-pointed directory
+cannot stall startup. A bundle added mid-session is picked up on the next
+session.
+
+## Working with a bundle
+
+The `okf` skill carries the full format model and drives these workflows. It is
+compiled into the binary, so it works offline.
+
+- **Consume** — read `<bundle>/index.md` first, then follow links into the
+  concept documents relevant to the task instead of grepping blindly. The
+  capability's note nudges the agent to do this automatically.
+- **Author / convert** — create concept files (one idea per file, always a
+  `type`), link them with `/`-absolute concept links, and keep `index.md` and
+  `log.md` current. The skill also covers converting a Notion export, Obsidian
+  vault, or CSV into OKF.
+- **Validate** — the skill ships a zero-dependency checker for the three
+  conformance rules, with `--strict` (require `title`/`description`/`timestamp`)
+  and `--check-links` (report broken intra-bundle links) modes.
+- **Produce / maintain** — because the skill teaches authoring, a repository can
+  instruct Yolop (for example from `AGENTS.md`) to keep its bundle current after
+  changes that alter durable facts; Yolop updates the affected concepts,
+  `index.md`, and `log.md` through the skill. No separate feature is needed.
+
+Ask in plain language:
+
+```text
+document this service as an OKF bundle
+validate the .okf bundle
+what does the knowledge base say about auth?
+```
+
+## Configuration
+
+| Setting | Effect |
+|---|---|
+| `YOLOP_OKF_BUNDLE_DIR` | Point detection at a bundle in a non-conventional location (workspace-relative or absolute). Otherwise `.okf/` and `okf/` are auto-detected by content signature. |
+
+There is nothing to enable: the capability is on by default and does nothing
+until a bundle is present.
+
+## Related
+
+- [`specs/okf.md`](../../specs/okf.md)
+- [`specs/skills.md`](../../specs/skills.md)
+- [OKF specification](https://okf.md/spec/)


### PR DESCRIPTION
## What changed

Adds `docs/features/okf.md`, the user-facing feature doc for native
[Open Knowledge Format](https://okf.md/spec/) support, and links it from the
README OKF bullet. This fills the gap left by the OKF feature PR (#349), which
shipped the code plus `specs/okf.md` (design) and a README bullet, but no
`docs/features/` page like `approvals`, `hooks`, and `repo-map` each have.

The doc follows the established `docs/features/` house style — frontmatter
(`title`/`description`), a "How it works" mermaid flow, bundle layout with a
concept example, the detection resolution table, consume/author/validate/produce
workflows, configuration (`YOLOP_OKF_BUNDLE_DIR`), and a Related section linking
`specs/okf.md` and `specs/skills.md`.

## Why

`docs/features/` is Yolop's user-facing documentation (linked from the README);
`specs/` holds design intent for contributors. OKF had the spec and a README
mention but no how-to page, so a user couldn't find bundle layout, detection
rules, or workflows in the place the other features document them.

## Before / After

- **Before:** no `docs/features/okf.md`; the README OKF bullet linked only
  `specs/okf.md`.
- **After:** `docs/features/okf.md` exists and renders on GitHub (mermaid inline,
  like `hooks.md`); the README bullet links both the feature doc and the spec.
  All relative links resolve; code-fence/mermaid blocks are balanced. No CI
  markdown/link linter exists, so this was verified locally.

## Risk

- **Low.** Documentation only — no code, config, or behavior change.

## Security

No security-relevant code changes — documentation only.

## Follow-ups

No follow-ups.

## Checklist
- [x] Tests added or updated — N/A, docs-only (no runtime behavior to test)
- [x] Backward compatibility considered — N/A, docs-only

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTws11JdeEH1Cz8qTvRfCV)_