### PR TITLE
chore(docs): define public documentation boundary

### DIFF
--- a/.agents/skills/maintenance/SKILL.md
+++ b/.agents/skills/maintenance/SKILL.md
@@ -82,14 +82,14 @@ useful changes:
 
 ### Specs And Docs Alignment
 
-- changed behavior reflected in `specs/`, `README.md`, or `AGENTS.md`
+- changed behavior reflected in `specs/`, `README.md`, `docs/`, or `AGENTS.md`
 - stale duplicate prose removed in favor of links to source files
 - README provider and model lists match `runtime.rs`
 
 ### Feature Completeness Drift
 
 A feature is ready only when its surfaces agree: CLI flags, TUI behavior,
-`specs/`, `README.md`, tests, bundled `skills/`.
+`specs/`, `README.md`, `docs/`, tests, bundled `skills/`.
 
 - diff `clap` definitions in `src/` against the README flag table
 - check recently shipped features (see `git log` since the last tag) for a test that exercises them and a spec/README mention

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -58,7 +58,8 @@ Use this skill when the user asks to:
    - Fix issues you find and refresh the evidence.
 
 5. **Relevant artifacts stay in sync.**
-   - Update only the artifacts affected by the change: `specs/`, `AGENTS.md`, `README.md`.
+   - Update only the artifacts affected by the change: `specs/`, `AGENTS.md`,
+     `README.md`, `docs/`.
 
 6. **Smoke test impacted functionality.**
    - Always smoke test the flows affected by the change end-to-end. This is in

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,13 @@ jobs:
       - name: Format check
         run: cargo fmt --all -- --check
 
+      - name: Public docs boundary
+        run: |
+          if grep -R -n -E --include='*.md' '\]\([^)]*(specs/|\.agents/)' README.md docs; then
+            echo "::error::Public documentation must not link to internal specs/ or .agents/ files."
+            exit 1
+          fi
+
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,9 @@ doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" <command>'
 
 - `specs/` contains durable feature specifications. Read the relevant spec
   before changing behavior in that area.
-- `README.md` is the user-facing entry point — keep it current.
+- `README.md` is the public entry point; `docs/` contains standalone guidance
+  for external users. Neither may link to internal `specs/` or `.agents/`
+  material. See `specs/documentation.md` for the documentation contract.
 - Specs capture **why** and **what**, not exhaustive **how**. Do not duplicate
   fields, enum variants, or exact tool schemas already in source.
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   access are denied, and macOS also makes workspace `.git` metadata read-only.
   You can set `sandbox = "off"` only when yolop already runs inside a trusted
   VM/container; Yolop marks that mode `UNSAFE HOST` and warns that it exposes
-  host files, processes, and network.
+  host files, processes, and network. See
+  [Shell sandboxing](./docs/features/sandboxing.md).
 - **Soft approval** — an optional spoken-consent layer for critical actions.
   yolop batches the safe work and pauses to ask, in plain chat, only before
   destructive or outward-facing steps; you approve by replying "yes". The
@@ -93,7 +94,7 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
 - **Goal loops** — `/goal <condition>` keeps working across turns until a
   separate evaluator model confirms the condition from the transcript; use
   `/goal` for status and `/goal clear` to stop early. Works in `--print` mode
-  (`yolop -p "/goal …"`). See [`specs/goal.md`](./specs/goal.md).
+  (`yolop -p "/goal …"`).
 - **Planning** — `write_todos` keeps multi-step tasks on track, and
   loop detection stops the model from retrying the same failing tool call.
 - **One-shot mode** — `--print` runs a single prompt non-interactively, for
@@ -112,14 +113,14 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
 - **AST edit** *(optional, off by default)* — `ast_edit` applies
   pattern/replacement rewrites with a preview-first `dry_run` flow (default)
   before writing. Enable with `[[capabilities]] ref = "ast_edit"` in
-  `settings.toml`. See [`specs/ast_edit.md`](./specs/ast_edit.md).
+  `settings.toml`.
 - **LSP** *(optional, off by default)* — real language servers
   (rust-analyzer, typescript-language-server, pyright, gopls, clangd, or any
   configured binary) behind `lsp_diagnostics`, `lsp_definition`,
   `lsp_references`, `lsp_hover`, `lsp_rename` (workspace-wide, fixes every
   reference), `lsp_symbols`, and `lsp_code_actions`. Servers spawn lazily
   per language on first use. Enable with `[[capabilities]] ref = "lsp"` in
-  `settings.toml`. See [`specs/lsp.md`](./specs/lsp.md).
+  `settings.toml`.
 - **Shell** — `bash -lc` from the workspace root, with a 120 s wall-clock
   timeout and per-stream 1 MiB output cap; large output is spilled to disk
   under the session folder and stays readable for model tool calls. Use
@@ -138,7 +139,6 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   schedule fires or a task finishes while the session is idle, yolop
   proactively wakes the agent with a turn so it reacts without waiting for
   your next prompt (turn off with the `proactive_wake` setting).
-  See [`specs/background.md`](./specs/background.md).
 - **Web** — `free_web_search` (best-effort SERP/developer search), `web_fetch`
   (HTTP GET/HEAD with markdown/text conversion and DNS-pinned SSRF protection),
   and `duckduckgo_instant_answer` (curated facts and abstracts). All work
@@ -159,33 +159,29 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   `recall` / `forget` tools. Only memory *titles* are injected each turn
   (progressive disclosure); bodies are recalled on demand, so the prompt stays
   small however much you remember. Tunable through the generic capability-config
-  system (`disclosed_titles`, `recall_limit`, `soft_cap`). See
-  [`specs/memory.md`](./specs/memory.md).
+  system (`disclosed_titles`, `recall_limit`, `soft_cap`).
 - **Skills** — `SKILL.md` files discovered from workspace
   (`.agents/skills/`), global (`<config_dir>/yolop/skills/`), ephemeral
   environment integrations, and system (bundled) scopes, exposed via
   `list_skills`, `read_skill`, `write_skill`, and `activate_skill`.
   Workspace/global skills installed after startup are
   available immediately; the bundled `skill-management` skill covers search,
-  npx-style imports, and upgrades. See [`specs/skills.md`](./specs/skills.md).
+  npx-style imports, and upgrades.
 - **OKF knowledge** — native [Open Knowledge Format](https://okf.md/spec/)
   support. The bundled `okf` skill teaches reading, authoring, and validating
   OKF bundles (knowledge as a directory of markdown + YAML frontmatter), and the
   default-on `okf` capability detects a bundle in the workspace and points the
   agent at it — inert when none is present. Override the location with
   `YOLOP_OKF_BUNDLE_DIR`; otherwise `.okf/` and `okf/` are auto-detected by
-  content signature. See [OKF](./docs/features/okf.md) and
-  [`specs/okf.md`](./specs/okf.md).
+  content signature. See [OKF](./docs/features/okf.md).
 - **Herdr-aware sessions** — when launched in a Herdr pane, Yolop reports
   `working`, `idle`, and explicit `blocked` lifecycle states and exposes
-  read-only Herdr operating guidance without installing a global skill. See
-  [`specs/herdr.md`](./specs/herdr.md).
+  read-only Herdr operating guidance without installing a global skill.
 - **Infinity context** — older history is trimmed out of the live prompt but
   stays queryable via `query_history`, so long sessions don't hit the wall.
 - **Tool search** — provider-agnostic deferred tool loading: core file/shell
   tools stay loaded, long-tail tools are hidden until the model pulls them in
-  on demand, saving input tokens on every provider. See
-  [`specs/tool-search.md`](./specs/tool-search.md).
+  on demand, saving input tokens on every provider.
 - **Prompt caching** — Anthropic prompt-caching markers out of the box.
 
 ### Extensibility
@@ -214,12 +210,11 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
 - **Checkpoint rewind** — every turn gets a durable conversation checkpoint and,
   in Yolop-owned Git worktrees, an exact workspace snapshot. `/undo`, `/redo`,
   and `/rewind` preview and restore either axis without changing `HEAD` or the
-  real Git index. See [`specs/checkpointing.md`](specs/checkpointing.md).
+  real Git index.
 - **Session search** — `search_sessions` finds recent local sessions by a
   distinctive user/assistant phrase, or lists recent sessions when no query is
   supplied. This keeps investigations of prior or crashed runs grounded in the
-  saved event log before source-code analysis. See
-  [`specs/session-history.md`](specs/session-history.md).
+  saved event log before source-code analysis.
 
 ### Providers
 
@@ -271,9 +266,11 @@ The current level is always shown in the status bar. Change it with
 less careful ("stop asking me", "yolo mode") — it switches the level itself.
 The setting is saved to `settings.toml`, so it persists across sessions.
 
-Soft approval is judgement, not a guarantee. Native shell
-[sandboxing](specs/sandboxing.md) supplies the kernel boundary; deterministic
-hooks can additionally block specific operations. The controls compose.
+Soft approval is judgement, not a guarantee. Native shell sandboxing supplies
+the kernel boundary; deterministic hooks can additionally block specific
+operations. The controls compose. See
+[Shell sandboxing](./docs/features/sandboxing.md) for containment setup,
+platform requirements, and limitations.
 For the public user-facing details, see
 [Approvals](./docs/features/approvals.md).
 
@@ -297,9 +294,7 @@ yolop into zed
 
 That adds a custom ACP agent server to `~/.config/zed/settings.json` using
 the current yolop executable, preserving any existing `env` and extra
-settings on re-run. Then pick **yolop** in Zed's agent panel. See
-[`specs/acp.md`](./specs/acp.md) for the full protocol surface, mappings, and
-current limitations.
+settings on re-run. Then pick **yolop** in Zed's agent panel.
 
 ## MCP servers
 
@@ -357,7 +352,7 @@ server in `.mcp.json` if that repo needs to override it:
 Trust model: HTTP requests keep yolop's DNS-pinned SSRF protection; stdio
 servers run local processes you listed yourself, so authoring `.mcp.json` is
 the act of consent. MCP tools run autonomously like the rest of yolop's
-tools. See [`specs/mcp.md`](specs/mcp.md).
+tools.
 
 ## Reference
 
@@ -467,8 +462,8 @@ never echoed — but it is plain text on disk, so treat it the same way you
 would `~/.aws/credentials`.
 
 The settings file is also **schema-described**: every key carries a title,
-description, type, default, and examples (see `specs/configuration.md`). yolop
-itself can read and edit it through the `get_config` and `set_config` tools or
+description, type, default, and examples. yolop itself can read and edit it
+through the `get_config` and `set_config` tools or
 the `yolop-config` skill — for example, "use anthropic by default", "store my
 OpenAI key", or "set the default model to gpt-5.5 high". Unknown keys in the
 file are ignored, never fatal, so the format stays forward-compatible.
@@ -544,8 +539,7 @@ sets it up.
 ## Releases
 
 Yolop ships to the `everruns/homebrew-tap` Homebrew tap and to crates.io as
-the `yolop` crate. See [`specs/release.md`](./specs/release.md) for the
-release procedure and [`CHANGELOG.md`](./CHANGELOG.md) for what shipped in
+the `yolop` crate. See [`CHANGELOG.md`](./CHANGELOG.md) for what shipped in
 each version.
 
 ## License

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -8,8 +8,7 @@ there's a Rust SDK ([`yolop-yep`](../crates/yolop-yep)) that makes it a few
 lines.
 
 This page covers **setting up** an existing extension and **creating** your
-own. For the protocol and design rationale, see
-[`specs/extensions.md`](../specs/extensions.md).
+own.
 
 ![Setting up a yolop extension](extensions-setup.gif)
 
@@ -191,5 +190,4 @@ Both are generated from the `yolop-yep` types (`cargo run -p yolop-yep
 > SDK ([published on crates.io](https://crates.io/crates/yolop-yep)), a
 > `doctor_extension` conformance check, toolchain-free **crates.io installs**
 > (`install_extension source="crates.io:yolop-extension-<name>"`), and
-> language-neutral **`meta.json` + `schema.json`** wire artifacts. Remaining
-> follow-ups are listed in [`specs/extensions.md`](../specs/extensions.md).
+> language-neutral **`meta.json` + `schema.json`** wire artifacts.

--- a/docs/features/approvals.md
+++ b/docs/features/approvals.md
@@ -79,4 +79,5 @@ recorded in the session log.
 Soft approval is not a sandbox. It asks the model to pause at the right time,
 but it does not mechanically block a tool call. For deterministic enforcement,
 use hooks, which can block tool calls before they run. Soft approval is for
-judgement and workflow; hooks are for guarantees.
+judgement and workflow; hooks are for guarantees. See
+[Shell sandboxing](./sandboxing.md) for the kernel-enforced boundary.

--- a/docs/features/hooks.md
+++ b/docs/features/hooks.md
@@ -135,5 +135,5 @@ does not add a second hook engine.
 
 ## Related
 
-- [`specs/hooks.md`](../../specs/hooks.md)
-- [`specs/yolop.md`](../../specs/yolop.md)
+- [Approvals](./approvals.md)
+- [Shell sandboxing](./sandboxing.md)

--- a/docs/features/okf.md
+++ b/docs/features/okf.md
@@ -132,6 +132,4 @@ until a bundle is present.
 
 ## Related
 
-- [`specs/okf.md`](../../specs/okf.md)
-- [`specs/skills.md`](../../specs/skills.md)
 - [OKF specification](https://okf.md/spec/)

--- a/docs/features/sandboxing.md
+++ b/docs/features/sandboxing.md
@@ -1,0 +1,104 @@
+# Shell sandboxing
+
+Yolop runs shell commands inside native operating-system containment by
+default. The sandbox limits the damage an incorrect or compromised model can
+cause even after a command has been selected for execution.
+
+Sandboxing and [soft approval](./approvals.md) solve different problems.
+Approval asks whether an action is intended; sandboxing limits what the command
+can reach.
+
+## What is contained
+
+The same policy covers every Yolop shell entry point:
+
+- the model-facing `bash` tool;
+- background shell jobs;
+- the `/shell` command; and
+- the TUI `!shell` shortcut.
+
+With the default `native` mode:
+
+- the active workspace and a private temporary directory are writable;
+- writes outside those locations are denied;
+- internet and packet-network sockets are denied;
+- restrictions are inherited by child processes; and
+- provider credentials and local agent socket paths are removed from the shell
+  environment.
+
+Host files remain readable so compilers, SDKs, package caches, and installed
+skills continue to work. Structured file tools use Yolop's separate rooted
+workspace checks rather than the shell sandbox.
+
+## Platform support
+
+| Platform | Enforcement | Requirements |
+|---|---|---|
+| macOS | Seatbelt | `/usr/bin/sandbox-exec`, included with supported macOS versions |
+| Linux | Landlock filesystem rules and seccomp-BPF network filtering | Full Landlock ABI v3 support: Linux 6.2 or a vendor backport |
+| Other platforms | Native mode fails closed | Run Yolop inside trusted containment before disabling the sandbox |
+
+If the required operating-system primitive is unavailable, Yolop returns a
+sandbox setup error. It never silently retries the command on the host.
+
+## Worktrees and Git
+
+Yolop resolves the active workspace immediately before each command. Switching
+to another managed worktree changes the writable boundary for the next command
+without restarting the session.
+
+On macOS, `.git` below the active workspace is read-only to arbitrary shell
+commands. On Linux, Landlock cannot subtract an in-workspace `.git` directory
+from the writable workspace grant, so that metadata is writable. Metadata for
+a linked worktree that lives outside the active workspace remains protected.
+
+## Disabling the sandbox
+
+Disable native containment only when Yolop already runs inside a trusted VM,
+container, or remote sandbox:
+
+```toml
+sandbox = "off"
+```
+
+Add the setting to Yolop's `settings.toml`, or ask Yolop to set the `sandbox`
+configuration key to `off`. The change applies on the next run.
+
+> **Danger:** `sandbox = "off"` gives shell commands unrestricted access to
+> host files, processes, credentials present in the environment, and the
+> network. A jailbroken or confused model can damage the host.
+
+Yolop marks this state as `UNSAFE HOST` in configuration output, startup
+warnings, the TUI transcript, and the status bar. Remove the setting or set it
+back to `native` to restore containment.
+
+## Troubleshooting
+
+### Native sandbox unavailable on Linux
+
+Check the kernel version and whether the distribution enables Landlock. Yolop
+requires full ABI v3 enforcement because earlier versions do not mediate every
+filesystem operation needed by the write boundary.
+
+### A build cannot download dependencies
+
+Native mode intentionally denies network access. Populate dependency caches
+before starting Yolop, use structured integrations outside the shell boundary,
+or run Yolop inside separate trusted containment before choosing `off`.
+
+### A command cannot write a file
+
+Confirm the target is below the currently active workspace. Absolute paths,
+symlink targets, and linked-worktree metadata outside that boundary remain
+read-only.
+
+## Current limitations
+
+- Host reads are allowed for toolchain compatibility.
+- There is no per-command mount policy or network allowlist.
+- Linux permits `.git` writes when the metadata is physically inside the
+  writable workspace.
+- User-configured MCP and extension server processes are control-plane
+  processes and are not automatically moved into the shell sandbox.
+- Wall-clock and output limits apply, but native mode does not yet provide
+  cgroup or VM resource quotas.

--- a/specs/documentation.md
+++ b/specs/documentation.md
@@ -1,0 +1,77 @@
+# Documentation Specification
+
+## Purpose
+
+This specification defines the boundary between Yolop's public documentation
+and its internal product memory. Public documentation must help users operate
+Yolop without requiring knowledge of repository internals.
+
+## Information architecture
+
+- `README.md` is the public entry point. It explains what Yolop is, presents
+  the primary workflows, and links to public guides for details.
+- `docs/` is public, task-oriented documentation for external users. A page in
+  this directory must stand on its own for someone who installed Yolop.
+- `docs/features/` contains focused guides for user-visible features. Use a
+  short kebab-case filename such as `sandboxing.md`.
+- `specs/` is internal durable product and design memory. It records intent,
+  constraints, tradeoffs, and architectural decisions for maintainers.
+- `.agents/` and `AGENTS.md` contain contributor and agent workflows, not user
+  guidance.
+
+## Direction of links
+
+The public documentation boundary is one-way:
+
+- `README.md` and files below `docs/` MUST NOT link to internal documents below
+  `specs/` or `.agents/`, or require users to read them. Public configuration
+  examples may still name product-owned paths such as `.agents/hooks.json`.
+- Public pages MAY link to other public pages, external standards, and public
+  API/source artifacts when those links help complete a user task.
+- Specs MAY link to public documentation to identify the user-facing surface.
+- Internal contributor material MAY link to both specs and public docs.
+
+Removing an internal link must not remove information users need. Move or
+summarize the relevant operational guidance in public docs first.
+
+## Public feature guides
+
+A feature guide should include the sections relevant to its risk and
+complexity:
+
+1. What the feature does and when a user would use it.
+2. Defaults, prerequisites, supported platforms, and compatibility limits.
+3. Concrete commands or configuration examples.
+4. Security or data-loss warnings placed before the risky action.
+5. Expected behavior, including interactions with related public features.
+6. Troubleshooting for likely failures.
+7. Honest limitations that affect user decisions.
+
+Pages should use product language, not implementation history. Do not include
+roadmaps, rejected alternatives, internal provider comparisons, test strategy,
+or source-level schemas unless the user must author that schema directly.
+
+## Change requirements
+
+- A new user-visible feature needs a discoverable README mention. Add a public
+  feature guide when the README cannot provide enough setup, safety, and
+  troubleshooting detail without becoming unwieldy.
+- Behavior changes must update the affected README or public guide in the same
+  change. Architectural changes must update the affected spec as well.
+- Public and internal descriptions must agree, but they should not duplicate
+  exhaustive source-level details.
+- Renames and removals must repair inbound public links in the same change.
+- Documentation-only changes are validated with the public-boundary check and
+  review of changed relative links; runtime test suites are unnecessary unless
+  behavior also changes.
+
+## Enforcement
+
+CI rejects Markdown links from `README.md` and `docs/` into `specs/` or
+`.agents/`. Review still owns clarity, task completeness, working examples,
+and accurate warnings.
+
+## Public surface
+
+- [`README.md`](../README.md)
+- [`docs/`](../docs/)

--- a/specs/maintenance.md
+++ b/specs/maintenance.md
@@ -13,7 +13,9 @@ The canonical agent workflow lives in [`.agents/skills/maintenance/SKILL.md`](..
 3. Match validation depth to the actual risk surface.
 4. Keep release claims honest.
 5. Detect drift between yolop and its upstream source (`examples/coding-cli` in `everruns/everruns`).
-6. Detect feature-completeness drift: features that look shipped on one surface (CLI flags, TUI behavior, specs, README, tests, bundled skills) but are missing or stale on another.
+6. Detect feature-completeness drift: features that look shipped on one surface
+   (CLI flags, TUI behavior, specs, README, docs, tests, bundled skills) but are
+   missing or stale on another.
 
 ## Ownership Boundary
 
@@ -24,7 +26,8 @@ The canonical agent workflow lives in [`.agents/skills/maintenance/SKILL.md`](..
 
 - Maintenance is risk-proportional, not sweep-proportional.
 - The selected scope must be explained, including what was skipped and why.
-- If maintenance changes code or behavior, affected artifacts must stay in sync: `README.md`, `AGENTS.md`, `specs/`.
+- If maintenance changes code or behavior, affected artifacts must stay in sync:
+  `README.md`, `docs/`, `AGENTS.md`, `specs/`.
 - Maintenance prefers concrete fixes over ceremonial audits when a safe local fix exists.
 - Dependency upgrades against external registries should respect a short release-age floor (≥1 day for patch, ≥7 days for minor/major) to avoid landing same-day yanks.
 
@@ -51,10 +54,11 @@ Deferred items are not failures. Untracked ones are.
 
 A feature is not release-ready merely because one surface exists. Yolop's
 surfaces are the CLI flags, the presentation model, the TUI behavior, `--print`
-output, ACP output, `specs/`, `README.md`, the test suite, and bundled system
-skills. Maintenance should catch:
+output, ACP output, `specs/`, `README.md`, `docs/`, the test suite, and bundled
+system skills. Maintenance should catch:
 
-- flags or behavior present in `src/` but absent from `README.md` or `specs/`
+- flags or behavior present in `src/` but absent from `README.md`, `docs/`, or
+  `specs/`
 - specs or README describing behavior the binary no longer has
 - shipped features with no test exercising them
 - user-visible transcript/status behavior tested only through terminal buffers
@@ -130,4 +134,5 @@ Specs preserve design intent, rationale, and constraints — not implementation 
 ## Related
 
 - [`.agents/skills/maintenance/SKILL.md`](../.agents/skills/maintenance/SKILL.md)
+- [`specs/documentation.md`](./documentation.md)
 - [`specs/shipping.md`](./shipping.md)

--- a/specs/shipping.md
+++ b/specs/shipping.md
@@ -10,7 +10,8 @@ The canonical agent workflow lives in [`.agents/skills/ship/SKILL.md`](../.agent
 
 1. Reach the requested goal, not just perform rituals around it.
 2. Match validation depth to the actual risk surface.
-3. Keep affected artifacts in sync (`README.md`, `AGENTS.md`, `specs/`).
+3. Keep affected artifacts in sync (`README.md`, `docs/`, `AGENTS.md`,
+   `specs/`).
 4. Merge only from a safe branch state with green CI.
 
 ## Ownership Boundary
@@ -26,7 +27,7 @@ Every shipped change MUST satisfy ALL of these. These are mandatory, not suggest
 2. **Goal achieved with evidence.** The requested behavior is implemented and validated with proof matching the risk.
 3. **Feature tested before merge.** Every behavior change is covered by an automated test that exercises the new or changed behavior directly — driving its real entry point, not merely adjacent code that still compiles — added or updated as part of the change. A behavior that is genuinely impractical to test automatically is the only exception: the PR body must say so, describe the manual verification performed instead, and list the gap under **Follow-ups**. Docs-only or config-only changes with no behavior change are exempt with stated justification. Changes to user-visible agent output, live activity, or status values must include tests against the terminal-independent presentation model in [`presentation.md`](./presentation.md); terminal-buffer tests alone are not enough.
 4. **Merge-ready code.** Touched code is reviewed for avoidable complexity. A structured security review is performed (see `.agents/skills/ship/SKILL.md` § Security Review). Issues are addressed or explicitly blocked.
-5. **Synced artifacts.** Affected artifacts are updated: README, AGENTS.md, specs. No code-duplicating prose.
+5. **Synced artifacts.** Affected artifacts are updated: README, docs, AGENTS.md, specs. No code-duplicating prose.
 6. **Smoke test impacted functionality.** In addition to the automated test in outcome 3, smoke test the affected flows end-to-end. Mandatory unless the change is docs-only or config-only with explicit justification. For runtime changes, run at least one live-provider smoke through Doppler.
 7. **Follow-ups surfaced.** TODOs, partial fixes, declined suggestions, missed edges, and spec/doc drift are explicitly listed under **Follow-ups** in the PR body (or `"No follow-ups."` if none).
 8. **Safe merge.** PR uses the template, CI is green, every review comment is addressed (via a code change when needed), answered inline on its own thread with a written reply, and marked resolved before merge. An inline reply is required even when the resolution is a pure code change. Merge is squash-only after a final clean comment sweep. Async reviewer bots get at least 2 minutes to comment after CI turns green.
@@ -54,7 +55,7 @@ Use the smallest set that gives high confidence.
 6. `doppler run -- cargo run -- --provider openai -p "<focused prompt>"` for end-to-end smoke.
 7. `cargo run -- --provider llmsim -p "hi"` for offline smoke when CI access to provider keys is unavailable.
 8. Ensure test coverage proves the fix or acceptance criteria, including important negative paths. For visible transcript or status changes, assert the presentation model output directly.
-9. Update `README.md`, `AGENTS.md`, and `specs/` when relevant.
+9. Update `README.md`, `docs/`, `AGENTS.md`, and `specs/` when relevant.
 
 ## Merge Discipline
 
@@ -66,6 +67,7 @@ Use the smallest set that gives high confidence.
 
 ## Related
 
+- [`specs/documentation.md`](./documentation.md)
 - [`specs/maintenance.md`](./maintenance.md)
 - [`.agents/skills/ship/SKILL.md`](../.agents/skills/ship/SKILL.md)
 - [`.agents/skills/maintenance/SKILL.md`](../.agents/skills/maintenance/SKILL.md)


### PR DESCRIPTION
## What changed

Added a standalone public guide for native shell sandboxing, made it discoverable from the README and related feature guides, and defined the repository's public/internal documentation boundary.

Public README and docs links into internal `specs/` and `.agents/` material were removed. CI now rejects new inline Markdown links that cross that boundary, and shipping/maintenance guidance treats `docs/` as a required user-facing surface.

## Why

External users need complete operational guidance without depending on Yolop's internal product memory. Sandboxing also needs one public place covering defaults, platform support, worktrees, the unsafe opt-out, troubleshooting, and limitations.

## Before / After

Before: sandbox behavior was summarized in the README while detailed guidance lived only in an internal spec; several public pages linked into internal specs.

After: `docs/features/sandboxing.md` is the public guide, the README links to it, existing public-to-internal links are removed, and CI enforces the boundary.

## Risk

- Low
- Documentation or link discoverability could regress; the boundary check, relative-target review, and upstream OKF integration check cover the changed surface.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `actionlint .github/workflows/ci.yml`
- Public-doc boundary check against the repository plus a known-failing internal-link fixture
- Changed relative link targets verified to exist
- Runtime tests and smoke testing skipped: this is a docs-only change plus a fixed CI grep rule and does not alter runtime behavior.

## Security

No security-relevant runtime code changes. Reviewed the CI policy for command injection, secret exposure, path traversal, dependency risk, and resource exhaustion: it uses fixed repository paths and a constant grep pattern, introduces no dependencies, and handles no untrusted input.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated — docs-only exemption; CI boundary behavior was exercised directly
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (final sweep pending)
