### PR TITLE
chore(release): prepare v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ mechanical `### What's Changed` list of merged PRs.
 Releases are cut via [`/release`](./.agents/skills/release/SKILL.md), which
 tags the version and publishes to crates.io and the Homebrew tap.
 
+## [0.10.0] - 2026-07-20
+
+### Highlights
+
+- Add checkpoint rewind and undo for recovering earlier session state.
+- Contain shell execution by default, with clearer sandbox denials and temporary-directory support.
+- Add live extension hot-enabling and Open Knowledge Format support through the bundled skill.
+- Expand the fullscreen TUI with a richer composer, syntax highlighting, OSC 8 hyperlinks, and safer Tuika interoperability.
+
+### What's Changed
+
+* chore: deep maintenance — de-abstraction surface + audit cleanups ([#359](https://github.com/everruns/yolop/pull/359)) by @mchalyi
+* docs: move OKF feature doc into its own folder ([#358](https://github.com/everruns/yolop/pull/358)) by @mchalyi
+* refactor: skill-only OKF support (drop detection capability) ([#356](https://github.com/everruns/yolop/pull/356)) by @mchalyi
+* feat(sandbox): improve denial visibility and temp support ([#357](https://github.com/everruns/yolop/pull/357)) by @mchalyi
+* chore(docs): define public documentation boundary ([#355](https://github.com/everruns/yolop/pull/355)) by @mchalyi
+* docs: add user-facing OKF feature doc ([#354](https://github.com/everruns/yolop/pull/354)) by @mchalyi
+* feat(tuika): add safe ratatui composition foundation ([#353](https://github.com/everruns/yolop/pull/353)) by @mchalyi
+* feat: native Open Knowledge Format (OKF) support ([#349](https://github.com/everruns/yolop/pull/349)) by @mchalyi
+* feat(tuika): styled-span text wrapping (`wrap_lines` + `Wrap`) ([#351](https://github.com/everruns/yolop/pull/351)) by @mchalyi
+* feat(sandbox): contain shell execution by default ([#348](https://github.com/everruns/yolop/pull/348)) by @mchalyi
+* feat(tui): demo and end-to-end proof for OSC 8 hyperlinks ([#350](https://github.com/everruns/yolop/pull/350)) by @mchalyi
+* feat(tui): opt-in OSC 8 hyperlinks (`tuika` `HyperlinkBackend`) ([#343](https://github.com/everruns/yolop/pull/343)) by @mchalyi
+* fix(tui): stop leaked subprocess output from corrupting the TUI ([commit](https://github.com/everruns/yolop/commit/784883e77c2532753e3cd5f836b4c4f507266532)) by @mchalyi
+* feat(session): add checkpoint rewind and undo ([#347](https://github.com/everruns/yolop/pull/347)) by @mchalyi
+* feat(extensions): hot-enable an extension on the live session ([#345](https://github.com/everruns/yolop/pull/345)) by @mchalyi
+* chore(deps): bump everruns to 0.17.14, unpin Rust to 1.94.0 ([#344](https://github.com/everruns/yolop/pull/344)) by @mchalyi
+* fix(tools): honor `/workspace` alias in host-path scope resolution ([#342](https://github.com/everruns/yolop/pull/342)) by @mchalyi
+* feat(tui): Codex-inspired composer, highlighting, and status features ([#341](https://github.com/everruns/yolop/pull/341)) by @mchalyi
+* fix(tui): unify fullscreen presentation ([#340](https://github.com/everruns/yolop/pull/340)) by @mchalyi
+
+**Full Changelog**: https://github.com/everruns/yolop/compare/v0.9.0...v0.10.0
+
 ## [0.9.0] - 2026-07-19
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ tags the version and publishes to crates.io and the Homebrew tap.
 * fix(tools): honor `/workspace` alias in host-path scope resolution ([#342](https://github.com/everruns/yolop/pull/342)) by @mchalyi
 * feat(tui): Codex-inspired composer, highlighting, and status features ([#341](https://github.com/everruns/yolop/pull/341)) by @mchalyi
 * fix(tui): unify fullscreen presentation ([#340](https://github.com/everruns/yolop/pull/340)) by @mchalyi
+* chore(deps): bump everruns to 0.17.13, pin Rust 1.96.0 ([#339](https://github.com/everruns/yolop/pull/339)) by @chaliy
 
 **Full Changelog**: https://github.com/everruns/yolop/compare/v0.9.0...v0.10.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6607,7 +6607,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuika"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "crossterm",
  "proptest",
@@ -7580,7 +7580,7 @@ dependencies = [
 
 [[package]]
 name = "yolop"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/tuika", "crates/yolop-yep"]
 
 [package]
 name = "yolop"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 authors = ["Everruns <support@everruns.com>"]
 license = "MIT"
@@ -65,7 +65,7 @@ yolop-yep = { version = "0.2.0", path = "crates/yolop-yep" }
 sha2 = "0.11"
 toml = "1"
 textwrap = "0.16"
-tuika = { version = "0.1.0", path = "crates/tuika" }
+tuika = { version = "0.2.0", path = "crates/tuika" }
 tokio = { version = "1.52", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tree-sitter = "0.26"

--- a/crates/tuika/Cargo.toml
+++ b/crates/tuika/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuika"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Everruns <support@everruns.com>"]


### PR DESCRIPTION
## Summary

Prepare the `v0.10.0` release. This release adds checkpoint rewind, default shell containment, live extension enablement, OKF support, and substantial fullscreen TUI and Tuika improvements.

## Before / After

**Before:** crates.io and the Homebrew tap serve `v0.9.0`; Tuika is `0.1.0`.

**After:** release automation will publish Yolop `0.10.0` and Tuika `0.2.0`, create `v0.10.0`, and update the Homebrew formula.

## [0.10.0] - 2026-07-20

### Highlights

- Add checkpoint rewind and undo for recovering earlier session state.
- Contain shell execution by default, with clearer sandbox denials and temporary-directory support.
- Add live extension hot-enabling and Open Knowledge Format support through the bundled skill.
- Expand the fullscreen TUI with a richer composer, syntax highlighting, OSC 8 hyperlinks, and safer Tuika interoperability.

### What's Changed

* chore: deep maintenance — de-abstraction surface + audit cleanups ([#359](https://github.com/everruns/yolop/pull/359)) by @mchalyi
* docs: move OKF feature doc into its own folder ([#358](https://github.com/everruns/yolop/pull/358)) by @mchalyi
* refactor: skill-only OKF support (drop detection capability) ([#356](https://github.com/everruns/yolop/pull/356)) by @mchalyi
* feat(sandbox): improve denial visibility and temp support ([#357](https://github.com/everruns/yolop/pull/357)) by @mchalyi
* chore(docs): define public documentation boundary ([#355](https://github.com/everruns/yolop/pull/355)) by @mchalyi
* docs: add user-facing OKF feature doc ([#354](https://github.com/everruns/yolop/pull/354)) by @mchalyi
* feat(tuika): add safe ratatui composition foundation ([#353](https://github.com/everruns/yolop/pull/353)) by @mchalyi
* feat: native Open Knowledge Format (OKF) support ([#349](https://github.com/everruns/yolop/pull/349)) by @mchalyi
* feat(tuika): styled-span text wrapping (`wrap_lines` + `Wrap`) ([#351](https://github.com/everruns/yolop/pull/351)) by @mchalyi
* feat(sandbox): contain shell execution by default ([#348](https://github.com/everruns/yolop/pull/348)) by @mchalyi
* feat(tui): demo and end-to-end proof for OSC 8 hyperlinks ([#350](https://github.com/everruns/yolop/pull/350)) by @mchalyi
* feat(tui): opt-in OSC 8 hyperlinks (`tuika` `HyperlinkBackend`) ([#343](https://github.com/everruns/yolop/pull/343)) by @mchalyi
* fix(tui): stop leaked subprocess output from corrupting the TUI ([commit](https://github.com/everruns/yolop/commit/784883e77c2532753e3cd5f836b4c4f507266532)) by @mchalyi
* feat(session): add checkpoint rewind and undo ([#347](https://github.com/everruns/yolop/pull/347)) by @mchalyi
* feat(extensions): hot-enable an extension on the live session ([#345](https://github.com/everruns/yolop/pull/345)) by @mchalyi
* chore(deps): bump everruns to 0.17.14, unpin Rust to 1.94.0 ([#344](https://github.com/everruns/yolop/pull/344)) by @mchalyi
* fix(tools): honor `/workspace` alias in host-path scope resolution ([#342](https://github.com/everruns/yolop/pull/342)) by @mchalyi
* feat(tui): Codex-inspired composer, highlighting, and status features ([#341](https://github.com/everruns/yolop/pull/341)) by @mchalyi
* fix(tui): unify fullscreen presentation ([#340](https://github.com/everruns/yolop/pull/340)) by @mchalyi
* chore(deps): bump everruns to 0.17.13, pin Rust 1.96.0 ([#339](https://github.com/everruns/yolop/pull/339)) by @chaliy

**Full Changelog**: https://github.com/everruns/yolop/compare/v0.9.0...v0.10.0

## Publish-readiness

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] `cargo publish --dry-run -p yolop-yep` and `-p tuika` (the libraries; `-p yolop` is validated in CI after they publish)
- [x] crates.io currently serves Yolop `0.9.0` and Tuika `0.1.0` → publishing Yolop `0.10.0` and Tuika `0.2.0`
- [x] `Cargo.toml` + `Cargo.lock` agree on Yolop `0.10.0` and Tuika `0.2.0`

## Post-merge verification

- [ ] `release.yml` created tag `v0.10.0` and the GitHub Release
- [ ] `publish.yml` finished green
- [ ] `cli-binaries.yml` finished green
- [ ] crates.io serves `0.10.0`
- [ ] Homebrew tap formula points at `v0.10.0`

## Testing

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo publish --dry-run -p yolop-yep`
- `cargo publish --dry-run -p tuika`

## Security

- No new credentials, network destinations, or release permissions.
- Shell containment and path-scope changes were already reviewed in their feature PRs; this PR changes release metadata only.

## Checklist

- [x] I ran relevant tests locally
- [x] I added/updated tests for behavior changes
- [x] I updated README/docs where needed

Produced by [yolop](https://everruns.com/yolop)

