### PR TITLE
feat(tuika): mouse subsystem — selection, clicks, hit-testing, OSC 52 copy

### DIFF
--- a/crates/tuika/README.md
+++ b/crates/tuika/README.md
@@ -171,6 +171,37 @@ so it works in both the inline and full-screen renderers; terminals that don't
 understand it ignore the sequence. yolop shows it (indeterminate) while a turn
 runs and clears it when idle.
 
+## Mouse, selection, and clipboard
+
+Enabling mouse capture (which `AltScreen` / `TerminalSession` do) means the
+terminal stops doing its own click-drag text selection and hands every drag to
+the app instead. The `mouse` module rebuilds those affordances over the grid
+you already rendered:
+
+- **Text selection.** `SelectionState` turns a left-button `Down → Drag → Up`
+  gesture into a `SelectionRange` (a plain click selects nothing; a new press
+  clears the old selection). `selected_text(buffer, area, range)` reads the text
+  back out of the rendered `ratatui::Buffer` — linear/stream selection like a
+  terminal's own, wide glyphs intact — and `highlight(buffer, area, range,
+  style)` paints it in.
+- **Clicks and regions.** `HitMap<T>` maps screen rects to values (a button, a
+  link, a row); the last-pushed match wins, so children/overlays registered
+  after their parents take precedence. `ClickTracker` turns a same-cell
+  `Down`/`Up` into a `Click` and lets an intervening drag cancel it.
+- **Clipboard.** `clipboard::write_clipboard(out, text)` copies via **OSC 52**
+  (`clipboard::osc52` is the pure encoder) — no platform clipboard library,
+  works over SSH. Same tmux caveat as OSC 8: needs `allow-passthrough on`.
+
+The enriched event model carries what selection and clicks need: `MouseKind` is
+`Down/Up/Drag(MouseButton)`, `Moved`, and `ScrollUp/Down/Left/Right`, and every
+`Mouse` reports `shift/ctrl/alt`. **Shift-drag** is deliberately left to the
+terminal — most emulators use it to bypass app mouse capture for a native
+selection — so a host should act on `plain()` left-drags.
+
+**Touch** arrives as mouse events: terminal emulators translate a tap to a
+`Down`+`Up` and a swipe to scroll or a drag, so touch flows through this same
+path — there is no separate touch event to handle.
+
 ## Testing
 
 Layout and rendering are tested hermetically by rendering into an in-memory

--- a/crates/tuika/src/clipboard.rs
+++ b/crates/tuika/src/clipboard.rs
@@ -1,0 +1,121 @@
+//! System clipboard writes via OSC 52.
+//!
+//! Like [`crate::hyperlink`] (OSC 8) and [`crate::native`] (OSC 9;4), this is an
+//! out-of-band terminal capability: the app writes an escape sequence and the
+//! terminal — not the app — puts the text on the system clipboard. It needs no
+//! platform clipboard library and works over SSH, which is why it's the right
+//! fit for copying a mouse selection (see [`crate::mouse`]).
+//!
+//! The sequence is `OSC 52 ; c ; <base64> ST`, where the payload is the text
+//! base64-encoded (RFC 4648) and `c` selects the system clipboard. Terminals
+//! that support OSC 52 (Ghostty, iTerm2 with it enabled, WezTerm, Kitty, recent
+//! VTE, xterm) copy it; others ignore the sequence. Under tmux it requires
+//! `set -g allow-passthrough on` (or tmux's own `set-clipboard`), the same
+//! passthrough caveat as OSC 8 hyperlinks.
+//!
+//! Terminals cap an OSC 52 sequence near 100 000 bytes; encoded, that bounds
+//! the copyable text at [`MAX_LEN`] bytes. Longer text is refused rather than
+//! sent truncated (a truncated clipboard is worse than a failed copy).
+
+use std::io::{self, Write};
+
+/// Maximum length, in bytes, of text a single OSC 52 write will copy. Beyond
+/// this the terminal would truncate the sequence, so [`osc52`] refuses it.
+pub const MAX_LEN: usize = 74_994;
+
+/// String terminator for the OSC sequence: `ESC \`.
+const ST: &str = "\x1b\\";
+
+/// Encode `text` as an OSC 52 clipboard-set sequence, or `None` when `text` is
+/// empty or longer than [`MAX_LEN`]. Pure and allocation-only — no I/O.
+pub fn osc52(text: &str) -> Option<String> {
+    if text.is_empty() || text.len() > MAX_LEN {
+        return None;
+    }
+    Some(format!("\x1b]52;c;{}{ST}", base64_encode(text.as_bytes())))
+}
+
+/// Copy `text` to the system clipboard by writing an OSC 52 sequence to `out`.
+/// Returns `Ok(true)` when a sequence was written, `Ok(false)` when `text` was
+/// empty or too large (see [`MAX_LEN`]).
+pub fn write_clipboard(out: &mut impl Write, text: &str) -> io::Result<bool> {
+    match osc52(text) {
+        Some(seq) => {
+            out.write_all(seq.as_bytes())?;
+            out.flush()?;
+            Ok(true)
+        }
+        None => Ok(false),
+    }
+}
+
+/// Standard base64 (RFC 4648) with `=` padding. Inlined to keep `tuika` free of
+/// a base64 dependency.
+fn base64_encode(data: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(data.len().div_ceil(3) * 4);
+    for chunk in data.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = *chunk.get(1).unwrap_or(&0) as u32;
+        let b2 = *chunk.get(2).unwrap_or(&0) as u32;
+        let n = (b0 << 16) | (b1 << 8) | b2;
+        out.push(ALPHABET[((n >> 18) & 0x3f) as usize] as char);
+        out.push(ALPHABET[((n >> 12) & 0x3f) as usize] as char);
+        out.push(if chunk.len() > 1 {
+            ALPHABET[((n >> 6) & 0x3f) as usize] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            ALPHABET[(n & 0x3f) as usize] as char
+        } else {
+            '='
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base64_matches_known_vectors() {
+        // RFC 4648 test vectors.
+        assert_eq!(base64_encode(b""), "");
+        assert_eq!(base64_encode(b"f"), "Zg==");
+        assert_eq!(base64_encode(b"fo"), "Zm8=");
+        assert_eq!(base64_encode(b"foo"), "Zm9v");
+        assert_eq!(base64_encode(b"foob"), "Zm9vYg==");
+        assert_eq!(base64_encode(b"fooba"), "Zm9vYmE=");
+        assert_eq!(base64_encode(b"foobar"), "Zm9vYmFy");
+    }
+
+    #[test]
+    fn osc52_wraps_base64_payload() {
+        assert_eq!(
+            osc52("foobar"),
+            Some("\x1b]52;c;Zm9vYmFy\x1b\\".to_string())
+        );
+    }
+
+    #[test]
+    fn osc52_refuses_empty_and_oversized() {
+        assert_eq!(osc52(""), None);
+        let big = "x".repeat(MAX_LEN + 1);
+        assert_eq!(osc52(&big), None);
+        // Exactly at the cap is allowed.
+        assert!(osc52(&"x".repeat(MAX_LEN)).is_some());
+    }
+
+    #[test]
+    fn write_clipboard_reports_whether_it_wrote() {
+        let mut buf: Vec<u8> = Vec::new();
+        assert!(write_clipboard(&mut buf, "hi").expect("write"));
+        assert_eq!(buf, b"\x1b]52;c;aGk=\x1b\\");
+
+        let mut empty: Vec<u8> = Vec::new();
+        assert!(!write_clipboard(&mut empty, "").expect("write"));
+        assert!(empty.is_empty());
+    }
+}

--- a/crates/tuika/src/event.rs
+++ b/crates/tuika/src/event.rs
@@ -63,17 +63,60 @@ pub enum KeyCode {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Mouse {
     pub kind: MouseKind,
+    /// Cell column (0-based, terminal coordinates).
     pub column: u16,
+    /// Cell row (0-based, terminal coordinates).
     pub row: u16,
+    pub shift: bool,
+    pub ctrl: bool,
+    pub alt: bool,
+}
+
+impl Mouse {
+    /// A bare event at `(column, row)` with the given kind and no modifiers —
+    /// convenience for tests and synthetic events.
+    pub fn at(kind: MouseKind, column: u16, row: u16) -> Self {
+        Self {
+            kind,
+            column,
+            row,
+            shift: false,
+            ctrl: false,
+            alt: false,
+        }
+    }
+
+    /// True when no modifier keys are held. Terminals also use Shift-drag to
+    /// bypass application mouse capture for native selection, so a host that
+    /// implements its own selection should generally act only on `plain()`
+    /// left-drags and leave Shift-drags to the terminal.
+    pub fn plain(&self) -> bool {
+        !self.shift && !self.ctrl && !self.alt
+    }
+}
+
+/// Which mouse button an event refers to.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MouseButton {
+    Left,
+    Right,
+    Middle,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MouseKind {
-    Down,
-    Up,
+    /// Button pressed.
+    Down(MouseButton),
+    /// Button released.
+    Up(MouseButton),
+    /// Pointer moved with a button held (a drag of that button).
+    Drag(MouseButton),
+    /// Pointer moved with no button held.
+    Moved,
     ScrollUp,
     ScrollDown,
-    Moved,
+    ScrollLeft,
+    ScrollRight,
 }
 
 /// Whether a component consumed an event or let it bubble.

--- a/crates/tuika/src/host.rs
+++ b/crates/tuika/src/host.rs
@@ -13,7 +13,7 @@ use std::io::{self, Write};
 use crossterm::cursor::{Hide, Show};
 use crossterm::event::{
     DisableMouseCapture, EnableMouseCapture, Event as CtEvent, KeyCode as CtKeyCode, KeyEventKind,
-    KeyModifiers, MouseEventKind as CtMouseKind,
+    KeyModifiers, MouseButton as CtMouseButton, MouseEventKind as CtMouseKind,
 };
 use crossterm::execute;
 use crossterm::terminal::{
@@ -24,7 +24,7 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::Style;
 
-use super::event::{Event, Key, KeyCode, Mouse, MouseKind};
+use super::event::{Event, Key, KeyCode, Mouse, MouseButton, MouseKind};
 use super::style::Theme;
 use super::surface::Surface;
 use super::view::{RenderCtx, View};
@@ -190,21 +190,34 @@ pub fn translate_event(event: CtEvent) -> Option<Event> {
         }
         CtEvent::Mouse(m) => {
             let kind = match m.kind {
-                CtMouseKind::Down(_) => MouseKind::Down,
-                CtMouseKind::Up(_) => MouseKind::Up,
+                CtMouseKind::Down(b) => MouseKind::Down(button(b)),
+                CtMouseKind::Up(b) => MouseKind::Up(button(b)),
+                CtMouseKind::Drag(b) => MouseKind::Drag(button(b)),
+                CtMouseKind::Moved => MouseKind::Moved,
                 CtMouseKind::ScrollUp => MouseKind::ScrollUp,
                 CtMouseKind::ScrollDown => MouseKind::ScrollDown,
-                CtMouseKind::Moved | CtMouseKind::Drag(_) => MouseKind::Moved,
-                _ => return None,
+                CtMouseKind::ScrollLeft => MouseKind::ScrollLeft,
+                CtMouseKind::ScrollRight => MouseKind::ScrollRight,
             };
             Some(Event::Mouse(Mouse {
                 kind,
                 column: m.column,
                 row: m.row,
+                shift: m.modifiers.contains(KeyModifiers::SHIFT),
+                ctrl: m.modifiers.contains(KeyModifiers::CONTROL),
+                alt: m.modifiers.contains(KeyModifiers::ALT),
             }))
         }
         CtEvent::Paste(text) => Some(Event::Paste(text)),
         CtEvent::Resize(width, height) => Some(Event::Resize { width, height }),
         _ => None,
+    }
+}
+
+fn button(b: CtMouseButton) -> MouseButton {
+    match b {
+        CtMouseButton::Left => MouseButton::Left,
+        CtMouseButton::Right => MouseButton::Right,
+        CtMouseButton::Middle => MouseButton::Middle,
     }
 }

--- a/crates/tuika/src/lib.rs
+++ b/crates/tuika/src/lib.rs
@@ -33,6 +33,7 @@
 //! [`TerminalSession`] and [`Runner`] are optional host-side lifecycle helpers.
 
 pub mod anim;
+pub mod clipboard;
 pub mod components;
 pub mod event;
 #[macro_use]
@@ -43,6 +44,7 @@ pub mod host;
 pub mod hyperlink;
 pub mod layout;
 pub mod live;
+pub mod mouse;
 pub mod native;
 pub mod overlay;
 pub mod ratatui_view;
@@ -54,18 +56,22 @@ pub mod view;
 
 // Curated top-level re-exports so callers write `tuika::Flex`, `tuika::Theme`,
 // etc. for the common surface without deep paths.
+pub use clipboard::{osc52, write_clipboard};
 pub use components::{
     Boxed, Constrained, Flex, KeyHints, Loader, Paragraph, ProgressBar, Responsive, Scroll,
     ScrollState, SelectList, SelectOutcome, SelectState, Spacer, Spinner, SpinnerStyle, StatusBar,
     Tabs, TabsState, Text, Wrap, wrap_lines,
 };
-pub use event::{Event, EventFlow, Key, KeyCode, Mouse, MouseKind};
+pub use event::{Event, EventFlow, Key, KeyCode, Mouse, MouseButton, MouseKind};
 pub use focus::FocusRegistry;
 pub use geometry::{Padding, Size};
 pub use host::{AltScreen, Overlay, TerminalSession, paint, translate_event};
 pub use hyperlink::{HyperlinkBackend, is_web_url, osc8, write_line};
 pub use layout::{Align, Dimension, Direction, Justify, LayoutStyle};
 pub use live::{Live, LiveView, RedrawHandle};
+pub use mouse::{
+    Click, ClickTracker, HitMap, SelectionRange, SelectionState, highlight, selected_text,
+};
 pub use native::{ProgressState, TerminalProgress};
 pub use overlay::{Anchor, Extent, OverlaySpec};
 pub use ratatui_view::RatatuiView;

--- a/crates/tuika/src/mouse.rs
+++ b/crates/tuika/src/mouse.rs
@@ -1,0 +1,279 @@
+//! Mouse interaction over the rendered cell grid: text selection, click
+//! hit-testing, and click detection.
+//!
+//! Terminals don't hand you selection or clickable regions — once an app
+//! enables mouse capture (see [`AltScreen`](crate::AltScreen)) the terminal's
+//! own click-drag selection stops working, and every drag arrives as a
+//! [`Mouse`] event instead. This module rebuilds those affordances *on top of*
+//! the grid the app already rendered:
+//!
+//! - [`SelectionState`] turns a left button `Down -> Drag -> Up` gesture into a
+//!   [`SelectionRange`]; [`selected_text`] reads the text back out of the
+//!   [`Buffer`] and [`highlight`] paints the selection into it. Pair with
+//!   [`crate::clipboard::write_clipboard`] to copy.
+//! - [`HitMap`] maps screen regions to values so a click resolves to whatever
+//!   was drawn there (a button, a link, a list row); [`ClickTracker`] turns a
+//!   `Down`/`Up` pair on the same cell into a click (and lets a drag cancel it).
+//!
+//! Selection is *linear* (stream) like a terminal's own: a multi-row selection
+//! covers the tail of the first row, all of the middle rows, and the head of
+//! the last row — not a rectangular block.
+//!
+//! **Touch:** terminal emulators deliver touch as mouse events (a tap is a
+//! `Down`+`Up`, a swipe is `ScrollUp`/`ScrollDown` or a `Drag`), so touch input
+//! flows through this same path — there is no separate touch event to model.
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+
+use crate::event::{Mouse, MouseButton, MouseKind};
+
+/// A normalized text selection in reading order: `start` is at or before `end`
+/// ordered by `(row, column)`. Both endpoints are inclusive cells.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SelectionRange {
+    /// `(column, row)` of the first selected cell.
+    pub start: (u16, u16),
+    /// `(column, row)` of the last selected cell (inclusive).
+    pub end: (u16, u16),
+}
+
+impl SelectionRange {
+    /// Order two cells into reading order (`(row, col)` ascending).
+    fn between(a: (u16, u16), b: (u16, u16)) -> Self {
+        let (start, end) = if (a.1, a.0) <= (b.1, b.0) {
+            (a, b)
+        } else {
+            (b, a)
+        };
+        SelectionRange { start, end }
+    }
+
+    /// The inclusive `[left, right]` selected column span on `row`, clamped to
+    /// `area`. Rows outside the selection return `None`.
+    fn row_span(&self, row: u16, area: Rect) -> Option<(u16, u16)> {
+        if row < self.start.1 || row > self.end.1 {
+            return None;
+        }
+        let left = if row == self.start.1 {
+            self.start.0
+        } else {
+            area.x
+        };
+        let right = if row == self.end.1 {
+            self.end.0
+        } else {
+            area.right().saturating_sub(1)
+        };
+        let left = left.max(area.x);
+        let right = right.min(area.right().saturating_sub(1));
+        (left <= right).then_some((left, right))
+    }
+
+    /// Whether `(column, row)` falls inside the selection within `area`.
+    pub fn contains(&self, column: u16, row: u16, area: Rect) -> bool {
+        self.row_span(row, area)
+            .is_some_and(|(l, r)| column >= l && column <= r)
+    }
+}
+
+/// Tracks a left-drag text selection across mouse events.
+///
+/// Left `Down` starts (and clears any previous selection); `Drag` extends;
+/// `Up` finishes. A press with no drag (a plain click) leaves no selection.
+/// Every other event is ignored. `handle` returns `true` when the selection
+/// changed, so a host knows to redraw.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SelectionState {
+    anchor: (u16, u16),
+    cursor: (u16, u16),
+    pressed: bool,
+    selecting: bool,
+}
+
+impl SelectionState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn handle(&mut self, m: &Mouse) -> bool {
+        match m.kind {
+            MouseKind::Down(MouseButton::Left) => {
+                self.anchor = (m.column, m.row);
+                self.cursor = (m.column, m.row);
+                self.pressed = true;
+                let had = self.selecting;
+                self.selecting = false;
+                // Redraw if we cleared an existing selection.
+                had
+            }
+            MouseKind::Drag(MouseButton::Left) if self.pressed => {
+                self.cursor = (m.column, m.row);
+                self.selecting = self.cursor != self.anchor;
+                true
+            }
+            MouseKind::Up(MouseButton::Left) if self.pressed => {
+                self.cursor = (m.column, m.row);
+                self.pressed = false;
+                self.selecting = self.cursor != self.anchor;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Clear the selection (e.g. on Esc or a new turn).
+    pub fn clear(&mut self) {
+        *self = Self::default();
+    }
+
+    /// The current selection, or `None` when nothing is selected.
+    pub fn range(&self) -> Option<SelectionRange> {
+        self.selecting
+            .then(|| SelectionRange::between(self.anchor, self.cursor))
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.selecting
+    }
+}
+
+/// Extract the selected text from `buffer`, reading the grid the way a terminal
+/// does: the tail of the first row, whole middle rows, and the head of the last
+/// row, joined with `\n`. Trailing blanks on each row are trimmed. Wide glyphs
+/// come back once (their trailing spacer cell is empty in the buffer).
+pub fn selected_text(buffer: &Buffer, area: Rect, sel: SelectionRange) -> String {
+    let mut out = String::new();
+    let mut first = true;
+    for row in sel.start.1..=sel.end.1 {
+        let Some((left, right)) = sel.row_span(row, area) else {
+            continue;
+        };
+        if !first {
+            out.push('\n');
+        }
+        first = false;
+        let mut line = String::new();
+        for col in left..=right {
+            line.push_str(buffer[(col, row)].symbol());
+        }
+        out.push_str(line.trim_end_matches(' '));
+    }
+    out
+}
+
+/// Paint `style` over the selected cells of `buffer` (patching, so glyphs and
+/// foreground survive; typically a reversed or selection-background style).
+pub fn highlight(buffer: &mut Buffer, area: Rect, sel: SelectionRange, style: Style) {
+    for row in sel.start.1..=sel.end.1 {
+        let Some((left, right)) = sel.row_span(row, area) else {
+            continue;
+        };
+        for col in left..=right {
+            buffer[(col, row)].set_style(style);
+        }
+    }
+}
+
+/// Maps screen regions to values for click hit-testing.
+///
+/// Push a region per clickable thing while laying out a frame, then resolve a
+/// click position to the value drawn there. Later pushes win, so registering
+/// children/overlays after their parents gives the innermost/topmost region
+/// precedence.
+#[derive(Clone, Debug)]
+pub struct HitMap<T> {
+    regions: Vec<(Rect, T)>,
+}
+
+impl<T> Default for HitMap<T> {
+    fn default() -> Self {
+        Self {
+            regions: Vec::new(),
+        }
+    }
+}
+
+impl<T> HitMap<T> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register `value` at `area`. A zero-area rect never matches.
+    pub fn push(&mut self, area: Rect, value: T) {
+        self.regions.push((area, value));
+    }
+
+    pub fn clear(&mut self) {
+        self.regions.clear();
+    }
+
+    /// The value of the last-pushed region containing `(column, row)`.
+    pub fn hit(&self, column: u16, row: u16) -> Option<&T> {
+        self.regions
+            .iter()
+            .rev()
+            .find(|(r, _)| in_rect(*r, column, row))
+            .map(|(_, v)| v)
+    }
+
+    /// Resolve a mouse event's position through the map.
+    pub fn hit_event(&self, m: &Mouse) -> Option<&T> {
+        self.hit(m.column, m.row)
+    }
+}
+
+fn in_rect(r: Rect, col: u16, row: u16) -> bool {
+    r.width > 0 && r.height > 0 && col >= r.x && col < r.right() && row >= r.y && row < r.bottom()
+}
+
+/// A completed click: the cell and button of a `Down`/`Up` pair on one cell.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Click {
+    pub column: u16,
+    pub row: u16,
+    pub button: MouseButton,
+}
+
+/// Turns `Down`/`Up` mouse pairs into [`Click`]s. A press then release on the
+/// *same* cell with the *same* button is a click; a drag in between cancels it
+/// (that gesture is a selection, not a click). Feed every mouse event; `handle`
+/// returns `Some(Click)` only on the completing `Up`.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ClickTracker {
+    down: Option<(u16, u16, MouseButton)>,
+}
+
+impl ClickTracker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn handle(&mut self, m: &Mouse) -> Option<Click> {
+        match m.kind {
+            MouseKind::Down(button) => {
+                self.down = Some((m.column, m.row, button));
+                None
+            }
+            MouseKind::Drag(_) | MouseKind::Moved => {
+                // Movement disqualifies the pending press from being a click.
+                self.down = None;
+                None
+            }
+            MouseKind::Up(button) => match self.down.take() {
+                Some((col, row, pressed))
+                    if pressed == button && col == m.column && row == m.row =>
+                {
+                    Some(Click {
+                        column: m.column,
+                        row: m.row,
+                        button,
+                    })
+                }
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+}

--- a/crates/tuika/src/tests.rs
+++ b/crates/tuika/src/tests.rs
@@ -12,11 +12,12 @@ use super::components::{
     Loader, Paragraph, ProgressBar, Scroll, ScrollState, SelectList, SelectOutcome, SelectState,
     Spinner, Text, Wrap, line_width, wrap_lines,
 };
-use super::event::{Event, EventFlow, Key, KeyCode, Mouse, MouseKind};
+use super::event::{Event, EventFlow, Key, KeyCode, Mouse, MouseButton, MouseKind};
 use super::focus::FocusRegistry;
 use super::geometry::{Padding, Size};
 use super::host::{self, Overlay};
 use super::layout::{Align, Dimension, Item, Justify, LayoutStyle, solve};
+use super::mouse::{ClickTracker, HitMap, SelectionState, highlight, selected_text};
 use super::native::{self, ProgressState};
 use super::overlay::{Anchor, Extent, OverlaySpec};
 use super::style::Theme;
@@ -435,6 +436,195 @@ fn wrap_component_renders_reflowed() {
     assert_eq!(row(&buf, 1), "cc");
 }
 
+// ---- mouse: selection, hit-testing, clicks -------------------------------
+
+fn down(col: u16, row: u16) -> Mouse {
+    Mouse::at(MouseKind::Down(MouseButton::Left), col, row)
+}
+fn drag(col: u16, row: u16) -> Mouse {
+    Mouse::at(MouseKind::Drag(MouseButton::Left), col, row)
+}
+fn up(col: u16, row: u16) -> Mouse {
+    Mouse::at(MouseKind::Up(MouseButton::Left), col, row)
+}
+
+#[test]
+fn selection_tracks_a_left_drag() {
+    let mut sel = SelectionState::new();
+    assert!(!sel.handle(&down(1, 0))); // fresh press: nothing to redraw yet
+    assert!(sel.handle(&drag(4, 0)));
+    assert!(sel.handle(&up(4, 0)));
+    let range = sel.range().expect("a drag selects");
+    assert_eq!(range.start, (1, 0));
+    assert_eq!(range.end, (4, 0));
+    assert!(sel.is_active());
+}
+
+#[test]
+fn selection_normalizes_a_backwards_drag() {
+    let mut sel = SelectionState::new();
+    sel.handle(&down(5, 1));
+    sel.handle(&drag(2, 0));
+    sel.handle(&up(2, 0));
+    let range = sel.range().expect("selection");
+    // Reading order: (col=2,row=0) comes before (col=5,row=1).
+    assert_eq!(range.start, (2, 0));
+    assert_eq!(range.end, (5, 1));
+}
+
+#[test]
+fn a_plain_click_leaves_no_selection() {
+    let mut sel = SelectionState::new();
+    sel.handle(&down(3, 0));
+    sel.handle(&up(3, 0)); // released on the same cell, no drag
+    assert!(sel.range().is_none());
+    assert!(!sel.is_active());
+}
+
+#[test]
+fn a_new_press_clears_the_previous_selection() {
+    let mut sel = SelectionState::new();
+    sel.handle(&down(0, 0));
+    sel.handle(&drag(3, 0));
+    sel.handle(&up(3, 0));
+    assert!(sel.range().is_some());
+    // Pressing again to start a new gesture must drop the old selection.
+    assert!(sel.handle(&down(1, 1)));
+    assert!(sel.range().is_none());
+}
+
+#[test]
+fn selected_text_reads_one_row() {
+    let theme = Theme::default();
+    let buf = crate::testing::render(&Text::raw("hello world"), 11, 1, &theme);
+    let mut sel = SelectionState::new();
+    sel.handle(&down(0, 0));
+    sel.handle(&drag(4, 0));
+    sel.handle(&up(4, 0));
+    let text = selected_text(&buf, buf.area, sel.range().unwrap());
+    assert_eq!(text, "hello");
+}
+
+#[test]
+fn selected_text_spans_rows_linearly() {
+    let theme = Theme::default();
+    let lines = vec![Line::from("hello"), Line::from("world")];
+    let buf = crate::testing::render(&Text::new(lines), 5, 2, &theme);
+    let mut sel = SelectionState::new();
+    // From the "llo" of row 0 through the "wo" of row 1.
+    sel.handle(&down(2, 0));
+    sel.handle(&drag(1, 1));
+    sel.handle(&up(1, 1));
+    let text = selected_text(&buf, buf.area, sel.range().unwrap());
+    assert_eq!(text, "llo\nwo");
+}
+
+#[test]
+fn selected_text_trims_trailing_blanks() {
+    let theme = Theme::default();
+    let buf = crate::testing::render(&Text::raw("hi"), 10, 1, &theme);
+    let mut sel = SelectionState::new();
+    sel.handle(&down(0, 0));
+    sel.handle(&drag(9, 0)); // drag well past the text into blank cells
+    sel.handle(&up(9, 0));
+    let text = selected_text(&buf, buf.area, sel.range().unwrap());
+    assert_eq!(text, "hi");
+}
+
+#[test]
+fn highlight_patches_selected_cells_only() {
+    use ratatui::style::Color;
+    let theme = Theme::default();
+    let mut buf = crate::testing::render(&Text::raw("hello"), 5, 1, &theme);
+    let area = buf.area;
+    let mut sel = SelectionState::new();
+    sel.handle(&down(0, 0));
+    sel.handle(&drag(2, 0));
+    sel.handle(&up(2, 0));
+    highlight(
+        &mut buf,
+        area,
+        sel.range().unwrap(),
+        Style::default().bg(Color::Blue),
+    );
+    // Selected cells (0..=2) get the highlight bg; the glyph survives.
+    for col in 0..=2 {
+        assert_eq!(
+            buf[(col, 0)].bg,
+            Color::Blue,
+            "cell {col} should be highlighted"
+        );
+    }
+    assert_eq!(
+        buf[(0, 0)].symbol(),
+        "h",
+        "highlight must not clobber the glyph"
+    );
+    // An unselected cell is untouched.
+    assert_ne!(buf[(4, 0)].bg, Color::Blue);
+}
+
+#[test]
+fn hit_map_last_region_wins_and_misses_return_none() {
+    let mut hits: HitMap<&str> = HitMap::new();
+    hits.push(Rect::new(0, 0, 10, 10), "background");
+    hits.push(Rect::new(2, 2, 3, 3), "panel"); // pushed later -> wins on overlap
+    hits.push(Rect::new(0, 0, 0, 0), "zero"); // zero-area never matches
+    assert_eq!(hits.hit(3, 3), Some(&"panel"));
+    assert_eq!(hits.hit(8, 8), Some(&"background"));
+    assert_eq!(hits.hit(50, 50), None);
+    // hit_event resolves an event's coordinates.
+    assert_eq!(hits.hit_event(&down(3, 3)), Some(&"panel"));
+}
+
+#[test]
+fn click_tracker_detects_a_click() {
+    let mut clicks = ClickTracker::new();
+    assert!(clicks.handle(&down(4, 2)).is_none()); // press alone is not a click
+    let click = clicks
+        .handle(&up(4, 2))
+        .expect("down+up on one cell is a click");
+    assert_eq!(
+        (click.column, click.row, click.button),
+        (4, 2, MouseButton::Left)
+    );
+}
+
+#[test]
+fn click_tracker_drag_cancels_the_click() {
+    let mut clicks = ClickTracker::new();
+    clicks.handle(&down(4, 2));
+    clicks.handle(&drag(6, 2)); // moved -> this is a selection, not a click
+    assert!(clicks.handle(&up(6, 2)).is_none());
+}
+
+#[test]
+fn click_tracker_release_on_another_cell_is_not_a_click() {
+    let mut clicks = ClickTracker::new();
+    clicks.handle(&down(4, 2));
+    assert!(clicks.handle(&up(9, 9)).is_none());
+}
+
+#[test]
+fn translate_maps_button_modifiers_and_drag() {
+    use crossterm::event::{
+        Event as CtEvent, KeyModifiers, MouseButton as CtButton, MouseEvent, MouseEventKind,
+    };
+    let ct = CtEvent::Mouse(MouseEvent {
+        kind: MouseEventKind::Down(CtButton::Right),
+        column: 7,
+        row: 3,
+        modifiers: KeyModifiers::SHIFT | KeyModifiers::CONTROL,
+    });
+    let Some(Event::Mouse(m)) = host::translate_event(ct) else {
+        panic!("expected a mouse event");
+    };
+    assert_eq!(m.kind, MouseKind::Down(MouseButton::Right));
+    assert_eq!((m.column, m.row), (7, 3));
+    assert!(m.shift && m.ctrl && !m.alt);
+    assert!(!m.plain());
+}
+
 // ---- scroll state --------------------------------------------------------
 
 #[test]
@@ -446,11 +636,7 @@ fn scroll_sticks_to_bottom_until_scrolled_up() {
     assert!(s.is_stuck_to_bottom());
 
     // Wheel up unsticks and moves up by 3.
-    let up = Event::Mouse(Mouse {
-        kind: MouseKind::ScrollUp,
-        column: 0,
-        row: 0,
-    });
+    let up = Event::Mouse(Mouse::at(MouseKind::ScrollUp, 0, 0));
     assert_eq!(s.handle(&up, 100, 10), EventFlow::Consumed);
     assert!(!s.is_stuck_to_bottom());
     assert_eq!(s.offset(), 87);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1925,11 +1925,7 @@ impl App {
             _ => return false,
         };
         let (content_h, viewport_h) = self.scroll_metrics;
-        let event = tuika::Event::Mouse(tuika::Mouse {
-            kind: tuika_kind,
-            column: 0,
-            row: 0,
-        });
+        let event = tuika::Event::Mouse(tuika::Mouse::at(tuika_kind, 0, 0));
         self.scroll.handle(&event, content_h, viewport_h).consumed()
     }
 


### PR DESCRIPTION
## What changed

Answers "does `--fullscreen` support mouse selection?" — it didn't (mouse capture suppresses the terminal's own selection, and tuika had nothing to replace it). This adds the **mouse foundation a best-in-class TUI needs**, entirely in tuika and fully unit-tested in-memory. Benchmarked against how the strong terminal apps do it — selection computed over the rendered cell grid, clipboard via **OSC 52** ([go-osc52](https://pkg.go.dev/github.com/aymanbagabas/go-osc52/v2), [opencode](https://github.com/anomalyco/opencode/issues/19982), [tmux passthrough](https://github.com/tmux/tmux/issues/3192)).

**Enriched event model** (`event.rs`) — `MouseKind` gains buttons + drag: `Down/Up/Drag(MouseButton)`, `Moved`, `ScrollUp/Down/Left/Right`; every `Mouse` reports `shift/ctrl/alt` (+ `plain()` and a `Mouse::at` ctor). `host.rs` maps crossterm buttons/modifiers.

**`mouse` module**
- **`SelectionState`** — a left `Down → Drag → Up` gesture becomes a `SelectionRange`; a plain click selects nothing, a new press clears the old selection.
- **`selected_text`** — linear/stream extraction from the rendered `ratatui::Buffer` (tail of the first row, whole middle rows, head of the last), trailing blanks trimmed, wide glyphs intact. **`highlight`** patches the selected cells (glyph + fg survive).
- **`HitMap<T>`** — region→value click hit-testing, last-pushed wins (children/overlays over parents). **`ClickTracker`** — a same-cell `Down`/`Up` is a `Click`; an intervening drag cancels it.

**`clipboard` module** — OSC 52 copy (`osc52` encoder + `write_clipboard`) with an **inline base64 encoder so tuika stays dependency-free**. Size-capped at 74,994 bytes (refuses rather than truncates); tmux `allow-passthrough` caveat documented, mirroring OSC 8.

**Touch** needs no separate API — emulators deliver taps/swipes as mouse events, so touch flows through this same path (documented, not faked).

## Testing

**17 new tests, 100 total in tuika, `clippy --all-targets -D warnings` clean.** Highlights (you asked specifically about clicks):

```
selection_tracks_a_left_drag / normalizes_a_backwards_drag ... ok
a_plain_click_leaves_no_selection ... ok
a_new_press_clears_the_previous_selection ... ok
selected_text_reads_one_row / spans_rows_linearly / trims_trailing_blanks ... ok
highlight_patches_selected_cells_only ... ok
hit_map_last_region_wins_and_misses_return_none ... ok
click_tracker_detects_a_click ... ok
click_tracker_drag_cancels_the_click ... ok
click_tracker_release_on_another_cell_is_not_a_click ... ok
translate_maps_button_modifiers_and_drag ... ok
base64_matches_known_vectors (RFC 4648) / osc52_wraps_base64 / refuses_oversized ... ok
```

`cargo build --bin yolop` green — the one consumer (`handle_fullscreen_scroll`) updated to the new `Mouse` shape.

## Why in tuika (not yolop)

It's a reusable terminal-UI capability with zero yolop knowledge — same home as the OSC 8 hyperlink and OSC 9;4 progress work. yolop (and any consumer) gets selection/clicks/clipboard for free.

## Risk

- **Low.** Additive module + a contained breaking change to tuika's pre-1.0 `Mouse`/`MouseKind` (one in-tree consumer, updated). No behavior change to yolop yet.

## Follow-up (needs a real terminal, like the hyperlinks work)

Wire selection into yolop's full-screen transcript — left-drag selects, `highlight` renders it, release copies via OSC 52 — plus a runnable `examples/mouse.rs`, verified across Ghostty / iTerm2 / WezTerm / Kitty / tmux. That's the manual-matrix half; this PR lands the verified foundation it builds on.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; single consumer updated)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LksbgmgJfiGmNXXGZphgW6)_