### PR TITLE
feat(tui): rebuild the full-screen renderer on the tuika view tree

### DIFF
--- a/crates/tuika/src/lib.rs
+++ b/crates/tuika/src/lib.rs
@@ -47,6 +47,7 @@ pub mod live;
 pub mod mouse;
 pub mod native;
 pub mod overlay;
+pub mod probe;
 pub mod ratatui_view;
 pub mod runner;
 pub mod style;
@@ -74,6 +75,7 @@ pub use mouse::{
 };
 pub use native::{ProgressState, TerminalProgress};
 pub use overlay::{Anchor, Extent, OverlaySpec};
+pub use probe::{Probe, RectProbe};
 pub use ratatui_view::RatatuiView;
 pub use runner::{Runner, RunnerConfig};
 pub use style::{BorderStyle, Theme};

--- a/crates/tuika/src/probe.rs
+++ b/crates/tuika/src/probe.rs
@@ -1,0 +1,87 @@
+//! Reading laid-out rects back out of the view tree.
+//!
+//! tuika's solver assigns every view a screen [`Rect`], but keeps it internal —
+//! views render into the rect they're handed and return nothing. A host that
+//! builds an app UI still needs some of those rects *after* the layout runs: to
+//! place the terminal cursor inside a composer, to bound a mouse selection to
+//! the transcript, or to register a clickable region. [`RectProbe`] closes that
+//! gap: wrap a view in [`Probe`] and the rect it was painted into is recorded
+//! into a shared handle the host can read once the frame is painted.
+//!
+//! ```ignore
+//! let input = RectProbe::new();
+//! let root = view! {
+//!     col {
+//!         grow(1) { node(transcript) }
+//!         fixed(3) { node(input.wrap(composer)) }   // reserve + probe the input
+//!     }
+//! };
+//! paint(frame.buffer_mut(), area, &theme, root.as_ref(), &[]);
+//! // Now `input.rect()` is where the composer landed — place the cursor in it.
+//! ```
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use ratatui::layout::Rect;
+
+use crate::geometry::Size;
+use crate::surface::Surface;
+use crate::view::{Element, RenderCtx, View, element};
+
+/// A shared handle that receives the screen [`Rect`] tuika assigned to a
+/// [`Probe`]-wrapped view during the last paint. Cheap to clone (shared cell);
+/// reads back [`Rect::ZERO`] until the probed view has been painted at least
+/// once, and updates every frame.
+#[derive(Clone, Debug, Default)]
+pub struct RectProbe(Rc<Cell<Rect>>);
+
+impl RectProbe {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The rect the probed view was last painted into ([`Rect::ZERO`] if it has
+    /// not been painted, e.g. it was laid out with zero size or clipped away).
+    pub fn rect(&self) -> Rect {
+        self.0.get()
+    }
+
+    /// Wrap `view` so its painted rect is reported here. Shorthand for
+    /// [`Probe::new`].
+    pub fn wrap(&self, view: Element) -> Element {
+        element(Probe::new(view, self))
+    }
+
+    fn set(&self, rect: Rect) {
+        self.0.set(rect);
+    }
+}
+
+/// A view that records the area it is painted into via a [`RectProbe`], then
+/// renders its inner view unchanged. Layout-transparent: it measures and draws
+/// exactly as the wrapped view does.
+pub struct Probe {
+    inner: Element,
+    probe: RectProbe,
+}
+
+impl Probe {
+    pub fn new(inner: Element, probe: &RectProbe) -> Self {
+        Self {
+            inner,
+            probe: probe.clone(),
+        }
+    }
+}
+
+impl View for Probe {
+    fn measure(&self, available: Size) -> Size {
+        self.inner.measure(available)
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+        self.probe.set(area);
+        self.inner.render(area, surface, ctx);
+    }
+}

--- a/crates/tuika/src/tests.rs
+++ b/crates/tuika/src/tests.rs
@@ -625,6 +625,21 @@ fn translate_maps_button_modifiers_and_drag() {
     assert!(!m.plain());
 }
 
+// ---- probe: reading laid-out rects back out ------------------------------
+
+#[test]
+fn probe_reports_the_rect_a_view_was_painted_into() {
+    let probe = crate::RectProbe::new();
+    assert_eq!(probe.rect(), Rect::ZERO, "an unpainted probe reads ZERO");
+    let root = crate::Flex::column()
+        .fixed(1, element(Text::raw("header")))
+        .grow(1, probe.wrap(element(Text::raw("body"))));
+    let theme = Theme::default();
+    let _ = crate::testing::render(&root, 10, 5, &theme);
+    // The grown body lands below the 1-row header and fills the rest.
+    assert_eq!(probe.rect(), Rect::new(0, 1, 10, 4));
+}
+
 // ---- scroll state --------------------------------------------------------
 
 #[test]

--- a/src/app/fullscreen.rs
+++ b/src/app/fullscreen.rs
@@ -1,14 +1,151 @@
-//! Alternate-screen renderer.
+//! Full-screen renderer, composed with the `tuika` view tree.
 //!
-//! Fullscreen mode deliberately shares the regular presentation renderer so
-//! both modes keep the same transcript, composer, colors, layout, and status
-//! bar. The mode remains responsible for alternate-screen lifecycle and
-//! fullscreen scrolling in `app::run_tui`.
+//! Where the inline renderer ([`super::render::draw_shared`]) lays out the
+//! chrome with a hand-rolled ratatui split, the full-screen mode builds the
+//! same vertical composition — transcript, the blue message separator, the
+//! composer, the gold status separator, the session status — as a `tuika`
+//! `Flex` column and paints it through `tuika::paint`. Content is the *same*
+//! styled lines the inline renderer uses (from `super::render`), so the design
+//! (colors, separators, status) cannot drift.
+//!
+//! Two regions are drawn by the shared ratatui renderers into rects `tuika`
+//! reserved for them (via [`tuika::RectProbe`]): the composer, which is the
+//! `ratatui-textarea` widget plus the real terminal cursor, and the streaming
+//! preview. Full-screen mouse text selection (see [`super::App`]) is applied
+//! over the transcript rect the same probe reports.
 
 use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::Line;
 
-use super::App;
+use tuika::{Element, Flex, Padding, RectProbe, Spacer, Text, element};
+
+use super::render;
+use super::{ACCENT_BLUE, ACCENT_GOLD, App};
 
 pub(crate) fn draw(f: &mut Frame, app: &mut App) {
-    super::render::draw_shared(f, app);
+    let area = f.area();
+
+    // Overlays own the whole viewport; reuse the shared sheet renderers.
+    if app.pending_ask.is_some() {
+        render::draw_ask_overlay(f, area, app);
+        return;
+    }
+    if app.setup.is_some() {
+        render::draw_setup_overlay(f, area, app);
+        return;
+    }
+    if app.background_panel.is_some() {
+        render::draw_background_panel(f, area, app);
+        return;
+    }
+    if area.width < 4 || area.height == 0 {
+        return;
+    }
+
+    let state = app.view_state();
+    let input_width = area.width.saturating_sub(2);
+    let desired_input_height = app.input_height(input_width);
+    let status_rows = state.status_row_count();
+    let preview_visible = render::chrome_preview_visible(&state);
+    let (chrome_height, input_height) = render::chrome_dimensions(
+        area.height,
+        desired_input_height,
+        status_rows,
+        preview_visible,
+    );
+    let preview_height = u16::from(input_height == 1 && preview_visible);
+    let status_sep_height = u16::from(input_height < 3);
+    let transcript_height = area.height.saturating_sub(chrome_height);
+
+    // Content as styled lines — the exact builders the inline renderer uses.
+    let inner_w = area.width.saturating_sub(2) as usize;
+    let transcript =
+        render::recent_transcript_lines(app, inner_w, transcript_height.max(1) as usize);
+    let message_separator = render::separator_line(
+        render::message_separator_title(&state),
+        area.width,
+        Style::default().fg(ACCENT_BLUE),
+    );
+    let status_separator =
+        render::separator_line(Line::from(""), area.width, Style::default().fg(ACCENT_GOLD));
+    let status_lines = render::session_status_lines(&state);
+
+    // Probes recover the rects tuika assigns to regions the shared ratatui
+    // renderers finish drawing (composer, preview) and the transcript.
+    let transcript_probe = RectProbe::new();
+    let preview_probe = RectProbe::new();
+    let input_probe = RectProbe::new();
+
+    let mut col = Flex::column().grow(1, transcript_view(transcript, &transcript_probe));
+    if preview_height > 0 {
+        col = col.fixed(preview_height, preview_probe.wrap(element(Spacer)));
+    }
+    col = col.fixed(1, element(Text::new(vec![message_separator])));
+    col = col.fixed(input_height, input_probe.wrap(element(Spacer)));
+    if status_sep_height > 0 {
+        col = col.fixed(
+            status_sep_height,
+            element(Text::new(vec![status_separator])),
+        );
+    }
+    if status_rows > 0 {
+        col = col.fixed(status_rows, element(Text::new(status_lines)));
+    }
+    let root = element(col);
+
+    // Transparent background so the styled lines' own colors show through.
+    let theme = tuika::Theme {
+        background: Color::Reset,
+        ..tuika::Theme::default()
+    };
+    tuika::paint(f.buffer_mut(), area, &theme, root.as_ref(), &[]);
+
+    // Mouse text selection over the transcript. Its selectable inner rect is the
+    // transcript region inset one column (matching `transcript_view`'s padding).
+    let t = transcript_probe.rect();
+    let selection = Rect {
+        x: t.x.saturating_add(1),
+        y: t.y,
+        width: t.width.saturating_sub(2),
+        height: t.height,
+    };
+    app.set_selection_area(selection);
+    if let Some(range) = app.selection_range() {
+        if app.take_pending_copy() {
+            let text = tuika::selected_text(f.buffer_mut(), selection, range);
+            if !text.is_empty() {
+                let _ = tuika::write_clipboard(&mut std::io::stdout(), &text);
+            }
+        }
+        tuika::highlight(
+            f.buffer_mut(),
+            selection,
+            range,
+            Style::default().add_modifier(Modifier::REVERSED),
+        );
+    }
+
+    // Ratatui-native regions, into the rects tuika reserved for them.
+    if preview_height > 0 {
+        render::draw_preview_slot(f, preview_probe.rect(), &state);
+    }
+    render::draw_input(f, input_probe.rect(), app);
+}
+
+/// The transcript: its styled lines bottom-aligned within a one-column inset,
+/// probed so the host can bound mouse selection to it.
+fn transcript_view(lines: Vec<Line<'static>>, probe: &RectProbe) -> Element {
+    let height = (lines.len() as u16).max(1);
+    let inner = Flex::column()
+        .padding(Padding {
+            left: 1,
+            right: 1,
+            top: 0,
+            bottom: 0,
+        })
+        .grow(1, element(Spacer))
+        .fixed(height, element(Text::new(lines)));
+    probe.wrap(element(inner))
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4292,15 +4292,59 @@ mod tests {
         test.app.input.insert_str("draft reply");
 
         test.app.set_render_mode(RenderMode::Inline);
-        let regular = render_app_lines(&mut test.app, 60, 20);
+        let regular = render_app_lines(&mut test.app, 60, 20).join("\n");
         test.app.set_render_mode(RenderMode::Fullscreen);
-        let fullscreen = render_app_lines(&mut test.app, 60, 20);
-        let joined = fullscreen.join("\n");
+        let fullscreen = render_app_lines(&mut test.app, 60, 20).join("\n");
 
-        assert_eq!(fullscreen, regular);
-        assert!(joined.contains("hello from user"));
-        assert!(joined.contains("draft reply"));
-        assert!(joined.contains("llmsim"));
+        // Full-screen is composed with tuika and is *visually equivalent* to the
+        // inline renderer (not necessarily byte-identical): the same transcript,
+        // separators, composer prompt, and status content appear in both.
+        for needle in ["hello from user", "draft reply", "llmsim", "───", "> "] {
+            assert!(
+                fullscreen.contains(needle),
+                "full-screen should render {needle:?}: {fullscreen}"
+            );
+            assert!(
+                regular.contains(needle),
+                "inline should render {needle:?}: {regular}"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fullscreen_renders_blue_and_gold_separators() {
+        use ratatui::backend::TestBackend;
+        let mut test = app_with_llmsim().await;
+        test.app.setup = None;
+        test.app.set_render_mode(RenderMode::Fullscreen);
+        test.app.push_user("hello".to_string());
+
+        let backend = TestBackend::new(60, 20);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal.draw(|f| draw(f, &mut test.app)).expect("draw");
+        let buffer = terminal.backend().buffer();
+
+        // tuika paints the message separator in blue and the status separator in
+        // gold — the design's "blue/gold line". Find a rule cell of each color.
+        let mut blue_rule = false;
+        let mut gold_rule = false;
+        for y in 0..buffer.area.height {
+            for x in 0..buffer.area.width {
+                let cell = &buffer[(x, y)];
+                if cell.symbol() == "─" {
+                    blue_rule |= cell.fg == ACCENT_BLUE;
+                    gold_rule |= cell.fg == ACCENT_GOLD;
+                }
+            }
+        }
+        assert!(
+            blue_rule,
+            "message separator should render in blue via tuika"
+        );
+        assert!(
+            gold_rule,
+            "status separator should render in gold via tuika"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -4473,19 +4517,22 @@ mod tests {
 
             let (fullscreen, regular) = render_regular_and_fullscreen(&mut test.app, 60, 20);
 
-            assert_eq!(
-                fullscreen, regular,
-                "full-screen must match regular presentation for state: {name}"
-            );
+            // Visual equivalence (tuika full-screen vs inline): both render a
+            // non-blank frame and, where checked, the same key content.
             assert!(
                 fullscreen.iter().any(|row| !row.is_empty()),
-                "state {name} should render a non-blank frame (parity must not be vacuous)"
+                "state {name} should render a non-blank frame"
             );
             if !needle.is_empty() {
-                let joined = fullscreen.join("\n");
+                let fs = fullscreen.join("\n");
+                let reg = regular.join("\n");
                 assert!(
-                    joined.contains(needle),
-                    "state {name} should render {needle:?}: {joined}"
+                    fs.contains(needle),
+                    "full-screen state {name} should render {needle:?}: {fs}"
+                );
+                assert!(
+                    reg.contains(needle),
+                    "inline state {name} should render {needle:?}: {reg}"
                 );
             }
         }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -76,33 +76,6 @@ pub(super) fn draw_shared(f: &mut ratatui::Frame, app: &mut App) {
     draw_recent_transcript(f, layout.transcript, app);
     draw_chrome_layout(f, layout.chrome, &state);
     draw_input(f, layout.chrome.input, app);
-
-    // Full-screen mouse selection: record the transcript's inner rect (so the
-    // event handler can bound drags to it), copy a just-released selection off
-    // this freshly rendered frame, and paint the highlight over it.
-    if app.render_mode.is_fullscreen() {
-        let inner = Rect {
-            x: layout.transcript.x.saturating_add(1),
-            y: layout.transcript.y,
-            width: layout.transcript.width.saturating_sub(2),
-            height: layout.transcript.height,
-        };
-        app.set_selection_area(inner);
-        if let Some(range) = app.selection_range() {
-            if app.take_pending_copy() {
-                let text = tuika::selected_text(f.buffer_mut(), inner, range);
-                if !text.is_empty() {
-                    let _ = tuika::write_clipboard(&mut std::io::stdout(), &text);
-                }
-            }
-            tuika::highlight(
-                f.buffer_mut(),
-                inner,
-                range,
-                Style::default().add_modifier(Modifier::REVERSED),
-            );
-        }
-    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -390,14 +363,21 @@ pub(crate) fn chrome_preview_visible(state: &ViewState) -> bool {
         || !state.command_suggestions.is_empty()
 }
 
-pub(crate) fn draw_chrome_layout(f: &mut ratatui::Frame, layout: ChromeLayout, state: &ViewState) {
+/// The preview row multiplexes (in priority order) the Ctrl+R reverse-search
+/// prompt, the `@`/command suggestions, and the streaming preview. Shared by the
+/// inline chrome and the full-screen renderer so both show the same popups.
+pub(crate) fn draw_preview_slot(f: &mut ratatui::Frame, area: Rect, state: &ViewState) {
     if let Some(search) = &state.history_search {
-        draw_history_search(f, layout.preview, search);
+        draw_history_search(f, area, search);
     } else if state.command_suggestions.is_empty() {
-        draw_stream_preview(f, layout.preview, state);
+        draw_stream_preview(f, area, state);
     } else {
-        draw_suggestions(f, layout.preview, &state.command_suggestions);
+        draw_suggestions(f, area, &state.command_suggestions);
     }
+}
+
+pub(crate) fn draw_chrome_layout(f: &mut ratatui::Frame, layout: ChromeLayout, state: &ViewState) {
+    draw_preview_slot(f, layout.preview, state);
     draw_message_separator(f, layout.message_separator, state);
     draw_status_separator(f, layout.status_separator);
     draw_session_status(f, layout.session_status, state);
@@ -1936,14 +1916,17 @@ pub(crate) fn draw_status_separator(f: &mut ratatui::Frame, area: Rect) {
     draw_separator(f, area, Line::from(""), Style::default().fg(ACCENT_GOLD));
 }
 
-pub(crate) fn draw_session_status(f: &mut ratatui::Frame, area: Rect, state: &ViewState) {
-    let lines = state
+pub(crate) fn session_status_lines(state: &ViewState) -> Vec<Line<'static>> {
+    state
         .presentation
         .status_lines()
         .iter()
         .map(status_line)
-        .collect::<Vec<_>>();
-    f.render_widget(Paragraph::new(lines), area);
+        .collect()
+}
+
+pub(crate) fn draw_session_status(f: &mut ratatui::Frame, area: Rect, state: &ViewState) {
+    f.render_widget(Paragraph::new(session_status_lines(state)), area);
 }
 
 fn status_line(line: &StatusLine) -> Line<'static> {


### PR DESCRIPTION
## What changed

`--fullscreen` is now **composed with tuika** instead of delegating to the inline ratatui renderer. The vertical stack — transcript, the **blue** message separator, composer, the **gold** status separator, session status — is a `tuika::Flex` column painted through `tuika::paint`. The content is the *same* styled lines the inline renderer builds (`recent_transcript_lines`, `separator_line` + `message_separator_title`, `session_status_lines`), so the design (colors, the blue/gold `───` rules, the composer, status) **cannot drift** from the regular UI.

### New tuika primitive: `RectProbe` / `Probe`
The extensibility gap this needed: the solver keeps assigned rects internal, but a host needs some of them back — to place the terminal cursor in the composer, bound a mouse selection to the transcript, or hit-test a region. Wrap a view in `Probe` and it records the rect it was painted into (`crates/tuika/src/probe.rs`, tested). The full-screen renderer uses it to reserve the composer + preview rows and to bound transcript selection.

### How the pieces map
- Transcript, separators, status → tuika `Text` / `Flex` (bottom-aligned, one-column inset).
- Composer (the `ratatui-textarea` widget + real cursor) and the preview/`@`-suggestion/`Ctrl+R` popup → drawn by the shared ratatui renderers into `Probe`-reserved rects (the textarea is inherently a ratatui widget — the intended interop path). Extracted `render::draw_preview_slot` so both renderers show the same popups.
- Full-screen mouse selection moved out of the now-inline-only `draw_shared` into `fullscreen`.

## Review artifact

A colorful VHS recording of the rebuilt UI (llmsim) is attached in the chat: blue `you` / gold `agent`, the blue message separator, the `> ` composer, and the status bar — visually equivalent to the inline design.

## Testing

- tuika: `probe_reports_the_rect_a_view_was_painted_into` (+ full suite green, clippy clean).
- yolop: **7 full-screen tests pass**, including a new `fullscreen_renders_blue_and_gold_separators` asserting tuika paints the message separator in `ACCENT_BLUE` and the status separator in `ACCENT_GOLD`, plus the `@`-suggestion / `Ctrl+R` popups and mouse-drag selection. The `fullscreen == inline` byte-equality tests are relaxed to **content-equivalence** (per the agreed visual-equivalence goal). `fmt` + `clippy` clean.

## Risk

- **Medium.** Replaces the full-screen render path (inline mode untouched). Overlays (setup/ask/background) still use the shared sheet renderers. Kept behind the existing `--fullscreen` flag (experimental). Recommend a manual look across terminals before making it the default.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (inline path unchanged; `--fullscreen` experimental)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LksbgmgJfiGmNXXGZphgW6)_