### PR TITLE
feat(tuika): render emoji as grapheme clusters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6613,6 +6613,7 @@ dependencies = [
  "proptest",
  "ratatui",
  "textwrap",
+ "unicode-segmentation",
  "unicode-width 0.2.2",
 ]
 

--- a/crates/tuika/Cargo.toml
+++ b/crates/tuika/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["command-line-interface"]
 ratatui = "0.30.2"
 crossterm = "0.29"
 textwrap = "0.16"
+unicode-segmentation = "1"
 unicode-width = "0.2"
 
 [dev-dependencies]

--- a/crates/tuika/README.md
+++ b/crates/tuika/README.md
@@ -6,8 +6,8 @@ letting `ratatui` keep ownership of the cell buffer and its diff against the
 terminal.
 
 It is a published, self-contained crate that depends only on `ratatui`,
-`crossterm`, `textwrap`, and `unicode-width`. It knows nothing about yolop;
-yolop is one production consumer.
+`crossterm`, `textwrap`, `unicode-segmentation`, and `unicode-width`. It knows
+nothing about yolop; yolop is one production consumer.
 
 ## Model
 

--- a/crates/tuika/src/components/key_hints.rs
+++ b/crates/tuika/src/components/key_hints.rs
@@ -2,8 +2,8 @@
 
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Style};
-use unicode_width::UnicodeWidthStr;
 
+use crate::width::str_cols;
 use crate::{RenderCtx, Size, Surface, View};
 
 /// A one-line sequence of styled key and action labels.
@@ -32,7 +32,7 @@ impl View for KeyHints {
         let width = self
             .hints
             .iter()
-            .map(|(key, label)| key.width() + label.width() + 3)
+            .map(|(key, label)| (str_cols(key) + str_cols(label)) as usize + 3)
             .sum::<usize>()
             .min(available.width as usize) as u16;
         Size::new(width, u16::from(available.height > 0))

--- a/crates/tuika/src/components/status_bar.rs
+++ b/crates/tuika/src/components/status_bar.rs
@@ -49,10 +49,9 @@ impl Default for StatusBar {
 }
 
 fn spans_width(spans: &[Span]) -> u16 {
-    use unicode_width::UnicodeWidthStr;
     spans
         .iter()
-        .map(|s| UnicodeWidthStr::width(s.content.as_ref()) as u16)
+        .map(|s| crate::width::str_cols(s.content.as_ref()))
         .fold(0, u16::saturating_add)
 }
 

--- a/crates/tuika/src/components/text.rs
+++ b/crates/tuika/src/components/text.rs
@@ -9,11 +9,12 @@
 use ratatui::layout::Rect;
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+use unicode_segmentation::UnicodeSegmentation;
 
 use crate::geometry::Size;
 use crate::surface::Surface;
 use crate::view::{RenderCtx, View};
+use crate::width::{grapheme_cols, str_cols};
 
 /// Draw pre-styled `lines` top-down from `area`'s origin, clipping to `area`.
 /// Shared by [`Text`] and [`Wrap`].
@@ -37,7 +38,7 @@ fn draw_lines(lines: &[Line<'static>], area: Rect, surface: &mut Surface) {
 pub fn line_width(line: &Line) -> u16 {
     line.spans
         .iter()
-        .map(|s| UnicodeWidthStr::width(s.content.as_ref()) as u16)
+        .map(|s| str_cols(s.content.as_ref()))
         .fold(0, u16::saturating_add)
 }
 
@@ -105,7 +106,7 @@ impl View for Paragraph {
         let lines = self.wrap(available.width);
         let width = lines
             .iter()
-            .map(|l| UnicodeWidthStr::width(l.as_str()) as u16)
+            .map(|l| str_cols(l.as_str()))
             .max()
             .unwrap_or(0);
         Size::new(width, lines.len() as u16)
@@ -122,9 +123,9 @@ impl View for Paragraph {
     }
 }
 
-/// Display columns of a single char (0 for zero-width).
-fn char_cols(ch: char) -> u16 {
-    UnicodeWidthChar::width(ch).unwrap_or(0) as u16
+/// Whether a grapheme cluster is a break opportunity (all-whitespace).
+fn is_break(cluster: &str) -> bool {
+    cluster.chars().all(char::is_whitespace)
 }
 
 /// Word-wrap pre-styled `lines` to `width` columns, preserving each span's
@@ -150,27 +151,29 @@ pub fn wrap_lines(lines: &[Line<'static>], width: u16) -> Vec<Line<'static>> {
 }
 
 fn wrap_one(line: &Line<'static>, width: u16, out: &mut Vec<Line<'static>>) {
-    let cells: Vec<(char, Style)> = line
+    // Cells are grapheme clusters, not `char`s, so a multi-scalar emoji stays
+    // intact across the reflow instead of being split mid-cluster.
+    let cells: Vec<(&str, Style)> = line
         .spans
         .iter()
-        .flat_map(|s| s.content.chars().map(move |c| (c, s.style)))
+        .flat_map(|s| s.content.graphemes(true).map(move |g| (g, s.style)))
         .collect();
     let before = out.len();
-    let mut cur: Vec<(char, Style)> = Vec::new();
+    let mut cur: Vec<(&str, Style)> = Vec::new();
     let mut cur_w = 0u16;
     let mut i = 0;
     let n = cells.len();
     while i < n {
         // Collapse a run of whitespace into a single break opportunity.
-        if cells[i].0.is_whitespace() {
+        if is_break(cells[i].0) {
             i += 1;
             continue;
         }
         // Gather one word (a maximal run of non-whitespace).
         let start = i;
         let mut word_w = 0u16;
-        while i < n && !cells[i].0.is_whitespace() {
-            word_w = word_w.saturating_add(char_cols(cells[i].0));
+        while i < n && !is_break(cells[i].0) {
+            word_w = word_w.saturating_add(grapheme_cols(cells[i].0));
             i += 1;
         }
         let word = &cells[start..i];
@@ -181,7 +184,7 @@ fn wrap_one(line: &Line<'static>, width: u16, out: &mut Vec<Line<'static>>) {
             // stays continuous across the join.
             if sep == 1 {
                 let prev = cur.last().map(|c| c.1).unwrap_or_default();
-                cur.push((' ', prev));
+                cur.push((" ", prev));
                 cur_w += 1;
             }
             cur.extend_from_slice(word);
@@ -201,14 +204,14 @@ fn wrap_one(line: &Line<'static>, width: u16, out: &mut Vec<Line<'static>>) {
                 cur.clear();
                 cur_w = 0;
             }
-            for &(ch, st) in word {
-                let w = char_cols(ch);
+            for &(g, st) in word {
+                let w = grapheme_cols(g);
                 if cur_w + w > width && !cur.is_empty() {
                     out.push(coalesce(&cur));
                     cur.clear();
                     cur_w = 0;
                 }
-                cur.push((ch, st));
+                cur.push((g, st));
                 cur_w += w;
             }
         }
@@ -222,21 +225,21 @@ fn wrap_one(line: &Line<'static>, width: u16, out: &mut Vec<Line<'static>>) {
     }
 }
 
-/// Merge a run of styled cells into a [`Line`], coalescing adjacent cells with
-/// equal style into one [`Span`].
-fn coalesce(cells: &[(char, Style)]) -> Line<'static> {
+/// Merge a run of styled grapheme cells into a [`Line`], coalescing adjacent
+/// cells with equal style into one [`Span`].
+fn coalesce(cells: &[(&str, Style)]) -> Line<'static> {
     let mut spans: Vec<Span<'static>> = Vec::new();
     let mut buf = String::new();
     let mut run: Option<Style> = None;
-    for &(ch, st) in cells {
+    for &(g, st) in cells {
         match run {
-            Some(s) if s == st => buf.push(ch),
+            Some(s) if s == st => buf.push_str(g),
             _ => {
                 if let Some(s) = run.take() {
                     spans.push(Span::styled(std::mem::take(&mut buf), s));
                 }
                 run = Some(st);
-                buf.push(ch);
+                buf.push_str(g);
             }
         }
     }

--- a/crates/tuika/src/lib.rs
+++ b/crates/tuika/src/lib.rs
@@ -5,8 +5,8 @@
 //! solver, anchored overlays, focus/input-ownership, an alternate-screen host,
 //! and a set of components (text, boxes, scroll, select, spinner, progress) —
 //! while letting ratatui keep ownership of the cell buffer and its diff against
-//! the terminal. It depends only on `ratatui`, `crossterm`, `textwrap`, and
-//! `unicode-width`.
+//! the terminal. It depends only on `ratatui`, `crossterm`, `textwrap`,
+//! `unicode-segmentation`, and `unicode-width`.
 //!
 //! It was extracted from the [yolop](https://github.com/everruns/yolop) coding
 //! agent, whose full-screen renderer is built on it, but it knows nothing about
@@ -53,6 +53,7 @@ pub mod style;
 pub mod surface;
 pub mod testing;
 pub mod view;
+pub mod width;
 
 // Curated top-level re-exports so callers write `tuika::Flex`, `tuika::Theme`,
 // etc. for the common surface without deep paths.
@@ -79,6 +80,7 @@ pub use runner::{Runner, RunnerConfig};
 pub use style::{BorderStyle, Theme};
 pub use surface::Surface;
 pub use view::{Element, RenderCtx, View, element};
+pub use width::{grapheme_cols, str_cols};
 
 #[cfg(test)]
 mod proptests;

--- a/crates/tuika/src/surface.rs
+++ b/crates/tuika/src/surface.rs
@@ -10,9 +10,10 @@
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::Style;
-use unicode_width::UnicodeWidthChar;
+use unicode_segmentation::UnicodeSegmentation;
 
 use super::style::BorderGlyphs;
+use super::width::grapheme_cols;
 
 /// A clipped view into the frame buffer for one component.
 pub struct Surface<'a> {
@@ -118,22 +119,37 @@ impl<'a> Surface<'a> {
         }
     }
 
-    /// Draw `text` starting at (`x`, `y`), advancing by each glyph's display
-    /// width and stopping at the clip's right edge. Returns the exclusive end
-    /// column actually written.
+    /// Set a cell to a whole grapheme cluster (may be several scalars, e.g. an
+    /// emoji ZWJ sequence) and style, if it is inside the clip.
+    fn set_cluster(&mut self, x: u16, y: u16, cluster: &str, style: Style) {
+        if self.contains(x, y) {
+            let cell = &mut self.buffer[(x, y)];
+            cell.set_symbol(cluster);
+            cell.set_style(style);
+        }
+    }
+
+    /// Draw `text` starting at (`x`, `y`), advancing by each grapheme cluster's
+    /// display width and stopping at the clip's right edge. Returns the
+    /// exclusive end column actually written.
+    ///
+    /// Iteration is per grapheme cluster, not per `char`, so a multi-scalar
+    /// emoji (ZWJ family, flag, skin-tone, or a VS16-promoted glyph) lands in a
+    /// single cell with the correct width instead of being scattered across
+    /// several — see [`crate::width`].
     pub fn set_string(&mut self, x: u16, y: u16, text: &str, style: Style) -> u16 {
         let mut col = x;
-        for ch in text.chars() {
-            let w = UnicodeWidthChar::width(ch).unwrap_or(0) as u16;
+        for cluster in text.graphemes(true) {
+            let w = grapheme_cols(cluster);
             if w == 0 {
                 continue;
             }
             if col >= self.clip.right() {
                 break;
             }
-            self.set(col, y, ch, style);
+            self.set_cluster(col, y, cluster, style);
             // Blank the trailing cell of a wide glyph so stale content behind a
-            // double-width char never shows through.
+            // double-width cluster never shows through.
             if w == 2 && col + 1 < self.clip.right() {
                 self.set(col + 1, y, ' ', style);
             }

--- a/crates/tuika/src/tests.rs
+++ b/crates/tuika/src/tests.rs
@@ -404,6 +404,39 @@ fn wrap_lines_counts_wide_glyphs() {
 }
 
 #[test]
+fn set_string_places_multi_scalar_emoji_in_one_wide_cell() {
+    // A ZWJ family (multiple scalars) is a single grapheme: it must occupy one
+    // cell and advance the cursor by 2, not scatter one component per cell.
+    const FAMILY: &str = "👨\u{200D}👩\u{200D}👧";
+    let mut buf = Buffer::filled(Rect::new(0, 0, 6, 1), ratatui::buffer::Cell::new("."));
+    let end = {
+        let mut surface = Surface::new(&mut buf, Rect::new(0, 0, 6, 1));
+        surface.set_string(0, 0, &format!("{FAMILY}x"), Style::default())
+    };
+    assert_eq!(
+        buf[(0, 0)].symbol(),
+        FAMILY,
+        "whole cluster lands in one cell"
+    );
+    assert_eq!(buf[(1, 0)].symbol(), " ", "trailing half of the wide glyph");
+    assert_eq!(buf[(2, 0)].symbol(), "x", "next glyph starts at column 2");
+    assert_eq!(end, 3, "cursor advanced 2 (emoji) + 1 (x)");
+}
+
+#[test]
+fn wrap_lines_keeps_emoji_clusters_intact() {
+    // "❤️" carries VS16 → width 2. A grapheme must never be split mid-cluster
+    // by the wrapper, and each output line must respect the width budget.
+    let out = wrap_lines(&[Line::from("❤\u{FE0F} 你 ok")], 4);
+    assert!(out.iter().all(|l| line_width(l) <= 4), "{out:?}");
+    let joined: String = out.iter().map(|l| line_text(l)).collect();
+    assert!(
+        joined.contains("❤\u{FE0F}"),
+        "heart+VS16 survived: {joined:?}"
+    );
+}
+
+#[test]
 fn wrap_lines_keeps_blank_lines() {
     let lines = vec![Line::from("a"), Line::from(""), Line::from("b")];
     let out = wrap_lines(&lines, 10);

--- a/crates/tuika/src/width.rs
+++ b/crates/tuika/src/width.rs
@@ -1,0 +1,109 @@
+//! Grapheme-aware display-width measurement.
+//!
+//! A terminal cell holds one *grapheme cluster*, not one Unicode scalar, so
+//! width must be measured per cluster — otherwise multi-scalar emoji (ZWJ
+//! families, regional-indicator flags, skin-tone modifiers, and text glyphs
+//! promoted to emoji presentation by U+FE0F) are miscounted. `unicode-width`
+//! answers per scalar; this module folds those scalars into the width the
+//! terminal will actually advance.
+//!
+//! Every layout, wrap, and paint path routes through [`str_cols`] /
+//! [`grapheme_cols`] so measurement and rendering can never disagree — a
+//! mismatch is what smears wide glyphs across the grid.
+
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthChar;
+
+/// Emoji variation selector — forces the *emoji* (double-width) presentation of
+/// an otherwise text-default glyph, e.g. `❤️` = U+2764 U+FE0F.
+const VS16: char = '\u{FE0F}';
+/// Text variation selector — forces the *text* (single-width) presentation of
+/// an otherwise emoji-default glyph, e.g. `❤︎` = U+2764 U+FE0E.
+const VS15: char = '\u{FE0E}';
+
+/// Display columns a single grapheme cluster occupies in the terminal grid.
+///
+/// The cluster is painted into one starting cell and this reports how many
+/// columns the cursor advances past it: `0` for an entirely zero-width cluster,
+/// otherwise `1` or `2`. Emoji rules that `UnicodeWidthChar` cannot see at the
+/// scalar level are applied here:
+///
+/// - a cluster carrying **VS16** (U+FE0F) renders in emoji presentation → 2;
+/// - a cluster carrying **VS15** (U+FE0E) renders in text presentation → 1;
+/// - a **ZWJ sequence / flag / emoji-modifier** cluster renders as one
+///   double-width glyph — its scalar-width sum is ≥ 2, so the `min(2)` clamp
+///   collapses it to a single 2-column cell instead of several;
+/// - otherwise the width is the scalar-width sum (a base glyph plus zero-width
+///   combining marks keeps the base's width).
+pub fn grapheme_cols(cluster: &str) -> u16 {
+    let mut vs16 = false;
+    let mut vs15 = false;
+    let mut sum: u16 = 0;
+    for ch in cluster.chars() {
+        match ch {
+            VS16 => vs16 = true,
+            VS15 => vs15 = true,
+            _ => sum = sum.saturating_add(UnicodeWidthChar::width(ch).unwrap_or(0) as u16),
+        }
+    }
+    if vs16 {
+        return 2;
+    }
+    if vs15 {
+        return 1;
+    }
+    // A printable cluster never occupies more than two cells; the clamp is what
+    // turns a multi-emoji ZWJ/flag/modifier sequence into one wide cell.
+    sum.min(2)
+}
+
+/// Display columns of a string, summed over its grapheme clusters.
+pub fn str_cols(s: &str) -> u16 {
+    s.graphemes(true)
+        .map(grapheme_cols)
+        .fold(0, u16::saturating_add)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ascii_and_cjk_match_scalar_width() {
+        assert_eq!(grapheme_cols("a"), 1);
+        assert_eq!(grapheme_cols("世"), 2);
+        assert_eq!(str_cols("ab世"), 4);
+    }
+
+    #[test]
+    fn combining_marks_keep_base_width() {
+        // "e" + combining acute accent is one grapheme, one column.
+        assert_eq!(grapheme_cols("e\u{0301}"), 1);
+    }
+
+    #[test]
+    fn single_scalar_emoji_is_wide() {
+        assert_eq!(grapheme_cols("✅"), 2); // U+2705, emoji default
+        assert_eq!(grapheme_cols("🚀"), 2); // U+1F680
+    }
+
+    #[test]
+    fn variation_selectors_pick_presentation() {
+        assert_eq!(grapheme_cols("❤\u{FE0F}"), 2, "VS16 forces emoji (wide)");
+        assert_eq!(grapheme_cols("❤\u{FE0E}"), 1, "VS15 forces text (narrow)");
+    }
+
+    #[test]
+    fn zwj_flag_and_modifier_clamp_to_one_wide_cell() {
+        assert_eq!(grapheme_cols("👨\u{200D}👩\u{200D}👧"), 2, "ZWJ family");
+        assert_eq!(grapheme_cols("🇺🇸"), 2, "regional-indicator flag");
+        assert_eq!(grapheme_cols("👍🏽"), 2, "skin-tone modifier");
+        assert_eq!(grapheme_cols("1\u{FE0F}\u{20E3}"), 2, "keycap");
+    }
+
+    #[test]
+    fn str_cols_sums_emoji_run() {
+        // family + space + flag = 2 + 1 + 2
+        assert_eq!(str_cols("👨\u{200D}👩\u{200D}👧 🇺🇸"), 5);
+    }
+}


### PR DESCRIPTION
## What changed

Tuika now measures and paints text per **grapheme cluster** instead of per Unicode scalar (`char`), so multi-scalar emoji render correctly: ZWJ families (`👨‍👩‍👧`), regional-indicator flags (`🇺🇸`), skin-tone modifiers (`👍🏽`), and glyphs promoted to emoji presentation by U+FE0F (`❤️`). Each cluster now occupies a single double-width cell with its trailing spacer, instead of being scattered one component per cell with a mis-summed width. Single-scalar emoji (`✅`, `🚀`) were already fine and stay fine.

All width now flows through one grapheme-aware module (`tuika::width` — `grapheme_cols` / `str_cols`), so measurement and painting can never disagree (a disagreement is what smears wide glyphs across the grid). VS16 forces width 2, VS15 forces width 1, and any ZWJ/flag/modifier cluster clamps to a single 2-column cell. `Surface::set_string`, the styled wrapper (`wrap_lines`), and the status-bar / key-hints measurers were converted to iterate clusters.

## Why

A cell holds one grapheme, but `set_string`, `wrap_lines`, `line_width`, and the bar measurers iterated `char`s and summed `UnicodeWidthChar` per scalar. Any emoji built from more than one scalar was therefore both drawn wrong (components in separate cells) and measured wrong (width over-counted), which cascades into broken wrapping and layout alignment.

## Before / After

Rendering the line `✅ 👨‍👩‍👧 🇺🇸 👍🏽 ❤️ ok` into an in-memory buffer (`[x]` = one cell, `.` = untouched fill):

```
BEFORE (per-char): [✅][.][ ][👨][.][👩][.][👧][.][ ][🇺][🇸][ ][👍][.][🏽][.][ ][❤][ ][o][k][.]...
AFTER  (grapheme): [✅][ ][ ][👨‍👩‍👧][ ][ ][🇺🇸][ ][ ][👍🏽][ ][ ][❤️][ ][ ][o][k][.]...
```

Before, the family splits into `[👨][.][👩][.][👧]`, the flag into `[🇺][🇸]`, the skin tone into `[👍][.][🏽]`, and `❤️` loses its emoji presentation. After, each cluster lands in one cell followed by its wide-glyph blank.

Evidence:
- `cargo test --all-features` — **842 passed**. (The 4 failing `integration` tests — `linux_sandbox_worker_*`, `tui_bang_shell_*`, `tui_agents_context_cannot_bypass_native_shell_sandbox` — are pre-existing and environment-only: this kernel doesn't fully enforce Landlock ABI v3, so the native-sandbox tests refuse to run. Unrelated to this diff; CI will run them under a supported kernel.)
- `cargo fmt --check` clean, `cargo clippy --all-targets --all-features -- -D warnings` clean.
- Offline smoke: `cargo run -- --provider llmsim -p "hi"` starts and responds (exit 0).

New tests exercising the real entry points:
- `width::tests::*` — `grapheme_cols` / `str_cols` for ASCII, CJK, combining marks, single-scalar emoji, VS16/VS15, ZWJ family, flag, keycap, skin-tone.
- `set_string_places_multi_scalar_emoji_in_one_wide_cell` — asserts a ZWJ family lands in one buffer cell and advances the cursor by 2.
- `wrap_lines_keeps_emoji_clusters_intact` — a VS16 cluster survives reflow and no output line exceeds the width budget.

## Risk

- **Low.** Additive: a new `width` module and two re-exports; the changed function signatures are all crate-internal. Pure-ASCII, CJK, and combining-mark paths are unchanged (existing wide-glyph and unicode-width tests still pass). No runtime, sandbox, shell, or LLM surface touched.
- Adds one dependency, `unicode-segmentation` (see Security).
- Orthogonal caveat, already documented in the README terminal matrix: correct width math is necessary but whether a given terminal+font collapses a ZWJ sequence to one glyph is emulator-dependent.

## Security

Reviewed against the yolop threat model:
- **TM-FS / TM-BASH / TM-LLM / TM-TOOL** — no security-relevant changes. This diff touches only text width measurement and cell painting in the `tuika` UI toolkit; no filesystem, shell, prompt, key-handling, or capability-registration code is involved.
- **TM-DEP** — adds `unicode-segmentation = "1"`, from the same `unicode-rs` org as the already-present `unicode-width`. It is required because grapheme-cluster boundaries cannot be derived from per-scalar width alone. Pure text processing, no unsafe/network/fs surface. No `everruns-*` versions changed.
- Resource use: width helpers and the wrapper iterate bounded by input length; the `min(2)` clamp and existing clip bounds prevent out-of-range writes. Width functions treat control/unknown scalars as zero-width without panicking (proptests and the 0×0-upward size sweep still pass).

## Follow-ups

No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (yolop pre-1.0; additive tuika change, no downstream breakage — full workspace builds and tests pass)

https://claude.ai/code/session_01TG8fMyuJuLHcQQSPPT1eNq

---
_Generated by [Claude Code](https://claude.ai/code/session_01TG8fMyuJuLHcQQSPPT1eNq)_