### PR TITLE
feat(tuika): multi-line TextInput component

### DIFF
--- a/crates/tuika/src/components/mod.rs
+++ b/crates/tuika/src/components/mod.rs
@@ -22,6 +22,7 @@ mod spinner;
 mod status_bar;
 mod tabs;
 mod text;
+mod textinput;
 
 pub use boxed::Boxed;
 pub use constrained::Constrained;
@@ -38,3 +39,4 @@ pub use spinner::{Spinner, SpinnerStyle};
 pub use status_bar::StatusBar;
 pub use tabs::{Tabs, TabsState};
 pub use text::{Paragraph, Text, Wrap, line_width, wrap_lines};
+pub use textinput::{TextInput, TextInputState};

--- a/crates/tuika/src/components/textinput.rs
+++ b/crates/tuika/src/components/textinput.rs
@@ -1,0 +1,372 @@
+//! A multi-line text editor: buffer, cursor, editing, soft-wrap, and a screen
+//! cursor position the host can hand to the terminal.
+//!
+//! Like the rest of tuika's interactive widgets, state and view are split:
+//! [`TextInputState`] owns the text and cursor and applies edits (via
+//! [`TextInputState::handle`] or the explicit methods); [`TextInput`] borrows it
+//! and renders. The view is char-soft-wrapped to the render width — a logical
+//! line longer than the area wraps onto extra visual rows, and a line that fills
+//! the width exactly wraps the cursor onto a fresh row, like a real editor.
+//!
+//! It is a *rendering + edit model*, not a terminal: the host reads
+//! [`TextInputState::cursor_screen`] after layout and calls the backend's
+//! `set_cursor_position`, and decides what a submit means (this widget treats
+//! Enter as a newline; a chat composer maps its own submit key before feeding
+//! events here).
+
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use unicode_width::UnicodeWidthChar;
+
+use crate::event::{Event, KeyCode};
+use crate::geometry::Size;
+use crate::surface::Surface;
+use crate::view::{RenderCtx, View};
+
+/// The editable text and cursor of a [`TextInput`].
+#[derive(Clone, Debug)]
+pub struct TextInputState {
+    /// Logical lines (split on `\n`); always at least one (possibly empty).
+    lines: Vec<String>,
+    /// Cursor row (logical line index).
+    row: usize,
+    /// Cursor column (char index within `lines[row]`).
+    col: usize,
+}
+
+impl Default for TextInputState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TextInputState {
+    pub fn new() -> Self {
+        Self {
+            lines: vec![String::new()],
+            row: 0,
+            col: 0,
+        }
+    }
+
+    /// Seed from `text`, cursor at the end.
+    pub fn from_text(text: &str) -> Self {
+        let mut s = Self::new();
+        s.set_text(text);
+        s
+    }
+
+    /// The full text, logical lines joined with `\n`.
+    pub fn text(&self) -> String {
+        self.lines.join("\n")
+    }
+
+    /// Whether the buffer is a single empty line.
+    pub fn is_empty(&self) -> bool {
+        self.lines.len() == 1 && self.lines[0].is_empty()
+    }
+
+    /// Number of logical lines.
+    pub fn line_count(&self) -> usize {
+        self.lines.len()
+    }
+
+    /// Cursor as `(row, col)` in logical (char-index) coordinates.
+    pub fn cursor(&self) -> (usize, usize) {
+        (self.row, self.col)
+    }
+
+    /// Replace all text; cursor moves to the end.
+    pub fn set_text(&mut self, text: &str) {
+        self.lines = text.split('\n').map(str::to_string).collect();
+        if self.lines.is_empty() {
+            self.lines.push(String::new());
+        }
+        self.row = self.lines.len() - 1;
+        self.col = self.lines[self.row].chars().count();
+    }
+
+    /// Clear to a single empty line.
+    pub fn clear(&mut self) {
+        *self = Self::new();
+    }
+
+    fn row_chars(&self, row: usize) -> Vec<char> {
+        self.lines[row].chars().collect()
+    }
+
+    fn set_row(&mut self, row: usize, chars: Vec<char>) {
+        self.lines[row] = chars.into_iter().collect();
+    }
+
+    /// Insert one char at the cursor.
+    pub fn insert_char(&mut self, ch: char) {
+        if ch == '\n' {
+            self.newline();
+            return;
+        }
+        let mut chars = self.row_chars(self.row);
+        let at = self.col.min(chars.len());
+        chars.insert(at, ch);
+        self.set_row(self.row, chars);
+        self.col = at + 1;
+    }
+
+    /// Insert a string (honoring embedded newlines) at the cursor.
+    pub fn insert_str(&mut self, s: &str) {
+        for ch in s.chars() {
+            self.insert_char(ch);
+        }
+    }
+
+    /// Split the current line at the cursor into two lines.
+    pub fn newline(&mut self) {
+        let chars = self.row_chars(self.row);
+        let at = self.col.min(chars.len());
+        let tail: String = chars[at..].iter().collect();
+        let head: String = chars[..at].iter().collect();
+        self.lines[self.row] = head;
+        self.lines.insert(self.row + 1, tail);
+        self.row += 1;
+        self.col = 0;
+    }
+
+    /// Delete the char before the cursor (joining lines at column 0).
+    pub fn backspace(&mut self) {
+        if self.col > 0 {
+            let mut chars = self.row_chars(self.row);
+            chars.remove(self.col - 1);
+            self.col -= 1;
+            self.set_row(self.row, chars);
+        } else if self.row > 0 {
+            let cur = self.lines.remove(self.row);
+            self.row -= 1;
+            self.col = self.lines[self.row].chars().count();
+            self.lines[self.row].push_str(&cur);
+        }
+    }
+
+    /// Delete the char at the cursor (joining the next line at line end).
+    pub fn delete(&mut self) {
+        let mut chars = self.row_chars(self.row);
+        if self.col < chars.len() {
+            chars.remove(self.col);
+            self.set_row(self.row, chars);
+        } else if self.row + 1 < self.lines.len() {
+            let next = self.lines.remove(self.row + 1);
+            self.lines[self.row].push_str(&next);
+        }
+    }
+
+    fn clamp_col(&mut self) {
+        self.col = self.col.min(self.lines[self.row].chars().count());
+    }
+
+    pub fn move_left(&mut self) {
+        if self.col > 0 {
+            self.col -= 1;
+        } else if self.row > 0 {
+            self.row -= 1;
+            self.col = self.lines[self.row].chars().count();
+        }
+    }
+
+    pub fn move_right(&mut self) {
+        let len = self.lines[self.row].chars().count();
+        if self.col < len {
+            self.col += 1;
+        } else if self.row + 1 < self.lines.len() {
+            self.row += 1;
+            self.col = 0;
+        }
+    }
+
+    pub fn move_up(&mut self) {
+        if self.row > 0 {
+            self.row -= 1;
+            self.clamp_col();
+        } else {
+            self.col = 0;
+        }
+    }
+
+    pub fn move_down(&mut self) {
+        if self.row + 1 < self.lines.len() {
+            self.row += 1;
+            self.clamp_col();
+        } else {
+            self.col = self.lines[self.row].chars().count();
+        }
+    }
+
+    pub fn move_home(&mut self) {
+        self.col = 0;
+    }
+
+    pub fn move_end(&mut self) {
+        self.col = self.lines[self.row].chars().count();
+    }
+
+    /// Apply an input event. Returns `true` when the buffer or cursor changed.
+    /// Enter inserts a newline; a host that submits on Enter should intercept it
+    /// before calling this.
+    pub fn handle(&mut self, event: &Event) -> bool {
+        match event {
+            Event::Key(k) if !k.ctrl && !k.alt => match k.code {
+                KeyCode::Char(c) => {
+                    self.insert_char(c);
+                    true
+                }
+                KeyCode::Enter => {
+                    self.newline();
+                    true
+                }
+                KeyCode::Backspace => {
+                    self.backspace();
+                    true
+                }
+                KeyCode::Delete => {
+                    self.delete();
+                    true
+                }
+                KeyCode::Left => {
+                    self.move_left();
+                    true
+                }
+                KeyCode::Right => {
+                    self.move_right();
+                    true
+                }
+                KeyCode::Up => {
+                    self.move_up();
+                    true
+                }
+                KeyCode::Down => {
+                    self.move_down();
+                    true
+                }
+                KeyCode::Home => {
+                    self.move_home();
+                    true
+                }
+                KeyCode::End => {
+                    self.move_end();
+                    true
+                }
+                _ => false,
+            },
+            Event::Paste(text) => {
+                self.insert_str(text);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Char-soft-wrap every logical line to `width`, returning the visual rows as
+    /// `(logical_row, chars)`. A line that fills the width exactly emits a
+    /// trailing empty row so the cursor can rest on a fresh line.
+    fn visual_rows(&self, width: u16) -> Vec<(usize, Vec<char>)> {
+        let width = width.max(1) as usize;
+        let mut rows = Vec::new();
+        for (r, line) in self.lines.iter().enumerate() {
+            let chars: Vec<char> = line.chars().collect();
+            if chars.is_empty() {
+                rows.push((r, Vec::new()));
+                continue;
+            }
+            let mut start = 0;
+            while start < chars.len() {
+                let end = (start + width).min(chars.len());
+                rows.push((r, chars[start..end].to_vec()));
+                start = end;
+            }
+            if chars.len().is_multiple_of(width) {
+                rows.push((r, Vec::new()));
+            }
+        }
+        rows
+    }
+
+    /// Number of visual rows the text occupies at `width`.
+    pub fn visual_height(&self, width: u16) -> u16 {
+        self.visual_rows(width).len().max(1) as u16
+    }
+
+    /// The cursor's visual `(row, col)` in wrapped coordinates at `width`.
+    fn visual_cursor(&self, width: u16) -> (u16, u16) {
+        let width = width.max(1) as usize;
+        let mut vrow: usize = 0;
+        for (r, line) in self.lines.iter().enumerate() {
+            let len = line.chars().count();
+            if r == self.row {
+                let vr = self.col / width;
+                let vc = self.col % width;
+                return ((vrow + vr) as u16, vc as u16);
+            }
+            vrow += (len / width) + 1; // rows for this line (incl. trailing/empty)
+        }
+        (vrow as u16, 0)
+    }
+
+    /// The cursor cell in terminal coordinates, given the rendered `area`.
+    /// Clamped inside `area`.
+    pub fn cursor_screen(&self, area: Rect) -> (u16, u16) {
+        let (vrow, vcol) = self.visual_cursor(area.width);
+        let x = area
+            .x
+            .saturating_add(vcol.min(area.width.saturating_sub(1)));
+        let y = area
+            .y
+            .saturating_add(vrow.min(area.height.saturating_sub(1)));
+        (x, y)
+    }
+}
+
+/// Renders a [`TextInputState`]'s wrapped text.
+pub struct TextInput<'a> {
+    state: &'a TextInputState,
+    style: Style,
+}
+
+impl<'a> TextInput<'a> {
+    pub fn new(state: &'a TextInputState) -> Self {
+        Self {
+            state,
+            style: Style::default(),
+        }
+    }
+
+    pub fn style(mut self, style: Style) -> Self {
+        self.style = style;
+        self
+    }
+}
+
+impl View for TextInput<'_> {
+    fn measure(&self, available: Size) -> Size {
+        Size::new(available.width, self.state.visual_height(available.width))
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, _ctx: &RenderCtx) {
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        for (vrow, (_logical, chars)) in self.state.visual_rows(area.width).into_iter().enumerate()
+        {
+            let y = area.y.saturating_add(vrow as u16);
+            if y >= area.bottom() {
+                break;
+            }
+            let mut x = area.x;
+            for ch in chars {
+                let w = UnicodeWidthChar::width(ch).unwrap_or(0) as u16;
+                if w == 0 || x >= area.right() {
+                    continue;
+                }
+                surface.set(x, y, ch, self.style);
+                x = x.saturating_add(w);
+            }
+        }
+    }
+}

--- a/crates/tuika/src/components/textinput.rs
+++ b/crates/tuika/src/components/textinput.rs
@@ -91,6 +91,13 @@ impl TextInputState {
         *self = Self::new();
     }
 
+    /// Move the cursor to `(row, col)`, clamped into the buffer. Lets a host
+    /// mirror an external editor's cursor into this state for rendering.
+    pub fn set_cursor(&mut self, row: usize, col: usize) {
+        self.row = row.min(self.lines.len().saturating_sub(1));
+        self.col = col.min(self.lines[self.row].chars().count());
+    }
+
     fn row_chars(&self, row: usize) -> Vec<char> {
         self.lines[row].chars().collect()
     }
@@ -267,25 +274,7 @@ impl TextInputState {
     /// `(logical_row, chars)`. A line that fills the width exactly emits a
     /// trailing empty row so the cursor can rest on a fresh line.
     fn visual_rows(&self, width: u16) -> Vec<(usize, Vec<char>)> {
-        let width = width.max(1) as usize;
-        let mut rows = Vec::new();
-        for (r, line) in self.lines.iter().enumerate() {
-            let chars: Vec<char> = line.chars().collect();
-            if chars.is_empty() {
-                rows.push((r, Vec::new()));
-                continue;
-            }
-            let mut start = 0;
-            while start < chars.len() {
-                let end = (start + width).min(chars.len());
-                rows.push((r, chars[start..end].to_vec()));
-                start = end;
-            }
-            if chars.len().is_multiple_of(width) {
-                rows.push((r, Vec::new()));
-            }
-        }
-        rows
+        wrap_visual_rows(&self.lines, width)
     }
 
     /// Number of visual rows the text occupies at `width`.
@@ -323,16 +312,48 @@ impl TextInputState {
     }
 }
 
-/// Renders a [`TextInputState`]'s wrapped text.
-pub struct TextInput<'a> {
-    state: &'a TextInputState,
+/// Char-soft-wrap `lines` to `width`, returning visual rows as
+/// `(logical_row, chars)`. A line that fills the width exactly emits a trailing
+/// empty row so the cursor can rest on a fresh line. Shared by [`TextInputState`]
+/// (cursor math) and [`TextInput`] (rendering).
+fn wrap_visual_rows(lines: &[String], width: u16) -> Vec<(usize, Vec<char>)> {
+    let width = width.max(1) as usize;
+    let mut rows = Vec::new();
+    for (r, line) in lines.iter().enumerate() {
+        let chars: Vec<char> = line.chars().collect();
+        if chars.is_empty() {
+            rows.push((r, Vec::new()));
+            continue;
+        }
+        let mut start = 0;
+        while start < chars.len() {
+            let end = (start + width).min(chars.len());
+            rows.push((r, chars[start..end].to_vec()));
+            start = end;
+        }
+        if chars.len().is_multiple_of(width) {
+            rows.push((r, Vec::new()));
+        }
+    }
+    rows
+}
+
+/// Renders a snapshot of a [`TextInputState`]'s wrapped text.
+///
+/// Owns its lines (cloned from the state at construction, like [`Scroll`]) so it
+/// is `'static` and composes into a [`view!`](crate::view!) tree. The host places
+/// the terminal cursor separately via [`TextInputState::cursor_screen`].
+///
+/// [`Scroll`]: crate::Scroll
+pub struct TextInput {
+    lines: Vec<String>,
     style: Style,
 }
 
-impl<'a> TextInput<'a> {
-    pub fn new(state: &'a TextInputState) -> Self {
+impl TextInput {
+    pub fn new(state: &TextInputState) -> Self {
         Self {
-            state,
+            lines: state.lines.clone(),
             style: Style::default(),
         }
     }
@@ -343,16 +364,19 @@ impl<'a> TextInput<'a> {
     }
 }
 
-impl View for TextInput<'_> {
+impl View for TextInput {
     fn measure(&self, available: Size) -> Size {
-        Size::new(available.width, self.state.visual_height(available.width))
+        let height = wrap_visual_rows(&self.lines, available.width).len().max(1) as u16;
+        Size::new(available.width, height)
     }
 
     fn render(&self, area: Rect, surface: &mut Surface, _ctx: &RenderCtx) {
         if area.width == 0 || area.height == 0 {
             return;
         }
-        for (vrow, (_logical, chars)) in self.state.visual_rows(area.width).into_iter().enumerate()
+        for (vrow, (_logical, chars)) in wrap_visual_rows(&self.lines, area.width)
+            .into_iter()
+            .enumerate()
         {
             let y = area.y.saturating_add(vrow as u16);
             if y >= area.bottom() {

--- a/crates/tuika/src/lib.rs
+++ b/crates/tuika/src/lib.rs
@@ -62,7 +62,7 @@ pub use clipboard::{osc52, write_clipboard};
 pub use components::{
     Boxed, Constrained, Flex, KeyHints, Loader, Paragraph, ProgressBar, Responsive, Rule, Scroll,
     ScrollState, SelectList, SelectOutcome, SelectState, Spacer, Spinner, SpinnerStyle, StatusBar,
-    Tabs, TabsState, Text, Wrap, wrap_lines,
+    Tabs, TabsState, Text, TextInput, TextInputState, Wrap, wrap_lines,
 };
 pub use event::{Event, EventFlow, Key, KeyCode, Mouse, MouseButton, MouseKind};
 pub use focus::FocusRegistry;

--- a/crates/tuika/src/tests.rs
+++ b/crates/tuika/src/tests.rs
@@ -10,7 +10,7 @@ use ratatui::text::{Line, Span};
 use super::anim;
 use super::components::{
     Loader, Paragraph, ProgressBar, Scroll, ScrollState, SelectList, SelectOutcome, SelectState,
-    Spinner, Text, Wrap, line_width, wrap_lines,
+    Spinner, Text, TextInput, TextInputState, Wrap, line_width, wrap_lines,
 };
 use super::event::{Event, EventFlow, Key, KeyCode, Mouse, MouseButton, MouseKind};
 use super::focus::FocusRegistry;
@@ -1495,4 +1495,154 @@ fn nested_flex_tree_lays_out_status_and_body() {
     // Body box drew a rounded border on the top row with its title.
     assert!(row(&buf, 0).contains("Body"));
     assert_eq!(buf[(0, 0)].symbol(), "╭");
+}
+
+// ---- TextInput -----------------------------------------------------------
+
+fn press(state: &mut TextInputState, code: KeyCode) -> bool {
+    state.handle(&Event::Key(Key::new(code)))
+}
+
+fn type_str(state: &mut TextInputState, s: &str) {
+    for ch in s.chars() {
+        assert!(press(state, KeyCode::Char(ch)));
+    }
+}
+
+#[test]
+fn text_input_starts_empty() {
+    let state = TextInputState::new();
+    assert!(state.is_empty());
+    assert_eq!(state.text(), "");
+    assert_eq!(state.cursor(), (0, 0));
+    assert_eq!(state.line_count(), 1);
+}
+
+#[test]
+fn text_input_types_and_edits() {
+    let mut state = TextInputState::new();
+    type_str(&mut state, "helo");
+    assert_eq!(state.text(), "helo");
+    assert_eq!(state.cursor(), (0, 4));
+
+    // Move back and insert the missing 'l' → "hello".
+    press(&mut state, KeyCode::Left);
+    press(&mut state, KeyCode::Left);
+    assert_eq!(state.cursor(), (0, 2));
+    assert!(press(&mut state, KeyCode::Char('l')));
+    assert_eq!(state.text(), "hello");
+    assert_eq!(state.cursor(), (0, 3));
+}
+
+#[test]
+fn text_input_backspace_and_delete() {
+    let mut state = TextInputState::from_text("abc");
+    assert_eq!(state.cursor(), (0, 3));
+    press(&mut state, KeyCode::Backspace);
+    assert_eq!(state.text(), "ab");
+    press(&mut state, KeyCode::Home);
+    press(&mut state, KeyCode::Delete);
+    assert_eq!(state.text(), "b");
+    assert_eq!(state.cursor(), (0, 0));
+}
+
+#[test]
+fn text_input_newline_splits_and_backspace_joins() {
+    let mut state = TextInputState::from_text("abcd");
+    press(&mut state, KeyCode::Home);
+    press(&mut state, KeyCode::Right);
+    press(&mut state, KeyCode::Right);
+    assert_eq!(state.cursor(), (0, 2));
+    press(&mut state, KeyCode::Enter);
+    assert_eq!(state.text(), "ab\ncd");
+    assert_eq!(state.line_count(), 2);
+    assert_eq!(state.cursor(), (1, 0));
+
+    // Backspace at column 0 rejoins the two logical lines.
+    press(&mut state, KeyCode::Backspace);
+    assert_eq!(state.text(), "abcd");
+    assert_eq!(state.cursor(), (0, 2));
+    assert_eq!(state.line_count(), 1);
+}
+
+#[test]
+fn text_input_vertical_movement_clamps_column() {
+    let mut state = TextInputState::from_text("longline\nhi");
+    // Cursor is at end of "hi" (row 1, col 2). Move up onto the longer line:
+    // column is preserved (2), not clamped, because "longline" is longer.
+    press(&mut state, KeyCode::Up);
+    assert_eq!(state.cursor(), (0, 2));
+    // From end of "longline" move down — clamps onto the shorter "hi".
+    press(&mut state, KeyCode::End);
+    assert_eq!(state.cursor(), (0, 8));
+    press(&mut state, KeyCode::Down);
+    assert_eq!(state.cursor(), (1, 2));
+}
+
+#[test]
+fn text_input_paste_inserts_multiline() {
+    let mut state = TextInputState::new();
+    assert!(state.handle(&Event::Paste("one\ntwo".to_string())));
+    assert_eq!(state.text(), "one\ntwo");
+    assert_eq!(state.line_count(), 2);
+    assert_eq!(state.cursor(), (1, 3));
+}
+
+#[test]
+fn text_input_ctrl_keys_ignored() {
+    let mut state = TextInputState::from_text("x");
+    let ctrl_a = Event::Key(Key {
+        code: KeyCode::Char('a'),
+        ctrl: true,
+        alt: false,
+        shift: false,
+    });
+    assert!(!state.handle(&ctrl_a));
+    assert_eq!(state.text(), "x");
+}
+
+fn render_view_rows(view: &dyn View, w: u16, h: u16) -> Vec<String> {
+    let theme = Theme::default();
+    let mut buf = buffer(w, h);
+    let area = buf.area;
+    let ctx = RenderCtx::new(&theme);
+    let mut surface = Surface::new(&mut buf, area);
+    view.render(area, &mut surface, &ctx);
+    (0..h).map(|y| row(&buf, y)).collect()
+}
+
+#[test]
+fn text_input_renders_wrapped_rows() {
+    let mut state = TextInputState::new();
+    type_str(&mut state, "abcdef");
+    // Width 4 wraps "abcdef" onto two visual rows: "abcd" / "ef".
+    assert_eq!(state.visual_height(4), 2);
+    let out = render_view_rows(&TextInput::new(&state), 4, 2);
+    assert_eq!(out[0], "abcd");
+    assert_eq!(out[1], "ef");
+}
+
+#[test]
+fn text_input_cursor_screen_follows_wrap() {
+    let mut state = TextInputState::new();
+    type_str(&mut state, "abcd");
+    // At width 4 the line fills exactly, so the cursor rests on a fresh row.
+    assert_eq!(state.visual_height(4), 2);
+    let area = Rect::new(2, 1, 4, 3);
+    // Cursor after "abcd" → visual row 1, col 0, offset by area origin.
+    assert_eq!(state.cursor_screen(area), (2, 2));
+    // Move home → back to the first visual row.
+    press(&mut state, KeyCode::Home);
+    assert_eq!(state.cursor_screen(area), (2, 1));
+}
+
+#[test]
+fn text_input_set_and_clear() {
+    let mut state = TextInputState::new();
+    state.set_text("hello\nworld");
+    assert_eq!(state.cursor(), (1, 5));
+    assert_eq!(state.line_count(), 2);
+    state.clear();
+    assert!(state.is_empty());
+    assert_eq!(state.cursor(), (0, 0));
 }

--- a/crates/tuika/src/tests.rs
+++ b/crates/tuika/src/tests.rs
@@ -1646,3 +1646,25 @@ fn text_input_set_and_clear() {
     assert!(state.is_empty());
     assert_eq!(state.cursor(), (0, 0));
 }
+
+#[test]
+fn text_input_set_cursor_clamps() {
+    let mut state = TextInputState::from_text("hi\nthere");
+    state.set_cursor(0, 1);
+    assert_eq!(state.cursor(), (0, 1));
+    // Row past the end clamps to the last line; col past its end clamps too.
+    state.set_cursor(9, 9);
+    assert_eq!(state.cursor(), (1, 5));
+}
+
+#[test]
+fn text_input_composes_into_view_tree() {
+    // Owning its snapshot makes TextInput `'static`, so it splices into a
+    // `view!` tree via `element(...)` — the property the fullscreen composer
+    // relies on.
+    let mut state = TextInputState::new();
+    type_str(&mut state, "hi");
+    let tree = element(TextInput::new(&state));
+    let out = render_el(&tree, 4, 1);
+    assert_eq!(out[0], "hi");
+}


### PR DESCRIPTION
## What changed

Adds `TextInput` / `TextInputState` to tuika — a multi-line text-editor component that gives the toolkit a real composer primitive. `TextInputState` owns the buffer and cursor and applies edits (typing, backspace/delete with line join, Enter split, left/right/up/down movement with column clamping, Home/End, bracketed paste). `TextInput` renders an owned snapshot of the state, char-soft-wrapped to the render width. After layout, the host reads `cursor_screen()` to place the terminal cursor.

`TextInput` owns its lines (cloned at construction, like `Scroll`) rather than borrowing the state, so it is `'static` and composes into a `view!` tree via `element(...)` — the property the fullscreen composer relies on. `TextInputState::set_cursor` lets a host mirror an external editor's cursor into the state for rendering.

This is a self-contained new component — nothing else in tuika or yolop consumes it yet. It's the composer primitive for the upcoming tuika-native fullscreen UI (the input box), landed on its own so it can be reviewed in isolation.

Design mirrors the existing state/view split (`Scroll`/`ScrollState`, `SelectList`/`SelectState`): state is persisted by the host, the view is a cheap snapshot. Enter inserts a newline; a chat composer intercepts its own submit key before feeding events to `handle()`.

## Why

The fullscreen renderer is being rebuilt on tuika so tuika owns all rendering, layout, and input rather than delegating the composer to ratatui-textarea. tuika had no editable-text widget; this fills that gap.

## Before / After

New component, no prior behavior. 12 unit tests cover typing/editing, newline split + backspace join, vertical movement column-clamp, multiline paste, ctrl-key pass-through, soft-wrap rendering, `cursor_screen` tracking the wrap, `set_cursor` clamping, and view-tree composition:

```
test tests::text_input_backspace_and_delete ... ok
test tests::text_input_composes_into_view_tree ... ok
test tests::text_input_cursor_screen_follows_wrap ... ok
test tests::text_input_ctrl_keys_ignored ... ok
test tests::text_input_newline_splits_and_backspace_joins ... ok
test tests::text_input_paste_inserts_multiline ... ok
test tests::text_input_renders_wrapped_rows ... ok
test tests::text_input_set_and_clear ... ok
test tests::text_input_set_cursor_clamps ... ok
test tests::text_input_starts_empty ... ok
test tests::text_input_vertical_movement_clamps_column ... ok
test tests::text_input_types_and_edits ... ok
```

`cargo clippy -p tuika --all-targets --all-features -- -D warnings` and `cargo fmt --check` clean.

## Risk

- Low
- New, unconsumed component; no existing code path changes.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; additive only)