### PR TITLE
feat(tui): rebuild the full-screen composer and chrome on a tuika view tree

### DIFF
--- a/src/app/fullscreen.rs
+++ b/src/app/fullscreen.rs
@@ -1,25 +1,33 @@
-//! Full-screen renderer, composed with the `tuika` view tree.
+//! Full-screen renderer, built as a native `tuika` view tree.
 //!
-//! Where the inline renderer ([`super::render::draw_shared`]) lays out the
-//! chrome with a hand-rolled ratatui split, the full-screen mode builds the
-//! same vertical composition — transcript, the blue message separator, the
-//! composer, the gold status separator, the session status — as a `tuika`
-//! `Flex` column and paints it through `tuika::paint`. Content is the *same*
-//! styled lines the inline renderer uses (from `super::render`), so the design
-//! (colors, separators, status) cannot drift.
+//! This is the tuika-native counterpart to the inline renderer
+//! ([`super::render::draw_shared`]). Where the inline mode paints the chrome
+//! with hand-rolled ratatui splits and widgets, the full-screen mode composes
+//! the whole frame — transcript, the blue message separator, the composer, the
+//! gold status separator, the session status, and the preview popup row — as a
+//! `tuika` [`view!`] tree of real components and paints it with
+//! [`tuika::paint`]:
 //!
-//! Two regions are drawn by the shared ratatui renderers into rects `tuika`
-//! reserved for them (via [`tuika::RectProbe`]): the composer, which is the
-//! `ratatui-textarea` widget plus the real terminal cursor, and the streaming
-//! preview. Full-screen mouse text selection (see [`super::App`]) is applied
-//! over the transcript rect the same probe reports.
+//! - **separators** are [`tuika::Rule`]s (blue message rule, gold status rule);
+//! - **the composer** is a [`tuika::TextInput`] fed from a snapshot of the
+//!   shared composer text model (`app.input`) — no ratatui-textarea widget;
+//! - **the preview row** (reverse-search / suggestions / streaming preview) and
+//!   **the status** are [`tuika::Text`] views built from the same pure line
+//!   builders the inline chrome uses, so the two modes cannot visually drift;
+//! - **the transcript** is bottom-aligned styled lines inside a probed region so
+//!   full-screen mouse text selection (see [`super::App`]) can be bounded to it.
+//!
+//! Crucially, the full-screen frame calls **no** `render::draw_*` painter for
+//! its own chrome — only the shared *content* builders (which return styled
+//! [`Line`]s). The setup / ask / background overlays still borrow the inline
+//! sheet renderers; they move onto tuika in a follow-up.
 
 use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
-use ratatui::text::Line;
+use ratatui::text::{Line, Span};
 
-use tuika::{Element, Flex, Padding, RectProbe, Spacer, Text, element};
+use tuika::{Element, Padding, RectProbe, Rule, Text, TextInput, TextInputState, element, view};
 
 use super::render;
 use super::{ACCENT_BLUE, ACCENT_GOLD, App};
@@ -27,7 +35,8 @@ use super::{ACCENT_BLUE, ACCENT_GOLD, App};
 pub(crate) fn draw(f: &mut Frame, app: &mut App) {
     let area = f.area();
 
-    // Overlays own the whole viewport; reuse the shared sheet renderers.
+    // Overlays own the whole viewport; borrow the shared sheet renderers until
+    // they move onto tuika.
     if app.pending_ask.is_some() {
         render::draw_ask_overlay(f, area, app);
         return;
@@ -59,41 +68,37 @@ pub(crate) fn draw(f: &mut Frame, app: &mut App) {
     let status_sep_height = u16::from(input_height < 3);
     let transcript_height = area.height.saturating_sub(chrome_height);
 
-    // Content as styled lines — the exact builders the inline renderer uses.
+    // Content as styled lines — the exact pure builders the inline renderer uses,
+    // so colors, separators, and status can never drift between the two modes.
     let inner_w = area.width.saturating_sub(2) as usize;
-    let transcript =
+    let transcript_lines =
         render::recent_transcript_lines(app, inner_w, transcript_height.max(1) as usize);
-    let message_separator = render::separator_line(
-        render::message_separator_title(&state),
-        area.width,
-        Style::default().fg(ACCENT_BLUE),
-    );
-    let status_separator =
-        render::separator_line(Line::from(""), area.width, Style::default().fg(ACCENT_GOLD));
     let status_lines = render::session_status_lines(&state);
+    let preview_line = render::preview_slot_line(&state, area.width);
 
-    // Probes recover the rects tuika assigns to regions the shared ratatui
-    // renderers finish drawing (composer, preview) and the transcript.
+    // The composer is a real tuika TextInput. Its text is a snapshot of the
+    // shared composer model (`app.input`); inline mode keeps owning that model,
+    // full-screen mode only reads it here.
+    let mut composer = TextInputState::new();
+    composer.set_text(&app.input.lines().join("\n"));
+    let cursor = app.input.cursor();
+    composer.set_cursor(cursor.0, cursor.1);
+
+    // Probes recover the rects tuika assigns so the host can place the terminal
+    // cursor inside the composer and bound mouse selection to the transcript.
     let transcript_probe = RectProbe::new();
-    let preview_probe = RectProbe::new();
     let input_probe = RectProbe::new();
 
-    let mut col = Flex::column().grow(1, transcript_view(transcript, &transcript_probe));
-    if preview_height > 0 {
-        col = col.fixed(preview_height, preview_probe.wrap(element(Spacer)));
-    }
-    col = col.fixed(1, element(Text::new(vec![message_separator])));
-    col = col.fixed(input_height, input_probe.wrap(element(Spacer)));
-    if status_sep_height > 0 {
-        col = col.fixed(
-            status_sep_height,
-            element(Text::new(vec![status_separator])),
-        );
-    }
-    if status_rows > 0 {
-        col = col.fixed(status_rows, element(Text::new(status_lines)));
-    }
-    let root = element(col);
+    let root = view! {
+        col {
+            grow(1) { node(transcript_view(transcript_lines, &transcript_probe)) }
+            fixed(preview_height) { node(preview_view(preview_line)) }
+            fixed(1) { node(message_rule(&state)) }
+            fixed(input_height) { node(composer_row(&composer, &input_probe)) }
+            fixed(status_sep_height) { node(status_rule()) }
+            fixed(status_rows) { node(Text::new(status_lines)) }
+        }
+    };
 
     // Transparent background so the styled lines' own colors show through.
     let theme = tuika::Theme {
@@ -127,25 +132,64 @@ pub(crate) fn draw(f: &mut Frame, app: &mut App) {
         );
     }
 
-    // Ratatui-native regions, into the rects tuika reserved for them.
-    if preview_height > 0 {
-        render::draw_preview_slot(f, preview_probe.rect(), &state);
+    // Place the real terminal cursor inside the composer's TextInput rect, unless
+    // a turn is running (input disabled).
+    if !app.busy {
+        let input_rect = input_probe.rect();
+        if input_rect.width > 0 && input_rect.height > 0 {
+            let (x, y) = composer.cursor_screen(input_rect);
+            f.set_cursor_position((x, y));
+        }
     }
-    render::draw_input(f, input_probe.rect(), app);
 }
 
-/// The transcript: its styled lines bottom-aligned within a one-column inset,
+/// The transcript region: styled lines bottom-aligned within a one-column inset,
 /// probed so the host can bound mouse selection to it.
 fn transcript_view(lines: Vec<Line<'static>>, probe: &RectProbe) -> Element {
     let height = (lines.len() as u16).max(1);
-    let inner = Flex::column()
-        .padding(Padding {
-            left: 1,
-            right: 1,
-            top: 0,
-            bottom: 0,
-        })
-        .grow(1, element(Spacer))
-        .fixed(height, element(Text::new(lines)));
-    probe.wrap(element(inner))
+    let inner = view! {
+        col(padding = Padding { left: 1, right: 1, top: 0, bottom: 0 }) {
+            grow(1) { spacer() }
+            fixed(height) { node(Text::new(lines)) }
+        }
+    };
+    probe.wrap(inner)
+}
+
+/// The preview popup row: one line (reverse-search / suggestions / stream tail)
+/// or empty when the row is hidden.
+fn preview_view(line: Option<Line<'static>>) -> Element {
+    element(Text::new(line.map(|l| vec![l]).unwrap_or_default()))
+}
+
+/// The blue message separator — a [`Rule`] whose title is the composer hint (or
+/// the busy "thinking" indicator), filled out with `─` in accent blue.
+fn message_rule(state: &super::ViewState) -> Element {
+    element(
+        Rule::new()
+            .title(render::message_separator_title(state))
+            .style(Style::default().fg(ACCENT_BLUE)),
+    )
+}
+
+/// The gold status separator — a full-width [`Rule`] with no title.
+fn status_rule() -> Element {
+    element(Rule::new().style(Style::default().fg(ACCENT_GOLD)))
+}
+
+/// The composer row: the blue `> ` prompt then the [`TextInput`], the latter
+/// probed so the host can place the terminal cursor in it.
+fn composer_row(composer: &TextInputState, probe: &RectProbe) -> Element {
+    let prompt = Line::from(Span::styled(
+        "> ",
+        Style::default()
+            .fg(ACCENT_BLUE)
+            .add_modifier(Modifier::BOLD),
+    ));
+    view! {
+        row {
+            fixed(2) { node(Text::new(vec![prompt])) }
+            grow(1) { node(probe.wrap(element(TextInput::new(composer)))) }
+        }
+    }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4348,6 +4348,45 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fullscreen_composer_renders_multiline_input_via_tuika() {
+        use ratatui::backend::TestBackend;
+        let mut test = app_with_llmsim().await;
+        test.app.setup = None;
+        test.app.set_render_mode(RenderMode::Fullscreen);
+        // Two composer rows; the tuika TextInput must render both, after the
+        // blue "> " prompt.
+        test.app.input.insert_str("first line");
+        test.app.input.insert_newline();
+        test.app.input.insert_str("second line");
+
+        let backend = TestBackend::new(60, 20);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal.draw(|f| draw(f, &mut test.app)).expect("draw");
+        let buffer = terminal.backend().buffer();
+
+        let text: String = (0..buffer.area.height)
+            .map(|y| {
+                (0..buffer.area.width)
+                    .map(|x| buffer[(x, y)].symbol().to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        for needle in ["first line", "second line", "> "] {
+            assert!(
+                text.contains(needle),
+                "tuika composer should render {needle:?}:\n{text}"
+            );
+        }
+        // The blue prompt is bold accent-blue at the composer's left edge.
+        let has_prompt = (0..buffer.area.height).any(|y| {
+            let cell = &buffer[(0, y)];
+            cell.symbol() == ">" && cell.fg == ACCENT_BLUE
+        });
+        assert!(has_prompt, "the blue '>' prompt should render");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn fullscreen_scroll_wheel_unsticks_from_bottom() {
         let mut test = app_with_llmsim().await;
         test.app.set_render_mode(RenderMode::Fullscreen);

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -376,6 +376,21 @@ pub(crate) fn draw_preview_slot(f: &mut ratatui::Frame, area: Rect, state: &View
     }
 }
 
+/// The multiplexed preview-row content, as one styled line, for the full-screen
+/// tuika renderer. Same priority order as [`draw_preview_slot`] — reverse
+/// search, else command suggestions, else the streaming preview — but pure, so
+/// the full-screen renderer paints it through a tuika view instead of a ratatui
+/// widget. `None` when the row is empty.
+pub(crate) fn preview_slot_line(state: &ViewState, width: u16) -> Option<Line<'static>> {
+    if let Some(search) = &state.history_search {
+        Some(history_search_preview_line(search, width))
+    } else if !state.command_suggestions.is_empty() {
+        Some(suggestion_preview_line(&state.command_suggestions, width))
+    } else {
+        stream_preview_line(state, width)
+    }
+}
+
 pub(crate) fn draw_chrome_layout(f: &mut ratatui::Frame, layout: ChromeLayout, state: &ViewState) {
     draw_preview_slot(f, layout.preview, state);
     draw_message_separator(f, layout.message_separator, state);
@@ -963,19 +978,16 @@ pub(crate) fn suggestion_preview_line(
     ])
 }
 
-pub(crate) fn draw_stream_preview(f: &mut ratatui::Frame, area: Rect, state: &ViewState) {
-    if area.height == 0 {
-        return;
-    }
-    let Some(preview) = state.presentation.stream_preview.as_ref() else {
-        return;
-    };
-    let inner_width = area.width as usize;
+/// The streaming-preview row: `label › …tail`, showing the most recent non-empty
+/// line of the accumulated stream so the eye tracks the live tail. `None` when
+/// nothing is streaming or `width` is zero. Pure so both the inline chrome and
+/// the full-screen tuika renderer draw the identical line.
+pub(crate) fn stream_preview_line(state: &ViewState, width: u16) -> Option<Line<'static>> {
+    let preview = state.presentation.stream_preview.as_ref()?;
+    let inner_width = width as usize;
     if inner_width == 0 {
-        return;
+        return None;
     }
-    // Show the most recent line of the accumulated stream so the eye
-    // tracks the live tail rather than the start of a long response.
     let tail = preview
         .text
         .lines()
@@ -987,18 +999,25 @@ pub(crate) fn draw_stream_preview(f: &mut ratatui::Frame, area: Rect, state: &Vi
     let prefix_w = prefix.chars().count();
     let max_text = inner_width.saturating_sub(prefix_w + 1).max(8);
     let truncated = truncate_tail_chars(tail, max_text);
-    f.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled(
-                prefix,
-                Style::default()
-                    .fg(preview.kind.color())
-                    .add_modifier(Modifier::DIM),
-            ),
-            Span::styled(truncated, Style::default().fg(TEXT_MUTED)),
-        ])),
-        area,
-    );
+    Some(Line::from(vec![
+        Span::styled(
+            prefix,
+            Style::default()
+                .fg(preview.kind.color())
+                .add_modifier(Modifier::DIM),
+        ),
+        Span::styled(truncated, Style::default().fg(TEXT_MUTED)),
+    ]))
+}
+
+pub(crate) fn draw_stream_preview(f: &mut ratatui::Frame, area: Rect, state: &ViewState) {
+    if area.height == 0 {
+        return;
+    }
+    let Some(line) = stream_preview_line(state, area.width) else {
+        return;
+    };
+    f.render_widget(Paragraph::new(line), area);
 }
 
 /// Keep the last `max_chars` of `text`. Streaming preview reads better


### PR DESCRIPTION
## What changed

The `--fullscreen` renderer's chrome is now a real `tuika` `view!` tree of components, and calls **no** `render::draw_*` painter for its own frame:

- **Separators** are `tuika::Rule`s — the blue message rule (with the composer hint / busy "thinking" title) and the gold status rule.
- **The composer** is a `tuika::TextInput`, fed from a snapshot of the shared composer text model (`app.input`). The ratatui-textarea widget is gone from full-screen; the terminal cursor is placed from `TextInputState::cursor_screen` via a `RectProbe`.
- **The preview row** (reverse-search prompt / `@` & command suggestions / streaming preview) and **the session status** are `tuika::Text` views built from pure line builders shared with the inline chrome, so the two modes cannot visually drift.
- **The transcript** stays bottom-aligned styled lines inside a probed region, so full-screen mouse text selection stays bounded to it.

Inline mode is untouched — it still owns `app.input` and paints with ratatui. To feed the full-screen preview row without a `draw_*` call, `render.rs` gains a pure `stream_preview_line` / `preview_slot_line` pair that the inline `draw_stream_preview` now also uses (so inline output is byte-identical).

This is the composer/chrome half of the "two isolate UI modes" rebuild. The setup / ask / background **overlays** still borrow the inline sheet renderers and move onto tuika in a follow-up.

## Why

The previous full-screen renderer laid out a tuika `Flex` column but delegated the composer and preview back to ratatui `draw_*` functions through reserved rects — it was a layout shim, not a tuika-native UI. This makes the composer, separators, preview, and status genuine tuika components expressed with the `view!` macro, so full-screen owns its rendering end to end.

## Before / After

Visual output is equivalent to the inline renderer (same transcript, blue/gold separators, `> ` prompt, status). Verified by the existing full-screen suite plus a new test that the tuika composer renders multi-line input after the blue `>` prompt:

```
test app::tests::fullscreen_composer_renders_multiline_input_via_tuika ... ok
test app::tests::fullscreen_matches_regular_presentation ... ok
test app::tests::fullscreen_renders_blue_and_gold_separators ... ok
test app::tests::fullscreen_renders_at_mention_suggestions ... ok
test app::tests::fullscreen_renders_reverse_search_prompt ... ok
test app::tests::fullscreen_scroll_wheel_unsticks_from_bottom ... ok
test app::tests::fullscreen_mouse_drag_selects_and_copies_transcript ... ok
test app::tests::fullscreen_shares_regular_presentation_across_states ... ok
```

`cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --check` clean.

## Risk

- Low / Medium
- Only the `--fullscreen` path changes; inline mode is untouched and its `draw_stream_preview` output is byte-identical (the extracted builder is a pure refactor). The composer text model stays shared, read-only from full-screen.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; `--fullscreen` is experimental)