### PR TITLE
feat(tui): composite full-screen overlays (setup/ask/background) on tuika

### DIFF
--- a/src/app/fullscreen.rs
+++ b/src/app/fullscreen.rs
@@ -27,26 +27,29 @@ use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 
-use tuika::{Element, Padding, RectProbe, Rule, Text, TextInput, TextInputState, element, view};
+use tuika::{
+    Boxed, Element, Overlay, Padding, RectProbe, Rule, Spacer, Text, TextInput, TextInputState,
+    element, view,
+};
 
 use super::render;
-use super::{ACCENT_BLUE, ACCENT_GOLD, App};
+use super::{ACCENT_BLUE, ACCENT_GOLD, App, DIFF_META, PANEL_BG, TEXT_PRIMARY};
 
 pub(crate) fn draw(f: &mut Frame, app: &mut App) {
     let area = f.area();
 
-    // Overlays own the whole viewport; borrow the shared sheet renderers until
-    // they move onto tuika.
+    // Overlays own the whole viewport, composited as tuika overlays over a blank
+    // base (same "sheet" behavior as inline, but tuika-native).
     if app.pending_ask.is_some() {
-        render::draw_ask_overlay(f, area, app);
+        draw_ask_overlay(f, area, app);
         return;
     }
     if app.setup.is_some() {
-        render::draw_setup_overlay(f, area, app);
+        draw_setup_overlay(f, area, app);
         return;
     }
     if app.background_panel.is_some() {
-        render::draw_background_panel(f, area, app);
+        draw_background_overlay(f, area, app);
         return;
     }
     if area.width < 4 || area.height == 0 {
@@ -192,4 +195,99 @@ fn composer_row(composer: &TextInputState, probe: &RectProbe) -> Element {
             grow(1) { node(probe.wrap(element(TextInput::new(composer)))) }
         }
     }
+}
+
+// ---- overlays (setup / ask / background) as tuika overlays ----------------
+
+/// Paint `lines` inside a centered bordered panel, composited as a tuika
+/// [`Overlay`] over a blank base — the "sheet" that owns the viewport. Places
+/// the terminal cursor at `cursor` (a `(row, col)` inside the panel interior)
+/// when given.
+///
+/// The panel uses the shared [`render::setup_panel_rect`] geometry, and
+/// [`Boxed`]'s default border + `symmetric(1, 0)` padding reproduces the inline
+/// overlay's interior rect exactly, so the two modes place content identically.
+fn draw_panel_overlay(
+    f: &mut Frame,
+    area: Rect,
+    lines: Vec<Line<'static>>,
+    cursor: Option<(usize, usize)>,
+) {
+    let panel = render::setup_panel_rect(area);
+    if panel.width == 0 || panel.height == 0 {
+        return;
+    }
+    let boxed = Boxed::new(element(Text::new(lines)))
+        .background(Style::default().bg(PANEL_BG).fg(TEXT_PRIMARY));
+    let theme = tuika::Theme {
+        background: Color::Reset,
+        surface: PANEL_BG,
+        ..tuika::Theme::default()
+    };
+    let overlay = Overlay {
+        area: panel,
+        view: &boxed,
+        clear: true,
+    };
+    tuika::paint(f.buffer_mut(), area, &theme, &Spacer, &[overlay]);
+
+    if let Some((row, col)) = cursor {
+        let inner_x = panel.x.saturating_add(2);
+        let inner_y = panel.y.saturating_add(1);
+        let inner_w = panel.width.saturating_sub(4);
+        let inner_h = panel.height.saturating_sub(2);
+        if inner_w > 0 && inner_h > row as u16 {
+            f.set_cursor_position((
+                inner_x.saturating_add((col as u16).min(inner_w.saturating_sub(1))),
+                inner_y.saturating_add(row as u16),
+            ));
+        }
+    }
+}
+
+fn draw_setup_overlay(f: &mut Frame, area: Rect, app: &App) {
+    if app.setup.is_none() || area.width == 0 || area.height == 0 {
+        return;
+    }
+    let (lines, cursor) = render::setup_overlay_content(app);
+    draw_panel_overlay(f, area, lines, cursor);
+}
+
+fn draw_ask_overlay(f: &mut Frame, area: Rect, app: &App) {
+    let Some(ask) = app.pending_ask.as_ref() else {
+        return;
+    };
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let (lines, cursor) = render::ask_overlay_content(ask);
+    draw_panel_overlay(f, area, lines, Some(cursor));
+}
+
+fn draw_background_overlay(f: &mut Frame, area: Rect, app: &App) {
+    let Some(offset) = app.background_panel else {
+        return;
+    };
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let panel = render::setup_panel_rect(area);
+    let inner_h = panel.height.saturating_sub(2) as usize;
+    let body = app.background_panel_body();
+    let texts = render::background_panel_lines(&body, offset, inner_h);
+    let lines: Vec<Line<'static>> = texts
+        .into_iter()
+        .enumerate()
+        .map(|(i, text)| {
+            if i == 0 {
+                Line::from(Span::styled(
+                    text,
+                    Style::default().fg(DIFF_META).add_modifier(Modifier::BOLD),
+                ))
+            } else {
+                Line::raw(text)
+            }
+        })
+        .collect();
+    draw_panel_overlay(f, area, lines, None);
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -305,7 +305,7 @@ struct PendingCodexLogin {
 
 /// An in-flight extension `ui/ask`: the prompt shown, the answer being typed,
 /// and the oneshot that delivers it back to the extension server.
-struct PendingAsk {
+pub(crate) struct PendingAsk {
     prompt: String,
     placeholder: Option<String>,
     value: String,
@@ -4384,6 +4384,39 @@ mod tests {
             cell.symbol() == ">" && cell.fg == ACCENT_BLUE
         });
         assert!(has_prompt, "the blue '>' prompt should render");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fullscreen_setup_overlay_renders_via_tuika() {
+        use ratatui::backend::TestBackend;
+        let mut test = app_with_llmsim().await;
+        test.app.set_render_mode(RenderMode::Fullscreen);
+        // First-run setup overlay is present; it should composite as a tuika
+        // overlay — a bordered panel with the setup content.
+        assert!(test.app.setup.is_some(), "first run should offer setup");
+
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal.draw(|f| draw(f, &mut test.app)).expect("draw");
+        let buffer = terminal.backend().buffer();
+
+        let text: String = (0..buffer.area.height)
+            .map(|y| {
+                (0..buffer.area.width)
+                    .map(|x| buffer[(x, y)].symbol().to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            text.contains("Set Up Yolop"),
+            "setup overlay title should render:\n{text}"
+        );
+        // tuika's Boxed draws a rounded border — find one of its corners.
+        let has_border = (0..buffer.area.height).any(|y| {
+            (0..buffer.area.width).any(|x| matches!(buffer[(x, y)].symbol(), "╭" | "╮" | "╰" | "╯"))
+        });
+        assert!(has_border, "the tuika overlay panel should draw a border");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -438,31 +438,11 @@ pub(crate) fn draw_setup_overlay(f: &mut ratatui::Frame, area: Rect, app: &App) 
     }
 }
 
-/// Overlay for an extension `ui/ask` prompt: the question plus a live echo of
-/// the answer being typed. Owns the viewport like the setup overlay.
-pub(crate) fn draw_ask_overlay(f: &mut ratatui::Frame, area: Rect, app: &App) {
-    let Some(ask) = app.pending_ask.as_ref() else {
-        return;
-    };
-    if area.width == 0 || area.height == 0 {
-        return;
-    }
-    let panel = setup_panel_rect(area);
-    if panel.width == 0 || panel.height == 0 {
-        return;
-    }
-    f.render_widget(Clear, area);
-    f.render_widget(Clear, panel);
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .style(Style::default().bg(PANEL_BG).fg(TEXT_PRIMARY));
-    f.render_widget(block, panel);
-    let inner = Rect {
-        x: panel.x.saturating_add(2),
-        y: panel.y.saturating_add(1),
-        width: panel.width.saturating_sub(4),
-        height: panel.height.saturating_sub(2),
-    };
+/// The `ui/ask` overlay body: the question plus a live echo of the answer being
+/// typed, and the `(row, col)` cursor cell within the panel interior. Pure, so
+/// both the inline sheet renderer and the full-screen tuika overlay show the
+/// same content.
+pub(crate) fn ask_overlay_content(ask: &PendingAsk) -> (Vec<Line<'static>>, (usize, usize)) {
     let field = if ask.value.is_empty() {
         ask.placeholder
             .as_ref()
@@ -488,18 +468,48 @@ pub(crate) fn draw_ask_overlay(f: &mut ratatui::Frame, area: Rect, app: &App) {
             Style::default().add_modifier(Modifier::DIM),
         )),
     ];
+    // The typed answer is on row 4, after the "> " prompt.
+    let cursor = (4, "> ".len() + ask.value.chars().count());
+    (lines, cursor)
+}
+
+/// Overlay for an extension `ui/ask` prompt: the question plus a live echo of
+/// the answer being typed. Owns the viewport like the setup overlay.
+pub(crate) fn draw_ask_overlay(f: &mut ratatui::Frame, area: Rect, app: &App) {
+    let Some(ask) = app.pending_ask.as_ref() else {
+        return;
+    };
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let panel = setup_panel_rect(area);
+    if panel.width == 0 || panel.height == 0 {
+        return;
+    }
+    f.render_widget(Clear, area);
+    f.render_widget(Clear, panel);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .style(Style::default().bg(PANEL_BG).fg(TEXT_PRIMARY));
+    f.render_widget(block, panel);
+    let inner = Rect {
+        x: panel.x.saturating_add(2),
+        y: panel.y.saturating_add(1),
+        width: panel.width.saturating_sub(4),
+        height: panel.height.saturating_sub(2),
+    };
+    let (lines, (cursor_row, cursor_col)) = ask_overlay_content(ask);
     f.render_widget(
         Paragraph::new(lines).style(Style::default().bg(PANEL_BG)),
         inner,
     );
     // Park the cursor after the typed value.
-    let col = "> ".len() + ask.value.chars().count();
-    if inner.width > 0 && inner.height > 4 {
+    if inner.width > 0 && inner.height > cursor_row as u16 {
         f.set_cursor_position((
             inner
                 .x
-                .saturating_add((col as u16).min(inner.width.saturating_sub(1))),
-            inner.y.saturating_add(4),
+                .saturating_add((cursor_col as u16).min(inner.width.saturating_sub(1))),
+            inner.y.saturating_add(cursor_row as u16),
         ));
     }
 }


### PR DESCRIPTION
## What changed

The `--fullscreen` overlays no longer borrow the inline ratatui sheet renderers. The setup wizard, the extension `ui/ask` prompt, and the background-tasks panel now composite as **tuika `Overlay`s** over a blank base via `tuika::paint`:

- A shared `draw_panel_overlay` wraps the (reused) pure content builders in a `tuika::Boxed` panel. `Boxed`'s default rounded border + `symmetric(1, 0)` padding reproduces the inline overlay's interior rect exactly, so both modes place content identically.
- The panel sits at the shared `render::setup_panel_rect` geometry; the terminal cursor is placed for the input steps (setup key/URL/token fields, `ui/ask` answer) from the content's reported `(row, col)` cell.

With this, the full-screen renderer is tuika-native end to end — no `render::draw_*` painter is used for the frame **or** the overlays. `render.rs` gains a pure `ask_overlay_content` builder (the inline `draw_ask_overlay` now uses it too), and `PendingAsk` becomes `pub(crate)`.

Inline mode is untouched — it still owns `app.input` and paints its overlays with ratatui.

## Why

This is the overlays half of the "two isolate UI modes" rebuild. After the composer/chrome rebuild (#371), the overlays were the last part of full-screen still delegating to the inline ratatui path; this finishes the port so tuika owns the full-screen UI completely.

## Before / After

Overlay content is equivalent to the inline sheets (same title, rows, hints, cursor). Verified by a new test that the full-screen setup overlay renders its title inside a tuika-drawn border, plus the existing full-screen suite:

```
test app::tests::fullscreen_setup_overlay_renders_via_tuika ... ok
test app::tests::fullscreen_composer_renders_multiline_input_via_tuika ... ok
test app::tests::fullscreen_matches_regular_presentation ... ok
test app::tests::fullscreen_renders_blue_and_gold_separators ... ok
test app::tests::fullscreen_renders_at_mention_suggestions ... ok
test app::tests::fullscreen_renders_reverse_search_prompt ... ok
test app::tests::fullscreen_scroll_wheel_unsticks_from_bottom ... ok
test app::tests::fullscreen_mouse_drag_selects_and_copies_transcript ... ok
test app::tests::fullscreen_shares_regular_presentation_across_states ... ok
```

`cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --check` clean.

## Risk

- Low / Medium
- Only the `--fullscreen` overlay path changes; inline overlays are untouched and the extracted `ask_overlay_content` is a pure refactor of the inline renderer.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; `--fullscreen` is experimental)