### PR TITLE
feat(tui): surface context compaction in transcript and status gauge

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   hyperlinks), multiline composer, a busy
   indicator with a live elapsed timer while a turn runs, status
   bar (with a `bg` count whenever the session has background tasks and a `ctx`
-  context-window gauge once the model reports usage), slash commands
+  context-window gauge, marked with the point where automatic context
+  compaction kicks in, once the model reports usage; compaction itself is
+  noted in the transcript when it runs), slash commands
   (`/help`, `/tools`, `/mcp`, `/cwd`, `/setup`, `/model`, `/effort`, `/goal`,
   `/shell`, `/background`, `/clear`, `/quit`), a read-only background-tasks panel
   toggled with `Ctrl+B`, `!<command>` as a direct shell shortcut, `@`-triggered

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -672,6 +672,9 @@ impl App {
             turn_elapsed_secs: self.turn_started_at.map(|start| start.elapsed().as_secs()),
             context_used_tokens: self.context_used_tokens,
             context_window_tokens: self.context_window_tokens(),
+            compaction_budget_percent: Some(
+                (crate::runtime::YOLOP_COMPACTION_BUDGET_PERCENT * 100.0).round() as u8,
+            ),
             status_layout: self.status_layout,
             hooks_summary: self.startup.hook_summary(),
             approval_mode,
@@ -4168,6 +4171,7 @@ mod tests {
             turn_elapsed_secs: None,
             context_used_tokens: None,
             context_window_tokens: None,
+            compaction_budget_percent: None,
             status_layout: StatusLayout::Compact,
             hooks_summary: "none".to_string(),
             approval_mode: "normal".to_string(),

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -35,6 +35,10 @@ pub(crate) struct PresentationState {
     pub context_used_tokens: Option<u32>,
     /// The active model's context-window size, when known.
     pub context_window_tokens: Option<u32>,
+    /// Whole percent (0–100) of the context window at which proactive compaction
+    /// is expected to trigger, when compaction is active. Drives the threshold
+    /// mark on the context gauge. `None` hides the mark.
+    pub compaction_budget_percent: Option<u8>,
     pub status_layout: StatusLayout,
     pub hooks_summary: String,
     pub approval_mode: String,
@@ -156,7 +160,11 @@ fn expanded_status_lines(state: &PresentationState) -> Vec<StatusLine> {
         status_value(message_count_label(state.lines_count)),
         status_field("tokens", token_label(state.session_tokens)),
     ];
-    if let Some(ctx) = context_label(state.context_used_tokens, state.context_window_tokens) {
+    if let Some(ctx) = context_label(
+        state.context_used_tokens,
+        state.context_window_tokens,
+        state.compaction_budget_percent,
+    ) {
         counts.push(status_field("ctx", ctx));
     }
     if let Some(bg) = background_label(state.background, false) {
@@ -208,7 +216,11 @@ fn status_contributions(state: &PresentationState) -> Vec<Vec<StatusField>> {
         StatusLayout::Expanded => "[collapse ↑]",
     };
     let mut counts = vec![status_value(message_count_label(state.lines_count))];
-    if let Some(ctx) = context_label(state.context_used_tokens, state.context_window_tokens) {
+    if let Some(ctx) = context_label(
+        state.context_used_tokens,
+        state.context_window_tokens,
+        state.compaction_budget_percent,
+    ) {
         counts.push(status_field("ctx", ctx));
     }
     if let Some(bg) = background_label(state.background, true) {
@@ -307,19 +319,57 @@ fn message_count_label(count: usize) -> String {
     format!("{count} msgs")
 }
 
-/// Context-window fill as `pct% (used/total)`, e.g. `45% (90k/200k)`. `None`
+/// Number of cells in the inline context-gauge bar.
+const CONTEXT_GAUGE_CELLS: u32 = 8;
+
+/// Context-window fill as a small gauge, e.g. `██╿█░░░░ 45% (90k/200k)`. `None`
 /// until we have both a usage sample and a known window size.
-pub(crate) fn context_label(used: Option<u32>, window: Option<u32>) -> Option<String> {
+///
+/// When `compaction_budget_percent` is set, a `╿` tick marks the fraction of the
+/// window at which proactive compaction is expected to trigger. The mark is a
+/// guide, not a guarantee: the gauge fill is real prompt-token usage, while
+/// compaction actually triggers on a char/4 token *estimate* of the message
+/// history (everruns-core `should_compact_proactively`), so the true trigger
+/// point can drift from the mark.
+pub(crate) fn context_label(
+    used: Option<u32>,
+    window: Option<u32>,
+    compaction_budget_percent: Option<u8>,
+) -> Option<String> {
     let (used, window) = (used?, window?);
     if window == 0 {
         return None;
     }
-    let pct = ((u64::from(used) * 100) / u64::from(window)).min(100);
+    let pct = ((u64::from(used) * 100) / u64::from(window)).min(100) as u32;
+    let bar = context_gauge_bar(pct, compaction_budget_percent);
     Some(format!(
-        "{pct}% ({}/{})",
+        "{bar} {pct}% ({}/{})",
         compact_token_count(used),
         compact_token_count(window)
     ))
+}
+
+/// Render the `CONTEXT_GAUGE_CELLS`-wide gauge: filled cells for `used_pct`, a
+/// `╿` tick at the compaction threshold when known (it overrides the cell it
+/// lands on). Both `used_pct` and `threshold` are whole percents (0–100).
+fn context_gauge_bar(used_pct: u32, threshold: Option<u8>) -> String {
+    let filled = (used_pct * CONTEXT_GAUGE_CELLS)
+        .div_ceil(100)
+        .min(CONTEXT_GAUGE_CELLS);
+    let tick = threshold
+        .filter(|&t| t <= 100)
+        .map(|t| (u32::from(t) * CONTEXT_GAUGE_CELLS / 100).min(CONTEXT_GAUGE_CELLS - 1));
+    (0..CONTEXT_GAUGE_CELLS)
+        .map(|i| {
+            if Some(i) == tick {
+                '╿'
+            } else if i < filled {
+                '█'
+            } else {
+                '░'
+            }
+        })
+        .collect()
 }
 
 /// Render a token count compactly: `900`, `90k`, `1.2M`.
@@ -354,6 +404,7 @@ mod tests {
             turn_elapsed_secs: None,
             context_used_tokens: None,
             context_window_tokens: None,
+            compaction_budget_percent: None,
             status_layout: StatusLayout::Compact,
             hooks_summary: "none".to_string(),
             approval_mode: "normal".to_string(),
@@ -530,22 +581,42 @@ mod tests {
 
     #[test]
     fn context_label_formats_percentage_and_compact_counts() {
+        // Without a compaction budget the gauge has no threshold tick.
         assert_eq!(
-            context_label(Some(90_000), Some(200_000)).as_deref(),
-            Some("45% (90k/200k)")
+            context_label(Some(90_000), Some(200_000), None).as_deref(),
+            Some("████░░░░ 45% (90k/200k)")
         );
         assert_eq!(
-            context_label(Some(1_500_000), Some(2_000_000)).as_deref(),
-            Some("75% (1.5M/2.0M)")
+            context_label(Some(1_500_000), Some(2_000_000), None).as_deref(),
+            Some("██████░░ 75% (1.5M/2.0M)")
         );
         // Clamped to 100% and safe against a zero/absent window.
         assert_eq!(
-            context_label(Some(300), Some(200)).as_deref(),
-            Some("100% (300/200)")
+            context_label(Some(300), Some(200), None).as_deref(),
+            Some("████████ 100% (300/200)")
         );
-        assert_eq!(context_label(Some(10), None), None);
-        assert_eq!(context_label(None, Some(200_000)), None);
-        assert_eq!(context_label(Some(10), Some(0)), None);
+        assert_eq!(context_label(Some(10), None, None), None);
+        assert_eq!(context_label(None, Some(200_000), None), None);
+        assert_eq!(context_label(Some(10), Some(0), None), None);
+    }
+
+    #[test]
+    fn context_label_marks_the_compaction_threshold() {
+        // 45% fill (4/8 cells), threshold 20% → tick lands on cell index 1.
+        assert_eq!(
+            context_label(Some(90_000), Some(200_000), Some(20)).as_deref(),
+            Some("█╿██░░░░ 45% (90k/200k)")
+        );
+        // Threshold clamps into range; 100% lands on the final cell.
+        assert_eq!(
+            context_label(Some(200_000), Some(200_000), Some(100)).as_deref(),
+            Some("███████╿ 100% (200k/200k)")
+        );
+        // An out-of-range budget is ignored rather than panicking.
+        assert_eq!(
+            context_label(Some(50_000), Some(200_000), Some(150)).as_deref(),
+            Some("██░░░░░░ 25% (50k/200k)")
+        );
     }
 
     #[test]
@@ -564,9 +635,38 @@ mod tests {
         assert!(
             values
                 .iter()
-                .any(|(label, value)| *label == Some("ctx") && value == "25% (50k/200k)"),
+                .any(|(label, value)| *label == Some("ctx") && value == "██░░░░░░ 25% (50k/200k)"),
             "expected a ctx gauge in {values:?}"
         );
+    }
+
+    #[test]
+    fn status_gauge_marks_compaction_threshold_in_both_layouts() {
+        // Fullscreen and inline share this status path, so proving the mark
+        // lands in the rendered `ctx` field covers both modes.
+        let base = PresentationState {
+            context_used_tokens: Some(50_000),
+            context_window_tokens: Some(200_000),
+            compaction_budget_percent: Some(20),
+            ..state()
+        };
+        for layout in [StatusLayout::Compact, StatusLayout::Expanded] {
+            let model = PresentationState {
+                status_layout: layout,
+                ..base.clone()
+            };
+            let ctx = model
+                .status_lines()
+                .into_iter()
+                .flat_map(|line| line.fields)
+                .find(|field| field.label == Some("ctx"))
+                .map(|field| field.value)
+                .unwrap_or_default();
+            assert!(
+                ctx.contains('╿'),
+                "{layout:?} ctx gauge should carry the compaction threshold mark: {ctx:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -904,6 +904,13 @@ const YOLOP_NEVER_DEFER_TOOLS: &[&str] = &[
 ];
 const YOLOP_KEEP_RECENT_TOOL_OUTPUTS: u64 = 3;
 
+/// Fraction of the model context window at which proactive compaction triggers.
+/// Kept low: yolop favors a tight, cheap context and lets the compaction cascade
+/// (observation masking → aggressive trim) keep older tool output from
+/// accumulating. Surfaced to the TUI so the context gauge can mark this point —
+/// see `crate::presentation::context_label`.
+pub(crate) const YOLOP_COMPACTION_BUDGET_PERCENT: f32 = 0.20;
+
 #[derive(Clone, Debug)]
 pub enum ProviderChoice {
     Anthropic {
@@ -2025,7 +2032,7 @@ fn default_coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabi
             serde_json::json!({
                 "strategy": "auto",
                 "proactive": true,
-                "budget_percent": 0.20,
+                "budget_percent": YOLOP_COMPACTION_BUDGET_PERCENT,
                 "observation_masking": {
                     "keep_recent_tool_outputs": YOLOP_KEEP_RECENT_TOOL_OUTPUTS,
                     "summary_format": "one_line"

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -268,8 +268,42 @@ pub fn lines_for_event(event: &RuntimeEvent) -> Vec<ChatLine> {
             }
             lines
         }
+        EventData::ContextCompacted(data) => vec![ChatLine {
+            author: Author::System,
+            text: compacted_summary_line(data),
+        }],
         _ => Vec::new(),
     }
+}
+
+/// One-line summary of a completed compaction, e.g.
+/// `⊟ compacted context · 142 → 38 msgs · observation_masking+aggressive_trim · 120ms`.
+fn compacted_summary_line(data: &everruns_core::events::ContextCompactedData) -> String {
+    let saved = data.messages_before.saturating_sub(data.messages_after);
+    let mut line = format!(
+        "⊟ compacted context · {} → {} msgs",
+        data.messages_before, data.messages_after
+    );
+    if saved > 0 {
+        line.push_str(&format!(" (−{saved})"));
+    }
+    if !data.strategy_used.is_empty() {
+        line.push_str(&format!(" · {}", data.strategy_used));
+    }
+    line.push_str(&format!(" · {}", format_duration_ms(data.duration_ms)));
+    line
+}
+
+/// Compact millisecond duration: `120ms`, `1.2s`, `1m03s`.
+fn format_duration_ms(ms: u64) -> String {
+    if ms < 1_000 {
+        return format!("{ms}ms");
+    }
+    let secs = ms / 1_000;
+    if secs < 60 {
+        return format!("{:.1}s", ms as f64 / 1_000.0);
+    }
+    format!("{}m{:02}s", secs / 60, secs % 60)
 }
 
 fn append_bash_diagnostics(lines: &mut Vec<ChatLine>, result: &Value) {
@@ -400,6 +434,10 @@ pub fn status_for_event(event: &RuntimeEvent) -> Option<ActivityStatus> {
             )))
         }
         EventData::ReasonThinkingStarted(_) => Some(fallback_status("thinking deeply")),
+        EventData::ContextCompacting(data) => Some(activity_status(format!(
+            "compacting context ({})…",
+            data.reason
+        ))),
         EventData::TurnCancelled(_) => Some(activity_status("turn cancelled")),
         EventData::TurnFailed(data) => Some(activity_status(format!(
             "turn failed: {}",
@@ -850,5 +888,88 @@ mod tests {
             summarize_tool_result(&data),
             "error: Invalid URL: must start with http:// or https://"
         );
+    }
+
+    fn event(data: impl Into<EventData>) -> RuntimeEvent {
+        RuntimeEvent::new(
+            everruns_core::typed_id::SessionId::new(),
+            everruns_core::events::EventContext::empty(),
+            data.into(),
+        )
+    }
+
+    #[test]
+    fn context_compacted_renders_a_system_summary_line() {
+        use everruns_core::events::{CompactionStepData, ContextCompactedData};
+
+        let event = event(ContextCompactedData {
+            strategy_used: "observation_masking+aggressive_trim".into(),
+            messages_before: 142,
+            messages_after: 38,
+            duration_ms: 120,
+            steps: vec![CompactionStepData {
+                strategy: "observation_masking".into(),
+                messages_after: 96,
+                duration_ms: 4,
+            }],
+        });
+
+        let lines = lines_for_event(&event);
+        assert_eq!(lines.len(), 1, "expected one summary line: {lines:?}");
+        let line = &lines[0];
+        assert_eq!(line.author, Author::System);
+        assert!(line.text.contains("142 → 38 msgs"), "{}", line.text);
+        assert!(line.text.contains("(−104)"), "{}", line.text);
+        assert!(
+            line.text.contains("observation_masking+aggressive_trim"),
+            "{}",
+            line.text
+        );
+        assert!(line.text.contains("120ms"), "{}", line.text);
+    }
+
+    #[test]
+    fn context_compacted_survives_replay() {
+        use everruns_core::events::ContextCompactedData;
+
+        let event = event(ContextCompactedData {
+            strategy_used: "native".into(),
+            messages_before: 50,
+            messages_after: 12,
+            duration_ms: 2_400,
+            steps: Vec::new(),
+        });
+
+        let lines = lines_for_replayed_event(&event);
+        assert_eq!(lines.len(), 1, "replay should render the notice: {lines:?}");
+        assert_eq!(lines[0].author, Author::System);
+        // sub-minute duration falls back to seconds formatting.
+        assert!(lines[0].text.contains("2.4s"), "{}", lines[0].text);
+    }
+
+    #[test]
+    fn context_compacting_reports_reason_as_activity() {
+        use everruns_core::events::{CompactionReason, ContextCompactingData};
+
+        let event = event(ContextCompactingData {
+            reason: CompactionReason::ProactiveBudget,
+            strategy: "auto".into(),
+            messages_before: 142,
+        });
+
+        let status = status_for_event(&event).expect("compacting should set activity");
+        assert!(
+            status.text.contains("compacting context"),
+            "{}",
+            status.text
+        );
+        assert!(status.text.contains("proactive_budget"), "{}", status.text);
+    }
+
+    #[test]
+    fn duration_formatting_scales_by_magnitude() {
+        assert_eq!(format_duration_ms(120), "120ms");
+        assert_eq!(format_duration_ms(2_400), "2.4s");
+        assert_eq!(format_duration_ms(63_000), "1m03s");
     }
 }


### PR DESCRIPTION
## What changed

Context compaction used to happen invisibly. everruns-core emits `context.compacting` / `context.compacted` events (the 85%-budget cascade and the `RequestTooLarge` fallback), but the TUI dropped both through match catch-alls, so the user never saw the context shrink beneath them, and the `ctx` gauge gave no hint of where compaction would kick in.

This surfaces compaction in two places, both terminal-independent so inline and full-screen modes stay in lockstep:

- **Transcript notice** — `context.compacted` renders a durable `system` line, e.g. `⊟ compacted context · 142 → 38 msgs (−104) · observation_masking+aggressive_trim · 120ms`. `context.compacting` sets a transient activity status naming the trigger (`proactive_budget` / `request_too_large` / `manual`). The notice also renders on session replay.
- **Status-gauge threshold mark** — the `ctx` gauge is now a small bar with a `╿` tick at the configured compaction budget: `█╿██░░░░ 45% (90k/200k)`. The budget (`0.20`) is promoted to a named constant and threaded through the presentation model, so the gauge shows *how close the context is to being compacted* instead of raw window fill.

Both renderers build their status from the same `presentation::status_lines()` builder (the full-screen tuika rebuild in #371 kept this shared), so one change covers both modes.

## Why

"Do we visualise compaction / progress toward it?" — we didn't. Codex/Claude Code both show context usage and a compaction signal; yolop had a richer compaction engine but zero surfacing. This closes that gap using events and config values that already exist — no everruns-core change.

## Before / After

Status gauge (asserted in `presentation::tests`):

- Before: `ctx  45% (90k/200k)`
- After:  `ctx  █╿██░░░░ 45% (90k/200k)`  — bar + compaction tick at 20%

Transcript when compaction runs:

- Before: *(nothing)*
- After:  `system › ⊟ compacted context · 142 → 38 msgs (−104) · observation_masking+aggressive_trim · 120ms`

The gauge is TUI-only, so it cannot be shown through `--print`/headless; the exact rendered strings are instead pinned by presentation-model unit tests (the proof form `specs/presentation.md` designates for status values). The mark is a guide, not a guarantee: the gauge fill is real prompt-token usage while compaction triggers on a char/4 token *estimate* of history, so the true trigger point can drift from the mark — documented in `context_label`.

## Risk
- **Low**
- Pure presentation/status change. No agent-loop, tool, filesystem, or provider wiring touched. Worst case is a cosmetic gauge/transcript-line regression, which the unit tests guard.

## Security

No security-relevant code changes. Text rendering of event data (strategy names, message counts, durations) only — no secrets, paths, or shell/filesystem involvement. The one config touch extracts the existing `budget_percent: 0.20` literal into a value-identical named constant. No new dependencies, no capability or write-blocklist changes, no `everruns-*` version changes beyond main's own 0.17.15 bump carried in by rebase.

## Validation

- `cargo test --bin yolop --all-features` → **852 passed, 0 failed** (new gauge, threshold, transcript, and duration tests included).
- `cargo fmt --check` → clean.
- `cargo clippy --all-targets --all-features -- -D warnings` → clean.
- `cargo test --all-features` → the only failures are 4 native-sandbox integration tests (`linux_sandbox_worker_*`, `tui_*_sandbox`, `tui_bang_shell_*`) that fail with `native sandbox unavailable: Landlock ABI v3 is not fully enforced by this Linux kernel` — an environment limitation of the dev container, unrelated to this diff; they exercise no code this PR touches and pass under CI.
- Offline smoke: `cargo run -- --provider llmsim -p "hi"` starts and exits 0.

## Follow-ups

- The threshold mark is placed on the real-usage axis while the trigger uses a char/4 estimate; a future refinement could drive the gauge from the same estimate the cascade uses so the mark and the actual trigger coincide exactly.
- Cost-control model-view masking (the always-on per-call trimming in `CompactionModelViewProvider`) is still log-only — deliberately not surfaced here, as it would be noisy and needs an event sink plumbed into `ModelViewContext` upstream.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; no compat contract; gauge falls back to the plain bar when no budget is known)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V47QBNXLkqwbBkEdysQ1gi)_