### PR TITLE
feat(tui): full-screen transcript scrolls full history via tuika Scroll

### DIFF
--- a/src/app/fullscreen.rs
+++ b/src/app/fullscreen.rs
@@ -14,13 +14,14 @@
 //! - **the preview row** (reverse-search / suggestions / streaming preview) and
 //!   **the status** are [`tuika::Text`] views built from the same pure line
 //!   builders the inline chrome uses, so the two modes cannot visually drift;
-//! - **the transcript** is bottom-aligned styled lines inside a probed region so
-//!   full-screen mouse text selection (see [`super::App`]) can be bounded to it.
+//! - **the transcript** is a [`tuika::Scroll`] over the *full* history, bound to
+//!   [`App`]'s persisted `ScrollState`, inside a probed region so full-screen
+//!   mouse text selection (see [`super::App`]) can be bounded to it.
 //!
-//! Crucially, the full-screen frame calls **no** `render::draw_*` painter for
-//! its own chrome — only the shared *content* builders (which return styled
-//! [`Line`]s). The setup / ask / background overlays still borrow the inline
-//! sheet renderers; they move onto tuika in a follow-up.
+//! Crucially, the full-screen frame calls **no** `render::draw_*` painter — not
+//! for its chrome and not for the setup / ask / background overlays (which
+//! composite as tuika [`Overlay`]s, see below). It uses only the shared *content*
+//! builders, which return styled [`Line`]s.
 
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -28,8 +29,8 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 
 use tuika::{
-    Boxed, Element, Overlay, Padding, RectProbe, Rule, Spacer, Text, TextInput, TextInputState,
-    element, view,
+    Boxed, Element, Overlay, Padding, RectProbe, Rule, Scroll, Spacer, Text, TextInput,
+    TextInputState, element, view,
 };
 
 use super::render;
@@ -61,6 +62,14 @@ pub(crate) fn draw(f: &mut Frame, app: &mut App) {
     let desired_input_height = app.input_height(input_width);
     let status_rows = state.status_row_count();
     let preview_visible = render::chrome_preview_visible(&state);
+    // NOTE (layout policy, item 2): `chrome_dimensions` stays hand-rolled on
+    // purpose. tuika's Flex solver places the rows of the `view!` tree below, but
+    // *how tall the composer may grow* and *whether the preview/status-separator
+    // rows appear at all* is yolop UX policy (shrink the composer to keep the
+    // transcript visible on a short viewport; mirror Codex's composer behavior) —
+    // not something a generic constraint solver can infer. We compute those
+    // heights here and hand the solver fixed sizes; the solver still owns
+    // placement, wrapping, and the transcript's `grow(1)` fill.
     let (chrome_height, input_height) = render::chrome_dimensions(
         area.height,
         desired_input_height,
@@ -69,15 +78,27 @@ pub(crate) fn draw(f: &mut Frame, app: &mut App) {
     );
     let preview_height = u16::from(input_height == 1 && preview_visible);
     let status_sep_height = u16::from(input_height < 3);
-    let transcript_height = area.height.saturating_sub(chrome_height);
+    let transcript_height = area.height.saturating_sub(chrome_height).max(1);
 
     // Content as styled lines — the exact pure builders the inline renderer uses,
     // so colors, separators, and status can never drift between the two modes.
     let inner_w = area.width.saturating_sub(2) as usize;
-    let transcript_lines =
-        render::recent_transcript_lines(app, inner_w, transcript_height.max(1) as usize);
     let status_lines = render::session_status_lines(&state);
     let preview_line = render::preview_slot_line(&state, area.width);
+
+    // The transcript is a real Scroll over the *full* history, bound to the
+    // persisted ScrollState. Short content is top-padded so it rests at the
+    // bottom (the inline scrollback feel); taller content scrolls, and
+    // stick-to-bottom keeps the newest line visible as the turn streams.
+    let scroll_lines = pad_to_bottom(
+        render::full_transcript_lines(app, inner_w),
+        transcript_height,
+    );
+    let scroll_content_h = scroll_lines.len() as u16;
+    // Record metrics + reconcile the offset before rendering, so the mouse-wheel
+    // / paging handlers (which reuse these metrics) clamp correctly.
+    app.scroll_metrics = (scroll_content_h, transcript_height);
+    app.scroll.clamp(scroll_content_h, transcript_height);
 
     // The composer is a real tuika TextInput. Its text is a snapshot of the
     // shared composer model (`app.input`); inline mode keeps owning that model,
@@ -92,9 +113,11 @@ pub(crate) fn draw(f: &mut Frame, app: &mut App) {
     let transcript_probe = RectProbe::new();
     let input_probe = RectProbe::new();
 
+    let transcript = Scroll::new(scroll_lines, &app.scroll);
+
     let root = view! {
         col {
-            grow(1) { node(transcript_view(transcript_lines, &transcript_probe)) }
+            grow(1) { node(transcript_view(transcript, &transcript_probe)) }
             fixed(preview_height) { node(preview_view(preview_line)) }
             fixed(1) { node(message_rule(&state)) }
             fixed(input_height) { node(composer_row(&composer, &input_probe)) }
@@ -146,14 +169,25 @@ pub(crate) fn draw(f: &mut Frame, app: &mut App) {
     }
 }
 
-/// The transcript region: styled lines bottom-aligned within a one-column inset,
-/// probed so the host can bound mouse selection to it.
-fn transcript_view(lines: Vec<Line<'static>>, probe: &RectProbe) -> Element {
-    let height = (lines.len() as u16).max(1);
+/// Top-pad `lines` with blanks so a history shorter than the viewport rests at
+/// the bottom of the scroll region (matching the inline scrollback feel). A
+/// history taller than the viewport is returned unchanged and simply scrolls.
+fn pad_to_bottom(lines: Vec<Line<'static>>, viewport_h: u16) -> Vec<Line<'static>> {
+    let deficit = (viewport_h as usize).saturating_sub(lines.len());
+    if deficit == 0 {
+        return lines;
+    }
+    let mut padded = vec![Line::from(""); deficit];
+    padded.extend(lines);
+    padded
+}
+
+/// The transcript region: a [`Scroll`] within a one-column inset, probed so the
+/// host can bound mouse selection to it.
+fn transcript_view(scroll: Scroll, probe: &RectProbe) -> Element {
     let inner = view! {
         col(padding = Padding { left: 1, right: 1, top: 0, bottom: 0 }) {
-            grow(1) { spacer() }
-            fixed(height) { node(Text::new(lines)) }
+            grow(1) { node(scroll) }
         }
     };
     probe.wrap(inner)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4435,6 +4435,35 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fullscreen_scroll_reveals_full_history() {
+        let mut test = app_with_llmsim().await;
+        test.app.setup = None;
+        test.app.set_render_mode(RenderMode::Fullscreen);
+        for i in 0..80 {
+            test.app.push_user(format!("line {i}"));
+        }
+        // Bottom-stuck by default: the newest line is visible, the oldest is
+        // scrolled off the top.
+        let bottom = render_app_lines(&mut test.app, 40, 12).join("\n");
+        assert!(
+            bottom.contains("line 79"),
+            "newest line should be visible at the bottom:\n{bottom}"
+        );
+        assert!(
+            !bottom.contains("line 0"),
+            "oldest line should be scrolled off:\n{bottom}"
+        );
+        // Scroll to the very top: the *full* history is reachable — the old
+        // recent-tail mirror could never render "line 0".
+        test.app.scroll.jump_to_top();
+        let top = render_app_lines(&mut test.app, 40, 12).join("\n");
+        assert!(
+            top.contains("line 0"),
+            "oldest line should be reachable by scrolling to the top:\n{top}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn fullscreen_mouse_drag_selects_and_copies_transcript() {
         let mut test = app_with_llmsim().await;
         test.app.setup = None;

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -321,6 +321,36 @@ pub(crate) fn recent_transcript_lines(
     chunks.into_iter().flatten().collect()
 }
 
+/// The **full** transcript as styled lines, oldest-first, for the full-screen
+/// `tuika::Scroll` viewport (which owns the alternate screen and can scroll the
+/// entire history, unlike the inline recent-tail mirror above).
+///
+/// NOTE: this deliberately duplicates the per-line assembly of
+/// [`recent_transcript_lines`] — same [`append_chat_lines`] formatting and
+/// [`should_insert_chat_gap`] spacing — but assembles the *whole* history
+/// forward with no tail bound and no `bounded_recent_chat_line` truncation,
+/// because the full-screen viewport scrolls rather than clipping to a fixed
+/// window. The shared piece is `append_chat_lines`; the traversal differs by
+/// design (reverse+bounded for inline, forward+unbounded here), so they are not
+/// worth collapsing into one function.
+pub(crate) fn full_transcript_lines(app: &App, width: usize) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    let mut prev_author: Option<Author> = None;
+    for (index, chat) in app.lines.iter().enumerate() {
+        if !include_line_in_recent_transcript_mirror(chat, index, &app.lines) {
+            continue;
+        }
+        if let Some(prev) = &prev_author
+            && should_insert_chat_gap(prev, Some(&chat.author))
+        {
+            lines.push(Line::from(""));
+        }
+        append_chat_lines(&mut lines, chat, width);
+        prev_author = Some(chat.author.clone());
+    }
+    lines
+}
+
 pub(crate) fn bounded_recent_chat_line(chat: &ChatLine) -> ChatLine {
     if chat.text.len() <= RECENT_TRANSCRIPT_MAX_TEXT_BYTES {
         return chat.clone();


### PR DESCRIPTION
## What changed

The `--fullscreen` transcript is now a real `tuika::Scroll` over the **entire** history, bound to `App`'s persisted `ScrollState` — not the inline recent-tail mirror clipped to the viewport. You can scroll back through the whole conversation; the mouse wheel already routes to this `ScrollState`.

- Short histories are top-padded so they still rest at the bottom (the scrollback feel); taller histories scroll, and stick-to-bottom keeps the newest line visible as a turn streams.
- New pure builder `render::full_transcript_lines` — a forward, unbounded assembly that shares `append_chat_lines` formatting with `recent_transcript_lines`. A NOTE documents why the two traversals (reverse+bounded for inline, forward+unbounded here) aren't merged.

This is items **2 + 3** of the "if we'd built on tuika from scratch" list:

- **Item 3 (Scroll transcript):** done — the transcript is `Scroll`/`ScrollState`, full history.
- **Item 2 (solver layout):** the `view!` tree's rows are placed by tuika's Flex solver; a NOTE documents why `chrome_dimensions` stays hand-rolled — it encodes composer-height/row-visibility **UX policy** (shrink the composer to keep the transcript visible on a short viewport; mirror Codex's composer) that a generic constraint solver can't infer. The solver still owns placement, wrapping, and the transcript's `grow(1)` fill.

Keyboard paging (PageUp/Home/End → scroll) lands with the input-routing change (item 5); mouse-wheel scrolling works today.

## Why

Owning the alternate screen is pointless if you can only see the recent tail. A real scroll region over full history is the whole reason full-screen exists, and it's the tuika-native design we'd have reached for from the start.

## Before / After

- **Before:** full-screen showed only the recent tail; older lines were unreachable.
- **After:** the full history scrolls. New test `fullscreen_scroll_reveals_full_history` pushes 80 lines and asserts the newest is visible at the bottom, and that scrolling to the top reveals `line 0` — which the recent-tail mirror could never render. The existing 9 full-screen tests (bottom-stick, mouse-drag select, separators, overlays, composer) still pass.

```
test app::tests::fullscreen_scroll_reveals_full_history ... ok
test app::tests::fullscreen_scroll_wheel_unsticks_from_bottom ... ok
test app::tests::fullscreen_mouse_drag_selects_and_copies_transcript ... ok
... (9 full-screen tests total, all ok)
```

`cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --check` clean.

## Risk

- Low / Medium
- Only the `--fullscreen` transcript changes; inline is untouched. Bottom-padding preserves the existing bottom-anchored look, so the mouse-selection test (which drags the bottom row) still holds.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; `--fullscreen` is experimental)