### PR TITLE
feat(tuika): tuika owns a neutral theme identity; yolop builds its own

### DIFF
--- a/crates/tuika/src/style.rs
+++ b/crates/tuika/src/style.rs
@@ -82,20 +82,22 @@ pub struct Theme {
 
 impl Default for Theme {
     fn default() -> Self {
-        // Kept in lockstep with the palette in `crate::app` so inline and
-        // full-screen share one look.
+        // tuika's own toolkit identity — a warm red-on-dark palette. This is a
+        // neutral default for any app built on tuika; it is deliberately NOT any
+        // one host's brand. A host with its own look builds its own `Theme` (see
+        // yolop's `fullscreen::yolop_theme`) rather than relying on this.
         Theme {
-            background: Color::Rgb(18, 18, 22),
-            surface: Color::Rgb(28, 28, 34),
-            text: Color::Rgb(230, 230, 232),
-            muted: Color::Rgb(140, 140, 145),
-            dim: Color::Rgb(72, 72, 78),
-            accent: Color::Rgb(45, 91, 158),
-            accent_alt: Color::Rgb(126, 94, 19),
-            border: Color::Rgb(72, 72, 78),
-            border_focused: Color::Rgb(45, 91, 158),
-            selection_bg: Color::Rgb(45, 91, 158),
-            selection_fg: Color::Rgb(230, 230, 232),
+            background: Color::Rgb(20, 18, 20),
+            surface: Color::Rgb(34, 28, 30),
+            text: Color::Rgb(235, 230, 230),
+            muted: Color::Rgb(150, 140, 142),
+            dim: Color::Rgb(90, 74, 78),
+            accent: Color::Rgb(200, 60, 70),
+            accent_alt: Color::Rgb(230, 140, 90),
+            border: Color::Rgb(90, 74, 78),
+            border_focused: Color::Rgb(200, 60, 70),
+            selection_bg: Color::Rgb(120, 30, 40),
+            selection_fg: Color::Rgb(240, 235, 235),
         }
     }
 }

--- a/crates/tuika/src/tests.rs
+++ b/crates/tuika/src/tests.rs
@@ -1238,6 +1238,19 @@ fn theme_helper_styles_map_to_slots() {
 }
 
 #[test]
+fn default_theme_is_the_toolkit_identity_not_a_host_brand() {
+    use ratatui::style::Color;
+    // tuika's own look is warm red-on-dark. It is deliberately a neutral toolkit
+    // identity, not any host's brand — a host with its own palette builds its own
+    // `Theme` (e.g. yolop's `fullscreen::yolop_theme`) instead of inheriting this.
+    let t = Theme::default();
+    assert_eq!(t.accent, Color::Rgb(200, 60, 70));
+    assert_eq!(t.selection_bg, Color::Rgb(120, 30, 40));
+    // Not yolop's accent blue.
+    assert_ne!(t.accent, Color::Rgb(45, 91, 158));
+}
+
+#[test]
 fn boxed_border_follows_theme_focus_color() {
     use super::components::{Boxed, Text};
     let t = rainbow_theme();

--- a/src/app/fullscreen.rs
+++ b/src/app/fullscreen.rs
@@ -9,8 +9,9 @@
 //! [`tuika::paint`]:
 //!
 //! - **separators** are [`tuika::Rule`]s (blue message rule, gold status rule);
-//! - **the composer** is a [`tuika::TextInput`] fed from a snapshot of the
-//!   shared composer text model (`app.input`) — no ratatui-textarea widget;
+//! - **the composer** is a [`tuika::TextInput`] over full-screen's own model of
+//!   record ([`App::composer`], a tuika `TextInputState` that handles its own
+//!   key events) — no ratatui-textarea widget;
 //! - **the preview row** (reverse-search / suggestions / streaming preview) and
 //!   **the status** are [`tuika::Text`] views built from the same pure line
 //!   builders the inline chrome uses, so the two modes cannot visually drift;
@@ -34,7 +35,34 @@ use tuika::{
 };
 
 use super::render;
-use super::{ACCENT_BLUE, ACCENT_GOLD, App, DIFF_META, PANEL_BG, TEXT_PRIMARY};
+use super::{
+    ACCENT_BLUE, ACCENT_GOLD, App, DIFF_META, PANEL_BG, TEXT_DIM, TEXT_MUTED, TEXT_PRIMARY,
+};
+
+/// The full-screen renderer's tuika [`Theme`](tuika::Theme), built from yolop's
+/// own palette.
+///
+/// NOTE (item 6): tuika's `Theme::default()` is the toolkit's neutral identity
+/// (a red-on-dark look), deliberately not any host's brand. yolop owns its
+/// colors here, so every theme-driven tuika component in full-screen — the
+/// `Scroll` scrollbar, `Boxed` borders, `SelectList` selection — renders in
+/// yolop's palette instead of the toolkit default. `background: Reset` lets the
+/// terminal's own background own the alternate screen.
+pub(crate) fn yolop_theme() -> tuika::Theme {
+    tuika::Theme {
+        background: Color::Reset,
+        surface: PANEL_BG,
+        text: TEXT_PRIMARY,
+        muted: TEXT_MUTED,
+        dim: TEXT_DIM,
+        accent: ACCENT_BLUE,
+        accent_alt: ACCENT_GOLD,
+        border: TEXT_DIM,
+        border_focused: ACCENT_BLUE,
+        selection_bg: ACCENT_BLUE,
+        selection_fg: TEXT_PRIMARY,
+    }
+}
 
 pub(crate) fn draw(f: &mut Frame, app: &mut App) {
     let area = f.area();
@@ -121,11 +149,9 @@ pub(crate) fn draw(f: &mut Frame, app: &mut App) {
         }
     };
 
-    // Transparent background so the styled lines' own colors show through.
-    let theme = tuika::Theme {
-        background: Color::Reset,
-        ..tuika::Theme::default()
-    };
+    // yolop's own palette (see `yolop_theme`); a Reset background lets the
+    // styled lines' own colors show through.
+    let theme = yolop_theme();
     tuika::paint(f.buffer_mut(), area, &theme, root.as_ref(), &[]);
 
     // Mouse text selection over the transcript. Its selectable inner rect is the
@@ -248,11 +274,7 @@ fn draw_panel_overlay(
     }
     let boxed = Boxed::new(element(Text::new(lines)))
         .background(Style::default().bg(PANEL_BG).fg(TEXT_PRIMARY));
-    let theme = tuika::Theme {
-        background: Color::Reset,
-        surface: PANEL_BG,
-        ..tuika::Theme::default()
-    };
+    let theme = yolop_theme();
     let overlay = Overlay {
         area: panel,
         view: &boxed,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4515,6 +4515,18 @@ mod tests {
         assert!(test.app.input.lines().join("").is_empty());
     }
 
+    #[test]
+    fn fullscreen_theme_uses_yolop_palette_not_tuika_default() {
+        // Full-screen builds its own tuika Theme from yolop's palette (item 6),
+        // rather than inheriting tuika's neutral toolkit default.
+        let theme = fullscreen::yolop_theme();
+        assert_eq!(theme.accent, ACCENT_BLUE);
+        assert_eq!(theme.accent_alt, ACCENT_GOLD);
+        assert_eq!(theme.surface, PANEL_BG);
+        // tuika's default is a different (red) identity.
+        assert_ne!(theme.accent, tuika::Theme::default().accent);
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn fullscreen_setup_overlay_renders_via_tuika() {
         use ratatui::backend::TestBackend;


### PR DESCRIPTION
## What changed

tuika's `Theme::default()` was silently a copy of yolop's palette (blue/gold on dark), kept in sync only by a comment. A general-purpose toolkit's default shouldn't *be* one host's brand, so:

- **tuika** now has its own neutral identity — a warm **red-on-dark** palette — as its `Theme::default()`.
- **yolop** constructs its own `Theme` from its palette in `fullscreen::yolop_theme()` and uses it for the full-screen frame and overlays.

This is item **6** ("colors in the theme") done properly: the palette lives in a `Theme` that the host owns, and every theme-driven tuika component in full-screen — the `Scroll` scrollbar, `Boxed` borders, `SelectList` selection — reads yolop's colors from that theme instead of a hardcoded default. The blue/gold separators are yolop brand and stay explicit.

Inline mode is pure ratatui and never touched tuika's `Theme`, so it is completely unaffected. The tuika-gallery demo keeps `tuika::Theme::default()` — so it now showcases tuika's *own* red identity, which is the point of a toolkit demo.

## Why

Coupling the toolkit's default to a specific app's brand is a latent trap — the "keep in lockstep" comment was load-bearing. Giving tuika its own identity makes the boundary honest: apps bring their own theme; the default is just tuika being tuika.

## Before / After

- **Before:** `tuika::Theme::default().accent == Rgb(45,91,158)` (yolop's blue). Full-screen inherited it, so the coupling was invisible.
- **After:** `tuika::Theme::default().accent == Rgb(200,60,70)` (red). Full-screen builds `yolop_theme()` (accent = `ACCENT_BLUE`), so its look is unchanged while the toolkit default is distinct.

Tests:
```
test tests::default_theme_is_the_toolkit_identity_not_a_host_brand ... ok   (tuika)
test app::tests::fullscreen_theme_uses_yolop_palette_not_tuika_default ... ok   (yolop)
```
The existing tuika theme tests compare against `Theme` fields (not literals), so the new default is transparent to them — full tuika suite (123) and full-screen suite (12) pass.

`cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --check` clean.

## Risk

- Low
- Only affects tuika-themed rendering (full-screen + the gallery demo). Full-screen explicitly rebuilds yolop's palette so its appearance is unchanged; inline is untouched.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; tuika default is a new toolkit identity by design)