### PR TITLE
feat(tui): full-screen setup pickers render as tuika SelectList

### DIFF
--- a/crates/tuika/src/components/select.rs
+++ b/crates/tuika/src/components/select.rs
@@ -39,6 +39,12 @@ impl SelectState {
         self.selected
     }
 
+    /// Set the highlighted index directly. Lets a host drive the selection from
+    /// its own state (e.g. mirroring an external index into the list).
+    pub fn select(&mut self, index: usize) {
+        self.selected = index;
+    }
+
     /// Keep the index in range as the list length changes.
     pub fn clamp(&mut self, len: usize) {
         if len == 0 {

--- a/crates/tuika/src/tests.rs
+++ b/crates/tuika/src/tests.rs
@@ -767,6 +767,14 @@ fn select_navigation_wraps_and_confirms() {
 }
 
 #[test]
+fn select_state_select_sets_index_directly() {
+    // A host can drive the highlight from its own state.
+    let mut s = SelectState::new();
+    s.select(2);
+    assert_eq!(s.selected(), 2);
+}
+
+#[test]
 fn select_highlights_current_row() {
     let items = vec![Line::from("alpha"), Line::from("beta")];
     let mut state = SelectState::new();

--- a/src/app/fullscreen.rs
+++ b/src/app/fullscreen.rs
@@ -30,8 +30,8 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 
 use tuika::{
-    Boxed, Element, Overlay, Padding, RectProbe, Rule, Scroll, Spacer, Text, TextInput,
-    TextInputState, element, view,
+    Boxed, Element, Overlay, Padding, RectProbe, Rule, Scroll, SelectList, SelectState, Spacer,
+    Text, TextInput, TextInputState, element, view,
 };
 
 use super::render;
@@ -268,12 +268,21 @@ fn draw_panel_overlay(
     lines: Vec<Line<'static>>,
     cursor: Option<(usize, usize)>,
 ) {
+    panel_overlay(f, area, element(Text::new(lines)), cursor);
+}
+
+/// Composite `content` inside the centered bordered panel as a tuika [`Overlay`]
+/// over a blank base, placing the terminal cursor at `cursor` when given.
+///
+/// The panel uses the shared [`render::setup_panel_rect`] geometry, and
+/// [`Boxed`]'s default border + `symmetric(1, 0)` padding reproduces the inline
+/// overlay's interior rect exactly, so the two modes place content identically.
+fn panel_overlay(f: &mut Frame, area: Rect, content: Element, cursor: Option<(usize, usize)>) {
     let panel = render::setup_panel_rect(area);
     if panel.width == 0 || panel.height == 0 {
         return;
     }
-    let boxed = Boxed::new(element(Text::new(lines)))
-        .background(Style::default().bg(PANEL_BG).fg(TEXT_PRIMARY));
+    let boxed = Boxed::new(content).background(Style::default().bg(PANEL_BG).fg(TEXT_PRIMARY));
     let theme = yolop_theme();
     let overlay = Overlay {
         area: panel,
@@ -300,8 +309,40 @@ fn draw_setup_overlay(f: &mut Frame, area: Rect, app: &App) {
     if app.setup.is_none() || area.width == 0 || area.height == 0 {
         return;
     }
-    let (lines, cursor) = render::setup_overlay_content(app);
-    draw_panel_overlay(f, area, lines, cursor);
+    // Bounded list steps (provider / credential / effort) render through a real
+    // tuika SelectList (item 4); other steps (input fields, Codex login, the
+    // windowed model picker) fall back to the styled-Line Text path.
+    if let Some(picker) = render::setup_picker(app) {
+        draw_setup_picker(f, area, picker);
+    } else {
+        let (lines, cursor) = render::setup_overlay_content(app);
+        draw_panel_overlay(f, area, lines, cursor);
+    }
+}
+
+/// Render a bounded setup step as `header · SelectList · footer` inside the
+/// panel. The `SelectState`'s index is driven from the step's own `selected`
+/// field (navigation still flows through `App::handle_setup_key`); promoting
+/// `SelectState` to the navigation source is the same deferred unification as the
+/// composer's.
+fn draw_setup_picker(f: &mut Frame, area: Rect, picker: render::SetupPicker) {
+    let render::SetupPicker {
+        header,
+        options,
+        selected,
+        footer,
+    } = picker;
+    let mut state = SelectState::new();
+    state.select(selected);
+    let list = SelectList::new(options, &state);
+    let content = view! {
+        col {
+            node(Text::new(header))
+            node(list)
+            node(Text::new(footer))
+        }
+    };
+    panel_overlay(f, area, content, None);
 }
 
 fn draw_ask_overlay(f: &mut Frame, area: Rect, app: &App) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4558,6 +4558,21 @@ mod tests {
             (0..buffer.area.width).any(|x| matches!(buffer[(x, y)].symbol(), "╭" | "╮" | "╰" | "╯"))
         });
         assert!(has_border, "the tuika overlay panel should draw a border");
+        // The provider list is a tuika SelectList (item 4): the selected row is
+        // caret-marked and highlighted with the theme's selection background
+        // (yolop's accent, via yolop_theme).
+        let has_caret = (0..buffer.area.height)
+            .any(|y| (0..buffer.area.width).any(|x| buffer[(x, y)].symbol() == "›"));
+        assert!(
+            has_caret,
+            "the SelectList should mark the selected row:\n{text}"
+        );
+        let has_selection_bg = (0..buffer.area.height)
+            .any(|y| (0..buffer.area.width).any(|x| buffer[(x, y)].bg == ACCENT_BLUE));
+        assert!(
+            has_selection_bg,
+            "the selected row should use the theme selection background"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -853,6 +853,152 @@ pub(crate) fn setup_overlay_content(app: &App) -> (Vec<Line<'static>>, Option<(u
     (lines, cursor)
 }
 
+/// A setup step's navigable option list, split from its chrome, for rendering as
+/// a tuika `SelectList` in the full-screen overlay.
+pub(crate) struct SetupPicker {
+    pub header: Vec<Line<'static>>,
+    pub options: Vec<Line<'static>>,
+    pub selected: usize,
+    pub footer: Vec<Line<'static>>,
+}
+
+/// The option rows + surrounding chrome for the *bounded* list steps (provider,
+/// credential method, reasoning effort), so full-screen can render them through a
+/// tuika `SelectList` instead of hand-highlighted [`setup_row`] lines (item 4).
+///
+/// NOTE (duplication): this intentionally mirrors the per-step option iteration
+/// in [`setup_overlay_content`] rather than refactoring it, so the inline sheet
+/// renderer stays byte-identical. The two share [`setup_option_line`] for the row
+/// formatting. The **model picker** is deliberately excluded — it windows a
+/// possibly-huge list (`model_window`) and has a custom-id input mode that
+/// `SelectList` can't yet express, so it keeps the windowed Text path; a
+/// windowing `SelectList` is a tuika follow-up. Input steps and Codex login
+/// return `None` too (nothing to select).
+pub(crate) fn setup_picker(app: &App) -> Option<SetupPicker> {
+    match app.setup.as_ref()? {
+        SetupStep::Provider { selected } => {
+            let header = vec![
+                setup_title("Set Up Yolop"),
+                setup_hint("Connected providers jump straight to model selection."),
+                Line::from(""),
+            ];
+            let current = app.current_provider_name();
+            let snapshot = app.settings.snapshot();
+            let options = PROVIDER_OPTIONS
+                .iter()
+                .enumerate()
+                .map(|(idx, option)| {
+                    let (_, status) = App::provider_status(&snapshot, option.name);
+                    let mut hint = format!("{} · {status}", option.hint);
+                    if option.name == current {
+                        hint.push_str(" · current");
+                    }
+                    setup_option_line(idx + 1, option.label, &hint)
+                })
+                .collect();
+            let footer = vec![setup_footer(
+                "Enter select · c configure key/URL · ↑/↓ move · Esc cancel",
+            )];
+            Some(SetupPicker {
+                header,
+                options,
+                selected: *selected,
+                footer,
+            })
+        }
+        SetupStep::Credential {
+            provider,
+            selected,
+            error,
+            ..
+        } => {
+            let header = vec![
+                setup_title(&format!("API Key for {}", App::provider_label(provider))),
+                setup_hint("Choose how yolop should authenticate this provider."),
+                Line::from(""),
+            ];
+            let options = App::credential_options(provider)
+                .iter()
+                .enumerate()
+                .map(|(idx, option)| setup_option_line(idx + 1, &option.label, &option.hint))
+                .collect();
+            let mut footer = Vec::new();
+            push_setup_error(&mut footer, error.as_deref());
+            footer.push(setup_footer("Enter confirm · ↑/↓ move · Esc back"));
+            Some(SetupPicker {
+                header,
+                options,
+                selected: *selected,
+                footer,
+            })
+        }
+        SetupStep::PickEffort { selected, error } => {
+            let effort_options = app.model.reasoning_effort_options();
+            if effort_options.is_empty() {
+                // No options — the Text path shows the explanatory hint instead.
+                return None;
+            }
+            let header = vec![
+                setup_title("Select Reasoning Effort"),
+                setup_hint(
+                    "Profile-defined options for the current model — this session and future sessions.",
+                ),
+                Line::from(""),
+            ];
+            let current = app.model.reasoning_effort();
+            let default = app.model.default_reasoning_effort();
+            let options = effort_options
+                .iter()
+                .enumerate()
+                .map(|(idx, option)| {
+                    let mut hint = String::new();
+                    if Some(option.value.as_str()) == current.as_deref() {
+                        hint.push_str("current");
+                    }
+                    if Some(option.value.as_str()) == default.as_deref() {
+                        if !hint.is_empty() {
+                            hint.push_str(" · ");
+                        }
+                        hint.push_str("profile default");
+                    }
+                    setup_option_line(idx + 1, &option.label, &hint)
+                })
+                .collect();
+            let mut footer = Vec::new();
+            push_setup_error(&mut footer, error.as_deref());
+            footer.push(setup_footer("Enter confirm · ↑/↓ move · Esc cancel"));
+            Some(SetupPicker {
+                header,
+                options,
+                selected: *selected,
+                footer,
+            })
+        }
+        _ => None,
+    }
+}
+
+/// One picker option row — `index. label   hint` — with no selection marker or
+/// highlight (the `SelectList` adds the caret and applies the selection style).
+/// Shares the label column width with [`setup_row`].
+pub(crate) fn setup_option_line(index: usize, label: &str, hint: &str) -> Line<'static> {
+    let pad = 28usize.saturating_sub(label.chars().count()).max(2);
+    Line::from(vec![
+        Span::styled(
+            format!("{index}. "),
+            Style::default().fg(TEXT_MUTED).bg(PANEL_BG),
+        ),
+        Span::styled(
+            format!("{label}{}", " ".repeat(pad)),
+            Style::default().fg(TEXT_PRIMARY).bg(PANEL_BG),
+        ),
+        Span::styled(
+            hint.to_string(),
+            Style::default().fg(TEXT_MUTED).bg(PANEL_BG),
+        ),
+    ])
+}
+
 pub(crate) fn setup_title(text: &str) -> Line<'static> {
     Line::from(Span::styled(
         text.to_string(),


### PR DESCRIPTION
## What changed

The `--fullscreen` setup wizard's **bounded** list steps — provider, credential method, reasoning effort — now render through a real `tuika::SelectList` (caret + theme selection highlight) instead of hand-highlighted `setup_row` lines. This is item **4** of the "if we'd built on tuika from scratch" list.

- New pure builder `render::setup_picker` splits each of those steps into `header` / `options` / `selected` / `footer`. Full-screen composes them as `header · SelectList · footer` inside the overlay `Boxed`.
- New `tuika::SelectState::select` lets the host drive the highlighted index from its own state.

## Scope & honesty note

This is the one item where the retrofit's shared-Line approach was already reasonable, so it's scoped deliberately:

- **Model picker excluded.** It windows a possibly-huge list (`model_window`, hundreds of OpenRouter entries) and has a custom-id input mode that `SelectList` can't yet express, so it keeps the windowed Text path. A windowing `SelectList` is a tuika follow-up. Input steps (URL/token) and Codex login return `None` too — nothing to select.
- **Duplication is intentional and NOTE'd.** `setup_picker` mirrors the per-step option iteration from `setup_overlay_content` rather than refactoring the shared builder, so the **inline** sheet renderer stays byte-identical (855 tests pass). The two share `setup_option_line` for row formatting.
- **Navigation unchanged.** `App::handle_setup_key` still owns Up/Down/Enter for both modes; the `SelectState` index is driven from the step's `selected` field each frame. Promoting `SelectState` to the navigation source is the same deferred unification as the composer's `TextInputState`.

## Why

Rendering the picker through the real component gives full-screen a consistent, theme-driven selection look (full-row highlight via `yolop_theme`'s selection background) matching its other tuika widgets.

## Before / After

- **Before:** the provider list was styled `setup_row` text with a colored/bold selected row.
- **After:** it's a `SelectList` with a `›` caret and the theme selection background. The full-screen setup test now asserts both the caret and a cell with the theme selection background render; title + border still present.

```
test app::tests::fullscreen_setup_overlay_renders_via_tuika ... ok
test tests::select_state_select_sets_index_directly ... ok   (tuika)
```

`cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --check` clean; 855 yolop tests pass (inline setup unchanged).

## Risk

- Low / Medium
- Only the `--fullscreen` bounded-picker rendering changes; inline setup and the full-screen model picker are untouched.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; inline unchanged, `--fullscreen` experimental)