### PR TITLE
feat(tuika): windowing SelectList (viewport + scrollbar)

### DIFF
--- a/crates/tuika/src/components/select.rs
+++ b/crates/tuika/src/components/select.rs
@@ -6,6 +6,7 @@
 //! [`SelectOutcome`] so the caller decides what "confirm" means.
 
 use ratatui::layout::Rect;
+use ratatui::style::Style;
 use ratatui::text::Line;
 
 use crate::event::{Event, EventFlow, KeyCode};
@@ -85,12 +86,19 @@ impl SelectState {
     }
 }
 
-/// Renders `items` with the selected row highlighted.
+/// Renders `items` with the selected row highlighted. With a [`viewport`] set,
+/// a list taller than the viewport is windowed around the selection and a
+/// scrollbar is drawn — the primitive for long pickers (hundreds of models).
+///
+/// [`viewport`]: SelectList::viewport
 ///
 /// ![select demo](https://raw.githubusercontent.com/everruns/yolop/main/crates/tuika/docs/demos/select.gif)
 pub struct SelectList {
     items: Vec<Line<'static>>,
     selected: usize,
+    /// Max visible rows; `None` shows the whole list.
+    viewport: Option<u16>,
+    scrollbar: bool,
 }
 
 impl SelectList {
@@ -98,6 +106,36 @@ impl SelectList {
         Self {
             items,
             selected: state.selected(),
+            viewport: None,
+            scrollbar: true,
+        }
+    }
+
+    /// Cap the visible rows to `rows`, windowing a longer list around the
+    /// selection so the highlighted row stays on screen.
+    pub fn viewport(mut self, rows: u16) -> Self {
+        self.viewport = Some(rows.max(1));
+        self
+    }
+
+    /// Show the overflow scrollbar (default true; only drawn when windowed).
+    pub fn scrollbar(mut self, show: bool) -> Self {
+        self.scrollbar = show;
+        self
+    }
+
+    /// The `(start, visible_rows)` window: the whole list unless a `viewport`
+    /// smaller than the list is set, in which case a slice centered on the
+    /// selection and clamped to the ends.
+    fn window(&self) -> (usize, usize) {
+        let total = self.items.len();
+        match self.viewport {
+            Some(v) if total > v as usize => {
+                let v = (v as usize).max(1);
+                let start = self.selected.saturating_sub(v / 2).min(total - v);
+                (start, v)
+            }
+            _ => (0, total),
         }
     }
 }
@@ -111,18 +149,32 @@ impl View for SelectList {
             .max()
             .unwrap_or(0)
             .saturating_add(2); // caret + space
-        Size::new(width.min(available.width), self.items.len() as u16)
+        let (_, rows) = self.window();
+        Size::new(width.min(available.width), rows as u16)
     }
 
     fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
-        for (row, item) in self.items.iter().enumerate() {
-            let y = area.y.saturating_add(row as u16);
+        let (start, rows) = self.window();
+        let overflow = self.items.len() > rows;
+        // Reserve the last column for the scrollbar when the list overflows.
+        let row_width = if overflow && self.scrollbar {
+            area.width.saturating_sub(1)
+        } else {
+            area.width
+        };
+        let row_right = area.x.saturating_add(row_width);
+        for i in 0..rows {
+            let idx = start + i;
+            let Some(item) = self.items.get(idx) else {
+                break;
+            };
+            let y = area.y.saturating_add(i as u16);
             if y >= area.bottom() {
                 break;
             }
-            let selected = row == self.selected;
+            let selected = idx == self.selected;
             if selected {
-                let mut line = surface.child(Rect::new(area.x, y, area.width, 1));
+                let mut line = surface.child(Rect::new(area.x, y, row_width, 1));
                 line.fill(ctx.theme.selection_style());
             }
             let caret = if selected { '›' } else { ' ' };
@@ -134,7 +186,7 @@ impl View for SelectList {
             surface.set(area.x, y, caret, caret_style);
             let mut x = area.x.saturating_add(2);
             for span in &item.spans {
-                if x >= area.right() {
+                if x >= row_right {
                     break;
                 }
                 let style = if selected {
@@ -144,6 +196,42 @@ impl View for SelectList {
                 };
                 x = surface.set_string(x, y, span.content.as_ref(), style);
             }
+        }
+        if overflow && self.scrollbar && row_width < area.width {
+            self.draw_scrollbar(area, start, rows, surface, ctx);
+        }
+    }
+}
+
+impl SelectList {
+    /// A right-edge scrollbar whose thumb tracks the window position, mirroring
+    /// [`Scroll`](super::Scroll)'s scrollbar.
+    fn draw_scrollbar(
+        &self,
+        area: Rect,
+        start: usize,
+        rows: usize,
+        surface: &mut Surface,
+        ctx: &RenderCtx,
+    ) {
+        let total = self.items.len();
+        let track_x = area.right() - 1;
+        let track_h = rows as u16;
+        let max_start = total.saturating_sub(rows).max(1) as u32;
+        let thumb_h = (((rows * rows) / total).max(1) as u16).min(track_h);
+        let travel = track_h.saturating_sub(thumb_h);
+        let thumb_y = area.y + ((start as u32 * travel as u32) / max_start) as u16;
+        let track_style = Style::default().fg(ctx.theme.dim);
+        let thumb_style = Style::default().fg(ctx.theme.muted);
+        for row in 0..track_h {
+            let y = area.y + row;
+            let within = y >= thumb_y && y < thumb_y.saturating_add(thumb_h);
+            let (glyph, style) = if within {
+                ('█', thumb_style)
+            } else {
+                ('│', track_style)
+            };
+            surface.set(track_x, y, glyph, style);
         }
     }
 }

--- a/crates/tuika/src/tests.rs
+++ b/crates/tuika/src/tests.rs
@@ -792,6 +792,46 @@ fn select_highlights_current_row() {
     assert_eq!(buf[(0, 0)].bg, ratatui::style::Color::Reset);
 }
 
+#[test]
+fn select_viewport_windows_a_long_list_and_keeps_selection_visible() {
+    // 20 items, viewport of 4: the selection must always be on screen.
+    let items: Vec<Line> = (0..20).map(|i| Line::from(format!("item{i}"))).collect();
+    let mut state = SelectState::new();
+    state.select(12);
+    let theme = Theme::default();
+    let list = SelectList::new(items.clone(), &state).viewport(4);
+    // Windowed height is the viewport, not the full list.
+    assert_eq!(list.measure(Size::new(20, 40)).height, 4);
+    let rendered = crate::testing::render(&list, 20, 4, &theme);
+    let text = crate::testing::grid(&rendered);
+    assert!(
+        text.contains("item12"),
+        "selection should be visible:\n{text}"
+    );
+    assert!(
+        !text.contains("item0\n") && !text.contains("item19"),
+        "far items windowed out"
+    );
+    // A scrollbar occupies the last column on at least one row.
+    let has_scrollbar = (0..4).any(|y| matches!(rendered[(19, y)].symbol(), "█" | "│"));
+    assert!(
+        has_scrollbar,
+        "overflowing list should draw a scrollbar:\n{text}"
+    );
+}
+
+#[test]
+fn select_viewport_shows_whole_list_when_it_fits() {
+    let items: Vec<Line> = (0..3).map(|i| Line::from(format!("item{i}"))).collect();
+    let state = SelectState::new();
+    let list = SelectList::new(items, &state).viewport(8);
+    // Fits within the viewport → no windowing, height is the item count.
+    assert_eq!(list.measure(Size::new(20, 40)).height, 3);
+    let theme = Theme::default();
+    let text = crate::testing::grid(&crate::testing::render(&list, 20, 3, &theme));
+    assert!(text.contains("item0") && text.contains("item2"));
+}
+
 // ---- overlay -------------------------------------------------------------
 
 #[test]


### PR DESCRIPTION
## What changed

`tuika::SelectList` gains `.viewport(rows)`: a list taller than the viewport is **windowed** around the selection (kept centered, clamped to the ends) and a right-edge **scrollbar** tracks the position, mirroring `Scroll`.

This is the missing primitive for long pickers — a model list with hundreds of entries — so a host no longer has to hand-roll windowing plus `↑/↓ more` hints in styled text. It's the foundation for moving yolop's full-screen model picker onto `SelectList` (the one setup step still on the Text path).

Additive and backward-compatible: `SelectList::new` is unchanged (`viewport` defaults to `None` = show the whole list); `.scrollbar(false)` opts out of the bar.

## Why

`SelectList` could only render a whole list, so anything long had to be windowed by the caller in raw text. Windowing belongs in the component.

## Before / After

- **Before:** `SelectList` rendered every item; long lists overflowed their area.
- **After:** `.viewport(n)` shows an `n`-row window around the selection with a scrollbar. New tests: a 20-item list at `viewport(4)` keeps the selection visible, windows out the far items, and draws a scrollbar; a short list within the viewport renders in full with no bar.

```
test tests::select_viewport_windows_a_long_list_and_keeps_selection_visible ... ok
test tests::select_viewport_shows_whole_list_when_it_fits ... ok
```

Full tuika suite (126) + clippy + fmt clean.

## Risk

- Low
- Additive to `SelectList`; existing callers (yolop's setup pickers) are unchanged.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (additive)