### PR TITLE
feat(tui): full-screen model picker renders as a windowed SelectList

### DIFF
--- a/src/tui/fullscreen.rs
+++ b/src/tui/fullscreen.rs
@@ -331,10 +331,14 @@ fn draw_setup_picker(f: &mut Frame, area: Rect, picker: render::SetupPicker) {
         options,
         selected,
         footer,
+        viewport,
     } = picker;
     let mut state = SelectState::new();
     state.select(selected);
-    let list = SelectList::new(options, &state);
+    let mut list = SelectList::new(options, &state);
+    if let Some(rows) = viewport {
+        list = list.viewport(rows);
+    }
     let content = view! {
         col {
             node(Text::new(header))

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -4540,6 +4540,33 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fullscreen_model_picker_is_a_windowed_selectlist() {
+        let mut test = app_with_llmsim().await;
+        // The model list renders as a windowed tuika SelectList (item 4 / PR J).
+        test.app.setup = Some(SetupStep::PickModel {
+            provider: "openai".to_string(),
+            selected: 0,
+            custom: None,
+            error: None,
+        });
+        let picker = render::setup_picker(&test.app).expect("model list is a picker");
+        assert_eq!(picker.viewport, Some(render::MAX_VISIBLE_MODEL_ROWS as u16));
+        assert!(!picker.options.is_empty(), "model list has options");
+        // The custom-id sub-mode is a text input, not a list, so it falls back to
+        // the shared text panel path (not a picker).
+        test.app.setup = Some(SetupStep::PickModel {
+            provider: "openai".to_string(),
+            selected: 0,
+            custom: Some("my-model".to_string()),
+            error: None,
+        });
+        assert!(
+            render::setup_picker(&test.app).is_none(),
+            "custom-id sub-mode is not a SelectList picker"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn fullscreen_setup_overlay_renders_via_tuika() {
         use ratatui::backend::TestBackend;
         let mut test = app_with_llmsim().await;

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -860,20 +860,25 @@ pub(crate) struct SetupPicker {
     pub options: Vec<Line<'static>>,
     pub selected: usize,
     pub footer: Vec<Line<'static>>,
+    /// Max visible option rows, for a `SelectList` viewport; `None` shows all.
+    pub viewport: Option<u16>,
 }
 
-/// The option rows + surrounding chrome for the *bounded* list steps (provider,
-/// credential method, reasoning effort), so full-screen can render them through a
-/// tuika `SelectList` instead of hand-highlighted [`setup_row`] lines (item 4).
+/// The option rows + surrounding chrome for the list-selection steps (provider,
+/// credential method, reasoning effort, and the model list), so full-screen can
+/// render them through a tuika `SelectList` instead of hand-highlighted
+/// [`setup_row`] lines (item 4). The model list sets [`SetupPicker::viewport`] so
+/// the `SelectList` windows its (possibly huge) options with a scrollbar.
 ///
 /// NOTE (duplication): this intentionally mirrors the per-step option iteration
 /// in [`setup_overlay_content`] rather than refactoring it, so the inline sheet
 /// renderer stays byte-identical. The two share [`setup_option_line`] for the row
-/// formatting. The **model picker** is deliberately excluded — it windows a
-/// possibly-huge list (`model_window`) and has a custom-id input mode that
-/// `SelectList` can't yet express, so it keeps the windowed Text path; a
-/// windowing `SelectList` is a tuika follow-up. Input steps and Codex login
-/// return `None` too (nothing to select).
+/// formatting. The model picker's **custom-id input** sub-mode (`custom: Some`)
+/// returns `None` here so it falls back to the shared text-input panel path —
+/// that sub-mode is a `TextInput`, not a list. Other input steps and Codex login
+/// return `None` too (nothing to select). The inline `setup_overlay_content` also
+/// draws a "─── more models ───" divider between recommended and other models;
+/// the `SelectList` path omits it (the scrollbar conveys position instead).
 pub(crate) fn setup_picker(app: &App) -> Option<SetupPicker> {
     match app.setup.as_ref()? {
         SetupStep::Provider { selected } => {
@@ -904,6 +909,7 @@ pub(crate) fn setup_picker(app: &App) -> Option<SetupPicker> {
                 options,
                 selected: *selected,
                 footer,
+                viewport: None,
             })
         }
         SetupStep::Credential {
@@ -930,6 +936,7 @@ pub(crate) fn setup_picker(app: &App) -> Option<SetupPicker> {
                 options,
                 selected: *selected,
                 footer,
+                viewport: None,
             })
         }
         SetupStep::PickEffort { selected, error } => {
@@ -972,6 +979,52 @@ pub(crate) fn setup_picker(app: &App) -> Option<SetupPicker> {
                 options,
                 selected: *selected,
                 footer,
+                viewport: None,
+            })
+        }
+        // The model list is a windowed SelectList. Its custom-id sub-mode
+        // (`custom: Some`) is a text input, so it falls back to the Text path.
+        SetupStep::PickModel {
+            provider,
+            selected,
+            custom: None,
+            error,
+        } => {
+            let header = vec![
+                setup_title("Select Model"),
+                setup_hint(&if provider == "custom" {
+                    "Model id served by your endpoint. Applies to this session and future sessions."
+                        .to_string()
+                } else {
+                    format!(
+                        "{} models. Applies to this session and future sessions.",
+                        App::provider_label(provider)
+                    )
+                }),
+                Line::from(""),
+            ];
+            let current = app.model.model_id();
+            let options = app
+                .model_options(provider)
+                .iter()
+                .enumerate()
+                .map(|(idx, option)| {
+                    let mut hint = option.hint.to_string();
+                    if option.spec.as_deref() == Some(current.as_str()) {
+                        hint.push_str(" · current");
+                    }
+                    setup_option_line(idx + 1, &option.label, &hint)
+                })
+                .collect();
+            let mut footer = Vec::new();
+            push_setup_error(&mut footer, error.as_deref());
+            footer.push(setup_footer("Enter confirm · ↑/↓ move · Esc back"));
+            Some(SetupPicker {
+                header,
+                options,
+                selected: *selected,
+                footer,
+                viewport: Some(MAX_VISIBLE_MODEL_ROWS as u16),
             })
         }
         _ => None,


### PR DESCRIPTION
## What changed

The full-screen **model list** — the one setup step still on the styled-Text path after #379 — now renders through the windowing `tuika::SelectList` (from #381), completing item 4's picker migration.

- `render::setup_picker` gains a `PickModel` arm that returns the model options with `SetupPicker::viewport = Some(MAX_VISIBLE_MODEL_ROWS)`, so the `SelectList` windows the (possibly hundreds of) options with a scrollbar instead of hand-rolled `↑/↓ more` text.
- The model picker's **custom-id sub-mode** (`custom: Some`) is a text input, not a list, so it returns `None` and falls back to the shared text-input panel path.

Inline `setup_overlay_content` is untouched (byte-identical). A NOTE records that the `SelectList` path omits inline's `─── more models ───` divider — the scrollbar conveys position instead.

## Why

The model list was the last picker rendering as raw windowed text, because `SelectList` couldn't window a long list. With the windowing primitive in place (#381), it becomes a real component like the other pickers.

## Before / After

- **Before:** the model list was styled `setup_row` text with hand-computed `↑ N more` / `↓ N more` hints.
- **After:** it's a windowed `SelectList` with a scrollbar. New test: the model list returns a picker with `viewport == Some(8)` and non-empty options; the custom-id sub-mode returns `None` (text path).

```
test tui::tests::fullscreen_model_picker_is_a_windowed_selectlist ... ok
```

Full suite (856) + clippy + fmt clean.

## Risk

- Low / Medium
- Only the `--fullscreen` model-list rendering changes; inline setup and the custom-id text sub-mode are untouched.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; inline unchanged)