### PR TITLE
feat(tuika): TextInput scrolls to its cursor within a bounded height

### DIFF
--- a/crates/tuika/src/components/textinput.rs
+++ b/crates/tuika/src/components/textinput.rs
@@ -284,32 +284,48 @@ impl TextInputState {
 
     /// The cursor's visual `(row, col)` in wrapped coordinates at `width`.
     fn visual_cursor(&self, width: u16) -> (u16, u16) {
-        let width = width.max(1) as usize;
-        let mut vrow: usize = 0;
-        for (r, line) in self.lines.iter().enumerate() {
-            let len = line.chars().count();
-            if r == self.row {
-                let vr = self.col / width;
-                let vc = self.col % width;
-                return ((vrow + vr) as u16, vc as u16);
-            }
-            vrow += (len / width) + 1; // rows for this line (incl. trailing/empty)
-        }
-        (vrow as u16, 0)
+        visual_cursor_at(&self.lines, self.row, self.col, width)
     }
 
-    /// The cursor cell in terminal coordinates, given the rendered `area`.
-    /// Clamped inside `area`.
+    /// The visual-row scroll offset that keeps the cursor visible in a
+    /// `height`-row viewport at `width`: once the text is taller than the
+    /// viewport the cursor rests on the last visible row; otherwise 0. A bounded
+    /// composer (see [`TextInput`]) renders and places its cursor through this.
+    pub fn scroll_offset(&self, width: u16, height: u16) -> u16 {
+        self.visual_cursor(width)
+            .0
+            .saturating_sub(height.saturating_sub(1))
+    }
+
+    /// The cursor cell in terminal coordinates, given the rendered `area`,
+    /// accounting for scroll-to-cursor when the text is taller than the area.
     pub fn cursor_screen(&self, area: Rect) -> (u16, u16) {
         let (vrow, vcol) = self.visual_cursor(area.width);
+        let offset = vrow.saturating_sub(area.height.saturating_sub(1));
         let x = area
             .x
             .saturating_add(vcol.min(area.width.saturating_sub(1)));
         let y = area
             .y
-            .saturating_add(vrow.min(area.height.saturating_sub(1)));
+            .saturating_add((vrow - offset).min(area.height.saturating_sub(1)));
         (x, y)
     }
+}
+
+/// The cursor's visual `(row, col)` for `lines` with the logical cursor at
+/// `(row, col)`, char-soft-wrapped to `width`. Shared by [`TextInputState`] and
+/// [`TextInput`] so the rendered scroll offset and the placed cursor agree.
+fn visual_cursor_at(lines: &[String], row: usize, col: usize, width: u16) -> (u16, u16) {
+    let width = width.max(1) as usize;
+    let mut vrow: usize = 0;
+    for (r, line) in lines.iter().enumerate() {
+        let len = line.chars().count();
+        if r == row {
+            return ((vrow + col / width) as u16, (col % width) as u16);
+        }
+        vrow += (len / width) + 1; // rows for this line (incl. trailing/empty)
+    }
+    (vrow as u16, 0)
 }
 
 /// Char-soft-wrap `lines` to `width`, returning visual rows as
@@ -341,14 +357,19 @@ fn wrap_visual_rows(lines: &[String], width: u16) -> Vec<(usize, Vec<char>)> {
 /// Renders a snapshot of a [`TextInputState`]'s wrapped text.
 ///
 /// Owns its lines (cloned from the state at construction, like [`Scroll`]) so it
-/// is `'static` and composes into a [`view!`](crate::view!) tree. The host places
-/// the terminal cursor separately via [`TextInputState::cursor_screen`].
+/// is `'static` and composes into a [`view!`](crate::view!) tree. When the text
+/// is taller than the render area it **scrolls to the cursor** (the cursor's
+/// visual row stays on screen), so it backs a bounded composer without losing the
+/// caret. The host places the terminal cursor through
+/// [`TextInputState::cursor_screen`], which derives the same offset.
 ///
 /// [`Scroll`]: crate::Scroll
 ///
 /// ![textinput demo](https://raw.githubusercontent.com/everruns/yolop/main/crates/tuika/docs/demos/textinput.gif)
 pub struct TextInput {
     lines: Vec<String>,
+    /// Logical cursor `(row, col)`, so a bounded render can scroll to it.
+    cursor: (usize, usize),
     style: Style,
 }
 
@@ -356,6 +377,7 @@ impl TextInput {
     pub fn new(state: &TextInputState) -> Self {
         Self {
             lines: state.lines.clone(),
+            cursor: (state.row, state.col),
             style: Style::default(),
         }
     }
@@ -363,6 +385,13 @@ impl TextInput {
     pub fn style(mut self, style: Style) -> Self {
         self.style = style;
         self
+    }
+
+    /// Visual-row offset that keeps the cursor on screen in `height` rows.
+    fn scroll_offset(&self, width: u16, height: u16) -> u16 {
+        visual_cursor_at(&self.lines, self.cursor.0, self.cursor.1, width)
+            .0
+            .saturating_sub(height.saturating_sub(1))
     }
 }
 
@@ -376,11 +405,13 @@ impl View for TextInput {
         if area.width == 0 || area.height == 0 {
             return;
         }
-        for (vrow, (_logical, chars)) in wrap_visual_rows(&self.lines, area.width)
+        let offset = self.scroll_offset(area.width, area.height) as usize;
+        for (i, (_logical, chars)) in wrap_visual_rows(&self.lines, area.width)
             .into_iter()
             .enumerate()
+            .skip(offset)
         {
-            let y = area.y.saturating_add(vrow as u16);
+            let y = area.y.saturating_add((i - offset) as u16);
             if y >= area.bottom() {
                 break;
             }

--- a/crates/tuika/src/tests.rs
+++ b/crates/tuika/src/tests.rs
@@ -1673,6 +1673,32 @@ fn render_view_rows(view: &dyn View, w: u16, h: u16) -> Vec<String> {
 }
 
 #[test]
+fn text_input_scrolls_to_cursor_when_taller_than_area() {
+    // 10 single-row lines; cursor at the end (line 9).
+    let mut state = TextInputState::new();
+    for i in 0..10 {
+        type_str(&mut state, &format!("line{i}"));
+        if i < 9 {
+            state.newline();
+        }
+    }
+    // A 3-row viewport shows the last three rows (containing the cursor), not the
+    // top — the composer scrolls to the caret.
+    let out = render_view_rows(&TextInput::new(&state), 10, 3);
+    assert_eq!(out, vec!["line7", "line8", "line9"]);
+    // The placed cursor sits on the last visible row, consistent with the scroll.
+    let (_, y) = state.cursor_screen(Rect::new(0, 0, 10, 3));
+    assert_eq!(y, 2);
+    // Move to the top: the viewport follows the cursor back up.
+    for _ in 0..9 {
+        state.move_up();
+    }
+    let out = render_view_rows(&TextInput::new(&state), 10, 3);
+    assert_eq!(out, vec!["line0", "line1", "line2"]);
+    assert_eq!(state.cursor_screen(Rect::new(0, 0, 10, 3)).1, 0);
+}
+
+#[test]
 fn text_input_renders_wrapped_rows() {
     let mut state = TextInputState::new();
     type_str(&mut state, "abcdef");


### PR DESCRIPTION
## What changed

When the text is taller than the render area, `tuika::TextInput` now offsets its visual rows so the **cursor's row stays on screen** (the cursor rests on the last visible row as you type past the bottom), and `TextInputState::cursor_screen` derives the *same* offset so the placed terminal cursor agrees.

This is the last capability a bounded, fixed-height composer needs from `TextInput` — the caret no longer scrolls out of view — which unblocks moving yolop's inline composer off `ratatui-textarea` onto one shared `TextInputState` (the "inline as adapter" unification).

- Factors the visual-cursor math into a shared `visual_cursor_at` so the state (cursor placement) and the view (row offset) compute it identically.
- Adds `TextInputState::scroll_offset(width, height)` for hosts that need the offset directly.

It also improves the full-screen composer for free: a composer taller than its slot now scrolls to the caret instead of clamping. Content that fits keeps offset 0, so existing behavior is unchanged.

## Why

`TextInput` rendered every wrapped row from the top and clipped the bottom, so a bounded input box would lose the cursor once the text overflowed. A composer must always show where you're typing.

## Before / After

- **Before:** a 10-line buffer in a 3-row area showed rows 0–2; the cursor (line 9) was off-screen.
- **After:** it shows the 3 rows around the cursor and follows it back to the top. New test:

```
test tests::text_input_scrolls_to_cursor_when_taller_than_area ... ok
```

Full tuika suite (127) + clippy + fmt clean.

## Risk

- Low
- Additive scroll behavior; short content (offset 0) renders exactly as before. `cursor_screen`'s signature is unchanged.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (offset 0 when content fits)