### PR TITLE
feat(tuika): emacs keymap for TextInputState (readline bindings)

### DIFF
--- a/crates/tuika/src/components/textinput.rs
+++ b/crates/tuika/src/components/textinput.rs
@@ -214,11 +214,179 @@ impl TextInputState {
         self.col = self.lines[self.row].chars().count();
     }
 
+    /// The column of the previous word start on the current line: skip trailing
+    /// whitespace, then the word itself. Used by word-move and word-delete.
+    fn prev_word_col(&self) -> usize {
+        let chars = self.row_chars(self.row);
+        let mut i = self.col.min(chars.len());
+        while i > 0 && chars[i - 1].is_whitespace() {
+            i -= 1;
+        }
+        while i > 0 && !chars[i - 1].is_whitespace() {
+            i -= 1;
+        }
+        i
+    }
+
+    /// The column of the next word end on the current line: skip leading
+    /// whitespace, then the word itself.
+    fn next_word_col(&self) -> usize {
+        let chars = self.row_chars(self.row);
+        let len = chars.len();
+        let mut i = self.col.min(len);
+        while i < len && chars[i].is_whitespace() {
+            i += 1;
+        }
+        while i < len && !chars[i].is_whitespace() {
+            i += 1;
+        }
+        i
+    }
+
+    /// Move to the previous word boundary, crossing to the prior line at col 0.
+    pub fn move_word_left(&mut self) {
+        if self.col == 0 {
+            self.move_left();
+            return;
+        }
+        self.col = self.prev_word_col();
+    }
+
+    /// Move to the next word boundary, crossing to the next line at line end.
+    pub fn move_word_right(&mut self) {
+        if self.col >= self.lines[self.row].chars().count() {
+            self.move_right();
+            return;
+        }
+        self.col = self.next_word_col();
+    }
+
+    /// Delete from the cursor back to the previous word boundary (joins the
+    /// prior line when already at col 0).
+    pub fn delete_word_left(&mut self) {
+        if self.col == 0 {
+            self.backspace();
+            return;
+        }
+        let start = self.prev_word_col();
+        let mut chars = self.row_chars(self.row);
+        chars.drain(start..self.col);
+        self.col = start;
+        self.set_row(self.row, chars);
+    }
+
+    /// Delete from the cursor forward to the next word boundary (joins the next
+    /// line when already at line end).
+    pub fn delete_word_right(&mut self) {
+        let len = self.lines[self.row].chars().count();
+        if self.col >= len {
+            self.delete();
+            return;
+        }
+        let end = self.next_word_col();
+        let mut chars = self.row_chars(self.row);
+        chars.drain(self.col..end);
+        self.set_row(self.row, chars);
+    }
+
+    /// Delete from the cursor to the end of the line; at line end, joins the
+    /// next line (emacs `C-k`).
+    pub fn kill_to_line_end(&mut self) {
+        let mut chars = self.row_chars(self.row);
+        if self.col < chars.len() {
+            chars.truncate(self.col);
+            self.set_row(self.row, chars);
+        } else {
+            self.delete();
+        }
+    }
+
+    /// Delete from the start of the line to the cursor (emacs `C-u`).
+    pub fn kill_to_line_start(&mut self) {
+        let chars = self.row_chars(self.row);
+        let tail: Vec<char> = chars[self.col.min(chars.len())..].to_vec();
+        self.set_row(self.row, tail);
+        self.col = 0;
+    }
+
     /// Apply an input event. Returns `true` when the buffer or cursor changed.
     /// Enter inserts a newline; a host that submits on Enter should intercept it
     /// before calling this.
+    ///
+    /// Beyond the plain keys, an emacs-style keymap covers the readline bindings
+    /// a terminal composer is expected to honor (so the widget matches what
+    /// `ratatui-textarea` gave hosts before): `C-a`/`C-e` line start/end,
+    /// `C-f`/`C-b` char move, `C-p`/`C-n` line move, `C-h`/`C-d` delete,
+    /// `C-k`/`C-u` kill to line end/start, `C-w`/`M-Backspace` delete word back,
+    /// `M-f`/`M-b` word move, `M-d` delete word forward.
     pub fn handle(&mut self, event: &Event) -> bool {
         match event {
+            Event::Key(k) if k.ctrl && !k.alt => match k.code {
+                KeyCode::Char('a') => {
+                    self.move_home();
+                    true
+                }
+                KeyCode::Char('e') => {
+                    self.move_end();
+                    true
+                }
+                KeyCode::Char('f') => {
+                    self.move_right();
+                    true
+                }
+                KeyCode::Char('b') => {
+                    self.move_left();
+                    true
+                }
+                KeyCode::Char('p') => {
+                    self.move_up();
+                    true
+                }
+                KeyCode::Char('n') => {
+                    self.move_down();
+                    true
+                }
+                KeyCode::Char('h') => {
+                    self.backspace();
+                    true
+                }
+                KeyCode::Char('d') => {
+                    self.delete();
+                    true
+                }
+                KeyCode::Char('k') => {
+                    self.kill_to_line_end();
+                    true
+                }
+                KeyCode::Char('u') => {
+                    self.kill_to_line_start();
+                    true
+                }
+                KeyCode::Char('w') => {
+                    self.delete_word_left();
+                    true
+                }
+                _ => false,
+            },
+            Event::Key(k) if k.alt && !k.ctrl => match k.code {
+                KeyCode::Char('f') => {
+                    self.move_word_right();
+                    true
+                }
+                KeyCode::Char('b') => {
+                    self.move_word_left();
+                    true
+                }
+                KeyCode::Char('d') => {
+                    self.delete_word_right();
+                    true
+                }
+                KeyCode::Backspace => {
+                    self.delete_word_left();
+                    true
+                }
+                _ => false,
+            },
             Event::Key(k) if !k.ctrl && !k.alt => match k.code {
                 KeyCode::Char(c) => {
                     self.insert_char(c);

--- a/crates/tuika/src/tests.rs
+++ b/crates/tuika/src/tests.rs
@@ -1564,6 +1564,24 @@ fn press(state: &mut TextInputState, code: KeyCode) -> bool {
     state.handle(&Event::Key(Key::new(code)))
 }
 
+fn press_ctrl(state: &mut TextInputState, code: KeyCode) -> bool {
+    state.handle(&Event::Key(Key {
+        code,
+        ctrl: true,
+        alt: false,
+        shift: false,
+    }))
+}
+
+fn press_alt(state: &mut TextInputState, code: KeyCode) -> bool {
+    state.handle(&Event::Key(Key {
+        code,
+        ctrl: false,
+        alt: true,
+        shift: false,
+    }))
+}
+
 fn type_str(state: &mut TextInputState, s: &str) {
     for ch in s.chars() {
         assert!(press(state, KeyCode::Char(ch)));
@@ -1650,16 +1668,99 @@ fn text_input_paste_inserts_multiline() {
 }
 
 #[test]
-fn text_input_ctrl_keys_ignored() {
+fn text_input_unbound_ctrl_keys_ignored() {
+    // A ctrl combo with no binding (C-z) is a no-op the host can repurpose.
     let mut state = TextInputState::from_text("x");
-    let ctrl_a = Event::Key(Key {
-        code: KeyCode::Char('a'),
-        ctrl: true,
-        alt: false,
-        shift: false,
-    });
-    assert!(!state.handle(&ctrl_a));
+    assert!(!press_ctrl(&mut state, KeyCode::Char('z')));
     assert_eq!(state.text(), "x");
+}
+
+#[test]
+fn text_input_emacs_cursor_bindings() {
+    let mut state = TextInputState::from_text("hello");
+    // C-a → line start, C-e → line end, C-f/C-b → char right/left.
+    assert!(press_ctrl(&mut state, KeyCode::Char('a')));
+    assert_eq!(state.cursor(), (0, 0));
+    assert!(press_ctrl(&mut state, KeyCode::Char('f')));
+    assert_eq!(state.cursor(), (0, 1));
+    assert!(press_ctrl(&mut state, KeyCode::Char('e')));
+    assert_eq!(state.cursor(), (0, 5));
+    assert!(press_ctrl(&mut state, KeyCode::Char('b')));
+    assert_eq!(state.cursor(), (0, 4));
+
+    // C-p / C-n move between logical lines.
+    state = TextInputState::from_text("ab\ncd");
+    press(&mut state, KeyCode::Home);
+    assert!(press_ctrl(&mut state, KeyCode::Char('p')));
+    assert_eq!(state.cursor(), (0, 0));
+    assert!(press_ctrl(&mut state, KeyCode::Char('n')));
+    assert_eq!(state.cursor(), (1, 0));
+}
+
+#[test]
+fn text_input_emacs_delete_bindings() {
+    // C-h backspaces, C-d deletes forward.
+    let mut state = TextInputState::from_text("abc");
+    assert!(press_ctrl(&mut state, KeyCode::Char('h')));
+    assert_eq!(state.text(), "ab");
+    press(&mut state, KeyCode::Home);
+    assert!(press_ctrl(&mut state, KeyCode::Char('d')));
+    assert_eq!(state.text(), "b");
+}
+
+#[test]
+fn text_input_kill_to_line_end_and_start() {
+    // C-k kills from the cursor to end of line.
+    let mut state = TextInputState::from_text("hello world");
+    press(&mut state, KeyCode::Home);
+    press(&mut state, KeyCode::Right);
+    press(&mut state, KeyCode::Right);
+    press(&mut state, KeyCode::Right);
+    press(&mut state, KeyCode::Right);
+    press(&mut state, KeyCode::Right); // cursor after "hello"
+    assert!(press_ctrl(&mut state, KeyCode::Char('k')));
+    assert_eq!(state.text(), "hello");
+    assert_eq!(state.cursor(), (0, 5));
+
+    // C-k at line end joins the next line.
+    let mut state = TextInputState::from_text("ab\ncd");
+    press(&mut state, KeyCode::Home);
+    press(&mut state, KeyCode::Up);
+    press(&mut state, KeyCode::End);
+    assert!(press_ctrl(&mut state, KeyCode::Char('k')));
+    assert_eq!(state.text(), "abcd");
+
+    // C-u kills from line start to the cursor.
+    let mut state = TextInputState::from_text("hello world");
+    assert!(press_ctrl(&mut state, KeyCode::Char('u')));
+    assert_eq!(state.text(), "");
+    assert_eq!(state.cursor(), (0, 0));
+}
+
+#[test]
+fn text_input_word_move_and_delete() {
+    // M-b / M-f jump by word; C-w / M-d delete a word back / forward.
+    let mut state = TextInputState::from_text("foo bar baz");
+    assert!(press_alt(&mut state, KeyCode::Char('b')));
+    assert_eq!(state.cursor(), (0, 8)); // start of "baz"
+    assert!(press_alt(&mut state, KeyCode::Char('b')));
+    assert_eq!(state.cursor(), (0, 4)); // start of "bar"
+
+    // C-w at the start of "bar" deletes the previous word "foo ".
+    assert!(press_ctrl(&mut state, KeyCode::Char('w')));
+    assert_eq!(state.text(), "bar baz");
+    assert_eq!(state.cursor(), (0, 0));
+
+    // M-f to the end of "bar", then M-d deletes the next word " baz".
+    assert!(press_alt(&mut state, KeyCode::Char('f')));
+    assert_eq!(state.cursor(), (0, 3)); // end of "bar"
+    assert!(press_alt(&mut state, KeyCode::Char('d')));
+    assert_eq!(state.text(), "bar");
+
+    // M-Backspace deletes the previous word too.
+    let mut state = TextInputState::from_text("alpha beta");
+    assert!(press_alt(&mut state, KeyCode::Backspace));
+    assert_eq!(state.text(), "alpha ");
 }
 
 fn render_view_rows(view: &dyn View, w: u16, h: u16) -> Vec<String> {


### PR DESCRIPTION
## What changed
`tuika::TextInputState::handle` now honors the readline/emacs editing bindings a terminal composer is expected to support. Before, only the plain keys (arrows, Home/End, Backspace/Delete, printable chars, paste) were handled and every Ctrl/Alt combo was ignored. Now the widget understands:

- **Cursor:** `C-a` line start, `C-e` line end, `C-f`/`C-b` char right/left, `C-p`/`C-n` line up/down
- **Delete:** `C-h` backspace, `C-d` delete forward
- **Kill:** `C-k` kill to line end (joins next line at EOL), `C-u` kill to line start
- **Word:** `M-f`/`M-b` word move, `M-d` delete word forward, `C-w`/`M-Backspace` delete word back

Unbound Ctrl combos (e.g. `C-z`) still return `false`, so a host can repurpose them.

## Why
This is the primitive the inline yolop composer needs before it can drop its own `ratatui-textarea` key handling and route through a single shared `TextInputState`. `ratatui-textarea` gave hosts these bindings for free; `TextInputState` had to reach parity first so the swap is behavior-preserving. Shipping the keymap as its own tuika change keeps it verifiable in isolation, ahead of the yolop-side swap.

## Before / After
**Before** — a Ctrl/Alt combo was a no-op:
```
C-a on "hello" (cursor at end) → cursor unchanged at (0,5), handle() == false
```
**After** — the same combo edits like readline:
```
C-a on "hello" (cursor at end) → cursor at (0,0), handle() == true
C-w at start of "bar" in "foo bar baz" → "bar baz"
M-d after "bar" in "bar baz" → "bar"
```
Covered by new unit tests: `text_input_emacs_cursor_bindings`, `text_input_emacs_delete_bindings`, `text_input_kill_to_line_end_and_start`, `text_input_word_move_and_delete`, plus `text_input_unbound_ctrl_keys_ignored`. `cargo test -p tuika` → 130 lib tests pass; `cargo clippy -p tuika --all-targets --all-features -- -D warnings` and `cargo fmt --check` clean.

## Risk
- Low
- Purely additive to `handle`'s match; the plain-key and paste arms are unchanged. The one behavior change is intended: `TextInputState` no longer ignores bound Ctrl/Alt combos (a host that previously relied on those bubbling up would now see them consumed) — no such host exists yet, since the composer swap that consumes this lands separately.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; tuika has no external consumers besides yolop, which does not yet route editing through `handle`)