### PR TITLE
feat(tuika): word-wrap TextInput at space boundaries

### DIFF
--- a/crates/tuika/src/components/textinput.rs
+++ b/crates/tuika/src/components/textinput.rs
@@ -4,9 +4,10 @@
 //! Like the rest of tuika's interactive widgets, state and view are split:
 //! [`TextInputState`] owns the text and cursor and applies edits (via
 //! [`TextInputState::handle`] or the explicit methods); [`TextInput`] borrows it
-//! and renders. The view is char-soft-wrapped to the render width — a logical
-//! line longer than the area wraps onto extra visual rows, and a line that fills
-//! the width exactly wraps the cursor onto a fresh row, like a real editor.
+//! and renders. The view is word-soft-wrapped to the render width — a logical
+//! line longer than the area breaks at the last space that fits (hard-breaking a
+//! word longer than the width), and a line that fills the width exactly wraps the
+//! cursor onto a fresh row, like a real editor.
 //!
 //! It is a *rendering + edit model*, not a terminal: the host reads
 //! [`TextInputState::cursor_screen`] after layout and calls the backend's
@@ -438,16 +439,9 @@ impl TextInputState {
         }
     }
 
-    /// Char-soft-wrap every logical line to `width`, returning the visual rows as
-    /// `(logical_row, chars)`. A line that fills the width exactly emits a
-    /// trailing empty row so the cursor can rest on a fresh line.
-    fn visual_rows(&self, width: u16) -> Vec<(usize, Vec<char>)> {
-        wrap_visual_rows(&self.lines, width)
-    }
-
     /// Number of visual rows the text occupies at `width`.
     pub fn visual_height(&self, width: u16) -> u16 {
-        self.visual_rows(width).len().max(1) as u16
+        wrap_visual_rows(&self.lines, width).len().max(1) as u16
     }
 
     /// The cursor's visual `(row, col)` in wrapped coordinates at `width`.
@@ -480,43 +474,89 @@ impl TextInputState {
     }
 }
 
-/// The cursor's visual `(row, col)` for `lines` with the logical cursor at
-/// `(row, col)`, char-soft-wrapped to `width`. Shared by [`TextInputState`] and
-/// [`TextInput`] so the rendered scroll offset and the placed cursor agree.
-fn visual_cursor_at(lines: &[String], row: usize, col: usize, width: u16) -> (u16, u16) {
-    let width = width.max(1) as usize;
-    let mut vrow: usize = 0;
-    for (r, line) in lines.iter().enumerate() {
-        let len = line.chars().count();
-        if r == row {
-            return ((vrow + col / width) as u16, (col % width) as u16);
-        }
-        vrow += (len / width) + 1; // rows for this line (incl. trailing/empty)
-    }
-    (vrow as u16, 0)
+/// One wrapped visual row: which logical line it came from, the char index in
+/// that line where it starts, and its chars.
+struct VisualRow {
+    logical: usize,
+    start: usize,
+    chars: Vec<char>,
 }
 
-/// Char-soft-wrap `lines` to `width`, returning visual rows as
-/// `(logical_row, chars)`. A line that fills the width exactly emits a trailing
-/// empty row so the cursor can rest on a fresh line. Shared by [`TextInputState`]
-/// (cursor math) and [`TextInput`] (rendering).
-fn wrap_visual_rows(lines: &[String], width: u16) -> Vec<(usize, Vec<char>)> {
+/// The cursor's visual `(row, col)` for `lines` with the logical cursor at
+/// `(row, col)`, word-soft-wrapped to `width`. Reuses [`wrap_visual_rows`] so the
+/// rendered scroll offset and the placed cursor always agree with what's drawn.
+fn visual_cursor_at(lines: &[String], row: usize, col: usize, width: u16) -> (u16, u16) {
+    let rows = wrap_visual_rows(lines, width);
+    let mut last_on_line: Option<(usize, usize)> = None; // (visual index, start col)
+    for (vi, vr) in rows.iter().enumerate() {
+        if vr.logical > row {
+            break;
+        }
+        if vr.logical != row {
+            continue;
+        }
+        let end = vr.start + vr.chars.len();
+        last_on_line = Some((vi, vr.start));
+        // A col at this row's end belongs to the next row's start, so only claim
+        // it here when it falls strictly inside — except the line's last row,
+        // handled below.
+        if col >= vr.start && col < end {
+            return (vi as u16, (col - vr.start) as u16);
+        }
+    }
+    // Cursor at the end of the logical line: rest at the end of its last row
+    // (which is an empty trailing row when the text filled the width exactly).
+    if let Some((vi, start)) = last_on_line {
+        return (vi as u16, col.saturating_sub(start) as u16);
+    }
+    (rows.len().saturating_sub(1) as u16, 0)
+}
+
+/// Word-soft-wrap `lines` to `width`: each logical line breaks at the last space
+/// that fits, falling back to a hard char-break for a word longer than `width`.
+/// A line whose final row fills the width exactly emits a trailing empty row so
+/// the cursor can rest on a fresh line. Shared by [`visual_cursor_at`] (cursor
+/// math) and [`TextInput`] (rendering) so both wrap identically.
+fn wrap_visual_rows(lines: &[String], width: u16) -> Vec<VisualRow> {
     let width = width.max(1) as usize;
     let mut rows = Vec::new();
     for (r, line) in lines.iter().enumerate() {
         let chars: Vec<char> = line.chars().collect();
         if chars.is_empty() {
-            rows.push((r, Vec::new()));
+            rows.push(VisualRow {
+                logical: r,
+                start: 0,
+                chars: Vec::new(),
+            });
             continue;
         }
         let mut start = 0;
+        let mut last_filled = false;
         while start < chars.len() {
-            let end = (start + width).min(chars.len());
-            rows.push((r, chars[start..end].to_vec()));
+            let remaining = chars.len() - start;
+            let end = if remaining <= width {
+                chars.len()
+            } else {
+                // Break after the last space within the width window; if the
+                // window holds no space, hard-break at the width boundary.
+                let hard = start + width;
+                let brk = (start + 1..hard).rev().find(|&i| chars[i] == ' ');
+                brk.map(|i| i + 1).unwrap_or(hard)
+            };
+            last_filled = end - start == width;
+            rows.push(VisualRow {
+                logical: r,
+                start,
+                chars: chars[start..end].to_vec(),
+            });
             start = end;
         }
-        if chars.len().is_multiple_of(width) {
-            rows.push((r, Vec::new()));
+        if last_filled {
+            rows.push(VisualRow {
+                logical: r,
+                start: chars.len(),
+                chars: Vec::new(),
+            });
         }
     }
     rows
@@ -574,7 +614,7 @@ impl View for TextInput {
             return;
         }
         let offset = self.scroll_offset(area.width, area.height) as usize;
-        for (i, (_logical, chars)) in wrap_visual_rows(&self.lines, area.width)
+        for (i, vr) in wrap_visual_rows(&self.lines, area.width)
             .into_iter()
             .enumerate()
             .skip(offset)
@@ -584,7 +624,7 @@ impl View for TextInput {
                 break;
             }
             let mut x = area.x;
-            for ch in chars {
+            for ch in vr.chars {
                 let w = UnicodeWidthChar::width(ch).unwrap_or(0) as u16;
                 if w == 0 || x >= area.right() {
                     continue;

--- a/crates/tuika/src/tests.rs
+++ b/crates/tuika/src/tests.rs
@@ -1811,6 +1811,46 @@ fn text_input_renders_wrapped_rows() {
 }
 
 #[test]
+fn text_input_word_wraps_at_spaces() {
+    let mut state = TextInputState::new();
+    type_str(&mut state, "hello world foo");
+    // Width 8 breaks at the last space that fits, not mid-word: "hello " then
+    // "world " then "foo".
+    assert_eq!(state.visual_height(8), 3);
+    let out = render_view_rows(&TextInput::new(&state), 8, 3);
+    assert_eq!(out[0], "hello");
+    assert_eq!(out[1], "world");
+    assert_eq!(out[2], "foo");
+}
+
+#[test]
+fn text_input_hard_breaks_overlong_word() {
+    let mut state = TextInputState::new();
+    type_str(&mut state, "abcdefghij");
+    // A single word longer than the width still hard-breaks so it fits.
+    assert_eq!(state.visual_height(4), 3);
+    let out = render_view_rows(&TextInput::new(&state), 4, 3);
+    assert_eq!(out[0], "abcd");
+    assert_eq!(out[1], "efgh");
+    assert_eq!(out[2], "ij");
+}
+
+#[test]
+fn text_input_cursor_tracks_word_wrap() {
+    let mut state = TextInputState::from_text("hello world");
+    // Cursor at end (col 11). Width 8 → "hello " / "world"; cursor sits after
+    // "world" on the second visual row at col 5.
+    let area = Rect::new(0, 0, 8, 3);
+    assert_eq!(state.cursor_screen(area), (5, 1));
+    // Move to just after the space (col 6, start of "world") → row 1, col 0.
+    state.move_home();
+    for _ in 0..6 {
+        state.move_right();
+    }
+    assert_eq!(state.cursor_screen(area), (0, 1));
+}
+
+#[test]
 fn text_input_cursor_screen_follows_wrap() {
     let mut state = TextInputState::new();
     type_str(&mut state, "abcd");


### PR DESCRIPTION
## Summary

`tuika::TextInput` soft-wrapped by **character** — a logical line longer than the render width broke mid-word at the exact width boundary. This changes it to **word-wrap**: each logical line breaks at the last space that fits, hard-breaking only a word that is itself longer than the width. The cursor math now reuses the same wrap pass, so the placed caret and the rendered text always agree for any wrap outcome.

This is the wrap behavior yolop's inline composer already gives users (via `ratatui-textarea`). Moving `TextInput` to word-wrap is the enabling step for swapping the inline composer onto the shared `TextInputState` without regressing wrapping — and it improves the `--fullscreen` composer (already on `TextInputState`) in the same stroke.

## What changed

- `wrap_visual_rows` now returns each visual row's start char-index and word-wraps each logical line (last-space-that-fits, hard-break fallback for an overlong word). A line whose final row fills the width exactly still emits a trailing empty row so the cursor can rest on a fresh line.
- `visual_cursor_at` walks the same wrapped rows to locate the caret instead of assuming fixed-width division — correct for word-wrapped rows of varying length.

## Before / After

Width 8, text `hello world foo`:

```
Before (char-wrap)   After (word-wrap)
hello wo             hello
rld foo              world
                     foo
```

## Tests

Added `text_input_word_wraps_at_spaces`, `text_input_hard_breaks_overlong_word`, and `text_input_cursor_tracks_word_wrap`. Existing wrap/cursor tests still pass (a single overlong word hard-breaks identically to the old char-wrap).

- `cargo test -p tuika` — 134 pass
- `cargo clippy -p tuika --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean

## Risk

Low. Confined to `crates/tuika` text rendering; behavior change is the intended wrap improvement, covered by new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LksbgmgJfiGmNXXGZphgW6)_