### PR TITLE
refactor(tui): route setup pickers through SelectState navigation

### DIFF
--- a/crates/tuika/src/components/select.rs
+++ b/crates/tuika/src/components/select.rs
@@ -55,6 +55,23 @@ impl SelectState {
         }
     }
 
+    /// Move the highlight up one row, clamping at the top (no wrap). The
+    /// non-wrapping stepping primitive; use it when a picker holds at the ends
+    /// rather than wrapping the way [`handle`](Self::handle) does.
+    pub fn move_up(&mut self) {
+        self.selected = self.selected.saturating_sub(1);
+    }
+
+    /// Move the highlight down one row, clamping at the last of `len` rows (no
+    /// wrap). The non-wrapping counterpart to [`move_up`](Self::move_up).
+    pub fn move_down(&mut self, len: usize) {
+        if len == 0 {
+            self.selected = 0;
+        } else {
+            self.selected = (self.selected + 1).min(len - 1);
+        }
+    }
+
     /// Navigate with arrow keys (wrapping), confirm with Enter, cancel on Esc.
     pub fn handle(&mut self, event: &Event, len: usize) -> SelectOutcome {
         if len == 0 {

--- a/crates/tuika/src/tests.rs
+++ b/crates/tuika/src/tests.rs
@@ -767,6 +767,27 @@ fn select_navigation_wraps_and_confirms() {
 }
 
 #[test]
+fn select_move_up_down_clamp_at_ends() {
+    let mut s = SelectState::new();
+    // Down steps forward, clamping at the last of `len` rows (no wrap).
+    s.move_down(3);
+    assert_eq!(s.selected(), 1);
+    s.move_down(3);
+    assert_eq!(s.selected(), 2);
+    s.move_down(3);
+    assert_eq!(s.selected(), 2); // held at the bottom, not wrapped
+    // Up steps back, clamping at the top.
+    s.move_up();
+    assert_eq!(s.selected(), 1);
+    s.move_up();
+    s.move_up();
+    assert_eq!(s.selected(), 0); // held at the top, not wrapped
+    // Degenerate: an empty list stays at 0.
+    s.move_down(0);
+    assert_eq!(s.selected(), 0);
+}
+
+#[test]
 fn select_state_select_sets_index_directly() {
     // A host can drive the highlight from its own state.
     let mut s = SelectState::new();

--- a/src/tui/fullscreen.rs
+++ b/src/tui/fullscreen.rs
@@ -322,9 +322,9 @@ fn draw_setup_overlay(f: &mut Frame, area: Rect, app: &App) {
 
 /// Render a bounded setup step as `header · SelectList · footer` inside the
 /// panel. The `SelectState`'s index is driven from the step's own `selected`
-/// field (navigation still flows through `App::handle_setup_key`); promoting
-/// `SelectState` to the navigation source is the same deferred unification as the
-/// composer's.
+/// field for rendering; the arrow-key transitions in `App::handle_setup_key`
+/// step that field through `SelectState`'s (clamping) `move_up`/`move_down`, so
+/// the pickers share one tested navigation source.
 fn draw_setup_picker(f: &mut Frame, area: Rect, picker: render::SetupPicker) {
     let render::SetupPicker {
         header,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -4844,6 +4844,34 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn setup_picker_navigation_clamps_at_ends() {
+        let mut test = app_with_llmsim().await;
+        let app = &mut test.app;
+        app.setup = Some(SetupStep::Provider { selected: 0 });
+
+        fn provider_selected(app: &App) -> usize {
+            match app.setup {
+                Some(SetupStep::Provider { selected }) => selected,
+                _ => panic!("expected the provider step"),
+            }
+        }
+
+        // Up at the top holds at 0 — navigation clamps, it does not wrap.
+        app.handle_setup_key(KeyEvent::new(KeyCode::Up, KeyModifiers::empty()))
+            .await;
+        assert_eq!(provider_selected(app), 0);
+
+        // Down walks forward one row at a time and clamps at the last option
+        // even when pressed past the end.
+        let last = PROVIDER_OPTIONS.len() - 1;
+        for _ in 0..last + 3 {
+            app.handle_setup_key(KeyEvent::new(KeyCode::Down, KeyModifiers::empty()))
+                .await;
+        }
+        assert_eq!(provider_selected(app), last);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn proactive_wake_disabled_by_setting_does_not_start_turn() {
         let mut test = app_with_llmsim().await;
         let app = &mut test.app;

--- a/src/tui/setup.rs
+++ b/src/tui/setup.rs
@@ -10,6 +10,25 @@
 
 use super::*;
 
+/// Step a picker selection up one row, clamping at the top. Routes the
+/// transition through tuika's [`SelectState`](tuika::SelectState) so every setup
+/// picker shares one tested navigation source instead of open-coding the clamp
+/// (see the `draw_setup_picker` note in `fullscreen.rs`).
+fn select_up(selected: usize) -> usize {
+    let mut state = tuika::SelectState::new();
+    state.select(selected);
+    state.move_up();
+    state.selected()
+}
+
+/// Step a picker selection down one row, clamping at the last of `len` rows.
+fn select_down(selected: usize, len: usize) -> usize {
+    let mut state = tuika::SelectState::new();
+    state.select(selected);
+    state.move_down(len);
+    state.selected()
+}
+
 impl App {
     pub(crate) fn start_setup(&mut self) {
         self.setup = Some(SetupStep::Provider {
@@ -630,12 +649,12 @@ impl App {
             }
             KeyCode::Up | KeyCode::Char('k') => {
                 self.setup = Some(SetupStep::Provider {
-                    selected: selected.saturating_sub(1),
+                    selected: select_up(selected),
                 });
             }
             KeyCode::Down | KeyCode::Char('j') => {
                 self.setup = Some(SetupStep::Provider {
-                    selected: (selected + 1).min(PROVIDER_OPTIONS.len().saturating_sub(1)),
+                    selected: select_down(selected, PROVIDER_OPTIONS.len()),
                 });
             }
             KeyCode::Char('c') => {
@@ -834,14 +853,14 @@ impl App {
             KeyCode::Up | KeyCode::Char('k') => {
                 self.setup = Some(SetupStep::Credential {
                     provider,
-                    selected: selected.saturating_sub(1),
+                    selected: select_up(selected),
                     error: None,
                 });
             }
             KeyCode::Down | KeyCode::Char('j') => {
                 self.setup = Some(SetupStep::Credential {
                     provider,
-                    selected: (selected + 1).min(options.len().saturating_sub(1)),
+                    selected: select_down(selected, options.len()),
                     error: None,
                 });
             }
@@ -1234,7 +1253,7 @@ impl App {
             KeyCode::Up | KeyCode::Char('k') => {
                 self.setup = Some(SetupStep::PickModel {
                     provider,
-                    selected: selected.saturating_sub(1),
+                    selected: select_up(selected),
                     custom: None,
                     error: None,
                 });
@@ -1242,7 +1261,7 @@ impl App {
             KeyCode::Down | KeyCode::Char('j') => {
                 self.setup = Some(SetupStep::PickModel {
                     provider,
-                    selected: (selected + 1).min(options.len().saturating_sub(1)),
+                    selected: select_down(selected, options.len()),
                     custom: None,
                     error: None,
                 });
@@ -1329,13 +1348,13 @@ impl App {
             }
             KeyCode::Up | KeyCode::Char('k') => {
                 self.setup = Some(SetupStep::PickEffort {
-                    selected: selected.saturating_sub(1),
+                    selected: select_up(selected),
                     error: None,
                 });
             }
             KeyCode::Down | KeyCode::Char('j') => {
                 self.setup = Some(SetupStep::PickEffort {
-                    selected: (selected + 1).min(options_len.saturating_sub(1)),
+                    selected: select_down(selected, options_len),
                     error: None,
                 });
             }


### PR DESCRIPTION
## Summary

The setup pickers (provider, credential, model, effort) each open-coded the **same** clamp arithmetic for arrow-key navigation — `selected.saturating_sub(1)` on Up, `(selected + 1).min(len - 1)` on Down — duplicated across four handlers, while the `SelectState` used to render the picker was purely a render mirror. This promotes `SelectState` to the pickers' single **navigation source**.

This is the last deferred unification flagged in `fullscreen.rs`'s `draw_setup_picker` note (the composer half shipped in #388).

## What changed

- **tuika**: `SelectState` gains clamping stepping primitives — `move_up()` (holds at the top) and `move_down(len)` (holds at the last row). These are the **non-wrapping** counterpart to the existing `handle`, which wraps. `handle`'s wrapping behavior is untouched (it has no production callers today; used by tuika's own tests).
- **yolop**: the four setup handlers route their Up/Down transitions through two small helpers (`select_up` / `select_down`) that drive a `SelectState`, replacing the duplicated arithmetic. The vim `j`/`k` aliases, Enter/Esc, digit shortcuts, and the render mirror are all unchanged.

## Behavior

**Unchanged.** Navigation still **clamps** at the ends — Up on the first row stays put, Down on the last row stays put — matching today's UX. (Per maintainer direction, clamp was kept rather than adopting `SelectState::handle`'s wrap.)

## Tests

- tuika: `select_move_up_down_clamp_at_ends` — steps, clamps at both ends, and the empty-list case.
- yolop: `setup_picker_navigation_clamps_at_ends` — drives the provider step via `handle_setup_key`, asserting Up holds at 0 and Down clamps at the last option even when pressed past the end.
- `cargo test -p tuika` (135) and `cargo test -p yolop --bin yolop` (873) pass; `clippy -D warnings` and `fmt --check` clean.

The four `tests/integration.rs` sandboxed-shell cases fail in this container only (kernel lacks Landlock ABI v3); they're unrelated and run on CI's Landlock-capable kernel.

## Risk

Low. Pure refactor with identical behavior; the navigation arithmetic moves into a tested tuika primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LksbgmgJfiGmNXXGZphgW6)_