### PR TITLE
test: skip native-sandbox tests when Landlock is unavailable

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -57,9 +57,64 @@ fn run_linux_sandbox_worker(cwd: &Path, temp: &Path, script: &str) -> std::proce
         .expect("spawn Linux sandbox worker")
 }
 
+/// Whether the native shell sandbox can actually be enforced on this host.
+/// Reuses the real worker path on Linux (Landlock ABI v3) and checks for
+/// `sandbox-exec` on macOS; other platforms have no native sandbox to probe.
+/// Probed once and cached.
+fn native_sandbox_available() -> bool {
+    use std::sync::OnceLock;
+    static AVAILABLE: OnceLock<bool> = OnceLock::new();
+    *AVAILABLE.get_or_init(|| {
+        #[cfg(target_os = "linux")]
+        {
+            let dir = tempfile::tempdir().expect("sandbox probe tempdir");
+            let ws = dir.path().join("ws");
+            let tmp = dir.path().join("tmp");
+            std::fs::create_dir_all(&ws).expect("probe workspace");
+            std::fs::create_dir_all(&tmp).expect("probe temp");
+            let out = run_linux_sandbox_worker(&ws, &tmp, "true");
+            if out.status.success() {
+                return true;
+            }
+            // Only the explicit refusal means "unavailable"; any other failure
+            // should surface in the test rather than be swallowed as a skip.
+            !String::from_utf8_lossy(&out.stderr).contains("native sandbox unavailable")
+        }
+        #[cfg(target_os = "macos")]
+        {
+            std::path::Path::new("/usr/bin/sandbox-exec").exists()
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        {
+            true
+        }
+    })
+}
+
+/// Gate a sandbox-dependent test: skip locally when the native sandbox is
+/// unavailable, but make its absence a hard failure under `CI` so the sandbox
+/// contract is never silently un-tested where it can run. Mirrors
+/// `require_python3` in the MCP e2e suite.
+fn require_native_sandbox(test: &str) -> bool {
+    if native_sandbox_available() {
+        return true;
+    }
+    assert!(
+        std::env::var_os("CI").is_none(),
+        "{test}: the native shell sandbox is required in CI but is unavailable on this host",
+    );
+    eprintln!(
+        "skipping {test}: native shell sandbox unavailable (set CI=1 to make this a hard failure)"
+    );
+    false
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 fn linux_sandbox_worker_enforces_filesystem_and_network_contract() {
+    if !require_native_sandbox("linux_sandbox_worker_enforces_filesystem_and_network_contract") {
+        return;
+    }
     use std::net::TcpListener;
 
     let root = tempfile::Builder::new()
@@ -119,6 +174,9 @@ fn linux_sandbox_worker_enforces_filesystem_and_network_contract() {
 #[cfg(target_os = "linux")]
 #[test]
 fn linux_sandbox_worker_tracks_each_active_worktree() {
+    if !require_native_sandbox("linux_sandbox_worker_tracks_each_active_worktree") {
+        return;
+    }
     let root = tempfile::Builder::new()
         .prefix("yolop-linux-worktree-test-")
         .tempdir_in(std::env::current_dir().unwrap())
@@ -1510,6 +1568,9 @@ fn tui_submit_turn_renders_assistant_in_scrollback() {
 
 #[test]
 fn tui_bang_shell_runs_shell_without_model_turn() {
+    if !require_native_sandbox("tui_bang_shell_runs_shell_without_model_turn") {
+        return;
+    }
     let mut tui = spawn_tui_llmsim(&yolop_binary());
     assert!(
         tui.wait_for_output("type /help", Duration::from_secs(3)),
@@ -1546,6 +1607,9 @@ fn tui_bang_shell_runs_shell_without_model_turn() {
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 #[test]
 fn tui_agents_context_cannot_bypass_native_shell_sandbox() {
+    if !require_native_sandbox("tui_agents_context_cannot_bypass_native_shell_sandbox") {
+        return;
+    }
     let root = tempfile::Builder::new()
         .prefix("yolop-tui-sandbox-test-")
         .tempdir_in(std::env::current_dir().unwrap())


### PR DESCRIPTION
## What changed

The four integration tests that exercise the native shell sandbox — `linux_sandbox_worker_enforces_filesystem_and_network_contract`, `linux_sandbox_worker_tracks_each_active_worktree`, `tui_bang_shell_runs_shell_without_model_turn`, and `tui_agents_context_cannot_bypass_native_shell_sandbox` — now gate on a `require_native_sandbox()` probe:

- **Sandbox available** (Landlock ABI v3 on Linux, `sandbox-exec` on macOS) → the test runs exactly as before.
- **Unavailable locally** → the test skips with an explicit message instead of failing.
- **Unavailable under `CI`** → the test hard-fails, so the sandbox contract is never silently un-tested where it can run.

The probe reuses the real worker path (it runs `yolop __sandbox-exec` with a trivial script on Linux and matches the product's own `native sandbox unavailable` refusal), so the test and the product agree on what "available" means. It's cached via a `OnceLock`.

## Why

These tests hard-require a working sandbox to run their assertions (they write files and assert the kernel blocks escapes — there's nothing to mock). On kernels or containers without Landlock — some dev containers, older kernels, certain WSL setups — they fail with `native sandbox unavailable: Landlock ABI v3 is not fully enforced by this kernel`, which is environment noise, not a real regression. This mirrors the existing `require_python3` pattern the MCP e2e suite already uses for a capability that isn't present everywhere.

## Before / After

Same host (a dev container without Landlock):

```
# Before
test linux_sandbox_worker_tracks_each_active_worktree ... FAILED
  panicked: native sandbox unavailable: Landlock ABI v3 is not fully enforced by this kernel

# After (no CI)
skipping linux_sandbox_worker_tracks_each_active_worktree: native shell sandbox unavailable (set CI=1 to make this a hard failure)
test linux_sandbox_worker_tracks_each_active_worktree ... ok
test result: ok. 4 passed; 0 failed

# After (CI=1) — coverage is not silently dropped
test linux_sandbox_worker_tracks_each_active_worktree ... FAILED
  panicked: ...: the native shell sandbox is required in CI but is unavailable on this host
```

CI runners have the sandbox, so on GitHub Actions all four continue to run and pass (unchanged), confirmed by the Sandbox Contract jobs.

## Risk

- **Low.** Test-infrastructure only; no product code changes. The one thing that could go wrong — silently losing sandbox coverage — is prevented by the `CI` hard-fail. Both branches were exercised locally (skip without `CI`, panic with `CI=1`).

## Security

No security-relevant product code changes. The change is careful *because* these are security-boundary tests: it never weakens CI coverage — under `CI` the sandbox contract must still be enforceable or the run fails loudly. Only the explicit "unavailable" refusal is treated as a skip signal; any other worker failure still surfaces in the test rather than being swallowed.

## Follow-ups

No follow-ups.

## Checklist
- [x] Tests added or updated (this is the test change; both skip and CI-hard-fail paths verified)
- [x] Backward compatibility considered (CI behavior unchanged; only local runs on sandbox-less hosts differ)


---
_Generated by [Claude Code](https://claude.ai/code/session_012g1Xyyb1SLXU7DSuNjFvCS)_