### PR TITLE
feat(cli): add no-sandbox override

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,8 @@ to this file.
 To disable kernel containment for an already isolated environment, add
 `sandbox_mode = "danger-full-access"` or ask Yolop to set that config key. This is dangerous on a
 normal host: commands then have unrestricted host file, process, and network
-access. Clearing the key restores `workspace-write`.
+access. For a one-run override that does not change settings, pass
+`--no-sandbox`. Clearing the key restores `workspace-write`.
 
 The model picker queries the provider's models API live (OpenAI, Anthropic,
 and OpenRouter via the everruns drivers; Ollama, Gemini, and other

--- a/docs/features/sandboxing/sandboxing.md
+++ b/docs/features/sandboxing/sandboxing.md
@@ -126,6 +126,13 @@ container, or remote sandbox:
 sandbox_mode = "danger-full-access"
 ```
 
+For a single invocation, pass `--no-sandbox` instead. It selects the same
+dangerous full-host-access mode without changing `settings.toml`:
+
+```bash
+yolop --no-sandbox
+```
+
 Add the setting to Yolop's `settings.toml`, or ask Yolop to set the
 `sandbox_mode` configuration key. The change applies on the next run.
 

--- a/specs/sandboxing.md
+++ b/specs/sandboxing.md
@@ -107,6 +107,9 @@ Users already running Yolop inside a trusted VM/container may set:
 sandbox_mode = "danger-full-access"
 ```
 
+The `--no-sandbox` CLI flag applies the same mode to one process, including
+its print, TUI, or ACP runtime, without modifying persistent configuration.
+
 The same change is available through
 `set_config key=sandbox_mode value=danger-full-access`.
 Disabling applies on the next run. Yolop communicates the risk in three places:

--- a/src/editor/acp/mod.rs
+++ b/src/editor/acp/mod.rs
@@ -25,7 +25,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 
 use crate::capabilities::ClientUiContext;
-use crate::config::SettingsStore;
+use crate::config::{SandboxMode, SettingsStore};
 use crate::runtime::session_log::{legacy_session_log_path, session_dir_path, session_log_path};
 use crate::runtime::{BuildOptions, BuiltRuntime, ProviderChoice, build_with_options};
 use everruns_core::ScopedMcpServers;
@@ -41,6 +41,7 @@ struct ConfigRuntimeFactory {
     provider: ProviderChoice,
     settings: Arc<SettingsStore>,
     sessions_dir: PathBuf,
+    sandbox_mode_override: Option<SandboxMode>,
 }
 
 #[async_trait]
@@ -70,6 +71,7 @@ impl RuntimeFactory for ConfigRuntimeFactory {
                 provider_model: model_selection,
                 client_mcp_servers,
                 tool_approver,
+                sandbox_mode_override: self.sandbox_mode_override,
                 ..BuildOptions::default()
             },
         )
@@ -84,11 +86,13 @@ pub async fn run_stdio(
     provider: ProviderChoice,
     settings: Arc<SettingsStore>,
     sessions_dir: PathBuf,
+    sandbox_mode_override: Option<SandboxMode>,
 ) -> Result<()> {
     let factory = Arc::new(ConfigRuntimeFactory {
         provider,
         settings,
         sessions_dir,
+        sandbox_mode_override,
     });
     serve(tokio::io::stdin(), tokio::io::stdout(), factory).await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,11 @@ struct Cli {
     /// terminal scrollback is unavailable in this mode.
     #[arg(long)]
     fullscreen: bool,
+
+    /// Disable shell sandboxing for this run. DANGER: commands receive
+    /// unrestricted access to host files, processes, and the network.
+    #[arg(long)]
+    no_sandbox: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -509,6 +514,11 @@ async fn async_main() -> Result<()> {
         std::path::PathBuf::from("/dev/null/yolop/settings.toml")
     });
     let settings = Arc::new(SettingsStore::open(settings_path));
+    let sandbox_mode_override = cli
+        .no_sandbox
+        .then_some(config::SandboxMode::DangerFullAccess);
+    let effective_sandbox_mode =
+        sandbox_mode_override.unwrap_or_else(|| settings.snapshot().sandbox_mode());
     let (mut provider, mut notes) = pick_provider(&cli, &settings);
     let snapshot = settings.snapshot();
     let (reconciled, catalog_notes) =
@@ -535,20 +545,21 @@ async fn async_main() -> Result<()> {
     // ACP mode builds runtimes per session (cwd arrives via `session/new`), so
     // it bypasses the up-front runtime build and the TUI.
     if cli.acp {
-        if let Some(warning) = exec::sandbox::danger_warning(settings.snapshot().sandbox_mode()) {
+        if let Some(warning) = exec::sandbox::danger_warning(effective_sandbox_mode) {
             eprintln!("yolop: {warning}");
         }
         if cli.trajectory_out.is_some() {
             eprintln!("yolop: --trajectory-out is ignored in --acp mode");
         }
-        return editor::acp::run_stdio(provider, settings, sessions_dir).await;
+        return editor::acp::run_stdio(provider, settings, sessions_dir, sandbox_mode_override)
+            .await;
     }
 
     // Only the interactive TUI can apply terminal-side commands (overlays,
     // transcript clear, quit), so only it enables `ClientCommandsCapability`.
     // `--print` is one-shot and never dispatches them.
     let interactive = cli.print.is_none();
-    if let Some(warning) = exec::sandbox::danger_warning(settings.snapshot().sandbox_mode()) {
+    if let Some(warning) = exec::sandbox::danger_warning(effective_sandbox_mode) {
         eprintln!("yolop: {warning}");
     }
     let runtime = runtime::build_with_options(
@@ -570,6 +581,7 @@ async fn async_main() -> Result<()> {
                 runtime::session_log::SessionKind::Print
             },
             initial_prompt: cli.print.clone(),
+            sandbox_mode_override,
             ..Default::default()
         },
     )
@@ -1506,6 +1518,7 @@ mod tests {
             session_dir: None,
             trajectory_out: None,
             fullscreen: false,
+            no_sandbox: false,
         }
     }
 
@@ -1563,6 +1576,7 @@ mod tests {
             session_dir: None,
             trajectory_out: None,
             fullscreen: false,
+            no_sandbox: false,
         };
 
         let (provider, _notes) = pick_provider(&cli, &settings);

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2169,6 +2169,9 @@ pub struct BuiltRuntime {
     /// to resolve credentials when querying provider models APIs and to show
     /// per-provider connection status in the setup overlay.
     pub settings: Arc<SettingsStore>,
+    /// CLI-only sandbox override for this process, if present. Hosts use this
+    /// to display the runtime's effective mode without persisting it.
+    pub sandbox_mode_override: Option<crate::config::SandboxMode>,
     /// Receiver for terminal-side commands emitted by
     /// [`ClientCommandsCapability`]. The TUI drains it in its event loop;
     /// other hosts ignore it. Empty/never-written when
@@ -2458,6 +2461,9 @@ pub struct BuildOptions {
     pub(crate) provider_model: Option<ProviderChoice>,
     pub session_kind: SessionKind,
     pub initial_prompt: Option<String>,
+    /// Per-process sandbox override. CLI flags use this instead of persisting
+    /// a settings change, so the next invocation returns to configured mode.
+    pub sandbox_mode_override: Option<crate::config::SandboxMode>,
     /// Register [`ClientCommandsCapability`], which contributes the
     /// terminal-side commands (help/tools/mcp/cwd/model/effort/clear/shell/quit)
     /// and drives them through the host UI channel. Only a host that can apply
@@ -2484,6 +2490,7 @@ impl Default for BuildOptions {
             provider_model: None,
             session_kind: SessionKind::Interactive,
             initial_prompt: None,
+            sandbox_mode_override: None,
             client_commands: false,
             client_ui: ClientUiContext::None,
             client_mcp_servers: ScopedMcpServers::new(),
@@ -2506,9 +2513,13 @@ pub async fn build_with_options(
     // Unit-test binaries are libtest harnesses and cannot service the Linux
     // worker subcommand. Real-binary coverage lives in tests/integration.rs.
     #[cfg(all(test, target_os = "linux"))]
-    let sandbox_mode = crate::config::SandboxMode::DangerFullAccess;
+    let sandbox_mode = options
+        .sandbox_mode_override
+        .unwrap_or(crate::config::SandboxMode::DangerFullAccess);
     #[cfg(not(all(test, target_os = "linux")))]
-    let sandbox_mode = settings.snapshot().sandbox_mode();
+    let sandbox_mode = options
+        .sandbox_mode_override
+        .unwrap_or_else(|| settings.snapshot().sandbox_mode());
     let sandbox = crate::exec::sandbox::provider(sandbox_mode);
     let approval_policy = settings.snapshot().approval_policy();
     let (sandbox_approval_gate, sandbox_approval_rx) = if options.client_ui == ClientUiContext::Tui
@@ -3231,6 +3242,7 @@ pub async fn build_with_options(
         },
         model: ModelState::new(provider_state),
         settings,
+        sandbox_mode_override: options.sandbox_mode_override,
         ui_rx,
         ask_rx,
         sandbox_approval_rx,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -151,6 +151,8 @@ pub struct App {
     /// provider models APIs and to show per-provider connection status in
     /// the setup overlay.
     settings: Arc<crate::config::SettingsStore>,
+    /// Per-process override, when one differs from persisted settings.
+    sandbox_mode_override: Option<crate::config::SandboxMode>,
     /// Models discovered from each provider's models API, keyed by provider
     /// name. Once populated, replaces the curated fallback list in the
     /// model picker.
@@ -491,6 +493,7 @@ impl App {
             sandbox_approval_rx: runtime.sandbox_approval_rx,
             pending_sandbox_approval: None,
             settings: runtime.settings,
+            sandbox_mode_override: runtime.sandbox_mode_override,
             model_catalog: HashMap::new(),
             model_fetches_in_flight: HashSet::new(),
             model_discovery_enabled: true,
@@ -674,7 +677,9 @@ impl App {
 
     pub(crate) fn presentation_state(&self) -> PresentationState {
         let settings = self.settings.snapshot();
-        let sandbox = settings.sandbox_mode();
+        let sandbox = self
+            .sandbox_mode_override
+            .unwrap_or_else(|| settings.sandbox_mode());
         let approval_mode = if sandbox == crate::config::SandboxMode::DangerFullAccess {
             format!(
                 "{} · {} · UNSAFE HOST",
@@ -803,7 +808,9 @@ impl App {
             self.startup.workspace_root.display()
         ));
         self.push_system(format!("model: {}", self.model.provider_label()));
-        let sandbox_mode = self.settings.snapshot().sandbox_mode();
+        let sandbox_mode = self
+            .sandbox_mode_override
+            .unwrap_or_else(|| self.settings.snapshot().sandbox_mode());
         self.push_system(format!("sandbox: {}", sandbox_mode.as_str()));
         self.push_system(format!(
             "approval policy: {}",

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -301,6 +301,10 @@ fn help_flag_succeeds() {
     );
     assert!(stdout.contains("--print"), "help output missing --print");
     assert!(stdout.contains("--image"), "help output missing --image");
+    assert!(
+        stdout.contains("--no-sandbox"),
+        "help output missing --no-sandbox"
+    );
 }
 
 #[test]
@@ -1635,6 +1639,53 @@ fn tui_bang_shell_runs_shell_without_model_turn() {
         "double Ctrl-C should exit cleanly, got {status:?}: {}",
         tui.output_text()
     );
+}
+
+#[cfg(not(windows))]
+#[test]
+fn no_sandbox_flag_gives_shell_commands_full_host_access_for_one_run() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let workspace = root.path().join("workspace");
+    std::fs::create_dir(&workspace).expect("create workspace");
+    let outside = root.path().join("outside.txt");
+    let mut tui = spawn_tui_llmsim_with(
+        &yolop_binary(),
+        TuiSpawnOptions {
+            workspace: Some(workspace),
+            no_sandbox: true,
+            ..TuiSpawnOptions::default()
+        },
+    );
+    assert!(
+        tui.wait_for_output("UNSAFE HOST", Duration::from_secs(3)),
+        "TUI did not show the effective unsafe mode: {}",
+        tui.output_text()
+    );
+    assert!(
+        tui.wait_for_output("type /help", Duration::from_secs(3)),
+        "TUI did not finish startup: {}",
+        tui.output_text()
+    );
+
+    tui.write_input(b"!shell touch ../outside.txt\r");
+    assert!(
+        tui.wait_for_output("shell exited with code 0", Duration::from_secs(5)),
+        "full-access shell did not complete: {}",
+        tui.output_text()
+    );
+    assert!(
+        outside.exists(),
+        "--no-sandbox shell could not write outside cwd"
+    );
+    assert!(
+        !std::fs::read_to_string(tui.settings_path())
+            .expect("read settings")
+            .contains("danger-full-access"),
+        "one-run override must not persist to settings"
+    );
+
+    tui.write_input(b"\x03\x03");
+    assert!(tui.wait_or_kill(Duration::from_secs(3)).success());
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]

--- a/tests/support/tui_harness.rs
+++ b/tests/support/tui_harness.rs
@@ -39,6 +39,8 @@ pub struct TuiSpawnOptions {
     pub fullscreen: bool,
     /// Workspace passed through `-C`; useful for real-binary containment tests.
     pub workspace: Option<PathBuf>,
+    /// Disable shell sandboxing for this process.
+    pub no_sandbox: bool,
 }
 
 impl Default for TuiSpawnOptions {
@@ -51,6 +53,7 @@ impl Default for TuiSpawnOptions {
             path_prefix: None,
             fullscreen: false,
             workspace: None,
+            no_sandbox: false,
         }
     }
 }
@@ -199,6 +202,9 @@ pub fn spawn_tui_llmsim_with_settings(
     cmd.arg(session_dir.path());
     if options.fullscreen {
         cmd.arg("--fullscreen");
+    }
+    if options.no_sandbox {
+        cmd.arg("--no-sandbox");
     }
     if let Some(workspace) = options.workspace {
         cmd.arg("-C");


### PR DESCRIPTION
## What changed
Adds `--no-sandbox` as an explicit per-process override for print, TUI, and ACP runs. It selects `danger-full-access` without modifying persistent settings, emits the existing unsafe-host warning, and keeps the TUI status/banner aligned with the effective runtime mode.

## Why
Users already running Yolop inside trusted external containment need a convenient one-run opt-out without editing and later restoring `settings.toml`.

## Before / After
Before: disabling native containment required persisting `sandbox_mode = "danger-full-access"`.

After: `yolop --no-sandbox ...` grants shell commands full host access for that process only. The real-binary PTY test runs `!shell touch ../outside.txt`, proves the out-of-workspace write succeeds, verifies the TUI shows `UNSAFE HOST`, and confirms settings remain unchanged.

## Risk
- Medium: the flag intentionally removes shell containment when explicitly supplied.
- The existing prominent danger warning remains active, and the override does not persist.

## Security
- TM-FS / TM-TOOL: reviewed the explicit full-host-access path. Only shell execution receives the unsafe provider; file-tool workspace boundaries and the default write blocklist remain unchanged and covered by the full suite.
- TM-BASH: execution still uses the shared bounded runner with existing timeouts, cancellation, and output caps.
- TM-LLM: no prompt, credential, logging, or session persistence changes.
- TM-DEP: no dependency changes.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (888 unit passed, 43 integration passed, parallel and TUI PTY suites passed; credential/tooling-specific ignores unchanged)
- `cargo build --release`
- `target/release/yolop --no-sandbox --provider llmsim --session-dir /tmp/yolop-no-sandbox-offline-smoke-24791 -p hi`
- Live OpenAI and OpenRouter integration smokes passed in the full integration suite. A separate Doppler CLI smoke could not start because this worktree has no Doppler project configured.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)