### PR TITLE
fix(context): avoid ephemeral default compaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,7 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   hyperlinks), multiline composer, a busy
   indicator with a live elapsed timer while a turn runs, status
   bar (with a `bg` count whenever the session has background tasks and a `ctx`
-  context-window gauge, marked with the point where automatic context
-  compaction kicks in, once the model reports usage; compaction itself is
-  noted in the transcript when it runs), slash commands
+  context-window gauge once the model reports usage), slash commands
   (`/help`, `/tools`, `/mcp`, `/cwd`, `/setup`, `/model`, `/effort`, `/goal`,
   `/shell`, `/background`, `/clear`, `/quit`), a read-only background-tasks panel
   toggled with `Ctrl+B`, `!<command>` as a direct shell shortcut, `@`-triggered

--- a/src/capabilities/context_cost_control.rs
+++ b/src/capabilities/context_cost_control.rs
@@ -1,0 +1,129 @@
+use async_trait::async_trait;
+use everruns_core::capabilities::{
+    Capability, CapabilityStatus, CompactionConfig, ModelViewContext, ModelViewProvider,
+    apply_cost_control_masking,
+};
+use everruns_core::message::Message;
+use std::sync::Arc;
+
+pub(crate) const CONTEXT_COST_CONTROL_CAPABILITY_ID: &str = "context_cost_control";
+
+/// A prompt-view-only reducer for stale tool payloads.
+///
+/// Full outputs remain in session storage, while cold turns remain discoverable
+/// through `query_history`. This capability only avoids paying to resend bulky
+/// old observations. It deliberately does not activate the runtime's compaction
+/// cascade or claim ownership of the infinity-context retrieval budget.
+pub(crate) struct ContextCostControlCapability;
+
+#[async_trait]
+impl Capability for ContextCostControlCapability {
+    fn id(&self) -> &str {
+        CONTEXT_COST_CONTROL_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Context Cost Control"
+    }
+
+    fn description(&self) -> &str {
+        "Masks stale tool payloads in the model view while preserving lossless session history."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Optimization")
+    }
+
+    fn model_view_provider(&self) -> Option<Arc<dyn ModelViewProvider>> {
+        Some(Arc::new(ContextCostControlModelViewProvider))
+    }
+}
+
+struct ContextCostControlModelViewProvider;
+
+impl ModelViewProvider for ContextCostControlModelViewProvider {
+    fn apply_model_view(
+        &self,
+        messages: Vec<Message>,
+        config: &serde_json::Value,
+        context: &ModelViewContext<'_>,
+    ) -> Vec<Message> {
+        let config = CompactionConfig::from_json(config);
+        let result = apply_cost_control_masking(&messages, &config, context.prior_usage);
+        if result.masked_count > 0 {
+            tracing::debug!(
+                session_id = %context.session_id,
+                masked_count = result.masked_count,
+                tool_result_bytes_before = result.tool_result_bytes_before,
+                tool_result_bytes_after = result.tool_result_bytes_after,
+                "masked stale tool results in prompt view"
+            );
+        }
+        result.messages
+    }
+
+    fn priority(&self) -> i32 {
+        50
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::tool_types::ToolCall;
+    use everruns_core::typed_id::SessionId;
+
+    #[test]
+    fn contributes_only_a_model_view_reducer() {
+        let capability = ContextCostControlCapability;
+
+        assert!(capability.model_view_provider().is_some());
+        assert!(capability.message_filter_provider().is_none());
+    }
+
+    #[test]
+    fn masks_old_large_tool_results_without_dropping_messages() {
+        let mut messages = Vec::new();
+        for index in 0..4 {
+            let call_id = format!("call_{index}");
+            messages.push(Message::assistant_with_tools(
+                "",
+                vec![ToolCall {
+                    id: call_id.clone(),
+                    name: "read_file".to_string(),
+                    arguments: serde_json::json!({ "path": format!("file_{index}") }),
+                }],
+            ));
+            messages.push(Message::tool_result(
+                call_id,
+                Some(serde_json::json!({ "output": "x".repeat(10_000) })),
+                None,
+            ));
+        }
+        let bytes_before = serde_json::to_vec(&messages)
+            .expect("serialize messages")
+            .len();
+
+        let reduced = ContextCostControlModelViewProvider.apply_model_view(
+            messages.clone(),
+            &serde_json::json!({}),
+            &ModelViewContext {
+                session_id: SessionId::new(),
+                prior_usage: None,
+            },
+        );
+        let bytes_after = serde_json::to_vec(&reduced)
+            .expect("serialize reduced messages")
+            .len();
+
+        assert_eq!(reduced.len(), messages.len());
+        assert!(bytes_after * 4 < bytes_before * 3);
+        assert_ne!(reduced[1].content, messages[1].content);
+        assert_eq!(reduced[6].content, messages[6].content);
+        assert_eq!(reduced[7].content, messages[7].content);
+    }
+}

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod background;
 pub(crate) mod checkpoint;
 pub(crate) mod client_commands;
 pub(crate) mod config;
+pub(crate) mod context_cost_control;
 pub(crate) mod edit_file_override;
 pub(crate) mod free_search;
 pub(crate) mod goal;
@@ -43,6 +44,9 @@ pub(crate) use background::{
 pub(crate) use checkpoint::{CHECKPOINT_CAPABILITY_ID, CheckpointCapability};
 pub(crate) use client_commands::{CLIENT_COMMANDS_CAPABILITY_ID, ClientCommandsCapability};
 pub(crate) use config::{CONFIG_CAPABILITY_ID, ConfigCapability};
+pub(crate) use context_cost_control::{
+    CONTEXT_COST_CONTROL_CAPABILITY_ID, ContextCostControlCapability,
+};
 pub(crate) use free_search::FreeSearchCapability;
 pub(crate) use goal::GoalCapability;
 pub(crate) use herdr::{HERDR_CAPABILITY_ID, HerdrCapability};

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -15,12 +15,13 @@ use crate::capabilities::{
     APPROVAL_CAPABILITY_ID, AST_GREP_CAPABILITY_ID, ATTRIBUTION_CAPABILITY_ID, ApprovalCapability,
     AstEditCapability, AstGrepCapability, AttributionCapability, BACKGROUND_CAPABILITY_ID,
     BackgroundCapability, CHECKPOINT_CAPABILITY_ID, CLIENT_COMMANDS_CAPABILITY_ID,
-    CODING_BASH_CAPABILITY_ID, CONFIG_CAPABILITY_ID, CheckpointCapability,
-    ClientCommandsCapability, ClientUiContext, CodingBashCapability,
-    CodingCliEnvironmentCapability, ConfigCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID,
-    GOAL_CAPABILITY_ID, GoalCapability, HERDR_CAPABILITY_ID, HOOKS_CAPABILITY_ID, HerdrCapability,
-    HooksCapability, LspCapability, PROGRESS_GUARD_CAPABILITY_ID, ProgressGuardCapability,
-    REPO_MAP_CAPABILITY_ID, RepoMapCapability, SESSION_HISTORY_CAPABILITY_ID, SETUP_CAPABILITY_ID,
+    CODING_BASH_CAPABILITY_ID, CONFIG_CAPABILITY_ID, CONTEXT_COST_CONTROL_CAPABILITY_ID,
+    CheckpointCapability, ClientCommandsCapability, ClientUiContext, CodingBashCapability,
+    CodingCliEnvironmentCapability, ConfigCapability, ContextCostControlCapability,
+    ENVIRONMENT_CONTEXT_CAPABILITY_ID, GOAL_CAPABILITY_ID, GoalCapability, HERDR_CAPABILITY_ID,
+    HOOKS_CAPABILITY_ID, HerdrCapability, HooksCapability, LspCapability,
+    PROGRESS_GUARD_CAPABILITY_ID, ProgressGuardCapability, REPO_MAP_CAPABILITY_ID,
+    RepoMapCapability, SESSION_HISTORY_CAPABILITY_ID, SETUP_CAPABILITY_ID,
     SessionHistoryCapability, SetupCapability, USER_ASK_CAPABILITY_ID, UserAskCapability,
     WorktreeCapability,
 };
@@ -41,14 +42,14 @@ use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 use everruns_core::capabilities::{
     AGENT_INSTRUCTIONS_CAPABILITY_ID, AgentInstructionsCapability, BTW_CAPABILITY_ID,
-    BtwCapability, COMPACTION_CAPABILITY_ID, CompactionCapability, INFINITY_CONTEXT_CAPABILITY_ID,
-    InfinityContextCapability, LOOP_DETECTION_CAPABILITY_ID, LoopDetectionCapability,
-    MessageMetadataCapability, PROMPT_CACHING_CAPABILITY_ID, PromptCachingCapability,
-    SESSION_FILE_SYSTEM_CAPABILITY_ID, SESSION_STORAGE_CAPABILITY_ID, SESSION_TASKS_CAPABILITY_ID,
-    SKILLS_CAPABILITY_ID, STATELESS_TODO_LIST_CAPABILITY_ID, ScopedSkillsCapability,
-    SessionStorageCapability, StatelessTodoListCapability, TOOL_OUTPUT_PERSISTENCE_CAPABILITY_ID,
-    TOOL_SEARCH_CAPABILITY_ID, ToolOutputPersistenceCapability, ToolSearchCapability,
-    USER_HOOKS_CAPABILITY_ID, UserHooksCapability, WEB_FETCH_CAPABILITY_ID, WebFetchCapability,
+    BtwCapability, CompactionCapability, INFINITY_CONTEXT_CAPABILITY_ID, InfinityContextCapability,
+    LOOP_DETECTION_CAPABILITY_ID, LoopDetectionCapability, MessageMetadataCapability,
+    PROMPT_CACHING_CAPABILITY_ID, PromptCachingCapability, SESSION_FILE_SYSTEM_CAPABILITY_ID,
+    SESSION_STORAGE_CAPABILITY_ID, SESSION_TASKS_CAPABILITY_ID, SKILLS_CAPABILITY_ID,
+    STATELESS_TODO_LIST_CAPABILITY_ID, ScopedSkillsCapability, SessionStorageCapability,
+    StatelessTodoListCapability, TOOL_OUTPUT_PERSISTENCE_CAPABILITY_ID, TOOL_SEARCH_CAPABILITY_ID,
+    ToolOutputPersistenceCapability, ToolSearchCapability, USER_HOOKS_CAPABILITY_ID,
+    UserHooksCapability, WEB_FETCH_CAPABILITY_ID, WebFetchCapability,
 };
 use everruns_core::command::CommandDescriptor;
 use everruns_core::driver_registry::{DriverRegistry, ProviderMetadata};
@@ -889,15 +890,6 @@ const YOLOP_NEVER_DEFER_TOOLS: &[&str] = &[
     "lsp_symbols",
     "lsp_code_actions",
 ];
-const YOLOP_KEEP_RECENT_TOOL_OUTPUTS: u64 = 3;
-
-/// Fraction of the model context window at which proactive compaction triggers.
-/// Kept low: yolop favors a tight, cheap context and lets the compaction cascade
-/// (observation masking → aggressive trim) keep older tool output from
-/// accumulating. Surfaced to the TUI so the context gauge can mark this point —
-/// see `crate::tui::presentation::context_label`.
-pub(crate) const YOLOP_COMPACTION_BUDGET_PERCENT: f32 = 0.20;
-
 #[derive(Clone, Debug)]
 pub enum ProviderChoice {
     Anthropic {
@@ -2013,19 +2005,13 @@ fn default_coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabi
         AgentCapabilityConfig::new(SESSION_HISTORY_CAPABILITY_ID),
         AgentCapabilityConfig::new(CHECKPOINT_CAPABILITY_ID),
         AgentCapabilityConfig::new(AST_GREP_CAPABILITY_ID),
+        // The runtime's compaction cascade currently rewrites only one outbound
+        // model view. The next turn reconstructs the full stored transcript and
+        // compacts the same messages again, sometimes without reducing them at
+        // all. Keep a bounded recent window with searchable cold history until
+        // compaction can persist a canonical replacement-history checkpoint.
         AgentCapabilityConfig::new(INFINITY_CONTEXT_CAPABILITY_ID),
-        AgentCapabilityConfig::with_config(
-            COMPACTION_CAPABILITY_ID,
-            serde_json::json!({
-                "strategy": "auto",
-                "proactive": true,
-                "budget_percent": YOLOP_COMPACTION_BUDGET_PERCENT,
-                "observation_masking": {
-                    "keep_recent_tool_outputs": YOLOP_KEEP_RECENT_TOOL_OUTPUTS,
-                    "summary_format": "one_line"
-                }
-            }),
-        ),
+        AgentCapabilityConfig::new(CONTEXT_COST_CONTROL_CAPABILITY_ID),
         AgentCapabilityConfig::new(STATELESS_TODO_LIST_CAPABILITY_ID),
         AgentCapabilityConfig::new(LOOP_DETECTION_CAPABILITY_ID),
         AgentCapabilityConfig::new(PROGRESS_GUARD_CAPABILITY_ID),
@@ -2729,8 +2715,8 @@ pub async fn build_with_options(
     //   * repo_map            - on-demand multi-language symbol map for broad codebase orientation
     //   * ast_grep            - read-only structural code search
     //   * ast_edit            - previewed ast-grep rewrites (opt-in)
-    //   * infinity_context     — keeps long sessions usable; adds query_history
-    //   * compaction           — proactively masks older large tool outputs
+    //   * infinity_context     — bounds the live context and adds query_history
+    //   * compaction           — registered for opt-in use, not enabled by default
     //   * stateless_todo_list  — write_todos tool for multi-step tasks
     //   * loop_detection       — safety net against repeated identical tool calls
     //   * prompt_caching       — Anthropic prompt caching; free token savings
@@ -2899,6 +2885,7 @@ pub async fn build_with_options(
     mcp_server_names.sort();
     capabilities.register(InfinityContextCapability);
     capabilities.register(CompactionCapability);
+    capabilities.register(ContextCostControlCapability);
     capabilities.register(StatelessTodoListCapability);
     capabilities.register(LoopDetectionCapability);
     capabilities.register(PromptCachingCapability::new());
@@ -6256,20 +6243,18 @@ mod tests {
     }
 
     #[test]
-    fn coding_harness_keeps_small_recent_tool_output_window() {
+    fn coding_harness_uses_searchable_bounded_history_without_ephemeral_compaction() {
         let ids = coding_harness_capabilities(false, None, &Settings::default());
-        let compaction = ids
-            .iter()
-            .find(|cap| cap.capability_id() == COMPACTION_CAPABILITY_ID)
-            .expect("compaction capability");
 
-        assert_eq!(
-            compaction
-                .config
-                .pointer("/observation_masking/keep_recent_tool_outputs")
-                .and_then(|value| value.as_u64()),
-            Some(3)
+        assert!(
+            ids.iter()
+                .any(|cap| cap.capability_id() == INFINITY_CONTEXT_CAPABILITY_ID)
         );
+        assert!(
+            ids.iter()
+                .any(|cap| cap.capability_id() == CONTEXT_COST_CONTROL_CAPABILITY_ID)
+        );
+        assert!(!ids.iter().any(|cap| cap.capability_id() == "compaction"));
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -707,9 +707,7 @@ impl App {
             turn_elapsed_secs: self.turn_started_at.map(|start| start.elapsed().as_secs()),
             context_used_tokens: self.context_used_tokens,
             context_window_tokens: self.context_window_tokens(),
-            compaction_budget_percent: Some(
-                (crate::runtime::YOLOP_COMPACTION_BUDGET_PERCENT * 100.0).round() as u8,
-            ),
+            compaction_budget_percent: None,
             status_layout: self.status_layout,
             hooks_summary: self.startup.hook_summary(),
             approval_mode,


### PR DESCRIPTION
## What changed
Yolop no longer enables Everruns' retry-local compaction cascade by default. It keeps searchable bounded history and applies stale tool-output masking only to the outbound model view, preserving lossless session history.

The context gauge no longer advertises an automatic compaction threshold while durable checkpoint compaction is unavailable.

## Why
The previous default repeatedly reconstructed and compacted the same stored transcript across turns. Some runs emitted compaction events with negligible or zero reduction.

## Before / After
Before: proactive compaction could report repeated reductions such as 325 → 325 messages and reprocess the same history on the next turn.

After: old large tool observations are masked in the prompt view while stored history stays intact; no default compaction event or threshold marker is emitted.

Live Codex smoke: `compaction quick fix smoke ok`

## Risk
- Medium
- Prompt context selection changes for long sessions. Full tool outputs remain stored and searchable.
- OpenAI API-key smoke reached the provider but the configured account reported `insufficient_quota`; authenticated Codex smoke passed.

## Security
- TM-LLM: reviewed prompt construction and confirmed masking changes only the outbound model view.
- No API keys are logged or persisted by this change.
- No filesystem, shell execution, capability write access, or dependency changes.

## Follow-ups
- Implement durable provider-native compaction checkpoints in Everruns, then re-enable compaction in Yolop.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] Authenticated Codex provider smoke
