### PR TITLE
fix(tui): remove extra spacing from diffs

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -4089,7 +4089,7 @@ mod tests {
     }
 
     #[test]
-    fn should_not_insert_chat_gap_inside_tool_blocks() {
+    fn should_not_insert_chat_gap_inside_tool_or_diff_blocks() {
         assert!(!should_insert_chat_gap(&Author::Tool, Some(&Author::Tool)));
         assert!(!should_insert_chat_gap(
             &Author::Tool,
@@ -4108,6 +4108,11 @@ mod tests {
             Some(&Author::Assistant)
         ));
         assert!(!should_insert_chat_gap(&Author::ToolDetail, None));
+        assert!(!should_insert_chat_gap(&Author::Diff, Some(&Author::Diff)));
+        assert!(should_insert_chat_gap(
+            &Author::Diff,
+            Some(&Author::Assistant)
+        ));
     }
 
     #[test]

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1324,6 +1324,7 @@ pub(crate) fn should_insert_chat_gap(current: &Author, next: Option<&Author>) ->
             | (&Author::Stderr, &Author::ToolDetail)
             | (&Author::Stderr, &Author::Stderr)
             | (&Author::Stderr, &Author::Sandbox)
+            | (&Author::Diff, &Author::Diff)
     )
 }
 


### PR DESCRIPTION
## Summary

Fix transcript rendering so physical lines belonging to one diff are displayed contiguously instead of receiving chat-block spacing between every line. The shared presentation rule covers fullscreen and inline rendering.

## Before / After

**Before:** every diff line was represented as a `Diff` transcript entry, and the generic chat-gap rule inserted a blank row between adjacent entries.

**After:** adjacent `Diff` entries are treated as one output block; normal spacing remains when a diff transitions to assistant output.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test should_not_insert_chat_gap_inside_tool_or_diff_blocks --all-features`
- `cargo run -- --provider llmsim -p hi`
- Full `cargo test --all-features` was also run; native-sandbox integration cases fail when executed outside Yolop's native sandbox, while the changed regression test passes.

## Security

No security-relevant code changes. This only changes terminal-independent transcript spacing and adds a unit assertion; filesystem, shell, prompt, capability, dependency, and trust-boundary behavior are unchanged.

## Follow-ups

No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
