### PR TITLE
fix(tui): show runtime system notices

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -4127,7 +4127,7 @@ mod tests {
             text: "hello".into(),
         });
 
-        let visible = recent_transcript_lines(&app, 80, 10);
+        let visible = recent_transcript_lines(app, 80, 10);
         let visible = visible.iter().map(line_text).collect::<Vec<_>>();
         assert!(!visible.iter().any(|line| line.contains("workspace: /tmp")));
         assert!(visible.iter().any(|line| line.contains("hello")));
@@ -4135,7 +4135,7 @@ mod tests {
 
     #[test]
     fn recent_transcript_mirror_includes_session_system_notices_after_chat() {
-        let lines = vec![
+        let lines = [
             ChatLine {
                 author: Author::System,
                 text: "workspace: /tmp".into(),
@@ -4168,7 +4168,7 @@ mod tests {
         app.startup_banner_len = app.lines.len();
         app.push_system("attached clipboard image #1 (640x480 PNG)".into());
 
-        let visible = recent_transcript_lines(&app, 80, 10);
+        let visible = recent_transcript_lines(app, 80, 10);
         let visible = visible.iter().map(line_text).collect::<Vec<_>>();
         assert!(!visible.iter().any(|line| line.contains("workspace: /tmp")));
         assert!(

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -96,6 +96,8 @@ pub struct App {
     model: ModelState,
     pub lines: Vec<ChatLine>,
     printed_lines: usize,
+    /// Number of leading system lines that belong to the startup banner.
+    startup_banner_len: usize,
     /// The single composer model, shared by **both** renderers: a tuika
     /// [`TextInputState`](tuika::TextInputState) that owns the draft text and
     /// cursor and applies its own edits (emacs bindings, word movement, wrapping).
@@ -468,6 +470,7 @@ impl App {
             model: runtime.model,
             lines: Vec::new(),
             printed_lines: 0,
+            startup_banner_len: 0,
             composer: tuika::TextInputState::new(),
             busy: false,
             should_quit: false,
@@ -533,6 +536,7 @@ impl App {
             context_used_tokens: None,
         };
         app.emit_system_banner();
+        app.startup_banner_len = app.lines.len();
         if should_setup {
             app.start_first_run_setup();
         } else if app.goal_store.is_paused(session_id)
@@ -1868,6 +1872,7 @@ impl App {
                 self.goal_store.clear_active(self.session.session_id());
                 self.user_ask_store.clear_active(self.session.session_id());
                 self.emit_system_banner();
+                self.startup_banner_len = self.lines.len();
             }
             UiCommand::RunShell { command } => self.start_shell_command(command),
             UiCommand::Quit => self.should_quit = true,
@@ -4108,24 +4113,24 @@ mod tests {
         assert!(!should_insert_chat_gap(&Author::ToolDetail, None));
     }
 
-    #[test]
-    fn recent_transcript_mirror_excludes_startup_banner_system_lines() {
-        let lines = vec![
-            ChatLine {
-                author: Author::System,
-                text: "workspace: /tmp".into(),
-            },
-            ChatLine {
-                author: Author::User,
-                text: "hello".into(),
-            },
-        ];
-        assert!(!include_line_in_recent_transcript_mirror(
-            &lines[0], 0, &lines
-        ));
-        assert!(include_line_in_recent_transcript_mirror(
-            &lines[1], 1, &lines
-        ));
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn recent_transcript_mirror_excludes_startup_banner_system_lines() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.lines = vec![ChatLine {
+            author: Author::System,
+            text: "workspace: /tmp".into(),
+        }];
+        app.startup_banner_len = app.lines.len();
+        app.lines.push(ChatLine {
+            author: Author::User,
+            text: "hello".into(),
+        });
+
+        let visible = recent_transcript_lines(&app, 80, 10);
+        let visible = visible.iter().map(line_text).collect::<Vec<_>>();
+        assert!(!visible.iter().any(|line| line.contains("workspace: /tmp")));
+        assert!(visible.iter().any(|line| line.contains("hello")));
     }
 
     #[test]
@@ -4148,12 +4153,29 @@ mod tests {
                 text: "attached clipboard image #1 (640x480 PNG)".into(),
             },
         ];
-        assert!(!include_line_in_recent_transcript_mirror(
-            &lines[0], 0, &lines
-        ));
-        assert!(include_line_in_recent_transcript_mirror(
-            &lines[3], 3, &lines
-        ));
+        assert!(!include_line_in_recent_transcript_mirror(&lines[0], 0, 1));
+        assert!(include_line_in_recent_transcript_mirror(&lines[3], 3, 1));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn recent_transcript_mirror_includes_image_notice_before_first_chat() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.lines = vec![ChatLine {
+            author: Author::System,
+            text: "workspace: /tmp".into(),
+        }];
+        app.startup_banner_len = app.lines.len();
+        app.push_system("attached clipboard image #1 (640x480 PNG)".into());
+
+        let visible = recent_transcript_lines(&app, 80, 10);
+        let visible = visible.iter().map(line_text).collect::<Vec<_>>();
+        assert!(!visible.iter().any(|line| line.contains("workspace: /tmp")));
+        assert!(
+            visible
+                .iter()
+                .any(|line| line.contains("attached clipboard image #1 (640x480 PNG)"))
+        );
     }
 
     // ====================================================================
@@ -5505,6 +5527,7 @@ mod tests {
         let app = &mut fixture.app;
         app.setup = None;
         app.lines.clear();
+        app.startup_banner_len = 0;
         app.push_user("first question".into());
         app.lines.push(ChatLine {
             author: Author::Assistant,
@@ -5531,6 +5554,7 @@ mod tests {
         let app = &mut fixture.app;
         app.setup = None;
         app.lines.clear();
+        app.startup_banner_len = 0;
         app.push_user("first question".into());
         app.lines.push(ChatLine {
             author: Author::Assistant,
@@ -5563,6 +5587,7 @@ mod tests {
         let app = &mut fixture.app;
         app.setup = None;
         app.lines.clear();
+        app.startup_banner_len = 0;
         app.push_user("run it".into());
         app.lines.push(ChatLine {
             author: Author::Assistant,

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -251,24 +251,15 @@ pub(crate) fn draw_recent_transcript(f: &mut ratatui::Frame, area: Rect, app: &A
 
 /// Whether a transcript line belongs in the inline viewport mirror.
 ///
-/// Startup banner system lines stay scrollback-only. Once the session has user
-/// or assistant content, later system notices (image paste, turn status, etc.)
-/// should appear above the composer instead of only in the flushed band.
+/// Startup banner system lines stay scrollback-only. Runtime system notices
+/// (image paste, turn status, etc.) should appear above the composer even when
+/// they arrive before the first user message.
 pub(crate) fn include_line_in_recent_transcript_mirror(
     line: &ChatLine,
     index: usize,
-    lines: &[ChatLine],
+    startup_banner_len: usize,
 ) -> bool {
-    if !matches!(line.author, Author::System) {
-        return true;
-    }
-    let Some(first_chat) = lines
-        .iter()
-        .position(|entry| !matches!(entry.author, Author::System))
-    else {
-        return false;
-    };
-    index >= first_chat
+    !matches!(line.author, Author::System) || index >= startup_banner_len
 }
 
 pub(crate) fn recent_transcript_lines(
@@ -291,7 +282,9 @@ pub(crate) fn recent_transcript_lines(
         .iter()
         .enumerate()
         .rev()
-        .filter(|(index, line)| include_line_in_recent_transcript_mirror(line, *index, &app.lines))
+        .filter(|(index, line)| {
+            include_line_in_recent_transcript_mirror(line, *index, app.startup_banner_len)
+        })
         .take(RECENT_TRANSCRIPT_SOURCE_LINES)
         .map(|(_, line)| line)
         .collect();
@@ -337,7 +330,7 @@ pub(crate) fn full_transcript_lines(app: &App, width: usize) -> Vec<Line<'static
     let mut lines = Vec::new();
     let mut prev_author: Option<Author> = None;
     for (index, chat) in app.lines.iter().enumerate() {
-        if !include_line_in_recent_transcript_mirror(chat, index, &app.lines) {
+        if !include_line_in_recent_transcript_mirror(chat, index, app.startup_banner_len) {
             continue;
         }
         if let Some(prev) = &prev_author


### PR DESCRIPTION
## What changed
The inline TUI transcript now distinguishes startup banner messages from runtime system notices. Startup details remain scrollback-only, while image attachment confirmations and other runtime notices appear above the composer immediately, including before the first user message.

## Why
The previous heuristic hid every system line until user or assistant chat existed. As a result, inserting an image before typing a prompt produced no visible confirmation and made the attachment appear to be ignored.

## Before / After
**Before:** Startup details were suppressed, but image attachment confirmations inserted before the first prompt were suppressed too.

**After:** Startup details remain out of the inline transcript; an image attachment immediately displays `attached clipboard image #…` above the composer.

Presentation-model tests directly assert both outcomes. The llmsim smoke test also confirms the binary starts and completes a turn.

## Risk
- Low
- Risk is limited to which existing transcript lines are mirrored above the composer. Terminal scrollback and message persistence are unchanged.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test recent_transcript_mirror --all-features`
- `cargo test --lib --all-features` (947 passed)
- `cargo run -- --provider llmsim -p hi`

The complete integration suite has three environment-sensitive failures also reproducible individually: Alt+Enter PTY input handling, native shell sandbox denial wording, and combined-resize redraw timing. None is in the changed presentation-model logic.

## Security
Reviewed TM-FS, TM-BASH, TM-LLM, TM-TOOL, and TM-DEP. This change only tracks the startup-banner boundary and filters existing presentation lines; it adds no filesystem or shell operations, trust-boundary inputs, key handling, capabilities, or dependencies. No new injection, data-exposure, traversal, or resource-exhaustion risk found.

## Follow-ups
No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
