### PR TITLE
fix(tui): support configurable enter behavior

### DIFF
--- a/crates/tuika/src/components/mod.rs
+++ b/crates/tuika/src/components/mod.rs
@@ -39,4 +39,4 @@ pub use spinner::{Spinner, SpinnerStyle};
 pub use status_bar::StatusBar;
 pub use tabs::{Tabs, TabsState};
 pub use text::{Paragraph, Text, Wrap, line_width, wrap_lines};
-pub use textinput::{TextInput, TextInputState};
+pub use textinput::{TextInput, TextInputEvent, TextInputMode, TextInputState};

--- a/crates/tuika/src/components/textinput.rs
+++ b/crates/tuika/src/components/textinput.rs
@@ -11,9 +11,8 @@
 //!
 //! It is a *rendering + edit model*, not a terminal: the host reads
 //! [`TextInputState::cursor_screen`] after layout and calls the backend's
-//! `set_cursor_position`, and decides what a submit means (this widget treats
-//! Enter as a newline; a chat composer maps its own submit key before feeding
-//! events here).
+//! `set_cursor_position`. Hosts can configure whether Enter or Shift+Enter
+//! submits via [`TextInputMode`]; the other chord inserts a newline.
 
 use ratatui::layout::Rect;
 use ratatui::style::Style;
@@ -33,6 +32,24 @@ pub struct TextInputState {
     row: usize,
     /// Cursor column (char index within `lines[row]`).
     col: usize,
+    mode: TextInputMode,
+}
+
+/// Controls which Enter chord submits a text input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TextInputMode {
+    /// Enter submits; Shift+Enter inserts a newline.
+    #[default]
+    SubmitOnEnter,
+    /// Shift+Enter submits; Enter inserts a newline.
+    SubmitOnShiftEnter,
+}
+
+/// Result of applying an Enter chord to a text input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TextInputEvent {
+    Changed,
+    Submit,
 }
 
 impl Default for TextInputState {
@@ -47,6 +64,31 @@ impl TextInputState {
             lines: vec![String::new()],
             row: 0,
             col: 0,
+            mode: TextInputMode::default(),
+        }
+    }
+
+    /// Set how Enter and Shift+Enter submit or insert newlines.
+    pub fn set_mode(&mut self, mode: TextInputMode) {
+        self.mode = mode;
+    }
+
+    /// Return the current Enter behavior.
+    pub fn mode(&self) -> TextInputMode {
+        self.mode
+    }
+
+    /// Apply an Enter chord according to the configured mode.
+    pub fn handle_enter(&mut self, shift: bool) -> TextInputEvent {
+        let submit = match self.mode {
+            TextInputMode::SubmitOnEnter => !shift,
+            TextInputMode::SubmitOnShiftEnter => shift,
+        };
+        if submit {
+            TextInputEvent::Submit
+        } else {
+            self.newline();
+            TextInputEvent::Changed
         }
     }
 
@@ -969,5 +1011,23 @@ mod tests {
         let tree = element(TextInput::new(&state));
         let out = render_el(&tree, 4, 1);
         assert_eq!(out[0], "hi");
+    }
+
+    #[test]
+    fn submit_on_enter_mode_uses_shift_enter_for_newline() {
+        let mut state = TextInputState::new();
+        assert_eq!(state.mode(), TextInputMode::SubmitOnEnter);
+        assert_eq!(state.handle_enter(false), TextInputEvent::Submit);
+        assert_eq!(state.handle_enter(true), TextInputEvent::Changed);
+        assert_eq!(state.text(), "\n");
+    }
+
+    #[test]
+    fn submit_on_shift_enter_mode_reverses_enter_chords() {
+        let mut state = TextInputState::new();
+        state.set_mode(TextInputMode::SubmitOnShiftEnter);
+        assert_eq!(state.handle_enter(false), TextInputEvent::Changed);
+        assert_eq!(state.handle_enter(true), TextInputEvent::Submit);
+        assert_eq!(state.text(), "\n");
     }
 }

--- a/crates/tuika/src/lib.rs
+++ b/crates/tuika/src/lib.rs
@@ -62,7 +62,8 @@ pub use clipboard::{osc52, write_clipboard};
 pub use components::{
     Boxed, Constrained, Flex, KeyHints, Loader, Paragraph, ProgressBar, Responsive, Rule, Scroll,
     ScrollState, SelectList, SelectOutcome, SelectState, Spacer, Spinner, SpinnerStyle, StatusBar,
-    Tabs, TabsState, Text, TextInput, TextInputState, Wrap, wrap_lines,
+    Tabs, TabsState, Text, TextInput, TextInputEvent, TextInputMode, TextInputState, Wrap,
+    wrap_lines,
 };
 pub use event::{Event, EventFlow, Key, KeyCode, Mouse, MouseButton, MouseKind};
 pub use focus::FocusRegistry;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -472,7 +472,11 @@ impl App {
             lines: Vec::new(),
             printed_lines: 0,
             startup_banner_len: 0,
-            composer: tuika::TextInputState::new(),
+            composer: {
+                let mut composer = tuika::TextInputState::new();
+                composer.set_mode(tuika::TextInputMode::SubmitOnEnter);
+                composer
+            },
             busy: false,
             should_quit: false,
             ctrl_c_exit: false,
@@ -1325,12 +1329,13 @@ impl App {
             return;
         }
         match key.code {
-            KeyCode::Enter if key.modifiers == KeyModifiers::SHIFT => {
-                self.composer_insert_newline();
-            }
-            KeyCode::Enter => {
-                self.submit_input().await;
-            }
+            KeyCode::Enter => match self
+                .composer
+                .handle_enter(key.modifiers == KeyModifiers::SHIFT)
+            {
+                tuika::TextInputEvent::Changed => {}
+                tuika::TextInputEvent::Submit => self.submit_input().await,
+            },
             KeyCode::Tab => {
                 if let Some(suggestion) = self.suggestions().first() {
                     self.set_input_text(suggestion.completion.clone());
@@ -1344,11 +1349,6 @@ impl App {
                 self.composer_edit_key(normalize_printable_key(key));
             }
         }
-    }
-
-    /// Insert a newline in the composer.
-    fn composer_insert_newline(&mut self) {
-        self.composer.newline();
     }
 
     /// Feed one editing key to the composer. The tuika `TextInputState` handles
@@ -6844,6 +6844,27 @@ mod tests {
         app.handle_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL))
             .await;
         assert!(app.history_search.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn shift_enter_inserts_newline_instead_of_submitting() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::empty()))
+            .await;
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT))
+            .await;
+        app.handle_key(KeyEvent::new(KeyCode::Char('b'), KeyModifiers::empty()))
+            .await;
+
+        assert_eq!(app.input_text(), "a\nb");
+        assert!(
+            !app.lines
+                .iter()
+                .any(|line| matches!(line.author, Author::User))
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -892,6 +892,42 @@ fn tui_alt_enter_sequence_submits_like_enter() {
 }
 
 #[test]
+fn tui_ghostty_shift_enter_sequence_inserts_newline() {
+    let mut tui = spawn_tui_llmsim(&yolop_binary());
+    assert!(
+        tui.wait_for_output("type /help", Duration::from_secs(3)),
+        "TUI did not render startup banner: {}",
+        tui.output_text()
+    );
+
+    // Ghostty emits CSI 13;2u for Shift-Enter after Yolop enables enhanced
+    // keyboard reporting. It must edit the composer rather than submit it.
+    tui.write_input(b"one\x1b[13;2utwo");
+    std::thread::sleep(Duration::from_millis(200));
+    let before_submit = strip_ansi(&tui.output_text());
+    assert!(
+        !before_submit.contains("offline mode"),
+        "Shift-Enter submitted instead of inserting a newline: {before_submit}"
+    );
+
+    tui.write_input(b"\r");
+    assert!(
+        tui.wait_for_output("offline mode", Duration::from_secs(3)),
+        "plain Enter did not submit multiline input: {}",
+        tui.output_text()
+    );
+    let after_submit = strip_ansi(&tui.output_text());
+    assert!(
+        after_submit.contains("one") && after_submit.contains("two"),
+        "multiline input should render after submission: {after_submit}"
+    );
+
+    tui.write_input(b"\x03\x03");
+    let status = tui.wait_or_kill(Duration::from_secs(3));
+    assert!(status.success(), "TUI did not exit cleanly: {status:?}");
+}
+
+#[test]
 fn tui_survives_slow_cursor_position_reply_after_resize() {
     // Regression test for the TUI dying right around turn completion under
     // xterm.js-backed terminals (ttyd / vhs recordings). Those emulators


### PR DESCRIPTION
## What changed
Tuika text inputs now expose two configurable Enter modes:

- `SubmitOnEnter`: Enter submits and Shift+Enter inserts a newline.
- `SubmitOnShiftEnter`: Shift+Enter submits and Enter inserts a newline.

Yolop explicitly keeps `SubmitOnEnter`, so Shift+Enter adds a newline to the message composer without submitting it.

## Why
Enter handling belonged to Yolop rather than Tuika's input component, leaving Tuika consumers no supported way to choose their multiline submission convention. Moving the policy into `TextInputState` makes both conventions available while preserving Yolop's existing Shift+Enter-for-newline default.

## Before / After
**Before:** Enter behavior was hard-coded in Yolop and not represented by Tuika's text-input API.

**After:** the composer delegates Enter chords to Tuika's configured mode. A PTY regression test sends Ghostty's real enhanced-keyboard sequence (`CSI 13;2u`), verifies it does not submit, then submits the multiline draft with plain Enter.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p tuika textinput --lib`
- `cargo test shift_enter_inserts_newline_instead_of_submitting --bin yolop`
- `cargo test --test integration tui_ghostty_shift_enter_sequence_inserts_newline -- --nocapture`
- `cargo run -- --provider llmsim -p hi`
- Local Ghostty 1.2.3 capture: Shift press `CSI 57447;2u`; Shift+Enter `CSI 13;2u`

`cargo test --all-features` passed all changed-feature tests but reported two unrelated PTY timing failures (`no_sandbox_flag_gives_shell_commands_full_host_access_for_one_run` and `tui_agents_context_cannot_bypass_native_shell_sandbox`); both passed when rerun individually.

## Risk
- Low.
- Limited to Enter-key policy in Tuika text inputs and Yolop's composer delegation.

## Security
No security-relevant code changes. This only maps keyboard chords to submit/newline events; filesystem access, shell execution, credentials, dependencies, capability registration, and resource bounds are unchanged.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

## Follow-ups
No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
