### PR TITLE
fix(tui): preserve context in exit message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1098,7 +1098,8 @@ async fn run_tui(
     }
     let result = app.run(&mut terminal).await;
     let show_resume_hint = app.should_show_resume_hint();
-    let session_id = app.session_id();
+    let session_id = app.session_id().to_string();
+    let last_assistant_message = app.last_assistant_message().map(str::to_owned);
 
     // Cosmetic cleanup must not turn a successful session into an error
     // exit: since ratatui 0.30.1 `Terminal::clear` issues the same blocking
@@ -1131,12 +1132,67 @@ async fn run_tui(
 
     if show_resume_hint {
         println!();
+        if fullscreen && let Some(message) = last_assistant_message {
+            println!("{message}\n");
+        }
         print_resume_divider();
-        println!("Resume with yolop --session {session_id}");
+        println!(
+            "Continue with {}",
+            continuation_command(std::env::args_os(), &session_id)
+        );
         println!();
         print_centered_ukraine_banner();
     }
     result
+}
+
+fn continuation_command(
+    args: impl IntoIterator<Item = std::ffi::OsString>,
+    session_id: &str,
+) -> String {
+    let mut args = args.into_iter();
+    let _executable = args.next();
+    let mut preserved = Vec::new();
+    let mut skip_value = false;
+
+    for arg in args {
+        if skip_value {
+            skip_value = false;
+            continue;
+        }
+        let value = arg.to_string_lossy();
+        if matches!(
+            value.as_ref(),
+            "-p" | "--print" | "-i" | "--image" | "--session" | "--trajectory-out"
+        ) {
+            skip_value = true;
+            continue;
+        }
+        if value.starts_with("--print=")
+            || value.starts_with("--image=")
+            || value.starts_with("--session=")
+            || value.starts_with("--trajectory-out=")
+        {
+            continue;
+        }
+        preserved.push(shell_quote(&value));
+    }
+
+    preserved.push("--session".to_string());
+    preserved.push(shell_quote(session_id));
+    format!("yolop {}", preserved.join(" "))
+}
+
+fn shell_quote(value: &str) -> String {
+    if !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || b"_@%+=:,./-".contains(&byte))
+    {
+        value.to_string()
+    } else {
+        format!("'{}'", value.replace('\'', "'\"'\"'"))
+    }
 }
 
 struct RawModeGuard {
@@ -1503,6 +1559,31 @@ fn paint(enabled: bool, code: &str, text: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
+
+    #[test]
+    fn continuation_preserves_reusable_arguments_and_replaces_turn_arguments() {
+        let args = [
+            "yolop",
+            "--fullscreen",
+            "--no-sandbox",
+            "--model",
+            "gpt test",
+            "--print",
+            "do not repeat",
+            "--image=initial.png",
+            "--trajectory-out",
+            "old.json",
+            "--session=old-session",
+        ]
+        .into_iter()
+        .map(OsString::from);
+
+        assert_eq!(
+            continuation_command(args, "new-session"),
+            "yolop --fullscreen --no-sandbox --model 'gpt test' --session new-session"
+        );
+    }
 
     fn cli_with_reasoning_effort(reasoning_effort: Option<&str>) -> Cli {
         Cli {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -639,6 +639,15 @@ impl App {
         self.ctrl_c_exit
     }
 
+    /// Final assistant text to leave visible after the full-screen UI closes.
+    pub fn last_assistant_message(&self) -> Option<&str> {
+        self.lines
+            .iter()
+            .rev()
+            .find(|line| line.author == Author::Assistant)
+            .map(|line| line.text.as_str())
+    }
+
     pub fn session_id(&self) -> SessionId {
         self.session.session_id()
     }
@@ -2753,6 +2762,31 @@ mod tests {
     use everruns_core::{MessageId, SessionId, TurnId};
 
     use everruns_core::command::{CommandArg, CommandDescriptor, CommandSource};
+
+    #[tokio::test]
+    async fn last_assistant_message_ignores_later_non_assistant_lines() {
+        let mut test = app_with_llmsim().await;
+        test.app.lines.extend([
+            ChatLine {
+                author: Author::Assistant,
+                text: "first".into(),
+            },
+            ChatLine {
+                author: Author::Tool,
+                text: "tool output".into(),
+            },
+            ChatLine {
+                author: Author::Assistant,
+                text: "last answer".into(),
+            },
+            ChatLine {
+                author: Author::System,
+                text: "done".into(),
+            },
+        ]);
+
+        assert_eq!(test.app.last_assistant_message(), Some("last answer"));
+    }
 
     fn setup_capability_command() -> CommandDescriptor {
         CommandDescriptor {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -753,8 +753,9 @@ fn tui_escape_does_not_exit_and_ctrl_c_exits() {
         tui.output_text()
     );
     assert!(
-        tui.output_text().contains("Resume with yolop --session"),
-        "Ctrl-C cleanup should print resume hint: {}",
+        tui.output_text()
+            .contains("Continue with yolop --provider llmsim"),
+        "Ctrl-C cleanup should print continuation hint: {}",
         tui.output_text()
     );
 }
@@ -831,6 +832,21 @@ fn tui_smoke(fullscreen: bool) {
         "{mode}: second Ctrl-C should exit cleanly, got {status:?}: {}",
         tui.output_text()
     );
+    let output = strip_ansi(&tui.output_text());
+    assert!(
+        output.contains("Continue with yolop --provider llmsim"),
+        "{mode}: continuation command should preserve reusable arguments: {output}"
+    );
+    if fullscreen {
+        assert!(
+            output.matches("real responses").count() >= 2,
+            "fullscreen: final assistant message should be reprinted after exit: {output}"
+        );
+        assert!(
+            output.contains("--fullscreen --session"),
+            "fullscreen: continuation command should preserve --fullscreen: {output}"
+        );
+    }
 }
 
 #[test]
@@ -1138,8 +1154,9 @@ fn tui_exits_cleanly_when_emulator_stops_answering_cursor_queries() {
         tui.output_text()
     );
     assert!(
-        tui.output_text().contains("Resume with yolop --session"),
-        "cleanup should still print resume hint: {}",
+        tui.output_text()
+            .contains("Continue with yolop --provider llmsim"),
+        "cleanup should still print continuation hint: {}",
         tui.output_text()
     );
 }


### PR DESCRIPTION
## What changed
The Ctrl-C end message now:

- reprints the final assistant response after leaving full-screen mode
- shows a runnable continuation command
- preserves reusable launch arguments, including `--fullscreen`, `--no-sandbox`, provider/model settings, and other persistent options
- removes one-shot inputs (`--print`, `--image`, `--trajectory-out`) and replaces any prior `--session`
- shell-quotes preserved values so the suggested command remains safe to paste

## Why
The prior end message discarded launch context and full-screen terminal restoration removed the final answer from view, making continuation needlessly lossy.

## Before / After

Before:
```text
Resume with yolop --session <id>
```

After (example):
```text
<final assistant response>

Continue with yolop --fullscreen --no-sandbox --provider llmsim --session <id>
```

Proof:
- full-screen PTY integration coverage asserts the final response is visible after exit and `--fullscreen` survives
- inline PTY integration coverage asserts reusable provider arguments survive
- unit coverage verifies one-shot arguments are removed, sessions are replaced, and values are shell-quoted

## Risk
- Low
- Limited to Ctrl-C end-message presentation and command construction
- A malformed suggestion could affect pasted shell commands; values are POSIX shell-quoted and covered by tests

## Security
Reviewed TM-FS, TM-BASH, TM-LLM, TM-TOOL, and TM-DEP. This change adds no filesystem/tool/dependency/API-key behavior. Continuation text derives from local argv, excludes one-shot data-bearing inputs, and shell-quotes preserved values to prevent shell injection when pasted. No execution occurs automatically.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p hi`

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

Produced by [yolop](https://everruns.com/yolop)
