### PR TITLE
fix(tui): emit OSC 8 hyperlinks so transcript URLs are clickable

### DIFF
--- a/src/tui/fullscreen.rs
+++ b/src/tui/fullscreen.rs
@@ -154,6 +154,11 @@ pub(crate) fn draw(f: &mut Frame, app: &mut App) {
     let theme = yolop_theme();
     tuika::paint(f.buffer_mut(), area, &theme, root.as_ref(), &[]);
 
+    // Make transcript URLs clickable via OSC 8 (scoped to the transcript so a
+    // URL being typed in the composer isn't wrapped mid-edit).
+    let transcript_rect = transcript_probe.rect();
+    super::hyperlink::linkify_buffer(f.buffer_mut(), transcript_rect);
+
     // Mouse text selection over the transcript. Its selectable inner rect is the
     // transcript region inset one column (matching `transcript_view`'s padding).
     let t = transcript_probe.rect();

--- a/src/tui/hyperlink.rs
+++ b/src/tui/hyperlink.rs
@@ -1,0 +1,159 @@
+//! OSC 8 terminal hyperlinks over a rendered ratatui [`Buffer`].
+//!
+//! ratatui's high-level `Line`/`Span` model has no hyperlink attribute, so URLs
+//! were only *styled* and left to the terminal's own URL auto-detection — which
+//! many terminals don't do, leaving links unclickable. ratatui-core 0.1.2 (under
+//! ratatui 0.30) does let a single cell carry an arbitrary symbol string plus a
+//! [`CellDiffOption::ForcedWidth`], so an OSC 8 escape can ride along in the
+//! cell without throwing off column accounting.
+//!
+//! [`linkify_buffer`] runs *after* normal rendering: it scans each row for
+//! `http(s)://…` runs and wraps each run's first and last cell with the OSC 8
+//! open (`ESC ] 8 ; ; URL ESC \`) and close (`ESC ] 8 ; ; ESC \`) sequences,
+//! forcing those two cells to width 1 so the hidden escapes cost no columns.
+//! Terminals without OSC 8 support ignore the unknown OSC and render the visible
+//! text unchanged, so this is safe to always emit.
+
+use std::num::NonZeroU16;
+
+use ratatui::buffer::{Buffer, CellDiffOption};
+use ratatui::layout::Rect;
+
+/// Byte offset of the next `http://` or `https://` in `s`, if any.
+pub(crate) fn next_url_start(s: &str) -> Option<usize> {
+    match (s.find("https://"), s.find("http://")) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (Some(a), None) => Some(a),
+        (None, b) => b,
+    }
+}
+
+/// Byte length of the URL at the start of `from`: up to the next whitespace,
+/// with trailing sentence punctuation trimmed so `(see https://x.dev).` links
+/// just the URL.
+pub(crate) fn url_end(from: &str) -> usize {
+    let raw_end = from.find(char::is_whitespace).unwrap_or(from.len());
+    from[..raw_end]
+        .trim_end_matches(|c| {
+            matches!(
+                c,
+                '.' | ',' | ';' | ':' | '!' | '?' | ')' | ']' | '}' | '\'' | '"'
+            )
+        })
+        .len()
+}
+
+/// Wrap every `http(s)://…` run visible in `area` with OSC 8 hyperlink escapes so
+/// the terminal makes it clickable. Idempotent per render: it only touches the
+/// two boundary cells of each run and leaves already-wrapped cells alone.
+pub(crate) fn linkify_buffer(buf: &mut Buffer, area: Rect) {
+    let left = area.left().max(buf.area.left());
+    let right = area.right().min(buf.area.right());
+    let top = area.top().max(buf.area.top());
+    let bottom = area.bottom().min(buf.area.bottom());
+
+    for y in top..bottom {
+        // Reconstruct the row text and a byte→column map so a URL found in the
+        // text maps back to the cells it occupies (URLs are ASCII, one cell per
+        // char, but earlier cells may hold wide glyphs).
+        let mut row = String::new();
+        let mut col_of_byte: Vec<u16> = Vec::new();
+        for x in left..right {
+            let symbol = buf[(x, y)].symbol().to_string();
+            for _ in symbol.bytes() {
+                col_of_byte.push(x);
+            }
+            row.push_str(&symbol);
+        }
+
+        let mut search_from = 0;
+        while let Some(rel) = next_url_start(&row[search_from..]) {
+            let start = search_from + rel;
+            let len = url_end(&row[start..]);
+            if len == 0 {
+                search_from = start + 1;
+                continue;
+            }
+            let end = start + len; // byte-exclusive
+            let url = row[start..end].to_string();
+            let xs = col_of_byte[start];
+            let xe = col_of_byte[end - 1];
+            if xe <= xs {
+                // A single-cell "URL" can't be a real link; skip it.
+                search_from = end;
+                continue;
+            }
+
+            // Opening sequence rides in the first cell; closing in the last.
+            let head = buf[(xs, y)].symbol().to_string();
+            buf[(xs, y)]
+                .set_symbol(&format!("\x1b]8;;{url}\x1b\\{head}"))
+                .set_diff_option(CellDiffOption::ForcedWidth(NonZeroU16::new(1).unwrap()));
+            let tail = buf[(xe, y)].symbol().to_string();
+            buf[(xe, y)]
+                .set_symbol(&format!("{tail}\x1b]8;;\x1b\\"))
+                .set_diff_option(CellDiffOption::ForcedWidth(NonZeroU16::new(1).unwrap()));
+
+            search_from = end;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::text::Line;
+    use ratatui::widgets::{Paragraph, Widget};
+
+    fn rendered(text: &str, width: u16) -> Buffer {
+        let mut buf = Buffer::empty(Rect::new(0, 0, width, 1));
+        Paragraph::new(Line::from(text)).render(buf.area, &mut buf);
+        buf
+    }
+
+    #[test]
+    fn wraps_a_url_run_in_osc8() {
+        let mut buf = rendered("see https://example.com/x now", 40);
+        let area = buf.area;
+        linkify_buffer(&mut buf, area);
+
+        // The 'h' of the URL now carries the OSC 8 opener; the last URL char the
+        // closer. The plain text is preserved inside the escapes.
+        let head = buf[(4, 0)].symbol().to_string();
+        assert!(
+            head.starts_with("\x1b]8;;https://example.com/x\x1b\\") && head.ends_with('h'),
+            "opener cell: {head:?}"
+        );
+        // "https://example.com/x" is 21 chars starting at column 4 → last at 24.
+        let tail = buf[(24, 0)].symbol().to_string();
+        assert!(
+            tail.starts_with('x') && tail.ends_with("\x1b]8;;\x1b\\"),
+            "closer cell: {tail:?}"
+        );
+    }
+
+    #[test]
+    fn leaves_url_free_rows_untouched() {
+        let mut buf = rendered("no links here at all", 40);
+        let before = buf.clone();
+        let area = buf.area;
+        linkify_buffer(&mut buf, area);
+        assert_eq!(buf, before);
+    }
+
+    #[test]
+    fn trailing_punctuation_stays_outside_the_link() {
+        // "(see https://x.dev)." → the link is just the URL, ')' and '.' excluded.
+        let mut buf = rendered("(see https://x.dev).", 40);
+        let area = buf.area;
+        linkify_buffer(&mut buf, area);
+        // URL starts at column 5 ('h'); "https://x.dev" is 13 chars → last at 17.
+        let tail = buf[(17, 0)].symbol().to_string();
+        assert!(
+            tail.starts_with('v') && tail.ends_with("\x1b]8;;\x1b\\"),
+            "{tail:?}"
+        );
+        // The ')' at column 18 is untouched.
+        assert_eq!(buf[(18, 0)].symbol(), ")");
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -34,6 +34,7 @@ use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, oneshot};
 
 mod fullscreen;
+mod hyperlink;
 mod markdown_table;
 mod render;
 mod setup;
@@ -1209,6 +1210,10 @@ impl App {
         for chunk in rendered.chunks(u16::MAX as usize) {
             terminal.insert_before(chunk.len() as u16, |buf| {
                 Paragraph::new(chunk.to_vec()).render(buf.area, buf);
+                // Make any URL clickable via OSC 8 before it commits to
+                // scrollback — styling alone isn't enough on terminals that
+                // don't auto-detect links.
+                hyperlink::linkify_buffer(buf, buf.area);
             })?;
         }
         self.printed_lines = self.lines.len();
@@ -4251,6 +4256,37 @@ mod tests {
             scrollback_height: terminal.backend().scrollback().area.height,
             viewport_bottom: viewport.y.saturating_add(viewport.height),
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn inline_transcript_urls_commit_osc8_hyperlinks() {
+        let mut test = app_with_llmsim().await;
+        let app = &mut test.app;
+        app.setup = None;
+        app.push_system("see https://github.com/everruns/yolop/pull/510 for CI".into());
+
+        let backend = TestBackend::new(80, 6);
+        let mut terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Inline(COMPOSER_VIEWPORT_HEIGHT),
+            },
+        )
+        .expect("terminal");
+        app.flush_transcript(&mut terminal).expect("flush");
+
+        // The committed scrollback row carries a real OSC 8 hyperlink around the
+        // URL, not just styled text — so it is clickable regardless of whether
+        // the terminal auto-detects links.
+        let scrollback = terminal.backend().scrollback();
+        let opener = "\x1b]8;;https://github.com/everruns/yolop/pull/510\x1b\\";
+        let found = (0..scrollback.area.height).any(|y| {
+            (0..scrollback.area.width).any(|x| scrollback[(x, y)].symbol().contains(opener))
+        });
+        assert!(
+            found,
+            "flushed transcript should wrap the URL in an OSC 8 hyperlink"
+        );
     }
 
     fn presentation_state_idle() -> PresentationState {

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -3,6 +3,7 @@
 //! line formatting helpers. Pure rendering over `&App` / `&ViewState`; state
 //! mutation lives elsewhere.
 
+use super::hyperlink::{next_url_start, url_end};
 use super::*;
 use std::collections::HashMap;
 
@@ -1771,10 +1772,9 @@ pub(crate) fn inline_code_spans(text: &str) -> Vec<Span<'static>> {
 }
 
 /// Split plain text into spans, styling any `http(s)://` URL as a link
-/// (accent + underline). ratatui 0.30 can't emit OSC 8 hyperlink escapes
-/// through its cell buffer, but styling the raw URL keeps it visually distinct
-/// and — because the literal URL stays in the terminal scrollback — modern
-/// emulators still auto-linkify it for click/⌘-click.
+/// (accent + underline). The styling is only the *visual* cue; clickability
+/// comes from [`hyperlink::linkify_buffer`](super::hyperlink::linkify_buffer),
+/// which wraps the same URL runs in OSC 8 escapes after the buffer is rendered.
 pub(crate) fn linkify(text: &str) -> Vec<Span<'static>> {
     if text.is_empty() {
         return Vec::new();
@@ -1803,30 +1803,6 @@ pub(crate) fn linkify(text: &str) -> Vec<Span<'static>> {
         spans.push(Span::raw(text.to_string()));
     }
     spans
-}
-
-/// Byte offset of the next `http://` or `https://` in `s`, if any.
-fn next_url_start(s: &str) -> Option<usize> {
-    match (s.find("https://"), s.find("http://")) {
-        (Some(a), Some(b)) => Some(a.min(b)),
-        (Some(a), None) => Some(a),
-        (None, b) => b,
-    }
-}
-
-/// Byte length of the URL at the start of `from`: up to the next whitespace,
-/// with trailing sentence punctuation trimmed so `(see https://x.dev).` links
-/// just the URL.
-fn url_end(from: &str) -> usize {
-    let raw_end = from.find(char::is_whitespace).unwrap_or(from.len());
-    from[..raw_end]
-        .trim_end_matches(|c| {
-            matches!(
-                c,
-                '.' | ',' | ';' | ':' | '!' | '?' | ')' | ']' | '}' | '\'' | '"'
-            )
-        })
-        .len()
 }
 
 pub(crate) fn simple_code_highlight(text: &str) -> Vec<Span<'static>> {


### PR DESCRIPTION
## What changed

URLs in the transcript render but aren't clickable. They were only **styled** (accent + underline) and left to the terminal's own URL auto-detection — which many terminals don't do — so `⌘/Ctrl`-clicking a link did nothing.

This emits real **OSC 8 hyperlinks**. The previous code assumed ratatui couldn't carry hyperlink escapes through its cell buffer, but that's no longer true: `ratatui-core 0.1.2` (under ratatui 0.30) lets a single cell hold an arbitrary symbol string plus a `CellDiffOption::ForcedWidth`, so an OSC 8 escape can ride inside a cell without throwing off column accounting.

## How

New `src/tui/hyperlink.rs` adds a post-render pass, `linkify_buffer(buf, area)`, that:
1. scans each rendered row for `http(s)://…` runs (same detection/trailing-punctuation rules the styling already used — those helpers moved here and are now shared), and
2. wraps each run's **first** cell with the OSC 8 opener (`ESC ] 8 ; ; URL ESC \`) and its **last** cell with the closer (`ESC ] 8 ; ; ESC \`), forcing both to width 1 so the hidden escapes cost no columns.

Wired into both renderers after their normal draw:
- **inline**: inside the `insert_before` closure in `flush_transcript`, so links commit into native scrollback.
- **full-screen**: after the transcript paint (scoped to the transcript rect, so a URL being typed in the composer isn't wrapped mid-edit).

Terminals without OSC 8 support ignore the unknown OSC and render the visible text unchanged, so it's safe to always emit — no capability detection needed.

## Before / After

Same visible text (still accent + underline); the difference is the emitted bytes for a URL cell run:

```
Before:  https://github.com/everruns/yolop/pull/510        (plain styled text)
After:   \e]8;;https://github.com/everruns/yolop/pull/510\e\ h ... 0 \e]8;;\e\   (OSC 8 wrapped → clickable)
```

## Tests

- `hyperlink.rs`: wraps a URL run in OSC 8, leaves URL-free rows untouched, keeps trailing `).` outside the link.
- `inline_transcript_urls_commit_osc8_hyperlinks`: drives the real `flush_transcript` path and asserts the committed **scrollback** carries the OSC 8 opener around the URL.
- `cargo test -p yolop --bin yolop` (888) and `-p tuika` pass; `clippy -D warnings` and `fmt --check` clean.

Known limitation (unchanged from before): a URL longer than the wrap width still soft-wraps across rows and isn't linkified — the common single-line case is fixed.

The four `tests/integration.rs` sandboxed-shell cases fail in this container only (kernel lacks Landlock ABI v3); unrelated, and they pass on CI.

## Risk

Low–medium. Confined to a post-render buffer pass over the transcript; no change to layout or the visible glyphs. OSC 8 is widely supported and gracefully ignored elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LksbgmgJfiGmNXXGZphgW6)_