### PR TITLE
feat(context): collect dynamic environment contributions

### DIFF
--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -17,7 +17,10 @@ Phase 4: hook subscriptions (`yolop.hooks` — `pre_tool_use`/`post_tool_use`
 with a tool-name glob, `timeout_ms`, and `on_error`) fired on the warm
 server via `hook/fire`, and a `dynamic_prompt` facet recomputing the
 system-prompt contribution per turn via `prompt/contribution` (falling back
-to the static handshake prompt). Pre-hooks can block; per-hook timeout +
+to the static handshake prompt). Extension prompt contributions are collected
+in the trailing environment-context segment so per-turn changes preserve the
+stable system-prompt prefix for provider prompt caches. Pre-hooks can block;
+per-hook timeout +
 `on_error` (warn/block) bound the cost; the whole-bash-per-event
 `user_hooks` precedent makes a warm-process RPC strictly cheaper.
 Phase 5 (foundation): the **`yolop-yep`** crate (`crates/yolop-yep/`) — the

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -18,6 +18,7 @@ use everruns_core::tool_types::ToolCall;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_runtime::RuntimeProviderStore;
 use serde_json::{Value, json};
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Arc, RwLock};
@@ -26,10 +27,44 @@ use std::sync::{Arc, RwLock};
 
 pub(crate) const ENVIRONMENT_CONTEXT_CAPABILITY_ID: &str = "code_environment_context";
 
+/// Mutable per-turn context rendered by the final prompt capability.
+///
+/// Contributors update named entries before this capability runs. Keeping
+/// dynamic data in one trailing prompt segment avoids invalidating the stable
+/// capability prefix in provider prompt caches.
+#[derive(Clone, Default)]
+pub(crate) struct EnvironmentContextRegistry {
+    entries: Arc<RwLock<BTreeMap<String, String>>>,
+}
+
+impl EnvironmentContextRegistry {
+    pub(crate) fn set(&self, key: impl Into<String>, value: impl Into<String>) {
+        self.entries
+            .write()
+            .expect("environment context registry poisoned")
+            .insert(key.into(), value.into());
+    }
+
+    pub(crate) fn remove(&self, key: &str) {
+        self.entries
+            .write()
+            .expect("environment context registry poisoned")
+            .remove(key);
+    }
+
+    pub(crate) fn snapshot(&self) -> BTreeMap<String, String> {
+        self.entries
+            .read()
+            .expect("environment context registry poisoned")
+            .clone()
+    }
+}
+
 pub(crate) struct CodingCliEnvironmentCapability {
     repo_root: PathBuf,
     active_root: Arc<RwLock<PathBuf>>,
     client_ui: ClientUiContext,
+    registry: EnvironmentContextRegistry,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -56,11 +91,13 @@ impl CodingCliEnvironmentCapability {
         repo_root: PathBuf,
         active_root: Arc<RwLock<PathBuf>>,
         client_ui: ClientUiContext,
+        registry: EnvironmentContextRegistry,
     ) -> Self {
         Self {
             repo_root,
             active_root,
             client_ui,
+            registry,
         }
     }
 
@@ -91,6 +128,7 @@ impl CodingCliEnvironmentCapability {
             } else {
                 None
             },
+            contributions: self.registry.snapshot(),
         }
     }
 }
@@ -147,6 +185,7 @@ struct EnvironmentContext {
     repo_root: String,
     git_current_branch: Option<String>,
     worktree_path: Option<String>,
+    contributions: BTreeMap<String, String>,
 }
 
 fn render_environment_context(context: &EnvironmentContext) -> String {
@@ -179,6 +218,13 @@ fn render_environment_context(context: &EnvironmentContext) -> String {
         && let Some(value) = &context.git_current_branch
     {
         push_xml_field(&mut out, "git_current_branch", value);
+    }
+    for (key, value) in &context.contributions {
+        out.push_str("  <contribution name=\"");
+        out.push_str(&xml_escape(key));
+        out.push_str("\">");
+        out.push_str(&xml_escape(value));
+        out.push_str("</contribution>\n");
     }
     out.push_str("</environment_context>");
     out
@@ -1601,6 +1647,10 @@ mod tests {
             repo_root: "/repo".to_string(),
             git_current_branch: Some("feature<context>".to_string()),
             worktree_path: None,
+            contributions: BTreeMap::from([
+                ("sandbox_mode".to_string(), "workspace-write".to_string()),
+                ("unsafe<name>".to_string(), "value & more".to_string()),
+            ]),
         });
 
         assert!(rendered.starts_with("<environment_context>\n"));
@@ -1618,6 +1668,13 @@ mod tests {
             rendered
                 .contains("  <git_current_branch>feature&lt;context&gt;</git_current_branch>\n")
         );
+        assert!(
+            rendered
+                .contains("  <contribution name=\"sandbox_mode\">workspace-write</contribution>\n")
+        );
+        assert!(rendered.contains(
+            "  <contribution name=\"unsafe&lt;name&gt;\">value &amp; more</contribution>\n"
+        ));
         assert!(rendered.ends_with("</environment_context>"));
     }
 

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -53,8 +53,8 @@ pub(crate) use herdr::{HERDR_CAPABILITY_ID, HerdrCapability};
 pub(crate) use hooks::{HOOKS_CAPABILITY_ID, HooksCapability};
 pub(crate) use host::{
     CODING_BASH_CAPABILITY_ID, ClientUiContext, CodingBashCapability,
-    CodingCliEnvironmentCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID, SETUP_CAPABILITY_ID,
-    SetupCapability,
+    CodingCliEnvironmentCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID, EnvironmentContextRegistry,
+    SETUP_CAPABILITY_ID, SetupCapability,
 };
 pub(crate) use lsp::LspCapability;
 pub(crate) use progress_guard::{PROGRESS_GUARD_CAPABILITY_ID, ProgressGuardCapability};

--- a/src/extensions/capability.rs
+++ b/src/extensions/capability.rs
@@ -9,6 +9,7 @@ use super::manager::{
     DEFAULT_REQUEST_TIMEOUT_MS, ExtensionProcess, ExtensionProcessSpec, LiveProcessRegistry,
 };
 use super::package::{ExtensionPackage, ToolDefinition, extension_capability_id};
+use crate::capabilities::EnvironmentContextRegistry;
 use async_trait::async_trait;
 use everruns_core::capabilities::{Capability, SystemPromptContext};
 use everruns_core::command::{
@@ -38,6 +39,7 @@ pub struct ExtensionCapability {
     /// Shared live-process registry so `reload_extension` can restart this
     /// extension's server mid-session; `None` outside the runtime (tests).
     live_processes: Option<LiveProcessRegistry>,
+    environment_context: Option<EnvironmentContextRegistry>,
     /// Process shared by all tool instances so the server persists across
     /// turns; rebuilt (killing the old server) when the config changes —
     /// the same cache-by-config pattern as `LspCapability::manager_for`.
@@ -53,6 +55,7 @@ impl ExtensionCapability {
             status_sink: None,
             ask_sink: None,
             live_processes: None,
+            environment_context: None,
             process: Mutex::new(None),
         }
     }
@@ -61,6 +64,11 @@ impl ExtensionCapability {
     /// reloaded mid-session via `reload_extension`.
     pub fn with_process_registry(mut self, registry: LiveProcessRegistry) -> Self {
         self.live_processes = Some(registry);
+        self
+    }
+
+    pub(crate) fn with_environment_context(mut self, registry: EnvironmentContextRegistry) -> Self {
+        self.environment_context = Some(registry);
         self
     }
 
@@ -227,11 +235,18 @@ impl Capability for ExtensionCapability {
             }
         } else {
             process.prompt_contribution().await
-        }?;
-        Some(format!(
-            "<capability id=\"{}\">\n{}\n</capability>",
-            self.id, text
-        ))
+        };
+        if let Some(registry) = &self.environment_context {
+            let key = format!("extension_{}", manifest.name);
+            if let Some(text) = text {
+                registry.set(key, text);
+            } else {
+                registry.remove(&key);
+            }
+            None
+        } else {
+            text.map(|text| format!("<capability id=\"{}\">\n{}\n</capability>", self.id, text))
+        }
     }
 
     fn pre_tool_use_hooks_with_config(

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -42,6 +42,7 @@ mod spawn_tests {
 
     use super::capability::ExtensionCapability;
     use super::package::{ExtensionPackage, parse_manifest};
+    use crate::capabilities::EnvironmentContextRegistry;
     use everruns_core::capabilities::Capability;
     use everruns_core::tools::ToolExecutionResult;
     use serde_json::json;
@@ -229,21 +230,26 @@ mod spawn_tests {
     }
 
     #[tokio::test]
-    async fn prompt_contribution_comes_from_handshake_clamped_by_manifest() {
+    async fn prompt_contribution_updates_trailing_environment_context() {
         let Some(python) = python3() else {
             eprintln!("skipping: python3 not available");
             return;
         };
-        let capability = ExtensionCapability::new(fixture_package(&python), std::env::temp_dir());
+        let registry = EnvironmentContextRegistry::default();
+        let capability = ExtensionCapability::new(fixture_package(&python), std::env::temp_dir())
+            .with_environment_context(registry.clone());
         let ctx = everruns_core::capabilities::SystemPromptContext::without_file_store(
             everruns_core::typed_id::SessionId::new(),
         );
-        let contribution = capability
-            .system_prompt_contribution(&ctx)
-            .await
-            .expect("prompt facet");
-        assert!(contribution.contains("<capability id=\"ext:echo\">"));
-        assert!(contribution.contains("echo fixture prompt"));
+        let contribution = capability.system_prompt_contribution(&ctx).await;
+        assert_eq!(contribution, None);
+        assert_eq!(
+            registry
+                .snapshot()
+                .get("extension_echo")
+                .map(String::as_str),
+            Some("echo fixture prompt")
+        );
     }
 
     /// A hook + dynamic-prompt manifest whose server is the same fixture.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -18,9 +18,9 @@ use crate::capabilities::{
     CODING_BASH_CAPABILITY_ID, CONFIG_CAPABILITY_ID, CONTEXT_COST_CONTROL_CAPABILITY_ID,
     CheckpointCapability, ClientCommandsCapability, ClientUiContext, CodingBashCapability,
     CodingCliEnvironmentCapability, ConfigCapability, ContextCostControlCapability,
-    ENVIRONMENT_CONTEXT_CAPABILITY_ID, GOAL_CAPABILITY_ID, GoalCapability, HERDR_CAPABILITY_ID,
-    HOOKS_CAPABILITY_ID, HerdrCapability, HooksCapability, LspCapability,
-    PROGRESS_GUARD_CAPABILITY_ID, ProgressGuardCapability, REPO_MAP_CAPABILITY_ID,
+    ENVIRONMENT_CONTEXT_CAPABILITY_ID, EnvironmentContextRegistry, GOAL_CAPABILITY_ID,
+    GoalCapability, HERDR_CAPABILITY_ID, HOOKS_CAPABILITY_ID, HerdrCapability, HooksCapability,
+    LspCapability, PROGRESS_GUARD_CAPABILITY_ID, ProgressGuardCapability, REPO_MAP_CAPABILITY_ID,
     RepoMapCapability, SESSION_HISTORY_CAPABILITY_ID, SETUP_CAPABILITY_ID,
     SessionHistoryCapability, SetupCapability, USER_ASK_CAPABILITY_ID, UserAskCapability,
     WorktreeCapability,
@@ -2696,6 +2696,8 @@ pub async fn build_with_options(
     //   * user_hooks           — executes user-authored hook specs loaded from
     //                            global/workspace hook config
     let mut capabilities = CapabilityRegistry::new();
+    let environment_context = EnvironmentContextRegistry::default();
+    environment_context.set("sandbox_mode", sandbox_mode.as_str());
     capabilities.register(AgentInstructionsCapability);
     // TODO(EVE-620): revert to `capabilities.register(FileSystemCapability)` once
     // everruns ships an edits[]-only edit_file. This wrapper drops the ambiguous
@@ -2822,7 +2824,8 @@ pub async fn build_with_options(
                 crate::extensions::ExtensionCapability::new(package, effective_root.clone())
                     .with_status_sink(status_sink.clone())
                     .with_ask_sink(ask_sink.clone())
-                    .with_process_registry(live_processes.clone());
+                    .with_process_registry(live_processes.clone())
+                    .with_environment_context(environment_context.clone());
             if enabled {
                 let contributed = capability.contributed_mcp_servers();
                 if !contributed.is_empty() {
@@ -2893,6 +2896,7 @@ pub async fn build_with_options(
         repo_root.clone().unwrap_or_else(|| canonical_root.clone()),
         shared_workspace_root.clone(),
         options.client_ui.clone(),
+        environment_context,
     ));
     // Read-only consumer of the shared config service. `SettingsStore`
     // implements `ConfigService`, so the same handle that backs writes also


### PR DESCRIPTION
## Summary

Collect mutable capability and extension context in the trailing environment-context prompt segment. This gives capabilities a generic named contribution registry, keeps dynamic extension prompts cache-friendly, and exposes the effective sandbox mode to the model.

## Before / After

**Before:** dynamic extension prompt text occupied its own capability segment, so per-turn changes could invalidate the stable prompt prefix. Sandbox mode was not represented in environment context.

**After:** dynamic values render at the prompt suffix as escaped, deterministic entries such as:

```xml
<contribution name="sandbox_mode">workspace-write</contribution>
<contribution name="extension_echo">echo fixture prompt</contribution>
```

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` — 935 unit tests and 117 integration tests passed
- `cargo test --all-features --test integration tui_agents_context_cannot_bypass_native_shell_sandbox -- --exact`
- `cargo run -- --provider llmsim -p "Reply with exactly: environment context smoke ok"`
- Live OpenAI smoke attempted via Doppler but unavailable because this checkout has no Doppler project or fallback configuration.

## Security

- **TM-LLM:** contribution names and values are XML-escaped before prompt insertion; deterministic ordering avoids ambiguous output and dynamic values remain in the trailing segment.
- **TM-TOOL:** no new tools or write permissions; extension contributions continue through the existing bounded extension protocol.
- **TM-FS / TM-BASH:** no filesystem or shell-execution behavior changed. Existing sandbox integration test remains green.
- **TM-DEP:** no dependency changes.
- No API keys, provider environment variables, or session logging paths changed.

## Follow-ups

No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
