### PR TITLE
feat(approval): allow session-wide shell approval

### DIFF
--- a/docs/features/approvals.md
+++ b/docs/features/approvals.md
@@ -16,7 +16,10 @@ including destructive or outward-facing structured tools.
 | `on-request` | Run sandboxed by default; ask only when the agent explicitly requests `danger-full-access`. This is the default. |
 | `never` | Never prompt and never grant a full-access escalation. |
 
-The TUI renders shell approvals as a yes/no prompt with the command and reason.
+The TUI renders shell approvals with the command and reason. Press `y` to
+approve once, `a` to approve requests with the displayed sandbox scope for the
+rest of the session, or `n`/Escape to deny. Session approval is not persisted to
+later yolop sessions, and sandbox-only approval never grants `danger-full-access`.
 One-shot print and ACP sessions do not service this shell-escalation gate, so
 those requests fail closed. ACP's separate general tool-permission gate remains
 available to compatible editor clients. The default **Auto** preset is

--- a/specs/sandboxing.md
+++ b/specs/sandboxing.md
@@ -45,9 +45,11 @@ from inheriting a broader writable ancestor.
 Approval policies are independent: `untrusted` gates commands outside a
 conservative read-only allowlist; `on-failure` gates a full-access retry after a
 likely sandbox denial; `on-request` gates explicit `require_escalated` calls;
-and `never` refuses escalation without prompting. The TUI owns the shell yes/no
-gate. Print and ACP shell escalation requests fail closed; ACP's separate
-general tool-permission gate is unchanged.
+and `never` refuses escalation without prompting. The TUI owns the shell gate:
+users can deny, approve one command, or approve the displayed sandbox scope for
+the rest of the session. A sandbox-only session grant does not grant later
+`danger-full-access` requests. Print and ACP shell escalation requests fail
+closed; ACP's separate general tool-permission gate is unchanged.
 
 On macOS and Linux, native execution is fail closed: if the required OS
 primitive is unavailable, the command returns a sandbox-setup error and is not

--- a/src/exec/tools.rs
+++ b/src/exec/tools.rs
@@ -716,7 +716,9 @@ mod tests {
             let (request, reply) = approvals.recv().await.unwrap();
             assert!(request.full_access);
             assert_eq!(request.reason, "write the requested result");
-            reply.send(true).unwrap();
+            reply
+                .send(crate::sandbox_approval::ApprovalDecision::ApproveOnce)
+                .unwrap();
         };
         let (result, ()) = tokio::join!(execute, approve);
         let ToolExecutionResult::Success(result) = result else {

--- a/src/sandbox_approval.rs
+++ b/src/sandbox_approval.rs
@@ -1,6 +1,9 @@
 //! Hard approval gate for shell commands that need to cross the sandbox boundary.
 
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU8, Ordering},
+};
 use tokio::sync::{mpsc, oneshot};
 
 #[derive(Debug, Clone)]
@@ -10,14 +13,27 @@ pub(crate) struct ApprovalRequest {
     pub full_access: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ApprovalDecision {
+    Deny,
+    ApproveOnce,
+    ApproveForSession,
+}
+
 pub(crate) type ApprovalReceiver =
-    mpsc::UnboundedReceiver<(ApprovalRequest, oneshot::Sender<bool>)>;
+    mpsc::UnboundedReceiver<(ApprovalRequest, oneshot::Sender<ApprovalDecision>)>;
 
 #[derive(Clone)]
 pub(crate) enum ApprovalGate {
     Deny,
-    Channel(mpsc::UnboundedSender<(ApprovalRequest, oneshot::Sender<bool>)>),
+    Channel {
+        tx: mpsc::UnboundedSender<(ApprovalRequest, oneshot::Sender<ApprovalDecision>)>,
+        approved_scopes: Arc<AtomicU8>,
+    },
 }
+
+const SANDBOX_SCOPE: u8 = 1 << 0;
+const FULL_ACCESS_SCOPE: u8 = 1 << 1;
 
 impl ApprovalGate {
     pub(crate) fn deny() -> Arc<Self> {
@@ -26,18 +42,43 @@ impl ApprovalGate {
 
     pub(crate) fn channel() -> (Arc<Self>, ApprovalReceiver) {
         let (tx, rx) = mpsc::unbounded_channel();
-        (Arc::new(Self::Channel(tx)), rx)
+        (
+            Arc::new(Self::Channel {
+                tx,
+                approved_scopes: Arc::new(AtomicU8::new(0)),
+            }),
+            rx,
+        )
     }
 
     pub(crate) async fn approve(&self, request: ApprovalRequest) -> bool {
-        let Self::Channel(tx) = self else {
+        let Self::Channel {
+            tx,
+            approved_scopes,
+        } = self
+        else {
             return false;
         };
+        let scope = if request.full_access {
+            FULL_ACCESS_SCOPE
+        } else {
+            SANDBOX_SCOPE
+        };
+        if approved_scopes.load(Ordering::Acquire) & scope != 0 {
+            return true;
+        }
         let (reply, answer) = oneshot::channel();
         if tx.send((request, reply)).is_err() {
             return false;
         }
-        answer.await.unwrap_or(false)
+        match answer.await.unwrap_or(ApprovalDecision::Deny) {
+            ApprovalDecision::Deny => false,
+            ApprovalDecision::ApproveOnce => true,
+            ApprovalDecision::ApproveForSession => {
+                approved_scopes.fetch_or(scope, Ordering::AcqRel);
+                true
+            }
+        }
     }
 }
 
@@ -68,7 +109,7 @@ mod tests {
         let (gate, mut rx) = ApprovalGate::channel();
         let responder = tokio::spawn(async move {
             let (_, reply) = rx.recv().await.unwrap();
-            reply.send(true).unwrap();
+            reply.send(ApprovalDecision::ApproveOnce).unwrap();
         });
         assert!(
             gate.approve(ApprovalRequest {
@@ -79,5 +120,60 @@ mod tests {
             .await
         );
         responder.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn session_approval_bypasses_later_prompts() {
+        let (gate, mut rx) = ApprovalGate::channel();
+        let first = gate.approve(ApprovalRequest {
+            command: "cargo test".into(),
+            reason: "run tests".into(),
+            full_access: true,
+        });
+        let respond = async {
+            let (_, reply) = rx.recv().await.unwrap();
+            reply.send(ApprovalDecision::ApproveForSession).unwrap();
+        };
+        let (approved, ()) = tokio::join!(first, respond);
+        assert!(approved);
+
+        assert!(
+            gate.approve(ApprovalRequest {
+                command: "cargo clippy".into(),
+                reason: "run lint".into(),
+                full_access: true,
+            })
+            .await
+        );
+        assert!(rx.try_recv().is_err(), "later approval should not prompt");
+    }
+
+    #[tokio::test]
+    async fn sandbox_session_approval_does_not_grant_full_access() {
+        let (gate, mut rx) = ApprovalGate::channel();
+        let sandboxed = gate.approve(ApprovalRequest {
+            command: "cargo test".into(),
+            reason: "untrusted command".into(),
+            full_access: false,
+        });
+        let respond = async {
+            let (_, reply) = rx.recv().await.unwrap();
+            reply.send(ApprovalDecision::ApproveForSession).unwrap();
+        };
+        let (approved, ()) = tokio::join!(sandboxed, respond);
+        assert!(approved);
+
+        let full_access = gate.approve(ApprovalRequest {
+            command: "cargo publish".into(),
+            reason: "publish release".into(),
+            full_access: true,
+        });
+        let deny = async {
+            let (request, reply) = rx.recv().await.unwrap();
+            assert!(request.full_access);
+            reply.send(ApprovalDecision::Deny).unwrap();
+        };
+        let (approved, ()) = tokio::join!(full_access, deny);
+        assert!(!approved);
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -332,7 +332,7 @@ pub(crate) struct PendingAsk {
 }
 
 struct PendingSandboxApproval {
-    reply: oneshot::Sender<bool>,
+    reply: oneshot::Sender<crate::sandbox_approval::ApprovalDecision>,
 }
 
 enum CodexLoginEvent {
@@ -1042,7 +1042,9 @@ impl App {
             } else {
                 "this command inside the active sandbox"
             };
-            self.push_system(format!("press y to approve {scope}, n or Esc to deny"));
+            self.push_system(format!(
+                "press y to approve {scope} once, a to approve {scope} for this session, n or Esc to deny"
+            ));
             self.pending_sandbox_approval = Some(PendingSandboxApproval { reply });
             return Ok(());
         }
@@ -1277,8 +1279,18 @@ impl App {
             match key.code {
                 KeyCode::Char('y') | KeyCode::Char('Y') => {
                     if let Some(pending) = self.pending_sandbox_approval.take() {
-                        let _ = pending.reply.send(true);
+                        let _ = pending
+                            .reply
+                            .send(crate::sandbox_approval::ApprovalDecision::ApproveOnce);
                         self.push_system("approved".into());
+                    }
+                }
+                KeyCode::Char('a') | KeyCode::Char('A') => {
+                    if let Some(pending) = self.pending_sandbox_approval.take() {
+                        let _ = pending
+                            .reply
+                            .send(crate::sandbox_approval::ApprovalDecision::ApproveForSession);
+                        self.push_system("approved for this session".into());
                     }
                 }
                 KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
@@ -1714,7 +1726,9 @@ impl App {
 
     fn deny_pending_sandbox_approval(&mut self) {
         if let Some(pending) = self.pending_sandbox_approval.take() {
-            let _ = pending.reply.send(false);
+            let _ = pending
+                .reply
+                .send(crate::sandbox_approval::ApprovalDecision::Deny);
             self.push_system("denied".into());
         }
     }
@@ -4951,6 +4965,26 @@ mod tests {
             _workspace: workspace,
             _sessions: sessions,
         }
+    }
+
+    #[tokio::test]
+    async fn sandbox_approval_can_be_granted_for_the_session() {
+        let mut test = app_with_llmsim().await;
+        let (reply, answer) = oneshot::channel();
+        test.app.pending_sandbox_approval = Some(PendingSandboxApproval { reply });
+
+        test.app
+            .handle_key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::empty()))
+            .await;
+
+        assert_eq!(
+            answer.await.unwrap(),
+            crate::sandbox_approval::ApprovalDecision::ApproveForSession
+        );
+        assert!(test.app.pending_sandbox_approval.is_none());
+        assert!(test.app.lines.iter().any(|line| {
+            line.author == Author::System && line.text == "approved for this session"
+        }));
     }
 
     /// Seed a synthetic everruns completion signal onto the app's wake channel,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1658,6 +1658,59 @@ fn tui_bang_shell_runs_shell_without_model_turn() {
     );
 }
 
+#[test]
+fn tui_shell_session_approval_skips_later_prompts_for_the_same_scope() {
+    let mut tui = spawn_tui_llmsim_with_settings(
+        &yolop_binary(),
+        TuiSpawnOptions {
+            no_sandbox: true,
+            ..TuiSpawnOptions::default()
+        },
+        "provider = \"llmsim\"\napproval_policy = \"untrusted\"\n",
+    );
+    assert!(
+        tui.wait_for_output("type /help", Duration::from_secs(3)),
+        "TUI did not render startup banner: {}",
+        tui.output_text()
+    );
+
+    tui.write_input(b"!shell printf first-session-command\r");
+    assert!(
+        tui.wait_for_output("approval needed", Duration::from_secs(5)),
+        "shell approval prompt did not render: {}",
+        tui.output_text()
+    );
+    tui.write_input(b"a");
+    assert!(
+        tui.wait_for_output("first-session-command", Duration::from_secs(5))
+            && tui.wait_for_output("shell exited with code 0", Duration::from_secs(5)),
+        "approved shell command did not finish: {}",
+        tui.output_text()
+    );
+
+    tui.clear_output();
+    tui.write_input(b"!shell printf second-session-command\r");
+    assert!(
+        tui.wait_for_output("second-session-command", Duration::from_secs(5))
+            && tui.wait_for_output("shell exited with code 0", Duration::from_secs(5)),
+        "second shell command did not inherit session approval: {}",
+        tui.output_text()
+    );
+    let second = strip_ansi(&tui.output_text());
+    assert!(
+        !second.contains("approval needed"),
+        "same-scope session approval prompted again: {second}"
+    );
+
+    tui.write_input(b"\x03\x03");
+    let status = tui.wait_or_kill(Duration::from_secs(3));
+    assert!(
+        status.success(),
+        "double Ctrl-C should exit cleanly, got {status:?}: {}",
+        tui.output_text()
+    );
+}
+
 #[cfg(not(windows))]
 #[test]
 fn no_sandbox_flag_gives_shell_commands_full_host_access_for_one_run() {


### PR DESCRIPTION
## What changed

Interactive shell approval prompts now offer a third choice: press `a` to approve the displayed sandbox scope for the rest of the current Yolop session. `y` remains approve-once, and `n`/Escape still deny.

Session grants live only in the in-memory approval gate. They are scoped by privilege: approving commands inside the active sandbox never grants later `danger-full-access` requests, and no grant persists into another Yolop session.

## Why

Repeated shell escalations interrupt longer interactive runs even after the user has decided to trust that scope for the session. Users need an explicit session-level choice without weakening the default one-shot approval or crossing sandbox privilege boundaries.

## Before / After

Before:

```text
press y to approve danger-full-access, n or Esc to deny
```

After:

```text
press y to approve danger-full-access once, a to approve danger-full-access for this session, n or Esc to deny
```

A real-PTY integration test approves the first untrusted shell command with `a`, then proves a second same-scope command runs without another prompt. Unit coverage also proves a sandbox-only session grant does not authorize a later full-access request.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (953 passed, 3 ignored)
- Focused real-PTY approval smoke: `cargo test --all-features --test integration tui_shell_session_approval_skips_later_prompts_for_the_same_scope -- --nocapture`
- Live provider smoke through Doppler: Anthropic returned `live approval smoke ok`
- OpenAI smoke reached the provider but its configured account reported `insufficient_quota`; Anthropic is the documented secondary provider and passed.

## Risk

- Medium: this changes a shell authorization boundary.
- The grant is explicit, in-memory only, and limited to the exact displayed sandbox scope. Denial and approve-once behavior remain fail-closed and unchanged.

## Security

- **TM-BASH:** reviewed the approval boundary and preserved existing command timeouts/output caps. Session grants are stored only after an explicit `ApproveForSession` decision and are privilege-scoped; a negative test prevents sandbox-only approval from widening to `danger-full-access`.
- **TM-FS:** no filesystem policy or path handling changed.
- **TM-LLM / TM-TOOL:** no prompt construction, key handling, capability registration, or tool schema changed.
- **TM-DEP:** no dependencies added or updated.
- No command text, credentials, or approval state is newly persisted or logged.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed
