### PR TITLE
feat(sandbox): make shell containment opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,18 +56,18 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
 
 ### Agent core
 
-- **Automatic by default** — Yolop uses `workspace-write` shell containment
-  with `on-request` approvals: routine work inside the workspace runs without
-  prompting, while a command that needs full host access must ask first. A standing **write blocklist** rejects writes
+- **Unrestricted by default** — Yolop gives shell commands full host access
+  unless you opt into `workspace-write` containment with `--sandbox` or the
+  `sandbox_mode` setting. A standing **write blocklist** rejects writes
   into `.git/`, `node_modules/`, `target/`, `dist/`, `build/`, `.next/`,
   `.venv/`, `venv/`, `.tox/`, `.gradle/` at any depth; reads are unrestricted
   inside the workspace.
-- **Shell sandbox modes × approval policies** — every foreground, background, slash,
-  and direct shell command runs under Seatbelt on macOS or Landlock + seccomp
-  on Linux. Choose `read-only`, `workspace-write` (default), or
-  `danger-full-access` independently from `untrusted`, `on-failure`,
-  `on-request` (default), or `never` approvals. The default pair is the
-  low-friction **Auto** preset. Yolop marks full access `UNSAFE HOST`. See
+- **Shell sandbox modes × approval policies** — sandboxed foreground, background, slash,
+  and direct shell commands run under Seatbelt on macOS or Landlock + seccomp
+  on Linux. Choose `read-only`, `workspace-write`, or
+  `danger-full-access` (default) independently from `untrusted`, `on-failure`,
+  `on-request` (default), or `never` approvals. Yolop marks full access
+  `UNSAFE HOST`. See
   [Shell sandboxing](./docs/features/sandboxing/sandboxing.md).
 - **Soft approval** — an optional spoken-consent layer for critical actions.
   yolop batches the safe work and pauses to ask, in plain chat, only before
@@ -400,7 +400,7 @@ tools.
 A small TOML settings file persists the preferred provider, per-provider
 model picks, custom endpoint base URLs, the soft-approval level
 (`approval_mode`), shell sandbox mode (`sandbox_mode`, default
-`workspace-write`), hard shell approval policy (`approval_policy`, default
+`danger-full-access`), hard shell approval policy (`approval_policy`, default
 `on-request`), Codex
 subscription login metadata, and (optionally) provider API tokens across runs:
 `<config_dir>/yolop/settings.toml` —
@@ -416,11 +416,10 @@ jumps straight to model selection, and `c` opens key/base-URL configuration
 for any provider. Provider, model, and custom base URL choices are written
 to this file.
 
-To disable kernel containment for an already isolated environment, add
-`sandbox_mode = "danger-full-access"` or ask Yolop to set that config key. This is dangerous on a
-normal host: commands then have unrestricted host file, process, and network
-access. For a one-run override that does not change settings, pass
-`--no-sandbox`. Clearing the key restores `workspace-write`.
+Shell commands have unrestricted host file, process, and network access by
+default. For a one-run sandbox that does not change settings, pass `--sandbox`.
+To persist containment, add `sandbox_mode = "workspace-write"` or ask Yolop to
+set that config key. Clearing the key restores `danger-full-access`.
 
 The model picker queries the provider's models API live (OpenAI, Anthropic,
 and OpenRouter via the everruns drivers; Ollama, Gemini, and other

--- a/docs/features/sandboxing/sandboxing.md
+++ b/docs/features/sandboxing/sandboxing.md
@@ -1,8 +1,8 @@
 # Shell sandboxing
 
-Yolop runs shell commands inside native operating-system containment by
-default. The sandbox limits the damage an incorrect or compromised model can
-cause even after a command has been selected for execution.
+Yolop can run shell commands inside native operating-system containment. The
+sandbox limits the damage an incorrect or compromised model can cause after a
+command has been selected for execution, but it is opt-in.
 
 Sandbox mode and [approval policy](../approvals.md) form a matrix. The sandbox
 sets the technical boundary; hard approval controls when Yolop may ask to cross
@@ -24,10 +24,10 @@ The modes are:
 | Mode | Shell access |
 |---|---|
 | `read-only` | Host reads and temporary writes; workspace writes and network denied. |
-| `workspace-write` | Host reads plus writes in the active workspace and temporary directories; network denied. This is the default. |
-| `danger-full-access` | Unrestricted host execution. Yolop marks this `UNSAFE HOST`. |
+| `workspace-write` | Host reads plus writes in the active workspace and temporary directories; network denied. |
+| `danger-full-access` | Unrestricted host execution. This is the default, and Yolop marks this `UNSAFE HOST`. |
 
-With the default `workspace-write` mode:
+With `workspace-write` mode:
 
 - the active workspace, `/tmp`, and a private temporary directory are writable;
 - writes outside those locations are denied;
@@ -101,7 +101,7 @@ worktrees; do not treat `/tmp` as session isolation.
 
 ## Modes × approvals
 
-The default **Auto** preset is `workspace-write × on-request`. `untrusted` asks
+The default policy is `danger-full-access × on-request`. `untrusted` asks
 before commands outside a conservative read-only allowlist. `on-failure` tries
 inside the sandbox, then asks before a full-access retry after a likely sandbox
 denial. `on-request` asks only when the agent explicitly requests escalation.
@@ -113,36 +113,29 @@ still works with compatible editor clients. Direct, model-facing, and
 background shell calls use the same policy.
 
 ```toml
-sandbox_mode = "workspace-write" # implicit default
+sandbox_mode = "workspace-write" # opt into containment
 approval_policy = "on-request"   # implicit default
 ```
 
-## Disabling the sandbox
+## Enabling the sandbox
 
-Disable native containment only when Yolop already runs inside a trusted VM,
-container, or remote sandbox:
-
-```toml
-sandbox_mode = "danger-full-access"
-```
-
-For a single invocation, pass `--no-sandbox` instead. It selects the same
-dangerous full-host-access mode without changing `settings.toml`:
+Enable native containment for one invocation with:
 
 ```bash
-yolop --no-sandbox
+yolop --sandbox
 ```
 
-Add the setting to Yolop's `settings.toml`, or ask Yolop to set the
-`sandbox_mode` configuration key. The change applies on the next run.
+To persist containment, add `sandbox_mode = "workspace-write"` to Yolop's
+`settings.toml`, or ask Yolop to set the `sandbox_mode` configuration key. The
+change applies on the next run. Clearing the key restores the default.
 
-> **Danger:** `danger-full-access` gives shell commands unrestricted access to
-> host files, processes, credentials present in the environment, and the
-> network. A jailbroken or confused model can damage the host.
+> **Danger:** The default `danger-full-access` mode gives shell commands
+> unrestricted access to host files, processes, credentials present in the
+> environment, and the network. A jailbroken or confused model can damage the
+> host.
 
 Yolop marks this state as `UNSAFE HOST` in configuration output, startup
-warnings, the TUI transcript, and the status bar. Remove the setting or set it
-back to `workspace-write` to restore containment.
+warnings, the TUI transcript, and the status bar.
 
 ## Troubleshooting
 

--- a/specs/sandboxing.md
+++ b/specs/sandboxing.md
@@ -29,12 +29,11 @@ backend can implement the same seam without changing tool schemas.
 
 ## Modes × approvals
 
-The implicit **Auto** preset is `sandbox_mode = "workspace-write"` plus
-`approval_policy = "on-request"`. It provides a live writable
-workspace, writable shared `/tmp`, a private temporary directory exposed as
-`$TMPDIR` and `$HOME`, no network, and restrictions inherited by descendant
-processes. The provider is selected once when a runtime is built; each command
-resolves the current workspace again, so worktree activation is reflected on
+The implicit default is `sandbox_mode = "danger-full-access"` plus
+`approval_policy = "on-request"`. Shell commands run directly on the host and
+are surfaced as `UNSAFE HOST`. The provider is selected once when a runtime is
+built; each command resolves the current workspace again, so worktree
+activation is reflected on
 the next command.
 
 `read-only` removes both the workspace and shared `/tmp` grants while retaining
@@ -92,7 +91,7 @@ a known limit.
 ### Windows
 
 There is no native sandbox on Windows yet, so the platform is fail *open*, not
-fail closed: every mode — including the `workspace-write` default — runs the
+fail closed: every mode — including `workspace-write` — runs the
 shell with full host access. The shell is PowerShell (`powershell.exe -NoProfile
 -NonInteractive -Command`) rather than bash, since it ships in-box on every
 supported Windows. Because nothing is contained, the startup warning fires for
@@ -101,28 +100,27 @@ emits the right syntax. A native provider built on
 Windows primitives (restricted tokens, ACLs, a firewall-isolated user) is the
 path to fail-closed parity and is tracked as future work.
 
-## Unsafe opt-out
+## Sandbox opt-in
 
-Users already running Yolop inside a trusted VM/container may set:
+The `--sandbox` CLI flag applies `workspace-write` to one process, including
+its print, TUI, or ACP runtime, without modifying persistent configuration.
+Users may persist the same mode with:
 
 ```toml
-sandbox_mode = "danger-full-access"
+sandbox_mode = "workspace-write"
 ```
 
-The `--no-sandbox` CLI flag applies the same mode to one process, including
-its print, TUI, or ACP runtime, without modifying persistent configuration.
-
 The same change is available through
-`set_config key=sandbox_mode value=danger-full-access`.
-Disabling applies on the next run. Yolop communicates the risk in three places:
+`set_config key=sandbox_mode value=workspace-write`. Enabling applies on the
+next run. Yolop communicates the risk of the unsandboxed default in three
+places:
 
 - `set_config` returns an explicit `DANGER` / `UNSAFE HOST` message;
 - startup writes the warning to stderr and the TUI transcript; and
 - the status bar appends `UNSAFE HOST` to its persistent approval indicator.
 
-Clearing the setting restores `workspace-write`. Yolop never writes the safe
-default to the file, so a `danger-full-access` entry is conspicuous during
-review.
+Clearing the setting restores `danger-full-access`. An explicit
+`workspace-write` entry remains visible in the file.
 
 ## Provider contract and future composition
 
@@ -167,7 +165,7 @@ host executable or silently widen mounts/network.
 
 ## Containment providers
 
-- **Workspace write** is the default kernel-enforced local provider.
+- **Workspace write** is the opt-in kernel-enforced local provider.
 - **Bashkit** is a containment provider in its own right: it interprets a bash
   subset against a virtual filesystem and does not spawn arbitrary OS
   processes. It would advertise different capabilities from native execution,
@@ -217,8 +215,8 @@ isolation.
 
 The automated suite exercises the real `BashTool` launch path and asserts:
 
-- the safe default and sparse settings serialization;
-- explicit unsafe opt-out persistence and danger messaging;
+- the full-access default and sparse settings serialization;
+- explicit sandbox opt-in persistence and danger messaging;
 - writes inside the workspace succeed;
 - writes in shared `/tmp` succeed;
 - writes outside the workspace and `/tmp` fail;

--- a/src/capabilities/config.rs
+++ b/src/capabilities/config.rs
@@ -530,10 +530,10 @@ impl SetConfigTool {
             KeyTarget::Sandbox => {
                 if clearing {
                     self.settings
-                        .set_sandbox_mode(crate::config::SandboxMode::WorkspaceWrite)
+                        .set_sandbox_mode(crate::config::SandboxMode::DangerFullAccess)
                         .map_err(map_err)?;
                     return Ok(saved(
-                        "cleared sandbox_mode (default workspace-write); applies next run"
+                        "cleared sandbox_mode (default danger-full-access); applies next run"
                             .to_string(),
                     ));
                 }
@@ -852,7 +852,7 @@ mod tests {
             .await;
         assert_eq!(
             settings.snapshot().sandbox_mode(),
-            crate::config::SandboxMode::WorkspaceWrite
+            crate::config::SandboxMode::DangerFullAccess
         );
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -84,9 +84,9 @@ pub enum SandboxMode {
     /// Host reads plus private-temp writes; workspace writes and network denied.
     ReadOnly,
     /// Host reads plus workspace/private-temp writes; network denied.
-    #[default]
     WorkspaceWrite,
     /// Explicitly run commands directly on the host. Dangerous.
+    #[default]
     DangerFullAccess,
 }
 
@@ -383,7 +383,7 @@ impl Settings {
                 Value::String(self.worktrees.as_str().to_string()),
             );
         }
-        if self.sandbox != SandboxMode::WorkspaceWrite {
+        if self.sandbox != SandboxMode::DangerFullAccess {
             table.insert(
                 "sandbox_mode".to_string(),
                 Value::String(self.sandbox.as_str().to_string()),
@@ -886,25 +886,25 @@ mod tests {
     }
 
     #[test]
-    fn sandbox_defaults_to_workspace_write_and_full_access_round_trips() {
+    fn sandbox_defaults_to_full_access_and_workspace_write_round_trips() {
         let settings = Settings::from_table(&Table::new());
-        assert_eq!(settings.sandbox_mode(), SandboxMode::WorkspaceWrite);
+        assert_eq!(settings.sandbox_mode(), SandboxMode::DangerFullAccess);
         assert!(!settings.to_table().contains_key("sandbox_mode"));
 
         let tmp = tempfile::tempdir().expect("tmp");
         let path = tmp.path().join("settings.toml");
         let store = SettingsStore::open(path.clone());
         store
-            .set_sandbox_mode(SandboxMode::DangerFullAccess)
+            .set_sandbox_mode(SandboxMode::WorkspaceWrite)
             .expect("save");
         assert!(
             std::fs::read_to_string(&path)
                 .expect("read")
-                .contains("sandbox_mode = \"danger-full-access\"")
+                .contains("sandbox_mode = \"workspace-write\"")
         );
         assert_eq!(
             SettingsStore::open(path).snapshot().sandbox_mode(),
-            SandboxMode::DangerFullAccess
+            SandboxMode::WorkspaceWrite
         );
     }
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -203,7 +203,7 @@ pub fn schema() -> &'static [ConfigField] {
             title: "Shell sandbox",
             description: "Containment for every shell command: `read-only`, `workspace-write`, or `danger-full-access`. Full access is dangerous; use it only when Yolop already runs inside an isolated VM or container.",
             kind: ValueKind::Text,
-            default: Some("workspace-write"),
+            default: Some("danger-full-access"),
             examples: &["read-only", "workspace-write", "danger-full-access"],
             provider_scoped: false,
         },

--- a/src/exec/sandbox.rs
+++ b/src/exec/sandbox.rs
@@ -434,7 +434,7 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn windows_warns_unsandboxed_for_every_mode() {
-        // Windows has no sandbox, so even the workspace-write default must
+        // Windows has no sandbox, so even workspace-write must
         // warn that commands run with full host access.
         for mode in [
             SandboxMode::ReadOnly,

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,10 +123,10 @@ struct Cli {
     #[arg(long)]
     fullscreen: bool,
 
-    /// Disable shell sandboxing for this run. DANGER: commands receive
-    /// unrestricted access to host files, processes, and the network.
+    /// Enable shell sandboxing for this run. Commands may write only in the
+    /// workspace and temporary directories, and network access is blocked.
     #[arg(long)]
-    no_sandbox: bool,
+    sandbox: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -514,9 +514,7 @@ async fn async_main() -> Result<()> {
         std::path::PathBuf::from("/dev/null/yolop/settings.toml")
     });
     let settings = Arc::new(SettingsStore::open(settings_path));
-    let sandbox_mode_override = cli
-        .no_sandbox
-        .then_some(config::SandboxMode::DangerFullAccess);
+    let sandbox_mode_override = cli.sandbox.then_some(config::SandboxMode::WorkspaceWrite);
     let effective_sandbox_mode =
         sandbox_mode_override.unwrap_or_else(|| settings.snapshot().sandbox_mode());
     let (mut provider, mut notes) = pick_provider(&cli, &settings);
@@ -1566,7 +1564,7 @@ mod tests {
         let args = [
             "yolop",
             "--fullscreen",
-            "--no-sandbox",
+            "--sandbox",
             "--model",
             "gpt test",
             "--print",
@@ -1581,7 +1579,7 @@ mod tests {
 
         assert_eq!(
             continuation_command(args, "new-session"),
-            "yolop --fullscreen --no-sandbox --model 'gpt test' --session new-session"
+            "yolop --fullscreen --sandbox --model 'gpt test' --session new-session"
         );
     }
 
@@ -1599,7 +1597,7 @@ mod tests {
             session_dir: None,
             trajectory_out: None,
             fullscreen: false,
-            no_sandbox: false,
+            sandbox: false,
         }
     }
 
@@ -1657,7 +1655,7 @@ mod tests {
             session_dir: None,
             trajectory_out: None,
             fullscreen: false,
-            no_sandbox: false,
+            sandbox: false,
         };
 
         let (provider, _notes) = pick_provider(&cli, &settings);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1662,10 +1662,7 @@ fn tui_bang_shell_runs_shell_without_model_turn() {
 fn tui_shell_session_approval_skips_later_prompts_for_the_same_scope() {
     let mut tui = spawn_tui_llmsim_with_settings(
         &yolop_binary(),
-        TuiSpawnOptions {
-            no_sandbox: true,
-            ..TuiSpawnOptions::default()
-        },
+        TuiSpawnOptions::default(),
         "provider = \"llmsim\"\napproval_policy = \"untrusted\"\n",
     );
     assert!(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1715,6 +1715,7 @@ fn shell_commands_have_full_host_access_by_default() {
     let workspace = root.path().join("workspace");
     std::fs::create_dir(&workspace).expect("create workspace");
     let outside = root.path().join("outside.txt");
+    let command = format!("!shell touch '{}'\r", outside.display());
     let mut tui = spawn_tui_llmsim_with(
         &yolop_binary(),
         TuiSpawnOptions {
@@ -1733,7 +1734,7 @@ fn shell_commands_have_full_host_access_by_default() {
         tui.output_text()
     );
 
-    tui.write_input(b"!shell touch ../outside.txt\r");
+    tui.write_input(command.as_bytes());
     assert!(
         tui.wait_for_output("shell exited with code 0", Duration::from_secs(5)),
         "full-access shell did not complete: {}",
@@ -1764,6 +1765,7 @@ fn sandbox_flag_restricts_shell_writes_for_one_run() {
     let workspace = root.path().join("workspace");
     std::fs::create_dir(&workspace).expect("create workspace");
     let outside = root.path().join("outside.txt");
+    let command = format!("!shell touch '{}'\r", outside.display());
     let mut tui = spawn_tui_llmsim_with(
         &yolop_binary(),
         TuiSpawnOptions {
@@ -1778,7 +1780,7 @@ fn sandbox_flag_restricts_shell_writes_for_one_run() {
         tui.output_text()
     );
 
-    tui.write_input(b"!shell touch ../outside.txt\r");
+    tui.write_input(command.as_bytes());
     assert!(
         tui.wait_for_output("shell exited with code", Duration::from_secs(5)),
         "sandboxed shell did not complete: {}",

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -302,8 +302,8 @@ fn help_flag_succeeds() {
     assert!(stdout.contains("--print"), "help output missing --print");
     assert!(stdout.contains("--image"), "help output missing --image");
     assert!(
-        stdout.contains("--no-sandbox"),
-        "help output missing --no-sandbox"
+        stdout.contains("--sandbox"),
+        "help output missing --sandbox"
     );
 }
 
@@ -1713,7 +1713,7 @@ fn tui_shell_session_approval_skips_later_prompts_for_the_same_scope() {
 
 #[cfg(not(windows))]
 #[test]
-fn no_sandbox_flag_gives_shell_commands_full_host_access_for_one_run() {
+fn shell_commands_have_full_host_access_by_default() {
     let root = tempfile::tempdir().expect("tempdir");
     let workspace = root.path().join("workspace");
     std::fs::create_dir(&workspace).expect("create workspace");
@@ -1722,7 +1722,6 @@ fn no_sandbox_flag_gives_shell_commands_full_host_access_for_one_run() {
         &yolop_binary(),
         TuiSpawnOptions {
             workspace: Some(workspace),
-            no_sandbox: true,
             ..TuiSpawnOptions::default()
         },
     );
@@ -1745,7 +1744,7 @@ fn no_sandbox_flag_gives_shell_commands_full_host_access_for_one_run() {
     );
     assert!(
         outside.exists(),
-        "--no-sandbox shell could not write outside cwd"
+        "default shell could not write outside cwd"
     );
     assert!(
         !std::fs::read_to_string(tui.settings_path())
@@ -1753,6 +1752,42 @@ fn no_sandbox_flag_gives_shell_commands_full_host_access_for_one_run() {
             .contains("danger-full-access"),
         "one-run override must not persist to settings"
     );
+
+    tui.write_input(b"\x03\x03");
+    assert!(tui.wait_or_kill(Duration::from_secs(3)).success());
+}
+
+#[cfg(not(windows))]
+#[test]
+fn sandbox_flag_restricts_shell_writes_for_one_run() {
+    if !require_native_sandbox("sandbox_flag_restricts_shell_writes_for_one_run") {
+        return;
+    }
+    let root = tempfile::tempdir().expect("tempdir");
+    let workspace = root.path().join("workspace");
+    std::fs::create_dir(&workspace).expect("create workspace");
+    let outside = root.path().join("outside.txt");
+    let mut tui = spawn_tui_llmsim_with(
+        &yolop_binary(),
+        TuiSpawnOptions {
+            workspace: Some(workspace),
+            sandbox: true,
+            ..TuiSpawnOptions::default()
+        },
+    );
+    assert!(
+        tui.wait_for_output("type /help", Duration::from_secs(3)),
+        "TUI did not finish startup: {}",
+        tui.output_text()
+    );
+
+    tui.write_input(b"!shell touch ../outside.txt\r");
+    assert!(
+        tui.wait_for_output("shell exited with code", Duration::from_secs(5)),
+        "sandboxed shell did not complete: {}",
+        tui.output_text()
+    );
+    assert!(!outside.exists(), "--sandbox allowed a write outside cwd");
 
     tui.write_input(b"\x03\x03");
     assert!(tui.wait_or_kill(Duration::from_secs(3)).success());
@@ -1831,6 +1866,7 @@ fn tui_agents_context_cannot_bypass_native_shell_sandbox() {
         &yolop_binary(),
         TuiSpawnOptions {
             workspace: Some(workspace),
+            sandbox: true,
             ..TuiSpawnOptions::default()
         },
     );

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1711,7 +1711,10 @@ fn tui_shell_session_approval_skips_later_prompts_for_the_same_scope() {
 #[cfg(not(windows))]
 #[test]
 fn shell_commands_have_full_host_access_by_default() {
-    let root = tempfile::tempdir().expect("tempdir");
+    let root = tempfile::Builder::new()
+        .prefix("yolop-default-host-access-test-")
+        .tempdir_in(std::env::current_dir().expect("current directory"))
+        .expect("tempdir outside shared temp");
     let workspace = root.path().join("workspace");
     std::fs::create_dir(&workspace).expect("create workspace");
     let outside = root.path().join("outside.txt");
@@ -1761,7 +1764,10 @@ fn sandbox_flag_restricts_shell_writes_for_one_run() {
     if !require_native_sandbox("sandbox_flag_restricts_shell_writes_for_one_run") {
         return;
     }
-    let root = tempfile::tempdir().expect("tempdir");
+    let root = tempfile::Builder::new()
+        .prefix("yolop-sandbox-flag-test-")
+        .tempdir_in(std::env::current_dir().expect("current directory"))
+        .expect("tempdir outside shared temp");
     let workspace = root.path().join("workspace");
     std::fs::create_dir(&workspace).expect("create workspace");
     let outside = root.path().join("outside.txt");

--- a/tests/support/tui_harness.rs
+++ b/tests/support/tui_harness.rs
@@ -39,8 +39,8 @@ pub struct TuiSpawnOptions {
     pub fullscreen: bool,
     /// Workspace passed through `-C`; useful for real-binary containment tests.
     pub workspace: Option<PathBuf>,
-    /// Disable shell sandboxing for this process.
-    pub no_sandbox: bool,
+    /// Enable shell sandboxing for this process.
+    pub sandbox: bool,
 }
 
 impl Default for TuiSpawnOptions {
@@ -53,7 +53,7 @@ impl Default for TuiSpawnOptions {
             path_prefix: None,
             fullscreen: false,
             workspace: None,
-            no_sandbox: false,
+            sandbox: false,
         }
     }
 }
@@ -203,8 +203,8 @@ pub fn spawn_tui_llmsim_with_settings(
     if options.fullscreen {
         cmd.arg("--fullscreen");
     }
-    if options.no_sandbox {
-        cmd.arg("--no-sandbox");
+    if options.sandbox {
+        cmd.arg("--sandbox");
     }
     if let Some(workspace) = options.workspace {
         cmd.arg("-C");


### PR DESCRIPTION
## What changed
Shell commands now run with full host access by default. Users can opt into the existing `workspace-write` containment for one process with `--sandbox`, or persist it with `sandbox_mode = "workspace-write"`.

Configuration clearing, CLI help, safety messaging, tests, README guidance, user documentation, and the durable sandbox specification now reflect the opt-in model.

## Why
The default should support unrestricted local development environments while retaining a simple explicit switch for users who want native shell containment.

## Before / After
Before:
```text
$ yolop --help
    --no-sandbox  Disable shell sandboxing for this run
```
Shell commands used `workspace-write` containment unless explicitly disabled.

After:
```text
$ yolop --help
    --sandbox  Enable shell sandboxing for this run
```
Shell commands use `danger-full-access` by default. Automated PTY coverage proves default shell commands can write outside the workspace and `--sandbox` blocks the same class of write.

## Risk
- Medium
- Shell commands receive unrestricted filesystem, process, and network access unless users opt into containment. Yolop continues to surface `UNSAFE HOST`, and the approval policy remains independent and unchanged.
- Existing users who persisted `sandbox_mode = "workspace-write"` retain containment.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"`

## Security
- **TM-BASH:** Reviewed the shell execution delta. The bounded execution implementation, timeouts, output caps, and native sandbox providers are unchanged; only default mode selection and the CLI override direction changed.
- **TM-FS:** The write blocklist and workspace boundary implementation are unchanged. The `--sandbox` integration test directly verifies a write outside the workspace is denied.
- **TM-LLM / TM-TOOL / TM-DEP:** No prompt, key handling, capability registration, or dependency changes.
- No new injection, path traversal, data exposure, or resource-exhaustion surface was introduced.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

Produced by [yolop](https://everruns.com/yolop)
