### PR TITLE
feat(session): add automatic session titles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -219,7 +219,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1418,7 +1418,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1619,7 +1619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1672,8 +1672,7 @@ dependencies = [
 [[package]]
 name = "everruns-anthropic"
 version = "0.17.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db661b45cb8ba4225b29ba3e97a313321d0a0ae7b44a8d290e008cd3119669c7"
+source = "git+https://github.com/everruns/everruns?branch=main#8586f79c5bd3ca6cac04c05a663144f8e034fa96"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1690,8 +1689,7 @@ dependencies = [
 [[package]]
 name = "everruns-core"
 version = "0.17.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d893cdb50361d7452e0c0baf99c786bb6dfac7202c9f3436722eeed5f04b1c6"
+source = "git+https://github.com/everruns/everruns?branch=main#8586f79c5bd3ca6cac04c05a663144f8e034fa96"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -1737,8 +1735,7 @@ dependencies = [
 [[package]]
 name = "everruns-integrations-daytona"
 version = "0.17.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cde81dbfc6711e4c8215e6f5f44f6c6214bd370658f1fa8bb28ed5d0f168d94"
+source = "git+https://github.com/everruns/everruns?branch=main#8586f79c5bd3ca6cac04c05a663144f8e034fa96"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1754,8 +1751,7 @@ dependencies = [
 [[package]]
 name = "everruns-integrations-duckduckgo"
 version = "0.17.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e0d6488be8d410bece28e0dfad3129a71156abbde9f8b98916b989413126e8"
+source = "git+https://github.com/everruns/everruns?branch=main#8586f79c5bd3ca6cac04c05a663144f8e034fa96"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1770,8 +1766,7 @@ dependencies = [
 [[package]]
 name = "everruns-integrations-parallel"
 version = "0.17.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0ecf0dd993bbd2d2f874f40104a04084709d1751503949a9c80acaa655fe413"
+source = "git+https://github.com/everruns/everruns?branch=main#8586f79c5bd3ca6cac04c05a663144f8e034fa96"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1784,8 +1779,7 @@ dependencies = [
 [[package]]
 name = "everruns-local"
 version = "0.17.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b6070f3f35c93403307b05d3e6904e3246ef1b597198207222e4eccb75f1b9e"
+source = "git+https://github.com/everruns/everruns?branch=main#8586f79c5bd3ca6cac04c05a663144f8e034fa96"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1808,8 +1802,7 @@ dependencies = [
 [[package]]
 name = "everruns-mcp"
 version = "0.17.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a84682077fa85947d7c52d8a298df6494f11adb837211d23c399a9823cad459"
+source = "git+https://github.com/everruns/everruns?branch=main#8586f79c5bd3ca6cac04c05a663144f8e034fa96"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1823,8 +1816,7 @@ dependencies = [
 [[package]]
 name = "everruns-openai"
 version = "0.17.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb492b3b1cf30b4a9b252f1c2f388f49b4efc8748c3ad4bce77dd8e2abd8ac3"
+source = "git+https://github.com/everruns/everruns?branch=main#8586f79c5bd3ca6cac04c05a663144f8e034fa96"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1839,8 +1831,7 @@ dependencies = [
 [[package]]
 name = "everruns-openrouter"
 version = "0.17.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7bf4e518c24ceeafe31a849a4f4107bd91fdb4b0d61449cd04ba31f1ab690a4"
+source = "git+https://github.com/everruns/everruns?branch=main#8586f79c5bd3ca6cac04c05a663144f8e034fa96"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1853,8 +1844,7 @@ dependencies = [
 [[package]]
 name = "everruns-provider"
 version = "0.17.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ccd00689f13f2a58054bfb2169ac4334b3539aa05981bc7ee8461a926f56e03"
+source = "git+https://github.com/everruns/everruns?branch=main#8586f79c5bd3ca6cac04c05a663144f8e034fa96"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1881,8 +1871,7 @@ dependencies = [
 [[package]]
 name = "everruns-runtime"
 version = "0.17.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5418948f509aa5e7977aca0abcea8a0ce1fce42630721bfbad2f2c96a78c60"
+source = "git+https://github.com/everruns/everruns?branch=main#8586f79c5bd3ca6cac04c05a663144f8e034fa96"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3439,7 +3428,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3740,7 +3729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4442,7 +4431,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4981,7 +4970,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5049,7 +5038,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5561,7 +5550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5803,7 +5792,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5836,7 +5825,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7208,7 +7197,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,20 +90,20 @@ tree-sitter-zig = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-everruns-anthropic = "0.17.15"
-everruns-core = "0.17.15"
-everruns-openai = "0.17.15"
+everruns-anthropic = { git = "https://github.com/everruns/everruns", branch = "main" }
+everruns-core = { git = "https://github.com/everruns/everruns", branch = "main" }
+everruns-openai = { git = "https://github.com/everruns/everruns", branch = "main" }
 # OpenRouter's first-class driver was split out of everruns-openai into its own
 # crate in 0.13.0; register it alongside openai to keep DriverId::OpenRouter.
-everruns-openrouter = "0.17.15"
-everruns-local = "0.17.15"
-everruns-mcp = "0.17.15"
+everruns-openrouter = { git = "https://github.com/everruns/everruns", branch = "main" }
+everruns-local = { git = "https://github.com/everruns/everruns", branch = "main" }
+everruns-mcp = { git = "https://github.com/everruns/everruns", branch = "main" }
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (specs/mcp.md, upstream runtime-mcp.md D2).
-everruns-runtime = { version = "0.17.15", features = ["mcp-stdio"] }
-everruns-integrations-duckduckgo = "0.17.15"
-everruns-integrations-parallel = "0.17.15"
-everruns-integrations-daytona = "0.17.15"
+everruns-runtime = { git = "https://github.com/everruns/everruns", branch = "main", features = ["mcp-stdio"] }
+everruns-integrations-duckduckgo = { git = "https://github.com/everruns/everruns", branch = "main" }
+everruns-integrations-parallel = { git = "https://github.com/everruns/everruns", branch = "main" }
+everruns-integrations-daytona = { git = "https://github.com/everruns/everruns", branch = "main" }
 arboard = { version = "3", features = ["wayland-data-control"] }
 futures = "0.3"
 html-escape = "0.2"

--- a/README.md
+++ b/README.md
@@ -202,9 +202,10 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   [Agent Client Protocol](https://agentclientprotocol.com) over stdio, so
   editors such as Zed can drive yolop as an external agent (see
   [Editor integration](#editor-integration-acp)).
-- **Sessions** — every run writes a durable per-session event log; resume any
-  conversation with `--session <id>` (see
-  [Session persistence](#session-persistence)).
+- **Sessions** — yolop assigns a concise title after the first substantive
+  request, updates it when the conversation's primary theme changes, and writes
+  a durable per-session event log. Resume any conversation with
+  `--session <id>` (see [Session persistence](#session-persistence)).
 - **Checkpoint rewind** — every turn gets a durable conversation checkpoint and,
   in Yolop-owned Git worktrees, an exact workspace snapshot. `/undo`, `/redo`,
   and `/rewind` preview and restore either axis without changing `HEAD` or the
@@ -485,7 +486,9 @@ stored in `<session_folder>/workspace.json`; large tool output is spilled under
 `<session_folder>/outputs/`. On Unix the session folder is `0o700` and the log
 and workspace metadata are `0o600` (owner-only). The log keeps everything
 needed to restore the transcript and provider continuation state on resume —
-including prompts, tool arguments and output, and reasoning artifacts.
+including prompts, tool arguments and output, reasoning artifacts, and semantic
+session-title updates. The latest title is also projected into `workspace.json`
+and restored from the event log on resume.
 
 To continue a previous conversation:
 

--- a/specs/session-titles.md
+++ b/specs/session-titles.md
@@ -1,0 +1,28 @@
+# Automatic session titles
+
+Yolop enables Everruns' `session` capability with automatic title maintenance.
+After the first substantive request, the agent assigns a concise title and
+updates it only when the conversation's primary theme materially changes.
+Greetings, acknowledgements, minor subtopics, follow-ups, and implementation
+details do not trigger a rename.
+
+The upstream capability owns this behavioral policy and the
+`write_session_title` tool. Yolop keeps the tool's full schema available on the
+first turn rather than deferring it behind tool search.
+
+## Event projection
+
+Every effective title mutation emits Everruns' typed
+`session.title.updated` event. Yolop treats that event as the durable semantic
+record and:
+
+- persists it in the session `events.jsonl` log;
+- projects its latest title into `workspace.json` for local session discovery;
+- restores the latest event-projected title when resuming a session.
+
+Repeated writes of the current title are no-ops and emit no event. Worktree
+metadata updates preserve the projected title and other session metadata.
+
+The runtime session store is the live source of truth. `workspace.json` is a
+Yolop-owned projection; replaying the event log repairs that projection after
+an interrupted write.

--- a/src/exec/worktree.rs
+++ b/src/exec/worktree.rs
@@ -6,7 +6,8 @@
 
 use crate::config::WorktreesMode;
 use crate::runtime::session_log::{
-    SessionWorkspaceMetadata, WorktreeMetadata, write_session_workspace,
+    SessionWorkspaceMetadata, WorktreeMetadata, read_session_workspace_metadata,
+    write_session_workspace,
 };
 use anyhow::{Context, Result, bail};
 use everruns_core::typed_id::SessionId;
@@ -295,7 +296,11 @@ impl WorktreeManager {
     }
 
     fn persist_metadata(&self, info: &WorktreeInfo) -> Result<()> {
-        let mut metadata = SessionWorkspaceMetadata::new(info.path.clone(), self.repo_root.clone());
+        let mut metadata =
+            read_session_workspace_metadata(&self.session_dir)?.unwrap_or_else(|| {
+                SessionWorkspaceMetadata::new(info.path.clone(), self.repo_root.clone())
+            });
+        metadata.active_root = info.path.clone();
         metadata.worktree = Some(WorktreeMetadata {
             path: info.path.clone(),
             branch: info.branch.clone(),
@@ -937,6 +942,56 @@ mod tests {
             Some(info),
         );
         assert!(manager.owned_worktree_info().is_none());
+    }
+
+    #[test]
+    fn persisting_worktree_preserves_session_metadata() {
+        let root = tempfile::tempdir().expect("root");
+        let session = tempfile::tempdir().expect("session");
+        let session_id = SessionId::from_seed(9842);
+        let mut metadata = SessionWorkspaceMetadata::new(
+            root.path().to_path_buf(),
+            Some(root.path().to_path_buf()),
+        );
+        metadata.title = Some("Automatic session titles".to_string());
+        metadata.summary = Some("Preserve projected session metadata".to_string());
+        metadata.session_kind = crate::runtime::session_log::SessionKind::Acp;
+        write_session_workspace(session.path(), &metadata).expect("seed metadata");
+
+        let manager = WorktreeManager::new(
+            WorktreesMode::Off,
+            Some(root.path().to_path_buf()),
+            root.path().to_path_buf(),
+            session_id,
+            session.path().to_path_buf(),
+            None,
+        );
+        let info = WorktreeInfo {
+            path: root.path().join("feature-worktree"),
+            branch: "codex/automatic-session-titles".to_string(),
+            base_ref: "origin/main".to_string(),
+            slug: "automatic-session-titles".to_string(),
+        };
+
+        manager.persist_metadata(&info).expect("persist worktree");
+
+        let written = read_session_workspace_metadata(session.path())
+            .expect("read metadata")
+            .expect("metadata present");
+        assert_eq!(written.title.as_deref(), Some("Automatic session titles"));
+        assert_eq!(
+            written.summary.as_deref(),
+            Some("Preserve projected session metadata")
+        );
+        assert_eq!(
+            written.session_kind,
+            crate::runtime::session_log::SessionKind::Acp
+        );
+        assert_eq!(written.active_root, info.path);
+        assert_eq!(
+            written.worktree.map(|worktree| worktree.branch),
+            Some("codex/automatic-session-titles".to_string())
+        );
     }
 
     #[test]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -44,10 +44,11 @@ use everruns_core::capabilities::{
     AGENT_INSTRUCTIONS_CAPABILITY_ID, AgentInstructionsCapability, BTW_CAPABILITY_ID,
     BtwCapability, CompactionCapability, INFINITY_CONTEXT_CAPABILITY_ID, InfinityContextCapability,
     LOOP_DETECTION_CAPABILITY_ID, LoopDetectionCapability, MessageMetadataCapability,
-    PROMPT_CACHING_CAPABILITY_ID, PromptCachingCapability, SESSION_FILE_SYSTEM_CAPABILITY_ID,
-    SESSION_STORAGE_CAPABILITY_ID, SESSION_TASKS_CAPABILITY_ID, SKILLS_CAPABILITY_ID,
-    STATELESS_TODO_LIST_CAPABILITY_ID, ScopedSkillsCapability, SessionStorageCapability,
-    StatelessTodoListCapability, TOOL_OUTPUT_PERSISTENCE_CAPABILITY_ID, TOOL_SEARCH_CAPABILITY_ID,
+    PROMPT_CACHING_CAPABILITY_ID, PromptCachingCapability, SESSION_CAPABILITY_ID,
+    SESSION_FILE_SYSTEM_CAPABILITY_ID, SESSION_STORAGE_CAPABILITY_ID, SESSION_TASKS_CAPABILITY_ID,
+    SKILLS_CAPABILITY_ID, STATELESS_TODO_LIST_CAPABILITY_ID, ScopedSkillsCapability,
+    SessionCapability, SessionStorageCapability, StatelessTodoListCapability,
+    TOOL_OUTPUT_PERSISTENCE_CAPABILITY_ID, TOOL_SEARCH_CAPABILITY_ID,
     ToolOutputPersistenceCapability, ToolSearchCapability, USER_HOOKS_CAPABILITY_ID,
     UserHooksCapability, WEB_FETCH_CAPABILITY_ID, WebFetchCapability,
 };
@@ -84,9 +85,9 @@ use everruns_runtime::{
 use crate::exec::workspace_host::WorkspaceHost;
 use crate::exec::worktree::{WorktreeManager, detect_repo_root, restore_worktree_from_metadata};
 use crate::runtime::session_log::{
-    JsonlEventEmitter, SessionKind, SessionWorkspaceMetadata, migrate_legacy_session_log,
-    read_session_workspace_metadata, replay, session_dir_path, session_log_path,
-    write_session_workspace,
+    JsonlEventEmitter, SessionKind, SessionWorkspaceMetadata, latest_session_title,
+    migrate_legacy_session_log, read_session_workspace_metadata, replay, session_dir_path,
+    session_log_path, update_session_workspace_title, write_session_workspace,
 };
 use std::path::PathBuf;
 use std::sync::{Arc, LazyLock, RwLock};
@@ -841,6 +842,7 @@ const YOLOP_NEVER_DEFER_TOOLS: &[&str] = &[
     "bash",
     "spawn_background",
     "write_todos",
+    "write_session_title",
     // Skill activation is a routing tool with required arguments; hiding its
     // tiny schema makes malformed calls like activate_skill({}) more likely.
     "activate_skill",
@@ -1966,6 +1968,10 @@ fn default_coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabi
         caps.push(AgentCapabilityConfig::new(CLIENT_COMMANDS_CAPABILITY_ID));
     }
     caps.extend([
+        AgentCapabilityConfig::with_config(
+            SESSION_CAPABILITY_ID,
+            serde_json::json!({ "auto_title": true }),
+        ),
         AgentCapabilityConfig::new(SESSION_FILE_SYSTEM_CAPABILITY_ID),
         AgentCapabilityConfig::new(SKILLS_CAPABILITY_ID),
         AgentCapabilityConfig::new(HERDR_CAPABILITY_ID),
@@ -2622,6 +2628,9 @@ pub async fn build_with_options(
     let active_events = checkpoints.filter_active_events(replayed.events);
     let replayed_events_count = active_events.len();
     let active_messages = crate::runtime::session_log::messages_from_events(&active_events);
+    if let Some(title) = latest_session_title(&active_events) {
+        update_session_workspace_title(&session_dir, &title)?;
+    }
 
     // Only the selected timeline branch enters the live stores. Abandoned
     // suffixes remain in events.jsonl for redo and local history inspection.
@@ -2698,6 +2707,7 @@ pub async fn build_with_options(
     let mut capabilities = CapabilityRegistry::new();
     let environment_context = EnvironmentContextRegistry::default();
     environment_context.set("sandbox_mode", sandbox_mode.as_str());
+    capabilities.register(SessionCapability);
     capabilities.register(AgentInstructionsCapability);
     // TODO(EVE-620): revert to `capabilities.register(FileSystemCapability)` once
     // everruns ships an edits[]-only edit_file. This wrapper drops the ambiguous
@@ -3080,7 +3090,9 @@ pub async fn build_with_options(
 
     // Seed harness/agent/session explicitly so Yolop can attach harness
     // metadata that Everruns forwards to LLM calls and observability.
-    let session_title = format!("yolop @ {}", effective_root.display());
+    let session_title = read_session_workspace_metadata(&session_dir)?
+        .and_then(|metadata| metadata.title)
+        .unwrap_or_else(|| format!("yolop @ {}", effective_root.display()));
     let mut harness_capabilities = coding_harness_capabilities(
         options.client_commands,
         hook_capability_config,
@@ -3414,7 +3426,19 @@ mod tests {
     }
 
     #[test]
-    fn system_prompt_leaves_project_files_framing_to_the_capability() {
+    fn session_capability_enables_automatic_titles_by_default() {
+        let caps = default_coding_harness_capabilities(false);
+        let session = caps
+            .iter()
+            .find(|capability| capability.capability_id() == SESSION_CAPABILITY_ID)
+            .expect("session capability must be enabled");
+
+        assert_eq!(session.config, serde_json::json!({ "auto_title": true }));
+        assert!(YOLOP_NEVER_DEFER_TOOLS.contains(&"write_session_title"));
+    }
+
+    #[test]
+    fn harness_prompt_leaves_project_files_framing_to_the_capability() {
         // The agent_instructions capability owns the <agent-instructions>
         // framing, so the base prompt must not hardcode project-file rules.
         assert!(!SYSTEM_PROMPT.contains("CLAUDE.md"));
@@ -3602,6 +3626,75 @@ mod tests {
                 .is_none(),
             "no credential configured yet"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn scripted_title_tool_updates_runtime_event_log_and_metadata() {
+        use everruns_core::events::EventData;
+        use everruns_core::llmsim_driver::{SimToolCall, SimTurn};
+
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+        let options = BuildOptions {
+            llmsim_override: Some(LlmSimConfig::scripted(vec![
+                SimTurn::ToolCalls(vec![SimToolCall {
+                    name: "write_session_title".to_string(),
+                    arguments: serde_json::json!({ "title": "Automatic session titles" }),
+                    id: None,
+                }]),
+                SimTurn::Assistant("Title set.".to_string()),
+            ])),
+            ..BuildOptions::default()
+        };
+        let built = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Sim,
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            options,
+        )
+        .await
+        .expect("build runtime");
+        let session_id = built.handles.session_id;
+        let result = built
+            .handles
+            .run_checkpointed_turn(
+                "Implement automatic session titles",
+                built
+                    .model
+                    .input_message("Implement automatic session titles"),
+            )
+            .await
+            .expect("run turn");
+
+        assert!(result.success, "scripted title turn: {result:?}");
+        assert_eq!(result.tool_calls_count, 1);
+        let session = built
+            .handles
+            .session_store
+            .get_session(session_id)
+            .await
+            .expect("get runtime session")
+            .expect("runtime session present");
+        assert_eq!(session.title.as_deref(), Some("Automatic session titles"));
+        let events = built
+            .handles
+            .runtime
+            .events()
+            .await
+            .expect("runtime events");
+        assert!(events.iter().any(|event| matches!(
+            &event.data,
+            EventData::SessionTitleUpdated(data)
+                if data.title == "Automatic session titles"
+        )));
+        let metadata =
+            read_session_workspace_metadata(&session_dir_path(sessions.path(), session_id))
+                .expect("read workspace metadata")
+                .expect("workspace metadata present");
+        assert_eq!(metadata.title.as_deref(), Some("Automatic session titles"));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -6011,6 +6104,7 @@ mod tests {
                 hints: ToolHints::default(),
                 full_parameters: None,
             }),
+            fake_tool("write_session_title"),
         ];
         tools
             .extend((0..DEFAULT_TOOL_SEARCH_THRESHOLD).map(|idx| fake_tool(format!("fake_{idx}"))));
@@ -6039,6 +6133,15 @@ mod tests {
         assert!(
             activate_skill.parameters().get("properties").is_some(),
             "activate_skill must keep its full schema so models pass the required name field"
+        );
+
+        let write_session_title = transformed
+            .iter()
+            .find(|tool| tool.name() == "write_session_title")
+            .expect("write_session_title definition");
+        assert!(
+            write_session_title.parameters().get("properties").is_some(),
+            "write_session_title must be callable on the first substantive turn"
         );
 
         let fake = transformed

--- a/src/runtime/session_log.rs
+++ b/src/runtime/session_log.rs
@@ -25,6 +25,8 @@
 //   (`input.message`, `output.message.completed`, `tool.completed`) and
 //   (b) the agent needs to restore the live transcript view and provider
 //   continuation state on resume (`reason.completed`, `reason.item`).
+//   Semantic `session.title.updated` events are also retained so the latest
+//   title can repair the `workspace.json` projection after interruption.
 //   Streaming `*.delta` events have no replay value and would otherwise
 //   inflate the log O(n²) for long streamed responses.
 // * Assistant `thinking` / `thinking_signature` fields ARE persisted in
@@ -57,7 +59,8 @@ use chrono::{DateTime, Utc};
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::events::{
     Event, EventData, EventRequest, INPUT_MESSAGE, OUTPUT_MESSAGE_COMPLETED,
-    OutputMessageCompletedData, REASON_COMPLETED, REASON_ITEM, TOOL_COMPLETED,
+    OutputMessageCompletedData, REASON_COMPLETED, REASON_ITEM, SESSION_TITLE_UPDATED,
+    TOOL_COMPLETED,
 };
 use everruns_core::message::{ContentPart, Message};
 use everruns_core::tools::ToolResultImage;
@@ -282,6 +285,21 @@ pub fn write_session_workspace(
     write_private_file(&path, &bytes)
 }
 
+pub fn update_session_workspace_title(session_dir: &Path, title: &str) -> Result<bool> {
+    let Some(mut metadata) = read_session_workspace_metadata(session_dir)? else {
+        return Err(AgentLoopError::config(format!(
+            "session workspace metadata not found: {}",
+            session_workspace_path(session_dir).display()
+        )));
+    };
+    if metadata.title.as_deref() == Some(title) {
+        return Ok(false);
+    }
+    metadata.title = Some(title.to_string());
+    write_session_workspace(session_dir, &metadata)?;
+    Ok(true)
+}
+
 fn write_private_file(path: &Path, bytes: &[u8]) -> Result<()> {
     let mut opts = OpenOptions::new();
     opts.create(true).write(true).truncate(true);
@@ -412,7 +430,8 @@ pub fn replay(path: &Path, expected: SessionId) -> Result<ReplayedSession> {
 /// restore the live transcript view and provider continuation state on
 /// resume (`reason.completed` carries the safe `text_preview` narration,
 /// `reason.item` carries opaque/encrypted reasoning context curated by the
-/// provider). Streaming `*.delta` events and pure lifecycle markers
+/// provider), plus semantic title updates used to repair workspace metadata.
+/// Streaming `*.delta` events and pure lifecycle markers
 /// (`reason.started`, `reason.thinking.*`, `output.message.started`) are
 /// dropped — they are live status signals only and the delta types would
 /// bloat the log O(n²) since each delta carries the accumulated text so
@@ -420,8 +439,20 @@ pub fn replay(path: &Path, expected: SessionId) -> Result<ReplayedSession> {
 fn is_replay_relevant(event_type: &str) -> bool {
     matches!(
         event_type,
-        INPUT_MESSAGE | OUTPUT_MESSAGE_COMPLETED | TOOL_COMPLETED | REASON_COMPLETED | REASON_ITEM
+        INPUT_MESSAGE
+            | OUTPUT_MESSAGE_COMPLETED
+            | TOOL_COMPLETED
+            | REASON_COMPLETED
+            | REASON_ITEM
+            | SESSION_TITLE_UPDATED
     )
+}
+
+pub(crate) fn latest_session_title(events: &[Event]) -> Option<String> {
+    events.iter().rev().find_map(|event| match &event.data {
+        EventData::SessionTitleUpdated(data) => Some(data.title.clone()),
+        _ => None,
+    })
 }
 
 /// EventEmitter that appends replay-relevant events as JSONL to a file
@@ -435,6 +466,7 @@ pub struct JsonlEventEmitter {
     sequence: Arc<AtomicI32>,
     persisted_sequence: Arc<AtomicI32>,
     file: Arc<Mutex<File>>,
+    session_dir: PathBuf,
     /// Live fan-out of every emitted event (including deltas) for in-process
     /// subscribers like the TUI's streaming renderer. Filesystem persistence
     /// still filters by `is_replay_relevant`; this channel does not.
@@ -559,6 +591,10 @@ impl JsonlEventEmitter {
             sequence: Arc::new(AtomicI32::new(start_sequence.saturating_sub(1))),
             persisted_sequence: Arc::new(AtomicI32::new(start_sequence.saturating_sub(1))),
             file: Arc::new(Mutex::new(file)),
+            session_dir: path
+                .parent()
+                .unwrap_or_else(|| Path::new("."))
+                .to_path_buf(),
             live,
         })
     }
@@ -635,6 +671,16 @@ impl EventEmitter for JsonlEventEmitter {
             file.flush()
                 .map_err(|e| AgentLoopError::config(format!("flush session log: {e}")))?;
             self.persisted_sequence.fetch_max(seq_val, Ordering::AcqRel);
+        }
+
+        if let EventData::SessionTitleUpdated(data) = &event.data
+            && let Err(error) = update_session_workspace_title(&self.session_dir, &data.title)
+        {
+            tracing::warn!(
+                session_id = %event.session_id,
+                error = %error,
+                "failed to project session title into workspace metadata"
+            );
         }
 
         // Fan out to live subscribers. `send` errors only when there are
@@ -731,7 +777,8 @@ fn parse_structured_tool_result_text(text: &str) -> serde_json::Value {
 mod tests {
     use super::*;
     use everruns_core::events::{
-        EventContext, InputMessageData, OutputMessageCompletedData, ToolCompletedData,
+        EventContext, InputMessageData, OutputMessageCompletedData, SessionTitleUpdatedData,
+        ToolCompletedData,
     };
     use everruns_core::message::Message;
 
@@ -741,6 +788,67 @@ mod tests {
             EventContext::default(),
             InputMessageData::new(Message::user(text)),
         )
+    }
+
+    fn title_event(session_id: SessionId, previous_title: Option<&str>, title: &str) -> Event {
+        Event::new(
+            session_id,
+            EventContext::default(),
+            SessionTitleUpdatedData {
+                previous_title: previous_title.map(str::to_string),
+                title: title.to_string(),
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn title_event_is_persisted_and_projected() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionId::from_seed(483);
+        let session_dir = session_dir_path(dir.path(), session_id);
+        write_session_workspace(
+            &session_dir,
+            &SessionWorkspaceMetadata::new(dir.path().to_path_buf(), None),
+        )
+        .expect("seed workspace metadata");
+        let emitter = JsonlEventEmitter::open(&session_log_path(&session_dir), 1).expect("open");
+
+        emitter
+            .emit(EventRequest::new(
+                session_id,
+                EventContext::default(),
+                SessionTitleUpdatedData {
+                    previous_title: None,
+                    title: "Automatic session titles".to_string(),
+                },
+            ))
+            .await
+            .expect("emit title update");
+
+        let replayed = replay(&session_log_path(&session_dir), session_id).expect("replay");
+        assert_eq!(
+            latest_session_title(&replayed.events).as_deref(),
+            Some("Automatic session titles")
+        );
+        let metadata = read_session_workspace_metadata(&session_dir)
+            .expect("read metadata")
+            .expect("metadata present");
+        assert_eq!(metadata.title.as_deref(), Some("Automatic session titles"));
+    }
+
+    #[test]
+    fn latest_title_uses_last_semantic_update() {
+        let session_id = SessionId::from_seed(484);
+        let events = vec![
+            title_event(session_id, None, "First theme"),
+            input_event(session_id, "switch topics"),
+            title_event(session_id, Some("First theme"), "Second theme"),
+        ];
+
+        assert_eq!(
+            latest_session_title(&events).as_deref(),
+            Some("Second theme")
+        );
     }
 
     #[tokio::test]

--- a/src/tui/transcript.rs
+++ b/src/tui/transcript.rs
@@ -903,6 +903,7 @@ mod tests {
         use everruns_core::events::{CompactionStepData, ContextCompactedData};
 
         let event = event(ContextCompactedData {
+            checkpoint_id: None,
             strategy_used: "observation_masking+aggressive_trim".into(),
             messages_before: 142,
             messages_after: 38,
@@ -933,6 +934,7 @@ mod tests {
         use everruns_core::events::ContextCompactedData;
 
         let event = event(ContextCompactedData {
+            checkpoint_id: None,
             strategy_used: "native".into(),
             messages_before: 50,
             messages_after: 12,


### PR DESCRIPTION
## What changed
Yolop now enables the Everruns session capability to assign a concise title after the first substantive request and retitle only when the primary theme materially changes. Effective title changes are durable `session.title.updated` events, projected into `workspace.json`, restored on resume, and preserved across worktree metadata updates.

The Everruns crates temporarily track Git `main`, pinned by `Cargo.lock` to `8586f79c5bd3ca6cac04c05a663144f8e034fa96`, so Yolop can consume the shipped-but-unreleased capability.

## Why
Prompt-derived session summaries are static and cannot represent topic changes. Everruns now owns the reusable policy, tool, mutation, and event contract; Yolop wires that capability into its harness and local persistence model.

## Before / After
Before: a real Anthropic smoke completed a substantive request and a topic switch without calling `write_session_title`; no semantic title event existed.

After, in one resumed session:
- first substantive request: `write_session_title` at sequence 12, `session.title.updated` at sequence 16, then the answer; title `Rust ownership prevents use-after-free`
- minor follow-up: no additional title event
- explicit topic switch: `write_session_title` at sequence 58, update event at sequence 62 with the correct previous title, then the answer; title `Why sourdough starter rises`
- `workspace.json` contained the final projected title

## Risk
- Medium
- Git `main` is a temporary moving dependency declaration, but the committed lockfile pins every Everruns package to one reviewed merge SHA.
- Session titles contain model-selected text. They are serialized through JSON into the existing owner-only session directory and never influence paths or shell commands. The event log already stores the more sensitive prompts and tool output.
- Projection failure is best-effort and recoverable: the durable semantic event repairs `workspace.json` on resume.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (907 unit passed, 2 ignored; 46 integration passed, 1 ignored; parallel and TUI suites passed)
- focused title, worktree metadata, and transcript tests after rebasing onto latest `main`
- real Anthropic first-title / minor-follow-up / topic-retitle smoke

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; no compatibility requirement; existing session logs remain readable)