### PR TITLE
feat(context): persist native compaction checkpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1672,7 +1672,7 @@ dependencies = [
 [[package]]
 name = "everruns-anthropic"
 version = "0.17.15"
-source = "git+https://github.com/everruns/everruns?branch=main#8586f79c5bd3ca6cac04c05a663144f8e034fa96"
+source = "git+https://github.com/everruns/everruns?branch=main#adcb933ccae591b22d646297c0cd0343601f9b9e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1689,7 +1689,7 @@ dependencies = [
 [[package]]
 name = "everruns-core"
 version = "0.17.15"
-source = "git+https://github.com/everruns/everruns?branch=main#8586f79c5bd3ca6cac04c05a663144f8e034fa96"
+source = "git+https://github.com/everruns/everruns?branch=main#adcb933ccae591b22d646297c0cd0343601f9b9e"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -1735,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "everruns-integrations-daytona"
 version = "0.17.15"
-source = "git+https://github.com/everruns/everruns?branch=main#8586f79c5bd3ca6cac04c05a663144f8e034fa96"
+source = "git+https://github.com/everruns/everruns?branch=main#adcb933ccae591b22d646297c0cd0343601f9b9e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1751,7 +1751,7 @@ dependencies = [
 [[package]]
 name = "everruns-integrations-duckduckgo"
 version = "0.17.15"
-source = "git+https://github.com/everruns/everruns?branch=main#8586f79c5bd3ca6cac04c05a663144f8e034fa96"
+source = "git+https://github.com/everruns/everruns?branch=main#adcb933ccae591b22d646297c0cd0343601f9b9e"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1766,7 +1766,7 @@ dependencies = [
 [[package]]
 name = "everruns-integrations-parallel"
 version = "0.17.15"
-source = "git+https://github.com/everruns/everruns?branch=main#8586f79c5bd3ca6cac04c05a663144f8e034fa96"
+source = "git+https://github.com/everruns/everruns?branch=main#adcb933ccae591b22d646297c0cd0343601f9b9e"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1779,7 +1779,7 @@ dependencies = [
 [[package]]
 name = "everruns-local"
 version = "0.17.15"
-source = "git+https://github.com/everruns/everruns?branch=main#8586f79c5bd3ca6cac04c05a663144f8e034fa96"
+source = "git+https://github.com/everruns/everruns?branch=main#adcb933ccae591b22d646297c0cd0343601f9b9e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1802,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "everruns-mcp"
 version = "0.17.15"
-source = "git+https://github.com/everruns/everruns?branch=main#8586f79c5bd3ca6cac04c05a663144f8e034fa96"
+source = "git+https://github.com/everruns/everruns?branch=main#adcb933ccae591b22d646297c0cd0343601f9b9e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1816,7 +1816,7 @@ dependencies = [
 [[package]]
 name = "everruns-openai"
 version = "0.17.15"
-source = "git+https://github.com/everruns/everruns?branch=main#8586f79c5bd3ca6cac04c05a663144f8e034fa96"
+source = "git+https://github.com/everruns/everruns?branch=main#adcb933ccae591b22d646297c0cd0343601f9b9e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1831,7 +1831,7 @@ dependencies = [
 [[package]]
 name = "everruns-openrouter"
 version = "0.17.15"
-source = "git+https://github.com/everruns/everruns?branch=main#8586f79c5bd3ca6cac04c05a663144f8e034fa96"
+source = "git+https://github.com/everruns/everruns?branch=main#adcb933ccae591b22d646297c0cd0343601f9b9e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1844,7 +1844,7 @@ dependencies = [
 [[package]]
 name = "everruns-provider"
 version = "0.17.15"
-source = "git+https://github.com/everruns/everruns?branch=main#8586f79c5bd3ca6cac04c05a663144f8e034fa96"
+source = "git+https://github.com/everruns/everruns?branch=main#adcb933ccae591b22d646297c0cd0343601f9b9e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1871,7 +1871,7 @@ dependencies = [
 [[package]]
 name = "everruns-runtime"
 version = "0.17.15"
-source = "git+https://github.com/everruns/everruns?branch=main#8586f79c5bd3ca6cac04c05a663144f8e034fa96"
+source = "git+https://github.com/everruns/everruns?branch=main#adcb933ccae591b22d646297c0cd0343601f9b9e"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,8 +116,10 @@ comfy-table = { version = "7.2.2", default-features = false }
 # seccomp-BPF for network denial. Both are pure-Rust wrappers over kernel APIs.
 [target.'cfg(target_os = "linux")'.dependencies]
 landlock = "0.4.4"
-libc = "0.2"
 seccompiler = "0.5.0"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 
 [dev-dependencies]
 inventory = "0.3"

--- a/README.md
+++ b/README.md
@@ -181,6 +181,10 @@ yolop --provider llmsim -p "hi"        # offline demo, no API key required
   tools stay loaded, long-tail tools are hidden until the model pulls them in
   on demand, saving input tokens on every provider.
 - **Prompt caching** — Anthropic prompt-caching markers out of the box.
+- **Durable context compaction** — at 85% of the model's reported context
+  window, supported providers replace old model input with a native compact
+  checkpoint plus the new suffix. Raw session history remains lossless and
+  searchable, and ineffective no-op compactions are ignored.
 
 ### Extensibility
 
@@ -480,10 +484,13 @@ data directory:
 | macOS   | `~/Library/Application Support/yolop/sessions/<session_id>/` |
 | Windows | `%APPDATA%\yolop\sessions\<session_id>\`                   |
 
-The event log lives at `<session_folder>/events.jsonl`; the workspace root is
-stored in `<session_folder>/workspace.json`; large tool output is spilled under
-`<session_folder>/outputs/`. On Unix the session folder is `0o700` and the log
-and workspace metadata are `0o600` (owner-only). The log keeps everything
+The event log lives at `<session_folder>/events.jsonl`; native model-context
+checkpoints live in `<session_folder>/compaction-checkpoints.jsonl`; the
+workspace root is stored in `<session_folder>/workspace.json`; large tool output
+is spilled under `<session_folder>/outputs/`. On Unix the session folder is
+`0o700` and these metadata files are `0o600` (owner-only). The compaction file
+may contain retained message text and provider-encrypted opaque context, so it
+must remain private. The log keeps everything
 needed to restore the transcript and provider continuation state on resume —
 including prompts, tool arguments and output, reasoning artifacts, and semantic
 session-title updates. The latest title is also projected into `workspace.json`

--- a/specs/checkpointing.md
+++ b/specs/checkpointing.md
@@ -87,6 +87,7 @@ The existing per-session directory gains:
 <session>/
   events.jsonl                 # immutable event payloads, as today
   timeline.jsonl               # append-only checkpoint/head/restore records
+  compaction-checkpoints.jsonl # append-only model-context replacements
   workspace.json               # existing session/worktree metadata
 ```
 
@@ -116,6 +117,23 @@ Each timeline record is JSONL and owner-only. Relevant record types are:
 The journal is append-only and flushed before the turn begins or a restore is
 reported successful. A compact derived index may be added later, but it is never
 the source of truth.
+
+### Model-context checkpoints
+
+Model-context compaction is a separate, derived projection over the lossless
+event log. A successful native compaction appends the provider/model, source
+event sequence, format version, and provider-opaque replacement to
+`compaction-checkpoints.jsonl`. Subsequent calls reconstruct model input as the
+latest compatible checkpoint on the active timeline plus raw messages after its
+source boundary. The raw events are never rewritten or deleted.
+
+Rewind and redo select checkpoints by the active timeline. A checkpoint on an
+abandoned suffix remains append-only data but cannot shadow the latest surviving
+ancestor. Installation is monotonic for each provider/model/version, and a
+failed or ineffective compact call leaves the prior checkpoint unchanged. On
+Unix the file is owner-only (`0o600`) because provider-native replacements may
+contain retained message text and encrypted opaque context; those payloads must
+not enter public events or logs.
 
 ## Conversation replay
 

--- a/src/drivers/codex.rs
+++ b/src/drivers/codex.rs
@@ -5,12 +5,15 @@ use eventsource_stream::Eventsource;
 use everruns_core::driver_registry::{
     ChatDriver, DriverConfig, LlmCallConfig, LlmCompletionMetadata, LlmContentPart, LlmMessage,
     LlmMessageContent, LlmMessageRole, LlmResponseStream, LlmStreamError, LlmStreamEvent,
-    ProviderMetadata,
+    ProviderMetadata, ProviderOpaqueContext,
 };
 use everruns_core::driver_registry::{DiscoveredModel, DriverRegistry};
 use everruns_core::error::{AgentLoopError, Result as EverrunsResult};
 use everruns_core::tool_types::{ToolCall, ToolDefinition};
-use everruns_core::{DriverId, ModelProfile, get_model_profile};
+use everruns_core::{
+    CompactContent, CompactContentPart, CompactOutputItem, CompactRequest, CompactResponse,
+    DriverId, ModelProfile, get_model_profile,
+};
 use futures::StreamExt;
 use reqwest::header::{HeaderMap, HeaderValue};
 use serde::Serialize;
@@ -58,6 +61,7 @@ struct CodexTokens {
 #[derive(Clone)]
 pub struct CodexChatDriver {
     client: reqwest::Client,
+    responses_url: String,
     tokens: Arc<tokio::sync::Mutex<CodexTokens>>,
     auth_store: Option<Arc<dyn CodexAuthStore>>,
 }
@@ -97,6 +101,7 @@ impl CodexChatDriver {
             .and_then(|auth| auth.email);
         Self {
             client: reqwest::Client::new(),
+            responses_url: CODEX_RESPONSES_URL.to_string(),
             tokens: Arc::new(tokio::sync::Mutex::new(CodexTokens {
                 access_token,
                 refresh_token,
@@ -274,7 +279,8 @@ impl ChatDriver for CodexChatDriver {
         config: &LlmCallConfig,
     ) -> EverrunsResult<LlmResponseStream> {
         let tokens = self.token_snapshot().await?;
-        let (instructions, input) = build_input(&messages);
+        let (instructions, transcript_input) = build_input(&messages);
+        let input = compose_input(config.provider_opaque_context.as_ref(), transcript_input);
         let request = CodexResponsesRequest {
             model: config.model.clone(),
             store: false,
@@ -293,24 +299,11 @@ impl ChatDriver for CodexChatDriver {
                 }),
         };
 
-        let mut headers = HeaderMap::new();
-        headers.insert("OpenAI-Beta", HeaderValue::from_static(CODEX_BETA_HEADER));
-        headers.insert("originator", HeaderValue::from_static(CODEX_ORIGINATOR));
-        if let Some(account_id) = &tokens.account_id
-            && let Ok(value) = HeaderValue::from_str(account_id)
-        {
-            headers.insert("chatgpt-account-id", value.clone());
-            headers.insert("ChatGPT-Account-Id", value);
-        }
-        if let Some(session_id) = config.metadata.get("session_id")
-            && let Ok(value) = HeaderValue::from_str(session_id)
-        {
-            headers.insert("session_id", value);
-        }
+        let headers = codex_headers(&tokens, config.metadata.get("session_id"));
 
         let response = self
             .client
-            .post(CODEX_RESPONSES_URL)
+            .post(&self.responses_url)
             .bearer_auth(&tokens.access_token)
             .headers(headers)
             .json(&request)
@@ -365,6 +358,69 @@ impl ChatDriver for CodexChatDriver {
     async fn list_models(&self) -> EverrunsResult<Option<Vec<DiscoveredModel>>> {
         Ok(None)
     }
+
+    fn supports_compact(&self) -> bool {
+        true
+    }
+
+    fn effective_context_window(&self, model: &str) -> Option<usize> {
+        model_profile(model).and_then(|profile| {
+            profile
+                .limits
+                .map(|limits| usize::try_from(limits.context).unwrap_or(usize::MAX))
+        })
+    }
+
+    async fn compact(&self, request: CompactRequest) -> EverrunsResult<Option<CompactResponse>> {
+        let tokens = self.token_snapshot().await?;
+        let response = self
+            .client
+            .post(format!(
+                "{}/compact",
+                self.responses_url.trim_end_matches('/')
+            ))
+            .bearer_auth(&tokens.access_token)
+            .headers(codex_headers(&tokens, None))
+            .json(&request)
+            .send()
+            .await
+            .map_err(|err| {
+                AgentLoopError::llm(format!("Failed to send Codex compact request: {err}"))
+            })?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(AgentLoopError::llm_kind(
+                everruns_core::error::LlmErrorKind::from_provider_status(status.as_u16(), &body),
+                format!("Codex compact API error ({status}): {body}"),
+            ));
+        }
+
+        let compact = response
+            .json::<CompactResponse>()
+            .await
+            .map_err(|err| AgentLoopError::llm(format!("Invalid Codex compact response: {err}")))?;
+        Ok(Some(compact))
+    }
+}
+
+fn codex_headers(tokens: &CodexTokens, session_id: Option<&String>) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert("OpenAI-Beta", HeaderValue::from_static(CODEX_BETA_HEADER));
+    headers.insert("originator", HeaderValue::from_static(CODEX_ORIGINATOR));
+    if let Some(account_id) = &tokens.account_id
+        && let Ok(value) = HeaderValue::from_str(account_id)
+    {
+        headers.insert("chatgpt-account-id", value.clone());
+        headers.insert("ChatGPT-Account-Id", value);
+    }
+    if let Some(session_id) = session_id
+        && let Ok(value) = HeaderValue::from_str(session_id)
+    {
+        headers.insert("session_id", value);
+    }
+    headers
 }
 
 #[derive(Debug, Serialize)]
@@ -413,6 +469,10 @@ enum CodexInputItem {
     Reasoning {
         r#type: String,
         id: String,
+        encrypted_content: String,
+    },
+    Compaction {
+        r#type: String,
         encrypted_content: String,
     },
 }
@@ -508,6 +568,54 @@ fn build_input(messages: &[LlmMessage]) -> (Option<String>, Vec<CodexInputItem>)
     }
     let instructions = (!instructions.is_empty()).then(|| instructions.join("\n\n"));
     (instructions, repair_unpaired_function_items(input))
+}
+
+fn compose_input(
+    compacted_context: Option<&ProviderOpaqueContext>,
+    transcript_input: Vec<CodexInputItem>,
+) -> Vec<CodexInputItem> {
+    let Some(ProviderOpaqueContext::OpenResponsesCompact { output }) = compacted_context else {
+        return transcript_input;
+    };
+
+    output
+        .iter()
+        .map(compact_output_item)
+        .chain(transcript_input)
+        .collect()
+}
+
+fn compact_output_item(item: &CompactOutputItem) -> CodexInputItem {
+    match item {
+        CompactOutputItem::Message { role, content } => CodexInputItem::Message {
+            r#type: "message".to_string(),
+            role: role.clone(),
+            content: match content {
+                CompactContent::Text(text) => CodexContent::Text(text.clone()),
+                CompactContent::Parts(parts) => CodexContent::Parts(
+                    parts
+                        .iter()
+                        .map(|part| match part {
+                            CompactContentPart::InputText { text } => CodexContentPart::InputText {
+                                r#type: "input_text".to_string(),
+                                text: text.clone(),
+                            },
+                            CompactContentPart::InputImage { image_url } => {
+                                CodexContentPart::InputImage {
+                                    r#type: "input_image".to_string(),
+                                    image_url: image_url.clone(),
+                                }
+                            }
+                        })
+                        .collect(),
+                ),
+            },
+        },
+        CompactOutputItem::Compaction { encrypted_content } => CodexInputItem::Compaction {
+            r#type: "compaction".to_string(),
+            encrypted_content: encrypted_content.clone(),
+        },
+    }
 }
 
 fn convert_message(message: &LlmMessage) -> CodexInputItem {
@@ -910,7 +1018,11 @@ fn metadata_extra_i64(metadata: &ProviderMetadata, key: &str) -> Option<i64> {
 mod tests {
     use super::*;
     use everruns_core::driver_registry::{LlmMessage, LlmMessageRole};
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
     use std::sync::Mutex as StdMutex;
+    use std::sync::mpsc;
+    use std::thread;
 
     #[derive(Default)]
     struct MemoryAuthStore {
@@ -945,6 +1057,153 @@ mod tests {
             account_id: Some("acc".to_string()),
             email: Some("user@example.com".to_string()),
         }
+    }
+
+    fn test_driver(responses_url: String) -> CodexChatDriver {
+        CodexChatDriver {
+            client: reqwest::Client::new(),
+            responses_url,
+            tokens: Arc::new(tokio::sync::Mutex::new(CodexTokens {
+                access_token: "test-access-token".to_string(),
+                refresh_token: None,
+                expires_at: Some(crate::auth::codex::now_epoch_millis() + 3_600_000),
+                account_id: Some("account-test".to_string()),
+                email: None,
+            })),
+            auth_store: None,
+        }
+    }
+
+    fn serve_one_json_response(response_body: &'static str) -> (String, mpsc::Receiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock Codex server");
+        let address = listener.local_addr().expect("mock server address");
+        let (request_tx, request_rx) = mpsc::channel();
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept Codex request");
+            let mut request = Vec::new();
+            let mut buffer = [0u8; 4096];
+            let header_end = loop {
+                let count = stream.read(&mut buffer).expect("read Codex request");
+                assert!(count > 0, "request ended before headers");
+                request.extend_from_slice(&buffer[..count]);
+                if let Some(index) = request.windows(4).position(|bytes| bytes == b"\r\n\r\n") {
+                    break index + 4;
+                }
+            };
+            let headers = String::from_utf8_lossy(&request[..header_end]);
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().expect("content length"))
+                })
+                .unwrap_or(0);
+            while request.len() < header_end + content_length {
+                let count = stream.read(&mut buffer).expect("read Codex request body");
+                assert!(count > 0, "request body ended early");
+                request.extend_from_slice(&buffer[..count]);
+            }
+            request_tx
+                .send(String::from_utf8(request).expect("UTF-8 request"))
+                .expect("capture request");
+
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                response_body.len(),
+                response_body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write compact response");
+        });
+        (format!("http://{address}/responses"), request_rx)
+    }
+
+    #[test]
+    fn compacted_context_is_preserved_in_order_before_raw_suffix() {
+        let context = ProviderOpaqueContext::OpenResponsesCompact {
+            output: vec![
+                CompactOutputItem::Message {
+                    role: "user".to_string(),
+                    content: CompactContent::Text("retained".to_string()),
+                },
+                CompactOutputItem::Compaction {
+                    encrypted_content: "opaque-checkpoint".to_string(),
+                },
+            ],
+        };
+        let suffix = vec![CodexInputItem::Message {
+            r#type: "message".to_string(),
+            role: "user".to_string(),
+            content: CodexContent::Text("fresh suffix".to_string()),
+        }];
+
+        assert_eq!(
+            serde_json::to_value(compose_input(Some(&context), suffix)).unwrap(),
+            json!([
+                { "type": "message", "role": "user", "content": "retained" },
+                { "type": "compaction", "encrypted_content": "opaque-checkpoint" },
+                { "type": "message", "role": "user", "content": "fresh suffix" }
+            ])
+        );
+    }
+
+    #[test]
+    fn reports_the_codex_model_context_window_to_runtime_policy() {
+        let driver = test_driver("http://127.0.0.1:1/responses".to_string());
+
+        assert_eq!(
+            ChatDriver::effective_context_window(&driver, "gpt-5.6-sol"),
+            Some(1_050_000)
+        );
+    }
+
+    #[tokio::test]
+    async fn compact_calls_codex_endpoint_with_native_request_and_auth_headers() {
+        let (responses_url, request_rx) = serve_one_json_response(
+            r#"{"output":[{"type":"compaction","encrypted_content":"opaque-result"}],"usage":{"input_tokens":100,"output_tokens":12,"total_tokens":112}}"#,
+        );
+        let driver = test_driver(responses_url);
+
+        let response = ChatDriver::compact(
+            &driver,
+            CompactRequest {
+                model: "gpt-5.6".to_string(),
+                input: vec![everruns_core::CompactInputItem::Message {
+                    role: "user".to_string(),
+                    content: CompactContent::Text("compact me".to_string()),
+                }],
+                previous_response_id: None,
+                instructions: Some("instructions".to_string()),
+            },
+        )
+        .await
+        .expect("compact request")
+        .expect("native compact response");
+
+        assert!(matches!(
+            response.output.as_slice(),
+            [CompactOutputItem::Compaction { encrypted_content }]
+                if encrypted_content == "opaque-result"
+        ));
+        let request = request_rx.recv().expect("captured request");
+        assert!(request.starts_with("POST /responses/compact HTTP/1.1\r\n"));
+        assert!(
+            request
+                .to_ascii_lowercase()
+                .contains("authorization: bearer test-access-token")
+        );
+        assert!(
+            request
+                .to_ascii_lowercase()
+                .contains("chatgpt-account-id: account-test")
+        );
+        let body = request.split_once("\r\n\r\n").expect("request body").1;
+        let body: Value = serde_json::from_str(body).expect("compact JSON body");
+        assert_eq!(body["model"], "gpt-5.6");
+        assert_eq!(body["input"][0]["type"], "message");
+        assert!(body.get("previous_response_id").is_none());
     }
 
     #[tokio::test]

--- a/src/runtime/compaction_checkpoint.rs
+++ b/src/runtime/compaction_checkpoint.rs
@@ -1,0 +1,609 @@
+//! Owner-private, append-only persistence for provider compaction checkpoints.
+
+use async_trait::async_trait;
+use everruns_core::error::{AgentLoopError, Result};
+use everruns_core::typed_id::SessionId;
+use everruns_core::{
+    CompactionCheckpoint, CompactionCheckpointPayload, CompactionCheckpointStore,
+    ProactiveCompactionAttempt,
+};
+use serde::{Deserialize, Serialize};
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use crate::session_state::checkpoint::CheckpointManager;
+
+const CHECKPOINT_LOG: &str = "compaction-checkpoints.jsonl";
+
+type ActiveSequenceFilter = dyn Fn(i64) -> bool + Send + Sync;
+
+pub(crate) struct JsonlCompactionCheckpointStore {
+    session_id: SessionId,
+    path: PathBuf,
+    active_sequence: Arc<ActiveSequenceFilter>,
+    access: Mutex<()>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredCheckpoint {
+    id: String,
+    session_id: SessionId,
+    source_sequence: i64,
+    provider_type: String,
+    model: String,
+    format_version: u32,
+    payload: CompactionCheckpointPayload,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredAttempt {
+    session_id: SessionId,
+    provider_type: String,
+    model: String,
+    source_sequence: i64,
+    estimated_input_tokens: u64,
+    input_message_count: usize,
+    source_fingerprint: [u8; 32],
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "record_type", content = "record", rename_all = "snake_case")]
+enum StoredRecord {
+    Checkpoint(StoredCheckpoint),
+    ProactiveAttempt(StoredAttempt),
+}
+
+#[derive(Default)]
+struct StoredState {
+    checkpoints: Vec<CompactionCheckpoint>,
+    attempts: Vec<StoredAttempt>,
+}
+
+impl JsonlCompactionCheckpointStore {
+    pub(crate) fn open(
+        session_dir: &Path,
+        session_id: SessionId,
+        timeline: Arc<CheckpointManager>,
+    ) -> Result<Self> {
+        let timeline_filter = timeline.clone();
+        Self::with_active_sequence(
+            session_dir.join(CHECKPOINT_LOG),
+            session_id,
+            Arc::new(move |sequence| timeline_filter.is_event_sequence_active(sequence)),
+        )
+    }
+
+    fn with_active_sequence(
+        path: PathBuf,
+        session_id: SessionId,
+        active_sequence: Arc<ActiveSequenceFilter>,
+    ) -> Result<Self> {
+        match open_private_read(&path) {
+            Ok(file) => tighten_file_permissions(&file)?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(store_error("open existing checkpoint log", error)),
+        }
+        Ok(Self {
+            session_id,
+            path,
+            active_sequence,
+            access: Mutex::new(()),
+        })
+    }
+
+    fn load(&self) -> Result<StoredState> {
+        let file = match open_private_read(&self.path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(StoredState::default());
+            }
+            Err(error) => return Err(store_error("open checkpoint log", error)),
+        };
+        let mut state = StoredState::default();
+        for (index, line) in BufReader::new(file).lines().enumerate() {
+            let line = line.map_err(|error| store_error("read checkpoint log", error))?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            let stored: StoredRecord = match serde_json::from_str(&line) {
+                Ok(stored) => stored,
+                Err(error) => {
+                    tracing::warn!(
+                        line = index + 1,
+                        error = %error,
+                        "skipping malformed private compaction record"
+                    );
+                    continue;
+                }
+            };
+            match stored {
+                StoredRecord::Checkpoint(checkpoint) => {
+                    if checkpoint.session_id != self.session_id {
+                        tracing::warn!(
+                            line = index + 1,
+                            "skipping compaction checkpoint for another session"
+                        );
+                        continue;
+                    }
+                    state.checkpoints.push(checkpoint.try_into()?);
+                }
+                StoredRecord::ProactiveAttempt(attempt) => {
+                    if attempt.session_id != self.session_id {
+                        tracing::warn!(
+                            line = index + 1,
+                            "skipping compaction attempt for another session"
+                        );
+                        continue;
+                    }
+                    state.attempts.push(attempt);
+                }
+            }
+        }
+        Ok(state)
+    }
+
+    fn append(&self, record: &StoredRecord) -> Result<()> {
+        let mut options = OpenOptions::new();
+        options.create(true).append(true).read(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options
+                .mode(0o600)
+                .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+        }
+        let mut file = options
+            .open(&self.path)
+            .map_err(|error| store_error("open checkpoint log for append", error))?;
+        validate_private_file(&file)?;
+        tighten_file_permissions(&file)?;
+        let length = file
+            .metadata()
+            .map_err(|error| store_error("inspect checkpoint log", error))?
+            .len();
+        if length > 0 {
+            file.seek(SeekFrom::End(-1))
+                .map_err(|error| store_error("seek checkpoint log", error))?;
+            let mut last = [0_u8; 1];
+            file.read_exact(&mut last)
+                .map_err(|error| store_error("read checkpoint log tail", error))?;
+            if last[0] != b'\n' {
+                // A process crash can leave a partial final JSON object. Keep it
+                // isolated so the next valid append remains independently readable.
+                file.write_all(b"\n")
+                    .map_err(|error| store_error("repair checkpoint log tail", error))?;
+            }
+        }
+        serde_json::to_writer(&mut file, record)
+            .map_err(|error| store_error("serialize compaction record", error))?;
+        file.write_all(b"\n")
+            .and_then(|_| file.flush())
+            .and_then(|_| file.sync_data())
+            .map_err(|error| store_error("persist checkpoint", error))
+    }
+}
+
+#[async_trait]
+impl CompactionCheckpointStore for JsonlCompactionCheckpointStore {
+    async fn get_latest(
+        &self,
+        session_id: SessionId,
+        provider_type: &str,
+        model: &str,
+    ) -> Result<Option<CompactionCheckpoint>> {
+        if session_id != self.session_id {
+            return Ok(None);
+        }
+        let _guard = self.access.lock().await;
+        Ok(self
+            .load()?
+            .checkpoints
+            .into_iter()
+            .filter(|checkpoint| {
+                checkpoint.provider_type == provider_type
+                    && checkpoint.model == model
+                    && (self.active_sequence)(checkpoint.source_sequence)
+            })
+            .max_by_key(|checkpoint| checkpoint.source_sequence))
+    }
+
+    async fn install(&self, checkpoint: CompactionCheckpoint) -> Result<bool> {
+        if checkpoint.session_id != self.session_id
+            || !(self.active_sequence)(checkpoint.source_sequence)
+        {
+            return Ok(false);
+        }
+        let _guard = self.access.lock().await;
+        let newer_exists = self.load()?.checkpoints.into_iter().any(|current| {
+            current.provider_type == checkpoint.provider_type
+                && current.model == checkpoint.model
+                && current.format_version == checkpoint.format_version
+                && (self.active_sequence)(current.source_sequence)
+                && current.source_sequence >= checkpoint.source_sequence
+        });
+        if newer_exists {
+            return Ok(false);
+        }
+        self.append(&StoredRecord::Checkpoint(StoredCheckpoint::from(
+            &checkpoint,
+        )))?;
+        Ok(true)
+    }
+
+    async fn get_proactive_attempt(
+        &self,
+        session_id: SessionId,
+        provider_type: &str,
+        model: &str,
+    ) -> Result<Option<ProactiveCompactionAttempt>> {
+        if session_id != self.session_id {
+            return Ok(None);
+        }
+        let _guard = self.access.lock().await;
+        Ok(self
+            .load()?
+            .attempts
+            .into_iter()
+            .filter(|stored| {
+                stored.provider_type == provider_type
+                    && stored.model == model
+                    && (self.active_sequence)(stored.source_sequence)
+            })
+            .max_by_key(|stored| stored.source_sequence)
+            .map(StoredAttempt::into_attempt))
+    }
+
+    async fn record_proactive_attempt(
+        &self,
+        session_id: SessionId,
+        provider_type: &str,
+        model: &str,
+        attempt: ProactiveCompactionAttempt,
+    ) -> Result<()> {
+        if session_id != self.session_id || !(self.active_sequence)(attempt.source_sequence) {
+            return Ok(());
+        }
+        let _guard = self.access.lock().await;
+        let duplicate_or_newer = self.load()?.attempts.into_iter().any(|stored| {
+            stored.provider_type == provider_type
+                && stored.model == model
+                && (self.active_sequence)(stored.source_sequence)
+                && stored.source_sequence >= attempt.source_sequence
+        });
+        if !duplicate_or_newer {
+            self.append(&StoredRecord::ProactiveAttempt(StoredAttempt {
+                session_id,
+                provider_type: provider_type.to_string(),
+                model: model.to_string(),
+                source_sequence: attempt.source_sequence,
+                estimated_input_tokens: attempt.estimated_input_tokens,
+                input_message_count: attempt.input_message_count,
+                source_fingerprint: attempt.source_fingerprint,
+            }))?;
+        }
+        Ok(())
+    }
+}
+
+impl StoredAttempt {
+    fn into_attempt(self) -> ProactiveCompactionAttempt {
+        ProactiveCompactionAttempt {
+            source_sequence: self.source_sequence,
+            estimated_input_tokens: self.estimated_input_tokens,
+            input_message_count: self.input_message_count,
+            source_fingerprint: self.source_fingerprint,
+        }
+    }
+}
+
+impl From<&CompactionCheckpoint> for StoredCheckpoint {
+    fn from(checkpoint: &CompactionCheckpoint) -> Self {
+        Self {
+            id: checkpoint.id.to_string(),
+            session_id: checkpoint.session_id,
+            source_sequence: checkpoint.source_sequence,
+            provider_type: checkpoint.provider_type.clone(),
+            model: checkpoint.model.clone(),
+            format_version: checkpoint.format_version,
+            payload: checkpoint.payload.clone(),
+        }
+    }
+}
+
+impl TryFrom<StoredCheckpoint> for CompactionCheckpoint {
+    type Error = AgentLoopError;
+
+    fn try_from(stored: StoredCheckpoint) -> Result<Self> {
+        Ok(Self {
+            id: stored
+                .id
+                .parse()
+                .map_err(|error| store_error("parse checkpoint id", error))?,
+            session_id: stored.session_id,
+            source_sequence: stored.source_sequence,
+            provider_type: stored.provider_type,
+            model: stored.model,
+            format_version: stored.format_version,
+            payload: stored.payload,
+        })
+    }
+}
+
+fn open_private_read(path: &Path) -> std::io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    }
+    let file = options.open(path)?;
+    validate_private_file_io(&file)?;
+    Ok(file)
+}
+
+fn validate_private_file(file: &File) -> Result<()> {
+    validate_private_file_io(file).map_err(|error| store_error("validate checkpoint log", error))
+}
+
+fn validate_private_file_io(file: &File) -> std::io::Result<()> {
+    let metadata = file.metadata()?;
+    if !metadata.is_file() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "checkpoint log is not a regular file",
+        ));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if metadata.nlink() != 1 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "checkpoint log has multiple hard links",
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn tighten_file_permissions(file: &File) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    file.set_permissions(std::fs::Permissions::from_mode(0o600))
+        .map_err(|error| store_error("set checkpoint permissions", error))
+}
+
+#[cfg(not(unix))]
+fn tighten_file_permissions(_file: &File) -> Result<()> {
+    Ok(())
+}
+
+fn store_error(action: &str, error: impl std::fmt::Display) -> AgentLoopError {
+    AgentLoopError::store(format!("{action}: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::{
+        COMPACTION_CHECKPOINT_FORMAT_VERSION, CompactOutputItem, ProviderOpaqueContext,
+    };
+    use std::collections::BTreeSet;
+    use std::sync::RwLock;
+
+    fn checkpoint(session_id: SessionId, sequence: i64) -> CompactionCheckpoint {
+        CompactionCheckpoint {
+            id: format!("00000000-0000-7000-8000-{sequence:012}")
+                .parse()
+                .expect("checkpoint UUID"),
+            session_id,
+            source_sequence: sequence,
+            provider_type: "openai-codex".to_string(),
+            model: "gpt-5.6".to_string(),
+            format_version: COMPACTION_CHECKPOINT_FORMAT_VERSION,
+            payload: CompactionCheckpointPayload::ProviderOpaque {
+                context: ProviderOpaqueContext::OpenResponsesCompact {
+                    output: vec![CompactOutputItem::Compaction {
+                        encrypted_content: format!("opaque-{sequence}"),
+                    }],
+                },
+            },
+        }
+    }
+
+    fn attempt(sequence: i64) -> ProactiveCompactionAttempt {
+        ProactiveCompactionAttempt {
+            source_sequence: sequence,
+            estimated_input_tokens: sequence as u64 * 1_000,
+            input_message_count: sequence as usize,
+            source_fingerprint: [sequence as u8; 32],
+        }
+    }
+
+    #[tokio::test]
+    async fn persists_latest_active_checkpoint_across_store_instances() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join(CHECKPOINT_LOG);
+        let session_id = SessionId::new();
+        let active = Arc::new(RwLock::new(BTreeSet::<i64>::from([10, 20])));
+        let filter = {
+            let active = active.clone();
+            Arc::new(move |sequence| active.read().unwrap().contains(&sequence))
+                as Arc<ActiveSequenceFilter>
+        };
+        let first = JsonlCompactionCheckpointStore::with_active_sequence(
+            path.clone(),
+            session_id,
+            filter.clone(),
+        )
+        .unwrap();
+        assert!(first.install(checkpoint(session_id, 10)).await.unwrap());
+        assert!(first.install(checkpoint(session_id, 20)).await.unwrap());
+        assert!(!first.install(checkpoint(session_id, 20)).await.unwrap());
+
+        let resumed =
+            JsonlCompactionCheckpointStore::with_active_sequence(path, session_id, filter.clone())
+                .unwrap();
+        assert_eq!(
+            resumed
+                .get_latest(session_id, "openai-codex", "gpt-5.6")
+                .await
+                .unwrap()
+                .unwrap()
+                .source_sequence,
+            20
+        );
+
+        active.write().unwrap().remove(&20);
+        assert_eq!(
+            resumed
+                .get_latest(session_id, "openai-codex", "gpt-5.6")
+                .await
+                .unwrap()
+                .unwrap()
+                .source_sequence,
+            10,
+            "an abandoned checkpoint must not shadow the surviving branch"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn checkpoint_log_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join(CHECKPOINT_LOG);
+        let session_id = SessionId::new();
+        let store = JsonlCompactionCheckpointStore::with_active_sequence(
+            path.clone(),
+            session_id,
+            Arc::new(|_| true),
+        )
+        .unwrap();
+        assert!(store.install(checkpoint(session_id, 1)).await.unwrap());
+        assert_eq!(
+            std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
+    #[tokio::test]
+    async fn persists_attempt_watermark_and_tracks_the_active_branch() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join(CHECKPOINT_LOG);
+        let session_id = SessionId::new();
+        let active = Arc::new(RwLock::new(BTreeSet::<i64>::from([10, 20])));
+        let filter = {
+            let active = active.clone();
+            Arc::new(move |sequence| active.read().unwrap().contains(&sequence))
+                as Arc<ActiveSequenceFilter>
+        };
+        let first = JsonlCompactionCheckpointStore::with_active_sequence(
+            path.clone(),
+            session_id,
+            filter.clone(),
+        )
+        .unwrap();
+        first
+            .record_proactive_attempt(session_id, "openai-codex", "gpt-5.6", attempt(10))
+            .await
+            .unwrap();
+        first
+            .record_proactive_attempt(session_id, "openai-codex", "gpt-5.6", attempt(20))
+            .await
+            .unwrap();
+
+        let resumed =
+            JsonlCompactionCheckpointStore::with_active_sequence(path, session_id, filter).unwrap();
+        assert_eq!(
+            resumed
+                .get_proactive_attempt(session_id, "openai-codex", "gpt-5.6")
+                .await
+                .unwrap()
+                .unwrap(),
+            attempt(20)
+        );
+
+        active.write().unwrap().remove(&20);
+        assert_eq!(
+            resumed
+                .get_proactive_attempt(session_id, "openai-codex", "gpt-5.6")
+                .await
+                .unwrap()
+                .unwrap(),
+            attempt(10)
+        );
+    }
+
+    #[tokio::test]
+    async fn partial_crash_tail_does_not_hide_later_checkpoints() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join(CHECKPOINT_LOG);
+        std::fs::write(&path, b"{\"partial\":").unwrap();
+        let session_id = SessionId::new();
+        let store = JsonlCompactionCheckpointStore::with_active_sequence(
+            path,
+            session_id,
+            Arc::new(|_| true),
+        )
+        .unwrap();
+
+        assert!(store.install(checkpoint(session_id, 1)).await.unwrap());
+        assert_eq!(
+            store
+                .get_latest(session_id, "openai-codex", "gpt-5.6")
+                .await
+                .unwrap()
+                .unwrap()
+                .source_sequence,
+            1
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refuses_checkpoint_log_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("target");
+        std::fs::write(&target, "do not touch").unwrap();
+        let path = temp.path().join(CHECKPOINT_LOG);
+        symlink(&target, &path).unwrap();
+
+        let error = JsonlCompactionCheckpointStore::with_active_sequence(
+            path,
+            SessionId::new(),
+            Arc::new(|_| true),
+        )
+        .err()
+        .expect("symlink must be rejected");
+        assert!(error.to_string().contains("checkpoint log"));
+        assert_eq!(std::fs::read_to_string(target).unwrap(), "do not touch");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refuses_checkpoint_log_hard_links() {
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("target");
+        std::fs::write(&target, "do not touch").unwrap();
+        let path = temp.path().join(CHECKPOINT_LOG);
+        std::fs::hard_link(&target, &path).unwrap();
+
+        assert!(
+            JsonlCompactionCheckpointStore::with_active_sequence(
+                path,
+                SessionId::new(),
+                Arc::new(|_| true),
+            )
+            .is_err()
+        );
+        assert_eq!(std::fs::read_to_string(target).unwrap(), "do not touch");
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -5,6 +5,7 @@
 // configured containment provider instead of running against the VFS.
 
 pub mod background_wake;
+mod compaction_checkpoint;
 pub mod session;
 pub mod session_log;
 
@@ -42,13 +43,13 @@ use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 use everruns_core::capabilities::{
     AGENT_INSTRUCTIONS_CAPABILITY_ID, AgentInstructionsCapability, BTW_CAPABILITY_ID,
-    BtwCapability, CompactionCapability, INFINITY_CONTEXT_CAPABILITY_ID, InfinityContextCapability,
-    LOOP_DETECTION_CAPABILITY_ID, LoopDetectionCapability, MessageMetadataCapability,
-    PROMPT_CACHING_CAPABILITY_ID, PromptCachingCapability, SESSION_CAPABILITY_ID,
-    SESSION_FILE_SYSTEM_CAPABILITY_ID, SESSION_STORAGE_CAPABILITY_ID, SESSION_TASKS_CAPABILITY_ID,
-    SKILLS_CAPABILITY_ID, STATELESS_TODO_LIST_CAPABILITY_ID, ScopedSkillsCapability,
-    SessionCapability, SessionStorageCapability, StatelessTodoListCapability,
-    TOOL_OUTPUT_PERSISTENCE_CAPABILITY_ID, TOOL_SEARCH_CAPABILITY_ID,
+    BtwCapability, COMPACTION_CAPABILITY_ID, CompactionCapability, INFINITY_CONTEXT_CAPABILITY_ID,
+    InfinityContextCapability, LOOP_DETECTION_CAPABILITY_ID, LoopDetectionCapability,
+    MessageMetadataCapability, PROMPT_CACHING_CAPABILITY_ID, PromptCachingCapability,
+    SESSION_CAPABILITY_ID, SESSION_FILE_SYSTEM_CAPABILITY_ID, SESSION_STORAGE_CAPABILITY_ID,
+    SESSION_TASKS_CAPABILITY_ID, SKILLS_CAPABILITY_ID, STATELESS_TODO_LIST_CAPABILITY_ID,
+    ScopedSkillsCapability, SessionCapability, SessionStorageCapability,
+    StatelessTodoListCapability, TOOL_OUTPUT_PERSISTENCE_CAPABILITY_ID, TOOL_SEARCH_CAPABILITY_ID,
     ToolOutputPersistenceCapability, ToolSearchCapability, USER_HOOKS_CAPABILITY_ID,
     UserHooksCapability, WEB_FETCH_CAPABILITY_ID, WebFetchCapability,
 };
@@ -1957,6 +1958,7 @@ fn reasoning_effort_value(value: &everruns_core::ReasoningEffort) -> Option<Stri
 // instead of scattering string literals.
 pub(crate) const DUCKDUCKGO_CAPABILITY_ID: &str = "duckduckgo";
 pub(crate) const DAYTONA_CAPABILITY_ID: &str = "daytona";
+pub(crate) const COMPACTION_BUDGET_PERCENT: u8 = 85;
 
 fn default_coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabilityConfig> {
     let mut caps = Vec::new();
@@ -1979,12 +1981,18 @@ fn default_coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabi
         AgentCapabilityConfig::new(SESSION_HISTORY_CAPABILITY_ID),
         AgentCapabilityConfig::new(CHECKPOINT_CAPABILITY_ID),
         AgentCapabilityConfig::new(AST_GREP_CAPABILITY_ID),
-        // The runtime's compaction cascade currently rewrites only one outbound
-        // model view. The next turn reconstructs the full stored transcript and
-        // compacts the same messages again, sometimes without reducing them at
-        // all. Keep a bounded recent window with searchable cold history until
-        // compaction can persist a canonical replacement-history checkpoint.
+        // Raw history stays searchable while the runtime persists a canonical
+        // provider-native replacement plus the uncompacted suffix. Auto keeps
+        // provider-neutral fallbacks for drivers without native compaction.
         AgentCapabilityConfig::new(INFINITY_CONTEXT_CAPABILITY_ID),
+        AgentCapabilityConfig::with_config(
+            COMPACTION_CAPABILITY_ID,
+            serde_json::json!({
+                "strategy": "auto",
+                "proactive": true,
+                "budget_percent": 0.85,
+            }),
+        ),
         AgentCapabilityConfig::new(CONTEXT_COST_CONTROL_CAPABILITY_ID),
         AgentCapabilityConfig::new(STATELESS_TODO_LIST_CAPABILITY_ID),
         AgentCapabilityConfig::new(LOOP_DETECTION_CAPABILITY_ID),
@@ -2625,6 +2633,12 @@ pub async fn build_with_options(
         message_store.clone(),
         replayed.max_sequence.unwrap_or(0),
     )?);
+    let compaction_checkpoints =
+        Arc::new(compaction_checkpoint::JsonlCompactionCheckpointStore::open(
+            &session_dir,
+            session_id,
+            checkpoints.clone(),
+        )?);
     let active_events = checkpoints.filter_active_events(replayed.events);
     let replayed_events_count = active_events.len();
     let active_messages = crate::runtime::session_log::messages_from_events(&active_events);
@@ -2646,6 +2660,7 @@ pub async fn build_with_options(
     let base_backends = RuntimeBackends::in_memory()
         .with_event_bus(event_bus)
         .with_message_store(message_store)
+        .with_compaction_checkpoint_store(compaction_checkpoints)
         .with_connection_resolver(connection_resolver);
     let local_profile = LocalProfile::new(sessions_dir.join("everruns-local"))
         .with_workspace_root(effective_root.clone());
@@ -2693,7 +2708,7 @@ pub async fn build_with_options(
     //   * ast_grep            - read-only structural code search
     //   * ast_edit            - previewed ast-grep rewrites (opt-in)
     //   * infinity_context     — bounds the live context and adds query_history
-    //   * compaction           — registered for opt-in use, not enabled by default
+    //   * compaction           — durable native replacement with safe fallbacks
     //   * stateless_todo_list  — write_todos tool for multi-step tasks
     //   * loop_detection       — safety net against repeated identical tool calls
     //   * prompt_caching       — Anthropic prompt caching; free token savings
@@ -6318,7 +6333,7 @@ mod tests {
     }
 
     #[test]
-    fn coding_harness_uses_searchable_bounded_history_without_ephemeral_compaction() {
+    fn coding_harness_enables_durable_compaction_with_searchable_history() {
         let ids = coding_harness_capabilities(false, None, &Settings::default());
 
         assert!(
@@ -6329,7 +6344,13 @@ mod tests {
             ids.iter()
                 .any(|cap| cap.capability_id() == CONTEXT_COST_CONTROL_CAPABILITY_ID)
         );
-        assert!(!ids.iter().any(|cap| cap.capability_id() == "compaction"));
+        let compaction = ids
+            .iter()
+            .find(|cap| cap.capability_id() == COMPACTION_CAPABILITY_ID)
+            .expect("durable compaction must be enabled");
+        assert_eq!(compaction.config["strategy"], "auto");
+        assert_eq!(compaction.config["proactive"], true);
+        assert_eq!(compaction.config["budget_percent"], serde_json::json!(0.85));
     }
 
     #[test]

--- a/src/session_state/checkpoint.rs
+++ b/src/session_state/checkpoint.rs
@@ -282,6 +282,18 @@ impl CheckpointManager {
         filter_active_events(&state, events)
     }
 
+    /// Whether an event boundary belongs to the currently selected timeline.
+    ///
+    /// Durable model-context checkpoints use this to ignore replacements made
+    /// on an abandoned conversation branch without deleting append-only data.
+    pub fn is_event_sequence_active(&self, sequence: i64) -> bool {
+        let Ok(sequence) = i32::try_from(sequence) else {
+            return false;
+        };
+        let state = self.state.lock().expect("checkpoint state lock");
+        event_sequence_is_active(&state, sequence)
+    }
+
     pub fn begin_turn(&self, prompt: &str) -> Result<String> {
         self.close_interrupted_turn()?;
         if let Some(prepared) = self.prepared.lock().expect("prepared restore lock").take() {
@@ -872,24 +884,26 @@ impl CheckpointManager {
 }
 
 fn filter_active_events(state: &TimelineState, events: Vec<Event>) -> Vec<Event> {
-    let mut ranges = vec![(i32::MIN, state.baseline_end)];
-    for id in active_path(state) {
-        if let Some(node) = state.nodes.get(&id)
-            && let Some(end) = node.event_end
-        {
-            ranges.push((node.event_start, end));
-        }
-    }
     events
         .into_iter()
         .filter(|event| {
-            event.sequence.is_none_or(|sequence| {
-                ranges
-                    .iter()
-                    .any(|(start, end)| sequence >= *start && sequence <= *end)
-            })
+            event
+                .sequence
+                .is_none_or(|sequence| event_sequence_is_active(state, sequence))
         })
         .collect()
+}
+
+fn event_sequence_is_active(state: &TimelineState, sequence: i32) -> bool {
+    if sequence <= state.baseline_end {
+        return true;
+    }
+    active_path(state).into_iter().any(|id| {
+        state.nodes.get(&id).is_some_and(|node| {
+            node.event_end
+                .is_some_and(|end| sequence >= node.event_start && sequence <= end)
+        })
+    })
 }
 
 fn active_path(state: &TimelineState) -> Vec<String> {
@@ -1272,6 +1286,15 @@ mod tests {
         std::fs::write(root.path().join("tracked.txt"), "second\n").expect("second edit");
         emit_user(&manager, "second prompt").await;
         manager.finish_turn(&second, true).expect("finish second");
+        let second_sequence = manager
+            .events
+            .collected_events()
+            .await
+            .into_iter()
+            .filter_map(|event| event.sequence)
+            .max()
+            .expect("second turn event sequence");
+        assert!(manager.is_event_sequence_active(i64::from(second_sequence)));
 
         let preview = manager
             .prepare_rewind(&second, RestoreMode::Both)
@@ -1293,6 +1316,7 @@ mod tests {
             .filter_map(|message| message.text().map(str::to_string))
             .collect::<Vec<_>>();
         assert_eq!(texts, vec!["first prompt"]);
+        assert!(!manager.is_event_sequence_active(i64::from(second_sequence)));
 
         let redo = manager
             .prepare_redo(RestoreMode::Both)
@@ -1308,6 +1332,7 @@ mod tests {
             .filter_map(|message| message.text().map(str::to_string))
             .collect::<Vec<_>>();
         assert_eq!(texts, vec!["first prompt", "second prompt"]);
+        assert!(manager.is_event_sequence_active(i64::from(second_sequence)));
         assert!(manager.prepare_redo(RestoreMode::Both).is_err());
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -725,7 +725,7 @@ impl App {
             turn_elapsed_secs: self.turn_started_at.map(|start| start.elapsed().as_secs()),
             context_used_tokens: self.context_used_tokens,
             context_window_tokens: self.context_window_tokens(),
-            compaction_budget_percent: None,
+            compaction_budget_percent: Some(crate::runtime::COMPACTION_BUDGET_PERCENT),
             status_layout: self.status_layout,
             hooks_summary: self.startup.hook_summary(),
             approval_mode,

--- a/src/tui/transcript.rs
+++ b/src/tui/transcript.rs
@@ -907,6 +907,10 @@ mod tests {
             strategy_used: "observation_masking+aggressive_trim".into(),
             messages_before: 142,
             messages_after: 38,
+            tokens_before: Some(100_000),
+            tokens_after: Some(25_000),
+            bytes_before: None,
+            bytes_after: None,
             duration_ms: 120,
             steps: vec![CompactionStepData {
                 strategy: "observation_masking".into(),
@@ -934,10 +938,14 @@ mod tests {
         use everruns_core::events::ContextCompactedData;
 
         let event = event(ContextCompactedData {
-            checkpoint_id: None,
+            checkpoint_id: Some("checkpoint-test".into()),
             strategy_used: "native".into(),
             messages_before: 50,
             messages_after: 12,
+            tokens_before: Some(40_000),
+            tokens_after: Some(8_000),
+            bytes_before: None,
+            bytes_after: None,
             duration_ms: 2_400,
             steps: Vec::new(),
         });
@@ -957,6 +965,8 @@ mod tests {
             reason: CompactionReason::ProactiveBudget,
             strategy: "auto".into(),
             messages_before: 142,
+            tokens_before: Some(100_000),
+            bytes_before: None,
         });
 
         let status = status_for_event(&event).expect("compacting should set activity");


### PR DESCRIPTION
## What changed\nYolop now enables durable proactive compaction at 85% of the model-reported context window. Codex uses the native Responses compact endpoint, carries the ordered opaque checkpoint before the raw suffix on later calls, and reports its 1,050,000-token model window to Everruns policy.\n\nCompaction checkpoints and failed/no-op attempt watermarks persist in an owner-private append-only session journal. Resume, rewind, redo, rollback, and abandoned branches select only compatible checkpoints on the active timeline. Lossless events remain unchanged and searchable.\n\nAll Everruns dependencies track git main; Cargo.lock currently resolves main at adcb933c.\n\n## Why\nThe previous model-view reduction was ephemeral: every turn reconstructed the full transcript, so compaction could repeat with 325 to 325 messages and accomplish little or nothing. The runtime also fell back to a 128K context estimate for the external Codex driver.\n\nEverruns now supplies the durable checkpoint, native compaction, effectiveness, and hysteresis contracts. This change integrates those contracts into Yolop.\n\n## Before / After\nBefore:\n- compaction could be reported despite negligible reduction\n- the next turn reconstructed and compacted the same history again\n- Codex policy could use the 128K fallback instead of its actual model profile\n- restart and timeline changes had no durable model-context replacement\n\nAfter:\n- native checkpoints persist as checkpoint plus uncompacted suffix across turns and restart\n- compaction succeeds only after at least 5% reduction with a 32-unit small-input floor\n- no-op retries wait for meaningful growth: max of 4,096 estimated tokens or 5%\n- Codex policy uses the 1,050,000-token context window and triggers at 85%\n- raw session history is never rewritten or deleted\n\nEvidence:\n- cargo fmt --check\n- cargo clippy --all-targets --all-features -- -D warnings\n- cargo test --all-features: 917 unit passed, 2 ignored; 48 integration passed, 1 ignored; parallel passed; 4 PTY passed\n- llmsim print smoke completed\n- authenticated Codex print smoke returned compaction-codex-ok\n\n## Risk\n- Medium\n- This changes default context policy and adds a session-side persistence file.\n- Provider-native opaque payloads are sensitive session data. The journal is 0600 on Unix, rejects symlinks, hard links, and non-regular files, flushes and syncs append records, and never emits opaque payloads into public events or logs.\n- Store failure is fail-open for advisory retry watermarks; failed checkpoint installs do not replace the previous checkpoint.\n\n## Security\n- Reviewed provider payload handling, OAuth headers, filesystem race/link attacks, permissions, crash tails, and branch selection.\n- Codex credentials remain in the existing auth store and are never written to the checkpoint journal.\n- Native compact output is persisted only in the owner-private session file and is not logged.\n- Tests cover 0600 mode, symlink/hard-link rejection, partial-tail recovery, monotonic installs, and active-timeline filtering.\n\n## Checklist\n- [x] Tests added or updated\n- [x] Backward compatibility considered\n\n## Follow-ups\nNo follow-ups.