### PR TITLE
fix(background): store artifacts in session directory

### DIFF
--- a/specs/background.md
+++ b/specs/background.md
@@ -34,9 +34,11 @@ spawn_background { tool: "bash", args: { command: "gh pr checks 42 --watch" } }
 ```
 
 The run executes on a detached task, streams to a session-file log
-(`/.background/<run_id>/output.log`), writes a `result.json`, and mirrors its
-lifecycle onto a `background_tool` session task (`Running` → `Succeeded` /
-`Failed` / `Canceled`). `signal_on_completion` defaults to `true`.
+(`/.background/<run_id>/output.log` in the VFS, backed by
+`<session_dir>/.background/<run_id>/output.log`), writes a `result.json`, and
+mirrors its lifecycle onto a `background_tool` session task (`Running` →
+`Succeeded` / `Failed` / `Canceled`). It never creates `.background` in the
+workspace. `signal_on_completion` defaults to `true`.
 Foreground shell calls retain the short interactive deadline; detached shell
 runs use a separate 24-hour wall-clock limit so CI watches can outlive a turn
 without becoming unbounded host processes.

--- a/src/editor/acp/mod.rs
+++ b/src/editor/acp/mod.rs
@@ -1355,7 +1355,7 @@ mod tests {
         ]);
 
         let sessions = tempfile::tempdir().expect("sessions tempdir").keep();
-        let (mut client_w, mut reader, _server) = start_raw_server(config, sessions);
+        let (mut client_w, mut reader, _server) = start_raw_server(config, sessions.clone());
 
         send_json(
             &mut client_w,
@@ -1416,6 +1416,14 @@ mod tests {
         assert!(
             woke.unwrap_or(false),
             "expected a proactive wake turn after spawn_background finished (via the wake seam)"
+        );
+        assert!(
+            sessions.join(&session_id).join(".background").is_dir(),
+            "background artifacts should live in the session directory"
+        );
+        assert!(
+            !cwd.join(".background").exists(),
+            "background execution must not create .background in the workspace"
         );
     }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -556,14 +556,18 @@ impl CodingCliSessionFileStore {
         {
             return Some((store, rest));
         }
-        Self::session_output_path(path).map(|path| (&self.session, path))
+        Self::session_artifact_path(path).map(|path| (&self.session, path))
     }
 
     // Keep project files rooted at the user's workspace, but route generated
     // tool artifacts into yolop's durable per-session folder.
-    fn session_output_path(path: &str) -> Option<String> {
+    fn session_artifact_path(path: &str) -> Option<String> {
         let normalized = everruns_core::session_path::to_session_path(path);
-        if normalized == "/outputs" || normalized.starts_with("/outputs/") {
+        if normalized == "/outputs"
+            || normalized.starts_with("/outputs/")
+            || normalized == "/.background"
+            || normalized.starts_with("/.background/")
+        {
             Some(normalized)
         } else {
             None
@@ -576,11 +580,14 @@ impl CodingCliSessionFileStore {
 
         let absolute = self.session_dir.join(path.trim_start_matches('/'));
 
-        // For arbitrarily nested paths under `/outputs`, harden every
-        // ancestor from the artifact's immediate parent up to and including
-        // `<session_dir>/outputs`. Stopping at the outputs root keeps the
-        // session root and unrelated sibling directories untouched.
-        let outputs_root = self.session_dir.join("outputs");
+        // Harden every artifact ancestor without crossing above the routed
+        // top-level directory into the session root or its parents.
+        let artifact_root = self.session_dir.join(
+            path.trim_start_matches('/')
+                .split('/')
+                .next()
+                .expect("routed artifact path has a top-level directory"),
+        );
         let mut current = absolute.parent();
         while let Some(dir) = current {
             std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700)).map_err(|e| {
@@ -589,7 +596,7 @@ impl CodingCliSessionFileStore {
                     dir.display()
                 ))
             })?;
-            if dir == outputs_root {
+            if dir == artifact_root {
                 break;
             }
             current = dir.parent();
@@ -656,7 +663,7 @@ impl SessionFileSystem for CodingCliSessionFileStore {
             let file = store
                 .write_file(session_id, &path, content, encoding)
                 .await?;
-            if Self::session_output_path(&path).is_some() {
+            if Self::session_artifact_path(&path).is_some() {
                 self.secure_session_artifact_path(&path)?;
             }
             return Ok(file);
@@ -750,7 +757,7 @@ impl SessionFileSystem for CodingCliSessionFileStore {
         {
             return store.grep_files(session_id, pattern, Some(&path)).await;
         }
-        match path_pattern.and_then(Self::session_output_path) {
+        match path_pattern.and_then(Self::session_artifact_path) {
             Some(path) => {
                 self.session
                     .grep_files(session_id, pattern, Some(path.trim_start_matches('/')))
@@ -5520,6 +5527,31 @@ mod tests {
             .expect("grep workspace via host display path");
         assert_eq!(host_path_grep.len(), 1);
         assert_eq!(host_path_grep[0].path, "/src/lib.rs");
+    }
+
+    #[tokio::test]
+    async fn yolop_file_store_routes_background_artifacts_to_session_dir() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let session = tempfile::tempdir().expect("session");
+        let store = test_file_store(workspace.path(), session.path());
+        let session_id = SessionId::from_seed(3);
+
+        store
+            .write_file(
+                session_id,
+                "/.background/run_1/output.log",
+                "background output",
+                "text",
+            )
+            .await
+            .expect("write background artifact");
+
+        assert_eq!(
+            std::fs::read_to_string(session.path().join(".background/run_1/output.log"))
+                .expect("session background artifact"),
+            "background output"
+        );
+        assert!(!workspace.path().join(".background").exists());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed
Background task logs and result files now live under the owning Yolop session directory instead of creating a `.background` directory in the active repository. The VFS paths remain `/.background/<run_id>/...`, while the disk backing is `<session_dir>/.background/<run_id>/...`.

The session artifact router and permission hardening now cover both background artifacts and persisted tool outputs. The background execution spec documents the disk location.

## Why
Background execution is session state, not repository content. Writing it into the active workspace dirties repositories and can expose internal run artifacts to unrelated project tooling.

## Before / After
Before: an end-to-end `spawn_background` run created `<workspace>/.background/<run_id>/output.log` and `result.json`.

After: a live Anthropic smoke produced:

- `<session_dir>/.background/<run_id>/output.log`
- `<session_dir>/.background/<run_id>/result.json`
- no `<workspace>/.background`

The ACP regression test drives `spawn_background` through a real session and asserts both the session artifact directory and the clean workspace.

## Risk
- Low
- The change is limited to routing the reserved `/.background` VFS subtree into the existing owner-private session store.
- Existing `.background` directories from older Yolop runs are not migrated or removed.

## Security
- TM-FS reviewed: background artifacts remain behind `RealDiskFileStore` path and symlink containment, and generated artifact permissions remain owner-only. The workspace write blocklist is unchanged.
- TM-BASH reviewed: shell execution, timeouts, cancellation, and output caps are unchanged.
- TM-LLM / TM-TOOL reviewed: no prompt construction, credential handling, capability registration, or tool schema changes.
- TM-DEP reviewed: no dependency changes.
- No command injection, path traversal, data exposure, or resource-exhaustion issues found in the changed surface.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features -- --test-threads=1` (918 unit tests, 48 integration tests, 1 parallel integration test, and 4 PTY tests passed; 3 credential/tooling-dependent tests ignored)
- Live provider smoke through Doppler with Anthropic: `spawn_background` ran `printf background-smoke`, returned the expected output, stored both artifacts under the session directory, and left the workspace clean.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
