### PR TITLE
docs: remove docs.rs badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![CI](https://github.com/everruns/yolop/actions/workflows/ci.yml/badge.svg)](https://github.com/everruns/yolop/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Crates.io](https://img.shields.io/crates/v/yolop.svg)](https://crates.io/crates/yolop)
-[![docs.rs](https://img.shields.io/docsrs/yolop)](https://docs.rs/yolop)
 [![Homebrew](https://img.shields.io/badge/Homebrew-everruns%2Ftap-blue)](https://github.com/everruns/homebrew-tap)
 [![Repo: Agent Friendly](https://img.shields.io/badge/Repo-Agent%20Friendly-blue)](AGENTS.md)
 


### PR DESCRIPTION
## What changed
Removes the docs.rs badge from the README header. The remaining badges (CI,
License, Crates.io, Homebrew, Agent Friendly) are unchanged.

## Why
yolop is a binary, not a library. docs.rs only builds API documentation for
library crates, so the docs.rs build has nothing to produce and the badge
renders as "docs failing" — misleading noise in the README.

## Before / After
Docs-only change, no behavior change.

- **Before:** README header showed a `docs | failing` badge linking to docs.rs.
- **After:** That badge is gone; the rest of the badge row is intact.

## Risk
- Low
- Nothing can break — a single Markdown badge line was removed.

## Checklist
- [ ] Tests added or updated (n/a — docs-only)
- [x] Backward compatibility considered (n/a — docs-only)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XTWaMWzePTsEddgt12jpeS)_