### PR TITLE
docs(tuika): document public API and enforce missing_docs lint

### DIFF
--- a/crates/tuika/src/components/boxed.rs
+++ b/crates/tuika/src/components/boxed.rs
@@ -26,6 +26,7 @@ pub struct Boxed {
 }
 
 impl Boxed {
+    /// Wrap `child` with default rounded border and symmetric horizontal padding.
     pub fn new(child: Element) -> Self {
         Self {
             child,
@@ -36,21 +37,25 @@ impl Boxed {
         }
     }
 
+    /// Set the border style (`BorderStyle::None` removes the border).
     pub fn border(mut self, border: BorderStyle) -> Self {
         self.border = border;
         self
     }
 
+    /// Set the padding between the border and the child.
     pub fn padding(mut self, padding: Padding) -> Self {
         self.padding = padding;
         self
     }
 
+    /// Set a title drawn on the top border, clipped between the corners.
     pub fn title(mut self, title: impl Into<Line<'static>>) -> Self {
         self.title = Some(title.into());
         self
     }
 
+    /// Fill the box interior with `style` before drawing the child.
     pub fn background(mut self, style: Style) -> Self {
         self.background = Some(style);
         self

--- a/crates/tuika/src/components/flex.rs
+++ b/crates/tuika/src/components/flex.rs
@@ -29,6 +29,7 @@ pub struct Flex {
 }
 
 impl Flex {
+    /// An empty flex container with the given layout style.
     pub fn new(style: LayoutStyle) -> Self {
         Self {
             style,
@@ -37,10 +38,12 @@ impl Flex {
         }
     }
 
+    /// An empty container laying children left-to-right along the horizontal axis.
     pub fn row() -> Self {
         Self::new(LayoutStyle::row())
     }
 
+    /// An empty container stacking children top-to-bottom along the vertical axis.
     pub fn column() -> Self {
         Self::new(LayoutStyle::column())
     }

--- a/crates/tuika/src/components/loader.rs
+++ b/crates/tuika/src/components/loader.rs
@@ -23,6 +23,7 @@ pub struct Loader {
 }
 
 impl Loader {
+    /// A loader for the given frame counter showing `message` next to the spinner.
     pub fn new(frame: u64, message: impl Into<String>) -> Self {
         Self {
             frame,
@@ -38,6 +39,7 @@ impl Loader {
         self
     }
 
+    /// Set the spinner glyph set.
     pub fn spinner_style(mut self, style: SpinnerStyle) -> Self {
         self.spinner_style = style;
         self

--- a/crates/tuika/src/components/progress_bar.rs
+++ b/crates/tuika/src/components/progress_bar.rs
@@ -58,6 +58,7 @@ impl ProgressBar {
         self
     }
 
+    /// Override the filled and track colors (default to theme accent and dim).
     pub fn colors(mut self, filled: ratatui::style::Color, track: ratatui::style::Color) -> Self {
         self.filled = Some(filled);
         self.track = Some(track);

--- a/crates/tuika/src/components/scroll.rs
+++ b/crates/tuika/src/components/scroll.rs
@@ -26,6 +26,7 @@ pub struct ScrollState {
 }
 
 impl ScrollState {
+    /// A fresh state at the top with bottom-stick armed.
     pub fn new() -> Self {
         Self {
             offset: 0,
@@ -33,10 +34,12 @@ impl ScrollState {
         }
     }
 
+    /// Top visible content row (0-based).
     pub fn offset(&self) -> u16 {
         self.offset
     }
 
+    /// Whether the view is pinned to the newest content.
     pub fn is_stuck_to_bottom(&self) -> bool {
         self.stick_to_bottom
     }
@@ -130,6 +133,7 @@ pub struct Scroll {
 }
 
 impl Scroll {
+    /// Build a viewport over `lines`, windowed at `state`'s offset.
     pub fn new(lines: Vec<Line<'static>>, state: &ScrollState) -> Self {
         Self {
             lines,
@@ -138,11 +142,13 @@ impl Scroll {
         }
     }
 
+    /// Toggle the scrollbar (shown by default when content overflows).
     pub fn scrollbar(mut self, show: bool) -> Self {
         self.scrollbar = show;
         self
     }
 
+    /// Total content height in rows (one per line).
     pub fn content_height(&self) -> u16 {
         self.lines.len() as u16
     }

--- a/crates/tuika/src/components/select.rs
+++ b/crates/tuika/src/components/select.rs
@@ -32,10 +32,12 @@ pub struct SelectState {
 }
 
 impl SelectState {
+    /// A fresh state with the first row highlighted.
     pub fn new() -> Self {
         Self { selected: 0 }
     }
 
+    /// The currently highlighted index.
     pub fn selected(&self) -> usize {
         self.selected
     }
@@ -119,6 +121,7 @@ pub struct SelectList {
 }
 
 impl SelectList {
+    /// A list of `items` with the row from `state` highlighted.
     pub fn new(items: Vec<Line<'static>>, state: &SelectState) -> Self {
         Self {
             items,

--- a/crates/tuika/src/components/spacer.rs
+++ b/crates/tuika/src/components/spacer.rs
@@ -7,6 +7,7 @@ use crate::geometry::Size;
 use crate::surface::Surface;
 use crate::view::{RenderCtx, View};
 
+/// An empty filler view that paints nothing; used as a flex or fixed gap.
 pub struct Spacer;
 
 impl View for Spacer {

--- a/crates/tuika/src/components/spinner.rs
+++ b/crates/tuika/src/components/spinner.rs
@@ -24,6 +24,7 @@ pub enum SpinnerStyle {
 }
 
 impl SpinnerStyle {
+    /// The ordered glyph set the host cycles through for this style.
     pub fn frames(self) -> &'static [&'static str] {
         match self {
             SpinnerStyle::Braille => &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"],
@@ -52,11 +53,13 @@ impl Spinner {
         }
     }
 
+    /// Set the glyph set.
     pub fn style(mut self, style: SpinnerStyle) -> Self {
         self.style = style;
         self
     }
 
+    /// Override the glyph color (defaults to the theme accent).
     pub fn color(mut self, color: ratatui::style::Color) -> Self {
         self.color = Some(color);
         self

--- a/crates/tuika/src/components/status_bar.rs
+++ b/crates/tuika/src/components/status_bar.rs
@@ -20,6 +20,7 @@ pub struct StatusBar {
 }
 
 impl StatusBar {
+    /// An empty status bar with no segments and the default surface background.
     pub fn new() -> Self {
         Self {
             left: Vec::new(),
@@ -28,16 +29,19 @@ impl StatusBar {
         }
     }
 
+    /// Set the left-anchored segment group.
     pub fn left(mut self, spans: Vec<Span<'static>>) -> Self {
         self.left = spans;
         self
     }
 
+    /// Set the right-anchored segment group.
     pub fn right(mut self, spans: Vec<Span<'static>>) -> Self {
         self.right = spans;
         self
     }
 
+    /// Override the row background (defaults to the theme surface color).
     pub fn background(mut self, style: Style) -> Self {
         self.background = Some(style);
         self

--- a/crates/tuika/src/components/text.rs
+++ b/crates/tuika/src/components/text.rs
@@ -50,6 +50,7 @@ pub struct Text {
 }
 
 impl Text {
+    /// A text block from pre-styled lines.
     pub fn new(lines: Vec<Line<'static>>) -> Self {
         Self { lines }
     }
@@ -78,6 +79,7 @@ pub struct Paragraph {
 }
 
 impl Paragraph {
+    /// A paragraph that wraps `text` in a single `style`.
     pub fn new(text: impl Into<String>, style: Style) -> Self {
         Self {
             text: text.into(),
@@ -263,6 +265,7 @@ pub struct Wrap {
 }
 
 impl Wrap {
+    /// A wrapping view over pre-styled lines.
     pub fn new(lines: Vec<Line<'static>>) -> Self {
         Self { lines }
     }

--- a/crates/tuika/src/components/textinput.rs
+++ b/crates/tuika/src/components/textinput.rs
@@ -48,7 +48,9 @@ pub enum TextInputMode {
 /// Result of applying an Enter chord to a text input.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TextInputEvent {
+    /// The chord inserted a newline; text changed.
     Changed,
+    /// The chord requested submission.
     Submit,
 }
 
@@ -59,6 +61,7 @@ impl Default for TextInputState {
 }
 
 impl TextInputState {
+    /// An empty single-line buffer with cursor at the start.
     pub fn new() -> Self {
         Self {
             lines: vec![String::new()],
@@ -212,6 +215,7 @@ impl TextInputState {
         self.col = self.col.min(self.lines[self.row].chars().count());
     }
 
+    /// Move one char left, wrapping to the end of the previous line.
     pub fn move_left(&mut self) {
         if self.col > 0 {
             self.col -= 1;
@@ -221,6 +225,7 @@ impl TextInputState {
         }
     }
 
+    /// Move one char right, wrapping to the start of the next line.
     pub fn move_right(&mut self) {
         let len = self.lines[self.row].chars().count();
         if self.col < len {
@@ -231,6 +236,7 @@ impl TextInputState {
         }
     }
 
+    /// Move to the previous line (clamping column), or to line start at the top.
     pub fn move_up(&mut self) {
         if self.row > 0 {
             self.row -= 1;
@@ -240,6 +246,7 @@ impl TextInputState {
         }
     }
 
+    /// Move to the next line (clamping column), or to line end at the bottom.
     pub fn move_down(&mut self) {
         if self.row + 1 < self.lines.len() {
             self.row += 1;
@@ -249,10 +256,12 @@ impl TextInputState {
         }
     }
 
+    /// Move the cursor to the start of the current line.
     pub fn move_home(&mut self) {
         self.col = 0;
     }
 
+    /// Move the cursor to the end of the current line.
     pub fn move_end(&mut self) {
         self.col = self.lines[self.row].chars().count();
     }
@@ -624,6 +633,7 @@ pub struct TextInput {
 }
 
 impl TextInput {
+    /// Snapshot `state`'s text and cursor for rendering.
     pub fn new(state: &TextInputState) -> Self {
         Self {
             lines: state.lines.clone(),
@@ -632,6 +642,7 @@ impl TextInput {
         }
     }
 
+    /// Set the text style applied to rendered glyphs.
     pub fn style(mut self, style: Style) -> Self {
         self.style = style;
         self

--- a/crates/tuika/src/event.rs
+++ b/crates/tuika/src/event.rs
@@ -8,25 +8,36 @@
 /// A translated input event.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Event {
+    /// A key press.
     Key(Key),
+    /// A mouse action.
     Mouse(Mouse),
     /// Bracketed-paste payload.
     Paste(String),
+    /// Terminal resized to the given cell dimensions.
     Resize {
+        /// New width in cells.
         width: u16,
+        /// New height in cells.
         height: u16,
     },
 }
 
+/// A key press with its modifier state.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Key {
+    /// The key that was pressed.
     pub code: KeyCode,
+    /// Ctrl held during the press.
     pub ctrl: bool,
+    /// Alt held during the press.
     pub alt: bool,
+    /// Shift held during the press.
     pub shift: bool,
 }
 
 impl Key {
+    /// A key with the given code and no modifiers held.
     pub fn new(code: KeyCode) -> Self {
         Self {
             code,
@@ -36,39 +47,62 @@ impl Key {
         }
     }
 
+    /// True when neither Ctrl nor Alt is held (Shift is ignored, as it is
+    /// already folded into the character for text input).
     pub fn plain(&self) -> bool {
         !self.ctrl && !self.alt
     }
 }
 
+/// A physical/logical key, independent of modifier state.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum KeyCode {
+    /// A printable character.
     Char(char),
+    /// Enter/Return.
     Enter,
+    /// Escape.
     Esc,
+    /// Backspace (delete before cursor).
     Backspace,
+    /// Delete (delete under/after cursor).
     Delete,
+    /// Tab.
     Tab,
+    /// Back-tab (Shift-Tab).
     BackTab,
+    /// Up arrow.
     Up,
+    /// Down arrow.
     Down,
+    /// Left arrow.
     Left,
+    /// Right arrow.
     Right,
+    /// Home.
     Home,
+    /// End.
     End,
+    /// Page Up.
     PageUp,
+    /// Page Down.
     PageDown,
 }
 
+/// A mouse event at a terminal cell, with modifier state.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Mouse {
+    /// What the pointer did (button press/release/drag, move, or scroll).
     pub kind: MouseKind,
     /// Cell column (0-based, terminal coordinates).
     pub column: u16,
     /// Cell row (0-based, terminal coordinates).
     pub row: u16,
+    /// Shift held during the event.
     pub shift: bool,
+    /// Ctrl held during the event.
     pub ctrl: bool,
+    /// Alt held during the event.
     pub alt: bool,
 }
 
@@ -98,11 +132,15 @@ impl Mouse {
 /// Which mouse button an event refers to.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MouseButton {
+    /// Left (primary) button.
     Left,
+    /// Right (secondary) button.
     Right,
+    /// Middle button.
     Middle,
 }
 
+/// The kind of mouse interaction an event represents.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MouseKind {
     /// Button pressed.
@@ -113,9 +151,13 @@ pub enum MouseKind {
     Drag(MouseButton),
     /// Pointer moved with no button held.
     Moved,
+    /// Wheel scrolled up.
     ScrollUp,
+    /// Wheel scrolled down.
     ScrollDown,
+    /// Wheel scrolled left.
     ScrollLeft,
+    /// Wheel scrolled right.
     ScrollRight,
 }
 
@@ -129,6 +171,7 @@ pub enum EventFlow {
 }
 
 impl EventFlow {
+    /// True for [`EventFlow::Consumed`].
     pub fn consumed(self) -> bool {
         matches!(self, EventFlow::Consumed)
     }

--- a/crates/tuika/src/focus.rs
+++ b/crates/tuika/src/focus.rs
@@ -19,6 +19,7 @@ pub struct FocusRegistry {
 }
 
 impl FocusRegistry {
+    /// Create an empty registry with no registered or focused regions.
     pub fn new() -> Self {
         Self::default()
     }

--- a/crates/tuika/src/geometry.rs
+++ b/crates/tuika/src/geometry.rs
@@ -11,16 +11,20 @@ use ratatui::layout::Rect;
 /// An intrinsic size in terminal cells.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct Size {
+    /// Width in terminal cells.
     pub width: u16,
+    /// Height in terminal cells.
     pub height: u16,
 }
 
 impl Size {
+    /// A zero-by-zero size.
     pub const ZERO: Size = Size {
         width: 0,
         height: 0,
     };
 
+    /// A size of `width` by `height` cells.
     pub fn new(width: u16, height: u16) -> Self {
         Self { width, height }
     }
@@ -46,7 +50,9 @@ impl From<Rect> for Size {
 /// The layout axis a flex container distributes children along.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Axis {
+    /// Main axis runs left-to-right; children stack in a row.
     Horizontal,
+    /// Main axis runs top-to-bottom; children stack in a column.
     Vertical,
 }
 
@@ -98,13 +104,18 @@ impl Axis {
 /// Symmetric-per-edge padding, in cells.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct Padding {
+    /// Cells inset from the left edge.
     pub left: u16,
+    /// Cells inset from the right edge.
     pub right: u16,
+    /// Cells inset from the top edge.
     pub top: u16,
+    /// Cells inset from the bottom edge.
     pub bottom: u16,
 }
 
 impl Padding {
+    /// No padding on any edge.
     pub const ZERO: Padding = Padding {
         left: 0,
         right: 0,
@@ -132,10 +143,12 @@ impl Padding {
         }
     }
 
+    /// Combined left + right padding, in cells.
     pub fn horizontal(self) -> u16 {
         self.left.saturating_add(self.right)
     }
 
+    /// Combined top + bottom padding, in cells.
     pub fn vertical(self) -> u16 {
         self.top.saturating_add(self.bottom)
     }

--- a/crates/tuika/src/host.rs
+++ b/crates/tuika/src/host.rs
@@ -119,7 +119,9 @@ impl Drop for TerminalSession {
 
 /// An overlay to composite over the base tree at a resolved rect.
 pub struct Overlay<'a> {
+    /// Rect the overlay is composited into.
     pub area: Rect,
+    /// View painted within `area`.
     pub view: &'a dyn View,
     /// Clear the rect (fill with the theme background) before painting.
     pub clear: bool,

--- a/crates/tuika/src/layout.rs
+++ b/crates/tuika/src/layout.rs
@@ -31,8 +31,11 @@ pub enum Dimension {
 /// where a column's children should fill its width (and a row's its height).
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum Align {
+    /// Pack children against the cross-axis start edge.
     Start,
+    /// Center children on the cross axis.
     Center,
+    /// Pack children against the cross-axis end edge.
     End,
     /// Fill the full cross extent.
     #[default]
@@ -42,9 +45,12 @@ pub enum Align {
 /// Main-axis distribution of leftover space when no child is [`Dimension::Flex`].
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum Justify {
+    /// Pack children against the main-axis start; leftover space trails them.
     #[default]
     Start,
+    /// Center children on the main axis, splitting leftover space at both ends.
     Center,
+    /// Pack children against the main-axis end; leftover space leads them.
     End,
     /// Even gaps between children, none at the ends.
     SpaceBetween,
@@ -53,12 +59,15 @@ pub enum Justify {
 /// Direction a flex container stacks its children.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum Direction {
+    /// Stack children left-to-right (main axis horizontal).
     Row,
+    /// Stack children top-to-bottom (main axis vertical).
     #[default]
     Column,
 }
 
 impl Direction {
+    /// The main [`Axis`] this direction stacks children along.
     pub fn axis(self) -> Axis {
         match self {
             Direction::Row => Axis::Horizontal,
@@ -70,14 +79,20 @@ impl Direction {
 /// Declarative layout properties for a flex container.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct LayoutStyle {
+    /// Which axis children stack along.
     pub direction: Direction,
+    /// Padding inset applied inside the container before children are placed.
     pub padding: Padding,
+    /// Cells of empty space inserted between adjacent children.
     pub gap: u16,
+    /// Cross-axis alignment applied to every child.
     pub align_items: Align,
+    /// Main-axis distribution of leftover space.
     pub justify: Justify,
 }
 
 impl LayoutStyle {
+    /// A row-direction style; all other properties default.
     pub fn row() -> Self {
         Self {
             direction: Direction::Row,
@@ -85,6 +100,7 @@ impl LayoutStyle {
         }
     }
 
+    /// A column-direction style; all other properties default.
     pub fn column() -> Self {
         Self {
             direction: Direction::Column,
@@ -92,21 +108,25 @@ impl LayoutStyle {
         }
     }
 
+    /// Set the between-children gap, in cells.
     pub fn gap(mut self, gap: u16) -> Self {
         self.gap = gap;
         self
     }
 
+    /// Set the container padding.
     pub fn padding(mut self, padding: Padding) -> Self {
         self.padding = padding;
         self
     }
 
+    /// Set the cross-axis alignment of children.
     pub fn align(mut self, align: Align) -> Self {
         self.align_items = align;
         self
     }
 
+    /// Set the main-axis distribution of leftover space.
     pub fn justify(mut self, justify: Justify) -> Self {
         self.justify = justify;
         self
@@ -120,11 +140,14 @@ impl LayoutStyle {
 /// cross alignment.
 #[derive(Clone, Copy, Debug)]
 pub struct Item {
+    /// The child's main-axis sizing rule.
     pub dimension: Dimension,
+    /// The child's measured intrinsic content size.
     pub intrinsic: Size,
 }
 
 impl Item {
+    /// An item with the given main-axis sizing rule and intrinsic size.
     pub fn new(dimension: Dimension, intrinsic: Size) -> Self {
         Self {
             dimension,

--- a/crates/tuika/src/lib.rs
+++ b/crates/tuika/src/lib.rs
@@ -32,6 +32,8 @@
 //! which preserves Tuika clipping without exposing the frame buffer.
 //! [`TerminalSession`] and [`Runner`] are optional host-side lifecycle helpers.
 
+#![warn(missing_docs)]
+
 pub mod anim;
 pub mod clipboard;
 pub mod components;

--- a/crates/tuika/src/macros.rs
+++ b/crates/tuika/src/macros.rs
@@ -34,6 +34,16 @@
 //! `MyWidget { … }` syntax for external components; the `node(expr)` escape
 //! hatch covers that case today.
 
+/// Build a tuika [`Element`](crate::view::Element) tree from a declarative,
+/// top-down layout description.
+///
+/// Each keyword consumes exactly one node: `col`/`row` open flex containers
+/// (with optional `gap`/`padding`/`align`/`justify`/`background` attrs and a
+/// `{ children }` block), `boxed` wraps a single child in a border (with
+/// `title`/`border`/`padding`/`background` attrs), `text(expr)` and `spacer()`
+/// emit leaves, `grow(n)`/`fixed(n)` set a child's main-axis size, and
+/// `node(expr)` splices any `impl View`. Expands to plain builder calls with no
+/// runtime cost.
 #[macro_export]
 macro_rules! view {
     // ---- public entry: a single node -> Element -----------------------------

--- a/crates/tuika/src/mouse.rs
+++ b/crates/tuika/src/mouse.rs
@@ -93,10 +93,13 @@ pub struct SelectionState {
 }
 
 impl SelectionState {
+    /// A state with no selection in progress.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Feed a mouse event; returns `true` when the selection changed and a
+    /// redraw is warranted.
     pub fn handle(&mut self, m: &Mouse) -> bool {
         match m.kind {
             MouseKind::Down(MouseButton::Left) => {
@@ -134,6 +137,7 @@ impl SelectionState {
             .then(|| SelectionRange::between(self.anchor, self.cursor))
     }
 
+    /// Whether a non-empty selection currently exists.
     pub fn is_active(&self) -> bool {
         self.selecting
     }
@@ -196,6 +200,7 @@ impl<T> Default for HitMap<T> {
 }
 
 impl<T> HitMap<T> {
+    /// An empty map with no registered regions.
     pub fn new() -> Self {
         Self::default()
     }
@@ -205,6 +210,7 @@ impl<T> HitMap<T> {
         self.regions.push((area, value));
     }
 
+    /// Drop all registered regions, ready for the next frame.
     pub fn clear(&mut self) {
         self.regions.clear();
     }
@@ -231,8 +237,11 @@ fn in_rect(r: Rect, col: u16, row: u16) -> bool {
 /// A completed click: the cell and button of a `Down`/`Up` pair on one cell.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Click {
+    /// Clicked cell column (0-based).
     pub column: u16,
+    /// Clicked cell row (0-based).
     pub row: u16,
+    /// The mouse button that was pressed and released.
     pub button: MouseButton,
 }
 
@@ -246,10 +255,13 @@ pub struct ClickTracker {
 }
 
 impl ClickTracker {
+    /// A tracker with no press pending.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Feed a mouse event; returns `Some(Click)` on the `Up` that completes a
+    /// press/release on the same cell with the same button.
     pub fn handle(&mut self, m: &Mouse) -> Option<Click> {
         match m.kind {
             MouseKind::Down(button) => {

--- a/crates/tuika/src/native.rs
+++ b/crates/tuika/src/native.rs
@@ -53,6 +53,7 @@ pub struct TerminalProgress {
 }
 
 impl TerminalProgress {
+    /// Create a driver with no indicator shown yet.
     pub fn new() -> Self {
         Self { active: false }
     }

--- a/crates/tuika/src/overlay.rs
+++ b/crates/tuika/src/overlay.rs
@@ -14,15 +14,24 @@ use super::geometry::Size;
 /// Where an overlay sits relative to the screen.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum Anchor {
+    /// Centered horizontally and vertically.
     #[default]
     Center,
+    /// Centered horizontally, flush to the top edge.
     Top,
+    /// Centered horizontally, flush to the bottom edge.
     Bottom,
+    /// Centered vertically, flush to the left edge.
     Left,
+    /// Centered vertically, flush to the right edge.
     Right,
+    /// Flush to the top-left corner.
     TopLeft,
+    /// Flush to the top-right corner.
     TopRight,
+    /// Flush to the bottom-left corner.
     BottomLeft,
+    /// Flush to the bottom-right corner.
     BottomRight,
 }
 
@@ -30,7 +39,9 @@ pub enum Anchor {
 /// with optional min/max clamps.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Extent {
+    /// An absolute size in terminal cells.
     Cells(u16),
+    /// A percentage (0–100) of the available screen extent.
     Percent(u16),
 }
 
@@ -46,13 +57,21 @@ impl Extent {
 /// Anchored, sized overlay placement relative to a screen rect.
 #[derive(Clone, Copy, Debug)]
 pub struct OverlaySpec {
+    /// Where the resolved rect sits within the screen.
     pub anchor: Anchor,
+    /// Requested width, absolute or a percentage of the screen width.
     pub width: Extent,
+    /// Requested height, absolute or a percentage of the screen height.
     pub height: Extent,
+    /// Lower clamp on the resolved width, in cells.
     pub min_width: u16,
+    /// Lower clamp on the resolved height, in cells.
     pub min_height: u16,
+    /// Upper clamp on the resolved width, in cells.
     pub max_width: u16,
+    /// Upper clamp on the resolved height, in cells.
     pub max_height: u16,
+    /// Gap in cells kept between the overlay and every screen edge.
     pub margin: u16,
 }
 
@@ -71,23 +90,27 @@ impl OverlaySpec {
         }
     }
 
+    /// Set the anchor that positions the overlay within the screen.
     pub fn anchor(mut self, anchor: Anchor) -> Self {
         self.anchor = anchor;
         self
     }
 
+    /// Set the minimum resolved size in cells.
     pub fn min_size(mut self, width: u16, height: u16) -> Self {
         self.min_width = width;
         self.min_height = height;
         self
     }
 
+    /// Set the maximum resolved size in cells.
     pub fn max_size(mut self, width: u16, height: u16) -> Self {
         self.max_width = width;
         self.max_height = height;
         self
     }
 
+    /// Set the gap in cells kept between the overlay and every screen edge.
     pub fn margin(mut self, margin: u16) -> Self {
         self.margin = margin;
         self

--- a/crates/tuika/src/probe.rs
+++ b/crates/tuika/src/probe.rs
@@ -37,6 +37,8 @@ use crate::view::{Element, RenderCtx, View, element};
 pub struct RectProbe(Rc<Cell<Rect>>);
 
 impl RectProbe {
+    /// Create a fresh handle reading back [`Rect::ZERO`] until its probed view
+    /// is painted.
     pub fn new() -> Self {
         Self::default()
     }
@@ -67,6 +69,7 @@ pub struct Probe {
 }
 
 impl Probe {
+    /// Wrap `inner` so its painted rect is reported to `probe`.
     pub fn new(inner: Element, probe: &RectProbe) -> Self {
         Self {
             inner,

--- a/crates/tuika/src/style.rs
+++ b/crates/tuika/src/style.rs
@@ -11,15 +11,19 @@ use ratatui::style::{Color, Modifier, Style};
 /// Line-drawing style for bordered components.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum BorderStyle {
+    /// Rounded corners (`╭╮╰╯`) with light edges.
     #[default]
     Rounded,
+    /// Square corners (`┌┐└┘`) with light edges.
     Plain,
+    /// Heavy corners and edges (`┏┓┗┛━┃`).
     Thick,
+    /// No border; drawn as blank spaces.
     None,
 }
 
 impl BorderStyle {
-    /// (top_left, top_right, bottom_left, bottom_right, horizontal, vertical)
+    /// The six line-drawing glyphs (corners, horizontal, vertical) for this style.
     pub fn glyphs(self) -> BorderGlyphs {
         match self {
             BorderStyle::Rounded => BorderGlyphs::new('╭', '╮', '╰', '╯', '─', '│'),
@@ -30,13 +34,20 @@ impl BorderStyle {
     }
 }
 
+/// The resolved corner and edge glyphs for a [`BorderStyle`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct BorderGlyphs {
+    /// Top-left corner glyph.
     pub top_left: char,
+    /// Top-right corner glyph.
     pub top_right: char,
+    /// Bottom-left corner glyph.
     pub bottom_left: char,
+    /// Bottom-right corner glyph.
     pub bottom_right: char,
+    /// Horizontal edge glyph (top and bottom sides).
     pub horizontal: char,
+    /// Vertical edge glyph (left and right sides).
     pub vertical: char,
 }
 
@@ -67,16 +78,27 @@ impl BorderGlyphs {
 /// own `Theme` and the whole component tree follows.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Theme {
+    /// Base fill behind the whole screen.
     pub background: Color,
+    /// Raised fill for panels and overlays that sit above the background.
     pub surface: Color,
+    /// Primary foreground for body text.
     pub text: Color,
+    /// De-emphasized foreground for secondary text, hints, and scrollbar thumbs.
     pub muted: Color,
+    /// Faintest foreground, dimmer than `muted`, for inactive tracks and rules.
     pub dim: Color,
+    /// Primary highlight for active/emphasized elements (progress fill, spinner).
     pub accent: Color,
+    /// Secondary accent for complementary highlights distinct from `accent`.
     pub accent_alt: Color,
+    /// Border color for unfocused bordered components.
     pub border: Color,
+    /// Border color for the focused component.
     pub border_focused: Color,
+    /// Background of the selected item in lists and menus.
     pub selection_bg: Color,
+    /// Foreground of the selected item in lists and menus.
     pub selection_fg: Color,
 }
 
@@ -103,20 +125,24 @@ impl Default for Theme {
 }
 
 impl Theme {
+    /// Style for primary body text (`text` foreground).
     pub fn text_style(&self) -> Style {
         Style::default().fg(self.text)
     }
 
+    /// Style for de-emphasized text (`muted` foreground).
     pub fn muted_style(&self) -> Style {
         Style::default().fg(self.muted)
     }
 
+    /// Bold style in the primary `accent` color.
     pub fn accent_style(&self) -> Style {
         Style::default()
             .fg(self.accent)
             .add_modifier(Modifier::BOLD)
     }
 
+    /// Border color for a component, `border_focused` when `focused` else `border`.
     pub fn border_color(&self, focused: bool) -> Color {
         if focused {
             self.border_focused
@@ -125,6 +151,7 @@ impl Theme {
         }
     }
 
+    /// Bold style for a selected item (`selection_fg` on `selection_bg`).
     pub fn selection_style(&self) -> Style {
         Style::default()
             .bg(self.selection_bg)

--- a/crates/tuika/src/view.rs
+++ b/crates/tuika/src/view.rs
@@ -18,6 +18,7 @@ use super::surface::Surface;
 
 /// Context threaded to every `View::render`.
 pub struct RenderCtx<'a> {
+    /// The active theme supplying colors and styles for this frame.
     pub theme: &'a Theme,
     /// Whether the focused component of the frame is this one. Containers pass
     /// this down unchanged; focus-aware leaves use it to highlight borders.
@@ -25,6 +26,7 @@ pub struct RenderCtx<'a> {
 }
 
 impl<'a> RenderCtx<'a> {
+    /// A root context for `theme`, unfocused.
     pub fn new(theme: &'a Theme) -> Self {
         Self {
             theme,
@@ -48,7 +50,9 @@ impl<'a> RenderCtx<'a> {
 /// `render` paints into the `area` the layout assigned, through the clipped
 /// `surface`.
 pub trait View {
+    /// Report the intrinsic content size wanted given `available`.
     fn measure(&self, available: Size) -> Size;
+    /// Paint the view into the assigned `area` through `surface`.
     fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx);
 }
 


### PR DESCRIPTION
## What changed
Turns on `#[warn(missing_docs)]` for the `tuika` crate and documents every public API item the lint surfaced — **191 items** across 24 files. Because the CI clippy gate runs `-D warnings`, `missing_docs` is now effectively a **deny**: any undocumented public API fails the build going forward.

Highlights of what got documented:
- **`Theme`'s 11 color fields**, previously the biggest gap — a public theming API where nothing distinguished the confusable slots. Docs now explain `background` (base screen fill) vs `surface` (raised panels/overlays), `muted` (secondary text/scrollbar thumbs) vs `dim` (fainter — inactive tracks/rules), `accent` vs `accent_alt`, and `border` vs `border_focused`, based on actual usage across the crate.
- **All builder methods and options** across `layout` (`LayoutStyle`, `Align`, `Justify`, `Direction`), `overlay` (`Anchor`, `OverlaySpec`, `Extent`), `event` (`Key`, `KeyCode`, `Mouse`, `MouseKind`), `mouse`, `geometry` (`Padding`, `Size`), and the component set (Boxed, Flex, Scroll, Select, Spinner, StatusBar, Text, TextInput, …).
- The `view!` macro now documents its declarative grammar.

Also fixes a **stale doc**: `BorderStyle::glyphs()` carried a comment describing a 6-tuple return (`(top_left, top_right, …)`) that the method no longer has — it returns a `BorderGlyphs` struct.

## Why
A review of tuika's rustdoc found the prose strong but the reference layer incomplete: the most option-like struct in the crate (`Theme`) had zero field docs, many builder methods were undocumented, there was doc rot in `style.rs`, and nothing enforced coverage — which is exactly how those gaps accrued. Enabling `missing_docs` both closes the current gaps and prevents regressions.

## Before / After
Docs-only change; no runtime behavior changes. Evidence is the lint going from noisy to clean:

**Before** — `cargo build -p tuika`:
```
warning: missing documentation for a struct field   --> crates/tuika/src/style.rs:70:5   (× 191)
```

**After** — `cargo build -p tuika 2>&1 | grep -c "missing documentation"` → `0`, and the CI gate `cargo clippy --all-targets --all-features -- -D warnings` passes at the workspace root (exit 0). On docs.rs, `Theme`'s fields and every builder option now carry descriptions instead of bare signatures.

## Risk
- **Low**
- No code paths change — only doc comments were added plus one stale comment replaced, and the crate-level `#[warn(missing_docs)]` attribute. The only forward-looking effect: a new undocumented public item in `tuika` will now fail CI, which is the intended guardrail.

## Security
No security-relevant code changes — documentation comments and a lint attribute only; no logic, I/O, dependencies, or capability surface touched.

## Follow-ups
- Inline rustdoc code examples (doctests) for the major components (Flex, Boxed, Select) remain a nice-to-have; the crate's runnable examples currently live under `examples/` and `docs/components.md` rather than inline. Deferred — out of scope for this pass, which was about completeness and enforcement of option/field descriptions.

## Checklist
- [x] Tests added or updated — N/A (docs-only, no behavior change); existing suite (137 tests + doctests) stays green.
- [x] Backward compatibility considered — no API changes; `tuika` is pre-1.0 regardless.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HE6AxShv4FZ4Cf7N9VbvH8)_