### PR TITLE
chore(ci): scope PR jobs to what the diff touches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,39 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
+  # Classify the diff once, up front, so the rest of the pipeline can scope
+  # itself to what actually changed. A docs-only PR (e.g. a README badge tweak)
+  # must not spin up the whole Rust toolchain, burn a live-provider API budget,
+  # or occupy the scarce macOS/Windows runners. GitHub treats a job skipped by
+  # `if:` as a passing required check, so skipped legs never block merge.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            rust:
+              - '**/*.rs'
+              - '**/Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - '**/build.rs'
+              - '.github/workflows/ci.yml'
+            docs:
+              - '**/*.md'
+
   tuika-msrv:
     name: Tuika MSRV
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -41,8 +72,30 @@ jobs:
       - name: Verify component gallery assets
         run: cargo run --locked -p tuika --example demo -- check
 
+  # Cheap guard for the documentation boundary (README/docs must not link into
+  # internal specs/ or .agents/). Runs whenever Markdown changes — including
+  # docs-only PRs, where the Rust `lint` job below is skipped — and needs no
+  # Rust toolchain, so it stays fast.
+  docs-boundary:
+    name: Docs boundary
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Public docs boundary
+        run: |
+          if grep -R -n -E --include='*.md' '\]\([^)]*(specs/|\.agents/)' README.md docs; then
+            echo "::error::Public documentation must not link to internal specs/ or .agents/ files."
+            exit 1
+          fi
+
   lint:
     name: Format + Clippy
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -61,18 +114,13 @@ jobs:
       - name: Format check
         run: cargo fmt --all -- --check
 
-      - name: Public docs boundary
-        run: |
-          if grep -R -n -E --include='*.md' '\]\([^)]*(specs/|\.agents/)' README.md docs; then
-            echo "::error::Public documentation must not link to internal specs/ or .agents/ files."
-            exit 1
-          fi
-
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
   test:
     name: Build + Tests + Offline Smoke
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
@@ -162,6 +210,8 @@ jobs:
 
   sandbox-contract:
     name: Sandbox Contract (${{ matrix.os }})
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
@@ -182,30 +232,8 @@ jobs:
       - name: Run sandbox contract suite
         run: cargo test sandbox -- --nocapture
 
-  # Detect whether this change touches anything that could affect the Windows
-  # build, so the (comparatively scarce) Windows runner only spins up when it's
-  # actually relevant — not on doc- or eval-only changes.
-  changes:
-    name: Detect Rust changes
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      rust: ${{ steps.filter.outputs.rust }}
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            rust:
-              - '**/*.rs'
-              - '**/Cargo.toml'
-              - 'Cargo.lock'
-              - 'rust-toolchain.toml'
-              - 'build.rs'
-              - '.github/workflows/ci.yml'
-
+  # The (comparatively scarce) Windows runner only spins up when the change
+  # actually touches Rust — not on doc- or eval-only changes.
   windows:
     name: Windows Build + Shell Smoke
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
+      tuika: ${{ steps.filter.outputs.tuika }}
       docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@v7
@@ -46,13 +47,24 @@ jobs:
               - 'rust-toolchain.toml'
               - '**/build.rs'
               - '.github/workflows/ci.yml'
+            # The dedicated MSRV check only compiles `-p tuika`, which depends on
+            # neither yolop, yolop-yep, nor tuika-codeformatters. Scope it to
+            # tuika's own sources plus the workspace-wide inputs that reach it
+            # (root manifest, lockfile, this workflow). A yolop-only change still
+            # compiles tuika via the workspace `test` job — it just skips this
+            # extra 1.88 + gallery-asset leg.
+            tuika:
+              - 'crates/tuika/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '.github/workflows/ci.yml'
             docs:
               - '**/*.md'
 
   tuika-msrv:
     name: Tuika MSRV
     needs: changes
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.tuika == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## What changed
CI now classifies each PR's diff once, up front, and runs only the jobs that
diff can affect. Previously every job ran on every PR, so a one-line README
change spun up the whole Rust toolchain, the live-provider smoke (which spends
an API budget), both sandbox runners, and the scarce macOS/Windows runners.

- A single `changes` job emits three `paths-filter` outputs: `rust`, `tuika`, `docs`.
- `lint`, `test`, `sandbox-contract`, and `windows` are gated on `rust`;
  `live-smoke` auto-skips with them (it `needs: [lint, test]`).
- `tuika-msrv` is gated on a narrower `tuika` filter (`crates/tuika/**` + the
  workspace-wide inputs that reach it), because it only runs `cargo check -p
  tuika` and `tuika` depends on none of the other workspace crates.
- The `Public docs boundary` check moved out of `lint` into its own
  `docs-boundary` job gated on `docs`, so it still runs on docs-only PRs — which
  is exactly when it matters — without pulling in a Rust toolchain.

Workspace-wide tuika coverage is unchanged: the `test` job still builds and
tests `--workspace` on any Rust change; only the dedicated MSRV/gallery leg is
tuika-scoped. This PR touches only `.github/workflows/ci.yml`.

## Why
Trigger: PR #416 removed a single README badge line and ran 13 checks, including
`Live Provider Smoke (Doppler)`, `Sandbox Contract` on Ubuntu **and** macOS, and
`Tuika MSRV` — none of which a Markdown change can affect. The repo already had a
`paths-filter` job but only the Windows leg consumed it; this generalizes that
proven pattern to the whole pipeline. GitHub treats a job skipped by `if:` as a
passing required check (the Windows gate already relies on this), so skipped legs
never block merge.

## Before / After
Gating verified by simulating the `dorny/paths-filter` globs against
representative diffs:

```
scenario                         | tuika-msrv  docs-boundary  lint   test   sandbox  windows
README badge only (PR #416)      | skip        RUN            skip   skip   skip     skip
yolop src only                   | skip        skip           RUN    RUN    RUN      RUN
yolop-yep src only               | skip        skip           RUN    RUN    RUN      RUN
tuika src                        | RUN         skip           RUN    RUN    RUN      RUN
Cargo.lock dep bump              | RUN         skip           RUN    RUN    RUN      RUN
this PR (ci.yml)                 | RUN         skip           RUN    RUN    RUN      RUN
docs + rust mixed                | skip        RUN            RUN    RUN    RUN      RUN
eval markdown only               | skip        RUN            skip   skip   skip     skip
(live-smoke needs [lint,test] -> RUN only when both run)
```

- **Before:** a README-only PR ran all six jobs above + live-smoke across three OSes.
- **After:** a README-only PR runs only `docs-boundary` (one lightweight ubuntu job, no Rust toolchain).
- **This PR** edits `ci.yml`, which is in the `rust` and `tuika` filters, so it receives the full Rust + tuika suite — its own green run is the positive-path evidence.

## Risk
- Low
- Path-based gating can only *reduce* what runs on a diff it doesn't match. It
  cannot let unvalidated Rust through: any Rust-affecting file flips `rust`
  (`**/*.rs`, `**/Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`, `**/build.rs`),
  and edits to `ci.yml` itself are in both the `rust` and `tuika` filters, so a
  change to the gating always runs the full suite on that PR.

## Security
No security-relevant code changes — workflow YAML only. `permissions: contents:
read` and the `DOPPLER_TOKEN` gate on `live-smoke` are unchanged; no new action
dependency (`dorny/paths-filter@v3` is already in use). The gating cannot bypass
required Rust validation: skipping a required check requires a diff with no
Rust-affecting files, and any Rust code change flips the `rust` filter on.
TM-FS/TM-BASH/TM-LLM/TM-TOOL are not applicable — no filesystem, shell, prompt,
or capability surface is touched.

## Follow-ups
- The `CodeQL` / `Analyze (rust|python|actions)` checks that also ran on PR #416
  come from GitHub **default setup**, not a workflow file, so they can't be
  path-filtered from here. Narrowing them needs a repo-settings change (advanced
  setup with a `codeql.yml` carrying `paths-ignore`). Deferred — out of scope for
  the `ci.yml` change and requires admin settings access.

## Checklist
- [x] Tests added or updated — n/a (CI-config only, no Rust behavior). Gating validated by the path-filter simulation above; this PR's own run exercises the positive path.
- [x] Backward compatibility considered — n/a; pre-1.0, and skipped-as-passing keeps required checks green.

https://claude.ai/code/session_01K4osiDkzAyH4zdhcTnYktf