### PR TITLE
docs(tuika): fix missing_docs on main + add Flex/Boxed/Select doctests

### DIFF
--- a/crates/tuika/src/components/boxed.rs
+++ b/crates/tuika/src/components/boxed.rs
@@ -16,6 +16,24 @@ use super::text::line_width;
 
 /// A bordered, padded container wrapping one child.
 ///
+/// # Example
+///
+/// ```
+/// use tuika::{Boxed, Text, Theme, element};
+/// use tuika::testing::{grid, render};
+///
+/// // Default rounded border with symmetric horizontal padding.
+/// let view = Boxed::new(element(Text::raw("hi")));
+///
+/// let buffer = render(&view, 6, 3, &Theme::default());
+/// assert_eq!(
+///     grid(&buffer),
+///     "╭────╮\n\
+///      │ hi │\n\
+///      ╰────╯",
+/// );
+/// ```
+///
 /// ![boxed demo](https://raw.githubusercontent.com/everruns/yolop/main/crates/tuika/docs/demos/boxed.gif)
 pub struct Boxed {
     child: Element,

--- a/crates/tuika/src/components/flex.rs
+++ b/crates/tuika/src/components/flex.rs
@@ -21,6 +21,21 @@ struct Child {
 
 /// A flexbox container of child views.
 ///
+/// # Example
+///
+/// ```
+/// use tuika::{Flex, Text, Theme, element};
+/// use tuika::testing::{grid, render};
+///
+/// // A row of two fixed-width cells, laid left to right.
+/// let view = Flex::row()
+///     .fixed(3, element(Text::raw("abc")))
+///     .fixed(3, element(Text::raw("xyz")));
+///
+/// let buffer = render(&view, 6, 1, &Theme::default());
+/// assert_eq!(grid(&buffer), "abcxyz");
+/// ```
+///
 /// ![flex demo](https://raw.githubusercontent.com/everruns/yolop/main/crates/tuika/docs/demos/flex.gif)
 pub struct Flex {
     style: LayoutStyle,

--- a/crates/tuika/src/components/select.rs
+++ b/crates/tuika/src/components/select.rs
@@ -111,6 +111,22 @@ impl SelectState {
 ///
 /// [`viewport`]: SelectList::viewport
 ///
+/// # Example
+///
+/// ```
+/// use ratatui::text::Line;
+/// use tuika::{SelectList, SelectState, Theme};
+/// use tuika::testing::{grid, render};
+///
+/// // A fresh state highlights the first row; the caret `›` marks it.
+/// let state = SelectState::new();
+/// let items = vec![Line::from("one"), Line::from("two")];
+/// let view = SelectList::new(items, &state);
+///
+/// let buffer = render(&view, 5, 2, &Theme::default());
+/// assert_eq!(grid(&buffer), "› one\n  two");
+/// ```
+///
 /// ![select demo](https://raw.githubusercontent.com/everruns/yolop/main/crates/tuika/docs/demos/select.gif)
 pub struct SelectList {
     items: Vec<Line<'static>>,

--- a/crates/tuika/src/highlight.rs
+++ b/crates/tuika/src/highlight.rs
@@ -27,6 +27,9 @@ use crate::style::Theme;
 /// source without re-deriving line boundaries; an implementation that cannot
 /// uphold it (event stream desynced from source lines) must return [`None`].
 pub trait Highlighter {
+    /// Highlight `lines` of `lang` source, returning one styled span vector per
+    /// input line (same length and order), or [`None`] if the language is
+    /// unknown or the source cannot be highlighted line-for-line.
     fn highlight(
         &self,
         lang: &str,

--- a/crates/tuika/src/markdown.rs
+++ b/crates/tuika/src/markdown.rs
@@ -773,6 +773,8 @@ pub struct Markdown<'a> {
 }
 
 impl<'a> Markdown<'a> {
+    /// A markdown view over `source`, rendering fenced code as plain text until
+    /// a highlighter is attached with [`highlighter`](Self::highlighter).
     pub fn new(source: impl Into<String>) -> Self {
         Self {
             source: source.into(),
@@ -780,6 +782,7 @@ impl<'a> Markdown<'a> {
         }
     }
 
+    /// Use `highlighter` to syntax-highlight fenced code blocks.
     pub fn highlighter(mut self, highlighter: &'a dyn Highlighter) -> Self {
         self.highlighter = CodeHighlighter::With(highlighter);
         self

--- a/crates/tuika/src/style.rs
+++ b/crates/tuika/src/style.rs
@@ -129,12 +129,19 @@ pub struct CodeTheme {
     /// Language-tag label above a fenced block.
     pub label: Color,
     // Syntax roles a highlighter maps token classes onto.
+    /// Keywords and language reserved words.
     pub keyword: Color,
+    /// Function and method names.
     pub function: Color,
+    /// Type names, traits, and other type-level identifiers.
     pub type_name: Color,
+    /// Constants, literals, and enum-like values.
     pub constant: Color,
+    /// String and character literals.
     pub string: Color,
+    /// Comments.
     pub comment: Color,
+    /// Punctuation, operators, and delimiters.
     pub punctuation: Color,
 }
 


### PR DESCRIPTION
## What changed
Two related documentation changes:

1. **Fixes red `main` CI.** The `markdown`/`highlight` work (`CodeTheme`'s syntax-role color fields, the `Highlighter` trait method, and `Markdown::new`/`highlighter`) merged onto `main` after the `#[warn(missing_docs)]` branch (#417) was cut. Once #417 landed and turned `missing_docs` into a build error under the CI `clippy -D warnings` gate, those still-undocumented public items broke the build — the `main` CI run for `5f5ef10` is **red**. This documents all 10 flagged items, restoring green.
2. **Adds the deferred inline doctests.** `Flex`, `Boxed`, and `SelectList` each now carry a runnable, rendered-and-asserted example in their rustdoc, built with the public `tuika::testing` helpers. This closes the "good descriptions, no inline examples" gap from the original docs assessment — a docs.rs reader now gets copy-pasteable, `cargo test --doc`-verified usage.

The `examples/` gallery and `docs/components.md` are **untouched** and remain the visual/runnable reference, as requested.

## Why
The missing_docs gate is only valuable if it stays green; a parallel merge slipped undocumented public API past it. And the enforcement itself was the reason to finally add inline examples — they're now guarded by the same gate.

## Before / After
Docs-only; no runtime behavior changes.

**Before** — on current `main`:
```
$ cargo build -p tuika 2>&1 | grep -c "missing documentation"
10                     # CodeTheme fields, Highlighter::highlight, Markdown::new/highlighter
# → main CI run 5f5ef10: "CI: completed/failure"
```

**After**:
```
$ cargo build -p tuika 2>&1 | grep -c "missing documentation"
0
$ cargo test -p tuika --doc
test result: ok. 8 passed; 0 failed; 2 ignored
```
The three new examples render and assert real output, e.g. `Flex::row().fixed(3, …).fixed(3, …)` → `"abcxyz"`, and `Boxed::new(…)` renders its rounded border.

## Risk
- **Low**
- Only doc comments and rustdoc examples added; no logic, signatures, or dependencies touched. The doctests exercise only already-public API through the already-public `testing` helpers.

## Security
No security-relevant code changes — documentation and doctest examples only.

## Follow-ups
No follow-ups. This completes the docs-quality work: full public-API coverage, the `missing_docs` gate green on main, and inline examples for the core containers.

## Checklist
- [x] Tests added or updated — three rustdoc doctests, run by `cargo test --doc`.
- [x] Backward compatibility considered — no API changes; `tuika` is pre-1.0.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HE6AxShv4FZ4Cf7N9VbvH8)_