### PR TITLE
docs(readme): restore Origin of the name to the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ integration over the Agent Client Protocol.
 
 ![yolop upgrading a project's dependencies](https://raw.githubusercontent.com/everruns/yolop/main/docs/demo.gif)
 
+## Origin of the name
+
+`yolop` comes from the Ukrainian `Йолоп`: a dummy, fool, or not-too-bright
+person. The name was meant to sound clever and funny in Ukrainian while also
+describing the agent's starting point: Yolop avoids per-tool approval pop-ups.
+Routine workspace work runs automatically; hard prompts are reserved for the
+configured shell boundary, with [soft approval](#soft-approval) for critical
+moments that need spoken consent and an audit trail.
+
 ## Install
 
 ```bash
@@ -389,15 +398,6 @@ Yolop-owned worktree and never changes the branch, `HEAD`, commits, or index.
 > reasoning artifacts — deliberately unredacted, with no retention policy. If a
 > session should not be persisted, point `--session-dir` at a wipeable path (e.g.
 > a `tmpfs`) or delete the JSONL after the run.
-
-## Origin of the name
-
-`yolop` comes from the Ukrainian `Йолоп`: a dummy, fool, or not-too-bright
-person. The name was meant to sound clever and funny in Ukrainian while also
-describing the agent's starting point: Yolop avoids per-tool approval pop-ups.
-Routine workspace work runs automatically; hard prompts are reserved for the
-configured shell boundary, with [soft approval](#soft-approval) for critical
-moments that need spoken consent and an audit trail.
 
 ## Contributing
 


### PR DESCRIPTION
## What changed

Moves the **Origin of the name** section back to the top of the README — right after the intro and demo, before Install — where it sat before #421. Pure relocation of the existing section; no wording changes.

## Why

Follow-up to #421. Demoting the name story to the bottom was the wrong call: `yolop` (Ukrainian `Йолоп` — "fool") is part of the product's identity, and the paragraph also explains Yolop's core stance — it avoids per-tool approval pop-ups, running routine work automatically and reserving prompts for the shell boundary. That framing belongs up front, not buried under the reference material.

## Before / After

Docs-only, no runtime behavior change.

- **Before (as of #421):** section order was Intro → Install → … → Session persistence → **Origin of the name** → Contributing.
- **After:** Intro → **Origin of the name** → Install → Quick start → Features → …

Diff is a clean move (9 insertions / 9 deletions). The `#soft-approval` anchor it links to still resolves (the Soft approval section is unchanged), and no `README.md`/`docs/` links point into `specs/` or `.agents/`.

## Risk

- **Low.** Documentation-only; single section relocated, no content edits.

## Security

No security-relevant code changes — documentation prose only.

## Follow-ups

No follow-ups.

## Checklist
- [x] Tests added or updated — N/A, docs-only change with no behavior change
- [x] Backward compatibility considered — documentation only

https://claude.ai/code/session_016qgng85PvLh5cBE8kzTAqy

---
_Generated by [Claude Code](https://claude.ai/code/session_016qgng85PvLh5cBE8kzTAqy)_