### PR TITLE
test(tui): de-flake combined-resize composer test

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1110,13 +1110,14 @@ fn tui_combined_resize_reconstructs_composer_at_screen_bottom() {
     tui.clear_output();
     tui.resize(60, 40);
     tui.write_input(b" ");
-    assert!(
-        tui.wait_for_output("[expand", Duration::from_secs(3)),
-        "TUI did not redraw after combined resize: {}",
-        tui.output_text()
-    );
 
-    let screen = tui.screen_lines();
+    // The resize redraws over several frames; wait for the one where the
+    // composer has re-anchored to the new bottom (status row at row 40) before
+    // snapshotting, otherwise we race a mid-transition frame (see
+    // `wait_for_screen`).
+    let screen = tui.wait_for_screen(Duration::from_secs(3), |screen| {
+        screen.len() == 40 && screen.last().is_some_and(|row| row.contains("llmsim"))
+    });
     assert_eq!(
         screen.len(),
         40,

--- a/tests/support/tui_harness.rs
+++ b/tests/support/tui_harness.rs
@@ -143,6 +143,29 @@ impl TuiHarness {
             .collect()
     }
 
+    /// Poll the reconstructed screen grid until `predicate` holds or `timeout`
+    /// elapses, returning the final grid either way.
+    ///
+    /// A PTY resize makes the app emit several intermediate frames before it
+    /// settles (the composer re-anchors to the new bottom row over more than one
+    /// redraw). `wait_for_output` returns the instant a needle's bytes appear —
+    /// which can be a mid-transition frame — so snapshotting `screen_lines`
+    /// right after it races the final layout. Poll on the settled grid instead.
+    pub fn wait_for_screen(
+        &mut self,
+        timeout: Duration,
+        mut predicate: impl FnMut(&[String]) -> bool,
+    ) -> Vec<String> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let screen = self.screen_lines();
+            if predicate(&screen) || Instant::now() >= deadline {
+                return screen;
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+    }
+
     pub fn clear_output(&mut self) {
         while self.output_rx.try_recv().is_ok() {}
         self.output.clear();


### PR DESCRIPTION
## What changed
`tui_combined_resize_reconstructs_composer_at_screen_bottom` no longer races
the terminal's post-resize redraw. It now waits for the *settled* frame before
asserting on the reconstructed grid, via a new
`TuiHarness::wait_for_screen(timeout, predicate)` helper that polls
`screen_lines()` until the predicate holds.

## Why
The test snapshotted the screen immediately after
`wait_for_output("[expand", …)` returned. But a PTY resize repaints over
**several frames**, and that needle can land in a mid-transition frame — before
the composer has re-anchored to the new bottom row. `vt100`'s `contents()`
trims trailing blank rows, so an unsettled grid reports the last non-empty row
as its length: the run that failed in CI captured the status bar at row 22 and
asserted `screen.len() == 40`, giving `left: 22, right: 40`.

This surfaced in CI on PR #419: the `Build + Tests` job went red on this test
even though the PR only touched `.github/workflows/ci.yml` — a textbook flake.

## Before / After
- **Before:** `wait_for_output("[expand")` → immediate `screen_lines()` snapshot. Passed almost always, but flaked when the settle frame hadn't arrived (`screen.len()` == 22).
- **After:** `wait_for_screen(3s, |s| s.len() == 40 && s.last().is_some_and(|r| r.contains("llmsim")))` → assert on the returned settled grid.

Stress-verified locally — the previously-flaky test run 40× in a loop:

```
RESULT: 40 passed, 0 failed out of 40
```

(`cargo fmt --check` clean.)

## Risk
- Low
- Test-only change. `wait_for_screen` returns the last grid on timeout, so a
  genuine regression still fails the same assertions (now with a settled grid in
  the message) rather than hanging — no false green. The helper is reusable for
  other post-resize snapshot assertions.

## Security
No security-relevant code changes — test harness and a single integration test
only; no runtime, dependency, or capability surface touched.

## Follow-ups
No follow-ups. (The sibling `screen_lines()` assertions — the setup-overlay and
banner tests — wait on a last-rendered element rather than a resize settle, so
they don't share this race and are left unchanged.)

## Checklist
- [x] Tests added or updated — this *is* a test-reliability fix; validated by a 40× stress loop of the affected test.
- [x] Backward compatibility considered — n/a; test-only, pre-1.0.

https://claude.ai/code/session_01K4osiDkzAyH4zdhcTnYktf

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4osiDkzAyH4zdhcTnYktf)_