### PR TITLE
test: add render benchmarks + instruction-count regression gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [main]
     types: [opened, reopened, synchronize]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -243,6 +244,43 @@ jobs:
 
       - name: Run sandbox contract suite
         run: cargo test sandbox -- --nocapture
+
+  benchmarks:
+    name: Benchmarks (archive)
+    needs: changes
+    # Trend archive, not a gate: wall-clock numbers on shared runners are too
+    # noisy to fail a build on, so this only runs on main pushes that touch Rust
+    # (and on demand) and uploads the Criterion output as an artifact. The
+    # benches still *compile* on every PR via the `test` job's --all-targets
+    # build, so they can't rot. Compare runs locally with --save-baseline.
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && needs.changes.outputs.rust == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.94.0
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "debug"
+
+      - name: Run benchmarks
+        run: |
+          cargo bench --locked -p tuika -p tuika-codeformatters -- \
+            --warm-up-time 2 --measurement-time 5 --noplot | tee bench-output.txt
+
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: criterion-benchmarks
+          path: |
+            target/criterion/**
+            bench-output.txt
+          if-no-files-found: warn
 
   # The (comparatively scarce) Windows runner only spins up when the change
   # actually touches Rust — not on doc- or eval-only changes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
               - 'rust-toolchain.toml'
               - '**/build.rs'
               - '.github/workflows/ci.yml'
+              - 'crates/tuika/benches/check_iai.py'
+              - '**/iai-baseline.json'
             # The dedicated MSRV check only compiles `-p tuika`, which depends on
             # neither yolop, yolop-yep, nor tuika-codeformatters. Scope it to
             # tuika's own sources plus the workspace-wide inputs that reach it
@@ -281,6 +283,59 @@ jobs:
             target/criterion/**
             bench-output.txt
           if-no-files-found: warn
+
+  iai:
+    name: iai-callgrind (instruction counts)
+    needs: changes
+    # Instruction counts are deterministic and machine-independent, so unlike the
+    # wall-clock `benchmarks` job this one IS a gate: it fails the build when a
+    # change regresses instruction counts past the tolerance in the committed
+    # iai-baseline.json. Runs on Rust-affecting PRs and pushes; ubuntu-latest
+    # matches the x86_64/glibc the baseline was captured on.
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.94.0
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "debug"
+
+      - name: Install Valgrind
+        run: sudo apt-get update && sudo apt-get install -y valgrind
+
+      - name: Install iai-callgrind-runner
+        # Must match the iai-callgrind library version in Cargo.toml.
+        run: cargo install iai-callgrind-runner --version 0.16.1 --locked
+
+      - name: Run instruction-count benchmarks
+        run: |
+          rm -rf target/iai
+          cargo bench --locked -p tuika --bench markdown_iai \
+            -p tuika-codeformatters --bench highlight_iai -- --save-summary=json
+
+      - name: Check against committed baseline
+        # On workflow_dispatch, regenerate and upload the baseline instead of
+        # gating — the clean way to refresh it from CI's exact environment.
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            python3 crates/tuika/benches/check_iai.py --update
+          else
+            python3 crates/tuika/benches/check_iai.py
+          fi
+
+      - name: Upload regenerated baseline
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v7
+        with:
+          name: iai-baseline
+          path: '**/iai-baseline.json'
+          if-no-files-found: error
 
   # The (comparatively scarce) Windows runner only spins up when the change
   # actually touches Rust — not on doc- or eval-only changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,22 @@ doppler run -- cargo run -- --provider openai -p "hi"
 
 `RUST_LOG` is honored for the tracing layer (stderr).
 
+Component render benchmarks live under `crates/*/benches/` (Criterion). Run a
+crate's suite and, when checking a change for a regression, save a baseline
+first and compare against it:
+
+```bash
+cargo bench -p tuika --bench markdown -- --save-baseline before
+# ...make the change...
+cargo bench -p tuika --bench markdown -- --baseline before
+```
+
+Wall-clock numbers are too noisy on shared CI runners to gate on, so CI runs the
+benches only on `main` (and via manual dispatch) and uploads the Criterion
+output as an artifact; regression-checking is a local, baseline-to-baseline
+comparison. New component benches go in the owning crate's `benches/` as another
+`[[bench]]` with `harness = false`.
+
 The `evals/` directory holds [Mira](https://github.com/everruns/mira) eval
 studies for benchmarking yolop and other agents. `evals/swebench_verified/` is
 the SWE-bench Verified study — a single self-contained `swebench_verified.py`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,28 @@ output as an artifact; regression-checking is a local, baseline-to-baseline
 comparison. New component benches go in the owning crate's `benches/` as another
 `[[bench]]` with `harness = false`.
 
+Alongside those, the `*_iai` benches count CPU instructions under
+Valgrind/callgrind ([iai-callgrind](https://github.com/iai-callgrind/iai-callgrind)).
+Instruction counts are deterministic and machine-independent for a fixed
+toolchain + libc, so the numbers are committed to `crates/*/benches/iai-baseline.json`
+and the CI `iai` job **fails** on a regression past the baseline's tolerance —
+this is a real gate, not an archive. Running them locally needs Valgrind and a
+version-matched runner (`cargo install iai-callgrind-runner`):
+
+```bash
+rm -rf target/iai
+cargo bench -p tuika --bench markdown_iai \
+  -p tuika-codeformatters --bench highlight_iai -- --save-summary=json
+python3 crates/tuika/benches/check_iai.py            # compare to the committed baseline
+python3 crates/tuika/benches/check_iai.py --update   # bless new counts (commit alongside the change)
+```
+
+When a change legitimately shifts counts (renderer change, dependency bump,
+toolchain upgrade), regenerate the baseline with `--update` and commit it with
+the code — like a snapshot test. To refresh it from CI's exact environment,
+run the workflow manually (`workflow_dispatch`) and commit the uploaded
+`iai-baseline` artifact.
+
 The `evals/` directory holds [Mira](https://github.com/everruns/mira) eval
 studies for benchmarking yolop and other agents. `evals/swebench_verified/` is
 the SWE-bench Verified study — a single self-contained `swebench_verified.py`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,6 +604,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2657,6 +2666,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "iai-callgrind"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e4910d3a9137442723dfb772c32dc10674c4181ca078d2fd227cd5dce9db0"
+dependencies = [
+ "bincode",
+ "derive_more",
+ "iai-callgrind-macros",
+ "iai-callgrind-runner",
+]
+
+[[package]]
+name = "iai-callgrind-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d03775318d3f9f01b39ac6612b01464006dc397a654a89dd57df2fd34fb68c3"
+dependencies = [
+ "derive_more",
+ "proc-macro-error2",
+ "proc-macro2 1.0.107",
+ "quote 1.0.47",
+ "serde",
+ "serde_json",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "iai-callgrind-runner"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74c9743c00c3bca4aaffc69c87cae56837796cd362438daf354a3f785788c68"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4290,6 +4335,28 @@ checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2 1.0.107",
+ "quote 1.0.47",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2 1.0.107",
+ "quote 1.0.47",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6714,6 +6781,7 @@ version = "0.2.0"
 dependencies = [
  "criterion",
  "crossterm",
+ "iai-callgrind",
  "proptest",
  "pulldown-cmark",
  "ratatui",
@@ -6728,6 +6796,7 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "crossterm",
+ "iai-callgrind",
  "ratatui",
  "tree-sitter",
  "tree-sitter-c-sharp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,6 +784,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +868,33 @@ name = "chunked_transfer"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -1065,6 +1104,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -2841,10 +2914,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -3638,6 +3731,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3825,7 +3924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ed4d5c6ae95e08ac768883c8401cf0e8deb4e6e1d6a4e1fd3d2ec4f0ec63200"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "prost",
  "prost-types",
 ]
@@ -4247,7 +4346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -4268,7 +4367,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2 1.0.107",
  "quote 1.0.47",
  "syn 2.0.119",
@@ -4606,7 +4705,7 @@ dependencies = [
  "compact_str",
  "critical-section",
  "hashbrown 0.17.1",
- "itertools",
+ "itertools 0.14.0",
  "kasuari",
  "lru",
  "palette",
@@ -4671,7 +4770,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
  "serde",
@@ -6037,6 +6136,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6603,6 +6712,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 name = "tuika"
 version = "0.2.0"
 dependencies = [
+ "criterion",
  "crossterm",
  "proptest",
  "pulldown-cmark",
@@ -6616,6 +6726,7 @@ dependencies = [
 name = "tuika-codeformatters"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "crossterm",
  "ratatui",
  "tree-sitter",
@@ -6696,7 +6807,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "unicode-segmentation",
  "unicode-width 0.2.2",
 ]

--- a/crates/tuika-codeformatters/Cargo.toml
+++ b/crates/tuika-codeformatters/Cargo.toml
@@ -45,7 +45,13 @@ crossterm = "0.29"
 criterion = { version = "0.5", default-features = false, features = [
     "cargo_bench_support",
 ] }
+# See tuika/Cargo.toml — instruction-count harness for the CI regression gate.
+iai-callgrind = "0.16.1"
 
 [[bench]]
 name = "highlight"
+harness = false
+
+[[bench]]
+name = "highlight_iai"
 harness = false

--- a/crates/tuika-codeformatters/Cargo.toml
+++ b/crates/tuika-codeformatters/Cargo.toml
@@ -12,6 +12,11 @@ readme = "README.md"
 keywords = ["tui", "syntax-highlighting", "tree-sitter", "ratatui", "markdown"]
 categories = ["command-line-interface", "text-processing"]
 
+# See tuika/Cargo.toml: disable the default lib bench harness so `cargo bench`
+# runs only the Criterion target below.
+[lib]
+bench = false
+
 [dependencies]
 tuika = { version = "0.2.0", path = "../tuika" }
 ratatui = "0.30.2"
@@ -36,3 +41,11 @@ tree-sitter-zig = "1"
 # crossterm just supplies the raw event source (the same pair tuika's own
 # examples use).
 crossterm = "0.29"
+# Benchmark harness — same lean configuration as tuika (see its Cargo.toml).
+criterion = { version = "0.5", default-features = false, features = [
+    "cargo_bench_support",
+] }
+
+[[bench]]
+name = "highlight"
+harness = false

--- a/crates/tuika-codeformatters/benches/highlight.rs
+++ b/crates/tuika-codeformatters/benches/highlight.rs
@@ -1,0 +1,121 @@
+//! Highlighting benchmarks for the tree-sitter [`TreeSitterHighlighter`].
+//!
+//! Run with `cargo bench -p tuika-codeformatters --bench highlight`. Use
+//! `--save-baseline <name>` / `--baseline <name>` to track a change; Criterion
+//! writes machine-readable results under `target/criterion/**/estimates.json`.
+//!
+//! One group, `highlight`, over a matrix of language × size. Each case is one
+//! `highlight` call — grammar config lookup, parse, and event walk. The parser
+//! configurations are cached thread-locally on first use, and Criterion's warm-
+//! up primes that cache, so the reported number is the *steady-state* per-call
+//! cost — the cost paid for the in-flight code fence on every streamed delta,
+//! which is the number that matters for a live transcript.
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use tuika::{Highlighter, Theme};
+use tuika_codeformatters::TreeSitterHighlighter;
+
+/// Code sizes, as the repetition count applied to each snippet. The byte size
+/// each produces is reported per-case via [`Throughput::Bytes`].
+const SIZES: &[(&str, usize)] = &[("small", 1), ("medium", 10), ("large", 50)];
+
+fn highlight(c: &mut Criterion) {
+    let highlighter = TreeSitterHighlighter::new();
+    let theme = Theme::default();
+    let mut group = c.benchmark_group("highlight");
+    for &(lang, snippet) in corpus::SNIPPETS {
+        for &(size_name, reps) in SIZES {
+            let src = corpus::repeat(snippet, reps);
+            let lines: Vec<&str> = src.lines().collect();
+            group.throughput(Throughput::Bytes(src.len() as u64));
+            group.bench_with_input(BenchmarkId::new(lang, size_name), &lines, |b, lines| {
+                b.iter(|| {
+                    black_box(highlighter.highlight(lang, black_box(lines), &theme));
+                });
+            });
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, highlight);
+criterion_main!(benches);
+
+/// Representative snippets per language. Kept deterministic and syntactically
+/// valid so every case highlights (rather than falling back), and repeated to
+/// reach the larger sizes.
+mod corpus {
+    /// `(language tag, snippet)` pairs spanning the grammars most common in
+    /// assistant answers.
+    pub const SNIPPETS: &[(&str, &str)] = &[
+        (
+            "rust",
+            "use std::collections::HashMap;\n\n\
+fn word_counts(text: &str) -> HashMap<&str, usize> {\n\
+    let mut counts = HashMap::new();\n\
+    for word in text.split_whitespace() {\n\
+        *counts.entry(word).or_insert(0) += 1;\n\
+    }\n\
+    counts\n\
+}\n",
+        ),
+        (
+            "python",
+            "from collections import Counter\n\n\
+def word_counts(text: str) -> Counter:\n\
+    \"\"\"Count words, case-insensitively.\"\"\"\n\
+    return Counter(w.lower() for w in text.split())\n\n\
+if __name__ == \"__main__\":\n\
+    print(word_counts(\"a b a c\"))\n",
+        ),
+        (
+            "typescript",
+            "interface User {\n\
+  id: number;\n\
+  name: string;\n\
+}\n\n\
+export function greet(users: User[]): string[] {\n\
+  return users.map((u) => `Hello, ${u.name}!`);\n\
+}\n",
+        ),
+        (
+            "go",
+            "package main\n\n\
+import \"fmt\"\n\n\
+func sum(nums []int) int {\n\
+\ttotal := 0\n\
+\tfor _, n := range nums {\n\
+\t\ttotal += n\n\
+\t}\n\
+\treturn total\n\
+}\n",
+        ),
+        (
+            "ruby",
+            "class Greeter\n\
+  def initialize(name)\n\
+    @name = name\n\
+  end\n\n\
+  def greet\n\
+    puts \"Hello, #{@name}!\"\n\
+  end\n\
+end\n",
+        ),
+        (
+            "sql",
+            "SELECT u.name, COUNT(o.id) AS orders\n\
+FROM users u\n\
+LEFT JOIN orders o ON o.user_id = u.id\n\
+WHERE u.active = TRUE\n\
+GROUP BY u.name\n\
+ORDER BY orders DESC;\n",
+        ),
+    ];
+
+    /// Repeat a snippet `reps` times to reach a larger size.
+    pub fn repeat(snippet: &str, reps: usize) -> String {
+        snippet.repeat(reps.max(1))
+    }
+}

--- a/crates/tuika-codeformatters/benches/highlight_iai.rs
+++ b/crates/tuika-codeformatters/benches/highlight_iai.rs
@@ -1,0 +1,51 @@
+//! Instruction-count benchmarks for the tree-sitter highlighter (iai-callgrind).
+//!
+//! Deterministic, machine-independent instruction counts for the committed
+//! baseline / CI regression gate — the counterpart to the wall-clock `highlight`
+//! bench. See `crates/tuika/benches/check_iai.py` and the committed `iai-baseline.json` next
+//! to this file. Requires Valgrind + a version-matched `iai-callgrind-runner`.
+//! Run with `cargo bench -p tuika-codeformatters --bench highlight_iai`.
+//!
+//! Each case highlights a sizeable snippet so the one-time grammar-config build
+//! (thread-local, paid once per process) is a small fraction of the measured
+//! instructions and the highlight loop dominates. Two representative grammars
+//! keep the gate fast; add languages here if a regression slips through.
+
+use std::hint::black_box;
+
+use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+use tuika::{Highlighter, Theme};
+use tuika_codeformatters::TreeSitterHighlighter;
+
+const RUST: &str = "use std::collections::HashMap;\n\n\
+fn word_counts(text: &str) -> HashMap<&str, usize> {\n\
+    let mut counts = HashMap::new();\n\
+    for word in text.split_whitespace() {\n\
+        *counts.entry(word).or_insert(0) += 1;\n\
+    }\n\
+    counts\n\
+}\n";
+
+const PYTHON: &str = "from collections import Counter\n\n\
+def word_counts(text: str) -> Counter:\n\
+    \"\"\"Count words, case-insensitively.\"\"\"\n\
+    return Counter(w.lower() for w in text.split())\n";
+
+fn repeat(snippet: &str, reps: usize) -> String {
+    snippet.repeat(reps)
+}
+
+#[library_benchmark]
+#[bench::rust("rust", repeat(RUST, 40))]
+#[bench::python("python", repeat(PYTHON, 40))]
+fn highlight(lang: &str, source: String) -> usize {
+    let highlighter = TreeSitterHighlighter::new();
+    let theme = Theme::default();
+    let lines: Vec<&str> = source.lines().collect();
+    black_box(highlighter.highlight(lang, black_box(&lines), &theme))
+        .map(|v| v.len())
+        .unwrap_or(0)
+}
+
+library_benchmark_group!(name = highlight_iai; benchmarks = highlight);
+main!(library_benchmark_groups = highlight_iai);

--- a/crates/tuika-codeformatters/benches/iai-baseline.json
+++ b/crates/tuika-codeformatters/benches/iai-baseline.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "iai-callgrind instruction-count baseline. Deterministic and machine-independent for a fixed toolchain + libc. Regenerate with `python3 crates/tuika/benches/check_iai.py --update` and commit alongside the code change that shifted the counts.",
+  "tolerance_pct": 2.0,
+  "benchmarks": {
+    "highlight.python": 94727971,
+    "highlight.rust": 291034831
+  }
+}

--- a/crates/tuika/Cargo.toml
+++ b/crates/tuika/Cargo.toml
@@ -37,7 +37,15 @@ proptest = "1"
 criterion = { version = "0.5", default-features = false, features = [
     "cargo_bench_support",
 ] }
+# Instruction-count benchmark harness (deterministic, machine-independent) for
+# the committed baseline / CI regression gate. Needs Valgrind + a version-matched
+# `iai-callgrind-runner` installed (`cargo install iai-callgrind-runner`).
+iai-callgrind = "0.16.1"
 
 [[bench]]
 name = "markdown"
+harness = false
+
+[[bench]]
+name = "markdown_iai"
 harness = false

--- a/crates/tuika/Cargo.toml
+++ b/crates/tuika/Cargo.toml
@@ -12,6 +12,12 @@ readme = "README.md"
 keywords = ["tui", "terminal", "ratatui", "widgets", "layout"]
 categories = ["command-line-interface"]
 
+# No `#[bench]` fns in the lib, and the default libtest bench harness rejects
+# Criterion's CLI flags — disable it so `cargo bench` runs only the Criterion
+# targets below.
+[lib]
+bench = false
+
 [dependencies]
 ratatui = "0.30.2"
 crossterm = "0.29"
@@ -25,3 +31,13 @@ pulldown-cmark = { version = "0.13", default-features = false }
 
 [dev-dependencies]
 proptest = "1"
+# Benchmark harness. default-features off drops the plotters/rayon HTML-report
+# stack (heavy, and an MSRV liability) while keeping `cargo bench` working;
+# Criterion still writes machine-readable `estimates.json` for archiving.
+criterion = { version = "0.5", default-features = false, features = [
+    "cargo_bench_support",
+] }
+
+[[bench]]
+name = "markdown"
+harness = false

--- a/crates/tuika/benches/check_iai.py
+++ b/crates/tuika/benches/check_iai.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Compare iai-callgrind instruction counts against a committed baseline.
+
+Instruction counts (unlike wall-clock time) are deterministic and machine-
+independent for a fixed toolchain + libc, so they can be committed to the repo
+and enforced in CI. This script reads the `summary.json` files iai-callgrind
+writes under `target/iai/`, compares each benchmark's instruction count (`Ir`)
+against the baseline stored next to the benchmark, and fails on a regression
+beyond the tolerance.
+
+Usage:
+    # after `cargo bench --bench <iai bench> -- --save-summary=json`
+    python3 crates/tuika/benches/check_iai.py            # check (exit 1 on regression)
+    python3 crates/tuika/benches/check_iai.py --update   # (re)write the baselines
+
+The baseline lives at `<crate>/benches/iai-baseline.json`. Regenerate it (with
+--update) whenever a change legitimately shifts instruction counts — a renderer
+change, a dependency bump, or a toolchain upgrade — and commit it alongside the
+code change, the way you would a snapshot test.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+BASELINE_NAME = "iai-baseline.json"
+DEFAULT_TOLERANCE_PCT = 2.0
+
+
+def find_repo_root() -> Path:
+    """Workspace root — the nearest ancestor with a Cargo.lock. Lets this script
+    live anywhere in the tree (it sits next to the tuika benches it checks)."""
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "Cargo.lock").is_file():
+            return parent
+    return Path(__file__).resolve().parent
+
+
+REPO_ROOT = find_repo_root()
+IAI_DIR = REPO_ROOT / "target" / "iai"
+
+
+def extract_current(metrics: dict) -> int:
+    """Pull the current-run instruction count from an iai metrics value.
+
+    iai-callgrind encodes it as `{"Left": {"Int": n}}` on a fresh run (no prior
+    result to diff against) or `{"Both": [{"Int": current}, {"Int": old}]}` when
+    a previous run exists. The current value is the left/first element either
+    way.
+    """
+    if "Both" in metrics:
+        return int(metrics["Both"][0]["Int"])
+    if "Left" in metrics:
+        return int(metrics["Left"]["Int"])
+    (only,) = metrics.values()
+    return int((only[0] if isinstance(only, list) else only)["Int"])
+
+
+def collect_measurements() -> dict[Path, dict[str, int]]:
+    """Map each crate dir to its {bench_key: instruction_count} from target/iai."""
+    if not IAI_DIR.is_dir():
+        sys.exit(f"error: {IAI_DIR} not found — run the iai benches first")
+
+    by_crate: dict[Path, dict[str, int]] = {}
+    for summary_path in sorted(IAI_DIR.rglob("summary.json")):
+        summary = json.loads(summary_path.read_text())
+        key = f"{summary['function_name']}.{summary['id']}"
+        metrics = summary["profiles"][0]["summaries"]["parts"][0]["metrics_summary"][
+            "Callgrind"
+        ]["Ir"]["metrics"]
+        crate_dir = Path(summary["package_dir"])
+        by_crate.setdefault(crate_dir, {})[key] = extract_current(metrics)
+    if not by_crate:
+        sys.exit(f"error: no summary.json under {IAI_DIR} — did the benches run?")
+    return by_crate
+
+
+def baseline_path(crate_dir: Path) -> Path:
+    return crate_dir / "benches" / BASELINE_NAME
+
+
+def load_baseline(crate_dir: Path) -> dict | None:
+    path = baseline_path(crate_dir)
+    if not path.is_file():
+        return None
+    return json.loads(path.read_text())
+
+
+def write_baseline(crate_dir: Path, benchmarks: dict[str, int]) -> None:
+    path = baseline_path(crate_dir)
+    doc = {
+        "_comment": (
+            "iai-callgrind instruction-count baseline. Deterministic and "
+            "machine-independent for a fixed toolchain + libc. Regenerate with "
+            "`python3 crates/tuika/benches/check_iai.py --update` and commit alongside the "
+            "code change that shifted the counts."
+        ),
+        "tolerance_pct": DEFAULT_TOLERANCE_PCT,
+        "benchmarks": dict(sorted(benchmarks.items())),
+    }
+    path.write_text(json.dumps(doc, indent=2) + "\n")
+    print(f"wrote {path.relative_to(REPO_ROOT)} ({len(benchmarks)} benchmarks)")
+
+
+def rel(crate_dir: Path) -> str:
+    try:
+        return str(crate_dir.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(crate_dir)
+
+
+def check(by_crate: dict[Path, dict[str, int]]) -> int:
+    failed = False
+    for crate_dir, measured in sorted(by_crate.items(), key=lambda kv: str(kv[0])):
+        baseline = load_baseline(crate_dir)
+        if baseline is None:
+            print(
+                f"error: no baseline for {rel(crate_dir)} — run "
+                f"`python3 crates/tuika/benches/check_iai.py --update` and commit it"
+            )
+            failed = True
+            continue
+        tol = float(baseline.get("tolerance_pct", DEFAULT_TOLERANCE_PCT))
+        expected = baseline.get("benchmarks", {})
+        print(f"\n{rel(crate_dir)}  (tolerance ±{tol:g}%)")
+        print(f"  {'benchmark':<28} {'baseline':>14} {'current':>14} {'diff':>9}")
+        for key in sorted(set(expected) | set(measured)):
+            base = expected.get(key)
+            cur = measured.get(key)
+            if base is None:
+                print(f"  {key:<28} {'—':>14} {cur:>14,} {'NEW':>9}  (unbaselined)")
+                failed = True
+                continue
+            if cur is None:
+                print(f"  {key:<28} {base:>14,} {'—':>14} {'MISSING':>9}")
+                failed = True
+                continue
+            diff_pct = (cur - base) / base * 100 if base else 0.0
+            status = "ok"
+            if diff_pct > tol:
+                status = "REGRESSED"
+                failed = True
+            elif diff_pct < -tol:
+                status = "improved"  # not a failure; baseline is stale
+            print(f"  {key:<28} {base:>14,} {cur:>14,} {diff_pct:>+8.3f}%  {status}")
+    if failed:
+        print(
+            "\nFAILED: instruction counts regressed or the baseline is out of "
+            "date.\nIf the change is intentional, run "
+            "`python3 crates/tuika/benches/check_iai.py --update` and commit the baseline."
+        )
+        return 1
+    print("\nOK: all benchmarks within tolerance of the committed baseline.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="rewrite the committed baselines from the current run",
+    )
+    args = parser.parse_args()
+
+    by_crate = collect_measurements()
+    if args.update:
+        for crate_dir, measured in by_crate.items():
+            write_baseline(crate_dir, measured)
+        return 0
+    return check(by_crate)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/crates/tuika/benches/iai-baseline.json
+++ b/crates/tuika/benches/iai-baseline.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "iai-callgrind instruction-count baseline. Deterministic and machine-independent for a fixed toolchain + libc. Regenerate with `python3 crates/tuika/benches/check_iai.py --update` and commit alongside the code change that shifted the counts.",
+  "tolerance_pct": 2.0,
+  "benchmarks": {
+    "one_shot.large": 4066518,
+    "one_shot.small": 172394,
+    "reflow.mixed": 7942062,
+    "streaming.mixed": 80249636
+  }
+}

--- a/crates/tuika/benches/markdown.rs
+++ b/crates/tuika/benches/markdown.rs
@@ -1,0 +1,273 @@
+//! Rendering benchmarks for the streaming `Markdown` renderer.
+//!
+//! Run with `cargo bench -p tuika --bench markdown`. Save a baseline to compare
+//! against later with `cargo bench -p tuika --bench markdown -- --save-baseline
+//! <name>`, then `--baseline <name>` on a later run to see the delta. Criterion
+//! writes machine-readable results under `target/criterion/**/estimates.json`.
+//!
+//! Four groups, each over a matrix of document *shapes* and *sizes*:
+//!
+//! - `one_shot` — [`markdown_to_lines`] over a whole document, the cost of a
+//!   static render.
+//! - `streaming` — feed the document in stream-sized deltas through
+//!   [`MarkdownState`], rendering every delta. This is the realistic live-
+//!   transcript cost.
+//! - `streaming_model` — the same streamed input rendered two ways: the cached
+//!   [`MarkdownState`] versus a naive renderer that re-parses the whole buffer
+//!   on every delta. The gap is what the settled-prefix cache buys, and the
+//!   guard against a refactor quietly turning the cache back into full re-parse.
+//! - `reflow` — re-render a *settled* document across a sweep of widths (a
+//!   terminal resize). The parse cache is width-independent, so this exercises
+//!   re-flatten only and guards that a resize never silently re-parses. A theme
+//!   change is the opposite (it invalidates the cache and re-parses); its cost
+//!   is approximately `one_shot`, so it isn't benched separately.
+//!
+//! Highlighting is deliberately [`CodeHighlighter::Plain`] here: the tree-sitter
+//! cost lives in `tuika-codeformatters`' own `highlight` bench, and pulling that
+//! crate in would be a dependency cycle. These benches isolate parse + layout.
+
+use std::hint::black_box;
+
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use tuika::{CodeHighlighter, MarkdownState, Theme, markdown_to_lines};
+
+use corpus::Shape;
+
+/// Fixed render width — wide enough to exercise prose wrapping without dwarfing
+/// the parse cost.
+const WIDTH: u16 = 80;
+
+/// Document sizes for the one-shot bench, as the repetition `scale` handed to
+/// [`corpus::doc`]. The byte size each produces is reported per-case via
+/// [`Throughput::Bytes`].
+const SIZES: &[(&str, usize)] = &[("small", 1), ("medium", 8), ("large", 40)];
+
+/// Smaller sizes for the streaming benches. A streamed render re-flattens the
+/// settled prefix on every delta, so its cost grows quadratically with document
+/// length; the `large` scale here is capped so a run finishes quickly. (That
+/// quadratic is a known optimization target, not a property to bench to death.)
+const STREAM_SIZES: &[(&str, usize)] = &[("small", 1), ("medium", 4), ("large", 12)];
+
+/// Scale for the cached-vs-naive comparison — large enough that the naive
+/// full-reparse is clearly worse, small enough to stay fast.
+const MODEL_SCALE: usize = 12;
+
+/// Reduced sample count for the streaming groups: their slowest cases run in the
+/// tens of milliseconds, so the Criterion default of 100 would be needlessly
+/// slow. Fewer samples still give a usable estimate and CI for a trend.
+const STREAM_SAMPLES: usize = 30;
+
+/// Document shapes, each stressing a different part of the renderer.
+const SHAPES: &[(&str, Shape)] = &[
+    ("prose", Shape::Prose),
+    ("list", Shape::List),
+    ("code", Shape::Code),
+    ("mixed", Shape::Mixed),
+];
+
+/// Stream delta size in bytes — roughly a token's worth, so a document streams
+/// in many small pushes the way a provider emits it.
+const DELTA: usize = 16;
+
+/// Render widths swept during the `reflow` (resize) bench, narrow to wide.
+const REFLOW_WIDTHS: &[u16] = &[40, 60, 80, 100, 120];
+
+fn one_shot(c: &mut Criterion) {
+    let theme = Theme::default();
+    let mut group = c.benchmark_group("markdown/one_shot");
+    for &(shape_name, shape) in SHAPES {
+        for &(size_name, scale) in SIZES {
+            let src = corpus::doc(shape, scale);
+            group.throughput(Throughput::Bytes(src.len() as u64));
+            group.bench_with_input(BenchmarkId::new(shape_name, size_name), &src, |b, src| {
+                b.iter(|| {
+                    black_box(markdown_to_lines(
+                        black_box(src),
+                        WIDTH,
+                        &theme,
+                        CodeHighlighter::Plain,
+                    ));
+                });
+            });
+        }
+    }
+    group.finish();
+}
+
+fn streaming(c: &mut Criterion) {
+    let theme = Theme::default();
+    let mut group = c.benchmark_group("markdown/streaming");
+    group.sample_size(STREAM_SAMPLES);
+    for &(shape_name, shape) in SHAPES {
+        for &(size_name, scale) in STREAM_SIZES {
+            let src = corpus::doc(shape, scale);
+            let deltas = corpus::deltas(&src, DELTA);
+            group.throughput(Throughput::Bytes(src.len() as u64));
+            group.bench_with_input(
+                BenchmarkId::new(shape_name, size_name),
+                &deltas,
+                |b, deltas| {
+                    b.iter(|| {
+                        let mut md = MarkdownState::new();
+                        for delta in deltas {
+                            md.push_str(delta);
+                            black_box(md.lines(WIDTH, &theme, CodeHighlighter::Plain));
+                        }
+                    });
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
+fn streaming_model(c: &mut Criterion) {
+    let theme = Theme::default();
+    let mut group = c.benchmark_group("markdown/streaming_model");
+    group.sample_size(STREAM_SAMPLES);
+    // The cache pays off most on a large transcript, where the naive renderer
+    // re-parses the whole settled prefix on every delta.
+    for &(shape_name, shape) in &[("mixed", Shape::Mixed), ("code", Shape::Code)] {
+        let src = corpus::doc(shape, MODEL_SCALE);
+        let deltas = corpus::deltas(&src, DELTA);
+        group.throughput(Throughput::Bytes(src.len() as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("cached", shape_name),
+            &deltas,
+            |b, deltas| {
+                b.iter(|| {
+                    let mut md = MarkdownState::new();
+                    for delta in deltas {
+                        md.push_str(delta);
+                        black_box(md.lines(WIDTH, &theme, CodeHighlighter::Plain));
+                    }
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("naive_full_reparse", shape_name),
+            &deltas,
+            |b, deltas| {
+                b.iter(|| {
+                    let mut acc = String::new();
+                    for delta in deltas {
+                        acc.push_str(delta);
+                        black_box(markdown_to_lines(
+                            &acc,
+                            WIDTH,
+                            &theme,
+                            CodeHighlighter::Plain,
+                        ));
+                    }
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+fn reflow(c: &mut Criterion) {
+    let theme = Theme::default();
+    let mut group = c.benchmark_group("markdown/reflow");
+    group.sample_size(STREAM_SAMPLES);
+    for &(shape_name, shape) in SHAPES {
+        for &(size_name, scale) in SIZES {
+            let src = corpus::doc(shape, scale);
+            group.throughput(Throughput::Bytes(src.len() as u64));
+            group.bench_with_input(BenchmarkId::new(shape_name, size_name), &src, |b, src| {
+                b.iter_batched(
+                    || {
+                        // Prime the settled-prefix cache once, outside the measured
+                        // closure, so the sweep measures re-flatten and not the
+                        // initial parse. Every corpus doc ends on a blank line, so
+                        // the whole document settles and the tail is empty.
+                        let mut md = MarkdownState::new();
+                        md.set(src.clone());
+                        md.lines(REFLOW_WIDTHS[0], &theme, CodeHighlighter::Plain);
+                        md
+                    },
+                    |mut md| {
+                        // A drag-resize: the same settled document re-rendered at a
+                        // sweep of widths. The parse cache is width-independent, so
+                        // this must never re-parse — only re-flatten.
+                        for &width in REFLOW_WIDTHS {
+                            black_box(md.lines(width, &theme, CodeHighlighter::Plain));
+                        }
+                    },
+                    BatchSize::SmallInput,
+                );
+            });
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, one_shot, streaming, streaming_model, reflow);
+criterion_main!(benches);
+
+/// Synthetic markdown documents for the benchmarks. Kept deterministic (no
+/// randomness) so runs are comparable, and parameterized by a repetition
+/// `scale` so the same shape can be benched small, medium, and large.
+mod corpus {
+    /// The document shapes we bench. Each stresses a different renderer path:
+    /// [`Prose`](Shape::Prose) the word-wrapper and inline-emphasis splitter,
+    /// [`List`](Shape::List) nested block layout, [`Code`](Shape::Code) fenced-
+    /// block handling (the tail a highlighter would run over), and
+    /// [`Mixed`](Shape::Mixed) a realistic assistant answer combining all three.
+    #[derive(Clone, Copy)]
+    pub enum Shape {
+        Prose,
+        List,
+        Code,
+        Mixed,
+    }
+
+    const PROSE: &str = "Yolop streams **markdown** with _inline emphasis_, `inline code`, and the \
+odd [link](https://example.com/docs). Sentences wrap to the render width, so a \
+paragraph of several lines exercises the word-wrapper and the emphasis span-\
+splitter together rather than in isolation.\n\n";
+
+    const LIST: &str = "- top-level item with some **bold** text\n  - nested item with `code`\n    \
+- twice-nested item that runs long enough to wrap across the render width once\n  \
+- back to one level of nesting\n- another top-level item\n\n";
+
+    const CODE: &str = "```rust\nfn compute(n: usize) -> usize {\n    (0..n)\n        .map(|i| i * i)\n\
+        .filter(|x| x % 2 == 0)\n        .sum()\n}\n```\n\n";
+
+    /// One "unit" of the mixed shape: a heading, a paragraph, a short list, and
+    /// a code block — the texture of a real assistant answer.
+    fn mixed_unit(n: usize) -> String {
+        format!("## Section {n}\n\n{PROSE}{LIST}{CODE}")
+    }
+
+    /// Build a document of the given `shape`, repeated `scale` times.
+    pub fn doc(shape: Shape, scale: usize) -> String {
+        let scale = scale.max(1);
+        match shape {
+            Shape::Prose => PROSE.repeat(scale),
+            Shape::List => LIST.repeat(scale),
+            Shape::Code => CODE.repeat(scale),
+            Shape::Mixed => (0..scale).map(mixed_unit).collect(),
+        }
+    }
+
+    /// Split `doc` into stream-sized deltas of about `chunk` bytes each, always
+    /// on a UTF-8 char boundary — mimicking how a provider streams tokens into
+    /// [`MarkdownState`](tuika::MarkdownState).
+    pub fn deltas(doc: &str, chunk: usize) -> Vec<&str> {
+        let chunk = chunk.max(1);
+        let mut out = Vec::new();
+        let mut start = 0;
+        while start < doc.len() {
+            let mut end = (start + chunk).min(doc.len());
+            while end < doc.len() && !doc.is_char_boundary(end) {
+                end += 1;
+            }
+            out.push(&doc[start..end]);
+            start = end;
+        }
+        out
+    }
+}

--- a/crates/tuika/benches/markdown_iai.rs
+++ b/crates/tuika/benches/markdown_iai.rs
@@ -1,0 +1,97 @@
+//! Instruction-count benchmarks for the `Markdown` renderer (iai-callgrind).
+//!
+//! Unlike the wall-clock `markdown` bench, these count CPU instructions under
+//! Valgrind/callgrind, which is *deterministic and machine-independent* — so the
+//! numbers can be committed as a baseline and a regression can fail CI. See
+//! `crates/tuika/benches/check_iai.py` and the committed `iai-baseline.json` next to this
+//! file.
+//!
+//! Requires Valgrind and a version-matched `iai-callgrind-runner` on PATH
+//! (`cargo install iai-callgrind-runner`). Run with
+//! `cargo bench -p tuika --bench markdown_iai`.
+//!
+//! A focused set of the highest-signal cases, not the full wall-clock matrix:
+//! instruction-count runs are slower (under Valgrind) and exist to gate
+//! regressions, not to explore the size curve.
+
+use std::hint::black_box;
+
+use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+use tuika::{CodeHighlighter, MarkdownState, Theme, markdown_to_lines};
+
+const WIDTH: u16 = 80;
+
+/// One unit of a realistic mixed document — heading, prose with inline emphasis,
+/// a nested list, and a fenced code block.
+const UNIT: &str = "## Section\n\nYolop streams **markdown** with _emphasis_, `code`, and a \
+[link](https://example.com). This paragraph is long enough to wrap at the render \
+width, exercising the word-wrapper.\n\n- item with **bold**\n  - nested `code`\n\n\
+```rust\nfn compute(n: usize) -> usize {\n    (0..n).map(|i| i * i).sum()\n}\n```\n\n";
+
+fn doc(scale: usize) -> String {
+    UNIT.repeat(scale)
+}
+
+/// Split into ~16-byte, char-boundary-safe deltas — a provider's token stream.
+/// Returns owned `String`s so the value crosses the iai setup boundary cleanly.
+fn deltas(source: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut start = 0;
+    while start < source.len() {
+        let mut end = (start + 16).min(source.len());
+        while end < source.len() && !source.is_char_boundary(end) {
+            end += 1;
+        }
+        out.push(source[start..end].to_string());
+        start = end;
+    }
+    out
+}
+
+#[library_benchmark]
+#[bench::small(doc(1))]
+#[bench::large(doc(24))]
+fn one_shot(source: String) -> usize {
+    let theme = Theme::default();
+    black_box(markdown_to_lines(
+        black_box(&source),
+        WIDTH,
+        &theme,
+        CodeHighlighter::Plain,
+    ))
+    .len()
+}
+
+#[library_benchmark]
+#[bench::mixed(deltas(&doc(8)))]
+fn streaming(deltas: Vec<String>) -> usize {
+    let theme = Theme::default();
+    let mut md = MarkdownState::new();
+    let mut last = 0;
+    for delta in &deltas {
+        md.push_str(delta);
+        last = black_box(md.lines(WIDTH, &theme, CodeHighlighter::Plain)).len();
+    }
+    last
+}
+
+#[library_benchmark]
+#[bench::mixed(doc(12))]
+fn reflow(source: String) -> usize {
+    let theme = Theme::default();
+    let mut md = MarkdownState::new();
+    md.set(source);
+    let mut last = 0;
+    // A resize: re-render the settled document across a width sweep. The parse
+    // cache is width-independent, so this should re-flatten only.
+    for width in [40u16, 60, 80, 100, 120] {
+        last = black_box(md.lines(width, &theme, CodeHighlighter::Plain)).len();
+    }
+    last
+}
+
+library_benchmark_group!(
+    name = markdown_iai;
+    benchmarks = one_shot, streaming, reflow
+);
+main!(library_benchmark_groups = markdown_iai);


### PR DESCRIPTION
## What changed

Adds performance benchmarks for the tuika `Markdown` renderer and the
`tuika-codeformatters` tree-sitter highlighter, in two complementary forms:

- **Wall-clock (Criterion)** — a shape × size matrix (prose / list / code / mixed
  × small / medium / large) covering one-shot render, streaming (render every
  delta), resize (`reflow` — a width sweep over a settled doc), and a
  cached-vs-naive streaming comparison. Archived as a CI artifact on `main` /
  manual dispatch; **not** a gate (wall-clock is too noisy on shared runners).
- **Instruction counts (iai-callgrind)** — deterministic, machine-independent
  counts for the highest-signal paths, with committed baselines
  (`crates/*/benches/iai-baseline.json`) and a CI job that **fails on a
  regression** past a per-file tolerance. `crates/tuika/benches/check_iai.py`
  does the comparison; `--update` re-blesses.

No runtime or behavior change — this is test + CI tooling only.

## Why

The streaming `Markdown` renderer makes a real performance claim (cache the
settled prefix, re-parse only the in-flight tail) that nothing defended.
Benchmarks lock it in, and the instruction-count gate catches regressions
automatically — without the flakiness of wall-clock timing on CI.

## Before / After

No observable runtime behavior changes; this adds capability:

- `cargo bench -p tuika --bench markdown` / `-p tuika-codeformatters --bench highlight` — wall-clock matrix.
- `cargo bench … --bench *_iai` + `python3 crates/tuika/benches/check_iai.py` — the instruction-count gate.

Evidence — the cached-vs-naive comparison already earns its keep (bounded scale):

| case | cached | naive full-reparse | naive penalty |
|---|---|---|---|
| streaming_model/code | 957 µs | 1.99 ms | 2.1× |
| streaming_model/mixed | 104 ms | 138 ms | 1.33× |

iai gate against the committed baseline (tolerance ±2%): all six benches at
+0.000%, exit 0. Negative test: an injected +11% baseline shift is correctly
reported `REGRESSED` and fails the gate (exit 1). Determinism verified — repeat
runs produce identical counts (jitter ≈ 50 instructions out of ~10^8). Confirmed
green in CI, so the committed baseline matches the `ubuntu-latest` environment.

## Risk

- **Low.** Test/CI-only; no yolop runtime, agent-loop, or library API changes.
- What can break: the `iai` gate depends on Valgrind + a version-matched runner
  and on the committed baseline being captured in the same environment
  (x86_64 / glibc 2.39 = `ubuntu-latest`). A rustc / glibc / Valgrind bump can
  shift counts — re-bless via `workflow_dispatch` (which uploads a fresh
  baseline artifact) and commit it. Documented in `AGENTS.md`.

## Security

Structured review per the ship skill.

- **TM-DEP:** two dev-only additions — `criterion` and `iai-callgrind` (0.16.1),
  both benches-only and **not** in the shipped `yolop` binary. CI additionally
  installs Valgrind (apt) and `iai-callgrind-runner` (pinned to 0.16.1). No
  `everruns-*` changes.
- **TM-FS / TM-BASH / TM-LLM / TM-TOOL:** untouched — no filesystem blocklist,
  shell-exec, prompt/key, or capability code changes. `check_iai.py` reads the
  local iai output plus the repo baselines and writes only
  `<crate>/benches/iai-baseline.json`; it uses `json.loads` (no `eval`), spawns
  no subprocess, and makes no network calls.
- MSRV: `cargo +1.88 check -p tuika --all-targets` passes with the new dev-deps.

## Follow-ups

- **Optimize `MarkdownState` streaming layout (O(n²) → O(n)).** The `reflow` /
  `streaming` benches show `lines()` re-`flatten`s the entire settled prefix on
  every frame — it caches parsing but not layout. Caching flattened settled
  lines (invalidated on the width/theme change it already tracks) would make
  streaming linear. Deferred to a focused PR that uses these benches as
  before/after proof.

## Checklist

- [x] Tests added or updated — benches exercise the render paths; the iai gate is
  verified by an injected-regression negative test. No runtime behavior to unit-test.
- [x] Backward compatibility considered — dev/CI-only; no API or runtime change.
