### PR TITLE
fix(tuika): cache flattened settled lines so streaming stays linear

### DIFF
--- a/crates/tuika/benches/iai-baseline.json
+++ b/crates/tuika/benches/iai-baseline.json
@@ -4,7 +4,7 @@
   "benchmarks": {
     "one_shot.large": 4066518,
     "one_shot.small": 172394,
-    "reflow.mixed": 7942062,
-    "streaming.mixed": 80249636
+    "reflow.mixed": 7935987,
+    "streaming.mixed": 8565881
   }
 }

--- a/crates/tuika/benches/markdown.rs
+++ b/crates/tuika/benches/markdown.rs
@@ -42,10 +42,10 @@ const WIDTH: u16 = 80;
 /// [`Throughput::Bytes`].
 const SIZES: &[(&str, usize)] = &[("small", 1), ("medium", 8), ("large", 40)];
 
-/// Smaller sizes for the streaming benches. A streamed render re-flattens the
-/// settled prefix on every delta, so its cost grows quadratically with document
-/// length; the `large` scale here is capped so a run finishes quickly. (That
-/// quadratic is a known optimization target, not a property to bench to death.)
+/// Smaller sizes for the streaming benches. `MarkdownState` flattens settled
+/// blocks once and re-does only the in-flight tail per delta, so streaming is
+/// linear in the transcript length; these scales are kept modest simply so the
+/// per-delta loops (which still render every frame) finish quickly.
 const STREAM_SIZES: &[(&str, usize)] = &[("small", 1), ("medium", 4), ("large", 12)];
 
 /// Scale for the cached-vs-naive comparison — large enough that the naive

--- a/crates/tuika/examples/demo.rs
+++ b/crates/tuika/examples/demo.rs
@@ -639,7 +639,9 @@ fn scene_markdown(frame: u64, theme: &Theme) -> Element {
     state.set(revealed);
     // Rendered at a fixed width for the demo frame; a real host passes the live
     // viewport width so prose re-wraps on resize.
-    let lines = state.lines(64, theme, tuika::CodeHighlighter::With(&HL));
+    let lines = state
+        .lines(64, theme, tuika::CodeHighlighter::With(&HL))
+        .to_vec();
     element(Text::new(lines))
 }
 

--- a/crates/tuika/examples/markdown.rs
+++ b/crates/tuika/examples/markdown.rs
@@ -177,7 +177,9 @@ fn main() -> io::Result<()> {
         terminal.draw(|f| {
             let area = f.area();
             let width = area.width.saturating_sub(4);
-            let lines = state.lines(width, &theme, CodeHighlighter::With(&highlighter));
+            let lines = state
+                .lines(width, &theme, CodeHighlighter::With(&highlighter))
+                .to_vec();
             let status = if cursor < doc.len() {
                 format!("streaming… {}/{} glyphs", cursor, doc.len())
             } else {

--- a/crates/tuika/src/markdown.rs
+++ b/crates/tuika/src/markdown.rs
@@ -635,14 +635,15 @@ fn stable_boundary(source: &str, from: usize) -> usize {
 /// Feed it deltas with [`push_str`](Self::push_str) (or replace the whole buffer
 /// with [`set`](Self::set)); call [`lines`](Self::lines) each frame for the
 /// current width-fitted rendering. Settled blocks — everything before the last
-/// blank line outside an open code fence — are parsed and highlighted **once**
-/// and cached; only the in-flight tail re-parses. That is what keeps a long
-/// transcript from re-tokenizing, and tree-sitter from re-highlighting settled
-/// code, on every delta.
+/// blank line outside an open code fence — are parsed, highlighted, **and
+/// flattened once** and cached; each delta re-does only the in-flight tail. That
+/// keeps a streamed render linear in the transcript length, instead of
+/// re-tokenizing and re-laying-out the whole settled prefix on every delta.
 ///
-/// The cache is width-independent (wrapping happens at [`lines`](Self::lines)
-/// time), so a resize is cheap; it is invalidated only when [`set`](Self::set)
-/// replaces the buffer or the [`Theme`] passed to [`lines`](Self::lines) changes.
+/// The parse/highlight cache is width-independent. The flattened-line cache is
+/// per-width: a resize re-wraps the settled prefix once (then reuses it), and a
+/// [`set`](Self::set) or [`Theme`] change discards everything. [`lines`](Self::lines)
+/// returns a borrow of the cached line buffer — clone it with `.to_vec()` to own it.
 ///
 /// ```
 /// use tuika::{MarkdownState, CodeHighlighter, Theme};
@@ -659,6 +660,20 @@ pub struct MarkdownState {
     stable_len: usize,
     stable: Vec<MdItem>,
     cached_theme: Option<Theme>,
+    // Settled lines are flattened *once*, as blocks settle, and kept here across
+    // frames — never re-flattened while streaming. Without this, `lines` would
+    // re-flatten (re-wrap, re-lay-out, re-clone) the whole settled prefix every
+    // delta, making a streamed render O(n²) in the transcript length. Returning a
+    // borrow of this buffer also avoids re-materializing the prefix per frame.
+    /// Flattened settled lines followed by the current in-flight tail.
+    rendered: Vec<Line<'static>>,
+    /// Count of leading `rendered` entries that are settled (cached) lines; the
+    /// rest is the per-frame tail, dropped and rebuilt on the next call.
+    settled_lines: usize,
+    /// Count of `stable` items already flattened into the settled prefix.
+    flattened_items: usize,
+    /// Width `rendered` was flattened at; a change re-wraps the whole prefix.
+    rendered_width: Option<u16>,
 }
 
 impl MarkdownState {
@@ -687,6 +702,10 @@ impl MarkdownState {
     fn reset_cache(&mut self) {
         self.stable_len = 0;
         self.stable.clear();
+        self.rendered.clear();
+        self.settled_lines = 0;
+        self.flattened_items = 0;
+        self.rendered_width = None;
     }
 
     /// Render the current buffer to final, width-fitted styled lines, advancing
@@ -696,16 +715,30 @@ impl MarkdownState {
     /// every color via [`Theme::code`](crate::CodeTheme); `highlighter` colors
     /// fenced code ([`CodeHighlighter::Plain`] for none). Draw the result
     /// **without** further wrapping (e.g. ratatui `Paragraph` with no `.wrap`).
+    ///
+    /// Returns a borrow of an internally-cached line buffer: settled blocks are
+    /// flattened once and only the in-flight tail is recomputed per call, so a
+    /// streamed render stays linear in the transcript length. The borrow is valid
+    /// until the next mutation of `self`; clone with `.to_vec()` if you need to
+    /// own it (e.g. to move into a ratatui `Text`).
     pub fn lines(
         &mut self,
         width: u16,
         theme: &Theme,
         highlighter: CodeHighlighter,
-    ) -> Vec<Line<'static>> {
-        // A theme change restyles everything, so the cache is invalid.
+    ) -> &[Line<'static>] {
+        // A theme change restyles everything, so every cache is invalid.
         if self.cached_theme != Some(*theme) {
             self.cached_theme = Some(*theme);
             self.reset_cache();
+        }
+        // A width change re-wraps every settled line, but the width-independent
+        // parse cache survives; drop only the flattened lines.
+        if self.rendered_width != Some(width) {
+            self.rendered_width = Some(width);
+            self.rendered.clear();
+            self.settled_lines = 0;
+            self.flattened_items = 0;
         }
 
         let boundary = stable_boundary(&self.source, self.stable_len);
@@ -724,19 +757,30 @@ impl MarkdownState {
             self.stable_len = boundary;
         }
 
+        // Drop the previous frame's tail (and settled/tail gap), then extend the
+        // settled prefix with any blocks that settled since — flattened once.
+        // `flatten` maps each item independently, so appending the new items'
+        // lines equals re-flattening the whole prefix.
+        self.rendered.truncate(self.settled_lines);
+        if self.flattened_items < self.stable.len() {
+            let settled = flatten(&self.stable[self.flattened_items..], width, theme);
+            self.rendered.extend(settled);
+            self.flattened_items = self.stable.len();
+            self.settled_lines = self.rendered.len();
+        }
+
         let tail = parse(&self.source[self.stable_len..], theme, highlighter);
-        let mut all = flatten(&self.stable, width, theme);
         let tail_lines = flatten(&tail, width, theme);
         // The tail begins just past the boundary's blank line; keep that gap.
-        if !all.is_empty()
+        if !self.rendered.is_empty()
             && !tail_lines.is_empty()
-            && !is_blank_line(all.last().unwrap())
+            && !is_blank_line(self.rendered.last().unwrap())
             && !is_blank_line(&tail_lines[0])
         {
-            all.push(Line::default());
+            self.rendered.push(Line::default());
         }
-        all.extend(tail_lines);
-        all
+        self.rendered.extend(tail_lines);
+        &self.rendered
     }
 }
 
@@ -1020,6 +1064,40 @@ mod tests {
                 .collect();
         }
         assert_eq!(streamed, one_shot);
+    }
+
+    #[test]
+    fn streaming_then_resize_matches_one_shot_at_new_width() {
+        // The settled-prefix line cache is width-specific: a width change must
+        // re-wrap the whole prefix, not serve stale lines flattened at the old
+        // width. Settle several blocks at a wide width, then render narrower.
+        let theme = Theme::default();
+        let chunks = [
+            "# A wide head",
+            "ing that wraps when narrow\n\nA para",
+            "graph long enough to wrap differently at 24 columns than at 60.\n\n",
+            "- a bullet that also wraps\n\nDone.",
+        ];
+        let full: String = chunks.concat();
+
+        let mut state = MarkdownState::new();
+        for chunk in chunks {
+            state.push_str(chunk);
+            let _ = state.lines(60, &theme, CodeHighlighter::Plain);
+        }
+        let resized: Vec<String> = state
+            .lines(24, &theme, CodeHighlighter::Plain)
+            .iter()
+            .map(text)
+            .collect();
+        let one_shot: Vec<String> = markdown_to_lines(&full, 24, &theme, CodeHighlighter::Plain)
+            .iter()
+            .map(text)
+            .collect();
+        assert_eq!(
+            resized, one_shot,
+            "resized stream must equal a one-shot render at the new width"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1007,7 +1007,9 @@ fn build_gallery(frame: u64, theme: &tuika::Theme) -> tuika::Element {
     let highlighter = tuika_codeformatters::TreeSitterHighlighter::new();
     let mut markdown = MarkdownState::new();
     markdown.set(md_doc);
-    let markdown_lines = markdown.lines(46, theme, CodeHighlighter::With(&highlighter));
+    let markdown_lines = markdown
+        .lines(46, theme, CodeHighlighter::With(&highlighter))
+        .to_vec();
 
     tuika::view! {
         col(


### PR DESCRIPTION
## What changed

`MarkdownState` cached parsing and highlighting of settled blocks but
re-`flatten`ed the entire settled prefix — re-wrapping, re-laying-out, and
re-cloning it — on every delta, and returned a freshly-owned `Vec` each frame.
A streamed render was therefore **O(n²)** in the transcript length (exactly what
the benches merged in #425 surfaced).

Now each settled block is flattened **once** into an internal line buffer,
extended only with newly-settled blocks per delta, and `lines()` returns a
**borrow** (`&[Line]`) of that buffer. Streaming is linear.

- A width change re-wraps the settled prefix once, then reuses it; a theme change
  or `set()` still discards everything.
- **API:** `MarkdownState::lines` now returns `&[Line<'static>]` instead of
  `Vec<Line<'static>>`; callers that need to own the lines use `.to_vec()`
  (yolop's gallery panel + two tuika examples). tuika is pre-1.0.

## Why

The streaming renderer exists precisely to avoid redoing work per delta, but it
cached only parsing — not layout — leaving the dominant per-frame cost
quadratic. The new benches made that measurable, so this is the fix they pointed
at.

## Before / After

Rendered output is unchanged (byte-identical). Performance, measured on the
committed benches:

| metric | before | after | improvement |
|---|---|---|---|
| iai `streaming.mixed` (instructions, deterministic) | 80,249,636 | 8,565,881 | −89% (9.4×) |
| wall-clock `streaming_model/cached/mixed` | ~104 ms | ~5.2 ms | ~20× |
| cached-vs-naive `mixed` gap | 1.33× | 26× | — |

The `iai` gate flagged the −89% shift, and the committed
`crates/tuika/benches/iai-baseline.json` is re-blessed to the new counts.

## Risk

- **Low.** Display-rendering only; no agent-loop, tool, filesystem, shell, or
  provider changes.
- Behavior-preserving: the existing `streaming_matches_one_shot_render` still
  passes byte-identical, and a new `streaming_then_resize_matches_one_shot_at_new_width`
  covers the width-invalidation path. The return-type change is contained to
  three in-repo callers.

## Security

No security-relevant code changes — this is display rendering of already-received
text into styled spans, which executes nothing. No TM-FS / TM-BASH / TM-LLM /
TM-TOOL surface and no new dependencies. Resource use strictly decreases
(O(n²) → O(n)); the single `.unwrap()` is guarded by a preceding non-empty check.

## Follow-ups

No follow-ups — the optimization the #425 benches surfaced is this PR.

## Checklist

- [x] Tests added or updated — new resize test; the existing streaming test guards byte-identical output.
- [x] Backward compatibility considered — `lines()` return type changed (`Vec` → `&[Line]`); tuika is pre-1.0 and all in-repo callers are updated.
