### PR TITLE
fix(evals): treat provider outages as inconclusive, not a regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       rust: ${{ steps.filter.outputs.rust }}
       tuika: ${{ steps.filter.outputs.tuika }}
       docs: ${{ steps.filter.outputs.docs }}
+      eval-analyzers: ${{ steps.filter.outputs.eval-analyzers }}
     steps:
       - uses: actions/checkout@v7
 
@@ -63,6 +64,14 @@ jobs:
               - '.github/workflows/ci.yml'
             docs:
               - '**/*.md'
+            # The regression-gate analyzers under harness_basic are pure Python
+            # and decide whether the nightly Search Efficiency Eval passes. They
+            # never touch the Rust toolchain, so give them their own fast leg that
+            # runs whenever an analyzer or its tests change.
+            eval-analyzers:
+              - 'evals/harness_basic/*.py'
+              - 'evals/harness_basic/tests/**'
+              - '.github/workflows/ci.yml'
 
   tuika-msrv:
     name: Tuika MSRV
@@ -106,6 +115,20 @@ jobs:
             echo "::error::Public documentation must not link to internal specs/ or .agents/ files."
             exit 1
           fi
+
+  eval-analyzers:
+    name: Eval analyzers (Python)
+    needs: changes
+    if: needs.changes.outputs.eval-analyzers == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run analyzer unit tests
+        # Standard library only — no third-party deps, so the system python is
+        # enough and there's nothing to install.
+        run: python3 -m unittest discover -s evals/harness_basic/tests -v
 
   lint:
     name: Format + Clippy

--- a/evals/harness_basic/README.md
+++ b/evals/harness_basic/README.md
@@ -253,6 +253,14 @@ the focused and control presets, gates both reports, and uploads the complete
 Mira run archives. It is intentionally excluded from pull-request CI because
 it is a live-model regression monitor, not a deterministic unit test.
 
+Trials that fail because the provider or infrastructure was unavailable (quota
+exhaustion, rate limits, 5xx, network) carry no signal and are dropped from the
+gate like skipped trials; harness timeouts stay real failures. When an outage
+wipes out a majority of a sample's trials the sample is reported *inconclusive*
+rather than a regression, and a run with nothing left to compare exits green so
+a throttled account never pages as a fleet-wide regression. The gate logic is
+covered by pure-Python unit tests (`tests/`) that do run in pull-request CI.
+
 For progress-efficiency, the distribution gate additionally requires fewer
 workspace-state revisits in the dependency case and fewer redundant validation
 calls in both focused cases. Ordinary-task token and cost regressions are gated

--- a/evals/harness_basic/analyze_search_efficiency.py
+++ b/evals/harness_basic/analyze_search_efficiency.py
@@ -31,6 +31,60 @@ METRICS = (
     "duration_ms",
 )
 
+# Substrings that mark a failed trial as a provider/infrastructure outage
+# (quota exhaustion, rate limiting, 5xx, network) rather than the agent getting
+# the task wrong. When the provider is down every trial — baseline and candidate
+# alike — fails identically, so reading those failures as pass-rate would report
+# a fleet-wide "regression" every night the account is throttled. Such trials
+# carry no signal about search efficiency and are excluded from the gate, exactly
+# like a skipped trial. Kept lowercase for case-insensitive matching.
+INFRA_ERROR_MARKERS = (
+    "insufficient_quota",
+    "exceeded your current quota",
+    "rate_limit",
+    "rate limit",
+    "too many requests",
+    "server_error",
+    "api_error",
+    "overloaded",
+    "service_unavailable",
+    "service unavailable",
+    "bad gateway",
+    "internal server error",
+    "connection error",
+    "connection refused",
+    "connection reset",
+    "failed to connect",
+    "network error",
+    "temporarily unavailable",
+)
+
+
+def error_text(case: dict) -> str:
+    """Collect the failure text a case exposes: the harness transcript error plus
+    the reason from the `succeeded` scorer (which mirrors it). Lowercased."""
+    parts = [str(case.get("transcript", {}).get("error") or "")]
+    for score in case.get("scores", []):
+        if score.get("scorer") == "succeeded" and not score.get("pass"):
+            parts.append(str(score.get("reason") or ""))
+    return " ".join(parts).lower()
+
+
+def is_infra_failure(case: dict) -> bool:
+    """True when a *failed* trial errored because the provider or infrastructure
+    was unavailable, not because the agent solved the task wrong. Harness timeouts
+    and empty-event runs are findings about the agent under test, not the
+    environment, so they stay real failures — mirroring the infra-vs-failure split
+    the Rust harness makes in main.rs."""
+    if case.get("passed"):
+        return False
+    error = error_text(case)
+    if not error.strip():
+        return False
+    if "timeout after" in error or "no events at" in error:
+        return False
+    return any(marker in error for marker in INFRA_ERROR_MARKERS)
+
 
 def value(case: dict, metric: str) -> float:
     transcript = case.get("transcript", {})
@@ -43,7 +97,7 @@ def value(case: dict, metric: str) -> float:
     return float(transcript.get("metrics", {}).get(metric, 0))
 
 
-def analyze_reports(reports: list[dict]) -> tuple[list[str], list[str]]:
+def analyze_reports(reports: list[dict]) -> tuple[list[str], list[str], list[str]]:
     grouped: dict[tuple[str, str], list[dict]] = defaultdict(list)
     for report in reports:
         for case in report.get("cases", []):
@@ -55,20 +109,37 @@ def analyze_reports(reports: list[dict]) -> tuple[list[str], list[str]]:
 
     samples = sorted(EXPECTED_SAMPLES)
     failures: list[str] = []
+    notes: list[str] = []
     rows: list[str] = []
     improved = 0
+    gradable_focused = 0
     for sample in samples:
-        baseline = grouped.get((sample, "baseline"), [])
-        candidate = grouped.get((sample, "candidate"), [])
-        if not baseline or not candidate:
+        baseline_all = grouped.get((sample, "baseline"), [])
+        candidate_all = grouped.get((sample, "candidate"), [])
+        if not baseline_all or not candidate_all:
             failures.append(f"{sample}: missing baseline or candidate trials")
             continue
         expected_trials = CONTROL_TRIALS if sample in CONTROLS else FOCUSED_TRIALS
-        if len(baseline) != expected_trials or len(candidate) != expected_trials:
+        if len(baseline_all) != expected_trials or len(candidate_all) != expected_trials:
             failures.append(
                 f"{sample}: expected {expected_trials} trials per binary, got "
-                f"{len(baseline)} baseline / {len(candidate)} candidate"
+                f"{len(baseline_all)} baseline / {len(candidate_all)} candidate"
             )
+
+        # Drop provider/infrastructure-error trials before scoring: they carry no
+        # signal. If an outage takes out a majority of either binary's trials the
+        # sample can no longer be compared fairly, so record it as inconclusive and
+        # skip its gates rather than reading the outage as a regression.
+        baseline = [c for c in baseline_all if not is_infra_failure(c)]
+        candidate = [c for c in candidate_all if not is_infra_failure(c)]
+        min_valid = expected_trials // 2 + 1
+        if len(baseline) < min_valid or len(candidate) < min_valid:
+            notes.append(
+                f"{sample}: inconclusive — provider/infra errors left "
+                f"{len(baseline)}/{len(baseline_all)} baseline and "
+                f"{len(candidate)}/{len(candidate_all)} candidate valid trials"
+            )
+            continue
         base_pass = sum(bool(case.get("passed")) for case in baseline) / len(baseline)
         cand_pass = sum(bool(case.get("passed")) for case in candidate) / len(candidate)
         if cand_pass < base_pass:
@@ -77,8 +148,10 @@ def analyze_reports(reports: list[dict]) -> tuple[list[str], list[str]]:
             )
         if sample in FOCUSED and cand_pass < 2 / 3:
             failures.append(f"{sample}: candidate focused pass rate {cand_pass:.0%} < 67%")
-        if sample in FOCUSED and cand_pass > base_pass:
-            improved += 1
+        if sample in FOCUSED:
+            gradable_focused += 1
+            if cand_pass > base_pass:
+                improved += 1
 
         medians = {}
         for metric in METRICS:
@@ -113,12 +186,15 @@ def analyze_reports(reports: list[dict]) -> tuple[list[str], list[str]]:
             f"bytes {medians[('baseline', 'total_tool_result_bytes')]:g}->"
             f"{medians[('candidate', 'total_tool_result_bytes')]:g}"
         )
-    if improved == 0:
+    # Only demand an improvement when at least one focused case actually produced
+    # signal. A provider outage that leaves every focused case inconclusive must
+    # not fail here — there was nothing to improve on.
+    if gradable_focused and improved == 0:
         failures.append("no focused case improved over baseline")
-    return rows, failures
+    return rows, failures, notes
 
 
-def analyze(report: dict) -> tuple[list[str], list[str]]:
+def analyze(report: dict) -> tuple[list[str], list[str], list[str]]:
     """Analyze one report; retained for callers with a combined report."""
     return analyze_reports([report])
 
@@ -132,15 +208,28 @@ def main() -> int:
         help="focused 3-trial and control 5-trial report.json files",
     )
     args = parser.parse_args()
-    rows, failures = analyze_reports(
+    rows, failures, notes = analyze_reports(
         [json.loads(report.read_text()) for report in args.reports]
     )
     print("\n".join(rows))
+    if notes:
+        print("\nInconclusive (excluded from the gate):", file=sys.stderr)
+        for note in notes:
+            print(f"- {note}", file=sys.stderr)
     if failures:
         print("\nRegression gates:", file=sys.stderr)
         for failure in failures:
             print(f"- {failure}", file=sys.stderr)
         return 1
+    if not rows and notes:
+        # Nothing was gradable: a provider/infrastructure outage, not a code
+        # regression. Say so plainly and let the scheduled run stay green rather
+        # than paging on a throttled account.
+        print(
+            "\nRegression gate inconclusive: provider/infrastructure errors left "
+            "no valid trials to compare; not gating CI on a provider outage."
+        )
+        return 0
     print("\nRegression gates passed.")
     return 0
 

--- a/evals/harness_basic/tests/test_analyze_search_efficiency.py
+++ b/evals/harness_basic/tests/test_analyze_search_efficiency.py
@@ -8,22 +8,31 @@ analyzer = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(analyzer)
 
 
-def case(sample, binary, passed, tools=1, tokens=100, failures=0):
+def case(sample, binary, passed, tools=1, tokens=100, failures=0, error=None):
+    transcript = {
+        "tool_calls_count": tools,
+        "metrics": {
+            "llm_calls": 2,
+            "tool_calls_failed": failures,
+            "total_tool_result_bytes": 1000,
+        },
+        "usage": {"input_tokens": tokens, "cost_usd": 0.01},
+        "timing": {"duration_ms": 1000},
+    }
+    if error is not None:
+        transcript["error"] = error
     return {
         "sample": sample,
         "passed": passed,
         "params": {"binary": binary},
-        "transcript": {
-            "tool_calls_count": tools,
-            "metrics": {
-                "llm_calls": 2,
-                "tool_calls_failed": failures,
-                "total_tool_result_bytes": 1000,
-            },
-            "usage": {"input_tokens": tokens, "cost_usd": 0.01},
-            "timing": {"duration_ms": 1000},
-        },
+        "transcript": transcript,
     }
+
+
+QUOTA_ERROR = (
+    "yolop exit 1: turn error: LLM error: insufficient_quota: "
+    "You exceeded your current quota, please check your plan and billing details."
+)
 
 
 def focused_cases():
@@ -53,32 +62,101 @@ def control_cases(candidate_passed=True, candidate_tokens=100, trials=5):
     return cases
 
 
+def outage_cases():
+    """Every focused and control trial fails with a provider quota error — the
+    shape of a full provider outage (baseline and candidate both wiped out)."""
+    cases = []
+    for sample in sorted(analyzer.FOCUSED):
+        for _ in range(3):
+            for binary in ("baseline", "candidate"):
+                cases.append(case(sample, binary, False, error=QUOTA_ERROR))
+    for sample in sorted(analyzer.CONTROLS):
+        for _ in range(5):
+            for binary in ("baseline", "candidate"):
+                cases.append(case(sample, binary, False, error=QUOTA_ERROR))
+    return cases
+
+
 class AnalyzeTests(unittest.TestCase):
     def test_accepts_split_reports_with_stable_five_trial_controls(self):
-        _, failures = analyzer.analyze_reports(
+        _, failures, notes = analyzer.analyze_reports(
             [{"cases": focused_cases()}, {"cases": control_cases()}]
         )
         self.assertEqual(failures, [])
+        self.assertEqual(notes, [])
 
     def test_rejects_control_cost_and_correctness_regression(self):
         cases = focused_cases() + control_cases(
             candidate_passed=False, candidate_tokens=120
         )
-        _, failures = analyzer.analyze({"cases": cases})
+        _, failures, _ = analyzer.analyze({"cases": cases})
         self.assertTrue(any("correctness regressed" in failure for failure in failures))
         self.assertTrue(any("input_tokens regressed" in failure for failure in failures))
 
     def test_rejects_three_trial_controls(self):
         cases = focused_cases() + control_cases(trials=3)
-        _, failures = analyzer.analyze({"cases": cases})
+        _, failures, _ = analyzer.analyze({"cases": cases})
         self.assertTrue(
             any("add-fn: expected 5 trials per binary" in failure for failure in failures)
         )
 
     def test_rejects_missing_preset_report(self):
-        _, failures = analyzer.analyze({"cases": focused_cases()})
+        _, failures, _ = analyzer.analyze({"cases": focused_cases()})
         self.assertTrue(
             any("add-fn: missing baseline or candidate trials" in failure for failure in failures)
+        )
+
+    def test_provider_outage_is_inconclusive_not_regression(self):
+        # A full provider outage (every trial hit insufficient_quota) must not be
+        # read as a regression: no gate fires, every sample is flagged inconclusive.
+        rows, failures, notes = analyzer.analyze({"cases": outage_cases()})
+        self.assertEqual(failures, [])
+        self.assertEqual(rows, [])
+        self.assertEqual(len(notes), len(analyzer.EXPECTED_SAMPLES))
+        self.assertTrue(all("inconclusive" in note for note in notes))
+
+    def test_minority_infra_dropouts_still_grade(self):
+        # One infra-failed trial per focused binary (1 of 3) leaves a valid
+        # majority, so the sample is still graded on its surviving trials.
+        cases = []
+        for sample in sorted(analyzer.FOCUSED):
+            cases.append(case(sample, "baseline", False, error=QUOTA_ERROR, tools=4))
+            cases += [case(sample, "baseline", False, tools=4) for _ in range(2)]
+            cases.append(case(sample, "candidate", False, error=QUOTA_ERROR, tools=2))
+            cases += [case(sample, "candidate", True, tools=2) for _ in range(2)]
+        cases += control_cases()
+        rows, failures, notes = analyzer.analyze_reports([{"cases": cases}])
+        self.assertEqual(failures, [])
+        self.assertEqual(notes, [])
+        self.assertEqual(len(rows), len(analyzer.EXPECTED_SAMPLES))
+
+    def test_real_task_failure_still_regresses(self):
+        # A non-infra failure (agent got it wrong) must still count against the
+        # candidate — infra detection must not swallow genuine regressions.
+        cases = []
+        for sample in sorted(analyzer.FOCUSED):
+            for _ in range(3):
+                cases.append(case(sample, "baseline", True, tools=4))
+                cases.append(case(sample, "candidate", False, tools=2))
+        cases += control_cases()
+        _, failures, notes = analyzer.analyze_reports([{"cases": cases}])
+        self.assertEqual(notes, [])
+        self.assertTrue(
+            any("candidate focused pass rate" in failure for failure in failures)
+        )
+
+    def test_harness_timeout_is_not_treated_as_infra(self):
+        # A run that never finishes is a finding about the agent, not the
+        # environment — it stays a real failure, not an inconclusive dropout.
+        self.assertFalse(
+            analyzer.is_infra_failure(
+                case("repo-map-bounded", "candidate", False, error="timeout after 300s")
+            )
+        )
+        self.assertTrue(
+            analyzer.is_infra_failure(
+                case("repo-map-bounded", "candidate", False, error=QUOTA_ERROR)
+            )
         )
 
 


### PR DESCRIPTION
## What changed
The nightly **Search Efficiency Eval** regression gate no longer fails when the
provider (OpenAI, via Doppler) is unavailable. Trials that fail because of a
provider/infrastructure outage — quota exhaustion, rate limits, 5xx, network —
now carry no signal and are dropped from the gate exactly like a skipped trial.
When an outage takes out a majority of a sample's trials the sample is reported
**inconclusive**; a run with nothing left to compare exits green. Genuine
(non-infra) task failures, and harness timeouts, still gate exactly as before.

The previously-unexercised Python analyzer unit tests are now wired into
pull-request CI as a fast, standard-library-only job so the gate logic is
covered on every change that touches it.

## Why
The Search Efficiency Eval on `main` had been red for days. Every trial —
baseline and candidate alike — failed with OpenAI `insufficient_quota`, and the
distribution analyzer read those identical provider failures as a fleet-wide
search-efficiency regression, failing CI on an environment problem the code
cannot fix. A regression monitor that pages on a throttled billing account is
noise that trains people to ignore it. This mirrors the infra-vs-failure split
the Rust harness already makes (`main.rs`: "not the model's fault → N/A").

## Before / After
Run against the actual failed run's archived reports
(`search-efficiency-29899674295`):

**Before**
```
Regression gates:
- add-fn: ordinary control did not pass every trial
- find-constant: ordinary control did not pass every trial
- grep-files-nested-glob: candidate focused pass rate 0% < 67%
- repo-map-bounded: candidate focused pass rate 0% < 67%
- zero-result-search-recovery: candidate focused pass rate 0% < 67%
- no focused case improved over baseline
##[error]Process completed with exit code 1
```

**After**
```
Inconclusive (excluded from the gate):
- add-fn: inconclusive — provider/infra errors left 0/5 baseline and 0/5 candidate valid trials
- ... (all samples) ...

Regression gate inconclusive: provider/infrastructure errors left no valid
trials to compare; not gating CI on a provider outage.
exit 0
```

New unit tests (`15 passed`) cover: full outage → inconclusive/green; minority
infra dropouts still grade on surviving trials; genuine task failures still
regress; harness timeouts stay real failures.

## Risk
- Low
- The gate could in principle mask a real regression if a genuine failure's
  error text coincidentally contained a provider-error marker. Mitigated by
  matching only failed trials, by an explicit deny-list for harness timeouts /
  empty-event runs, and by requiring a *majority* of a binary's trials to be
  lost before a sample is declared inconclusive. A real correctness regression
  (task fails without a provider error) still gates.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; analyzer return signature is internal to the eval)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnjJMyCYrf7tzocAx35d5e)_