### PR TITLE
test(tuika): add Scroll render + paging benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,7 +339,7 @@ jobs:
       - name: Run instruction-count benchmarks
         run: |
           rm -rf target/iai
-          cargo bench --locked -p tuika --bench markdown_iai \
+          cargo bench --locked -p tuika --bench markdown_iai --bench scroll_iai \
             -p tuika-codeformatters --bench highlight_iai -- --save-summary=json
 
       - name: Check against committed baseline

--- a/crates/tuika/Cargo.toml
+++ b/crates/tuika/Cargo.toml
@@ -31,6 +31,10 @@ pulldown-cmark = { version = "0.13", default-features = false }
 
 [dev-dependencies]
 proptest = "1"
+# Benches build `Vec<Line>` corpora and paint into a `Buffer` directly, so they
+# name ratatui types the library only re-exports selectively. Same version as the
+# normal dependency above.
+ratatui = "0.30.2"
 # Benchmark harness. default-features off drops the plotters/rayon HTML-report
 # stack (heavy, and an MSRV liability) while keeping `cargo bench` working;
 # Criterion still writes machine-readable `estimates.json` for archiving.
@@ -48,4 +52,12 @@ harness = false
 
 [[bench]]
 name = "markdown_iai"
+harness = false
+
+[[bench]]
+name = "scroll"
+harness = false
+
+[[bench]]
+name = "scroll_iai"
 harness = false

--- a/crates/tuika/benches/iai-baseline.json
+++ b/crates/tuika/benches/iai-baseline.json
@@ -4,7 +4,10 @@
   "benchmarks": {
     "one_shot.large": 4066518,
     "one_shot.small": 172394,
+    "paging.large": 130441,
     "reflow.mixed": 7935987,
+    "render.large": 707868,
+    "render.small": 707805,
     "streaming.mixed": 8565881
   }
 }

--- a/crates/tuika/benches/scroll.rs
+++ b/crates/tuika/benches/scroll.rs
@@ -1,0 +1,132 @@
+//! Rendering benchmarks for the windowed [`Scroll`] viewport.
+//!
+//! Run with `cargo bench -p tuika --bench scroll`. Save a baseline to compare
+//! against later with `cargo bench -p tuika --bench scroll -- --save-baseline
+//! <name>`, then `--baseline <name>` on a later run to see the delta. Criterion
+//! writes machine-readable results under `target/criterion/**/estimates.json`.
+//!
+//! [`Scroll`] is the primitive that replaces native scrollback in the
+//! full-screen renderer: it holds the *whole* pre-wrapped transcript but paints
+//! only the `area.height` rows at the current offset. The defining property is
+//! that a frame costs O(viewport), not O(transcript) — these benches exist to
+//! keep it that way. Three groups:
+//!
+//! - `render` — paint one frame at the bottom (stick-to-bottom) offset across a
+//!   sweep of transcript *sizes* at a fixed viewport. The times must stay flat
+//!   as the transcript grows; a time that tracks the size is the regression
+//!   (windowing quietly turned into a full walk).
+//! - `render_offset` — paint one frame of a large transcript at the top vs the
+//!   bottom offset. Where the visible window sits must not change the cost.
+//! - `paging` — drive [`ScrollState`] from top to bottom one page at a time.
+//!   Each event is O(1); the traversal is O(transcript / viewport), and this
+//!   guards the event path against sneaking in per-row work.
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Style};
+use ratatui::text::{Line, Span};
+use tuika::{Event, Key, KeyCode, RenderCtx, Scroll, ScrollState, Surface, Theme, View};
+
+/// Fixed viewport the render benches paint into — a typical terminal transcript
+/// pane. Only these `HEIGHT` rows are ever drawn, whatever the transcript size.
+const WIDTH: u16 = 80;
+const HEIGHT: u16 = 24;
+
+/// Transcript sizes, in pre-wrapped rows. The point of the sweep is that `render`
+/// time stays flat across it; `large` is past `u16::MAX` so it also covers the
+/// long-session regime the offset/height arithmetic is now `usize` for.
+const SIZES: &[(&str, usize)] = &[("small", 100), ("medium", 10_000), ("large", 100_000)];
+
+/// Build a transcript of `rows` pre-wrapped lines. Deterministic (no randomness)
+/// so runs compare, and each row carries a couple of styled spans — a gutter and
+/// a body — so `render` does representative per-span painting rather than one
+/// trivial write.
+fn transcript(rows: usize) -> Vec<Line<'static>> {
+    (0..rows)
+        .map(|i| {
+            Line::from(vec![
+                Span::styled(format!("{i:>6} │ "), Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    "the quick brown fox jumps over the lazy dog once more",
+                    Style::default().fg(Color::Gray),
+                ),
+            ])
+        })
+        .collect()
+}
+
+/// A `Scroll` over a fresh `rows`-row transcript, offset to the bottom (the
+/// live-transcript default) unless `top` pins it to the first row.
+fn scroll_at(rows: usize, top: bool) -> Scroll {
+    let mut state = ScrollState::new();
+    if top {
+        state.jump_to_top();
+    } else {
+        state.clamp(rows, HEIGHT as usize);
+    }
+    Scroll::new(transcript(rows), &state)
+}
+
+/// Paint one frame. The `Surface` is rebuilt each call (it just re-borrows the
+/// buffer — no allocation), and the buffer is reused, so the measured work is
+/// the windowing + span painting, not viewport allocation.
+fn paint_frame(scroll: &Scroll, buffer: &mut Buffer, area: Rect, ctx: &RenderCtx) {
+    let mut surface = Surface::new(buffer, area);
+    scroll.render(black_box(area), &mut surface, ctx);
+}
+
+fn render(c: &mut Criterion) {
+    let theme = Theme::default();
+    let ctx = RenderCtx::new(&theme);
+    let area = Rect::new(0, 0, WIDTH, HEIGHT);
+    let mut group = c.benchmark_group("scroll/render");
+    for &(name, rows) in SIZES {
+        let scroll = scroll_at(rows, false);
+        let mut buffer = Buffer::empty(area);
+        group.bench_function(name, |b| {
+            b.iter(|| paint_frame(&scroll, &mut buffer, area, &ctx));
+        });
+    }
+    group.finish();
+}
+
+fn render_offset(c: &mut Criterion) {
+    let theme = Theme::default();
+    let ctx = RenderCtx::new(&theme);
+    let area = Rect::new(0, 0, WIDTH, HEIGHT);
+    let rows = 100_000;
+    let mut group = c.benchmark_group("scroll/render_offset");
+    for &(name, top) in &[("top", true), ("bottom", false)] {
+        let scroll = scroll_at(rows, top);
+        let mut buffer = Buffer::empty(area);
+        group.bench_function(name, |b| {
+            b.iter(|| paint_frame(&scroll, &mut buffer, area, &ctx));
+        });
+    }
+    group.finish();
+}
+
+fn paging(c: &mut Criterion) {
+    let mut group = c.benchmark_group("scroll/paging");
+    let page_down = Event::Key(Key::new(KeyCode::PageDown));
+    for &(name, rows) in SIZES {
+        group.bench_with_input(BenchmarkId::from_parameter(name), &rows, |b, &rows| {
+            b.iter(|| {
+                let mut state = ScrollState::new();
+                state.jump_to_top();
+                // Page to the bottom; `handle` re-arms stick-to-bottom at the end.
+                while !state.is_stuck_to_bottom() {
+                    state.handle(black_box(&page_down), rows, HEIGHT as usize);
+                }
+                black_box(state.offset())
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, render, render_offset, paging);
+criterion_main!(benches);

--- a/crates/tuika/benches/scroll_iai.rs
+++ b/crates/tuika/benches/scroll_iai.rs
@@ -1,0 +1,106 @@
+//! Instruction-count benchmarks for the windowed [`Scroll`] viewport
+//! (iai-callgrind).
+//!
+//! Unlike the wall-clock `scroll` bench, these count CPU instructions under
+//! Valgrind/callgrind, which is *deterministic and machine-independent* — so the
+//! numbers can be committed as a baseline and a regression can fail CI. See
+//! `crates/tuika/benches/check_iai.py` and the committed `iai-baseline.json` next
+//! to this file.
+//!
+//! Requires Valgrind and a version-matched `iai-callgrind-runner` on PATH
+//! (`cargo install iai-callgrind-runner`). Run with
+//! `cargo bench -p tuika --bench scroll_iai`.
+//!
+//! `Scroll` paints only the visible window, so a frame is O(viewport) no matter
+//! how tall the transcript is. `render.small` (100 rows) and `render.large`
+//! (100k rows) render the *same* viewport: their instruction counts should be
+//! nearly equal, and the baseline gate turns "render started scaling with the
+//! transcript" into a CI failure. `paging.large` guards the O(1)-per-event
+//! `ScrollState` path across a full top-to-bottom traversal.
+
+use std::hint::black_box;
+
+use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Style};
+use ratatui::text::{Line, Span};
+use tuika::{Event, Key, KeyCode, RenderCtx, Scroll, ScrollState, Surface, Theme, View};
+
+const WIDTH: u16 = 80;
+const HEIGHT: u16 = 24;
+
+/// A `rows`-row transcript of styled, pre-wrapped lines — a gutter span plus a
+/// body span each — matching the wall-clock `scroll` bench's corpus.
+fn transcript(rows: usize) -> Vec<Line<'static>> {
+    (0..rows)
+        .map(|i| {
+            Line::from(vec![
+                Span::styled(format!("{i:>6} │ "), Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    "the quick brown fox jumps over the lazy dog once more",
+                    Style::default().fg(Color::Gray),
+                ),
+            ])
+        })
+        .collect()
+}
+
+/// A `Scroll` over a fresh `rows`-row transcript pinned to the bottom (the
+/// live-transcript default). Built in iai *setup*, so the corpus construction is
+/// untimed and only the render is measured.
+fn scroll_at_bottom(rows: usize) -> Scroll {
+    let mut state = ScrollState::new();
+    state.clamp(rows, HEIGHT as usize);
+    Scroll::new(transcript(rows), &state)
+}
+
+#[library_benchmark]
+#[bench::small(scroll_at_bottom(100))]
+#[bench::large(scroll_at_bottom(100_000))]
+fn render(scroll: Scroll) -> usize {
+    let theme = Theme::default();
+    let ctx = RenderCtx::new(&theme);
+    let area = Rect::new(0, 0, WIDTH, HEIGHT);
+    let mut buffer = Buffer::empty(area);
+    {
+        let mut surface = Surface::new(&mut buffer, area);
+        scroll.render(black_box(area), &mut surface, &ctx);
+    }
+    // Fold the painted cells so the render can't be optimized away.
+    let mut painted = 0usize;
+    for y in 0..HEIGHT {
+        for x in 0..WIDTH {
+            if buffer[(x, y)].symbol() != " " {
+                painted += 1;
+            }
+        }
+    }
+    // Isolate the O(viewport) paint: dropping the `large` transcript here would
+    // be an O(rows) free that swamps the render we're measuring (and would make
+    // `render.large` scale with the transcript, defeating the whole point of the
+    // case). Leak it — the bench process exits the moment this returns. The
+    // wall-clock `scroll` bench avoids this by building the `Scroll` once,
+    // outside the measured closure.
+    std::mem::forget(scroll);
+    black_box(painted)
+}
+
+#[library_benchmark]
+#[bench::large(100_000)]
+fn paging(rows: usize) -> usize {
+    let mut state = ScrollState::new();
+    state.jump_to_top();
+    let page_down = Event::Key(Key::new(KeyCode::PageDown));
+    // Page from top to bottom; `handle` re-arms stick-to-bottom at the end.
+    while !state.is_stuck_to_bottom() {
+        state.handle(black_box(&page_down), rows, HEIGHT as usize);
+    }
+    black_box(state.offset())
+}
+
+library_benchmark_group!(
+    name = scroll_iai;
+    benchmarks = render, paging
+);
+main!(library_benchmark_groups = scroll_iai);


### PR DESCRIPTION
## What changed

Adds benchmarks for tuika's windowed `Scroll` viewport, mirroring the `markdown`
bench pair added in #425:

- **`scroll.rs`** (Criterion, wall-clock, archived trend): `render` paints a
  fixed 80×24 viewport across transcript sizes 100 → 10k → 100k rows;
  `render_offset` compares top vs bottom offset at 100k rows; `paging` drives
  `ScrollState` top-to-bottom one page at a time.
- **`scroll_iai.rs`** (iai-callgrind, deterministic instruction counts, CI
  gate): `render.small`, `render.large`, `paging.large`.

Supporting wiring: `ratatui` added as a tuika dev-dependency (benches build
`Vec<Line>` and paint a `Buffer`), the two `[[bench]]` targets, the three new
`scroll` entries in `iai-baseline.json`, and `scroll_iai` added to the CI
instruction-count job.

## Why

#418 made the full-screen transcript render O(viewport) instead of O(session).
Nothing guarded that property, so a future refactor could quietly turn windowing
back into a full walk. These benches encode it: `Scroll` holds the whole
pre-wrapped transcript but paints only the visible rows, and the `render` cases
prove the cost is flat as the transcript grows — with the iai gate failing CI on
a >2% regression.

## Before / After

No runtime behavior changes; this is test/measurement infrastructure. Evidence
from running the benches locally:

**`render` cost is flat across a 1000× size increase (the O(viewport) property):**

| case | 100 rows | 100,000 rows |
|---|---|---|
| `scroll/render` wall-clock | ~50 µs | ~49 µs |
| `render` instructions (iai) | 707,805 | 707,868 (+0.009%) |

`scroll/paging` scales O(transcript / viewport) with O(1) per event (≈9 ns for
one page, ≈1 µs for ~416 pages). `check_iai.py` reports all 7 tuika benchmarks
(4 markdown + 3 scroll) within the ±2% baseline tolerance.

## Risk

- **Low.** Bench-only + CI-config; no library or binary code changes.
- The iai baseline was captured on this session's toolchain, which is an exact
  match for CI's gate environment (pinned rustc 1.94.0 + Ubuntu GLIBC 2.39); the
  committed markdown counts reproduced to the instruction, confirming the new
  scroll counts are valid for the gate. Markdown's baseline values were left
  untouched.

## Security

No security-relevant code changes — benchmarks and a CI job edit only. No
filesystem, shell, prompt/key handling, capability registration, or new runtime
dependencies (the added `ratatui` dev-dep is build/test-only and already a normal
dependency at the same version). TM-FS / TM-BASH / TM-LLM / TM-TOOL / TM-DEP: none
apply.

## Follow-ups

No follow-ups.

## Checklist
- [x] Tests added or updated (benchmarks + iai regression baseline)
- [x] Backward compatibility considered (pre-1.0; no public API or runtime change)
