### PR TITLE
feat: add a --theme selector and persist it in settings

### DIFF
--- a/src/capabilities/config.rs
+++ b/src/capabilities/config.rs
@@ -551,6 +551,27 @@ impl SetConfigTool {
                     )))
                 }
             }
+            KeyTarget::Theme => {
+                if clearing {
+                    self.settings.set_theme(None).map_err(map_err)?;
+                    return Ok(saved(
+                        "cleared theme (default: yolop's own palette)".to_string(),
+                    ));
+                }
+                // Validate against the same names `--theme` accepts (yolop + tuika presets).
+                if crate::tui::fullscreen::resolve_theme(value).is_none() {
+                    return Err(format!(
+                        "unknown theme `{value}`; expected one of: {}",
+                        crate::tui::fullscreen::theme_names().join(", ")
+                    ));
+                }
+                self.settings
+                    .set_theme(Some(value.to_string()))
+                    .map_err(map_err)?;
+                Ok(saved(format!(
+                    "theme = {value}; applies to new interactive sessions"
+                )))
+            }
             KeyTarget::Model(provider) => {
                 if clearing {
                     let existed = self.settings.clear_model(provider).map_err(map_err)?;
@@ -780,6 +801,30 @@ mod tests {
 
         let bad = tool
             .execute(json!({ "key": "approval_mode", "value": "whenever" }))
+            .await;
+        assert!(matches!(bad, ToolExecutionResult::ToolError(_)));
+    }
+
+    #[tokio::test]
+    async fn set_config_routes_theme() {
+        let (_tmp, settings) = store();
+        let tool = set_config_tool(settings.clone());
+
+        // A bundled preset persists.
+        let ok = tool
+            .execute(json!({ "key": "theme", "value": "gruvbox-dark" }))
+            .await;
+        assert!(matches!(ok, ToolExecutionResult::Success(_)));
+        assert_eq!(settings.snapshot().theme(), Some("gruvbox-dark"));
+
+        // `yolop` means the default and is not persisted.
+        tool.execute(json!({ "key": "theme", "value": "yolop" }))
+            .await;
+        assert_eq!(settings.snapshot().theme(), None);
+
+        // An unknown theme is rejected at the entry point.
+        let bad = tool
+            .execute(json!({ "key": "theme", "value": "no-such-theme" }))
             .await;
         assert!(matches!(bad, ToolExecutionResult::ToolError(_)));
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -247,6 +247,10 @@ pub struct Settings {
     pub worktrees: WorktreesMode,
     /// Sandbox boundary for arbitrary shell commands.
     pub sandbox: SandboxMode,
+    /// Interactive-TUI color theme: `yolop` (yolop's own palette) or a bundled
+    /// tuika preset name. `None` means the default (yolop's palette). The
+    /// `--theme` flag overrides this for a single run.
+    pub theme: Option<String>,
     /// Global MCP servers (`[mcp.servers.<name>]` in settings.toml). Repo `.mcp.json` entries override these by name.
     pub mcp: McpSettings,
     /// Ordered harness capability overrides (`[[capabilities]]` in settings.toml).
@@ -268,6 +272,7 @@ impl Default for Settings {
             proactive_wake: true,
             worktrees: WorktreesMode::Auto,
             sandbox: SandboxMode::WorkspaceWrite,
+            theme: None,
             mcp: McpSettings::default(),
             capabilities: Vec::new(),
         }
@@ -316,6 +321,10 @@ impl Settings {
             .and_then(Value::as_str)
             .and_then(SandboxMode::parse)
             .unwrap_or_default();
+        let theme = table
+            .get("theme")
+            .and_then(Value::as_str)
+            .map(str::to_string);
         let string_map = |key: &str| {
             let mut map = BTreeMap::new();
             if let Some(t) = table.get(key).and_then(Value::as_table) {
@@ -344,6 +353,7 @@ impl Settings {
             proactive_wake,
             worktrees,
             sandbox,
+            theme,
             mcp: parse_mcp_settings(table),
             capabilities: parse_capabilities_table(table),
         }
@@ -388,6 +398,14 @@ impl Settings {
                 "sandbox_mode".to_string(),
                 Value::String(self.sandbox.as_str().to_string()),
             );
+        }
+        // Only persist a real selection; `yolop`/unset both mean the default.
+        if let Some(theme) = self
+            .theme
+            .as_deref()
+            .filter(|t| !t.eq_ignore_ascii_case("yolop"))
+        {
+            table.insert("theme".to_string(), Value::String(theme.to_string()));
         }
         let mut insert_map = |key: &str, map: &BTreeMap<String, String>| {
             if !map.is_empty() {
@@ -474,6 +492,14 @@ impl Settings {
 
     pub fn sandbox_mode(&self) -> SandboxMode {
         self.sandbox
+    }
+
+    /// The persisted TUI theme name, if the user selected a non-default one.
+    /// `None` (and `yolop`) both mean yolop's own palette.
+    pub fn theme(&self) -> Option<&str> {
+        self.theme
+            .as_deref()
+            .filter(|t| !t.eq_ignore_ascii_case("yolop"))
     }
 
     pub fn capability_overrides_for(&self, id: &str) -> Vec<(usize, &CapabilityOverride)> {
@@ -646,6 +672,12 @@ impl SettingsStore {
     pub fn set_attribution(&self, enabled: bool) -> Result<()> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
         guard.attribution = enabled;
+        save_to(&self.path, &guard)
+    }
+
+    pub fn set_theme(&self, theme: Option<String>) -> Result<()> {
+        let mut guard = self.inner.lock().expect("settings lock poisoned");
+        guard.theme = theme;
         save_to(&self.path, &guard)
     }
 
@@ -841,6 +873,36 @@ mod tests {
         assert_eq!(
             reloaded.snapshot().default_provider.as_deref(),
             Some("anthropic")
+        );
+    }
+
+    #[test]
+    fn theme_roundtrip_via_disk() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join("settings.toml");
+        let store = SettingsStore::open(path.clone());
+        assert_eq!(store.snapshot().theme(), None);
+
+        store
+            .set_theme(Some("gruvbox-dark".to_string()))
+            .expect("save");
+        let on_disk = std::fs::read_to_string(&path).expect("read");
+        assert!(
+            on_disk.contains("theme = \"gruvbox-dark\""),
+            "expected TOML key/value, got: {on_disk}"
+        );
+        assert_eq!(
+            SettingsStore::open(path.clone()).snapshot().theme(),
+            Some("gruvbox-dark")
+        );
+
+        // `yolop` and clearing both mean the default and stay out of the file.
+        store.set_theme(Some("yolop".to_string())).expect("save");
+        assert_eq!(store.snapshot().theme(), None);
+        let on_disk = std::fs::read_to_string(&path).expect("read");
+        assert!(
+            !on_disk.contains("theme ="),
+            "yolop should not be persisted, got: {on_disk}"
         );
     }
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -208,6 +208,24 @@ pub fn schema() -> &'static [ConfigField] {
             provider_scoped: false,
         },
         ConfigField {
+            key: "theme",
+            aliases: &[],
+            title: "TUI color theme",
+            description: "Color theme for the interactive TUI. `yolop` is yolop's own palette; \
+                          other values select a bundled tuika preset. The `--theme` flag \
+                          overrides this for a single run.",
+            kind: ValueKind::Text,
+            default: Some("yolop"),
+            examples: &[
+                "yolop",
+                "solarized-dark",
+                "gruvbox-dark",
+                "dracula",
+                "light",
+            ],
+            provider_scoped: false,
+        },
+        ConfigField {
             key: "capabilities",
             aliases: &["capability"],
             title: "Harness capabilities",
@@ -259,6 +277,8 @@ pub enum KeyTarget {
     ProactiveWake,
     Worktrees,
     Sandbox,
+    /// Interactive TUI color theme.
+    Theme,
     /// Per-provider model spec, for the named provider.
     Model(String),
     /// Per-provider API token.
@@ -285,6 +305,7 @@ impl KeyTarget {
             KeyTarget::ProactiveWake => "proactive_wake",
             KeyTarget::Worktrees => "worktrees",
             KeyTarget::Sandbox => "sandbox_mode",
+            KeyTarget::Theme => "theme",
             KeyTarget::Model(_) => "models",
             KeyTarget::Token(_) => "tokens",
             KeyTarget::BaseUrl(_) => "base_urls",
@@ -340,6 +361,7 @@ pub fn parse_key(input: &str) -> Result<KeyTarget, String> {
         "proactive_wake" | "background_wake" | "wake" => scalar(KeyTarget::ProactiveWake),
         "worktrees" | "worktree" => scalar(KeyTarget::Worktrees),
         "sandbox_mode" | "sandbox" | "containment" => scalar(KeyTarget::Sandbox),
+        "theme" => scalar(KeyTarget::Theme),
         "models" | "model_for" => scoped(KeyTarget::Model),
         "tokens" | "token" => scoped(KeyTarget::Token),
         "base_urls" | "base_url" | "url" => scoped(KeyTarget::BaseUrl),

--- a/src/config/service.rs
+++ b/src/config/service.rs
@@ -75,6 +75,10 @@ pub(crate) fn current_value(settings: &Settings, target: &KeyTarget) -> Value {
         KeyTarget::ProactiveWake => Value::Bool(settings.proactive_wake_enabled()),
         KeyTarget::Worktrees => Value::String(settings.worktrees_mode().as_str().to_string()),
         KeyTarget::Sandbox => Value::String(settings.sandbox_mode().as_str().to_string()),
+        KeyTarget::Theme => settings
+            .theme()
+            .map(|t| Value::String(t.to_string()))
+            .unwrap_or(Value::Null),
         KeyTarget::Model(p) => settings
             .model_for(p)
             .map(|s| Value::String(s.to_string()))

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,6 +123,13 @@ struct Cli {
     #[arg(long)]
     fullscreen: bool,
 
+    /// Color theme for the interactive TUI. `yolop` (default) is yolop's own
+    /// palette; other values select a bundled `tuika` preset (e.g.
+    /// `solarized-dark`, `gruvbox-dark`, `dracula`, `light`). Persisted default
+    /// comes from settings when unset.
+    #[arg(long, value_name = "NAME")]
+    theme: Option<String>,
+
     /// Enable shell sandboxing for this run. Commands may write only in the
     /// workspace and temporary directories, and network access is blocked.
     #[arg(long)]
@@ -560,6 +567,9 @@ async fn async_main() -> Result<()> {
     if let Some(warning) = exec::sandbox::danger_warning(effective_sandbox_mode) {
         eprintln!("yolop: {warning}");
     }
+    // Captured before `settings` is moved into the runtime build below; used to
+    // resolve the TUI theme once the runtime is ready.
+    let saved_theme = settings.snapshot().theme().map(str::to_string);
     let runtime = runtime::build_with_options(
         cwd,
         provider,
@@ -584,6 +594,28 @@ async fn async_main() -> Result<()> {
         },
     )
     .await?;
+
+    // Resolve the interactive TUI theme: the `--theme` flag wins, else the
+    // persisted `theme` setting. Done before the print-mode branch so a bad
+    // `--theme` is rejected in every mode; the override only affects the TUI
+    // (print/ACP never read it), so setting it here is otherwise harmless.
+    if let Some(name) = cli.theme.as_deref() {
+        // An explicit flag is a hard error when unknown.
+        let theme = tui::fullscreen::resolve_theme(name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "unknown --theme `{name}`; expected one of: {}",
+                tui::fullscreen::theme_names().join(", ")
+            )
+        })?;
+        tui::fullscreen::set_theme_override(theme);
+    } else if let Some(name) = saved_theme.as_deref() {
+        // A persisted value is best-effort: warn and fall back rather than
+        // refusing to start (e.g. a theme from a newer version).
+        match tui::fullscreen::resolve_theme(name) {
+            Some(theme) => tui::fullscreen::set_theme_override(theme),
+            None => eprintln!("yolop: ignoring unknown saved theme `{name}`"),
+        }
+    }
 
     if let Some(prompt) = cli.print {
         let image_parts = tui::input::image_input::load_image_parts(&cli.images)?;
@@ -1615,6 +1647,7 @@ mod tests {
             session_dir: None,
             trajectory_out: None,
             fullscreen: false,
+            theme: None,
             sandbox: false,
         }
     }
@@ -1673,6 +1706,7 @@ mod tests {
             session_dir: None,
             trajectory_out: None,
             fullscreen: false,
+            theme: None,
             sandbox: false,
         };
 

--- a/src/tui/fullscreen.rs
+++ b/src/tui/fullscreen.rs
@@ -40,8 +40,43 @@ use super::{
     TEXT_PRIMARY,
 };
 
-/// The full-screen renderer's tuika [`Theme`](tuika::Theme), built from yolop's
-/// own palette.
+/// Startup-selected theme override. `None` (the default) renders yolop's own
+/// palette ([`native_theme`]); a `--theme <name>` / config selection sets it
+/// once to a bundled tuika preset before the TUI starts. Written a single time
+/// at startup, then only read, so a plain `OnceLock` is enough — no locking on
+/// the render path.
+static THEME_OVERRIDE: std::sync::OnceLock<tuika::Theme> = std::sync::OnceLock::new();
+
+/// Install the process-wide theme override. Call once, before the TUI runs;
+/// later calls are ignored (the first selection wins).
+pub(crate) fn set_theme_override(theme: tuika::Theme) {
+    let _ = THEME_OVERRIDE.set(theme);
+}
+
+/// Resolve a theme name to a palette: a bundled tuika preset by name, or
+/// `"yolop"` for yolop's own [`native_theme`]. Returns `None` for anything else
+/// so the caller can report the valid choices.
+pub(crate) fn resolve_theme(name: &str) -> Option<tuika::Theme> {
+    if name.eq_ignore_ascii_case("yolop") {
+        return Some(native_theme());
+    }
+    tuika::theme_by_name(name)
+}
+
+/// The names a `--theme` value may take: `yolop` plus every bundled preset.
+pub(crate) fn theme_names() -> Vec<&'static str> {
+    std::iter::once("yolop")
+        .chain(tuika::themes::PRESETS.iter().map(|p| p.name))
+        .collect()
+}
+
+/// The full-screen renderer's tuika [`Theme`](tuika::Theme): the startup
+/// override if one was selected, otherwise yolop's own [`native_theme`].
+pub(crate) fn yolop_theme() -> tuika::Theme {
+    THEME_OVERRIDE.get().copied().unwrap_or_else(native_theme)
+}
+
+/// yolop's own palette.
 ///
 /// NOTE (item 6): tuika's `Theme::default()` is the toolkit's neutral identity
 /// (a red-on-dark look), deliberately not any host's brand. yolop owns its
@@ -49,7 +84,7 @@ use super::{
 /// `Scroll` scrollbar, `Boxed` borders, `SelectList` selection — renders in
 /// yolop's palette instead of the toolkit default. `background: Reset` lets the
 /// terminal's own background own the alternate screen.
-pub(crate) fn yolop_theme() -> tuika::Theme {
+pub(crate) fn native_theme() -> tuika::Theme {
     tuika::Theme {
         background: Color::Reset,
         surface: PANEL_BG,
@@ -403,4 +438,30 @@ fn draw_background_overlay(f: &mut Frame, area: Rect, app: &App) {
         })
         .collect();
     draw_panel_overlay(f, area, lines, None);
+}
+
+#[cfg(test)]
+mod theme_tests {
+    use super::*;
+
+    #[test]
+    fn resolve_theme_maps_yolop_and_presets() {
+        // `yolop` is yolop's own palette, not a tuika preset.
+        assert_eq!(resolve_theme("yolop"), Some(native_theme()));
+        assert_eq!(resolve_theme("YOLOP"), Some(native_theme()));
+        // Every bundled preset resolves to its tuika struct.
+        for p in tuika::themes::PRESETS {
+            assert_eq!(resolve_theme(p.name), Some(p.theme));
+        }
+        assert_eq!(resolve_theme("no-such-theme"), None);
+    }
+
+    #[test]
+    fn theme_names_lists_yolop_first_then_presets() {
+        let names = theme_names();
+        assert_eq!(names.first(), Some(&"yolop"));
+        for p in tuika::themes::PRESETS {
+            assert!(names.contains(&p.name), "missing {}", p.name);
+        }
+    }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -33,7 +33,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, oneshot};
 
-mod fullscreen;
+pub(crate) mod fullscreen;
 mod render;
 mod setup;
 mod viewport;


### PR DESCRIPTION
> The tuika themes this builds on landed in #430; this PR now targets `main` and contains only the yolop-side changes.

## What changed
yolop's interactive TUI can now use any of tuika's bundled themes. A `--theme <name>` flag selects a bundled preset or `yolop` (yolop's own palette) for the run, and a persisted `theme` settings key remembers the choice across runs (via `set_config theme=<name>`). Resolution order is **flag > persisted setting > yolop's palette**.

Validation: an explicit `--theme` is a hard error on an unknown name (and lists the valid ones); an unknown *persisted* value warns and falls back rather than blocking startup. `set_config theme=` validates against the same names.

## Why
Bundling themes in tuika (#430) is only useful if yolop lets users pick one. This wires the selector and makes the choice sticky across runs.

## Before / After
**Before:** the full-screen renderer always used yolop's hardcoded palette.
**After:**
```
$ yolop --theme gruvbox-dark
# runs in the Gruvbox palette

$ yolop --theme nope
Error: unknown --theme `nope`; expected one of: yolop, solarized-dark, solarized-light, gruvbox-dark, light, dracula

# persisted, survives restarts:
set_config theme=dracula
```

## Risk
- **Low**
- Default behavior is unchanged (no flag and no setting → yolop's own palette). Config plumbing adds one scalar key; an unknown persisted value is non-fatal.

## Security
Reviewed under the TM-* categories. No filesystem-blocklist, shell-execution, or key-handling changes. The `theme` value is validated against a fixed allowlist (yolop + bundled presets) before persisting, and written to `settings.toml` the same sparse way as other scalar keys — no secrets, no new dependencies. The value never reaches a shell, path, or prompt, so there is no injection surface.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — `resolve_theme`/`theme_names`, `theme_roundtrip_via_disk`, `set_config_routes_theme` (drives the config write entry point)
- [x] Backward compatibility considered — yolop is pre-1.0; default look unchanged
