### PR TITLE
perf(tui): window the full-screen transcript to O(viewport) per frame

### DIFF
--- a/crates/tuika/benches/iai-baseline.json
+++ b/crates/tuika/benches/iai-baseline.json
@@ -2,12 +2,14 @@
   "_comment": "iai-callgrind instruction-count baseline. Deterministic and machine-independent for a fixed toolchain + libc. Regenerate with `python3 crates/tuika/benches/check_iai.py --update` and commit alongside the code change that shifted the counts.",
   "tolerance_pct": 2.0,
   "benchmarks": {
+    "frame_full.large": 75211852,
+    "frame_windowed.large": 725841,
     "one_shot.large": 4066518,
     "one_shot.small": 172394,
     "paging.large": 130441,
     "reflow.mixed": 7935987,
-    "render.large": 707868,
-    "render.small": 707805,
+    "render.large": 707828,
+    "render.small": 707765,
     "streaming.mixed": 8565881
   }
 }

--- a/crates/tuika/benches/scroll.rs
+++ b/crates/tuika/benches/scroll.rs
@@ -9,7 +9,7 @@
 //! full-screen renderer: it holds the *whole* pre-wrapped transcript but paints
 //! only the `area.height` rows at the current offset. The defining property is
 //! that a frame costs O(viewport), not O(transcript) — these benches exist to
-//! keep it that way. Three groups:
+//! keep it that way. Four groups:
 //!
 //! - `render` — paint one frame at the bottom (stick-to-bottom) offset across a
 //!   sweep of transcript *sizes* at a fixed viewport. The times must stay flat
@@ -20,6 +20,12 @@
 //! - `paging` — drive [`ScrollState`] from top to bottom one page at a time.
 //!   Each event is O(1); the traversal is O(transcript / viewport), and this
 //!   guards the event path against sneaking in per-row work.
+//! - `frame` — the realistic per-frame cost of feeding [`Scroll`]: build the
+//!   rows, construct, paint, drop. `full` clones the whole transcript into
+//!   [`Scroll::new`] every frame (what the renderer paid before windowing);
+//!   `windowed` clones only the visible slice into [`Scroll::windowed`]. The gap
+//!   between them, widening with transcript size, is the win — `full` is
+//!   O(transcript), `windowed` is O(viewport).
 
 use std::hint::black_box;
 
@@ -128,5 +134,44 @@ fn paging(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, render, render_offset, paging);
+fn frame(c: &mut Criterion) {
+    let theme = Theme::default();
+    let ctx = RenderCtx::new(&theme);
+    let area = Rect::new(0, 0, WIDTH, HEIGHT);
+    let h = HEIGHT as usize;
+    let mut group = c.benchmark_group("scroll/frame");
+    for &(name, rows) in SIZES {
+        let content = transcript(rows);
+        let mut state = ScrollState::new();
+        state.clamp(rows, h); // bottom-stuck
+        let offset = state.offset();
+        let mut buffer = Buffer::empty(area);
+
+        // Pre-windowing: clone the whole transcript into a fresh Scroll, paint,
+        // drop it — every frame. O(transcript).
+        group.bench_with_input(BenchmarkId::new("full", name), &content, |b, content| {
+            b.iter(|| {
+                let scroll = Scroll::new(content.clone(), &state);
+                paint_frame(&scroll, &mut buffer, area, &ctx);
+            });
+        });
+
+        // Windowed: clone only the visible slice. O(viewport), flat across sizes.
+        group.bench_with_input(
+            BenchmarkId::new("windowed", name),
+            &content,
+            |b, content| {
+                b.iter(|| {
+                    let end = (offset + h).min(content.len());
+                    let window = content[offset..end].to_vec();
+                    let scroll = Scroll::windowed(window, content.len(), &state);
+                    paint_frame(&scroll, &mut buffer, area, &ctx);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, render, render_offset, paging, frame);
 criterion_main!(benches);

--- a/crates/tuika/benches/scroll_iai.rs
+++ b/crates/tuika/benches/scroll_iai.rs
@@ -55,10 +55,9 @@ fn scroll_at_bottom(rows: usize) -> Scroll {
     Scroll::new(transcript(rows), &state)
 }
 
-#[library_benchmark]
-#[bench::small(scroll_at_bottom(100))]
-#[bench::large(scroll_at_bottom(100_000))]
-fn render(scroll: Scroll) -> usize {
+/// Paint `scroll` into a fresh viewport buffer and fold the painted cells so the
+/// render can't be optimized away.
+fn paint_count(scroll: &Scroll) -> usize {
     let theme = Theme::default();
     let ctx = RenderCtx::new(&theme);
     let area = Rect::new(0, 0, WIDTH, HEIGHT);
@@ -67,7 +66,6 @@ fn render(scroll: Scroll) -> usize {
         let mut surface = Surface::new(&mut buffer, area);
         scroll.render(black_box(area), &mut surface, &ctx);
     }
-    // Fold the painted cells so the render can't be optimized away.
     let mut painted = 0usize;
     for y in 0..HEIGHT {
         for x in 0..WIDTH {
@@ -76,6 +74,14 @@ fn render(scroll: Scroll) -> usize {
             }
         }
     }
+    painted
+}
+
+#[library_benchmark]
+#[bench::small(scroll_at_bottom(100))]
+#[bench::large(scroll_at_bottom(100_000))]
+fn render(scroll: Scroll) -> usize {
+    let painted = paint_count(&scroll);
     // Isolate the O(viewport) paint: dropping the `large` transcript here would
     // be an O(rows) free that swamps the render we're measuring (and would make
     // `render.large` scale with the transcript, defeating the whole point of the
@@ -83,6 +89,37 @@ fn render(scroll: Scroll) -> usize {
     // wall-clock `scroll` bench avoids this by building the `Scroll` once,
     // outside the measured closure.
     std::mem::forget(scroll);
+    black_box(painted)
+}
+
+// `frame_full`: the per-frame cost the renderer paid *before* windowing — clone
+// the whole transcript into a fresh `Scroll`, paint, drop the clone. O(rows).
+// The input `content` is leaked so only the frame's own clone+drop is measured,
+// not a second free of the kept-alive corpus. (Doc comments can't sit on a
+// `#[library_benchmark]` fn, so this is a plain comment.)
+#[library_benchmark]
+#[bench::large(transcript(100_000))]
+fn frame_full(content: Vec<Line<'static>>) -> usize {
+    let mut state = ScrollState::new();
+    state.clamp(content.len(), HEIGHT as usize);
+    let painted = paint_count(&Scroll::new(content.clone(), &state));
+    std::mem::forget(content);
+    black_box(painted)
+}
+
+// `frame_windowed`: the windowed per-frame cost — clone only the visible slice
+// into `Scroll::windowed`, paint, drop it. O(viewport), so it stays far below
+// `frame_full` at the same transcript size.
+#[library_benchmark]
+#[bench::large(transcript(100_000))]
+fn frame_windowed(content: Vec<Line<'static>>) -> usize {
+    let mut state = ScrollState::new();
+    state.clamp(content.len(), HEIGHT as usize);
+    let offset = state.offset();
+    let end = (offset + HEIGHT as usize).min(content.len());
+    let window = content[offset..end].to_vec();
+    let painted = paint_count(&Scroll::windowed(window, content.len(), &state));
+    std::mem::forget(content);
     black_box(painted)
 }
 
@@ -101,6 +138,6 @@ fn paging(rows: usize) -> usize {
 
 library_benchmark_group!(
     name = scroll_iai;
-    benchmarks = render, paging
+    benchmarks = render, frame_full, frame_windowed, paging
 );
 main!(library_benchmark_groups = scroll_iai);

--- a/crates/tuika/src/components/scroll.rs
+++ b/crates/tuika/src/components/scroll.rs
@@ -127,22 +127,67 @@ impl ScrollState {
     }
 }
 
-/// A windowed view of `lines`, showing the slice at `offset` and a scrollbar
+/// A windowed view of content, showing the slice at `offset` and a scrollbar
 /// when content overflows.
+///
+/// Two constructors trade off who holds the rows. [`new`](Scroll::new) owns the
+/// *whole* content and paints the visible slice out of it — simplest, and right
+/// for short lists. [`windowed`](Scroll::windowed) is handed *only* the visible
+/// slice plus the true content height; for very long content that turns a frame
+/// from O(content) (clone every row in, drop it out) into O(viewport). Both draw
+/// identically; only the ownership differs.
 ///
 /// ![scroll demo](https://raw.githubusercontent.com/everruns/yolop/main/crates/tuika/docs/demos/scroll.gif)
 pub struct Scroll {
+    /// The rows this view holds: the whole content in [`new`](Scroll::new), or
+    /// just `content[window_start..]` in [`windowed`](Scroll::windowed).
     lines: Vec<Line<'static>>,
+    /// Absolute content-row index of `lines[0]`. Zero for `new`; `offset` for
+    /// `windowed`, so `render` maps a content row to a `lines` index the same
+    /// way in both modes.
+    window_start: usize,
+    /// Total content height in rows, even when `lines` holds only a window.
+    content_height: usize,
+    /// Top visible content row.
     offset: usize,
     scrollbar: bool,
 }
 
 impl Scroll {
-    /// Build a viewport over `lines`, windowed at `state`'s offset.
+    /// Build a viewport over the whole `lines`, painting the slice at `state`'s
+    /// offset. The view owns every row; for content far taller than the viewport
+    /// prefer [`windowed`](Scroll::windowed).
     pub fn new(lines: Vec<Line<'static>>, state: &ScrollState) -> Self {
         Self {
+            content_height: lines.len(),
             lines,
+            window_start: 0,
             offset: state.offset(),
+            scrollbar: true,
+        }
+    }
+
+    /// Build a viewport that already holds only the visible window —
+    /// `content[offset .. offset + viewport_height]`, where `offset` is
+    /// `state`'s offset — instead of the whole content. `content_height` is the
+    /// full row count, so the scrollbar and [`measure`](View::measure) still
+    /// reflect the entire content.
+    ///
+    /// This is the O(viewport) path for very long content: the caller slices its
+    /// own cache once per frame rather than handing over — and dropping — every
+    /// row. The window may be shorter than the viewport near the bottom;
+    /// `render` simply stops at its end.
+    pub fn windowed(
+        window: Vec<Line<'static>>,
+        content_height: usize,
+        state: &ScrollState,
+    ) -> Self {
+        let offset = state.offset();
+        Self {
+            lines: window,
+            window_start: offset,
+            content_height,
+            offset,
             scrollbar: true,
         }
     }
@@ -153,9 +198,9 @@ impl Scroll {
         self
     }
 
-    /// Total content height in rows (one per line).
+    /// Total content height in rows (one per line), even in windowed mode.
     pub fn content_height(&self) -> usize {
-        self.lines.len()
+        self.content_height
     }
 }
 
@@ -180,9 +225,12 @@ impl View for Scroll {
             area.width
         };
 
-        let start = self.offset;
         for row in 0..area.height {
-            let idx = start + row as usize;
+            // Map the content row (offset + row) to an index into `lines`, which
+            // begins at `window_start` (0 in full mode, `offset` when windowed).
+            let Some(idx) = (self.offset + row as usize).checked_sub(self.window_start) else {
+                break;
+            };
             let Some(line) = self.lines.get(idx) else {
                 break;
             };
@@ -314,6 +362,44 @@ mod tests {
             c == "█" || c == "│"
         });
         assert!(has_bar, "expected a scrollbar in the right column");
+    }
+
+    #[test]
+    fn scroll_windowed_matches_full_render() {
+        // `windowed` holds only the visible slice but must paint byte-for-byte
+        // identically to `new` (which owns the whole content), scrollbar and all.
+        let content: Vec<Line<'static>> =
+            (0..1000).map(|i| Line::from(format!("line{i}"))).collect();
+        let (width, height) = (12u16, 6u16);
+        let theme = Theme::default();
+        let ctx = RenderCtx::new(&theme);
+
+        // A mid-content offset (not top, not bottom) exercises the window origin.
+        let mut state = ScrollState::new();
+        state.clamp(content.len(), height as usize);
+        state.jump_to_top();
+        let end = Event::Key(Key::new(KeyCode::PageDown));
+        state.handle(&end, content.len(), height as usize); // one page down
+        let offset = state.offset();
+        assert!(offset > 0 && offset < content.len() - height as usize);
+
+        let render = |scroll: Scroll| {
+            let mut buf = buffer(width, height);
+            let area = buf.area;
+            let mut surface = Surface::new(&mut buf, area);
+            scroll.render(area, &mut surface, &ctx);
+            buf
+        };
+
+        let full = render(Scroll::new(content.clone(), &state));
+        // The window is exactly what `windowed`'s caller would slice.
+        let window = content[offset..offset + height as usize].to_vec();
+        let windowed = render(Scroll::windowed(window, content.len(), &state));
+
+        assert_eq!(
+            full.content, windowed.content,
+            "windowed render diverged from the full render"
+        );
     }
 
     #[test]

--- a/src/tui/fullscreen.rs
+++ b/src/tui/fullscreen.rs
@@ -133,24 +133,34 @@ pub(crate) fn draw(f: &mut Frame, app: &mut App) {
     let preview_line = render::preview_slot_line(&state, area.width);
 
     // The transcript is a real Scroll over the *full* history, bound to the
-    // persisted ScrollState. Short content is top-padded so it rests at the
-    // bottom (the inline scrollback feel); taller content scrolls, and
+    // persisted ScrollState. Metrics + offset are reconciled before rendering so
+    // the mouse-wheel / paging handlers (which reuse these metrics) clamp
+    // correctly. Content height is `usize`: a long transcript wraps past
+    // u16::MAX rows (see `ScrollState`).
+    let viewport_h = transcript_height as usize;
+    let content_h = app.refresh_transcript_cache(inner_w);
+    app.scroll_metrics = (content_h, viewport_h);
+    app.scroll.clamp(content_h, viewport_h);
+
+    // Hand `Scroll` only what it paints. Short content is top-padded so it rests
+    // at the bottom (the inline scrollback feel) and handed over whole — it's
+    // tiny. Taller content is *windowed*: we clone just `[offset .. offset+h]`
+    // out of the cache instead of the whole transcript, so a frame stays
+    // O(viewport) rather than cloning (and dropping) every retained row.
     // stick-to-bottom keeps the newest line visible as the turn streams.
-    let scroll_lines = pad_to_bottom(app.full_transcript_lines_cached(inner_w), transcript_height);
-    let scroll_content_h = scroll_lines.len();
-    // Record metrics + reconcile the offset before rendering, so the mouse-wheel
-    // / paging handlers (which reuse these metrics) clamp correctly. Metrics are
-    // `usize`: a long transcript wraps past u16::MAX rows (see `ScrollState`).
-    app.scroll_metrics = (scroll_content_h, transcript_height as usize);
-    app.scroll
-        .clamp(scroll_content_h, transcript_height as usize);
+    let transcript = if content_h <= viewport_h {
+        let all = pad_to_bottom(app.transcript_window(0, content_h), transcript_height);
+        Scroll::new(all, &app.scroll)
+    } else {
+        let offset = app.scroll.offset();
+        let window = app.transcript_window(offset, (offset + viewport_h).min(content_h));
+        Scroll::windowed(window, content_h, &app.scroll)
+    };
 
     // Probes recover the rects tuika assigns so the host can place the terminal
     // cursor inside the composer and bound mouse selection to the transcript.
     let transcript_probe = RectProbe::new();
     let input_probe = RectProbe::new();
-
-    let transcript = Scroll::new(scroll_lines, &app.scroll);
 
     // The composer is a real tuika TextInput reading full-screen's own composer
     // model of record (`app.composer`) — no per-frame mirror from a

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -900,14 +900,18 @@ impl App {
         });
     }
 
-    /// The full-screen transcript as wrapped lines, memoized across frames.
+    /// Refresh the memoized full-screen transcript wrapping for `width` and
+    /// return the total wrapped-line count.
     ///
     /// Re-wraps only the lines appended since the last call while the width and
     /// [`transcript_generation`](Self::transcript_generation) are unchanged; a
     /// width change or a generation bump (transcript reset) rebuilds from
-    /// scratch. Output is identical to a full
-    /// [`render::append_transcript_range`] pass over the whole history.
-    fn full_transcript_lines_cached(&mut self, width: usize) -> Vec<Line<'static>> {
+    /// scratch. The cached rows match a full [`render::append_transcript_range`]
+    /// pass over the whole history. Read them back with [`transcript_window`] so
+    /// a caller can clone just the slice it paints instead of the whole cache.
+    ///
+    /// [`transcript_window`]: Self::transcript_window
+    fn refresh_transcript_cache(&mut self, width: usize) -> usize {
         // Move the cache out so we can borrow `self.lines` immutably alongside.
         let mut cache = std::mem::take(&mut self.transcript_cache);
         let stale = cache.width != width
@@ -929,9 +933,28 @@ impl App {
             cache.prev_author.take(),
         );
         cache.source_len = self.lines.len();
-        let out = cache.lines.clone();
+        let len = cache.lines.len();
         self.transcript_cache = cache;
-        out
+        len
+    }
+
+    /// Clone the cached wrapped rows in `start..end`. Call
+    /// [`refresh_transcript_cache`](Self::refresh_transcript_cache) first; `end`
+    /// must not exceed the count it returned. Cloning just the visible window
+    /// (rather than the whole cache) is what keeps a full-screen frame
+    /// O(viewport) for a long transcript.
+    fn transcript_window(&self, start: usize, end: usize) -> Vec<Line<'static>> {
+        self.transcript_cache.lines[start..end].to_vec()
+    }
+
+    /// The whole cached transcript, cloned. Convenience over
+    /// [`refresh_transcript_cache`](Self::refresh_transcript_cache) +
+    /// [`transcript_window`](Self::transcript_window) for callers that want every
+    /// row; the full-screen renderer takes only the visible window instead.
+    #[cfg(test)]
+    fn full_transcript_lines_cached(&mut self, width: usize) -> Vec<Line<'static>> {
+        let len = self.refresh_transcript_cache(width);
+        self.transcript_window(0, len)
     }
 
     /// Drop transcript history beyond [`MAX_RETAINED_TRANSCRIPT_LINES`] so a very


### PR DESCRIPTION
## What changed

Virtualizes the full-screen transcript so a frame is O(viewport) end to end, not
just in the paint.

`Scroll` already painted only the visible rows, but `Scroll::new` takes the
*whole* `Vec<Line>` by value — so yolop cloned its entire wrapped-transcript
cache (bounded to 50k rows by #418's cap) into a fresh `Scroll` every frame and
dropped it again. That clone+drop was the residual O(retained) cost flagged as a
follow-up in #418.

- **tuika:** adds `Scroll::windowed(window, content_height, state)` — handed only
  the visible slice plus the true content height. It renders byte-for-byte
  identically to `Scroll::new` (a `window_start` origin maps content rows to the
  held slice); the scrollbar and `measure` still reflect the whole content.
  `Scroll::new` stays for short lists (demo, snapshots, tests). This is the same
  own-the-whole-thing vs. hand-over-the-window split the windowed `SelectList`
  (#381/#382) established.
- **yolop:** `fullscreen::draw` now clamps the scroll state, then clones only
  `cache.lines[offset .. offset+height]` into `Scroll::windowed` for long
  transcripts (short content still pads-to-bottom through `Scroll::new`, it's
  tiny). The wrap cache is exposed as `refresh_transcript_cache` (returns the row
  count) + `transcript_window(start, end)` so the caller slices instead of
  cloning the whole cache.

## Why

On a long session the full-screen renderer cloned and freed the entire retained
transcript (up to 50k styled rows) on every redraw — pure overhead to show ~24
rows. Windowing makes the per-frame allocation proportional to the viewport.

## Before / After

New `frame` benches (`construct + render + drop`, the real per-frame cost) at
100,000 rows, measured locally:

| | wall-clock | instructions (iai) |
|---|---|---|
| `frame/full` (clone whole transcript — old behavior) | ~7 ms | 75,211,852 |
| `frame/windowed` (clone visible slice — new) | ~50 µs | 725,841 |

**~104× fewer instructions per frame**, and `frame/windowed` ≈ the `render` cost
(707k) — i.e. purely O(viewport). At 10k rows the wall-clock gap is already ~14×
(716 µs → 50 µs); it widens with transcript length while windowed stays flat.
Rendered output is unchanged: the tuika `scroll_windowed_matches_full_render`
test asserts windowed and full produce an identical buffer (scrollbar included),
and yolop's `fullscreen_scroll_reveals_full_history` still reaches line 0 at the
top and the newest line at the bottom through the windowed path.

## Risk

- **Low–medium.** Touches the full-screen render hot path, but the visible
  contract is pinned by an identical-buffer test at the component level and the
  existing full-screen presentation/selection/scroll tests at the host level.
- The short-content branch is unchanged (`Scroll::new` + pad-to-bottom); only
  the long-content path is windowed.

## Security

No security-relevant code changes — a rendering optimization plus benchmarks. No
filesystem, shell, prompt/key handling, capability registration, or new runtime
dependencies. TM-FS / TM-BASH / TM-LLM / TM-TOOL / TM-DEP: none apply.

## Follow-ups

No follow-ups. (This closes the virtualization follow-up noted in #418.)

## Checklist
- [x] Tests added or updated (windowed==full render test; frame benches + iai baseline)
- [x] Backward compatibility considered (pre-1.0; `Scroll::new` unchanged, `windowed` is additive)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1DZMd4MDKxbZSFGKhaRoC)_