### PR TITLE
fix(tui): capitalize Codex Subscription label

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -396,7 +396,7 @@ const PROVIDER_OPTIONS: &[ProviderOption] = &[
     },
     ProviderOption {
         name: "codex",
-        label: "Codex subscription",
+        label: "Codex Subscription",
         hint: "ChatGPT Plus/Pro login",
     },
     ProviderOption {
@@ -7216,6 +7216,12 @@ mod tests {
         let rendered = setup_overlay_text(app);
         assert!(rendered.iter().any(|line| line.contains("Set Up Yolop")));
         assert!(rendered.iter().any(|line| line.contains("OpenAI")));
+        assert!(
+            rendered
+                .iter()
+                .any(|line| line.contains("Codex Subscription")),
+            "provider picker should use the title-cased Codex Subscription label: {rendered:?}"
+        );
         assert!(rendered.iter().any(|line| line.contains("Offline demo")));
     }
 


### PR DESCRIPTION
## Summary

Capitalizes the Codex Subscription label in the setup provider picker for consistent title casing.

## Before / After

- Before: `Codex subscription`
- After: `Codex Subscription`

## Validation

- `cargo test --all-features setup_overlay_renders_full_provider_picker`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run --quiet -- --provider llmsim -p hi`

## Security

No security-relevant code changes. This only changes static presentation text and its render assertion; it does not affect filesystem, shell, LLM credential, capability, dependency, or trust-boundary behavior.

## Follow-ups

No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
