### PR TITLE
chore: clarify GitHub auth fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,8 @@ doppler run -- cargo test --all-features
 doppler run -- cargo run -- -p "say hi"
 ```
 
-If GitHub auth fails, do not tell the user the token expired. Try:
+Use `gh` directly first. Only if `gh` reports that it is not authenticated, retry
+through Doppler; do not invoke Doppler preemptively for GitHub commands:
 
 ```bash
 doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" <command>'


### PR DESCRIPTION
## What
Clarify the repository's GitHub authentication fallback order.

## Why
Agents should use the existing `gh` authentication first and only involve Doppler when `gh` explicitly reports that it is unauthenticated.

## How
Update `AGENTS.md` to prohibit preemptive Doppler use for GitHub commands and retain Doppler as the authentication fallback.

## Validation
- `git diff --check`

## Risk
Low. Guidance-only change with no runtime behavior impact.

## Security
No security-relevant code changes. The guidance reduces unnecessary secret-provider access while preserving the authenticated fallback.

## Follow-ups
No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
