### PR TITLE
feat(tuika): add mouse text interactions

### DIFF
--- a/crates/tuika/docs/features.md
+++ b/crates/tuika/docs/features.md
@@ -77,9 +77,14 @@ event model (`MouseKind` carries `Down`/`Up`/`Drag`, `Moved`, and scroll, with
 <img src="demos/mouse.gif" width="880" alt="Mouse demo: a left-drag selection highlight growing across the phrase 'the quick brown fox jumps over the lazy dog', and a row of clickable Run / Diff / Cancel regions with one highlighted as active.">
 
 - `SelectionState` turns a left-button `Down → Drag → Up` gesture into a
-  `SelectionRange`; `selected_text(buffer, area, range)` reads the selected text
+  `SelectionRange`, and a same-cell double click selects the word under the
+  pointer. Call `resolve(buffer, area)` after rendering to resolve pending word
+  boundaries; `selected_text(buffer, area, range)` then reads the selected text
   back out of the rendered buffer (wide glyphs intact) and `highlight(buffer,
   area, range, style)` paints it in.
+- `ctrl_click_url(event, buffer, area)` returns the visible bare `http://` or
+  `https://` URL under a Ctrl+left-button release. The host remains responsible
+  for opening it; Yolop's fullscreen host opens it in the system browser.
 - `HitMap<T>` maps screen rects to values (a button, a link, a row); the
   last-pushed match wins, so children and overlays registered after their
   parents take precedence. `ClickTracker` turns a same-cell `Down`/`Up` into a

--- a/crates/tuika/examples/mouse.rs
+++ b/crates/tuika/examples/mouse.rs
@@ -105,6 +105,9 @@ fn main() -> io::Result<()> {
                 quit_btn,
             );
 
+            if sel.resolve(f.buffer_mut(), text_area) {
+                pending_copy = true;
+            }
             if let Some(range) = sel.range() {
                 // Read the selected text off the freshly rendered frame *before*
                 // highlighting (highlight only changes style, so order is cosmetic).

--- a/crates/tuika/src/hyperlink.rs
+++ b/crates/tuika/src/hyperlink.rs
@@ -152,6 +152,41 @@ fn sanitize_url(url: &str, policy: LinkPolicy) -> Option<String> {
     None
 }
 
+/// Return the visible HTTP(S) URL under a Ctrl+left-button release.
+///
+/// The coordinates are resolved against the rendered buffer. Opening the URL
+/// remains the host's responsibility.
+pub fn ctrl_click_url(
+    event: &crate::Mouse,
+    buffer: &ratatui::buffer::Buffer,
+    area: ratatui::layout::Rect,
+) -> Option<String> {
+    if event.kind != crate::MouseKind::Up(crate::MouseButton::Left)
+        || !event.ctrl
+        || event.shift
+        || event.alt
+        || event.row < area.y
+        || event.row >= area.bottom()
+        || event.column < area.x
+        || event.column >= area.right()
+    {
+        return None;
+    }
+    let mut row = String::new();
+    let mut clicked_bytes = 0..0;
+    for column in area.x..area.right() {
+        let start = row.len();
+        row.push_str(buffer[(column, event.row)].symbol());
+        if column == event.column {
+            clicked_bytes = start..row.len();
+        }
+    }
+    find_links(&row, LinkPolicy::default())
+        .into_iter()
+        .find(|(start, end)| *start < clicked_bytes.end && clicked_bytes.start < *end)
+        .map(|(start, end)| row[start..end].to_string())
+}
+
 /// Byte ranges of every linkable URL in `s` under `policy`, left to right,
 /// non-overlapping. Each match runs to the next whitespace with trailing
 /// sentence punctuation trimmed, matching how the host styles links; a
@@ -532,6 +567,40 @@ mod tests {
         let out = bytes(&line);
         assert!(!out.contains("\x1b]8;;"));
         assert!(out.contains("no links here"));
+    }
+
+    #[test]
+    fn ctrl_click_returns_visible_url_under_pointer() {
+        use crate::{Mouse, MouseButton, MouseKind};
+        use ratatui::{buffer::Buffer, layout::Rect, style::Style};
+        let area = Rect::new(3, 2, 40, 1);
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 50, 5));
+        buffer.set_string(
+            area.x,
+            area.y,
+            "see https://example.com/docs now",
+            Style::default(),
+        );
+        let mut event = Mouse::at(MouseKind::Up(MouseButton::Left), 15, area.y);
+        event.ctrl = true;
+        assert_eq!(
+            ctrl_click_url(&event, &buffer, area).as_deref(),
+            Some("https://example.com/docs")
+        );
+    }
+
+    #[test]
+    fn ctrl_click_ignores_plain_clicks_and_non_url_text() {
+        use crate::{Mouse, MouseButton, MouseKind};
+        use ratatui::{buffer::Buffer, layout::Rect, style::Style};
+        let area = Rect::new(0, 0, 30, 1);
+        let mut buffer = Buffer::empty(area);
+        buffer.set_string(0, 0, "https://example.com plain", Style::default());
+        let plain = Mouse::at(MouseKind::Up(MouseButton::Left), 10, 0);
+        let mut text = Mouse::at(MouseKind::Up(MouseButton::Left), 23, 0);
+        text.ctrl = true;
+        assert_eq!(ctrl_click_url(&plain, &buffer, area), None);
+        assert_eq!(ctrl_click_url(&text, &buffer, area), None);
     }
 
     #[test]

--- a/crates/tuika/src/lib.rs
+++ b/crates/tuika/src/lib.rs
@@ -76,7 +76,8 @@ pub use geometry::{Padding, Size};
 pub use highlight::{CodeHighlighter, Highlighter, PlainHighlighter};
 pub use host::{AltScreen, Overlay, TerminalSession, paint, translate_event};
 pub use hyperlink::{
-    HyperlinkBackend, LinkPolicy, is_web_url, osc8, osc8_with, write_line, write_line_with,
+    HyperlinkBackend, LinkPolicy, ctrl_click_url, is_web_url, osc8, osc8_with, write_line,
+    write_line_with,
 };
 pub use layout::{Align, Dimension, Direction, Justify, LayoutStyle};
 pub use live::{Live, LiveView, RedrawHandle};

--- a/crates/tuika/src/mouse.rs
+++ b/crates/tuika/src/mouse.rs
@@ -26,6 +26,7 @@
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::Style;
+use std::time::{Duration, Instant};
 
 use crate::event::{Mouse, MouseButton, MouseKind};
 
@@ -78,18 +79,20 @@ impl SelectionRange {
     }
 }
 
-/// Tracks a left-drag text selection across mouse events.
+/// Tracks click-drag and double-click text selection across mouse events.
 ///
 /// Left `Down` starts (and clears any previous selection); `Drag` extends;
-/// `Up` finishes. A press with no drag (a plain click) leaves no selection.
-/// Every other event is ignored. `handle` returns `true` when the selection
-/// changed, so a host knows to redraw.
+/// `Up` finishes. Two plain clicks on the same cell within the double-click
+/// interval queue a word selection. Call [`Self::resolve`] after rendering so
+/// word boundaries can be read from the current buffer.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct SelectionState {
     anchor: (u16, u16),
     cursor: (u16, u16),
     pressed: bool,
     selecting: bool,
+    last_click: Option<((u16, u16), Instant)>,
+    pending_word: Option<(u16, u16)>,
 }
 
 impl SelectionState {
@@ -114,16 +117,46 @@ impl SelectionState {
             MouseKind::Drag(MouseButton::Left) if self.pressed => {
                 self.cursor = (m.column, m.row);
                 self.selecting = self.cursor != self.anchor;
+                self.last_click = None;
+                self.pending_word = None;
                 true
             }
             MouseKind::Up(MouseButton::Left) if self.pressed => {
                 self.cursor = (m.column, m.row);
                 self.pressed = false;
                 self.selecting = self.cursor != self.anchor;
+                if self.selecting {
+                    self.last_click = None;
+                } else {
+                    let position = self.cursor;
+                    let now = Instant::now();
+                    let is_double = self.last_click.is_some_and(|(previous, at)| {
+                        previous == position && now.duration_since(at) <= DOUBLE_CLICK_INTERVAL
+                    });
+                    self.last_click = Some((position, now));
+                    self.pending_word = is_double.then_some(position);
+                }
                 true
             }
             _ => false,
         }
+    }
+
+    /// Resolve a pending double-click against the freshly rendered buffer.
+    ///
+    /// Returns `true` when a word was selected. Word characters are Unicode
+    /// alphanumerics plus `_`; punctuation is selected as a contiguous run.
+    pub fn resolve(&mut self, buffer: &Buffer, area: Rect) -> bool {
+        let Some((column, row)) = self.pending_word.take() else {
+            return false;
+        };
+        let Some(range) = word_at(buffer, area, column, row) else {
+            return false;
+        };
+        self.anchor = range.start;
+        self.cursor = range.end;
+        self.selecting = true;
+        true
     }
 
     /// Clear the selection (e.g. on Esc or a new turn).
@@ -141,6 +174,48 @@ impl SelectionState {
     pub fn is_active(&self) -> bool {
         self.selecting
     }
+}
+
+const DOUBLE_CLICK_INTERVAL: Duration = Duration::from_millis(500);
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CellClass {
+    Word,
+    Punctuation,
+    Blank,
+}
+
+fn cell_class(buffer: &Buffer, column: u16, row: u16) -> CellClass {
+    let symbol = buffer[(column, row)].symbol();
+    let Some(ch) = symbol.chars().next() else {
+        return CellClass::Blank;
+    };
+    if ch.is_whitespace() {
+        CellClass::Blank
+    } else if ch.is_alphanumeric() || ch == '_' {
+        CellClass::Word
+    } else {
+        CellClass::Punctuation
+    }
+}
+
+fn word_at(buffer: &Buffer, area: Rect, column: u16, row: u16) -> Option<SelectionRange> {
+    if !in_rect(area, column, row) {
+        return None;
+    }
+    let class = cell_class(buffer, column, row);
+    if class == CellClass::Blank {
+        return None;
+    }
+    let mut left = column;
+    while left > area.x && cell_class(buffer, left - 1, row) == class {
+        left -= 1;
+    }
+    let mut right = column;
+    while right + 1 < area.right() && cell_class(buffer, right + 1, row) == class {
+        right += 1;
+    }
+    Some(SelectionRange::between((left, row), (right, row)))
 }
 
 /// Extract the selected text from `buffer`, reading the grid the way a terminal
@@ -351,6 +426,37 @@ mod tests {
         assert!(sel.range().is_some());
         // Pressing again to start a new gesture must drop the old selection.
         assert!(sel.handle(&down(1, 1)));
+        assert!(sel.range().is_none());
+    }
+
+    #[test]
+    fn double_click_selects_the_word_under_the_pointer() {
+        let theme = Theme::default();
+        let buf = crate::testing::render(&Text::raw("hello, brave_world!"), 19, 1, &theme);
+        let mut sel = SelectionState::new();
+        sel.handle(&down(9, 0));
+        sel.handle(&up(9, 0));
+        sel.handle(&down(9, 0));
+        sel.handle(&up(9, 0));
+
+        assert!(sel.resolve(&buf, buf.area));
+        let range = sel.range().expect("double click selects a word");
+        assert_eq!(range.start, (7, 0));
+        assert_eq!(range.end, (17, 0));
+        assert_eq!(selected_text(&buf, buf.area, range), "brave_world");
+    }
+
+    #[test]
+    fn double_click_on_blank_space_does_not_select() {
+        let theme = Theme::default();
+        let buf = crate::testing::render(&Text::raw("hi"), 5, 1, &theme);
+        let mut sel = SelectionState::new();
+        sel.handle(&down(4, 0));
+        sel.handle(&up(4, 0));
+        sel.handle(&down(4, 0));
+        sel.handle(&up(4, 0));
+
+        assert!(!sel.resolve(&buf, buf.area));
         assert!(sel.range().is_none());
     }
 

--- a/src/tui/fullscreen.rs
+++ b/src/tui/fullscreen.rs
@@ -226,6 +226,8 @@ pub(crate) fn draw(f: &mut Frame, app: &mut App) {
         height: t.height,
     };
     app.set_selection_area(selection);
+    app.resolve_link_click(f.buffer_mut());
+    app.resolve_selection(f.buffer_mut());
     if let Some(range) = app.selection_range() {
         if app.take_pending_copy() {
             let text = tuika::selected_text(f.buffer_mut(), selection, range);

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -243,6 +243,8 @@ pub struct App {
     selection: tuika::SelectionState,
     selection_area: Rect,
     pending_copy: bool,
+    pending_link_click: Option<tuika::Mouse>,
+    pending_open_url: Option<String>,
     /// Drives the terminal's native OSC 9;4 progress indicator (Ghostty top
     /// bar / taskbar) while a turn runs. Works in both renderers. Enabled only
     /// for real TUI sessions via [`App::enable_native_progress`] so tests and
@@ -563,6 +565,8 @@ impl App {
             selection: tuika::SelectionState::new(),
             selection_area: Rect::ZERO,
             pending_copy: false,
+            pending_link_click: None,
+            pending_open_url: None,
             term_progress: tuika::TerminalProgress::new(),
             native_progress: false,
             // Tests run in-memory so recall never reads or appends to the real
@@ -604,6 +608,23 @@ impl App {
 
     /// The active full-screen transcript selection, if any (read by the draw to
     /// highlight and copy it).
+    pub(crate) fn resolve_selection(&mut self, buffer: &ratatui::buffer::Buffer) {
+        if self.selection.resolve(buffer, self.selection_area) {
+            self.pending_copy = true;
+        }
+    }
+
+    pub(crate) fn resolve_link_click(&mut self, buffer: &ratatui::buffer::Buffer) {
+        let Some(event) = self.pending_link_click.take() else {
+            return;
+        };
+        self.pending_open_url = tuika::ctrl_click_url(&event, buffer, self.selection_area);
+    }
+
+    pub(crate) fn take_pending_open_url(&mut self) -> Option<String> {
+        self.pending_open_url.take()
+    }
+
     pub(crate) fn selection_range(&self) -> Option<tuika::SelectionRange> {
         self.selection.range()
     }
@@ -628,6 +649,12 @@ impl App {
         else {
             return false;
         };
+        if m.kind == tuika::MouseKind::Up(tuika::MouseButton::Left) && m.ctrl && !m.shift && !m.alt
+        {
+            self.selection.clear();
+            self.pending_link_click = Some(m);
+            return true;
+        }
         if !m.plain() {
             return false;
         }
@@ -1080,6 +1107,12 @@ impl App {
             maybe_reanchor_inline_viewport(terminal)?;
         }
         terminal.draw(|f| draw(f, self))?;
+
+        if let Some(url) = self.take_pending_open_url()
+            && let Err(error) = crate::auth::oauth_flow::open_browser(&url)
+        {
+            tracing::warn!(%error, %url, "failed to open ctrl-clicked link");
+        }
 
         // 1) drain background turn events
         if let Some(rx) = self.rx.as_mut() {
@@ -4951,6 +4984,34 @@ mod tests {
         test.app.trim_transcript();
         assert_eq!(test.app.lines.len(), MAX_RETAINED_TRANSCRIPT_LINES);
         assert_eq!(test.app.printed_lines, MAX_RETAINED_TRANSCRIPT_LINES);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fullscreen_ctrl_click_resolves_visible_url() {
+        let mut test = app_with_llmsim().await;
+        test.app.setup = None;
+        test.app.set_render_mode(RenderMode::Fullscreen);
+        let area = Rect::new(2, 3, 40, 1);
+        test.app.set_selection_area(area);
+        let event = MouseEvent {
+            kind: MouseEventKind::Up(MouseButton::Left),
+            column: area.x + 10,
+            row: area.y,
+            modifiers: KeyModifiers::CONTROL,
+        };
+        assert!(test.app.handle_fullscreen_selection(event));
+        let mut buffer = ratatui::buffer::Buffer::empty(Rect::new(0, 0, 50, 8));
+        buffer.set_string(
+            area.x,
+            area.y,
+            "see https://example.com/docs now",
+            Style::default(),
+        );
+        test.app.resolve_link_click(&buffer);
+        assert_eq!(
+            test.app.take_pending_open_url().as_deref(),
+            Some("https://example.com/docs")
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary

- add double-click word selection to Tuika while preserving drag selection
- add Ctrl+click activation for visible bare HTTP(S) URLs in Yolop fullscreen mode
- document mouse selection and link activation in Tuika's public feature guide

## Why

Tuika's fullscreen text interactions lagged native terminal expectations: users could drag-select, but could not double-click a word or deliberately open a rendered URL with a modifier click.

## Before / After

**Before:** double-clicking left no selection, and Ctrl+clicking a visible URL had no effect.

**After:** a same-cell double click selects and copies the rendered word; Ctrl+left-click on a visible bare `http://` or `https://` URL opens it through Yolop's existing detached system-browser launcher.

Proof from the pseudo-terminal smoke test:

```text
PASS: mouse capture enabled
PASS: double-click copied Drag
PASS: copy status rendered
PASS: clean exit
```

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"`
- pseudo-terminal smoke test of `cargo build -p tuika --example mouse` with injected SGR double-click events

## Security

- **TM-FS:** no filesystem-access changes.
- **TM-BASH:** no shell-tool or execution-bound changes.
- **TM-LLM:** no prompt, provider, or credential changes.
- **TM-TOOL:** no capability-registration changes.
- **TM-DEP:** no new or updated dependencies.
- Ctrl+click only returns URLs recognized by the existing HTTP(S) link policy and only on an explicit Ctrl+left-button release. Browser opening reuses the existing argument-safe `Command` launcher; no shell interpolation is introduced.

## Follow-ups

- Markdown labels whose visible text differs from their target are not activated because Ratatui buffers retain rendered cells, not source link metadata. Defer until Tuika exposes retained hyperlink hit metadata.

Produced by [yolop](https://everruns.com/yolop)
