### PR TITLE
feat(tuika): honor Line alignment and add Boxed bottom title

### DIFF
--- a/crates/tuika/docs/components.md
+++ b/crates/tuika/docs/components.md
@@ -65,14 +65,28 @@ clipped. `Paragraph` word-wraps plain text in one style; `Wrap` word-wraps
 pre-styled lines while preserving per-span styles.
 [API](https://docs.rs/tuika/latest/tuika/struct.Text.html)
 
+Horizontal alignment is honored. `Text` and `Wrap` read each `Line`'s
+`alignment` (unset = flush-left), so centered titles, right-aligned totals, and
+centered empty-state messages built by an existing formatting layer render as
+intended; `Wrap` carries a line's alignment onto every reflowed row.
+`Paragraph` takes one alignment for the whole block via `.alignment(..)`.
+
 <img src="demos/text.gif" width="880" alt="Text demo">
 
 ```rust
-use tuika::{Paragraph, view};
+use ratatui::layout::Alignment;
+use ratatui::text::Line;
+use tuika::{Paragraph, Text, view};
 view! {
     col(gap = 1) {
-        text("a plain line")
-        node(Paragraph::new("word-wrapped prose", style))
+        // Per-line alignment on pre-styled lines.
+        node(Text::new(vec![
+            Line::from("flush left"),
+            Line::from("centered").centered(),
+            Line::from("flush right").right_aligned(),
+        ]))
+        // One alignment for a wrapped plain-text block.
+        node(Paragraph::new("word-wrapped prose", style).alignment(Alignment::Center))
     }
 }
 ```
@@ -181,6 +195,9 @@ view! {
 ### `Boxed`
 
 A border + padding + title wrapping one child; the border color is focus-aware.
+An optional `title_bottom` rides the bottom border — the slot for a `1 of 3`
+position counter, a footer legend, or a hint. Both titles honor their `Line`
+alignment; unset, the top title is flush-left and the bottom title flush-right.
 [API](https://docs.rs/tuika/latest/tuika/struct.Boxed.html)
 
 <img src="demos/boxed.gif" width="880" alt="Boxed demo">
@@ -188,7 +205,7 @@ A border + padding + title wrapping one child; the border color is focus-aware.
 ```rust
 use tuika::{BorderStyle, view};
 view! {
-    boxed(title = " title ", border = BorderStyle::Rounded) {
+    boxed(title = " title ", title_bottom = " 1/3 ", border = BorderStyle::Rounded) {
         node(child)
     }
 }

--- a/crates/tuika/examples/gallery.rs
+++ b/crates/tuika/examples/gallery.rs
@@ -50,8 +50,19 @@ fn build(frame: u64, theme: &Theme) -> tuika::Element {
                 }
             }
             fixed(3) {
-                boxed(title = Line::from(Span::styled(" loader ", theme.accent_style()))) {
+                boxed(title = Line::from(Span::styled(" loader ", theme.accent_style())),
+                      title_bottom = Line::from(Span::styled(" 3 of 3 ", theme.muted_style()))) {
                     node(Loader::new(frame, "working…").hint("esc to quit"))
+                }
+            }
+            fixed(5) {
+                boxed(title = Line::from(Span::styled(" alignment ", theme.accent_style()))) {
+                    // Per-line alignment carried straight off each `Line`.
+                    node(Text::new(vec![
+                        Line::from(Span::styled("left", theme.muted_style())),
+                        Line::from(Span::styled("centered", theme.accent_style())).centered(),
+                        Line::from(Span::styled("right", theme.muted_style())).right_aligned(),
+                    ]))
                 }
             }
             grow(1) { spacer() }

--- a/crates/tuika/src/components/boxed.rs
+++ b/crates/tuika/src/components/boxed.rs
@@ -3,7 +3,7 @@
 //! context reports focus. This is `tuika`'s framing primitive (Pi's
 //! `DynamicBorder` / `Box`).
 
-use ratatui::layout::Rect;
+use ratatui::layout::{Alignment, Rect};
 use ratatui::style::Style;
 use ratatui::text::Line;
 
@@ -12,7 +12,7 @@ use crate::style::BorderStyle;
 use crate::surface::Surface;
 use crate::view::{Element, RenderCtx, View};
 
-use super::text::line_width;
+use super::text::{aligned_x, line_width};
 
 /// A bordered, padded container wrapping one child.
 ///
@@ -34,12 +34,33 @@ use super::text::line_width;
 /// );
 /// ```
 ///
+/// A secondary title can ride the bottom border — a position counter, footer
+/// legend, or hint — and defaults to flush-right:
+///
+/// ```
+/// use tuika::{Boxed, Text, Theme, element};
+/// use tuika::testing::{grid, render};
+///
+/// let view = Boxed::new(element(Text::raw("hi")))
+///     .title(" files ")
+///     .title_bottom(" 1/3 ");
+///
+/// let buffer = render(&view, 12, 3, &Theme::default());
+/// assert_eq!(
+///     grid(&buffer),
+///     "╭─ files ──╮\n\
+///      │ hi       │\n\
+///      ╰──── 1/3 ─╯",
+/// );
+/// ```
+///
 /// ![boxed demo](https://raw.githubusercontent.com/everruns/yolop/main/crates/tuika/docs/demos/boxed.gif)
 pub struct Boxed {
     child: Element,
     border: BorderStyle,
     padding: Padding,
     title: Option<Line<'static>>,
+    title_bottom: Option<Line<'static>>,
     background: Option<Style>,
 }
 
@@ -51,6 +72,7 @@ impl Boxed {
             border: BorderStyle::Rounded,
             padding: Padding::symmetric(1, 0),
             title: None,
+            title_bottom: None,
             background: None,
         }
     }
@@ -68,8 +90,24 @@ impl Boxed {
     }
 
     /// Set a title drawn on the top border, clipped between the corners.
+    ///
+    /// The title's horizontal placement honors its [`Line::alignment`]; an unset
+    /// alignment (the default) is flush-left, matching a plain string title.
     pub fn title(mut self, title: impl Into<Line<'static>>) -> Self {
         self.title = Some(title.into());
+        self
+    }
+
+    /// Set a secondary title drawn on the bottom border, clipped between the
+    /// corners — the slot list/table TUIs use for a `1 of 3` position counter, a
+    /// footer legend, or a keybinding hint.
+    ///
+    /// Placement honors the title's [`Line::alignment`]. An unset alignment
+    /// defaults to flush-**right** here (unlike the top title's flush-left),
+    /// since a bottom-right counter is the common case; pass a `.centered()` or
+    /// `.left_aligned()` [`Line`] to override.
+    pub fn title_bottom(mut self, title: impl Into<Line<'static>>) -> Self {
+        self.title_bottom = Some(title.into());
         self
     }
 
@@ -133,20 +171,46 @@ impl View for Boxed {
             let border_style = Style::default().fg(ctx.theme.border_color(ctx.focused));
             surface.draw_border(area, self.border.glyphs(), border_style);
             if let Some(title) = &self.title {
-                // Title sits on the top border, one cell in, clipped to fit
-                // between the corners.
-                let max = area.width.saturating_sub(4);
-                let mut x = area.x.saturating_add(2);
-                if line_width(title) <= max {
-                    for span in &title.spans {
-                        x = surface.set_string(x, area.y, span.content.as_ref(), span.style);
-                    }
-                }
+                draw_title(surface, area, area.y, title, Alignment::Left);
+            }
+            if let Some(title) = &self.title_bottom {
+                let bottom = area.bottom().saturating_sub(1);
+                draw_title(surface, area, bottom, title, Alignment::Right);
             }
         }
         let inner = self.inner(area);
         let mut inner_surface = surface.child(inner);
         self.child.render(inner, &mut inner_surface, ctx);
+    }
+}
+
+/// Draw a border `title` on row `y`, inset one cell from each corner and clipped
+/// to fit between them. Horizontal placement honors the line's alignment,
+/// falling back to `default_align` when it is unset. A title too wide for the
+/// span between the corners is dropped rather than overrunning a corner.
+fn draw_title(
+    surface: &mut Surface,
+    area: Rect,
+    y: u16,
+    title: &Line<'static>,
+    default_align: Alignment,
+) {
+    let max = area.width.saturating_sub(4);
+    if line_width(title) > max {
+        return;
+    }
+    // The title span runs from one cell past the left corner to one cell before
+    // the right corner; align the content within that inset region.
+    let region = Rect {
+        x: area.x.saturating_add(2),
+        y,
+        width: max,
+        height: 1,
+    };
+    let align = title.alignment.unwrap_or(default_align);
+    let mut x = aligned_x(align, line_width(title), region);
+    for span in &title.spans {
+        x = surface.set_string(x, y, span.content.as_ref(), span.style);
     }
 }
 
@@ -156,7 +220,7 @@ mod tests {
     use crate::Surface;
     use crate::components::Text;
     use crate::style::Theme;
-    use crate::test_support::{buffer, rainbow_theme};
+    use crate::test_support::{buffer, rainbow_theme, row};
     use crate::view::{RenderCtx, View, element};
     use ratatui::style::Color;
 
@@ -176,6 +240,66 @@ mod tests {
                 assert_eq!(buf[(w - 1, h - 1)].symbol(), "╯", "bottom-right at {w}x{h}");
             }
         }
+    }
+
+    #[test]
+    fn bottom_title_defaults_flush_right() {
+        let theme = Theme::default();
+        let ctx = RenderCtx::new(&theme);
+        let mut buf = buffer(10, 3);
+        let area = buf.area;
+        let mut surface = Surface::new(&mut buf, area);
+        // Plain string title, no explicit alignment -> flush-right on the
+        // bottom border, one cell inside the right corner.
+        Boxed::new(element(Text::raw("x")))
+            .title_bottom(" 1/3 ")
+            .render(area, &mut surface, &ctx);
+        // Width 10: corners at 0 and 9, inset span [2..8) is 6 cols, " 1/3 " is
+        // 5 cols -> right-aligned start at column 3.
+        assert_eq!(row(&buf, 2), "╰── 1/3 ─╯");
+    }
+
+    #[test]
+    fn bottom_title_honors_explicit_alignment() {
+        let theme = Theme::default();
+        let ctx = RenderCtx::new(&theme);
+        let mut buf = buffer(10, 3);
+        let area = buf.area;
+        let mut surface = Surface::new(&mut buf, area);
+        Boxed::new(element(Text::raw("x")))
+            .title_bottom(Line::from("ab").left_aligned())
+            .render(area, &mut surface, &ctx);
+        // Left-aligned -> one cell in from the left corner.
+        assert_eq!(row(&buf, 2), "╰─ab─────╯");
+    }
+
+    #[test]
+    fn top_title_honors_center_alignment() {
+        let theme = Theme::default();
+        let ctx = RenderCtx::new(&theme);
+        let mut buf = buffer(10, 3);
+        let area = buf.area;
+        let mut surface = Surface::new(&mut buf, area);
+        Boxed::new(element(Text::raw("x")))
+            .title(Line::from("ab").centered())
+            .render(area, &mut surface, &ctx);
+        // Inset span [2..8) width 6, content 2 -> slack 4, centered start col
+        // 2 + 4/2 = 4.
+        assert_eq!(row(&buf, 0), "╭───ab───╮");
+    }
+
+    #[test]
+    fn oversized_bottom_title_is_dropped() {
+        let theme = Theme::default();
+        let ctx = RenderCtx::new(&theme);
+        let mut buf = buffer(6, 3);
+        let area = buf.area;
+        let mut surface = Surface::new(&mut buf, area);
+        Boxed::new(element(Text::raw("x")))
+            .title_bottom("a title far too wide")
+            .render(area, &mut surface, &ctx);
+        // Doesn't fit between the corners -> border stays intact, no overrun.
+        assert_eq!(row(&buf, 2), "╰────╯");
     }
 
     #[test]

--- a/crates/tuika/src/components/text.rs
+++ b/crates/tuika/src/components/text.rs
@@ -5,8 +5,15 @@
 //! plus one style and word-wraps it to the available width. [`Wrap`] is the
 //! styled counterpart to `Paragraph`: it word-wraps pre-styled `Line`s while
 //! preserving each span's style across the reflow (see [`wrap_lines`]).
+//!
+//! Horizontal alignment is honored throughout. [`Text`] and [`Wrap`] read each
+//! [`Line::alignment`] (unset = flush-left), so centered titles, right-aligned
+//! totals, and centered empty-state messages built elsewhere render as intended
+//! rather than snapping to the left edge; `Wrap` carries a line's alignment onto
+//! every row it reflows to. [`Paragraph`] takes a single alignment for the whole
+//! block via [`Paragraph::alignment`].
 
-use ratatui::layout::Rect;
+use ratatui::layout::{Alignment, Rect};
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 use unicode_segmentation::UnicodeSegmentation;
@@ -16,7 +23,22 @@ use crate::surface::Surface;
 use crate::view::{RenderCtx, View};
 use crate::width::{grapheme_cols, str_cols};
 
+/// Starting column for `content_width` columns of content placed in `area`
+/// under `alignment`: flush-left, centered, or flush-right within the width.
+/// Content wider than the area pins to the left edge (slack saturates to 0).
+pub(crate) fn aligned_x(alignment: Alignment, content_width: u16, area: Rect) -> u16 {
+    let slack = area.width.saturating_sub(content_width);
+    match alignment {
+        Alignment::Left => area.x,
+        Alignment::Center => area.x.saturating_add(slack / 2),
+        Alignment::Right => area.x.saturating_add(slack),
+    }
+}
+
 /// Draw pre-styled `lines` top-down from `area`'s origin, clipping to `area`.
+/// Each line's horizontal start honors its [`Line::alignment`] — an unset
+/// alignment is flush-left, so pre-styled lines built elsewhere keep their
+/// centered/right-aligned intent instead of silently snapping to the left.
 /// Shared by [`Text`] and [`Wrap`].
 fn draw_lines(lines: &[Line<'static>], area: Rect, surface: &mut Surface) {
     for (row, line) in lines.iter().enumerate() {
@@ -24,7 +46,8 @@ fn draw_lines(lines: &[Line<'static>], area: Rect, surface: &mut Surface) {
         if y >= area.bottom() {
             break;
         }
-        let mut x = area.x;
+        let align = line.alignment.unwrap_or(Alignment::Left);
+        let mut x = aligned_x(align, line_width(line), area);
         for span in &line.spans {
             if x >= area.right() {
                 break;
@@ -43,6 +66,28 @@ pub fn line_width(line: &Line) -> u16 {
 }
 
 /// A block of pre-styled lines, drawn top-down and clipped.
+///
+/// Each line is placed horizontally by its own [`Line::alignment`]: an unset
+/// alignment (the default) is flush-left, while lines built with ratatui's
+/// `.centered()` / `.right_aligned()` render centered or flush-right within the
+/// render width. This lets a host feed in `Line`s produced by an existing
+/// formatting layer without losing their alignment.
+///
+/// ```
+/// use tuika::{Text, Theme};
+/// use ratatui::text::Line;
+/// # use tuika::testing::render;
+/// let view = Text::new(vec![
+///     Line::from("left"),
+///     Line::from("mid").centered(),
+///     Line::from("end").right_aligned(),
+/// ]);
+/// let buffer = render(&view, 7, 3, &Theme::default());
+/// # use tuika::testing::grid;
+/// // width 7: "left" flush-left, "mid" centered (slack 4 -> col 2),
+/// // "end" flush-right (slack 4 -> col 4). `grid` keeps trailing cells.
+/// assert_eq!(grid(&buffer), "left   \n  mid  \n    end");
+/// ```
 ///
 /// ![text demo](https://raw.githubusercontent.com/everruns/yolop/main/crates/tuika/docs/demos/text.gif)
 pub struct Text {
@@ -76,15 +121,25 @@ impl View for Text {
 pub struct Paragraph {
     text: String,
     style: Style,
+    align: Alignment,
 }
 
 impl Paragraph {
-    /// A paragraph that wraps `text` in a single `style`.
+    /// A paragraph that wraps `text` in a single `style`, flush-left.
     pub fn new(text: impl Into<String>, style: Style) -> Self {
         Self {
             text: text.into(),
             style,
+            align: Alignment::Left,
         }
+    }
+
+    /// Horizontally align every wrapped line within the render width. Defaults
+    /// to [`Alignment::Left`]; pass [`Alignment::Center`] for a centered
+    /// empty-state message or [`Alignment::Right`] for a right-aligned block.
+    pub fn alignment(mut self, align: Alignment) -> Self {
+        self.align = align;
+        self
     }
 
     fn wrap(&self, width: u16) -> Vec<String> {
@@ -122,7 +177,8 @@ impl View for Paragraph {
             if y >= area.bottom() {
                 break;
             }
-            surface.set_string(area.x, y, &line, self.style);
+            let x = aligned_x(self.align, str_cols(line.as_str()), area);
+            surface.set_string(x, y, &line, self.style);
         }
     }
 }
@@ -226,6 +282,13 @@ fn wrap_one(line: &Line<'static>, width: u16, out: &mut Vec<Line<'static>>) {
     // Preserve a blank (empty or all-whitespace) input line as one blank row.
     if out.len() == before {
         out.push(Line::default());
+    }
+    // Carry the source line's alignment onto every row it reflowed to, so a
+    // centered/right-aligned line stays aligned after wrapping.
+    if let Some(align) = line.alignment {
+        for produced in &mut out[before..] {
+            produced.alignment = Some(align);
+        }
     }
 }
 
@@ -434,6 +497,51 @@ mod tests {
         let out = wrap_lines(&[Line::from("hello world")], 0);
         assert_eq!(out.len(), 1);
         assert_eq!(line_text(&out[0]), "hello world");
+    }
+
+    #[test]
+    fn text_honors_line_alignment() {
+        let mut buf = buffer(7, 3);
+        let text = Text::new(vec![
+            Line::from("ab"),
+            Line::from("cd").centered(),
+            Line::from("ef").right_aligned(),
+        ]);
+        let theme = Theme::default();
+        let ctx = RenderCtx::new(&theme);
+        let area = buf.area;
+        let mut surface = Surface::new(&mut buf, area);
+        text.render(area, &mut surface, &ctx);
+        assert_eq!(row(&buf, 0), "ab", "unset alignment is flush-left");
+        // width 7, content 2 -> slack 5, centered start = 5/2 = 2.
+        assert_eq!(row(&buf, 1), "  cd", "centered line offset by slack/2");
+        // right start = x + slack = 5.
+        assert_eq!(row(&buf, 2), "     ef", "right-aligned pins to right edge");
+    }
+
+    #[test]
+    fn paragraph_alignment_positions_each_wrapped_line() {
+        // "aa bb" at width 6 stays one line; center slack = 1, start col 0 (1/2).
+        let mut buf = buffer(6, 2);
+        let p = Paragraph::new("aa bb", Style::default()).alignment(Alignment::Right);
+        let theme = Theme::default();
+        let ctx = RenderCtx::new(&theme);
+        let area = buf.area;
+        let mut surface = Surface::new(&mut buf, area);
+        p.render(area, &mut surface, &ctx);
+        // width 6, content 5 -> slack 1, right start = 1.
+        assert_eq!(row(&buf, 0), " aa bb");
+    }
+
+    #[test]
+    fn wrap_carries_alignment_onto_reflowed_rows() {
+        // A right-aligned line wide enough to wrap keeps its alignment per row.
+        let out = wrap_lines(&[Line::from("aa bb cc").right_aligned()], 5);
+        assert!(out.len() >= 2, "expected a wrap: {out:?}");
+        assert!(
+            out.iter().all(|l| l.alignment == Some(Alignment::Right)),
+            "every reflowed row keeps the source alignment: {out:?}"
+        );
     }
 
     #[test]

--- a/crates/tuika/src/macros.rs
+++ b/crates/tuika/src/macros.rs
@@ -20,7 +20,8 @@
 //!   Attrs: `gap = e`, `padding = e`, `align = e`, `justify = e` (comma-separated,
 //!   all optional; the whole `( … )` may be omitted).
 //! - `boxed( attrs ) { child }` — bordered container of one child.
-//!   Attrs: `title = e`, `border = e`, `padding = e`, `background = e`.
+//!   Attrs: `title = e`, `title_bottom = e`, `border = e`, `padding = e`,
+//!   `background = e`.
 //! - `text( expr )` — a `Text::raw` line. `spacer()` — a `Spacer`.
 //! - `grow(n) { node }` / `fixed(n) { node }` — set a child's main-axis size
 //!   (default is auto).
@@ -40,7 +41,7 @@
 /// Each keyword consumes exactly one node: `col`/`row` open flex containers
 /// (with optional `gap`/`padding`/`align`/`justify`/`background` attrs and a
 /// `{ children }` block), `boxed` wraps a single child in a border (with
-/// `title`/`border`/`padding`/`background` attrs), `text(expr)` and `spacer()`
+/// `title`/`title_bottom`/`border`/`padding`/`background` attrs), `text(expr)` and `spacer()`
 /// emit leaves, `grow(n)`/`fixed(n)` set a child's main-axis size, and
 /// `node(expr)` splices any `impl View`. Expands to plain builder calls with no
 /// runtime cost.
@@ -128,6 +129,9 @@ macro_rules! view {
     (@boxattrs $b:expr; title = $e:expr $(, $($rest:tt)*)?) => {
         $crate::view!(@boxattrs $b.title($e); $($($rest)*)?)
     };
+    (@boxattrs $b:expr; title_bottom = $e:expr $(, $($rest:tt)*)?) => {
+        $crate::view!(@boxattrs $b.title_bottom($e); $($($rest)*)?)
+    };
     (@boxattrs $b:expr; border = $e:expr $(, $($rest:tt)*)?) => {
         $crate::view!(@boxattrs $b.border($e); $($($rest)*)?)
     };
@@ -170,6 +174,27 @@ mod tests {
         let b = render_el(&macroed, 20, 5);
         assert_eq!(a, b, "view! must render identically to the builder form");
         assert!(b.iter().any(|l| l.contains('t')), "{b:?}");
+    }
+
+    #[test]
+    fn view_macro_forwards_title_bottom() {
+        // `title_bottom =` folds to `Boxed::title_bottom` and renders on the
+        // bottom border, flush-right by default.
+        let built: Element = element(
+            Boxed::new(element(Text::raw("hi")))
+                .title(" top ")
+                .title_bottom(" 1/3 "),
+        );
+        let macroed: Element = crate::view! {
+            boxed(title = " top ", title_bottom = " 1/3 ") { text("hi") }
+        };
+        let a = render_el(&built, 12, 3);
+        let b = render_el(&macroed, 12, 3);
+        assert_eq!(a, b, "title_bottom must render identically to the builder");
+        assert!(
+            b.last().is_some_and(|l| l.contains("1/3")),
+            "bottom border carries the secondary title: {b:?}"
+        );
     }
 
     /// A `View` standing in for a component defined in some other crate.


### PR DESCRIPTION
## What changed

Two additions to the `tuika` toolkit for the class of apps that adopt it incrementally or reuse an existing formatting layer:

- **`Text` and `Wrap` honor each `Line`'s alignment.** Previously every line drew flush-left, silently discarding the `alignment` field of pre-styled `Line`s built elsewhere. Now an unset alignment is flush-left (unchanged for existing callers), while `.centered()` / `.right_aligned()` lines render as intended. `Wrap` carries a source line's alignment onto every reflowed row. `Paragraph` gains a whole-block `.alignment(Alignment)` builder.
- **`Boxed` gains an optional `title_bottom`** on the bottom border — the slot list/table TUIs use for a "1 of 3" position counter, a footer legend, or a hint. Both titles honor their `Line` alignment; unset, the top title stays flush-left and the bottom title defaults flush-right (the common counter case). The `view!` macro forwards a `title_bottom =` attribute.

Additive only — no existing signature or default rendering changes.

## Why

Apps feeding tuika pre-styled `Line`s from a reusable formatting layer (the common case when adopting tuika incrementally) lost centered titles, right-aligned totals, and centered empty-state messages, and had to re-implement alignment per consumer. Boxed supported only a single top title, so the near-universal bottom-border secondary label (position counter / footer legend, as in lazygit / k9s / gitui) couldn't be expressed at all and had to be hand-drawn.

## Before / After

Rendered output is asserted directly in doctests and unit tests.

**Line alignment** — `Text` at width 7 with three lines (`grid` keeps trailing cells):

```
Before (alignment ignored)   After (Line::alignment honored)
left                         left
mid                            mid
end                              end
```

**Boxed bottom title** — `.title(" files ").title_bottom(" 1/3 ")` at 12×3:

```
Before (no bottom slot)   After
╭─ files ──╮              ╭─ files ──╮
│ hi       │              │ hi       │
╰──────────╯              ╰──── 1/3 ─╯
```

Both features are also wired into the runnable `gallery` example (`cargo run -p tuika --example gallery`): an `alignment` box demonstrating left/center/right lines, and a `3 of 3` bottom-title counter on the loader box.

## Risk

- **Low.**
- Purely additive layout math in the `tuika` UI crate: new `aligned_x` helper (saturating arithmetic, no new loops), a `draw_title` helper, one new optional field on `Boxed`, one new `Paragraph` builder, one new macro arm. No public signature changes; unset alignment preserves the prior flush-left rendering, so existing consumers are unaffected.

## Validation

- `cargo fmt --check` — clean
- `cargo clippy -p tuika --all-targets --all-features -- -D warnings` — clean
- `cargo test -p tuika --all-features` — 205 lib tests + 12 doctests pass, including new coverage:
  - `text.rs`: center/right line alignment, `Paragraph::alignment`, wrap-carries-alignment onto reflowed rows
  - `boxed.rs`: bottom title default-right, explicit-left override, top-center, oversized-title dropped (no corner overrun)
  - `macros.rs`: `title_bottom =` forwards identically to the builder
  - doctests on `Text` and `Boxed` asserting rendered grids
- Offline smoke: `cargo run -- --provider llmsim -p "hi"` — binary starts and renders (exit 0)

## Security

No security-relevant code changes. The diff is layout arithmetic and rendering in the `tuika` crate — no filesystem, shell, prompt/API-key, capability-registration, or dependency changes (confirmed by scanning the diff for `std::fs` / `std::process` / `env::` / `api_key` / `unsafe` / `Cargo.toml` — none present).

## Follow-ups

These were called out in the same request but are larger, independent features and belong in their own PRs (not started here):

- Columned/`Table` component (header, per-column widths, full-row selection, windowing).
- Host-settable `ScrollState::set_offset` + horizontal panning.
- Standalone `layout::solve` re-exported at the crate root for computing rects before/without painting.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (additive; unset alignment preserves prior flush-left rendering)

---
_Generated by [Claude Code](https://claude.ai/code/session_013X4ivPR4SXng9sr3RJbvQy)_