### PR TITLE
feat(tuika): stream markdown image pixels + add Sixel protocol

### DIFF
--- a/crates/tuika/docs/features.md
+++ b/crates/tuika/docs/features.md
@@ -239,14 +239,16 @@ ESC ] 1337 ; File=inline=1;width=<cols>;height=<rows>;preserveAspectRatio=0;size
 iTerm2 (its own protocol). Others show the alt-text fallback. See the `image`
 example (`cargo run -p tuika --example image`).
 
-Markdown `![alt](url)` renders too. The [`Markdown`](components.md) view's
-`.images(resolver, support, layer)` takes a host `ImageResolver` (URL →
-`ImageData` — markdown carries only the URL, never pixels, exactly like the code
-`Highlighter` seam), reserves a block for each resolved image, and paints it with
-the same `Image` machinery — real pixels where supported, alt text otherwise.
-Unresolved images stay a marked, link-styled inline placeholder rather than
-dropping the URL. (Pixels in the *streaming* `MarkdownState`, and the Sixel
-protocol, are the remaining follow-ups.)
+Markdown `![alt](url)` renders too, in both the one-shot `Markdown` view and the
+streaming `MarkdownState`. A host `ImageResolver` decodes each URL to `ImageData`
+(markdown carries only the URL, never pixels, exactly like the code `Highlighter`
+seam); a resolved image reserves a block and is painted with the same `Image`
+machinery — real pixels where supported, alt text otherwise. The view's
+`.images(resolver, support, layer)` overlays them for you; a host driving
+`MarkdownState::lines` reads `MarkdownState::images()` and paints each
+`MarkdownImage` at its `rect(area)`. Unresolved images stay a marked, link-styled
+inline placeholder rather than dropping the URL. (The Sixel protocol is the
+remaining follow-up.)
 
 ## See also
 

--- a/crates/tuika/docs/features.md
+++ b/crates/tuika/docs/features.md
@@ -174,11 +174,11 @@ Terminal and ConEmu (taskbar), WezTerm, Konsole, mintty. Others swallow the
 unknown OSC. Writes are best-effort — a failed progress write never disrupts the
 session.
 
-## Images (Kitty & iTerm2 graphics protocols)
+## Images (Kitty, iTerm2 & Sixel graphics protocols)
 
 Paint real pixels — an avatar, a chart, a rendered diagram — over the cells a
-view reserves for them, using the **Kitty graphics protocol** or the **iTerm2
-inline-image protocol**, whichever the terminal speaks.
+view reserves for them, using the **Kitty**, **iTerm2**, or **Sixel** graphics
+protocol, whichever the terminal speaks.
 [API](https://docs.rs/tuika/latest/tuika/image/index.html)
 
 <img src="demos/image.svg" width="880" alt="Image demo, side by side: on a Kitty/Ghostty/WezTerm/Konsole terminal the Image view renders a red/green gradient in place; on every other terminal the same view shows a dimmed italic '[image: a red/green gradient]' placeholder.">
@@ -235,9 +235,18 @@ iTerm2 carries a PNG file sized in cells:
 ESC ] 1337 ; File=inline=1;width=<cols>;height=<rows>;preserveAspectRatio=0;size=<bytes> : <base64> BEL
 ```
 
+Sixel carries a palette-quantized bitmap (it has no cell-based sizing, so tuika
+resamples the pixels to an assumed cell geometry first):
+
+```text
+ESC P q "1;1;<px_w>;<px_h> <color registers> <band data> ESC \
+```
+
 **Supported terminals:** Kitty, Ghostty, WezTerm, Konsole (Kitty protocol);
-iTerm2 (its own protocol). Others show the alt-text fallback. See the `image`
-example (`cargo run -p tuika --example image`).
+iTerm2 (its own protocol); foot, xterm +sixel, mlterm, contour (Sixel). Others
+show the alt-text fallback. Sixel has no reliable environment signal, so a host
+on a Sixel terminal usually sets `ImageSupport::Sixel` explicitly. See the
+`image` example (`cargo run -p tuika --example image`).
 
 Markdown `![alt](url)` renders too, in both the one-shot `Markdown` view and the
 streaming `MarkdownState`. A host `ImageResolver` decodes each URL to `ImageData`
@@ -247,8 +256,7 @@ machinery — real pixels where supported, alt text otherwise. The view's
 `.images(resolver, support, layer)` overlays them for you; a host driving
 `MarkdownState::lines` reads `MarkdownState::images()` and paints each
 `MarkdownImage` at its `rect(area)`. Unresolved images stay a marked, link-styled
-inline placeholder rather than dropping the URL. (The Sixel protocol is the
-remaining follow-up.)
+inline placeholder rather than dropping the URL.
 
 ## See also
 

--- a/crates/tuika/examples/image.rs
+++ b/crates/tuika/examples/image.rs
@@ -66,6 +66,7 @@ fn main() -> io::Result<()> {
             let status = match support {
                 ImageSupport::Kitty => " graphics: Kitty protocol detected ",
                 ImageSupport::ITerm2 => " graphics: iTerm2 protocol detected ",
+                ImageSupport::Sixel => " graphics: Sixel protocol detected ",
                 ImageSupport::None => " graphics: none — showing text fallback ",
             };
             let bar = StatusBar::new()

--- a/crates/tuika/src/components/mod.rs
+++ b/crates/tuika/src/components/mod.rs
@@ -25,7 +25,9 @@ mod tabs;
 mod text;
 mod textinput;
 
-pub use crate::markdown::{ImageResolver, Markdown, MarkdownState, markdown_to_lines};
+pub use crate::markdown::{
+    ImageResolver, Markdown, MarkdownImage, MarkdownState, markdown_to_lines,
+};
 pub use boxed::Boxed;
 pub use code_block::CodeBlock;
 pub use constrained::Constrained;

--- a/crates/tuika/src/image.rs
+++ b/crates/tuika/src/image.rs
@@ -1,4 +1,4 @@
-//! Terminal image rendering via the Kitty and iTerm2 graphics protocols.
+//! Terminal image rendering via the Kitty, iTerm2, and Sixel graphics protocols.
 //!
 //! A cell in ratatui's buffer carries one grapheme plus a style and nothing
 //! else, so a picture has no home there — the same wall [`crate::hyperlink`]
@@ -95,8 +95,6 @@ impl ImageData {
 }
 
 /// Which graphics protocol a terminal is believed to speak.
-///
-/// Sixel is a future variant selected by the same detection.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ImageSupport {
     /// No known graphics protocol — [`Image`] renders its text fallback.
@@ -107,6 +105,11 @@ pub enum ImageSupport {
     /// The iTerm2 inline-image protocol (iTerm2, WezTerm). Transmits an encoded
     /// image file — tuika PNG-encodes the RGBA for it.
     ITerm2,
+    /// The Sixel protocol (foot, xterm +sixel, mlterm, contour, …). Transmits a
+    /// palette-quantized bitmap. Reliable auto-detection isn't possible from the
+    /// environment alone, so hosts on a Sixel terminal usually set this
+    /// explicitly rather than relying on [`detect`](Self::detect).
+    Sixel,
 }
 
 impl ImageSupport {
@@ -151,6 +154,13 @@ impl ImageSupport {
         // iTerm2 speaks its own inline-image protocol (TERM_PROGRAM=iTerm.app).
         if program.as_deref().is_some_and(|p| p.contains("iterm")) {
             return ImageSupport::ITerm2;
+        }
+        // Sixel has no reliable env signal (a DA1 query would be needed), so only
+        // the few terminals that advertise themselves in `TERM` are matched here;
+        // other Sixel terminals need an explicit `ImageSupport::Sixel`.
+        if term.is_some_and(|t| t.contains("foot") || t.contains("mlterm") || t.contains("contour"))
+        {
+            return ImageSupport::Sixel;
         }
         ImageSupport::None
     }
@@ -231,6 +241,7 @@ impl ImageLayer {
             write!(out, "\x1b[{row};{col}H")?;
             let escape = match p.support {
                 ImageSupport::ITerm2 => encode_iterm2(&p.data, p.rect.width, p.rect.height),
+                ImageSupport::Sixel => encode_sixel(&p.data, p.rect.width, p.rect.height),
                 // None shouldn't record, but Kitty is the safe default encoding.
                 _ => encode_kitty(&p.data, p.rect.width, p.rect.height),
             };
@@ -295,7 +306,10 @@ impl Image {
     /// Whether this image will be emitted through a graphics protocol (as
     /// opposed to falling back to text).
     fn will_paint(&self) -> bool {
-        matches!(self.support, ImageSupport::Kitty | ImageSupport::ITerm2) && self.layer.is_some()
+        matches!(
+            self.support,
+            ImageSupport::Kitty | ImageSupport::ITerm2 | ImageSupport::Sixel
+        ) && self.layer.is_some()
     }
 }
 
@@ -436,6 +450,113 @@ fn encode_iterm2(data: &ImageData, cols: u16, rows: u16) -> String {
         "\x1b]1337;File=inline=1;width={cols};height={rows};preserveAspectRatio=0;size={}:{payload}\x07",
         png.len()
     )
+}
+
+/// Assumed terminal cell pixel size, used only to scale a Sixel image into its
+/// reserved `cols × rows` cells: unlike Kitty (`c`/`r`) and iTerm2
+/// (`width`/`height`), the Sixel protocol has no cell-based sizing — it paints at
+/// the bitmap's pixel size — so tuika resamples to an assumed cell geometry.
+const SIXEL_CELL_W: u32 = 10;
+const SIXEL_CELL_H: u32 = 20;
+
+/// Encode `data` as a Sixel bitmap scaled to fill `cols × rows` cells.
+///
+/// Pure and allocation-only, like [`encode_kitty`]. The RGBA is nearest-neighbor
+/// resampled to `cols*SIXEL_CELL_W × rows*SIXEL_CELL_H` pixels (Sixel can't scale
+/// to cells itself), quantized to a fixed 6×6×6 color cube, and emitted band by
+/// band (6 rows each), one color pass per band with run-length encoding. The
+/// sequence is `ESC P q "1;1;W;H <palette><data> ESC \`.
+fn encode_sixel(data: &ImageData, cols: u16, rows: u16) -> String {
+    let tw = (cols as u32 * SIXEL_CELL_W).max(1);
+    let th = (rows as u32 * SIXEL_CELL_H).max(1);
+    let (sw, sh) = (data.pixel_width.max(1), data.pixel_height.max(1));
+
+    // Nearest-neighbor resample into a target grid of 6×6×6-cube palette indices.
+    let mut idx = vec![0u8; (tw * th) as usize];
+    for ty in 0..th {
+        let sy = ty * sh / th;
+        for tx in 0..tw {
+            let sx = tx * sw / tw;
+            let p = ((sy * sw + sx) * 4) as usize;
+            let q = |c: u8| (c as u32 * 5 + 127) / 255; // 0..=5
+            idx[(ty * tw + tx) as usize] =
+                (q(data.rgba[p]) * 36 + q(data.rgba[p + 1]) * 6 + q(data.rgba[p + 2])) as u8;
+        }
+    }
+
+    let mut out = String::new();
+    out.push_str("\x1bPq"); // DCS, default params
+    out.push_str(&format!("\"1;1;{tw};{th}")); // raster: 1:1 aspect, W×H pixels
+    // Define the 216-color cube once (channels scaled to Sixel's 0..=100).
+    for i in 0u32..216 {
+        let (r, g, b) = (i / 36 % 6, i / 6 % 6, i % 6);
+        out.push_str(&format!("#{};2;{};{};{}", i, r * 20, g * 20, b * 20));
+    }
+
+    let bands = th.div_ceil(6);
+    for band in 0..bands {
+        let y0 = band * 6;
+        // Which palette colors appear anywhere in this 6-row band.
+        let mut present = [false; 216];
+        for p in 0..6 {
+            let y = y0 + p;
+            if y >= th {
+                break;
+            }
+            for tx in 0..tw {
+                present[idx[(y * tw + tx) as usize] as usize] = true;
+            }
+        }
+        let colors: Vec<usize> = (0..216).filter(|&c| present[c]).collect();
+        for (ci, &c) in colors.iter().enumerate() {
+            out.push_str(&format!("#{c}"));
+            // One sixel char per column: bit p set when row y0+p is this color.
+            let (mut run, mut len) = (0u8, 0u32);
+            for tx in 0..tw {
+                let mut bits = 0u8;
+                for p in 0..6 {
+                    let y = y0 + p;
+                    if y < th && idx[(y * tw + tx) as usize] as usize == c {
+                        bits |= 1 << p;
+                    }
+                }
+                if bits == run {
+                    len += 1;
+                } else {
+                    sixel_run(&mut out, run, len);
+                    run = bits;
+                    len = 1;
+                }
+            }
+            sixel_run(&mut out, run, len);
+            // Overlay the next color on the same band (`$`), else advance a band.
+            if ci + 1 < colors.len() {
+                out.push('$');
+            }
+        }
+        if band + 1 < bands {
+            out.push('-');
+        }
+    }
+    out.push_str("\x1b\\");
+    out
+}
+
+/// Emit a run of `len` copies of sixel value `bits` (0..=63), run-length-encoded
+/// with `!` for runs of three or more.
+fn sixel_run(out: &mut String, bits: u8, len: u32) {
+    if len == 0 {
+        return;
+    }
+    let ch = (0x3f + bits) as char;
+    if len >= 3 {
+        out.push_str(&format!("!{len}"));
+        out.push(ch);
+    } else {
+        for _ in 0..len {
+            out.push(ch);
+        }
+    }
 }
 
 /// Encode `rgba` (`w × h`, 8-bit RGBA) as a PNG, using stored (uncompressed)
@@ -792,6 +913,81 @@ mod tests {
         // IHDR carries the dimensions; IDAT and IEND are present.
         let s = String::from_utf8_lossy(&png);
         assert!(s.contains("IHDR") && s.contains("IDAT") && s.contains("IEND"));
+    }
+
+    #[test]
+    fn encode_sixel_has_dcs_frame_palette_and_data() {
+        let img = solid(2, 2, [255, 0, 0, 255]); // pure red
+        let out = encode_sixel(&img, 1, 1);
+        // DCS intro + `q`, raster attributes sized to cols*10 × rows*20 pixels.
+        assert!(
+            out.starts_with("\x1bPq\"1;1;10;20"),
+            "intro/raster: {:?}",
+            &out[..24]
+        );
+        assert!(out.ends_with("\x1b\\"), "ST terminated");
+        // Pure red quantizes to cube index r=5,g=0,b=0 → 180, defined as RGB 100;0;0.
+        assert!(out.contains("#180;2;100;0;0"), "red register defined");
+        // The band data selects that register and run-length-encodes a full column
+        // (all six rows set → value 63 → '~').
+        assert!(out.contains("#180"), "red register selected in data");
+        assert!(
+            out.contains("!"),
+            "run-length encoding used for the solid fill"
+        );
+        assert!(
+            out.contains('~'),
+            "a fully-set sixel column (0x3f+63) present"
+        );
+    }
+
+    #[test]
+    fn encode_sixel_bytes_stay_in_range() {
+        // Every sixel data byte must be printable in the sixel range or a control
+        // (#, !, $, -, digits, ;, ", ESC, P, q, backslash). Assert no stray bytes.
+        let img = solid(3, 2, [0, 128, 255, 255]);
+        let out = encode_sixel(&img, 2, 1);
+        for b in out.bytes() {
+            let ok = b == 0x1b
+                || b == b'P'
+                || b == b'q'
+                || b == b'\\'
+                || b == b'"'
+                || b == b'#'
+                || b == b'!'
+                || b == b'$'
+                || b == b'-'
+                || b == b';'
+                || b.is_ascii_digit()
+                || (0x3f..=0x7e).contains(&b);
+            assert!(ok, "unexpected sixel byte {b:#x}");
+        }
+    }
+
+    #[test]
+    fn detect_recognizes_sixel_terminals() {
+        assert_eq!(
+            ImageSupport::detect_from(Some("foot"), None, None, None),
+            ImageSupport::Sixel
+        );
+        assert_eq!(
+            ImageSupport::detect_from(Some("xterm-mlterm"), None, None, None),
+            ImageSupport::Sixel
+        );
+    }
+
+    #[test]
+    fn emit_dispatches_sixel() {
+        let layer = ImageLayer::new();
+        layer.record(
+            Rect::new(0, 0, 2, 1),
+            solid(1, 1, [1, 2, 3, 255]),
+            ImageSupport::Sixel,
+        );
+        let mut out: Vec<u8> = Vec::new();
+        layer.emit(&mut out).expect("emit");
+        let s = String::from_utf8(out).expect("utf8");
+        assert!(s.contains("\x1bPq"), "sixel DCS emitted: {s:?}");
     }
 
     #[test]

--- a/crates/tuika/src/lib.rs
+++ b/crates/tuika/src/lib.rs
@@ -66,10 +66,10 @@ pub mod width;
 // etc. for the common surface without deep paths.
 pub use clipboard::{osc52, write_clipboard};
 pub use components::{
-    Boxed, CodeBlock, Constrained, Flex, ImageResolver, KeyHints, Loader, Markdown, MarkdownState,
-    Paragraph, ProgressBar, Responsive, Rule, Scroll, ScrollState, SelectList, SelectOutcome,
-    SelectState, Spacer, Spinner, SpinnerStyle, StatusBar, Tabs, TabsState, Text, TextInput,
-    TextInputEvent, TextInputMode, TextInputState, Wrap, markdown_to_lines, wrap_lines,
+    Boxed, CodeBlock, Constrained, Flex, ImageResolver, KeyHints, Loader, Markdown, MarkdownImage,
+    MarkdownState, Paragraph, ProgressBar, Responsive, Rule, Scroll, ScrollState, SelectList,
+    SelectOutcome, SelectState, Spacer, Spinner, SpinnerStyle, StatusBar, Tabs, TabsState, Text,
+    TextInput, TextInputEvent, TextInputMode, TextInputState, Wrap, markdown_to_lines, wrap_lines,
 };
 pub use event::{Event, EventFlow, Key, KeyCode, Mouse, MouseButton, MouseKind};
 pub use focus::FocusRegistry;

--- a/crates/tuika/src/markdown.rs
+++ b/crates/tuika/src/markdown.rs
@@ -54,17 +54,42 @@ pub trait ImageResolver {
     fn resolve(&self, url: &str) -> Option<ImageData>;
 }
 
-/// A block image discovered during [`flatten`]: the row it reserved in the
-/// output, its cell size, and the pixels to paint there. The [`Markdown`] view
-/// turns each into an [`Image`] overlay at the matching screen rect.
+/// A block image in a rendered markdown document: the row it reserved (0-based,
+/// within the returned lines), its cell footprint, the alt text, and the pixels.
+///
+/// The [`Markdown`] view overlays these itself. A host that draws
+/// [`MarkdownState::lines`] manually reads [`MarkdownState::images`] and paints
+/// each one — build an [`Image`] from `data`/`cols`/`rows`/`alt` and render it at
+/// [`rect`](Self::rect) against the area the lines were drawn into.
 #[derive(Clone, Debug)]
-struct BlockImage {
-    row: u16,
-    indent: u16,
-    cols: u16,
-    rows: u16,
-    data: ImageData,
-    alt: String,
+pub struct MarkdownImage {
+    /// Row the image reserved, 0-based within the rendered lines.
+    pub row: u16,
+    /// Left indent in cells (list / block-quote nesting).
+    pub indent: u16,
+    /// Width in cells.
+    pub cols: u16,
+    /// Height in cells.
+    pub rows: u16,
+    /// Decoded pixels to paint.
+    pub data: ImageData,
+    /// Alt text, shown as the fallback where graphics aren't supported.
+    pub alt: String,
+}
+
+impl MarkdownImage {
+    /// The absolute screen rect for this image, given the `area` the markdown
+    /// lines were drawn into — clamped so it never exceeds `area`.
+    pub fn rect(&self, area: Rect) -> Rect {
+        let x = area.x.saturating_add(self.indent).min(area.right());
+        let y = area.y.saturating_add(self.row).min(area.bottom());
+        Rect {
+            x,
+            y,
+            width: self.cols.min(area.right().saturating_sub(x)),
+            height: self.rows.min(area.bottom().saturating_sub(y)),
+        }
+    }
 }
 
 /// Cell footprint for a block image at `avail` columns: capped at
@@ -554,7 +579,7 @@ fn flatten_into(
     items: &[MdItem],
     width: u16,
     theme: &Theme,
-    images: &mut Vec<BlockImage>,
+    images: &mut Vec<MarkdownImage>,
 ) -> Vec<Line<'static>> {
     let mut out = Vec::new();
     for item in items {
@@ -578,7 +603,7 @@ fn flatten_into(
             MdItem::Image { data, alt, indent } => {
                 let avail = width.saturating_sub(*indent).max(1);
                 let (cols, rows) = image_cell_size(data, avail);
-                images.push(BlockImage {
+                images.push(MarkdownImage {
                     row: out.len().min(u16::MAX as usize) as u16,
                     indent: *indent,
                     cols,
@@ -839,12 +864,41 @@ pub struct MarkdownState {
     flattened_items: usize,
     /// Width `rendered` was flattened at; a change re-wraps the whole prefix.
     rendered_width: Option<u16>,
+    /// Optional host hook turning image URLs into pixels; off ⇒ text placeholders.
+    resolver: Option<Box<dyn ImageResolver>>,
+    /// Block images in the settled prefix, with their absolute `rendered` rows —
+    /// accumulated once as blocks settle, mirroring `settled_lines`.
+    settled_images: Vec<MarkdownImage>,
+    /// Settled + tail images with absolute rows, rebuilt each [`lines`](Self::lines)
+    /// call; returned by [`images`](Self::images).
+    frame_images: Vec<MarkdownImage>,
 }
 
 impl MarkdownState {
     /// An empty renderer.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Render `![alt](url)` images as real pixels, resolving each URL to
+    /// [`ImageData`] via `resolver` (markdown carries only the URL — see
+    /// [`ImageResolver`]). After each [`lines`](Self::lines) call, read the
+    /// reserved placements from [`images`](Self::images) and paint them.
+    ///
+    /// The resolver may be called repeatedly for an image still in the in-flight
+    /// tail (re-parsed each frame), so a host that decodes lazily should cache.
+    pub fn with_image_resolver(mut self, resolver: Box<dyn ImageResolver>) -> Self {
+        self.resolver = Some(resolver);
+        self.reset_cache();
+        self
+    }
+
+    /// The block images reserved by the last [`lines`](Self::lines) call, with
+    /// rows relative to those lines. Empty unless a resolver is attached (see
+    /// [`with_image_resolver`](Self::with_image_resolver)). Paint each by
+    /// rendering an [`Image`] at [`MarkdownImage::rect`] against the same area.
+    pub fn images(&self) -> &[MarkdownImage] {
+        &self.frame_images
     }
 
     /// Append a streamed delta to the buffer (the settled-prefix cache is kept).
@@ -871,6 +925,8 @@ impl MarkdownState {
         self.settled_lines = 0;
         self.flattened_items = 0;
         self.rendered_width = None;
+        self.settled_images.clear();
+        self.frame_images.clear();
     }
 
     /// Render the current buffer to final, width-fitted styled lines, advancing
@@ -898,18 +954,20 @@ impl MarkdownState {
             self.reset_cache();
         }
         // A width change re-wraps every settled line, but the width-independent
-        // parse cache survives; drop only the flattened lines.
+        // parse cache survives; drop only the flattened lines (and their images,
+        // whose row offsets and sizes are width-dependent).
         if self.rendered_width != Some(width) {
             self.rendered_width = Some(width);
             self.rendered.clear();
             self.settled_lines = 0;
             self.flattened_items = 0;
+            self.settled_images.clear();
         }
 
         let boundary = stable_boundary(&self.source, self.stable_len);
         if boundary > self.stable_len {
             let segment = &self.source[self.stable_len..boundary];
-            let mut items = parse(segment, theme, highlighter);
+            let mut items = parse_with(segment, theme, highlighter, self.resolver.as_deref());
             // Each segment parses in isolation, so the blank-line separation the
             // boundary sits on is lost — restore it between committed segments.
             if !items.is_empty()
@@ -928,14 +986,31 @@ impl MarkdownState {
         // lines equals re-flattening the whole prefix.
         self.rendered.truncate(self.settled_lines);
         if self.flattened_items < self.stable.len() {
-            let settled = flatten(&self.stable[self.flattened_items..], width, theme);
+            let base = self.rendered.len() as u16;
+            let mut settled_imgs = Vec::new();
+            let settled = flatten_into(
+                &self.stable[self.flattened_items..],
+                width,
+                theme,
+                &mut settled_imgs,
+            );
+            for mut img in settled_imgs {
+                img.row = img.row.saturating_add(base);
+                self.settled_images.push(img);
+            }
             self.rendered.extend(settled);
             self.flattened_items = self.stable.len();
             self.settled_lines = self.rendered.len();
         }
 
-        let tail = parse(&self.source[self.stable_len..], theme, highlighter);
-        let tail_lines = flatten(&tail, width, theme);
+        let tail = parse_with(
+            &self.source[self.stable_len..],
+            theme,
+            highlighter,
+            self.resolver.as_deref(),
+        );
+        let mut tail_imgs = Vec::new();
+        let tail_lines = flatten_into(&tail, width, theme, &mut tail_imgs);
         // The tail begins just past the boundary's blank line; keep that gap.
         if !self.rendered.is_empty()
             && !tail_lines.is_empty()
@@ -944,7 +1019,18 @@ impl MarkdownState {
         {
             self.rendered.push(Line::default());
         }
+        let tail_base = self.rendered.len() as u16;
         self.rendered.extend(tail_lines);
+
+        // Republish this frame's placements: the settled prefix (fixed) plus the
+        // in-flight tail, each shifted to its absolute row in `rendered`.
+        self.frame_images.clear();
+        self.frame_images
+            .extend(self.settled_images.iter().cloned());
+        for mut img in tail_imgs {
+            img.row = img.row.saturating_add(tail_base);
+            self.frame_images.push(img);
+        }
         &self.rendered
     }
 }
@@ -1025,7 +1111,11 @@ impl<'a> Markdown<'a> {
     }
 
     /// Flatten the source to lines plus the block images it reserved.
-    fn lines_and_images(&self, width: u16, theme: &Theme) -> (Vec<Line<'static>>, Vec<BlockImage>) {
+    fn lines_and_images(
+        &self,
+        width: u16,
+        theme: &Theme,
+    ) -> (Vec<Line<'static>>, Vec<MarkdownImage>) {
         let items = parse_with(&self.source, theme, self.highlighter, self.resolver);
         let mut images = Vec::new();
         let lines = flatten_into(&items, width, theme, &mut images);
@@ -1534,5 +1624,81 @@ mod tests {
         let (_, tr) = image_cell_size(&tall, 40);
         assert!(wr < tr, "tall image reserves more rows: {wr} vs {tr}");
         assert!(wr >= 1 && tr <= 30, "rows are clamped: {wr}, {tr}");
+    }
+
+    #[test]
+    fn streaming_state_reports_a_block_image_placement() {
+        let theme = Theme::default();
+        let mut md = MarkdownState::new().with_image_resolver(Box::new(StubResolver));
+        md.set("intro line\n\n![a cat](ok.png)\n\ntail line");
+        let lines = md.lines(40, &theme, CodeHighlighter::Plain).to_vec();
+        let imgs = md.images();
+        assert_eq!(imgs.len(), 1, "one block image reported");
+        let img = &imgs[0];
+        assert_eq!(img.alt, "a cat");
+        // The reported row is inside the rendered lines and is a reserved blank.
+        assert!((img.row as usize) < lines.len(), "row within lines");
+        assert!(
+            is_blank_line(&lines[img.row as usize]),
+            "reserved row is blank"
+        );
+        // "intro line" is above the image, "tail line" below it.
+        assert!(text(&lines[0]).contains("intro"));
+    }
+
+    #[test]
+    fn streaming_image_row_matches_one_shot() {
+        // Feeding the same document incrementally lands the image on the same row
+        // as parsing it whole — the settled/tail offset bookkeeping is consistent.
+        let theme = Theme::default();
+        let doc = "# Title\n\nbefore\n\n![pic](ok.png)\n\nafter paragraph here";
+
+        let mut whole = MarkdownState::new().with_image_resolver(Box::new(StubResolver));
+        whole.set(doc);
+        let _ = whole.lines(30, &theme, CodeHighlighter::Plain);
+        let whole_row = whole.images()[0].row;
+
+        let mut streamed = MarkdownState::new().with_image_resolver(Box::new(StubResolver));
+        for chunk in [
+            "# Title\n\nbe",
+            "fore\n\n![pic](ok",
+            ".png)\n\nafter ",
+            "paragraph here",
+        ] {
+            streamed.push_str(chunk);
+            let _ = streamed.lines(30, &theme, CodeHighlighter::Plain);
+        }
+        assert_eq!(streamed.images().len(), 1);
+        assert_eq!(
+            streamed.images()[0].row,
+            whole_row,
+            "streamed image row matches one-shot"
+        );
+    }
+
+    #[test]
+    fn no_resolver_means_no_streaming_placements() {
+        let theme = Theme::default();
+        let mut md = MarkdownState::new();
+        md.set("![a cat](ok.png)");
+        let _ = md.lines(40, &theme, CodeHighlighter::Plain);
+        assert!(md.images().is_empty(), "images() empty without a resolver");
+    }
+
+    #[test]
+    fn markdown_image_rect_offsets_by_area_and_row() {
+        let img = MarkdownImage {
+            row: 3,
+            indent: 2,
+            cols: 10,
+            rows: 4,
+            data: ImageData::from_rgba(2, 2, vec![0u8; 16]).unwrap(),
+            alt: String::new(),
+        };
+        let rect = img.rect(Rect::new(5, 1, 40, 20));
+        assert_eq!((rect.x, rect.y, rect.width, rect.height), (7, 4, 10, 4));
+        // Clamped to the area when it would overflow.
+        let tight = img.rect(Rect::new(5, 1, 8, 5));
+        assert_eq!(tight.width, 6, "clamped to area right edge");
     }
 }

--- a/specs/tuika-images.md
+++ b/specs/tuika-images.md
@@ -39,15 +39,17 @@ Scope is deliberately phased:
     and renders a marked, link-styled placeholder (the alt text, or the URL when
     there is no alt) instead of silently dropping the URL. No new API, no
     streaming-cache change — it flows through the existing inline machinery.
-  - **3b: pixels in markdown (done, one-shot view).** `Markdown::images`
-    resolves each image URL to `ImageData` via a host-supplied resolver (the
-    `Highlighter` pattern again — markdown has only a URL, never pixels), the
-    parser promotes a resolved `![alt](url)` to a block `MdItem::Image`, `flatten`
-    reserves its rows and reports where it landed, and the view overlays the
-    standalone `Image` component there — reusing its protocol emission and alt
-    fallback. **Remaining:** the same for the streaming `MarkdownState`, which
-    means threading image placements through the settled-prefix cache and
-    exposing them alongside `lines()` for the host to emit.
+  - **3b: pixels in markdown (done).** `Markdown::images` and
+    `MarkdownState::with_image_resolver` resolve each image URL to `ImageData`
+    via a host-supplied resolver (the `Highlighter` pattern again — markdown has
+    only a URL, never pixels), the parser promotes a resolved `![alt](url)` to a
+    block `MdItem::Image`, `flatten` reserves its rows and reports where it
+    landed, and the view overlays the standalone `Image` component there — reusing
+    its protocol emission and alt fallback. Streaming works too: block-image
+    placements are threaded through the settled-prefix cache (fixed rows for
+    settled blocks, re-derived each frame for the in-flight tail) and published
+    via `MarkdownState::images()` as `MarkdownImage`s, which a host paints at
+    `rect(area)` after drawing `lines()`.
 
 ## Design
 

--- a/specs/tuika-images.md
+++ b/specs/tuika-images.md
@@ -30,10 +30,13 @@ Scope is deliberately phased:
   after each frame. Capability detection gates the protocol; unsupported
   terminals get the alt-text fallback.
 - **Phase 2: more protocols** behind the same component, selected by capability
-  detection. **iTerm2 inline images: done** — `ImageLayer::emit` dispatches per
-  the recorded protocol, and RGBA is PNG-encoded (in-tuika, dependency-free) for
-  iTerm2, which transmits an image file rather than raw pixels. **Sixel:**
-  remaining.
+  detection. **Done.** `ImageLayer::emit` dispatches per the recorded protocol.
+  iTerm2 transmits an image file, so RGBA is PNG-encoded (in-tuika,
+  dependency-free). Sixel has no cell-based sizing, so the RGBA is
+  nearest-neighbor resampled to an assumed cell geometry, quantized to a fixed
+  6×6×6 color cube, and emitted band-by-band with run-length encoding; detection
+  is best-effort (`foot`/`mlterm`/`contour` in `TERM`) since Sixel has no
+  reliable env signal, so hosts usually set `ImageSupport::Sixel` explicitly.
 - **Phase 3: markdown `![alt](url)`**, in two steps:
   - **3a (done): visible placeholder.** The markdown builder parses `Tag::Image`
     and renders a marked, link-styled placeholder (the alt text, or the URL when


### PR DESCRIPTION
## What changed

The two follow-ups deferred from the image-rendering PR (#445), completing
`specs/tuika-images.md`:

- **Streaming markdown pixels** — `MarkdownState::with_image_resolver` extends
  image rendering to the streaming path (what a live transcript uses). Block-image
  placements are threaded through the settled-prefix cache and published as
  `MarkdownImage`s via `MarkdownState::images()`; a host paints each at
  `MarkdownImage::rect(area)` after drawing `lines()`. The internal `BlockImage`
  is now the public `MarkdownImage` (with a `rect` helper), shared by the one-shot
  `Markdown` view and the streaming state.
- **Sixel protocol** — `ImageSupport::Sixel` + a Sixel arm in `ImageLayer::emit`,
  broadening pixel rendering to foot, xterm +sixel, mlterm, and contour.

New public API: `tuika::MarkdownImage`, `MarkdownState::{with_image_resolver,
images}`, `ImageSupport::Sixel`.

## Why

Image rendering merged in #445 covered the standalone component (Kitty + iTerm2)
and one-shot markdown, but left two gaps: the **streaming** `MarkdownState` — the
path yolop's transcript actually uses — still showed placeholders, and Sixel
terminals had no pixel path.

**Streaming — the cache-offset problem.** `MarkdownState` flattens settled blocks
once and re-flattens only the in-flight tail each frame, returning `&[Line]`.
Image placements can't ride in that borrow, so they're accumulated separately:
settled images get fixed absolute rows as blocks settle (mirroring
`settled_lines`), the tail's are re-derived each frame at the tail's base offset,
and the two are concatenated into what `images()` returns. A test feeds a document
both whole and in four deltas and asserts the image lands on the same row either
way, so the offset bookkeeping stays honest.

**Sixel — no cell sizing.** Unlike Kitty (`c`/`r`) and iTerm2 (`width`/`height`),
Sixel paints at the bitmap's pixel size with no cell-based scaling. So the RGBA is
nearest-neighbor resampled to an assumed cell geometry (10×20 px), quantized to a
fixed 6×6×6 color cube, and emitted band-by-band (6 rows each) with one
run-length-encoded color pass per band. The encoder is self-contained — no
image-codec dependency, consistent with the rest of the feature. Detection is
best-effort (`foot`/`mlterm`/`contour` in `TERM`) because Sixel has no reliable
env signal; hosts on a Sixel terminal usually set `ImageSupport::Sixel`
explicitly.

## Before / After

- **Streaming markdown** — before: `[alt](url)` in a streamed message showed only
  the placeholder. After: with a resolver attached, it reserves a block and
  `MarkdownState::images()` reports the pixels to paint, live as the message
  streams.
- **Sixel** — before: Sixel terminals fell back to alt text. After: they paint
  pixels. The wire format is a pure, tested function:

```text
ESC P q "1;1;<px_w>;<px_h> <color registers> <band data> ESC \
```

Test evidence — full tuika suite green, 8 new tests (streaming placements,
one-shot/streamed row parity, `rect`, Sixel structure/byte-range/detection/emit
dispatch):

```
test result: ok. 213 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Gates run locally: `cargo fmt --check`, `cargo clippy --all-targets
--all-features -D warnings`, `cargo build --locked --all-targets`, the `demo --
check` drift gate, and the `iai-callgrind` instruction-count gate (streaming
+0.16%, within ±2%) all pass.

## Security

No change to the safety posture established in #445: emitted escapes carry only
numeric dimensions/coordinates and a closed palette/base64/sixel alphabet — no
user- or content-controlled string reaches the escape stream. Image URLs and alt
text render only as clipped cell text. `ImageData::from_rgba` still validates the
buffer invariant at the sole constructor, so the Sixel resampler and encoders
can't over-read.

## Risk

- **Low.** Additive. Streaming images are off unless a host attaches a resolver;
  the `MarkdownState` changes only add fields + methods (no existing signature
  changed) and the settled/tail row math is covered by the parity test. Sixel is a
  new `emit` arm reached only when a placement records `ImageSupport::Sixel`.
- Known limitations (documented in the spec): Sixel's assumed 10×20 cell geometry
  is approximate (the protocol can't query real cell-pixel size), and its fixed
  216-color quantization trades fidelity for a dependency-free encoder.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (additive; tuika is pre-1.0)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkDY2v4wzioCdobQA42Q7g)_