### PR TITLE
feat(tuika): first-class, paint-free flexbox solve

### DIFF
--- a/crates/tuika/docs/components.md
+++ b/crates/tuika/docs/components.md
@@ -192,6 +192,22 @@ view! {
 }
 ```
 
+Need the child rects *before* (or without) painting — to size a scroll region
+to a pane's real height, hit-test a click, or decide what fits? `Flex::solve`
+runs the same measure-then-solve pass render uses and returns one `Rect` per
+child, painting nothing. The underlying flexbox solver is also callable directly
+as `tuika::solve(area, &style, &items)` for layouts built without a `Flex`.
+
+```rust
+use tuika::{Flex, Text, element};
+use ratatui::layout::Rect;
+
+let flex = Flex::row()
+    .fixed(8, element(Text::raw("sidebar")))
+    .grow(1, element(Text::raw("content")));
+let rects = flex.solve(Rect::new(0, 0, 40, 10)); // [sidebar_rect, content_rect]
+```
+
 ### `Boxed`
 
 A border + padding + title wrapping one child; the border color is focus-aware.

--- a/crates/tuika/src/components/flex.rs
+++ b/crates/tuika/src/components/flex.rs
@@ -120,6 +120,31 @@ impl Flex {
             .map(|c| Item::new(c.dimension, c.view.measure(available)))
             .collect()
     }
+
+    /// Resolve the child rects this container would assign inside `area`,
+    /// without painting anything.
+    ///
+    /// This is the same measure-then-[`solve`] pass `render` runs, exposed so a
+    /// host can compute layout ahead of (or instead of) a render — to clamp a
+    /// scroll offset to a pane's real height, hit-test a click against child
+    /// rects, or decide what fits before drawing. The returned `Vec` has one
+    /// rect per child, in insertion order.
+    ///
+    /// ```
+    /// use tuika::{Flex, Text, element};
+    /// use ratatui::layout::Rect;
+    ///
+    /// let flex = Flex::row()
+    ///     .fixed(4, element(Text::raw("abcd")))
+    ///     .grow(1, element(Text::raw("rest")));
+    /// let rects = flex.solve(Rect::new(0, 0, 10, 1));
+    /// assert_eq!(rects.len(), 2);
+    /// assert_eq!(rects[0], Rect::new(0, 0, 4, 1));
+    /// assert_eq!(rects[1], Rect::new(4, 0, 6, 1)); // grows into the leftover
+    /// ```
+    pub fn solve(&self, area: Rect) -> Vec<Rect> {
+        solve(area, &self.style, &self.items(Size::from(area)))
+    }
 }
 
 impl View for Flex {
@@ -156,11 +181,64 @@ impl View for Flex {
             let mut fill = surface.child(area);
             fill.fill(bg);
         }
-        let items = self.items(Size::from(area));
-        let rects = solve(area, &self.style, &items);
+        let rects = self.solve(area);
         for (child, rect) in self.children.iter().zip(rects) {
             let mut child_surface = surface.child(rect);
             child.view.render(rect, &mut child_surface, ctx);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::components::Text;
+    use crate::probe::RectProbe;
+    use crate::style::Theme;
+    use crate::view::element;
+
+    #[test]
+    fn solve_matches_the_rects_render_paints_into() {
+        // Probe every child, render, then compare the painted rects to what the
+        // paint-free `solve` returns for the same area — they must be identical.
+        let area = Rect::new(0, 0, 20, 6);
+        let probes: Vec<RectProbe> = (0..3).map(|_| RectProbe::new()).collect();
+        let flex = Flex::column()
+            .fixed(1, probes[0].wrap(element(Text::raw("header"))))
+            .grow(1, probes[1].wrap(element(Text::raw("body"))))
+            .fixed(2, probes[2].wrap(element(Text::raw("footer"))));
+
+        let precomputed = flex.solve(area);
+        let _ = crate::testing::render(&flex, area.width, area.height, &Theme::default());
+
+        let painted: Vec<Rect> = probes.iter().map(|p| p.rect()).collect();
+        assert_eq!(
+            precomputed, painted,
+            "solve() must return exactly the rects render() paints into"
+        );
+        // And they are the expected column layout: 1-row header, grown body, 2-row footer.
+        assert_eq!(precomputed[0], Rect::new(0, 0, 20, 1));
+        assert_eq!(precomputed[1], Rect::new(0, 1, 20, 3));
+        assert_eq!(precomputed[2], Rect::new(0, 4, 20, 2));
+    }
+
+    #[test]
+    fn solve_of_empty_container_is_empty() {
+        let flex = Flex::row();
+        assert!(flex.solve(Rect::new(0, 0, 10, 3)).is_empty());
+    }
+
+    #[test]
+    fn crate_root_reexports_solver_primitives() {
+        // `solve` and `Item` are reachable from the crate root, not just
+        // `tuika::layout` — build a layout by hand without a Flex.
+        use crate::{Dimension, Item, LayoutStyle, Size, solve};
+        let items = [
+            Item::new(Dimension::Fixed(3), Size::new(3, 1)),
+            Item::new(Dimension::Flex(1), Size::new(0, 1)),
+        ];
+        let rects = solve(Rect::new(0, 0, 10, 1), &LayoutStyle::row(), &items);
+        assert_eq!(rects[0], Rect::new(0, 0, 3, 1));
+        assert_eq!(rects[1], Rect::new(3, 0, 7, 1));
     }
 }

--- a/crates/tuika/src/layout.rs
+++ b/crates/tuika/src/layout.rs
@@ -162,6 +162,28 @@ impl Item {
 /// single line: resolve fixed/percent/auto main sizes, distribute remaining
 /// main space to flex children (or to `justify` when there are none), then
 /// align each child on the cross axis.
+///
+/// This is the flexbox solver as a standalone, callable step — re-exported at
+/// the crate root as [`tuika::solve`](crate::solve) alongside [`Item`],
+/// [`LayoutStyle`], and the [`Dimension`] rules. Reach for it (or the
+/// higher-level [`Flex::solve`](crate::Flex::solve)) when an app needs child
+/// rects *before* or *without* a render pass — to size a scroll region to a
+/// pane's real height, hit-test a click, or decide what fits — so the flexbox
+/// drives those layouts instead of a second engine.
+///
+/// ```
+/// use tuika::{Dimension, Item, LayoutStyle, Size, solve};
+/// use ratatui::layout::Rect;
+///
+/// // A sidebar of 8 columns, then the rest of the row for content.
+/// let items = [
+///     Item::new(Dimension::Fixed(8), Size::new(8, 1)),
+///     Item::new(Dimension::Flex(1), Size::new(0, 1)),
+/// ];
+/// let rects = solve(Rect::new(0, 0, 30, 1), &LayoutStyle::row(), &items);
+/// assert_eq!(rects[0], Rect::new(0, 0, 8, 1));
+/// assert_eq!(rects[1], Rect::new(8, 0, 22, 1));
+/// ```
 pub fn solve(area: Rect, style: &LayoutStyle, items: &[Item]) -> Vec<Rect> {
     if items.is_empty() {
         return Vec::new();

--- a/crates/tuika/src/lib.rs
+++ b/crates/tuika/src/lib.rs
@@ -81,7 +81,7 @@ pub use hyperlink::{
     write_line_with,
 };
 pub use image::{Image, ImageData, ImageLayer, ImageSupport};
-pub use layout::{Align, Dimension, Direction, Justify, LayoutStyle};
+pub use layout::{Align, Dimension, Direction, Item, Justify, LayoutStyle, solve};
 pub use live::{Live, LiveView, RedrawHandle};
 pub use mouse::{
     Click, ClickTracker, HitMap, SelectionRange, SelectionState, highlight, selected_text,


### PR DESCRIPTION
## What changed

The flexbox solver is now usable as a standalone, callable step instead of only running inside a `Flex` render pass:

- **`solve` and `Item` are re-exported at the crate root** (`tuika::solve`, `tuika::Item`) alongside `LayoutStyle`, `Align`, `Justify`, `Direction`, and the `Dimension` rules — so a host can build and solve a layout by hand without reaching into `tuika::layout::…`.
- **`Flex::solve(area) -> Vec<Rect>`** runs the same measure-then-solve pass `render` uses and returns one `Rect` per child, painting nothing. `Flex::render` now goes through this method, so the paint-free layout and the painted layout can never diverge.

Additive only — no signature changes to existing APIs.

## Why

`layout::solve` was `pub` but not re-exported at the crate root and required hand-building `Item`s, and there was no way to ask a `Flex` "what rects would you assign in this area?" outside a render pass. Apps frequently need child rects *before* paint — to size/clamp a scroll region to a pane's real height, hit-test a click, or decide what fits — and without this they fall back to a second layout engine, so the flexbox isn't actually driving those layouts. This closes the loop.

## Before / After

Rendered/precomputed rects are asserted directly in tests and doctests.

```rust
// After — get child rects without painting:
let flex = Flex::row()
    .fixed(8, element(Text::raw("sidebar")))
    .grow(1, element(Text::raw("content")));
let rects = flex.solve(Rect::new(0, 0, 40, 10)); // [sidebar_rect, content_rect]

// After — solver as a standalone step, no Flex:
let items = [
    Item::new(Dimension::Fixed(8), Size::new(8, 1)),
    Item::new(Dimension::Flex(1), Size::new(0, 1)),
];
let rects = tuika::solve(Rect::new(0, 0, 30, 1), &LayoutStyle::row(), &items);
```

Before: neither was reachable — `solve`/`Item` weren't at the crate root, and `Flex` only produced rects internally during `render`.

## Risk

- **Low.** New re-exports and one new method; `Flex::render` refactored to call `Flex::solve`, which is the exact same measure-then-`solve` sequence it already ran (behavior-identical — a test cross-checks `solve()` against the rects `render()` actually paints into via `RectProbe`).

## Validation

- `cargo fmt --check` — clean
- `cargo clippy -p tuika --all-targets --all-features -- -D warnings` — clean
- `cargo test -p tuika --all-features` — 208 lib + 14 doctests pass, including:
  - `solve()` cross-checked against `RectProbe`-captured painted rects (paint-free == painted)
  - empty-container `solve()` returns empty
  - crate-root `tuika::solve` / `tuika::Item` re-export builds a layout by hand
  - doctests on `Flex::solve` and the free `solve`

## Security

No security-relevant code changes — layout arithmetic and re-exports in the `tuika` crate only (no filesystem, shell, prompt/key, capability, or dependency changes).

## Follow-ups

No follow-ups. (Part of the item 1–5 tuika series; the remaining items — host-driven/horizontal `Scroll` and a columned `Table` — ship as their own PRs.)

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (purely additive)

---
_Generated by [Claude Code](https://claude.ai/code/session_013X4ivPR4SXng9sr3RJbvQy)_