### PR TITLE
feat(tuika): host-settable ScrollState::set_offset

### DIFF
--- a/crates/tuika/docs/components.md
+++ b/crates/tuika/docs/components.md
@@ -234,7 +234,10 @@ events, the view borrows it for a frame.
 ### `Scroll` + `ScrollState`
 
 A windowed view over long content with a scrollbar; `ScrollState` handles
-paging, wheel scroll, and stick-to-bottom.
+paging, wheel scroll, and stick-to-bottom. The offset is also **host-drivable**:
+`set_offset(n)` mirrors an app-owned scroll position into the view — the
+vertical peer of `SelectState::select` — for event-loop apps that track their
+own position.
 [API](https://docs.rs/tuika/latest/tuika/struct.Scroll.html)
 
 <img src="demos/scroll.gif" width="880" alt="Scroll demo">
@@ -242,7 +245,8 @@ paging, wheel scroll, and stick-to-bottom.
 ```rust
 use tuika::{Scroll, ScrollState, view};
 let mut state = ScrollState::new();          // held by the host across frames
-state.handle(&event, content_h, viewport_h);
+state.handle(&event, content_h, viewport_h); // built-in wheel/paging, or…
+state.set_offset(app.scroll_row);            // …mirror an app-owned position
 view! { node(Scroll::new(lines, &state)) }
 ```
 

--- a/crates/tuika/src/components/scroll.rs
+++ b/crates/tuika/src/components/scroll.rs
@@ -5,6 +5,11 @@
 //! persisted [`ScrollState`], and the state handles wheel/paging events. The
 //! offset is measured in content rows from the top; a "stick to bottom" flag
 //! keeps a live transcript pinned to the newest line until the user scrolls up.
+//!
+//! Beyond the built-in wheel/paging [`handle`](ScrollState::handle), the offset
+//! is **host-drivable**: an app that owns its scroll position in its own model
+//! mirrors it into the view with [`set_offset`](ScrollState::set_offset), the
+//! vertical peer of [`SelectState::select`](crate::SelectState::select).
 
 use ratatui::layout::Rect;
 use ratatui::style::Style;
@@ -42,6 +47,19 @@ impl ScrollState {
     /// Top visible content row (0-based).
     pub fn offset(&self) -> usize {
         self.offset
+    }
+
+    /// Set the top visible content row explicitly, detaching bottom-stick.
+    ///
+    /// The vertical counterpart to [`SelectState::select`](crate::SelectState::select):
+    /// an event-loop app that already owns a scroll position in its own model
+    /// mirrors it into the view each frame with this, instead of only nudging
+    /// via [`handle`](Self::handle). A following [`clamp`](Self::clamp) still
+    /// bounds it to the content, so an out-of-range value snaps into range
+    /// rather than scrolling past the end.
+    pub fn set_offset(&mut self, offset: usize) {
+        self.offset = offset;
+        self.stick_to_bottom = false;
     }
 
     /// Whether the view is pinned to the newest content.
@@ -326,6 +344,23 @@ mod tests {
         assert_eq!(s.handle(&up, content_h, viewport_h), EventFlow::Consumed);
         assert!(!s.is_stuck_to_bottom());
         assert_eq!(s.offset(), content_h - viewport_h - (viewport_h - 1));
+    }
+
+    #[test]
+    fn set_offset_positions_view_and_detaches_stick() {
+        let mut s = ScrollState::new();
+        s.clamp(100, 10);
+        assert!(s.is_stuck_to_bottom(), "starts stuck to bottom");
+        // Host mirrors its own scroll row in; stick detaches and clamp honors it.
+        s.set_offset(40);
+        assert!(!s.is_stuck_to_bottom());
+        s.clamp(100, 10);
+        assert_eq!(s.offset(), 40);
+        // An out-of-range value snaps into range on the next clamp rather than
+        // scrolling past the end.
+        s.set_offset(500);
+        s.clamp(100, 10);
+        assert_eq!(s.offset(), 90, "clamped to content height - viewport");
     }
 
     #[test]


### PR DESCRIPTION
## What changed

`ScrollState::set_offset(row)` — an absolute setter for the vertical scroll offset. An event-loop app that already tracks its scroll position in its own model can now mirror it into the view each frame, the vertical peer of `SelectState::select(index)`. Setting it detaches stick-to-bottom; a following `clamp()` still bounds it to the content.

Additive only — no existing signature or behavior changes.

## Why

`ScrollState` owned its offset and only exposed relative nudges via `handle()` (wheel/paging). Apps that drive scroll position from their own model had no way to push an absolute offset in — `SelectState` has `select(index)`; `ScrollState` was missing the equivalent. This adds it.

## Scope note — horizontal panning deferred

The originating request paired this with **horizontal panning** (`h_offset` / `scroll_left` / `scroll_right`). I implemented and benched it, but it can't land cleanly yet: column-accurate panning needs grapheme-aware paint code, and under this crate's `lto = "thin"` + `codegen-units = 1`, adding any second grapheme-iteration site de-inlines `Graphemes::next` from the shared `Surface::set_string` — regressing **all** text painting (not just scroll) by ~4–10% and tripping the `scroll_iai` instruction-count gate. Measured, reproduced, and reverted rather than blessed, since it would tax every `set_string` caller.

Doing horizontal pan right needs a focused change — e.g. refactoring `set_string`'s grapheme walk so a skip variant shares it without extra inline pressure, or a deliberate re-baseline with sign-off — so it's split into its own follow-up rather than riding along here. `set_offset` (the more-requested half — "SelectState has select(index), ScrollState needs the equivalent") is clean and independent, so it ships now.

## Before / After

```rust
// Before: offset was relative-only.
state.handle(&wheel_event, content_h, viewport_h);   // nudge

// After: mirror an app-owned absolute position.
state.set_offset(app.scroll_row);                    // absolute
state.clamp(content_h, viewport_h);                  // still bounded to content
```

## Risk

- **Low.** One new `ScrollState` method (sets the offset, clears stick-to-bottom). `Scroll::render` is untouched — the `scroll_iai` render baselines are unchanged at +0.000%.

## Validation

- `cargo fmt --check` — clean
- `cargo clippy -p tuika --all-targets --all-features -- -D warnings` — clean
- `cargo test -p tuika --all-features` — 206 lib + 12 doctests pass, incl. a new test: `set_offset` positions the view, detaches stick-to-bottom, and an out-of-range value snaps into range on the next `clamp`
- `cargo bench -p tuika --bench scroll_iai` + `check_iai.py` — `render.{small,large}` and `frame_windowed.large` all **+0.000%** vs the committed baseline

## Security

No security-relevant code changes — a state accessor in the `tuika` crate (no filesystem, shell, prompt/key, capability, or dependency changes).

## Follow-ups

- **Horizontal panning for `Scroll`** — deferred as above; needs a `set_string`-sharing grapheme-skip design (or an accepted re-baseline) to avoid regressing the shared paint path.
- Columned `Table` component — the remaining tuika series item, its own PR.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (purely additive)

---
_Generated by [Claude Code](https://claude.ai/code/session_013X4ivPR4SXng9sr3RJbvQy)_