### PR TITLE
feat(tuika): add async runner behind the "async" feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,6 +1210,7 @@ dependencies = [
  "crossterm_winapi",
  "derive_more",
  "document-features",
+ "futures-core",
  "mio",
  "parking_lot",
  "rustix",
@@ -6793,6 +6794,8 @@ dependencies = [
  "pulldown-cmark",
  "ratatui",
  "textwrap",
+ "tokio",
+ "tokio-stream",
  "unicode-segmentation",
  "unicode-width",
 ]

--- a/crates/tuika/Cargo.toml
+++ b/crates/tuika/Cargo.toml
@@ -12,15 +12,32 @@ readme = "README.md"
 keywords = ["tui", "terminal", "ratatui", "widgets", "layout"]
 categories = ["command-line-interface"]
 
+# Build docs with every feature so the optional `async` runner is documented,
+# and set the `docsrs` cfg that turns on per-item feature badges (see lib.rs).
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 # No `#[bench]` fns in the lib, and the default libtest bench harness rejects
 # Criterion's CLI flags — disable it so `cargo bench` runs only the Criterion
 # targets below.
 [lib]
 bench = false
 
+[features]
+# The async runner (`AsyncRunner`). Off by default so sync-only hosts don't pull
+# in a Tokio runtime. Enabling it adds Tokio (timer + `select!` macro), a
+# `StreamExt` for polling the event stream, and crossterm's async `EventStream`.
+async = ["dep:tokio", "dep:tokio-stream", "crossterm/event-stream"]
+
 [dependencies]
 ratatui = "0.30.2"
 crossterm = "0.29"
+# Async runner only (feature = "async"). `time` for the tick interval, `macros`
+# for `tokio::select!`; the host application brings its own runtime, so no `rt`.
+tokio = { version = "1", features = ["time", "macros"], optional = true }
+# `StreamExt::{next, filter_map}` for driving the crossterm `EventStream`.
+tokio-stream = { version = "0.1", optional = true }
 textwrap = "0.16"
 unicode-segmentation = "1"
 unicode-width = "0.2"
@@ -45,6 +62,11 @@ criterion = { version = "0.8", default-features = false, features = [
 # the committed baseline / CI regression gate. Needs Valgrind + a version-matched
 # `iai-callgrind-runner` installed (`cargo install iai-callgrind-runner`).
 iai-callgrind = "0.16.1"
+# The `async` runner's tests drive `AsyncRunner` on a Tokio runtime with a fake
+# event stream; `test-util` gives paused-clock control so ticks are deterministic
+# instead of wall-clock-timed. Reachable only when `--features async` is on.
+tokio = { version = "1", features = ["rt", "macros", "time", "test-util"] }
+tokio-stream = "0.1"
 
 [[bench]]
 name = "markdown"
@@ -61,3 +83,7 @@ harness = false
 [[bench]]
 name = "scroll_iai"
 harness = false
+
+[[example]]
+name = "async_dashboard"
+required-features = ["async"]

--- a/crates/tuika/README.md
+++ b/crates/tuika/README.md
@@ -17,7 +17,9 @@ terminal.
 
 It is a published, self-contained crate that depends only on `ratatui`,
 `crossterm`, `textwrap`, `unicode-segmentation`, and `unicode-width`, and is
-host-agnostic — it knows nothing about the application embedding it.
+host-agnostic — it knows nothing about the application embedding it. (The
+optional `async` feature adds Tokio for [`AsyncRunner`](#terminal-lifecycle-and-runner);
+it is off by default.)
 
 ## Install
 
@@ -164,6 +166,7 @@ Each enters the alternate screen; press `q` (or `esc`) to quit.
 | [`select`](examples/select.rs)   | `cargo run -p tuika --example select`     | `SelectState` + `SelectList` (stateful-widget idiom) |
 | [`overlay`](examples/overlay.rs)  | `cargo run -p tuika --example overlay`    | `OverlaySpec` centered dialog + input routing      |
 | [`ratatui_dashboard`](examples/ratatui_dashboard.rs) | `cargo run -p tuika --example ratatui_dashboard` | mixed Ratatui widgets + responsive live data |
+| [`async_dashboard`](examples/async_dashboard.rs) | `cargo run -p tuika --example async_dashboard --features async` | `AsyncRunner` polling on a Tokio runtime, no shared state |
 | [`mouse`](examples/mouse.rs)     | `cargo run -p tuika --example mouse`      | drag-to-select + highlight + OSC 52 copy, clickable buttons |
 | [`image`](examples/image.rs)     | `cargo run -p tuika --example image`      | Kitty-protocol `Image` over reserved cells, alt-text fallback |
 
@@ -250,8 +253,42 @@ cursor visibility themselves.
 
 `Runner` is an optional synchronous event loop for dashboards and small tools.
 It owns `TerminalSession`, frame scheduling, Crossterm event translation, and
-data-driven redraw checks. Async applications can keep their existing loop and
-call `paint` directly.
+data-driven redraw checks.
+
+`AsyncRunner` (behind `features = ["async"]`) is the same loop for applications
+that already have a Tokio runtime — anything doing network or disk I/O. It ties
+`TerminalSession`, `paint`, and `translate_event` to crossterm's async
+`EventStream` and a tick timer in one `tokio::select!`, so the host keeps a
+single event loop instead of bolting `spawn_blocking` + a shared `Live` +
+`Notify` + a stop flag onto the synchronous `Runner` to feed it. The loop threads
+one owned `state` value through a `view` closure (`&state` → the frame) and an
+`async` `update` closure (`&mut state` on each `Signal` — a tick or an event —
+and it may `.await`):
+
+```rust,ignore
+use std::ops::ControlFlow;
+use std::time::Duration;
+use tuika::{AsyncRunner, Event, KeyCode, RunnerConfig, Signal, Text, Theme, element};
+
+let runner = AsyncRunner::new(RunnerConfig { tick_rate: Duration::from_secs(2) });
+let mut stats = Stats::default();
+runner.run(
+    &Theme::default(),
+    &mut stats,
+    |stats, _frame| element(Text::raw(stats.summary())),
+    async |stats, signal| match signal {
+        Signal::Tick => { stats.ingest(fetch(&url).await?); ControlFlow::Continue(()) }
+        Signal::Event(Event::Key(k)) if k.plain() && k.code == KeyCode::Char('q') =>
+            ControlFlow::Break(()),
+        _ => ControlFlow::Continue(()),
+    },
+).await?;
+```
+
+Enabling `async` adds Tokio (timer + `select!`) and crossterm's `event-stream`
+feature; it stays off by default so sync-only hosts pull in no runtime. The
+[`async_dashboard`](examples/async_dashboard.rs) example is the runnable
+counterpart to `ratatui_dashboard` with no shared state at all.
 
 ## Native terminal progress
 

--- a/crates/tuika/examples/async_dashboard.rs
+++ b/crates/tuika/examples/async_dashboard.rs
@@ -1,0 +1,127 @@
+//! Async live dashboard driven by [`tuika::AsyncRunner`].
+//!
+//! The synchronous [`ratatui_dashboard`](ratatui_dashboard.rs) example spawns a
+//! background thread and shares its metrics through `Live` so the blocking
+//! `Runner` can read them. This one does the same job on a Tokio runtime with
+//! **no** shared state: `Metrics` is a plain local value the loop owns, polled
+//! on every tick (and on demand with `r`) by an `async` update closure. There is
+//! no `Live`, no `Notify`, no stop flag, no `spawn_blocking` — the runner's
+//! single `tokio::select!` is the whole event loop.
+//!
+//! Run with: `cargo run -p tuika --example async_dashboard --features async`.
+//! Press `q`/`esc` to quit, `r` to refresh now.
+
+use std::ops::ControlFlow;
+use std::time::Duration;
+
+use ratatui::layout::Constraint;
+use ratatui::widgets::{Block, Borders, Row, Sparkline, Table, Widget};
+use tuika::{
+    AsyncRunner, Dimension, Element, Event, Flex, KeyCode, KeyHints, RatatuiView, RunnerConfig,
+    Signal, Theme, element,
+};
+
+/// The dashboard's entire state — owned by the run loop, not shared.
+struct Metrics {
+    requests: u64,
+    errors: u64,
+    history: Vec<u64>,
+}
+
+impl Metrics {
+    fn new() -> Self {
+        Self {
+            requests: 0,
+            errors: 0,
+            history: Vec::new(),
+        }
+    }
+
+    /// Fold a freshly fetched sample into the rolling view.
+    fn ingest(&mut self, requests: u64) {
+        self.requests = requests;
+        self.errors = requests / 7;
+        self.history.push(requests % 20);
+        if self.history.len() > 40 {
+            self.history.remove(0);
+        }
+    }
+}
+
+/// Stand-in for a real network/database call: an `async` source of a monotonic
+/// request count. A real app would `reqwest::get(&url).await?` here; the point
+/// is that the update closure can simply `.await` it.
+async fn fetch_stats(previous: u64) -> u64 {
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    previous + 1
+}
+
+fn table(metrics: &Metrics) -> Element {
+    let (requests, errors) = (metrics.requests, metrics.errors);
+    element(RatatuiView::fill(move |area, buffer| {
+        Table::new(
+            [
+                Row::new(["requests", &requests.to_string()]),
+                Row::new(["errors", &errors.to_string()]),
+            ],
+            [Constraint::Percentage(60), Constraint::Percentage(40)],
+        )
+        .block(Block::bordered().title(" Metrics "))
+        .render(area, buffer);
+    }))
+}
+
+fn sparkline(metrics: &Metrics) -> Element {
+    let history = metrics.history.clone();
+    element(RatatuiView::fill(move |area, buffer| {
+        Sparkline::default()
+            .data(&history)
+            .block(Block::default().borders(Borders::ALL).title(" Requests "))
+            .render(area, buffer);
+    }))
+}
+
+fn dashboard(metrics: &Metrics) -> Element {
+    element(
+        Flex::column()
+            .gap(1)
+            .child(Dimension::Fixed(4), table(metrics))
+            .child(Dimension::Flex(1), sparkline(metrics))
+            .child(
+                Dimension::Fixed(1),
+                element(KeyHints::new([("q", "quit"), ("r", "refresh")])),
+            ),
+    )
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> std::io::Result<()> {
+    let runner = AsyncRunner::new(RunnerConfig {
+        tick_rate: Duration::from_millis(500),
+    });
+    let mut metrics = Metrics::new();
+
+    runner
+        .run(
+            &Theme::default(),
+            &mut metrics,
+            |metrics, _frame| dashboard(metrics),
+            async |metrics, signal| match signal {
+                // Poll on the tick and on `r`; both simply await the fetch.
+                Signal::Tick => {
+                    metrics.ingest(fetch_stats(metrics.requests).await);
+                    ControlFlow::Continue(())
+                }
+                Signal::Event(Event::Key(key)) if key.plain() => match key.code {
+                    KeyCode::Char('q') | KeyCode::Esc => ControlFlow::Break(()),
+                    KeyCode::Char('r') => {
+                        metrics.ingest(fetch_stats(metrics.requests).await);
+                        ControlFlow::Continue(())
+                    }
+                    _ => ControlFlow::Continue(()),
+                },
+                _ => ControlFlow::Continue(()),
+            },
+        )
+        .await
+}

--- a/crates/tuika/src/async_runner.rs
+++ b/crates/tuika/src/async_runner.rs
@@ -1,0 +1,455 @@
+//! An asynchronous full-screen runner (`feature = "async"`).
+//!
+//! [`AsyncRunner`] ties tuika's public host primitives — [`TerminalSession`],
+//! [`paint`], [`translate_event`] — to crossterm's async
+//! [`EventStream`] and a tick timer in a single
+//! `tokio::select!` loop. An application that already has a Tokio runtime (it is
+//! doing network or disk I/O) gets lifecycle, redraw scheduling, and event
+//! translation in one place, and its data becomes a plain local value the loop
+//! owns — no `spawn_blocking`, no shared `RwLock`/`Notify`/stop flag bolted onto
+//! the synchronous [`Runner`](crate::Runner) just to feed it.
+//!
+//! The loop threads a single `state` value through two callbacks: `view` builds
+//! the frame from `&state`, and `update` mutates `&mut state` in response to a
+//! [`Signal`] (a tick or an input event) and may `.await` while doing so. Both
+//! borrow the same value at different times, which is why it is a runner
+//! argument rather than a capture — a closure cannot hold `&state` and
+//! `&mut state` at once.
+//!
+//! ```no_run
+//! use std::ops::ControlFlow;
+//! use std::time::Duration;
+//!
+//! use tuika::{AsyncRunner, Event, KeyCode, RunnerConfig, Signal, Text, Theme, element};
+//!
+//! # async fn fetch_stats() -> std::io::Result<u64> { Ok(0) }
+//! // Call from inside your own `#[tokio::main]` (or any Tokio runtime).
+//! async fn dashboard() -> std::io::Result<()> {
+//!     let runner = AsyncRunner::new(RunnerConfig {
+//!         tick_rate: Duration::from_secs(2),
+//!     });
+//!     let mut requests = 0u64;
+//!
+//!     runner
+//!         .run(
+//!             &Theme::default(),
+//!             &mut requests,
+//!             |requests, _frame| element(Text::raw(format!("requests: {requests}"))),
+//!             async |requests, signal| match signal {
+//!                 // Poll on every tick and on `r`; both may await.
+//!                 Signal::Tick => {
+//!                     *requests = fetch_stats().await.unwrap_or(*requests);
+//!                     ControlFlow::Continue(())
+//!                 }
+//!                 Signal::Event(Event::Key(k)) if k.plain() => match k.code {
+//!                     KeyCode::Char('q') | KeyCode::Esc => ControlFlow::Break(()),
+//!                     KeyCode::Char('r') => {
+//!                         *requests = fetch_stats().await.unwrap_or(*requests);
+//!                         ControlFlow::Continue(())
+//!                     }
+//!                     _ => ControlFlow::Continue(()),
+//!                 },
+//!                 _ => ControlFlow::Continue(()),
+//!             },
+//!         )
+//!         .await
+//! }
+//! ```
+
+use std::io;
+use std::ops::ControlFlow;
+use std::time::Duration;
+
+use crossterm::event::EventStream;
+use ratatui::backend::{Backend, CrosstermBackend};
+use ratatui::{Terminal, TerminalOptions, Viewport};
+use tokio::time::{MissedTickBehavior, interval};
+use tokio_stream::{Stream, StreamExt};
+
+use crate::{Element, Event, RunnerConfig, TerminalSession, Theme, paint, translate_event};
+
+/// A tick or an input event delivered to an [`AsyncRunner`]'s update callback.
+#[derive(Clone, Debug)]
+pub enum Signal {
+    /// The periodic tick fired. Its interval is [`RunnerConfig::tick_rate`]; the
+    /// first tick fires immediately after the initial frame is painted, so a
+    /// data-polling app loads on start without a special case.
+    Tick,
+    /// An input event arrived, already translated to a tuika [`Event`]. Events
+    /// crossterm reports but tuika does not model (key-release, unmapped codes)
+    /// are dropped before they reach here.
+    Event(Event),
+}
+
+/// An asynchronous Crossterm event and rendering loop.
+///
+/// See the [module documentation](self) for the full picture. Construct one with
+/// a [`RunnerConfig`], then drive it with [`run`](Self::run) (real terminal),
+/// [`run_with_backend`](Self::run_with_backend) (caller-supplied backend, such as
+/// [`HyperlinkBackend`](crate::HyperlinkBackend)), or
+/// [`run_with_events`](Self::run_with_events) (caller-supplied backend *and*
+/// event stream, for tests and hosts that own the terminal lifecycle).
+pub struct AsyncRunner {
+    config: RunnerConfig,
+}
+
+impl AsyncRunner {
+    /// Create a runner without touching the terminal.
+    pub fn new(mut config: RunnerConfig) -> Self {
+        // A zero interval would busy-spin the `select!` even when the app has no
+        // events or updates. Enforce the same scheduling floor the synchronous
+        // `Runner` does.
+        config.tick_rate = config.tick_rate.max(Duration::from_millis(1));
+        Self { config }
+    }
+
+    /// Run on the real terminal until `update` returns [`ControlFlow::Break`].
+    ///
+    /// Enters a [`TerminalSession`] (restored on return, including on error or
+    /// panic) and reads input from crossterm's async
+    /// [`EventStream`].
+    pub async fn run<S, V, U>(
+        &self,
+        theme: &Theme,
+        state: &mut S,
+        view: V,
+        update: U,
+    ) -> io::Result<()>
+    where
+        V: FnMut(&S, u64) -> Element,
+        U: AsyncFnMut(&mut S, Signal) -> ControlFlow<()>,
+    {
+        self.run_with_backend(
+            theme,
+            CrosstermBackend::new(io::stdout()),
+            state,
+            view,
+            update,
+        )
+        .await
+    }
+
+    /// Run with a caller-provided backend, such as
+    /// [`HyperlinkBackend`](crate::HyperlinkBackend). Otherwise identical to
+    /// [`run`](Self::run): it owns the [`TerminalSession`] and the
+    /// [`EventStream`].
+    pub async fn run_with_backend<S, B, V, U>(
+        &self,
+        theme: &Theme,
+        backend: B,
+        state: &mut S,
+        view: V,
+        update: U,
+    ) -> io::Result<()>
+    where
+        B: Backend<Error = io::Error>,
+        V: FnMut(&S, u64) -> Element,
+        U: AsyncFnMut(&mut S, Signal) -> ControlFlow<()>,
+    {
+        let _session = TerminalSession::enter()?;
+        let mut terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Fullscreen,
+            },
+        )?;
+        // Translate crossterm events to tuika events at the stream boundary,
+        // dropping the ones tuika does not model and surfacing read errors.
+        let events = EventStream::new().filter_map(|result| match result {
+            Ok(raw) => translate_event(raw).map(Ok),
+            Err(error) => Some(Err(error)),
+        });
+        let result = self
+            .run_with_events(&mut terminal, theme, state, events, view, update)
+            .await;
+
+        // Some terminal emulators do not answer the cursor-position query used
+        // by `clear`; a cosmetic cleanup failure must not turn a completed run
+        // into an application error. (Session restoration is the `_session`
+        // guard's job and happens regardless.)
+        let _ = terminal.clear();
+        result
+    }
+
+    /// The core loop: caller-owned `terminal` and `events`, no terminal
+    /// lifecycle. This is what [`run`](Self::run) builds on, and the seam tests
+    /// use to drive the runner against a
+    /// [`TestBackend`](ratatui::backend::TestBackend) with a scripted event
+    /// stream. Hosts that already own their terminal and event source (or want a
+    /// non-crossterm one) can call it directly.
+    ///
+    /// The backend error and the event-stream error share one type `Er`, which
+    /// is the run's error type: for the real terminal that is [`io::Error`], but
+    /// leaving it generic lets an infallible backend
+    /// ([`TestBackend`](ratatui::backend::TestBackend), whose error is
+    /// [`Infallible`](std::convert::Infallible)) pair with an infallible stream.
+    ///
+    /// `events` yields already-translated tuika [`Event`]s. An `Err` item ends
+    /// the run by propagating out; `None` (a finite stream running dry) stops
+    /// event delivery but leaves the tick timer running, so the loop still exits
+    /// only when `update` returns [`ControlFlow::Break`].
+    pub async fn run_with_events<S, B, V, U, E, Er>(
+        &self,
+        terminal: &mut Terminal<B>,
+        theme: &Theme,
+        state: &mut S,
+        mut events: E,
+        mut view: V,
+        mut update: U,
+    ) -> Result<(), Er>
+    where
+        B: Backend<Error = Er>,
+        E: Stream<Item = Result<Event, Er>> + Unpin,
+        V: FnMut(&S, u64) -> Element,
+        U: AsyncFnMut(&mut S, Signal) -> ControlFlow<()>,
+    {
+        let mut events_done = false;
+        let mut frame = 0u64;
+
+        let mut ticker = interval(self.config.tick_rate);
+        // A slow `update` must not make the timer fire a burst of catch-up ticks
+        // the moment it returns; skip the missed ticks and resume the cadence.
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+        // Paint once before waiting for the first signal so the UI is visible
+        // immediately rather than after the first tick or keypress.
+        draw(terminal, theme, &mut view, state, &mut frame)?;
+
+        loop {
+            let signal = tokio::select! {
+                _ = ticker.tick() => Signal::Tick,
+                // Once the stream is exhausted the guard disables this branch so
+                // `select!` waits on the tick alone instead of spinning on a
+                // stream that keeps returning `None`.
+                item = events.next(), if !events_done => match item {
+                    Some(Ok(event)) => Signal::Event(event),
+                    Some(Err(error)) => return Err(error),
+                    None => {
+                        events_done = true;
+                        continue;
+                    }
+                },
+            };
+
+            if update(state, signal).await.is_break() {
+                break;
+            }
+            // Redraws are a ratatui buffer diff, so repainting after every
+            // handled signal only flushes the cells that actually changed.
+            draw(terminal, theme, &mut view, state, &mut frame)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Paint one frame from the current `state` and advance the frame counter that
+/// drives motion components (spinners, indeterminate bars).
+fn draw<S, B, V, Er>(
+    terminal: &mut Terminal<B>,
+    theme: &Theme,
+    view: &mut V,
+    state: &S,
+    frame: &mut u64,
+) -> Result<(), Er>
+where
+    B: Backend<Error = Er>,
+    V: FnMut(&S, u64) -> Element,
+{
+    terminal.draw(|terminal_frame| {
+        let area = terminal_frame.area();
+        let root = view(state, *frame);
+        paint(terminal_frame.buffer_mut(), area, theme, root.as_ref(), &[]);
+    })?;
+    *frame = frame.wrapping_add(1);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+
+    use super::*;
+    use crate::components::Text;
+    use crate::event::{Key, KeyCode};
+    use crate::view::element;
+    use ratatui::backend::TestBackend;
+
+    /// A key event as the infallible-stream item the `TestBackend` tests use.
+    fn key(code: KeyCode) -> Result<Event, Infallible> {
+        Ok(Event::Key(Key {
+            code,
+            ctrl: false,
+            alt: false,
+            shift: false,
+        }))
+    }
+
+    fn terminal(width: u16, height: u16) -> Terminal<TestBackend> {
+        Terminal::new(TestBackend::new(width, height)).expect("test terminal")
+    }
+
+    fn buffer_text(terminal: &Terminal<TestBackend>) -> String {
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect()
+    }
+
+    #[test]
+    fn zero_tick_rate_is_clamped() {
+        let runner = AsyncRunner::new(RunnerConfig {
+            tick_rate: Duration::ZERO,
+        });
+        assert_eq!(runner.config.tick_rate, Duration::from_millis(1));
+    }
+
+    // Events flow through `update`, mutate the owned local state, and a quit key
+    // breaks the loop with `Ok(())`. A far-off tick rate keeps the timer out of
+    // this test so it stays timing-independent.
+    #[tokio::test]
+    async fn events_drive_state_and_quit_breaks() {
+        let runner = AsyncRunner::new(RunnerConfig {
+            tick_rate: Duration::from_secs(3600),
+        });
+        let mut terminal = terminal(24, 1);
+        let mut count = 0u64;
+        let events = tokio_stream::iter([
+            key(KeyCode::Char('a')),
+            key(KeyCode::Char('a')),
+            key(KeyCode::Char('q')),
+        ]);
+
+        let result = runner
+            .run_with_events(
+                &mut terminal,
+                &Theme::default(),
+                &mut count,
+                events,
+                |count, _frame| element(Text::raw(format!("count={count}"))),
+                async |count, signal| match signal {
+                    Signal::Event(Event::Key(k)) if k.code == KeyCode::Char('q') => {
+                        ControlFlow::Break(())
+                    }
+                    Signal::Event(Event::Key(_)) => {
+                        *count += 1;
+                        ControlFlow::Continue(())
+                    }
+                    _ => ControlFlow::Continue(()),
+                },
+            )
+            .await;
+
+        assert!(result.is_ok());
+        assert_eq!(count, 2, "both 'a' presses counted, 'q' quit");
+        assert!(
+            buffer_text(&terminal).contains("count=2"),
+            "final frame reflects state: {:?}",
+            buffer_text(&terminal)
+        );
+    }
+
+    // The initial frame is painted before any signal is handled, so a run that
+    // quits on the very first event still shows state on screen.
+    #[tokio::test]
+    async fn initial_frame_paints_before_first_signal() {
+        let runner = AsyncRunner::new(RunnerConfig::default());
+        let mut terminal = terminal(16, 1);
+        let mut state = "hello";
+        let events = tokio_stream::iter([key(KeyCode::Esc)]);
+
+        runner
+            .run_with_events(
+                &mut terminal,
+                &Theme::default(),
+                &mut state,
+                events,
+                |state, _frame| element(Text::raw(*state)),
+                async |_state, _signal| ControlFlow::Break(()),
+            )
+            .await
+            .unwrap();
+
+        assert!(buffer_text(&terminal).contains("hello"));
+    }
+
+    // Ticks fire on the interval and can await. Under a paused clock the runtime
+    // auto-advances time whenever it goes idle, so the interval fires
+    // deterministically with no wall-clock wait; the empty event stream runs dry
+    // and the tick-only loop keeps going until the third tick breaks it.
+    #[tokio::test(start_paused = true)]
+    async fn ticks_fire_and_can_await() {
+        let runner = AsyncRunner::new(RunnerConfig {
+            tick_rate: Duration::from_millis(50),
+        });
+        let mut terminal = terminal(20, 1);
+        let mut ticks = 0u64;
+        let events = tokio_stream::iter(Vec::<Result<Event, Infallible>>::new());
+
+        runner
+            .run_with_events(
+                &mut terminal,
+                &Theme::default(),
+                &mut ticks,
+                events,
+                |ticks, _frame| element(Text::raw(format!("ticks={ticks}"))),
+                async |ticks, signal| {
+                    if let Signal::Tick = signal {
+                        // Prove an await inside tick handling is fine.
+                        tokio::task::yield_now().await;
+                        *ticks += 1;
+                    }
+                    if *ticks >= 3 {
+                        ControlFlow::Break(())
+                    } else {
+                        ControlFlow::Continue(())
+                    }
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(ticks, 3);
+        // The break tick is not painted (the loop exits before the redraw), so
+        // the last frame on screen is the preceding tick's `ticks=2`. This is
+        // the same "no redraw after Break" rule the event test relies on.
+        assert!(
+            buffer_text(&terminal).contains("ticks=2"),
+            "last painted frame: {:?}",
+            buffer_text(&terminal)
+        );
+    }
+
+    // A read error from the event stream propagates out of the run. This uses a
+    // real `io::Error` backend (crossterm over a `Vec` sink) so the run's error
+    // type is `io::Error` rather than the `Infallible` of `TestBackend`.
+    #[tokio::test]
+    async fn stream_error_propagates() {
+        use ratatui::backend::CrosstermBackend;
+
+        let runner = AsyncRunner::new(RunnerConfig {
+            tick_rate: Duration::from_secs(3600),
+        });
+        let mut terminal =
+            Terminal::new(CrosstermBackend::new(Vec::<u8>::new())).expect("test terminal");
+        let mut state = ();
+        let events = tokio_stream::iter([Err::<Event, io::Error>(io::Error::other("boom"))]);
+
+        let result = runner
+            .run_with_events(
+                &mut terminal,
+                &Theme::default(),
+                &mut state,
+                events,
+                |_state, _frame| element(Text::raw("x")),
+                async |_state, _signal| ControlFlow::Continue(()),
+            )
+            .await;
+
+        let error = result.expect_err("stream error should propagate");
+        assert_eq!(error.to_string(), "boom");
+    }
+}

--- a/crates/tuika/src/async_runner.rs
+++ b/crates/tuika/src/async_runner.rs
@@ -425,16 +425,25 @@ mod tests {
 
     // A read error from the event stream propagates out of the run. This uses a
     // real `io::Error` backend (crossterm over a `Vec` sink) so the run's error
-    // type is `io::Error` rather than the `Infallible` of `TestBackend`.
+    // type is `io::Error` rather than the `Infallible` of `TestBackend`. A fixed
+    // viewport is required: `Terminal::new`/`Fullscreen` queries the terminal
+    // size, which has no TTY to answer under CI and would panic; `Fixed` uses the
+    // given rect and never touches the terminal.
     #[tokio::test]
     async fn stream_error_propagates() {
         use ratatui::backend::CrosstermBackend;
+        use ratatui::layout::Rect;
 
         let runner = AsyncRunner::new(RunnerConfig {
             tick_rate: Duration::from_secs(3600),
         });
-        let mut terminal =
-            Terminal::new(CrosstermBackend::new(Vec::<u8>::new())).expect("test terminal");
+        let mut terminal = Terminal::with_options(
+            CrosstermBackend::new(Vec::<u8>::new()),
+            TerminalOptions {
+                viewport: Viewport::Fixed(Rect::new(0, 0, 10, 1)),
+            },
+        )
+        .expect("test terminal");
         let mut state = ();
         let events = tokio_stream::iter([Err::<Event, io::Error>(io::Error::other("boom"))]);
 

--- a/crates/tuika/src/lib.rs
+++ b/crates/tuika/src/lib.rs
@@ -31,10 +31,17 @@
 //! Existing ratatui widgets should normally be wrapped in [`RatatuiView`],
 //! which preserves Tuika clipping without exposing the frame buffer.
 //! [`TerminalSession`] and [`Runner`] are optional host-side lifecycle helpers.
+//! With `feature = "async"`, `AsyncRunner` (in the `async_runner` module) is the
+//! same loop for hosts that already run on Tokio.
 
 #![warn(missing_docs)]
+// On docs.rs (nightly, `--cfg docsrs`) annotate feature-gated items with the
+// feature that enables them. A no-op on stable builds.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub mod anim;
+#[cfg(feature = "async")]
+pub mod async_runner;
 pub mod clipboard;
 pub mod components;
 pub mod event;
@@ -64,6 +71,8 @@ pub mod width;
 
 // Curated top-level re-exports so callers write `tuika::Flex`, `tuika::Theme`,
 // etc. for the common surface without deep paths.
+#[cfg(feature = "async")]
+pub use async_runner::{AsyncRunner, Signal};
 pub use clipboard::{osc52, write_clipboard};
 pub use components::{
     Boxed, CodeBlock, Constrained, Flex, ImageResolver, KeyHints, Loader, Markdown, MarkdownImage,


### PR DESCRIPTION
## What changed

`tuika` now ships **`AsyncRunner`** (behind the off-by-default `async` feature): a
first-class async event/render loop for hosts that already run on Tokio. It ties
tuika's existing public primitives — `TerminalSession`, `paint`,
`translate_event` — to crossterm's async `EventStream` and a tick timer in one
`tokio::select!`. The host keeps a single event loop and owns its UI state as a
plain local value, threaded through a `view` closure (`&state` → the frame) and
an `async` `update` closure (`&mut state` per `Signal`, which may `.await`).

Also new: the `Signal` enum (`Tick` | `Event`), a runnable `async_dashboard`
example, README + rustdoc coverage, and docs.rs metadata so the gated items are
documented with feature badges.

Three entry points mirror the sync `Runner`: `run` (real terminal),
`run_with_backend` (custom backend, e.g. `HyperlinkBackend`), and
`run_with_events` (caller-owned terminal + event stream — the generic-over-error
core that the tests drive against a `TestBackend`).

## Why

The synchronous `Runner` blocks its thread, so any app with an existing async
runtime (network or disk I/O) had to bolt `spawn_blocking` + a shared
`Live`/`RwLock` + `Notify` + an `AtomicBool` stop flag around it just to feed it.
tuika already exposed the hard parts publicly but shipped no loop tying them to
`EventStream` + a tick — its own docs punted on the async case. This is the one
reusable capability that friction pointed at, and it's something every async TUI
on tuika would want.

## Before / After

**Before** — an async host bridges into the blocking runner:

```rust
// spawn_blocking(run) + Arc<RwLock<Data>> + Notify + AtomicBool stop flag,
// with a background poller task mutating the shared Data and pinging Notify.
```

**After** — one loop owns its state, no shared-state machinery:

```rust
runner.run(&theme, &mut data,
    |data, _frame| view(data),
    async |data, signal| match signal {
        Signal::Tick => { data.ingest(fetch_stats(&url).await?); ControlFlow::Continue(()) }
        Signal::Event(Event::Key(k)) if quit(k) => ControlFlow::Break(()),
        _ => ControlFlow::Continue(()),
    },
).await?;
```

Evidence:

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` (full workspace) — clean
- `cargo test -p tuika --all-features` — **218 lib + 13 doc passed**, including 5
  new async tests: config clamp, an end-to-end smoke test driving the whole loop
  (initial paint → state mutation → quit) through `run_with_events` on a
  `TestBackend`, a paused-clock test proving ticks fire and can `.await`, an
  initial-frame test, and stream-error propagation.
- `cargo build -p tuika` (no features) — compiles with **no** Tokio pulled in
  (dependency gating verified).
- `cargo run -- --provider llmsim -p "hi"` — binary still starts.

## Risk

- **Low.**
- All new code is behind the non-default `async` feature; the default build and
  dependency tree are unchanged. `tokio` is already a workspace dependency and
  `tokio-stream` is already in the lockfile — neither is a new third-party crate,
  they are just newly used by `tuika` (and only under the feature). `yolop` does
  not enable the feature.

## Security

No filesystem, shell, LLM/prompt, or tool-capability code is touched — the change
is terminal I/O in a library crate. **TM-DEP:** `tokio` (existing workspace dep) +
`tokio-stream` (already in the lockfile) provide `StreamExt` for polling
crossterm's `EventStream`; crossterm's `event-stream` feature adds `futures-core`.
All optional and gated behind `async`. **Resource exhaustion:** `tick_rate` is
floored at 1ms so the `select!` can't busy-spin, and an exhausted event stream
disables its `select!` branch (via a guard) instead of spinning on repeated
`None`. Read errors from the stream propagate out of the run rather than being
swallowed.

## Follow-ups

- Migrate the full-screen dashboard consumer (`app.rs`) onto `AsyncRunner`,
  deleting its `spawn_blocking` + `Live`/`Notify`/stop-flag bridge. Deferred to
  keep this PR a focused, reviewable capability addition (it also touches
  publish/versioning decisions worth their own review).

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered — new feature, off by default; `tuika` is pre-1.0