### PR TITLE
feat(tuika): add a terminal Capabilities detection subsystem

### DIFF
--- a/crates/tuika/README.md
+++ b/crates/tuika/README.md
@@ -335,6 +335,12 @@ streaming `MarkdownState`: attach a host `ImageResolver` (URL → `ImageData`, t
 same seam as the highlighter) and resolved images become real pixels — a
 link-styled placeholder for the rest, never a dropped URL.
 
+To check support across every terminal feature in one place — `graphics`,
+`hyperlinks`, `clipboard`, `progress`, `truecolor` — use `Capabilities`:
+`Capabilities::from_env()` is an instant advisory guess, and
+`Capabilities::query(timeout)` adds a Device Attributes probe that confirms Sixel
+(the one protocol the environment can't reliably reveal).
+
 ## Mouse, selection, and clipboard
 
 Enabling mouse capture (which `AltScreen` / `TerminalSession` do) means the
@@ -369,7 +375,7 @@ path — there is no separate touch event to handle.
 > See the [terminal features guide](docs/features.md) for these
 > terminal-integration capabilities — OSC 8 hyperlinks, mouse selection and
 > clicks, OSC 52 clipboard, OSC 9;4 progress, and Kitty/iTerm2/Sixel images —
-> with demos and runnable examples.
+> plus `Capabilities` detection, with demos and runnable examples.
 
 ## Testing your UI
 

--- a/crates/tuika/docs/features.md
+++ b/crates/tuika/docs/features.md
@@ -12,6 +12,36 @@ terminal that understands the sequence acts on it; one that does not silently
 ignores the unknown OSC, so the feature degrades to plain text or a no-op
 rather than leaking escape codes onto the screen.
 
+## Capabilities
+
+`Capabilities` is the one place to ask what the terminal can do —
+`graphics` (an `ImageSupport`, the Images section below), `hyperlinks`,
+`clipboard`, `progress`, and `truecolor`.
+[API](https://docs.rs/tuika/latest/tuika/capabilities/index.html)
+
+```rust
+use tuika::Capabilities;
+
+let caps = Capabilities::from_env();   // instant, no terminal I/O
+if caps.supports_images() { /* … */ }
+```
+
+Two tiers. `Capabilities::from_env()` is an **advisory** guess from `TERM`,
+`TERM_PROGRAM`, `COLORTERM`, `KITTY_WINDOW_ID`, and the Ghostty marker — instant,
+never blocks. Because the OSC features above degrade harmlessly, you emit them
+regardless; the flag only decides whether to *show an affordance* (a "copy" hint,
+a link underline) the terminal can't act on, so those flags lean conservative.
+
+For accuracy — mainly to confirm **Sixel**, which has no reliable environment
+signal — `Capabilities::query(timeout)` also does a **Device Attributes** probe:
+it writes `DA1_REQUEST` (`ESC [ c`), reads the reply, and upgrades `graphics`
+when the terminal reports Sixel (DA1 feature `4`). Call it once at startup, in
+raw mode, before the event loop reads stdin (Unix ttys only; elsewhere it is just
+`from_env`). The pieces are also exposed standalone — `DA1_REQUEST` and
+`DeviceAttributes::parse` — so a host with its own read strategy can do the
+round-trip itself. Kitty and iTerm2 keep their reliable environment detection
+(DA1 doesn't report them).
+
 ## Hyperlinks (OSC 8)
 
 Turn a bare `http(s)` URL into a real clickable link, in place, without changing
@@ -262,7 +292,8 @@ inline placeholder rather than dropping the URL.
 
 - [Component gallery](components.md) — the widgets that paint the grid.
 - [API documentation](https://docs.rs/tuika) — the complete reference for the
-  `hyperlink`, `mouse`, `clipboard`, `native`, and `image` modules.
+  `capabilities`, `hyperlink`, `mouse`, `clipboard`, `native`, and `image`
+  modules.
 - [Runnable examples](../examples/) — `mouse` records the selection/clipboard
   workflow live; quit with `q`/`esc`.
 - [README](../README.md) — the model behind the toolkit.

--- a/crates/tuika/src/capabilities.rs
+++ b/crates/tuika/src/capabilities.rs
@@ -1,0 +1,338 @@
+//! Terminal capability detection.
+//!
+//! What can the terminal actually do — paint pixels, open links, copy to the
+//! system clipboard, show 24-bit color? tuika answers this in two tiers, the same
+//! way it splits pure logic from host I/O everywhere else:
+//!
+//! - [`Capabilities::from_env`] — an **instant, advisory** guess from the
+//!   environment (`TERM`, `TERM_PROGRAM`, `COLORTERM`, `KITTY_WINDOW_ID`, the
+//!   Ghostty marker). No terminal round-trip, so it never blocks; good enough to
+//!   decide whether to *show an affordance*, but not authoritative — especially
+//!   for Sixel, which has no reliable environment signal.
+//! - A **Device Attributes probe** for accuracy: emit [`DA1_REQUEST`], read the
+//!   reply, parse it with [`DeviceAttributes::parse`], and fold it in with
+//!   [`Capabilities::with_device_attributes`] — which *confirms* Sixel (DA1
+//!   feature `4`). [`Capabilities::query`] wraps that round-trip on Unix ttys.
+//!
+//! The `graphics` field reuses [`ImageSupport`], so image support is just
+//! `caps.graphics` (or [`supports_images`](Capabilities::supports_images)). The
+//! `hyperlinks` / `clipboard` / `progress` flags are **advisory only**: those
+//! escapes ([`crate::hyperlink`], [`crate::clipboard`], [`crate::native`]) are
+//! swallowed harmlessly by terminals that don't understand them, so you emit them
+//! regardless — the flag only helps a host decide whether to render UI (a "copy"
+//! hint, a link underline) the terminal can't act on. They lean conservative, so
+//! a `false` means "don't assume", not "definitely unsupported".
+//!
+//! ```no_run
+//! use std::time::Duration;
+//! use tuika::Capabilities;
+//!
+//! // Instant, advisory (no I/O):
+//! let caps = Capabilities::from_env();
+//! if caps.supports_images() { /* … */ }
+//!
+//! // Accurate: probe the terminal once at startup, in raw mode, before the
+//! // event loop reads stdin (Unix ttys only; elsewhere this is just `from_env`).
+//! let caps = Capabilities::query(Duration::from_millis(100));
+//! ```
+
+use crate::image::ImageSupport;
+
+/// The Primary Device Attributes request (`ESC [ c`). A terminal replies with
+/// `ESC [ ? <codes> c`; feed that reply to [`DeviceAttributes::parse`].
+pub const DA1_REQUEST: &str = "\x1b[c";
+
+/// A snapshot of what the terminal is believed to support.
+///
+/// Build it with [`from_env`](Self::from_env) (advisory) or
+/// [`query`](Self::query) (env + a Device Attributes probe).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Capabilities {
+    /// Graphics protocol for images ([`ImageSupport::None`] if none).
+    pub graphics: ImageSupport,
+    /// OSC 8 hyperlinks (advisory).
+    pub hyperlinks: bool,
+    /// OSC 52 system-clipboard writes (advisory).
+    pub clipboard: bool,
+    /// OSC 9;4 native progress (advisory).
+    pub progress: bool,
+    /// 24-bit "true color" (advisory; from `COLORTERM` and known terminals).
+    pub truecolor: bool,
+}
+
+impl Capabilities {
+    /// Detect from the process environment only — instant, no terminal I/O.
+    ///
+    /// Advisory: reliable for Kitty/iTerm2 graphics and true color, conservative
+    /// (false-leaning) for the OSC features, and weak for Sixel. Use
+    /// [`query`](Self::query) when accuracy matters.
+    pub fn from_env() -> Self {
+        let env = |k: &str| std::env::var(k).ok();
+        Self::from_env_parts(
+            env("TERM").as_deref(),
+            env("TERM_PROGRAM").as_deref(),
+            env("COLORTERM").as_deref(),
+            env("KITTY_WINDOW_ID").as_deref(),
+            env("GHOSTTY_RESOURCES_DIR").as_deref(),
+        )
+    }
+
+    /// The pure core of [`from_env`](Self::from_env), taking the environment
+    /// explicitly so the heuristics are unit-testable.
+    pub fn from_env_parts(
+        term: Option<&str>,
+        term_program: Option<&str>,
+        colorterm: Option<&str>,
+        kitty_window_id: Option<&str>,
+        ghostty_resources_dir: Option<&str>,
+    ) -> Self {
+        let graphics =
+            ImageSupport::detect_from(term, term_program, kitty_window_id, ghostty_resources_dir);
+        let program = term_program.unwrap_or_default().to_ascii_lowercase();
+        let term = term.unwrap_or_default();
+        let colorterm = colorterm.unwrap_or_default().to_ascii_lowercase();
+        let is = |p: &str| program == p;
+        let term_has = |s: &str| term.contains(s);
+
+        // A "modern" terminal: anything with a graphics protocol, plus a curated
+        // set known to speak OSC 8 and OSC 52. Conservative — a terminal we can't
+        // place (a bare `xterm-256color` from GNOME Terminal, say) reads as false.
+        let modern = graphics != ImageSupport::None
+            || is("wezterm")
+            || is("ghostty")
+            || is("iterm.app")
+            || term_has("kitty")
+            || term_has("foot")
+            || term_has("contour")
+            || term_has("alacritty");
+
+        Self {
+            graphics,
+            hyperlinks: modern,
+            clipboard: modern,
+            // OSC 9;4 has a narrower support set than the OSC 8/52 features.
+            progress: is("ghostty") || is("wezterm") || is("konsole") || term_has("konsole"),
+            truecolor: modern || colorterm == "truecolor" || colorterm == "24bit",
+        }
+    }
+
+    /// Detect from the environment, then refine with a Device Attributes probe.
+    ///
+    /// On a Unix tty this writes [`DA1_REQUEST`] and reads the reply (up to
+    /// `timeout`), upgrading `graphics` to Sixel when the terminal reports it —
+    /// the accuracy the env-only path can't reach. **Call once at startup, after
+    /// entering raw mode and before the event loop reads stdin.** On non-ttys and
+    /// non-Unix platforms it is exactly [`from_env`](Self::from_env).
+    pub fn query(timeout: std::time::Duration) -> Self {
+        let caps = Self::from_env();
+        match probe_device_attributes(timeout) {
+            Some(da) => caps.with_device_attributes(&da),
+            None => caps,
+        }
+    }
+
+    /// Fold a parsed Device Attributes reply into these capabilities: a reported
+    /// Sixel feature upgrades `graphics` when the environment found no protocol.
+    /// A protocol already detected from the environment (Kitty/iTerm2, which DA1
+    /// does not report) is kept.
+    pub fn with_device_attributes(mut self, da: &DeviceAttributes) -> Self {
+        if da.sixel() && self.graphics == ImageSupport::None {
+            self.graphics = ImageSupport::Sixel;
+        }
+        self
+    }
+
+    /// Whether any image graphics protocol is available.
+    pub fn supports_images(&self) -> bool {
+        self.graphics != ImageSupport::None
+    }
+}
+
+/// A parsed Primary Device Attributes (DA1) reply — the terminal's feature codes.
+///
+/// The reply is `ESC [ ? <n> (; <n>)* c`; the numbers are VT feature codes, of
+/// which `4` means Sixel graphics and `22` means ANSI color.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DeviceAttributes {
+    codes: Vec<u16>,
+}
+
+impl DeviceAttributes {
+    /// Parse a DA1 reply, or `None` if `response` has no `ESC [ … c` frame with a
+    /// numeric code. Ignores anything before the frame and any non-numeric
+    /// parameters, so a reply mixed with other terminal chatter still parses.
+    pub fn parse(response: &[u8]) -> Option<Self> {
+        let start = response.windows(2).position(|w| w == b"\x1b[")? + 2;
+        let rest = &response[start..];
+        let rest = rest.strip_prefix(b"?").unwrap_or(rest);
+        let end = rest.iter().position(|&b| b == b'c')?;
+        let mut codes = Vec::new();
+        for part in rest[..end].split(|&b| b == b';') {
+            if let Ok(s) = std::str::from_utf8(part)
+                && let Ok(n) = s.parse::<u16>()
+            {
+                codes.push(n);
+            }
+        }
+        (!codes.is_empty()).then_some(Self { codes })
+    }
+
+    /// Whether the reply lists VT feature `code`.
+    pub fn has(&self, code: u16) -> bool {
+        self.codes.contains(&code)
+    }
+
+    /// Whether the terminal reported Sixel graphics (DA1 feature `4`).
+    pub fn sixel(&self) -> bool {
+        self.has(4)
+    }
+}
+
+/// Write [`DA1_REQUEST`] to the terminal and read the reply, returning the parsed
+/// attributes or `None` on a non-tty, a timeout, or an I/O error.
+///
+/// Unix only: reads raw bytes from fd 0 (which must be in raw mode) in a helper
+/// thread bounded by `timeout`. A real tty answers DA1 immediately, so the read
+/// completes at once; the timeout only guards exotic terminals that ignore the
+/// query. Borrows fd 0 without owning it, so it never closes stdin, and reads
+/// exactly up to the reply's terminating `c`, so it consumes no input beyond it.
+#[cfg(unix)]
+fn probe_device_attributes(timeout: std::time::Duration) -> Option<DeviceAttributes> {
+    use std::fs::File;
+    use std::io::{IsTerminal, Read, Write, stdin, stdout};
+    use std::mem::ManuallyDrop;
+    use std::os::fd::FromRawFd;
+    use std::sync::mpsc;
+    use std::thread;
+
+    if !stdin().is_terminal() || !stdout().is_terminal() {
+        return None;
+    }
+    {
+        let mut out = stdout();
+        out.write_all(DA1_REQUEST.as_bytes()).ok()?;
+        out.flush().ok()?;
+    }
+
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        // Borrow fd 0 without owning it (ManuallyDrop ⇒ never closes stdin), and
+        // read unbuffered so no bytes past the reply are swallowed.
+        let mut input = ManuallyDrop::new(unsafe { File::from_raw_fd(0) });
+        let mut buf = Vec::new();
+        let mut byte = [0u8; 1];
+        while buf.len() < 64 {
+            match input.read(&mut byte) {
+                Ok(1) => {
+                    buf.push(byte[0]);
+                    // The reply ends at the `c` that closes the CSI frame.
+                    if byte[0] == b'c' && buf.contains(&b'[') {
+                        break;
+                    }
+                }
+                _ => break,
+            }
+        }
+        let _ = tx.send(buf);
+    });
+
+    let buf = rx.recv_timeout(timeout).ok()?;
+    DeviceAttributes::parse(&buf)
+}
+
+/// Non-Unix stub: no DA probe, so [`Capabilities::query`] is just `from_env`.
+#[cfg(not(unix))]
+fn probe_device_attributes(_timeout: std::time::Duration) -> Option<DeviceAttributes> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_detects_kitty_graphics_and_truecolor() {
+        let c = Capabilities::from_env_parts(Some("xterm-kitty"), None, None, Some("1"), None);
+        assert_eq!(c.graphics, ImageSupport::Kitty);
+        assert!(c.supports_images());
+        assert!(
+            c.hyperlinks && c.clipboard,
+            "graphics terminals speak OSC 8/52"
+        );
+        assert!(c.truecolor);
+    }
+
+    #[test]
+    fn env_marks_ghostty_progress() {
+        let c = Capabilities::from_env_parts(None, Some("ghostty"), None, None, Some("/x"));
+        assert!(c.progress, "Ghostty drives OSC 9;4");
+        assert!(c.hyperlinks);
+    }
+
+    #[test]
+    fn env_is_conservative_for_unknown_terminals() {
+        // A bare xterm-256color we can't place: no image protocol, OSC flags off,
+        // but COLORTERM still reveals true color.
+        let c = Capabilities::from_env_parts(
+            Some("xterm-256color"),
+            Some("Apple_Terminal"),
+            Some("truecolor"),
+            None,
+            None,
+        );
+        assert_eq!(c.graphics, ImageSupport::None);
+        assert!(!c.supports_images());
+        assert!(!c.hyperlinks && !c.clipboard && !c.progress);
+        assert!(c.truecolor, "COLORTERM=truecolor still detected");
+    }
+
+    #[test]
+    fn env_foot_gets_sixel_and_osc() {
+        let c = Capabilities::from_env_parts(Some("foot"), None, None, None, None);
+        assert_eq!(c.graphics, ImageSupport::Sixel);
+        assert!(c.hyperlinks && c.clipboard);
+    }
+
+    #[test]
+    fn parse_reads_da1_feature_codes() {
+        let da = DeviceAttributes::parse(b"\x1b[?62;1;4;22c").expect("parses");
+        assert!(da.has(62) && da.has(4) && da.has(22));
+        assert!(da.sixel());
+    }
+
+    #[test]
+    fn parse_finds_the_frame_amid_other_bytes() {
+        // A reply can arrive glued to unrelated output; the frame is still found.
+        let da = DeviceAttributes::parse(b"junk\x1b[?1;2c").expect("parses");
+        assert!(da.has(1) && da.has(2));
+        assert!(!da.sixel());
+    }
+
+    #[test]
+    fn parse_rejects_non_da_input() {
+        assert!(DeviceAttributes::parse(b"no attributes here").is_none());
+        assert!(
+            DeviceAttributes::parse(b"\x1b[?c").is_none(),
+            "no numeric codes"
+        );
+    }
+
+    #[test]
+    fn device_attributes_upgrade_sixel_only_when_env_found_nothing() {
+        let sixel = DeviceAttributes::parse(b"\x1b[?4c").unwrap();
+        // Env found nothing → DA1 Sixel report promotes graphics to Sixel.
+        let none = Capabilities::from_env_parts(Some("xterm-256color"), None, None, None, None);
+        assert_eq!(none.graphics, ImageSupport::None);
+        assert_eq!(
+            none.with_device_attributes(&sixel).graphics,
+            ImageSupport::Sixel
+        );
+        // A Kitty terminal (DA1 never reports Kitty) is left untouched.
+        let kitty = Capabilities::from_env_parts(Some("xterm-kitty"), None, None, None, None);
+        let no_sixel = DeviceAttributes::parse(b"\x1b[?1;2c").unwrap();
+        assert_eq!(
+            kitty.with_device_attributes(&no_sixel).graphics,
+            ImageSupport::Kitty
+        );
+    }
+}

--- a/crates/tuika/src/lib.rs
+++ b/crates/tuika/src/lib.rs
@@ -42,6 +42,7 @@
 pub mod anim;
 #[cfg(feature = "async")]
 pub mod async_runner;
+pub mod capabilities;
 pub mod clipboard;
 pub mod components;
 pub mod event;
@@ -73,6 +74,7 @@ pub mod width;
 // etc. for the common surface without deep paths.
 #[cfg(feature = "async")]
 pub use async_runner::{AsyncRunner, Signal};
+pub use capabilities::{Capabilities, DA1_REQUEST, DeviceAttributes};
 pub use clipboard::{osc52, write_clipboard};
 pub use components::{
     Boxed, CodeBlock, Column, Constrained, Flex, FocusScope, ImageResolver, KeyHints, Loader,


### PR DESCRIPTION
## What changed

Adds a `capabilities` module so code has **one place** to ask what the terminal
supports — generalizing `ImageSupport::detect`, which was the crate's only
capability check.

`Capabilities { graphics, hyperlinks, clipboard, progress, truecolor }`, built two
ways:

- **`Capabilities::from_env()`** — instant, advisory heuristics from `TERM`,
  `TERM_PROGRAM`, `COLORTERM`, `KITTY_WINDOW_ID`, and the Ghostty marker. No
  terminal I/O.
- **`Capabilities::query(timeout)`** — env plus a **Device Attributes** probe
  (writes `DA1_REQUEST` = `ESC [ c`, reads the reply) that confirms **Sixel** (DA1
  feature `4`) — the one protocol the environment can't reliably reveal. Unix ttys
  only; elsewhere it's exactly `from_env`.

`supports_images()` is the direct "are images supported?" helper the question that
prompted this asked for. New public API: `tuika::{Capabilities, DeviceAttributes,
DA1_REQUEST}`.

## Why

Someone asked whether tuika had a helper to know if images are supported, and
whether there was a general capability subsystem. The answer was "images yes
(`ImageSupport::detect`), general no" — the OSC features (hyperlinks, clipboard,
progress) had no detection because they degrade harmlessly, so you emit them
unconditionally. This adds the general subsystem while preserving that: the
OSC-feature flags are **advisory** — you still emit regardless; the flag only
decides whether to render an affordance (a "copy" hint, a link underline) the
terminal can't act on, so those flags lean conservative (a `false` means "don't
assume", not "definitely unsupported").

Design follows tuika's split of pure logic from host I/O:

- `from_env_parts`, `DeviceAttributes::parse`, and `with_device_attributes` are
  **pure and unit-tested** — the whole detection matrix and the DA1 wire parser.
- `DA1_REQUEST` and `DeviceAttributes::parse` are exposed standalone, so a host
  with its own read strategy (crossterm poll, an existing event loop) can do the
  round-trip itself rather than use the bundled probe.
- The bundled probe (Unix) reads raw bytes from fd 0 (which must already be in raw
  mode) in a helper thread bounded by `timeout`. It borrows fd 0 without owning it
  (`ManuallyDrop`), so it never closes stdin, and reads exactly to the reply's
  terminating `c`, so it consumes no input past it. A real tty answers DA1
  instantly; the timeout only guards a terminal that ignores the query. Documented
  to be called once at startup, in raw mode, before the event loop reads stdin.

Kitty and iTerm2 keep their reliable environment detection — DA1 doesn't report
them, so the probe only ever *upgrades* to Sixel when the env found no protocol.

## Before / After

```rust
use tuika::Capabilities;

// Before: only images had a check, via ImageSupport::detect().
// After — one struct for everything:
let caps = Capabilities::from_env();
caps.supports_images();      // graphics != None
caps.clipboard;              // advisory: show a "copy" hint?
let caps = Capabilities::query(std::time::Duration::from_millis(100)); // + DA1 Sixel confirm
```

Test evidence — 8 new tests (env matrix incl. conservative unknown-terminal case,
DA1 parse incl. frame-amid-noise and rejection, Sixel upgrade only when env found
nothing):

```
test result: ok. 224 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Gates run locally: `cargo fmt --check`, `cargo clippy --all-targets
--all-features -D warnings`, doc build (0 warnings), the `demo -- check` drift
gate. No hot-path or bench code touched.

## Security

The probe writes only the fixed `DA1_REQUEST` constant — no user/content data
reaches the terminal. `DeviceAttributes::parse` treats the reply as untrusted:
bounded read (≤64 bytes), numeric-only parsing, non-numeric params ignored, no
panics. Borrowing fd 0 via `ManuallyDrop` cannot close stdin.

## Risk

- **Low.** Additive — new module and exports, nothing existing changed. The env
  path is pure; the probe is opt-in (`query`), Unix-tty-gated, and falls back to
  `from_env` everywhere else. The advisory OSC flags are explicitly non-binding
  (emission is unconditional as before).

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (additive; tuika is pre-1.0)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkDY2v4wzioCdobQA42Q7g)_