### PR TITLE
feat(tuika): horizontal pan on Scroll + max-offset accessors

### DIFF
--- a/crates/tuika/docs/components.md
+++ b/crates/tuika/docs/components.md
@@ -275,7 +275,11 @@ A windowed view over long content with a scrollbar; `ScrollState` handles
 paging, wheel scroll, and stick-to-bottom. The offset is also **host-drivable**:
 `set_offset(n)` mirrors an app-owned scroll position into the view — the
 vertical peer of `SelectState::select` — for event-loop apps that track their
-own position.
+own position. Content wider than the pane (logs, diffs, wide tables, deep paths)
+**pans horizontally** with `set_x_offset(cols)` (bind to `h`/`l` or `←`/`→`),
+bounded by `clamp_x` — the pan is width-aware, so wide/CJK glyphs never split.
+`ScrollState::max_offset` / `max_x_offset` expose the in-range bounds for a host
+driving the offsets itself.
 [API](https://docs.rs/tuika/latest/tuika/struct.Scroll.html)
 
 <img src="demos/scroll.gif" width="880" alt="Scroll demo">
@@ -284,7 +288,9 @@ own position.
 use tuika::{Scroll, ScrollState, view};
 let mut state = ScrollState::new();          // held by the host across frames
 state.handle(&event, content_h, viewport_h); // built-in wheel/paging, or…
-state.set_offset(app.scroll_row);            // …mirror an app-owned position
+state.set_offset(app.scroll_row);            // …mirror an app-owned row, and
+state.set_x_offset(app.scroll_col);          // …pan wide lines left/right
+state.clamp_x(widest_line_w, viewport_w);    // keep the pan within the content
 view! { node(Scroll::new(lines, &state)) }
 ```
 

--- a/crates/tuika/src/components/scroll.rs
+++ b/crates/tuika/src/components/scroll.rs
@@ -1,4 +1,4 @@
-//! Vertical scroll viewport with a scrollbar.
+//! Scroll viewport with a scrollbar.
 //!
 //! This is the primitive that replaces native terminal scrollback in the
 //! full-screen renderer: content taller than the viewport is windowed by a
@@ -10,6 +10,15 @@
 //! is **host-drivable**: an app that owns its scroll position in its own model
 //! mirrors it into the view with [`set_offset`](ScrollState::set_offset), the
 //! vertical peer of [`SelectState::select`](crate::SelectState::select).
+//!
+//! Content wider than the pane — logs, unified diffs, wide tables, deep paths —
+//! **pans horizontally**: [`set_x_offset`](ScrollState::set_x_offset) shifts the
+//! view left by a number of display columns (bind it to `h`/`l` or `←`/`→`), and
+//! [`clamp_x`](ScrollState::clamp_x) bounds it to the widest line. The pan is
+//! width-aware — it skips whole grapheme clusters, so wide/CJK glyphs never
+//! split. [`max_offset`](ScrollState::max_offset) and
+//! [`max_x_offset`](ScrollState::max_x_offset) expose the in-range bounds for a
+//! host that drives the offsets itself.
 
 use ratatui::layout::Rect;
 use ratatui::style::Style;
@@ -30,6 +39,9 @@ use crate::view::{RenderCtx, View};
 pub struct ScrollState {
     /// Top visible content row.
     offset: usize,
+    /// Leftmost visible display column (horizontal pan). Zero unless the host
+    /// pans; used by wide viewers — logs, diffs, wide tables, deep paths.
+    x_offset: usize,
     /// When true, `clamp` snaps to the bottom on content growth so new
     /// transcript output stays visible.
     stick_to_bottom: bool,
@@ -40,6 +52,7 @@ impl ScrollState {
     pub fn new() -> Self {
         Self {
             offset: 0,
+            x_offset: 0,
             stick_to_bottom: true,
         }
     }
@@ -62,13 +75,41 @@ impl ScrollState {
         self.stick_to_bottom = false;
     }
 
+    /// Leftmost visible display column (0-based). Zero unless the view is panned.
+    pub fn x_offset(&self) -> usize {
+        self.x_offset
+    }
+
+    /// Set the leftmost visible display column (horizontal pan) — the twin of
+    /// [`set_offset`](Self::set_offset). Panning is measured in display columns,
+    /// not bytes or `char`s, so wide/CJK glyphs stay whole. Bind it to `h`/`l`
+    /// or `←`/`→`, or mirror an app-owned column. Follow with
+    /// [`clamp_x`](Self::clamp_x) to keep it within the widest line.
+    pub fn set_x_offset(&mut self, cols: usize) {
+        self.x_offset = cols;
+    }
+
     /// Whether the view is pinned to the newest content.
     pub fn is_stuck_to_bottom(&self) -> bool {
         self.stick_to_bottom
     }
 
-    fn max_offset(content_h: usize, viewport_h: usize) -> usize {
+    /// The largest in-range vertical offset for the given content and viewport
+    /// heights (`content_h - viewport_h`, floored at 0).
+    ///
+    /// Exposed so a host driving the offset from its own model (see
+    /// [`set_offset`](Self::set_offset)) can bound its own key handling with the
+    /// same arithmetic the view uses, rather than reimplementing it.
+    pub fn max_offset(content_h: usize, viewport_h: usize) -> usize {
         content_h.saturating_sub(viewport_h)
+    }
+
+    /// The largest in-range horizontal pan for the given content and viewport
+    /// widths (`content_w - viewport_w`, floored at 0), where `content_w` is the
+    /// widest line's display width. The horizontal peer of
+    /// [`max_offset`](Self::max_offset).
+    pub fn max_x_offset(content_w: usize, viewport_w: usize) -> usize {
+        content_w.saturating_sub(viewport_w)
     }
 
     /// Reconcile the offset with current content/viewport dimensions, honoring
@@ -80,6 +121,14 @@ impl ScrollState {
         } else {
             self.offset = self.offset.min(max);
         }
+    }
+
+    /// Bound the horizontal pan to the widest line: `x_offset` is clamped to
+    /// `content_w - viewport_w`, so panning can't scroll past the end of the
+    /// longest line. `content_w` is that line's display width; `viewport_w` is
+    /// the visible column count. The horizontal peer of [`clamp`](Self::clamp).
+    pub fn clamp_x(&mut self, content_w: usize, viewport_w: usize) {
+        self.x_offset = self.x_offset.min(Self::max_x_offset(content_w, viewport_w));
     }
 
     fn scroll_up(&mut self, lines: usize) {
@@ -168,6 +217,9 @@ pub struct Scroll {
     content_height: usize,
     /// Top visible content row.
     offset: usize,
+    /// Leftmost visible display column; each line is drawn skipping this many
+    /// columns from its left. Zero (the default) is the flush-left fast path.
+    x_offset: usize,
     scrollbar: bool,
 }
 
@@ -181,6 +233,7 @@ impl Scroll {
             lines,
             window_start: 0,
             offset: state.offset(),
+            x_offset: state.x_offset(),
             scrollbar: true,
         }
     }
@@ -206,6 +259,7 @@ impl Scroll {
             window_start: offset,
             content_height,
             offset,
+            x_offset: state.x_offset(),
             scrollbar: true,
         }
     }
@@ -254,12 +308,16 @@ impl View for Scroll {
             };
             let y = area.y + row;
             let mut clip = surface.child(Rect::new(area.x, y, text_width, 1));
+            // Skip `x_offset` display columns from the left of each line (the
+            // horizontal pan), carried across the line's spans. A zero offset is
+            // exactly the flush-left `set_string` path.
+            let mut skip = self.x_offset.min(u16::MAX as usize) as u16;
             let mut x = area.x;
             for span in &line.spans {
                 if x >= area.x + text_width {
                     break;
                 }
-                x = clip.set_string(x, y, span.content.as_ref(), span.style);
+                x = clip.set_string_skip(x, y, span.content.as_ref(), span.style, &mut skip);
             }
         }
 
@@ -306,7 +364,7 @@ mod tests {
     use crate::test_support::{buffer, rainbow_theme, row};
     use crate::view::{RenderCtx, View};
     use ratatui::style::Color;
-    use ratatui::text::Line;
+    use ratatui::text::{Line, Span};
 
     #[test]
     fn scroll_sticks_to_bottom_until_scrolled_up() {
@@ -361,6 +419,74 @@ mod tests {
         s.set_offset(500);
         s.clamp(100, 10);
         assert_eq!(s.offset(), 90, "clamped to content height - viewport");
+    }
+
+    #[test]
+    fn horizontal_pan_offset_clamp_and_max() {
+        let mut s = ScrollState::new();
+        assert_eq!(s.x_offset(), 0, "no pan by default");
+        s.set_x_offset(34);
+        assert_eq!(s.x_offset(), 34);
+        // clamp_x bounds the pan to the widest line minus the viewport (30-10).
+        s.clamp_x(30, 10);
+        assert_eq!(s.x_offset(), 20);
+        // A pan already within bounds is untouched.
+        s.clamp_x(30, 10);
+        assert_eq!(s.x_offset(), 20);
+        // The static bounds helpers expose the arithmetic a host would otherwise
+        // reimplement.
+        assert_eq!(ScrollState::max_offset(100, 10), 90);
+        assert_eq!(ScrollState::max_offset(5, 10), 0, "floors at zero");
+        assert_eq!(ScrollState::max_x_offset(30, 10), 20);
+    }
+
+    #[test]
+    fn scroll_view_pans_long_lines_horizontally() {
+        // One line "0123456789" in a 5-wide viewport panned right by 3 shows the
+        // slice starting at display column 3: "34567".
+        let mut state = ScrollState::new();
+        state.set_x_offset(3);
+        let scroll = Scroll::new(vec![Line::from("0123456789")], &state);
+        let mut buf = buffer(5, 1);
+        let theme = Theme::default();
+        let ctx = RenderCtx::new(&theme);
+        let area = buf.area;
+        let mut surface = Surface::new(&mut buf, area);
+        scroll.render(area, &mut surface, &ctx);
+        assert_eq!(row(&buf, 0), "34567");
+    }
+
+    #[test]
+    fn horizontal_pan_is_width_aware_across_spans() {
+        // "aa你好bb" columns: a(0) a(1) 你(2-3) 好(4-5) b(6) b(7). Panning to
+        // column 3 straddles 你 (spans 2-3): it is dropped, and the pan carries
+        // across the two spans so 好 and the trailing b's still show.
+        let mut state = ScrollState::new();
+        state.set_x_offset(3);
+        let line = Line::from(vec![
+            Span::raw("aa你"), // first span ends mid-way through the pan
+            Span::raw("好bb"),
+        ]);
+        let scroll = Scroll::new(vec![line], &state);
+        let mut buf = buffer(6, 1);
+        let theme = Theme::default();
+        let ctx = RenderCtx::new(&theme);
+        let area = buf.area;
+        let mut surface = Surface::new(&mut buf, area);
+        scroll.render(area, &mut surface, &ctx);
+        let rendered = row(&buf, 0);
+        assert!(
+            rendered.contains("好"),
+            "resumes at the next whole glyph: {rendered:?}"
+        );
+        assert!(
+            rendered.contains("bb"),
+            "pan carried across spans: {rendered:?}"
+        );
+        assert!(
+            !rendered.contains("你"),
+            "straddling wide glyph dropped: {rendered:?}"
+        );
     }
 
     #[test]

--- a/crates/tuika/src/surface.rs
+++ b/crates/tuika/src/surface.rs
@@ -138,10 +138,37 @@ impl<'a> Surface<'a> {
     /// single cell with the correct width instead of being scattered across
     /// several — see [`crate::width`].
     pub fn set_string(&mut self, x: u16, y: u16, text: &str, style: Style) -> u16 {
+        let mut skip = 0;
+        self.set_string_skip(x, y, text, style, &mut skip)
+    }
+
+    /// Like [`set_string`](Self::set_string) but first skips `*skip` display
+    /// columns of `text`, decrementing `*skip` by the columns consumed; returns
+    /// the exclusive end column written. Draw a whole line span-by-span with one
+    /// shared `skip` to honor a horizontal pan offset — each span resumes where
+    /// the previous left off. A wide glyph straddling the skip boundary is
+    /// dropped (its full width consumed from `skip`) rather than shown half.
+    ///
+    /// [`set_string`](Self::set_string) is this with `skip = 0`; both go through
+    /// the same grapheme walk, so panning adds no second cluster-iteration site
+    /// to the crate's paint hot path (which under whole-program optimization
+    /// would de-inline the common flush-left path and regress it).
+    pub fn set_string_skip(
+        &mut self,
+        x: u16,
+        y: u16,
+        text: &str,
+        style: Style,
+        skip: &mut u16,
+    ) -> u16 {
         let mut col = x;
         for cluster in text.graphemes(true) {
             let w = grapheme_cols(cluster);
             if w == 0 {
+                continue;
+            }
+            if *skip > 0 {
+                *skip = skip.saturating_sub(w);
                 continue;
             }
             if col >= self.clip.right() {
@@ -274,6 +301,55 @@ mod tests {
         assert_eq!(buf[(1, 0)].symbol(), " ", "trailing half of the wide glyph");
         assert_eq!(buf[(2, 0)].symbol(), "x", "next glyph starts at column 2");
         assert_eq!(end, 3, "cursor advanced 2 (emoji) + 1 (x)");
+    }
+
+    #[test]
+    fn set_string_skip_pans_and_carries_across_calls() {
+        // "abcdef" drawn with a running skip of 2: "ab" dropped, "cdef" drawn
+        // from x=0. A second call keeps consuming from the same skip.
+        let mut buf = Buffer::filled(Rect::new(0, 0, 6, 1), ratatui::buffer::Cell::new("."));
+        let mut surface = Surface::new(&mut buf, Rect::new(0, 0, 6, 1));
+        let mut skip = 2u16;
+        let end = surface.set_string_skip(0, 0, "abcdef", Style::default(), &mut skip);
+        assert_eq!(skip, 0, "skip fully consumed by the drawn span");
+        assert_eq!(end, 4, "drew 4 cols (cdef) starting at x=0");
+        assert_eq!(buf[(0, 0)].symbol(), "c");
+        assert_eq!(buf[(3, 0)].symbol(), "f");
+
+        // With skip still set, a whole short span is consumed without drawing and
+        // the skip carries to the next call.
+        let mut buf2 = Buffer::filled(Rect::new(0, 0, 4, 1), ratatui::buffer::Cell::new("."));
+        let mut s2 = Surface::new(&mut buf2, Rect::new(0, 0, 4, 1));
+        let mut skip = 3u16;
+        let x = s2.set_string_skip(0, 0, "ab", Style::default(), &mut skip); // fully skipped
+        assert_eq!(skip, 1, "1 column of skip remains after the 2-col span");
+        assert_eq!(x, 0, "nothing drawn, cursor unmoved");
+        let x = s2.set_string_skip(x, 0, "cd", Style::default(), &mut skip); // skip 'c', draw 'd'
+        assert_eq!(skip, 0);
+        assert_eq!(buf2[(0, 0)].symbol(), "d", "resumes after the carried skip");
+        assert_eq!(x, 1);
+    }
+
+    #[test]
+    fn set_string_skip_zero_matches_set_string() {
+        // The flush-left fast path: skip == 0 must be identical to set_string.
+        let render = |use_skip: bool| {
+            let mut buf = Buffer::filled(Rect::new(0, 0, 8, 1), ratatui::buffer::Cell::new("."));
+            let end = {
+                let mut s = Surface::new(&mut buf, Rect::new(0, 0, 8, 1));
+                if use_skip {
+                    let mut skip = 0u16;
+                    s.set_string_skip(0, 0, "hi 世界", Style::default(), &mut skip)
+                } else {
+                    s.set_string(0, 0, "hi 世界", Style::default())
+                }
+            };
+            (buf, end)
+        };
+        let (a, ea) = render(false);
+        let (b, eb) = render(true);
+        assert_eq!(ea, eb);
+        assert_eq!(a.content, b.content, "skip=0 diverged from set_string");
     }
 
     #[test]


### PR DESCRIPTION
## What changed

Closes the last hand-rolled-viewport gap for wide-content viewers.

- **Horizontal pan on `Scroll` / `ScrollState`** — `x_offset()` / `set_x_offset(cols)` / `clamp_x(content_w, viewport_w)`, the horizontal twin of the vertical offset API. `Scroll` draws each line shifted left by that many **display columns**, so logs, unified diffs, wide tables, and deep paths pan with `h`/`l` or `←`/`→`. The pan is width-aware — it skips whole grapheme clusters (a new `Surface::set_string_skip`), so wide/CJK/emoji glyphs never split; a glyph straddling the pan edge is dropped rather than shown half.
- **`ScrollState::max_offset` made public + `max_x_offset` added** — a host driving the offset from its own model (the `set_offset` use case) can now bound its own key handling with tuika's own `content − viewport` arithmetic instead of reimplementing the private helper.

Additive and backward-compatible: `x_offset` defaults to 0, so existing `Scroll` behavior is unchanged. No horizontal scrollbar is drawn (per the ask — the offset is the essential part; a host can add one later, opt-in like the vertical one). `shift`-drag / native selection interplay is out of scope; this is keyboard/programmatic pan.

## Why

`ScrollState` scrolled only vertically, so any viewer of content wider than the pane had to drop `Scroll` and re-implement the whole viewport — vertical slice, per-column horizontal offset, and scrollbar. For the multi-pane adopter this was the last ~110-line block that couldn't be deleted; with this, every scroll surface becomes toolkit-native and that block goes away. For the toolkit it makes `Scroll` usable for the log/diff/table-viewer category — a large slice of the CLI-tool space tuika targets.

## Before / After

```rust
// Before: vertical only.
state.handle(&event, content_h, viewport_h);

// After: pan wide lines horizontally, width-correct.
state.set_x_offset(app.scroll_col);              // shift left by N display columns
state.clamp_x(widest_line_w, viewport_w);        // bounded to the widest line
// "the quick brown fox…" panned right by 4 renders "quick brown fox…"

// After: bound host-owned key handling with tuika's arithmetic.
let max = ScrollState::max_x_offset(widest_line_w, viewport_w);
```

## The perf angle (why this can land now)

When I first attempted horizontal pan it regressed the `scroll_iai` instruction-count gate ~4–10%, because adding a second grapheme-iteration call site de-inlined `Graphemes::next` from the shared `Surface::set_string` under the crate's `lto = "thin"` + `codegen-units = 1` — taxing **all** text painting, not just scroll.

This version avoids that: `set_string` now **delegates** to the new skip-aware `set_string_skip` (calling it with `skip = 0`), so the crate keeps exactly **one** cluster-iteration site — unchanged from baseline. The common flush-left paint path stays within the committed baseline at **+1.5%** (under the ±2% gate), so **no re-baseline is needed** — the gate passes as-is.

## Risk

- **Low.** Additive `ScrollState` API + a shared `set_string`/`set_string_skip` core. The flush-left path (`x_offset = 0`) is the same grapheme walk as before, verified to stay within the iai baseline; a direct test asserts `set_string_skip(skip = 0)` renders identically to `set_string`.

## Validation

- `cargo fmt --check` — clean
- `cargo clippy -p tuika --all-targets --all-features -- -D warnings` — clean
- `cargo test -p tuika --all-features` — 232 lib + 16 doctests pass, incl. new coverage:
  - `Scroll` pans a long line to the correct display-column slice
  - width-aware pan **across spans** (a wide glyph straddling the pan edge is dropped; the pan carries across spans so following glyphs still show)
  - `x_offset` / `set_x_offset` / `clamp_x` bounds, and `max_offset` / `max_x_offset` arithmetic
  - `Surface::set_string_skip` carries skip across calls, and `skip == 0` is byte-identical to `set_string`
- `cargo bench -p tuika --bench markdown_iai --bench scroll_iai` + `check_iai.py` — **OK, all within tolerance** (render +1.5%, no baseline change)
- Offline smoke: `cargo run -- --provider llmsim -p "hi"` — binary starts

## Security

No security-relevant code changes — layout/paint arithmetic in the `tuika` crate (no filesystem, shell, prompt/key, capability, or dependency changes).

## Follow-ups

- **Optional `Table` cosmetics** (surfaced by the same adopter, explicitly low-priority / "toolkit's call"): a `.caret(char)` for the gutter marker, and `.header_style(Style)` + a preserve-cell-fg-on-selection mode for hosts that colour-code columns. None blocked adoption; not built here to keep this PR focused — happy to add if wanted.
- An opt-in **horizontal scrollbar** for `Scroll`, if demand appears.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (purely additive; `x_offset` defaults to 0)

---
_Generated by [Claude Code](https://claude.ai/code/session_013X4ivPR4SXng9sr3RJbvQy)_