### PR TITLE
feat(tuika): open Table chrome — caret, header style, selection fg

### DIFF
--- a/crates/tuika/docs/components.md
+++ b/crates/tuika/docs/components.md
@@ -317,7 +317,10 @@ per-column width policy, a full-row selection highlight, a caret gutter, and
 windowed scrolling. Column widths come from the same flexbox `solve` as every
 other container — a `Column` is `fixed`, `auto` (widest cell), or `flex`
 (shares leftover width). Selection reuses `SelectState`, so a list and a table
-share one state type.
+share one state type. Chrome follows the theme by default but is overridable
+(the `Boxed::border_color` pattern): `.caret(char)` sets the gutter marker,
+`.header_style(Style)` restyles the header, and `.preserve_selection_fg(true)`
+keeps color-coded columns' own colors under the selection highlight.
 [API](https://docs.rs/tuika/latest/tuika/struct.Table.html)
 
 ```rust
@@ -326,7 +329,7 @@ use tuika::{Column, Table, SelectState, view};
 let mut state = SelectState::new();
 state.handle(&event, rows.len());
 let columns = vec![Column::auto("branch"), Column::fixed("ahead", 5), Column::flex("subject", 1)];
-view! { node(Table::new(columns, rows, &state).viewport(20)) }
+view! { node(Table::new(columns, rows, &state).viewport(20).caret('▶')) }
 ```
 
 ### `Tabs` + `TabsState`

--- a/crates/tuika/examples/gallery.rs
+++ b/crates/tuika/examples/gallery.rs
@@ -107,7 +107,11 @@ fn build(frame: u64, theme: &Theme) -> tuika::Element {
                             vec![Line::from("wip"), Line::from("3"), Line::from("table component")],
                             vec![Line::from("fix"), Line::from("1"), Line::from("scrollbar math")],
                         ];
-                        Table::new(columns, rows, &sel).header(true)
+                        // Custom caret + preserve column colors under the highlight.
+                        Table::new(columns, rows, &sel)
+                            .header(true)
+                            .caret('▶')
+                            .preserve_selection_fg(true)
                     })
                 }
             }

--- a/crates/tuika/src/components/table.rs
+++ b/crates/tuika/src/components/table.rs
@@ -12,7 +12,14 @@
 //! (`handle` for arrows/Enter/Esc, `select` to drive it from a host model), so a
 //! single-column list and a table share one state type.
 //!
+//! Chrome follows the theme by default but is overridable, the same
+//! theme-by-default / explicit-override pattern as [`Boxed::border_color`]:
+//! [`Table::caret`] sets the gutter marker glyph, [`Table::header_style`]
+//! restyles the header row, and [`Table::preserve_selection_fg`] keeps each
+//! column's own color under the selection highlight.
+//!
 //! [`SelectList`]: crate::SelectList
+//! [`Boxed::border_color`]: crate::Boxed::border_color
 
 use ratatui::layout::Rect;
 use ratatui::style::Style;
@@ -27,6 +34,7 @@ use super::select::SelectState;
 use super::text::line_width;
 
 /// One table column: a header cell and a main-axis width policy.
+#[derive(Clone)]
 pub struct Column {
     header: Line<'static>,
     width: Dimension,
@@ -94,6 +102,9 @@ pub struct Table {
     gutter: bool,
     show_header: bool,
     gap: u16,
+    caret: char,
+    header_style: Option<Style>,
+    preserve_selection_fg: bool,
 }
 
 impl Table {
@@ -108,6 +119,9 @@ impl Table {
             gutter: true,
             show_header: true,
             gap: 2,
+            caret: '›',
+            header_style: None,
+            preserve_selection_fg: false,
         }
     }
 
@@ -139,6 +153,30 @@ impl Table {
     /// Columns of blank between adjacent columns (default 2).
     pub fn gap(mut self, gap: u16) -> Self {
         self.gap = gap;
+        self
+    }
+
+    /// The glyph marking the selected row in the gutter (default `›`). Let a
+    /// host keep an existing marker, e.g. `▶`.
+    pub fn caret(mut self, caret: char) -> Self {
+        self.caret = caret;
+        self
+    }
+
+    /// Style the header row explicitly, overriding the default
+    /// (`theme.accent_style()`) — the same theme-by-default, explicit-override
+    /// pattern as [`Boxed::border_color`](crate::Boxed::border_color).
+    pub fn header_style(mut self, style: Style) -> Self {
+        self.header_style = Some(style);
+        self
+    }
+
+    /// Keep each cell's own foreground on the selected row, applying only the
+    /// selection background (default off — the selected row is recolored to a
+    /// uniform `selection_style`). Turn this on for a table whose columns are
+    /// color-coded so those colors survive under the highlight.
+    pub fn preserve_selection_fg(mut self, preserve: bool) -> Self {
+        self.preserve_selection_fg = preserve;
         self
     }
 
@@ -264,17 +302,14 @@ impl View for Table {
         );
         let col_rects = self.solve_columns(cols_area);
 
-        // Header row.
+        // Header row — explicit `header_style` wins over the theme default.
         if self.show_header {
             let headers: Vec<Line<'static>> =
                 self.columns.iter().map(|c| c.header.clone()).collect();
-            self.draw_cells(
-                &headers,
-                &col_rects,
-                area.y,
-                Some(ctx.theme.accent_style()),
-                surface,
-            );
+            let header_style = self
+                .header_style
+                .unwrap_or_else(|| ctx.theme.accent_style());
+            self.draw_cells(&headers, &col_rects, area.y, Some(header_style), surface);
         }
 
         // Data rows, windowed around the selection.
@@ -295,12 +330,18 @@ impl View for Table {
                 // Highlight spans the whole row: gutter, columns, and gaps.
                 let mut band = surface.child(Rect::new(area.x, y, row_span_w, 1));
                 band.fill(sel);
-                Some(sel)
+                // Cells get the full selection style (uniform fg) by default, or
+                // just its background when preserving each column's own color.
+                Some(if self.preserve_selection_fg {
+                    Style::default().bg(ctx.theme.selection_bg)
+                } else {
+                    sel
+                })
             } else {
                 None
             };
             if self.gutter {
-                let caret = if selected { '›' } else { ' ' };
+                let caret = if selected { self.caret } else { ' ' };
                 let caret_style = if selected {
                     ctx.theme.selection_style()
                 } else {
@@ -363,7 +404,7 @@ mod tests {
     use crate::test_support::{buffer, rainbow_theme, row};
     use crate::view::{RenderCtx, View};
     use crate::{Size, Surface};
-    use ratatui::text::Line;
+    use ratatui::text::{Line, Span};
 
     fn sample() -> (Vec<Column>, Vec<Vec<Line<'static>>>) {
         let cols = vec![Column::auto("name"), Column::auto("kind")];
@@ -475,5 +516,84 @@ mod tests {
         let theme = Theme::default();
         let text = crate::testing::grid(&crate::testing::render(&table, 20, 2, &theme));
         assert!(text.contains("only"));
+    }
+
+    #[test]
+    fn table_custom_caret_marks_selection() {
+        let (cols, rows) = sample();
+        let mut state = SelectState::new();
+        state.select(0);
+        let table = Table::new(cols, rows, &state).caret('▶');
+        let mut buf = buffer(20, 3);
+        let theme = Theme::default();
+        let ctx = RenderCtx::new(&theme);
+        let area = buf.area;
+        let mut surface = Surface::new(&mut buf, area);
+        table.render(area, &mut surface, &ctx);
+        assert_eq!(
+            buf[(0, 1)].symbol(),
+            "▶",
+            "custom caret on the selected row"
+        );
+    }
+
+    #[test]
+    fn table_header_style_overrides_the_theme_default() {
+        use ratatui::style::{Color, Style};
+        let (cols, rows) = sample();
+        let t = rainbow_theme();
+        let state = SelectState::new();
+        let table =
+            Table::new(cols, rows, &state).header_style(Style::default().fg(Color::Indexed(200)));
+        let mut buf = buffer(20, 3);
+        let area = buf.area;
+        let ctx = RenderCtx::new(&t);
+        let mut surface = Surface::new(&mut buf, area);
+        table.render(area, &mut surface, &ctx);
+        // The header cell text uses the explicit color, not theme.accent.
+        assert_eq!(buf[(2, 0)].fg, Color::Indexed(200), "header 'name' fg");
+        assert_ne!(
+            Color::Indexed(200),
+            t.accent,
+            "and it differs from the default"
+        );
+    }
+
+    #[test]
+    fn table_preserve_selection_fg_keeps_cell_colors() {
+        use ratatui::style::{Color, Style};
+        let t = rainbow_theme();
+        let cols = vec![Column::auto("c")];
+        // A color-coded cell on the (only, selected) data row.
+        let rows = vec![vec![Line::from(Span::styled(
+            "ok",
+            Style::default().fg(Color::Indexed(46)),
+        ))]];
+        let state = SelectState::new(); // row 0 selected
+
+        let render = |preserve: bool| {
+            let table = Table::new(cols.clone(), rows.clone(), &state)
+                .preserve_selection_fg(preserve)
+                .gutter(false);
+            let mut buf = buffer(6, 2);
+            let area = buf.area;
+            let ctx = RenderCtx::new(&t);
+            let mut surface = Surface::new(&mut buf, area);
+            table.render(area, &mut surface, &ctx);
+            let cell = &buf[(0, 1)]; // first cell of the selected data row
+            (cell.fg, cell.bg)
+        };
+
+        // Preserve on: the cell keeps its own fg but gains the selection bg.
+        let (fg, bg) = render(true);
+        assert_eq!(
+            fg,
+            Color::Indexed(46),
+            "column color survives the highlight"
+        );
+        assert_eq!(bg, t.selection_bg, "selection background still applied");
+        // Default (off): the selected row is recolored to the uniform selection fg.
+        let (fg_off, _) = render(false);
+        assert_eq!(fg_off, t.selection_fg, "default overwrites cell fg");
     }
 }


### PR DESCRIPTION
## What changed

`Table`'s chrome followed the theme with no per-instance escape hatch. Three overrides now let a host match a prior look — the same theme-by-default / explicit-override pattern as `Boxed::border_color`:

- **`.caret(char)`** — the glyph marking the selected row in the gutter (default `›`), e.g. `▶`.
- **`.header_style(Style)`** — restyle the header row, overriding the default `theme.accent_style()`.
- **`.preserve_selection_fg(bool)`** — keep each cell's own foreground on the selected row (applying only the selection *background*), so a table whose columns are color-coded keeps those colors under the highlight instead of being recolored to the uniform selection fg. Default off (prior behavior).

Also derives `Clone` on `Column`. All additive; every default reproduces the prior rendering exactly.

## Why

Surfaced while adopting `Table` in a multi-pane TUI: none blocked adoption, but all three are "let a host match its prior look" niceties that the toolkit couldn't express. The caret was hard-coded, the header was forced to `theme.accent_style()`, and the selected row overwrote every cell's fg with a uniform `selection_style` — losing column color-coding under the highlight. This closes those out with the same override shape already used across the toolkit (`Boxed::border_color`, `Boxed::background`, `Paragraph::alignment`).

## Before / After

```rust
// Before: caret hard-coded ›; header always theme.accent; selection recolors cell fg.

// After:
Table::new(columns, rows, &state)
    .caret('▶')                       // keep an existing marker
    .header_style(my_header_style)     // restyle the header row
    .preserve_selection_fg(true);      // color-coded columns survive the highlight
```

The runnable `gallery` table box now demonstrates `▶` + `preserve_selection_fg(true)` with color-coded columns.

## Risk

- **Low.** Three additive builders + one field each; unset reproduces the exact prior behavior (default caret `›`, header `theme.accent_style()`, selection recolors cell fg). Not exercised by any iai bench, so instruction-count baselines are unaffected.

## Validation

- `cargo fmt --check` — clean
- `cargo clippy -p tuika --all-targets --all-features -- -D warnings` — clean
- `cargo test -p tuika --all-features` — 257 lib + 19 doctests pass, incl. new coverage:
  - a custom caret marks the selected row
  - `header_style` wins over the theme default (asserted on the rendered header cell fg)
  - `preserve_selection_fg(true)` keeps the cell's own fg and applies the selection bg, while the default overwrites fg with `selection_fg`
- `cargo build -p tuika --example gallery` — the updated table box builds

## Security

No security-relevant code changes — a rendering component in the `tuika` crate (no filesystem, shell, prompt/key, capability, or dependency changes).

## Follow-ups

No follow-ups — this completes the tuika adoption asks. (The whole series: aligned `Text`, bottom titles, `Flex::solve`, `Boxed::border_color` + `FocusScope`, `Table`, host-driven + horizontal `Scroll`, and now `Table` chrome overrides.)

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (purely additive; defaults reproduce prior behavior)

---
_Generated by [Claude Code](https://claude.ai/code/session_013X4ivPR4SXng9sr3RJbvQy)_