### PR TITLE
refactor(tuika): build on ratatui-core, drop the umbrella

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6793,6 +6793,8 @@ dependencies = [
  "proptest",
  "pulldown-cmark",
  "ratatui",
+ "ratatui-core",
+ "ratatui-crossterm",
  "textwrap",
  "tokio",
  "tokio-stream",

--- a/crates/tuika/Cargo.toml
+++ b/crates/tuika/Cargo.toml
@@ -31,7 +31,22 @@ bench = false
 async = ["dep:tokio", "dep:tokio-stream", "crossterm/event-stream"]
 
 [dependencies]
-ratatui = "0.30.2"
+# tuika uses only ratatui's cell buffer, style/text/layout primitives, the
+# `Widget`/`StatefulWidget` traits, and the `Terminal`/backend loop — all of
+# which live in `ratatui-core`. It renders none of ratatui's own widgets, so it
+# depends on the sub-crates directly instead of the `ratatui` umbrella. This
+# drops `ratatui-widgets` (Block/Paragraph/Table/Calendar/…) and `ratatui-macros`
+# — and with them the `time`/`lru`/`line-clipping` transitive weight — from
+# tuika's build. Downstream users keep every ratatui widget: they bring their own
+# `ratatui` and render it through `Surface::render_ratatui`/`RatatuiView`, whose
+# seam is a raw `&mut Buffer` from this same `ratatui-core` (Cargo unifies the
+# version). `underline-color` matches the umbrella default so cell rendering is
+# byte-identical; `std` is required for the terminal I/O loop.
+ratatui-core = { version = "0.1", features = ["std", "underline-color"] }
+# `CrosstermBackend` (+ `ClearType`/`WindowSize` impls) — the only piece tuika
+# needs that is not in `ratatui-core`. Default features pin the crossterm 0.29
+# backend, matching the direct `crossterm` dep below so Cargo dedups it.
+ratatui-crossterm = "0.1"
 crossterm = "0.29"
 # Async runner only (feature = "async"). `time` for the tick interval, `macros`
 # for `tokio::select!`; the host application brings its own runtime, so no `rt`.
@@ -48,9 +63,11 @@ pulldown-cmark = { version = "0.13", default-features = false }
 
 [dev-dependencies]
 proptest = "1"
-# Benches build `Vec<Line>` corpora and paint into a `Buffer` directly, so they
-# name ratatui types the library only re-exports selectively. Same version as the
-# normal dependency above.
+# The `ratatui` umbrella is a dev-dependency only: benches build `Vec<Line>`
+# corpora and paint into a `Buffer` directly, and the doc examples demonstrate
+# wrapping real ratatui *widgets* through `RatatuiView`/`Surface::render_ratatui`.
+# Its `ratatui-core` matches the version the library depends on, so the `Buffer`
+# type is shared across the interop seam.
 ratatui = "0.30.2"
 # Benchmark harness. default-features off drops the plotters/rayon HTML-report
 # stack (heavy, and an MSRV liability) while keeping `cargo bench` working;

--- a/crates/tuika/README.md
+++ b/crates/tuika/README.md
@@ -15,11 +15,16 @@ overlay, focus, and component primitives that `ratatui` leaves to you, while
 letting `ratatui` keep ownership of the cell buffer and its diff against the
 terminal.
 
-It is a published, self-contained crate that depends only on `ratatui`,
-`crossterm`, `textwrap`, `unicode-segmentation`, and `unicode-width`, and is
-host-agnostic — it knows nothing about the application embedding it. (The
-optional `async` feature adds Tokio for [`AsyncRunner`](#terminal-lifecycle-and-runner);
-it is off by default.)
+It is a published, self-contained crate that depends only on `ratatui-core`
+(plus `ratatui-crossterm` for the terminal backend), `crossterm`, `textwrap`,
+`unicode-segmentation`, and `unicode-width`, and is host-agnostic — it knows
+nothing about the application embedding it. tuika renders none of ratatui's own
+widgets, so it builds against `ratatui-core` directly rather than the `ratatui`
+umbrella — keeping `ratatui-widgets`, `ratatui-macros`, and their transitive
+weight out of its dependency tree. Your application still uses any ratatui
+widget it likes (see [Compatibility](#compatibility)). (The optional `async`
+feature adds Tokio for [`AsyncRunner`](#terminal-lifecycle-and-runner); it is
+off by default.)
 
 ## Install
 
@@ -28,8 +33,10 @@ cargo add tuika
 ```
 
 `ratatui` and `crossterm` are part of `tuika`'s public interoperability
-surface, so pin the same minor versions in your own crate and Cargo will
-deduplicate them (see [Compatibility](#compatibility)).
+surface, so add `ratatui` to your own crate and pin a compatible minor version.
+tuika depends on `ratatui-core`, which the `ratatui` umbrella re-exports, so
+Cargo unifies the shared `Buffer`/`Rect`/`Style` types and your widgets compose
+with tuika's surfaces (see [Compatibility](#compatibility)).
 
 ## Model
 
@@ -417,8 +424,15 @@ Building something on tuika? Open a PR adding it here.
 - Tuika 0.x follows Cargo semver: minor releases may make deliberate breaking
   API changes; patch releases do not.
 - Ratatui and Crossterm are part of Tuika's public interoperability surface.
-  Tuika tracks compatible minor lines deliberately; applications should use
-  matching versions so Cargo can deduplicate them.
+  Tuika builds against `ratatui-core` (and `ratatui-crossterm`) directly, not
+  the `ratatui` umbrella; the umbrella re-exports that same `ratatui-core`, so a
+  matching `ratatui` minor line in your application resolves to one shared
+  `ratatui-core` and Cargo deduplicates the core types. Widgets such as
+  `Block`/`Paragraph`/`Table` live in `ratatui-widgets` (pulled in by your
+  `ratatui` dependency, not by tuika) and compose through
+  [`Surface::render_ratatui`](https://docs.rs/tuika/latest/tuika/surface/struct.Surface.html#method.render_ratatui)
+  and [`RatatuiView`](https://docs.rs/tuika/latest/tuika/struct.RatatuiView.html),
+  whose seam is a raw `ratatui-core` `Buffer`.
 
 ## Extending
 

--- a/crates/tuika/src/async_runner.rs
+++ b/crates/tuika/src/async_runner.rs
@@ -61,8 +61,9 @@ use std::ops::ControlFlow;
 use std::time::Duration;
 
 use crossterm::event::EventStream;
-use ratatui::backend::{Backend, CrosstermBackend};
-use ratatui::{Terminal, TerminalOptions, Viewport};
+use ratatui_core::backend::Backend;
+use ratatui_core::terminal::{Terminal, TerminalOptions, Viewport};
+use ratatui_crossterm::CrosstermBackend;
 use tokio::time::{MissedTickBehavior, interval};
 use tokio_stream::{Stream, StreamExt};
 
@@ -174,14 +175,14 @@ impl AsyncRunner {
     /// The core loop: caller-owned `terminal` and `events`, no terminal
     /// lifecycle. This is what [`run`](Self::run) builds on, and the seam tests
     /// use to drive the runner against a
-    /// [`TestBackend`](ratatui::backend::TestBackend) with a scripted event
+    /// [`TestBackend`](ratatui_core::backend::TestBackend) with a scripted event
     /// stream. Hosts that already own their terminal and event source (or want a
     /// non-crossterm one) can call it directly.
     ///
     /// The backend error and the event-stream error share one type `Er`, which
     /// is the run's error type: for the real terminal that is [`io::Error`], but
     /// leaving it generic lets an infallible backend
-    /// ([`TestBackend`](ratatui::backend::TestBackend), whose error is
+    /// ([`TestBackend`](ratatui_core::backend::TestBackend), whose error is
     /// [`Infallible`](std::convert::Infallible)) pair with an infallible stream.
     ///
     /// `events` yields already-translated tuika [`Event`]s. An `Err` item ends
@@ -273,7 +274,7 @@ mod tests {
     use crate::components::Text;
     use crate::event::{Key, KeyCode};
     use crate::view::element;
-    use ratatui::backend::TestBackend;
+    use ratatui_core::backend::TestBackend;
 
     /// A key event as the infallible-stream item the `TestBackend` tests use.
     fn key(code: KeyCode) -> Result<Event, Infallible> {
@@ -431,8 +432,8 @@ mod tests {
     // given rect and never touches the terminal.
     #[tokio::test]
     async fn stream_error_propagates() {
-        use ratatui::backend::CrosstermBackend;
-        use ratatui::layout::Rect;
+        use ratatui_core::layout::Rect;
+        use ratatui_crossterm::CrosstermBackend;
 
         let runner = AsyncRunner::new(RunnerConfig {
             tick_rate: Duration::from_secs(3600),

--- a/crates/tuika/src/components/boxed.rs
+++ b/crates/tuika/src/components/boxed.rs
@@ -4,9 +4,9 @@
 //! explicit color for semantic frames (accent/danger modals, per-pane colors).
 //! This is `tuika`'s framing primitive (Pi's `DynamicBorder` / `Box`).
 
-use ratatui::layout::{Alignment, Rect};
-use ratatui::style::{Color, Style};
-use ratatui::text::Line;
+use ratatui_core::layout::{Alignment, Rect};
+use ratatui_core::style::{Color, Style};
+use ratatui_core::text::Line;
 
 use crate::geometry::{Padding, Size};
 use crate::style::{BorderStyle, Role};
@@ -260,7 +260,7 @@ mod tests {
     use crate::style::Theme;
     use crate::test_support::{buffer, rainbow_theme, row};
     use crate::view::{RenderCtx, View, element};
-    use ratatui::style::Color;
+    use ratatui_core::style::Color;
 
     #[test]
     fn boxed_border_closed_across_sizes() {

--- a/crates/tuika/src/components/code_block.rs
+++ b/crates/tuika/src/components/code_block.rs
@@ -11,9 +11,9 @@
 //! width, never word-wrapped) because indentation is meaningful in code — unlike
 //! prose, which [`Markdown`](crate::components::Markdown) word-wraps.
 
-use ratatui::layout::Rect;
-use ratatui::style::{Modifier, Style};
-use ratatui::text::{Line, Span};
+use ratatui_core::layout::Rect;
+use ratatui_core::style::{Modifier, Style};
+use ratatui_core::text::{Line, Span};
 
 use crate::components::text::line_width;
 use crate::geometry::Size;

--- a/crates/tuika/src/components/constrained.rs
+++ b/crates/tuika/src/components/constrained.rs
@@ -1,6 +1,6 @@
 //! Intrinsic min/max sizing for responsive flex children.
 
-use ratatui::layout::Rect;
+use ratatui_core::layout::Rect;
 
 use crate::{Element, RenderCtx, Size, Surface, View};
 

--- a/crates/tuika/src/components/flex.rs
+++ b/crates/tuika/src/components/flex.rs
@@ -6,8 +6,8 @@
 //! child into its rect through a clipped child surface. Nesting `Flex`es is how
 //! every screen is built.
 
-use ratatui::layout::Rect;
-use ratatui::style::Style;
+use ratatui_core::layout::Rect;
+use ratatui_core::style::Style;
 
 use crate::geometry::Size;
 use crate::layout::{Dimension, Item, LayoutStyle, solve};
@@ -132,7 +132,7 @@ impl Flex {
     ///
     /// ```
     /// use tuika::{Flex, Text, element};
-    /// use ratatui::layout::Rect;
+    /// use ratatui_core::layout::Rect;
     ///
     /// let flex = Flex::row()
     ///     .fixed(4, element(Text::raw("abcd")))

--- a/crates/tuika/src/components/focus_scope.rs
+++ b/crates/tuika/src/components/focus_scope.rs
@@ -10,7 +10,7 @@
 //! focus-aware view inside it (notably [`Boxed`](crate::Boxed)) recolors
 //! accordingly.
 
-use ratatui::layout::Rect;
+use ratatui_core::layout::Rect;
 
 use crate::geometry::Size;
 use crate::surface::Surface;
@@ -82,7 +82,7 @@ mod tests {
 
     /// The focus flag a `FocusScope` imposes on its subtree wins over the root
     /// context's flag — a `Boxed` inside picks the matching theme border color.
-    fn corner_color(scope_focused: bool, root_focused: bool) -> ratatui::style::Color {
+    fn corner_color(scope_focused: bool, root_focused: bool) -> ratatui_core::style::Color {
         let t = rainbow_theme();
         let mut buf = buffer(8, 3);
         let area = buf.area;

--- a/crates/tuika/src/components/key_hints.rs
+++ b/crates/tuika/src/components/key_hints.rs
@@ -1,7 +1,7 @@
 //! Compact, responsive key/action hints.
 
-use ratatui::layout::Rect;
-use ratatui::style::{Color, Style};
+use ratatui_core::layout::Rect;
+use ratatui_core::style::{Color, Style};
 
 use crate::width::str_cols;
 use crate::{RenderCtx, Size, Surface, View};

--- a/crates/tuika/src/components/loader.rs
+++ b/crates/tuika/src/components/loader.rs
@@ -4,7 +4,7 @@
 //! [`Boxed`](super::Boxed) when they want a frame; on its own it fits inline in
 //! a status row or overlay.
 
-use ratatui::layout::Rect;
+use ratatui_core::layout::Rect;
 
 use crate::geometry::Size;
 use crate::surface::Surface;

--- a/crates/tuika/src/components/progress_bar.rs
+++ b/crates/tuika/src/components/progress_bar.rs
@@ -4,8 +4,8 @@
 //! bar shows 160 distinct levels. Indeterminate bars slide a bright segment
 //! across a dim track, driven by the host frame counter (see [`crate::anim`]).
 
-use ratatui::layout::Rect;
-use ratatui::style::Style;
+use ratatui_core::layout::Rect;
+use ratatui_core::style::Style;
 
 use crate::anim;
 use crate::geometry::Size;
@@ -25,8 +25,8 @@ pub struct ProgressBar {
     frame: u64,
     /// Append a right-aligned `NN%` label to a determinate bar.
     show_percent: bool,
-    filled: Option<ratatui::style::Color>,
-    track: Option<ratatui::style::Color>,
+    filled: Option<ratatui_core::style::Color>,
+    track: Option<ratatui_core::style::Color>,
 }
 
 impl ProgressBar {
@@ -59,7 +59,11 @@ impl ProgressBar {
     }
 
     /// Override the filled and track colors (default to theme accent and dim).
-    pub fn colors(mut self, filled: ratatui::style::Color, track: ratatui::style::Color) -> Self {
+    pub fn colors(
+        mut self,
+        filled: ratatui_core::style::Color,
+        track: ratatui_core::style::Color,
+    ) -> Self {
         self.filled = Some(filled);
         self.track = Some(track);
         self
@@ -170,7 +174,7 @@ mod tests {
     use crate::style::Theme;
     use crate::test_support::{buffer, rainbow_theme, row};
     use crate::view::{RenderCtx, View};
-    use ratatui::style::Color;
+    use ratatui_core::style::Color;
 
     #[test]
     fn progress_bar_determinate_fills_by_fraction() {

--- a/crates/tuika/src/components/responsive.rs
+++ b/crates/tuika/src/components/responsive.rs
@@ -1,6 +1,6 @@
 //! Width-driven view selection for responsive terminal layouts.
 
-use ratatui::layout::Rect;
+use ratatui_core::layout::Rect;
 
 use crate::{Element, RenderCtx, Size, Surface, View};
 

--- a/crates/tuika/src/components/rule.rs
+++ b/crates/tuika/src/components/rule.rs
@@ -6,9 +6,9 @@
 //! the reusable form of the blue/gold separators a chat UI draws above and
 //! below its composer.
 
-use ratatui::layout::Rect;
-use ratatui::style::Style;
-use ratatui::text::{Line, Span};
+use ratatui_core::layout::Rect;
+use ratatui_core::style::Style;
+use ratatui_core::text::{Line, Span};
 
 use super::line_width;
 use crate::geometry::Size;
@@ -96,8 +96,8 @@ mod tests {
     use super::*;
     use crate::style::Theme;
     use crate::test_support::row;
-    use ratatui::style::{Color, Style};
-    use ratatui::text::{Line, Span};
+    use ratatui_core::style::{Color, Style};
+    use ratatui_core::text::{Line, Span};
 
     #[test]
     fn rule_renders_title_then_fills_to_width() {

--- a/crates/tuika/src/components/scroll.rs
+++ b/crates/tuika/src/components/scroll.rs
@@ -20,9 +20,9 @@
 //! [`max_x_offset`](ScrollState::max_x_offset) expose the in-range bounds for a
 //! host that drives the offsets itself.
 
-use ratatui::layout::Rect;
-use ratatui::style::Style;
-use ratatui::text::Line;
+use ratatui_core::layout::Rect;
+use ratatui_core::style::Style;
+use ratatui_core::text::Line;
 
 use crate::event::{Event, EventFlow, KeyCode, MouseKind};
 use crate::geometry::Size;
@@ -363,8 +363,8 @@ mod tests {
     use crate::style::Theme;
     use crate::test_support::{buffer, rainbow_theme, row};
     use crate::view::{RenderCtx, View};
-    use ratatui::style::Color;
-    use ratatui::text::{Line, Span};
+    use ratatui_core::style::Color;
+    use ratatui_core::text::{Line, Span};
 
     #[test]
     fn scroll_sticks_to_bottom_until_scrolled_up() {

--- a/crates/tuika/src/components/select.rs
+++ b/crates/tuika/src/components/select.rs
@@ -5,9 +5,9 @@
 //! the theme selection style and a caret. Enter is surfaced to the host via
 //! [`SelectOutcome`] so the caller decides what "confirm" means.
 
-use ratatui::layout::Rect;
-use ratatui::style::Style;
-use ratatui::text::Line;
+use ratatui_core::layout::Rect;
+use ratatui_core::style::Style;
+use ratatui_core::text::Line;
 
 use crate::event::{Event, EventFlow, KeyCode};
 use crate::geometry::Size;
@@ -114,7 +114,7 @@ impl SelectState {
 /// # Example
 ///
 /// ```
-/// use ratatui::text::Line;
+/// use ratatui_core::text::Line;
 /// use tuika::{SelectList, SelectState, Theme};
 /// use tuika::testing::{grid, render};
 ///
@@ -280,7 +280,7 @@ mod tests {
     use crate::test_support::{buffer, rainbow_theme, row};
     use crate::view::{RenderCtx, View};
     use crate::{Size, Surface};
-    use ratatui::text::Line;
+    use ratatui_core::text::Line;
 
     #[test]
     fn select_navigation_wraps_and_confirms() {
@@ -344,7 +344,7 @@ mod tests {
         assert!(row(&buf, 1).contains("beta"));
         // Selected row carries the selection background.
         assert_eq!(buf[(0, 1)].bg, theme.selection_bg);
-        assert_eq!(buf[(0, 0)].bg, ratatui::style::Color::Reset);
+        assert_eq!(buf[(0, 0)].bg, ratatui_core::style::Color::Reset);
     }
 
     #[test]

--- a/crates/tuika/src/components/spacer.rs
+++ b/crates/tuika/src/components/spacer.rs
@@ -1,7 +1,7 @@
 //! Spacer — empty, flexible filler. Paints nothing; useful as a
 //! `Dimension::Flex` child to push siblings apart, or fixed to insert a gap.
 
-use ratatui::layout::Rect;
+use ratatui_core::layout::Rect;
 
 use crate::geometry::Size;
 use crate::surface::Surface;

--- a/crates/tuika/src/components/spinner.rs
+++ b/crates/tuika/src/components/spinner.rs
@@ -4,8 +4,8 @@
 //! for that frame. Pair with a steady tick (yolop advances `busy_frame` every
 //! loop iteration while a turn runs) for smooth motion.
 
-use ratatui::layout::Rect;
-use ratatui::style::Style;
+use ratatui_core::layout::Rect;
+use ratatui_core::style::Style;
 
 use crate::geometry::Size;
 use crate::surface::Surface;
@@ -40,7 +40,7 @@ impl SpinnerStyle {
 pub struct Spinner {
     style: SpinnerStyle,
     frame: u64,
-    color: Option<ratatui::style::Color>,
+    color: Option<ratatui_core::style::Color>,
 }
 
 impl Spinner {
@@ -60,7 +60,7 @@ impl Spinner {
     }
 
     /// Override the glyph color (defaults to the theme accent).
-    pub fn color(mut self, color: ratatui::style::Color) -> Self {
+    pub fn color(mut self, color: ratatui_core::style::Color) -> Self {
         self.color = Some(color);
         self
     }

--- a/crates/tuika/src/components/status_bar.rs
+++ b/crates/tuika/src/components/status_bar.rs
@@ -2,9 +2,9 @@
 //! surface-colored background. Used for the full-screen renderer's model /
 //! mode / token line, mirroring yolop's inline status chrome.
 
-use ratatui::layout::Rect;
-use ratatui::style::Style;
-use ratatui::text::Span;
+use ratatui_core::layout::Rect;
+use ratatui_core::style::Style;
+use ratatui_core::text::Span;
 
 use crate::geometry::Size;
 use crate::surface::Surface;
@@ -106,7 +106,7 @@ mod tests {
     use crate::Surface;
     use crate::test_support::{buffer, rainbow_theme};
     use crate::view::{RenderCtx, View};
-    use ratatui::text::Span;
+    use ratatui_core::text::Span;
 
     #[test]
     fn status_bar_background_is_theme_surface() {

--- a/crates/tuika/src/components/table.rs
+++ b/crates/tuika/src/components/table.rs
@@ -21,9 +21,9 @@
 //! [`SelectList`]: crate::SelectList
 //! [`Boxed::border_color`]: crate::Boxed::border_color
 
-use ratatui::layout::Rect;
-use ratatui::style::Style;
-use ratatui::text::Line;
+use ratatui_core::layout::Rect;
+use ratatui_core::style::Style;
+use ratatui_core::text::Line;
 
 use crate::geometry::Size;
 use crate::layout::{Dimension, Item, LayoutStyle, solve};
@@ -75,7 +75,7 @@ impl Column {
 /// # Example
 ///
 /// ```
-/// use ratatui::text::Line;
+/// use ratatui_core::text::Line;
 /// use tuika::{Column, Table, SelectState, Theme};
 /// use tuika::testing::{grid, render};
 ///
@@ -404,7 +404,7 @@ mod tests {
     use crate::test_support::{buffer, rainbow_theme, row};
     use crate::view::{RenderCtx, View};
     use crate::{Size, Surface};
-    use ratatui::text::{Line, Span};
+    use ratatui_core::text::{Line, Span};
 
     fn sample() -> (Vec<Column>, Vec<Vec<Line<'static>>>) {
         let cols = vec![Column::auto("name"), Column::auto("kind")];
@@ -539,7 +539,7 @@ mod tests {
 
     #[test]
     fn table_header_style_overrides_the_theme_default() {
-        use ratatui::style::{Color, Style};
+        use ratatui_core::style::{Color, Style};
         let (cols, rows) = sample();
         let t = rainbow_theme();
         let state = SelectState::new();
@@ -561,7 +561,7 @@ mod tests {
 
     #[test]
     fn table_preserve_selection_fg_keeps_cell_colors() {
-        use ratatui::style::{Color, Style};
+        use ratatui_core::style::{Color, Style};
         let t = rainbow_theme();
         let cols = vec![Column::auto("c")];
         // A color-coded cell on the (only, selected) data row.

--- a/crates/tuika/src/components/tabs.rs
+++ b/crates/tuika/src/components/tabs.rs
@@ -1,8 +1,8 @@
 //! Focus-independent tab navigation with host-owned selection state.
 
-use ratatui::layout::Rect;
-use ratatui::style::{Modifier, Style};
-use ratatui::text::Line;
+use ratatui_core::layout::Rect;
+use ratatui_core::style::{Modifier, Style};
+use ratatui_core::text::Line;
 
 use crate::{Event, EventFlow, KeyCode, RenderCtx, Size, Surface, View};
 
@@ -117,7 +117,7 @@ mod tests {
     use crate::event::{Event, EventFlow, Key, KeyCode};
     use crate::style::Theme;
     use crate::test_support::row;
-    use ratatui::text::Line;
+    use ratatui_core::text::Line;
 
     #[test]
     fn tabs_state_wraps_and_tabs_render_selection() {
@@ -138,7 +138,7 @@ mod tests {
         assert!(
             rendered[(10, 0)]
                 .modifier
-                .contains(ratatui::style::Modifier::UNDERLINED)
+                .contains(ratatui_core::style::Modifier::UNDERLINED)
         );
     }
 }

--- a/crates/tuika/src/components/text.rs
+++ b/crates/tuika/src/components/text.rs
@@ -13,9 +13,9 @@
 //! every row it reflows to. [`Paragraph`] takes a single alignment for the whole
 //! block via [`Paragraph::alignment`].
 
-use ratatui::layout::{Alignment, Rect};
-use ratatui::style::Style;
-use ratatui::text::{Line, Span};
+use ratatui_core::layout::{Alignment, Rect};
+use ratatui_core::style::Style;
+use ratatui_core::text::{Line, Span};
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::geometry::Size;
@@ -75,7 +75,7 @@ pub fn line_width(line: &Line) -> u16 {
 ///
 /// ```
 /// use tuika::{Text, Theme};
-/// use ratatui::text::Line;
+/// use ratatui_core::text::Line;
 /// # use tuika::testing::render;
 /// let view = Text::new(vec![
 ///     Line::from("left"),
@@ -354,8 +354,8 @@ mod tests {
     use crate::test_support::{buffer, row};
     use crate::view::{RenderCtx, View};
     use crate::{Size, Surface};
-    use ratatui::style::{Color, Modifier, Style};
-    use ratatui::text::{Line, Span};
+    use ratatui_core::style::{Color, Modifier, Style};
+    use ratatui_core::text::{Line, Span};
 
     /// Concatenated text of a line's spans.
     fn line_text(line: &Line) -> String {

--- a/crates/tuika/src/components/textinput.rs
+++ b/crates/tuika/src/components/textinput.rs
@@ -14,8 +14,8 @@
 //! `set_cursor_position`. Hosts can configure whether Enter or Shift+Enter
 //! submits via [`TextInputMode`]; the other chord inserts a newline.
 
-use ratatui::layout::Rect;
-use ratatui::style::Style;
+use ratatui_core::layout::Rect;
+use ratatui_core::style::Style;
 use unicode_width::UnicodeWidthChar;
 
 use crate::event::{Event, KeyCode};
@@ -695,7 +695,7 @@ mod tests {
     use crate::event::{Event, Key, KeyCode};
     use crate::test_support::{render_el, render_view_rows};
     use crate::view::element;
-    use ratatui::layout::Rect;
+    use ratatui_core::layout::Rect;
 
     fn press(state: &mut TextInputState, code: KeyCode) -> bool {
         state.handle(&Event::Key(Key::new(code)))

--- a/crates/tuika/src/geometry.rs
+++ b/crates/tuika/src/geometry.rs
@@ -1,12 +1,12 @@
 //! Geometry helpers shared across `tuika`.
 //!
 //! `tuika` reuses ratatui's [`Rect`] as its area type so the compositor can
-//! draw straight into a ratatui [`Buffer`](ratatui::buffer::Buffer), but the
+//! draw straight into a ratatui [`Buffer`](ratatui_core::buffer::Buffer), but the
 //! layout solver reasons about a direction-agnostic main/cross axis. The
 //! helpers here bridge the two: an [`Axis`] projects a `Rect` onto its main or
 //! cross extent so the flex solver can be written once for rows and columns.
 
-use ratatui::layout::Rect;
+use ratatui_core::layout::Rect;
 
 /// An intrinsic size in terminal cells.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]

--- a/crates/tuika/src/highlight.rs
+++ b/crates/tuika/src/highlight.rs
@@ -10,7 +10,7 @@
 //! token colors. The companion crate `tuika-codeformatters` ships a tree-sitter
 //! implementation; hosts can also write their own.
 
-use ratatui::text::Span;
+use ratatui_core::text::Span;
 
 use crate::style::Theme;
 

--- a/crates/tuika/src/host.rs
+++ b/crates/tuika/src/host.rs
@@ -20,9 +20,9 @@ use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
     is_raw_mode_enabled,
 };
-use ratatui::buffer::Buffer;
-use ratatui::layout::Rect;
-use ratatui::style::Style;
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::Rect;
+use ratatui_core::style::Style;
 
 use super::event::{Event, Key, KeyCode, Mouse, MouseButton, MouseKind};
 use super::style::{StyleSheet, Theme};
@@ -254,9 +254,9 @@ mod tests {
     use crate::style::Theme;
     use crate::test_support::{buffer, rainbow_theme, row};
     use crate::view::{Element, element};
-    use ratatui::buffer::Buffer;
-    use ratatui::layout::Rect;
-    use ratatui::text::{Line, Span};
+    use ratatui_core::buffer::Buffer;
+    use ratatui_core::layout::Rect;
+    use ratatui_core::text::{Line, Span};
 
     /// A representative tree: a scrollable bordered body, a progress bar, and a
     /// status bar — the shapes the full-screen renderer actually composes.

--- a/crates/tuika/src/hyperlink.rs
+++ b/crates/tuika/src/hyperlink.rs
@@ -28,11 +28,12 @@ use crossterm::style::{
     Attribute, Color as CtColor, Print, ResetColor, SetAttribute, SetBackgroundColor,
     SetForegroundColor,
 };
-use ratatui::backend::{Backend, ClearType, CrosstermBackend, WindowSize};
-use ratatui::buffer::Cell;
-use ratatui::layout::{Position, Size};
-use ratatui::style::{Color, Modifier};
-use ratatui::text::{Line, Span};
+use ratatui_core::backend::{Backend, ClearType, WindowSize};
+use ratatui_core::buffer::Cell;
+use ratatui_core::layout::{Position, Size};
+use ratatui_core::style::{Color, Modifier};
+use ratatui_core::text::{Line, Span};
+use ratatui_crossterm::CrosstermBackend;
 
 /// String terminator for an OSC sequence: `ESC \`.
 const ST: &str = "\x1b\\";
@@ -158,8 +159,8 @@ fn sanitize_url(url: &str, policy: LinkPolicy) -> Option<String> {
 /// remains the host's responsibility.
 pub fn ctrl_click_url(
     event: &crate::Mouse,
-    buffer: &ratatui::buffer::Buffer,
-    area: ratatui::layout::Rect,
+    buffer: &ratatui_core::buffer::Buffer,
+    area: ratatui_core::layout::Rect,
 ) -> Option<String> {
     if event.kind != crate::MouseKind::Up(crate::MouseButton::Left)
         || !event.ctrl
@@ -545,7 +546,7 @@ mod tests {
     fn write_line_emits_color_and_underline_then_resets() {
         let line = Line::from(Span::styled(
             "https://a.dev",
-            ratatui::style::Style::default()
+            ratatui_core::style::Style::default()
                 .fg(Color::Rgb(45, 91, 158))
                 .add_modifier(Modifier::UNDERLINED),
         ));
@@ -572,7 +573,7 @@ mod tests {
     #[test]
     fn ctrl_click_returns_visible_url_under_pointer() {
         use crate::{Mouse, MouseButton, MouseKind};
-        use ratatui::{buffer::Buffer, layout::Rect, style::Style};
+        use ratatui_core::{buffer::Buffer, layout::Rect, style::Style};
         let area = Rect::new(3, 2, 40, 1);
         let mut buffer = Buffer::empty(Rect::new(0, 0, 50, 5));
         buffer.set_string(
@@ -592,7 +593,7 @@ mod tests {
     #[test]
     fn ctrl_click_ignores_plain_clicks_and_non_url_text() {
         use crate::{Mouse, MouseButton, MouseKind};
-        use ratatui::{buffer::Buffer, layout::Rect, style::Style};
+        use ratatui_core::{buffer::Buffer, layout::Rect, style::Style};
         let area = Rect::new(0, 0, 30, 1);
         let mut buffer = Buffer::empty(area);
         buffer.set_string(0, 0, "https://example.com plain", Style::default());
@@ -690,7 +691,7 @@ mod tests {
     /// Render a row of single-char cells through a backend built with `policy`
     /// and return the emitted bytes.
     fn draw_row_with(text: &str, policy: LinkPolicy) -> String {
-        use ratatui::buffer::Cell;
+        use ratatui_core::buffer::Cell;
         let cells: Vec<(u16, u16, Cell)> = text
             .chars()
             .enumerate()

--- a/crates/tuika/src/image.rs
+++ b/crates/tuika/src/image.rs
@@ -34,8 +34,8 @@ use std::io::{self, Write};
 use std::rc::Rc;
 use std::sync::Arc;
 
-use ratatui::layout::Rect;
-use ratatui::style::{Modifier, Style};
+use ratatui_core::layout::Rect;
+use ratatui_core::style::{Modifier, Style};
 
 use crate::geometry::Size;
 use crate::surface::Surface;

--- a/crates/tuika/src/integration.rs
+++ b/crates/tuika/src/integration.rs
@@ -5,7 +5,7 @@
 //! no single owner: composing a real tree, and surviving tiny/degenerate
 //! screens where scroll and overlay resolution interact.
 
-use ratatui::text::{Line, Span};
+use ratatui_core::text::{Line, Span};
 
 use crate::components::{Boxed, Flex, Scroll, ScrollState, StatusBar, Text};
 use crate::overlay::OverlaySpec;
@@ -16,7 +16,7 @@ use crate::view::{RenderCtx, View, element};
 
 #[test]
 fn scroll_and_overlay_survive_tiny_screens() {
-    use ratatui::layout::Rect;
+    use ratatui_core::layout::Rect;
 
     // A tall scroll region rendered into a 1×1 viewport.
     let lines: Vec<Line<'static>> = (0..50).map(|i| Line::from(format!("l{i}"))).collect();

--- a/crates/tuika/src/layout.rs
+++ b/crates/tuika/src/layout.rs
@@ -7,7 +7,7 @@
 //! rects for one axis. It is written once against a direction-agnostic
 //! [`Axis`] so rows and columns share the same code path.
 
-use ratatui::layout::Rect;
+use ratatui_core::layout::Rect;
 
 use super::geometry::{Axis, Padding, Size};
 
@@ -173,7 +173,7 @@ impl Item {
 ///
 /// ```
 /// use tuika::{Dimension, Item, LayoutStyle, Size, solve};
-/// use ratatui::layout::Rect;
+/// use ratatui_core::layout::Rect;
 ///
 /// // A sidebar of 8 columns, then the rest of the row for content.
 /// let items = [
@@ -295,7 +295,7 @@ pub fn solve(area: Rect, style: &LayoutStyle, items: &[Item]) -> Vec<Rect> {
 mod tests {
     use super::*;
     use crate::geometry::{Padding, Size};
-    use ratatui::layout::Rect;
+    use ratatui_core::layout::Rect;
 
     fn item(dim: Dimension, w: u16, h: u16) -> Item {
         Item::new(dim, Size::new(w, h))

--- a/crates/tuika/src/lib.rs
+++ b/crates/tuika/src/lib.rs
@@ -5,7 +5,10 @@
 //! solver, anchored overlays, focus/input-ownership, an alternate-screen host,
 //! and a set of components (text, boxes, scroll, select, spinner, progress) —
 //! while letting ratatui keep ownership of the cell buffer and its diff against
-//! the terminal. It depends only on `ratatui`, `crossterm`, `textwrap`,
+//! the terminal. It builds against `ratatui-core` (and `ratatui-crossterm` for
+//! the backend) directly rather than the `ratatui` umbrella — it renders none of
+//! ratatui's own widgets — so `ratatui-widgets` and `ratatui-macros` stay out of
+//! its dependency tree. It otherwise depends only on `crossterm`, `textwrap`,
 //! `unicode-segmentation`, and `unicode-width`.
 //!
 //! It was extracted from the [yolop](https://github.com/everruns/yolop) coding

--- a/crates/tuika/src/live.rs
+++ b/crates/tuika/src/live.rs
@@ -7,7 +7,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 
-use ratatui::layout::Rect;
+use ratatui_core::layout::Rect;
 
 use crate::{Element, RenderCtx, Size, Surface, View};
 

--- a/crates/tuika/src/macros.rs
+++ b/crates/tuika/src/macros.rs
@@ -152,8 +152,8 @@ mod tests {
     use crate::test_support::render_el;
     use crate::view::{Element, RenderCtx, View, element};
     use crate::{Size, Surface};
-    use ratatui::layout::Rect;
-    use ratatui::style::Style;
+    use ratatui_core::layout::Rect;
+    use ratatui_core::style::Style;
 
     #[test]
     fn view_macro_matches_builder() {
@@ -202,7 +202,7 @@ mod tests {
 
     #[test]
     fn view_macro_forwards_border_color() {
-        use ratatui::style::Color;
+        use ratatui_core::style::Color;
         // `border_color =` folds to `Boxed::border_color`, rendering identically
         // to the builder form.
         let built: Element =

--- a/crates/tuika/src/markdown.rs
+++ b/crates/tuika/src/markdown.rs
@@ -21,9 +21,9 @@
 //! in a layout.
 
 use pulldown_cmark::{Alignment, CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, TagEnd};
-use ratatui::layout::Rect;
-use ratatui::style::{Modifier, Style};
-use ratatui::text::{Line, Span};
+use ratatui_core::layout::Rect;
+use ratatui_core::style::{Modifier, Style};
+use ratatui_core::text::{Line, Span};
 
 use crate::components::code_block::code_block_lines;
 use crate::components::{line_width, wrap_lines};
@@ -1471,7 +1471,7 @@ mod tests {
 
     #[test]
     fn custom_sheet_restyles_both_links_and_bare_urls() {
-        use ratatui::style::Color;
+        use ratatui_core::style::Color;
         let theme = Theme::default();
         // One central rule remaps the link role: green + bold, no underline.
         let sheet = StyleSheet {
@@ -1506,7 +1506,7 @@ mod tests {
 
     #[test]
     fn custom_sheet_restyles_headings() {
-        use ratatui::style::Color;
+        use ratatui_core::style::Color;
         let theme = Theme::default();
         let sheet = StyleSheet {
             heading: StyleBundle::new().fg(Color::Magenta).italic(),
@@ -1523,7 +1523,7 @@ mod tests {
 
     #[test]
     fn sheet_change_invalidates_stream_cache() {
-        use ratatui::style::Color;
+        use ratatui_core::style::Color;
         let theme = Theme::default();
         let mut state = MarkdownState::new();
         state.set("A [link](https://ex.com) in prose.");
@@ -1687,7 +1687,7 @@ mod tests {
         assert!(state.stable_len > 0);
 
         let mut b = Theme::default();
-        b.code.heading = ratatui::style::Color::Indexed(200);
+        b.code.heading = ratatui_core::style::Color::Indexed(200);
         let _ = state.lines(40, &b, &StyleSheet::from_theme(&b), CodeHighlighter::Plain);
         // Cache was rebuilt under the new theme; still consistent, no stale panic.
         assert_eq!(state.cached_theme, Some(b));

--- a/crates/tuika/src/mouse.rs
+++ b/crates/tuika/src/mouse.rs
@@ -23,9 +23,9 @@
 //! `Down`+`Up`, a swipe is `ScrollUp`/`ScrollDown` or a `Drag`), so touch input
 //! flows through this same path — there is no separate touch event to model.
 
-use ratatui::buffer::Buffer;
-use ratatui::layout::Rect;
-use ratatui::style::Style;
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::Rect;
+use ratatui_core::style::Style;
 use std::time::{Duration, Instant};
 
 use crate::event::{Mouse, MouseButton, MouseKind};
@@ -371,8 +371,8 @@ mod tests {
     use crate::components::Text;
     use crate::event::{Mouse, MouseButton, MouseKind};
     use crate::style::Theme;
-    use ratatui::layout::Rect;
-    use ratatui::style::{Color, Style};
+    use ratatui_core::layout::Rect;
+    use ratatui_core::style::{Color, Style};
 
     fn down(col: u16, row: u16) -> Mouse {
         Mouse::at(MouseKind::Down(MouseButton::Left), col, row)
@@ -474,7 +474,7 @@ mod tests {
 
     #[test]
     fn selected_text_spans_rows_linearly() {
-        use ratatui::text::Line;
+        use ratatui_core::text::Line;
         let theme = Theme::default();
         let lines = vec![Line::from("hello"), Line::from("world")];
         let buf = crate::testing::render(&Text::new(lines), 5, 2, &theme);

--- a/crates/tuika/src/overlay.rs
+++ b/crates/tuika/src/overlay.rs
@@ -7,7 +7,7 @@
 //! [`OverlaySpec`] resolves a target [`Rect`] from an [`Anchor`] plus size
 //! constraints relative to the screen.
 
-use ratatui::layout::Rect;
+use ratatui_core::layout::Rect;
 
 use super::geometry::Size;
 
@@ -64,7 +64,7 @@ impl Extent {
 ///
 /// ```
 /// use tuika::OverlaySpec;
-/// use ratatui::layout::Rect;
+/// use ratatui_core::layout::Rect;
 ///
 /// // A centered dialog at 50% × 40% of a 100 × 40 screen, never smaller than 34 × 7.
 /// let rect = OverlaySpec::centered(50, 40).min_size(34, 7).resolve(Rect::new(0, 0, 100, 40));
@@ -190,7 +190,7 @@ impl OverlaySpec {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ratatui::layout::Rect;
+    use ratatui_core::layout::Rect;
 
     #[test]
     fn overlay_centered_percentage() {

--- a/crates/tuika/src/probe.rs
+++ b/crates/tuika/src/probe.rs
@@ -23,7 +23,7 @@
 use std::cell::Cell;
 use std::rc::Rc;
 
-use ratatui::layout::Rect;
+use ratatui_core::layout::Rect;
 
 use crate::geometry::Size;
 use crate::surface::Surface;
@@ -95,7 +95,7 @@ mod tests {
     use crate::components::{Flex, Text};
     use crate::style::Theme;
     use crate::view::element;
-    use ratatui::layout::Rect;
+    use ratatui_core::layout::Rect;
 
     #[test]
     fn probe_reports_the_rect_a_view_was_painted_into() {

--- a/crates/tuika/src/proptests.rs
+++ b/crates/tuika/src/proptests.rs
@@ -6,7 +6,7 @@
 //! the resize suite is exactly the kind proptest finds automatically).
 
 use proptest::prelude::*;
-use ratatui::layout::Rect;
+use ratatui_core::layout::Rect;
 
 use super::geometry::{Axis, Padding, Size};
 use super::layout::{Align, Dimension, Direction, Item, Justify, LayoutStyle, solve};

--- a/crates/tuika/src/ratatui_view.rs
+++ b/crates/tuika/src/ratatui_view.rs
@@ -4,8 +4,8 @@
 //! [`Surface::render_ratatui`](crate::Surface::render_ratatui), so arbitrary
 //! widget code never receives the frame's underlying buffer.
 
-use ratatui::buffer::Buffer;
-use ratatui::layout::Rect;
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::Rect;
 
 use crate::{RenderCtx, Size, Surface, View};
 

--- a/crates/tuika/src/runner.rs
+++ b/crates/tuika/src/runner.rs
@@ -10,8 +10,9 @@ use std::ops::ControlFlow;
 use std::time::{Duration, Instant};
 
 use crossterm::event;
-use ratatui::backend::{Backend, CrosstermBackend};
-use ratatui::{Terminal, TerminalOptions, Viewport};
+use ratatui_core::backend::Backend;
+use ratatui_core::terminal::{Terminal, TerminalOptions, Viewport};
+use ratatui_crossterm::CrosstermBackend;
 
 use crate::{Element, Event, RedrawHandle, TerminalSession, Theme, paint, translate_event};
 

--- a/crates/tuika/src/snapshots.rs
+++ b/crates/tuika/src/snapshots.rs
@@ -7,9 +7,9 @@
 //! To (re)generate after an intentional change:
 //! `UPDATE_SNAPSHOTS=1 cargo test --all-features tuika::snapshots`.
 
-use ratatui::buffer::Buffer;
-use ratatui::layout::Rect;
-use ratatui::text::{Line, Span};
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::Rect;
+use ratatui_core::text::{Line, Span};
 
 use super::components::{
     Boxed, Flex, ProgressBar, Scroll, ScrollState, SelectList, SelectState, Spinner, SpinnerStyle,

--- a/crates/tuika/src/style.rs
+++ b/crates/tuika/src/style.rs
@@ -6,7 +6,7 @@
 //! restyles every component at once, and downstream libraries can ship their
 //! own palette without touching component code.
 
-use ratatui::style::{Color, Modifier, Style};
+use ratatui_core::style::{Color, Modifier, Style};
 
 use crate::geometry::Padding;
 
@@ -382,7 +382,7 @@ pub enum Role {
 ///
 /// ```
 /// use tuika::{StyleBundle, StyleSheet, Theme};
-/// use ratatui::style::Color;
+/// use ratatui_core::style::Color;
 ///
 /// let theme = Theme::default();
 /// let sheet = StyleSheet {
@@ -471,7 +471,7 @@ impl Default for StyleSheet {
 mod tests {
     use super::*;
     use crate::test_support::rainbow_theme;
-    use ratatui::style::Modifier;
+    use ratatui_core::style::Modifier;
 
     #[test]
     fn theme_helper_styles_map_to_slots() {
@@ -490,7 +490,7 @@ mod tests {
 
     #[test]
     fn default_theme_is_the_toolkit_identity_not_a_host_brand() {
-        use ratatui::style::Color;
+        use ratatui_core::style::Color;
         // tuika's own look is warm red-on-dark. It is deliberately a neutral toolkit
         // identity, not any host's brand — a host with its own palette builds its own
         // `Theme` (e.g. yolop's `fullscreen::yolop_theme`) instead of inheriting this.
@@ -503,7 +503,7 @@ mod tests {
 
     #[test]
     fn bundle_apply_overrides_color_but_only_adds_modifiers() {
-        use ratatui::style::Color;
+        use ratatui_core::style::Color;
         // A modifier-only bundle keeps the base's color and adds its modifier.
         let base = Style::default().fg(Color::Red);
         let emphasized = StyleBundle::new().italic().apply(base);
@@ -543,7 +543,7 @@ mod tests {
 
     #[test]
     fn overriding_one_role_leaves_the_rest_at_theme_defaults() {
-        use ratatui::style::Color;
+        use ratatui_core::style::Color;
         let t = rainbow_theme();
         let sheet = StyleSheet {
             link: StyleBundle::new().fg(Color::Green).bold(),

--- a/crates/tuika/src/surface.rs
+++ b/crates/tuika/src/surface.rs
@@ -7,9 +7,9 @@
 //! still owns the shadow-buffer diff against the terminal, so `tuika` pays
 //! nothing extra for dirty-cell tracking.
 
-use ratatui::buffer::Buffer;
-use ratatui::layout::Rect;
-use ratatui::style::Style;
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::Rect;
+use ratatui_core::style::Style;
 use unicode_segmentation::UnicodeSegmentation;
 
 use super::style::BorderGlyphs;
@@ -214,19 +214,19 @@ mod tests {
     use crate::style::Theme;
     use crate::test_support::{buffer, row};
     use crate::view::{RenderCtx, View, element};
-    use ratatui::buffer::Buffer;
-    use ratatui::layout::Rect;
-    use ratatui::style::Style;
+    use ratatui_core::buffer::Buffer;
+    use ratatui_core::layout::Rect;
+    use ratatui_core::style::Style;
 
     #[test]
     fn ratatui_rendering_preserves_clip_even_if_buffer_expands() {
-        let mut buf = Buffer::filled(Rect::new(0, 0, 12, 3), ratatui::buffer::Cell::new("#"));
+        let mut buf = Buffer::filled(Rect::new(0, 0, 12, 3), ratatui_core::buffer::Cell::new("#"));
         let clip = Rect::new(4, 1, 4, 1);
         {
             let mut surface = Surface::new(&mut buf, clip);
             surface.render_ratatui(Rect::new(2, 0, 8, 3), |_area, scratch| {
                 let expanded =
-                    Buffer::filled(Rect::new(0, 0, 12, 3), ratatui::buffer::Cell::new("x"));
+                    Buffer::filled(Rect::new(0, 0, 12, 3), ratatui_core::buffer::Cell::new("x"));
                 scratch.merge(&expanded);
             });
         }
@@ -245,9 +245,9 @@ mod tests {
 
     #[test]
     fn ratatui_rendering_starts_with_existing_cells() {
-        use ratatui::style::Color;
+        use ratatui_core::style::Color;
 
-        let mut cell = ratatui::buffer::Cell::new(".");
+        let mut cell = ratatui_core::buffer::Cell::new(".");
         cell.set_bg(Color::Blue);
         let mut buf = Buffer::filled(Rect::new(0, 0, 4, 1), cell);
         let area = buf.area;
@@ -273,7 +273,7 @@ mod tests {
 
     #[test]
     fn ratatui_rendering_tolerates_a_callback_that_resizes_its_buffer() {
-        let mut buf = Buffer::filled(Rect::new(0, 0, 4, 1), ratatui::buffer::Cell::new("#"));
+        let mut buf = Buffer::filled(Rect::new(0, 0, 4, 1), ratatui_core::buffer::Cell::new("#"));
         let area = buf.area;
         let mut surface = Surface::new(&mut buf, area);
         surface.render_ratatui(area, |_area, scratch| {
@@ -288,7 +288,7 @@ mod tests {
         // A ZWJ family (multiple scalars) is a single grapheme: it must occupy one
         // cell and advance the cursor by 2, not scatter one component per cell.
         const FAMILY: &str = "👨\u{200D}👩\u{200D}👧";
-        let mut buf = Buffer::filled(Rect::new(0, 0, 6, 1), ratatui::buffer::Cell::new("."));
+        let mut buf = Buffer::filled(Rect::new(0, 0, 6, 1), ratatui_core::buffer::Cell::new("."));
         let end = {
             let mut surface = Surface::new(&mut buf, Rect::new(0, 0, 6, 1));
             surface.set_string(0, 0, &format!("{FAMILY}x"), Style::default())
@@ -307,7 +307,7 @@ mod tests {
     fn set_string_skip_pans_and_carries_across_calls() {
         // "abcdef" drawn with a running skip of 2: "ab" dropped, "cdef" drawn
         // from x=0. A second call keeps consuming from the same skip.
-        let mut buf = Buffer::filled(Rect::new(0, 0, 6, 1), ratatui::buffer::Cell::new("."));
+        let mut buf = Buffer::filled(Rect::new(0, 0, 6, 1), ratatui_core::buffer::Cell::new("."));
         let mut surface = Surface::new(&mut buf, Rect::new(0, 0, 6, 1));
         let mut skip = 2u16;
         let end = surface.set_string_skip(0, 0, "abcdef", Style::default(), &mut skip);
@@ -318,7 +318,7 @@ mod tests {
 
         // With skip still set, a whole short span is consumed without drawing and
         // the skip carries to the next call.
-        let mut buf2 = Buffer::filled(Rect::new(0, 0, 4, 1), ratatui::buffer::Cell::new("."));
+        let mut buf2 = Buffer::filled(Rect::new(0, 0, 4, 1), ratatui_core::buffer::Cell::new("."));
         let mut s2 = Surface::new(&mut buf2, Rect::new(0, 0, 4, 1));
         let mut skip = 3u16;
         let x = s2.set_string_skip(0, 0, "ab", Style::default(), &mut skip); // fully skipped
@@ -334,7 +334,8 @@ mod tests {
     fn set_string_skip_zero_matches_set_string() {
         // The flush-left fast path: skip == 0 must be identical to set_string.
         let render = |use_skip: bool| {
-            let mut buf = Buffer::filled(Rect::new(0, 0, 8, 1), ratatui::buffer::Cell::new("."));
+            let mut buf =
+                Buffer::filled(Rect::new(0, 0, 8, 1), ratatui_core::buffer::Cell::new("."));
             let end = {
                 let mut s = Surface::new(&mut buf, Rect::new(0, 0, 8, 1));
                 if use_skip {

--- a/crates/tuika/src/test_support.rs
+++ b/crates/tuika/src/test_support.rs
@@ -6,9 +6,9 @@
 //! identifiable "rainbow" theme, rendering an element to text — live here so
 //! they are defined once.
 
-use ratatui::buffer::Buffer;
-use ratatui::layout::Rect;
-use ratatui::style::Color;
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::Rect;
+use ratatui_core::style::Color;
 
 use crate::Surface;
 use crate::style::Theme;

--- a/crates/tuika/src/testing.rs
+++ b/crates/tuika/src/testing.rs
@@ -1,7 +1,7 @@
 //! Public helpers for hermetic view and resize tests.
 
-use ratatui::buffer::Buffer;
-use ratatui::layout::Rect;
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::Rect;
 
 use crate::{Theme, View, paint};
 

--- a/crates/tuika/src/themes.rs
+++ b/crates/tuika/src/themes.rs
@@ -18,7 +18,7 @@
 //! its own slots (`background`, `surface`, `accent`, the [`CodeTheme`] syntax
 //! roles); it does not reproduce every upstream UI element.
 
-use ratatui::style::Color;
+use ratatui_core::style::Color;
 
 use crate::style::{CodeTheme, Theme};
 

--- a/crates/tuika/src/view.rs
+++ b/crates/tuika/src/view.rs
@@ -10,7 +10,7 @@
 //! `View` for its render, and, if interactive, a small state struct with an
 //! event handler. No trait-object tree to reconcile.
 
-use ratatui::layout::Rect;
+use ratatui_core::layout::Rect;
 
 use super::geometry::Size;
 use super::style::{StyleSheet, Theme};


### PR DESCRIPTION
## What changed

`tuika` now depends on `ratatui-core` (+ `ratatui-crossterm` for the terminal backend) directly instead of the `ratatui` umbrella crate. tuika renders none of ratatui's own widgets — it uses only the cell buffer, the style/text/layout primitives, the `Widget`/`StatefulWidget` traits, and the `Terminal`/backend loop, all of which live in `ratatui-core`. The umbrella pulled `ratatui-widgets` and `ratatui-macros` in non-optionally, plus (via the default `all-widgets` → calendar feature) the whole `time` stack.

Net effect on tuika's **normal** dependency tree: **75 → 64 unique crates**, removing `ratatui` (umbrella), `ratatui-widgets`, `ratatui-macros`, `time`, `deranged`, `num-conv`, `num_threads`, `powerfmt`, `time-core`, and `line-clipping`. No new packages enter `Cargo.lock` — the sub-crates were already present transitively under the umbrella, so this is a *net reduction* in surface, not an addition.

Downstream users are unaffected in capability: they add `ratatui` to their own crate (as any TUI app already does) and render any widget through `Surface::render_ratatui` / `RatatuiView`, whose interop seam is a raw `ratatui-core` `Buffer`. The umbrella re-exports that same `ratatui-core`, so Cargo unifies the shared `Buffer`/`Rect`/`Style` types and widget composition still type-checks. `ratatui` remains a **dev-dependency** for benches and the widget-interop doc examples.

Docs updated to match: `README.md` (intro, install note, Compatibility) and the `lib.rs` crate docs.

## Why

`tuika` is a published, self-contained crate. Depending on the umbrella forced every consumer to compile `ratatui-widgets` + `ratatui-macros` + the `time` date/calendar stack that tuika never touches. Building against `ratatui-core` gives tuika a leaner, more honest dependency footprint with zero loss of function.

## Before / After

Pure dependency-graph change; no runtime behavior changes.

```
tuika normal-deps unique crate count:   75  →  64   (-11)
removed: ratatui, ratatui-widgets, ratatui-macros, time, deranged,
         num-conv, num_threads, powerfmt, time-core, line-clipping
Cargo.lock new packages: 0  (only 2 dependency edges re-pointed)
```

Validation (all green):
- `cargo build -p tuika --all-features` — compiles with only `ratatui-core` + `ratatui-crossterm`
- `cargo test -p tuika --all-features` — 254 unit + 19 doctests pass, **including the `render_ratatui`/`RatatuiView` widget-interop doctests** (they use the `ratatui` dev-dep exactly as a downstream user would), proving the seam still composes real widgets after the umbrella was dropped
- `cargo build --workspace --all-features` — yolop + tuika-codeformatters consume tuika's now-`ratatui-core`-typed public API unchanged
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo test -p tuika-codeformatters --all-features` — pass
- `cargo run -- --provider llmsim -p "hi"` — binary starts

## Risk

- **Low.** No behavior change. The only public-facing change is that tuika's API types are now spelled `ratatui_core::…` internally; because the `ratatui` umbrella re-exports the identical `ratatui-core`, the types a downstream user passes in are the same and Cargo deduplicates them. The existing version-pinning contract (use a compatible `ratatui` minor line) is unchanged.
- What could break: a downstream user pinned to a `ratatui` line whose re-exported `ratatui-core` diverges from tuika's — the same mismatch risk that already existed with the umbrella, and it surfaces as a compile error, not silent misbehavior.

## Security

**No security-relevant code changes.** TM-DEP: no new third-party crates enter `Cargo.lock`; the change re-points two existing dependency edges to official ratatui workspace sub-crates (`ratatui-core` 0.1.2, `ratatui-crossterm` 0.1.2 — the exact versions the umbrella already resolved to) and removes several crates. Net attack surface decreases. No changes to filesystem, shell, prompt, or key handling.

## Follow-ups

- The `yolop` root package and `tuika-codeformatters` still depend on the `ratatui` umbrella directly, so the yolop *binary* still compiles it — this PR does not shrink the final binary, only tuika's published footprint. A separate investigation could check whether yolop itself uses any concrete ratatui widget and, if not, apply the same slimming. Out of scope here per the "tuika only" ask.

## Checklist
- [x] Tests added or updated — existing widget-interop doctests + 254 unit tests cover the seam; no behavior change to add new tests for
- [x] Backward compatibility considered — interop preserved via shared `ratatui-core` re-export

---
_Generated by [Claude Code](https://claude.ai/code/session_015dczNZmM6PpLc7m3xiSJfU)_