### PR TITLE
feat(extensions): trace facet, Logfire export, config & secrets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7851,6 +7851,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "yolop-extension-logfire"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "serde_json",
+ "ureq",
+ "yolop-yep",
+]
+
+[[package]]
 name = "yolop-yep"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7855,8 +7855,10 @@ name = "yolop-extension-logfire"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "serde_json",
- "ureq",
  "yolop-yep",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,10 @@
 [workspace]
-members = ["crates/tuika", "crates/tuika-codeformatters", "crates/yolop-yep"]
+members = [
+    "crates/tuika",
+    "crates/tuika-codeformatters",
+    "crates/yolop-yep",
+    "crates/yolop-extension-logfire",
+]
 
 [package]
 name = "yolop"

--- a/crates/yolop-extension-logfire/Cargo.toml
+++ b/crates/yolop-extension-logfire/Cargo.toml
@@ -18,4 +18,19 @@ path = "src/main.rs"
 yolop-yep = { path = "../yolop-yep", version = "0.2" }
 serde_json = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
-ureq = "2.12"
+# The official OpenTelemetry Rust SDK + OTLP/HTTP exporter — the path Logfire's
+# "alternative clients" guide documents. `reqwest-blocking-client` fits the
+# synchronous serve loop (no tokio runtime); `reqwest-rustls` is required per
+# the Logfire docs to avoid a cryptic TLS export failure.
+opentelemetry = { version = "0.32", default-features = false, features = ["trace"] }
+opentelemetry_sdk = { version = "0.32", default-features = false, features = ["trace"] }
+opentelemetry-otlp = { version = "0.32", default-features = false, features = [
+    "trace",
+    "http-proto",
+    "reqwest-blocking-client",
+    "reqwest-rustls",
+] }
+
+[dev-dependencies]
+# In-memory span exporter for offline assertions on the emitted spans.
+opentelemetry_sdk = { version = "0.32", default-features = false, features = ["trace", "testing"] }

--- a/crates/yolop-extension-logfire/Cargo.toml
+++ b/crates/yolop-extension-logfire/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "yolop-extension-logfire"
+version = "0.1.0"
+edition = "2024"
+authors = ["Everruns <support@everruns.com>"]
+license = "MIT"
+description = "yolop extension: export agentic traces to Pydantic Logfire (OTLP)."
+homepage = "https://github.com/everruns/yolop"
+repository = "https://github.com/everruns/yolop"
+keywords = ["yolop", "yolop-extension", "logfire", "opentelemetry", "tracing"]
+categories = ["development-tools"]
+
+[[bin]]
+name = "yolop-extension-logfire"
+path = "src/main.rs"
+
+[dependencies]
+yolop-yep = { path = "../yolop-yep", version = "0.2" }
+serde_json = "1.0"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
+ureq = "2.12"

--- a/crates/yolop-extension-logfire/README.md
+++ b/crates/yolop-extension-logfire/README.md
@@ -26,8 +26,15 @@ the package's `bin/`, per the usual extension rule.
 
 ## Configure
 
-Configuration is by environment, inherited from the yolop process — the same
-variables Logfire's onboarding checklist uses:
+The token is a `secret` config field, so on `enable_extension` (or via
+`set_extension_secret name=logfire field=token`) yolop prompts **you** for it
+directly — the agent never sees the value. It's stored in the credential store
+(`connections.toml`, 0600), not in settings, and injected into this server as
+`LOGFIRE_TOKEN`. `endpoint` and `service_name` are ordinary config fields.
+
+You can also set everything by environment, inherited from the yolop process —
+the same variables Logfire's onboarding checklist uses (env always overrides
+stored config):
 
 | Variable | Purpose | Default |
 | --- | --- | --- |

--- a/crates/yolop-extension-logfire/README.md
+++ b/crates/yolop-extension-logfire/README.md
@@ -28,9 +28,10 @@ the package's `bin/`, per the usual extension rule.
 
 The token is a `secret` config field, so on `enable_extension` (or via
 `set_extension_secret name=logfire field=token`) yolop prompts **you** for it
-directly — the agent never sees the value. It's stored in the credential store
-(`connections.toml`, 0600), not in settings, and injected into this server as
-`LOGFIRE_TOKEN`. `endpoint` and `service_name` are ordinary config fields.
+directly, with masked input — the agent never sees the value. It's stored in the
+credential store (`connections.toml`, 0600), not in settings, and injected into
+this server as `LOGFIRE_TOKEN`. `endpoint` and `service_name` are ordinary
+config fields, read from `initialize.config`.
 
 You can also set everything by environment, inherited from the yolop process —
 the same variables Logfire's onboarding checklist uses (env always overrides

--- a/crates/yolop-extension-logfire/README.md
+++ b/crates/yolop-extension-logfire/README.md
@@ -1,0 +1,51 @@
+# yolop-extension-logfire
+
+A [yolop](https://github.com/everruns/yolop) extension that exports the agent's
+live trace — turns, reasoning, tool calls, and LLM generations — to
+[Pydantic Logfire](https://logfire.pydantic.dev/) so a run shows up as a nested
+trace with token usage, timing, and tool arguments.
+
+It uses yolop's `trace` extension facet: the host forwards each agentic
+lifecycle event as a fire-and-forget notification, and this server folds them
+into OpenTelemetry spans and POSTs them to Logfire's OTLP/HTTP endpoint. No
+Logfire client library is required — it speaks OTLP directly, the same wire
+Logfire's own SDKs use.
+
+## Install
+
+```bash
+# From this repo (dev): build the binary onto PATH, then install the package.
+cargo install --path crates/yolop-extension-logfire
+/extensions install <path-to>/crates/yolop-extension-logfire
+/extensions enable logfire
+```
+
+The server binary (`yolop-extension-logfire`) must be resolvable on `PATH` or in
+the package's `bin/`, per the usual extension rule.
+
+## Configure
+
+Configuration is by environment, inherited from the yolop process — the same
+variables Logfire's onboarding checklist uses:
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `LOGFIRE_TOKEN` (or `LOGFIRE_WRITE_TOKEN`) | Logfire **write token**. Required — without it spans are dropped and the extension is inert. | — |
+| `LOGFIRE_ENDPOINT` (or `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`) | OTLP traces URL | `https://logfire-api.pydantic.dev/v1/traces` |
+| `OTEL_SERVICE_NAME` (or `LOGFIRE_SERVICE_NAME`) | Service name on the spans | `yolop` |
+
+```bash
+export LOGFIRE_TOKEN=pylf_v1_...   # from your Logfire project settings
+doppler run -- cargo run -- -p "say hi"   # this run is now traced to Logfire
+```
+
+## What gets exported
+
+One trace per session; each turn is a root span, with `reason`/`act`/`tool`
+spans nested under their turn. Event `data` scalars (token counts, model, tool
+name, …) become span attributes; `*.failed` events mark the span's status as
+error. High-frequency streaming deltas are not exported — the paired
+`*.started` / `*.completed` events already bound the work.
+
+Export is best-effort: a slow or unreachable Logfire never stalls the agent, and
+spans flush at each turn boundary.

--- a/crates/yolop-extension-logfire/README.md
+++ b/crates/yolop-extension-logfire/README.md
@@ -7,9 +7,10 @@ trace with token usage, timing, and tool arguments.
 
 It uses yolop's `trace` extension facet: the host forwards each agentic
 lifecycle event as a fire-and-forget notification, and this server folds them
-into OpenTelemetry spans and POSTs them to Logfire's OTLP/HTTP endpoint. No
-Logfire client library is required — it speaks OTLP directly, the same wire
-Logfire's own SDKs use.
+into OpenTelemetry spans and ships them to Logfire through the official
+`opentelemetry-otlp` exporter (HTTP/protobuf, blocking client) — the approach
+Logfire's [alternative-clients guide](https://logfire.pydantic.dev/docs/how-to-guides/alternative-clients/)
+documents for Rust. No Logfire client library is required.
 
 ## Install
 
@@ -30,8 +31,8 @@ variables Logfire's onboarding checklist uses:
 
 | Variable | Purpose | Default |
 | --- | --- | --- |
-| `LOGFIRE_TOKEN` (or `LOGFIRE_WRITE_TOKEN`) | Logfire **write token**. Required — without it spans are dropped and the extension is inert. | — |
-| `LOGFIRE_ENDPOINT` (or `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`) | OTLP traces URL | `https://logfire-api.pydantic.dev/v1/traces` |
+| `LOGFIRE_TOKEN` (or `LOGFIRE_WRITE_TOKEN`) | Logfire **write token**, sent raw in the `Authorization` header (no `Bearer` prefix). Required — without it the extension runs but exports nowhere. | — |
+| `LOGFIRE_ENDPOINT` (or `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`) | OTLP traces URL. Use `logfire-eu` for an EU project. | `https://logfire-us.pydantic.dev/v1/traces` |
 | `OTEL_SERVICE_NAME` (or `LOGFIRE_SERVICE_NAME`) | Service name on the spans | `yolop` |
 
 ```bash
@@ -41,11 +42,12 @@ doppler run -- cargo run -- -p "say hi"   # this run is now traced to Logfire
 
 ## What gets exported
 
-One trace per session; each turn is a root span, with `reason`/`act`/`tool`
-spans nested under their turn. Event `data` scalars (token counts, model, tool
-name, …) become span attributes; `*.failed` events mark the span's status as
-error. High-frequency streaming deltas are not exported — the paired
-`*.started` / `*.completed` events already bound the work.
+One trace per turn: `turn.*` is the root span, with `reason`/`act`/`tool` spans
+nested under it and `llm.generation` as a point span. Event `data` scalars
+(token counts, model, tool name, exit code, …) become span attributes;
+`*.failed` events mark the span's status as error. High-frequency streaming
+deltas are not exported — the paired `*.started` / `*.completed` events already
+bound the work.
 
-Export is best-effort: a slow or unreachable Logfire never stalls the agent, and
-spans flush at each turn boundary.
+Export is best-effort: a slow or unreachable Logfire never stalls the agent (the
+host never awaits `trace/event`), and spans are exported as they end.

--- a/crates/yolop-extension-logfire/plugin.json
+++ b/crates/yolop-extension-logfire/plugin.json
@@ -19,12 +19,10 @@
         },
         "endpoint": {
           "type": "string",
-          "env": "LOGFIRE_ENDPOINT",
           "description": "OTLP traces endpoint (default: Logfire US; use logfire-eu for EU projects)"
         },
         "service_name": {
           "type": "string",
-          "env": "OTEL_SERVICE_NAME",
           "description": "Service name on the exported spans (default: yolop)"
         }
       }

--- a/crates/yolop-extension-logfire/plugin.json
+++ b/crates/yolop-extension-logfire/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "logfire",
+  "version": "0.1.0",
+  "description": "Export agentic traces (turns, reasoning, tool calls, LLM generations) to Pydantic Logfire over OTLP.",
+  "engines": { "yolop": ">=0.11" },
+  "yolop": {
+    "protocol_version": "1.0",
+    "capabilityServer": { "command": "yolop-extension-logfire", "args": [] },
+    "trace": true
+  }
+}

--- a/crates/yolop-extension-logfire/plugin.json
+++ b/crates/yolop-extension-logfire/plugin.json
@@ -6,6 +6,28 @@
   "yolop": {
     "protocol_version": "1.0",
     "capabilityServer": { "command": "yolop-extension-logfire", "args": [] },
-    "trace": true
+    "trace": true,
+    "config_schema": {
+      "type": "object",
+      "required": ["token"],
+      "properties": {
+        "token": {
+          "type": "string",
+          "secret": true,
+          "env": "LOGFIRE_TOKEN",
+          "description": "Logfire write token"
+        },
+        "endpoint": {
+          "type": "string",
+          "env": "LOGFIRE_ENDPOINT",
+          "description": "OTLP traces endpoint (default: Logfire US; use logfire-eu for EU projects)"
+        },
+        "service_name": {
+          "type": "string",
+          "env": "OTEL_SERVICE_NAME",
+          "description": "Service name on the exported spans (default: yolop)"
+        }
+      }
+    }
   }
 }

--- a/crates/yolop-extension-logfire/src/exporter.rs
+++ b/crates/yolop-extension-logfire/src/exporter.rs
@@ -1,0 +1,540 @@
+//! The stateful trace exporter: folds the host's stream of agentic
+//! `trace/event` notifications into OpenTelemetry spans and hands finished
+//! batches to a sink as OTLP/HTTP JSON.
+//!
+//! Kept transport-free on purpose — the sink is a plain `FnMut(&str)` that
+//! receives the serialized OTLP body — so the event→span logic is unit-tested
+//! without a network (see the tests below) and `main.rs` only supplies the HTTP
+//! POST. All work is best-effort: a malformed or unknown event is skipped, never
+//! fatal, so a live agent run is never disturbed by the exporter.
+
+use serde_json::{Value, json};
+use std::collections::HashMap;
+
+/// Families of events we render as spans. Everything else (session/task/file/
+/// budget/context/message-delta) is ignored so the trace stays span-shaped.
+/// Each is a `<family>.<phase>` event; `started` opens a span, a terminal phase
+/// closes it.
+const SPAN_FAMILIES: &[&str] = &["turn", "reason", "act", "tool"];
+
+/// Terminal phases that close an open span (or, unpaired, emit a point span).
+fn is_terminal_phase(phase: &str) -> bool {
+    matches!(
+        phase,
+        "completed" | "failed" | "cancelled" | "sealed" | "recovered"
+    )
+}
+
+/// One event, split into the fields the exporter reasons about.
+struct Parsed<'a> {
+    family: &'a str,
+    phase: &'a str,
+    ts_nanos: i128,
+    session_id: &'a str,
+    context: &'a Value,
+    data: &'a Value,
+    event_type: &'a str,
+    event_id: &'a str,
+}
+
+/// An in-progress span awaiting its terminal event.
+struct OpenSpan {
+    span_id: [u8; 8],
+    parent: Option<[u8; 8]>,
+    name: String,
+    start_nanos: i128,
+    attributes: Vec<(String, Value)>,
+}
+
+/// A closed span ready to serialize into OTLP.
+struct FinishedSpan {
+    span_id: [u8; 8],
+    parent: Option<[u8; 8]>,
+    name: String,
+    start_nanos: i128,
+    end_nanos: i128,
+    attributes: Vec<(String, Value)>,
+    /// OTLP status code: 0 unset, 2 error.
+    status: u8,
+}
+
+/// Folds events into spans and flushes finished batches through `sink`.
+pub struct SpanExporter<F: FnMut(&str)> {
+    service_name: String,
+    sink: F,
+    /// One trace per session, derived deterministically from the session id.
+    trace_id: Option<[u8; 16]>,
+    session_id: String,
+    /// Open spans keyed by `<family>:<correlation-id>`.
+    open: HashMap<String, OpenSpan>,
+    /// The current turn's span id, so child spans (reason/act/tool) parent to it.
+    turn_span: HashMap<String, [u8; 8]>,
+    finished: Vec<FinishedSpan>,
+}
+
+/// Cap the buffer so a run that never hits a turn boundary can't grow unbounded.
+const MAX_BUFFERED_SPANS: usize = 256;
+
+impl<F: FnMut(&str)> SpanExporter<F> {
+    pub fn new(service_name: impl Into<String>, sink: F) -> Self {
+        Self {
+            service_name: service_name.into(),
+            sink,
+            trace_id: None,
+            session_id: String::new(),
+            open: HashMap::new(),
+            turn_span: HashMap::new(),
+            finished: Vec::new(),
+        }
+    }
+
+    /// Handle one `trace/event`. Never panics: unparseable or out-of-family
+    /// events are dropped.
+    pub fn handle(&mut self, params: &yolop_yep::TraceEventParams) {
+        let Some(parsed) = parse(params) else {
+            return;
+        };
+        if self.trace_id.is_none() {
+            self.trace_id = Some(trace_id_for(parsed.session_id));
+            self.session_id = parsed.session_id.to_string();
+        }
+        if !SPAN_FAMILIES.contains(&parsed.family) {
+            return;
+        }
+
+        if parsed.phase == "started" {
+            self.open_span(&parsed);
+        } else if is_terminal_phase(parsed.phase) {
+            self.close_span(&parsed);
+        }
+
+        // Flush at turn boundaries — one POST per turn — and as a backstop when
+        // the buffer grows large without a boundary.
+        if parsed.family == "turn" && is_terminal_phase(parsed.phase) {
+            self.flush();
+        } else if self.finished.len() >= MAX_BUFFERED_SPANS {
+            self.flush();
+        }
+    }
+
+    fn open_span(&mut self, parsed: &Parsed) {
+        let key = correlation_key(parsed);
+        let span_id = span_id_for(&key);
+        let parent = self.parent_for(parsed);
+        if parsed.family == "turn" {
+            if let Some(turn) = turn_id(parsed.context) {
+                self.turn_span.insert(turn.to_string(), span_id);
+            }
+        }
+        self.open.insert(
+            key,
+            OpenSpan {
+                span_id,
+                parent,
+                name: span_name(parsed),
+                start_nanos: parsed.ts_nanos,
+                attributes: attributes(parsed),
+            },
+        );
+    }
+
+    fn close_span(&mut self, parsed: &Parsed) {
+        let key = correlation_key(parsed);
+        let status = if parsed.phase == "failed" { 2 } else { 0 };
+        let finished = match self.open.remove(&key) {
+            Some(open) => FinishedSpan {
+                span_id: open.span_id,
+                parent: open.parent,
+                name: open.name,
+                start_nanos: open.start_nanos,
+                end_nanos: parsed.ts_nanos,
+                attributes: merge_attrs(open.attributes, attributes(parsed)),
+                status,
+            },
+            // Unpaired terminal (missed/absent `started`): a point span so the
+            // event is still recorded rather than silently dropped.
+            None => FinishedSpan {
+                span_id: span_id_for(&key),
+                parent: self.parent_for(parsed),
+                name: span_name(parsed),
+                start_nanos: parsed.ts_nanos,
+                end_nanos: parsed.ts_nanos,
+                attributes: attributes(parsed),
+                status,
+            },
+        };
+        if parsed.family == "turn" {
+            if let Some(turn) = turn_id(parsed.context) {
+                self.turn_span.remove(turn);
+            }
+        }
+        self.finished.push(finished);
+    }
+
+    /// Parent a child (reason/act/tool) to its enclosing turn span, if open.
+    fn parent_for(&self, parsed: &Parsed) -> Option<[u8; 8]> {
+        if parsed.family == "turn" {
+            return None;
+        }
+        turn_id(parsed.context).and_then(|t| self.turn_span.get(t).copied())
+    }
+
+    /// Serialize the finished spans as one OTLP/HTTP JSON body and hand it to
+    /// the sink. A no-op when there is nothing buffered.
+    pub fn flush(&mut self) {
+        if self.finished.is_empty() {
+            return;
+        }
+        let Some(trace_id) = self.trace_id else {
+            self.finished.clear();
+            return;
+        };
+        let spans = std::mem::take(&mut self.finished);
+        let body = otlp_body(&self.service_name, &self.session_id, trace_id, &spans);
+        (self.sink)(&body);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Parsing / naming / attributes
+
+fn parse(params: &yolop_yep::TraceEventParams) -> Option<Parsed<'_>> {
+    let (family, phase) = params
+        .event_type
+        .split_once('.')
+        .unwrap_or((params.event_type.as_str(), ""));
+    let ts_nanos = params
+        .ts
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .ok()?
+        .timestamp_nanos_opt()?
+        .into();
+    Some(Parsed {
+        family,
+        phase,
+        ts_nanos,
+        session_id: &params.session_id,
+        context: &params.context,
+        data: &params.data,
+        event_type: &params.event_type,
+        event_id: &params.id,
+    })
+}
+
+fn turn_id(context: &Value) -> Option<&str> {
+    context.get("turn_id").and_then(Value::as_str)
+}
+
+/// A stable per-span key so `started` and its terminal event coincide. Prefers
+/// the most specific correlation id available for the family and falls back to
+/// the event id (which makes an unpaired point span rather than a wrong pair).
+fn correlation_key(parsed: &Parsed) -> String {
+    let candidates: &[&str] = match parsed.family {
+        "tool" => &["tool_call_id", "exec_id", "call_id"],
+        "turn" => &["turn_id"],
+        _ => &["exec_id", "turn_id"],
+    };
+    for key in candidates {
+        if let Some(id) = parsed.context.get(*key).and_then(Value::as_str) {
+            return format!("{}:{id}", parsed.family);
+        }
+    }
+    format!("{}:{}", parsed.family, parsed.event_id)
+}
+
+fn span_name(parsed: &Parsed) -> String {
+    match parsed.family {
+        "tool" => {
+            let tool = parsed
+                .data
+                .get("tool_name")
+                .or_else(|| parsed.data.get("name"))
+                .and_then(Value::as_str);
+            match tool {
+                Some(name) => format!("tool {name}"),
+                None => "tool".to_string(),
+            }
+        }
+        other => other.to_string(),
+    }
+}
+
+/// Base attributes for a span: the concrete event type plus any scalar fields
+/// from the event `data` (token usage, model, tool name, …), namespaced.
+fn attributes(parsed: &Parsed) -> Vec<(String, Value)> {
+    let mut attrs = vec![("yolop.event_type".to_string(), json!(parsed.event_type))];
+    if let Some(map) = parsed.data.as_object() {
+        for (key, value) in map {
+            if value.is_object() || value.is_array() {
+                continue; // keep attributes flat and cheap
+            }
+            attrs.push((format!("yolop.{key}"), value.clone()));
+        }
+    }
+    attrs
+}
+
+fn merge_attrs(
+    mut base: Vec<(String, Value)>,
+    extra: Vec<(String, Value)>,
+) -> Vec<(String, Value)> {
+    for (k, v) in extra {
+        if !base.iter().any(|(bk, _)| *bk == k) {
+            base.push((k, v));
+        }
+    }
+    base
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic ids (FNV-1a; no rng dependency, reproducible in tests)
+
+fn fnv1a_64(bytes: &[u8]) -> u64 {
+    let mut hash = 0xcbf29ce484222325u64;
+    for &b in bytes {
+        hash ^= b as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
+fn trace_id_for(session_id: &str) -> [u8; 16] {
+    // Two independent 64-bit hashes give a 128-bit id that is non-zero and
+    // stable per session (all of a session's spans share one trace).
+    let hi = fnv1a_64(session_id.as_bytes());
+    let lo = fnv1a_64(format!("{session_id}#lo").as_bytes());
+    let mut id = [0u8; 16];
+    id[..8].copy_from_slice(&hi.to_be_bytes());
+    id[8..].copy_from_slice(&lo.to_be_bytes());
+    if id == [0u8; 16] {
+        id[15] = 1;
+    }
+    id
+}
+
+fn span_id_for(key: &str) -> [u8; 8] {
+    let mut id = fnv1a_64(key.as_bytes()).to_be_bytes();
+    if id == [0u8; 8] {
+        id[7] = 1;
+    }
+    id
+}
+
+fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+// ---------------------------------------------------------------------------
+// OTLP/HTTP JSON
+
+fn otlp_attributes(attrs: &[(String, Value)]) -> Vec<Value> {
+    attrs
+        .iter()
+        .map(|(k, v)| json!({ "key": k, "value": otlp_any_value(v) }))
+        .collect()
+}
+
+fn otlp_any_value(v: &Value) -> Value {
+    match v {
+        Value::String(s) => json!({ "stringValue": s }),
+        Value::Bool(b) => json!({ "boolValue": b }),
+        Value::Number(n) if n.is_i64() || n.is_u64() => json!({ "intValue": n.to_string() }),
+        Value::Number(n) => json!({ "doubleValue": n.as_f64().unwrap_or(0.0) }),
+        other => json!({ "stringValue": other.to_string() }),
+    }
+}
+
+/// Build the OTLP `POST /v1/traces` JSON body for a batch of finished spans.
+fn otlp_body(
+    service_name: &str,
+    session_id: &str,
+    trace_id: [u8; 16],
+    spans: &[FinishedSpan],
+) -> String {
+    let trace_hex = hex(&trace_id);
+    let otlp_spans: Vec<Value> = spans
+        .iter()
+        .map(|span| {
+            json!({
+                "traceId": trace_hex,
+                "spanId": hex(&span.span_id),
+                "parentSpanId": span.parent.map(|p| hex(&p)).unwrap_or_default(),
+                "name": span.name,
+                // SPAN_KIND_INTERNAL
+                "kind": 1,
+                "startTimeUnixNano": span.start_nanos.max(0).to_string(),
+                "endTimeUnixNano": span.end_nanos.max(0).to_string(),
+                "attributes": otlp_attributes(&span.attributes),
+                "status": { "code": span.status },
+            })
+        })
+        .collect();
+
+    json!({
+        "resourceSpans": [{
+            "resource": {
+                "attributes": otlp_attributes(&[
+                    ("service.name".to_string(), json!(service_name)),
+                    ("session.id".to_string(), json!(session_id)),
+                ]),
+            },
+            "scopeSpans": [{
+                "scope": { "name": "yolop-extension-logfire" },
+                "spans": otlp_spans,
+            }],
+        }],
+    })
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    fn ev(event_type: &str, ts: &str, ctx: Value, data: Value) -> yolop_yep::TraceEventParams {
+        yolop_yep::TraceEventParams {
+            event_type: event_type.to_string(),
+            id: format!("id-{event_type}"),
+            ts: ts.to_string(),
+            session_id: "sess-1".to_string(),
+            context: ctx,
+            data,
+        }
+    }
+
+    /// A collector sink capturing each flushed OTLP body as parsed JSON.
+    fn recorder() -> (Rc<RefCell<Vec<Value>>>, impl FnMut(&str)) {
+        let out = Rc::new(RefCell::new(Vec::new()));
+        let sink_out = out.clone();
+        let sink = move |body: &str| {
+            sink_out
+                .borrow_mut()
+                .push(serde_json::from_str(body).expect("valid json body"));
+        };
+        (out, sink)
+    }
+
+    #[test]
+    fn a_turn_with_a_tool_flushes_one_batch_of_nested_spans() {
+        let (out, sink) = recorder();
+        let mut exporter = SpanExporter::new("yolop", sink);
+        let turn = json!({ "turn_id": "t1" });
+        let tool_ctx = json!({ "turn_id": "t1", "tool_call_id": "c1" });
+
+        exporter.handle(&ev(
+            "turn.started",
+            "2024-01-01T00:00:00Z",
+            turn.clone(),
+            json!({}),
+        ));
+        exporter.handle(&ev(
+            "tool.started",
+            "2024-01-01T00:00:01Z",
+            tool_ctx.clone(),
+            json!({ "tool_name": "bash" }),
+        ));
+        exporter.handle(&ev(
+            "tool.completed",
+            "2024-01-01T00:00:02Z",
+            tool_ctx,
+            json!({ "tool_name": "bash", "ok": true }),
+        ));
+        // No flush yet — only a turn boundary flushes.
+        assert!(out.borrow().is_empty());
+
+        exporter.handle(&ev(
+            "turn.completed",
+            "2024-01-01T00:00:03Z",
+            turn,
+            json!({}),
+        ));
+
+        let batches = out.borrow();
+        assert_eq!(batches.len(), 1, "one POST at the turn boundary");
+        let spans = &batches[0]["resourceSpans"][0]["scopeSpans"][0]["spans"];
+        let spans = spans.as_array().unwrap();
+        assert_eq!(spans.len(), 2, "turn + tool");
+
+        let turn_span = spans.iter().find(|s| s["name"] == "turn").unwrap();
+        let tool_span = spans.iter().find(|s| s["name"] == "tool bash").unwrap();
+        // Same trace, tool parented to the turn.
+        assert_eq!(turn_span["traceId"], tool_span["traceId"]);
+        assert_eq!(tool_span["parentSpanId"], turn_span["spanId"]);
+        assert_eq!(turn_span["parentSpanId"], "");
+        // Real duration, not a point.
+        assert_ne!(tool_span["startTimeUnixNano"], tool_span["endTimeUnixNano"]);
+        // Data scalars became attributes.
+        let attrs = tool_span["attributes"].as_array().unwrap();
+        assert!(
+            attrs
+                .iter()
+                .any(|a| a["key"] == "yolop.tool_name" && a["value"]["stringValue"] == "bash")
+        );
+    }
+
+    #[test]
+    fn failed_event_marks_error_status() {
+        let (out, sink) = recorder();
+        let mut exporter = SpanExporter::new("yolop", sink);
+        let turn = json!({ "turn_id": "t9" });
+        exporter.handle(&ev(
+            "turn.started",
+            "2024-01-01T00:00:00Z",
+            turn.clone(),
+            json!({}),
+        ));
+        exporter.handle(&ev("turn.failed", "2024-01-01T00:00:01Z", turn, json!({})));
+        let batches = out.borrow();
+        let span = &batches[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0];
+        assert_eq!(span["status"]["code"], 2, "ERROR");
+    }
+
+    #[test]
+    fn non_span_families_are_ignored() {
+        let (out, sink) = recorder();
+        let mut exporter = SpanExporter::new("yolop", sink);
+        // session/file/budget events don't open spans; flushing yields nothing.
+        exporter.handle(&ev(
+            "session.started",
+            "2024-01-01T00:00:00Z",
+            json!({}),
+            json!({}),
+        ));
+        exporter.handle(&ev(
+            "file.written",
+            "2024-01-01T00:00:00Z",
+            json!({}),
+            json!({}),
+        ));
+        exporter.flush();
+        assert!(out.borrow().is_empty());
+    }
+
+    #[test]
+    fn ids_are_deterministic_and_nonzero() {
+        assert_eq!(trace_id_for("sess-1"), trace_id_for("sess-1"));
+        assert_ne!(trace_id_for("sess-1"), [0u8; 16]);
+        assert_eq!(span_id_for("turn:t1"), span_id_for("turn:t1"));
+        assert_ne!(span_id_for("turn:t1"), span_id_for("turn:t2"));
+    }
+
+    #[test]
+    fn unparseable_timestamp_is_skipped_not_fatal() {
+        let (out, sink) = recorder();
+        let mut exporter = SpanExporter::new("yolop", sink);
+        exporter.handle(&ev(
+            "turn.started",
+            "not-a-date",
+            json!({ "turn_id": "t1" }),
+            json!({}),
+        ));
+        exporter.flush();
+        assert!(out.borrow().is_empty());
+    }
+}

--- a/crates/yolop-extension-logfire/src/exporter.rs
+++ b/crates/yolop-extension-logfire/src/exporter.rs
@@ -1,21 +1,23 @@
-//! The stateful trace exporter: folds the host's stream of agentic
-//! `trace/event` notifications into OpenTelemetry spans and hands finished
-//! batches to a sink as OTLP/HTTP JSON.
+//! Folds the host's stream of agentic `trace/event` notifications into
+//! OpenTelemetry spans and emits them through the official OTLP exporter.
 //!
-//! Kept transport-free on purpose — the sink is a plain `FnMut(&str)` that
-//! receives the serialized OTLP body — so the event→span logic is unit-tested
-//! without a network (see the tests below) and `main.rs` only supplies the HTTP
-//! POST. All work is best-effort: a malformed or unknown event is skipped, never
-//! fatal, so a live agent run is never disturbed by the exporter.
+//! The lifecycle events are *already-completed* facts (a `*.started` then a
+//! terminal `*.completed`/`*.failed`), so we reconstruct spans with their real
+//! start/end timestamps via the tracer's `SpanBuilder` and parent context —
+//! rather than the usual "start a span, do work, end it" flow. One trace per
+//! **turn**: `turn.*` is the root span and `reason`/`act`/`tool`/`llm` spans
+//! nest under their turn's context. All work is best-effort: an unparseable or
+//! out-of-family event is skipped, never fatal.
 
-use serde_json::{Value, json};
+use opentelemetry::trace::{Span, SpanKind, Status, TraceContextExt, Tracer};
+use opentelemetry::{Context, KeyValue};
+use opentelemetry_sdk::trace::{SdkTracer, SdkTracerProvider, Span as SdkSpan};
+use serde_json::Value;
 use std::collections::HashMap;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-/// Families of events we render as spans. Everything else (session/task/file/
-/// budget/context/message-delta) is ignored so the trace stays span-shaped.
-/// Each is a `<family>.<phase>` event; `started` opens a span, a terminal phase
-/// closes it.
-const SPAN_FAMILIES: &[&str] = &["turn", "reason", "act", "tool"];
+/// Paired families: a `started` opens a span, a terminal phase closes it.
+const PAIRED_FAMILIES: &[&str] = &["turn", "reason", "act", "tool"];
 
 /// Terminal phases that close an open span (or, unpaired, emit a point span).
 fn is_terminal_phase(phase: &str) -> bool {
@@ -29,62 +31,33 @@ fn is_terminal_phase(phase: &str) -> bool {
 struct Parsed<'a> {
     family: &'a str,
     phase: &'a str,
-    ts_nanos: i128,
-    session_id: &'a str,
+    ts: SystemTime,
     context: &'a Value,
     data: &'a Value,
     event_type: &'a str,
     event_id: &'a str,
 }
 
-/// An in-progress span awaiting its terminal event.
-struct OpenSpan {
-    span_id: [u8; 8],
-    parent: Option<[u8; 8]>,
-    name: String,
-    start_nanos: i128,
-    attributes: Vec<(String, Value)>,
+/// Folds events into OpenTelemetry spans emitted through `tracer`.
+pub struct TraceExporter {
+    tracer: SdkTracer,
+    /// Kept alive for the program's lifetime; dropping it flushes/shuts down
+    /// the span processor.
+    _provider: SdkTracerProvider,
+    /// Open spans keyed by `<family>:<correlation-id>`, closed on their
+    /// terminal event.
+    open: HashMap<String, SdkSpan>,
+    /// Parent context for a turn's children, keyed by turn id.
+    turn_cx: HashMap<String, Context>,
 }
 
-/// A closed span ready to serialize into OTLP.
-struct FinishedSpan {
-    span_id: [u8; 8],
-    parent: Option<[u8; 8]>,
-    name: String,
-    start_nanos: i128,
-    end_nanos: i128,
-    attributes: Vec<(String, Value)>,
-    /// OTLP status code: 0 unset, 2 error.
-    status: u8,
-}
-
-/// Folds events into spans and flushes finished batches through `sink`.
-pub struct SpanExporter<F: FnMut(&str)> {
-    service_name: String,
-    sink: F,
-    /// One trace per session, derived deterministically from the session id.
-    trace_id: Option<[u8; 16]>,
-    session_id: String,
-    /// Open spans keyed by `<family>:<correlation-id>`.
-    open: HashMap<String, OpenSpan>,
-    /// The current turn's span id, so child spans (reason/act/tool) parent to it.
-    turn_span: HashMap<String, [u8; 8]>,
-    finished: Vec<FinishedSpan>,
-}
-
-/// Cap the buffer so a run that never hits a turn boundary can't grow unbounded.
-const MAX_BUFFERED_SPANS: usize = 256;
-
-impl<F: FnMut(&str)> SpanExporter<F> {
-    pub fn new(service_name: impl Into<String>, sink: F) -> Self {
+impl TraceExporter {
+    pub fn new(tracer: SdkTracer, provider: SdkTracerProvider) -> Self {
         Self {
-            service_name: service_name.into(),
-            sink,
-            trace_id: None,
-            session_id: String::new(),
+            tracer,
+            _provider: provider,
             open: HashMap::new(),
-            turn_span: HashMap::new(),
-            finished: Vec::new(),
+            turn_cx: HashMap::new(),
         }
     }
 
@@ -94,126 +67,104 @@ impl<F: FnMut(&str)> SpanExporter<F> {
         let Some(parsed) = parse(params) else {
             return;
         };
-        if self.trace_id.is_none() {
-            self.trace_id = Some(trace_id_for(parsed.session_id));
-            self.session_id = parsed.session_id.to_string();
-        }
-        if !SPAN_FAMILIES.contains(&parsed.family) {
-            return;
-        }
-
-        if parsed.phase == "started" {
-            self.open_span(&parsed);
-        } else if is_terminal_phase(parsed.phase) {
-            self.close_span(&parsed);
-        }
-
-        // Flush at turn boundaries — one POST per turn — and as a backstop when
-        // the buffer grows large without a boundary.
-        if parsed.family == "turn" && is_terminal_phase(parsed.phase) {
-            self.flush();
-        } else if self.finished.len() >= MAX_BUFFERED_SPANS {
-            self.flush();
+        match (parsed.family, parsed.phase) {
+            (f, "started") if PAIRED_FAMILIES.contains(&f) => self.open_span(&parsed),
+            (f, p) if PAIRED_FAMILIES.contains(&f) && is_terminal_phase(p) => {
+                self.close_span(&parsed)
+            }
+            // `llm.generation` is a point event: a zero-duration span under the
+            // turn, carrying model/token attributes.
+            ("llm", _) => self.point_span(&parsed),
+            _ => {}
         }
     }
 
     fn open_span(&mut self, parsed: &Parsed) {
-        let key = correlation_key(parsed);
-        let span_id = span_id_for(&key);
-        let parent = self.parent_for(parsed);
-        if parsed.family == "turn" {
-            if let Some(turn) = turn_id(parsed.context) {
-                self.turn_span.insert(turn.to_string(), span_id);
-            }
+        let parent_cx = self.parent_cx(parsed);
+        let span = self
+            .tracer
+            .span_builder(span_name(parsed))
+            .with_kind(SpanKind::Internal)
+            .with_start_time(parsed.ts)
+            .with_attributes(attributes(parsed))
+            .start_with_context(&self.tracer, &parent_cx);
+        // A turn is a root span; record its context so its children nest under it.
+        if parsed.family == "turn"
+            && let Some(turn) = turn_id(parsed.context)
+        {
+            let cx = Context::new().with_remote_span_context(span.span_context().clone());
+            self.turn_cx.insert(turn.to_string(), cx);
         }
-        self.open.insert(
-            key,
-            OpenSpan {
-                span_id,
-                parent,
-                name: span_name(parsed),
-                start_nanos: parsed.ts_nanos,
-                attributes: attributes(parsed),
-            },
-        );
+        self.open.insert(correlation_key(parsed), span);
     }
 
     fn close_span(&mut self, parsed: &Parsed) {
-        let key = correlation_key(parsed);
-        let status = if parsed.phase == "failed" { 2 } else { 0 };
-        let finished = match self.open.remove(&key) {
-            Some(open) => FinishedSpan {
-                span_id: open.span_id,
-                parent: open.parent,
-                name: open.name,
-                start_nanos: open.start_nanos,
-                end_nanos: parsed.ts_nanos,
-                attributes: merge_attrs(open.attributes, attributes(parsed)),
-                status,
-            },
-            // Unpaired terminal (missed/absent `started`): a point span so the
+        match self.open.remove(&correlation_key(parsed)) {
+            Some(mut span) => {
+                span.set_attributes(attributes(parsed));
+                if parsed.phase == "failed" {
+                    span.set_status(Status::error("failed"));
+                }
+                span.end_with_timestamp(parsed.ts);
+            }
+            // Unpaired terminal (absent/missed `started`): a point span so the
             // event is still recorded rather than silently dropped.
-            None => FinishedSpan {
-                span_id: span_id_for(&key),
-                parent: self.parent_for(parsed),
-                name: span_name(parsed),
-                start_nanos: parsed.ts_nanos,
-                end_nanos: parsed.ts_nanos,
-                attributes: attributes(parsed),
-                status,
-            },
-        };
-        if parsed.family == "turn" {
-            if let Some(turn) = turn_id(parsed.context) {
-                self.turn_span.remove(turn);
+            None => {
+                let mut span = self.point(parsed);
+                if parsed.phase == "failed" {
+                    span.set_status(Status::error("failed"));
+                }
+                span.end_with_timestamp(parsed.ts);
             }
         }
-        self.finished.push(finished);
+        if parsed.family == "turn"
+            && let Some(turn) = turn_id(parsed.context)
+        {
+            self.turn_cx.remove(turn);
+        }
     }
 
-    /// Parent a child (reason/act/tool) to its enclosing turn span, if open.
-    fn parent_for(&self, parsed: &Parsed) -> Option<[u8; 8]> {
+    fn point_span(&mut self, parsed: &Parsed) {
+        let mut span = self.point(parsed);
+        span.end_with_timestamp(parsed.ts);
+    }
+
+    /// Start a zero-duration span at the event's timestamp, parented to its turn.
+    fn point(&self, parsed: &Parsed) -> SdkSpan {
+        let parent_cx = self.parent_cx(parsed);
+        self.tracer
+            .span_builder(span_name(parsed))
+            .with_kind(SpanKind::Internal)
+            .with_start_time(parsed.ts)
+            .with_attributes(attributes(parsed))
+            .start_with_context(&self.tracer, &parent_cx)
+    }
+
+    /// Parent context: a turn is a root (empty context, new trace); a child
+    /// parents to its turn's span if that turn is open.
+    fn parent_cx(&self, parsed: &Parsed) -> Context {
         if parsed.family == "turn" {
-            return None;
+            return Context::new();
         }
-        turn_id(parsed.context).and_then(|t| self.turn_span.get(t).copied())
-    }
-
-    /// Serialize the finished spans as one OTLP/HTTP JSON body and hand it to
-    /// the sink. A no-op when there is nothing buffered.
-    pub fn flush(&mut self) {
-        if self.finished.is_empty() {
-            return;
-        }
-        let Some(trace_id) = self.trace_id else {
-            self.finished.clear();
-            return;
-        };
-        let spans = std::mem::take(&mut self.finished);
-        let body = otlp_body(&self.service_name, &self.session_id, trace_id, &spans);
-        (self.sink)(&body);
+        turn_id(parsed.context)
+            .and_then(|t| self.turn_cx.get(t).cloned())
+            .unwrap_or_default()
     }
 }
 
 // ---------------------------------------------------------------------------
-// Parsing / naming / attributes
+// Parsing / naming / attributes (pure, unit-tested)
 
 fn parse(params: &yolop_yep::TraceEventParams) -> Option<Parsed<'_>> {
     let (family, phase) = params
         .event_type
         .split_once('.')
         .unwrap_or((params.event_type.as_str(), ""));
-    let ts_nanos = params
-        .ts
-        .parse::<chrono::DateTime<chrono::Utc>>()
-        .ok()?
-        .timestamp_nanos_opt()?
-        .into();
+    let ts = ts_to_system_time(&params.ts)?;
     Some(Parsed {
         family,
         phase,
-        ts_nanos,
-        session_id: &params.session_id,
+        ts,
         context: &params.context,
         data: &params.data,
         event_type: &params.event_type,
@@ -221,13 +172,21 @@ fn parse(params: &yolop_yep::TraceEventParams) -> Option<Parsed<'_>> {
     })
 }
 
+fn ts_to_system_time(ts: &str) -> Option<SystemTime> {
+    let nanos = ts
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .ok()?
+        .timestamp_nanos_opt()?;
+    (nanos >= 0).then(|| UNIX_EPOCH + Duration::from_nanos(nanos as u64))
+}
+
 fn turn_id(context: &Value) -> Option<&str> {
     context.get("turn_id").and_then(Value::as_str)
 }
 
 /// A stable per-span key so `started` and its terminal event coincide. Prefers
-/// the most specific correlation id available for the family and falls back to
-/// the event id (which makes an unpaired point span rather than a wrong pair).
+/// the most specific correlation id for the family, falling back to the event
+/// id (an unpaired point span rather than a wrong pair).
 fn correlation_key(parsed: &Parsed) -> String {
     let candidates: &[&str] = match parsed.family {
         "tool" => &["tool_call_id", "exec_id", "call_id"],
@@ -244,158 +203,63 @@ fn correlation_key(parsed: &Parsed) -> String {
 
 fn span_name(parsed: &Parsed) -> String {
     match parsed.family {
-        "tool" => {
-            let tool = parsed
-                .data
-                .get("tool_name")
-                .or_else(|| parsed.data.get("name"))
-                .and_then(Value::as_str);
-            match tool {
-                Some(name) => format!("tool {name}"),
-                None => "tool".to_string(),
-            }
-        }
+        "tool" => match parsed
+            .data
+            .get("tool_name")
+            .or_else(|| parsed.data.get("name"))
+            .and_then(Value::as_str)
+        {
+            Some(name) => format!("tool {name}"),
+            None => "tool".to_string(),
+        },
+        // `llm.generation` etc. read best as the full event type.
+        "llm" => parsed.event_type.to_string(),
         other => other.to_string(),
     }
 }
 
-/// Base attributes for a span: the concrete event type plus any scalar fields
-/// from the event `data` (token usage, model, tool name, …), namespaced.
-fn attributes(parsed: &Parsed) -> Vec<(String, Value)> {
-    let mut attrs = vec![("yolop.event_type".to_string(), json!(parsed.event_type))];
+/// Span attributes: the concrete event type plus scalar `data` fields (token
+/// usage, model, tool name, exit code, …), namespaced under `yolop.`.
+fn attributes(parsed: &Parsed) -> Vec<KeyValue> {
+    let mut attrs = vec![KeyValue::new(
+        "yolop.event_type",
+        parsed.event_type.to_string(),
+    )];
     if let Some(map) = parsed.data.as_object() {
         for (key, value) in map {
-            if value.is_object() || value.is_array() {
-                continue; // keep attributes flat and cheap
+            let name = format!("yolop.{key}");
+            match value {
+                Value::String(s) => attrs.push(KeyValue::new(name, s.clone())),
+                Value::Bool(b) => attrs.push(KeyValue::new(name, *b)),
+                Value::Number(n) if n.is_i64() => {
+                    attrs.push(KeyValue::new(name, n.as_i64().unwrap()))
+                }
+                Value::Number(n) if n.is_u64() => {
+                    attrs.push(KeyValue::new(name, n.as_u64().unwrap() as i64))
+                }
+                Value::Number(n) => attrs.push(KeyValue::new(name, n.as_f64().unwrap_or(0.0))),
+                // Objects/arrays/null: skip, keeping attributes flat and cheap.
+                _ => {}
             }
-            attrs.push((format!("yolop.{key}"), value.clone()));
         }
     }
     attrs
-}
-
-fn merge_attrs(
-    mut base: Vec<(String, Value)>,
-    extra: Vec<(String, Value)>,
-) -> Vec<(String, Value)> {
-    for (k, v) in extra {
-        if !base.iter().any(|(bk, _)| *bk == k) {
-            base.push((k, v));
-        }
-    }
-    base
-}
-
-// ---------------------------------------------------------------------------
-// Deterministic ids (FNV-1a; no rng dependency, reproducible in tests)
-
-fn fnv1a_64(bytes: &[u8]) -> u64 {
-    let mut hash = 0xcbf29ce484222325u64;
-    for &b in bytes {
-        hash ^= b as u64;
-        hash = hash.wrapping_mul(0x100000001b3);
-    }
-    hash
-}
-
-fn trace_id_for(session_id: &str) -> [u8; 16] {
-    // Two independent 64-bit hashes give a 128-bit id that is non-zero and
-    // stable per session (all of a session's spans share one trace).
-    let hi = fnv1a_64(session_id.as_bytes());
-    let lo = fnv1a_64(format!("{session_id}#lo").as_bytes());
-    let mut id = [0u8; 16];
-    id[..8].copy_from_slice(&hi.to_be_bytes());
-    id[8..].copy_from_slice(&lo.to_be_bytes());
-    if id == [0u8; 16] {
-        id[15] = 1;
-    }
-    id
-}
-
-fn span_id_for(key: &str) -> [u8; 8] {
-    let mut id = fnv1a_64(key.as_bytes()).to_be_bytes();
-    if id == [0u8; 8] {
-        id[7] = 1;
-    }
-    id
-}
-
-fn hex(bytes: &[u8]) -> String {
-    let mut s = String::with_capacity(bytes.len() * 2);
-    for b in bytes {
-        s.push_str(&format!("{b:02x}"));
-    }
-    s
-}
-
-// ---------------------------------------------------------------------------
-// OTLP/HTTP JSON
-
-fn otlp_attributes(attrs: &[(String, Value)]) -> Vec<Value> {
-    attrs
-        .iter()
-        .map(|(k, v)| json!({ "key": k, "value": otlp_any_value(v) }))
-        .collect()
-}
-
-fn otlp_any_value(v: &Value) -> Value {
-    match v {
-        Value::String(s) => json!({ "stringValue": s }),
-        Value::Bool(b) => json!({ "boolValue": b }),
-        Value::Number(n) if n.is_i64() || n.is_u64() => json!({ "intValue": n.to_string() }),
-        Value::Number(n) => json!({ "doubleValue": n.as_f64().unwrap_or(0.0) }),
-        other => json!({ "stringValue": other.to_string() }),
-    }
-}
-
-/// Build the OTLP `POST /v1/traces` JSON body for a batch of finished spans.
-fn otlp_body(
-    service_name: &str,
-    session_id: &str,
-    trace_id: [u8; 16],
-    spans: &[FinishedSpan],
-) -> String {
-    let trace_hex = hex(&trace_id);
-    let otlp_spans: Vec<Value> = spans
-        .iter()
-        .map(|span| {
-            json!({
-                "traceId": trace_hex,
-                "spanId": hex(&span.span_id),
-                "parentSpanId": span.parent.map(|p| hex(&p)).unwrap_or_default(),
-                "name": span.name,
-                // SPAN_KIND_INTERNAL
-                "kind": 1,
-                "startTimeUnixNano": span.start_nanos.max(0).to_string(),
-                "endTimeUnixNano": span.end_nanos.max(0).to_string(),
-                "attributes": otlp_attributes(&span.attributes),
-                "status": { "code": span.status },
-            })
-        })
-        .collect();
-
-    json!({
-        "resourceSpans": [{
-            "resource": {
-                "attributes": otlp_attributes(&[
-                    ("service.name".to_string(), json!(service_name)),
-                    ("session.id".to_string(), json!(session_id)),
-                ]),
-            },
-            "scopeSpans": [{
-                "scope": { "name": "yolop-extension-logfire" },
-                "spans": otlp_spans,
-            }],
-        }],
-    })
-    .to_string()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::cell::RefCell;
-    use std::rc::Rc;
+    use opentelemetry::trace::{SpanId, Status as OtelStatus, TracerProvider as _};
+    use opentelemetry_sdk::trace::{InMemorySpanExporter, InMemorySpanExporterBuilder};
+
+    fn exporter() -> (TraceExporter, InMemorySpanExporter) {
+        let mem = InMemorySpanExporterBuilder::new().build();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(mem.clone())
+            .build();
+        let tracer = provider.tracer("test");
+        (TraceExporter::new(tracer, provider), mem)
+    }
 
     fn ev(event_type: &str, ts: &str, ctx: Value, data: Value) -> yolop_yep::TraceEventParams {
         yolop_yep::TraceEventParams {
@@ -408,133 +272,148 @@ mod tests {
         }
     }
 
-    /// A collector sink capturing each flushed OTLP body as parsed JSON.
-    fn recorder() -> (Rc<RefCell<Vec<Value>>>, impl FnMut(&str)) {
-        let out = Rc::new(RefCell::new(Vec::new()));
-        let sink_out = out.clone();
-        let sink = move |body: &str| {
-            sink_out
-                .borrow_mut()
-                .push(serde_json::from_str(body).expect("valid json body"));
-        };
-        (out, sink)
-    }
-
     #[test]
-    fn a_turn_with_a_tool_flushes_one_batch_of_nested_spans() {
-        let (out, sink) = recorder();
-        let mut exporter = SpanExporter::new("yolop", sink);
-        let turn = json!({ "turn_id": "t1" });
-        let tool_ctx = json!({ "turn_id": "t1", "tool_call_id": "c1" });
+    fn a_turn_with_a_tool_produces_one_trace_with_nested_spans() {
+        let (mut exp, mem) = exporter();
+        let turn = serde_json::json!({ "turn_id": "t1" });
+        let tool_ctx = serde_json::json!({ "turn_id": "t1", "tool_call_id": "c1" });
 
-        exporter.handle(&ev(
+        exp.handle(&ev(
             "turn.started",
             "2024-01-01T00:00:00Z",
             turn.clone(),
-            json!({}),
+            serde_json::json!({}),
         ));
-        exporter.handle(&ev(
+        exp.handle(&ev(
             "tool.started",
             "2024-01-01T00:00:01Z",
             tool_ctx.clone(),
-            json!({ "tool_name": "bash" }),
+            serde_json::json!({ "tool_name": "bash" }),
         ));
-        exporter.handle(&ev(
+        exp.handle(&ev(
             "tool.completed",
             "2024-01-01T00:00:02Z",
             tool_ctx,
-            json!({ "tool_name": "bash", "ok": true }),
+            serde_json::json!({ "tool_name": "bash", "exit_code": 0 }),
         ));
-        // No flush yet — only a turn boundary flushes.
-        assert!(out.borrow().is_empty());
-
-        exporter.handle(&ev(
+        exp.handle(&ev(
             "turn.completed",
             "2024-01-01T00:00:03Z",
             turn,
-            json!({}),
+            serde_json::json!({}),
         ));
 
-        let batches = out.borrow();
-        assert_eq!(batches.len(), 1, "one POST at the turn boundary");
-        let spans = &batches[0]["resourceSpans"][0]["scopeSpans"][0]["spans"];
-        let spans = spans.as_array().unwrap();
+        let spans = mem.get_finished_spans().expect("finished spans");
         assert_eq!(spans.len(), 2, "turn + tool");
+        let turn_span = spans.iter().find(|s| s.name == "turn").expect("turn span");
+        let tool_span = spans
+            .iter()
+            .find(|s| s.name == "tool bash")
+            .expect("tool span");
 
-        let turn_span = spans.iter().find(|s| s["name"] == "turn").unwrap();
-        let tool_span = spans.iter().find(|s| s["name"] == "tool bash").unwrap();
-        // Same trace, tool parented to the turn.
-        assert_eq!(turn_span["traceId"], tool_span["traceId"]);
-        assert_eq!(tool_span["parentSpanId"], turn_span["spanId"]);
-        assert_eq!(turn_span["parentSpanId"], "");
-        // Real duration, not a point.
-        assert_ne!(tool_span["startTimeUnixNano"], tool_span["endTimeUnixNano"]);
-        // Data scalars became attributes.
-        let attrs = tool_span["attributes"].as_array().unwrap();
+        // One trace; tool nested under the turn; turn is the root.
+        assert_eq!(
+            turn_span.span_context.trace_id(),
+            tool_span.span_context.trace_id()
+        );
+        assert_eq!(tool_span.parent_span_id, turn_span.span_context.span_id());
+        assert_eq!(turn_span.parent_span_id, SpanId::INVALID);
+        // Real duration.
+        assert!(tool_span.end_time > tool_span.start_time);
+        // Data scalars became attributes (string + int).
         assert!(
-            attrs
+            tool_span
+                .attributes
                 .iter()
-                .any(|a| a["key"] == "yolop.tool_name" && a["value"]["stringValue"] == "bash")
+                .any(|kv| kv.key.as_str() == "yolop.tool_name" && kv.value.as_str() == "bash")
+        );
+        assert!(
+            tool_span
+                .attributes
+                .iter()
+                .any(|kv| kv.key.as_str() == "yolop.exit_code")
         );
     }
 
     #[test]
-    fn failed_event_marks_error_status() {
-        let (out, sink) = recorder();
-        let mut exporter = SpanExporter::new("yolop", sink);
-        let turn = json!({ "turn_id": "t9" });
-        exporter.handle(&ev(
+    fn llm_generation_is_a_point_span_under_its_turn() {
+        let (mut exp, mem) = exporter();
+        let turn = serde_json::json!({ "turn_id": "t1" });
+        exp.handle(&ev(
             "turn.started",
             "2024-01-01T00:00:00Z",
             turn.clone(),
-            json!({}),
+            serde_json::json!({}),
         ));
-        exporter.handle(&ev("turn.failed", "2024-01-01T00:00:01Z", turn, json!({})));
-        let batches = out.borrow();
-        let span = &batches[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0];
-        assert_eq!(span["status"]["code"], 2, "ERROR");
+        exp.handle(&ev(
+            "llm.generation",
+            "2024-01-01T00:00:01Z",
+            serde_json::json!({ "turn_id": "t1" }),
+            serde_json::json!({ "model": "gpt", "input_tokens": 42, "output_tokens": 7 }),
+        ));
+        exp.handle(&ev(
+            "turn.completed",
+            "2024-01-01T00:00:02Z",
+            turn,
+            serde_json::json!({}),
+        ));
+
+        let spans = mem.get_finished_spans().unwrap();
+        let llm = spans
+            .iter()
+            .find(|s| s.name == "llm.generation")
+            .expect("llm span");
+        let turn_span = spans.iter().find(|s| s.name == "turn").unwrap();
+        assert_eq!(llm.parent_span_id, turn_span.span_context.span_id());
+        assert!(
+            llm.attributes
+                .iter()
+                .any(|kv| kv.key.as_str() == "yolop.input_tokens")
+        );
     }
 
     #[test]
-    fn non_span_families_are_ignored() {
-        let (out, sink) = recorder();
-        let mut exporter = SpanExporter::new("yolop", sink);
-        // session/file/budget events don't open spans; flushing yields nothing.
-        exporter.handle(&ev(
+    fn failed_event_sets_error_status() {
+        let (mut exp, mem) = exporter();
+        let turn = serde_json::json!({ "turn_id": "t9" });
+        exp.handle(&ev(
+            "turn.started",
+            "2024-01-01T00:00:00Z",
+            turn.clone(),
+            serde_json::json!({}),
+        ));
+        exp.handle(&ev(
+            "turn.failed",
+            "2024-01-01T00:00:01Z",
+            turn,
+            serde_json::json!({}),
+        ));
+        let spans = mem.get_finished_spans().unwrap();
+        let turn_span = spans.iter().find(|s| s.name == "turn").unwrap();
+        assert!(matches!(turn_span.status, OtelStatus::Error { .. }));
+    }
+
+    #[test]
+    fn non_span_families_and_bad_timestamps_are_ignored() {
+        let (mut exp, mem) = exporter();
+        exp.handle(&ev(
             "session.started",
             "2024-01-01T00:00:00Z",
-            json!({}),
-            json!({}),
+            serde_json::json!({}),
+            serde_json::json!({}),
         ));
-        exporter.handle(&ev(
+        exp.handle(&ev(
             "file.written",
             "2024-01-01T00:00:00Z",
-            json!({}),
-            json!({}),
+            serde_json::json!({}),
+            serde_json::json!({}),
         ));
-        exporter.flush();
-        assert!(out.borrow().is_empty());
-    }
-
-    #[test]
-    fn ids_are_deterministic_and_nonzero() {
-        assert_eq!(trace_id_for("sess-1"), trace_id_for("sess-1"));
-        assert_ne!(trace_id_for("sess-1"), [0u8; 16]);
-        assert_eq!(span_id_for("turn:t1"), span_id_for("turn:t1"));
-        assert_ne!(span_id_for("turn:t1"), span_id_for("turn:t2"));
-    }
-
-    #[test]
-    fn unparseable_timestamp_is_skipped_not_fatal() {
-        let (out, sink) = recorder();
-        let mut exporter = SpanExporter::new("yolop", sink);
-        exporter.handle(&ev(
+        exp.handle(&ev(
             "turn.started",
             "not-a-date",
-            json!({ "turn_id": "t1" }),
-            json!({}),
+            serde_json::json!({ "turn_id": "t1" }),
+            serde_json::json!({}),
         ));
-        exporter.flush();
-        assert!(out.borrow().is_empty());
+        assert!(mem.get_finished_spans().unwrap().is_empty());
     }
 }

--- a/crates/yolop-extension-logfire/src/main.rs
+++ b/crates/yolop-extension-logfire/src/main.rs
@@ -27,8 +27,10 @@ use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_otlp::{Protocol, SpanExporter, WithExportConfig, WithHttpConfig};
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::trace::SdkTracerProvider;
+use serde_json::Value;
 use std::collections::HashMap;
 use std::io::Write;
+use std::sync::{Arc, Mutex};
 
 const DEFAULT_ENDPOINT: &str = "https://logfire-us.pydantic.dev/v1/traces";
 const DEFAULT_SERVICE: &str = "yolop";
@@ -39,13 +41,19 @@ fn env_any(keys: &[&str]) -> Option<String> {
         .find_map(|k| std::env::var(k).ok().filter(|v| !v.trim().is_empty()))
 }
 
-fn main() -> std::io::Result<()> {
-    let token = env_any(&["LOGFIRE_TOKEN", "LOGFIRE_WRITE_TOKEN"]);
-    let endpoint = env_any(&["LOGFIRE_ENDPOINT", "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"])
-        .unwrap_or_else(|| DEFAULT_ENDPOINT.to_string());
-    let service = env_any(&["OTEL_SERVICE_NAME", "LOGFIRE_SERVICE_NAME"])
-        .unwrap_or_else(|| DEFAULT_SERVICE.to_string());
+fn config_str(config: &Value, key: &str, env_keys: &[&str], default: &str) -> String {
+    config
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| env_any(env_keys))
+        .unwrap_or_else(|| default.to_string())
+}
 
+fn main() -> std::io::Result<()> {
+    // The token is a `secret` config field, injected by the host as env; never
+    // delivered via `initialize.config`.
+    let token = env_any(&["LOGFIRE_TOKEN", "LOGFIRE_WRITE_TOKEN"]);
     if token.is_none() {
         // stderr is the server's free log channel (yolop drains it to tracing).
         let _ = writeln!(
@@ -55,12 +63,36 @@ fn main() -> std::io::Result<()> {
         );
     }
 
-    let provider = build_provider(token, endpoint, service);
-    let tracer = provider.tracer(TRACER_NAME);
-    let mut exporter = TraceExporter::new(tracer, provider);
+    // Built from `initialize.config` (endpoint/service_name), which arrives
+    // before any trace event; shared with the trace handler via a mutex (the
+    // serve loop is single-threaded, so it's uncontended).
+    let exporter: Arc<Mutex<Option<TraceExporter>>> = Arc::new(Mutex::new(None));
+    let on_config_exporter = exporter.clone();
+    let on_trace_exporter = exporter.clone();
 
     yolop_yep::Server::new("logfire")
-        .on_trace(move |event| exporter.handle(event))
+        .on_config(move |config| {
+            let endpoint = config_str(
+                config,
+                "endpoint",
+                &["LOGFIRE_ENDPOINT", "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"],
+                DEFAULT_ENDPOINT,
+            );
+            let service = config_str(
+                config,
+                "service_name",
+                &["OTEL_SERVICE_NAME", "LOGFIRE_SERVICE_NAME"],
+                DEFAULT_SERVICE,
+            );
+            let provider = build_provider(token.clone(), endpoint, service);
+            let tracer = provider.tracer(TRACER_NAME);
+            *on_config_exporter.lock().unwrap() = Some(TraceExporter::new(tracer, provider));
+        })
+        .on_trace(move |event| {
+            if let Some(exp) = on_trace_exporter.lock().unwrap().as_mut() {
+                exp.handle(event);
+            }
+        })
         .serve()
 }
 

--- a/crates/yolop-extension-logfire/src/main.rs
+++ b/crates/yolop-extension-logfire/src/main.rs
@@ -4,29 +4,35 @@
 //! It declares the `trace` facet: yolop forwards each agentic-lifecycle event
 //! (`turn.*`, `reason.*`, `act.*`, `tool.*`, `llm.generation`) as a
 //! fire-and-forget `trace/event` notification. This server folds those into
-//! OpenTelemetry spans ([`exporter`]) and POSTs them to Logfire's OTLP/HTTP
-//! endpoint — the same wire Logfire's own SDKs use, so runs show up as nested
-//! traces with no Logfire library dependency.
+//! OpenTelemetry spans ([`exporter`]) and ships them to Logfire through the
+//! official OTLP/HTTP exporter — the approach Logfire's "alternative clients"
+//! guide documents for Rust, so no Logfire client library is needed.
 //!
-//! Configuration is by environment (mirroring Logfire's onboarding checklist,
-//! <https://logfire.pydantic.dev/docs/>), inherited from the yolop process:
+//! Configuration is by environment (inherited from the yolop process), matching
+//! Logfire's onboarding checklist, <https://logfire.pydantic.dev/docs/>:
 //!
-//! - `LOGFIRE_TOKEN` (or `LOGFIRE_WRITE_TOKEN`) — the write token. **Required**;
-//!   without it spans are built but dropped (a one-line stderr note), so the
-//!   extension is inert until configured.
+//! - `LOGFIRE_TOKEN` (or `LOGFIRE_WRITE_TOKEN`) — the write token, sent raw in
+//!   the `Authorization` header (no `Bearer` prefix, per Logfire's OTLP setup).
+//!   **Required**; without it the server runs but exports nowhere (a one-line
+//!   stderr note), so the extension is inert until configured.
 //! - `LOGFIRE_ENDPOINT` (or `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`) — the OTLP
-//!   traces URL. Defaults to Logfire's ingest endpoint.
+//!   traces URL. Defaults to Logfire's US ingest endpoint.
 //! - `OTEL_SERVICE_NAME` (or `LOGFIRE_SERVICE_NAME`) — service name on the
 //!   spans. Defaults to `yolop`.
 
 mod exporter;
 
-use exporter::SpanExporter;
+use exporter::TraceExporter;
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_otlp::{Protocol, SpanExporter, WithExportConfig, WithHttpConfig};
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::trace::SdkTracerProvider;
+use std::collections::HashMap;
 use std::io::Write;
-use yolop_yep::Server;
 
-const DEFAULT_ENDPOINT: &str = "https://logfire-api.pydantic.dev/v1/traces";
+const DEFAULT_ENDPOINT: &str = "https://logfire-us.pydantic.dev/v1/traces";
 const DEFAULT_SERVICE: &str = "yolop";
+const TRACER_NAME: &str = "yolop-extension-logfire";
 
 fn env_any(keys: &[&str]) -> Option<String> {
     keys.iter()
@@ -44,41 +50,51 @@ fn main() -> std::io::Result<()> {
         // stderr is the server's free log channel (yolop drains it to tracing).
         let _ = writeln!(
             std::io::stderr(),
-            "yolop-extension-logfire: no LOGFIRE_TOKEN set; traces will be dropped. \
-             Set LOGFIRE_TOKEN to export to Logfire."
+            "yolop-extension-logfire: no LOGFIRE_TOKEN set; traces will not be exported. \
+             Set LOGFIRE_TOKEN to send to Logfire."
         );
     }
 
-    let http = build_http_sink(token, endpoint);
-    let mut exporter = SpanExporter::new(service, http);
+    let provider = build_provider(token, endpoint, service);
+    let tracer = provider.tracer(TRACER_NAME);
+    let mut exporter = TraceExporter::new(tracer, provider);
 
-    Server::new("logfire")
+    yolop_yep::Server::new("logfire")
         .on_trace(move |event| exporter.handle(event))
         .serve()
 }
 
-/// Build the OTLP/HTTP sink: POST each serialized batch to Logfire. Blocking
-/// (the serve loop is single-threaded), agent reused across calls. All failures
-/// degrade to a stderr note — the exporter must never sink the agent.
-fn build_http_sink(token: Option<String>, endpoint: String) -> impl FnMut(&str) {
-    let agent = ureq::AgentBuilder::new()
-        .timeout(std::time::Duration::from_secs(10))
-        .build();
-    move |body: &str| {
-        let Some(token) = token.as_deref() else {
-            return; // no token: already warned at startup; drop silently
-        };
-        let result = agent
-            .post(&endpoint)
-            .set("Content-Type", "application/json")
-            // Logfire authenticates OTLP with the write token in `Authorization`.
-            .set("Authorization", token)
-            .send_string(body);
-        if let Err(err) = result {
+/// Build the tracer provider. With a token, a simple (synchronous, blocking)
+/// OTLP/HTTP exporter POSTs each span to Logfire as it ends — fitting the
+/// single-threaded serve loop without a tokio runtime. Without a token, the
+/// provider has no exporter, so spans are built and dropped (inert).
+fn build_provider(token: Option<String>, endpoint: String, service: String) -> SdkTracerProvider {
+    let resource = Resource::builder().with_service_name(service).build();
+    let Some(token) = token else {
+        return SdkTracerProvider::builder().with_resource(resource).build();
+    };
+
+    let mut headers = HashMap::new();
+    headers.insert("Authorization".to_string(), token);
+
+    match SpanExporter::builder()
+        .with_http()
+        .with_protocol(Protocol::HttpBinary)
+        .with_endpoint(endpoint)
+        .with_headers(headers)
+        .build()
+    {
+        Ok(exporter) => SdkTracerProvider::builder()
+            .with_simple_exporter(exporter)
+            .with_resource(resource)
+            .build(),
+        Err(err) => {
             let _ = writeln!(
                 std::io::stderr(),
-                "yolop-extension-logfire: export failed: {err}"
+                "yolop-extension-logfire: could not build OTLP exporter ({err}); \
+                 traces will not be exported"
             );
+            SdkTracerProvider::builder().with_resource(resource).build()
         }
     }
 }

--- a/crates/yolop-extension-logfire/src/main.rs
+++ b/crates/yolop-extension-logfire/src/main.rs
@@ -1,0 +1,84 @@
+//! `yolop-extension-logfire` — a yolop extension capability server that exports
+//! the agent's live trace to [Pydantic Logfire](https://logfire.pydantic.dev/).
+//!
+//! It declares the `trace` facet: yolop forwards each agentic-lifecycle event
+//! (`turn.*`, `reason.*`, `act.*`, `tool.*`, `llm.generation`) as a
+//! fire-and-forget `trace/event` notification. This server folds those into
+//! OpenTelemetry spans ([`exporter`]) and POSTs them to Logfire's OTLP/HTTP
+//! endpoint — the same wire Logfire's own SDKs use, so runs show up as nested
+//! traces with no Logfire library dependency.
+//!
+//! Configuration is by environment (mirroring Logfire's onboarding checklist,
+//! <https://logfire.pydantic.dev/docs/>), inherited from the yolop process:
+//!
+//! - `LOGFIRE_TOKEN` (or `LOGFIRE_WRITE_TOKEN`) — the write token. **Required**;
+//!   without it spans are built but dropped (a one-line stderr note), so the
+//!   extension is inert until configured.
+//! - `LOGFIRE_ENDPOINT` (or `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`) — the OTLP
+//!   traces URL. Defaults to Logfire's ingest endpoint.
+//! - `OTEL_SERVICE_NAME` (or `LOGFIRE_SERVICE_NAME`) — service name on the
+//!   spans. Defaults to `yolop`.
+
+mod exporter;
+
+use exporter::SpanExporter;
+use std::io::Write;
+use yolop_yep::Server;
+
+const DEFAULT_ENDPOINT: &str = "https://logfire-api.pydantic.dev/v1/traces";
+const DEFAULT_SERVICE: &str = "yolop";
+
+fn env_any(keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|k| std::env::var(k).ok().filter(|v| !v.trim().is_empty()))
+}
+
+fn main() -> std::io::Result<()> {
+    let token = env_any(&["LOGFIRE_TOKEN", "LOGFIRE_WRITE_TOKEN"]);
+    let endpoint = env_any(&["LOGFIRE_ENDPOINT", "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"])
+        .unwrap_or_else(|| DEFAULT_ENDPOINT.to_string());
+    let service = env_any(&["OTEL_SERVICE_NAME", "LOGFIRE_SERVICE_NAME"])
+        .unwrap_or_else(|| DEFAULT_SERVICE.to_string());
+
+    if token.is_none() {
+        // stderr is the server's free log channel (yolop drains it to tracing).
+        let _ = writeln!(
+            std::io::stderr(),
+            "yolop-extension-logfire: no LOGFIRE_TOKEN set; traces will be dropped. \
+             Set LOGFIRE_TOKEN to export to Logfire."
+        );
+    }
+
+    let http = build_http_sink(token, endpoint);
+    let mut exporter = SpanExporter::new(service, http);
+
+    Server::new("logfire")
+        .on_trace(move |event| exporter.handle(event))
+        .serve()
+}
+
+/// Build the OTLP/HTTP sink: POST each serialized batch to Logfire. Blocking
+/// (the serve loop is single-threaded), agent reused across calls. All failures
+/// degrade to a stderr note — the exporter must never sink the agent.
+fn build_http_sink(token: Option<String>, endpoint: String) -> impl FnMut(&str) {
+    let agent = ureq::AgentBuilder::new()
+        .timeout(std::time::Duration::from_secs(10))
+        .build();
+    move |body: &str| {
+        let Some(token) = token.as_deref() else {
+            return; // no token: already warned at startup; drop silently
+        };
+        let result = agent
+            .post(&endpoint)
+            .set("Content-Type", "application/json")
+            // Logfire authenticates OTLP with the write token in `Authorization`.
+            .set("Authorization", token)
+            .send_string(body);
+        if let Err(err) = result {
+            let _ = writeln!(
+                std::io::stderr(),
+                "yolop-extension-logfire: export failed: {err}"
+            );
+        }
+    }
+}

--- a/crates/yolop-yep/src/lib.rs
+++ b/crates/yolop-yep/src/lib.rs
@@ -32,7 +32,7 @@ pub mod schema;
 mod server;
 
 pub use meta::{Meta, meta, meta_json};
-pub use protocol::PROTOCOL_VERSION;
+pub use protocol::{PROTOCOL_VERSION, TraceEventParams};
 #[cfg(feature = "schema")]
 pub use schema::schema_json;
 pub use server::{HookResponse, Server, ToolResponse};

--- a/crates/yolop-yep/src/meta.rs
+++ b/crates/yolop-yep/src/meta.rs
@@ -43,6 +43,11 @@ pub const METHODS: &[Method] = &[
         "Ask the user a question and wait for a typed answer (TUI hosts only).",
     ),
     Method::host("config/changed", "Notify the server its config changed."),
+    Method::host(
+        "trace/event",
+        "Notification: forward one agentic-lifecycle event (turn/reason/act/tool/llm) to an \
+         extension that declares `trace`, for export to a tracing backend.",
+    ),
     Method::host("shutdown", "Request a graceful stop."),
 ];
 
@@ -57,6 +62,7 @@ pub const CAPABILITY_TOKENS: &[&str] = &[
     "status",
     "commands",
     "ui_ask",
+    "trace",
 ];
 
 /// Direction a method flows.

--- a/crates/yolop-yep/src/protocol.rs
+++ b/crates/yolop-yep/src/protocol.rs
@@ -339,6 +339,44 @@ fn default_true() -> bool {
 }
 
 // ---------------------------------------------------------------------------
+// trace/event
+
+/// Host → server `trace/event` notification: one agentic-lifecycle event
+/// (a turn/reason/act/tool/llm event from the host's session event log),
+/// forwarded observe-only to an extension that declares the `trace` facet so
+/// it can export the run to an external tracing backend (Logfire, an OTLP
+/// collector, …). Fire-and-forget — the server never replies, so a slow or
+/// crashed exporter can never stall the agent loop.
+///
+/// The `data` field carries the event-type-specific payload verbatim (see the
+/// everruns event protocol, `specs/events.md`); the server maps it to spans.
+/// Lenient/defaulted per the forward-compat rules — a new event type parses
+/// with its `data` intact even if this struct predates it.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct TraceEventParams {
+    /// Event type, e.g. `turn.started`, `tool.completed`, `llm.generation`.
+    #[serde(default)]
+    pub event_type: String,
+    /// Stable event id from the host's session event log.
+    #[serde(default)]
+    pub id: String,
+    /// RFC 3339 timestamp of the event.
+    #[serde(default)]
+    pub ts: String,
+    /// Session the event belongs to.
+    #[serde(default)]
+    pub session_id: String,
+    /// Correlation ids (turn/exec/message/model/…) carried verbatim, for
+    /// stitching point-in-time events into spans.
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub context: Value,
+    /// Event-type-specific payload, carried verbatim.
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub data: Value,
+}
+
+// ---------------------------------------------------------------------------
 // status/changed
 
 /// Severity of a `status/changed` update. Purely presentational; the host may

--- a/crates/yolop-yep/src/protocol.rs
+++ b/crates/yolop-yep/src/protocol.rs
@@ -294,6 +294,16 @@ pub struct UiAskParams {
     /// Optional placeholder / hint for the input field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub placeholder: Option<String>,
+    /// When true, the host masks the typed input and never echoes the answer
+    /// (for credentials). The value still returns in `UiAskResult`.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub secret: bool,
+    /// When non-empty, the host presents a selector over these options instead
+    /// of a free-text field; the answer is the chosen option. Extensible: future
+    /// input kinds add fields here without breaking older peers (unknown fields
+    /// are ignored, missing ones default).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub options: Vec<String>,
 }
 
 /// Host → server `ui/ask` result: the user's answer (empty + `cancelled` when

--- a/crates/yolop-yep/src/schema.rs
+++ b/crates/yolop-yep/src/schema.rs
@@ -11,7 +11,7 @@
 use crate::protocol::{
     CapabilityParams, CommandExecuteParams, CommandExecuteResult, ErrorObject, HookDecision,
     HookFireParams, InitializeParams, InitializeResult, PromptContribution, StatusChangedParams,
-    ToolCallParams, ToolUpdateParams, UiAskParams, UiAskResult,
+    ToolCallParams, ToolUpdateParams, TraceEventParams, UiAskParams, UiAskResult,
 };
 use schemars::generate::SchemaSettings;
 use serde_json::{Value, json};
@@ -36,6 +36,7 @@ fn schema_document() -> Value {
     let ui_ask_params = ref_for(generator.subschema_for::<UiAskParams>());
     let ui_ask_result = ref_for(generator.subschema_for::<UiAskResult>());
     let status_changed = ref_for(generator.subschema_for::<StatusChangedParams>());
+    let trace_event = ref_for(generator.subschema_for::<TraceEventParams>());
     let capability_params = ref_for(generator.subschema_for::<CapabilityParams>());
     let error = ref_for(generator.subschema_for::<ErrorObject>());
 
@@ -51,6 +52,7 @@ fn schema_document() -> Value {
         "prompt/contribution": { "result": prompt_contribution },
         "command/execute": { "params": command_params, "result": command_result },
         "ui/ask": { "params": ui_ask_params, "result": ui_ask_result },
+        "trace/event": { "params": trace_event },
     });
 
     let defs: Value = generator.take_definitions(true).into();

--- a/crates/yolop-yep/src/server.rs
+++ b/crates/yolop-yep/src/server.rs
@@ -51,6 +51,7 @@ type ToolHandler = Box<dyn Fn(&Value) -> ToolResponse + Send>;
 type HookHandler = Box<dyn Fn(&HookFireParams) -> HookResponse + Send>;
 type PromptHandler = Box<dyn Fn() -> String + Send>;
 type TraceHandler = Box<dyn FnMut(&TraceEventParams) + Send>;
+type ConfigHandler = Box<dyn FnMut(&Value) + Send>;
 
 /// Builder for an extension capability server.
 pub struct Server {
@@ -60,6 +61,7 @@ pub struct Server {
     hook: Option<HookHandler>,
     dynamic_prompt: Option<PromptHandler>,
     trace: Option<TraceHandler>,
+    config: Option<ConfigHandler>,
 }
 
 impl Server {
@@ -71,6 +73,7 @@ impl Server {
             hook: None,
             dynamic_prompt: None,
             trace: None,
+            config: None,
         }
     }
 
@@ -124,6 +127,19 @@ impl Server {
         self
     }
 
+    /// Register a handler for the validated `initialize.config` (the host
+    /// delivers non-secret config here). Called once, at handshake, before any
+    /// tool/trace call — so an author can build state (an exporter, a client)
+    /// from config. `secret` config fields never arrive here; they are injected
+    /// as env by the host.
+    pub fn on_config<F>(mut self, handler: F) -> Self
+    where
+        F: FnMut(&Value) + Send + 'static,
+    {
+        self.config = Some(Box::new(handler));
+        self
+    }
+
     /// Run the stdio serve loop until EOF. Blocks the calling thread.
     pub fn serve(mut self) -> std::io::Result<()> {
         let stdin = std::io::stdin();
@@ -165,9 +181,17 @@ impl Server {
         }
     }
 
-    fn handle_request(&self, id: u64, method: &str, params: Value) -> String {
+    fn handle_request(&mut self, id: u64, method: &str, params: Value) -> String {
         match method {
-            "initialize" => self.initialize_result(id, &params),
+            "initialize" => {
+                // Deliver the validated config to the author's handler once,
+                // before serving any call.
+                if let Some(handler) = self.config.as_mut() {
+                    let config = params.get("config").cloned().unwrap_or(Value::Null);
+                    handler(&config);
+                }
+                self.initialize_result(id, &params)
+            }
             "tool/call" => self.tool_call_result(id, params),
             "hook/fire" => {
                 let params: HookFireParams = serde_json::from_value(params).unwrap_or_default();
@@ -356,6 +380,25 @@ mod tests {
         );
         assert!(none.is_none(), "notifications never get a response");
         assert_eq!(seen.lock().unwrap().as_slice(), &["tool.completed"]);
+    }
+
+    #[test]
+    fn on_config_receives_initialize_config() {
+        use std::sync::{Arc, Mutex};
+        let seen: Arc<Mutex<Value>> = Arc::new(Mutex::new(Value::Null));
+        let sink = seen.clone();
+        let mut server = Server::new("cfg").on_config(move |config| {
+            *sink.lock().unwrap() = config.clone();
+        });
+        server.dispatch(
+            &json!({ "id": 1, "method": "initialize",
+                     "params": { "protocol_version": "1.0",
+                                 "config": { "endpoint": "https://x", "region": "eu" } } })
+            .to_string(),
+        );
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen["endpoint"], "https://x");
+        assert_eq!(seen["region"], "eu");
     }
 
     #[test]

--- a/crates/yolop-yep/src/server.rs
+++ b/crates/yolop-yep/src/server.rs
@@ -4,7 +4,7 @@
 //! handshake, dispatch, and error shaping.
 
 use crate::protocol::{
-    ErrorObject, HookFireParams, PROTOCOL_VERSION, ToolCallParams, classify_line,
+    ErrorObject, HookFireParams, PROTOCOL_VERSION, ToolCallParams, TraceEventParams, classify_line,
     response_error_line, version_compatible,
 };
 use serde_json::{Value, json};
@@ -50,6 +50,7 @@ impl HookResponse {
 type ToolHandler = Box<dyn Fn(&Value) -> ToolResponse + Send>;
 type HookHandler = Box<dyn Fn(&HookFireParams) -> HookResponse + Send>;
 type PromptHandler = Box<dyn Fn() -> String + Send>;
+type TraceHandler = Box<dyn FnMut(&TraceEventParams) + Send>;
 
 /// Builder for an extension capability server.
 pub struct Server {
@@ -58,6 +59,7 @@ pub struct Server {
     tools: BTreeMap<String, ToolHandler>,
     hook: Option<HookHandler>,
     dynamic_prompt: Option<PromptHandler>,
+    trace: Option<TraceHandler>,
 }
 
 impl Server {
@@ -68,6 +70,7 @@ impl Server {
             tools: BTreeMap::new(),
             hook: None,
             dynamic_prompt: None,
+            trace: None,
         }
     }
 
@@ -107,8 +110,22 @@ impl Server {
         self
     }
 
+    /// Register a handler for `trace/event` notifications — one agentic
+    /// lifecycle event per call, forwarded observe-only when the manifest
+    /// declares the `trace` facet. The handler is `FnMut` so an exporter can
+    /// carry state (open spans keyed by correlation id) across events; the
+    /// serve loop is single-threaded, so no locking is needed. Registering it
+    /// advertises the `trace` capability in the handshake.
+    pub fn on_trace<F>(mut self, handler: F) -> Self
+    where
+        F: FnMut(&TraceEventParams) + Send + 'static,
+    {
+        self.trace = Some(Box::new(handler));
+        self
+    }
+
     /// Run the stdio serve loop until EOF. Blocks the calling thread.
-    pub fn serve(self) -> std::io::Result<()> {
+    pub fn serve(mut self) -> std::io::Result<()> {
         let stdin = std::io::stdin();
         let mut stdout = std::io::stdout();
         for line in stdin.lock().lines() {
@@ -126,14 +143,24 @@ impl Server {
     }
 
     /// Handle one wire line, returning the response line to write (if any).
-    fn dispatch(&self, line: &str) -> Option<String> {
+    fn dispatch(&mut self, line: &str) -> Option<String> {
         use crate::protocol::Incoming;
         let incoming = classify_line(line)?;
         match incoming {
             Incoming::Request { id, method, params } => {
                 Some(self.handle_request(id, &method, params))
             }
-            // Servers don't act on host notifications in this SDK; ignore.
+            // `trace/event` is the one host notification this SDK acts on; it
+            // never gets a response (fire-and-forget). All other notifications
+            // and stray responses are ignored.
+            Incoming::Notification { method, params } if method == "trace/event" => {
+                if let Some(handler) = self.trace.as_mut() {
+                    let params: TraceEventParams =
+                        serde_json::from_value(params).unwrap_or_default();
+                    handler(&params);
+                }
+                None
+            }
             Incoming::Notification { .. } | Incoming::Response { .. } => None,
         }
     }
@@ -192,6 +219,9 @@ impl Server {
         }
         if self.dynamic_prompt.is_some() {
             capabilities.push(Value::from("dynamic_prompt"));
+        }
+        if self.trace.is_some() {
+            capabilities.push(Value::from("trace"));
         }
         json!({ "id": id, "result": {
             "protocol_version": PROTOCOL_VERSION,
@@ -293,6 +323,39 @@ mod tests {
                 .unwrap()
                 .contains("no such tool")
         );
+    }
+
+    #[test]
+    fn trace_events_reach_the_handler_and_advertise_the_capability() {
+        use std::sync::{Arc, Mutex};
+        let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        let mut server = Server::new("tracer").on_trace(move |ev| {
+            sink.lock().unwrap().push(ev.event_type.clone());
+        });
+
+        // The handshake advertises `trace`.
+        let out = server.dispatch(
+            &json!({ "id": 1, "method": "initialize",
+                     "params": { "protocol_version": "1.0" } })
+            .to_string(),
+        );
+        let v: Value = serde_json::from_str(&out.unwrap()).unwrap();
+        assert!(
+            v["result"]["capabilities"]
+                .as_array()
+                .unwrap()
+                .contains(&Value::from("trace"))
+        );
+
+        // A `trace/event` notification runs the handler and yields no response.
+        let none = server.dispatch(
+            &json!({ "method": "trace/event",
+                     "params": { "event_type": "tool.completed", "id": "e1" } })
+            .to_string(),
+        );
+        assert!(none.is_none(), "notifications never get a response");
+        assert_eq!(seen.lock().unwrap().as_slice(), &["tool.completed"]);
     }
 
     #[test]

--- a/schema/yep/v1/meta.json
+++ b/schema/yep/v1/meta.json
@@ -53,6 +53,11 @@
       "description": "Notify the server its config changed."
     },
     {
+      "name": "trace/event",
+      "direction": "host",
+      "description": "Notification: forward one agentic-lifecycle event (turn/reason/act/tool/llm) to an extension that declares `trace`, for export to a tracing backend."
+    },
+    {
       "name": "shutdown",
       "direction": "host",
       "description": "Request a graceful stop."
@@ -67,6 +72,7 @@
     "mcp_servers",
     "status",
     "commands",
-    "ui_ask"
+    "ui_ask",
+    "trace"
   ]
 }

--- a/schema/yep/v1/schema.json
+++ b/schema/yep/v1/schema.json
@@ -296,6 +296,13 @@
     "UiAskParams": {
       "description": "Server → host `ui/ask` params: ask the user a question and wait for a typed\nanswer. The host prompts interactively (TUI); in headless/ACP hosts with no\nprompt surface the request is refused.",
       "properties": {
+        "options": {
+          "description": "When non-empty, the host presents a selector over these options instead\nof a free-text field; the answer is the chosen option. Extensible: future\ninput kinds add fields here without breaking older peers (unknown fields\nare ignored, missing ones default).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "placeholder": {
           "description": "Optional placeholder / hint for the input field.",
           "type": [
@@ -307,6 +314,10 @@
           "default": "",
           "description": "The question shown to the user.",
           "type": "string"
+        },
+        "secret": {
+          "description": "When true, the host masks the typed input and never echoes the answer\n(for credentials). The value still returns in `UiAskResult`.",
+          "type": "boolean"
         }
       },
       "type": "object"

--- a/schema/yep/v1/schema.json
+++ b/schema/yep/v1/schema.json
@@ -261,6 +261,38 @@
       },
       "type": "object"
     },
+    "TraceEventParams": {
+      "description": "Host → server `trace/event` notification: one agentic-lifecycle event\n(a turn/reason/act/tool/llm event from the host's session event log),\nforwarded observe-only to an extension that declares the `trace` facet so\nit can export the run to an external tracing backend (Logfire, an OTLP\ncollector, …). Fire-and-forget — the server never replies, so a slow or\ncrashed exporter can never stall the agent loop.\n\nThe `data` field carries the event-type-specific payload verbatim (see the\neverruns event protocol, `specs/events.md`); the server maps it to spans.\nLenient/defaulted per the forward-compat rules — a new event type parses\nwith its `data` intact even if this struct predates it.",
+      "properties": {
+        "context": {
+          "description": "Correlation ids (turn/exec/message/model/…) carried verbatim, for\nstitching point-in-time events into spans."
+        },
+        "data": {
+          "description": "Event-type-specific payload, carried verbatim."
+        },
+        "event_type": {
+          "default": "",
+          "description": "Event type, e.g. `turn.started`, `tool.completed`, `llm.generation`.",
+          "type": "string"
+        },
+        "id": {
+          "default": "",
+          "description": "Stable event id from the host's session event log.",
+          "type": "string"
+        },
+        "session_id": {
+          "default": "",
+          "description": "Session the event belongs to.",
+          "type": "string"
+        },
+        "ts": {
+          "default": "",
+          "description": "RFC 3339 timestamp of the event.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "UiAskParams": {
       "description": "Server → host `ui/ask` params: ask the user a question and wait for a typed\nanswer. The host prompts interactively (TUI); in headless/ACP hosts with no\nprompt surface the request is refused.",
       "properties": {
@@ -345,6 +377,11 @@
     "tool/update": {
       "params": {
         "$ref": "#/$defs/ToolUpdateParams"
+      }
+    },
+    "trace/event": {
+      "params": {
+        "$ref": "#/$defs/TraceEventParams"
       }
     },
     "ui/ask": {

--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -127,12 +127,23 @@ leak-protection is threefold: entry is out-of-band via `set_extension_secret`
 the agent triggers it but supplies no value and is refused if it passes one; all
 agent-facing reads (`list_extensions`) report a field's `set`/`unset` status,
 never its value; and a redacting `Secret` newtype keeps values out of logs. On
-`enable_extension`, any required `secret` that is unset is prompted for (best
-effort — headless stays inert until the env var is provided). The `logfire`
-extension dogfoods this: `token` (secret, `LOGFIRE_TOKEN`), `endpoint`, and
-`service_name`. Covered by `secret_config_field_is_injected_as_env`,
-`set_extension_secret_refuses_agent_value_and_needs_a_prompt`, and
-`list_reports_secret_status_never_values`.
+`enable_extension`, every required field that is unset is prompted for (setup on
+enable), dispatched by `ConfigField::kind`: `secret` → masked entry stored in the
+credential store; an `enum` field → a **selector**; otherwise free text — both
+persisted to capability config (`SettingsStore::set_capability_config`). The kind
+enum is the extension point: new input kinds slot in without touching callers.
+The prompts ride the one `ui/ask` reverse-request, now carrying `secret` (the
+host masks input and shows `(saved)`, never the value — both TUI overlays honor
+it via `ask_overlay_content`) and `options` (an arrow-key selector). Non-secret
+config reaches SDK servers through `Server::on_config`, a handler the SDK invokes
+once with `initialize.config` at handshake — so an author builds state (an
+exporter, a client) from config without hand-parsing the wire. The `logfire`
+extension dogfoods the whole path: `token` (secret → `LOGFIRE_TOKEN` env),
+`endpoint` and `service_name` (plain config consumed via `on_config`). Covered by
+`secret_config_field_is_injected_as_env`,
+`set_extension_secret_refuses_agent_value_and_needs_a_prompt`,
+`list_reports_secret_status_never_values`, `setup_on_enable_prompts_by_field_kind`,
+and the SDK's `on_config_receives_initialize_config`.
 Traces: an extension that declares `trace` in its manifest (the D4 opt-in)
 receives the session's agentic event stream — each lifecycle event (`turn.*`,
 `reason.*`, `act.*`, `tool.started/completed`, `llm.generation`) forwarded as a

--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -111,6 +111,28 @@ mid-turn, then resolves the request's oneshot with the typed answer (or
 another is pending is answered `cancelled`. Refused (`cancelled`) with no sink,
 so `--print`/ACP never blocks on it. Covered by
 `ui_ask_reverse_request_is_answered_by_the_sink`.
+Traces: an extension that declares `trace` in its manifest (the D4 opt-in)
+receives the session's agentic event stream — each lifecycle event (`turn.*`,
+`reason.*`, `act.*`, `tool.started/completed`, `llm.generation`) forwarded as a
+fire-and-forget host→server `trace/event` notification, so it can export the run
+to a tracing backend (Logfire, an OTLP collector). This is the observe-only dual
+of `hook/fire`: `hook/fire` is a *request* that can block one tool call;
+`trace/event` is a *notification* the host never awaits, so a slow or crashed
+exporter can never stall the agent loop. The host taps the existing session
+event broadcast (`JsonlEventEmitter::subscribe`, the same fan-out
+`herdr.start_monitor` uses) and, for each enabled declaring extension, spawns one
+forwarder task (`src/extensions/trace.rs`) filtered to the session; the facet is
+eager-spawned so early events aren't missed, and high-frequency streaming deltas
+are dropped (the paired `*.started`/`*.completed` events already bound the work).
+The wire type is `TraceEventParams` (event type, ids, timestamp, and the event
+`context`/`data` carried verbatim); the SDK exposes it as `Server::on_trace`
+(a stateful `FnMut` so an exporter can pair spans across events). The reference
+consumer is the `yolop-extension-logfire` crate — a capability server on the SDK
+that folds the events into OpenTelemetry spans and POSTs OTLP/HTTP to Logfire,
+configured by the same environment variables Logfire's onboarding checklist uses
+(`LOGFIRE_TOKEN`, `LOGFIRE_ENDPOINT`, `OTEL_SERVICE_NAME`). Covered by
+`trace_events_are_forwarded_to_a_declaring_server`; a non-declaring extension
+gets no forwarder (`non_declaring_extension_has_no_trace_process`).
 Live reload: `reload_extension name=<name>` restarts an already-enabled
 extension's *server process* in place, so implementation edits take effect
 mid-session without a yolop restart — the self-writing inner loop. Each
@@ -410,7 +432,7 @@ both sides: **ignore unknown fields** (no deny-unknown-fields on the wire),
 version sniffing**. The handshake's contribution facets are capability
 tokens with structured `capability_params` (open vocabulary, carried
 verbatim when unrecognized): `tools`, `streaming`, `hooks`, `prompt`,
-`dynamic_prompt`, `mcp_servers`, `commands`, `ui_ask`, `cancel`,
+`dynamic_prompt`, `mcp_servers`, `commands`, `ui_ask`, `trace`, `cancel`,
 `provider` (future). A server advertising only `tools` is fully conforming.
 
 ### Methods
@@ -425,6 +447,7 @@ verbatim when unrecognized): `tools`, `streaming`, `hooks`, `prompt`,
 | →server | `cancel` | req | `{id}` — abort any in-flight request (mira semantics: best-effort, aborted call resolves with error `cancelled`) |
 | →server | `prompt/contribution` | req | dynamic system prompt (only if declared `dynamic`); timeout + last-known-good |
 | →server | `hook/fire` | req | `{event, toolName, payload}` → decision per subscription (`allow/block/mutate`) |
+| →server | `trace/event` | ntf | forward one agentic-lifecycle event (turn/reason/act/tool/llm) to a `trace`-declaring extension; observe-only, never awaited |
 | →server | `config/changed` | req | new validated config → `ok` \| `restart-required` |
 | →server | `workspace/changed` | ntf | active worktree/root repointed |
 | ←server | `ui/ask` | req | user question/form — bridged to the `user_ask` capability |

--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -111,6 +111,28 @@ mid-turn, then resolves the request's oneshot with the typed answer (or
 another is pending is answered `cancelled`. Refused (`cancelled`) with no sink,
 so `--print`/ACP never blocks on it. Covered by
 `ui_ask_reverse_request_is_answered_by_the_sink`.
+Config & secrets: an extension's `config_schema` is also its setup form. Two
+yolop keywords extend JSON Schema at the property level: `secret: true` marks a
+value as a credential, and `env: "NAME"` injects the value into the server's
+environment under that name (so servers read env, not the wire). Non-secret
+fields flow through `initialize.config` as before; a non-secret field that also
+declares `env` is additionally injected as env, sourced from config. `secret`
+fields are stored in the shared credential store (`connections.toml`, 0600,
+redacted — `ExtensionSecrets`, keyed `ext:<name>`), **never** in `settings.toml`,
+and reach the server as injected env only (`capability.rs` strips any `secret`
+key from `initialize.config`). The `secret` marker decouples the concept from the
+location: moving credentials to a keychain later changes only `secrets.rs`. Agent
+leak-protection is threefold: entry is out-of-band via `set_extension_secret`
+(and setup-on-enable), which prompts the *user* through the `ui/ask` surface —
+the agent triggers it but supplies no value and is refused if it passes one; all
+agent-facing reads (`list_extensions`) report a field's `set`/`unset` status,
+never its value; and a redacting `Secret` newtype keeps values out of logs. On
+`enable_extension`, any required `secret` that is unset is prompted for (best
+effort — headless stays inert until the env var is provided). The `logfire`
+extension dogfoods this: `token` (secret, `LOGFIRE_TOKEN`), `endpoint`, and
+`service_name`. Covered by `secret_config_field_is_injected_as_env`,
+`set_extension_secret_refuses_agent_value_and_needs_a_prompt`, and
+`list_reports_secret_status_never_values`.
 Traces: an extension that declares `trace` in its manifest (the D4 opt-in)
 receives the session's agentic event stream — each lifecycle event (`turn.*`,
 `reason.*`, `act.*`, `tool.started/completed`, `llm.generation`) forwarded as a

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -846,12 +846,71 @@ impl SettingsStore {
         }
         Ok(changed)
     }
+
+    /// Set one key in a capability's inline config (creating an enabling
+    /// override if none exists yet). Used by extension setup to persist a
+    /// non-secret answer. Secrets never come here — they live in the credential
+    /// store.
+    pub fn set_capability_config(
+        &self,
+        capability_ref: &str,
+        key: &str,
+        value: serde_json::Value,
+    ) -> Result<()> {
+        let mut guard = self.inner.lock().expect("settings lock poisoned");
+        // The active (last non-remove) override for this ref, or a fresh one.
+        let index = guard
+            .capabilities
+            .iter()
+            .rposition(|entry| entry.capability_ref == capability_ref && !entry.is_remove());
+        let entry = match index {
+            Some(i) => &mut guard.capabilities[i],
+            None => {
+                guard
+                    .capabilities
+                    .push(CapabilityOverride::enable(capability_ref));
+                guard.capabilities.last_mut().expect("just pushed")
+            }
+        };
+        if !entry.config.is_object() {
+            entry.config = serde_json::Value::Object(serde_json::Map::new());
+        }
+        if let serde_json::Value::Object(map) = &mut entry.config {
+            map.insert(key.to_string(), value);
+        }
+        save_to(&self.path, &guard)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use everruns_core::McpServerAuthMode;
+
+    #[test]
+    fn set_capability_config_creates_override_and_persists() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join("settings.toml");
+        let store = SettingsStore::open(path.clone());
+        // No override yet → creates an enabling one carrying the config.
+        store
+            .set_capability_config("ext:obs", "mode", serde_json::json!("slow"))
+            .expect("write");
+        store
+            .set_capability_config("ext:obs", "label", serde_json::json!("x"))
+            .expect("write");
+        let reloaded = SettingsStore::open(path);
+        let config = reloaded
+            .snapshot()
+            .capability_overrides_for("ext:obs")
+            .iter()
+            .rev()
+            .find(|(_, e)| !e.is_remove())
+            .map(|(_, e)| e.config.clone())
+            .expect("override");
+        assert_eq!(config["mode"], "slow");
+        assert_eq!(config["label"], "x");
+    }
 
     #[test]
     fn default_provider_roundtrip_via_disk() {

--- a/src/extensions/capability.rs
+++ b/src/extensions/capability.rs
@@ -125,6 +125,19 @@ impl ExtensionCapability {
         process
     }
 
+    /// The live-server process to forward `trace/event` notifications to,
+    /// built with `config` (so it shares the per-config process cache with the
+    /// tool/hook/prompt facets), iff this extension declares the `trace` facet.
+    /// `None` otherwise — a non-declaring extension never sees the event stream
+    /// (D4). The runtime pairs this with a session event subscription to drive
+    /// forwarding (see `extensions::trace`).
+    pub fn trace_process(&self, config: &Value) -> Option<Arc<ExtensionProcess>> {
+        self.package
+            .manifest
+            .trace
+            .then(|| self.process_for(config))
+    }
+
     /// Tool names this extension asks to keep fully loaded (never deferred
     /// behind `tool_search`), bounded by the spec's per-extension budget.
     pub fn never_defer_tools(&self) -> Vec<String> {

--- a/src/extensions/capability.rs
+++ b/src/extensions/capability.rs
@@ -39,6 +39,9 @@ pub struct ExtensionCapability {
     /// Shared live-process registry so `reload_extension` can restart this
     /// extension's server mid-session; `None` outside the runtime (tests).
     live_processes: Option<LiveProcessRegistry>,
+    /// Per-extension secret store; supplies the injected env for `secret`
+    /// config fields. `None` outside the runtime (tests without secrets).
+    secrets: Option<super::secrets::ExtensionSecrets>,
     environment_context: Option<EnvironmentContextRegistry>,
     /// Process shared by all tool instances so the server persists across
     /// turns; rebuilt (killing the old server) when the config changes —
@@ -55,9 +58,17 @@ impl ExtensionCapability {
             status_sink: None,
             ask_sink: None,
             live_processes: None,
+            secrets: None,
             environment_context: None,
             process: Mutex::new(None),
         }
+    }
+
+    /// Wire the per-extension secret store, so `secret` config fields are
+    /// injected into the server's environment at spawn.
+    pub fn with_secrets(mut self, secrets: super::secrets::ExtensionSecrets) -> Self {
+        self.secrets = Some(secrets);
+        self
     }
 
     /// Wire the shared live-process registry so this extension's server can be
@@ -98,11 +109,34 @@ impl ExtensionCapability {
             .and_then(Value::as_u64)
             .unwrap_or(DEFAULT_REQUEST_TIMEOUT_MS)
             .clamp(1_000, 600_000);
+        let manifest = &self.package.manifest;
+        // Env injection: `secret` fields from the credential store, plus
+        // non-secret fields that declare an `env` mapping, sourced from config.
+        let mut env = self
+            .secrets
+            .as_ref()
+            .map(|s| s.env_overrides(manifest))
+            .unwrap_or_default();
+        for field in manifest.config_fields() {
+            if field.secret {
+                continue;
+            }
+            if let (Some(env_name), Some(value)) = (
+                field.env.as_ref(),
+                config.get(&field.name).and_then(Value::as_str),
+            ) {
+                env.insert(env_name.clone(), value.to_string());
+            }
+        }
+        // Cache by the original config (below); pass a secret-stripped copy to
+        // the server so a `secret` key never rides `initialize.config`.
+        let spec_config = strip_secret_keys(config, manifest);
         let process = Arc::new(ExtensionProcess::new(ExtensionProcessSpec {
             manifest: self.package.manifest.clone(),
             package_dir: self.package.dir.clone(),
             workspace_root: self.workspace_root.clone(),
-            config: config.clone(),
+            config: spec_config,
+            env,
             request_timeout: Duration::from_millis(timeout_ms),
             status_sink: self
                 .package
@@ -396,6 +430,30 @@ impl Capability for ExtensionCapability {
                 }) as Box<dyn Tool>
             })
             .collect()
+    }
+}
+
+/// Remove any `secret`-declared key from a config object so a credential never
+/// travels via `initialize.config` (secrets are injected as env instead). A
+/// non-object config is returned unchanged.
+fn strip_secret_keys(config: &Value, manifest: &super::package::ExtensionManifest) -> Value {
+    let secret_names: Vec<String> = manifest
+        .secret_fields()
+        .into_iter()
+        .map(|f| f.name)
+        .collect();
+    if secret_names.is_empty() {
+        return config.clone();
+    }
+    match config {
+        Value::Object(map) => {
+            let mut map = map.clone();
+            for name in &secret_names {
+                map.remove(name);
+            }
+            Value::Object(map)
+        }
+        other => other.clone(),
     }
 }
 

--- a/src/extensions/manage.rs
+++ b/src/extensions/manage.rs
@@ -4,9 +4,12 @@
 //! harness (like `connectors`) and owns the verbs. Tools so both the user
 //! and the model can drive setup; a thin `/extensions` command mirrors them.
 
+use super::client::AskSink;
 use super::manager::LiveProcessRegistry;
 use super::package::{discover_extensions, extension_capability_id};
+use super::protocol::UiAskParams;
 use super::scaffold::{self, HookSpec, Language, ScaffoldRequest, ToolSpec};
+use super::secrets::{ExtensionSecrets, Secret};
 use super::store::{self, CrateFetcher, GitRunner, Source, SystemCrateFetcher, SystemGit};
 use crate::config::SettingsStore;
 use crate::tui::host_ui::UiCommand;
@@ -32,6 +35,11 @@ pub struct ExtensionsCapability {
     /// extension on the live session after enable/disable; `None` in
     /// `--print`/ACP, where enable/disable only persists for the next session.
     ui_tx: Option<UnboundedSender<UiCommand>>,
+    /// Per-extension secret store (for `set_extension_secret` and the redacted
+    /// config status in `list_extensions`). `None` in tests without secrets.
+    secrets: Option<ExtensionSecrets>,
+    /// Prompt surface for interactive secret entry; `None` refuses it (headless).
+    ask_sink: Option<AskSink>,
 }
 
 impl ExtensionsCapability {
@@ -50,7 +58,22 @@ impl ExtensionsCapability {
             crates: Arc::new(SystemCrateFetcher::default()),
             live_processes,
             ui_tx,
+            secrets: None,
+            ask_sink: None,
         }
+    }
+
+    /// Wire the secret store so `set_extension_secret` can persist credentials
+    /// and `list_extensions` can report their (redacted) set/unset status.
+    pub fn with_secrets(mut self, secrets: ExtensionSecrets) -> Self {
+        self.secrets = Some(secrets);
+        self
+    }
+
+    /// Wire the interactive prompt surface for secret entry (TUI only).
+    pub fn with_ask_sink(mut self, ask_sink: Option<AskSink>) -> Self {
+        self.ask_sink = ask_sink;
+        self
     }
 }
 
@@ -100,6 +123,8 @@ impl Capability for ExtensionsCapability {
             crates: self.crates.clone(),
             live_processes: self.live_processes.clone(),
             ui_tx: self.ui_tx.clone(),
+            secrets: self.secrets.clone(),
+            ask_sink: self.ask_sink.clone(),
         });
         vec![
             Box::new(ManageTool::new(ctx.clone(), Verb::Scaffold)),
@@ -109,6 +134,7 @@ impl Capability for ExtensionsCapability {
             Box::new(ManageTool::new(ctx.clone(), Verb::Enable)),
             Box::new(ManageTool::new(ctx.clone(), Verb::Disable)),
             Box::new(ManageTool::new(ctx.clone(), Verb::Reload)),
+            Box::new(ManageTool::new(ctx.clone(), Verb::SetSecret)),
             Box::new(ManageTool::new(ctx, Verb::Doctor)),
         ]
     }
@@ -122,6 +148,8 @@ struct ManageCtx {
     crates: Arc<dyn CrateFetcher>,
     live_processes: LiveProcessRegistry,
     ui_tx: Option<UnboundedSender<UiCommand>>,
+    secrets: Option<ExtensionSecrets>,
+    ask_sink: Option<AskSink>,
 }
 
 #[derive(Clone, Copy)]
@@ -133,6 +161,7 @@ enum Verb {
     Enable,
     Disable,
     Reload,
+    SetSecret,
     Doctor,
 }
 
@@ -273,10 +302,14 @@ impl ManageTool {
             .iter()
             .map(|pkg| {
                 let cap_id = extension_capability_id(&pkg.manifest.name);
-                let enabled = settings
-                    .capability_overrides_for(&cap_id)
+                let overrides = settings.capability_overrides_for(&cap_id);
+                let enabled = overrides.iter().any(|(_, entry)| !entry.is_remove());
+                let ext_config = overrides
                     .iter()
-                    .any(|(_, entry)| !entry.is_remove());
+                    .rev()
+                    .find(|(_, entry)| !entry.is_remove())
+                    .map(|(_, entry)| entry.config.clone())
+                    .unwrap_or(Value::Null);
                 json!({
                     "name": pkg.manifest.name,
                     "description": pkg.manifest.description,
@@ -284,10 +317,46 @@ impl ManageTool {
                     "enabled": enabled,
                     "capability_ref": cap_id,
                     "tools": pkg.manifest.tools.iter().map(|t| &t.name).collect::<Vec<_>>(),
+                    // Setup fields with only their set/unset status — secret
+                    // VALUES are never included (the agent-leak guard).
+                    "config": self.config_status(&pkg.manifest, &ext_config),
                 })
             })
             .collect();
         ToolExecutionResult::Success(json!({ "extensions": items }))
+    }
+
+    /// Per-field setup status the agent may see: name, whether it's a secret,
+    /// whether it's required, and whether a value is set — never the value.
+    fn config_status(
+        &self,
+        manifest: &super::package::ExtensionManifest,
+        ext_config: &Value,
+    ) -> Vec<Value> {
+        manifest
+            .config_fields()
+            .into_iter()
+            .map(|field| {
+                let set = if field.secret {
+                    self.ctx
+                        .secrets
+                        .as_ref()
+                        .map(|s| s.is_set(&manifest.name, &field.name))
+                        .unwrap_or(false)
+                } else {
+                    ext_config
+                        .get(&field.name)
+                        .map(|v| !v.is_null())
+                        .unwrap_or(false)
+                };
+                json!({
+                    "name": field.name,
+                    "secret": field.secret,
+                    "required": field.required,
+                    "set": set,
+                })
+            })
+            .collect()
     }
 
     async fn install(&self, args: &Value) -> ToolExecutionResult {
@@ -338,6 +407,10 @@ impl ManageTool {
             .ctx
             .settings
             .set_capability_enabled(&extension_capability_id(name), false);
+        // And drop any stored secrets so a reinstall doesn't inherit stale ones.
+        if let Some(secrets) = &self.ctx.secrets {
+            let _ = secrets.clear(name);
+        }
         match store::remove(&self.ctx.extensions_dir, name) {
             Ok(true) => ToolExecutionResult::Success(json!({ "removed": name })),
             Ok(false) => ToolExecutionResult::ToolError(format!("no extension named `{name}`")),
@@ -394,6 +467,123 @@ impl ManageTool {
             }
             Err(err) => ToolExecutionResult::ToolError(format!("config write failed: {err}")),
         }
+    }
+
+    /// Prompt the user for one secret field and store it. The value comes from
+    /// the user through the ask surface — never from the agent — so it never
+    /// enters the model's context; the result is redacted. Returns whether a
+    /// value was stored.
+    async fn prompt_and_store_secret(
+        &self,
+        manifest: &super::package::ExtensionManifest,
+        field: &super::package::ConfigField,
+    ) -> Result<bool, String> {
+        let (Some(secrets), Some(ask)) = (&self.ctx.secrets, &self.ctx.ask_sink) else {
+            let hint = field
+                .env
+                .as_ref()
+                .map(|e| format!(" Set the `{e}` environment variable instead."))
+                .unwrap_or_default();
+            return Err(format!(
+                "interactive secret entry is not available in this session (headless).{hint}"
+            ));
+        };
+        let prompt = if field.description.is_empty() {
+            format!("Enter `{}` for extension `{}`", field.name, manifest.name)
+        } else {
+            format!(
+                "{} — `{}` for extension `{}`",
+                field.description, field.name, manifest.name
+            )
+        };
+        let answer = ask(UiAskParams {
+            prompt,
+            placeholder: Some("value is stored securely, not shown to the agent".into()),
+        })
+        .await;
+        if answer.cancelled || answer.answer.trim().is_empty() {
+            return Ok(false);
+        }
+        secrets
+            .set(&manifest.name, &field.name, Secret::new(answer.answer))
+            .map_err(|e| format!("could not store secret: {e}"))?;
+        Ok(true)
+    }
+
+    async fn set_secret(&self, args: &Value) -> ToolExecutionResult {
+        let Some(name) = args.get("name").and_then(Value::as_str) else {
+            return ToolExecutionResult::ToolError("`name` is required".into());
+        };
+        let Some(field_name) = args.get("field").and_then(Value::as_str) else {
+            return ToolExecutionResult::ToolError("`field` is required".into());
+        };
+        // A value must never be passed by the agent — that would put the secret
+        // in the transcript. Refuse it explicitly.
+        if args.get("value").is_some() {
+            return ToolExecutionResult::ToolError(
+                "do not pass `value`: secrets are entered by the user, never through the agent. \
+                 Call with just `name` and `field`."
+                    .into(),
+            );
+        }
+        let Some(pkg) = discover_extensions(&self.ctx.extensions_dir)
+            .into_iter()
+            .find(|pkg| pkg.manifest.name == name)
+        else {
+            return ToolExecutionResult::ToolError(format!(
+                "no extension named `{name}` is installed"
+            ));
+        };
+        let Some(field) = pkg
+            .manifest
+            .secret_fields()
+            .into_iter()
+            .find(|f| f.name == field_name)
+        else {
+            return ToolExecutionResult::ToolError(format!(
+                "extension `{name}` has no secret config field `{field_name}`"
+            ));
+        };
+        match self.prompt_and_store_secret(&pkg.manifest, &field).await {
+            Ok(true) => ToolExecutionResult::Success(json!({
+                "name": name,
+                "field": field_name,
+                "set": true,
+                "note": "Stored securely. Reload or restart the extension to apply it.",
+            })),
+            Ok(false) => ToolExecutionResult::Success(json!({
+                "name": name, "field": field_name, "set": false,
+                "note": "Cancelled; nothing stored.",
+            })),
+            Err(err) => ToolExecutionResult::ToolError(err),
+        }
+    }
+
+    /// Enable, prompting for any required secret that isn't set yet (setup on
+    /// enable). Prompting is best-effort — if there's no prompt surface, the
+    /// extension still enables and stays inert until its secret is provided.
+    async fn enable(&self, args: &Value) -> ToolExecutionResult {
+        if let Some(name) = args.get("name").and_then(Value::as_str)
+            && self.ctx.secrets.is_some()
+            && self.ctx.ask_sink.is_some()
+            && let Some(pkg) = discover_extensions(&self.ctx.extensions_dir)
+                .into_iter()
+                .find(|pkg| pkg.manifest.name == name)
+        {
+            for field in pkg.manifest.secret_fields() {
+                let unset = self
+                    .ctx
+                    .secrets
+                    .as_ref()
+                    .map(|s| !s.is_set(name, &field.name))
+                    .unwrap_or(true);
+                if field.required && unset {
+                    // Ignore prompt failures/cancellations: enable proceeds.
+                    let _ = self.prompt_and_store_secret(&pkg.manifest, &field).await;
+                }
+            }
+        }
+        self.toggle(args, true)
     }
 
     async fn reload(&self, args: &Value) -> ToolExecutionResult {
@@ -468,6 +658,7 @@ impl Tool for ManageTool {
             Verb::Enable => "enable_extension",
             Verb::Disable => "disable_extension",
             Verb::Reload => "reload_extension",
+            Verb::SetSecret => "set_extension_secret",
             Verb::Doctor => "doctor_extension",
         }
     }
@@ -507,6 +698,13 @@ impl Tool for ManageTool {
                  extension's server code — e.g. while iterating on one you authored. Manifest \
                  changes (adding a tool, changing a schema) still need a restart; reload never \
                  changes the approved surface."
+            }
+            Verb::SetSecret => {
+                "Set a secret config field (e.g. an API token) for an installed extension. \
+                 The user is prompted to enter the value directly — you never provide it and \
+                 never see it; it is stored in the credential store, not in settings, and \
+                 injected into the extension's server as env. Call with `name` and `field` \
+                 only (never `value`). Use for `secret` fields shown by `list_extensions`."
             }
             Verb::Doctor => {
                 "Conformance-check an installed extension: spawn its server, run the \
@@ -575,6 +773,15 @@ impl Tool for ManageTool {
                 },
                 "required": ["source"]
             }),
+            Verb::SetSecret => json!({
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string", "description": "Extension name." },
+                    "field": { "type": "string",
+                        "description": "The secret config field to set (from list_extensions)." }
+                },
+                "required": ["name", "field"]
+            }),
             _ => json!({
                 "type": "object",
                 "properties": {
@@ -591,9 +798,10 @@ impl Tool for ManageTool {
             Verb::List => self.list(),
             Verb::Install => self.install(&arguments).await,
             Verb::Remove => self.remove(&arguments),
-            Verb::Enable => self.toggle(&arguments, true),
+            Verb::Enable => self.enable(&arguments).await,
             Verb::Disable => self.toggle(&arguments, false),
             Verb::Reload => self.reload(&arguments).await,
+            Verb::SetSecret => self.set_secret(&arguments).await,
             Verb::Doctor => self.doctor(&arguments).await,
         }
     }
@@ -630,6 +838,8 @@ mod tests {
             crates: Arc::new(crate::extensions::store::SystemCrateFetcher::default()),
             live_processes: LiveProcessRegistry::default(),
             ui_tx: None,
+            secrets: None,
+            ask_sink: None,
         };
         (cap, settings, ext_dir)
     }
@@ -760,6 +970,124 @@ mod tests {
         }
     }
 
+    fn seed_secret_package(dir: &Path, name: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(
+            dir.join(MANIFEST_FILE),
+            json!({
+                "name": name, "description": "T.",
+                "yolop": { "protocol_version": "1.0",
+                    "capabilityServer": { "command": "x" }, "tools": [{"name": "t"}],
+                    "config_schema": { "type": "object", "required": ["token"], "properties": {
+                        "token": { "type": "string", "secret": true, "env": "TOK" } } } }
+            })
+            .to_string(),
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn set_extension_secret_refuses_agent_value_and_needs_a_prompt() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        seed_secret_package(&src, "logfire");
+        let (cap, _settings, _ext_dir) = capability(tmp.path());
+        let tools = cap.tools();
+        let get = |name: &str| tools.iter().find(|t| t.name() == name).unwrap();
+        get("install_extension")
+            .execute(json!({ "source": src.to_str().unwrap() }))
+            .await;
+
+        // A value from the agent is refused outright — secrets never enter the
+        // transcript.
+        match get("set_extension_secret")
+            .execute(json!({ "name": "logfire", "field": "token", "value": "pylf_leak" }))
+            .await
+        {
+            ToolExecutionResult::ToolError(m) => assert!(m.contains("do not pass `value`"), "{m}"),
+            other => panic!("{other:?}"),
+        }
+
+        // Without a prompt surface (no ask_sink in this unit test), interactive
+        // entry is refused with guidance — never silently no-ops.
+        match get("set_extension_secret")
+            .execute(json!({ "name": "logfire", "field": "token" }))
+            .await
+        {
+            ToolExecutionResult::ToolError(m) => {
+                assert!(m.contains("not available") && m.contains("TOK"), "{m}")
+            }
+            other => panic!("{other:?}"),
+        }
+
+        // A non-secret / unknown field is rejected.
+        match get("set_extension_secret")
+            .execute(json!({ "name": "logfire", "field": "nope" }))
+            .await
+        {
+            ToolExecutionResult::ToolError(m) => {
+                assert!(m.contains("no secret config field"), "{m}")
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn list_reports_secret_status_never_values() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        seed_secret_package(&src, "logfire");
+        let ext_dir = tmp.path().join("extensions");
+        let settings = Arc::new(SettingsStore::open(tmp.path().join("settings.toml")));
+        let secrets = crate::extensions::secrets::ExtensionSecrets::open_at(
+            tmp.path().join("connections.toml"),
+        );
+        let cap = ExtensionsCapability {
+            extensions_dir: ext_dir,
+            workspace_root: tmp.path().to_path_buf(),
+            settings,
+            git: Arc::new(crate::extensions::store::SystemGit),
+            crates: Arc::new(crate::extensions::store::SystemCrateFetcher::default()),
+            live_processes: LiveProcessRegistry::default(),
+            ui_tx: None,
+            secrets: Some(secrets.clone()),
+            ask_sink: None,
+        };
+        let tools = cap.tools();
+        let get = |name: &str| tools.iter().find(|t| t.name() == name).unwrap();
+        get("install_extension")
+            .execute(json!({ "source": src.to_str().unwrap() }))
+            .await;
+
+        // Unset secret: status shows `set:false`, and no value anywhere.
+        let before = match get("list_extensions").execute(json!({})).await {
+            ToolExecutionResult::Success(v) => v,
+            other => panic!("{other:?}"),
+        };
+        let token = &before["extensions"][0]["config"][0];
+        assert_eq!(token["name"], "token");
+        assert_eq!(token["secret"], true);
+        assert_eq!(token["set"], false);
+
+        // Store a secret, then the status flips to set — still no value shown.
+        secrets
+            .set(
+                "logfire",
+                "token",
+                crate::extensions::secrets::Secret::new("pylf_v1_topsecret"),
+            )
+            .unwrap();
+        let after = match get("list_extensions").execute(json!({})).await {
+            ToolExecutionResult::Success(v) => v,
+            other => panic!("{other:?}"),
+        };
+        assert_eq!(after["extensions"][0]["config"][0]["set"], true);
+        assert!(
+            !after.to_string().contains("topsecret"),
+            "secret value must never appear in list output"
+        );
+    }
+
     #[tokio::test]
     async fn reload_reports_when_nothing_is_live() {
         let tmp = tempfile::tempdir().unwrap();
@@ -809,6 +1137,8 @@ mod tests {
             crates: Arc::new(crate::extensions::store::SystemCrateFetcher::default()),
             live_processes: LiveProcessRegistry::default(),
             ui_tx: Some(ui_tx),
+            secrets: None,
+            ask_sink: None,
         };
         let tools = cap.tools();
         let get = |name: &str| tools.iter().find(|t| t.name() == name).unwrap();

--- a/src/extensions/manage.rs
+++ b/src/extensions/manage.rs
@@ -469,27 +469,28 @@ impl ManageTool {
         }
     }
 
-    /// Prompt the user for one secret field and store it. The value comes from
-    /// the user through the ask surface — never from the agent — so it never
-    /// enters the model's context; the result is redacted. Returns whether a
-    /// value was stored.
-    async fn prompt_and_store_secret(
+    /// Prompt the user for one setup field, honoring its kind: a `secret` is
+    /// masked, an `enum` becomes a selector, otherwise free text. The value
+    /// comes from the user through the ask surface — never from the agent, so it
+    /// never enters the model's context. Returns the entered value (`None` on
+    /// cancel/empty).
+    async fn prompt_field(
         &self,
         manifest: &super::package::ExtensionManifest,
         field: &super::package::ConfigField,
-    ) -> Result<bool, String> {
-        let (Some(secrets), Some(ask)) = (&self.ctx.secrets, &self.ctx.ask_sink) else {
+    ) -> Result<Option<String>, String> {
+        let Some(ask) = &self.ctx.ask_sink else {
             let hint = field
                 .env
                 .as_ref()
                 .map(|e| format!(" Set the `{e}` environment variable instead."))
                 .unwrap_or_default();
             return Err(format!(
-                "interactive secret entry is not available in this session (headless).{hint}"
+                "interactive setup is not available in this session (headless).{hint}"
             ));
         };
         let prompt = if field.description.is_empty() {
-            format!("Enter `{}` for extension `{}`", field.name, manifest.name)
+            format!("Set `{}` for extension `{}`", field.name, manifest.name)
         } else {
             format!(
                 "{} — `{}` for extension `{}`",
@@ -498,16 +499,62 @@ impl ManageTool {
         };
         let answer = ask(UiAskParams {
             prompt,
-            placeholder: Some("value is stored securely, not shown to the agent".into()),
+            placeholder: field
+                .secret
+                .then(|| "stored securely, not shown to the agent".to_string()),
+            secret: field.secret,
+            options: field.options.clone(),
         })
         .await;
         if answer.cancelled || answer.answer.trim().is_empty() {
-            return Ok(false);
+            Ok(None)
+        } else {
+            Ok(Some(answer.answer))
         }
-        secrets
-            .set(&manifest.name, &field.name, Secret::new(answer.answer))
-            .map_err(|e| format!("could not store secret: {e}"))?;
-        Ok(true)
+    }
+
+    /// Prompt for a `secret` field and store it in the credential store.
+    async fn prompt_and_store_secret(
+        &self,
+        manifest: &super::package::ExtensionManifest,
+        field: &super::package::ConfigField,
+    ) -> Result<bool, String> {
+        // Prompt first, so a headless session reports the env-var guidance
+        // (from `prompt_field`) rather than a storage-availability error.
+        match self.prompt_field(manifest, field).await? {
+            Some(value) => {
+                let Some(secrets) = self.ctx.secrets.clone() else {
+                    return Err("secret storage is not available in this session".into());
+                };
+                secrets
+                    .set(&manifest.name, &field.name, Secret::new(value))
+                    .map_err(|e| format!("could not store secret: {e}"))?;
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    }
+
+    /// Prompt for a non-secret field and persist it to the extension's config.
+    async fn prompt_and_store_config(
+        &self,
+        manifest: &super::package::ExtensionManifest,
+        field: &super::package::ConfigField,
+    ) -> Result<bool, String> {
+        match self.prompt_field(manifest, field).await? {
+            Some(value) => {
+                self.ctx
+                    .settings
+                    .set_capability_config(
+                        &extension_capability_id(&manifest.name),
+                        &field.name,
+                        Value::String(value),
+                    )
+                    .map_err(|e| format!("config write failed: {e}"))?;
+                Ok(true)
+            }
+            None => Ok(false),
+        }
     }
 
     async fn set_secret(&self, args: &Value) -> ToolExecutionResult {
@@ -559,31 +606,61 @@ impl ManageTool {
         }
     }
 
-    /// Enable, prompting for any required secret that isn't set yet (setup on
-    /// enable). Prompting is best-effort — if there's no prompt surface, the
-    /// extension still enables and stays inert until its secret is provided.
+    /// Enable, then run setup: prompt for any required field (secret, select, or
+    /// text) that isn't set yet. Best-effort — with no prompt surface the
+    /// extension still enables and stays inert until configured.
     async fn enable(&self, args: &Value) -> ToolExecutionResult {
+        let result = self.toggle(args, true);
+        if !matches!(result, ToolExecutionResult::Success(_)) {
+            return result;
+        }
         if let Some(name) = args.get("name").and_then(Value::as_str)
-            && self.ctx.secrets.is_some()
             && self.ctx.ask_sink.is_some()
             && let Some(pkg) = discover_extensions(&self.ctx.extensions_dir)
                 .into_iter()
                 .find(|pkg| pkg.manifest.name == name)
         {
-            for field in pkg.manifest.secret_fields() {
-                let unset = self
-                    .ctx
-                    .secrets
-                    .as_ref()
-                    .map(|s| !s.is_set(name, &field.name))
-                    .unwrap_or(true);
-                if field.required && unset {
-                    // Ignore prompt failures/cancellations: enable proceeds.
-                    let _ = self.prompt_and_store_secret(&pkg.manifest, &field).await;
+            let settings = self.ctx.settings.snapshot();
+            let ext_config = settings
+                .capability_overrides_for(&extension_capability_id(name))
+                .iter()
+                .rev()
+                .find(|(_, entry)| !entry.is_remove())
+                .map(|(_, entry)| entry.config.clone())
+                .unwrap_or(Value::Null);
+            for field in pkg.manifest.config_fields() {
+                if !field.required {
+                    continue;
                 }
+                let set = if field.secret {
+                    self.ctx
+                        .secrets
+                        .as_ref()
+                        .map(|s| s.is_set(name, &field.name))
+                        .unwrap_or(false)
+                } else {
+                    ext_config
+                        .get(&field.name)
+                        .map(|v| !v.is_null())
+                        .unwrap_or(false)
+                };
+                if set {
+                    continue;
+                }
+                // Dispatch by field kind (secret → store; text/select → config).
+                // Ignore prompt failures/cancellations: enable already applied.
+                let _ = match field.kind() {
+                    super::package::ConfigFieldKind::Secret => {
+                        self.prompt_and_store_secret(&pkg.manifest, &field).await
+                    }
+                    super::package::ConfigFieldKind::Text
+                    | super::package::ConfigFieldKind::Select => {
+                        self.prompt_and_store_config(&pkg.manifest, &field).await
+                    }
+                };
             }
         }
-        self.toggle(args, true)
+        result
     }
 
     async fn reload(&self, args: &Value) -> ToolExecutionResult {
@@ -1086,6 +1163,89 @@ mod tests {
             !after.to_string().contains("topsecret"),
             "secret value must never appear in list output"
         );
+    }
+
+    #[tokio::test]
+    async fn setup_on_enable_prompts_by_field_kind() {
+        use crate::extensions::protocol::{UiAskParams, UiAskResult};
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(
+            src.join(MANIFEST_FILE),
+            json!({
+                "name": "obs", "description": "T.",
+                "yolop": { "protocol_version": "1.0",
+                    "capabilityServer": { "command": "x" }, "tools": [{"name": "t"}],
+                    "config_schema": { "type": "object",
+                        "required": ["token", "mode", "label"],
+                        "properties": {
+                            "token": { "type": "string", "secret": true, "env": "TOK" },
+                            "mode": { "type": "string", "enum": ["fast", "slow"] },
+                            "label": { "type": "string" }
+                        } } }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        // A scripted prompt surface: picks option[1] for selects, a fixed
+        // secret for secret fields, and fixed text otherwise.
+        let ask: crate::extensions::AskSink = Arc::new(|p: UiAskParams| {
+            let answer = if !p.options.is_empty() {
+                p.options.get(1).cloned().unwrap_or_default()
+            } else if p.secret {
+                "s3cr3t".to_string()
+            } else {
+                "typed-text".to_string()
+            };
+            Box::pin(async move {
+                UiAskResult {
+                    answer,
+                    cancelled: false,
+                }
+            })
+                as std::pin::Pin<Box<dyn std::future::Future<Output = UiAskResult> + Send>>
+        });
+        let settings = Arc::new(SettingsStore::open(tmp.path().join("settings.toml")));
+        let secrets = crate::extensions::secrets::ExtensionSecrets::open_at(
+            tmp.path().join("connections.toml"),
+        );
+        let cap = ExtensionsCapability {
+            extensions_dir: tmp.path().join("extensions"),
+            workspace_root: tmp.path().to_path_buf(),
+            settings: settings.clone(),
+            git: Arc::new(crate::extensions::store::SystemGit),
+            crates: Arc::new(crate::extensions::store::SystemCrateFetcher::default()),
+            live_processes: LiveProcessRegistry::default(),
+            ui_tx: None,
+            secrets: Some(secrets.clone()),
+            ask_sink: Some(ask),
+        };
+        let tools = cap.tools();
+        let get = |name: &str| tools.iter().find(|t| t.name() == name).unwrap();
+        get("install_extension")
+            .execute(json!({ "source": src.to_str().unwrap() }))
+            .await;
+
+        get("enable_extension")
+            .execute(json!({ "name": "obs" }))
+            .await;
+
+        // Secret went to the credential store (redacted); text/select to config.
+        assert!(secrets.is_set("obs", "token"));
+        let snap = settings.snapshot();
+        let config = snap
+            .capability_overrides_for("ext:obs")
+            .iter()
+            .rev()
+            .find(|(_, e)| !e.is_remove())
+            .map(|(_, e)| e.config.clone())
+            .unwrap();
+        assert_eq!(config["mode"], "slow"); // selector picked option[1]
+        assert_eq!(config["label"], "typed-text");
+        // The secret is never written to settings config.
+        assert!(config.get("token").is_none());
     }
 
     #[tokio::test]

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -27,6 +27,12 @@ pub struct ExtensionProcessSpec {
     pub package_dir: PathBuf,
     pub workspace_root: PathBuf,
     pub config: Value,
+    /// Env vars injected into the server process (name → value), built from the
+    /// extension's `config_schema` `env` mappings: `secret` fields sourced from
+    /// the credential store, plain fields from config. Delivered host→server
+    /// only and never logged — the leak guard for credentials like a Logfire
+    /// token.
+    pub env: std::collections::BTreeMap<String, String>,
     pub request_timeout: Duration,
     /// Where the server's `status/changed` notifications go (status bar).
     /// Only wired when the extension declares `status` and the host has a
@@ -250,6 +256,11 @@ impl ExtensionProcess {
             if let Ok(joined) = std::env::join_paths(paths) {
                 command.env("PATH", joined);
             }
+        }
+        // Inject the extension's configured env (secrets + env-mapped config).
+        // Set after PATH so a value can't clobber it; never logged.
+        for (name, value) in &self.spec.env {
+            command.env(name, value);
         }
         let mut child = command.spawn().with_context(|| {
             format!(

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -161,6 +161,25 @@ impl ExtensionProcess {
         }
     }
 
+    /// Forward one agentic-lifecycle event to the server as a fire-and-forget
+    /// `trace/event` notification (the `trace` facet). Spawns/handshakes the
+    /// server first if needed — the facet is eager, so the first event brings
+    /// it up. Observe-only: the server never replies, so this returns as soon
+    /// as the line is queued; a dead connection is dropped so the next event
+    /// respawns. `Err` is only a spawn/handshake failure the caller logs.
+    pub async fn send_trace_event(&self, params: Value) -> Result<()> {
+        let connection = {
+            let mut state = self.state.lock().await;
+            self.ensure_live(&mut state).await?;
+            state.as_ref().expect("ensured live").connection.clone()
+        };
+        connection.notify("trace/event", params);
+        if connection.is_closed() {
+            *self.state.lock().await = None;
+        }
+        Ok(())
+    }
+
     /// Fire one subscribed lifecycle hook (`hook/fire`) and return the
     /// server's decision. `Err` is a transport/server failure the caller
     /// resolves per the subscription's `on_error` policy.

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod manager;
 pub(crate) mod package;
 pub(crate) mod protocol;
 pub(crate) mod scaffold;
+pub(crate) mod secrets;
 pub(crate) mod store;
 pub(crate) mod trace;
 
@@ -33,6 +34,7 @@ pub(crate) use manager::LiveProcessRegistry;
 pub(crate) use package::{
     discover_extensions, extension_capability_id, extension_skill_scopes, extensions_dir,
 };
+pub(crate) use secrets::ExtensionSecrets;
 
 #[cfg(test)]
 mod spawn_tests {
@@ -295,6 +297,84 @@ mod spawn_tests {
         let types: Vec<&str> = recorded.lines().collect();
         assert!(types.contains(&"turn.started"), "recorded: {types:?}");
         assert!(types.contains(&"tool.completed"), "recorded: {types:?}");
+    }
+
+    /// A `secret` config field is injected into the server's environment (per
+    /// its `env` mapping) from the secret store — never via `initialize.config`.
+    #[tokio::test]
+    async fn secret_config_field_is_injected_as_env() {
+        let Some(python) = python3() else {
+            eprintln!("skipping: python3 not available");
+            return;
+        };
+        let dir = tempfile::tempdir().expect("tempdir");
+        let log = dir.path().join("trace.log");
+        let server = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/yep_echo_server.py");
+        let manifest = parse_manifest(
+            &json!({
+                "name": "sec", "description": "t",
+                "yolop": {
+                    "protocol_version": "1.0",
+                    "capabilityServer": { "command": python,
+                        "args": [server.display().to_string()] },
+                    "trace": true,
+                    "config_schema": {
+                        "type": "object",
+                        "required": ["probe"],
+                        "properties": {
+                            "probe": { "type": "string", "secret": true, "env": "YEP_ECHO_ENV" }
+                        }
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .expect("secret manifest");
+
+        // Store the secret out-of-band (as the user prompt would).
+        let secrets = crate::extensions::secrets::ExtensionSecrets::open_at(
+            dir.path().join("connections.toml"),
+        );
+        secrets
+            .set(
+                "sec",
+                "probe",
+                crate::extensions::secrets::Secret::new("injected-value"),
+            )
+            .expect("store secret");
+
+        let capability = ExtensionCapability::new(
+            ExtensionPackage {
+                dir: std::env::temp_dir(),
+                manifest,
+            },
+            std::env::temp_dir(),
+        )
+        .with_secrets(secrets);
+        let process = capability
+            .trace_process(&json!({ "trace_log": log.display().to_string() }))
+            .expect("trace_process");
+        // Spawns the server (which echoes YEP_ECHO_ENV into the log on init).
+        process
+            .send_trace_event(json!({ "event_type": "turn.started", "session_id": "s" }))
+            .await
+            .expect("spawn + trace");
+
+        for _ in 0..50 {
+            if std::fs::read_to_string(&log)
+                .map(|c| c.contains("env:injected-value"))
+                .unwrap_or(false)
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        let recorded = std::fs::read_to_string(&log).unwrap_or_default();
+        assert!(
+            recorded.contains("env:injected-value"),
+            "recorded: {recorded:?}"
+        );
     }
 
     /// A non-declaring extension gets no trace process — the event stream is

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -24,6 +24,7 @@ pub(crate) mod package;
 pub(crate) mod protocol;
 pub(crate) mod scaffold;
 pub(crate) mod store;
+pub(crate) mod trace;
 
 pub(crate) use capability::ExtensionCapability;
 pub(crate) use client::{AskSink, StatusSink};
@@ -227,6 +228,81 @@ mod spawn_tests {
             }
             other => panic!("expected tool error, got {other:?}"),
         }
+    }
+
+    /// A `trace`-only manifest whose server is the same fixture (which records
+    /// received `trace/event` types to the file named in its config).
+    fn trace_package(python: &str) -> ExtensionPackage {
+        let server = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/yep_echo_server.py");
+        let manifest = parse_manifest(
+            &json!({
+                "name": "tracer",
+                "description": "Trace fixture.",
+                "yolop": {
+                    "protocol_version": "1.0",
+                    "capabilityServer": {
+                        "command": python,
+                        "args": [server.display().to_string()]
+                    },
+                    "trace": true
+                }
+            })
+            .to_string(),
+        )
+        .expect("trace manifest");
+        ExtensionPackage {
+            dir: std::env::temp_dir(),
+            manifest,
+        }
+    }
+
+    #[tokio::test]
+    async fn trace_events_are_forwarded_to_a_declaring_server() {
+        let Some(python) = python3() else {
+            eprintln!("skipping: python3 not available");
+            return;
+        };
+        let dir = tempfile::tempdir().expect("tempdir");
+        let log = dir.path().join("trace.log");
+        let capability = ExtensionCapability::new(trace_package(&python), std::env::temp_dir());
+
+        // The `trace` facet exposes the server process; config names the log file.
+        let process = capability
+            .trace_process(&json!({ "trace_log": log.display().to_string() }))
+            .expect("trace_process for a declaring extension");
+        process
+            .send_trace_event(json!({ "event_type": "turn.started", "session_id": "sess-1" }))
+            .await
+            .expect("forward turn.started");
+        process
+            .send_trace_event(json!({ "event_type": "tool.completed", "session_id": "sess-1" }))
+            .await
+            .expect("forward tool.completed");
+
+        // Notifications are fire-and-forget; give the server a moment to write,
+        // then a graceful shutdown flushes stdio.
+        for _ in 0..50 {
+            if std::fs::read_to_string(&log)
+                .map(|c| c.lines().count() >= 2)
+                .unwrap_or(false)
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        let recorded = std::fs::read_to_string(&log).unwrap_or_default();
+        let types: Vec<&str> = recorded.lines().collect();
+        assert!(types.contains(&"turn.started"), "recorded: {types:?}");
+        assert!(types.contains(&"tool.completed"), "recorded: {types:?}");
+    }
+
+    /// A non-declaring extension gets no trace process — the event stream is
+    /// never forwarded to it (D4).
+    #[test]
+    fn non_declaring_extension_has_no_trace_process() {
+        let capability = ExtensionCapability::new(sdk_example_package(), std::env::temp_dir());
+        assert!(capability.trace_process(&json!(null)).is_none());
     }
 
     #[tokio::test]

--- a/src/extensions/package.rs
+++ b/src/extensions/package.rs
@@ -232,6 +232,61 @@ pub struct ExtensionPackage {
     pub manifest: ExtensionManifest,
 }
 
+/// One field declared in an extension's `config_schema`, with yolop's setup
+/// vocabulary folded in: `secret` (the value is a credential — stored in the
+/// secret store, redacted, never shown to the agent) and `env` (inject the
+/// value into the server's environment under this name). `required` comes from
+/// the schema's top-level `required` array and drives setup prompting.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigField {
+    pub name: String,
+    pub secret: bool,
+    pub env: Option<String>,
+    pub required: bool,
+    pub description: String,
+}
+
+impl ExtensionManifest {
+    /// The setup fields declared in `config_schema.properties`. Empty when the
+    /// extension declares no schema. Lenient — unknown keywords are ignored.
+    pub fn config_fields(&self) -> Vec<ConfigField> {
+        let Some(schema) = &self.config_schema else {
+            return Vec::new();
+        };
+        let required: std::collections::HashSet<&str> = schema
+            .get("required")
+            .and_then(Value::as_array)
+            .map(|arr| arr.iter().filter_map(Value::as_str).collect())
+            .unwrap_or_default();
+        let Some(props) = schema.get("properties").and_then(Value::as_object) else {
+            return Vec::new();
+        };
+        props
+            .iter()
+            .map(|(name, spec)| ConfigField {
+                name: name.clone(),
+                secret: spec.get("secret").and_then(Value::as_bool).unwrap_or(false),
+                env: spec.get("env").and_then(Value::as_str).map(str::to_string),
+                required: required.contains(name.as_str()),
+                description: spec
+                    .get("description")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string(),
+            })
+            .collect()
+    }
+
+    /// The subset of `config_fields` marked `secret` — credentials that live in
+    /// the secret store, never in `settings.toml` config.
+    pub fn secret_fields(&self) -> Vec<ConfigField> {
+        self.config_fields()
+            .into_iter()
+            .filter(|f| f.secret)
+            .collect()
+    }
+}
+
 /// Capability ref for an extension: `ext:<name>`.
 pub fn extension_capability_id(name: &str) -> String {
     format!("ext:{name}")

--- a/src/extensions/package.rs
+++ b/src/extensions/package.rs
@@ -72,6 +72,14 @@ struct RawFacet {
     /// answer). D4 opt-in — a non-declaring extension's `ui/ask` is refused.
     #[serde(default)]
     ui_ask: bool,
+    /// Subscribes the extension to the session's agentic event stream: the host
+    /// forwards each lifecycle event (`turn.*`, `reason.*`, `act.*`,
+    /// `tool.started/completed`, `llm.generation`) as a fire-and-forget
+    /// `trace/event` notification, for export to a tracing backend. D4 opt-in —
+    /// the event stream is only forwarded to a declaring, enabled extension, and
+    /// the facet triggers an eager server spawn so no early events are missed.
+    #[serde(default)]
+    trace: bool,
 }
 
 /// A manifest-declared hook subscription. Static (the approved upper bound):
@@ -215,6 +223,7 @@ pub struct ExtensionManifest {
     pub status: bool,
     pub skills: bool,
     pub ui_ask: bool,
+    pub trace: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -280,6 +289,7 @@ pub fn parse_manifest(raw: &str) -> Result<ExtensionManifest, String> {
         && raw.yolop.commands.is_empty()
         && !raw.yolop.status
         && !raw.yolop.skills
+        && !raw.yolop.trace
     {
         return Err("extension declares no contributions; nothing to contribute".into());
     }
@@ -326,6 +336,7 @@ pub fn parse_manifest(raw: &str) -> Result<ExtensionManifest, String> {
         status: raw.yolop.status,
         skills: raw.yolop.skills,
         ui_ask: raw.yolop.ui_ask,
+        trace: raw.yolop.trace,
     })
 }
 

--- a/src/extensions/package.rs
+++ b/src/extensions/package.rs
@@ -244,6 +244,31 @@ pub struct ConfigField {
     pub env: Option<String>,
     pub required: bool,
     pub description: String,
+    /// Allowed values (from the schema `enum`); when non-empty the setup prompt
+    /// presents a selector instead of a free-text field.
+    pub options: Vec<String>,
+}
+
+impl ConfigField {
+    /// The setup input kind, derived from the field's shape. Extensible: new
+    /// kinds slot in here as the schema vocabulary grows.
+    pub fn kind(&self) -> ConfigFieldKind {
+        if self.secret {
+            ConfigFieldKind::Secret
+        } else if !self.options.is_empty() {
+            ConfigFieldKind::Select
+        } else {
+            ConfigFieldKind::Text
+        }
+    }
+}
+
+/// How a config field is entered during setup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigFieldKind {
+    Text,
+    Secret,
+    Select,
 }
 
 impl ExtensionManifest {
@@ -273,6 +298,15 @@ impl ExtensionManifest {
                     .and_then(Value::as_str)
                     .unwrap_or("")
                     .to_string(),
+                options: spec
+                    .get("enum")
+                    .and_then(Value::as_array)
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(str::to_string))
+                            .collect()
+                    })
+                    .unwrap_or_default(),
             })
             .collect()
     }

--- a/src/extensions/secrets.rs
+++ b/src/extensions/secrets.rs
@@ -1,0 +1,186 @@
+//! Per-extension secret storage and the redacting [`Secret`] type.
+//!
+//! Extension credentials (a `secret: true` config field — e.g. a Logfire write
+//! token) live in the shared credential store (`connections.toml`, written
+//! owner-only 0600, redacted in output), **never** in `settings.toml` config.
+//! Keeping them out of config is the core leak guard: the agent-readable config
+//! surface (`list_extensions`, `get_config`) never carries a secret value, and
+//! entry happens out-of-band through a user prompt, so a secret never enters the
+//! model's context. Secrets reach the extension server host→server only — as
+//! injected env at spawn (per the field's `env` mapping) — not via the wire
+//! `initialize.config`.
+//!
+//! The `secret` marker decouples the *concept* from the *location*: today the
+//! value sits in `connections.toml`; moving it to an OS keychain or a vault
+//! later changes only this module, not any extension manifest.
+
+use super::package::ExtensionManifest;
+use crate::connectors::ConnectionStore;
+use anyhow::Result;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+/// A secret string that never reveals itself through `Debug` (so it can't leak
+/// into logs, tracing, or panic output). Read the value only at the point of
+/// use via [`Secret::expose`].
+#[derive(Clone, Default, PartialEq, Eq)]
+pub struct Secret(String);
+
+impl Secret {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    /// The raw value. Call this only where the secret is actually needed
+    /// (env injection, an auth header) — never to log or return to the agent.
+    pub fn expose(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for Secret {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Secret(***)")
+    }
+}
+
+/// Per-extension secrets over the shared credential store. Keyed `ext:<name>`
+/// so extension secrets never collide with connector credentials in the same
+/// file.
+#[derive(Clone)]
+pub struct ExtensionSecrets {
+    store: Arc<ConnectionStore>,
+}
+
+impl ExtensionSecrets {
+    pub fn new(store: Arc<ConnectionStore>) -> Self {
+        Self { store }
+    }
+
+    fn key(ext: &str) -> String {
+        format!("ext:{ext}")
+    }
+
+    /// The stored value of one secret field, if set and non-empty.
+    pub fn get(&self, ext: &str, field: &str) -> Option<Secret> {
+        self.store
+            .get(&Self::key(ext))
+            .and_then(|conn| conn.fields.get(field).cloned())
+            .filter(|value| !value.trim().is_empty())
+            .map(Secret)
+    }
+
+    /// Whether a secret field has a stored value — the redacted status the agent
+    /// is allowed to see (never the value itself).
+    pub fn is_set(&self, ext: &str, field: &str) -> bool {
+        self.get(ext, field).is_some()
+    }
+
+    /// Store (or replace) one secret field. Persists owner-only via the store.
+    pub fn set(&self, ext: &str, field: &str, value: Secret) -> Result<()> {
+        let mut conn = self.store.get(&Self::key(ext)).unwrap_or_default();
+        conn.fields.insert(field.to_string(), value.0);
+        self.store.save(&Self::key(ext), conn)
+    }
+
+    /// Drop all secrets for an extension (e.g. on uninstall).
+    pub fn clear(&self, ext: &str) -> Result<bool> {
+        self.store.clear(&Self::key(ext))
+    }
+
+    /// Env-var name → value for the manifest's secret fields that declare an
+    /// `env` mapping and have a stored value — the injection set for spawn.
+    pub fn env_overrides(&self, manifest: &ExtensionManifest) -> BTreeMap<String, String> {
+        let mut env = BTreeMap::new();
+        for field in manifest.secret_fields() {
+            if let (Some(name), Some(secret)) =
+                (field.env.as_ref(), self.get(&manifest.name, &field.name))
+            {
+                env.insert(name.clone(), secret.expose().to_string());
+            }
+        }
+        env
+    }
+
+    /// Test/utility constructor over a throwaway store path.
+    #[cfg(test)]
+    pub fn open_at(path: std::path::PathBuf) -> Self {
+        Self::new(Arc::new(ConnectionStore::open(path)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn manifest_with_secret() -> ExtensionManifest {
+        crate::extensions::package::parse_manifest(
+            &json!({
+                "name": "logfire", "description": "t",
+                "yolop": {
+                    "protocol_version": "1.0",
+                    "capabilityServer": { "command": "x" },
+                    "trace": true,
+                    "config_schema": {
+                        "type": "object",
+                        "required": ["token"],
+                        "properties": {
+                            "token": { "type": "string", "secret": true, "env": "LOGFIRE_TOKEN" },
+                            "region": { "type": "string", "default": "us" }
+                        }
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn secret_debug_is_redacted() {
+        let s = Secret::new("pylf_v1_supersecret");
+        assert_eq!(format!("{s:?}"), "Secret(***)");
+        assert!(!format!("{s:?}").contains("supersecret"));
+        assert_eq!(s.expose(), "pylf_v1_supersecret");
+    }
+
+    #[test]
+    fn set_get_and_env_overrides_roundtrip_via_disk() {
+        let tmp = tempfile::tempdir().unwrap();
+        let secrets = ExtensionSecrets::open_at(tmp.path().join("connections.toml"));
+        assert!(!secrets.is_set("logfire", "token"));
+
+        secrets
+            .set("logfire", "token", Secret::new("pylf_v1_abc"))
+            .unwrap();
+        assert!(secrets.is_set("logfire", "token"));
+        assert_eq!(
+            secrets.get("logfire", "token").unwrap().expose(),
+            "pylf_v1_abc"
+        );
+
+        // Env override maps the field's `env` name to the value.
+        let env = secrets.env_overrides(&manifest_with_secret());
+        assert_eq!(
+            env.get("LOGFIRE_TOKEN").map(String::as_str),
+            Some("pylf_v1_abc")
+        );
+        // Non-secret fields never appear in the env-override set.
+        assert!(!env.contains_key("region"));
+    }
+
+    #[test]
+    fn config_fields_parse_secret_env_and_required() {
+        let manifest = manifest_with_secret();
+        let token = manifest
+            .config_fields()
+            .into_iter()
+            .find(|f| f.name == "token")
+            .unwrap();
+        assert!(token.secret);
+        assert!(token.required);
+        assert_eq!(token.env.as_deref(), Some("LOGFIRE_TOKEN"));
+        assert_eq!(manifest.secret_fields().len(), 1);
+    }
+}

--- a/src/extensions/trace.rs
+++ b/src/extensions/trace.rs
@@ -1,0 +1,155 @@
+//! Agentic-trace forwarding: fan the session's live event stream out to any
+//! enabled extension that declares the `trace` facet, as fire-and-forget
+//! `trace/event` notifications. The extension server maps events to spans and
+//! exports them to a tracing backend (Logfire, an OTLP collector, …).
+//!
+//! This mirrors `capabilities::herdr`'s `start_monitor`: one spawned task per
+//! trace extension consuming a `broadcast::Receiver<Event>`, filtered to the
+//! session. Forwarding is observe-only and best-effort — a slow or crashed
+//! exporter can never stall the agent loop (the host never awaits a reply),
+//! and a forward failure degrades to a warning.
+
+use super::manager::ExtensionProcess;
+use everruns_core::events::{
+    Event, OUTPUT_MESSAGE_DELTA, REASON_THINKING_DELTA, TOOL_OUTPUT_DELTA, TOOL_PROGRESS,
+};
+use everruns_core::typed_id::SessionId;
+use serde_json::Value;
+use std::sync::Arc;
+use tokio::sync::broadcast;
+
+/// High-frequency streaming deltas carry no span-shaped meaning on their own and
+/// would flood the exporter (and the broadcast channel); the paired
+/// `*.started`/`*.completed` events already bound the same work. Everything else
+/// — turn/reason/act/tool lifecycle and `llm.generation` — is forwarded.
+fn is_forwardable(event_type: &str) -> bool {
+    !matches!(
+        event_type,
+        OUTPUT_MESSAGE_DELTA | REASON_THINKING_DELTA | TOOL_OUTPUT_DELTA | TOOL_PROGRESS
+    )
+}
+
+/// Map one host event to `trace/event` params (the `yolop_yep::TraceEventParams`
+/// shape). `context` and `data` are carried verbatim so the exporter can stitch
+/// spans and read token usage without the host modelling every event type.
+pub(crate) fn trace_event_params(event: &Event) -> Value {
+    serde_json::json!({
+        "event_type": event.event_type,
+        "id": event.id.to_string(),
+        "ts": event.ts.to_rfc3339(),
+        "session_id": event.session_id.to_string(),
+        "context": serde_json::to_value(&event.context).unwrap_or(Value::Null),
+        "data": serde_json::to_value(&event.data).unwrap_or(Value::Null),
+    })
+}
+
+/// A trace-declaring extension paired with its live-server process, captured
+/// while the harness is assembled (before `session_id` and the event broadcast
+/// exist) and started once they do. Keeps `ExtensionProcess` out of the runtime
+/// wiring — the runtime only holds this handle and calls [`TraceForwarder::start`].
+pub(crate) struct TraceForwarder {
+    name: String,
+    process: Arc<ExtensionProcess>,
+}
+
+impl TraceForwarder {
+    /// Build a forwarder for `capability` iff it declares the `trace` facet.
+    /// `config` is the extension's effective harness config, so the trace
+    /// server shares the same process (and Logfire token) as its other facets.
+    pub(crate) fn for_capability(
+        capability: &super::capability::ExtensionCapability,
+        config: &serde_json::Value,
+    ) -> Option<Self> {
+        use everruns_core::capabilities::Capability;
+        capability.trace_process(config).map(|process| Self {
+            name: capability.name().to_string(),
+            process,
+        })
+    }
+
+    /// Begin forwarding this session's events to the extension server.
+    pub(crate) fn start(self, session_id: SessionId, events: broadcast::Receiver<Event>) {
+        spawn_forwarder(self.name, self.process, session_id, events);
+    }
+}
+
+/// Spawn the forwarder task: for `session_id`, push every forwardable event to
+/// `process` as a `trace/event` notification. Ends when the broadcast closes
+/// (session teardown).
+pub(crate) fn spawn_forwarder(
+    ext_name: String,
+    process: Arc<ExtensionProcess>,
+    session_id: SessionId,
+    mut events: broadcast::Receiver<Event>,
+) {
+    tokio::spawn(async move {
+        loop {
+            match events.recv().await {
+                Ok(event) if event.session_id == session_id => {
+                    if !is_forwardable(&event.event_type) {
+                        continue;
+                    }
+                    if let Err(err) = process.send_trace_event(trace_event_params(&event)).await {
+                        tracing::warn!(
+                            target: "yolop::ext", ext = %ext_name,
+                            "trace/event forward failed: {err}"
+                        );
+                    }
+                }
+                Ok(_) => {}
+                // The exporter fell behind the broadcast buffer: skip the gap
+                // rather than block the agent. A lossy trace beats a stalled run.
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    tracing::debug!(
+                        target: "yolop::ext", ext = %ext_name,
+                        "trace forwarder lagged, dropped {n} events"
+                    );
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::events::{EventContext, EventRequest};
+
+    #[test]
+    fn deltas_are_dropped_lifecycle_is_kept() {
+        assert!(is_forwardable("turn.started"));
+        assert!(is_forwardable("tool.completed"));
+        assert!(is_forwardable("llm.generation"));
+        assert!(!is_forwardable(OUTPUT_MESSAGE_DELTA));
+        assert!(!is_forwardable(TOOL_OUTPUT_DELTA));
+        assert!(!is_forwardable(TOOL_PROGRESS));
+    }
+
+    #[test]
+    fn params_carry_type_ids_and_verbatim_payload() {
+        let session = SessionId::new();
+        let request = EventRequest {
+            event_type: "tool.completed".into(),
+            ts: chrono::Utc::now(),
+            session_id: session,
+            context: EventContext::empty(),
+            data: everruns_core::events::EventData::unsupported(
+                "tool.completed".into(),
+                serde_json::json!({ "tool_name": "bash" }),
+            ),
+            metadata: None,
+            tags: None,
+        };
+        let event = request.into_event(everruns_core::typed_id::EventId::new(), 1);
+        let params = trace_event_params(&event);
+        assert_eq!(params["event_type"], "tool.completed");
+        assert_eq!(params["session_id"], session.to_string());
+        assert_eq!(params["id"], event.id.to_string());
+        assert!(params["ts"].as_str().unwrap().contains('T'));
+        // The event `context` is carried through verbatim as a JSON object for
+        // the exporter to stitch spans from (`data` likewise; here the fixture
+        // uses an unsupported variant, which upstream serializes as null).
+        assert!(params["context"].is_object(), "{params}");
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2811,6 +2811,8 @@ pub async fn build_with_options(
                     let _ = ask_tx.send(crate::tui::host_ui::AskRequest {
                         prompt: params.prompt,
                         placeholder: params.placeholder,
+                        secret: params.secret,
+                        options: params.options,
                         reply,
                     });
                     match answer.await {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2838,6 +2838,10 @@ pub async fn build_with_options(
     // `reload_extension` can restart one in place mid-session (self-writing
     // iteration) without a yolop restart.
     let live_processes = crate::extensions::LiveProcessRegistry::default();
+    // Per-extension secrets ride the shared credential store (`connections.toml`,
+    // 0600), keyed `ext:<name>` — never `settings.toml`. Injected as env at
+    // spawn; never surfaced to the agent.
+    let extension_secrets = crate::extensions::ExtensionSecrets::new(connections.clone());
     let mut extension_never_defer: Vec<String> = Vec::new();
     // Trace-facet extensions, captured here and started once `session_id` and
     // the event broadcast exist (below). Observe-only agentic-trace export.
@@ -2866,6 +2870,7 @@ pub async fn build_with_options(
                     .with_status_sink(status_sink.clone())
                     .with_ask_sink(ask_sink.clone())
                     .with_process_registry(live_processes.clone())
+                    .with_secrets(extension_secrets.clone())
                     .with_environment_context(environment_context.clone());
             if enabled {
                 let contributed = capability.contributed_mcp_servers();
@@ -2892,13 +2897,19 @@ pub async fn build_with_options(
         // Hand it the UI-command sink so enable/disable can activate the
         // capability on the live session (TUI only); `None` elsewhere.
         let manage_ui_tx = matches!(options.client_ui, ClientUiContext::Tui).then(|| ui_tx.clone());
-        capabilities.register(crate::extensions::ExtensionsCapability::new(
-            ext_dir,
-            effective_root.clone(),
-            settings.clone(),
-            live_processes.clone(),
-            manage_ui_tx,
-        ));
+        capabilities.register(
+            crate::extensions::ExtensionsCapability::new(
+                ext_dir,
+                effective_root.clone(),
+                settings.clone(),
+                live_processes.clone(),
+                manage_ui_tx,
+            )
+            .with_secrets(extension_secrets.clone())
+            // The `set_extension_secret` prompt reuses the extension `ui/ask`
+            // surface (TUI only); `None` elsewhere refuses interactive setup.
+            .with_ask_sink(ask_sink.clone()),
+        );
     }
     // Server name list for `/mcp` and StartupInfo, computed after extension
     // contributions are merged so provider-provenance entries show up too.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2839,6 +2839,9 @@ pub async fn build_with_options(
     // iteration) without a yolop restart.
     let live_processes = crate::extensions::LiveProcessRegistry::default();
     let mut extension_never_defer: Vec<String> = Vec::new();
+    // Trace-facet extensions, captured here and started once `session_id` and
+    // the event broadcast exist (below). Observe-only agentic-trace export.
+    let mut trace_forwarders: Vec<crate::extensions::trace::TraceForwarder> = Vec::new();
     if let Some(ext_dir) = crate::extensions::extensions_dir() {
         let settings_snapshot = settings.snapshot();
         for package in crate::extensions::discover_extensions(&ext_dir) {
@@ -2846,12 +2849,18 @@ pub async fn build_with_options(
             // extension is enabled in the harness — merged into scoped MCP
             // config so the runtime's own client discovers them, exactly like
             // `.mcp.json`. Workspace `.mcp.json` still overrides by name.
-            let enabled = settings_snapshot
-                .capability_overrides_for(&crate::extensions::extension_capability_id(
-                    &package.manifest.name,
-                ))
+            let overrides = settings_snapshot.capability_overrides_for(
+                &crate::extensions::extension_capability_id(&package.manifest.name),
+            );
+            let enabled = overrides.iter().any(|(_, entry)| !entry.is_remove());
+            // The effective harness config: the last non-remove override's
+            // inline config (empty when the extension is enabled without one).
+            let ext_config = overrides
                 .iter()
-                .any(|(_, entry)| !entry.is_remove());
+                .rev()
+                .find(|(_, entry)| !entry.is_remove())
+                .map(|(_, entry)| entry.config.clone())
+                .unwrap_or(serde_json::Value::Null);
             let capability =
                 crate::extensions::ExtensionCapability::new(package, effective_root.clone())
                     .with_status_sink(status_sink.clone())
@@ -2865,6 +2874,15 @@ pub async fn build_with_options(
                         &contributed,
                         &mcp_servers,
                     );
+                }
+                // Forward the session event stream to an enabled `trace`
+                // extension (the process is shared with its other facets via
+                // `ext_config`); started below once the session id exists.
+                if let Some(fwd) = crate::extensions::trace::TraceForwarder::for_capability(
+                    &capability,
+                    &ext_config,
+                ) {
+                    trace_forwarders.push(fwd);
                 }
             }
             extension_never_defer.extend(capability.never_defer_tools());
@@ -3204,6 +3222,13 @@ pub async fn build_with_options(
     let capability_commands = runtime.list_commands(session_id).await?;
 
     herdr.start_monitor(session_id, event_bus_typed.subscribe());
+
+    // Start agentic-trace forwarding for each enabled `trace` extension: one
+    // task per extension consuming its own subscription, filtered to this
+    // session. Observe-only — a slow exporter never stalls the run.
+    for forwarder in trace_forwarders {
+        forwarder.start(session_id, event_bus_typed.subscribe());
+    }
 
     Ok(BuiltRuntime {
         handles: RuntimeHandles {

--- a/src/tui/host_ui.rs
+++ b/src/tui/host_ui.rs
@@ -18,6 +18,10 @@ use tokio::sync::{mpsc, oneshot};
 pub struct AskRequest {
     pub prompt: String,
     pub placeholder: Option<String>,
+    /// Mask input and never echo the answer (credentials).
+    pub secret: bool,
+    /// When non-empty, present a selector over these options.
+    pub options: Vec<String>,
     pub reply: oneshot::Sender<AskAnswer>,
 }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -366,6 +366,12 @@ pub(crate) struct PendingAsk {
     prompt: String,
     placeholder: Option<String>,
     value: String,
+    /// Mask the input and never echo the answer (credentials).
+    secret: bool,
+    /// Selector options; when non-empty the overlay is a picker, not a field.
+    options: Vec<String>,
+    /// Highlighted option index (selector mode only).
+    selected: usize,
     reply: Option<oneshot::Sender<crate::tui::host_ui::AskAnswer>>,
 }
 
@@ -1206,6 +1212,9 @@ impl App {
                 prompt: request.prompt,
                 placeholder: request.placeholder,
                 value: String::new(),
+                secret: request.secret,
+                options: request.options,
+                selected: 0,
                 reply: Some(request.reply),
             });
             applied_ui_command = true;
@@ -1865,6 +1874,32 @@ impl App {
         let Some(ask) = self.pending_ask.as_mut() else {
             return;
         };
+        // Selector mode: arrow keys move, Enter picks the highlighted option.
+        if !ask.options.is_empty() {
+            match key.code {
+                KeyCode::Up => {
+                    ask.selected = ask.selected.saturating_sub(1);
+                }
+                KeyCode::Down => {
+                    ask.selected = (ask.selected + 1).min(ask.options.len() - 1);
+                }
+                KeyCode::Enter => {
+                    let answer = ask.options.get(ask.selected).cloned().unwrap_or_default();
+                    self.resolve_ask(crate::tui::host_ui::AskAnswer {
+                        answer,
+                        cancelled: false,
+                    });
+                }
+                KeyCode::Esc => {
+                    self.resolve_ask(crate::tui::host_ui::AskAnswer {
+                        answer: String::new(),
+                        cancelled: true,
+                    });
+                }
+                _ => {}
+            }
+            return;
+        }
         match key.code {
             KeyCode::Enter => {
                 let answer = ask.value.clone();
@@ -1894,6 +1929,9 @@ impl App {
         if let Some(mut ask) = self.pending_ask.take() {
             let shown = if answer.cancelled {
                 "(cancelled)".to_string()
+            } else if ask.secret {
+                // Never echo a secret answer into the transcript.
+                "(saved)".to_string()
             } else {
                 answer.answer.clone()
             };

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -452,15 +452,7 @@ pub(crate) fn draw_setup_overlay(f: &mut ratatui::Frame, area: Rect, app: &App) 
 /// both the inline sheet renderer and the full-screen tuika overlay show the
 /// same content.
 pub(crate) fn ask_overlay_content(ask: &PendingAsk) -> (Vec<Line<'static>>, (usize, usize)) {
-    let field = if ask.value.is_empty() {
-        ask.placeholder
-            .as_ref()
-            .map(|p| format!("({p})"))
-            .unwrap_or_default()
-    } else {
-        ask.value.clone()
-    };
-    let lines = vec![
+    let mut lines = vec![
         Line::from(Span::styled(
             "An extension is asking:",
             Style::default()
@@ -470,13 +462,47 @@ pub(crate) fn ask_overlay_content(ask: &PendingAsk) -> (Vec<Line<'static>>, (usi
         Line::from(""),
         Line::from(ask.prompt.clone()),
         Line::from(""),
-        Line::from(format!("> {field}")),
-        Line::from(""),
-        Line::from(Span::styled(
-            "Enter to answer · Esc to cancel",
-            Style::default().add_modifier(Modifier::DIM),
-        )),
     ];
+    // Selector mode: a highlighted list of options.
+    if !ask.options.is_empty() {
+        for (i, option) in ask.options.iter().enumerate() {
+            let selected = i == ask.selected;
+            let marker = if selected { "▶ " } else { "  " };
+            let style = if selected {
+                Style::default()
+                    .fg(TEXT_PRIMARY)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().add_modifier(Modifier::DIM)
+            };
+            lines.push(Line::from(Span::styled(format!("{marker}{option}"), style)));
+        }
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "↑/↓ to choose · Enter to select · Esc to cancel",
+            Style::default().add_modifier(Modifier::DIM),
+        )));
+        // No text cursor in selector mode; park it on the selected row.
+        return (lines, (4 + ask.selected, 0));
+    }
+    // Text / secret input. Secret input is masked; the placeholder (shown when
+    // empty) is never masked.
+    let field = if ask.value.is_empty() {
+        ask.placeholder
+            .as_ref()
+            .map(|p| format!("({p})"))
+            .unwrap_or_default()
+    } else if ask.secret {
+        "•".repeat(ask.value.chars().count())
+    } else {
+        ask.value.clone()
+    };
+    lines.push(Line::from(format!("> {field}")));
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "Enter to answer · Esc to cancel",
+        Style::default().add_modifier(Modifier::DIM),
+    )));
     // The typed answer is on row 4, after the "> " prompt.
     let cursor = (4, "> ".len() + ask.value.chars().count());
     (lines, cursor)

--- a/tests/fixtures/yep_echo_server.py
+++ b/tests/fixtures/yep_echo_server.py
@@ -46,6 +46,13 @@ def main():
             if isinstance(config, dict) and config.get("trace_log"):
                 global TRACE_LOG
                 TRACE_LOG = config["trace_log"]
+            # Echo an injected env var (for the secret-injection spawn test):
+            # the host injects `secret`/`env`-mapped config fields into our
+            # environment. Record it so the test can assert it arrived.
+            import os
+            probe = os.environ.get("YEP_ECHO_ENV")
+            if probe:
+                record_trace("env:" + probe)
             send({
                 "id": msg_id,
                 "result": {

--- a/tests/fixtures/yep_echo_server.py
+++ b/tests/fixtures/yep_echo_server.py
@@ -10,10 +10,24 @@ stdout carries only protocol JSON; this file has no dependencies.
 import json
 import sys
 
+# Set from `initialize.config.trace_log`: a file the server appends each
+# received `trace/event` type to. Lets a spawn test assert the host forwards
+# the session event stream to a `trace`-declaring extension (a fire-and-forget
+# notification, so there is nothing to reply on the wire). Config-driven rather
+# than env-driven so parallel tests don't collide.
+TRACE_LOG = None
+
 
 def send(obj):
     sys.stdout.write(json.dumps(obj) + "\n")
     sys.stdout.flush()
+
+
+def record_trace(event_type):
+    if not TRACE_LOG:
+        return
+    with open(TRACE_LOG, "a", encoding="utf-8") as handle:
+        handle.write(event_type + "\n")
 
 
 def main():
@@ -28,12 +42,16 @@ def main():
         method = msg.get("method")
         msg_id = msg.get("id")
         if method == "initialize":
+            config = (msg.get("params") or {}).get("config") or {}
+            if isinstance(config, dict) and config.get("trace_log"):
+                global TRACE_LOG
+                TRACE_LOG = config["trace_log"]
             send({
                 "id": msg_id,
                 "result": {
                     "protocol_version": "1.0",
                     "name": "echo",
-                    "capabilities": ["tools", "prompt", "streaming"],
+                    "capabilities": ["tools", "prompt", "streaming", "trace"],
                     "capability_params": {
                         "prompt": {"static": "echo fixture prompt"},
                         "tools": [{"name": "echo"}],
@@ -42,6 +60,10 @@ def main():
             })
         elif method == "initialized":
             continue
+        elif method == "trace/event":
+            # Fire-and-forget notification: record it, send nothing back.
+            params = msg.get("params") or {}
+            record_trace(params.get("event_type", ""))
         elif method == "tool/call":
             params = msg.get("params") or {}
             if params.get("name") != "echo":


### PR DESCRIPTION
## What changed

Adds agentic-trace logging to extensions, and the config/secrets machinery it needs — all generic, with `logfire` as the dogfood.

- **`trace` YEP facet** — an extension can subscribe to the session's agentic event stream (`turn.*`, `reason.*`, `act.*`, `tool.started/completed`, `llm.generation`), forwarded as fire-and-forget `trace/event` notifications. Observe-only: the host never awaits it, so a slow/crashed exporter can never stall the agent loop. High-frequency streaming deltas are dropped.
- **`yolop-extension-logfire`** — a reference capability server (new workspace crate) that folds those events into OpenTelemetry spans and ships them to Pydantic Logfire via the official `opentelemetry-otlp` HTTP/protobuf exporter (the path Logfire's alternative-clients guide documents). One trace per turn, tools nested under it.
- **Generic config + secrets** — a `config_schema` property gains `secret: true` (credential) and `env: "NAME"` (inject as env). Secrets live in the credential store (`connections.toml`, 0600, redacted), never `settings.toml`, and reach the server as injected env only. Setup-on-enable prompts the user (not the agent) for required fields by kind: **secret** (masked entry → store), **enum** (selector), or **text** (→ capability config). Non-secret config reaches SDK servers via a new `Server::on_config` handler.
- **Agent leak-protection** — secret entry is out-of-band via `set_extension_secret`/setup (the agent triggers, the user types, the agent is refused if it passes a value); all agent-facing reads report `set`/`unset` status only; a redacting `Secret` newtype keeps values out of logs; `ui/ask` gained a `secret` flag so the TUI masks input and shows `(saved)`.

## Why

Users want their agent runs traced to an observability backend (Logfire). Doing it right meant a reusable extension seam for observing the agent loop, plus first-class handling for the credential such an integration needs — without ever exposing that credential to the model.

## Before / After

**Before:** no way for an extension to observe turns/tools/LLM calls; no secret handling for extension config.

**After — live, against production Logfire:** the extension's exact OTLP protobuf body is accepted:

```
POST https://logfire-us.pydantic.dev/v1/traces
Content-Type: application/x-protobuf   Authorization: <write-token>
→ HTTP 200
```

A turn with a `bash` tool renders as one trace: a `turn` root span with a nested `tool bash` span (`yolop.tool_name=bash`, `yolop.exit_code=0`) and an `llm.generation` point span (`yolop.input_tokens`, `yolop.output_tokens`, `yolop.model`).

**Secrets, after:** `list_extensions` shows `{"name":"token","secret":true,"set":true}` — never the value; the token is stored in `connections.toml` (0600) and injected as `LOGFIRE_TOKEN`.

## Risk

- **Low–Medium.** All new surface is opt-in: the `trace`/config/secret machinery is inert unless an extension declares the facets and the user enables it. No change to the default harness, the agent loop, filesystem, or shell execution. The host-side forwarder reuses the existing event broadcast (same fan-out as `herdr.start_monitor`).
- What could break: an enabled trace extension adds one background task per session consuming the event broadcast; a misbehaving exporter is isolated by the fire-and-forget notification (no await).

## Security

Reviewed per the ship checklist; the concentrated categories:

- **TM-LLM (keys / prompt).** The secrets design is built around *not* leaking credentials to the model: secrets never enter `settings.toml`, never reach the agent (entry is user-prompted out-of-band; `set_config`/`set_extension_secret` refuse agent-supplied values; reads are redacted to `set`/`unset`), and never hit logs (redacting `Secret` newtype; spawn never logs injected env). The Logfire token is used only in an `Authorization` header and is not logged on error.
- **TM-FS.** Secret store reuses the existing 0600 `connections.toml` writer; write blocklist unchanged; no new writes to sensitive dirs.
- **TM-BASH.** No change to `tools.rs` / bash execution. Env injection is scoped to the extension's *own* child process (arbitrary code the user already installed), not yolop or other processes — not a privilege boundary crossing.
- **TM-TOOL.** New management tool `set_extension_secret` is prompt-only and value-refusing; the trace facet is observe-only.
- **TM-DEP.** New deps in the `logfire` crate only: `opentelemetry`, `opentelemetry_sdk`, `opentelemetry-otlp` (0.32 — already resolved in the workspace lock via everruns; the official OTLP SDK), and `chrono` (already in tree). `opentelemetry-otlp reqwest-blocking-client` pulls `reqwest` 0.13 transitively (host uses 0.12; separate crate, acceptable). `everruns-*` untouched at 0.17.16. No new deps in the `yolop` binary.
- **Data exposure note:** trace export sends agentic activity to the user-configured endpoint. The exporter maps only *scalar* event-`data` fields to span attributes (tool name, exit code, token counts, model) — object/array payloads (e.g. tool argument blobs) are not exported. Opt-in and off by default.

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features` — all green on the rebased branch.
- Feature tests exercise entry points directly: `trace_events_are_forwarded_to_a_declaring_server` (real server process), `secret_config_field_is_injected_as_env` (real spawn), `set_extension_secret_refuses_agent_value_and_needs_a_prompt`, `list_reports_secret_status_never_values`, `setup_on_enable_prompts_by_field_kind`, `set_capability_config_creates_override_and_persists`, and the SDK's `on_config_receives_initialize_config` / `trace_events_reach_the_handler`. Exporter span-mapping asserted offline via the OTel in-memory exporter.
- Live: HTTP 200 from production Logfire for the exporter's real protobuf body (above).
- Smoke: `./target/debug/yolop --provider llmsim -p "say hi"` starts and runs clean.
- The TUI masking/selector rendering is exercised structurally (shared `ask_overlay_content` + key-handling logic); the logic paths (mask, no-echo, option nav, kind dispatch) are covered headlessly — see Follow-ups.

## Follow-ups

- **Pixel-level TUI overlay test** for the masked/selector `ui/ask` overlay. The presentation logic is tested headlessly, but there's no PTY snapshot asserting the masked glyphs / selection highlight specifically.
- **Prebuilt-artifact install** for `yolop-extension-logfire` (crates.io provisioning) — today it installs package-only; the binary must be on `PATH`/`bin/`, same as other extensions.
- **Region auto-detection** for the Logfire endpoint (US default; EU via config/env override).

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered — additive facets/keywords; lenient wire (unknown fields ignored), pre-1.0 so no compat guarantee required.

https://claude.ai/code/session_01AwsHezVAGnidhEJFvQtdG7

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwsHezVAGnidhEJFvQtdG7)_