### PR TITLE
feat(tui): add responsive fullscreen status drawer

### DIFF
--- a/specs/presentation.md
+++ b/specs/presentation.md
@@ -31,6 +31,22 @@ widgets, overlays, and terminal-specific affordances. It must not be the only
 place where a user-visible transcript label, tool wording, or status-bar value
 is assembled.
 
+### Fullscreen Status Drawer
+
+The fullscreen host projects expanded session status as a responsive drawer.
+At wide terminal widths the Runtime, Session, and Workspace sections render as
+three columns; narrower widths reflow them to two columns. Compact mode remains
+one row. Values must fit their assigned column without escaping the frame.
+
+Status fields may carry typed host actions. Model and reasoning-effort fields
+open their existing selectors, background state opens its panel, and the
+explicit expand/collapse field changes layout. Empty status space has no action.
+
+The interactive TUI exposes a bounded, turn-scoped agent status contribution.
+The agent may update or clear that value while working; the host clears it when
+the turn finishes. Host-owned runtime, safety, session, and workspace values
+remain authoritative and cannot be replaced by the agent contribution.
+
 `--print` and ACP may project the model differently, but shared semantics should
 come from the same presentation model rather than parallel ad hoc formatting.
 

--- a/src/capabilities/client_commands.rs
+++ b/src/capabilities/client_commands.rs
@@ -37,6 +37,9 @@ client-command set. When the user asks for one of these terminal
 actions — for example "exit", "clear the screen", "show tools", "switch model",
 or "expand the status bar" — call `run_yolop_command`; do not merely tell the
 user to type the slash command.
+Use `set_status` for a concise live description of meaningful turn progress.
+The contribution is cleared automatically when the turn finishes; send an
+empty value to clear it earlier.
 </capability>"#;
 
 pub(crate) struct ClientCommandsCapability {
@@ -75,9 +78,14 @@ impl Capability for ClientCommandsCapability {
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
-        vec![Box::new(RunYolopCommandTool {
-            ui: self.ui.clone(),
-        })]
+        vec![
+            Box::new(RunYolopCommandTool {
+                ui: self.ui.clone(),
+            }),
+            Box::new(SetStatusTool {
+                ui: self.ui.clone(),
+            }),
+        ]
     }
 
     async fn execute_command(
@@ -159,6 +167,72 @@ fn ui_command_for(name: &str, arg: Option<String>) -> Option<UiCommand> {
 
 struct RunYolopCommandTool {
     ui: Arc<dyn HostUi>,
+}
+
+struct SetStatusTool {
+    ui: Arc<dyn HostUi>,
+}
+
+#[async_trait]
+impl Tool for SetStatusTool {
+    fn narrate(
+        &self,
+        tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        let _ = locale;
+        let status = arg_str(&tool_call.arguments, &["status"]).map(|value| truncate(value, 48));
+        Some(stable_labeled("Update status", status, phase))
+    }
+
+    fn name(&self) -> &str {
+        "set_status"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Status")
+    }
+
+    fn description(&self) -> &str {
+        "Set a concise, turn-scoped status shown in the interactive TUI. \
+         Use an empty status to clear it before the turn finishes."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "description": "Concise live progress, at most 120 characters. Empty clears it."
+                }
+            },
+            "required": ["status"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let Some(raw) = arguments.get("status").and_then(Value::as_str) else {
+            return ToolExecutionResult::tool_error("'status' is required");
+        };
+        let status = raw.trim();
+        if status.chars().count() > 120 {
+            return ToolExecutionResult::tool_error("status must be at most 120 characters");
+        }
+        if status.chars().any(char::is_control) {
+            return ToolExecutionResult::tool_error("status must be a single printable line");
+        }
+        self.ui.send(UiCommand::SetAgentStatus {
+            status: status.to_string(),
+        });
+        ToolExecutionResult::success(json!({
+            "success": true,
+            "status": status
+        }))
+    }
 }
 
 #[async_trait]
@@ -316,6 +390,7 @@ mod tests {
         assert!(prompt.contains("client-command set"));
         assert!(prompt.contains("/quit"));
         assert!(prompt.contains("/exit"));
+        assert!(prompt.contains("set_status"));
     }
 
     #[test]
@@ -368,6 +443,44 @@ mod tests {
 
         assert!(result.is_success(), "tool result: {result:?}");
         assert_eq!(ui.take(), vec![UiCommand::Quit]);
+    }
+
+    #[tokio::test]
+    async fn set_status_queues_turn_scoped_status_update() {
+        let ui = Arc::new(RecordingUi::default());
+        let tool = SetStatusTool { ui: ui.clone() };
+
+        let result = tool.execute(json!({ "status": "running tests 3/8" })).await;
+
+        assert!(result.is_success(), "tool result: {result:?}");
+        assert_eq!(
+            ui.take(),
+            vec![UiCommand::SetAgentStatus {
+                status: "running tests 3/8".to_string()
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn set_status_rejects_values_over_the_ui_limit() {
+        let ui = Arc::new(RecordingUi::default());
+        let tool = SetStatusTool { ui: ui.clone() };
+
+        let result = tool.execute(json!({ "status": "x".repeat(121) })).await;
+
+        assert!(result.is_error(), "tool result: {result:?}");
+        assert!(ui.take().is_empty());
+    }
+
+    #[tokio::test]
+    async fn set_status_rejects_terminal_control_characters() {
+        let ui = Arc::new(RecordingUi::default());
+        let tool = SetStatusTool { ui: ui.clone() };
+
+        let result = tool.execute(json!({ "status": "tests\u{1b}[2J" })).await;
+
+        assert!(result.is_error(), "tool result: {result:?}");
+        assert!(ui.take().is_empty());
     }
 
     #[tokio::test]

--- a/src/tui/fullscreen.rs
+++ b/src/tui/fullscreen.rs
@@ -141,7 +141,8 @@ pub(crate) fn draw(f: &mut Frame, app: &mut App) {
     let state = app.view_state();
     let input_width = area.width.saturating_sub(2);
     let desired_input_height = app.input_height(input_width);
-    let status_rows = state.status_row_count();
+    let status = render::fullscreen_status_layout(&state, area.width);
+    let status_rows = status.lines.len().try_into().unwrap_or(u16::MAX);
     let preview_visible = render::chrome_preview_visible(&state);
     // NOTE (layout policy, item 2): `chrome_dimensions` stays hand-rolled on
     // purpose. tuika's Flex solver places the rows of the `view!` tree below, but
@@ -161,10 +162,10 @@ pub(crate) fn draw(f: &mut Frame, app: &mut App) {
     let status_sep_height = u16::from(input_height < 3);
     let transcript_height = area.height.saturating_sub(chrome_height).max(1);
 
-    // Content as styled lines — the exact pure builders the inline renderer uses,
-    // so colors, separators, and status can never drift between the two modes.
+    // Transcript and compact chrome share the inline renderer's pure builders.
+    // Expanded status is a fullscreen projection over the same presentation
+    // fields so it can use responsive columns and typed hit targets.
     let inner_w = area.width.saturating_sub(2) as usize;
-    let status_lines = render::session_status_lines(&state);
     let preview_line = render::preview_slot_line(&state, area.width);
 
     // The transcript is a real Scroll over the *full* history, bound to the
@@ -207,7 +208,7 @@ pub(crate) fn draw(f: &mut Frame, app: &mut App) {
             fixed(1) { node(message_rule(&state)) }
             fixed(input_height) { node(composer_row(&app.composer, &input_probe)) }
             fixed(status_sep_height) { node(status_rule()) }
-            fixed(status_rows) { node(Text::new(status_lines)) }
+            fixed(status_rows) { node(Text::new(status.lines.clone())) }
         }
     };
 
@@ -215,6 +216,14 @@ pub(crate) fn draw(f: &mut Frame, app: &mut App) {
     // styled lines' own colors show through.
     let theme = yolop_theme();
     tuika::paint(f.buffer_mut(), area, &theme, root.as_ref(), &[]);
+    app.set_status_hit_regions(
+        Rect {
+            y: area.bottom().saturating_sub(status_rows),
+            height: status_rows,
+            ..area
+        },
+        &status.hits,
+    );
 
     // Mouse text selection over the transcript. Its selectable inner rect is the
     // transcript region inset one column (matching `transcript_view`'s padding).

--- a/src/tui/host_ui.rs
+++ b/src/tui/host_ui.rs
@@ -56,6 +56,8 @@ pub enum UiCommand {
     OpenModelOverlay { arg: Option<String> },
     /// Open the interactive reasoning-effort picker. `arg` pre-seeds it.
     OpenEffortOverlay { arg: Option<String> },
+    /// Set (or clear when empty) the agent's turn-scoped status contribution.
+    SetAgentStatus { status: String },
     /// Set (or, when `status` is empty, clear) an extension's status-bar field.
     /// Pushed by an extension server's `status/changed` notification.
     SetExtensionStatus { ext: String, status: String },

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -171,6 +171,8 @@ pub struct App {
     /// extension servers over `status/changed`. Rendered in the status bar via
     /// [`App::presentation_state`].
     extension_status: std::collections::BTreeMap<String, String>,
+    /// Turn-scoped status text set by the agent through the host UI.
+    agent_status: Option<String>,
     /// Incoming extension `ui/ask` requests; each is prompted one at a time via
     /// [`App::pending_ask`].
     ask_rx: mpsc::UnboundedReceiver<crate::tui::host_ui::AskRequest>,
@@ -244,6 +246,8 @@ pub struct App {
     /// the next draw, where the freshly rendered frame buffer is readable.
     selection: tuika::SelectionState,
     selection_area: Rect,
+    /// Click targets from the last fullscreen status layout.
+    status_hit_regions: Vec<(Rect, StatusAction)>,
     pending_copy: bool,
     pending_link_click: Option<tuika::Mouse>,
     pending_open_url: Option<String>,
@@ -546,6 +550,7 @@ impl App {
             session_tokens: None,
             ui_rx: runtime.ui_rx,
             extension_status: std::collections::BTreeMap::new(),
+            agent_status: None,
             ask_rx: runtime.ask_rx,
             pending_ask: None,
             sandbox_approval_rx: runtime.sandbox_approval_rx,
@@ -578,6 +583,7 @@ impl App {
             transcript_cache: TranscriptWrapCache::default(),
             selection: tuika::SelectionState::new(),
             selection_area: Rect::ZERO,
+            status_hit_regions: Vec::new(),
             pending_copy: false,
             pending_link_click: None,
             pending_open_url: None,
@@ -645,6 +651,23 @@ impl App {
     /// Record the transcript's inner rect (the selectable region) from the draw.
     pub(crate) fn set_selection_area(&mut self, area: Rect) {
         self.selection_area = area;
+    }
+
+    pub(crate) fn set_status_hit_regions(&mut self, area: Rect, hits: &[render::StatusHit]) {
+        self.status_hit_regions = hits
+            .iter()
+            .map(|hit| {
+                (
+                    Rect {
+                        x: area.x.saturating_add(hit.start_col),
+                        y: area.y.saturating_add(hit.row),
+                        width: hit.end_col.saturating_sub(hit.start_col),
+                        height: 1,
+                    },
+                    hit.action,
+                )
+            })
+            .collect();
     }
 
     /// Take and clear the deferred-copy flag set when a drag was released.
@@ -811,6 +834,7 @@ impl App {
             ask_indicator: self.ask_indicator(),
             worktree_compact: self.worktree.status_bar_compact(),
             worktree_expanded: self.worktree.status_bar_expanded(),
+            agent_status: self.agent_status.clone(),
             extension_status: self
                 .extension_status
                 .iter()
@@ -2140,6 +2164,10 @@ impl App {
             UiCommand::OpenEffortOverlay { arg } => {
                 self.start_effort_setup(arg.as_deref().unwrap_or(""))
             }
+            UiCommand::SetAgentStatus { status } => {
+                let status = status.trim();
+                self.agent_status = (!status.is_empty()).then(|| status.to_string());
+            }
             UiCommand::SetExtensionStatus { ext, status } => {
                 // Empty status clears the field; a live value replaces it.
                 if status.trim().is_empty() {
@@ -2403,6 +2431,25 @@ impl App {
         if !matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
             return false;
         }
+        if self.render_mode.is_fullscreen() {
+            let action = self.status_hit_regions.iter().find_map(|(area, action)| {
+                (mouse.column >= area.x
+                    && mouse.column < area.right()
+                    && mouse.row >= area.y
+                    && mouse.row < area.bottom())
+                .then_some(*action)
+            });
+            let Some(action) = action else {
+                return false;
+            };
+            match action {
+                StatusAction::ToggleLayout => self.set_status_layout(None),
+                StatusAction::OpenModel => self.start_model_setup(),
+                StatusAction::OpenEffort => self.start_effort_setup(""),
+                StatusAction::OpenBackground => self.background_panel = Some(0),
+            }
+            return true;
+        }
         if self.mouse_is_on_status(mouse, terminal_area) {
             self.set_status_layout(None);
             return true;
@@ -2495,6 +2542,7 @@ impl App {
         self.busy = false;
         self.busy_frame = 0;
         self.turn_activity = None;
+        self.agent_status = None;
         self.turn_started_at = None;
         self.stream_preview = None;
         self.rx = None;
@@ -4568,6 +4616,7 @@ mod tests {
             ask_indicator: None,
             worktree_compact: None,
             worktree_expanded: None,
+            agent_status: None,
             extension_status: Vec::new(),
         }
     }
@@ -8479,6 +8528,118 @@ mod tests {
             !status.contains("session "),
             "compact status should keep session id for expanded layout: {status}"
         );
+    }
+
+    #[test]
+    fn fullscreen_expanded_status_uses_responsive_columns() {
+        let state = ViewState {
+            presentation: PresentationState {
+                status_layout: StatusLayout::Expanded,
+                agent_status: Some("running tests 3/8".to_string()),
+                worktree_expanded: Some(("codex/status-drawer".into(), "…/bb69/yolop".into())),
+                ..presentation_state_idle()
+            },
+            ..view_state_idle()
+        };
+
+        let wide = fullscreen_status_layout(&state, 120);
+        let plain = |line: &Line<'_>| {
+            line.spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>()
+        };
+        let wide_text = wide.lines.iter().map(&plain).collect::<Vec<_>>().join("\n");
+        assert!(
+            wide_text.lines().next().is_some_and(|line| {
+                line.contains("Runtime") && line.contains("Session") && line.contains("Workspace")
+            }),
+            "wide drawer should place all sections in columns: {wide_text}"
+        );
+        assert!(wide_text.contains("agent running tests 3/8"));
+        assert!(
+            wide.lines
+                .iter()
+                .all(|line| tuika::components::line_width(line) <= 120)
+        );
+
+        let narrow = fullscreen_status_layout(&state, 80);
+        let narrow_text = narrow
+            .lines
+            .iter()
+            .map(plain)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            narrow.lines.len() > wide.lines.len(),
+            "two-column drawer should reflow to more rows"
+        );
+        assert!(narrow_text.lines().next().is_some_and(|line| {
+            line.contains("Runtime") && line.contains("Session") && !line.contains("Workspace")
+        }));
+        assert!(narrow_text.contains("Workspace"));
+        assert!(
+            narrow
+                .lines
+                .iter()
+                .all(|line| tuika::components::line_width(line) <= 80)
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fullscreen_status_model_and_effort_fields_are_clickable() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+        app.status_layout = StatusLayout::Expanded;
+        app.set_render_mode(RenderMode::Fullscreen);
+        let _ = render_app_lines(app, 120, 36);
+
+        for action in [StatusAction::OpenModel, StatusAction::OpenEffort] {
+            let area = app
+                .status_hit_regions
+                .iter()
+                .find_map(|(area, candidate)| (*candidate == action).then_some(*area))
+                .expect("status action hit region");
+            assert!(app.handle_mouse(
+                MouseEvent {
+                    kind: MouseEventKind::Down(MouseButton::Left),
+                    column: area.x,
+                    row: area.y,
+                    modifiers: KeyModifiers::empty(),
+                },
+                Rect::new(0, 0, 120, 36),
+            ));
+            match action {
+                StatusAction::OpenModel => {
+                    assert!(matches!(app.setup, Some(SetupStep::PickModel { .. })));
+                }
+                StatusAction::OpenEffort => {
+                    assert!(matches!(app.setup, Some(SetupStep::PickEffort { .. })));
+                }
+                _ => unreachable!(),
+            }
+            app.setup = None;
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn agent_status_is_visible_for_the_turn_and_clears_on_finish() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.apply_ui_command(UiCommand::SetAgentStatus {
+            status: "running tests 3/8".to_string(),
+        })
+        .await;
+
+        assert_eq!(
+            app.presentation_state().agent_status.as_deref(),
+            Some("running tests 3/8")
+        );
+
+        app.finish_busy();
+
+        assert!(app.presentation_state().agent_status.is_none());
     }
 
     #[test]

--- a/src/tui/presentation.rs
+++ b/src/tui/presentation.rs
@@ -49,6 +49,8 @@ pub(crate) struct PresentationState {
     pub ask_indicator: Option<String>,
     pub worktree_compact: Option<String>,
     pub worktree_expanded: Option<(String, String)>,
+    /// Turn-scoped status text contributed by the agent through the TUI host.
+    pub agent_status: Option<String>,
     /// Live status pushed by extensions over `status/changed`, as
     /// `(extension_name, status_text)` pairs. Rendered as its own status field.
     pub extension_status: Vec<(String, String)>,
@@ -78,6 +80,21 @@ pub(crate) struct StatusLine {
 pub(crate) struct StatusField {
     pub label: Option<&'static str>,
     pub value: String,
+    pub action: Option<StatusAction>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum StatusAction {
+    ToggleLayout,
+    OpenModel,
+    OpenEffort,
+    OpenBackground,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct StatusSection {
+    pub title: &'static str,
+    pub fields: Vec<StatusField>,
 }
 
 impl Author {
@@ -119,6 +136,69 @@ impl PresentationState {
             StatusLayout::Compact => compact_status_lines(self),
             StatusLayout::Expanded => expanded_status_lines(self),
         }
+    }
+
+    pub(crate) fn expanded_status_sections(&self) -> Vec<StatusSection> {
+        let mut session = vec![
+            status_value(message_count_label(self.lines_count)),
+            status_field("tokens", token_label(self.session_tokens)),
+        ];
+        if let Some(ctx) = context_label(
+            self.context_used_tokens,
+            self.context_window_tokens,
+            self.compaction_budget_percent,
+        ) {
+            session.push(status_field("ctx", ctx));
+        }
+        if let Some(bg) = background_label(self.background, false) {
+            session.push(status_field_action(
+                "background",
+                bg,
+                StatusAction::OpenBackground,
+            ));
+        }
+        session.push(status_field("goal", goal_label(self)));
+        session.push(status_field("ask", ask_label(self)));
+        if let Some(status) = self
+            .agent_status
+            .as_deref()
+            .or_else(|| self.activity_text())
+            .filter(|status| !status.is_empty())
+        {
+            session.push(status_field("agent", status));
+        }
+
+        let mut workspace = vec![
+            status_field("hooks", self.hooks_summary.clone()),
+            status_field("session", self.session_id.clone()),
+            status_field("version", VERSION_DETAILS),
+        ];
+        if let Some((branch, path)) = &self.worktree_expanded {
+            workspace.insert(0, status_field("path", path.clone()));
+            workspace.insert(0, status_field("worktree", branch.clone()));
+        }
+        workspace.extend(extension_status_fields(self));
+
+        vec![
+            StatusSection {
+                title: "Runtime",
+                fields: vec![
+                    status_value_action("[collapse ↑]", StatusAction::ToggleLayout),
+                    status_field("provider", self.provider_name.clone()),
+                    status_field_action("model", self.model_id.clone(), StatusAction::OpenModel),
+                    status_field_action("effort", effort_label(self), StatusAction::OpenEffort),
+                    status_field("approval", self.approval_mode.clone()),
+                ],
+            },
+            StatusSection {
+                title: "Session",
+                fields: session,
+            },
+            StatusSection {
+                title: "Workspace",
+                fields: workspace,
+            },
+        ]
     }
 
     pub(crate) fn activity_text(&self) -> Option<&str> {
@@ -170,7 +250,7 @@ fn expanded_status_lines(state: &PresentationState) -> Vec<StatusLine> {
         counts.push(status_field("ctx", ctx));
     }
     if let Some(bg) = background_label(state.background, false) {
-        counts.push(status_field("bg", bg));
+        counts.push(status_field_action("bg", bg, StatusAction::OpenBackground));
     }
     // Extension-pushed status shares the counts row so the expanded layout's
     // fixed row budget is unchanged.
@@ -179,14 +259,14 @@ fn expanded_status_lines(state: &PresentationState) -> Vec<StatusLine> {
     let mut lines = vec![
         StatusLine {
             fields: vec![
-                status_value("[collapse ↑]"),
+                status_value_action("[collapse ↑]", StatusAction::ToggleLayout),
                 status_field("provider", state.provider_name.clone()),
-                status_field("model", state.model_id.clone()),
+                status_field_action("model", state.model_id.clone(), StatusAction::OpenModel),
             ],
         },
         StatusLine {
             fields: vec![
-                status_field("effort", effort_label(state)),
+                status_field_action("effort", effort_label(state), StatusAction::OpenEffort),
                 status_field("approval", state.approval_mode.clone()),
                 status_field("hooks", state.hooks_summary.clone()),
                 status_field("goal", goal_label(state)),
@@ -226,19 +306,19 @@ fn status_contributions(state: &PresentationState) -> Vec<Vec<StatusField>> {
         counts.push(status_field("ctx", ctx));
     }
     if let Some(bg) = background_label(state.background, true) {
-        counts.push(status_field("bg", bg));
+        counts.push(status_field_action("bg", bg, StatusAction::OpenBackground));
     }
     if let Some(wt) = &state.worktree_compact {
         counts.push(status_field("wt", wt.clone()));
     }
     let mut groups = vec![
         vec![
-            status_value(toggle_label),
+            status_value_action(toggle_label, StatusAction::ToggleLayout),
             status_value(state.provider_name.clone()),
-            status_value(state.model_id.clone()),
+            status_value_action(state.model_id.clone(), StatusAction::OpenModel),
         ],
         vec![
-            status_field("effort", effort_label(state)),
+            status_field_action("effort", effort_label(state), StatusAction::OpenEffort),
             status_field("approval", state.approval_mode.clone()),
         ],
         vec![
@@ -294,6 +374,7 @@ fn status_value(value: impl Into<String>) -> StatusField {
     StatusField {
         label: None,
         value: value.into(),
+        action: None,
     }
 }
 
@@ -301,6 +382,27 @@ fn status_field(label: &'static str, value: impl Into<String>) -> StatusField {
     StatusField {
         label: Some(label),
         value: value.into(),
+        action: None,
+    }
+}
+
+fn status_value_action(value: impl Into<String>, action: StatusAction) -> StatusField {
+    StatusField {
+        label: None,
+        value: value.into(),
+        action: Some(action),
+    }
+}
+
+fn status_field_action(
+    label: &'static str,
+    value: impl Into<String>,
+    action: StatusAction,
+) -> StatusField {
+    StatusField {
+        label: Some(label),
+        value: value.into(),
+        action: Some(action),
     }
 }
 
@@ -416,6 +518,7 @@ mod tests {
             ask_indicator: None,
             worktree_compact: None,
             worktree_expanded: None,
+            agent_status: None,
             extension_status: Vec::new(),
         }
     }
@@ -448,6 +551,44 @@ mod tests {
         // No extensions → no stray field.
         s.extension_status.clear();
         assert!(!flatten(s.status_lines()).contains("git-guard"));
+    }
+
+    #[test]
+    fn expanded_sections_group_runtime_session_and_workspace_status() {
+        let model = PresentationState {
+            status_layout: StatusLayout::Expanded,
+            agent_status: Some("running tests 3/8".to_string()),
+            worktree_expanded: Some(("codex/status-drawer".into(), "…/bb69/yolop".into())),
+            ..state()
+        };
+
+        let sections = model.expanded_status_sections();
+
+        assert_eq!(
+            sections
+                .iter()
+                .map(|section| section.title)
+                .collect::<Vec<_>>(),
+            vec!["Runtime", "Session", "Workspace"]
+        );
+        assert!(sections[0].fields.iter().any(|field| {
+            field.label == Some("model") && field.action == Some(StatusAction::OpenModel)
+        }));
+        assert!(sections[0].fields.iter().any(|field| {
+            field.label == Some("effort") && field.action == Some(StatusAction::OpenEffort)
+        }));
+        assert!(
+            sections[1]
+                .fields
+                .iter()
+                .any(|field| field.label == Some("agent") && field.value == "running tests 3/8")
+        );
+        assert!(
+            sections[2]
+                .fields
+                .iter()
+                .any(|field| field.label == Some("worktree"))
+        );
     }
 
     #[test]

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1861,8 +1861,207 @@ pub(crate) fn session_status_lines(state: &ViewState) -> Vec<Line<'static>> {
         .collect()
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct StatusHit {
+    pub row: u16,
+    pub start_col: u16,
+    pub end_col: u16,
+    pub action: StatusAction,
+}
+
+pub(crate) struct FullscreenStatusLayout {
+    pub lines: Vec<Line<'static>>,
+    pub hits: Vec<StatusHit>,
+}
+
+pub(crate) fn fullscreen_status_layout(state: &ViewState, width: u16) -> FullscreenStatusLayout {
+    if state.presentation.status_layout == StatusLayout::Compact {
+        return linear_status_layout(&state.presentation.status_lines(), width);
+    }
+    section_status_layout(&state.presentation.expanded_status_sections(), width)
+}
+
 pub(crate) fn draw_session_status(f: &mut ratatui::Frame, area: Rect, state: &ViewState) {
     f.render_widget(Paragraph::new(session_status_lines(state)), area);
+}
+
+fn linear_status_layout(lines: &[StatusLine], width: u16) -> FullscreenStatusLayout {
+    let mut rendered = Vec::with_capacity(lines.len());
+    let mut hits = Vec::new();
+    for (row, line) in lines.iter().enumerate() {
+        let mut spans = vec![Span::styled(" ", Style::default().fg(TEXT_MUTED))];
+        let mut col: u16 = 1;
+        for (index, field) in line.fields.iter().enumerate() {
+            if index > 0 {
+                spans.push(Span::styled("  ·  ", Style::default().fg(TEXT_DIM)));
+                col = col.saturating_add(5);
+            }
+            let start = col;
+            if let Some(label) = field.label {
+                let label = format!("{label} ");
+                col = col.saturating_add(tuika::str_cols(&label));
+                spans.push(Span::styled(label, Style::default().fg(TEXT_DIM)));
+            }
+            col = col.saturating_add(tuika::str_cols(&field.value));
+            spans.push(Span::styled(
+                field.value.clone(),
+                Style::default().fg(TEXT_MUTED),
+            ));
+            if let Some(action) = field.action
+                && start < width
+            {
+                hits.push(StatusHit {
+                    row: row as u16,
+                    start_col: start,
+                    end_col: col.min(width),
+                    action,
+                });
+            }
+        }
+        rendered.push(Line::from(spans));
+    }
+    FullscreenStatusLayout {
+        lines: rendered,
+        hits,
+    }
+}
+
+struct StatusCell {
+    lines: Vec<Line<'static>>,
+    hits: Vec<StatusHit>,
+}
+
+fn section_status_layout(sections: &[StatusSection], width: u16) -> FullscreenStatusLayout {
+    if width == 0 {
+        return FullscreenStatusLayout {
+            lines: Vec::new(),
+            hits: Vec::new(),
+        };
+    }
+    let column_count = if width >= 96 { 3 } else { 2 }.min(sections.len()).max(1);
+    let mut lines = Vec::new();
+    let mut hits = Vec::new();
+    for group in sections.chunks(column_count) {
+        let group_columns = group.len();
+        let separators = group_columns.saturating_sub(1) as u16;
+        let columns_width = width.saturating_sub(separators);
+        let base_width = columns_width / group_columns as u16;
+        let extra = columns_width % group_columns as u16;
+        let widths = (0..group_columns)
+            .map(|index| base_width + u16::from((index as u16) < extra))
+            .collect::<Vec<_>>();
+        let cells = group
+            .iter()
+            .zip(widths.iter().copied())
+            .map(|(section, cell_width)| status_cell(section, cell_width))
+            .collect::<Vec<_>>();
+        let height = cells.iter().map(|cell| cell.lines.len()).max().unwrap_or(0);
+        let row_offset = lines.len() as u16;
+        for row in 0..height {
+            let mut spans = Vec::new();
+            for (column, &cell_width) in widths.iter().enumerate() {
+                if let Some(line) = cells.get(column).and_then(|cell| cell.lines.get(row)) {
+                    spans.extend(line.spans.clone());
+                    let line_width = line
+                        .spans
+                        .iter()
+                        .map(|span| tuika::str_cols(span.content.as_ref()))
+                        .fold(0, u16::saturating_add);
+                    if line_width < cell_width {
+                        spans.push(Span::raw(" ".repeat((cell_width - line_width) as usize)));
+                    }
+                } else {
+                    spans.push(Span::raw(" ".repeat(cell_width as usize)));
+                }
+                if column + 1 < group_columns {
+                    spans.push(Span::styled("│", Style::default().fg(TEXT_DIM)));
+                }
+            }
+            lines.push(Line::from(spans));
+        }
+
+        let mut column_offset: u16 = 0;
+        for (column, cell) in cells.iter().enumerate() {
+            hits.extend(cell.hits.iter().map(|hit| StatusHit {
+                row: row_offset.saturating_add(hit.row),
+                start_col: column_offset.saturating_add(hit.start_col),
+                end_col: column_offset.saturating_add(hit.end_col),
+                action: hit.action,
+            }));
+            column_offset = column_offset
+                .saturating_add(widths[column])
+                .saturating_add(1);
+        }
+    }
+
+    FullscreenStatusLayout { lines, hits }
+}
+
+fn status_cell(section: &StatusSection, width: u16) -> StatusCell {
+    let mut lines = Vec::with_capacity(section.fields.len() + 1);
+    let mut hits = Vec::new();
+    let title_text = fit_status_text(section.title, width.saturating_sub(2));
+    let title = format!(" {title_text} ");
+    let title_width = tuika::str_cols(&title).min(width);
+    lines.push(Line::from(vec![
+        Span::styled(title, Style::default().fg(ACCENT_GOLD)),
+        Span::styled(
+            "─".repeat(width.saturating_sub(title_width) as usize),
+            Style::default().fg(TEXT_DIM),
+        ),
+    ]));
+    for (row, field) in section.fields.iter().enumerate() {
+        let label = field
+            .label
+            .map(|label| format!("{label} "))
+            .unwrap_or_default();
+        let prefix_width = 1u16.saturating_add(tuika::str_cols(&label));
+        let value_width = width.saturating_sub(prefix_width);
+        let value = fit_status_text(&field.value, value_width);
+        let end_col = prefix_width
+            .saturating_add(tuika::str_cols(&value))
+            .min(width);
+        let mut spans = vec![Span::raw(" ")];
+        if !label.is_empty() {
+            spans.push(Span::styled(label, Style::default().fg(TEXT_DIM)));
+        }
+        spans.push(Span::styled(value, Style::default().fg(TEXT_MUTED)));
+        lines.push(Line::from(spans));
+        if let Some(action) = field.action
+            && end_col > 1
+        {
+            hits.push(StatusHit {
+                row: row as u16 + 1,
+                start_col: 1,
+                end_col,
+                action,
+            });
+        }
+    }
+    StatusCell { lines, hits }
+}
+
+fn fit_status_text(text: &str, width: u16) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    if tuika::str_cols(text) <= width {
+        return text.to_string();
+    }
+    if width == 1 {
+        return "…".to_string();
+    }
+    let wrapped = tuika::wrap_lines(&[Line::from(text.to_string())], width - 1);
+    let prefix = wrapped
+        .first()
+        .map(|line| {
+            line.spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>()
+        })
+        .unwrap_or_default();
+    format!("{}…", prefix.trim_end())
 }
 
 fn status_line(line: &StatusLine) -> Line<'static> {


### PR DESCRIPTION
## What changed

Fullscreen status now expands into a responsive multi-column drawer while preserving the existing compact mode.

- Groups host-owned status into Runtime, Session, and Workspace sections.
- Uses three columns on wide terminals and two columns on narrower terminals; long values fit safely within their cells.
- Makes model and effort fields open the existing setup pickers, and background activity open the existing background panel.
- Adds a bounded, turn-scoped `set_status` client tool so the agent can publish one transient status value without replacing host-owned fields.
- Keeps compact mode and `/status compact|expanded` behavior intact.

## Why

The previous expanded status was a single wrapped row. It was difficult to scan in fullscreen mode, did not use available width well, and treated the entire status area as one toggle target. The new drawer makes the state legible, responsive, and selectively interactive while establishing a safe path for agent-controlled status.

## Before / After

Before, expanded status was rendered as one wrapped sequence of fields and clicking anywhere in it toggled the layout.

After, the same 120-column fullscreen frame renders:

```text
Runtime                              │ Session                              │ Workspace
[collapse ↑]                         │ 8 msgs                               │ hooks none
provider llmsim                      │ tokens n/a                           │ session session_…
model llmsim-yolop                   │ goal —                               │ version 0.11.0…
effort n/a                           │ ask —
approval normal · on-request · …     │
```

The layout was also exercised interactively in a real 120x36 PTY with the bundled `llmsim` provider. Field-level tests verify that model and effort clicks enter their real picker flows.

## Risk

- **Medium**
- Fullscreen status layout and hit testing change across terminal widths.
- Agent status adds one new host-only client command, bounded to 120 characters and rejected when it contains terminal control characters.
- Compact rendering is unchanged and automated tests cover responsive section placement, click targets, tool validation, and turn-end cleanup.

## Security

- **Filesystem:** no filesystem access or write policy changes.
- **Shell:** no command execution, timeout, or output-cap changes.
- **LLM/secrets:** no credential, logging, or provider changes. The prompt only advertises the typed `set_status` command.
- **Tool boundary:** the new host-only tool can only enqueue `UiCommand::SetAgentStatus`; it cannot widen filesystem, shell, approval, or external action authority. Input is length-bounded and terminal controls are rejected.
- **Dependencies/resources:** no dependency changes; stored agent state is a single bounded string cleared when the turn finishes.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --bin yolop` — 929 passed, 2 ignored
- `cargo test --all-features --test integration --test parallel_integration` — 49 passed, 1 ignored
- `cargo build --release --all-features`
- Interactive fullscreen smoke with `llmsim` at 120x36

`cargo test --all-features --test tuika_pty -- --test-threads=1` passes 4/5 locally. The remaining pre-existing `gallery_paints_truecolor_and_braille` assertion does not observe a truecolor cell in this local PTY capture; this change does not touch the Tuika gallery or that test. GitHub Actions remains the CI source of truth.

The mandatory live OpenAI smoke could not run locally because this worktree has no Doppler project configuration, `DOPPLER_TOKEN`, or `OPENAI_API_KEY`.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
