### PR TITLE
docs(readme): refresh hero demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ that plans, edits, runs, and verifies code in your repository — autonomous by
 default, with persistent sessions, agent skills, MCP servers, and editor
 integration over the Agent Client Protocol.
 
-![yolop upgrading a project's dependencies](https://raw.githubusercontent.com/everruns/yolop/main/docs/demo.gif)
+![yolop upgrading a Rust CLI, adding JSON output, and running its tests](https://raw.githubusercontent.com/everruns/yolop/main/docs/demo.gif)
 
 ## Origin of the name
 

--- a/docs/demo-setup.sh
+++ b/docs/demo-setup.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+demo_dir=/tmp/yolop-hero-mission-control
+session_dir=/tmp/yolop-hero-sessions
+
+rm -rf "$demo_dir" "$session_dir"
+mkdir -p "$demo_dir/src" "$session_dir"
+
+cat >"$demo_dir/Cargo.toml" <<'EOF'
+[package]
+name = "mission-control"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+clap = { version = "=4.5.20", features = ["derive"] }
+serde = { version = "=1.0.210", features = ["derive"] }
+serde_json = "=1.0.128"
+EOF
+
+cat >"$demo_dir/src/main.rs" <<'EOF'
+use clap::Parser;
+
+#[derive(Parser)]
+#[command(name = "mission-control", about = "Print a spacecraft launch status")]
+struct Cli {
+    /// Mission callsign
+    #[arg(default_value = "Odyssey")]
+    mission: String,
+}
+
+fn status(mission: &str) -> String {
+    format!("{mission}: all systems nominal")
+}
+
+fn main() {
+    let cli = Cli::parse();
+    println!("{}", status(&cli.mission));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_text_status() {
+        assert_eq!(status("Odyssey"), "Odyssey: all systems nominal");
+    }
+}
+EOF
+
+cat >"$demo_dir/README.md" <<'EOF'
+# Mission Control
+
+A tiny launch-status CLI.
+
+```console
+$ cargo run -- Odyssey
+Odyssey: all systems nominal
+```
+EOF
+
+(
+    cd "$demo_dir"
+    cargo generate-lockfile -q
+)

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -1,0 +1,41 @@
+Require cargo
+
+Output docs/demo.gif
+
+Set Shell zsh
+Set Width 1200
+Set Height 720
+Set FontSize 17
+Set FontFamily "Menlo"
+Set LetterSpacing 0
+Set LineHeight 1.15
+Set TypingSpeed 24ms
+Set CursorBlink false
+Set Theme "Dracula"
+Set WindowBar Colorful
+Set BorderRadius 12
+Set Padding 14
+Set Margin 28
+Set MarginFill "#5b4b8a"
+Set Framerate 30
+Set PlaybackSpeed 2.4
+
+Env NO_COLOR ""
+Env COLORTERM "truecolor"
+Env RUST_LOG "error"
+
+Hide
+Type "cargo build -q && docs/demo-setup.sh && alias yolop='target/debug/yolop -C /tmp/yolop-hero-mission-control --fullscreen --theme dracula --provider codex -m gpt-5.6-sol --reasoning-effort low --session-dir /tmp/yolop-hero-sessions' && clear"
+Enter
+Wait+Line /[>$%#]/
+Show
+Sleep 1s
+
+Type "yolop"
+Enter
+Sleep 3s
+
+Type "Modernize mission-control: set clap=4.6.4, serde=1.0.229, and serde_json=1.0.151; add --json output; unit-test both text and JSON rendering using only existing dependencies; run fmt and tests. Skip Git. Keep it concise. Finish with Ready+for+launch (replace + with spaces)."
+Enter
+Wait+Screen@3m /Ready for launch/
+Sleep 4s


### PR DESCRIPTION
## What changed
Refreshes the README hero with a high-quality VHS capture of the current fullscreen TUI using Codex `gpt-5.6-sol`.

The demo starts at an empty shell prompt, types `yolop`, upgrades a small Rust project, adds JSON output, runs tests, and ends on a verified completion frame. The reproducible VHS tape and disposable fixture setup are included beside the generated asset.

## Why
The previous hero was a large, source-less capture of an older UI. The new hero shows the current product, model/status presentation, colored fullscreen theme, tool progress, and a complete coding workflow.

## Before / After
- Before: 24.98 MB GIF with no checked-in VHS source.
- After: 2.41 MB, 1200×720, 60.56-second GIF with a chronological shell-to-success flow.
- Visual smoke proof: first frame is an empty shell prompt; final frame reports two passing tests and `Ready for launch`.

## Validation
- `vhs validate docs/demo.tape`
- `bash -n docs/demo-setup.sh`
- `cargo fmt --check`
- Public documentation boundary scan
- Secret/personal-path scan over the changed public artifacts
- Live end-to-end VHS capture on current `origin/main` with Codex `gpt-5.6-sol`
- First/final frame inspection with ffmpeg

This is documentation-only and changes no runtime behavior, so no product automated test was required. The fixture's baseline Rust test passes, and the captured workflow itself runs two tests successfully.

## Security
No security-relevant runtime code, configuration, infrastructure, or dependency changes.

- TM-FS: unchanged. The setup script removes and recreates only two fixed `/tmp/yolop-hero-*` demo paths.
- TM-BASH, TM-LLM, TM-TOOL, TM-DEP: unchanged.
- No credentials, tokens, personal paths, or session identifiers are committed. Regeneration intentionally requires authenticated Codex/network access because the hero demonstrates the requested live `gpt-5.6-sol` workflow.

## Risk
- Low.
- The README continues referencing the same `docs/demo.gif` path.
- Live model output can vary when regenerating the tape; the committed asset and its start/end states were inspected.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — not required for this documentation-only change; VHS and fixture validation cover the changed artifacts
- [x] Backward compatibility considered — README asset path is unchanged
- [x] Security review completed
