### PR TITLE
chore(docs): document hero recording

### DIFF
--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -27,7 +27,7 @@ Env RUST_LOG "error"
 Hide
 Type "cargo build -q && docs/demo-setup.sh && alias yolop='target/debug/yolop -C /tmp/yolop-hero-mission-control --fullscreen --theme dracula --provider codex -m gpt-5.6-sol --reasoning-effort low --session-dir /tmp/yolop-hero-sessions' && clear"
 Enter
-Wait+Line /[>$%#]/
+Wait+Line@5m /[>$%#]/
 Show
 Sleep 1s
 

--- a/specs/documentation.md
+++ b/specs/documentation.md
@@ -116,6 +116,56 @@ installed browser instead of the `go-rod` download, point `ROD_BROWSER_BIN` at
 its `chrome` binary. These environment knobs belong in the shell around a
 recording, not in committed tapes, so tapes stay portable.
 
+## README hero capture
+
+The README hero is a checked-in VHS workflow, not a one-off screen recording:
+
+- `docs/demo.tape` owns the terminal presentation and interaction;
+- `docs/demo-setup.sh` creates the disposable project under
+  `/tmp/yolop-hero-*`; and
+- `docs/demo.gif` is the generated asset embedded by `README.md`.
+
+Unlike feature-guide captures, the hero intentionally uses an authenticated
+Codex subscription with `gpt-5.6-sol` so it demonstrates the advertised live
+agent. This is an explicit live-provider exception to the offline-capture
+preference above. Authentication comes from the operator's existing yolop
+settings; the tape and rendered frames must never contain credentials, personal
+paths, or session identifiers.
+
+Regenerate from the repository root:
+
+```bash
+cargo build
+vhs validate docs/demo.tape
+vhs docs/demo.tape
+```
+
+The explicit build warms incremental compilation; the tape also builds while
+capture is hidden and allows up to five minutes for a cold build. Keep
+`NO_COLOR` cleared so the TUI palette survives the recorder. Keep loop offset
+unset: frame one must be the idle shell, followed by typing `yolop`, TUI
+startup, the task, and its verified final response in chronological order.
+
+The fixture and prompt should bound model work rather than scripting model
+output. Prefer exact dependency versions, existing dependencies, a small test
+surface, and low reasoning effort. If the live turn becomes slow, simplify
+those inputs before increasing the visible wait. Tune `PlaybackSpeed` in the
+tape—not by rotating or trimming the finished GIF—to target about one minute
+and less than 5 MiB.
+
+Before committing, inspect both endpoints and the asset metadata:
+
+```bash
+bash -n docs/demo-setup.sh
+ffprobe -v error -select_streams v:0 \
+  -show_entries stream=width,height,nb_frames,duration \
+  -of default=noprint_wrappers=1 docs/demo.gif
+```
+
+Frame one must show the empty shell prompt. The last frame must show completed
+tests and the requested success phrase. Re-run the capture after rebasing when
+fullscreen presentation changes, so the hero matches current `main`.
+
 ## Enforcement
 
 CI rejects Markdown links from `README.md` and `docs/` into `specs/` or


### PR DESCRIPTION
## What changed
Documents the README hero's complete regeneration workflow in the documentation spec and raises the VHS tape's hidden setup wait from the default 15 seconds to five minutes.

The guidance records the canonical source/generated files, live `gpt-5.6-sol` exception, build and recording commands, privacy rules, chronological start requirement, color/playback guidance, size/duration targets, and first/final-frame QA.

## Why
The hero is intentionally a live-model capture with several non-obvious constraints. Without durable guidance, a future refresh could expose local data, lose color, rotate the timeline, time out during a cold build, or produce an unnecessarily large/slow asset.

## Before / After
- Before: no hero-specific regeneration contract; cold hidden builds used VHS's 15-second wait.
- After: repeatable workflow in `specs/documentation.md`; hidden setup allows up to five minutes.
- The rendered GIF is unchanged because presentation and interaction did not change.

## Validation
- `vhs validate docs/demo.tape`
- `bash -n docs/demo-setup.sh`
- `cargo fmt --check`
- `git diff --check`
- Public documentation boundary scan
- Credential/personal-path scan over changed files
- Existing asset metadata verified: 1200×720, 60.56 seconds, 1,514 frames

This is a documentation/tape-source-only change with no product runtime behavior, so product automated tests and runtime smoke testing are exempt. Regenerating the live-model asset was intentionally skipped because the visual workflow is unchanged.

## Security
No security-relevant runtime code, infrastructure, capabilities, or dependency changes.

- Documents that credentials must come from existing settings and must never appear in tape source or rendered frames.
- Documents the prohibition on personal paths and session identifiers.
- The longer wait is bounded at five minutes; no unbounded resource use is introduced.
- TM-FS, TM-BASH, TM-LLM, TM-TOOL, and TM-DEP runtime surfaces are unchanged.

## Risk
- Low.
- Only internal specification text and VHS setup timeout change.
- A five-minute cold build may delay a failed regeneration, but remains bounded and prevents the observed false timeout on valid builds.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — not required for this documentation/tape-source-only change
- [x] Backward compatibility considered — existing tape behavior is preserved with a longer bounded setup wait
- [x] Security review completed
