### PR TITLE
feat(skills): use shared agents directory

### DIFF
--- a/specs/skills.md
+++ b/specs/skills.md
@@ -42,10 +42,11 @@ a labeled VFS root that yolop's file store maps to a **real on-disk directory**:
 1. **Workspace** — `<workspace>/.agents/skills/<name>/` (VFS `/.agents/skills`).
    Lives in the project under version control; ships with the repo it belongs to.
    Writable.
-2. **Global** — `<config_dir>/yolop/skills/<name>/` (e.g.
-   `~/.config/yolop/skills/` on Linux; VFS `/.yolop/global-skills`), installed
-   once per user and shared across every workspace. Writable. Overridable with
-   `YOLOP_GLOBAL_SKILLS_DIR`.
+2. **Global** — `~/.agents/skills/<name>/` (VFS
+   `/.yolop/global-skills`), installed once per user and shared across every
+   workspace. Writable. Overridable with `YOLOP_GLOBAL_SKILLS_DIR`. The prior
+   `<config_dir>/yolop/skills/` root is imported temporarily for compatibility;
+   existing primary entries are never overwritten.
 3. **Environment** — optional, integration-owned skills mounted into the
    session-only VFS (VFS `/.yolop/environment-skills`). Always read-only and
    never materialized on disk. Herdr currently contributes this scope when its

--- a/src/bundled/system-skills/skill-management/SKILL.md
+++ b/src/bundled/system-skills/skill-management/SKILL.md
@@ -12,8 +12,9 @@ Use this skill when the user wants to customize Yolop with skills.
 
 - Installed skills are directories with a `SKILL.md`.
 - Workspace skills live under `.agents/skills/<name>/`.
-- Global skills live under Yolop's config directory, normally
-  `<config_dir>/yolop/skills/<name>/`.
+- Global skills live under `~/.agents/skills/<name>/`. The former
+  `<config_dir>/yolop/skills/<name>/` location is supported temporarily for
+  compatibility.
 - System skills are built into Yolop and are read-only.
 - Workspace skills shadow global skills; global skills shadow system skills.
 - New or changed workspace/global skills are available immediately through

--- a/src/capabilities/skills.rs
+++ b/src/capabilities/skills.rs
@@ -20,7 +20,7 @@
 // Scopes (precedence: workspace > global > system; the core capability de-dups
 // by skill directory name, so a nearer scope shadows a farther one):
 //   * workspace — `<workspace>/.agents/skills`           (writable)
-//   * global    — `<config_dir>/yolop/skills`            (writable; override: YOLOP_GLOBAL_SKILLS_DIR)
+//   * global    — `~/.agents/skills`                     (writable; override: YOLOP_GLOBAL_SKILLS_DIR)
 //   * system    — pre-packed, materialized once          (read-only; override: YOLOP_SYSTEM_SKILLS_DIR)
 
 use crate::capabilities::narration::stable_labeled;
@@ -38,6 +38,8 @@ use std::sync::Arc;
 
 /// Env override for the global skills directory.
 const GLOBAL_SKILLS_DIR_ENV: &str = "YOLOP_GLOBAL_SKILLS_DIR";
+/// Env override for the legacy global skills directory.
+const LEGACY_GLOBAL_SKILLS_DIR_ENV: &str = "YOLOP_LEGACY_GLOBAL_SKILLS_DIR";
 /// Env override for the system skills directory (skips materialization).
 const SYSTEM_SKILLS_DIR_ENV: &str = "YOLOP_SYSTEM_SKILLS_DIR";
 
@@ -79,7 +81,7 @@ static SYSTEM_SKILLS: Dir<'static> = include_dir!("$CARGO_MANIFEST_DIR/src/bundl
 pub struct SkillDirs {
     /// `<workspace>/.agents/skills` — always present (created on demand).
     pub workspace: PathBuf,
-    /// Global skills directory, or `None` when no platform config dir exists.
+    /// Global skills directory, or `None` when no home directory exists.
     pub global: Option<PathBuf>,
     /// Materialized system skills directory, or `None` when unavailable.
     pub system: Option<PathBuf>,
@@ -89,9 +91,21 @@ impl SkillDirs {
     /// Resolve the workspace/global/system directories for `workspace_root`.
     /// Materializes the embedded system skills as a side effect (idempotent).
     pub fn resolve(workspace_root: &Path) -> Self {
+        let global = global_skills_dir();
+        if let (Some(primary), Some(legacy)) = (&global, legacy_global_skills_dir())
+            && primary != &legacy
+            && let Err(error) = import_legacy_global_skills(&legacy, primary)
+        {
+            tracing::warn!(
+                legacy = %legacy.display(),
+                primary = %primary.display(),
+                %error,
+                "failed to import legacy global skills"
+            );
+        }
         Self {
             workspace: workspace_root.join(".agents").join("skills"),
-            global: global_skills_dir(),
+            global,
             system: system_skills_dir(),
         }
     }
@@ -190,15 +204,60 @@ impl SkillDirResolver for HostSkillDirResolver {
     }
 }
 
-/// Global skills directory, or `None` when no platform config directory exists.
-/// Honors `YOLOP_GLOBAL_SKILLS_DIR`; otherwise `<config_dir>/yolop/skills`.
+/// Global skills directory, or `None` when no home directory exists.
+/// Honors `YOLOP_GLOBAL_SKILLS_DIR`; otherwise `~/.agents/skills`.
 /// The path is returned even when absent so newly installed global skills become
 /// available without restarting the process.
 pub fn global_skills_dir() -> Option<PathBuf> {
     Some(match std::env::var(GLOBAL_SKILLS_DIR_ENV) {
         Ok(value) if !value.is_empty() => PathBuf::from(value),
+        _ => dirs::home_dir()?.join(".agents").join("skills"),
+    })
+}
+
+/// Previous global skills directory retained temporarily for discovery.
+pub fn legacy_global_skills_dir() -> Option<PathBuf> {
+    Some(match std::env::var(LEGACY_GLOBAL_SKILLS_DIR_ENV) {
+        Ok(value) if !value.is_empty() => PathBuf::from(value),
         _ => dirs::config_dir()?.join("yolop").join("skills"),
     })
+}
+
+/// Copy legacy global skills into the primary root without replacing newer entries.
+fn import_legacy_global_skills(legacy: &Path, primary: &Path) -> std::io::Result<()> {
+    let entries = match std::fs::read_dir(legacy) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    std::fs::create_dir_all(primary)?;
+    for entry in entries {
+        let entry = entry?;
+        let source = entry.path();
+        if !entry.file_type()?.is_dir() || !source.join("SKILL.md").is_file() {
+            continue;
+        }
+        let target = primary.join(entry.file_name());
+        if !target.exists() {
+            copy_dir_without_symlinks(&source, &target)?;
+        }
+    }
+    Ok(())
+}
+
+fn copy_dir_without_symlinks(source: &Path, target: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(target)?;
+    for entry in std::fs::read_dir(source)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let destination = target.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_dir_without_symlinks(&entry.path(), &destination)?;
+        } else if file_type.is_file() {
+            std::fs::copy(entry.path(), destination)?;
+        }
+    }
+    Ok(())
 }
 
 /// System skills directory, materializing the embedded skills first.
@@ -513,6 +572,37 @@ mod tests {
         assert_eq!(
             relative_under("/.agents/skills/foo", GLOBAL_SKILLS_VFS),
             None
+        );
+    }
+
+    #[test]
+    fn imports_legacy_global_skills_without_overwriting_primary() {
+        let legacy = tempfile::tempdir().unwrap();
+        let primary = tempfile::tempdir().unwrap();
+        let old = legacy.path().join("old-skill");
+        std::fs::create_dir_all(old.join("assets")).unwrap();
+        std::fs::write(old.join("SKILL.md"), "legacy").unwrap();
+        std::fs::write(old.join("assets/example.txt"), "asset").unwrap();
+        let existing = primary.path().join("existing");
+        std::fs::create_dir_all(&existing).unwrap();
+        std::fs::write(existing.join("SKILL.md"), "primary").unwrap();
+        let legacy_existing = legacy.path().join("existing");
+        std::fs::create_dir_all(&legacy_existing).unwrap();
+        std::fs::write(legacy_existing.join("SKILL.md"), "legacy replacement").unwrap();
+
+        import_legacy_global_skills(legacy.path(), primary.path()).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(primary.path().join("old-skill/SKILL.md")).unwrap(),
+            "legacy"
+        );
+        assert_eq!(
+            std::fs::read_to_string(primary.path().join("old-skill/assets/example.txt")).unwrap(),
+            "asset"
+        );
+        assert_eq!(
+            std::fs::read_to_string(existing.join("SKILL.md")).unwrap(),
+            "primary"
         );
     }
 

--- a/src/exec/sandbox.rs
+++ b/src/exec/sandbox.rs
@@ -7,6 +7,8 @@
 use crate::config::SandboxMode;
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
+
+use crate::capabilities::skills::global_skills_dir;
 use std::process::Stdio;
 use tokio::process::Command;
 
@@ -115,6 +117,9 @@ fn native_command(cwd: &Path, script: &str, mode: SandboxMode) -> Result<Command
     // covers macOS path canonicalization through the /tmp symlink.
     let temp = sandbox_temp_dir()?;
     let home = sandbox_home_dir(&temp)?;
+    if mode == SandboxMode::WorkspaceWrite {
+        prepared_global_skills_dir()?;
+    }
     let profile = macos_profile(cwd, &temp, mode);
     let mut command = Command::new(executable);
     command
@@ -192,12 +197,20 @@ pub(crate) fn run_linux_worker(
             AccessFs::from_all(abi),
         ))?;
     let ruleset = if mode == SandboxMode::WorkspaceWrite {
-        ruleset
+        let ruleset = ruleset
             .add_rule(PathBeneath::new(PathFd::new(cwd)?, AccessFs::from_all(abi)))?
             .add_rule(PathBeneath::new(
                 PathFd::new("/tmp")?,
                 AccessFs::from_all(abi),
+            ))?;
+        if let Some(skills) = prepared_global_skills_dir()? {
+            ruleset.add_rule(PathBeneath::new(
+                PathFd::new(skills)?,
+                AccessFs::from_all(abi),
             ))?
+        } else {
+            ruleset
+        }
     } else {
         ruleset
     };
@@ -251,6 +264,17 @@ fn native_command(_cwd: &Path, _script: &str, _mode: SandboxMode) -> Result<Comm
     anyhow::bail!(
         "native sandbox is supported only on macOS and Linux; refusing to run unsandboxed. Set `sandbox_mode = \"danger-full-access\"` only inside an already isolated environment"
     )
+}
+
+fn prepared_global_skills_dir() -> Result<Option<PathBuf>> {
+    let Some(path) = global_skills_dir() else {
+        return Ok(None);
+    };
+    std::fs::create_dir_all(&path)
+        .with_context(|| format!("create global skills directory: {}", path.display()))?;
+    Ok(Some(std::fs::canonicalize(&path).with_context(|| {
+        format!("canonicalize global skills directory: {}", path.display())
+    })?))
 }
 
 fn sandbox_temp_dir() -> Result<PathBuf> {
@@ -343,11 +367,19 @@ fn macos_profile(cwd: &Path, temp: &Path, mode: SandboxMode) -> String {
     } else {
         ""
     };
+    let global_skills_write = if mode == SandboxMode::WorkspaceWrite {
+        global_skills_dir()
+            .map(|path| format!(" (subpath \"{}\")", seatbelt_escape(&path)))
+            .unwrap_or_default()
+    } else {
+        String::new()
+    };
     format!(
-        "(version 1)\n(deny default)\n(allow process*)\n(allow file-read*)\n(allow sysctl-read)\n(allow mach-lookup)\n(allow file-write-data (require-all (path \"/dev/null\") (vnode-type CHARACTER-DEVICE)))\n(allow file-write*{} (subpath \"{}\"){})\n(deny network*)\n(deny file-write* (literal \"{}\") (subpath \"{}\"))",
+        "(version 1)\n(deny default)\n(allow process*)\n(allow file-read*)\n(allow sysctl-read)\n(allow mach-lookup)\n(allow file-write-data (require-all (path \"/dev/null\") (vnode-type CHARACTER-DEVICE)))\n(allow file-write*{} (subpath \"{}\"){}{})\n(deny network*)\n(deny file-write* (literal \"{}\") (subpath \"{}\"))",
         workspace_write,
         seatbelt_escape(temp),
         shared_temp_write,
+        global_skills_write,
         seatbelt_escape(&cwd.join(".git")),
         seatbelt_escape(&cwd.join(".git")),
     )
@@ -405,6 +437,26 @@ mod tests {
         assert!(profile.contains(
             r#"(allow file-write-data (require-all (path "/dev/null") (vnode-type CHARACTER-DEVICE)))"#
         ));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_workspace_write_policy_allows_global_skills_only_when_writable() {
+        let skills = global_skills_dir().expect("home directory should resolve");
+        let writable = macos_profile(
+            Path::new("/workspace"),
+            Path::new("/private/tmp/sandbox"),
+            SandboxMode::WorkspaceWrite,
+        );
+        let read_only = macos_profile(
+            Path::new("/workspace"),
+            Path::new("/private/tmp/sandbox"),
+            SandboxMode::ReadOnly,
+        );
+        let rule = format!(r#"(subpath "{}")"#, seatbelt_escape(&skills));
+
+        assert!(writable.contains(&rule));
+        assert!(!read_only.contains(&rule));
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary

Move user-global skills to the shared `~/.agents/skills` convention while preserving existing Yolop installations during a compatibility window.

- install new global skills under `~/.agents/skills`
- import legacy `<config_dir>/yolop/skills` entries without overwriting primary entries
- allow the primary skill directory in workspace-write native sandboxes
- update the skills specification and bundled skill-management guidance

## Before / After

**Before**

```text
Global installs: ~/Library/Application Support/yolop/skills/<name>/
Workspace-write shell sandbox: cannot write ~/.agents/skills
```

**After**

```text
Global installs: ~/.agents/skills/<name>/
Legacy entries: imported when missing from the primary directory
Workspace-write shell sandbox: can write ~/.agents/skills
Read-only shell sandbox: remains unable to write it
```

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "hi"`
- automated migration test covers recursive legacy import and no-overwrite behavior
- macOS policy test asserts the directory appears only in workspace-write mode

## Security

- **TM-FS:** The change grants workspace-write shells access only to the resolved global skills directory. Existing `.git` and generated-directory protections are unchanged. Legacy imports accept only direct skill directories containing `SKILL.md`, skip symlinks, and never overwrite primary entries.
- **TM-BASH:** No changes to execution timeouts or output limits.
- **TM-LLM:** No prompt or credential handling changes.
- **TM-TOOL:** Global skill writes continue through the existing scoped VFS route, now backed by `~/.agents/skills`.
- **TM-DEP:** No dependency changes.

## Follow-ups

No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
