### PR TITLE
docs(readme): remove task tree demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,6 @@ yolop --provider llmsim -p "hi"         # offline demo, no API key required
   survive a restart. `spawn_background` can also schedule one-shot or recurring
   monitors; when a schedule fires or a task finishes while the session is idle,
   yolop proactively wakes the agent (disable with `proactive_wake`).
-
-  ![Task tree with nested branches and usage rollups](docs/features/task-tree.gif)
 - **Web** — `free_web_search`, `web_fetch` (HTTP GET/HEAD with markdown/text
   conversion and DNS-pinned SSRF protection), and `duckduckgo_instant_answer`,
   all working without an API key. Set `EVERRUNS_SYSTEM_ALLOWLIST_ENABLED=true`


### PR DESCRIPTION
## What changed
Removed the task-tree demo GIF embed from the main README. The recorded asset remains in `docs/features/` and the task-tree feature documentation is otherwise unchanged.

## Why
Keep the main README focused and avoid displaying this demo inline.

## Before / After
Before: the Background tasks feature bullet displayed the animated task-tree demo.

After: the feature description flows directly into the next feature without an embedded image.

## Risk
- Low
- README-only removal; no runtime behavior or public API changes.

## Security
No security-relevant code changes. This PR removes one Markdown image reference only.

## Validation
- Exact CI public-docs boundary guard
- `git diff --check`
- Confirmed no remaining task-tree demo reference in README
- Runtime tests and smoke testing skipped: docs-only change with no executable behavior.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — exempt: docs-only change
- [x] Backward compatibility considered