### PR TITLE
feat(tuika): add keymap engine, route yolop shortcuts through it

### DIFF
--- a/crates/tuika/README.md
+++ b/crates/tuika/README.md
@@ -55,6 +55,11 @@ with tuika's surfaces (see [Compatibility](#compatibility)).
 - **Overlays** (`overlay`) anchor a view over the base tree; the **host**
   (`host`) owns the alternate screen, translates crossterm input, and
   composites the frame.
+- **Keymap** (`keymap`) resolves declarative key bindings to named commands:
+  chords (`ctrl+r`) and multi-stroke sequences (`g g`) grouped into
+  prioritized, mode-gated `Layer`s, dispatched from a translated `Key` and
+  queryable for help/`KeyHints` surfaces. Host-agnostic, so it unit-tests
+  without a terminal.
 - **Motion** (`anim`, `components::{Spinner, ProgressBar, Loader}`,
   `native::TerminalProgress`) animates from a host-supplied frame counter and
   can drive the terminal's own OSC 9;4 progress indicator.

--- a/crates/tuika/src/keymap.rs
+++ b/crates/tuika/src/keymap.rs
@@ -1,0 +1,798 @@
+//! A host-agnostic keymap engine: declarative key bindings resolved to named
+//! commands, with layered scoping, mode gating, and multi-stroke sequences.
+//!
+//! This is `tuika`'s answer to the same problem [OpenTUI's keymap][opentui]
+//! solves for the browser/terminal: decouple *what keys do* from the widget
+//! that reacts, so an application can declare its shortcuts once, gate them by
+//! mode, discover them for help UIs, and dispatch through a single seam. It
+//! follows OpenTUI's **register → dispatch → query** shape, adapted to idiomatic
+//! Rust and to `tuika`'s own [`Key`] events (so it needs no terminal and stays
+//! unit-testable).
+//!
+//! [opentui]: https://opentui.com/docs/keymap/overview/
+//!
+//! # Model
+//!
+//! - A [`Chord`] is one key press plus its modifiers (`ctrl+r`, `enter`, `?`).
+//! - A [`KeySequence`] is one or more chords typed in order (`g g`, `ctrl+x s`).
+//! - A [`Binding`] maps a sequence to a command value `C` (usually an app enum).
+//! - A [`Layer`] groups bindings under a name and priority, optionally *gated*
+//!   on runtime data so it is only active in a given mode.
+//! - A [`Keymap`] holds the layers plus a small runtime-data store and the
+//!   pending multi-stroke state, and turns incoming [`Key`]s into [`Dispatch`].
+//!
+//! # Example
+//!
+//! ```
+//! use tuika::event::{Key, KeyCode};
+//! use tuika::keymap::{Dispatch, Keymap, Layer};
+//!
+//! #[derive(Clone, Debug, PartialEq)]
+//! enum Action { Search, Quit, Top }
+//!
+//! let mut keymap = Keymap::new().layer(
+//!     Layer::new("global")
+//!         .bind("ctrl+r", Action::Search)
+//!         .bind("ctrl+d", Action::Quit)
+//!         // A two-stroke sequence, vim-style.
+//!         .bind("g g", Action::Top),
+//! );
+//!
+//! // A single chord resolves immediately.
+//! let ctrl_r = Key { code: KeyCode::Char('r'), ctrl: true, alt: false, shift: false };
+//! assert_eq!(keymap.dispatch(ctrl_r), Dispatch::Command(Action::Search));
+//!
+//! // A sequence stays pending until it completes.
+//! let g = Key::new(KeyCode::Char('g'));
+//! assert_eq!(keymap.dispatch(g), Dispatch::Pending);
+//! assert_eq!(keymap.dispatch(g), Dispatch::Command(Action::Top));
+//! ```
+
+use std::collections::HashMap;
+use std::fmt;
+
+use crate::event::{Key, KeyCode};
+
+/// One key press plus its modifier state, normalized for binding lookups.
+///
+/// Modifier state is explicit, but with one normalization that mirrors how
+/// terminals report input: for a [`KeyCode::Char`] the Shift flag is *dropped*,
+/// because the shifted character is already folded into the `char` itself (`?`
+/// arrives as `Char('?')`, not `Shift`+`Char('/')`). Shift is kept meaningful
+/// for non-character keys, where it is a distinct chord (`Shift`+`Enter`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Chord {
+    /// The key that was pressed.
+    pub code: KeyCode,
+    /// Ctrl held during the press.
+    pub ctrl: bool,
+    /// Alt held during the press.
+    pub alt: bool,
+    /// Shift held during the press (only meaningful for non-character keys).
+    pub shift: bool,
+}
+
+impl Chord {
+    /// A chord for `code` with no modifiers held.
+    pub fn new(code: KeyCode) -> Self {
+        Self {
+            code,
+            ctrl: false,
+            alt: false,
+            shift: false,
+        }
+    }
+
+    /// Build a chord from a translated [`Key`] event, applying the character
+    /// Shift-normalization described on [`Chord`].
+    pub fn from_key(key: Key) -> Self {
+        let shift = if matches!(key.code, KeyCode::Char(_)) {
+            false
+        } else {
+            key.shift
+        };
+        Self {
+            code: key.code,
+            ctrl: key.ctrl,
+            alt: key.alt,
+            shift,
+        }
+    }
+
+    /// Parse a single chord like `"ctrl+r"`, `"alt+shift+tab"`, `"enter"`, or
+    /// `"?"`. Modifiers (`ctrl`/`control`, `alt`/`option`, `shift`) are joined to
+    /// the key with `+`; the final segment is the key. A trailing `+` is the
+    /// literal plus key (`"ctrl++"`).
+    pub fn parse(spec: &str) -> Result<Self, KeyParseError> {
+        let spec = spec.trim();
+        if spec.is_empty() {
+            return Err(KeyParseError::new(spec));
+        }
+        let mut ctrl = false;
+        let mut alt = false;
+        let mut shift = false;
+
+        // Split on '+' while treating a trailing '+' as the literal key. Walk the
+        // segments; every segment but the last must be a known modifier.
+        let mut key_token: Option<&str> = None;
+        let segments = split_plus(spec);
+        let last = segments.len().saturating_sub(1);
+        for (index, segment) in segments.iter().enumerate() {
+            if index == last {
+                key_token = Some(segment);
+                break;
+            }
+            match segment.to_ascii_lowercase().as_str() {
+                "ctrl" | "control" => ctrl = true,
+                "alt" | "option" | "opt" | "meta" => alt = true,
+                "shift" => shift = true,
+                _ => return Err(KeyParseError::new(spec)),
+            }
+        }
+
+        let key_token = key_token.ok_or_else(|| KeyParseError::new(spec))?;
+        let mut code = parse_key_code(key_token).ok_or_else(|| KeyParseError::new(spec))?;
+        // A character key folds Shift into the char, matching `from_key`.
+        if matches!(code, KeyCode::Char(_)) {
+            shift = false;
+        }
+        // Terminals report Shift+Tab as a distinct `BackTab` key (as does
+        // `from_key`), so fold the spec to match what an event will carry.
+        if code == KeyCode::Tab && shift {
+            code = KeyCode::BackTab;
+            shift = false;
+        }
+        Ok(Self {
+            code,
+            ctrl,
+            alt,
+            shift,
+        })
+    }
+
+    /// A human-readable label such as `"Ctrl+R"`, `"Shift+Tab"`, or `"Space"`,
+    /// suitable for a [`KeyHints`](crate::KeyHints) row or a help overlay.
+    pub fn display(&self) -> String {
+        let mut out = String::new();
+        if self.ctrl {
+            out.push_str("Ctrl+");
+        }
+        if self.alt {
+            out.push_str("Alt+");
+        }
+        if self.shift {
+            out.push_str("Shift+");
+        }
+        out.push_str(&key_code_label(self.code));
+        out
+    }
+}
+
+/// Split a chord spec on `+`, but treat a trailing `+` as a literal segment so
+/// `"ctrl++"` parses as `["ctrl", "+"]` rather than `["ctrl", "", ""]`.
+fn split_plus(spec: &str) -> Vec<&str> {
+    if spec == "+" {
+        return vec!["+"];
+    }
+    if let Some(prefix) = spec.strip_suffix('+') {
+        // The literal '+' key, possibly with modifiers before it.
+        let mut parts: Vec<&str> = prefix.split('+').filter(|s| !s.is_empty()).collect();
+        parts.push("+");
+        return parts;
+    }
+    spec.split('+').collect()
+}
+
+/// Map a key-name token (already isolated from its modifiers) to a [`KeyCode`].
+fn parse_key_code(token: &str) -> Option<KeyCode> {
+    // A single character (including a literal "+") is a `Char`, case-sensitive.
+    let mut chars = token.chars();
+    if let (Some(c), None) = (chars.next(), chars.next()) {
+        return Some(KeyCode::Char(c));
+    }
+    Some(match token.to_ascii_lowercase().as_str() {
+        "enter" | "return" | "cr" => KeyCode::Enter,
+        "esc" | "escape" => KeyCode::Esc,
+        "tab" => KeyCode::Tab,
+        "backtab" => KeyCode::BackTab,
+        "backspace" | "bs" => KeyCode::Backspace,
+        "delete" | "del" => KeyCode::Delete,
+        "space" | "spc" => KeyCode::Char(' '),
+        "up" => KeyCode::Up,
+        "down" => KeyCode::Down,
+        "left" => KeyCode::Left,
+        "right" => KeyCode::Right,
+        "home" => KeyCode::Home,
+        "end" => KeyCode::End,
+        "pageup" | "pgup" => KeyCode::PageUp,
+        "pagedown" | "pgdn" => KeyCode::PageDown,
+        _ => return None,
+    })
+}
+
+/// A display label for a bare key code (no modifiers).
+fn key_code_label(code: KeyCode) -> String {
+    match code {
+        KeyCode::Char(' ') => "Space".to_string(),
+        KeyCode::Char(c) if c.is_ascii_alphabetic() => c.to_ascii_uppercase().to_string(),
+        KeyCode::Char(c) => c.to_string(),
+        KeyCode::Enter => "Enter".to_string(),
+        KeyCode::Esc => "Esc".to_string(),
+        KeyCode::Backspace => "Backspace".to_string(),
+        KeyCode::Delete => "Delete".to_string(),
+        KeyCode::Tab => "Tab".to_string(),
+        KeyCode::BackTab => "Shift+Tab".to_string(),
+        KeyCode::Up => "Up".to_string(),
+        KeyCode::Down => "Down".to_string(),
+        KeyCode::Left => "Left".to_string(),
+        KeyCode::Right => "Right".to_string(),
+        KeyCode::Home => "Home".to_string(),
+        KeyCode::End => "End".to_string(),
+        KeyCode::PageUp => "PageUp".to_string(),
+        KeyCode::PageDown => "PageDown".to_string(),
+    }
+}
+
+/// A parse failure for a chord or sequence spec, carrying the offending text.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct KeyParseError {
+    spec: String,
+}
+
+impl KeyParseError {
+    fn new(spec: &str) -> Self {
+        Self {
+            spec: spec.to_string(),
+        }
+    }
+}
+
+impl fmt::Display for KeyParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid key spec: {:?}", self.spec)
+    }
+}
+
+impl std::error::Error for KeyParseError {}
+
+/// One or more [`Chord`]s typed in order — a single stroke (`ctrl+r`) or a
+/// multi-stroke sequence (`g g`, `ctrl+x s`), written space-separated.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct KeySequence(Vec<Chord>);
+
+impl KeySequence {
+    /// Parse a whitespace-separated sequence of chords. An empty spec is an
+    /// error; a single chord yields a one-element sequence.
+    pub fn parse(spec: &str) -> Result<Self, KeyParseError> {
+        let chords = spec
+            .split_whitespace()
+            .map(Chord::parse)
+            .collect::<Result<Vec<_>, _>>()?;
+        if chords.is_empty() {
+            return Err(KeyParseError::new(spec));
+        }
+        Ok(Self(chords))
+    }
+
+    /// The chords making up this sequence.
+    pub fn chords(&self) -> &[Chord] {
+        &self.0
+    }
+
+    /// A human-readable label, chords joined by spaces (`"Ctrl+X S"`).
+    pub fn display(&self) -> String {
+        self.0
+            .iter()
+            .map(Chord::display)
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+}
+
+/// A binding from a [`KeySequence`] to a command value, with an optional label
+/// used for help/hint surfaces.
+#[derive(Clone, Debug)]
+pub struct Binding<C> {
+    sequence: KeySequence,
+    command: C,
+    label: Option<String>,
+}
+
+/// A named, prioritized group of bindings, optionally gated on runtime data so
+/// it is only active in a given application mode.
+///
+/// Gating mirrors OpenTUI's data-driven layer activation: `when("mode",
+/// "search")` makes the layer active only while the keymap's `"mode"` datum
+/// equals `"search"`. A layer with no `when` clauses is always active.
+#[derive(Clone, Debug)]
+pub struct Layer<C> {
+    name: String,
+    priority: i32,
+    when: Vec<(String, String)>,
+    bindings: Vec<Binding<C>>,
+}
+
+impl<C> Layer<C> {
+    /// A new, always-active layer with priority `0`.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            priority: 0,
+            when: Vec::new(),
+            bindings: Vec::new(),
+        }
+    }
+
+    /// This layer's name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Set the layer priority. When two active layers both bind the same
+    /// sequence, the higher priority wins.
+    pub fn priority(mut self, priority: i32) -> Self {
+        self.priority = priority;
+        self
+    }
+
+    /// Gate this layer on a runtime-data value: it is active only while the
+    /// keymap's datum for `key` equals `value`. Multiple `when` clauses must all
+    /// match (logical AND).
+    pub fn when(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.when.push((key.into(), value.into()));
+        self
+    }
+
+    /// Add a binding, parsing `keys` as a [`KeySequence`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `keys` is not a valid sequence spec. Bindings are normally
+    /// authored as static literals, so a malformed spec is a programmer error;
+    /// use [`Layer::try_bind`] to handle dynamic input fallibly.
+    pub fn bind(self, keys: &str, command: C) -> Self {
+        self.try_bind(keys, command)
+            .unwrap_or_else(|err| panic!("{err}"))
+    }
+
+    /// Add a binding with a help label, parsing `keys` as a [`KeySequence`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `keys` is not a valid sequence spec (see [`Layer::bind`]).
+    pub fn bind_labeled(self, keys: &str, label: impl Into<String>, command: C) -> Self {
+        self.try_bind_labeled(keys, Some(label.into()), command)
+            .unwrap_or_else(|err| panic!("{err}"))
+    }
+
+    /// Fallible [`Layer::bind`] for dynamically sourced specs.
+    pub fn try_bind(self, keys: &str, command: C) -> Result<Self, KeyParseError> {
+        self.try_bind_labeled(keys, None, command)
+    }
+
+    fn try_bind_labeled(
+        mut self,
+        keys: &str,
+        label: Option<String>,
+        command: C,
+    ) -> Result<Self, KeyParseError> {
+        let sequence = KeySequence::parse(keys)?;
+        self.bindings.push(Binding {
+            sequence,
+            command,
+            label,
+        });
+        Ok(self)
+    }
+
+    /// Whether this layer is active given the keymap's current runtime data.
+    fn is_active(&self, data: &HashMap<String, String>) -> bool {
+        self.when
+            .iter()
+            .all(|(key, value)| data.get(key).map(String::as_str) == Some(value.as_str()))
+    }
+}
+
+/// The outcome of feeding one key to a [`Keymap`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Dispatch<C> {
+    /// A binding matched fully; the host should run this command.
+    Command(C),
+    /// The keys typed so far are a prefix of one or more longer sequences; the
+    /// keymap is waiting for the next stroke and has consumed this key.
+    Pending,
+    /// No active binding matches; the host should handle the key itself.
+    Unmatched,
+}
+
+/// A discoverable binding for a help surface: its key label, optional
+/// description, and the command it runs.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Hint<C> {
+    /// The key sequence label, e.g. `"Ctrl+R"`.
+    pub keys: String,
+    /// The binding's help label, if one was given.
+    pub label: Option<String>,
+    /// The command the binding runs.
+    pub command: C,
+}
+
+/// The keymap engine: a set of [`Layer`]s, a runtime-data store used to gate
+/// them, and the pending multi-stroke state.
+///
+/// See the [module documentation](self) for the model and an example.
+#[derive(Clone, Debug, Default)]
+pub struct Keymap<C> {
+    layers: Vec<Layer<C>>,
+    data: HashMap<String, String>,
+    pending: Vec<Chord>,
+}
+
+impl<C: Clone> Keymap<C> {
+    /// An empty keymap.
+    pub fn new() -> Self {
+        Self {
+            layers: Vec::new(),
+            data: HashMap::new(),
+            pending: Vec::new(),
+        }
+    }
+
+    /// Add a layer (builder style).
+    pub fn layer(mut self, layer: Layer<C>) -> Self {
+        self.layers.push(layer);
+        self
+    }
+
+    /// Add a layer in place.
+    pub fn add_layer(&mut self, layer: Layer<C>) {
+        self.layers.push(layer);
+    }
+
+    /// Set a runtime-data value, used to gate layers via [`Layer::when`].
+    /// Changing data clears any pending multi-stroke sequence, since the
+    /// bindings that could complete it may no longer be active.
+    pub fn set_data(&mut self, key: impl Into<String>, value: impl Into<String>) {
+        self.data.insert(key.into(), value.into());
+        self.pending.clear();
+    }
+
+    /// Read a runtime-data value.
+    pub fn data(&self, key: &str) -> Option<&str> {
+        self.data.get(key).map(String::as_str)
+    }
+
+    /// The chords typed so far toward an unfinished multi-stroke sequence.
+    pub fn pending(&self) -> &[Chord] {
+        &self.pending
+    }
+
+    /// Abandon any pending multi-stroke sequence (e.g. on a focus change or a
+    /// sequence-timeout tick).
+    pub fn reset(&mut self) {
+        self.pending.clear();
+    }
+
+    /// Feed one translated [`Key`] to the keymap and resolve it.
+    ///
+    /// Single-stroke bindings resolve immediately. For multi-stroke sequences
+    /// the keymap accumulates strokes and returns [`Dispatch::Pending`] until a
+    /// binding completes ([`Dispatch::Command`]) or the strokes dead-end
+    /// ([`Dispatch::Unmatched`], after which the pending state is cleared and the
+    /// final stroke is retried on its own so it can begin a fresh sequence).
+    ///
+    /// An exact match wins immediately even when it is also the prefix of a
+    /// longer binding (so a bound `g` fires without waiting to see if `g g`
+    /// follows). Author overlapping bindings accordingly.
+    pub fn dispatch(&mut self, key: Key) -> Dispatch<C> {
+        let chord = Chord::from_key(key);
+        self.pending.push(chord);
+        let (exact, prefix) = self.resolve(&self.pending);
+        if let Some(command) = exact {
+            self.pending.clear();
+            return Dispatch::Command(command);
+        }
+        if prefix {
+            return Dispatch::Pending;
+        }
+        // The accumulated strokes dead-ended. Drop them and give this final
+        // stroke a fresh chance to start its own sequence.
+        self.pending.clear();
+        let single = [chord];
+        let (exact, prefix) = self.resolve(&single);
+        if let Some(command) = exact {
+            return Dispatch::Command(command);
+        }
+        if prefix {
+            self.pending.push(chord);
+            return Dispatch::Pending;
+        }
+        Dispatch::Unmatched
+    }
+
+    /// Resolve a candidate stroke sequence against the active layers, returning
+    /// the winning exact-match command (highest priority) and whether any active
+    /// binding is a strict extension of the candidate (a live prefix).
+    fn resolve(&self, candidate: &[Chord]) -> (Option<C>, bool) {
+        let mut best: Option<(i32, &C)> = None;
+        let mut prefix = false;
+        for layer in &self.layers {
+            if !layer.is_active(&self.data) {
+                continue;
+            }
+            for binding in &layer.bindings {
+                let seq = binding.sequence.chords();
+                if seq == candidate {
+                    if best.is_none_or(|(p, _)| layer.priority > p) {
+                        best = Some((layer.priority, &binding.command));
+                    }
+                } else if seq.len() > candidate.len() && seq.starts_with(candidate) {
+                    prefix = true;
+                }
+            }
+        }
+        (best.map(|(_, command)| command.clone()), prefix)
+    }
+
+    /// The bindings currently active (their layer's gate is satisfied),
+    /// suitable for building a [`KeyHints`](crate::KeyHints) row or a help
+    /// overlay. Higher-priority layers come first.
+    pub fn hints(&self) -> Vec<Hint<C>> {
+        let mut layers: Vec<&Layer<C>> = self
+            .layers
+            .iter()
+            .filter(|l| l.is_active(&self.data))
+            .collect();
+        layers.sort_by(|a, b| b.priority.cmp(&a.priority));
+        layers
+            .iter()
+            .flat_map(|layer| layer.bindings.iter())
+            .map(|binding| Hint {
+                keys: binding.sequence.display(),
+                label: binding.label.clone(),
+                command: binding.command.clone(),
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::{Key, KeyCode};
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    enum Action {
+        Search,
+        Quit,
+        Top,
+        Bottom,
+        Close,
+    }
+
+    fn key(code: KeyCode) -> Key {
+        Key::new(code)
+    }
+
+    fn ctrl(c: char) -> Key {
+        Key {
+            code: KeyCode::Char(c),
+            ctrl: true,
+            alt: false,
+            shift: false,
+        }
+    }
+
+    #[test]
+    fn parses_modifier_chords() {
+        assert_eq!(
+            Chord::parse("ctrl+r").unwrap(),
+            Chord {
+                code: KeyCode::Char('r'),
+                ctrl: true,
+                alt: false,
+                shift: false,
+            }
+        );
+        // Shift+Tab folds to BackTab, the key terminals actually report.
+        assert_eq!(
+            Chord::parse("alt+shift+tab").unwrap(),
+            Chord {
+                code: KeyCode::BackTab,
+                ctrl: false,
+                alt: true,
+                shift: false,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_named_and_literal_keys() {
+        assert_eq!(Chord::parse("enter").unwrap().code, KeyCode::Enter);
+        assert_eq!(Chord::parse("space").unwrap().code, KeyCode::Char(' '));
+        assert_eq!(Chord::parse("?").unwrap().code, KeyCode::Char('?'));
+        // A trailing '+' is the literal plus key, modifiers and all.
+        assert_eq!(
+            Chord::parse("ctrl++").unwrap(),
+            Chord {
+                code: KeyCode::Char('+'),
+                ctrl: true,
+                alt: false,
+                shift: false,
+            }
+        );
+    }
+
+    #[test]
+    fn char_chords_ignore_shift() {
+        // Shift is folded into the character, so a bare '?' never carries it.
+        assert!(!Chord::parse("shift+?").unwrap().shift);
+        let from = Chord::from_key(Key {
+            code: KeyCode::Char('?'),
+            ctrl: false,
+            alt: false,
+            shift: true,
+        });
+        assert!(!from.shift);
+    }
+
+    #[test]
+    fn rejects_garbage_specs() {
+        assert!(Chord::parse("").is_err());
+        assert!(Chord::parse("bogus+r").is_err());
+        assert!(KeySequence::parse("   ").is_err());
+    }
+
+    #[test]
+    fn display_is_human_readable() {
+        assert_eq!(Chord::parse("ctrl+r").unwrap().display(), "Ctrl+R");
+        assert_eq!(Chord::parse("space").unwrap().display(), "Space");
+        assert_eq!(Chord::parse("enter").unwrap().display(), "Enter");
+        assert_eq!(
+            KeySequence::parse("ctrl+x s").unwrap().display(),
+            "Ctrl+X S"
+        );
+    }
+
+    #[test]
+    fn dispatches_single_chords() {
+        let mut keymap = Keymap::new().layer(
+            Layer::new("global")
+                .bind("ctrl+r", Action::Search)
+                .bind("ctrl+d", Action::Quit),
+        );
+        assert_eq!(
+            keymap.dispatch(ctrl('r')),
+            Dispatch::Command(Action::Search)
+        );
+        assert_eq!(keymap.dispatch(ctrl('d')), Dispatch::Command(Action::Quit));
+        assert_eq!(keymap.dispatch(ctrl('z')), Dispatch::Unmatched);
+    }
+
+    #[test]
+    fn resolves_multi_stroke_sequences() {
+        let mut keymap = Keymap::new().layer(
+            Layer::new("nav")
+                .bind("g g", Action::Top)
+                .bind("g e", Action::Bottom),
+        );
+        assert_eq!(keymap.dispatch(key(KeyCode::Char('g'))), Dispatch::Pending);
+        assert_eq!(keymap.pending().len(), 1);
+        assert_eq!(
+            keymap.dispatch(key(KeyCode::Char('g'))),
+            Dispatch::Command(Action::Top)
+        );
+        // Pending is cleared after a completed sequence.
+        assert!(keymap.pending().is_empty());
+
+        assert_eq!(keymap.dispatch(key(KeyCode::Char('g'))), Dispatch::Pending);
+        assert_eq!(
+            keymap.dispatch(key(KeyCode::Char('e'))),
+            Dispatch::Command(Action::Bottom)
+        );
+    }
+
+    #[test]
+    fn dead_end_sequence_retries_final_stroke() {
+        let mut keymap = Keymap::new().layer(
+            Layer::new("nav")
+                .bind("g g", Action::Top)
+                .bind("ctrl+r", Action::Search),
+        );
+        // `g` starts a pending sequence; a following ctrl+r dead-ends `g g`, but
+        // ctrl+r is itself a live binding and should fire.
+        assert_eq!(keymap.dispatch(key(KeyCode::Char('g'))), Dispatch::Pending);
+        assert_eq!(
+            keymap.dispatch(ctrl('r')),
+            Dispatch::Command(Action::Search)
+        );
+        assert!(keymap.pending().is_empty());
+    }
+
+    #[test]
+    fn exact_match_wins_over_prefix() {
+        // `g` is both a complete binding and the prefix of `g g`; the exact
+        // match fires immediately without waiting.
+        let mut keymap = Keymap::new().layer(
+            Layer::new("nav")
+                .bind("g", Action::Bottom)
+                .bind("g g", Action::Top),
+        );
+        assert_eq!(
+            keymap.dispatch(key(KeyCode::Char('g'))),
+            Dispatch::Command(Action::Bottom)
+        );
+    }
+
+    #[test]
+    fn mode_gated_layers_activate_on_data() {
+        let mut keymap = Keymap::new()
+            .layer(Layer::new("global").bind("ctrl+d", Action::Quit))
+            .layer(
+                Layer::new("panel")
+                    .when("mode", "panel")
+                    .bind("q", Action::Close),
+            );
+        // The panel layer is dormant until the mode says so.
+        assert_eq!(
+            keymap.dispatch(key(KeyCode::Char('q'))),
+            Dispatch::Unmatched
+        );
+        keymap.set_data("mode", "panel");
+        assert_eq!(
+            keymap.dispatch(key(KeyCode::Char('q'))),
+            Dispatch::Command(Action::Close)
+        );
+        // The global layer stays active in every mode.
+        assert_eq!(keymap.dispatch(ctrl('d')), Dispatch::Command(Action::Quit));
+    }
+
+    #[test]
+    fn higher_priority_layer_wins_conflicts() {
+        let mut keymap = Keymap::new()
+            .layer(Layer::new("base").priority(0).bind("x", Action::Quit))
+            .layer(Layer::new("over").priority(10).bind("x", Action::Close));
+        assert_eq!(
+            keymap.dispatch(key(KeyCode::Char('x'))),
+            Dispatch::Command(Action::Close)
+        );
+    }
+
+    #[test]
+    fn changing_mode_clears_pending() {
+        let mut keymap = Keymap::new().layer(Layer::new("nav").bind("g g", Action::Top));
+        assert_eq!(keymap.dispatch(key(KeyCode::Char('g'))), Dispatch::Pending);
+        keymap.set_data("mode", "other");
+        assert!(keymap.pending().is_empty());
+    }
+
+    #[test]
+    fn hints_list_active_bindings_by_priority() {
+        let keymap = Keymap::new()
+            .layer(Layer::new("global").priority(0).bind_labeled(
+                "ctrl+r",
+                "search",
+                Action::Search,
+            ))
+            .layer(
+                Layer::new("panel")
+                    .priority(10)
+                    .when("mode", "panel")
+                    .bind_labeled("q", "close", Action::Close),
+            );
+        // Only the always-on layer contributes while no mode is set.
+        let hints = keymap.hints();
+        assert_eq!(hints.len(), 1);
+        assert_eq!(hints[0].keys, "Ctrl+R");
+        assert_eq!(hints[0].label.as_deref(), Some("search"));
+        assert_eq!(hints[0].command, Action::Search);
+
+        let mut keymap = keymap;
+        keymap.set_data("mode", "panel");
+        let hints = keymap.hints();
+        // Higher-priority panel layer first.
+        assert_eq!(hints.len(), 2);
+        assert_eq!(hints[0].command, Action::Close);
+        assert_eq!(hints[1].command, Action::Search);
+    }
+}

--- a/crates/tuika/src/lib.rs
+++ b/crates/tuika/src/lib.rs
@@ -57,6 +57,7 @@ pub mod highlight;
 pub mod host;
 pub mod hyperlink;
 pub mod image;
+pub mod keymap;
 pub mod layout;
 pub mod live;
 pub mod markdown;
@@ -96,6 +97,7 @@ pub use hyperlink::{
     ctrl_click_url_with, is_web_url, osc8, osc8_with, write_line, write_line_with,
 };
 pub use image::{Image, ImageData, ImageLayer, ImageSupport};
+pub use keymap::{Binding, Chord, Dispatch, Hint, KeyParseError, KeySequence, Keymap, Layer};
 pub use layout::{Align, Dimension, Direction, Item, Justify, LayoutStyle, solve};
 pub use live::{Live, LiveView, RedrawHandle};
 pub use mouse::{

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -44,6 +44,7 @@ and [`docs/`](../docs/); it must not link back into this internal bundle.
 - [OKF](specs/okf.md) — Open Knowledge Format integration.
 - [Trajectory export](specs/trajectory.md) — ATIF trajectory export.
 - [Tuika images](specs/tuika-images.md) — terminal image rendering.
+- [Tuika keymap](specs/keymap.md) — declarative key-binding dispatch.
 
 ## Safety and execution
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,10 @@
 Significant changes to Yolop's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
+## 2026-07-24
+
+- Added [Tuika keymap](specs/keymap.md): the tuika declarative key-binding engine and Yolop's dispatch of its global shortcuts through it.
+
 ## 2026-07-23
 
 - Established `knowledge/` as Yolop's OKF bundle.

--- a/knowledge/specs/keymap.md
+++ b/knowledge/specs/keymap.md
@@ -1,0 +1,107 @@
+---
+type: Product Specification
+title: tuika keymap
+description: Defines the tuika keymap engine and how Yolop dispatches key bindings through it.
+---
+
+# tuika keymap
+
+## Why
+
+Yolop's key handling grew as a hand-rolled cascade of `match key.code` blocks in
+the TUI event loop. Global chord shortcuts (Ctrl+R reverse search, Ctrl+C
+interrupt, Ctrl+D quit, Ctrl+B background panel, Ctrl+V paste) were scattered
+inline alongside modal handlers, so *what a key does* was neither declared in one
+place nor discoverable for help surfaces. Adding a shortcut meant editing an
+imperative branch and remembering its ordering relative to every modal guard.
+
+tuika is Yolop's own terminal-UI toolkit, and key routing is a toolkit concern —
+the same one [OpenTUI's keymap](https://opentui.com/docs/keymap/overview/) solves
+for the browser and terminal. tuika should own a declarative binding engine the
+way it owns layout, overlays, and focus, so any host (Yolop included) declares
+its shortcuts once and dispatches through a single seam.
+
+## What
+
+A host-agnostic keymap engine in tuika (`tuika::keymap`) that resolves declared
+key bindings to named command values, and Yolop's adoption of it for its
+app-global shortcuts.
+
+- **Chords and sequences.** A `Chord` is one key press plus modifiers, parsed
+  from a string (`ctrl+r`, `alt+shift+tab`, `?`, `space`, literal `ctrl++`). A
+  `KeySequence` is one or more chords typed in order, written space-separated
+  (`g g`, `ctrl+x s`), so multi-stroke bindings are first-class.
+- **Layers.** Bindings are grouped into named, prioritized `Layer`s. A layer may
+  be *gated* on runtime data (`when("mode", "panel")`) so it is active only in a
+  given application mode; an ungated layer is always active. When two active
+  layers bind the same sequence, the higher priority wins.
+- **Dispatch.** `Keymap::dispatch` takes a translated `Key` and returns
+  `Command(c)`, `Pending` (the strokes so far are a live prefix of a longer
+  binding), or `Unmatched` (the host should handle the key itself).
+- **Query.** `Keymap::hints` lists the currently-active bindings — key label,
+  optional help text, command — for a help overlay or `KeyHints` row.
+
+Yolop builds one `Keymap<GlobalAction>` of always-active chord shortcuts and
+routes them through `dispatch` at the top of the TUI key handler, replacing the
+former inline `match`. The engine's layer/mode/sequence features are available
+for the remaining modal handlers (setup, background panel, `ui/ask`) to adopt.
+
+## Design
+
+### Built on translated events, not crossterm
+
+The engine consumes tuika's own `Key` (the terminal-independent event the host
+already translates crossterm into), never a crossterm type. That keeps the
+engine free of terminal I/O, so it is unit-testable without a PTY — the same
+boundary that lets the rest of tuika's widget layer be tested against synthetic
+events.
+
+### Modifier normalization mirrors how terminals report input
+
+Matching is on a normalized `Chord`, so a binding matches the event a terminal
+actually delivers:
+
+- For a character key, Shift is folded into the character itself (`?` arrives as
+  `Char('?')`, not `Shift`+`Char('/')`), so the `shift` flag is dropped for
+  characters and kept meaningful only for non-character keys (`Shift`+`Enter`).
+- `Shift`+`Tab` folds to the distinct `BackTab` key that terminals report.
+
+Both the string parser and `Chord::from_key` apply the same normalization, so a
+parsed binding and a live event agree.
+
+### Sequence resolution: exact wins, dead-ends retry
+
+`dispatch` accumulates strokes into a pending buffer. On each key it resolves the
+pending buffer against the active layers: an exact match fires immediately and
+clears the buffer, even when the buffer is also the prefix of a longer binding
+(so a bound `g` fires without waiting to see whether `g g` follows — overlapping
+bindings are authored with that in mind). A live prefix with no exact match
+returns `Pending`. A buffer that matches nothing is dropped, and the final stroke
+is retried on its own so it can begin a fresh sequence. Changing runtime data
+clears the pending buffer, since the bindings that could complete it may no
+longer be active.
+
+### Bindings are static, so parse errors panic by construction
+
+`Layer::bind` panics on a malformed key spec, because bindings are authored as
+static literals — a bad spec is a programmer error caught on first run, like a
+malformed regex literal. `Chord::parse` / `Layer::try_bind` return a `Result` for
+the rare dynamic case (config-sourced bindings).
+
+### Yolop preserves dispatch ordering
+
+Yolop's global layer is ungated and dispatched ahead of every modal guard, which
+reproduces the exact precedence the inline `match` had: the global chords fire in
+any mode — mid-turn, during setup, or with an overlay open. A key that does not
+translate to an event (a release), or that no binding matches, yields no action
+and falls through to the composer and modal handlers unchanged.
+
+## Non-goals
+
+- No key *decoding* in the engine — the host translates crossterm into tuika
+  `Key` events first, exactly as the rest of tuika consumes input.
+- No sequence-timeout clock in the engine. Pending state is cleared explicitly
+  (a completed or dead-ended sequence, or a mode change); a host that wants a
+  timeout drives `Keymap::reset` from its own tick.
+- No user-facing rebinding/config format yet. The engine supports dynamically
+  sourced bindings (`try_bind`), but Yolop's bindings are code-defined.

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -1,0 +1,108 @@
+//! The app-global key bindings, declared through `tuika`'s [keymap
+//! engine](tuika::keymap).
+//!
+//! yolop's always-on chord shortcuts (reverse-history search, interrupt, quit,
+//! the background task panel, image paste) used to live as a hand-rolled
+//! `match` at the top of [`App::handle_key`](super::App::handle_key). They now
+//! resolve through a single [`tuika::Keymap`], so the bindings are declarative
+//! and discoverable in one place — and yolop dogfoods the toolkit's own keymap.
+//!
+//! These bindings are deliberately *global*: they fire regardless of the app's
+//! mode (mid-turn, during setup, or with an overlay open), which is why they sit
+//! in one always-active layer with no [`when`](tuika::Layer::when) gate. Modal
+//! key handling (setup steps, the background panel, `ui/ask` prompts) stays with
+//! the owning handler, which the engine's mode-gated layers could absorb later.
+
+use tuika::{Keymap, Layer};
+
+/// A global action a chord shortcut can trigger. Each maps to a method on
+/// [`App`](super::App) in [`App::handle_key`](super::App::handle_key).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum GlobalAction {
+    /// Open Ctrl+R reverse-history search over past prompts.
+    ReverseSearch,
+    /// Ctrl+C: interrupt the current turn, or arm/confirm exit when idle.
+    Interrupt,
+    /// Ctrl+D: quit the session.
+    Quit,
+    /// Ctrl+B: toggle the background task-tree panel.
+    ToggleBackground,
+    /// Ctrl+V: paste an image (or large text) from the clipboard into the composer.
+    PasteImage,
+}
+
+/// Build yolop's global keymap: one always-active layer of chord shortcuts.
+///
+/// The labels are carried on each binding so a future help overlay or
+/// [`KeyHints`](tuika::KeyHints) row can render them straight from
+/// [`Keymap::hints`](tuika::Keymap::hints).
+pub(crate) fn global_keymap() -> Keymap<GlobalAction> {
+    Keymap::new().layer(
+        Layer::new("global")
+            .bind_labeled("ctrl+r", "search history", GlobalAction::ReverseSearch)
+            .bind_labeled("ctrl+c", "interrupt", GlobalAction::Interrupt)
+            .bind_labeled("ctrl+d", "quit", GlobalAction::Quit)
+            .bind_labeled("ctrl+b", "background tasks", GlobalAction::ToggleBackground)
+            .bind_labeled("ctrl+v", "paste image", GlobalAction::PasteImage),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tuika::Dispatch;
+    use tuika::event::{Key, KeyCode};
+
+    fn ctrl(c: char) -> Key {
+        Key {
+            code: KeyCode::Char(c),
+            ctrl: true,
+            alt: false,
+            shift: false,
+        }
+    }
+
+    #[test]
+    fn binds_every_global_chord() {
+        let mut keymap = global_keymap();
+        assert_eq!(
+            keymap.dispatch(ctrl('r')),
+            Dispatch::Command(GlobalAction::ReverseSearch)
+        );
+        assert_eq!(
+            keymap.dispatch(ctrl('c')),
+            Dispatch::Command(GlobalAction::Interrupt)
+        );
+        assert_eq!(
+            keymap.dispatch(ctrl('d')),
+            Dispatch::Command(GlobalAction::Quit)
+        );
+        assert_eq!(
+            keymap.dispatch(ctrl('b')),
+            Dispatch::Command(GlobalAction::ToggleBackground)
+        );
+        assert_eq!(
+            keymap.dispatch(ctrl('v')),
+            Dispatch::Command(GlobalAction::PasteImage)
+        );
+    }
+
+    #[test]
+    fn leaves_unbound_keys_for_the_composer() {
+        let mut keymap = global_keymap();
+        // A plain letter and an unbound chord both fall through to the host.
+        assert_eq!(
+            keymap.dispatch(Key::new(KeyCode::Char('a'))),
+            Dispatch::Unmatched
+        );
+        assert_eq!(keymap.dispatch(ctrl('z')), Dispatch::Unmatched);
+    }
+
+    #[test]
+    fn every_binding_carries_a_help_label() {
+        let hints = global_keymap().hints();
+        assert_eq!(hints.len(), 5);
+        assert!(hints.iter().all(|hint| hint.label.is_some()));
+        assert!(hints.iter().any(|hint| hint.keys == "Ctrl+R"));
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -35,6 +35,7 @@ use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, oneshot};
 
 pub(crate) mod fullscreen;
+mod keymap;
 mod render;
 mod setup;
 mod viewport;
@@ -53,6 +54,7 @@ pub mod transcript;
 // The view-model types and runtime-event translation live in `crate::tui::transcript`
 // (the single boundary that interprets `everruns_core` events); re-export them
 // here so the TUI's own submodules keep referring to them as `crate::tui::*`.
+pub(crate) use self::keymap::{GlobalAction, global_keymap};
 pub(crate) use self::{render::*, viewport::*};
 pub(crate) use crate::tui::presentation::*;
 pub(crate) use crate::tui::transcript::*;
@@ -270,6 +272,9 @@ pub struct App {
     /// Active Ctrl+R reverse-history search, if any. While set it owns the
     /// keyboard and the composer previews the current match.
     history_search: Option<HistorySearch>,
+    /// App-global chord shortcuts (Ctrl+R/C/D/B/V), resolved through `tuika`'s
+    /// keymap engine rather than a hand-rolled match. See [`crate::tui::keymap`].
+    keymap: tuika::Keymap<GlobalAction>,
     /// When the active turn began, for the live elapsed timer on the busy
     /// indicator. `None` while idle.
     turn_started_at: Option<Instant>,
@@ -608,6 +613,7 @@ impl App {
                 crate::tui::prompt_history::PromptHistory::load()
             },
             history_search: None,
+            keymap: global_keymap(),
             turn_started_at: None,
             context_used_tokens: None,
         };
@@ -1495,35 +1501,28 @@ impl App {
         if self.busy && key.code != KeyCode::Esc {
             self.esc_pending_cancel = false;
         }
-        // Ctrl+R opens reverse-history search from the idle composer.
-        if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('r')) {
-            self.history_search_start();
-            return;
-        }
-        if key.modifiers.contains(KeyModifiers::CONTROL) {
-            match key.code {
-                KeyCode::Char('c') => {
-                    self.handle_ctrl_c();
-                    return;
-                }
-                KeyCode::Char('d') => {
+        // App-global chord shortcuts resolve through the keymap (see
+        // `crate::tui::keymap`), so yolop's bindings live in one declarative
+        // place instead of a hand-rolled match. They fire regardless of mode
+        // (mid-turn, during setup, or with an overlay open) — the same ordering
+        // they had before, since this sits ahead of every modal guard below.
+        if let Some(action) = self.dispatch_global_key(key) {
+            match action {
+                GlobalAction::ReverseSearch => self.history_search_start(),
+                GlobalAction::Interrupt => self.handle_ctrl_c(),
+                GlobalAction::Quit => {
                     self.abort_codex_login();
                     self.should_quit = true;
-                    return;
                 }
-                KeyCode::Char('b') => {
-                    // Clear the armed single-Ctrl+C exit ourselves, since this
-                    // branch returns before the shared reset below.
+                GlobalAction::ToggleBackground => {
+                    // This branch returns before the shared grace reset below, so
+                    // clear the armed single-Ctrl+C exit ourselves.
                     self.disarm_ctrl_c_pending_exit();
                     self.toggle_background_panel();
-                    return;
                 }
-                KeyCode::Char('v') => {
-                    self.try_paste_clipboard();
-                    return;
-                }
-                _ => {}
+                GlobalAction::PasteImage => self.try_paste_clipboard(),
             }
+            return;
         }
 
         self.disarm_ctrl_c_pending_exit_if_grace_elapsed();
@@ -1598,6 +1597,24 @@ impl App {
             _ => {
                 self.composer_edit_key(normalize_printable_key(key));
             }
+        }
+    }
+
+    /// Resolve one crossterm key against the app-global [`keymap`](crate::tui::keymap),
+    /// returning the [`GlobalAction`] to run when a global chord matches.
+    ///
+    /// Every global binding is a single stroke, so the keymap never returns
+    /// `Pending` here; a non-match (`Unmatched`) — or a key that does not
+    /// translate to a `tuika` event, such as a release — yields `None` so the
+    /// key falls through to the composer and modal handlers below.
+    fn dispatch_global_key(&mut self, key: KeyEvent) -> Option<GlobalAction> {
+        let tuika::Event::Key(translated) = tuika::translate_event(CrosstermEvent::Key(key))?
+        else {
+            return None;
+        };
+        match self.keymap.dispatch(translated) {
+            tuika::Dispatch::Command(action) => Some(action),
+            tuika::Dispatch::Pending | tuika::Dispatch::Unmatched => None,
         }
     }
 
@@ -5638,6 +5655,20 @@ mod tests {
             "Ctrl+B must disarm the pending Ctrl+C exit"
         );
         assert_eq!(app.background_panel, Some(0));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ctrl_d_quits_through_the_keymap() {
+        // Exercises the keymap dispatch seam end to end: the Ctrl+D chord must
+        // resolve to `GlobalAction::Quit` and set `should_quit`.
+        let mut test = app_with_llmsim().await;
+        let app = &mut test.app;
+        app.setup = None;
+        assert!(!app.should_quit);
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL))
+            .await;
+        assert!(app.should_quit, "Ctrl+D must quit the session");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## What changed

Adds a **host-agnostic keymap engine to `tuika`** (`tuika::keymap`) and routes
Yolop's always-on chord shortcuts through it.

- **`tuika::keymap`** — declarative key bindings resolved to named command
  values, modeled on [OpenTUI's keymap](https://opentui.com/docs/keymap/overview/)
  register/dispatch/query design:
  - `Chord` — one key + modifiers, string-parsed (`ctrl+r`, `alt+shift+tab`,
    `?`, `space`, literal `ctrl++`) with a human-readable `display()`.
  - `KeySequence` — multi-stroke chords, space-separated (`g g`, `ctrl+x s`).
  - `Layer` — named, prioritized binding groups, optionally **mode-gated** on
    runtime data (`when("mode", "panel")`).
  - `Keymap::dispatch(Key) -> Command | Pending | Unmatched`, with
    pending-sequence state; `hints()` exposes active bindings for help/`KeyHints`.
  - Built on tuika's own translated `Key`, so it unit-tests **without a terminal**.
- **Yolop** builds one `Keymap<GlobalAction>` of always-active shortcuts
  (Ctrl+R/C/D/B/V) and dispatches them at the top of `handle_key`, replacing the
  hand-rolled `match key.code` cascade. Bindings now live in one declarative,
  discoverable place.

**No user-visible behavior change:** every existing global shortcut works exactly
as before, at the same precedence (ahead of every modal guard, in any mode).

## Why

Key routing was scattered across imperative `match key.code` blocks in the TUI
loop, so *what a key does* was neither declared in one place nor discoverable for
help surfaces, and each shortcut's ordering vs. modal guards had to be
hand-reasoned. Key dispatch is a toolkit concern — the same one OpenTUI's keymap
solves — so `tuika` should own a declarative binding engine the way it already
owns layout, overlays, and focus. This lands that engine and has Yolop dogfood it.

## Before / After

No observable runtime behavior changes for existing shortcuts — this is an
internal dispatch refactor plus a new reusable capability. Proof that behavior is
preserved: the pre-existing `handle_key` tests (`ctrl_c_*`, `ctrl_r_*`,
`ctrl_b_clears_armed_ctrl_c_exit`) still pass unchanged, now flowing through the
keymap seam, plus a new `ctrl_d_quits_through_the_keymap` test.

**Before** — inline, imperative:
```rust
if key.modifiers.contains(KeyModifiers::CONTROL) {
    match key.code {
        KeyCode::Char('c') => { self.handle_ctrl_c(); return; }
        KeyCode::Char('d') => { self.abort_codex_login(); self.should_quit = true; return; }
        // ...b, v, r scattered nearby
    }
}
```

**After** — declarative bindings + single dispatch seam:
```rust
Layer::new("global")
    .bind_labeled("ctrl+r", "search history", GlobalAction::ReverseSearch)
    .bind_labeled("ctrl+c", "interrupt", GlobalAction::Interrupt)
    .bind_labeled("ctrl+d", "quit", GlobalAction::Quit)
    // ...

if let Some(action) = self.dispatch_global_key(key) { /* run action */ return; }
```

New capability the engine unlocks (covered by tuika tests): multi-stroke
sequences and mode-gated layers —
```rust
keymap.dispatch(g);   // Dispatch::Pending
keymap.dispatch(g);   // Dispatch::Command(Top)   // "g g"
```

## Risk

- **Low.**
- The only runtime-facing change is *how* the five global chords are dispatched;
  the resulting actions and their ordering vs. modal handlers are unchanged, and
  the existing + new `handle_key` tests lock that in. A key that no binding
  matches (or a release event) falls through exactly as before.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; existing behavior preserved regardless)
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Added [`knowledge/specs/keymap.md`](knowledge/specs/keymap.md) (tuika keymap
concept), linked from `index.md`, with a `log.md` entry. OKF bundle validates
clean (`scripts/validate_okf.py knowledge --check-links`). tuika `README.md`
gains a keymap bullet.

## Security

Reviewed against the threat-model categories; none apply. The engine is pure
input-routing logic over already-translated `Key` events:
- **TM-FS / TM-BASH / TM-TOOL** — no filesystem, shell, or capability-registration
  surface touched.
- **TM-LLM** — no prompt construction or API-key handling; nothing logged.
- **TM-DEP** — no new dependencies (std-only: `HashMap`, `fmt`).
- Input validation / resource use: chord/sequence specs come from static
  developer literals (`bind` panics on malformed literals by design; `try_bind`
  returns `Result` for dynamic use). The pending-sequence buffer is bounded by
  the longest bound sequence and cleared on completion, dead-end, or mode change —
  no unbounded growth. No injection, traversal, or exhaustion surface.

## Follow-ups

- Migrate the modal key handlers (setup steps, background task panel, `ui/ask`
  prompt) onto mode-gated `Layer`s so all key routing flows through one keymap;
  deferred to keep this PR a focused, behavior-preserving first cut.
- Optionally drive a `KeyHints`/help overlay from `Keymap::hints()` (labels are
  already carried on each binding); deferred as a separate UX change.

https://claude.ai/code/session_01Aqjs4z4qrngF1azEeQSZbF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aqjs4z4qrngF1azEeQSZbF)_