### PR TITLE
fix(tools): add missing activity narration

### DIFF
--- a/knowledge/specs/extensions.md
+++ b/knowledge/specs/extensions.md
@@ -481,7 +481,7 @@ verbatim when unrecognized): `tools`, `streaming`, `hooks`, `prompt`,
 | →server | `initialize` | req | protocol version, session id, workspace root, locale, validated config, host feature set |
 | ←server | (result) | — | identity, contributions (prompt, tools, hooks, MCP servers, commands), clamped by manifest |
 | →server | `initialized` | ntf | handshake complete |
-| →server | `tool/call` | req | `{tool_call_id, name, args}`; response is the final `ToolExecutionResult`-shaped payload |
+| →server | `tool/call` | req | `{tool_call_id, name, args}`; response is the final `ToolExecutionResult`-shaped payload; the host uses the manifest tool name as stable activity narration |
 | ←server | `tool/update` | ntf | streamed progress/partial output; correlates via `request_id` in the payload |
 | →server | `cancel` | req | `{id}` — abort any in-flight request (mira semantics: best-effort, aborted call resolves with error `cancelled`) |
 | →server | `prompt/contribution` | req | dynamic system prompt (only if declared `dynamic`); timeout + last-known-good |

--- a/src/capabilities/client_commands.rs
+++ b/src/capabilities/client_commands.rs
@@ -419,6 +419,31 @@ mod tests {
     }
 
     #[test]
+    fn set_status_narration_includes_truncated_status() {
+        use everruns_core::tool_narration::ToolNarrationPhase;
+        use everruns_core::tool_types::ToolCall;
+
+        let tool = SetStatusTool {
+            ui: Arc::new(RecordingUi::default()),
+        };
+        let tool_call = ToolCall {
+            id: "call-1".to_string(),
+            name: "set_status".to_string(),
+            arguments: json!({ "status": "Auditing tool narration" }),
+        };
+
+        assert_eq!(
+            tool.narrate(
+                &tool_call,
+                ToolNarrationPhase::Started,
+                None,
+                everruns_core::tool_narration::ToolNarrationContext::default(),
+            ),
+            Some("Update status: Auditing tool narration".to_string())
+        );
+    }
+
+    #[test]
     fn run_yolop_command_schema_accepts_slashed_aliases() {
         let tool = RunYolopCommandTool {
             ui: Arc::new(RecordingUi::default()),

--- a/src/connectors/capability.rs
+++ b/src/connectors/capability.rs
@@ -1,11 +1,14 @@
 //! The `connectors` capability — discover, connect, and disconnect sandbox
 //! and integration backends through a uniform tool surface.
 
+use crate::capabilities::narration::stable_labeled;
 use crate::connectors::catalog::{ConnectionCatalog, ConnectorInfo};
 use crate::connectors::store::ConnectionStore;
 use async_trait::async_trait;
 use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
 use everruns_core::connector::ConnectorType;
+use everruns_core::tool_narration::{ToolNarrationPhase, arg_str, truncate};
+use everruns_core::tool_types::ToolCall;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use serde_json::{Value, json};
 use std::collections::HashMap;
@@ -106,6 +109,18 @@ struct ListConnectorsTool {
 
 #[async_trait]
 impl Tool for ListConnectorsTool {
+    fn narrate(
+        &self,
+        _tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        let _ = locale;
+        let detail = None;
+        Some(stable_labeled("List connectors", detail, phase))
+    }
+
     fn name(&self) -> &str {
         "list_connectors"
     }
@@ -141,6 +156,18 @@ struct GetConnectorTool {
 
 #[async_trait]
 impl Tool for GetConnectorTool {
+    fn narrate(
+        &self,
+        tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        let _ = locale;
+        let detail = arg_str(&tool_call.arguments, &["provider"]).map(|value| truncate(value, 48));
+        Some(stable_labeled("Get connector", detail, phase))
+    }
+
     fn name(&self) -> &str {
         "get_connector"
     }
@@ -187,6 +214,18 @@ struct ConnectTool {
 
 #[async_trait]
 impl Tool for ConnectTool {
+    fn narrate(
+        &self,
+        tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        let _ = locale;
+        let detail = arg_str(&tool_call.arguments, &["provider"]).map(|value| truncate(value, 48));
+        Some(stable_labeled("Connect provider", detail, phase))
+    }
+
     fn name(&self) -> &str {
         "connect"
     }
@@ -283,6 +322,18 @@ struct DisconnectTool {
 
 #[async_trait]
 impl Tool for DisconnectTool {
+    fn narrate(
+        &self,
+        tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        let _ = locale;
+        let detail = arg_str(&tool_call.arguments, &["provider"]).map(|value| truncate(value, 48));
+        Some(stable_labeled("Disconnect provider", detail, phase))
+    }
+
     fn name(&self) -> &str {
         "disconnect"
     }
@@ -331,6 +382,29 @@ impl Tool for DisconnectTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn connector_narration_names_action_and_provider() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let store = Arc::new(ConnectionStore::open(tmp.path().join("connections.toml")));
+        let catalog = Arc::new(ConnectionCatalog::with_defaults());
+        let tool = GetConnectorTool { catalog, store };
+        let call = ToolCall {
+            id: "call-1".into(),
+            name: "get_connector".into(),
+            arguments: json!({ "provider": "daytona" }),
+        };
+
+        assert_eq!(
+            tool.narrate(
+                &call,
+                ToolNarrationPhase::Started,
+                None,
+                everruns_core::tool_narration::ToolNarrationContext::default(),
+            ),
+            Some("Get connector: daytona".into())
+        );
+    }
 
     #[tokio::test]
     async fn list_connectors_includes_daytona() {

--- a/src/extensions/capability.rs
+++ b/src/extensions/capability.rs
@@ -10,12 +10,15 @@ use super::manager::{
 };
 use super::package::{ExtensionPackage, ToolDefinition, extension_capability_id};
 use crate::capabilities::EnvironmentContextRegistry;
+use crate::capabilities::narration::stable_labeled;
 use async_trait::async_trait;
 use everruns_core::capabilities::{Capability, SystemPromptContext};
 use everruns_core::command::{
     CommandArg, CommandDescriptor, CommandExecutionContext, CommandResult, CommandSource,
     ExecuteCommandRequest,
 };
+use everruns_core::tool_narration::ToolNarrationPhase;
+use everruns_core::tool_types::ToolCall;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use serde_json::Value;
 use std::path::PathBuf;
@@ -464,6 +467,21 @@ struct ExtensionTool {
 
 #[async_trait]
 impl Tool for ExtensionTool {
+    fn narrate(
+        &self,
+        _tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        let _ = locale;
+        let mut label = self.definition.name.replace(['_', '-'], " ");
+        if let Some(first) = label.get_mut(..1) {
+            first.make_ascii_uppercase();
+        }
+        Some(stable_labeled(&label, None, phase))
+    }
+
     fn name(&self) -> &str {
         &self.definition.name
     }
@@ -501,6 +519,49 @@ mod tests {
     use crate::extensions::package::parse_manifest;
     use everruns_core::mcp_server::McpServerTransportType;
     use serde_json::json;
+
+    #[test]
+    fn extension_tool_narration_uses_manifest_tool_name() {
+        let manifest = parse_manifest(
+            &json!({
+                "name": "docs", "description": "Docs.",
+                "yolop": {
+                    "protocol_version": "1.0",
+                    "capabilityServer": { "command": "x" },
+                    "tools": [{
+                        "name": "search_docs",
+                        "description": "Search documentation.",
+                        "inputSchema": { "type": "object" }
+                    }]
+                }
+            })
+            .to_string(),
+        )
+        .expect("parse");
+        let cap = ExtensionCapability::new(
+            ExtensionPackage {
+                dir: std::env::temp_dir(),
+                manifest,
+            },
+            std::env::temp_dir(),
+        );
+        let tool = cap.tools().remove(0);
+        let call = ToolCall {
+            id: "call-1".into(),
+            name: "search_docs".into(),
+            arguments: json!({ "query": "narration" }),
+        };
+
+        assert_eq!(
+            tool.narrate(
+                &call,
+                ToolNarrationPhase::Started,
+                None,
+                everruns_core::tool_narration::ToolNarrationContext::default(),
+            ),
+            Some("Search docs".into())
+        );
+    }
 
     #[test]
     fn contributed_mcp_servers_are_prefixed_and_shaped() {

--- a/src/extensions/manage.rs
+++ b/src/extensions/manage.rs
@@ -11,10 +11,13 @@ use super::protocol::UiAskParams;
 use super::scaffold::{self, HookSpec, Language, ScaffoldRequest, ToolSpec};
 use super::secrets::{ExtensionSecrets, Secret};
 use super::store::{self, CrateFetcher, GitRunner, Source, SystemCrateFetcher, SystemGit};
+use crate::capabilities::narration::stable_labeled;
 use crate::config::SettingsStore;
 use crate::tui::host_ui::UiCommand;
 use async_trait::async_trait;
 use everruns_core::capabilities::Capability;
+use everruns_core::tool_narration::{ToolNarrationPhase, arg_str, truncate};
+use everruns_core::tool_types::ToolCall;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use serde_json::{Value, json};
 use std::path::PathBuf;
@@ -726,6 +729,34 @@ impl ManageTool {
 
 #[async_trait]
 impl Tool for ManageTool {
+    fn narrate(
+        &self,
+        tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        let _ = locale;
+        let label = match self.verb {
+            Verb::Scaffold => "Scaffold extension",
+            Verb::List => "List extensions",
+            Verb::Install => "Install extension",
+            Verb::Remove => "Remove extension",
+            Verb::Enable => "Enable extension",
+            Verb::Disable => "Disable extension",
+            Verb::Reload => "Reload extension",
+            Verb::SetSecret => "Set extension secret",
+            Verb::Doctor => "Check extension",
+        };
+        let key = if matches!(self.verb, Verb::Install) {
+            "source"
+        } else {
+            "name"
+        };
+        let detail = arg_str(&tool_call.arguments, &[key]).map(|value| truncate(value, 48));
+        Some(stable_labeled(label, detail, phase))
+    }
+
     fn name(&self) -> &str {
         match self.verb {
             Verb::Scaffold => "scaffold_extension",
@@ -919,6 +950,29 @@ mod tests {
             ask_sink: None,
         };
         (cap, settings, ext_dir)
+    }
+
+    #[test]
+    fn manage_tool_narration_names_action_and_extension() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (cap, _, _) = capability(tmp.path());
+        let mut tools = cap.tools();
+        let tool = tools.remove(4);
+        let call = ToolCall {
+            id: "call-1".into(),
+            name: "enable_extension".into(),
+            arguments: json!({ "name": "linear" }),
+        };
+
+        assert_eq!(
+            tool.narrate(
+                &call,
+                ToolNarrationPhase::Started,
+                None,
+                everruns_core::tool_narration::ToolNarrationContext::default(),
+            ),
+            Some("Enable extension: linear".into())
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- add concise activity narration to Yolop-owned status, connector, and extension-management tools
- present extension-contributed tool names as readable fallback narration
- add direct regression coverage for each affected tool family

## Motivation

Tools without explicit narration fall back to raw tool-call presentation, making routine activity harder to scan. Yolop should provide stable, bounded labels wherever it owns the tool semantics and a readable fallback for extension-contributed tools.

## Before / After

**Before:** affected calls displayed generic/raw tool activity, such as an unformatted extension tool name.

**After:** activity uses concise labels and bounded details, for example `Update status: Auditing tool narration`, `Get connector: daytona`, `Enable extension: linear`, and `Search docs`.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo run -- --provider llmsim -p "Set a concise status, then say hi"`

## Security

- Reviewed TM-TOOL: narration only reads bounded display arguments; capability registration and permissions are unchanged.
- Reviewed injection and data exposure: values are rendered as plain presentation text and truncated; no shell, path, prompt, or secret handling changed.
- TM-FS, TM-BASH, TM-LLM, and TM-DEP are unaffected. No dependencies added.

## Follow-ups

- Everruns-owned tools, including `write_session_title`, require an upstream narration audit; issue text was prepared for manual filing in Linear.

## Checklist

- [x] Tests added or updated
- [x] Local validation passes
- [x] Security review completed

Produced by [yolop](https://everruns.com/yolop)
