### PR TITLE
feat(tui): make fullscreen the default

### DIFF
--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -25,7 +25,7 @@ Env COLORTERM "truecolor"
 Env RUST_LOG "error"
 
 Hide
-Type "cargo build -q && docs/demo-setup.sh && alias yolop='target/debug/yolop -C /tmp/yolop-hero-mission-control --fullscreen --theme dracula --provider codex -m gpt-5.6-sol --reasoning-effort low --session-dir /tmp/yolop-hero-sessions' && clear"
+Type "cargo build -q && docs/demo-setup.sh && alias yolop='target/debug/yolop -C /tmp/yolop-hero-mission-control --theme dracula --provider codex -m gpt-5.6-sol --reasoning-effort low --session-dir /tmp/yolop-hero-sessions' && clear"
 Enter
 Wait+Line@5m /[>$%#]/
 Show

--- a/docs/features/sandboxing/sandbox-denial.tape
+++ b/docs/features/sandboxing/sandbox-denial.tape
@@ -15,7 +15,7 @@ Set MarginFill "#111318"
 Env NO_COLOR ""
 Env COLORTERM "truecolor"
 
-Type "target/debug/yolop --fullscreen --provider llmsim --session-dir /tmp/yolop-vhs-sessions"
+Type "target/debug/yolop --provider llmsim --session-dir /tmp/yolop-vhs-sessions"
 Enter
 Sleep 3s
 Type "!touch ../yolop-sandbox-escape-proof.txt"

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -8,3 +8,8 @@ wording, formatting, and link fixes do not need entries.
 - Established `knowledge/` as Yolop's OKF bundle.
 - Migrated product specifications to `knowledge/specs/` and added typed OKF metadata.
 - Added repository, shipping, maintenance, release, and CI rules to keep the bundle current.
+
+## 2026-07-24 — Fullscreen renderer became the default
+
+- Made the alternate-screen fullscreen renderer the default for interactive sessions.
+- Added `--inline` as the explicit opt-out for terminal-native scrollback.

--- a/knowledge/specs/presentation.md
+++ b/knowledge/specs/presentation.md
@@ -37,6 +37,13 @@ widgets, overlays, and terminal-specific affordances. It must not be the only
 place where a user-visible transcript label, tool wording, or status-bar value
 is assembled.
 
+### Interactive Renderer Default
+
+Interactive sessions use the fullscreen alternate-screen renderer by default.
+The application owns transcript scrolling, overlays, and viewport composition in
+this mode. `--inline` selects the scrollback-native composer when terminal
+history is preferred.
+
 ### Fullscreen Status Drawer
 
 The fullscreen host projects expanded session status as a responsive drawer.

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,12 +116,11 @@ struct Cli {
     #[arg(long, value_name = "PATH")]
     trajectory_out: Option<PathBuf>,
 
-    /// EXPERIMENTAL: render the interactive TUI full-screen on the alternate
-    /// screen (via the `tuika` toolkit) instead of the default inline
-    /// scrollback composer. Overlays and scrolling are owned in-app; native
-    /// terminal scrollback is unavailable in this mode.
+    /// Render the interactive TUI inline instead of using the default
+    /// fullscreen alternate-screen renderer. Native terminal scrollback is
+    /// available in this mode.
     #[arg(long)]
-    fullscreen: bool,
+    inline: bool,
 
     /// Color theme for the interactive TUI. `yolop` (default) is yolop's own
     /// palette; other values select a bundled `tuika` preset (e.g.
@@ -622,7 +621,7 @@ async fn async_main() -> Result<()> {
         return run_print_mode(runtime, prompt, image_parts, cli.trajectory_out).await;
     }
     let pending_images = tui::input::image_input::load_image_parts(&cli.images)?;
-    run_tui(runtime, pending_images, cli.trajectory_out, cli.fullscreen).await
+    run_tui(runtime, pending_images, cli.trajectory_out, !cli.inline).await
 }
 
 fn resolve_workspace_root(
@@ -1638,7 +1637,7 @@ mod tests {
     fn continuation_preserves_reusable_arguments_and_replaces_turn_arguments() {
         let args = [
             "yolop",
-            "--fullscreen",
+            "--inline",
             "--sandbox",
             "--model",
             "gpt test",
@@ -1654,7 +1653,7 @@ mod tests {
 
         assert_eq!(
             continuation_command(args, "new-session"),
-            "yolop --fullscreen --sandbox --model 'gpt test' --session new-session"
+            "yolop --inline --sandbox --model 'gpt test' --session new-session"
         );
     }
 
@@ -1671,7 +1670,7 @@ mod tests {
             session: None,
             session_dir: None,
             trajectory_out: None,
-            fullscreen: false,
+            inline: false,
             theme: None,
             sandbox: false,
         }
@@ -1730,7 +1729,7 @@ mod tests {
             session: None,
             session_dir: None,
             trajectory_out: None,
-            fullscreen: false,
+            inline: false,
             theme: None,
             sandbox: false,
         };

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -238,9 +238,8 @@ pub struct App {
     pending_images: Vec<ContentPart>,
     /// Large paste placeholders mapped to their full clipboard/terminal payloads.
     pending_pastes: Vec<(String, String)>,
-    /// Which renderer this session drives. `Inline` is the default
-    /// scrollback-native composer; `Fullscreen` is the experimental
-    /// alternate-screen `tuika` renderer (`--fullscreen`).
+    /// Which renderer this session drives. `Fullscreen` is the CLI default;
+    /// `Inline` is the scrollback-native composer selected by `--inline`.
     render_mode: RenderMode,
     /// Full-screen transcript scroll position (unused in inline mode).
     scroll: tuika::ScrollState,
@@ -298,10 +297,10 @@ pub(crate) struct HistorySearch {
 /// The renderer backing a TUI session.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) enum RenderMode {
-    /// Scrollback-native inline composer (default).
+    /// Scrollback-native inline composer.
     #[default]
     Inline,
-    /// Experimental full-screen alternate-screen renderer (`tuika`).
+    /// Full-screen alternate-screen renderer (`tuika`) and CLI default.
     Fullscreen,
 }
 
@@ -656,8 +655,8 @@ impl App {
         app
     }
 
-    /// Switch this session to the experimental full-screen renderer. Called by
-    /// `run_tui` before the loop when `--fullscreen` is set.
+    /// Switch this session to the full-screen renderer. Called by `run_tui`
+    /// unless `--inline` is set.
     pub(crate) fn set_render_mode(&mut self, mode: RenderMode) {
         self.render_mode = mode;
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -761,28 +761,28 @@ fn tui_escape_does_not_exit_and_ctrl_c_exits() {
 }
 
 #[test]
-fn tui_default_renders_and_responds_smoke() {
-    tui_smoke(false);
+fn tui_default_fullscreen_renders_and_responds_smoke() {
+    tui_smoke(
+        TuiSpawnOptions {
+            inline: false,
+            ..TuiSpawnOptions::default()
+        },
+        "default fullscreen",
+        true,
+    );
 }
 
 #[test]
-fn tui_fullscreen_renders_and_responds_smoke() {
-    tui_smoke(true);
+fn tui_inline_renders_and_responds_smoke() {
+    tui_smoke(TuiSpawnOptions::default(), "inline", false);
 }
 
 /// End-to-end smoke for both TUI renderers: start the TUI, drive one llmsim
 /// turn, and assert the rendered grid shows the composer and provider status
 /// bar with no subprocess output leaked onto the frame (the corruption this
 /// change fixes), then exit cleanly.
-fn tui_smoke(fullscreen: bool) {
-    let mode = if fullscreen { "fullscreen" } else { "default" };
-    let mut tui = spawn_tui_llmsim_with(
-        &yolop_binary(),
-        TuiSpawnOptions {
-            fullscreen,
-            ..TuiSpawnOptions::default()
-        },
-    );
+fn tui_smoke(options: TuiSpawnOptions, mode: &str, fullscreen: bool) {
+    let mut tui = spawn_tui_llmsim_with(&yolop_binary(), options);
     // Wait on the composer hint from the shared chrome, which both renderers
     // draw (unlike the startup banner, which inline flushes to scrollback that
     // the fullscreen alternate screen does not have).
@@ -809,7 +809,7 @@ fn tui_smoke(fullscreen: bool) {
         "{mode}: provider status bar should be on-screen:\n{screen}"
     );
     // The frame must not carry leaked child-process output. These are the git
-    // progress lines that corrupted the --fullscreen status bar before the
+    // progress lines that corrupted the fullscreen status bar before the
     // subprocess output was captured/detached.
     for leak in ["Preparing worktree", "HEAD is now at", "From github.com"] {
         assert!(
@@ -842,9 +842,10 @@ fn tui_smoke(fullscreen: bool) {
             output.matches("real responses").count() >= 2,
             "fullscreen: final assistant message should be reprinted after exit: {output}"
         );
+    } else {
         assert!(
-            output.contains("--fullscreen --session"),
-            "fullscreen: continuation command should preserve --fullscreen: {output}"
+            output.contains("--inline --session"),
+            "inline: continuation command should preserve --inline: {output}"
         );
     }
 }

--- a/tests/support/tui_harness.rs
+++ b/tests/support/tui_harness.rs
@@ -34,9 +34,8 @@ pub struct TuiSpawnOptions {
     pub cursor_reply_budget: usize,
     /// Directory prepended to `PATH` for subprocess lookup in the spawned TUI.
     pub path_prefix: Option<PathBuf>,
-    /// Launch the alternate-screen renderer (`--fullscreen`) instead of the
-    /// default inline TUI.
-    pub fullscreen: bool,
+    /// Pass `--inline` instead of using the default fullscreen renderer.
+    pub inline: bool,
     /// Workspace passed through `-C`; useful for real-binary containment tests.
     pub workspace: Option<PathBuf>,
     /// Enable shell sandboxing for this process.
@@ -51,7 +50,7 @@ impl Default for TuiSpawnOptions {
             cursor_row: 1,
             cursor_reply_budget: usize::MAX,
             path_prefix: None,
-            fullscreen: false,
+            inline: true,
             workspace: None,
             sandbox: false,
         }
@@ -223,8 +222,8 @@ pub fn spawn_tui_llmsim_with_settings(
     let mut cmd = CommandBuilder::new(binary);
     cmd.args(["--provider", "llmsim", "--session-dir"]);
     cmd.arg(session_dir.path());
-    if options.fullscreen {
-        cmd.arg("--fullscreen");
+    if options.inline {
+        cmd.arg("--inline");
     }
     if options.sandbox {
         cmd.arg("--sandbox");


### PR DESCRIPTION
## Summary

- make the fullscreen alternate-screen TUI the default for interactive sessions
- add `--inline` as the explicit opt-out for terminal-native scrollback
- keep continuation commands, demos, tests, and durable presentation guidance aligned

## Before / After

**Before:** `yolop` opened the inline composer; fullscreen required `--fullscreen`.

**After:** `yolop` opens fullscreen by default; `yolop --inline` selects the inline composer.

Proof: PTY integration tests launch the binary both with no renderer argument and with `--inline`, complete an llmsim turn, and verify the expected renderer behavior.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `python3 scripts/validate_okf.py knowledge --check-links`
- `cargo run -- --provider llmsim -p "hi"`

## Security

Reviewed TM-FS, TM-BASH, TM-LLM, TM-TOOL, and TM-DEP. This change only inverts local renderer selection and renames a CLI flag; it does not alter filesystem access, shell execution, prompt or credential handling, capability registration, dependencies, trust boundaries, or resource limits. No injection or data-exposure surface was added.

## Follow-ups

No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
