### PR TITLE
fix(tui): preserve panic diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,23 @@ Yolop-owned worktree and never changes the branch, `HEAD`, commits, or index.
 > session should not be persisted, point `--session-dir` at a wipeable path (e.g.
 > a `tmpfs`) or delete the JSONL after the run.
 
+### Crash reports
+
+If Yolop panics, it writes a local report containing the version, bounded panic
+message, source location, and bounded backtrace. Yolop does not add prompts,
+tool payloads, environment variables, credentials, or tracing logs. Because a
+panic message can still contain application data, review a report before
+sharing it. Yolop keeps the newest five:
+
+| OS      | Default location                                      |
+|---------|-------------------------------------------------------|
+| Linux   | `$XDG_DATA_HOME/yolop/crashes/`                       |
+| macOS   | `~/Library/Application Support/yolop/crashes/`        |
+| Windows | `%APPDATA%\yolop\crashes\`                            |
+
+On Unix the directory is `0o700` and reports are `0o600`. After restoring the
+terminal, Yolop prints the report path before preserving the original panic.
+
 ## Contributing
 
 Development setup, validation commands, and local smoke tests live in

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -48,6 +48,7 @@ and [`docs/`](../docs/); it must not link back into this internal bundle.
 
 ## Safety and execution
 
+- [Crash reporting](specs/crash-reporting.md) — local privacy-preserving panic diagnostics.
 - [Sandboxing](specs/sandboxing.md) — filesystem and process boundaries.
 
 ## Engineering processes

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -5,6 +5,8 @@ wording, formatting, and link fixes do not need entries.
 
 ## 2026-07-24
 
+- Added [Crash reporting](specs/crash-reporting.md): bounded, owner-only local
+  panic reports that remain visible after TUI terminal restoration.
 - Added [Tuika keymap](specs/keymap.md): the tuika declarative key-binding engine and Yolop's dispatch of its global shortcuts through it.
 
 ## 2026-07-23

--- a/knowledge/specs/crash-reporting.md
+++ b/knowledge/specs/crash-reporting.md
@@ -1,0 +1,33 @@
+---
+type: Product Specification
+title: Crash reporting
+description: Defines local, privacy-preserving reports for unexpected Yolop panics.
+---
+
+# Crash reporting
+
+Yolop writes a local crash report when a process thread panics. This is
+especially important for the alternate-screen TUI: the original panic hook runs
+before terminal guards restore the user's screen, so its output can otherwise
+disappear when the terminal returns to normal mode.
+
+Reports live under the platform user-data directory:
+
+- Linux: `$XDG_DATA_HOME/yolop/crashes/`
+- macOS: `~/Library/Application Support/yolop/crashes/`
+- Windows: `%APPDATA%\yolop\crashes\`
+
+Names combine a UTC timestamp with a random suffix. Yolop keeps the newest five
+reports. On Unix the directory is owner-only (`0o700`) and each report is
+`0o600`.
+
+A report contains only the Yolop version, timestamp, panic thread, source
+location, a bounded panic message, and a bounded backtrace. Yolop does not add
+prompts, messages, tool arguments or results, environment variables,
+credentials, or tracing logs. A panic message can still contain application
+data, so reports remain private local files and should be reviewed before
+sharing. Writing is best-effort and must never cause another panic.
+
+When the large-stack application thread panics, terminal guards restore the
+screen first. Yolop then prints the report path and resumes the original panic
+payload; the outer thread must not replace it with a generic `Any` diagnostic.

--- a/src/crash_report.rs
+++ b/src/crash_report.rs
@@ -1,0 +1,269 @@
+use rand::RngExt;
+use std::backtrace::Backtrace;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+const MAX_CRASH_REPORTS: usize = 5;
+const MAX_PANIC_MESSAGE_BYTES: usize = 8 * 1024;
+const MAX_REPORT_BYTES: usize = 256 * 1024;
+
+pub(crate) struct CrashReporter {
+    path: Option<PathBuf>,
+    written: Arc<AtomicBool>,
+}
+
+impl CrashReporter {
+    pub(crate) fn install() -> Self {
+        let written = Arc::new(AtomicBool::new(false));
+        let path = crash_report_dir()
+            .and_then(|dir| prepare_crash_dir(&dir).then_some(dir))
+            .map(|dir| {
+                let timestamp = chrono::Utc::now().format("%Y-%m-%dT%H-%M-%SZ");
+                let suffix = rand::rng().random::<u32>();
+                dir.join(format!("{timestamp}-{suffix:08x}-crash.log"))
+            });
+
+        if let Some(path) = path.clone() {
+            let hook_written = Arc::clone(&written);
+            let crash_dir = path.parent().map(Path::to_path_buf);
+            let previous = std::panic::take_hook();
+            std::panic::set_hook(Box::new(move |info| {
+                if hook_written
+                    .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                    .is_ok()
+                {
+                    if write_panic_report(&path, info).is_err() {
+                        hook_written.store(false, Ordering::SeqCst);
+                    } else if let Some(dir) = crash_dir.as_deref() {
+                        prune_old_reports(dir, MAX_CRASH_REPORTS);
+                    }
+                }
+                previous(info);
+            }));
+        }
+
+        Self { path, written }
+    }
+
+    pub(crate) fn report_path(&self) -> Option<&Path> {
+        self.written
+            .load(Ordering::SeqCst)
+            .then_some(self.path.as_deref())
+            .flatten()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn disabled() -> Self {
+        Self {
+            path: None,
+            written: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+fn crash_report_dir() -> Option<PathBuf> {
+    #[cfg(test)]
+    if let Some(path) = std::env::var_os("YOLOP_TEST_CRASH_DIR") {
+        return Some(PathBuf::from(path));
+    }
+    dirs::data_dir().map(|dir| dir.join("yolop").join("crashes"))
+}
+
+fn prepare_crash_dir(dir: &Path) -> bool {
+    if std::fs::create_dir_all(dir).is_err() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700)).is_err() {
+            return false;
+        }
+    }
+    prune_old_reports(dir, MAX_CRASH_REPORTS);
+    true
+}
+
+fn write_panic_report(path: &Path, info: &std::panic::PanicHookInfo<'_>) -> std::io::Result<()> {
+    let mut payload = if let Some(message) = info.payload().downcast_ref::<&str>() {
+        (*message).to_string()
+    } else if let Some(message) = info.payload().downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "non-string panic payload".to_string()
+    };
+    truncate_utf8(&mut payload, MAX_PANIC_MESSAGE_BYTES);
+    let location = info
+        .location()
+        .map(|location| {
+            format!(
+                "{}:{}:{}",
+                location.file(),
+                location.line(),
+                location.column()
+            )
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+    let thread = std::thread::current()
+        .name()
+        .unwrap_or("unnamed")
+        .to_string();
+    let mut body = format!(
+        "timestamp: {}\nversion: {}\nthread: {thread}\nlocation: {location}\npanic: {payload}\n\nbacktrace:\n{}\n",
+        chrono::Utc::now().to_rfc3339(),
+        crate::version::VERSION_DETAILS,
+        Backtrace::force_capture(),
+    );
+    truncate_utf8(&mut body, MAX_REPORT_BYTES);
+    write_report(path, body.as_bytes())
+}
+
+fn truncate_utf8(value: &mut String, max_bytes: usize) {
+    if value.len() <= max_bytes {
+        return;
+    }
+    let boundary = value
+        .char_indices()
+        .map(|(index, _)| index)
+        .take_while(|index| *index <= max_bytes.saturating_sub('…'.len_utf8()))
+        .last()
+        .unwrap_or(0);
+    value.truncate(boundary);
+    value.push('…');
+}
+
+fn write_report(path: &Path, body: &[u8]) -> std::io::Result<()> {
+    let mut options = OpenOptions::new();
+    options.create_new(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(path)?;
+    file.write_all(body)?;
+    file.flush()
+}
+
+fn prune_old_reports(dir: &Path, keep: usize) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut reports: Vec<PathBuf> = entries
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.is_file()
+                && path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.ends_with("-crash.log"))
+        })
+        .collect();
+    reports.sort();
+    let remove_count = reports.len().saturating_sub(keep);
+    for path in reports.into_iter().take(remove_count) {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    #[test]
+    fn crash_report_is_owner_only() {
+        let dir = tempfile::tempdir().expect("crash dir");
+        let path = dir.path().join("report-crash.log");
+        write_report(&path, b"panic: test\n").expect("write crash report");
+
+        assert_eq!(std::fs::read(&path).expect("read report"), b"panic: test\n");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(path)
+                    .expect("report metadata")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+    }
+
+    #[test]
+    fn crash_report_retention_keeps_newest_names() {
+        let dir = tempfile::tempdir().expect("crash dir");
+        for index in 0..7 {
+            let path = dir
+                .path()
+                .join(format!("2026-07-24T06-44-{index:02}Z-deadbeef-crash.log"));
+            write_report(&path, b"report").expect("write report");
+        }
+
+        prune_old_reports(dir.path(), 5);
+
+        let mut names: Vec<String> = std::fs::read_dir(dir.path())
+            .expect("read crash dir")
+            .map(|entry| {
+                entry
+                    .expect("crash entry")
+                    .file_name()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect();
+        names.sort();
+        assert_eq!(names.len(), 5);
+        assert!(names[0].contains("06-44-02Z"));
+        assert!(names[4].contains("06-44-06Z"));
+    }
+
+    #[test]
+    fn crash_report_bounds_unicode_panic_text() {
+        let mut message = "а".repeat(MAX_PANIC_MESSAGE_BYTES);
+        truncate_utf8(&mut message, MAX_PANIC_MESSAGE_BYTES);
+
+        assert!(message.len() <= MAX_PANIC_MESSAGE_BYTES);
+        assert!(message.ends_with('…'));
+    }
+
+    #[test]
+    fn panic_hook_writes_a_crash_report() {
+        let dir = tempfile::tempdir().expect("crash dir");
+        let output = Command::new(std::env::current_exe().expect("test executable"))
+            .args([
+                "--exact",
+                "crash_report::tests::panic_hook_child",
+                "--nocapture",
+            ])
+            .env("YOLOP_TEST_CRASH_DIR", dir.path())
+            .output()
+            .expect("run panic child");
+
+        assert!(!output.status.success(), "panic child should fail");
+        let reports: Vec<PathBuf> = std::fs::read_dir(dir.path())
+            .expect("read crash dir")
+            .map(|entry| entry.expect("crash entry").path())
+            .collect();
+        assert_eq!(reports.len(), 1);
+        let report = std::fs::read_to_string(&reports[0]).expect("read crash report");
+        assert!(report.contains("panic: crash-report-test"));
+        assert!(report.contains("thread: crash_report::tests::panic_hook_child"));
+        assert!(report.contains("backtrace:"));
+    }
+
+    #[test]
+    fn panic_hook_child() {
+        if std::env::var_os("YOLOP_TEST_CRASH_DIR").is_none() {
+            return;
+        }
+        let _reporter = CrashReporter::install();
+        panic!("crash-report-test");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod auth;
 mod capabilities;
 mod config;
 mod connectors;
+mod crash_report;
 mod drivers;
 mod editor;
 mod exec;
@@ -478,6 +479,7 @@ fn main() -> Result<()> {
     // stack so every platform behaves like the generous default, and give the
     // tokio worker threads a matching stack for deep async work spawned onto
     // them.
+    let crash_reporter = crash_report::CrashReporter::install();
     let worker = std::thread::Builder::new()
         .name("yolop-main".to_string())
         .stack_size(16 * 1024 * 1024)
@@ -491,7 +493,22 @@ fn main() -> Result<()> {
                 .block_on(async_main())
         })
         .expect("spawn yolop main thread");
-    worker.join().expect("yolop main thread panicked")
+    join_worker(worker, &crash_reporter)
+}
+
+fn join_worker<T>(
+    worker: std::thread::JoinHandle<T>,
+    crash_reporter: &crash_report::CrashReporter,
+) -> T {
+    match worker.join() {
+        Ok(result) => result,
+        Err(payload) => {
+            if let Some(path) = crash_reporter.report_path() {
+                eprintln!("yolop: crash report written to {}", path.display());
+            }
+            std::panic::resume_unwind(payload)
+        }
+    }
 }
 
 async fn async_main() -> Result<()> {
@@ -1632,6 +1649,21 @@ fn paint(enabled: bool, code: &str, text: &str) -> String {
 mod tests {
     use super::*;
     use std::ffi::OsString;
+
+    #[test]
+    fn worker_join_preserves_original_panic_payload() {
+        let reporter = crash_report::CrashReporter::disabled();
+        let worker = std::thread::spawn(|| panic!("original worker panic"));
+
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            join_worker(worker, &reporter)
+        }))
+        .expect_err("worker panic should propagate");
+        assert_eq!(
+            panic.downcast_ref::<&str>().copied(),
+            Some("original worker panic")
+        );
+    }
 
     #[test]
     fn continuation_preserves_reusable_arguments_and_replaces_turn_arguments() {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1098,13 +1098,13 @@ impl App {
     }
 
     fn refresh_session_tasks_if_due(&mut self) {
-        if self
+        let refresh_result = self
             .session_tasks_refresh
-            .as_ref()
-            .is_some_and(tokio::task::JoinHandle::is_finished)
-        {
-            let refresh = self.session_tasks_refresh.take().expect("checked above");
-            match refresh.now_or_never().expect("finished refresh") {
+            .as_mut()
+            .and_then(FutureExt::now_or_never);
+        if let Some(result) = refresh_result {
+            self.session_tasks_refresh = None;
+            match result {
                 Ok(tasks) => self.session_tasks = tasks,
                 Err(error) if error.is_cancelled() => {}
                 Err(error) => self
@@ -5863,6 +5863,29 @@ mod tests {
             .take()
             .expect("pending refresh")
             .abort();
+    }
+
+    #[tokio::test]
+    async fn completed_session_task_refresh_is_applied_without_panicking() {
+        let mut test = app_with_llmsim().await;
+        let mut expected = crate::tui::session_tasks_view::TaskTree::default();
+        expected.errors.push("refreshed".into());
+        test.app.session_tasks_refresh = Some(tokio::spawn(async move { expected }));
+        test.app.last_session_tasks_refresh = Some(Instant::now());
+        while !test
+            .app
+            .session_tasks_refresh
+            .as_ref()
+            .expect("refresh task")
+            .is_finished()
+        {
+            tokio::task::yield_now().await;
+        }
+
+        test.app.refresh_session_tasks_if_due();
+
+        assert!(test.app.session_tasks_refresh.is_none());
+        assert_eq!(test.app.session_tasks.errors, ["refreshed"]);
     }
 
     async fn app_with_llmsim() -> TestApp {


### PR DESCRIPTION
## What changed

- Prevent session-task refresh polling from panicking when a Tokio join handle reports finished but remains pending for one poll.
- Preserve and resume the original worker panic payload instead of replacing it with `Any { .. }`.
- Write bounded local crash reports under the platform data directory and print their path after terminal restoration. Reports use owner-only Unix permissions and retain the newest five.

## Why

A recent full-screen session crashed at `src/tui/mod.rs` with `finished refresh`. The outer large-stack thread wrapper then hid the useful payload behind `Any { .. }`, while alternate-screen restoration made the original panic output easy to lose.

## Before / After

Before:

```text
thread yolop-main panicked at src/tui/mod.rs:939:42:
finished refresh
...
yolop main thread panicked: Any { .. }
```

After:

```text
yolop: crash report written to ~/Library/Application Support/yolop/crashes/<timestamp>-<random>-crash.log
```

The report contains the original panic text, location, thread, version, and backtrace, and the original panic payload continues unwinding unchanged.

## Risk

- Low.
- Crash reporting is best-effort; failures to create or write a report leave existing panic behavior intact.
- Panic messages may contain application data, so reports are local, owner-only on Unix, bounded, and documented for review before sharing.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`: 967 unit tests, 49 integration tests, and the parallel integration test passed; one pre-existing `gallery_paints_truecolor_and_braille` PTY assertion failed identically on `origin/main` in this environment.
- Targeted crash-report, payload-preservation, and completed-refresh tests passed.
- `python3 scripts/validate_okf.py knowledge --check-links`
- `cargo run -- --provider llmsim -p "hi"`
- Live OpenAI smoke attempted through Doppler, but no Doppler project/config or provider token is configured in this checkout.

## Knowledge

Added `knowledge/specs/crash-reporting.md` and linked it from the knowledge index and log. Updated the public README with locations, privacy boundaries, permissions, and retention.

## Security

Reviewed filesystem, secret-disclosure, and resource-exhaustion risks. Reports use a fixed platform data directory, random `create_new` filenames, Unix `0700`/`0600` permissions, an 8 KiB panic-message bound, a 256 KiB report bound, and five-file retention. No prompts, tool payloads, environment variables, credentials, tracing logs, shell execution, network calls, or new dependencies are added.

## Follow-ups

The existing PTY truecolor test failure is outside this change and reproducible on `origin/main`.