### PR TITLE
chore(release): prepare v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ tags the version and publishes to crates.io and the Homebrew tap.
 - Fullscreen is now the default experience, with a responsive status drawer, an interactive task tree, non-blocking task refresh, and selection that spans transcript windows.
 - Extensions can emit trace events, export telemetry to Logfire, and request typed configuration and secrets through the expanded `yolop-yep` SDK and wire protocol.
 - MCP OAuth is conversational in both terminal modes, `/tools` updates live, OAuth callbacks are clearer, and tool activity narration is more complete.
-- Agent shortcuts now run through Tuika's configurable keymap engine, and skills can be shared from a common agents directory.
+- Agent shortcuts now run through Tuika's configurable keymap engine, skills can be shared from a common agents directory, and panic diagnostics survive fullscreen terminal restoration.
 
 #### Tuika
 
@@ -35,6 +35,7 @@ tags the version and publishes to crates.io and the Homebrew tap.
 
 ### What's Changed
 
+* fix(tui): preserve panic diagnostics ([#478](https://github.com/everruns/yolop/pull/478)) by @chaliy
 * fix(tui): let full-screen selection span more than one window ([#477](https://github.com/everruns/yolop/pull/477)) by @chaliy
 * feat(tui): make fullscreen the default ([#476](https://github.com/everruns/yolop/pull/476)) by @chaliy
 * feat(tuika): add keymap engine, route yolop shortcuts through it ([#474](https://github.com/everruns/yolop/pull/474)) by @chaliy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,70 @@ mechanical `### What's Changed` list of merged PRs.
 Releases are cut via [`/release`](./.agents/skills/release/SKILL.md), which
 tags the version and publishes to crates.io and the Homebrew tap.
 
+## [0.12.0] - 2026-07-24
+
+### Highlights
+
+#### Yolop
+
+- Fullscreen is now the default experience, with a responsive status drawer, an interactive task tree, non-blocking task refresh, and selection that spans transcript windows.
+- Extensions can emit trace events, export telemetry to Logfire, and request typed configuration and secrets through the expanded `yolop-yep` SDK and wire protocol.
+- MCP OAuth is conversational in both terminal modes, `/tools` updates live, OAuth callbacks are clearer, and tool activity narration is more complete.
+- Agent shortcuts now run through Tuika's configurable keymap engine, and skills can be shared from a common agents directory.
+
+#### Tuika
+
+- First-class terminal graphics support now covers Kitty, iTerm2, and Sixel, including streamed images embedded in Markdown.
+- A paint-free flexbox solver, terminal capability detection, centralized stylesheets, focus scopes, and an async runner provide stronger foundations for complex apps.
+- New components include selectable tables, timelines, diffs, QR codes, framebuffers, image views, and other OpenTUI-parity primitives.
+- Scrolling adds horizontal pan and host-controlled offsets; Boxed, Line, Table, TextInput, and Markdown links gain substantial interaction and styling improvements.
+
+### Breaking Changes
+
+- yolop now starts in fullscreen mode by default; use the existing mode controls when the classic inline presentation is preferred.
+- Tuika now builds directly on `ratatui-core` rather than the umbrella `ratatui` crate, so applications relying on Tuika's former transitive dependency may need to declare their own Ratatui dependencies.
+
+### What's Changed
+
+* fix(tui): let full-screen selection span more than one window ([#477](https://github.com/everruns/yolop/pull/477)) by @chaliy
+* feat(tui): make fullscreen the default ([#476](https://github.com/everruns/yolop/pull/476)) by @chaliy
+* feat(tuika): add keymap engine, route yolop shortcuts through it ([#474](https://github.com/everruns/yolop/pull/474)) by @chaliy
+* fix(mcp): conversational OAuth and live /tools in both modes ([#473](https://github.com/everruns/yolop/pull/473)) by @chaliy
+* fix(tools): add missing activity narration ([#475](https://github.com/everruns/yolop/pull/475)) by @chaliy
+* feat(auth): polish OAuth callback page ([#471](https://github.com/everruns/yolop/pull/471)) by @chaliy
+* feat(tuika): OpenTUI feature-parity components (timeline, diff, qr, framebuffer…) ([#469](https://github.com/everruns/yolop/pull/469)) by @chaliy
+* docs(readme): remove task tree demo ([#472](https://github.com/everruns/yolop/pull/472)) by @chaliy
+* chore(knowledge): migrate specs to OKF ([#465](https://github.com/everruns/yolop/pull/465)) by @chaliy
+* fix(tui): avoid blocking on task refresh ([#468](https://github.com/everruns/yolop/pull/468)) by @chaliy
+* fix(tuika): keep markdown link destinations Ctrl+clickable ([#466](https://github.com/everruns/yolop/pull/466)) by @chaliy
+* feat(skills): use shared agents directory ([#467](https://github.com/everruns/yolop/pull/467)) by @chaliy
+* chore(docs): document hero recording ([#464](https://github.com/everruns/yolop/pull/464)) by @chaliy
+* fix(tuika): honor enter mode and Ctrl+J newline ([#463](https://github.com/everruns/yolop/pull/463)) by @chaliy
+* docs(readme): refresh hero demo ([#462](https://github.com/everruns/yolop/pull/462)) by @chaliy
+* feat(tui): add interactive task tree ([#460](https://github.com/everruns/yolop/pull/460)) by @chaliy
+* feat(tui): add responsive fullscreen status drawer ([#461](https://github.com/everruns/yolop/pull/461)) by @chaliy
+* feat(extensions): trace facet, Logfire export, config & secrets ([#459](https://github.com/everruns/yolop/pull/459)) by @chaliy
+* refactor(tuika): build on ratatui-core, drop the umbrella ([#458](https://github.com/everruns/yolop/pull/458)) by @chaliy
+* feat(tuika): open Table chrome — caret, header style, selection fg ([#457](https://github.com/everruns/yolop/pull/457)) by @chaliy
+* feat(tuika): horizontal pan on Scroll + max-offset accessors ([#456](https://github.com/everruns/yolop/pull/456)) by @chaliy
+* feat(tuika): centralized stylesheet layer for roles + markdown ([#455](https://github.com/everruns/yolop/pull/455)) by @chaliy
+* feat(tuika): add a terminal Capabilities detection subsystem ([#454](https://github.com/everruns/yolop/pull/454)) by @chaliy
+* feat(tuika): add async runner behind the "async" feature ([#452](https://github.com/everruns/yolop/pull/452)) by @chaliy
+* feat(tuika): columned, selectable Table component ([#453](https://github.com/everruns/yolop/pull/453)) by @chaliy
+* feat(tuika): explicit Boxed border color + FocusScope ([#449](https://github.com/everruns/yolop/pull/449)) by @chaliy
+* feat(tuika): host-settable ScrollState::set_offset ([#450](https://github.com/everruns/yolop/pull/450)) by @chaliy
+* docs(tuika): showcase image rendering in the README ([#451](https://github.com/everruns/yolop/pull/451)) by @chaliy
+* feat(tuika): first-class, paint-free flexbox solve ([#448](https://github.com/everruns/yolop/pull/448)) by @chaliy
+* feat(tuika): stream markdown image pixels + add Sixel protocol ([#447](https://github.com/everruns/yolop/pull/447)) by @chaliy
+* feat(tuika): honor Line alignment and add Boxed bottom title ([#446](https://github.com/everruns/yolop/pull/446)) by @chaliy
+* feat(tuika): render images (Kitty + iTerm2, standalone & markdown) ([#445](https://github.com/everruns/yolop/pull/445)) by @chaliy
+* chore(deps): bump vt100 from 0.15.2 to 0.16.2 ([#435](https://github.com/everruns/yolop/pull/435)) by @dependabot[bot]
+* chore(deps): bump criterion from 0.5.1 to 0.8.2 ([#434](https://github.com/everruns/yolop/pull/434)) by @dependabot[bot]
+* chore(deps): bump dorny/paths-filter from 3 to 4 ([#433](https://github.com/everruns/yolop/pull/433)) by @dependabot[bot]
+* docs(tuika): document OverlaySpec with example and gallery demo ([#444](https://github.com/everruns/yolop/pull/444)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/yolop/compare/v0.11.0...v0.12.0
+
 ## [0.11.0] - 2026-07-23
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6785,7 +6785,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuika"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "crossterm",
@@ -7774,7 +7774,7 @@ dependencies = [
 
 [[package]]
 name = "yolop"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -7866,7 +7866,7 @@ dependencies = [
 
 [[package]]
 name = "yolop-yep"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "schemars 1.2.1",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 
 [package]
 name = "yolop"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 authors = ["Everruns <support@everruns.com>"]
 license = "MIT"
@@ -65,11 +65,11 @@ serde_json = "1.0"
 # The extension protocol wire types + server SDK live in their own crate so
 # extension authors can depend on them from crates.io; the host shares the
 # same source of truth (see knowledge/specs/extensions.md).
-yolop-yep = { version = "0.2.0", path = "crates/yolop-yep" }
+yolop-yep = { version = "0.3.0", path = "crates/yolop-yep" }
 sha2 = "0.11"
 toml = "1"
 textwrap = "0.16"
-tuika = { version = "0.3.0", path = "crates/tuika" }
+tuika = { version = "0.4.0", path = "crates/tuika" }
 # Tree-sitter Highlighter impl for tuika's CodeBlock/Markdown; owns the grammar
 # deps so tuika core stays dependency-light (see crates/tuika-codeformatters).
 tuika-codeformatters = { version = "0.1.0", path = "crates/tuika-codeformatters" }

--- a/crates/tuika-codeformatters/Cargo.toml
+++ b/crates/tuika-codeformatters/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["command-line-interface", "text-processing"]
 bench = false
 
 [dependencies]
-tuika = { version = "0.3.0", path = "../tuika" }
+tuika = { version = "0.4.0", path = "../tuika" }
 ratatui = "0.30.2"
 tree-sitter = "0.26"
 tree-sitter-highlight = "0.26"

--- a/crates/tuika/Cargo.toml
+++ b/crates/tuika/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuika"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Everruns <support@everruns.com>"]

--- a/crates/yolop-extension-logfire/Cargo.toml
+++ b/crates/yolop-extension-logfire/Cargo.toml
@@ -15,7 +15,7 @@ name = "yolop-extension-logfire"
 path = "src/main.rs"
 
 [dependencies]
-yolop-yep = { path = "../yolop-yep", version = "0.2" }
+yolop-yep = { path = "../yolop-yep", version = "0.3" }
 serde_json = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 # The official OpenTelemetry Rust SDK + OTLP/HTTP exporter — the path Logfire's

--- a/crates/yolop-yep/Cargo.toml
+++ b/crates/yolop-yep/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yolop-yep"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 authors = ["Everruns <support@everruns.com>"]
 license = "MIT"


### PR DESCRIPTION
## [0.12.0] - 2026-07-24

### Highlights

#### Yolop

- Fullscreen is now the default experience, with a responsive status drawer, an interactive task tree, non-blocking task refresh, and selection that spans transcript windows.
- Extensions can emit trace events, export telemetry to Logfire, and request typed configuration and secrets through the expanded `yolop-yep` SDK and wire protocol.
- MCP OAuth is conversational in both terminal modes, `/tools` updates live, OAuth callbacks are clearer, and tool activity narration is more complete.
- Agent shortcuts now run through Tuika's configurable keymap engine, skills can be shared from a common agents directory, and panic diagnostics survive fullscreen terminal restoration.

#### Tuika

- First-class terminal graphics support now covers Kitty, iTerm2, and Sixel, including streamed images embedded in Markdown.
- A paint-free flexbox solver, terminal capability detection, centralized stylesheets, focus scopes, and an async runner provide stronger foundations for complex apps.
- New components include selectable tables, timelines, diffs, QR codes, framebuffers, image views, and other OpenTUI-parity primitives.
- Scrolling adds horizontal pan and host-controlled offsets; Boxed, Line, Table, TextInput, and Markdown links gain substantial interaction and styling improvements.

### Breaking Changes

- yolop now starts in fullscreen mode by default; use the existing mode controls when the classic inline presentation is preferred.
- Tuika now builds directly on `ratatui-core` rather than the umbrella `ratatui` crate, so applications relying on Tuika's former transitive dependency may need to declare their own Ratatui dependencies.

### What's Changed

* fix(tui): preserve panic diagnostics ([#478](https://github.com/everruns/yolop/pull/478)) by @chaliy
* fix(tui): let full-screen selection span more than one window ([#477](https://github.com/everruns/yolop/pull/477)) by @chaliy
* feat(tui): make fullscreen the default ([#476](https://github.com/everruns/yolop/pull/476)) by @chaliy
* feat(tuika): add keymap engine, route yolop shortcuts through it ([#474](https://github.com/everruns/yolop/pull/474)) by @chaliy
* fix(mcp): conversational OAuth and live /tools in both modes ([#473](https://github.com/everruns/yolop/pull/473)) by @chaliy
* fix(tools): add missing activity narration ([#475](https://github.com/everruns/yolop/pull/475)) by @chaliy
* feat(auth): polish OAuth callback page ([#471](https://github.com/everruns/yolop/pull/471)) by @chaliy
* feat(tuika): OpenTUI feature-parity components (timeline, diff, qr, framebuffer…) ([#469](https://github.com/everruns/yolop/pull/469)) by @chaliy
* docs(readme): remove task tree demo ([#472](https://github.com/everruns/yolop/pull/472)) by @chaliy
* chore(knowledge): migrate specs to OKF ([#465](https://github.com/everruns/yolop/pull/465)) by @chaliy
* fix(tui): avoid blocking on task refresh ([#468](https://github.com/everruns/yolop/pull/468)) by @chaliy
* fix(tuika): keep markdown link destinations Ctrl+clickable ([#466](https://github.com/everruns/yolop/pull/466)) by @chaliy
* feat(skills): use shared agents directory ([#467](https://github.com/everruns/yolop/pull/467)) by @chaliy
* chore(docs): document hero recording ([#464](https://github.com/everruns/yolop/pull/464)) by @chaliy
* fix(tuika): honor enter mode and Ctrl+J newline ([#463](https://github.com/everruns/yolop/pull/463)) by @chaliy
* docs(readme): refresh hero demo ([#462](https://github.com/everruns/yolop/pull/462)) by @chaliy
* feat(tui): add interactive task tree ([#460](https://github.com/everruns/yolop/pull/460)) by @chaliy
* feat(tui): add responsive fullscreen status drawer ([#461](https://github.com/everruns/yolop/pull/461)) by @chaliy
* feat(extensions): trace facet, Logfire export, config & secrets ([#459](https://github.com/everruns/yolop/pull/459)) by @chaliy
* refactor(tuika): build on ratatui-core, drop the umbrella ([#458](https://github.com/everruns/yolop/pull/458)) by @chaliy
* feat(tuika): open Table chrome — caret, header style, selection fg ([#457](https://github.com/everruns/yolop/pull/457)) by @chaliy
* feat(tuika): horizontal pan on Scroll + max-offset accessors ([#456](https://github.com/everruns/yolop/pull/456)) by @chaliy
* feat(tuika): centralized stylesheet layer for roles + markdown ([#455](https://github.com/everruns/yolop/pull/455)) by @chaliy
* feat(tuika): add a terminal Capabilities detection subsystem ([#454](https://github.com/everruns/yolop/pull/454)) by @chaliy
* feat(tuika): add async runner behind the "async" feature ([#452](https://github.com/everruns/yolop/pull/452)) by @chaliy
* feat(tuika): columned, selectable Table component ([#453](https://github.com/everruns/yolop/pull/453)) by @chaliy
* feat(tuika): explicit Boxed border color + FocusScope ([#449](https://github.com/everruns/yolop/pull/449)) by @chaliy
* feat(tuika): host-settable ScrollState::set_offset ([#450](https://github.com/everruns/yolop/pull/450)) by @chaliy
* docs(tuika): showcase image rendering in the README ([#451](https://github.com/everruns/yolop/pull/451)) by @chaliy
* feat(tuika): first-class, paint-free flexbox solve ([#448](https://github.com/everruns/yolop/pull/448)) by @chaliy
* feat(tuika): stream markdown image pixels + add Sixel protocol ([#447](https://github.com/everruns/yolop/pull/447)) by @chaliy
* feat(tuika): honor Line alignment and add Boxed bottom title ([#446](https://github.com/everruns/yolop/pull/446)) by @chaliy
* feat(tuika): render images (Kitty + iTerm2, standalone & markdown) ([#445](https://github.com/everruns/yolop/pull/445)) by @chaliy
* chore(deps): bump vt100 from 0.15.2 to 0.16.2 ([#435](https://github.com/everruns/yolop/pull/435)) by @dependabot[bot]
* chore(deps): bump criterion from 0.5.1 to 0.8.2 ([#434](https://github.com/everruns/yolop/pull/434)) by @dependabot[bot]
* chore(deps): bump dorny/paths-filter from 3 to 4 ([#433](https://github.com/everruns/yolop/pull/433)) by @dependabot[bot]
* docs(tuika): document OverlaySpec with example and gallery demo ([#444](https://github.com/everruns/yolop/pull/444)) by @chaliy

**Full Changelog**: https://github.com/everruns/yolop/compare/v0.11.0...v0.12.0


## Publish-readiness

- [x] `python3 scripts/validate_okf.py knowledge --check-links`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] `cargo publish --dry-run --allow-dirty -p yolop-yep` and `-p tuika` (the libraries; `-p yolop` is validated in CI after they publish)
- [x] crates.io currently serves yolop `0.11.0`, tuika `0.3.0`, and yolop-yep `0.2.0`
- [x] `Cargo.toml` and `Cargo.lock` agree on yolop `0.12.0`, tuika `0.4.0`, and yolop-yep `0.3.0`

## Post-merge verification

- [ ] `release.yml` created tag `v0.12.0` and the GitHub Release
- [ ] `publish.yml` finished green
- [ ] `cli-binaries.yml` finished green
- [ ] crates.io serves `0.12.0`
- [ ] Homebrew tap formula points at `v0.12.0`

Produced by [yolop](https://everruns.com/yolop)

