### PR TITLE
fix(crash): report active session id

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -7,6 +7,8 @@ wording, formatting, and link fixes do not need entries.
 
 - Added [Crash reporting](specs/crash-reporting.md): bounded, owner-only local
   panic reports that remain visible after TUI terminal restoration.
+- Crash reports and restored-terminal diagnostics now identify the active
+  single-session runtime when its session ID is available.
 - Added [Tuika keymap](specs/keymap.md): the tuika declarative key-binding engine and Yolop's dispatch of its global shortcuts through it.
 
 ## 2026-07-23

--- a/knowledge/specs/crash-reporting.md
+++ b/knowledge/specs/crash-reporting.md
@@ -21,13 +21,15 @@ Names combine a UTC timestamp with a random suffix. Yolop keeps the newest five
 reports. On Unix the directory is owner-only (`0o700`) and each report is
 `0o600`.
 
-A report contains only the Yolop version, timestamp, panic thread, source
-location, a bounded panic message, and a bounded backtrace. Yolop does not add
-prompts, messages, tool arguments or results, environment variables,
-credentials, or tracing logs. A panic message can still contain application
-data, so reports remain private local files and should be reviewed before
-sharing. Writing is best-effort and must never cause another panic.
+A report contains only the Yolop version, timestamp, current session ID when a
+single-session runtime has already started, panic thread, source location, a
+bounded panic message, and a bounded backtrace. Yolop does not add prompts,
+messages, tool arguments or results, environment variables, credentials, or
+tracing logs. A panic message can still contain application data, so reports
+remain private local files and should be reviewed before sharing. Writing is
+best-effort and must never cause another panic.
 
 When the large-stack application thread panics, terminal guards restore the
-screen first. Yolop then prints the report path and resumes the original panic
-payload; the outer thread must not replace it with a generic `Any` diagnostic.
+screen first. Yolop then prints the session ID when known and the report path,
+and resumes the original panic payload; the outer thread must not replace it
+with a generic `Any` diagnostic.

--- a/src/crash_report.rs
+++ b/src/crash_report.rs
@@ -3,21 +3,24 @@ use std::backtrace::Backtrace;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 
 const MAX_CRASH_REPORTS: usize = 5;
 const MAX_PANIC_MESSAGE_BYTES: usize = 8 * 1024;
 const MAX_REPORT_BYTES: usize = 256 * 1024;
 
+#[derive(Clone)]
 pub(crate) struct CrashReporter {
     path: Option<PathBuf>,
     written: Arc<AtomicBool>,
+    session_id: Arc<Mutex<Option<String>>>,
 }
 
 impl CrashReporter {
     pub(crate) fn install() -> Self {
         let written = Arc::new(AtomicBool::new(false));
+        let session_id = Arc::new(Mutex::new(None));
         let path = crash_report_dir()
             .and_then(|dir| prepare_crash_dir(&dir).then_some(dir))
             .map(|dir| {
@@ -28,6 +31,7 @@ impl CrashReporter {
 
         if let Some(path) = path.clone() {
             let hook_written = Arc::clone(&written);
+            let hook_session_id = Arc::clone(&session_id);
             let crash_dir = path.parent().map(Path::to_path_buf);
             let previous = std::panic::take_hook();
             std::panic::set_hook(Box::new(move |info| {
@@ -35,7 +39,11 @@ impl CrashReporter {
                     .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
                     .is_ok()
                 {
-                    if write_panic_report(&path, info).is_err() {
+                    let session_id = hook_session_id
+                        .try_lock()
+                        .ok()
+                        .and_then(|session_id| session_id.clone());
+                    if write_panic_report(&path, info, session_id.as_deref()).is_err() {
                         hook_written.store(false, Ordering::SeqCst);
                     } else if let Some(dir) = crash_dir.as_deref() {
                         prune_old_reports(dir, MAX_CRASH_REPORTS);
@@ -45,7 +53,24 @@ impl CrashReporter {
             }));
         }
 
-        Self { path, written }
+        Self {
+            path,
+            written,
+            session_id,
+        }
+    }
+
+    pub(crate) fn set_session_id(&self, session_id: impl Into<String>) {
+        if let Ok(mut current) = self.session_id.lock() {
+            *current = Some(session_id.into());
+        }
+    }
+
+    pub(crate) fn session_id(&self) -> Option<String> {
+        self.session_id
+            .try_lock()
+            .ok()
+            .and_then(|session_id| session_id.clone())
     }
 
     pub(crate) fn report_path(&self) -> Option<&Path> {
@@ -60,6 +85,7 @@ impl CrashReporter {
         Self {
             path: None,
             written: Arc::new(AtomicBool::new(false)),
+            session_id: Arc::new(Mutex::new(None)),
         }
     }
 }
@@ -87,7 +113,11 @@ fn prepare_crash_dir(dir: &Path) -> bool {
     true
 }
 
-fn write_panic_report(path: &Path, info: &std::panic::PanicHookInfo<'_>) -> std::io::Result<()> {
+fn write_panic_report(
+    path: &Path,
+    info: &std::panic::PanicHookInfo<'_>,
+    session_id: Option<&str>,
+) -> std::io::Result<()> {
     let mut payload = if let Some(message) = info.payload().downcast_ref::<&str>() {
         (*message).to_string()
     } else if let Some(message) = info.payload().downcast_ref::<String>() {
@@ -111,8 +141,11 @@ fn write_panic_report(path: &Path, info: &std::panic::PanicHookInfo<'_>) -> std:
         .name()
         .unwrap_or("unnamed")
         .to_string();
+    let session = session_id
+        .map(|session_id| format!("session_id: {session_id}\n"))
+        .unwrap_or_default();
     let mut body = format!(
-        "timestamp: {}\nversion: {}\nthread: {thread}\nlocation: {location}\npanic: {payload}\n\nbacktrace:\n{}\n",
+        "timestamp: {}\nversion: {}\n{session}thread: {thread}\nlocation: {location}\npanic: {payload}\n\nbacktrace:\n{}\n",
         chrono::Utc::now().to_rfc3339(),
         crate::version::VERSION_DETAILS,
         Backtrace::force_capture(),
@@ -254,6 +287,7 @@ mod tests {
         assert_eq!(reports.len(), 1);
         let report = std::fs::read_to_string(&reports[0]).expect("read crash report");
         assert!(report.contains("panic: crash-report-test"));
+        assert!(report.contains("session_id: session_crash_report_test"));
         assert!(report.contains("thread: crash_report::tests::panic_hook_child"));
         assert!(report.contains("backtrace:"));
     }
@@ -263,7 +297,8 @@ mod tests {
         if std::env::var_os("YOLOP_TEST_CRASH_DIR").is_none() {
             return;
         }
-        let _reporter = CrashReporter::install();
+        let reporter = CrashReporter::install();
+        reporter.set_session_id("session_crash_report_test");
         panic!("crash-report-test");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -505,8 +505,8 @@ fn join_worker<T>(
         Ok(result) => result,
         Err(payload) => {
             if let Some(session_id) = crash_reporter.session_id() {
-                // codeql[rust/cleartext-logging] -- This opaque local identifier is
-                // intentionally emitted so users can recover the crashed session.
+                // Session IDs are opaque local locators, not credentials; emitting
+                // one here is intentional so users can recover a crashed session.
                 eprintln!("yolop: crashed session id: {session_id}");
             }
             if let Some(path) = crash_reporter.report_path() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -505,6 +505,8 @@ fn join_worker<T>(
         Ok(result) => result,
         Err(payload) => {
             if let Some(session_id) = crash_reporter.session_id() {
+                // codeql[rust/cleartext-logging] -- This opaque local identifier is
+                // intentionally emitted so users can recover the crashed session.
                 eprintln!("yolop: crashed session id: {session_id}");
             }
             if let Some(path) = crash_reporter.report_path() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -480,17 +480,18 @@ fn main() -> Result<()> {
     // tokio worker threads a matching stack for deep async work spawned onto
     // them.
     let crash_reporter = crash_report::CrashReporter::install();
+    let worker_crash_reporter = crash_reporter.clone();
     let worker = std::thread::Builder::new()
         .name("yolop-main".to_string())
         .stack_size(16 * 1024 * 1024)
-        .spawn(|| {
+        .spawn(move || {
             tokio::runtime::Builder::new_multi_thread()
                 .worker_threads(4)
                 .thread_stack_size(8 * 1024 * 1024)
                 .enable_all()
                 .build()
                 .expect("build tokio runtime")
-                .block_on(async_main())
+                .block_on(async_main(&worker_crash_reporter))
         })
         .expect("spawn yolop main thread");
     join_worker(worker, &crash_reporter)
@@ -503,6 +504,9 @@ fn join_worker<T>(
     match worker.join() {
         Ok(result) => result,
         Err(payload) => {
+            if let Some(session_id) = crash_reporter.session_id() {
+                eprintln!("yolop: crashed session id: {session_id}");
+            }
             if let Some(path) = crash_reporter.report_path() {
                 eprintln!("yolop: crash report written to {}", path.display());
             }
@@ -511,7 +515,7 @@ fn join_worker<T>(
     }
 }
 
-async fn async_main() -> Result<()> {
+async fn async_main(crash_reporter: &crash_report::CrashReporter) -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
@@ -610,6 +614,7 @@ async fn async_main() -> Result<()> {
         },
     )
     .await?;
+    crash_reporter.set_session_id(runtime.handles.session_id.to_string());
 
     // Resolve the interactive TUI theme: the `--theme` flag wins, else the
     // persisted `theme` setting. Done before the print-mode branch so a bad
@@ -1649,6 +1654,7 @@ fn paint(enabled: bool, code: &str, text: &str) -> String {
 mod tests {
     use super::*;
     use std::ffi::OsString;
+    use std::process::Command;
 
     #[test]
     fn worker_join_preserves_original_panic_payload() {
@@ -1663,6 +1669,37 @@ mod tests {
             panic.downcast_ref::<&str>().copied(),
             Some("original worker panic")
         );
+    }
+
+    #[test]
+    fn worker_join_prints_session_id() {
+        let output = Command::new(std::env::current_exe().expect("test executable"))
+            .args([
+                "--exact",
+                "tests::worker_join_prints_session_id_child",
+                "--nocapture",
+            ])
+            .env("YOLOP_TEST_WORKER_CRASH", "1")
+            .output()
+            .expect("run worker crash child");
+
+        assert!(!output.status.success(), "worker crash child should fail");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("yolop: crashed session id: session_worker_crash_test"),
+            "missing session id diagnostic: {stderr}"
+        );
+    }
+
+    #[test]
+    fn worker_join_prints_session_id_child() {
+        if std::env::var_os("YOLOP_TEST_WORKER_CRASH").is_none() {
+            return;
+        }
+        let reporter = crash_report::CrashReporter::disabled();
+        reporter.set_session_id("session_worker_crash_test");
+        let worker = std::thread::spawn(|| panic!("worker-crash-test"));
+        join_worker(worker, &reporter);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

Crash diagnostics now identify the active single-session runtime when its session ID is available. The restored-terminal diagnostic prints the ID, and the owner-only local crash report records it alongside the existing bounded panic metadata. Startup and multi-session ACP crashes omit the field rather than guessing.

## Why

A crash report path alone makes it harder to identify and resume the affected session.

## Before / After

Before:

```text
yolop: crash report written to <path>
```

After:

```text
yolop: crashed session id: <session_id>
yolop: crash report written to <path>
```

The crash report also contains `session_id: <session_id>` when known.

## Risk

- Low
- Panic handling now reads a small shared value. The hook uses `try_lock`, so contention omits the ID instead of blocking or replacing the original panic.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Focused crash-report and worker-join tests
- `python3 scripts/validate_okf.py knowledge --check-links`
- `cargo run -- --provider llmsim -p "hi"`
- `cargo build --release`
- Full local suite: 1,019 tests passed; the unrelated `gallery_paints_truecolor_and_braille` PTY color-capture test failed locally and also failed in isolation
- Live OpenAI smoke was unavailable because this worktree has no Doppler project/config or fallback secrets configured

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated `knowledge/specs/crash-reporting.md` and `knowledge/log.md` to document the session-ID diagnostic and privacy boundary.

## Security

Reviewed TM-FS, TM-BASH, TM-LLM, TM-TOOL, and TM-DEP. No filesystem boundary, shell execution, prompt/API-key handling, capability registration, or dependency changes. The only added persisted data is the typed runtime session UUID in the existing owner-only, bounded local crash report; no prompts, tool data, environment values, or credentials are exposed.

## Follow-ups

No follow-ups.