### PR TITLE
fix(release): publish formatter before yolop

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -176,9 +176,9 @@ SDK, the `tuika` TUI toolkit, and the `tuika-codeformatters` highlighter — plu
 the `yolop` binary. Each library is separately versioned; bump one when its API
 or published dependency range changes (and bump `yolop-yep` for wire-protocol
 changes). crates.io requires the libraries live **before** `yolop`, so CI
-(`publish.yml`) publishes `yolop-yep`, then `tuika`, then
-`tuika-codeformatters`, then `yolop` (each skipped if its version is already
-live). A consequence for this step: **`cargo publish --dry-run -p yolop` fails
+(`publish.yml`) derives a dependency-first order from Cargo metadata (currently
+`yolop-yep`, `tuika`, `tuika-codeformatters`, then `yolop`) and skips versions
+already live. A consequence for this step: **`cargo publish --dry-run -p yolop` fails
 locally** when a new in-tree library version isn't yet on crates.io — that is
 expected, not a broken release. Dry-run all three libraries instead (above);
 `yolop`'s own publish is validated in CI after they go live. When bumping a

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -165,26 +165,29 @@ packaging boundary, missing files referenced by `Cargo.toml`, version drift:
 ```bash
 cargo publish --dry-run -p yolop-yep   # SDK library; publishes first
 cargo publish --dry-run -p tuika       # TUI toolkit library; publishes first
+cargo publish --dry-run -p tuika-codeformatters # Highlighter; publishes after tuika
 cargo search yolop --limit 1     # confirm CURRENT crates.io version < X.Y.Z
 grep '^version' Cargo.toml       # confirm reads X.Y.Z
 grep '"yolop"' Cargo.lock | head -1  # confirm reads X.Y.Z
 ```
 
-**Three-crate workspace.** The repo publishes three crates: two libraries —
-the `yolop-yep` SDK and the `tuika` TUI toolkit (each separately versioned;
-bump one only when its own API changes, and for `yolop-yep` the wire protocol)
-— and the `yolop` binary, which depends on **both** by version. crates.io
-requires the libraries live **before** `yolop`, so CI (`publish.yml`) publishes
-`yolop-yep`, then `tuika`, then `yolop` (each skipped if its version is already
+**Four-crate workspace.** The repo publishes three libraries — the `yolop-yep`
+SDK, the `tuika` TUI toolkit, and the `tuika-codeformatters` highlighter — plus
+the `yolop` binary. Each library is separately versioned; bump one when its API
+or published dependency range changes (and bump `yolop-yep` for wire-protocol
+changes). crates.io requires the libraries live **before** `yolop`, so CI
+(`publish.yml`) publishes `yolop-yep`, then `tuika`, then
+`tuika-codeformatters`, then `yolop` (each skipped if its version is already
 live). A consequence for this step: **`cargo publish --dry-run -p yolop` fails
-locally** with *"no matching package named `tuika` found"* (or `yolop-yep`)
-whenever an in-tree library version isn't yet on crates.io — that is expected,
-not a broken release. Dry-run the two libraries instead (above); `yolop`'s own
-publish is validated in CI after they go live. When bumping a library, update
-its version in `crates/<crate>/Cargo.toml` **and** the
-`<crate> = { version = … }` requirement in the root `Cargo.toml`.
+locally** when a new in-tree library version isn't yet on crates.io — that is
+expected, not a broken release. Dry-run all three libraries instead (above);
+`yolop`'s own publish is validated in CI after they go live. When bumping a
+library, update its version in `crates/<crate>/Cargo.toml` **and** every
+workspace path dependency version requirement that references it. In
+particular, a Tuika bump usually requires a `tuika-codeformatters` bump because
+its published package pins a compatible Tuika range.
 
-If either library dry-run fails, fix the root cause and re-run. Do **not** open
+If any library dry-run fails, fix the root cause and re-run. Do **not** open
 a release PR with a known-broken publish path.
 
 ### 6. Commit and push
@@ -212,8 +215,9 @@ Body must include:
   - [x] `cargo fmt --check`
   - [x] `cargo clippy --all-targets --all-features -- -D warnings`
   - [x] `cargo test --all-features`
-  - [x] `cargo publish --dry-run -p yolop-yep` and `-p tuika` (the libraries;
-        `-p yolop` is validated in CI after they publish)
+  - [x] `cargo publish --dry-run -p yolop-yep`, `-p tuika`, and
+        `-p tuika-codeformatters` (the libraries; `-p yolop` is validated in CI
+        after they publish)
   - [x] crates.io currently serves `A.B.C` → publishing `X.Y.Z`
   - [x] `Cargo.toml` + `Cargo.lock` agree on `X.Y.Z`
   ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,10 +109,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Validate OKF knowledge bundle
+      - name: Validate release and knowledge metadata
         run: |
           python3 scripts/validate_okf.py knowledge --check-links
           python3 scripts/test_validate_okf.py
+          python3 scripts/test_publish_order.py
+          test "$(python3 scripts/publish_order.py | tail -1)" = yolop
 
       - name: Public docs boundary
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,14 +78,16 @@ jobs:
             return 1
           }
 
-          # yolop depends on all three library crates by version, so crates.io
-          # requires them live before yolop. tuika-codeformatters itself depends
-          # on tuika, so tuika must precede it. Order: leaf deps first, binary
-          # last (each skipped when its version is already published).
-          publish_if_missing yolop-yep
-          publish_if_missing tuika
-          publish_if_missing tuika-codeformatters
-          publish_if_missing yolop
+          # Derive the complete dependency-first order from Cargo metadata so a
+          # new publishable workspace dependency cannot be silently omitted.
+          mapfile -t crates < <(python3 scripts/publish_order.py)
+          if [[ "${crates[-1]}" != "yolop" ]]; then
+            echo "publish order must end with yolop: ${crates[*]}" >&2
+            exit 1
+          fi
+          for crate in "${crates[@]}"; do
+            publish_if_missing "$crate"
+          done
 
   verify-publish:
     name: Verify published version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ mechanical `### What's Changed` list of merged PRs.
 Releases are cut via [`/release`](./.agents/skills/release/SKILL.md), which
 tags the version and publishes to crates.io and the Homebrew tap.
 
+## [0.12.1] - 2026-07-24
+
+### Highlights
+
+#### Yolop
+
+- Fix crates.io installation by publishing a `tuika-codeformatters` release compatible with Tuika 0.4 before the Yolop binary.
+
+#### Tuika
+
+- Publish `tuika-codeformatters` 0.2.0 with its dependency updated to Tuika 0.4.
+
+### What's Changed
+
+* fix(release): publish compatible tuika-codeformatters before yolop
+
+**Full Changelog**: https://github.com/everruns/yolop/compare/v0.12.0...v0.12.1
+
 ## [0.12.0] - 2026-07-24
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6804,7 +6804,7 @@ dependencies = [
 
 [[package]]
 name = "tuika-codeformatters"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "crossterm",
@@ -7774,7 +7774,7 @@ dependencies = [
 
 [[package]]
 name = "yolop"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 
 [package]
 name = "yolop"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 authors = ["Everruns <support@everruns.com>"]
 license = "MIT"
@@ -72,7 +72,7 @@ textwrap = "0.16"
 tuika = { version = "0.4.0", path = "crates/tuika" }
 # Tree-sitter Highlighter impl for tuika's CodeBlock/Markdown; owns the grammar
 # deps so tuika core stays dependency-light (see crates/tuika-codeformatters).
-tuika-codeformatters = { version = "0.1.0", path = "crates/tuika-codeformatters" }
+tuika-codeformatters = { version = "0.2.0", path = "crates/tuika-codeformatters" }
 tokio = { version = "1.52", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tree-sitter = "0.26"

--- a/crates/tuika-codeformatters/Cargo.toml
+++ b/crates/tuika-codeformatters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuika-codeformatters"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Everruns <support@everruns.com>"]

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -5,6 +5,7 @@ wording, formatting, and link fixes do not need entries.
 
 ## 2026-07-24
 
+- Corrected the release contract to publish all four workspace crates in dependency order, including `tuika-codeformatters` before `yolop`.
 - Added [Crash reporting](specs/crash-reporting.md): bounded, owner-only local
   panic reports that remain visible after TUI terminal restoration.
 - Added [Tuika keymap](specs/keymap.md): the tuika declarative key-binding engine and Yolop's dispatch of its global shortcuts through it.

--- a/knowledge/specs/release.md
+++ b/knowledge/specs/release.md
@@ -119,8 +119,9 @@ When asked to release, the agent:
 
    **Four crates, ordered publish.** `yolop` depends on `yolop-yep`, `tuika`,
    and `tuika-codeformatters` by version, so crates.io requires all three live
-   first. `publish.yml` publishes `yolop-yep`, then `tuika`, then
-   `tuika-codeformatters`, then `yolop` (each skipped when already live). Because
+   first. `publish.yml` derives their dependency-first order from Cargo metadata
+   (currently `yolop-yep`, `tuika`, `tuika-codeformatters`, then `yolop`) and
+   skips versions already live. Because
    of that ordering, `cargo publish --dry-run -p yolop` can fail locally until
    all in-tree library versions are on crates.io. That is expected, not a broken
    release; dry-run all three library crates and rely on CI to validate `yolop`

--- a/knowledge/specs/release.md
+++ b/knowledge/specs/release.md
@@ -34,13 +34,13 @@ Every yolop release ships to:
 | Target          | Surface                                  | How users install                       |
 |-----------------|------------------------------------------|-----------------------------------------|
 | GitHub Release  | tag `vX.Y.Z`, source archive, binaries   | `gh release download vX.Y.Z`            |
-| crates.io       | `yolop` binary + `yolop-yep` & `tuika` libs | `cargo install yolop --locked`       |
+| crates.io       | `yolop` binary + three library crates       | `cargo install yolop --locked`       |
 | Homebrew tap    | formula at `everruns/homebrew-tap`       | `brew install everruns/tap/yolop`       |
 
-The two library crates (`yolop-yep`, `tuika`) are versioned independently of
-`yolop` and are published as a side effect of a `yolop` release only when their
-in-tree version isn't already on crates.io (see § `publish.yml`). They can also
-be consumed on their own (`cargo add tuika`).
+The three library crates (`yolop-yep`, `tuika`, and `tuika-codeformatters`)
+are versioned independently of `yolop` and are published as a side effect of a
+`yolop` release only when their in-tree version isn't already on crates.io (see
+§ `publish.yml`). They can also be consumed on their own (`cargo add tuika`).
 
 Prebuilt CLI binaries are produced for:
 
@@ -95,10 +95,12 @@ When asked to release, the agent:
 
 3. **Bump the version** in `Cargo.toml` and regenerate `Cargo.lock`
    (`cargo update -p yolop`). The library crates under `crates/` — the
-   `yolop-yep` SDK and the `tuika` TUI toolkit — are **versioned separately**:
-   bump one only when its own API changes (for `yolop-yep`, also the wire
-   protocol), and when you do, update both `crates/<crate>/Cargo.toml` and the
-   matching `<crate> = { version = … }` requirement in the root `Cargo.toml`.
+   `yolop-yep` SDK, the `tuika` TUI toolkit, and `tuika-codeformatters` — are
+   **versioned separately**: bump one when its API or published dependency range
+   changes (for `yolop-yep`, also the wire protocol), and update every workspace
+   path dependency requirement that references it. A Tuika bump usually requires
+   a `tuika-codeformatters` bump because the published formatter pins a compatible
+   Tuika range.
 
 4. **Run local verification:**
    - `cargo fmt --check`
@@ -107,21 +109,22 @@ When asked to release, the agent:
 
 5. **Verify publish-readiness** (catches what local tests don't — the
    `cargo publish` packaging step, missing files, version drift):
-   - `cargo publish --dry-run -p yolop-yep` must succeed.
+   - `cargo publish --dry-run -p yolop-yep`, `-p tuika`, and
+     `-p tuika-codeformatters` must succeed.
    - Confirm `Cargo.toml` and `Cargo.lock` agree on `X.Y.Z`.
    - Confirm `X.Y.Z` is greater than the latest published version on
      crates.io (`cargo search yolop --limit 1`).
    - If any check fails, fix the root cause and re-run before opening the
      PR. **Do not** merge a release PR with a known-broken publish path.
 
-   **Three crates, ordered publish.** `yolop` depends on both `yolop-yep` and
-   `tuika` by version, so crates.io requires both live first. `publish.yml`
-   publishes `yolop-yep`, then `tuika`, then `yolop` (each skipped when already
-   live). Because of that ordering, `cargo publish --dry-run -p yolop`
-   **fails locally** — *"no matching package named `tuika` found"* (or
-   `yolop-yep`) — until both in-tree library versions are on crates.io. That
-   is expected, not a broken release; dry-run the two library crates and rely
-   on CI to validate `yolop` after they go live.
+   **Four crates, ordered publish.** `yolop` depends on `yolop-yep`, `tuika`,
+   and `tuika-codeformatters` by version, so crates.io requires all three live
+   first. `publish.yml` publishes `yolop-yep`, then `tuika`, then
+   `tuika-codeformatters`, then `yolop` (each skipped when already live). Because
+   of that ordering, `cargo publish --dry-run -p yolop` can fail locally until
+   all in-tree library versions are on crates.io. That is expected, not a broken
+   release; dry-run all three library crates and rely on CI to validate `yolop`
+   after they go live.
 
 6. **Commit and push** the changes on a feature branch with message
    `chore(release): prepare vX.Y.Z`.
@@ -163,9 +166,9 @@ When asked to release, the agent:
 - **Trigger**: `release: published`, or `workflow_dispatch --ref vX.Y.Z` from
   `release.yml`.
 - **Actions**: installs the pinned Rust toolchain, verifies the tag matches
-  `Cargo.toml`, runs `cargo publish -p yolop`, then runs
-  `scripts/verify_crates_publish.py` to confirm crates.io serves the new
-  version.
+  `Cargo.toml`, publishes `yolop-yep`, `tuika`, `tuika-codeformatters`, and
+  `yolop` in dependency order (skipping versions already live), then runs
+  `scripts/verify_crates_publish.py` to confirm crates.io serves the new version.
 - **Secret**: `CARGO_REGISTRY_TOKEN`.
 
 ### `cli-binaries.yml`

--- a/scripts/publish_order.py
+++ b/scripts/publish_order.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Print publishable workspace crates in dependency-first order for yolop.
+
+The order is derived from Cargo metadata rather than duplicated in the release
+workflow, so adding a new in-workspace dependency cannot silently omit it from
+publishing.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+def load_metadata() -> Mapping[str, Any]:
+    output = subprocess.check_output(
+        ["cargo", "metadata", "--no-deps", "--format-version", "1"], text=True
+    )
+    return json.loads(output)
+
+
+def publish_order(metadata: Mapping[str, Any], root_name: str = "yolop") -> list[str]:
+    packages = {
+        package["name"]: package
+        for package in metadata["packages"]
+        if package["id"] in metadata["workspace_members"]
+    }
+    if root_name not in packages:
+        raise ValueError(f"workspace package {root_name!r} not found")
+
+    ordered: list[str] = []
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(name: str) -> None:
+        if name in visited:
+            return
+        if name in visiting:
+            raise ValueError(f"workspace dependency cycle involving {name}")
+        visiting.add(name)
+        package = packages[name]
+        dependencies: Sequence[Mapping[str, Any]] = package.get("dependencies", [])
+        for dependency in dependencies:
+            dependency_name = dependency["name"]
+            if dependency.get("path") and dependency_name in packages:
+                visit(dependency_name)
+        visiting.remove(name)
+        visited.add(name)
+        if package.get("publish") != []:
+            ordered.append(name)
+
+    visit(root_name)
+    return ordered
+
+
+def main() -> None:
+    for crate in publish_order(load_metadata()):
+        print(crate)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_publish_order.py
+++ b/scripts/test_publish_order.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+import unittest
+
+from publish_order import publish_order
+
+
+class PublishOrderTests(unittest.TestCase):
+    def test_orders_transitive_workspace_dependencies_before_root(self) -> None:
+        metadata = {
+            "workspace_members": ["yolop-id", "tuika-id", "formatter-id", "sdk-id"],
+            "packages": [
+                {
+                    "id": "yolop-id",
+                    "name": "yolop",
+                    "publish": None,
+                    "dependencies": [
+                        {"name": "tuika-codeformatters", "path": "formatter"},
+                        {"name": "yolop-yep", "path": "sdk"},
+                    ],
+                },
+                {
+                    "id": "formatter-id",
+                    "name": "tuika-codeformatters",
+                    "publish": None,
+                    "dependencies": [{"name": "tuika", "path": "tuika"}],
+                },
+                {
+                    "id": "tuika-id",
+                    "name": "tuika",
+                    "publish": None,
+                    "dependencies": [],
+                },
+                {
+                    "id": "sdk-id",
+                    "name": "yolop-yep",
+                    "publish": None,
+                    "dependencies": [],
+                },
+            ],
+        }
+
+        self.assertEqual(
+            publish_order(metadata),
+            ["tuika", "tuika-codeformatters", "yolop-yep", "yolop"],
+        )
+
+    def test_excludes_non_publishable_dependency(self) -> None:
+        metadata = {
+            "workspace_members": ["yolop-id", "private-id"],
+            "packages": [
+                {
+                    "id": "yolop-id",
+                    "name": "yolop",
+                    "publish": None,
+                    "dependencies": [{"name": "private", "path": "private"}],
+                },
+                {
+                    "id": "private-id",
+                    "name": "private",
+                    "publish": [],
+                    "dependencies": [],
+                },
+            ],
+        }
+
+        self.assertEqual(publish_order(metadata), ["yolop"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Roll forward the partial v0.12.0 publish by releasing `tuika-codeformatters` 0.2.0 before Yolop 0.12.1. The v0.12.0 workflow successfully published `yolop-yep` 0.3.0 and Tuika 0.4.0, then failed because the existing formatter release targeted Tuika 0.3.

## Before / After

**Before:** `cargo publish -p yolop` compiled against `tuika-codeformatters` 0.1.0 from crates.io and failed because its `Highlighter` implemented the Tuika 0.3 trait.

**After:** the workflow publishes `tuika-codeformatters` 0.2.0 against Tuika 0.4 before publishing Yolop 0.12.1.

## Publish-readiness

- [x] `python3 scripts/validate_okf.py knowledge --check-links`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] `cargo publish --dry-run --allow-dirty -p tuika-codeformatters`
- [x] crates.io serves `yolop-yep` 0.3.0 and Tuika 0.4.0
- [x] `Cargo.toml` and `Cargo.lock` agree on Yolop 0.12.1 and `tuika-codeformatters` 0.2.0

## Post-merge verification

- [ ] `release.yml` created tag `v0.12.1` and the GitHub Release
- [ ] `publish.yml` finished green
- [ ] `cli-binaries.yml` finished green
- [ ] crates.io serves Yolop 0.12.1 and `tuika-codeformatters` 0.2.0
- [ ] Homebrew tap formula points at `v0.12.1`

Produced by [yolop](https://everruns.com/yolop)
