### PR TITLE
chore(tuika): exclude demo GIFs from published crate

### DIFF
--- a/crates/tuika/Cargo.toml
+++ b/crates/tuika/Cargo.toml
@@ -11,6 +11,14 @@ repository = "https://github.com/everruns/yolop"
 readme = "README.md"
 keywords = ["tui", "terminal", "ratatui", "widgets", "layout"]
 categories = ["command-line-interface"]
+# The `docs/` demo/theme/styling GIFs total ~8 MiB and are consumed only by the
+# GitHub-rendered README and `docs/*.md` (served from the repo, not the crate).
+# rustdoc/docs.rs references none of them — the crate-level docs live in a
+# hand-written `//!` header in `lib.rs` — so bundling them just bloats the
+# published `.crate`. Keep `hero.gif` and `demos/image.svg`: those are the only
+# two the crates.io README (`README.md`) embeds by relative path. See
+# `tests/packaging.rs` for the guard that keeps this list honest.
+exclude = ["docs/demos/*.gif", "docs/styling/*.gif", "docs/themes/*.gif"]
 
 # Build docs with every feature so the optional `async` runner is documented,
 # and set the `docsrs` cfg that turns on per-item feature badges (see lib.rs).

--- a/crates/tuika/tests/packaging.rs
+++ b/crates/tuika/tests/packaging.rs
@@ -1,0 +1,78 @@
+//! Guards the published `.crate` contents.
+//!
+//! The `docs/` demo/theme/styling GIFs are ~8 MiB and serve only the
+//! GitHub-rendered README and `docs/*.md`; docs.rs builds from the hand-written
+//! `//!` header in `lib.rs`, which references no images. The `exclude` in
+//! `Cargo.toml` keeps them out of the tarball. This test drives the real
+//! packaging path (`cargo package --list`) so a stray asset — or a regression
+//! that drops an image the crates.io README needs — fails loudly instead of
+//! silently re-inflating the crate.
+
+use std::process::Command;
+
+/// Ask cargo which files it would put in tuika's `.crate`, exactly as `publish`
+/// would. `--list` resolves the manifest's `include`/`exclude` without building.
+fn packaged_files() -> Vec<String> {
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".into());
+    let output = Command::new(cargo)
+        .args([
+            "package",
+            "--list",
+            "--quiet",
+            "--allow-dirty",
+            "-p",
+            "tuika",
+        ])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .expect("run `cargo package --list`");
+    assert!(
+        output.status.success(),
+        "`cargo package --list` failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .expect("utf8 file list")
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+#[test]
+fn heavy_doc_gifs_are_excluded_from_the_package() {
+    let files = packaged_files();
+
+    // No demo/theme/styling GIF may ship: those are GitHub-only assets.
+    let bundled_heavy_gifs: Vec<&String> = files
+        .iter()
+        .filter(|f| {
+            f.ends_with(".gif")
+                && (f.starts_with("docs/demos/")
+                    || f.starts_with("docs/styling/")
+                    || f.starts_with("docs/themes/"))
+        })
+        .collect();
+    assert!(
+        bundled_heavy_gifs.is_empty(),
+        "these GIFs must not ship in the crate (see Cargo.toml `exclude`): {bundled_heavy_gifs:?}"
+    );
+}
+
+#[test]
+fn crates_io_readme_assets_and_source_are_kept() {
+    let files = packaged_files();
+    let has = |p: &str| files.iter().any(|f| f == p);
+
+    // The two assets the crates.io README embeds by relative path.
+    assert!(has("docs/hero.gif"), "README hero image must ship");
+    assert!(
+        has("docs/demos/image.svg"),
+        "README image-protocol asset must ship"
+    );
+    // Sanity: the crate still carries its source and manifest.
+    assert!(has("src/lib.rs"), "library source must ship");
+    assert!(has("Cargo.toml"), "manifest must ship");
+    assert!(has("README.md"), "README must ship");
+}

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -11,6 +11,7 @@ wording, formatting, and link fixes do not need entries.
 - Crash reports and restored-terminal diagnostics now identify the active
   single-session runtime when its session ID is available.
 - Added [Tuika keymap](specs/keymap.md): the tuika declarative key-binding engine and Yolop's dispatch of its global shortcuts through it.
+- Excluded the tuika demo/theme/styling GIFs from the published `.crate` (~8.8 MiB → ~1 MiB), keeping only the two README-embedded assets; documented the GitHub-only/crate split in the documentation spec.
 
 ## 2026-07-23
 

--- a/knowledge/specs/documentation.md
+++ b/knowledge/specs/documentation.md
@@ -105,6 +105,14 @@ Reproducing any VHS capture — the feature guides above, the tuika component
 demos (`crates/tuika/scripts/gen-tuika-demos.sh`), and the tuika README hero
 (`crates/tuika/scripts/gen-tuika-hero.sh`) — needs the same tools on `PATH`:
 
+The tuika demo/theme/styling GIFs are GitHub-only assets: they are consumed by
+the tuika README and `docs/*.md` (served from the repo) but excluded from the
+published `.crate` via `crates/tuika/Cargo.toml`, since docs.rs renders the
+hand-written `lib.rs` header and references none of them. Only `hero.gif` and
+`demos/image.svg` — the two the crates.io README embeds by relative path — ship
+in the crate. `crates/tuika/tests/packaging.rs` guards that split.
+
+
 - **VHS**, which drives **ttyd** and **ffmpeg** (both must be installed
   separately) and renders frames through a headless Chromium it fetches via
   `go-rod` on first run into `~/.cache/rod`.


### PR DESCRIPTION
## What changed

The published `tuika` crate on crates.io was **~8.8 MiB**. Almost all of that was the ~8 MiB of demo/theme/styling GIFs under `crates/tuika/docs/`, which `cargo package` bundled because the manifest had no `exclude`/`include`. Those GIFs are consumed **only** by the GitHub-rendered README and `docs/*.md` (served from the repo) and by nothing in the compiled crate: docs.rs builds the hand-written `//!` header in `lib.rs`, which references no images at all.

A Cargo `exclude` now drops the demo/theme/styling GIFs from the tarball while keeping the two assets the crates.io README embeds by relative path — `docs/hero.gif` and `docs/demos/image.svg`. A new `tests/packaging.rs` drives `cargo package --list` to guard the split so a stray asset can't silently re-inflate the crate.

## Why

Downstream users of `cargo add tuika` / `cargo install`-based builds pull ~8 MiB of animated GIFs they never use — a slow, wasteful download for a terminal-UI library whose source is only ~850 KB.

## Before / After

`cargo package` for the `tuika` crate:

| | Files | GIFs | Size (compressed) |
|---|---|---|---|
| Before | 138 | 36 | **8.78 MiB** |
| After | 104 | 1 (`hero.gif`) | **1.0 MiB** |

```
# after
Packaged 104 files, 1.8MiB (1.0MiB compressed)
```

crates.io README assets (`hero.gif`, `demos/image.svg`) still ship; docs.rs is unaffected (it referenced none of these files).

## Risk
- **Low**
- The only externally observable surface is the packaged file set. The two README-embedded assets are retained and asserted by the new test; docs.rs renders from `lib.rs` and never used these files. No runtime, API, or dependency change.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered — packaging-only; no API/runtime change (pre-1.0 crate regardless)
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated `knowledge/specs/documentation.md` to record the GitHub-only-vs-crate boundary for the tuika demo GIFs, and added a `knowledge/log.md` entry. No concepts added/removed/renamed, so `index.md` is unchanged. `python3 scripts/validate_okf.py knowledge --check-links` → 35 concepts, 0 errors.

## Security

No security-relevant code changed. The change is packaging metadata plus a test that spawns `cargo package --list` as a bounded subprocess. No new dependencies (TM-DEP), no filesystem/shell/LLM/tool-capability surface touched.

Validation: `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, `cargo test -p tuika --all-features` (27 + 2 new packaging tests pass), and offline smoke `cargo run -- --provider llmsim -p "hi"` (starts, exit 0).

## Follow-ups

Optional, deferred: switching the README's `hero.gif` reference to an absolute `raw.githubusercontent.com` URL would let `hero.gif` (764 KB) be excluded too, taking the crate to ~250 KB — deferred because keeping the hero image local avoids a dependency on an external URL for the crates.io landing page.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cq1geb2cyjPumnJHPtYCqF)_