### PR TITLE
fix(tui): use native terminal links

### DIFF
--- a/crates/tuika/docs/features.md
+++ b/crates/tuika/docs/features.md
@@ -67,14 +67,21 @@ There are two entry points:
 - `markdown_to_linked_lines` + `apply_buffer_links` — the markdown renderer
   preserves `[label](url)` destinations as [`BufferLink`]s through wrapping;
   after painting the lines, `apply_buffer_links` embeds OSC 8 into the boundary
-  cells (ForcedWidth) so a label that is not itself a URL stays Ctrl+clickable.
-  Configure schemes with `LinkPolicy` (and `Markdown::link_policy`).
+  cells (ForcedWidth) so a label that is not itself a URL stays clickable with
+  the terminal's native modifier. Configure schemes with `LinkPolicy` (and
+  `Markdown::link_policy`).
 
 Each of the first three has a policy-aware sibling — `osc8_with`, `write_line_with`, and
 `HyperlinkBackend::with_policy` — taking a `LinkPolicy` so the host chooses which
 schemes are linked. The default (`LinkPolicy::WEB`) is `http(s)`-only;
 `LinkPolicy::WEB.with_mailto()` also links `mailto:` addresses.
 `LinkPolicy::NONE` skips emission entirely.
+
+OSC 8 activation belongs to the terminal emulator. A host should not open the
+same URL again when mouse reporting also delivers the modifier-click to the
+application. Full-screen hosts that capture pointer motion can use
+`write_pointer_shape(..., PointerShape::Pointer)` on link hover; it emits OSC 22
+and should be paired with `PointerShape::Default` on hover exit and shutdown.
 
 ```rust
 use tuika::{osc8, is_web_url};

--- a/crates/tuika/src/event.rs
+++ b/crates/tuika/src/event.rs
@@ -104,6 +104,8 @@ pub struct Mouse {
     pub ctrl: bool,
     /// Alt held during the event.
     pub alt: bool,
+    /// Super/Command held during the event.
+    pub super_key: bool,
 }
 
 impl Mouse {
@@ -117,6 +119,7 @@ impl Mouse {
             shift: false,
             ctrl: false,
             alt: false,
+            super_key: false,
         }
     }
 
@@ -125,7 +128,7 @@ impl Mouse {
     /// implements its own selection should generally act only on `plain()`
     /// left-drags and leave Shift-drags to the terminal.
     pub fn plain(&self) -> bool {
-        !self.shift && !self.ctrl && !self.alt
+        !self.shift && !self.ctrl && !self.alt && !self.super_key
     }
 }
 

--- a/crates/tuika/src/host.rs
+++ b/crates/tuika/src/host.rs
@@ -48,6 +48,10 @@ impl AltScreen {
     pub fn leave(&mut self) {
         if self.active {
             let mut out = io::stdout();
+            let _ = out.write_all(
+                crate::native::encode_pointer_shape(crate::native::PointerShape::Default)
+                    .as_bytes(),
+            );
             let _ = execute!(out, DisableMouseCapture, LeaveAlternateScreen);
             let _ = out.flush();
             self.active = false;
@@ -102,6 +106,9 @@ impl TerminalSession {
             return;
         }
         let mut out = io::stdout();
+        let _ = out.write_all(
+            crate::native::encode_pointer_shape(crate::native::PointerShape::Default).as_bytes(),
+        );
         let _ = execute!(out, Show, DisableMouseCapture, LeaveAlternateScreen);
         let _ = out.flush();
         if self.raw_mode_owned {
@@ -230,6 +237,7 @@ pub fn translate_event(event: CtEvent) -> Option<Event> {
                 shift: m.modifiers.contains(KeyModifiers::SHIFT),
                 ctrl: m.modifiers.contains(KeyModifiers::CONTROL),
                 alt: m.modifiers.contains(KeyModifiers::ALT),
+                super_key: m.modifiers.contains(KeyModifiers::SUPER),
             }))
         }
         CtEvent::Paste(text) => Some(Event::Paste(text)),
@@ -284,14 +292,14 @@ mod tests {
             kind: MouseEventKind::Down(CtButton::Right),
             column: 7,
             row: 3,
-            modifiers: KeyModifiers::SHIFT | KeyModifiers::CONTROL,
+            modifiers: KeyModifiers::SHIFT | KeyModifiers::CONTROL | KeyModifiers::SUPER,
         });
         let Some(Event::Mouse(m)) = translate_event(ct) else {
             panic!("expected a mouse event");
         };
         assert_eq!(m.kind, MouseKind::Down(MouseButton::Right));
         assert_eq!((m.column, m.row), (7, 3));
-        assert!(m.shift && m.ctrl && !m.alt);
+        assert!(m.shift && m.ctrl && !m.alt && m.super_key);
         assert!(!m.plain());
     }
 

--- a/crates/tuika/src/hyperlink.rs
+++ b/crates/tuika/src/hyperlink.rs
@@ -79,6 +79,11 @@ impl LinkPolicy {
     pub const fn links_any(self) -> bool {
         self.web || self.mailto
     }
+
+    /// Whether `url` is a valid target under this policy.
+    pub fn allows(self, url: &str) -> bool {
+        sanitize_url(url, self).is_some()
+    }
 }
 
 impl Default for LinkPolicy {

--- a/crates/tuika/src/lib.rs
+++ b/crates/tuika/src/lib.rs
@@ -109,7 +109,9 @@ pub use live::{Live, LiveView, RedrawHandle};
 pub use mouse::{
     Click, ClickTracker, HitMap, SelectionRange, SelectionState, highlight, selected_text, word_at,
 };
-pub use native::{ProgressState, TerminalProgress};
+pub use native::{
+    PointerShape, ProgressState, TerminalProgress, encode_pointer_shape, write_pointer_shape,
+};
 pub use overlay::{Anchor, Extent, OverlaySpec};
 pub use probe::{Probe, RectProbe};
 pub use ratatui_view::RatatuiView;

--- a/crates/tuika/src/native.rs
+++ b/crates/tuika/src/native.rs
@@ -1,4 +1,4 @@
-//! Native terminal progress via the OSC 9;4 sequence.
+//! Native terminal affordances that live outside the cell grid.
 //!
 //! OSC 9;4 (originated by ConEmu) drives the terminal's *own* progress
 //! indicator — Ghostty renders a bar across the top of the window, Windows
@@ -11,6 +11,33 @@
 //! 0–100 and `state` is one of [`ProgressState`].
 
 use std::io::{self, Write};
+
+/// Mouse pointer shapes used by interactive terminal regions.
+///
+/// These are CSS cursor names, understood by Ghostty, Kitty, Foot, and recent
+/// iTerm2/xterm releases through OSC 22. Other terminals ignore the sequence.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum PointerShape {
+    /// Restore the terminal's configured pointer.
+    #[default]
+    Default,
+    /// Show the pointing-hand cursor used for links.
+    Pointer,
+}
+
+/// Encode an OSC 22 pointer-shape sequence.
+pub fn encode_pointer_shape(shape: PointerShape) -> &'static str {
+    match shape {
+        PointerShape::Default => "\x1b]22;default\x1b\\",
+        PointerShape::Pointer => "\x1b]22;pointer\x1b\\",
+    }
+}
+
+/// Set the terminal's mouse pointer shape.
+pub fn write_pointer_shape(out: &mut impl Write, shape: PointerShape) -> io::Result<()> {
+    out.write_all(encode_pointer_shape(shape).as_bytes())?;
+    out.flush()
+}
 
 /// OSC 9;4 progress states.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -110,6 +137,18 @@ impl Drop for TerminalProgress {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn osc_pointer_shape_encoding() {
+        assert_eq!(
+            encode_pointer_shape(PointerShape::Default),
+            "\x1b]22;default\x1b\\"
+        );
+        assert_eq!(
+            encode_pointer_shape(PointerShape::Pointer),
+            "\x1b]22;pointer\x1b\\"
+        );
+    }
 
     #[test]
     fn osc_progress_encoding() {

--- a/knowledge/specs/presentation.md
+++ b/knowledge/specs/presentation.md
@@ -44,6 +44,12 @@ The application owns transcript scrolling, overlays, and viewport composition in
 this mode. `--inline` selects the scrollback-native composer when terminal
 history is preferred.
 
+Transcript links use OSC 8 targets and leave activation to the terminal
+emulator, including its platform-native modifier (`Ctrl` on Linux, `Command` on
+macOS). The fullscreen host must not also launch the URL from the reported mouse
+event. While mouse capture is active, link hover may set the terminal pointer
+through OSC 22, and must restore the default pointer when the session ends.
+
 ### Fullscreen Status Drawer
 
 The fullscreen host projects expanded session status as a responsive drawer.

--- a/src/tui/fullscreen.rs
+++ b/src/tui/fullscreen.rs
@@ -268,6 +268,7 @@ pub(crate) fn draw(f: &mut Frame, app: &mut App) {
                 v
             })
             .collect();
+        let policy = crate::hyperlink_policy();
         tuika::apply_buffer_links(
             f.buffer_mut(),
             Position {
@@ -275,10 +276,20 @@ pub(crate) fn draw(f: &mut Frame, app: &mut App) {
                 y: origin_y,
             },
             &visible,
-            crate::hyperlink_policy(),
+            policy,
+        );
+        let interactive: Vec<_> = visible
+            .into_iter()
+            .filter(|link| policy.allows(&link.url))
+            .collect();
+        app.set_visible_links(
+            Position {
+                x: selection.x,
+                y: origin_y,
+            },
+            &interactive,
         );
     }
-    app.resolve_link_click(f.buffer_mut());
     app.resolve_selection(f.buffer_mut());
     // Copy reads the whole selection from the transcript cache (it may span rows
     // that are scrolled off-screen); highlight paints only the visible slice.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -122,7 +122,8 @@ struct TranscriptWrapCache {
     /// The wrapped, gap-spaced transcript rows.
     lines: Vec<Line<'static>>,
     /// Hyperlink runs into `lines` (labeled markdown links + bare URLs), used to
-    /// embed OSC 8 after painting so Ctrl+click works when the label ≠ URL.
+    /// embed native OSC 8 targets after painting when the label differs from
+    /// the URL.
     links: Vec<tuika::BufferLink>,
 }
 
@@ -263,11 +264,12 @@ pub struct App {
     /// the next draw, where the freshly rendered frame buffer is readable.
     selection: transcript_selection::TranscriptSelection,
     selection_area: Rect,
+    /// Link cell runs visible in the last full-screen transcript frame.
+    visible_link_regions: Vec<Rect>,
+    pointer_shape: tuika::PointerShape,
     /// Click targets from the last fullscreen status layout.
     status_hit_regions: Vec<(Rect, StatusAction)>,
     pending_copy: bool,
-    pending_link_click: Option<tuika::Mouse>,
-    pending_open_url: Option<String>,
     /// Drives the terminal's native OSC 9;4 progress indicator (Ghostty top
     /// bar / taskbar) while a turn runs. Works in both renderers. Enabled only
     /// for real TUI sessions via [`App::enable_native_progress`] so tests and
@@ -627,10 +629,10 @@ impl App {
             transcript_cache: TranscriptWrapCache::default(),
             selection: transcript_selection::TranscriptSelection::new(),
             selection_area: Rect::ZERO,
+            visible_link_regions: Vec::new(),
+            pointer_shape: tuika::PointerShape::Default,
             status_hit_regions: Vec::new(),
             pending_copy: false,
-            pending_link_click: None,
-            pending_open_url: None,
             term_progress: tuika::TerminalProgress::new(),
             native_progress: false,
             // Tests run in-memory so recall never reads or appends to the real
@@ -693,15 +695,45 @@ impl App {
         self.pending_copy = true;
     }
 
-    pub(crate) fn resolve_link_click(&mut self, buffer: &ratatui::buffer::Buffer) {
-        let Some(event) = self.pending_link_click.take() else {
-            return;
-        };
-        self.pending_open_url = tuika::ctrl_click_url(&event, buffer, self.selection_area);
+    pub(crate) fn set_visible_links(
+        &mut self,
+        origin: ratatui::layout::Position,
+        links: &[tuika::BufferLink],
+    ) {
+        self.visible_link_regions = links
+            .iter()
+            .filter(|link| link.end_col > link.start_col)
+            .map(|link| {
+                Rect::new(
+                    origin.x.saturating_add(link.start_col),
+                    origin.y.saturating_add(link.line),
+                    link.end_col.saturating_sub(link.start_col),
+                    1,
+                )
+            })
+            .collect();
     }
 
-    pub(crate) fn take_pending_open_url(&mut self) -> Option<String> {
-        self.pending_open_url.take()
+    fn update_link_pointer(&mut self, mouse: MouseEvent) -> Option<tuika::PointerShape> {
+        if !matches!(mouse.kind, MouseEventKind::Moved) {
+            return None;
+        }
+        let hovered = self.visible_link_regions.iter().any(|area| {
+            mouse.column >= area.x
+                && mouse.column < area.right()
+                && mouse.row >= area.y
+                && mouse.row < area.bottom()
+        });
+        let next = if hovered {
+            tuika::PointerShape::Pointer
+        } else {
+            tuika::PointerShape::Default
+        };
+        if next == self.pointer_shape {
+            return None;
+        }
+        self.pointer_shape = next;
+        Some(next)
     }
 
     /// The selection mapped into the *current* viewport window, for painting.
@@ -860,12 +892,6 @@ impl App {
         else {
             return false;
         };
-        if m.kind == tuika::MouseKind::Up(tuika::MouseButton::Left) && m.ctrl && !m.shift && !m.alt
-        {
-            self.selection.clear();
-            self.pending_link_click = Some(m);
-            return true;
-        }
         if !m.plain() {
             return false;
         }
@@ -1381,12 +1407,6 @@ impl App {
         }
         terminal.draw(|f| draw(f, self))?;
 
-        if let Some(url) = self.take_pending_open_url()
-            && let Err(error) = crate::auth::oauth_flow::open_browser(&url)
-        {
-            tracing::warn!(%error, %url, "failed to open ctrl-clicked link");
-        }
-
         // 1) drain background turn events
         if let Some(rx) = self.rx.as_mut() {
             match rx.try_recv() {
@@ -1565,6 +1585,9 @@ impl App {
                 }
                 CrosstermEvent::Mouse(mouse) => {
                     if self.render_mode.is_fullscreen() {
+                        if let Some(shape) = self.update_link_pointer(mouse) {
+                            let _ = tuika::write_pointer_shape(&mut std::io::stdout(), shape);
+                        }
                         if self.handle_fullscreen_scroll(mouse.kind) {
                             continue;
                         }
@@ -3643,11 +3666,12 @@ mod tests {
         );
         let has_link = lines.iter().flat_map(|line| line.spans.iter()).any(|span| {
             span.content.contains("https://rust-lang.org")
-                && span.style.add_modifier.contains(Modifier::UNDERLINED)
+                && span.style.fg == Some(fullscreen::yolop_theme().code.link)
+                && !span.style.add_modifier.contains(Modifier::UNDERLINED)
         });
         assert!(
             has_link,
-            "paragraph URL should be styled as a link: {lines:?}"
+            "paragraph URL should be link-colored without masking native hover: {lines:?}"
         );
         assert!(
             links.iter().any(|l| l.url.contains("rust-lang.org")),
@@ -3656,10 +3680,10 @@ mod tests {
     }
 
     #[test]
-    fn transcript_labeled_markdown_link_is_ctrl_clickable() {
+    fn transcript_labeled_markdown_link_has_native_target() {
         // Labeled `[text](url)` must stay clickable after the transcript paints —
         // the third time this regressed, style was kept but the destination was
-        // dropped so Ghostty Ctrl+click had nothing to open.
+        // dropped so Ghostty had nothing to open.
         use ratatui::layout::Position;
         let mut lines: Vec<Line> = Vec::new();
         let links = append_markdown_lines(
@@ -3695,7 +3719,7 @@ mod tests {
         assert_eq!(
             tuika::ctrl_click_url(&event, &buffer, Rect::new(0, 0, 120, 4)).as_deref(),
             Some(link.url.as_str()),
-            "Ctrl+click on the PR label must open the markdown destination"
+            "the PR label must preserve the markdown destination"
         );
     }
 
@@ -5546,7 +5570,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn fullscreen_ctrl_click_resolves_visible_url() {
+    async fn fullscreen_ctrl_click_is_left_to_the_terminal() {
         let mut test = app_with_llmsim().await;
         test.app.setup = None;
         test.app.set_render_mode(RenderMode::Fullscreen);
@@ -5558,18 +5582,38 @@ mod tests {
             row: area.y,
             modifiers: KeyModifiers::CONTROL,
         };
-        assert!(test.app.handle_fullscreen_selection(event));
-        let mut buffer = ratatui::buffer::Buffer::empty(Rect::new(0, 0, 50, 8));
-        buffer.set_string(
-            area.x,
-            area.y,
-            "see https://example.com/docs now",
-            Style::default(),
+        assert!(!test.app.handle_fullscreen_selection(event));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fullscreen_link_hover_changes_pointer_shape() {
+        let mut test = app_with_llmsim().await;
+        test.app.setup = None;
+        test.app.set_render_mode(RenderMode::Fullscreen);
+        test.app.set_visible_links(
+            ratatui::layout::Position { x: 4, y: 6 },
+            &[tuika::BufferLink {
+                line: 1,
+                start_col: 3,
+                end_col: 9,
+                url: "https://example.com".to_string(),
+            }],
         );
-        test.app.resolve_link_click(&buffer);
+        let moved = |column, row| MouseEvent {
+            kind: MouseEventKind::Moved,
+            column,
+            row,
+            modifiers: KeyModifiers::NONE,
+        };
+
         assert_eq!(
-            test.app.take_pending_open_url().as_deref(),
-            Some("https://example.com/docs")
+            test.app.update_link_pointer(moved(8, 7)),
+            Some(tuika::PointerShape::Pointer)
+        );
+        assert_eq!(test.app.update_link_pointer(moved(9, 7)), None);
+        assert_eq!(
+            test.app.update_link_pointer(moved(2, 2)),
+            Some(tuika::PointerShape::Default)
         );
     }
 

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1564,7 +1564,10 @@ pub(crate) fn append_markdown_lines<'a>(
     let prefix_cols = first_prefix.chars().count();
     let width = inner_width.saturating_sub(prefix_cols).max(1) as u16;
     let theme = super::fullscreen::yolop_theme();
-    let sheet = tuika::StyleSheet::from_theme(&theme);
+    let mut sheet = tuika::StyleSheet::from_theme(&theme);
+    // Leave underlining to the terminal's native OSC 8 hover/modifier state.
+    // Keeping it permanently underlined masks Ghostty's clickability feedback.
+    sheet.link = tuika::StyleBundle::new().fg(theme.code.link);
     let highlighter = tuika_codeformatters::TreeSitterHighlighter::new();
     let (rendered, md_links) = tuika::markdown_to_linked_lines(
         text,


### PR DESCRIPTION
## What changed
Fullscreen transcript links now rely on terminal-native OSC 8 activation instead of opening the same URL again inside Yolop. Links keep their color while native modifier hover remains visible, and supported terminals receive OSC 22 pointer-shape updates over clickable regions. Markdown labels preserve their hidden destinations.

Mouse modifier translation now includes Super/Command so macOS native link gestures do not become transcript selections. Terminal cleanup restores the default pointer even on unwind.

## Why
Ctrl/Command-click could open a browser twice, link activation state was hard to discover because links were permanently underlined, and fullscreen mouse capture prevented a clickable pointer affordance.

## Before / After
Before: modifier-click could invoke both Ghostty and Yolop browser opening; links did not visibly transition into their terminal-native active state; the pointer remained an I-beam.

After: the terminal owns one OSC 8 activation, Markdown labels open their encoded destinations, native modifier highlighting is visible, and hovering a clickable run uses a pointing-hand cursor where OSC 22 is supported.

Automated proof covers terminal-owned modifier-click handling, Markdown destination preservation, pointer hover transitions, Command modifier translation, and OSC 22 encoding.

## Risk
- Medium: terminal hyperlink and pointer behavior varies by emulator.
- Unsupported OSC 22 terminals ignore the fixed sequence; OSC 8 capability policy remains unchanged.
- Pointer state is restored during terminal-session cleanup.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p tuika` — 330 passed
- `cargo test --bin yolop --all-features` — 970 passed, 2 ignored
- `cargo test --all-features` — all impacted/unit/integration tests passed; one unrelated `gallery_paints_truecolor_and_braille` failure reproduces on clean `origin/main` on this macOS host
- `cargo run -- --provider llmsim -p "hi"`
- `python3 scripts/validate_okf.py knowledge --check-links`

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; Super modifier is additive and terminal OSC fallbacks are no-ops)
- [x] Knowledge concepts updated

## Knowledge
Updated `knowledge/specs/presentation.md` with terminal ownership of OSC 8 activation and pointer restoration.

## Security
Reviewed TM-FS, TM-BASH, TM-LLM, TM-TOOL, and TM-DEP. None of those privileged surfaces change. OSC 22 output is restricted to fixed `default`/`pointer` values; link targets continue through the existing sanitized `LinkPolicy`; no dependencies, secrets, filesystem access, shell execution, prompt construction, or capability registration changed. Hover work is bounded to links visible in the current viewport.

## Follow-ups
- The pre-existing macOS PTY truecolor assertion remains out of scope; it reproduces unchanged on `origin/main` and CI remains the source of truth.