### PR TITLE
chore(agents): rightsize AGENTS.md, knowledge, and skills

### DIFF
--- a/.agents/skills/author-extension/SKILL.md
+++ b/.agents/skills/author-extension/SKILL.md
@@ -28,29 +28,20 @@ not author an extension for it.
 
 ## What an extension can contribute
 
-Declare only what you need; a manifest must contribute at least one of:
+A manifest must contribute at least one facet; declare only what you need.
+[`extensions.md`](../../../knowledge/specs/extensions.md) defines each one — this is what to pass the
+scaffold and what it generates.
 
-- **tools** — functions the model can call (the model sees name + schema).
-- **hooks** — `pre_tool_use` (can **block** a tool call, e.g. deny git) or
-  `post_tool_use` (observe-only).
-- **prompt** — a static system-prompt contribution.
-- **mcpServers** — contributed MCP servers (declare in the manifest directly).
-- **status** — a status-bar field the server updates live by pushing
-  `status/changed` (e.g. a counter). Scaffold with `status: true`; the generated
-  server gets an `emit_status(text)` helper (empty text clears the field). Shows
-  in the inline and full-screen TUIs; a no-op in `--print`/ACP.
-- **skills** — a `skills/` directory of `SKILL.md` files, mounted read-only for
-  the enabled extension (same discovery as workspace/global skills). Scaffold
-  with `skills: true` to get a starter `skills/<name>/SKILL.md`.
-- **commands** — slash commands, registered namespaced as `/<ext>:<cmd>` in the
-  palette and dispatched to the server over `command/execute` (the result
-  message is shown to the user). Scaffold with `commands: ["name", …]`; the
-  generated server gets a `handle_command(name, arguments)` seam.
-- **ui_ask** — declare `ui_ask: true`, then the server may send a `ui/ask`
-  request (`{prompt, placeholder?}`) to prompt the user for a typed answer
-  mid-turn; the TUI shows an overlay and returns `{answer, cancelled}`. Refused
-  in `--print`/ACP. (No scaffold-template helper yet — send the request by hand
-  from your server.)
+| Facet | Scaffold | Generated seam |
+| --- | --- | --- |
+| **tools** | `tools=[…]` | `handle_tool(name, args)` returning the result dict |
+| **hooks** | `hooks=[…]` | `handle_hook(event, tool_name, args)` — `pre_tool_use` can block, `post_tool_use` observes |
+| **prompt** | `prompt=…` | a static system-prompt contribution |
+| **mcpServers** | — | declared in the manifest directly |
+| **status** | `status: true` | `emit_status(text)`; empty text clears the field. TUI-only, a no-op in `--print`/ACP |
+| **skills** | `skills: true` | a starter `skills/<name>/SKILL.md`, mounted read-only when the extension is enabled |
+| **commands** | `commands: ["name", …]` | `handle_command(name, arguments)`; registered as `/<ext>:<cmd>` |
+| **ui_ask** | — | declare `ui_ask: true` and send `ui/ask` (`{prompt, placeholder?}`) by hand; refused in `--print`/ACP |
 
 Not yet available: providers.
 
@@ -68,13 +59,10 @@ Not yet available: providers.
    templates skip that.
 
 2. **Implement.** Open the generated server (the tool result prints its path)
-   and fill in the `handle_*` bodies:
-   - `handle_tool(name, args)` — return the tool result dict.
-   - `handle_hook(event, tool_name, args)` — return `{}` to allow, or
-     `{"block": True, "reason": "…"}` to deny (pre_tool_use only). The server
-     receives *every* subscribed tool call, so gate on `tool_name`/`args`.
-   - Keep stdout for protocol JSON only; log to stderr.
-   Edit only the marked handler bodies — leave the protocol plumbing alone.
+   and fill in the marked `handle_*` bodies; leave the protocol plumbing alone.
+   A hook returns `{}` to allow or `{"block": True, "reason": "…"}` to deny —
+   and it receives *every* subscribed tool call, so gate on `tool_name`/`args`.
+   Keep stdout for protocol JSON only; log to stderr.
 
 3. **Install.** `install_extension source=<package dir>` — copies the package
    into the store and pins it. Installing runs third-party code; since *you*

--- a/.agents/skills/maintenance/SKILL.md
+++ b/.agents/skills/maintenance/SKILL.md
@@ -8,177 +8,48 @@ user-invocable: true
 
 # Maintenance
 
-Goal: leave the repo materially healthier and closer to release-ready, with evidence.
+Goal: leave the repo materially healthier and closer to release-ready, with
+evidence.
 
-This skill implements [`knowledge/specs/maintenance.md`](../../../knowledge/specs/maintenance.md). Keep operational guidance here. Keep design intent and constraints in the spec.
+[`knowledge/specs/maintenance.md`](../../../knowledge/specs/maintenance.md) owns the success bar and the
+rationale behind each surface. This skill owns how to work a pass.
+[`surfaces.md`](surfaces.md) holds the per-surface commands and heuristics —
+open it for the surfaces your scope actually covers.
 
-This skill is outcome-oriented. Choose the smallest set of actions that closes the real maintenance risk in front of you.
+## Scope
 
-## When To Use
+Use the scope the user gave; otherwise state the one you inferred before
+starting. Typical scopes: release readiness, CI health on `main`, `everruns-*`
+dependency refresh, knowledge or docs drift, feature-completeness drift across
+CLI / TUI / knowledge / README / tests, test gaps, code simplification, security
+hygiene, performance of recently changed code, AGENTS / skills / command hygiene.
 
-- release-readiness review
-- CI health on `main`
-- dependency refreshes (especially the `everruns-*` family)
-- knowledge or docs drift
-- feature-completeness drift across CLI / TUI / knowledge / README / tests
-- test coverage gaps
-- code simplification / removing over-abstraction and dead code
-- security hygiene review
-- performance review of recently changed code
-- AGENTS / skills / command hygiene
+## Working a pass
 
-## Required Outcomes
+A red CI on `main` outranks every other scope — fix it first, or open an issue
+and report the pass **blocked**. Otherwise go highest-signal first: recent
+diffs, failing checks, stale knowledge, outdated `everruns-*` versions.
 
-1. **The maintenance scope is explicit.** If the user provided one, use it; otherwise state the inferred scope.
-2. **The work produces concrete improvement.** Fix small/local issues; capture crisp findings for the rest.
-3. **Validation matches risk.** Run checks that prove the updated areas are healthy.
-4. **A release claim is backed by evidence.** Do not declare release-ready unless the changed surfaces were actually checked.
+Prefer fixing over reporting. Fix what is small and local; for anything larger,
+write a crisp finding and defer it to a GitHub issue naming the problem and its
+user-visible impact — then put the issue number in the report. Skipping a
+surface is fine; skipping it silently is not.
 
-## Operating Model
+Keep each change PR-sized and independently reviewable. Do not fold a
+simplification sweep into an unrelated fix. When a bug surfaces, prefer the
+failing test before the fix.
 
-- Start from goals and risk surface, not checklist order.
-- A red CI on `main` outranks every other scope. Fix it first or open an issue and report the pass as blocked.
-- Highest-signal first: recent diffs, failing checks, stale knowledge, outdated `everruns-*` versions.
-- Skip untouched areas with a reason. Prefer fixing over reporting.
-- For bugs uncovered, prefer a failing test before the fix when practical.
-- Keep changes PR-sized. Defer anything larger to a GitHub issue and record the issue number in the report.
+Validation matches the surfaces you touched — the
+[checks in `AGENTS.md`](../../../AGENTS.md), plus a live-provider smoke through
+Doppler when the pass touched runtime behavior. Do not declare release-ready
+for surfaces you did not actually check.
 
-## Maintenance Surfaces
+## Report
 
-### CI Health
+- scope covered, and what was intentionally skipped with a reason
+- what was fixed, and what was found
+- evidence gathered
+- deferred findings with their GitHub issue numbers
+- **blocked** if `main` CI is red and out of reach
 
-- check the latest workflow runs on `main` (`gh run list --branch main --limit 5`, through Doppler if GitHub auth fails directly)
-- any red run is a hard gate: the pass is not complete while `main` is red
-- if the failure is out of reach, open an issue with the failing run linked and report blocked
-
-### Dependency Health
-
-The `everruns-*` family (`everruns-runtime`, `-core`, `-anthropic`, `-openai`,
-`-integrations-duckduckgo`) is the single most important dependency vector for
-yolop. Keep them in lockstep at the same minor version.
-
-Actions:
-- check the latest version of each `everruns-*` crate (`cargo search everruns-runtime --limit 1`)
-- bump them together — mixing minor versions is a soft API break
-- run `cargo update` for transitive dependency drift
-- check `ratatui`, `crossterm`, `clap`, `tokio` minors; they tend to ship breaking-feeling clippy/lint changes
-- flag deprecated crates and identify replacements
-- review `cargo tree --duplicates` for split transitive versions; fix or note why unfixable
-- run `cargo audit` when available; otherwise check the repo's Dependabot alerts
-- grep for direct dependencies no longer used in `src/`
-
-Good evidence:
-- `cargo build` + `cargo test --all-features` after bumps
-- a successful smoke test (`doppler run -- cargo run -- --provider openai -p "hi"`) against at least one real provider
-
-### Upstream Mirror Hygiene
-
-Yolop began as `examples/coding-cli` in `everruns/everruns`. When upstream lands
-useful changes:
-
-- compare `src/` against the latest upstream example
-- mirror non-everruns-specific improvements (UI tweaks, bug fixes, capability
-  wiring) — leave behind anything tied to internal everruns paths
-- record meaningful divergence as a comment near the diverged code, not a separate doc
-
-### Knowledge And Docs Alignment
-
-- read `knowledge/index.md`, then inspect concepts affected by behavior changed
-  since the last maintenance point
-- run `python3 scripts/validate_okf.py knowledge --check-links`
-- check for durable behavior, intent, architecture, policy, constraints,
-  terminology, or maintainer process that is missing from or contradicted by the
-  bundle; staleness is based on contradiction or missing coverage, not age alone
-- ensure `knowledge/index.md` covers every concept and accurately classifies it
-- remove or mark superseded obsolete concepts; update `knowledge/log.md` for
-  significant additions, removals, or changes
-- keep `README.md`, `docs/`, and `AGENTS.md` aligned without linking public docs
-  into `knowledge/` or duplicating source-level detail
-- README provider and model lists match `runtime.rs`
-
-### Feature Completeness Drift
-
-A feature is ready only when its surfaces agree: CLI flags, TUI behavior,
-`knowledge/`, `README.md`, `docs/`, tests, bundled `skills/`.
-
-- diff `clap` definitions in `src/` against the README flag table
-- check recently shipped features (see `git log` since the last tag) for a test that exercises them and a knowledge/README mention
-- outcome: a small reconnecting fix, or a finding naming the missing surface and user-visible impact
-
-### Code Simplification And De-Abstraction
-
-A first-class maintenance surface, not just incidental cleanup on touched
-files. A deep pass actively hunts for complexity the codebase no longer earns.
-Bias toward deleting code: the best maintenance often removes more than it adds.
-
-On code touched during the pass, always:
-
-- delete dead code, unreachable branches, commented-out blocks
-- drop TODOs that are already resolved
-
-On a deep pass, also scan for and collapse over-abstraction:
-
-- **Single-use abstractions** — traits with one impl, a wrapper type that only
-  forwards, a generic with one instantiation, a builder for a two-field struct.
-  Inline them unless the seam is load-bearing (a real second impl, a public
-  extension point, a test double that earns its keep).
-- **Premature generalization** — code shaped for hypothetical futures instead of
-  current needs. Delete the unused flexibility; the git history keeps it.
-- **Indirection with no payoff** — a helper called once that only renames a
-  standard-library call, a module that re-exports one item, a config knob no
-  caller sets to anything but the default.
-- **Duplication that wants a helper** — the inverse: the same 5+ lines pasted in
-  three places is under-abstraction. Consolidate only when it genuinely reduces
-  total code and reads clearer, not to chase a DRY score.
-- **Deep nesting and sprawling match arms** — flatten with early returns, `let
-  ... else`, or extracted functions where it lowers cognitive load.
-- **Unclear names** — rename functions, variables, and types so intent is
-  legible without chasing definitions.
-
-Guardrails: keep each simplification small and independently reviewable; do not
-bundle a de-abstraction sweep with an unrelated fix. Verify with
-`cargo build`, `cargo clippy`, and `cargo test` — a simplification that changes
-behavior is a bug, not a cleanup. Removing a public API from a published crate
-(`yolop-yep`, `tuika`) is a breaking change: note it in the PR and confirm no
-external contract depends on it. When a simplification is too large to land
-inline (a cross-cutting abstraction with many call sites), defer it to a
-GitHub issue naming the abstraction and why it no longer pays its way.
-
-### Security And Threat Posture
-
-Yolop's threat surface is the host machine: filesystem and shell.
-
-- verify the write blocklist in `runtime.rs` still covers `.git/`, `node_modules/`, `target/`, `dist/`, `build/`, `.next/`, `.venv/`, `venv/`, `.tox/`, `.gradle/`
-- verify the bash tool still enforces a wall-clock timeout and per-stream output cap
-- verify session JSONL log permissions stay at `0o600` on Unix
-- confirm provider API keys are only read from process env, never logged or persisted to the session log
-
-### Test And Runtime Confidence
-
-- `cargo test --all-features` clean
-- live integration test (`tests/integration.rs`) passes under Doppler
-- offline smoke (`cargo run -- --provider llmsim -p "hi"`) prints a non-empty response and exits 0
-
-## Common Evidence Commands
-
-- `cargo fmt --check`
-- `cargo clippy --all-targets --all-features -- -D warnings`
-- `cargo test --all-features`
-- `cargo search everruns-runtime --limit 1`
-- `cargo outdated` (when available)
-- `cargo audit` (when available)
-- `doppler run -- cargo run -- --provider openai -p "summarize this repo in one paragraph"` — live provider smoke
-- `cargo run -- --provider llmsim -p "hi"` — offline smoke
-
-## Deliverable
-
-Report:
-
-- what scope was covered
-- what was fixed or found
-- what evidence was gathered
-- deferred findings, each with its GitHub issue number
-- what was intentionally skipped and why
-- **blocked** status if `main` CI is red and out of reach
-
-If the user asks to ship after maintenance, hand off to [`/ship`](../ship/SKILL.md).
+If the user asks to ship the result, hand off to [`/ship`](../ship/SKILL.md).

--- a/.agents/skills/maintenance/surfaces.md
+++ b/.agents/skills/maintenance/surfaces.md
@@ -1,0 +1,90 @@
+# Maintenance surfaces — commands and heuristics
+
+Operational companion to [`SKILL.md`](SKILL.md). Why each surface matters is in
+[`knowledge/specs/maintenance.md`](../../../knowledge/specs/maintenance.md); this file is what to run.
+
+## CI health
+
+```bash
+gh run list --branch main --limit 5   # through Doppler if GitHub auth fails
+```
+
+Any red run is a hard gate. If the failure is out of reach, open an issue with
+the failing run linked and report the pass blocked.
+
+## Dependency health
+
+The `everruns-*` family (`-runtime`, `-core`, `-anthropic`, `-openai`,
+`-integrations-duckduckgo`) moves in lockstep at one minor version.
+
+```bash
+cargo search everruns-runtime --limit 1
+cargo update                    # transitive drift
+cargo tree --duplicates         # split transitive versions: fix or explain
+cargo audit                     # when available; otherwise Dependabot alerts
+```
+
+Also check `ratatui`, `crossterm`, `clap`, and `tokio` minors — they tend to
+ship breaking-feeling lint changes. Grep for direct dependencies no longer used
+in `src/`, and flag deprecated crates with a replacement.
+
+Evidence after a bump: `cargo test --all-features`, plus one real-provider
+smoke (`doppler run -- cargo run -- --provider openai -p "hi"`).
+
+## Upstream mirror
+
+Compare `src/` against the current `examples/coding-cli` in `everruns/everruns`.
+Mirror improvements that are not tied to internal everruns paths; record
+meaningful divergence as a comment next to the diverged code.
+
+## Knowledge and docs alignment
+
+```bash
+python3 scripts/validate_okf.py knowledge --check-links
+```
+
+Read `knowledge/index.md`, then inspect the concepts touched by behavior that
+changed since the last pass. Staleness means contradiction or missing coverage,
+not age. Confirm the index covers and correctly classifies every concept, mark
+superseded concepts, and log significant changes in `knowledge/log.md`.
+
+Check `AGENTS.md`, `README.md`, and `docs/` against
+[`knowledge/specs/agent-context.md`](../../../knowledge/specs/agent-context.md) and
+[`documentation.md`](../../../knowledge/specs/documentation.md): no rule owned in two places, no public
+page linking into `knowledge/` or `.agents/`, README provider and model lists
+matching `runtime.rs`.
+
+## Feature-completeness drift
+
+Diff the `clap` definitions in `src/` against the README flag table. For
+features shipped since the last tag (`git log`), confirm each has a test that
+exercises it and a knowledge/README mention. The outcome is a small reconnecting
+fix, or a finding naming the missing surface and its user-visible impact.
+
+## Simplification and de-abstraction
+
+On code touched during the pass: delete dead code, unreachable branches,
+commented-out blocks, and resolved TODOs.
+
+On a deep pass, hunt for complexity the codebase no longer earns — single-use
+abstractions, premature generalization, indirection with no payoff, duplication
+that wants a helper, deep nesting, names that hide intent. Verify with `cargo
+build`, `cargo clippy`, and `cargo test`: a simplification that changes behavior
+is a bug. Removing a public item from `yolop-yep` or `tuika` is a breaking
+change — call it out in the PR.
+
+## Security posture
+
+- the write blocklist in `runtime.rs` still covers `.git/`, `node_modules/`,
+  `target/`, `dist/`, `build/`, `.next/`, `.venv/`, `venv/`, `.tox/`, `.gradle/`
+- the bash tool still enforces a wall-clock timeout and per-stream output cap
+- session JSONL log permissions stay `0o600` on Unix
+- provider keys are read from process env only — never logged or persisted
+
+## Test and runtime confidence
+
+```bash
+cargo test --all-features
+doppler run -- cargo test --all-features --test integration
+cargo run -- --provider llmsim -p "hi"     # non-empty response, exit 0
+```

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -8,191 +8,92 @@ user-invocable: true
 
 # Release
 
-Goal: cut a new yolop release and verify it lands on **both** crates.io and
-the `everruns/homebrew-tap` Homebrew tap.
+Goal: cut a new yolop release and verify it lands on **both** crates.io and the
+`everruns/homebrew-tap` Homebrew tap.
 
-This skill implements [`knowledge/specs/release.md`](../../../knowledge/specs/release.md). Keep
-operational guidance here. Keep design intent in the spec.
+[`knowledge/specs/release.md`](../../../knowledge/specs/release.md) owns the versioning rules, the changelog
+format, the CI automation contract, post-release verification, hotfix and
+rollback policy, and the secrets table. This skill owns the procedure. For a
+non-release change, use [`/ship`](../ship/SKILL.md) instead.
 
-## When To Use
+Releases are agent-prepared, human-merged, CI-published. The agent never tags
+the release and never pushes to the tap — `release.yml` and `cli-binaries.yml`
+do that.
 
-Use this skill when the user asks to:
+## 0. Sync local state
 
-- release / cut a release / publish vX.Y.Z
-- ship to crates.io or Homebrew
-- prepare a release PR or a hotfix release
-
-For a generic "ship this change" request (PR → CI → merge of a non-release
-change), use [`/ship`](../ship/SKILL.md) instead.
-
-## Required Outcomes
-
-**All outcomes below are MANDATORY.**
-
-1. **The version is correct.** `Cargo.toml` and `Cargo.lock` agree on
-   `X.Y.Z`. `X.Y.Z` is strictly greater than the latest version on crates.io.
-2. **The changelog is honest.** `CHANGELOG.md` lists every commit landed
-   since the previous tag, in descending order, with PR numbers and authors.
-3. **Publish-readiness is proven before merge.** The library dry-runs
-   (`cargo publish --dry-run -p yolop-yep` and `-p tuika`) succeed; `yolop`'s
-   own publish is validated in CI once the libraries are live (dry-running it
-   locally fails until then — see step 5). The PR body includes a
-   publish-readiness report.
-4. **Post-merge verification is a hard gate.** After the release PR merges,
-   the agent must monitor CI and independently confirm that crates.io serves
-   `X.Y.Z` and the Homebrew tap formula points at `vX.Y.Z`. A "release" is
-   not done, shipped, or closed out until both are confirmed.
-5. **A failure rolls forward, not backward.** If a publish fails, open a
-   hotfix PR (or fix-forward in the same PR if not yet merged). Do not
-   leave the release half-shipped.
-6. **Durable knowledge is release-current.** Validate the OKF bundle and verify
-   that significant released behavior, architecture, policy, and process changes
-   since the previous tag are represented without exposing internal knowledge
-   through public documentation links.
-
-## Operating Model
-
-- Releases are agent-prepared, human-merged, CI-published.
-- Start by gathering the unreleased commit set, not by guessing the version.
-- The agent never tags the release directly — `release.yml` does that when
-  the `chore(release): prepare vX.Y.Z` commit lands on `main`.
-- The agent never pushes to `everruns/homebrew-tap` directly —
-  `cli-binaries.yml` does that.
-
-## Step-By-Step
-
-### 0. Sync local state
-
-Shallow clones lie. Before counting commits, force a full history:
+Shallow clones lie: cloud sandboxes default to depth ≈ 50 and silently drop
+older commits from `git log`.
 
 ```bash
 git fetch --unshallow origin main 2>/dev/null || git fetch origin main
 git fetch --tags
-```
 
-Cross-check the commit count if anything looks off:
-
-```bash
 LATEST=$(git describe --tags --abbrev=0)
 git log "$LATEST"..origin/main --oneline | wc -l
 gh api "repos/everruns/yolop/compare/$LATEST...main" --jq '.total_commits'
 ```
 
-If those disagree, the clone is still shallow.
+If those two counts disagree, the clone is still shallow.
 
-### 1. Pick the version
+## 1. Pick the version
 
-If the user gave a version, use it. Otherwise, propose based on the diff:
+Use the version the user gave. Otherwise propose one from the unreleased commit
+set under the spec's versioning rules, and confirm before proceeding.
 
-- only `fix`, `docs`, `chore`, `refactor`, `test` commits → patch
-- one or more `feat` commits → minor
-- breaking changes flagged in commit bodies → major (or minor pre-1.0 with
-  an explicit `### Breaking Changes` block)
+## 2. Update the changelog
 
-Confirm with the user before proceeding.
-
-### 2. Update the changelog
-
-`CHANGELOG.md` lives at the repo root. Add a section at the top under any
-intro:
-
-```markdown
-## [X.Y.Z] - YYYY-MM-DD
-
-### Highlights
-
-- 2–5 bullets summarizing the most user-visible changes.
-
-### Breaking Changes
-
-- (only when applicable; required for MINOR / MAJOR with breakage)
-
-### What's Changed
-
-* feat(scope): description ([#42](https://github.com/everruns/yolop/pull/42)) by @contributor
-* fix(scope): description ([#41](https://github.com/everruns/yolop/pull/41)) by @contributor
-
-**Full Changelog**: https://github.com/everruns/yolop/compare/vA.B.C...vX.Y.Z
-```
-
-Build the PR list mechanically:
+Build the commit list mechanically, then write the section in the format the
+spec defines (§ Changelog Format):
 
 ```bash
 git log "$LATEST"..HEAD --pretty=format:'%s' --reverse \
   | grep -v '^chore(release): prepare v'
 ```
 
-Map commits to PRs via `gh pr list --state merged --base main --limit 200`
-when commit subjects don't carry the PR number.
+Map commits to PRs with `gh pr list --state merged --base main --limit 200`
+when the subjects don't carry the number.
 
-### 3. Bump the version
+## 3. Bump the version
 
-Edit `Cargo.toml`:
+Edit `version` in `Cargo.toml`, then `cargo update -p yolop` to refresh the
+lockfile entry.
 
-```toml
-[package]
-name = "yolop"
-version = "X.Y.Z"
-```
+The three library crates are versioned separately. Bump one when its API or its
+published dependency range changes (for `yolop-yep`, also when the wire protocol
+changes) and update every workspace path dependency requirement that references
+it — a `tuika` bump usually forces a `tuika-codeformatters` bump, because the
+published formatter pins a compatible tuika range.
 
-Refresh the lockfile entry:
+## 4. Verify locally
 
-```bash
-cargo update -p yolop
-```
+Review the commits since the previous tag for durable knowledge impact and
+update the affected concepts, `knowledge/index.md`, and `knowledge/log.md`.
+Confirm `README.md` and `docs/` describe the released behavior. Then run the
+[checks in `AGENTS.md`](../../../AGENTS.md).
 
-### 4. Run local verification
+## 5. Verify publish-readiness
 
-Review commits since the previous tag for durable knowledge impact. Update the
-relevant concepts, `knowledge/index.md`, and `knowledge/log.md` when needed, then
-verify the bundle and code:
-
-```bash
-python3 scripts/validate_okf.py knowledge --check-links
-cargo fmt --check
-cargo clippy --all-targets --all-features -- -D warnings
-cargo test --all-features
-```
-
-Confirm `README.md` and `docs/` describe released user-facing behavior while
-remaining independent of internal `knowledge/` and `.agents/` paths.
-
-### 5. Verify publish-readiness
-
-This is the step that catches what local tests don't — the `cargo publish`
-packaging boundary, missing files referenced by `Cargo.toml`, version drift:
+This is the step local tests can't stand in for — it exercises the `cargo
+publish` packaging boundary, missing files referenced by `Cargo.toml`, and
+version drift.
 
 ```bash
-cargo publish --dry-run -p yolop-yep   # SDK library; publishes first
-cargo publish --dry-run -p tuika       # TUI toolkit library; publishes first
-cargo publish --dry-run -p tuika-codeformatters # Highlighter; publishes after tuika
-cargo search yolop --limit 1     # confirm CURRENT crates.io version < X.Y.Z
-grep '^version' Cargo.toml       # confirm reads X.Y.Z
-grep '"yolop"' Cargo.lock | head -1  # confirm reads X.Y.Z
+cargo publish --dry-run -p yolop-yep            # SDK
+cargo publish --dry-run -p tuika                # TUI toolkit
+cargo publish --dry-run -p tuika-codeformatters # highlighter; publishes after tuika
+cargo search yolop --limit 1                    # crates.io version must be < X.Y.Z
+grep '^version' Cargo.toml
+grep '"yolop"' Cargo.lock | head -1
 ```
 
-**Four-crate workspace.** The repo publishes three libraries — the `yolop-yep`
-SDK, the `tuika` TUI toolkit, and the `tuika-codeformatters` highlighter — plus
-the `yolop` binary. Each library is separately versioned; bump one when its API
-or published dependency range changes (and bump `yolop-yep` for wire-protocol
-changes). crates.io requires the libraries live **before** `yolop`, so CI
-(`publish.yml`) derives a dependency-first order from Cargo metadata (currently
-`yolop-yep`, `tuika`, `tuika-codeformatters`, then `yolop`) and skips versions
-already live. A consequence for this step: **`cargo publish --dry-run -p yolop` fails
-locally** when a new in-tree library version isn't yet on crates.io — that is
-expected, not a broken release. Dry-run all three libraries instead (above);
-`yolop`'s own publish is validated in CI after they go live. When bumping a
-library, update its version in `crates/<crate>/Cargo.toml` **and** every
-workspace path dependency version requirement that references it. In
-particular, a Tuika bump usually requires a `tuika-codeformatters` bump because
-its published package pins a compatible Tuika range.
+`cargo publish --dry-run -p yolop` **fails locally** whenever a new in-tree
+library version isn't on crates.io yet — expected, not a broken release. CI
+validates `yolop`'s own publish after the libraries go live. If a *library*
+dry-run fails, fix the root cause and re-run; never open a release PR with a
+known-broken publish path.
 
-If any library dry-run fails, fix the root cause and re-run. Do **not** open
-a release PR with a known-broken publish path.
-
-### 6. Commit and push
-
-Stage explicitly — never `git add .`:
+## 6. Commit, push, open the PR
 
 ```bash
 git add CHANGELOG.md Cargo.toml Cargo.lock
@@ -200,45 +101,18 @@ git commit -m "chore(release): prepare vX.Y.Z"
 git push -u origin "$(git branch --show-current)"
 ```
 
-### 7. Open the PR
+Title the PR `chore(release): prepare vX.Y.Z`. The body carries the full
+changelog section, a **Publish-readiness** report (which dry-runs ran, what
+crates.io currently serves, that `Cargo.toml` and `Cargo.lock` agree), and an
+unchecked **Post-merge verification** list covering `release.yml`, `publish.yml`,
+`cli-binaries.yml`, crates.io, and the tap formula.
 
-Title: `chore(release): prepare vX.Y.Z` (under 70 chars).
+Do not enable auto-merge: a human must click squash so a real reviewer reads the
+changelog.
 
-Body must include:
+## 7. Monitor after merge
 
-- The full `## [X.Y.Z] - …` changelog section.
-- A **Publish-readiness** block:
-
-  ```markdown
-  ## Publish-readiness
-
-  - [x] `cargo fmt --check`
-  - [x] `cargo clippy --all-targets --all-features -- -D warnings`
-  - [x] `cargo test --all-features`
-  - [x] `cargo publish --dry-run -p yolop-yep`, `-p tuika`, and
-        `-p tuika-codeformatters` (the libraries; `-p yolop` is validated in CI
-        after they publish)
-  - [x] crates.io currently serves `A.B.C` → publishing `X.Y.Z`
-  - [x] `Cargo.toml` + `Cargo.lock` agree on `X.Y.Z`
-  ```
-
-- A **Post-merge verification** block stating that the release is not complete
-  until the agent has checked:
-
-  ```markdown
-  ## Post-merge verification
-
-  - [ ] `release.yml` created tag `vX.Y.Z` and the GitHub Release
-  - [ ] `publish.yml` finished green
-  - [ ] `cli-binaries.yml` finished green
-  - [ ] crates.io serves `X.Y.Z`
-  - [ ] Homebrew tap formula points at `vX.Y.Z`
-  ```
-
-### 8. Monitor publishing after merge
-
-Subscribe to PR activity for the release PR so the loop wakes you on each
-workflow completion. Then watch:
+Subscribe to PR activity so workflow completions wake you, then watch:
 
 ```bash
 gh run list --workflow=release.yml      --limit 1
@@ -246,47 +120,12 @@ gh run list --workflow=publish.yml      --limit 1
 gh run list --workflow=cli-binaries.yml --limit 1
 ```
 
-Confirm each finishes green, then run the post-release checks yourself. Do not
-ask the user to verify these manually and do not declare the release shipped
-from workflow status alone.
+Green workflows are not proof. Run the spec's post-release verification yourself
+and declare **shipped** only when crates.io reports `X.Y.Z` and the tap formula
+points at `vX.Y.Z`. crates.io publishes near-instantly; Homebrew takes minutes
+for the build and tap commit, so a half-verified release looks shipped when it
+isn't.
 
-```bash
-# crates.io
-cargo search yolop --limit 1   # shows X.Y.Z
-
-# GitHub Release
-gh release view "vX.Y.Z"       # tag + 3 tarballs + 3 sha256 files
-
-# Homebrew tap
-curl -sSfL https://raw.githubusercontent.com/everruns/homebrew-tap/main/Formula/yolop.rb \
-  | grep -oE 'download/v[0-9][^/]*' | sed 's|download/||'   # shows vX.Y.Z
-```
-
-Declare **shipped** only when crates.io reports `X.Y.Z` and the Homebrew tap
-formula points at `vX.Y.Z`. If a workflow fails, inspect logs (`gh run view
-<id> --log-failed`) and either re-run (transient — network / registry
-propagation) or open a hotfix PR (packaging bug — see `knowledge/specs/release.md` §
-Hotfix Releases).
-
-## Common Pitfalls
-
-- **Shallow clone.** Cloud sandboxes default to depth ≈ 50 and silently
-  drop older commits from `git log`. Always `git fetch --unshallow` first.
-- **Tag/Cargo drift.** A v0.4.0 → v0.4.1-style hotfix is almost always
-  caused by version drift between `Cargo.toml` and what `cargo publish`
-  actually sees. The dry-run catches it.
-- **Half-shipped releases.** crates.io publishes near-instantly; Homebrew
-  takes minutes (build + tap commit). Don't declare shipped until the tap
-  formula reflects the new version.
-- **Auto-merge.** Do not enable auto-merge on the release PR. A human must
-  click the squash button so a real reviewer sees the changelog.
-
-## Authentication
-
-Required repo secrets — set up once, see [`knowledge/specs/release.md`](../../../knowledge/specs/release.md)
-§ Authentication for the full table.
-
-- `CARGO_REGISTRY_TOKEN` — crates.io publish scope.
-- `DOPPLER_TOKEN` — service token; the Doppler config holds
-  `HOMEBREW_TAP_GITHUB_TOKEN`, a fine-grained PAT scoped to the tap repo
-  only.
+On failure, read the logs (`gh run view <id> --log-failed`) and either re-run
+(transient — network or registry propagation) or roll forward with a hotfix PR
+per the spec. Never leave a release half-shipped.

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -8,124 +8,88 @@ user-invocable: true
 
 # Ship
 
-Goal: land the requested change safely, with evidence, and merge only after CI is green.
+Goal: land the requested change safely, with evidence, and merge only after CI
+is green.
 
-This skill implements [`knowledge/specs/shipping.md`](../../../knowledge/specs/shipping.md). Keep operational guidance here. Keep the shipping success bar and constraints in the spec.
+Read [`knowledge/specs/shipping.md`](../../../knowledge/specs/shipping.md) § Required Outcomes first — it
+owns the bar every shipped change must clear. This skill owns how to reach it.
 
-This skill is outcome-oriented. Do not blindly walk a fixed checklist. Start from the goal and changed risk surface, then choose the smallest path that proves the change is ready.
+"Fix and ship" means implement first, then switch into shipping mode.
 
-## When To Use
+## Working the change
 
-Use this skill when the user asks to:
+Start from the goal and the changed risk surface, not from checklist order.
+Review the delta (`git diff origin/main...HEAD`, `git log origin/main..HEAD`),
+confirm the requested behavior is actually implemented, then pick the smallest
+evidence that would convince a skeptical reviewer — targeted diff review,
+focused tests, then the [checks in `AGENTS.md`](../../../AGENTS.md) for the
+surfaces you touched.
 
-- ship or fix and ship a change
-- take work through validation, PR creation, CI, and merge
-- prove a branch is merge-ready
+Two pieces of evidence are not interchangeable, and neither substitutes for the
+other:
 
-## Required Outcomes
+- **The feature test.** It must drive the changed behavior's real entry point —
+  dispatch the command, call the handler, run the turn — not assert on a
+  constructor or on adjacent code that still compiles. Changes to transcript
+  output, live activity, or status values assert the terminal-independent
+  presentation model; terminal-buffer tests are layout coverage, not proof of
+  visible semantics.
+- **The smoke test.** Run the affected flow end to end. Agent-loop changes go
+  through a live provider (`doppler run -- cargo run -- --provider openai -p
+  "<focused prompt>"`); for offline-safe changes, `--provider llmsim` proving
+  the binary still starts is enough.
 
-**ALL outcomes below are MANDATORY. Do not skip or weaken any requirement.**
+Before pushing, reread the diff for duplication and accidental complexity you
+introduced, and fix it.
 
-1. **The branch state is safe.**
-   - Do not ship from `main` or `master`.
-   - The working tree must be clean before the final push.
-   - Prefer rebasing onto the latest `origin/main` before merge.
+Stop and report only for blockers you cannot resolve alone: merge conflicts you
+cannot judge, missing credentials, ambiguous product intent, CI failures you
+cannot reproduce.
 
-2. **The requested goal is achieved with evidence.**
-   - Review the delta with `git diff origin/main...HEAD` and `git log origin/main..HEAD`.
-   - Confirm the requested behavior is actually implemented.
-   - Validation must match risk. For bugs, prefer a failing test first when practical.
+## Security review
 
-3. **The changed feature is tested before merge.**
-   - Every behavior change MUST be covered by an automated test that exercises
-     the new or changed behavior directly — not merely adjacent code that still
-     compiles. Add or update the test as part of the change.
-   - The test must actually drive the feature's entry point (e.g. dispatch the
-     command, call the handler, run the turn), not just assert on a constructor.
-   - Changes to user-visible transcript output, live activity, or status values
-     must assert the terminal-independent presentation model directly. Terminal
-     buffer tests alone are layout coverage, not proof of visible semantics.
-   - If a behavior is genuinely impractical to cover automatically, say so
-     explicitly in the PR body, describe the manual verification you performed
-     instead, and list the gap under **Follow-ups**. "Hard to test" is not a
-     silent pass.
-   - Docs-only or config-only changes with no behavior change are exempt (state
-     why).
+Mandatory for every change touching code, configuration, or infrastructure —
+perceived low risk does not excuse it. Yolop is a coding agent with disk and
+shell access on the user's host, so the categories are concentrated:
 
-4. **The changed code is fit to merge.**
-   - Simplify obvious duplication or accidental complexity.
-   - Perform the structured security review below.
-   - Fix issues you find and refresh the evidence.
+- **TM-FS** — filesystem. The write blocklist still covers `.git/`,
+  `node_modules/`, `target/`, `dist/`, `build/`, `.next/`, `.venv/`, `venv/`,
+  `.tox/`, `.gradle/` at any depth; reads stay unrestricted only inside the
+  workspace root.
+- **TM-BASH** — shell execution. Timeouts and per-stream output caps survive.
+  Any change to `tools.rs` must preserve the bounded execution model.
+- **TM-LLM** — prompt construction and key handling. Keys are read from process
+  env only, and never logged or written to session JSONL.
+- **TM-TOOL** — capability registration. New capabilities respect the write
+  blocklist.
+- **TM-DEP** — dependency risk. A new crate needs a one-line justification.
+  `everruns-*` versions move together; mismatched versions are a soft API break.
 
-5. **Relevant artifacts stay in sync.**
-   - Review whether the change alters durable behavior, intent, architecture,
-     policy, constraints, terminology, or maintainer process.
-   - If it does, update the affected `knowledge/` concepts in the same change;
-     update `knowledge/index.md` for added, removed, renamed, or reclassified
-     concepts and `knowledge/log.md` for significant knowledge changes.
-   - If it does not, record "No knowledge update required" with a short reason in
-     the PR body. Keep `AGENTS.md`, `README.md`, and `docs/` aligned where relevant.
-   - Validate changed knowledge with
-     `python3 scripts/validate_okf.py knowledge --check-links`.
+For each relevant category, check the diff for injection (command, prompt, path
+traversal), data exposure, missing validation at trust boundaries, and resource
+exhaustion (unbounded loops, missing limits).
 
-6. **Smoke test impacted functionality.**
-   - Always smoke test the flows affected by the change end-to-end. This is in
-     addition to, not a substitute for, the automated feature test in outcome 3.
-   - For changes that touch the agent loop, run `doppler run -- cargo run -- --provider openai -p "<focused prompt>"` and read the output.
-   - For offline-safe changes, `cargo run -- --provider llmsim -p "hi"` is enough to prove the binary still starts.
-   - Docs-only or config-only changes that do not affect runtime may skip smoke testing with explicit justification.
+Record the result in the PR body under **Security**. Docs-only, comment-only, or
+test-only changes may state "No security-relevant code changes" with a one-line
+justification.
 
-7. **Follow-ups are surfaced, not silently dropped.**
-   - Default to implementing everything in scope before merging.
-   - For each candidate, decide explicitly: **implement now** (preferred) or **defer**.
-   - For anything deferred, list it under a **Follow-ups** section in the PR body with a one-line rationale.
-   - If there are no follow-ups, state "No follow-ups." in the PR body.
+## PR and merge
 
-8. **The PR is mergeable and merged safely.**
-   - Push the branch.
-   - Create or update the PR.
-   - Address every review comment — including low-confidence suggestions, nits, and bot comments. For each comment, post an inline reply on the same thread explaining the resolution (and apply a code change too when one is needed), then mark that thread resolved. An inline reply is required even when the fix is a pure code change; no comment may be left unanswered or unresolved before merge.
-   - Wait for CI to go green.
-   - Merge with squash only after CI is green and the final review sweep is clean.
-   - After merging, monitor main CI for the merge commit. If it fails, fix or revert promptly.
+Write the body around functional change and impact — what changed, why, how it
+was validated, notable risks — using
+[`.github/pull_request_template.md`](../../../.github/pull_request_template.md).
+Two sections are never omitted: **Security** (above) and **Follow-ups**
+(everything deferred, one line of rationale each, or "No follow-ups."). Default
+to implementing in-scope work rather than deferring it.
 
-## Operating Model
+Record the knowledge decision explicitly: either the concepts you updated, or
+"No knowledge update required" with a reason.
 
-- Start from the goal and risk surface, not checklist order.
-- Choose the highest-signal path first: targeted diff review, focused tests, relevant builds, then smoke tests.
-- "Fix and ship" means implement first, then switch into shipping mode.
-- Stop only for blockers you cannot safely resolve alone: merge conflicts, missing credentials, ambiguous product intent, or CI failures you cannot reproduce.
+Every review comment gets an inline reply on its own thread and is marked
+resolved — including nits, low-confidence suggestions, and bot comments. A reply
+is required even when the resolution is a pure code change.
 
-## Security Review
-
-Mandatory for every change that touches code, configuration, or infrastructure. Yolop is a coding agent with disk and shell access on the user's host, so the relevant categories are concentrated:
-
-- **TM-FS** — filesystem access. Verify the write blocklist still covers `.git/`, `node_modules/`, `target/`, `dist/`, `build/`, `.next/`, `.venv/`, `venv/`, `.tox/`, `.gradle/` at any depth. Verify reads remain unrestricted only inside the workspace root.
-- **TM-BASH** — shell execution. Verify timeouts and output caps. Any change to `tools.rs` must preserve the bounded execution model.
-- **TM-LLM** — prompt construction and API key handling. Verify keys are never logged or written to session JSONL. Verify provider env vars are read from process env only.
-- **TM-TOOL** — capability registration. Verify new capabilities respect the write blocklist.
-- **TM-DEP** — dependency risk. New crates need a one-line justification. Bump `everruns-*` versions together; mismatched versions are a soft API break.
-
-For every relevant category, check the diff for: injection (command/prompt/path traversal), data exposure (keys in logs, session files), input validation at trust boundaries, dependency risk, and resource exhaustion (unbounded loops, missing limits).
-
-Document the review in the PR body under **Security**. Changes that are purely docs, comments, or test-only may state "No security-relevant code changes" with a one-line justification.
-
-## Common Evidence Commands
-
-Pick only what matches the changed surface:
-
-- `cargo fmt --check`
-- `cargo clippy --all-targets --all-features -- -D warnings`
-- `cargo test --all-features`
-- `cargo fetch --locked`
-- `cargo build --release` (when changing binary surface or release profile)
-- `doppler run -- cargo test --all-features --test integration` (when a live-provider integration test is relevant)
-- `doppler run -- cargo run -- --provider openai -p "<smoke prompt>"`
-
-## PR And Merge
-
-- Use a Conventional Commit style PR title under 70 characters.
-- In the PR body, explain what changed, why, how it was validated, notable risks, and an explicit **Follow-ups** section (or "No follow-ups.").
-- After CI is green, wait at least 2 minutes for async reviewer bots, then do one last comment sweep before merge.
-- Merge with `gh pr merge --squash` only after CI is green and the final review sweep is clean.
-- Do not use auto-merge: async review bots can post after the last push.
+Merge with `gh pr merge --squash` after CI is green and a final comment sweep is
+clean; give async reviewer bots at least 2 minutes after CI turns green. Do not
+enable auto-merge — bots can post after the last push. After the merge lands,
+watch main CI for the merge commit and fix or revert promptly if it fails.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,186 +1,107 @@
 # Yolop — coding-agent guidance
 
-Yolop is a terminal coding agent built on top of
-[`everruns-runtime`](https://crates.io/crates/everruns-runtime). The binary is
-named `yolop`; the crate is `yolop`.
+Yolop is a terminal coding agent built on
+[`everruns-runtime`](https://crates.io/crates/everruns-runtime). The binary and
+the crate are both named `yolop`.
 
-This file is read on every turn by the agent itself when run inside this
-repository, so keep it short, factual, and project-specific.
+This file is read on every turn. It carries repository facts and gotchas only;
+depth lives behind the links below. [`knowledge/specs/agent-context.md`](knowledge/specs/agent-context.md)
+defines how this repository organizes what agents read.
 
-## Workflow
+Telegraph — keep updates short and factual. Fix root causes; when you are still
+stuck after reading the code, ask with short options.
 
-- Telegraph. Drop filler. Keep updates short and factual.
-- Fix the root cause. If unsure, read more code; if still stuck, ask with short options.
-- When `repo_map` or `repo_symbols` reveals a likely owning module, narrow to that module next. Read it and one or two call sites/tests before doing more broad grep; resume broad search only if the owner is disproven.
-- Unrecognized working-tree changes are probably from another agent or the user. Work with them. Stop only if they make the task unsafe.
-- Start from latest `main` by default: `git fetch origin main`, then branch from or rebase onto `origin/main`.
-- Keep changes small, PR-sized, testable, and runnable locally.
-- For bug fixes, write or update a failing test before the fix when practical.
-- Important decisions belong as concise comments near the relevant code, not in scratch docs.
-- No backward compatibility required unless a spec says so — `yolop` is pre-1.0.
+## Layout
 
-## Cloud and secrets
+A Cargo workspace of four packages; root `cargo test` / `cargo clippy` cover all
+of them.
 
-Use Doppler for any secret-backed command. `OPENAI_API_KEY` is the default
-provider key; `ANTHROPIC_API_KEY` is the secondary. CI loads both via the
-`DOPPLER_TOKEN` repository secret.
+- `.` — the `yolop` binary.
+- `crates/yolop-yep/` — the YEP extension protocol and server SDK, published
+  separately for extension authors; the host depends on it for the wire types.
+- `crates/tuika/` — a standalone terminal-UI toolkit over ratatui (layout,
+  overlays, focus, streaming `Markdown`, `CodeBlock`), separately versioned,
+  powering the fullscreen renderer. See [`crates/tuika/README.md`](crates/tuika/README.md).
+- `crates/tuika-codeformatters/` — tuika's tree-sitter `Highlighter`, kept
+  separate so tuika core stays grammar-free.
 
-```bash
-doppler run -- cargo test --all-features
-doppler run -- cargo run -- -p "say hi"
-```
+## Gotchas
 
-Use `gh` directly first. Only if `gh` reports that it is not authenticated, retry
-through Doppler; do not invoke Doppler preemptively for GitHub commands:
+- Secrets come from Doppler. `OPENAI_API_KEY` is the default provider key,
+  `ANTHROPIC_API_KEY` the secondary; CI loads both from the `DOPPLER_TOKEN`
+  repository secret.
 
-```bash
-doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" <command>'
-```
+  ```bash
+  doppler run -- cargo test --all-features
+  doppler run -- cargo run -- --provider openai -p "hi"
+  ```
 
-## Knowledge and docs
+- Try `gh` directly first. Only if it reports that it is not authenticated,
+  retry through Doppler — do not reach for Doppler preemptively:
+  `doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" <command>'`.
+- `--provider llmsim` needs no API key, so `cargo run -- --provider llmsim -p "hi"`
+  is the offline smoke test.
+- Yolop is pre-1.0: no backward compatibility is required unless a spec says so.
+- Unrecognized working-tree changes are probably from another agent or the user.
+  Work with them; stop only if they make the task unsafe.
+- Decisions worth keeping belong as concise comments near the relevant code, not
+  in scratch documents.
+- For bug fixes, prefer writing the failing test before the fix.
 
-- `knowledge/` is the repository's Open Knowledge Format (OKF) bundle and durable
-  development memory. Read `knowledge/index.md` first, then only the concepts
-  relevant to the task and their links.
-- When a change alters durable behavior, intent, architecture, policy, constraints,
-  terminology, or maintainer process, update the affected concepts in the same
-  change. Update `knowledge/index.md` when concepts are added, removed, renamed, or
-  reclassified; update `knowledge/log.md` for significant knowledge changes.
-- Keep transient plans, task status, test output, and source-level details out of
-  the bundle. Knowledge captures **why** and **what**, not exhaustive **how**.
-- `README.md` is the public entry point; `docs/` contains standalone guidance for
-  external users. Neither may link to internal `knowledge/` or `.agents/` material.
-  See `knowledge/specs/documentation.md` for the documentation contract.
+`RUST_LOG` is honored for the tracing layer (stderr).
 
-## Local dev and tests
-
-Yolop is a small Cargo **workspace**: the root package is the `yolop` binary,
-`crates/yolop-yep/` is the extension-protocol library + server SDK (published
-separately for extension authors; the host depends on it for the wire types),
-`crates/tuika/` is a standalone terminal-UI toolkit (layout, overlays, focus,
-components over ratatui — including the streaming `Markdown` renderer and
-`CodeBlock`) with its own version, powering the experimental `--fullscreen`
-renderer — see `crates/tuika/README.md`, and `crates/tuika-codeformatters/` is
-tuika's tree-sitter `Highlighter` implementation (kept separate so tuika core
-stays grammar-free; yolop's markdown/code rendering flows through both).
-`cargo test`/`clippy` at the root cover all four. For touched code:
+## Checks
 
 ```bash
 cargo fmt --check
 cargo clippy --all-targets --all-features -- -D warnings
 cargo test --all-features
+python3 scripts/validate_okf.py knowledge --check-links   # when knowledge/ changed
 ```
 
-Quick offline smoke test (no API key needed — uses the bundled `llmsim`
-provider):
+## Where things live
 
-```bash
-cargo run -- --provider llmsim -p "hi"
-```
+- [`knowledge/`](knowledge/index.md) — the OKF bundle and durable development
+  memory: intent, architecture, policy, constraints, and the success bars for
+  shipping, maintenance, and release. Read the index first, then only the
+  concepts the task touches.
+- [`.agents/skills/`](.agents/skills) — workflows the user can request by name:
+  `/ship`, `/maintenance`, `/release`, `/author-extension`.
+- [`crates/tuika/benches/README.md`](crates/tuika/benches/README.md) — Criterion
+  and iai-callgrind procedure. The iai instruction counts are a committed
+  baseline and a CI gate.
+- [`evals/README.md`](evals/README.md) — the Mira eval studies (SWE-bench
+  Verified, harness A/Bs, LSP isolation). Outside the Cargo workspace.
+- [`README.md`](README.md) and [`docs/`](docs/) — the public surface. Neither may
+  link into `knowledge/` or `.agents/`; see
+  [`knowledge/specs/documentation.md`](knowledge/specs/documentation.md).
 
-Real provider smoke test through Doppler:
+## Keeping knowledge current
 
-```bash
-doppler run -- cargo run -- --provider openai -p "hi"
-```
+When a change alters durable behavior, intent, architecture, policy,
+constraints, terminology, or maintainer process, update the affected concepts in
+the same change. Update `knowledge/index.md` when concepts are added, removed,
+renamed, or reclassified, and `knowledge/log.md` for significant knowledge
+changes. Transient plans, task status, and source-level detail stay out of the
+bundle.
 
-`RUST_LOG` is honored for the tracing layer (stderr).
+## Commits
 
-Component render benchmarks live under `crates/*/benches/` (Criterion). Run a
-crate's suite and, when checking a change for a regression, save a baseline
-first and compare against it:
+- Conventional Commits: `type(scope): description`, using `feat`, `fix`, `docs`,
+  `refactor`, `test`, or `chore`. `chore` covers `knowledge/`, `AGENTS.md`, and
+  CI metadata.
+- Stage files explicitly by name. Avoid `git add .` / `git add -A`.
+- Never add Claude/session/AI attribution to commits, PRs, docs, or comments.
+- Commit attribution must be a real human user. If the git identity is missing
+  or agent-like, stop and ask before committing.
 
-```bash
-cargo bench -p tuika --bench markdown -- --save-baseline before
-# ...make the change...
-cargo bench -p tuika --bench markdown -- --baseline before
-```
-
-Wall-clock numbers are too noisy on shared CI runners to gate on, so CI runs the
-benches only on `main` (and via manual dispatch) and uploads the Criterion
-output as an artifact; regression-checking is a local, baseline-to-baseline
-comparison. New component benches go in the owning crate's `benches/` as another
-`[[bench]]` with `harness = false`.
-
-Alongside those, the `*_iai` benches count CPU instructions under
-Valgrind/callgrind ([iai-callgrind](https://github.com/iai-callgrind/iai-callgrind)).
-Instruction counts are deterministic and machine-independent for a fixed
-toolchain + libc, so the numbers are committed to `crates/*/benches/iai-baseline.json`
-and the CI `iai` job **fails** on a regression past the baseline's tolerance —
-this is a real gate, not an archive. Running them locally needs Valgrind and a
-version-matched runner (`cargo install iai-callgrind-runner`):
-
-```bash
-rm -rf target/iai
-cargo bench -p tuika --bench markdown_iai \
-  -p tuika-codeformatters --bench highlight_iai -- --save-summary=json
-python3 crates/tuika/benches/check_iai.py            # compare to the committed baseline
-python3 crates/tuika/benches/check_iai.py --update   # bless new counts (commit alongside the change)
-```
-
-When a change legitimately shifts counts (renderer change, dependency bump,
-toolchain upgrade), regenerate the baseline with `--update` and commit it with
-the code — like a snapshot test. To refresh it from CI's exact environment,
-run the workflow manually (`workflow_dispatch`) and commit the uploaded
-`iai-baseline` artifact.
-
-The `evals/` directory holds [Mira](https://github.com/everruns/mira) eval
-studies for benchmarking yolop and other agents. `evals/swebench_verified/` is
-the SWE-bench Verified study — a single self-contained `swebench_verified.py`
-built on the `mira-eval` Python SDK, with PEP 723 inline deps; the `mira` host
-CLI drives it from that directory (`mira --cmd "uv run swebench_verified.py"
-run`). It is outside the Cargo workspace; `uv run` provisions its deps on first
-use, and its tests (which import the SDK) run with `uv run --with mira-eval -m
-unittest discover -s evals/swebench_verified/tests`. `evals/harness_basic/` is
-a pure-Rust study on the `mira-eval` SDK (its own standalone crate, outside
-this Cargo package) that A/Bs yolop harness configurations on basic coding
-cases through headless `yolop -p`; `cargo test` inside that directory runs its
-tests. `evals/lsp_integration/` follows the same pure-Rust pattern but isolates
-the optional LSP capability on semantic-navigation traps (its `bootstrap.sh`
-installs the language servers the `lsp` variant needs). See
-[`evals/README.md`](evals/README.md).
-
-## Git and commits
-
-- Conventional Commits: `type(scope): description`.
-- Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`.
-- Use `chore` for updates to `knowledge/`, `AGENTS.md`, or CI metadata.
-- Never add Claude/session/AI attribution links in commits, PRs, docs, or code comments.
-- Stage files explicitly by name. Avoid broad `git add .` / `git add -A`.
-
-Commit attribution must be a real human user. If git identity is missing or
-agent-like, stop and ask before committing.
-
-## PRs and CI
-
-- Use `.github/pull_request_template.md`. Center the description on functional
-  change and impact, not a code-location walkthrough (the diff shows that). Add a
-  Before / After with proof — CLI output, logs, or screenshots for UI — whenever
-  behavior changes.
-- PR titles must be Conventional Commits and under 70 characters.
-- Use **Squash and Merge**.
-- GitHub Actions is the CI source of truth.
-- Never merge red CI.
-- Before merge, prefer rebasing onto latest `origin/main`.
-
-## Shipping, maintenance, and releases
-
-- "Ship" means implement, test the changed feature with an automated test that
-  exercises it, gather evidence, perform a security review, open a mergeable PR,
-  address every review comment, and merge only after CI is green.
-- When asked to ship, follow [`.agents/skills/ship/SKILL.md`](.agents/skills/ship/SKILL.md)
-  and [`knowledge/specs/shipping.md`](knowledge/specs/shipping.md).
-- When asked for maintenance or release readiness, follow
-  [`.agents/skills/maintenance/SKILL.md`](.agents/skills/maintenance/SKILL.md)
-  and [`knowledge/specs/maintenance.md`](knowledge/specs/maintenance.md).
-- When asked to release, cut a version, or publish to crates.io / Homebrew,
-  follow [`.agents/skills/release/SKILL.md`](.agents/skills/release/SKILL.md)
-  and [`knowledge/specs/release.md`](knowledge/specs/release.md). Releases publish to both
-  crates.io and the `everruns/homebrew-tap` Homebrew tap.
+Start from latest `main` by default: `git fetch origin main`, then branch from or
+rebase onto `origin/main`. The merge bar (PR template, CI, squash) is owned by
+[`knowledge/specs/shipping.md`](knowledge/specs/shipping.md).
 
 ## Upstream relationship
 
-Yolop is a friendly fork / promotion of the `examples/coding-cli` example in
-[`everruns/everruns`](https://github.com/everruns/everruns). When the upstream
-example changes meaningfully, mirror the useful parts here. Keep public
-runtime crate versions in lockstep with what is published on crates.io.
+Yolop is a friendly fork of the `examples/coding-cli` example in
+[`everruns/everruns`](https://github.com/everruns/everruns). Mirror meaningful
+upstream changes, and keep the public runtime crate versions in lockstep with
+what is published on crates.io.

--- a/crates/tuika/benches/README.md
+++ b/crates/tuika/benches/README.md
@@ -1,0 +1,45 @@
+# tuika benchmarks
+
+Two suites with different jobs. Criterion measures wall-clock and is advisory;
+iai-callgrind counts instructions and is a CI gate.
+
+## Criterion (wall clock)
+
+`markdown.rs` and `scroll.rs` are Criterion targets. Wall-clock numbers are too
+noisy on shared runners to gate on, so CI runs these only on `main` (and via
+manual dispatch) and uploads the Criterion output as an artifact. Regression
+checking is local and baseline-to-baseline:
+
+```bash
+cargo bench -p tuika --bench markdown -- --save-baseline before
+# ...make the change...
+cargo bench -p tuika --bench markdown -- --baseline before
+```
+
+A new component bench goes in the owning crate's `benches/` as another
+`[[bench]]` with `harness = false`.
+
+## iai-callgrind (instruction counts)
+
+The `*_iai` targets count CPU instructions under Valgrind/callgrind
+([iai-callgrind](https://github.com/iai-callgrind/iai-callgrind)). Counts are
+deterministic and machine-independent for a fixed toolchain + libc, so they are
+committed to `iai-baseline.json` and the CI `iai` job **fails** on a regression
+past the baseline's tolerance. This is a real gate, not an archive.
+
+Running locally needs Valgrind and a version-matched runner
+(`cargo install iai-callgrind-runner`):
+
+```bash
+rm -rf target/iai
+cargo bench -p tuika --bench markdown_iai \
+  -p tuika-codeformatters --bench highlight_iai -- --save-summary=json
+python3 crates/tuika/benches/check_iai.py            # compare to the committed baseline
+python3 crates/tuika/benches/check_iai.py --update   # bless new counts
+```
+
+Treat the baseline like a snapshot test: when a change legitimately shifts
+counts (renderer change, dependency bump, toolchain upgrade), regenerate with
+`--update` and commit it alongside the code. To refresh from CI's exact
+environment, run the workflow manually (`workflow_dispatch`) and commit the
+uploaded `iai-baseline` artifact.

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -57,3 +57,4 @@ and [`docs/`](../docs/); it must not link back into this internal bundle.
 - [Maintenance](specs/maintenance.md) — repository health and release readiness.
 - [Release](specs/release.md) — publishing crates and Homebrew releases.
 - [Documentation](specs/documentation.md) — public/internal documentation contract.
+- [Agent context](specs/agent-context.md) — how AGENTS.md, knowledge, and skills are layered.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,21 @@
 Significant changes to Yolop's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
+## 2026-07-24 — Agent context layering
+
+- Added [Agent context](specs/agent-context.md): one owner per rule, progressive
+  disclosure across `AGENTS.md` → specs → skills → code, and constraint reserved
+  for irreversible actions.
+- Applied it: `AGENTS.md` now carries repository facts and gotchas only, with
+  benchmark procedure moved to `crates/tuika/benches/README.md` and eval
+  procedure left to `evals/README.md`; the ship, maintenance, and release skills
+  stopped restating their specs' bars, and maintenance and release split their
+  reference material out of `SKILL.md`.
+- Resolved two conflicting constraints: the ship skill no longer both mandates a
+  checklist and tells the agent not to walk one, and the release pre-release
+  checklist no longer requires a `-p yolop` dry-run that is expected to fail
+  locally.
+
 ## 2026-07-24
 
 - Corrected the release contract to publish all four workspace crates in dependency order, including `tuika-codeformatters` before `yolop`.

--- a/knowledge/specs/agent-context.md
+++ b/knowledge/specs/agent-context.md
@@ -1,0 +1,90 @@
+---
+type: Policy
+title: Agent Context Specification
+description: Defines how this repository organizes the context coding agents read — AGENTS.md, knowledge, and skills.
+---
+
+# Agent Context Specification
+
+## Purpose
+
+Yolop's repository is read by coding agents on every turn. This specification
+defines how that context is organized so the agent gets high-signal material
+without paying for the whole repository up front.
+
+The guidance targets current-generation models, which need less constraint and
+more judgment space than earlier ones. Instructions that spell out steps a
+capable model would choose anyway do not improve behavior; they crowd out the
+project-specific facts that do.
+
+## Principles
+
+1. **One owner per instruction.** Any rule lives in exactly one place. A spec
+   states the bar; the skill states the workflow; `AGENTS.md` states the
+   repository facts. Restating a rule in a second file makes the two drift and
+   forces the agent to reconcile them.
+2. **Progressive disclosure.** Load context when it is needed, not before.
+   `AGENTS.md` is read every turn, so it carries only what is needed on every
+   turn; depth lives behind a link the agent follows when the task calls for it.
+3. **Gotchas, not the obvious.** Document what an agent cannot infer from the
+   file system, `Cargo.toml`, or the code: non-obvious ordering, environment
+   requirements, invariants a test does not express. Do not restate what
+   reading the repository already shows.
+4. **Judgment over ritual.** State the required outcome and the constraint that
+   makes it non-negotiable, then let the agent choose the path. Prescribe exact
+   steps only where the cost of a wrong choice is high and irreversible —
+   publishing, security review, credentials, git history.
+5. **No conflicting constraints.** A hard requirement and an invitation to use
+   judgment must not cover the same ground. Where both appear, the agent
+   deliberates instead of working. Pick one and mean it.
+6. **Prefer references in code.** A test, a script, a manifest, or a runnable
+   command is higher-fidelity than prose describing it. Point at the artifact
+   rather than paraphrasing it; paraphrase drifts, the artifact does not.
+
+## Layers
+
+| Layer | Read when | Carries |
+| --- | --- | --- |
+| `AGENTS.md` | Every turn | Repository purpose, gotchas, the commands that gate a change, pointers to the layers below. |
+| `knowledge/specs/` | The task touches the concept | Durable intent, constraints, tradeoffs, and the success bar. Why and what, never exhaustive how. |
+| `.agents/skills/` | The named workflow is requested | Execution workflow for a request the user can name (`/ship`, `/release`). |
+| Code, tests, benches, `evals/` | The task reaches them | The authoritative how, colocated with what it describes. |
+
+Detail belongs at the deepest layer that can hold it. Operational how-to about
+a directory belongs in that directory — bench procedure next to the benches,
+eval procedure next to the evals — not in `AGENTS.md`.
+
+## Skills
+
+A skill is a lightweight guide for retrieving the right context, not a
+procedure manual. `SKILL.md` carries the goal, when to use it, the outcomes
+that define success, and the decision points. Reference material — templates,
+long command sequences, per-surface checklists — goes in sibling files under
+the skill directory and is read when that part of the work comes up.
+
+Constrain hard only where it matters: gates that protect users, published
+artifacts, or credentials. Everywhere else, the outcome is the instruction.
+
+## Ownership boundary
+
+- A spec MUST NOT restate a skill's workflow, and a skill MUST NOT restate a
+  spec's rationale. Each links to the other.
+- `AGENTS.md` MUST NOT duplicate a spec's bar or a skill's steps. It names them
+  and links.
+- Public documentation stays outside this boundary entirely; see
+  [`documentation.md`](./documentation.md).
+
+## Change requirements
+
+- Adding a rule means choosing its single owner first. If it already exists
+  elsewhere, update that copy instead of adding a second.
+- Growing `AGENTS.md` is a signal, not a neutral act: prefer moving the detail
+  to the layer that owns it and leaving a pointer.
+- When a skill file grows past the point where its opening section still
+  answers "what am I being asked to do", split the reference material out.
+
+## Related
+
+- [`documentation.md`](./documentation.md) — the public/internal documentation boundary.
+- [`skills.md`](./skills.md) — the runtime skills capability yolop ships.
+- [`okf.md`](./okf.md) — why the knowledge bundle is plain OKF markdown.

--- a/knowledge/specs/documentation.md
+++ b/knowledge/specs/documentation.md
@@ -25,7 +25,8 @@ Yolop without requiring knowledge of repository internals.
 - `knowledge/specs/` is internal durable product and design memory. It records intent,
   constraints, tradeoffs, and architectural decisions for maintainers.
 - `.agents/` and `AGENTS.md` contain contributor and agent workflows, not user
-  guidance.
+  guidance. How that internal context is layered and kept non-duplicative is
+  defined in [`agent-context.md`](./agent-context.md).
 
 ## Direction of links
 

--- a/knowledge/specs/maintenance.md
+++ b/knowledge/specs/maintenance.md
@@ -169,8 +169,19 @@ Specs preserve design intent, rationale, and constraints — not implementation 
 - replace exhaustive feature-flag or capability lists with links to source
 - keep the "why" and constraints; link to code for the "what"
 
+## Agent Context Hygiene
+
+The context agents read drifts the same way code does, and duplication is its
+characteristic failure: a rule stated in `AGENTS.md`, restated in a spec, and
+restated again in a skill will disagree within a few changes. Maintenance should
+check the layering defined in [`agent-context.md`](./agent-context.md) — one
+owner per rule, `AGENTS.md` carrying only every-turn facts, skills thin at the
+top with reference material split out, and no instruction that both mandates a
+step and invites judgment about it.
+
 ## Related
 
 - [`.agents/skills/maintenance/SKILL.md`](../../.agents/skills/maintenance/SKILL.md)
+- [`knowledge/specs/agent-context.md`](./agent-context.md)
 - [`knowledge/specs/documentation.md`](./documentation.md)
 - [`knowledge/specs/shipping.md`](./shipping.md)

--- a/knowledge/specs/release.md
+++ b/knowledge/specs/release.md
@@ -77,75 +77,35 @@ registries silently failed.
 
 ### Agent Steps
 
-When asked to release, the agent:
+The procedure lives in [`.agents/skills/release/SKILL.md`](../../.agents/skills/release/SKILL.md). These are the
+constraints it must satisfy:
 
-0. **Ensure full git history.** Cloud sandboxes are often shallow-cloned,
+1. **The commit set is complete.** Cloud sandboxes are often shallow-cloned,
    which silently hides commits and yields a wrong commit count or changelog.
-   Run `git fetch --unshallow origin main 2>/dev/null || git fetch origin main`
-   before counting or listing commits.
+   Full history is established before anything is counted or listed.
+2. **The version is confirmed.** Either given by the human, or proposed from the
+   unreleased commits under § Versioning and confirmed before proceeding.
+3. **The changelog is honest.** Every commit since the previous tag appears, in
+   the format defined in § Changelog Format.
+4. **Versions agree.** `Cargo.toml` and `Cargo.lock` read `X.Y.Z`, and each
+   separately versioned library crate carries a version consistent with every
+   workspace path dependency requirement that references it.
+5. **Publish-readiness is proven before the PR opens.** The library dry-runs
+   succeed and `X.Y.Z` exceeds what crates.io serves. A release PR is never
+   opened, and never merged, with a known-broken publish path.
+6. **Post-merge verification is independent.** Green workflows are not evidence
+   of a release. The agent checks crates.io and the Homebrew tap itself and
+   declares **shipped** only when both report the new version. A failure rolls
+   forward via hotfix rather than leaving the release half-published.
 
-1. **Determine the version.** Use the version specified by the human, or
-   propose the next version based on the unreleased commits (patch / minor /
-   major) and confirm before proceeding.
-
-2. **Update `CHANGELOG.md`.** Add a `## [X.Y.Z] - YYYY-MM-DD` section, list
-   PRs in descending order with GitHub-style links and contributor handles,
-   end with `**Full Changelog**: URL`. For minor/major bumps, add an explicit
-   `### Breaking Changes` block with before/after migration snippets.
-
-3. **Bump the version** in `Cargo.toml` and regenerate `Cargo.lock`
-   (`cargo update -p yolop`). The library crates under `crates/` — the
-   `yolop-yep` SDK, the `tuika` TUI toolkit, and `tuika-codeformatters` — are
-   **versioned separately**: bump one when its API or published dependency range
-   changes (for `yolop-yep`, also the wire protocol), and update every workspace
-   path dependency requirement that references it. A Tuika bump usually requires
-   a `tuika-codeformatters` bump because the published formatter pins a compatible
-   Tuika range.
-
-4. **Run local verification:**
-   - `cargo fmt --check`
-   - `cargo clippy --all-targets --all-features -- -D warnings`
-   - `cargo test`
-
-5. **Verify publish-readiness** (catches what local tests don't — the
-   `cargo publish` packaging step, missing files, version drift):
-   - `cargo publish --dry-run -p yolop-yep`, `-p tuika`, and
-     `-p tuika-codeformatters` must succeed.
-   - Confirm `Cargo.toml` and `Cargo.lock` agree on `X.Y.Z`.
-   - Confirm `X.Y.Z` is greater than the latest published version on
-     crates.io (`cargo search yolop --limit 1`).
-   - If any check fails, fix the root cause and re-run before opening the
-     PR. **Do not** merge a release PR with a known-broken publish path.
-
-   **Four crates, ordered publish.** `yolop` depends on `yolop-yep`, `tuika`,
-   and `tuika-codeformatters` by version, so crates.io requires all three live
-   first. `publish.yml` derives their dependency-first order from Cargo metadata
-   (currently `yolop-yep`, `tuika`, `tuika-codeformatters`, then `yolop`) and
-   skips versions already live. Because
-   of that ordering, `cargo publish --dry-run -p yolop` can fail locally until
-   all in-tree library versions are on crates.io. That is expected, not a broken
-   release; dry-run all three library crates and rely on CI to validate `yolop`
-   after they go live.
-
-6. **Commit and push** the changes on a feature branch with message
-   `chore(release): prepare vX.Y.Z`.
-
-7. **Open a PR** titled `chore(release): prepare vX.Y.Z`. Include the
-   changelog excerpt and a **publish-readiness report** (which dry-runs ran,
-   what the registry currently shows).
-
-8. **Monitor and verify post-merge publishing.** After the human
-   squash-merges the PR:
-   - Watch `release.yml` complete and confirm tag `vX.Y.Z` + the GitHub
-     Release were created.
-   - Watch `publish.yml` and `cli-binaries.yml` to completion. Surface any
-     failure immediately.
-   - Run post-release verification (see below) yourself and report which
-     targets show the new version. Workflow success is not enough: the agent
-     must independently check crates.io and the Homebrew tap after merge.
-   - Only declare the release **shipped** when crates.io reports `X.Y.Z` and
-     the Homebrew tap formula points at `vX.Y.Z`. If one fails, open a hotfix
-     PR rather than leaving the release half-published.
+**Four crates, ordered publish.** `yolop` depends on `yolop-yep`, `tuika`, and
+`tuika-codeformatters` by version, so crates.io requires all three live first.
+`publish.yml` derives their dependency-first order from Cargo metadata
+(currently `yolop-yep`, `tuika`, `tuika-codeformatters`, then `yolop`) and skips
+versions already live. A consequence: `cargo publish --dry-run -p yolop` can
+fail locally until all in-tree library versions are on crates.io. That is
+expected, not a broken release — the libraries are dry-run locally and CI
+validates `yolop` after they go live.
 
 ## CI Automation
 
@@ -192,7 +152,8 @@ The agent verifies before opening the release PR:
 - [ ] `cargo fmt`, `cargo clippy`, `cargo test` clean.
 - [ ] `CHANGELOG.md` has an entry for every commit since the last release.
 - [ ] `Cargo.toml` and `Cargo.lock` both read `X.Y.Z`.
-- [ ] `cargo publish --dry-run -p yolop` succeeds.
+- [ ] `cargo publish --dry-run` succeeds for each library crate (`-p yolop` is
+      validated by CI once they are live — see § Agent Steps).
 - [ ] `X.Y.Z` is greater than the latest crates.io version.
 - [ ] Manual terminal matrix walked (see below) if the TUI renderer changed.
 

--- a/knowledge/specs/shipping.md
+++ b/knowledge/specs/shipping.md
@@ -42,26 +42,23 @@ Every shipped change MUST satisfy ALL of these. These are mandatory, not suggest
 
 - Shipping is outcome-oriented, not a mandatory linear checklist.
 - Validation starts with the smallest high-signal proof and deepens only when risk requires it.
-- Bug fixes prefer a failing test before the fix when practical.
 - Docs-only or config-only changes may skip code tests if the choice is justified and the relevant lint/build was run.
 - Security review is mandatory for code, configuration, or infrastructure changes. Perceived low risk does not justify skipping it.
 - Every review comment must be explicitly addressed, answered inline on its own thread with a written reply (in addition to any code change), and resolved before merge — including low-confidence suggestions, nits, and bot comments.
 - Auto-merge is not used: async reviewer bots can post after the last push or after CI turns green.
 - If a blocker cannot be resolved safely by the agent alone, shipping stops and reports rather than guesses.
 
-## Validation Menu
+## Validation Depth
 
-Use the smallest set that gives high confidence.
+Use the smallest set of checks that gives high confidence, drawn from the
+[checks in `AGENTS.md`](../../AGENTS.md) plus what the changed surface demands —
+`cargo build --release` for binary-surface or release-profile changes, the
+Doppler live-provider integration test when the change touches the agent loop or
+tool wiring.
 
-1. `cargo fmt --check`
-2. `cargo clippy --all-targets --all-features -- -D warnings`
-3. `cargo test --all-features`
-4. `cargo build --release` when changing the binary surface or release profile.
-5. `doppler run -- cargo test --all-features --test integration` for live-provider proof when the change touches the agent loop or tool wiring.
-6. `doppler run -- cargo run -- --provider openai -p "<focused prompt>"` for end-to-end smoke.
-7. `cargo run -- --provider llmsim -p "hi"` for offline smoke when CI access to provider keys is unavailable.
-8. Ensure test coverage proves the fix or acceptance criteria, including important negative paths. For visible transcript or status changes, assert the presentation model output directly.
-9. Update `README.md`, `docs/`, `AGENTS.md`, and `knowledge/specs/` when relevant.
+Coverage must prove the fix or the acceptance criteria, including the important
+negative paths. Visible transcript or status changes assert the presentation
+model output directly.
 
 ## Merge Discipline
 
@@ -73,6 +70,7 @@ Use the smallest set that gives high confidence.
 
 ## Related
 
+- [`knowledge/specs/agent-context.md`](./agent-context.md)
 - [`knowledge/specs/documentation.md`](./documentation.md)
 - [`knowledge/specs/maintenance.md`](./maintenance.md)
 - [`.agents/skills/ship/SKILL.md`](../../.agents/skills/ship/SKILL.md)


### PR DESCRIPTION
## What changed

The context this repository hands a coding agent is now layered instead of front-loaded, and every rule has exactly one owner.

- **New policy concept** — `knowledge/specs/agent-context.md` defines the layering: one owner per rule, progressive disclosure across `AGENTS.md` → specs → skills → code, gotchas rather than the obvious, and hard constraint reserved for irreversible actions (publishing, security review, credentials, git history). Indexed, logged, and cross-linked from the documentation, shipping, and maintenance specs.
- **`AGENTS.md` 186 → 107 lines.** It keeps what is needed on every turn — purpose, workspace layout, gotchas, the gate commands, commit rules — and links out for the rest. The Criterion/iai procedure moved to a new `crates/tuika/benches/README.md`; the eval paragraph gave way to the already-thorough `evals/README.md`.
- **Skills stopped restating their specs.** `ship` reads the shipping bar from the spec and owns only how to reach it. `maintenance` (184 → 55 lines) split its per-surface commands into `surfaces.md`. `release` (292 → 131 lines) defers changelog format, post-release verification, and the secrets table to `knowledge/specs/release.md`. `author-extension` compressed its facet catalog into a scaffold/seam table.
- **Two conflicting constraints resolved.** The `ship` skill no longer both declares "ALL outcomes MANDATORY, do not skip" and "do not blindly walk a fixed checklist". The release pre-release checklist no longer requires `cargo publish --dry-run -p yolop` to succeed — the same spec explains two sections later why that is expected to fail locally until the libraries are live.

Net: **+590 / -795** across 14 files. No fact was deleted without a home; each moved to the layer that owns it.

## Why

`AGENTS.md` is re-read on every turn, and it had grown into a manual: iai-callgrind procedure, the Mira eval topology, and bench baseline mechanics were all being paid for on turns that never touched a benchmark. Meanwhile the shipping and maintenance specs and their skills had drifted into near-verbatim copies of each other, so a rule changed in one place quietly disagreed with the other.

Both are the failure modes described in [The new rules of context engineering for Claude 5 generation models](https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models): front-loading instead of progressive disclosure, duplicated instructions across surfaces, and prescription where the outcome would do. This applies that guidance to the repository.

## Before / After

Documentation-only; no runtime behavior changes. The observable effect is what an agent pays for per turn and where it looks for depth.

**Before** — `AGENTS.md` carried the detail inline:

```
## Local dev and tests
... 70 lines covering the workspace, Criterion baselines, iai-callgrind gating,
check_iai.py --update, and the three Mira eval studies ...
```

**After** — the same facts, one link away from the turn that needs them:

```
- crates/tuika/benches/README.md — Criterion and iai-callgrind procedure. The
  iai instruction counts are a committed baseline and a CI gate.
- evals/README.md — the Mira eval studies (SWE-bench Verified, harness A/Bs,
  LSP isolation). Outside the Cargo workspace.
```

The full `docs-boundary` CI job passes locally:

```
$ python3 scripts/validate_okf.py knowledge --check-links
36 concept(s) checked in knowledge — 0 error(s)
$ python3 scripts/test_validate_okf.py && python3 scripts/test_publish_order.py
Ran 3 tests in 0.003s   OK
Ran 2 tests in 0.000s   OK
$ test "$(python3 scripts/publish_order.py | tail -1)" = yolop && echo OK
OK
$ grep -R -n -E --include='*.md' '\]\([^)]*(knowledge/|\.agents/)' README.md docs
(no matches — public boundary clean)
```

Every relative link in `AGENTS.md` and the four skills was resolved against the working tree: 0 broken.

## Risk

- **Low**
- Nothing compiles differently — the diff touches only Markdown. The one file under a Rust crate (`crates/tuika/benches/README.md`) trips the `tuika` path filter, so the MSRV leg runs; `crates/tuika/tests/packaging.rs` asserts presence/absence of specific paths (`docs/hero.gif`, `docs/demos/image.svg`, `src/lib.rs`, `Cargo.toml`, root `README.md`, no `docs/**/*.gif`), none of which a new `benches/README.md` can flip.
- The real risk is behavioral: guidance an agent no longer sees. Every removed line was either relocated (benches, evals), consolidated into its single owner (merge discipline → `shipping.md`, per-surface commands → `surfaces.md`), or deliberately dropped — see Follow-ups for the one deliberate drop.

## Checklist
- [x] Tests added or updated — n/a, documentation-only; the OKF validator and docs-boundary grep already gate this material and both pass
- [x] Backward compatibility considered — no wire, CLI, or API surface touched
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Added `knowledge/specs/agent-context.md` (Policy) and registered it in `knowledge/index.md` under Engineering processes. Updated `knowledge/specs/documentation.md` (points at the new concept for internal layering), `knowledge/specs/maintenance.md` (new *Agent Context Hygiene* surface so this layering is checked on a pass, not just established once), `knowledge/specs/shipping.md` (validation menu no longer restates the `AGENTS.md` commands; the failing-test-first default moved to `AGENTS.md`), and `knowledge/specs/release.md` (Agent Steps became constraints pointing at the skill; the contradictory dry-run checklist item fixed). Logged in `knowledge/log.md`.

## Security

No security-relevant code changes — the diff is Markdown only. The `ship` skill's threat-model categories (TM-FS, TM-BASH, TM-LLM, TM-TOOL, TM-DEP) and the maintenance security-posture checks were carried over intact, not weakened; the write-blocklist paths, the bash timeout and output-cap requirement, the `0o600` session-log mode, and the process-env-only key rule all survive verbatim in their new locations.

## Follow-ups

- **Dropped: the `repo_map`/`repo_symbols` narrowing heuristic.** Per the guidance, search-tool usage patterns belong in the tool description rather than restated per-repository — but those descriptions live upstream in `everruns-core`, so this is a removal rather than a move. If the behavior is worth keeping, the right fix is upstream in the tool description, not back in `AGENTS.md`.
- **Not audited: the bundled system skills** under `src/bundled/system-skills/` (`ast-grep`, `okf`, `skill-management`, `yolop`, `yolop-config`, `yolop-hooks`, `joke`). They are product surface shipped in the binary, and the same rightsizing likely applies, but changing them changes what users get and deserves its own PR with its own tests.
