### PR TITLE
feat(tui): render mermaid fences as terminal diagrams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3399,6 +3399,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mmdflux"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc3d57274846e2bab54eeb7e77e5418c76b8ea3e3ef4c5808daf73e1e68b89a6"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tracing",
+ "unicode-width",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6686,6 +6701,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tuika-mermaid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cdbe844e64cef702bd6a25ee5000a14d56634cf4307f25404fc6cb3b5c5bce7"
+dependencies = [
+ "mmdflux",
+ "ratatui-core",
+ "tuika",
+]
+
+[[package]]
 name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7707,6 +7733,7 @@ dependencies = [
  "tree-sitter-zig",
  "tuika",
  "tuika-codeformatters",
+ "tuika-mermaid",
  "urlencoding",
  "vt100",
  "yolop-yep",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,10 @@ tuika = "0.5.0"
 # Tree-sitter Highlighter impl for tuika's CodeBlock/Markdown; owns the grammar
 # deps so tuika core stays dependency-light. Published from the tuika repo.
 tuika-codeformatters = "0.3.0"
+# FencedBlockRenderer impl that turns ```mermaid fences into Unicode diagrams
+# via mmdflux; keeps diagram layout out of tuika core. Published from the tuika
+# repo.
+tuika-mermaid = "0.1.0"
 tokio = { version = "1.52", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tree-sitter = "0.26"

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,14 @@
 Significant changes to Yolop's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
+## 2026-07-25 — Mermaid fences in the transcript
+
+- Yolop fills tuika's `FencedBlockRenderer` seam with `tuika-mermaid`, so
+  ` ```mermaid ` fences render as Unicode diagrams. [Tuika](specs/tuika.md)
+  gained the third companion crate and the rule that a fenced block which does
+  not fit the transcript width falls back to the themed code block rather than
+  being painted clipped.
+
 ## 2026-07-24 — Tuika moved to its own repository
 
 - `tuika` and `tuika-codeformatters` left this workspace for

--- a/knowledge/specs/tuika.md
+++ b/knowledge/specs/tuika.md
@@ -23,12 +23,15 @@ than a one-line convenience.
 
 ## What
 
-Yolop depends on two crates from crates.io:
+Yolop depends on three crates from crates.io:
 
 - `tuika` — the toolkit. Version-pinned like any other dependency, with no path
   override.
 - `tuika-codeformatters` — the tree-sitter `Highlighter` implementation. Kept
   separate upstream so tuika core stays grammar-free.
+- `tuika-mermaid` — the `FencedBlockRenderer` that turns ` ```mermaid ` fences
+  into Unicode cell diagrams. Kept separate upstream so tuika core takes on no
+  diagram engine.
 
 ## Where the boundary falls
 
@@ -38,6 +41,7 @@ tuika owns *presentation*; yolop owns *acquisition and meaning*. Concretely:
 | --- | --- | --- |
 | Code highlighting | `CodeBlock` framing, gutter, wrapping | the `Highlighter` (`tuika-codeformatters`) |
 | Markdown images | block reservation and protocol emission | an `ImageResolver` that decodes bytes to RGBA |
+| Mermaid fences | the `FencedBlockRenderer` seam | the renderer (`tuika-mermaid`) and the transcript's width guard |
 | Key bindings | the keymap engine (chords, sequences, gated layers, dispatch) | the binding table and what each command *means* |
 | Links | OSC 8 encoding and the `LinkPolicy` sanitizer | which schemes are allowed, and the transcript's link runs |
 | Progress | the OSC 9;4 encoder | when a turn is running |
@@ -65,8 +69,14 @@ it receives, or a modifier-click opens the browser twice. See
 - **A yolop-only feature does not belong upstream.** If a proposed tuika change
   only makes sense for yolop, the right shape is a new seam (a trait, a state
   type, a callback) that yolop fills in.
-- **The two crates move together.** `tuika-codeformatters` pins a compatible
-  `tuika` range, so bumping one usually means bumping both.
+- **The companion crates move with tuika.** `tuika-codeformatters` and
+  `tuika-mermaid` pin a compatible `tuika` range, so bumping one usually means
+  bumping all three.
+- **A fenced block that does not fit is not painted.** A companion renderer may
+  lay content out at its natural size and ignore the offered width;
+  `tuika-mermaid` does. The transcript falls back to the themed code block
+  rather than paint a diagram the viewport will clip, so the source stays
+  readable at any terminal width.
 - **`ratatui` stays aligned.** Yolop and tuika must resolve to one shared
   `ratatui-core`, since the interoperability seam is a raw `Buffer` from it. A
   `ratatui` major bump is a coordinated change across both repositories.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -4842,6 +4842,124 @@ mod tests {
         );
     }
 
+    /// A `mermaid` fence in an assistant message is painted as a diagram, not
+    /// echoed as source.
+    #[test]
+    fn markdown_mermaid_fence_renders_as_a_diagram() {
+        let mut lines = Vec::new();
+        append_chat_lines(
+            &mut lines,
+            &ChatLine {
+                author: Author::Assistant,
+                text: "```mermaid\nflowchart LR\n  A[Parse] --> B[Paint]\n```".to_string(),
+            },
+            80,
+        );
+
+        let body = lines.iter().map(line_text).collect::<Vec<_>>().join("\n");
+        assert!(
+            body.contains("Parse") && body.contains("Paint"),
+            "node labels should survive rendering: {body}"
+        );
+        assert!(
+            !body.contains("flowchart LR"),
+            "the Mermaid source should be replaced by the diagram: {body}"
+        );
+        assert!(
+            body.contains('─') || body.contains('│'),
+            "the diagram should be drawn with box-drawing cells: {body}"
+        );
+        assert!(
+            lines.iter().all(|line| line_text(line).starts_with("agent")
+                || line_text(line).starts_with("      ")),
+            "diagram rows should keep the author gutter: {lines:?}"
+        );
+    }
+
+    /// Mermaid mmdflux cannot parse falls back to the ordinary code block, so
+    /// the source a user can still read stays on screen.
+    #[test]
+    fn markdown_unrenderable_mermaid_falls_back_to_source() {
+        let mut lines = Vec::new();
+        append_chat_lines(
+            &mut lines,
+            &ChatLine {
+                author: Author::Assistant,
+                text: "```mermaid\nthis is not a diagram\n```".to_string(),
+            },
+            80,
+        );
+
+        let body = lines.iter().map(line_text).collect::<Vec<_>>().join("\n");
+        assert!(
+            body.contains("this is not a diagram"),
+            "unrenderable Mermaid should keep its source visible: {body}"
+        );
+    }
+
+    /// mmdflux lays diagrams out at their natural size; when that overflows the
+    /// transcript we show the source instead of a clipped half-diagram.
+    #[test]
+    fn markdown_mermaid_too_wide_for_the_transcript_falls_back_to_source() {
+        let text = "```mermaid\nflowchart LR\n  A[Parse] --> B[Layout] --> C[Paint]\n```";
+        let mut narrow = Vec::new();
+        append_chat_lines(
+            &mut narrow,
+            &ChatLine {
+                author: Author::Assistant,
+                text: text.to_string(),
+            },
+            30,
+        );
+
+        let body = narrow.iter().map(line_text).collect::<Vec<_>>().join("\n");
+        assert!(
+            body.contains("flowchart LR"),
+            "a diagram wider than the transcript should fall back to source: {body}"
+        );
+
+        // The same diagram fits — and renders — once the transcript is wide
+        // enough, so the fallback is about width, not about this input.
+        let mut wide = Vec::new();
+        append_chat_lines(
+            &mut wide,
+            &ChatLine {
+                author: Author::Assistant,
+                text: text.to_string(),
+            },
+            80,
+        );
+        assert!(
+            !wide
+                .iter()
+                .map(line_text)
+                .collect::<Vec<_>>()
+                .join("\n")
+                .contains("flowchart LR"),
+            "the same diagram should render at width 80: {wide:?}"
+        );
+    }
+
+    /// Other fence languages keep the syntax-highlighted code block.
+    #[test]
+    fn markdown_non_mermaid_fence_is_untouched_by_the_diagram_renderer() {
+        let mut lines = Vec::new();
+        append_chat_lines(
+            &mut lines,
+            &ChatLine {
+                author: Author::Assistant,
+                text: "```rust\nfn main() { println!(\"hi\"); }\n```".to_string(),
+            },
+            60,
+        );
+
+        let body = lines.iter().map(line_text).collect::<Vec<_>>().join("\n");
+        assert!(
+            body.contains("fn main()"),
+            "rust fences should render as code: {body}"
+        );
+    }
+
     #[test]
     fn markdown_lines_wrap_styled_content_to_available_width() {
         let width = 32;

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1542,9 +1542,39 @@ pub(crate) fn diff_line_style(line: &str) -> Style {
     Style::default().fg(color)
 }
 
+/// `tuika-mermaid` with a transcript-width guard.
+///
+/// mmdflux lays a diagram out at its natural size and ignores the width tuika
+/// offers, so a wide flowchart in a narrow terminal would be painted clipped —
+/// half a box, no way to read the rest. Falling back to `None` there hands the
+/// block back to tuika's themed code block, which keeps the Mermaid source
+/// itself on screen.
+struct MermaidFencedBlocks;
+
+impl tuika::components::markdown::FencedBlockRenderer for MermaidFencedBlocks {
+    fn render(
+        &self,
+        language: &str,
+        source: &str,
+        width: u16,
+        theme: &tuika::style::Theme,
+    ) -> Option<Vec<Line<'static>>> {
+        let rendered =
+            tuika_mermaid::MermaidRenderer::new().render(language, source, width, theme)?;
+        rendered
+            .iter()
+            .all(|line| line_width(line) <= width as usize)
+            .then_some(rendered)
+    }
+}
+
 /// Render assistant markdown to transcript lines via tuika's streaming markdown
-/// renderer + tree-sitter code highlighting (see `crates/tuika` and
-/// `crates/tuika-codeformatters`).
+/// renderer + tree-sitter code highlighting (see the `tuika` and
+/// `tuika-codeformatters` crates).
+///
+/// ` ```mermaid ` fences go through [`MermaidFencedBlocks`], which paints them
+/// as Unicode cell diagrams; unsupported, malformed, or too-wide diagrams keep
+/// the ordinary code-block fallback so the source stays readable.
 ///
 /// The tuika renderer word-wraps prose and lays code/tables out to a width; we
 /// render at `inner_width` minus the header prefix, then prepend the header to
@@ -1570,12 +1600,14 @@ pub(crate) fn append_markdown_lines<'a>(
     // Keeping it permanently underlined masks Ghostty's clickability feedback.
     sheet.link = tuika::style::StyleBundle::new().fg(theme.code.link);
     let highlighter = tuika_codeformatters::TreeSitterHighlighter::new();
-    let (rendered, md_links) = tuika::components::markdown::to_linked_lines(
+    let mermaid = MermaidFencedBlocks;
+    let (rendered, md_links) = tuika::components::markdown::to_linked_lines_with_renderer(
         text,
         width,
         &theme,
         &sheet,
         tuika::highlight::CodeHighlighter::With(&highlighter),
+        &mermaid,
     );
 
     let base_line = lines.len() as u16;


### PR DESCRIPTION
## What changed

Assistant messages containing a ` ```mermaid ` fence now show a terminal-native
diagram instead of raw Mermaid source. Diagrams are Unicode cells — no browser,
no JavaScript runtime, no image protocol.

Fences the diagram engine cannot lay out, and diagrams wider than the transcript
viewport, keep the ordinary themed code block so the source stays on screen. All
other fence languages are untouched.

## Why

tuika 0.5.0 introduced the `FencedBlockRenderer` seam and the `tuika-mermaid`
companion crate that fills it; yolop was not using either, so agents that answer
with a diagram produced a wall of Mermaid syntax. Filling the seam is exactly the
host-side composition the tuika boundary asks for — the diagram engine stays
upstream, yolop decides where it applies.

## Before / After

Real terminal grid, captured by driving the `yolop` binary under a pty with a
seeded session (100 columns):

**Before**

```
 agent › Here is the pipeline:

         ▏ mermaid
         ▏ flowchart LR
         ▏   A[Parse] --> B[Layout] --> C[Paint]
```

**After**

```
 agent › Here is the pipeline:

         ┌───────┐    ┌────────┐     ┌───────┐
         │ Parse │───►│ Layout │────►│ Paint │
         └───────┘    └────────┘     └───────┘

         And an unsupported one:

         ▏ mermaid
         ▏ not a diagram
```

The same session at 46 columns, where the diagram no longer fits, falls back
rather than painting a clipped half-box:

```
 agent › Here is the pipeline:

         ▏ mermaid
         ▏ flowchart LR
         ▏   A[Parse] --> B[Layout] --> C[Pa
```

## Risk

- Low
- What can break: a fence that mmdflux renders but yolop previously showed as
  source now looks different; a diagram costs layout work once per message (and
  again on resize), where before it cost only syntax highlighting. Non-mermaid
  fences and all other markdown are unaffected — the renderer returns `None` for
  every other language.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated [`knowledge/specs/tuika.md`](knowledge/specs/tuika.md): the third
companion crate, a `Mermaid fences` row in the boundary table, the constraint
that the companions move with tuika, and a new constraint that a fenced block
which does not fit the transcript width is not painted. Logged in
`knowledge/log.md`.

## Security

Reviewed. Relevant categories:

- **TM-DEP** — two new crates. `tuika-mermaid` 0.1.0 ships from
  [everruns/tuika](https://github.com/everruns/tuika) alongside the already-trusted
  `tuika` and `tuika-codeformatters`, and pins the same `tuika` line. It pulls
  `mmdflux` 2.6.0, a pure-Rust Mermaid layout engine whose direct dependencies are
  `pest`/`pest_derive`, `serde`, `serde_json`, `thiserror`, `tracing`, and
  `unicode-width` — no network, no process spawning, no JS runtime. No
  `everruns-*` version moved.
- **TM-LLM** — diagram content is model-authored, so it is untrusted text painted
  into the terminal. `tuika-mermaid` renders with mmdflux color disabled and drops
  every control character before building spans, so a node label cannot smuggle
  escape sequences into the cell stream; yolop adds no path that bypasses that.
- **Resource exhaustion** — `tuika-mermaid` caps input at 64 KiB and output at
  1 MiB. Layout is roughly linear in node count (measured in a debug build:
  ~4 ms at 10 nodes, ~204 ms at 400) and the full-screen renderer memoizes
  wrapping over `App::lines`, so it runs once per message rather than per frame.
  A pathological diagram costs that again on resize.

No change to filesystem, shell, or capability registration (TM-FS, TM-BASH,
TM-TOOL untouched).

## Follow-ups

- The width guard rejects a diagram only after mmdflux has laid it out; the cost
  is paid and discarded. Cheap to live with at current sizes, and fixing it
  properly means a width-aware layout API upstream in `tuika-mermaid`.
- The code-block fallback does not wrap long source lines, so at narrow widths the
  Mermaid source is clipped at the right edge (visible in the 46-column capture
  above). That is pre-existing tuika `CodeBlock` behavior for every language, not
  something this change introduces; a fix belongs upstream.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UREpAJfJ9bnkiFGYjgSPsE)_