### PR TITLE
feat(prompt): tell the model what the host can render

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,16 @@
 Significant changes to Yolop's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
+## 2026-07-25 — Host rendering advertised to the model
+
+- `<environment_context>` now carries `ui_capabilities` beside `client_ui` — an
+  additive list of what the host renders — so the model can decide whether a
+  diagram is worth drawing.
+  [System prompt composition](specs/system-prompt.md) gained the rule these
+  fields follow: state the host's capability rather than an instruction, and
+  keep the fields static per host so a mid-session change cannot churn the
+  cached prefix.
+
 ## 2026-07-25 — Mermaid fences in the transcript
 
 - Yolop fills tuika's `FencedBlockRenderer` seam with `tuika-mermaid`, so

--- a/knowledge/specs/system-prompt.md
+++ b/knowledge/specs/system-prompt.md
@@ -76,6 +76,32 @@ two cannot drift. Reveals are per session and the registry is bounded.
 disclose every turn, the framing paragraph waits for a reveal, and empty memory
 with no reveal contributes nothing.
 
+### The host's rendering is a fact the model cannot infer
+
+An answer is text until something paints it, and what paints it differs per
+host: the TUI renders the transcript itself, `--print` writes raw text, and an
+ACP editor renders the markdown its own way. The model cannot deduce which one
+it is talking to, so anything it might reasonably decide *because* of the answer
+being rendered belongs in `<environment_context>` next to `client_ui`.
+
+`ui_capabilities` is that field: an additive list of what the host is known to
+render (`supports_markdown`, `supports_markdown_mermaid`), or `none` for a host
+that renders nothing. Additive is the point. A listed capability is a claim
+yolop can stand behind; an absent one means "not known to render", which is the
+only honest thing to say about Mermaid over ACP — the editor renders the
+markdown, and the protocol never says how. A per-capability true/false would
+force a guess there, and `none` beats omitting the field, which would read as a
+value yolop failed to compute.
+
+State the capability, not the instruction: whether a diagram is worth drawing is
+the model's call.
+
+Keep these fields *static per host*. Live values that change mid-session — the
+terminal width, the current scroll position — would rewrite the prefix on every
+resize and cost the cached prefix that `AGENTS.md`'s placement exists to
+protect. A capability that only holds at some widths still advertises `true`;
+degrading gracefully at the narrow end is the renderer's job, not the prompt's.
+
 ### Judgement yields to measurement
 
 Judgment over ritual applies here as it does everywhere

--- a/knowledge/specs/tuika.md
+++ b/knowledge/specs/tuika.md
@@ -41,7 +41,7 @@ tuika owns *presentation*; yolop owns *acquisition and meaning*. Concretely:
 | --- | --- | --- |
 | Code highlighting | `CodeBlock` framing, gutter, wrapping | the `Highlighter` (`tuika-codeformatters`) |
 | Markdown images | block reservation and protocol emission | an `ImageResolver` that decodes bytes to RGBA |
-| Mermaid fences | the `FencedBlockRenderer` seam | the renderer (`tuika-mermaid`) and the transcript's width guard |
+| Mermaid fences | the `FencedBlockRenderer` seam | the renderer (`tuika-mermaid`), the transcript's width guard, and telling the model the TUI paints them ([system prompt](./system-prompt.md)) |
 | Key bindings | the keymap engine (chords, sequences, gated layers, dispatch) | the binding table and what each command *means* |
 | Links | OSC 8 encoding and the `LinkPolicy` sanitizer | which schemes are allowed, and the transcript's link runs |
 | Progress | the OSC 9;4 encoder | when a turn is running |

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -84,6 +84,28 @@ impl ClientUiContext {
             Self::None => "none",
         }
     }
+
+    /// What the host is known to render, so the model can decide how much
+    /// formatting an answer is worth.
+    ///
+    /// A listed capability is a claim yolop can stand behind; an absent one
+    /// means "not known to render", which is why the list is additive rather
+    /// than a per-capability true/false. That distinction is load-bearing for
+    /// ACP: the editor renders agent messages as markdown, but nothing in the
+    /// protocol says whether it draws Mermaid, so `supports_markdown` is listed
+    /// and `supports_markdown_mermaid` is not.
+    ///
+    /// The TUI renders the transcript itself and claims both — full-screen and
+    /// the inline mirror share one markdown path, so they cannot diverge.
+    /// `--print` writes raw text to stdout and headless runs have no viewer at
+    /// all, so neither claims anything.
+    fn ui_capabilities(&self) -> &'static [&'static str] {
+        match self {
+            Self::Tui => &["supports_markdown", "supports_markdown_mermaid"],
+            Self::Acp => &["supports_markdown"],
+            Self::Print | Self::None => &[],
+        }
+    }
 }
 
 impl CodingCliEnvironmentCapability {
@@ -142,7 +164,7 @@ impl Capability for CodingCliEnvironmentCapability {
         "Coding CLI Environment Context"
     }
     fn description(&self) -> &str {
-        "Adds current workspace, shell, date, timezone, and Git context to the prompt."
+        "Adds current workspace, shell, date, timezone, Git, and UI rendering context to the prompt."
     }
     fn status(&self) -> CapabilityStatus {
         CapabilityStatus::Available
@@ -159,6 +181,7 @@ impl Capability for CodingCliEnvironmentCapability {
 <environment_context>
   <cwd>/path/to/workspace</cwd>
   <client_ui>TUI|print|ACP|none</client_ui>
+  <ui_capabilities>supports_markdown, supports_markdown_mermaid</ui_capabilities>
   <shell>zsh</shell>
   <current_date>YYYY-MM-DD</current_date>
   <timezone>Region/City</timezone>
@@ -193,6 +216,19 @@ fn render_environment_context(context: &EnvironmentContext) -> String {
     out.push_str("<environment_context>\n");
     push_xml_field(&mut out, "cwd", &context.cwd);
     push_xml_field(&mut out, "client_ui", context.client_ui.as_str());
+    // Empty stays "none" rather than an empty element: a host that renders
+    // nothing is a fact worth stating, and an absent field would read as one
+    // yolop failed to compute.
+    let ui_capabilities = context.client_ui.ui_capabilities();
+    push_xml_field(
+        &mut out,
+        "ui_capabilities",
+        &if ui_capabilities.is_empty() {
+            "none".to_string()
+        } else {
+            ui_capabilities.join(", ")
+        },
+    );
     push_xml_field(&mut out, "repo_root", &context.repo_root);
     if let Some(path) = &context.worktree_path {
         out.push_str("  <git_worktree>\n");
@@ -1655,6 +1691,9 @@ mod tests {
         assert!(rendered.starts_with("<environment_context>\n"));
         assert!(rendered.contains("  <cwd>/repo</cwd>\n"));
         assert!(rendered.contains("  <client_ui>TUI</client_ui>\n"));
+        assert!(rendered.contains(
+            "  <ui_capabilities>supports_markdown, supports_markdown_mermaid</ui_capabilities>\n"
+        ));
         assert!(rendered.contains("  <shell>zsh</shell>\n"));
         assert!(rendered.contains("  <current_date>2026-05-20</current_date>\n"));
         assert!(rendered.contains("  <timezone>America/Chicago</timezone>\n"));
@@ -1675,6 +1714,77 @@ mod tests {
             "  <contribution name=\"unsafe&lt;name&gt;\">value &amp; more</contribution>\n"
         ));
         assert!(rendered.ends_with("</environment_context>"));
+    }
+
+    /// The transcript renderer is what decides what gets drawn, so the list
+    /// follows the host: yolop paints the TUI itself, an ACP editor renders the
+    /// markdown its own way, and `--print` emits raw text.
+    ///
+    /// Mermaid over ACP is the case the additive list exists for — unlisted,
+    /// because the protocol never says whether the editor draws it.
+    #[test]
+    fn ui_capabilities_follow_the_client_ui() {
+        assert_eq!(
+            ClientUiContext::Tui.ui_capabilities(),
+            ["supports_markdown", "supports_markdown_mermaid"]
+        );
+        assert_eq!(
+            ClientUiContext::Acp.ui_capabilities(),
+            ["supports_markdown"]
+        );
+        assert!(ClientUiContext::Print.ui_capabilities().is_empty());
+        assert!(ClientUiContext::None.ui_capabilities().is_empty());
+    }
+
+    /// End to end through the capability the runtime registers, so the field
+    /// is proven to reach the assembled prompt rather than only the renderer.
+    #[tokio::test]
+    async fn environment_capability_contributes_ui_capabilities() {
+        let dir = std::env::temp_dir();
+        let capability = CodingCliEnvironmentCapability::new(
+            dir.clone(),
+            Arc::new(RwLock::new(dir)),
+            ClientUiContext::Tui,
+            EnvironmentContextRegistry::default(),
+        );
+        let ctx = everruns_core::capabilities::SystemPromptContext::without_file_store(
+            everruns_core::typed_id::SessionId::new(),
+        );
+
+        let contribution = capability
+            .system_prompt_contribution(&ctx)
+            .await
+            .expect("environment context always contributes");
+
+        assert!(
+            contribution.contains(
+                "<ui_capabilities>supports_markdown, supports_markdown_mermaid</ui_capabilities>"
+            ),
+            "{contribution}"
+        );
+    }
+
+    /// A host that renders nothing says so, rather than dropping the field and
+    /// leaving the model to guess whether it was simply not computed.
+    #[test]
+    fn environment_context_reports_no_ui_capabilities_for_print() {
+        let rendered = render_environment_context(&EnvironmentContext {
+            cwd: "/repo".to_string(),
+            client_ui: ClientUiContext::Print,
+            shell: "zsh".to_string(),
+            current_date: "2026-05-20".to_string(),
+            timezone: "America/Chicago".to_string(),
+            git_repo: None,
+            git_user: None,
+            git_email: None,
+            repo_root: "/repo".to_string(),
+            git_current_branch: None,
+            worktree_path: None,
+            contributions: BTreeMap::new(),
+        });
+
+        assert!(rendered.contains("  <client_ui>print</client_ui>\n"));
+        assert!(rendered.contains("  <ui_capabilities>none</ui_capabilities>\n"));
     }
 
     #[test]


### PR DESCRIPTION
## What changed

`<environment_context>` now carries `ui_capabilities` beside `client_ui` — an
additive list of what the host is known to render:

| Host | `ui_capabilities` |
| --- | --- |
| TUI (full-screen and inline) | `supports_markdown, supports_markdown_mermaid` |
| ACP | `supports_markdown` |
| `--print`, headless | `none` |

The list is additive rather than a flag per capability, because absence carries
meaning. A listed capability is a claim yolop can stand behind; an unlisted one
means "not known to render". That is the only honest thing to say about Mermaid
over ACP — the editor renders the markdown, and the protocol never says how — and
it still lets the model format normally there instead of falling back to plain
text.

The field states the capability, not an instruction: whether a diagram is worth
drawing stays the model's call.

## Why

#490 made the TUI render ` ```mermaid ` fences as diagrams, but nothing told the
model that. The renderer is what decides how much of an answer's formatting
reaches the user, and the model cannot infer which host it is talking to — so a
diagram was equally likely to be drawn into `--print`, where it stays raw source.

## Before / After

The system prompt actually sent, captured by pointing `--provider custom` at a
local OpenAI-compatible endpoint that records the request body.

**Before** — nothing about rendering:

```
<environment_context>
  <cwd>/home/user/yolop</cwd>
  <client_ui>TUI</client_ui>
  <repo_root>/home/user/yolop</repo_root>
  ...
```

**After**, driving the real TUI under a pty:

```
  <client_ui>TUI</client_ui>
  <ui_capabilities>supports_markdown, supports_markdown_mermaid</ui_capabilities>
```

**After**, same build under `--print`:

```
  <client_ui>print</client_ui>
  <ui_capabilities>none</ui_capabilities>
```

## Risk

- Low
- What can break: the prompt prefix gains one line, so the first cached prefix
  after this lands is rebuilt once. The field is static per host, so it cannot
  churn the cache mid-session. Behaviorally the model may now draw diagrams in
  the TUI where it previously answered in prose, and should stop drawing them
  under `--print`; that is the intent, but it is a real change in answer shape
  and is not covered by an eval (see Follow-ups).

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

[`knowledge/specs/system-prompt.md`](knowledge/specs/system-prompt.md) gained
"The host's rendering is a fact the model cannot infer": why these fields belong
next to `client_ui`, why the list is additive, and the rule that they stay static
per host so a mid-session change cannot cost the cached prefix that `AGENTS.md`'s
late placement exists to protect. Cross-referenced from the Mermaid row in
[`knowledge/specs/tuika.md`](knowledge/specs/tuika.md); logged in
`knowledge/log.md`.

## Security

Reviewed. **TM-LLM** is the only category this touches: the field is a fixed
literal chosen by a `match` on the host, with no user, model, or repository input
flowing into it, so it adds no injection surface and no new prompt-cache
behavior. It discloses nothing sensitive — that the terminal renders markdown is
not a secret. Values still go through the same `xml_escape` path as every other
field.

No filesystem, shell, capability-registration, or dependency changes (TM-FS,
TM-BASH, TM-TOOL, TM-DEP untouched).

## Follow-ups

- **Not A/B'd.** `knowledge/specs/system-prompt.md` asks for prompt-composition
  changes to go through `evals/harness_basic` before they are trusted. This adds
  a fact rather than rephrasing guidance, and the eval harness needs provider
  credentials the authoring environment lacks. What remains unverified is how a
  real model *behaves* on seeing the field — worth an eval run before leaning on
  it further.
- The TUI also renders images and OSC 8 hyperlinks, which the list could carry.
  Left out deliberately: image support depends on runtime terminal-protocol
  detection, which is exactly the mid-session-variable value the spec now says to
  keep out of the cached prefix.

### Smoke-test note

The authoring environment has neither the Doppler CLI nor a provider key, so the
live-provider smoke could not run locally. Substituted a wire-level one: a local
OpenAI-compatible endpoint recording the exact request, driven once through
`--print` and once through the real TUI under a pty (both captures above). CI's
`Live Provider Smoke (Doppler)` job then ran the real live smoke on this commit
and passed, so the required coverage exists — it just came from CI rather than
from the authoring environment.
