### PR TITLE
feat(okf): rewrite the bundled skill against the OKF v0.2 spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ yolop --provider llmsim -p "hi"         # offline demo, no API key required
   `read_skill`, `write_skill`, and `activate_skill`. Skills installed after
   startup are available immediately.
 - **OKF knowledge** — a bundled `okf` skill for the
-  [Open Knowledge Format](https://okf.md/spec/): read, author, convert to, and
+  [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md):
+  read, author, convert to, and
   validate knowledge bundles. See [OKF](./docs/features/okf/okf.md).
 - **Herdr-aware sessions** — when launched in a Herdr pane, Yolop reports
   `working` / `idle` / `blocked` lifecycle states and exposes read-only Herdr

--- a/docs/features/okf/okf.md
+++ b/docs/features/okf/okf.md
@@ -3,17 +3,17 @@ title: OKF
 description: Read, author, and validate Open Knowledge Format bundles — portable markdown knowledge — with Yolop's built-in okf skill.
 ---
 
-The [Open Knowledge Format](https://okf.md/spec/) (OKF, an open specification
-from Google Cloud) represents a body of knowledge as a plain **directory of
-markdown files with YAML frontmatter** — no database, SDK, or runtime. It is a
-portable way to keep the curated context an agent needs — architecture notes,
-data models, metrics, processes, conventions — right in the repo. If you can
-`cat` a file, you can read OKF.
+The [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+(OKF, an open specification from Google Cloud) represents a body of knowledge as
+a plain **directory of markdown files with YAML frontmatter** — no database,
+SDK, or runtime. It is a portable way to keep the curated context an agent needs
+— architecture notes, data models, metrics, processes, conventions — right in
+the repo. If you can `cat` a file, you can read OKF.
 
 Yolop ships a built-in **`okf` skill** that knows the format end to end: it
 reads a bundle as high-signal context, authors new concepts, converts other
 sources into OKF, and validates conformance. The skill is compiled into the
-binary, so it works offline.
+binary, so it works offline, and it tracks OKF v0.2.
 
 ## What a bundle looks like
 
@@ -33,21 +33,44 @@ title: Auth
 description: Session and credential handling for the API.
 resource: file:///src/auth
 tags: [security, api]
-timestamp: 2026-07-20T10:30:00Z
+status: stable
+generated: { by: yolop/opus, at: 2026-07-20T10:30:00Z }
+verified: { by: human:mchaliy, at: 2026-07-21T08:00:00Z }
 ---
 
 # Auth
 
 Handles login, tokens, and session lifecycle.
 
-## Relationships
-- Emits the [signups metric](/metrics/signups)
+# Relationships
+
+Emits the [signups metric](/metrics/signups.md).
 ```
 
 `index.md` and `log.md` are **reserved** files (both optional): `index.md` is a
 listing you read first for cheap orientation, `log.md` is a dated changelog. A
-bundle conforms to OKF v0.1 when every non-reserved `.md` file has parseable
-frontmatter with a non-empty `type` — everything else is soft guidance.
+bundle conforms when every non-reserved `.md` file has parseable frontmatter
+with a non-empty `type` — everything else is soft guidance.
+
+## Provenance and trust
+
+Because bundles are increasingly written by agents, OKF v0.2 makes "where did
+this come from" and "how much should I trust it" answerable from frontmatter,
+and the skill reads and writes all of it:
+
+- **`sources`** — what a concept was derived from, with per-source signals
+  (`author`, `usage_count`, `last_modified`) and footnotes keyed to a source `id`
+  for per-claim attribution.
+- **`generated` / `verified`** — who wrote it versus who confirmed it, using one
+  actor convention (`agent/version`, `human:<id>`, `process:<id>`). A human
+  verifier is what separates a reviewed fact from a machine-confirmed one.
+- **`status` and `stale_after`** — `draft`/`stable`/`deprecated`, and the date a
+  concept goes stale. Yolop weighs both before relying on a concept, and checks
+  against the real system when a concept is deprecated or past its date.
+- **Attested computations** — a `type: Attested Computation` concept carries a
+  sanctioned computation plus the executor and attester that prove a value came
+  from it. Yolop supplies parameter values only; it will not rewrite a sanctioned
+  computation.
 
 ## Working with a bundle
 
@@ -66,8 +89,9 @@ what does the knowledge base say about auth?
   `/`-absolute concept links; `index.md` and `log.md` kept current. Covers
   converting a Notion export, Obsidian vault, or CSV into OKF.
 - **Validate** — a zero-dependency checker enforces the three conformance rules,
-  with `--strict` (also require `title`/`description`/`timestamp`) and
-  `--check-links` (report broken intra-bundle links) modes.
+  with `--strict` (also lint the recommended fields, `generated`, and the
+  `runtime` an attested computation needs) and `--check-links` (report broken
+  intra-bundle links) modes.
 
 ## How Yolop finds your bundle
 
@@ -86,5 +110,5 @@ read, and maintain, the bundle through the `okf` skill.
 
 ## Related
 
-- [OKF specification](https://okf.md/spec/)
-- [OKF overview](https://okf.md/)
+- [OKF specification (v0.2)](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+- [knowledge-catalog repository](https://github.com/GoogleCloudPlatform/knowledge-catalog)

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,19 @@
 Significant changes to Yolop's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
+## 2026-07-26 — OKF skill tracks the authoritative v0.2 spec
+
+- The bundled `okf` skill was rewritten against `SPEC.md` in
+  `GoogleCloudPlatform/knowledge-catalog`, now named as the only authoritative
+  source; the `okf.md` site it previously cited is not normative and described a
+  superseded v0.1 model. [`okf`](specs/okf.md) gained the v0.2 families the skill
+  must teach — `sources` with credibility signals, `generated`/`verified` with
+  the actor convention and trust tiers, `status`/`stale_after`, and the
+  `Attested Computation` contract — plus the rule that validator lint stays
+  behind `--strict` so a permissive format is not taught as a strict one, and the
+  requirement that the skill's validator copy stay byte-identical to the one CI
+  runs.
+
 ## 2026-07-25 — Host rendering advertised to the model
 
 - `<environment_context>` now carries `ui_capabilities` beside `client_ui` — an

--- a/knowledge/specs/okf.md
+++ b/knowledge/specs/okf.md
@@ -11,26 +11,65 @@ Status: implemented as a bundled skill in `src/bundled/system-skills/okf/`.
 
 ## Why
 
-[OKF](https://okf.md/spec/) (Open Knowledge Format, Google Cloud, v0.1)
-represents a body of knowledge as a plain directory of markdown files with YAML
-frontmatter — no database, SDK, or runtime. It is a portable way to hand an
-agent curated context: architecture, data models, metrics, processes,
-conventions. Yolop should be able to read such a bundle as high-signal context,
-and author/validate one on request, without the user re-explaining the format.
+[OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+(Open Knowledge Format, Google Cloud) represents a body of knowledge as a plain
+directory of markdown files with YAML frontmatter — no database, SDK, or
+runtime. It is a portable way to hand an agent curated context: architecture,
+data models, metrics, processes, conventions. Yolop should be able to read such
+a bundle as high-signal context, and author, maintain, or validate one on
+request, without the user re-explaining the format.
+
+## Authority
+
+`SPEC.md` in the `GoogleCloudPlatform/knowledge-catalog` repository is the only
+authoritative source, and it is what the skill tracks. Third-party sites that
+restate the format — including the `okf.md` domain the skill previously cited —
+are not normative and must not be linked as if they were; they lagged the spec
+and described a superseded v0.1 model.
 
 ## What
 
 A single system skill, `okf`, compiled into the binary so it works regardless of
-network policy. Its `SKILL.md` carries the whole v0.1 mental model inline —
-bundle, concept, concept-id, links, the reserved `index.md`/`log.md`, the
-required `type` frontmatter field plus recommended fields, and the three
-conformance rules — and links the spec for depth. It ships a zero-dependency
-validator (`scripts/validate_okf.py`, `--strict` and `--check-links` modes).
+network policy. Its `SKILL.md` carries the whole v0.2 mental model inline:
 
-The skill covers reading, authoring, converting to (Notion/Obsidian/CSV), and
-validating OKF. Because it teaches authoring, **producing/maintaining** a bundle
-needs no separate feature: a repository can instruct the agent (e.g. from
-`AGENTS.md`) to keep its bundle current, and the agent does so through the skill.
+- Structure — bundle, concept, concept ID, links, the reserved `index.md` and
+  `log.md`, and the fact that OKF defines no root marker or directory name.
+- Frontmatter — the required `type`, the recommended
+  `title`/`description`/`resource`/`tags`, and the rule that unknown keys are
+  preserved rather than rejected.
+- Provenance, trust, lifecycle — `sources` with per-source credibility signals
+  and footnote attribution keyed to `sources[].id`, `generated`/`verified` with
+  the actor convention and the trust tiers derived from it, `status`, and
+  `stale_after`.
+- Attested computations — the `Attested Computation` type, its `runtime`,
+  `parameters`, `computation`, `executor`, and `attester` fields, and the
+  agent-facing rule that only parameter values may be supplied, never edits to
+  the computation.
+- Conformance — the three hard rules, and the permissiveness that makes
+  everything else soft guidance.
+
+The version-specific families exist because an agent-maintained corpus needs
+frontmatter answers to provenance, trust, freshness, and attestation. The skill
+teaches them as *consumption* signals too: a deprecated or past-`stale_after`
+concept is verified against the real system before it is acted on.
+
+Because the skill teaches authoring, **producing/maintaining** a bundle needs no
+separate feature: a repository can instruct the agent (e.g. from `AGENTS.md`) to
+keep its bundle current, and the agent does so through the skill.
+
+## Validator
+
+The skill ships a zero-dependency validator, `scripts/validate_okf.py`. Its
+default run enforces only the three conformance rules; producer-side lint —
+`title`, `description`, `generated`, the `runtime` an attested computation
+requires, the shapes of `status`/`stale_after`/`okf_version`, and the v0.1 fields
+v0.2 superseded — sits behind `--strict`, and intra-bundle link resolution behind
+`--check-links`. Splitting them this way keeps the tool from teaching a
+permissive format as a strict one.
+
+The repository's own copy at `scripts/validate_okf.py` and the skill's copy are
+byte-identical, pinned by `scripts/test_validate_okf.py`, because a bundled
+script that drifts from the one CI runs is worse than either alone.
 
 ## Why no detection capability
 
@@ -57,3 +96,6 @@ directory convention, no always-on probe.
   file tools already read it.
 - No new authoring tools in the binary; authoring lives in the skill.
 - No automatic bundle detection or fixed directory convention (see above).
+- No execution or attestation runtime. The skill teaches the attested-computation
+  contract and the gating rules; the executor and attester behind a `resource`
+  are the consuming system's, not Yolop's.

--- a/scripts/test_validate_okf.py
+++ b/scripts/test_validate_okf.py
@@ -39,6 +39,70 @@ class ValidateOkfTests(unittest.TestCase):
             self.assertEqual(concepts, 0)
             self.assertEqual(messages, ["index.md: broken link -> specs/missing.md"])
 
+    def test_v0_2_families_pass_strict(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "index.md").write_text('---\nokf_version: "0.2"\n---\n\n# Index\n')
+            (root / "revenue.md").write_text(
+                "---\n"
+                "type: Attested Computation\n"
+                "title: Revenue\n"
+                "description: Recognized revenue for a fiscal year.\n"
+                "status: stable\n"
+                "runtime: bigquery\n"
+                "parameters:\n"
+                "  - { name: year, type: integer, required: true }\n"
+                "stale_after: 2026-12-31\n"
+                "generated: { by: human:ahormati, at: 2026-06-20T22:53:05Z }\n"
+                "---\n\n# Computation\n"
+            )
+            messages, concepts = validate(root, strict=True, check_links=True)
+            self.assertEqual(messages, [])
+            self.assertEqual(concepts, 1)
+
+    def test_strict_reports_soft_guidance_only_under_strict(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "metric.md").write_text(
+                "---\n"
+                "type: Attested Computation\n"
+                "title: Revenue\n"
+                "description: Recognized revenue.\n"
+                "status: published\n"
+                "stale_after: 90d\n"
+                "timestamp: 2026-05-28T22:53:05Z\n"
+                "---\n"
+            )
+            self.assertEqual(validate(root)[0], [])
+            messages = validate(root, strict=True)[0]
+            self.assertTrue(any("requires `generated`" in message for message in messages))
+            self.assertTrue(any("superseded by" in message for message in messages))
+            self.assertTrue(any("requires `runtime`" in message for message in messages))
+            self.assertTrue(any("`status` must be one of" in message for message in messages))
+            self.assertTrue(any("`stale_after` must be" in message for message in messages))
+
+    def test_strict_rejects_frontmatter_on_a_nested_index(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "specs").mkdir()
+            (root / "specs" / "index.md").write_text("---\ntype: Index\n---\n\n# Specs\n")
+            messages, _ = validate(root, strict=True)
+            self.assertEqual(
+                messages, ["specs/index.md: index.md must not carry frontmatter keys ['type']"]
+            )
+
+    def test_bundled_skill_copy_is_identical(self):
+        bundled = (
+            MODULE_PATH.parents[1]
+            / "src"
+            / "bundled"
+            / "system-skills"
+            / "okf"
+            / "scripts"
+            / "validate_okf.py"
+        )
+        self.assertEqual(bundled.read_bytes(), MODULE_PATH.read_bytes())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/validate_okf.py
+++ b/scripts/validate_okf.py
@@ -1,10 +1,19 @@
 #!/usr/bin/env python3
-"""Validate an Open Knowledge Format bundle using only the standard library.
+"""Validate an Open Knowledge Format (OKF v0.2) bundle using only the standard library.
 
-Usage: python3 scripts/validate_okf.py <bundle-dir> [--strict] [--check-links]
+Usage: python3 validate_okf.py <bundle-dir> [--strict] [--check-links]
 
---strict requires title, description, and timestamp in addition to OKF's
-required type field. --check-links validates local Markdown link targets.
+Without flags this checks only OKF conformance: every non-reserved `.md` file
+has parseable YAML frontmatter with a non-empty `type`. Everything else in the
+format is soft guidance, so it lives behind the opt-in flags.
+
+--strict adds producer-side lint: `title`, `description`, and `generated`; the
+`runtime` an Attested Computation requires; the shapes of `status`, `stale_after`
+and `okf_version`; and the v0.1 fields v0.2 superseded. --check-links resolves
+intra-bundle Markdown link targets. Findings from either flag are reasons to
+improve a bundle you own, never to reject one you are only reading.
+
+Spec: https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md
 """
 
 from __future__ import annotations
@@ -17,9 +26,18 @@ RESERVED = {"index.md", "log.md"}
 FRONTMATTER_RE = re.compile(r"\A---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 LINK_RE = re.compile(r"\]\(([^)\s]+)(?:\s+['\"][^)]*['\"])?\)")
 SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:")
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+STATUSES = {"draft", "stable", "deprecated"}
+ATTESTED_COMPUTATION = "attested computation"
+# v0.1 fields v0.2 replaced. A bundle carrying them still conforms; --strict
+# reports them so a producer migrates instead of writing new legacy documents.
+SUPERSEDED = {"timestamp": "generated: { by, at }"}
 
 
 def parse_frontmatter(text: str) -> tuple[dict[str, str], str | None]:
+    """Return (top-level fields, error). Nested structures are flattened to their
+    raw text, which is enough for presence and shape checks without a YAML
+    dependency."""
     match = FRONTMATTER_RE.match(text)
     if not match:
         return {}, "missing or malformed YAML frontmatter"
@@ -27,6 +45,8 @@ def parse_frontmatter(text: str) -> tuple[dict[str, str], str | None]:
     for line in match.group(1).splitlines():
         stripped = line.strip()
         if not stripped or stripped.startswith("#") or line[:1].isspace():
+            continue
+        if stripped.startswith("- "):  # continuation of a block sequence
             continue
         if ":" not in line:
             return {}, f"malformed frontmatter line: {line!r}"
@@ -51,6 +71,38 @@ def local_link_target(root: Path, source: Path, target: str) -> Path | None:
     return source.parent / target
 
 
+def lint_concept(fields: dict[str, str]) -> list[str]:
+    """Soft guidance from the spec, reported only under --strict."""
+    findings: list[str] = []
+    for recommended in ("title", "description", "generated"):
+        if not fields.get(recommended):
+            findings.append(f"--strict requires `{recommended}`")
+    for legacy, replacement in SUPERSEDED.items():
+        if legacy in fields:
+            findings.append(f"`{legacy}` is superseded by `{replacement}`")
+    if fields.get("type", "").lower() == ATTESTED_COMPUTATION and not fields.get("runtime"):
+        findings.append("`type: Attested Computation` requires `runtime`")
+    status = fields.get("status")
+    if status and status not in STATUSES:
+        findings.append(f"`status` must be one of {sorted(STATUSES)}, got {status!r}")
+    stale_after = fields.get("stale_after")
+    if stale_after and not DATE_RE.match(stale_after):
+        findings.append(f"`stale_after` must be an absolute YYYY-MM-DD date, got {stale_after!r}")
+    return findings
+
+
+def lint_index(fields: dict[str, str], is_bundle_root: bool) -> list[str]:
+    """Index files carry no frontmatter, except `okf_version` at the bundle root."""
+    allowed = {"okf_version"} if is_bundle_root else set()
+    extra = sorted(set(fields) - allowed)
+    if extra:
+        return [f"index.md must not carry frontmatter keys {extra}"]
+    version = fields.get("okf_version")
+    if version and not re.match(r"^\d+\.\d+$", version):
+        return [f"`okf_version` must be `<major>.<minor>`, got {version!r}"]
+    return []
+
+
 def validate(root: Path, *, strict: bool = False, check_links: bool = False) -> tuple[list[str], int]:
     messages: list[str] = []
     concepts = 0
@@ -58,17 +110,21 @@ def validate(root: Path, *, strict: bool = False, check_links: bool = False) -> 
         rel = path.relative_to(root).as_posix()
         text = path.read_text(encoding="utf-8", errors="replace")
         if path.name not in RESERVED:
-            frontmatter, error = parse_frontmatter(text)
+            fields, error = parse_frontmatter(text)
             if error:
                 messages.append(f"{rel}: {error}")
                 continue
             concepts += 1
-            if not frontmatter.get("type"):
+            if not fields.get("type"):
                 messages.append(f"{rel}: frontmatter has no non-empty `type` field")
             if strict:
-                for required in ("title", "description", "timestamp"):
-                    if not frontmatter.get(required):
-                        messages.append(f"{rel}: --strict requires `{required}`")
+                messages.extend(f"{rel}: {finding}" for finding in lint_concept(fields))
+        elif strict and path.name == "index.md" and text.startswith("---"):
+            fields, error = parse_frontmatter(text)
+            if error:
+                messages.append(f"{rel}: {error}")
+            else:
+                messages.extend(f"{rel}: {f}" for f in lint_index(fields, rel == "index.md"))
         if check_links:
             for target in LINK_RE.findall(text):
                 local = local_link_target(root, path, target)
@@ -80,7 +136,7 @@ def validate(root: Path, *, strict: bool = False, check_links: bool = False) -> 
 def main() -> int:
     args = [arg for arg in sys.argv[1:] if not arg.startswith("--")]
     flags = {arg for arg in sys.argv[1:] if arg.startswith("--")}
-    if len(args) != 1:
+    if len(args) != 1 or flags - {"--strict", "--check-links"}:
         print(__doc__)
         return 2
     root = Path(args[0])

--- a/src/bundled/system-skills/okf/SKILL.md
+++ b/src/bundled/system-skills/okf/SKILL.md
@@ -1,46 +1,66 @@
 ---
 name: okf
-description: Read, author, and validate Open Knowledge Format (OKF) bundles — knowledge represented as a directory of markdown files with YAML frontmatter. Use when a repo contains an OKF bundle (concept docs with a `type` field, an `index.md`/`log.md`), when the user mentions OKF or the Open Knowledge Format, or when asked to author, validate, convert to, or keep an OKF knowledge base current.
+description: Read, author, maintain, and validate Open Knowledge Format (OKF v0.2) bundles — knowledge as a directory of markdown files with YAML frontmatter, carrying provenance, trust, lifecycle, and attested computations. Use when a repo holds an OKF bundle (concept docs with a `type` field, an `index.md`/`log.md`), when the user mentions OKF or the Open Knowledge Format, or when asked to author, validate, convert to, or keep an OKF knowledge base current.
 user-invocable: true
 ---
 
-# Open Knowledge Format (OKF)
+# Open Knowledge Format (OKF) v0.2
 
-OKF is an open spec (Google Cloud, v0.1) for representing knowledge as a plain
-**directory of markdown files with YAML frontmatter** — no database, SDK, or
-runtime. If you can `cat` a file, you can read OKF. This skill carries the whole
-mental model inline so it works offline; consult the spec only for edge cases.
+OKF represents knowledge as a plain **directory of markdown files with YAML
+frontmatter** — no database, SDK, or runtime. If you can `cat` a file, you can
+read OKF; if you can `git clone` a repo, you can ship it.
 
-Spec: <https://okf.md/spec/> · Overview: <https://okf.md/>
+The one authoritative spec is `SPEC.md` in the Google Cloud knowledge-catalog
+repository:
+<https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md>.
+Treat any other site or summary as hearsay. This skill carries the working model
+inline so it functions offline; read the spec itself for edge cases.
 
-## The model (all of it)
+The point of v0.2 is that a corpus is now mostly **written and maintained by
+agents**, so a reader needs frontmatter answers to: what was this made from
+(provenance), how much should I trust it (trust), is it still true (freshness),
+and was this number computed the sanctioned way (attestation).
+
+## The model
 
 - **Bundle** — a directory tree of markdown; the unit of distribution. There is
-  **no required root marker file** and no mandated directory name, so a bundle is
-  simply a directory someone declares to be OKF (often `.okf/`, `okf/`, or
-  `knowledge/`, but that is convention, not spec).
+  **no root marker file and no mandated directory name**: a bundle is whatever
+  directory someone declares to be one (`knowledge/`, `okf/`, `.okf/` are
+  conventions, not spec). Never guess — take the location from the user or from
+  `AGENTS.md`.
 - **Concept** — one `.md` file = one unit of knowledge: a table, an API, a
   metric, a process, an idea.
-- **Concept-id** — the file path within the bundle minus `.md`
+- **Concept ID** — the file path within the bundle minus `.md`
   (`tables/users.md` → `tables/users`).
-- **Links** — plain markdown links between concepts turn the tree into a graph.
-  Prefer bundle-absolute paths starting with `/` (`[users](/tables/users)`).
-- **Reserved files** (both optional):
+- **Links** — ordinary markdown links between concepts make the tree a graph.
+  Prefer bundle-absolute paths starting with `/` (`[users](/tables/users.md)`);
+  relative paths are also valid. A link asserts an untyped relationship; the
+  prose around it says what kind.
+- **Reserved files** (both optional, at any directory level, never concepts):
   - `index.md` — a directory listing for **progressive disclosure**: read it
-    first to see what a bundle holds without opening every file.
-  - `log.md` — a chronological changelog, newest-relevant, dated ISO 8601.
+    first to see what a bundle holds without opening every file. No frontmatter,
+    except that the bundle-root `index.md` may carry `okf_version: "0.2"`.
+  - `log.md` — dated change history, newest first, `## YYYY-MM-DD` headings.
 
 ## Frontmatter
 
-Every concept file has YAML frontmatter. Only one field is **required**:
+Only `type` is required. A concept carrying nothing but `type` is fully
+conformant.
 
-- `type` (required) — a short producer-chosen string, e.g. `BigQuery Table`,
-  `Metric`, `Playbook`. Values are not centrally registered.
+| Field | Status | Notes |
+|---|---|---|
+| `type` | **required** | Producer-chosen string: `Metric`, `BigQuery Table`, `Playbook`, `Attested Computation`. Not centrally registered. |
+| `title` | recommended | Display name; consumers may fall back to the filename. |
+| `description` | recommended | One sentence; feeds `index.md` entries and search snippets. |
+| `resource` | recommended | URI of the underlying asset. Absent for abstract concepts. |
+| `tags` | recommended | List of short strings. |
 
-Recommended optional fields: `title`, `description` (one sentence), `resource`
-(a URI for the underlying asset), `tags` (list), `timestamp` (ISO 8601 of last
-significant change). Producers may add more keys; **consumers must preserve
-unknown keys** and must not choke on them.
+Producers may add any other key. As a consumer, **preserve unknown keys** when
+round-tripping and never reject a document for carrying them.
+
+Bodies are plain markdown; prefer headings, lists, tables, and fenced code over
+freeform prose. `# Schema`, `# Examples`, and `# Computation` are conventional
+headings — use them when they apply.
 
 ```markdown
 ---
@@ -48,65 +68,174 @@ type: Module
 title: tuika
 description: Standalone terminal-UI toolkit powering the --fullscreen renderer.
 resource: file:///crates/tuika
-tags: [ui, ratatui, terminal]
-timestamp: 2026-07-19T10:30:00Z
+tags: [ui, terminal]
+status: stable
+generated: { by: human:mchaliy, at: 2026-07-19T10:30:00Z }
 ---
 
 # tuika
 
-Layout, overlays, focus, and components over ratatui.
+Layout, overlays, focus, and components for terminal UIs.
 
-## Relationships
-- Consumed by the [yolop host](/modules/yolop-yep)
+# Relationships
+
+Consumed by the [yolop host](/modules/yolop-yep.md).
 ```
 
-## Conformance (the only hard rules)
+## Provenance, trust, lifecycle
 
-A bundle conforms to OKF v0.1 if:
+All optional — but their **absence carries meaning**, so populate them for
+anything an agent generated. Never reject a concept for lacking them.
 
-1. Every non-reserved `.md` file has parseable YAML frontmatter.
-2. Every such frontmatter has a non-empty `type` field.
-3. Reserved files (`index.md`, `log.md`) follow their structure.
+**`sources`** — the materials a concept derives from:
 
-Everything else is **soft guidance**. Do not reject a bundle for missing
-optional fields, unknown `type` values, broken links, or an absent `index.md` —
-the format is deliberately permissive. Validate with `scripts/validate_okf.py`
-under `${SKILL_DIR}` (no dependencies): `python3 ${SKILL_DIR}/scripts/validate_okf.py <bundle-dir>`.
+```yaml
+sources:
+  - id: ga4-schema                     # stable key for per-claim attribution
+    resource: https://developers.google.com/analytics/bigquery/export-schema
+    title: GA4 BigQuery Export schema  # required within an entry: resource
+    author: team:ga4-docs              # credibility signal: authority
+    usage_count: 5000                  # credibility signal: adoption/liveness
+    last_modified: 2026-05-30          # credibility signal: recency of the source
+usage_window: { from: 2026-06-01, to: 2026-06-30 }   # frames every usage_count
+```
+
+`resource` may name a followable artifact (URL, bundle path, `references/` file)
+or a scope descriptor it cannot follow (`all queries in project X`). OKF stores
+objective **signals**, never a credibility score — infer, do not persist a
+verdict. Read `usage_count` as liveness and trend, not a precise ranking.
+Lineage is expressed by linking: when a `resource` points at another concept,
+recurse into its own `sources`.
+
+Attribute a specific claim with a markdown footnote whose label **is** a
+`sources[].id` — keyed, so reordering the list cannot misattribute:
+
+```markdown
+The `events_` table is sharded daily as `events_YYYYMMDD`.[^ga4-schema]
+
+[^ga4-schema]: GA4 BigQuery Export schema
+```
+
+**`generated` and `verified`** — who wrote it versus who confirmed it, kept
+deliberately separate:
+
+```yaml
+generated: { by: reference_agent/gemini-2.5-pro, at: 2026-06-20T22:53:05Z }
+verified:
+  - { by: human:ahormati, at: 2026-06-25T09:00:00Z }
+  - { by: process:finance-nightly, at: 2026-06-26T02:00:00Z }
+```
+
+`generated.by` is required within `generated`; `generated.at` marks the last
+meaningful content change. A bare `verified: { by, at }` mapping **must** be
+read as a one-element list. Actors follow one convention: `<producer>/<version>`
+for agents, `human:<id>` for people, `process:<id>` for automated processes. The
+`human:` prefix is load-bearing — trust tiers key off it:
+
+- no `verified` ⇒ **unverified**
+- `verified` by non-`human:` actors only ⇒ **machine-confirmed**
+- any `human:<id>` verifier ⇒ **human-reviewed**
+
+**Lifecycle** — `status: draft | stable | deprecated` (absent ⇒ `stable`) and
+`stale_after: YYYY-MM-DD`, an absolute date; a concept is stale when
+`today >= stale_after`.
+
+## Attested computations
+
+A sanctioned computation is its own concept, `type: Attested Computation`, that
+value-consuming concepts (a `Metric`, a table) link to. Provenance answers
+"where did this claim come from"; attestation answers "was this number produced
+the way we said it must be".
+
+```yaml
+runtime: bigquery                      # REQUIRED for this type; defines what parameters mean
+parameters:
+  - { name: year, type: integer, required: true }
+computation: references/computations/revenue.sql   # or omit and inline under `# Computation`
+executor:
+  resource: references/skills/run-on-bq.md         # run instructions/code
+  receipt: [job_id, executed_sql, result]          # evidence a run must return
+attester:
+  resource: references/attesters/sql-equality.py   # deterministic, no-LLM check
+```
+
+Rules that matter when you are the agent in the loop:
+
+- You may supply **values** for declared `parameters` only. You **must not**
+  author or edit the computation — rewriting it is exactly what attestation
+  detects.
+- Discover → load contract → parameterize → execute (executor returns a receipt)
+  → attest (deterministic code compares the expanded artifact against the
+  sanctioned one) → gate. Refuse to present a failing attestation; warn when
+  `today >= stale_after`. Receipts and verdicts are runtime artifacts — never
+  write them into the bundle.
+- `verified` and attestation are both needed: `verified` says the *definition*
+  still matches policy, attestation says a *single run* was honest.
+
+Each computation carries its own trust state, so revenue can be fresh while
+profit is stale. One figure, one concept.
+
+## Conformance
+
+A bundle conforms if, and only if:
+
+1. Every non-reserved `.md` file has a parseable YAML frontmatter block.
+2. Every such frontmatter has a non-empty `type`.
+3. Present `index.md`/`log.md` files follow their structures.
+
+Everything else is soft guidance. Do **not** reject a bundle for missing
+optional fields, unknown `type` values, unknown frontmatter keys, broken links
+(they may be not-yet-written knowledge), or an absent `index.md`. Unrecognized
+`okf_version` ⇒ best-effort consumption, not refusal.
+
+Check with the bundled zero-dependency validator:
+
+```bash
+python3 ${SKILL_DIR}/scripts/validate_okf.py <bundle-dir>                  # the 3 rules
+python3 ${SKILL_DIR}/scripts/validate_okf.py <bundle-dir> --strict --check-links
+```
+
+`--strict` adds producer-side lint (`title`, `description`, `generated`,
+`runtime` on attested computations, `status`/date shapes, legacy `timestamp`);
+`--check-links` resolves intra-bundle link targets. Both go beyond conformance —
+their findings are reasons to improve a bundle you own, never to reject one you
+are merely reading.
 
 ## Consuming a bundle
 
-When a repo contains an OKF bundle, treat it as curated, high-signal context:
+Treat it as curated, high-signal context that beats grepping:
 
-1. Read `index.md` at the bundle root first — it maps the territory cheaply.
-2. Open only the concept docs relevant to the task; follow links to related
-   concepts instead of grepping blindly.
-3. Check `log.md` when recency matters.
+1. Read the bundle-root `index.md` first — it maps the territory cheaply.
+2. Open only the concepts the task touches, then follow their links.
+3. Weigh before relying: `status: deprecated` or `today >= stale_after` means
+   verify against the real system before acting; an unverified, agent-generated
+   concept is a lead, a human-reviewed one is a fact.
+4. Read `log.md` when recency or "what changed" matters.
 
-## Authoring a concept
+## Authoring and maintaining
 
-1. Pick a stable concept-id (its path); group related concepts in subdirectories.
-2. Write frontmatter — always `type`; add `title`/`description`/`timestamp` for
-   anything others will read.
-3. Write the body as normal markdown; link related concepts with `/`-absolute
-   paths so links survive moves.
-4. Keep `index.md` and `log.md` current when you add or change concepts.
+1. Pick a stable concept ID (its path); group related concepts into
+   subdirectories with their own `index.md`.
+2. Write frontmatter: always `type`; add `title`/`description` for anything
+   others read; set `generated: { by, at }` with the correct actor — use
+   `human:<id>` only for genuinely human-authored content.
+3. Write a structured body; link related concepts with `/`-absolute paths so
+   links survive moves. Cite claims with footnotes keyed to `sources[].id`.
+4. Keep `index.md` (when the concept set changes) and `log.md` (a dated entry)
+   current in the same change.
 
-## Producing / maintaining a bundle in this repo
-
-If this repo asks yolop to keep a knowledge bundle current (e.g. an `.okf/`
-directory referenced from `AGENTS.md`), after a change that alters durable facts
-about the codebase:
-
-- Add or update the affected concept file(s), bumping their `timestamp`.
-- Update `index.md` if the set of concepts changed.
-- Append a dated entry to `log.md`.
-
-Write down only durable, reusable knowledge — architecture, contracts,
-invariants, processes — not transient task notes. A bundle that rots into stale
-docs is worse than none; keep it accurate or leave it out.
+When a repo asks yolop to keep its bundle current, update the affected concepts
+after any change to durable facts, refresh `generated.at`, and record it in
+`log.md`. Write down only durable, reusable knowledge — architecture, contracts,
+invariants, processes — never transient task notes. A bundle that rots into
+stale docs is worse than none.
 
 ## Converting into OKF
 
 From a wiki, Notion export, Obsidian vault, or CSV: one source page/row → one
-concept file; choose a `type`; carry titles/descriptions into frontmatter;
-rewrite internal links as `/`-absolute concept links; add an `index.md`.
+concept file; pick a descriptive `type`; carry titles and summaries into
+`title`/`description`; rewrite internal links as `/`-absolute concept links;
+record where each concept came from in `sources` and stamp `generated`; add an
+`index.md`. Migrating a v0.1 bundle: `timestamp` → `generated: { by, at }`, and
+a body `# Citations` list → frontmatter `sources`. Everything else carries over
+unchanged.

--- a/src/bundled/system-skills/okf/scripts/validate_okf.py
+++ b/src/bundled/system-skills/okf/scripts/validate_okf.py
@@ -1,18 +1,21 @@
 #!/usr/bin/env python3
-"""Validate an OKF v0.1 bundle. Zero dependencies (stdlib only).
-
-Hard conformance rules (a failure exits non-zero):
-  1. Every non-reserved `.md` file has a parseable YAML frontmatter block.
-  2. Every such frontmatter has a non-empty `type` field.
-  3. Reserved files (`index.md`, `log.md`) are exempt from the `type` rule.
-
-Optional modes:
-  --strict       also require `title`, `description`, and `timestamp`.
-  --check-links  report broken `/`-absolute intra-bundle links (informational;
-                 never fails the run — broken links are soft guidance in OKF).
+"""Validate an Open Knowledge Format (OKF v0.2) bundle using only the standard library.
 
 Usage: python3 validate_okf.py <bundle-dir> [--strict] [--check-links]
+
+Without flags this checks only OKF conformance: every non-reserved `.md` file
+has parseable YAML frontmatter with a non-empty `type`. Everything else in the
+format is soft guidance, so it lives behind the opt-in flags.
+
+--strict adds producer-side lint: `title`, `description`, and `generated`; the
+`runtime` an Attested Computation requires; the shapes of `status`, `stale_after`
+and `okf_version`; and the v0.1 fields v0.2 superseded. --check-links resolves
+intra-bundle Markdown link targets. Findings from either flag are reasons to
+improve a bundle you own, never to reject one you are only reading.
+
+Spec: https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md
 """
+
 from __future__ import annotations
 
 import re
@@ -20,36 +23,120 @@ import sys
 from pathlib import Path
 
 RESERVED = {"index.md", "log.md"}
+FRONTMATTER_RE = re.compile(r"\A---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+LINK_RE = re.compile(r"\]\(([^)\s]+)(?:\s+['\"][^)]*['\"])?\)")
+SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:")
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+STATUSES = {"draft", "stable", "deprecated"}
+ATTESTED_COMPUTATION = "attested computation"
+# v0.1 fields v0.2 replaced. A bundle carrying them still conforms; --strict
+# reports them so a producer migrates instead of writing new legacy documents.
+SUPERSEDED = {"timestamp": "generated: { by, at }"}
 
 
-def parse_frontmatter(text: str):
-    """Return (frontmatter_dict, error). Only top-level `key: value` pairs are
-    read — enough for conformance without a YAML dependency. Nested structures
-    are ignored, not rejected."""
-    if not text.startswith("---"):
-        return None, "missing YAML frontmatter (file must start with `---`)"
-    # Split off the block between the first two `---` fences.
-    parts = text.split("\n")
-    if parts[0].strip() != "---":
-        return None, "frontmatter fence `---` must be on the first line"
+def parse_frontmatter(text: str) -> tuple[dict[str, str], str | None]:
+    """Return (top-level fields, error). Nested structures are flattened to their
+    raw text, which is enough for presence and shape checks without a YAML
+    dependency."""
+    match = FRONTMATTER_RE.match(text)
+    if not match:
+        return {}, "missing or malformed YAML frontmatter"
     fields: dict[str, str] = {}
-    closed = False
-    for line in parts[1:]:
-        if line.strip() == "---":
-            closed = True
-            break
-        m = re.match(r"^([A-Za-z0-9_-]+)\s*:\s*(.*)$", line)
-        if m:
-            fields[m.group(1)] = m.group(2).strip()
-    if not closed:
-        return None, "frontmatter block is not closed with a trailing `---`"
+    for line in match.group(1).splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or line[:1].isspace():
+            continue
+        if stripped.startswith("- "):  # continuation of a block sequence
+            continue
+        if ":" not in line:
+            return {}, f"malformed frontmatter line: {line!r}"
+        key, value = line.split(":", 1)
+        fields[key.strip()] = value.strip().strip("'\"")
     return fields, None
 
 
+def local_link_target(root: Path, source: Path, target: str) -> Path | None:
+    target = target.split("#", 1)[0]
+    if not target or target.startswith("#") or SCHEME_RE.match(target):
+        return None
+    if target.startswith("/"):
+        candidate = root / target.lstrip("/")
+        if candidate.suffix == "":
+            candidate = candidate.with_suffix(".md")
+        return candidate
+    # Bare placeholders such as `(url)` are not filesystem links. Repository
+    # links have a path marker, a Markdown suffix, or name a directory.
+    if "/" not in target and not target.endswith(".md"):
+        return None
+    return source.parent / target
+
+
+def lint_concept(fields: dict[str, str]) -> list[str]:
+    """Soft guidance from the spec, reported only under --strict."""
+    findings: list[str] = []
+    for recommended in ("title", "description", "generated"):
+        if not fields.get(recommended):
+            findings.append(f"--strict requires `{recommended}`")
+    for legacy, replacement in SUPERSEDED.items():
+        if legacy in fields:
+            findings.append(f"`{legacy}` is superseded by `{replacement}`")
+    if fields.get("type", "").lower() == ATTESTED_COMPUTATION and not fields.get("runtime"):
+        findings.append("`type: Attested Computation` requires `runtime`")
+    status = fields.get("status")
+    if status and status not in STATUSES:
+        findings.append(f"`status` must be one of {sorted(STATUSES)}, got {status!r}")
+    stale_after = fields.get("stale_after")
+    if stale_after and not DATE_RE.match(stale_after):
+        findings.append(f"`stale_after` must be an absolute YYYY-MM-DD date, got {stale_after!r}")
+    return findings
+
+
+def lint_index(fields: dict[str, str], is_bundle_root: bool) -> list[str]:
+    """Index files carry no frontmatter, except `okf_version` at the bundle root."""
+    allowed = {"okf_version"} if is_bundle_root else set()
+    extra = sorted(set(fields) - allowed)
+    if extra:
+        return [f"index.md must not carry frontmatter keys {extra}"]
+    version = fields.get("okf_version")
+    if version and not re.match(r"^\d+\.\d+$", version):
+        return [f"`okf_version` must be `<major>.<minor>`, got {version!r}"]
+    return []
+
+
+def validate(root: Path, *, strict: bool = False, check_links: bool = False) -> tuple[list[str], int]:
+    messages: list[str] = []
+    concepts = 0
+    for path in sorted(root.rglob("*.md")):
+        rel = path.relative_to(root).as_posix()
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if path.name not in RESERVED:
+            fields, error = parse_frontmatter(text)
+            if error:
+                messages.append(f"{rel}: {error}")
+                continue
+            concepts += 1
+            if not fields.get("type"):
+                messages.append(f"{rel}: frontmatter has no non-empty `type` field")
+            if strict:
+                messages.extend(f"{rel}: {finding}" for finding in lint_concept(fields))
+        elif strict and path.name == "index.md" and text.startswith("---"):
+            fields, error = parse_frontmatter(text)
+            if error:
+                messages.append(f"{rel}: {error}")
+            else:
+                messages.extend(f"{rel}: {f}" for f in lint_index(fields, rel == "index.md"))
+        if check_links:
+            for target in LINK_RE.findall(text):
+                local = local_link_target(root, path, target)
+                if local is not None and not local.resolve().exists():
+                    messages.append(f"{rel}: broken link -> {target}")
+    return messages, concepts
+
+
 def main() -> int:
-    args = [a for a in sys.argv[1:] if not a.startswith("--")]
-    flags = {a for a in sys.argv[1:] if a.startswith("--")}
-    if len(args) != 1:
+    args = [arg for arg in sys.argv[1:] if not arg.startswith("--")]
+    flags = {arg for arg in sys.argv[1:] if arg.startswith("--")}
+    if len(args) != 1 or flags - {"--strict", "--check-links"}:
         print(__doc__)
         return 2
     root = Path(args[0])
@@ -57,49 +144,13 @@ def main() -> int:
         print(f"error: {root} is not a directory")
         return 2
 
-    strict = "--strict" in flags
-    check_links = "--check-links" in flags
-
-    md_files = sorted(root.rglob("*.md"))
-    ids = {f.relative_to(root).with_suffix("").as_posix() for f in md_files}
-
-    errors: list[str] = []
-    warnings: list[str] = []
-    concepts = 0
-
-    for f in md_files:
-        rel = f.relative_to(root).as_posix()
-        reserved = f.name in RESERVED
-        text = f.read_text(encoding="utf-8", errors="replace")
-        fm, err = parse_frontmatter(text)
-        if reserved:
-            continue
-        if err:
-            errors.append(f"{rel}: {err}")
-            continue
-        concepts += 1
-        if not fm.get("type"):
-            errors.append(f"{rel}: frontmatter has no non-empty `type` field")
-        if strict:
-            for req in ("title", "description", "timestamp"):
-                if not fm.get(req):
-                    errors.append(f"{rel}: --strict requires `{req}`")
-        if check_links:
-            for target in re.findall(r"\]\((/[^)\s]+)\)", text):
-                cid = target.lstrip("/").removesuffix(".md")
-                if cid not in ids:
-                    warnings.append(f"{rel}: broken link -> {target}")
-
-    for w in warnings:
-        print(f"warn: {w}")
-    for e in errors:
-        print(f"FAIL: {e}")
-
-    print(
-        f"\n{concepts} concept(s) checked in {root} — "
-        f"{len(errors)} error(s), {len(warnings)} warning(s)"
+    messages, concepts = validate(
+        root, strict="--strict" in flags, check_links="--check-links" in flags
     )
-    return 1 if errors else 0
+    for message in messages:
+        print(f"FAIL: {message}")
+    print(f"\n{concepts} concept(s) checked in {root} — {len(messages)} error(s)")
+    return 1 if messages else 0
 
 
 if __name__ == "__main__":

--- a/src/capabilities/skills.rs
+++ b/src/capabilities/skills.rs
@@ -737,6 +737,31 @@ mod tests {
             "yolop skill description should mention keyboard shortcuts: {:?}",
             yolop_parsed.description
         );
+
+        // The okf skill teaches a format from an external spec, so pin what it
+        // cites: `okf.md` is not normative and describes a superseded v0.1
+        // model, and the skill's documented validator command only works if the
+        // nested `scripts/` directory materializes with it.
+        let okf_md = std::fs::read_to_string(dest.join("okf").join("SKILL.md")).unwrap();
+        let okf_parsed = everruns_core::skill::parse_skill_md(&okf_md).unwrap();
+        assert!(okf_parsed.user_invocable);
+        assert!(
+            okf_md.contains(
+                "https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md"
+            ),
+            "okf skill must cite the authoritative spec"
+        );
+        assert!(
+            !okf_md.contains("okf.md/spec"),
+            "okf skill must not cite the non-normative okf.md site"
+        );
+        assert!(
+            dest.join("okf")
+                .join("scripts")
+                .join("validate_okf.py")
+                .is_file(),
+            "okf skill ships its validator"
+        );
     }
 
     // ---------- delete_skill ----------


### PR DESCRIPTION
## What changed

The bundled `okf` skill now teaches OKF **v0.2** from the only authoritative
source — `SPEC.md` in `GoogleCloudPlatform/knowledge-catalog` — instead of v0.1
from the non-normative `okf.md` site. When the skill activates, Yolop now knows
the families that make an agent-maintained corpus usable:

- `sources` with per-source credibility signals (`author`, `usage_count`,
  `last_modified`, `usage_window`) and per-claim attribution via footnotes keyed
  to `sources[].id`.
- `generated` / `verified`, the actor convention (`agent/version`, `human:<id>`,
  `process:<id>`), and the three trust tiers derived from it.
- `status` and `stale_after`, taught as *consumption* signals: a deprecated or
  past-date concept gets verified against the real system before it is acted on.
- The `Attested Computation` contract (`runtime`, `parameters`, `computation`,
  `executor`, `attester`) with the agent-facing rule that only parameter values
  may be supplied — never edits to the sanctioned computation — and that a
  failing attestation is surfaced, not swallowed.

The validator now matches the format's permissiveness. A default run enforces
only the three conformance rules; every producer-side opinion moved behind
`--strict`, which also learned v0.2 (`generated` instead of the retired
`timestamp`, `runtime` on attested computations, `status`/`stale_after`/
`okf_version` shapes) and reports `timestamp` as superseded rather than
requiring it.

The skill's copy of the validator had silently drifted from the copy CI runs —
two different implementations of the same script in one tree. They are now
byte-identical and pinned by a test.

Docs, `README.md`, and `knowledge/specs/okf.md` follow, with every `okf.md` link
replaced by the spec URL.

## Why

`okf.md` is not normative. It lagged the format and described a superseded v0.1
model, so the skill confidently taught the wrong thing: `timestamp` where v0.2
has `generated: { by, at }`, a body `# Citations` list where v0.2 has frontmatter
`sources`, and no notion of trust, freshness, or attestation at all. A skill that
teaches a format from a stale mirror is worse than no skill — the model states
its content with authority.

The `--strict` mode had the same problem in the other direction: it demanded
`timestamp`, a field v0.2 retired, and presented producer preferences as though
they were conformance.

## Before / After

Default run stays conformance-only; the opinions are now opt-in and v0.2-aware:

```
$ python3 scripts/validate_okf.py knowledge --check-links
36 concept(s) checked in knowledge — 0 error(s)

# before: --strict demanded `timestamp`, a field v0.2 retired
$ python3 scripts/validate_okf.py bundle --strict
FAIL: metric.md: --strict requires `generated`
FAIL: metric.md: `timestamp` is superseded by `generated: { by, at }`
FAIL: metric.md: `type: Attested Computation` requires `runtime`
FAIL: metric.md: `status` must be one of ['deprecated', 'draft', 'stable'], got 'published'
FAIL: metric.md: `stale_after` must be an absolute YYYY-MM-DD date, got '90d'
```

The rewritten skill is compiled into the binary, and the stale citation is gone
from it:

```
$ grep -c "Attested Computation" target/debug/yolop   # present
$ grep -c "okf.md/spec" target/debug/yolop            # absent
```

## Risk

- Low
- The only shipped-binary change is the content of an embedded `SKILL.md` and its
  sibling script; no runtime, capability, or tool wiring is touched. The
  plausible failure is prose that misteaches the format, which is why the spec
  citation and the shipped validator path are now asserted rather than assumed.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

Backward compatibility: `validate_okf.py`'s default run is unchanged, so the CI
invocation and any existing v0.1 bundle still pass. `--strict` is stricter about
different things — deliberately, since it previously required a retired field.
The skill teaches the v0.1 → v0.2 migration so older bundles are still readable.

## Knowledge

Updated [`knowledge/specs/okf.md`](knowledge/specs/okf.md): named the
authoritative spec and recorded why third-party mirrors are not normative, the
v0.2 families the skill must teach, the rule that validator lint stays behind
`--strict`, the byte-identity requirement between the two validator copies, and a
new non-goal (no execution or attestation runtime). Logged in
[`knowledge/log.md`](knowledge/log.md).

## Security

Reviewed against the threat-model categories; no security-relevant behavior
changed.

- **TM-FS** — no filesystem code in the binary changed. `validate_okf.py` is
  read-only: it globs the user-supplied bundle directory and reads text, never
  writing, deleting, or executing. Link checking calls `.exists()` on resolved
  paths, which can probe outside the bundle if a bundle links there, but reads no
  content and is unchanged from the prior implementation.
- **TM-BASH** — untouched; no change to `tools.rs` or the bounded execution model.
- **TM-LLM** — `SKILL.md` is prompt content. It carries no credentials and no
  instruction to fetch, exfiltrate, or execute anything; the single external URL
  is cited as a reference for a human or agent to read, not fetched automatically.
- **TM-TOOL** — no new capability or registration. The added test only asserts
  existing materialization behavior.
- **TM-DEP** — no new dependencies. The validator remains stdlib-only; its regexes
  are linear with no nested quantifiers, so no backtracking blowup on hostile
  input.

## Follow-ups

- This repo's own `knowledge/` bundle sets only `type`/`title`/`description`, so
  all 36 concepts fail `--strict` on `generated`. CI runs non-strict and is
  unaffected. Stamping `generated`/`verified` across the bundle is a deliberate
  editorial decision about who is recorded as the author of each concept, so it
  is left to the maintainer rather than bundled into a skill rewrite.
- `docs/features/okf/okf.svg` and its `.mmd` source still illustrate only the
  v0.1 anatomy (index, concepts, log). The diagram remains accurate as far as it
  goes; extending it to show the trust and attestation families is a separate
  design pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1iNk75aAHhC83GcYpxkis)_