### PR TITLE
chore(deps): bump everruns to 0.17.17 and tuika to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1686,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.16"
+version = "0.17.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e7d3f6384f3c4a2a90e14eabc8afe30b233b3d34c5e637b6c73340892ee976"
+checksum = "5c569d0b6b224c3e4759b49040a4735c330f0a80d33688f22c644f4357e4a693"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1704,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.16"
+version = "0.17.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edea51824ed7ae8f2791f4de0b00f35f51e33e7ae3cad9424ec086585aab2cf"
+checksum = "85429c86801a0b64d0294c8bbed56db3525a13f202fa632b57cfd1ef0564c186"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -1751,9 +1751,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.16"
+version = "0.17.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4af09252857ff754044cc658edd88d4438753476ea45631da7520224d95fda12"
+checksum = "49447435cdbce95d8f02aa1644be676fcd46e3941d091abe77c823f0b6223f13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1768,9 +1768,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.16"
+version = "0.17.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426a9bf1ffc2160fa2c739ec97b40e52826d87ed79fba381c5e7b33a49256958"
+checksum = "d28a7c179b96f3fc79e6af99dd2ef6e23a426c3c00038cc7ff577f4f99c849cc"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1784,9 +1784,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.16"
+version = "0.17.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d9272f7a6adcac27f4d4572eca53b7b1e04db72cf2b7651a4f5aee83ef8cbab"
+checksum = "d18a8005534334c83332a0105b6e79174ad13b1b8d859802c6aa4c98c325e497"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1798,9 +1798,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.16"
+version = "0.17.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5143552bbb3cebadccc884d96a3ff3b791a93060daf72492ac7a3d812976a01"
+checksum = "62971d0ace84c2647e22486e4d81410b3dd56cd45cc4b2d6d9964876ecf90868"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1822,9 +1822,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.16"
+version = "0.17.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d396b389886ac8df35444577b5e459330e64d07e5c956d3516d86da12eb33e5e"
+checksum = "694326d6428bc086fd57ae015984e12e2190ce58a730b04ae6ce3e59f587714f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1837,9 +1837,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.16"
+version = "0.17.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710dd0d4a3311718bc89c8ff215028be81daa80daf1bdeeee03cbaaffafc1682"
+checksum = "ec0c91563ce5d985e4ef4724f73f14c89ac4e287b1017baf3ba3ec55ea111a08"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1853,9 +1853,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.16"
+version = "0.17.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad16b74e932b59b1ffc1fe0e67aba4cbe6ad1c057625a6676c56013a58a7b07"
+checksum = "fc05fbd54a21604728015898bbba83ac042369e174b82225ea45d78152a093fc"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1867,9 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-provider"
-version = "0.17.16"
+version = "0.17.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d60ff18f892be0b161af65723d96437932aa870e66479415269c851d39a8676c"
+checksum = "01b762b7831b74af64270f4aae795451674eea58af200f9d35406bbac8cfb961"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1895,9 +1895,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.16"
+version = "0.17.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8062552738073f1f6f448a48b67f13f0753e0c79bd9744bc06462548bd34bb"
+checksum = "278e800d06d20a23afcb7c7819a4ee5692fa158a0ac79b1a807f74d7ca487a82"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6662,9 +6662,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuika"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d13f294a90d47ad9998ab4302436ef06635621ff694f0f050d04582350dfd6e"
+checksum = "d19d29f435a03a089f7a3842bbfc5b2b3a01fc4758cea0bb34bc9f6f0df99333"
 dependencies = [
  "crossterm",
  "pulldown-cmark",
@@ -6677,9 +6677,9 @@ dependencies = [
 
 [[package]]
 name = "tuika-codeformatters"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c2d868b9230714b229f7e7eac637e4e356ea11d000661699c847046d543302"
+checksum = "0091249e75f39c03aedb69555341d3ffb662c4693428d8b60b67497a64b585d7"
 dependencies = [
  "ratatui",
  "tree-sitter",
@@ -6702,9 +6702,9 @@ dependencies = [
 
 [[package]]
 name = "tuika-mermaid"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cdbe844e64cef702bd6a25ee5000a14d56634cf4307f25404fc6cb3b5c5bce7"
+checksum = "38fbe4d52e3e8e791d9d1f08b67d15b2d139c7542042306690638a590dc1acf1"
 dependencies = [
  "mmdflux",
  "ratatui-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,14 +70,14 @@ textwrap = "0.16"
 # The TUI toolkit behind the full-screen renderer. It lives in its own
 # repository (everruns/tuika) and is consumed from crates.io like any other
 # dependency; yolop gets no special treatment there.
-tuika = "0.5.0"
+tuika = "0.6.0"
 # Tree-sitter Highlighter impl for tuika's CodeBlock/Markdown; owns the grammar
 # deps so tuika core stays dependency-light. Published from the tuika repo.
-tuika-codeformatters = "0.3.0"
+tuika-codeformatters = "0.3.1"
 # FencedBlockRenderer impl that turns ```mermaid fences into Unicode diagrams
 # via mmdflux; keeps diagram layout out of tuika core. Published from the tuika
 # repo.
-tuika-mermaid = "0.1.0"
+tuika-mermaid = "0.1.1"
 tokio = { version = "1.52", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tree-sitter = "0.26"
@@ -102,20 +102,20 @@ tree-sitter-zig = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-everruns-anthropic = "0.17.16"
-everruns-core = "0.17.16"
-everruns-openai = "0.17.16"
+everruns-anthropic = "0.17.17"
+everruns-core = "0.17.17"
+everruns-openai = "0.17.17"
 # OpenRouter's first-class driver was split out of everruns-openai into its own
 # crate in 0.13.0; register it alongside openai to keep DriverId::OpenRouter.
-everruns-openrouter = "0.17.16"
-everruns-local = "0.17.16"
-everruns-mcp = { version = "0.17.16", features = ["stdio"] }
+everruns-openrouter = "0.17.17"
+everruns-local = "0.17.17"
+everruns-mcp = { version = "0.17.17", features = ["stdio"] }
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (knowledge/specs/mcp.md, upstream runtime-mcp.md D2).
-everruns-runtime = { version = "0.17.16", features = ["mcp-stdio"] }
-everruns-integrations-duckduckgo = "0.17.16"
-everruns-integrations-parallel = "0.17.16"
-everruns-integrations-daytona = "0.17.16"
+everruns-runtime = { version = "0.17.17", features = ["mcp-stdio"] }
+everruns-integrations-duckduckgo = "0.17.17"
+everruns-integrations-parallel = "0.17.17"
+everruns-integrations-daytona = "0.17.17"
 arboard = { version = "3", features = ["wayland-data-control"] }
 futures = "0.3"
 html-escape = "0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1040,6 +1040,9 @@ fn run_tuika_gallery() -> Result<()> {
     progress.indeterminate();
     let runner = tuika::Runner::new(tuika::RunnerConfig {
         tick_rate: Duration::from_millis(80),
+        // The gallery owns the whole terminal; `ScreenMode::Alternate` is the
+        // default, and split-footer mode is for hosts that publish scrollback.
+        ..tuika::RunnerConfig::default()
     });
     runner.run_with_backend(
         &theme,


### PR DESCRIPTION
## What changed

Dependency bump with no user-visible behavior change.

- All `everruns-*` crates move together from 0.17.16 to 0.17.17 (patch; no API change, nothing to adopt).
- The tuika trio moves to `tuika` 0.6.0, `tuika-codeformatters` 0.3.1, `tuika-mermaid` 0.1.1 — the companion crates' releases exist only to widen their tuika requirement for 0.6, so they move as a set per [`knowledge/specs/tuika.md`](knowledge/specs/tuika.md).

tuika 0.6.0 has exactly one breaking change: `RunnerConfig` gains a `screen_mode` field. The hidden `tuika-gallery` demo's config literal takes the upstream migration (`..RunnerConfig::default()`), which resolves to `ScreenMode::Alternate` — the previous and still-default mode. The release's new seams (split-footer mode, `Scrollback` publishing, borrowed `ScopedScene` roots, the `scrolling-regions` feature) are deliberately not adopted: they are opt-in host choices, and adopting any of them is a renderer change, not a bump.

## Why

Stay current with the runtime and the toolkit, and keep the `everruns-*` set at one version — a mismatch there is a soft API break.

## Before / After

No observable behavior change. The gallery still owns the alternate screen and drives the same OSC 9;4 progress and OSC 8 hyperlinks; `tests/tuika_pty.rs` asserts that against the real binary and passes unchanged.

## Risk

- Low
- What can break: a silent tuika rendering regression the pinned snapshots don't cover, or an `everruns-*` patch-level behavior change in the agent loop. Both are covered — see Validation.

## Validation

- `cargo fmt --check` — clean.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo test --all-features` — 978 + 50 + 1 + 5 passed, 0 failed. This includes `tests/tuika_pty.rs`, which drives the changed code path (`gallery_drives_altscreen_and_native_progress`, `gallery_emits_osc8_hyperlink_when_enabled`, `gallery_survives_resize`) through the real `yolop` binary under a pty.
- Offline smoke: `cargo run -- --provider llmsim -p "hi"` starts and completes a turn.
- Live-provider smoke against the bumped runtime, on **both** providers — plain turn and tool loop each:
  - Plain turn (`-p "Reply with exactly the word OK and nothing else."`) → `OK` on `--provider openai` and on `--provider anthropic`.
  - Tool loop (`-p "Use your tools to read Cargo.toml and tell me only the value of the 'tuika' dependency version…"`) → `0.6.0` on both providers. This is the load-bearing one: it exercises capability dispatch and the tool-result round trip through `everruns-runtime` 0.17.17, and the answer is the bumped pin read back off disk.

## Checklist
- [x] Tests added or updated — no new test; the existing pty gallery tests already drive the changed line, and a dependency bump adds no new behavior to assert.
- [x] Backward compatibility considered — yolop is pre-1.0 and this changes no public surface.
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

No knowledge update required — [`knowledge/specs/tuika.md`](knowledge/specs/tuika.md) already owns this process (crates.io pin, no path override, companion crates move together, one shared `ratatui-core`) and pins no version numbers. Durable behavior, architecture, policy, and constraints are unchanged.

## Security

**TM-DEP** — the only relevant category. No new crates are introduced, so no new-dependency justification is owed; every change is a version move on a crate already in the tree. All `everruns-*` crates were bumped together to 0.17.17, avoiding the mismatched-version soft API break. The `scrolling-regions` feature tuika 0.6.0 adds is left off, which is both the default and the safe choice — enabling it makes the terminal discard rows scrolled out of a DECSTBM region instead of retaining them in scrollback.

Not implicated: **TM-FS** (write blocklist untouched), **TM-BASH** (`tools.rs` untouched, bounded execution model intact), **TM-LLM** (no prompt-construction or key-handling change; keys still read from process env only), **TM-TOOL** (no capability registration change). The single source edit is a struct-literal default in a demo command — no trust boundary, no input parsing, no new loop or unbounded allocation.

## Follow-ups

- Split-footer mode is not adopted. Running the transcript in the terminal's own scrollback is a real renderer change with its own design questions (what yolop publishes, how the composer is pinned, resize behavior) and belongs in its own change, not a bump.