### PR TITLE
chore(release): prepare v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,33 @@ mechanical `### What's Changed` list of merged PRs.
 Releases are cut via [`/release`](./.agents/skills/release/SKILL.md), which
 tags the version and publishes to crates.io and the Homebrew tap.
 
+## [0.13.0] - 2026-07-27
+
+### Highlights
+
+- Mermaid fences in assistant messages render as Unicode terminal diagrams, falling back to the themed code block when a diagram would overflow the viewport.
+- Transcript links now activate through the terminal's own OSC 8 handling instead of opening the URL a second time inside yolop, with OSC 22 pointer feedback over clickable regions.
+- The system prompt stops restating tool descriptions on every turn and gates how-to on tool reveal, while telling the model which formatting the host can actually render.
+- The bundled OKF skill is rewritten against the authoritative OKF v0.2 spec, and its validator is now byte-identical to the one CI runs.
+- `tuika` and `tuika-codeformatters` have left this workspace for [everruns/tuika](https://github.com/everruns/tuika) and are consumed from crates.io like any other dependency.
+
+### What's Changed
+
+* chore(deps): bump everruns to 0.17.17 and tuika to 0.6.0 ([#493](https://github.com/everruns/yolop/pull/493)) by @chaliy
+* feat(okf): rewrite the bundled skill against the OKF v0.2 spec ([#492](https://github.com/everruns/yolop/pull/492)) by @chaliy
+* feat(prompt): tell the model what the host can render ([#491](https://github.com/everruns/yolop/pull/491)) by @chaliy
+* feat(tui): render mermaid fences as terminal diagrams ([#490](https://github.com/everruns/yolop/pull/490)) by @chaliy
+* refactor: consume tuika from its own repository ([#489](https://github.com/everruns/yolop/pull/489)) by @chaliy
+* chore(deps): upgrade ACP and ast-grep ([#488](https://github.com/everruns/yolop/pull/488)) by @chaliy
+* fix(prompt): restore the repo_map truncation rule ([#487](https://github.com/everruns/yolop/pull/487)) by @chaliy
+* refactor(prompt): cut per-turn prompt prose and gate how-to on reveal ([#486](https://github.com/everruns/yolop/pull/486)) by @chaliy
+* chore(agents): rightsize AGENTS.md, knowledge, and skills ([#485](https://github.com/everruns/yolop/pull/485)) by @chaliy
+* fix(tui): use native terminal links ([#484](https://github.com/everruns/yolop/pull/484)) by @chaliy
+* chore(tuika): exclude demo GIFs from published crate ([#483](https://github.com/everruns/yolop/pull/483)) by @chaliy
+* fix(crash): report active session id ([#481](https://github.com/everruns/yolop/pull/481)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/yolop/compare/v0.12.1...v0.13.0
+
 ## [0.12.1] - 2026-07-24
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7660,7 +7660,7 @@ dependencies = [
 
 [[package]]
 name = "yolop"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "yolop"
-version = "0.12.1"
+version = "0.13.0"
 edition = "2024"
 authors = ["Everruns <support@everruns.com>"]
 license = "MIT"


### PR DESCRIPTION
## What changed

Cuts **v0.13.0**. Bumps `version` in `Cargo.toml` (0.12.1 → 0.13.0), refreshes the
`Cargo.lock` entry, and adds the `CHANGELOG.md` section for the 12 commits merged
since `v0.12.1`. No source changes.

MINOR under the release spec's versioning rules: the set carries three `feat`
commits (mermaid rendering, host-render prompt block, the OKF v0.2 skill rewrite).
No user-visible breaking changes, so no `### Breaking Changes` block.

`yolop-yep` stays at **0.3.0** — it is unchanged since `v0.12.1` and that version
is already live on crates.io, so `publish.yml` will skip it and publish `yolop`
alone. `tuika` / `tuika-codeformatters` ship from
[everruns/tuika](https://github.com/everruns/tuika) and are not released here.

## Why

Twelve merged PRs are unreleased, including three user-visible features and two
TUI fixes. Users on crates.io and the Homebrew tap are still on 0.12.1.

## Before / After

### Changelog section

```markdown
## [0.13.0] - 2026-07-27

### Highlights

- Mermaid fences in assistant messages render as Unicode terminal diagrams, falling back to the themed code block when a diagram would overflow the viewport.
- Transcript links now activate through the terminal's own OSC 8 handling instead of opening the URL a second time inside yolop, with OSC 22 pointer feedback over clickable regions.
- The system prompt stops restating tool descriptions on every turn and gates how-to on tool reveal, while telling the model which formatting the host can actually render.
- The bundled OKF skill is rewritten against the authoritative OKF v0.2 spec, and its validator is now byte-identical to the one CI runs.
- `tuika` and `tuika-codeformatters` have left this workspace for everruns/tuika and are consumed from crates.io like any other dependency.

### What's Changed

* chore(deps): bump everruns to 0.17.17 and tuika to 0.6.0 (#493) by @chaliy
* feat(okf): rewrite the bundled skill against the OKF v0.2 spec (#492) by @chaliy
* feat(prompt): tell the model what the host can render (#491) by @chaliy
* feat(tui): render mermaid fences as terminal diagrams (#490) by @chaliy
* refactor: consume tuika from its own repository (#489) by @chaliy
* chore(deps): upgrade ACP and ast-grep (#488) by @chaliy
* fix(prompt): restore the repo_map truncation rule (#487) by @chaliy
* refactor(prompt): cut per-turn prompt prose and gate how-to on reveal (#486) by @chaliy
* chore(agents): rightsize AGENTS.md, knowledge, and skills (#485) by @chaliy
* fix(tui): use native terminal links (#484) by @chaliy
* chore(tuika): exclude demo GIFs from published crate (#483) by @chaliy
* fix(crash): report active session id (#481) by @chaliy
```

The commit list was built mechanically from
`git log v0.12.1..HEAD --pretty=format:'%s' --reverse`; all 12 subjects appear,
listed newest-first by PR number as the spec requires. `git rev-list --count`
and the GitHub compare both report 12, so the clone is not shallow.

### Publish-readiness

| Check | Result |
|---|---|
| `cargo publish --dry-run -p yolop-yep` | **Pass** — packaged 11 files, 55.1 KiB (15.3 KiB compressed) |
| `cargo publish --dry-run -p yolop` | **Pass** — verified and packaged at 0.13.0 |
| crates.io currently serves | `yolop` **0.12.1**, `yolop-yep` **0.3.0** → 0.13.0 > 0.12.1 |
| `Cargo.toml` | `version = "0.13.0"` |
| `Cargo.lock` | `name = "yolop"` / `version = "0.13.0"` — agrees |

The `-p yolop` dry-run normally fails locally when a new `yolop-yep` is not yet
live; here `yolop-yep` 0.3.0 is unchanged and already published, so the real
publish path was exercised end to end rather than deferred to CI.

## Risk

- Low
- What can break: a publish-time failure in `publish.yml` (both dry-runs pass, so
  the packaging boundary is proven), or a Homebrew formula regeneration failure in
  `cli-binaries.yml` (unchanged since the last successful release). A release
  carrying renderer changes (#484, #490) could regress how a specific emulator
  paints output — see the terminal matrix note below.

## Validation

- `cargo fmt --check` — clean.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo test --all-features` — **1034 passed, 0 failed**, including
  `tests/tuika_pty.rs` (alt-screen, OSC 9;4 progress, OSC 8 hyperlinks on and off,
  truecolor, Braille, resize) driven against the real binary.
- `python3 scripts/validate_okf.py knowledge --check-links` — 36 concepts, 0 errors.
- Offline smoke: `cargo run -- --provider llmsim -p "hi"` completes a turn.
- CI green on `main` at `87fed69`, the commit this branch is cut from.
- **Manual terminal matrix**: the TUI renderer changed this cycle, so the spec's
  matrix applies. It has **not** been walked by hand — this sandbox has no GUI
  emulators. The asserted **tmux** leg of `nightly-terminals.yml` is green as of
  the 2026-07-27 run, which covers the box chrome, a real Braille glyph, and the
  footer URL in a real emulator; the best-effort kitty / iTerm2 / Windows Terminal
  legs are screenshot-only. Per-emulator painting is the outstanding gap.

## Checklist
- [x] Tests added or updated — none needed; a version bump and changelog add no
      behavior to assert, and the existing suite gates the packaged binary.
- [x] Backward compatibility considered — no CLI flags, providers, or config
      changed; nothing in the release set is user-visibly breaking.
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

No knowledge update required — each merged PR updated the concepts it touched, and
cutting a release changes no durable intent, architecture, policy, constraint, or
maintainer process. `knowledge/specs/release.md` already owns this procedure and
pins no version numbers.

## Security

No security-relevant code changed. The diff is three files: a version string, a
lockfile entry for that same version, and changelog prose. No trust boundary,
input parsing, dependency addition, or capability registration is touched —
**TM-DEP**, **TM-FS**, **TM-BASH**, **TM-LLM**, and **TM-TOOL** are all
unimplicated. The publish path itself is unchanged and its secrets
(`CARGO_REGISTRY_TOKEN`, `DOPPLER_TOKEN` → tap-scoped PAT) are untouched.

## Post-merge verification

- [ ] `release.yml` — tags `v0.13.0`, creates the GitHub Release, dispatches downstream
- [ ] `publish.yml` — publishes to crates.io (skips `yolop-yep` 0.3.0, already live)
- [ ] `cli-binaries.yml` — builds the three CLI targets, uploads tarballs + checksums, pushes the tap formula
- [ ] crates.io serves `0.13.0`
- [ ] `everruns/homebrew-tap` `Formula/yolop.rb` points at `v0.13.0`

## Follow-ups

- The manual terminal matrix is unwalked for the renderer changes in #484 and #490;
  promoting a best-effort nightly leg to asserting would close this gap
  structurally rather than per-release.

Do not enable auto-merge — the release spec requires a human to click squash so a
reviewer reads the changelog.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHWHczyhS82Nsp1AhQXfQz)_