### PR TITLE
fix(tui): restore fullscreen composer behavior

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1162,16 +1162,18 @@ async fn run_tui(
     let trajectory_handles = runtime.handles.clone();
     let trajectory_model = runtime.model.clone();
     let mut raw_mode = RawModeGuard::new()?;
-    let mut keyboard_enhancements = KeyboardEnhancementGuard::new();
-    let mut bracketed_paste = BracketedPasteGuard::new();
     // In full-screen mode `tuika` owns the alternate screen + mouse capture via
     // an RAII guard that restores them on drop. The viewport becomes the whole
     // terminal instead of a short inline strip.
-    let alt_screen = if fullscreen {
+    let mut alt_screen = if fullscreen {
         Some(tuika::host::AltScreen::enter()?)
     } else {
         None
     };
+    // Kitty keyboard modes are screen-local, so enable them only after entering
+    // the alternate screen and restore them before leaving it.
+    let mut keyboard_enhancements = KeyboardEnhancementGuard::new();
+    let mut bracketed_paste = BracketedPasteGuard::new();
     let stdout = io::stdout();
     // Opt-in OSC 8 hyperlinks: wrap the crossterm backend so http(s) (and, with
     // YOLOP_HYPERLINK_MAILTO, mailto) URLs in rendered output become clickable.
@@ -1216,13 +1218,13 @@ async fn run_tui(
         tracing::warn!("cursor restore failed: {err:#}");
     }
     drop(terminal);
-    // Leave the alternate screen before any post-loop stdout (resume hint) so
-    // it lands on the user's normal screen, not the one about to be torn down.
-    if let Some(mut alt) = alt_screen {
-        alt.leave();
-    }
     bracketed_paste.disable();
     keyboard_enhancements.disable();
+    // Leave the alternate screen before any post-loop stdout (resume hint) so
+    // it lands on the user's normal screen, not the one about to be torn down.
+    if let Some(alt) = alt_screen.as_mut() {
+        alt.leave();
+    }
     raw_mode.disable()?;
 
     write_trajectory_if_requested(

--- a/src/tui/fullscreen.rs
+++ b/src/tui/fullscreen.rs
@@ -149,9 +149,9 @@ pub(crate) fn draw(f: &mut Frame, app: &mut App) {
     let preview_visible = render::chrome_preview_visible(&state);
     // NOTE (layout policy, item 2): `chrome_dimensions` stays hand-rolled on
     // purpose. tuika's Flex solver places the rows of the `view!` tree below, but
-    // *how tall the composer may grow* and *whether the preview/status-separator
-    // rows appear at all* is yolop UX policy (shrink the composer to keep the
-    // transcript visible on a short viewport; mirror Codex's composer behavior) —
+    // *how tall the composer may grow* and *whether the preview row appears at
+    // all* is yolop UX policy (shrink the composer to keep the transcript
+    // visible on a short viewport; mirror Codex's composer behavior) —
     // not something a generic constraint solver can infer. We compute those
     // heights here and hand the solver fixed sizes; the solver still owns
     // placement, wrapping, and the transcript's `grow(1)` fill.
@@ -162,7 +162,6 @@ pub(crate) fn draw(f: &mut Frame, app: &mut App) {
         preview_visible,
     );
     let preview_height = u16::from(input_height == 1 && preview_visible);
-    let status_sep_height = u16::from(input_height < 3);
     let transcript_height = area.height.saturating_sub(chrome_height).max(1);
 
     // Transcript and compact chrome share the inline renderer's pure builders.
@@ -210,7 +209,7 @@ pub(crate) fn draw(f: &mut Frame, app: &mut App) {
             fixed(preview_height) { node(preview_view(preview_line)) }
             fixed(1) { node(message_rule(&state)) }
             fixed(input_height) { node(composer_row(&app.composer, &input_probe)) }
-            fixed(status_sep_height) { node(status_rule()) }
+            fixed(render::STATUS_SEPARATOR_HEIGHT) { node(status_rule()) }
             fixed(status_rows) { node(Text::new(status.lines.clone())) }
         }
     };

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -3990,16 +3990,16 @@ mod tests {
         assert_eq!(chrome_height(1, 1, true), 5);
         assert_eq!(chrome_height(1, 4, false), 7);
         assert_eq!(chrome_height(1, 4, true), 8);
-        assert_eq!(chrome_height(3, 1, false), 5);
-        assert_eq!(chrome_height(3, 4, false), 8);
-        assert_eq!(chrome_height(4, 1, false), 6);
-        assert_eq!(chrome_height(4, 4, false), 9);
+        assert_eq!(chrome_height(3, 1, false), 6);
+        assert_eq!(chrome_height(3, 4, false), 9);
+        assert_eq!(chrome_height(4, 1, false), 7);
+        assert_eq!(chrome_height(4, 4, false), 10);
     }
 
     #[test]
     fn chrome_dimensions_clamp_input_to_visible_frame() {
         assert_eq!(chrome_dimensions(7, MAX_INPUT_HEIGHT, 4, false), (7, 1));
-        assert_eq!(chrome_dimensions(5, MAX_INPUT_HEIGHT, 1, false), (5, 3));
+        assert_eq!(chrome_dimensions(5, MAX_INPUT_HEIGHT, 1, false), (5, 2));
         assert_eq!(chrome_dimensions(0, MAX_INPUT_HEIGHT, 1, false), (0, 0));
     }
 
@@ -5399,6 +5399,36 @@ mod tests {
         assert!(
             gold_rule,
             "status separator should render in gold via tuika"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fullscreen_keeps_gold_separator_after_two_newlines() {
+        use ratatui::backend::TestBackend;
+        let mut test = app_with_llmsim().await;
+        test.app.setup = None;
+        test.app.set_render_mode(RenderMode::Fullscreen);
+        for _ in 0..2 {
+            test.app
+                .handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT))
+                .await;
+        }
+        assert_eq!(test.app.input_height(58), 3);
+
+        let backend = TestBackend::new(60, 20);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal.draw(|f| draw(f, &mut test.app)).expect("draw");
+        let buffer = terminal.backend().buffer();
+        let gold_rule = (0..buffer.area.height).any(|y| {
+            (0..buffer.area.width).any(|x| {
+                let cell = &buffer[(x, y)];
+                cell.symbol() == "─" && cell.fg == ACCENT_GOLD
+            })
+        });
+
+        assert!(
+            gold_rule,
+            "status separator should remain visible after two composer newlines"
         );
     }
 

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -6,6 +6,8 @@
 use super::*;
 use tuika::width::str_cols;
 
+pub(crate) const STATUS_SEPARATOR_HEIGHT: u16 = 1;
+
 // Color presentation for the transcript view-model types defined in
 // `crate::tui::transcript`. Labels and status semantics live in `crate::tui::presentation`
 // so they can be tested without a terminal renderer.
@@ -130,14 +132,13 @@ impl ChromeLayout {
         preview_visible: bool,
     ) -> Self {
         let preview_height = u16::from(input_height == 1 && preview_visible);
-        let status_height = u16::from(input_height < 3);
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
                 Constraint::Length(preview_height),
                 Constraint::Length(1),
                 Constraint::Length(input_height),
-                Constraint::Length(status_height),
+                Constraint::Length(STATUS_SEPARATOR_HEIGHT),
                 Constraint::Length(status_rows),
             ])
             .split(area);
@@ -208,7 +209,7 @@ pub(crate) fn app_layout_for_frame(
 fn chrome_fixed_rows(input_height: u16, status_rows: u16, preview_visible: bool) -> u16 {
     u16::from(input_height == 1 && preview_visible)
         .saturating_add(1)
-        .saturating_add(u16::from(input_height < 3))
+        .saturating_add(STATUS_SEPARATOR_HEIGHT)
         .saturating_add(status_rows)
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -929,6 +929,50 @@ fn tui_ghostty_shift_enter_sequence_inserts_newline() {
 }
 
 #[test]
+fn fullscreen_enables_modified_key_reporting_after_entering_alternate_screen() {
+    let mut tui = spawn_tui_llmsim_with(
+        &yolop_binary(),
+        TuiSpawnOptions {
+            inline: false,
+            ..TuiSpawnOptions::default()
+        },
+    );
+    assert!(
+        tui.wait_for_output("Enter to send", Duration::from_secs(3)),
+        "TUI did not render the composer: {}",
+        tui.output_text()
+    );
+
+    let output = tui.output_text();
+    let alternate_screen = output
+        .find("\x1b[?1049h")
+        .expect("fullscreen must enter the alternate screen");
+    let keyboard_enhancement = output
+        .find("\x1b[>9u")
+        .expect("fullscreen must request modified-key reporting");
+    assert!(
+        alternate_screen < keyboard_enhancement,
+        "keyboard reporting is screen-local and must be enabled after entering the alternate screen"
+    );
+
+    tui.write_input(b"\x03\x03");
+    let status = tui.wait_or_kill(Duration::from_secs(3));
+    assert!(status.success(), "TUI did not exit cleanly: {status:?}");
+
+    let output = tui.output_text();
+    let keyboard_restore = output
+        .rfind("\x1b[<1u")
+        .expect("fullscreen must restore modified-key reporting");
+    let leave_alternate_screen = output
+        .rfind("\x1b[?1049l")
+        .expect("fullscreen must leave the alternate screen");
+    assert!(
+        keyboard_restore < leave_alternate_screen,
+        "keyboard reporting must be restored before leaving its screen-local stack"
+    );
+}
+
+#[test]
 fn tui_raw_lf_shift_enter_inserts_newline() {
     // Terminals that lack the kitty keyboard protocol commonly map Shift+Enter
     // to a bare LF. In raw mode that arrives as Ctrl+J and must edit the


### PR DESCRIPTION
## What changed

Fullscreen input now receives modified keys such as Shift+Enter because keyboard
enhancement is enabled after entering the alternate screen and restored before
leaving it. The gold separator above the status bar also remains visible as the
multiline composer grows.

## Why

Kitty keyboard modes are screen-local. Yolop enabled the mode on the normal
screen before switching to fullscreen, so the terminal could not distinguish
Shift+Enter from Enter there. Separately, the chrome layout deliberately dropped
the status separator once the composer reached three rows, making the lower
boundary disappear after two newlines.

## Before / After

Before:
- Shift+Enter submitted input in the default fullscreen renderer on supported terminals.
- After two composer newlines, the gold status separator disappeared.

After:
- Shift+Enter inserts a newline in fullscreen, while Enter still submits.
- The gold status separator remains visible at every composer height; short
  terminals shrink the bounded composer instead of removing structural chrome.

Evidence:
- PTY coverage asserts alternate-screen entry precedes keyboard enhancement and
  keyboard restoration precedes alternate-screen exit.
- A fullscreen buffer test drives two Shift+Enter events and asserts the
  three-row composer still paints the gold separator.
- The reporter manually confirmed the installed Shift+Enter fix.

## Risk

- Low.
- The change affects terminal-mode lifecycle ordering and reserves one additional
  chrome row for multiline input. Tiny-frame geometry remains covered.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

No knowledge update required — this restores the existing fullscreen input and
gold-separator design already documented in code and the presentation/Tuika
specifications.

## Security

Reviewed TM-FS, TM-BASH, TM-LLM, TM-TOOL, and TM-DEP. No filesystem, shell,
prompt/secret, capability-registration, or dependency behavior changes. Terminal
input remains bounded by the existing event loop, and composer height remains
capped; no injection, data-exposure, or resource-exhaustion issue found.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --test integration fullscreen_enables_modified_key_reporting_after_entering_alternate_screen`
- `cargo test --bin yolop fullscreen_keeps_gold_separator_after_two_newlines`
- `cargo test --bin yolop shift_enter`
- `cargo test --all-features -- --skip gallery_paints_truecolor_and_braille`
  (the skipped RGB-gallery assertion is environment-sensitive in the Codex
  terminal; all other tests pass and CI runs the unfiltered suite)
- `cargo build --release`
- `doppler run --project yolop --config ci -- cargo run -- --provider openai -p "Reply with exactly: fullscreen composer smoke passed"`

## Follow-ups

No follow-ups.
