### PR TITLE
fix(prompt): restore progress_guard anticipatory system-prompt line

### DIFF
--- a/knowledge/specs/system-prompt.md
+++ b/knowledge/specs/system-prompt.md
@@ -49,9 +49,13 @@ A fact belongs in exactly one place, chosen by what the fact is about:
 | Cross-cutting policy — safety, untrusted input, output shape | `system.md` |
 
 A capability block that names its own tools and explains how to call them is
-duplicating the tool description; delete it. `progress_guard` and `repo_map` are
-the reference cases for the second row: both emit their guidance inside the
-result, at the moment it applies, so neither needs a block.
+duplicating the tool description; delete it. `repo_map` is the reference case
+for the second row: it emits its guidance inside the result, at the moment it
+applies, and needs no block for that guidance. `progress_guard` also emits its
+guidance inside the result, but — see "Reactive text does not substitute for
+anticipatory text" below — the model still needs a one-line anticipatory rule
+carried ahead of the warning, because the warning names the *situation* but
+arrives too late to shape the *next call*.
 
 ### Discovery is always on; how-to is reveal-gated
 
@@ -110,13 +114,19 @@ numeric thresholds ("only for work with at least three steps"), counters ("if
 stuck twice, ask"), and habit instructions ("do not repeat passing checks").
 
 The prompt-specific caveat is that the preference is a default, not an absolute.
-Two blocks are directive on measured grounds:
+Three blocks are directive on measured grounds:
 
 - `lsp` — softer phrasing drove adoption to near zero in `evals/lsp_integration`.
 - `repo_map` — its truncation rule was deleted on the reasoning that the same
   words already ship inside the truncated result, and `repo-map-bounded`
   regressed on gpt-5.5: repeated exploration calls breached their zero bar in
   5/5 trials against 2/5 before.
+- `progress_guard` — its entire block was deleted on the same "the result
+  already says it" reasoning, and the nightly Search Efficiency Eval caught
+  the same shape of regression on `zero-result-search-recovery`:
+  gpt-5.5 landed at exactly one `tool_calls`/`llm_calls` call over budget every
+  run, with the correct answer already in the response. A minimal anticipatory
+  line was restored.
 
 Where an eval contradicts the preference, the eval wins — and a preference is
 not evidence.
@@ -128,14 +138,26 @@ above. Putting guidance in the tool result is right when it tells the model what
 a result *means*. It is not sufficient when the guidance must shape the choice
 the model makes *on seeing* that result: by then the next call is already being
 formed, and a rule it has been carrying is not the same as a rule it has just
-been handed. `progress_guard` remains result-only because its warnings interrupt
-a pattern rather than steer the next call.
+been handed.
+
+`progress_guard` was believed to be an exception — its warnings interrupt a
+pattern rather than steer the next call, so result-only seemed sufficient — but
+the nightly Search Efficiency Eval measured otherwise: every run after its
+block was deleted, `zero-result-search-recovery` put gpt-5.5 exactly one
+`tool_calls`/`llm_calls` call over budget, correct answer included, on
+`openai/gpt-5.5`. Interrupting a pattern still requires knowing, ahead of time,
+that the interruption means "act now" rather than "note this and continue as
+planned" — that framing is itself anticipatory. The restored block is one
+line, not the original's full paragraph: only the framing needed to be
+carried ahead, not the per-threshold detail the result text already supplies.
 
 The distinction is also model-specific. The same deletion that cost gpt-5.5 an
 extra call per truncated map was free on claude-sonnet-4-5. Prompt content that
 looks redundant against one model's judgement can be load-bearing for another's,
 which is why composition changes get A/B'd on both providers rather than
-reasoned about.
+reasoned about — and why, absent a claude-sonnet-4-5 measurement of the
+`progress_guard` regression, the restored line is kept cheap enough that being
+unnecessary for that model costs little.
 
 ### The budget is a test
 

--- a/src/capabilities/progress_guard.rs
+++ b/src/capabilities/progress_guard.rs
@@ -6,7 +6,7 @@
 
 use async_trait::async_trait;
 use everruns_core::atoms::{PostToolExecHook, PostToolExecHookPriority};
-use everruns_core::capabilities::{Capability, CapabilityStatus};
+use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
 use everruns_core::tool_types::{ToolCall, ToolDefinition, ToolResult};
 use everruns_core::traits::ToolContext;
 use serde_json::{Map, Value, json};
@@ -64,10 +64,27 @@ impl Capability for ProgressGuardCapability {
         true
     }
 
-    // No system-prompt contribution. Every warning this capability emits already
-    // names the situation and the required next action, and it arrives in the
-    // tool result at the moment it applies. Pre-announcing the mechanism on every
-    // turn paid for a warning that usually never fires.
+    /// A one-line anticipatory rule, restored after the "no contribution" theory
+    /// regressed `evals/harness_basic`'s `zero-result-search-recovery` gate on
+    /// gpt-5.5: every nightly run since the deletion landed the candidate at
+    /// `tool_calls`/`llm_calls` exactly one call over budget, with the correct
+    /// answer already in the response. The warning names the situation and the
+    /// action, but it arrives inside the result the model is already reacting
+    /// to — by the time it reads the warning the next call is being formed, so
+    /// the model spends one extra call deciding what a warning it has never
+    /// been told about means before it acts. Carrying the rule ahead of time
+    /// collapses that decision into the same call. See "Reactive text does not
+    /// substitute for anticipatory text" in `knowledge/specs/system-prompt.md`.
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        Some(
+            "<capability id=\"progress_guard\">\n\
+             If a progress_guard warning appears in a tool result, stop broad exploration and \
+             act on it immediately: use the evidence already gathered, or make one targeted \
+             next call.\n\
+             </capability>"
+                .to_string(),
+        )
+    }
 
     fn system_prompt_preview(&self) -> Option<String> {
         Some(


### PR DESCRIPTION
## Status (2026-07-28, post-validation)

**The validation run did not confirm the fix.** `workflow_dispatch` run
[30369969694](https://github.com/everruns/yolop/actions/runs/30369969694)
(dispatched 14:45:46Z, completed 15:09:23Z, ~24 min, conclusion `failure`)
reproduces the exact same `zero-result-search-recovery` regression this PR
was meant to close — same metrics, same margin, same all-3-trials pattern.
Restoring the anticipatory line was not sufficient on its own. Leaving this
as a draft pending further investigation; **not merging**.

## What changed
Restores a minimal, one-line `system_prompt_contribution` on
`ProgressGuardCapability` (`src/capabilities/progress_guard.rs`), which PR #486
deleted entirely. The restored line is not the full block PR #486 removed —
just enough to carry the "act on a progress_guard warning immediately"
framing ahead of the warning itself. Also updates
`knowledge/specs/system-prompt.md`'s "Reactive text does not substitute for
anticipatory text" section, which documented `progress_guard`'s result-only
design as measured and correct; that measurement is what this PR's evidence
overturns.

## Why
The nightly "Search Efficiency Eval" (`.github/workflows/search-efficiency-eval.yml`)
has failed 4 nights running (2026-07-25 through 2026-07-28) on the
`zero-result-search-recovery` case, dropping from a historically ~100% pass
rate to 0% for the candidate binary, on `openai/gpt-5.5`. All 4 nightly runs
fail identically: the model's response is correct (GUARD-203 is always
found), but the candidate lands at exactly one call over budget —
`metric llm_calls 6 > 5; metric tool_calls 5 > 4` — every single trial, every
single night, since the very first scheduled run after PR #486 (bb165dd)
deleted `system_prompt_contribution` from both `RepoMapCapability` and
`ProgressGuardCapability`.

PR #487 (2da8aa9) already found and fixed the same shape of regression for
`repo_map` on gpt-5.5, and documented (in `knowledge/specs/system-prompt.md`)
a considered decision to leave `progress_guard` result-only, reasoning that
its warnings "interrupt a pattern rather than steer the next call." That
reasoning wasn't wrong as a heuristic, but the evidence said it didn't hold
here: the progress_guard warning names the *situation* correctly, but by the
time the model reads it inside a tool result, the next call is already being
formed — reacting to an unannounced warning costs one extra call to decide
what it means, exactly the "reactive text does not substitute for
anticipatory text" pattern the same spec document names for `repo_map`. That
was the hypothesis; **the validation run below shows it did not hold in
practice for `progress_guard`.**

This PR does not change anything about `repo_map` (already fixed) or
`repo-map-bounded`'s flapping (separate, already-understood pre-existing
flake unrelated to this change, and not one of the workflow's regression
gates).

## Before / After

**Before** — every nightly run's regression gate (identical pattern all 4
nights, e.g. run 30337962813 / 2026-07-28):
```
- zero-result-search-recovery: correctness regressed 100% -> 0%
- zero-result-search-recovery: candidate focused pass rate 0% < 67%
zero-result-search-recovery: pass 100%->0%; tools 7->5; tokens 9908->7598; bytes 2043->1431
```
Per-trial detail (all 3 candidate trials, all 4 nights):
```
[FAIL] .../zero-result-search-recovery@openai/gpt-5.5[binary=candidate,...] (80%)
       ✓ succeeded — no error
       ✗ checks — metric llm_calls 6 > 5; metric tool_calls 5 > 4
```
(response always contained `GUARD-203`; only the efficiency budget failed)

**After** — `workflow_dispatch` validation run on this branch, run
[30369969694](https://github.com/everruns/yolop/actions/runs/30369969694),
head `f74a2f2d9cda94572a6176e3463d3d53423995fb` (this PR's commit),
completed 2026-07-28T15:09:23Z with conclusion `failure`. The gate fired
again, unchanged:
```
Regression gates:
- zero-result-search-recovery: correctness regressed 100% -> 0%
- zero-result-search-recovery: candidate focused pass rate 0% < 67%
zero-result-search-recovery: pass 100%->0%; tools 7->5; tokens 18884->11204; bytes 2047->1431
```
Per-trial detail (all 3 candidate trials, this run):
```
[FAIL] basic_coding/zero-result-search-recovery@openai/gpt-5.5[binary=candidate,...]#0 (80%)
       ✗ checks — metric llm_calls 6 > 5; metric tool_calls 5 > 4
[FAIL] basic_coding/zero-result-search-recovery@openai/gpt-5.5[binary=candidate,...]#1 (80%)
       ✗ checks — metric llm_calls 6 > 5; metric tool_calls 5 > 4
[FAIL] basic_coding/zero-result-search-recovery@openai/gpt-5.5[binary=candidate,...]#2 (80%)
       ✗ checks — metric llm_calls 6 > 5; metric tool_calls 5 > 4
[PASS] basic_coding/zero-result-search-recovery@openai/gpt-5.5[binary=baseline,...]#0-2 (100%)
```
Same margin (exactly one call over budget), same trial count (3/3), same
gate. No `insufficient_quota` or other error text appears anywhere in the
job log — this is not the known infra-flake pattern from #93/#352, it's a
clean reproduction of the original regression on the patched binary. The
other two `[FAIL]` groups in this run (`prior-session-reference@baseline`,
`grep-files-nested-glob@baseline`, `repo-map-bounded` both variants) are not
regression gates and match the pre-existing, already-understood flakiness
noted above — they are not evidence about this PR's change.

**Conclusion:** the one-line anticipatory restoration is not, by itself,
sufficient to close the gap PR #487 closed for `repo_map`. Possible next
steps to investigate before re-attempting: whether the restored line's
wording/placement actually differs meaningfully from `repo_map`'s (rather
than just being present), whether `progress_guard`'s warning needs to move
earlier as well as gaining an anticipatory line, or whether the budget
itself (5 llm_calls / 4 tool_calls) is simply too tight for this case
regardless of prompt wording.

## Risk
- Low. Prompt-composition-only change: one static string added back to one
  capability's `system_prompt_contribution`. No tool behavior, no parsing, no
  control flow changed. `progress_guard`'s runtime enforcement (the hook that
  actually detects patterns and injects warnings) is untouched.
- What can break: prompt token budget for every turn grows by the length of
  the restored block (~230 bytes). `system_prompt_within_budget` and
  `always_on_capability_prompts_within_budget` both pass locally; the
  restored block isn't in the latter's accounting list, consistent with how
  PR #487 handled the same restoration for `repo_map`.

## Checklist
- [x] Tests added or updated — n/a, no new unit-testable behavior (static
      prompt string); relies on the harness eval for behavioral validation,
      per this repo's prompt-validation convention. **The harness eval did
      not validate the fix — see Status and After above.**
- [x] Backward compatibility considered — pre-1.0, no compatibility
      constraint applies.
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge
Updated `knowledge/specs/system-prompt.md`: the "Judgement yields to
measurement" list now includes `progress_guard` as a third directive-on-
measured-grounds block, and "Reactive text does not substitute for
anticipatory text" now documents that `progress_guard` needed a minimal
anticipatory line rather than remaining fully result-only, correcting its
previous claim that "`progress_guard` remains result-only because its
warnings interrupt a pattern rather than steer the next call." **This
knowledge update should be reconsidered given the validation run above did
not confirm the fix — leaving as-is for now since this PR is not merging,
but a follow-up should revisit it once the actual root cause is found.**

## Security
No injection surface: the addition is a static string with no user or model
input interpolated into it, identical in kind to the existing `repo_map`
block. No TM-LLM-relevant behavior change.

## Follow-ups
- No claude-sonnet-4-5 measurement was gathered for this regression (the
  original gpt-5.5 finding came from the nightly's own matrix, which already
  includes gpt-5.5).
- **New:** the validation run (30369969694) shows this fix does not close
  the regression. Needs further investigation before re-attempting — see
  Conclusion under "Before / After" above. Do not merge this PR as-is.


---
_Generated by [Claude Code](https://claude.ai/code/session_013pZBVSv1tMNVe821JakYk8)_