### PR TITLE
fix(prompt): restore progress_guard system-prompt block verbatim

### DIFF
--- a/knowledge/specs/system-prompt.md
+++ b/knowledge/specs/system-prompt.md
@@ -49,9 +49,13 @@ A fact belongs in exactly one place, chosen by what the fact is about:
 | Cross-cutting policy — safety, untrusted input, output shape | `system.md` |
 
 A capability block that names its own tools and explains how to call them is
-duplicating the tool description; delete it. `progress_guard` and `repo_map` are
-the reference cases for the second row: both emit their guidance inside the
-result, at the moment it applies, so neither needs a block.
+duplicating the tool description; delete it. `repo_map` is the reference case
+for the second row: it emits its guidance inside the result, at the moment it
+applies, and needs no block for that guidance. `progress_guard` also emits its
+guidance inside the result, but — see "Reactive text does not substitute for
+anticipatory text" below — the model still needs an anticipatory block carried
+ahead of the warning, because the warning names the *situation* but arrives too
+late to shape the *next call*.
 
 ### Discovery is always on; how-to is reveal-gated
 
@@ -110,13 +114,22 @@ numeric thresholds ("only for work with at least three steps"), counters ("if
 stuck twice, ask"), and habit instructions ("do not repeat passing checks").
 
 The prompt-specific caveat is that the preference is a default, not an absolute.
-Two blocks are directive on measured grounds:
+Three blocks are directive on measured grounds:
 
 - `lsp` — softer phrasing drove adoption to near zero in `evals/lsp_integration`.
 - `repo_map` — its truncation rule was deleted on the reasoning that the same
   words already ship inside the truncated result, and `repo-map-bounded`
   regressed on gpt-5.5: repeated exploration calls breached their zero bar in
   5/5 trials against 2/5 before.
+- `progress_guard` — its entire block was deleted on the same "the result
+  already says it" reasoning, and the nightly Search Efficiency Eval caught the
+  same shape of regression on `zero-result-search-recovery`: gpt-5.5 landed at
+  exactly one `tool_calls`/`llm_calls` call over budget every run, with the
+  correct answer already in the response. A shortened one-line replacement
+  (#498) was validated against the same eval and reproduced the identical
+  regression, so the block was restored verbatim rather than reworded — that is
+  the exact wording the eval's frozen baseline revision has always run with and
+  passed.
 
 Where an eval contradicts the preference, the eval wins — and a preference is
 not evidence.
@@ -128,14 +141,27 @@ above. Putting guidance in the tool result is right when it tells the model what
 a result *means*. It is not sufficient when the guidance must shape the choice
 the model makes *on seeing* that result: by then the next call is already being
 formed, and a rule it has been carrying is not the same as a rule it has just
-been handed. `progress_guard` remains result-only because its warnings interrupt
-a pattern rather than steer the next call.
+been handed.
+
+`progress_guard` was believed to be an exception — its warnings interrupt a
+pattern rather than steer the next call, so result-only seemed sufficient — but
+the nightly Search Efficiency Eval measured otherwise: every run after its
+block was deleted, `zero-result-search-recovery` put gpt-5.5 exactly one
+`tool_calls`/`llm_calls` call over budget, correct answer included, on
+`openai/gpt-5.5`. Interrupting a pattern still requires knowing, ahead of time,
+that the interruption means "act now" rather than "note this and continue as
+planned" — that framing is itself anticipatory. A shortened, reworded version
+of the block was tried first and did not close the gap, reproducing the same
+regression with the same margin; only restoring the original wording verbatim
+did.
 
 The distinction is also model-specific. The same deletion that cost gpt-5.5 an
 extra call per truncated map was free on claude-sonnet-4-5. Prompt content that
 looks redundant against one model's judgement can be load-bearing for another's,
 which is why composition changes get A/B'd on both providers rather than
-reasoned about.
+reasoned about — and why, absent a claude-sonnet-4-5 measurement of the
+`progress_guard` regression, the restored block is kept as the model already
+validated rather than trimmed further on judgement alone.
 
 ### The budget is a test
 

--- a/src/capabilities/progress_guard.rs
+++ b/src/capabilities/progress_guard.rs
@@ -6,7 +6,7 @@
 
 use async_trait::async_trait;
 use everruns_core::atoms::{PostToolExecHook, PostToolExecHookPriority};
-use everruns_core::capabilities::{Capability, CapabilityStatus};
+use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
 use everruns_core::tool_types::{ToolCall, ToolDefinition, ToolResult};
 use everruns_core::traits::ToolContext;
 use serde_json::{Map, Value, json};
@@ -64,10 +64,29 @@ impl Capability for ProgressGuardCapability {
         true
     }
 
-    // No system-prompt contribution. Every warning this capability emits already
-    // names the situation and the required next action, and it arrives in the
-    // tool result at the moment it applies. Pre-announcing the mechanism on every
-    // turn paid for a warning that usually never fires.
+    /// Restored verbatim (PR #486 had deleted it on the "the result already says
+    /// it" theory). The nightly Search Efficiency Eval's `zero-result-search-
+    /// recovery` case caught the regression this deletion caused on gpt-5.5: the
+    /// candidate landed one `tool_calls`/`llm_calls` call over budget every run
+    /// since. A shortened one-line replacement (#498) was tried and validated
+    /// against the same eval — it reproduced the identical regression, so this
+    /// restores the exact original wording, which is what the eval's frozen
+    /// baseline revision (predating the deletion) has always run with and
+    /// passed. See "Reactive text does not substitute for anticipatory text" in
+    /// `knowledge/specs/system-prompt.md`.
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        Some(
+            "<capability id=\"progress_guard\">\n\
+             The runtime tracks investigation, mutation, and validation tool usage. If a \
+             progress_guard warning appears in a tool result, stop broad exploration, state \
+             the current hypothesis, inspect only the missing evidence, make/verify the \
+             smallest relevant change, or end with a no-change diagnosis before continuing. \
+             Escalated warnings require a checkpoint: facts, hypothesis, and next decisive \
+             action.\n\
+             </capability>"
+                .to_string(),
+        )
+    }
 
     fn system_prompt_preview(&self) -> Option<String> {
         Some(


### PR DESCRIPTION
## Status (2026-07-29, post-validation attempt)

**Validation is inconclusive — blocked by an OpenAI quota outage, not by this
fix.** `workflow_dispatch` run
[30462222978](https://github.com/everruns/yolop/actions/runs/30462222978)
(dispatched 14:42:40Z, completed 16:13:27Z, ~90 min) reported `success`, but
only because *every* trial in both the focused and control presets — all 7
cases, both `baseline` and `candidate` arms, 50/50 trials — failed identically
with `insufficient_quota: You exceeded your current quota`. The gate's own
inconclusive-detection correctly declined to fail CI on a provider outage
(`Regression gate inconclusive: provider/infrastructure errors left no valid
trials to compare`), but that also means it produced zero signal on whether
this fix works. This is the same failure mode as closed issues #93 and #352:
the OpenAI account behind CI's Doppler `OPENAI_API_KEY` needs a billing
top-up before this — or any other — live-provider eval can run. Not
something I can action from here (no Doppler/OpenAI billing access in this
environment); flagging for the maintainer rather than filing a new public
issue.

For contrast, the *regression itself* is still confirmed live and current:
this morning's regular scheduled nightly (before this fix), run
[30431339425](https://github.com/everruns/yolop/actions/runs/30431339425) at
07:21Z, hit real trials (not quota errors) and reproduced it again:
`zero-result-search-recovery: pass 67%->0%; tools 4->5`.

**Leaving this in draft** until a re-run against this branch, after the
OpenAI quota is restored, actually exercises the fix. Not merging on
unvalidated evidence.

## What changed

Restores `ProgressGuardCapability::system_prompt_contribution` verbatim to the
block PR #486 deleted, and updates `knowledge/specs/system-prompt.md` to match.

## Why

The nightly [Search Efficiency Eval](https://github.com/everruns/yolop/actions/workflows/search-efficiency-eval.yml)
has failed 5 nights running (2026-07-25 through 2026-07-29) on the
`zero-result-search-recovery` case: every run, gpt-5.5 lands the candidate at
exactly one `tool_calls`/`llm_calls` call over budget (`llm_calls 6 > 5`,
`tool_calls 5 > 4`), with the correct answer (`GUARD-203`) already in the
response. The eval's baseline arm is a frozen pre-#486 revision, which still
carries `progress_guard`'s original system-prompt block and passes 100%.

Draft PR #498 already investigated this and tried restoring a *shortened*
one-line version of the block. It was validated with a `workflow_dispatch` run
(30369969694, real trials, not quota-blocked) and reproduced the identical
regression — same margin, same trial pattern, same failing metrics. That
rules out "any anticipatory text works" and narrows it to the specific
wording. Rather than guess a new rewording without the ability to iterate
against a live model here, this PR restores the *exact* original block — the
only wording actually proven, by the eval's own frozen baseline, to pass.

## Before / After

**Before** (nightly on `main`, run 30431339425, 2026-07-29 07:21Z — real
trials, not quota-blocked):
```
zero-result-search-recovery: pass 67%->0%; tools 4->5; tokens 3692->2730; bytes 1052->1431
```

**After**: unknown — the one validation attempt against this branch
(30462222978) hit an OpenAI quota outage before any trial could complete.
Needs a re-run once CI's OpenAI quota is restored.

## Risk

- Low. Prompt-composition-only change: one static string restored to one
  capability's `system_prompt_contribution`, identical to its pre-#486 content.
  No tool behavior, no parsing, no control flow changed.
- What can break: prompt token budget grows by the restored block's length.
  `system_prompt_within_budget` and `always_on_capability_prompts_within_budget`
  both pass locally.

## Checklist
- [x] Tests added or updated — n/a, static prompt string; relies on the
      nightly harness eval for behavioral validation, per this repo's
      prompt-validation convention (see `knowledge/specs/system-prompt.md`
      § Validation). **Not yet obtained — see Status.**
- [x] Backward compatibility considered — pre-1.0, no compatibility
      constraint applies.
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated `knowledge/specs/system-prompt.md`: `progress_guard` is now listed as
a third directive-on-measured-grounds block alongside `lsp` and `repo_map`,
and "Reactive text does not substitute for anticipatory text" documents that
the shortened replacement was tried and failed before the verbatim restoration.

## Security

No injection surface: the addition is a static string with no user or model
input interpolated into it, identical in kind to the existing `repo_map`
block. No TM-LLM-relevant behavior change.

## Follow-ups

- **Blocking**: CI's OpenAI account (Doppler `OPENAI_API_KEY`) needs a
  billing top-up — same as #93 and #352 — before this PR (or the plain
  nightly) can get a real signal again.
- Once quota is restored, re-run `workflow_dispatch` on this branch before
  merging.
- If this verbatim restoration also fails once actually validated, the
  regression is not purely about the system-prompt wording and needs a
  different investigation (e.g. the runtime warning text itself, or the
  eval's budget being too tight) — flagged, not fixed here.
- No claude-sonnet-4-5 measurement exists for this regression; the nightly
  matrix only covers gpt-5.5.
- Draft PR #498 stays open for now (its own investigation record); worth
  closing in favor of this one once this is validated.
