### PR TITLE
feat(evals): add the Terminal-Bench 2.1 eval study

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       rust: ${{ steps.filter.outputs.rust }}
       docs: ${{ steps.filter.outputs.docs }}
       eval-analyzers: ${{ steps.filter.outputs.eval-analyzers }}
+      terminal-bench: ${{ steps.filter.outputs.terminal-bench }}
     steps:
       - uses: actions/checkout@v7
 
@@ -57,6 +58,13 @@ jobs:
             eval-analyzers:
               - 'evals/harness_basic/*.py'
               - 'evals/harness_basic/tests/**'
+              - '.github/workflows/ci.yml'
+            # The terminal_bench study and its Harbor agent adapter. Its tests
+            # need no Docker, network, or API key, but they do import the study's
+            # third-party deps, so they get their own uv leg rather than joining
+            # the stdlib-only analyzer job above.
+            terminal-bench:
+              - 'evals/terminal_bench/**'
               - '.github/workflows/ci.yml'
 
   # Cheap guard for the documentation boundary (README/docs must not link into
@@ -99,6 +107,27 @@ jobs:
         # Standard library only — no third-party deps, so the system python is
         # enough and there's nothing to install.
         run: python3 -m unittest discover -s evals/harness_basic/tests -v
+
+  terminal-bench-study:
+    name: Terminal-Bench study (Python)
+    needs: changes
+    if: needs.changes.outputs.terminal-bench == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Run study + adapter unit tests
+        working-directory: evals/terminal_bench
+        # Hermetic by design: no Docker, no network beyond the dependency
+        # install, no provider key. uv resolves the study's deps (mira-eval for
+        # the protocol types, harbor for the agent base class and ATIF models).
+        env:
+          PYTHONPATH: .
+        run: uv run --python 3.12 --with mira-eval --with harbor -m unittest discover -s tests -v
 
   lint:
     name: Format + Clippy

--- a/evals/README.md
+++ b/evals/README.md
@@ -9,6 +9,7 @@ agent, scoring). One study per subfolder.
 | Study | What it measures |
 |-------|------------------|
 | [`swebench_verified/`](swebench_verified/) | yolop (and other coding agents) on **SWE-bench Verified** — resolve rate via the official Docker `FAIL_TO_PASS` harness, plus tokens/cost/latency. |
+| [`terminal_bench/`](terminal_bench/) | yolop (and other terminal agents) on **Terminal-Bench 2.1** — 89 containerized terminal tasks scored by each task's own tests, run through [Harbor](https://harborframework.com) with a yolop agent adapter. |
 | [`harness_basic/`](harness_basic/) | **yolop feature A/Bs** on basic coding cases — models × reasoning effort × yolop harness configurations (out-of-the-box, ast-grep off, …), pure Rust on the `mira-eval` SDK, driving headless `yolop -p`. |
 | [`lsp_integration/`](lsp_integration/) | The optional **LSP capability**, isolated — semantic-navigation traps (decoy renames, re-export chains, no-build diagnostics) run with the capability off vs on, plus `lsp_*` adoption metrics. Same pure-Rust `mira-eval` pattern as `harness_basic/`; language servers come from its `bootstrap.sh`. |
 

--- a/evals/terminal_bench/.gitignore
+++ b/evals/terminal_bench/.gitignore
@@ -1,0 +1,8 @@
+# Python virtualenv
+.venv/
+__pycache__/
+*.pyc
+
+# Local caches: the downloaded task tree and Harbor's per-case job dirs
+# (containers logs, trajectories, verifier output).
+.cache/

--- a/evals/terminal_bench/README.md
+++ b/evals/terminal_bench/README.md
@@ -127,6 +127,41 @@ fast enough to repeat.
 | `configure-git-webserver` | hard | system-administration | 900s |
 | `fix-code-vulnerability` | hard | security | 900s |
 
+### Baseline
+
+yolop · **gpt-5.6-terra** (OpenAI), run `20260731T014824Z-3c1e` — **6/8 for
+$1.34**, 22 minutes wall clock, every case ran to its own completion (no
+timeout, no budget stop, no infra N/A):
+
+| difficulty | resolved |
+|---|---|
+| easy | 3/3 |
+| medium | 2/3 |
+| hard | 1/2 |
+
+| task | | cost | wall | llm calls | tool calls |
+|---|---|---|---|---|---|
+| `cobol-modernization` | ✓ | $0.192 | 108s | 13 | 12 |
+| `fix-git` | ✓ | $0.156 | 100s | 16 | 15 |
+| `overfull-hbox` | ✓ | $0.198 | 318s | 15 | 14 |
+| `modernize-scientific-stack` | ✓ | $0.091 | 78s | 10 | 9 |
+| `count-dataset-tokens` | ✓ | $0.114 | 164s | 11 | 10 |
+| `chess-best-move` | ✗ | $0.267 | 343s | 18 | 17 |
+| `fix-code-vulnerability` | ✓ | $0.178 | 86s | 13 | 20 |
+| `configure-git-webserver` | ✗ | $0.149 | 116s | 11 | 10 |
+
+**Cost here is over-stated and not comparable across providers.** For providers
+that return no inline price (OpenAI, Anthropic), yolop estimates from a price
+table that bills full `prompt_tokens` — and OpenAI's `prompt_tokens` *includes*
+cache reads, which dominate an agentic run. The same `cobol-modernization` case
+cost $0.192 on this run and $0.106 through OpenRouter, where the figure is the
+provider's actual charge. Read OpenAI-direct costs as a ceiling; `swebench_verified`
+documents the same effect.
+
+Two failures worth watching rather than chasing: `chess-best-move` used the most
+turns and the most money of the eight, and `configure-git-webserver` gave up
+cheapest of the eight at 10 tool calls — an early stop, not an exhausted budget.
+
 It is selected deterministically by `suites/select_control.py` — no hand-picking:
 tasks needing a GPU or more than 4 GiB are excluded (so the suite runs
 concurrently on an ordinary box), each tier is ordered by `(agent timeout, name)`

--- a/evals/terminal_bench/README.md
+++ b/evals/terminal_bench/README.md
@@ -109,6 +109,46 @@ A Harbor/Docker failure, a harness timeout, and a budget stop are all reported a
 **infra errors** (`error_kind`), so the host treats them as **N/A** and retries
 rather than counting them as the model failing the task.
 
+## Control suite
+
+`suites/control-v1.json` is the **periodic regression set**: 8 fixed tasks
+(3 easy / 3 medium / 2 hard) run on a cadence to notice yolop moving. The whole
+89 is for headline numbers; this is for noticing movement, and it is cheap and
+fast enough to repeat.
+
+| task | difficulty | category | agent timeout |
+|---|---|---|---|
+| `overfull-hbox` | easy | debugging | 750s |
+| `cobol-modernization` | easy | software-engineering | 900s |
+| `fix-git` | easy | software-engineering | 900s |
+| `modernize-scientific-stack` | medium | scientific-computing | 600s |
+| `chess-best-move` | medium | games | 900s |
+| `count-dataset-tokens` | medium | model-training | 900s |
+| `configure-git-webserver` | hard | system-administration | 900s |
+| `fix-code-vulnerability` | hard | security | 900s |
+
+It is selected deterministically by `suites/select_control.py` — no hand-picking:
+tasks needing a GPU or more than 4 GiB are excluded (so the suite runs
+concurrently on an ordinary box), each tier is ordered by `(agent timeout, name)`
+so the cheapest come first, and a task is taken only if its category is not
+already in the suite. Only `easy` needs the fallback — there are four easy tasks
+and three of them are `software-engineering`. Seven categories over eight tasks.
+
+```bash
+uv run suites/select_control.py --check    # verify the committed file reproduces
+mira run --preset control --group-by difficulty
+mira run --tag control-v1 --targets anthropic-claude-opus-4.8   # ad-hoc
+```
+
+Every sample is tagged with the suites it belongs to, so `--tag control-v1`
+selects it anywhere. Re-running the selector on the same dataset reproduces the
+committed set exactly; **bump to `control-v2` rather than editing v1**, so
+historical numbers stay comparable.
+
+Eight tasks is a regression signal, not a resolve rate — a one-task swing is
+12.5%. Read it as movement over time on a fixed set, and use the `full` preset
+when you need a number to quote.
+
 ## Cost cap
 
 Two nested caps, because a terminal task can loop for its full agent timeout:
@@ -176,6 +216,7 @@ targets.
 | Preset | Purpose | Samples | Targets |
 |--------|---------|---------|---------|
 | `smoke` | Integration check / validate a new config before a full run | `fix-git`, `cobol-modernization` | gpt-5.6-terra |
+| `control` | The periodic regression run ([Control suite](#control-suite)) | 8 (`control-v1`) | gpt-5.6-terra |
 | `compare` | yolop vs the other terminal agents on identical tasks | the `easy` tier | yolop ×2 + terminus-2 + claude-code + codex |
 | `full` | The headline number | all 89 | gpt-5.6-terra |
 
@@ -223,6 +264,7 @@ evals/terminal_bench/
                       #   per-case cost cap
   prompt_autonomous.md # instruction template: no user to ask, only disk is graded
   mira.toml           # host config: [results].dir -> ./results, presets
+  suites/             # curated task subsets (control-v1.json + its selector)
   bootstrap.sh        # uv deps + musl build + mira + task tree
   tests/              # unit tests (no Docker, no network, no key)
   results/            # mira run archives (<run_id>/)

--- a/evals/terminal_bench/README.md
+++ b/evals/terminal_bench/README.md
@@ -1,0 +1,242 @@
+# terminal_bench — yolop on Terminal-Bench 2.1
+
+Benchmarks yolop on [**Terminal-Bench 2.1**](https://www.tbench.ai/news/terminal-bench-2-1):
+89 containerized terminal tasks — compile a toolchain, recover a corrupted
+database, break a cipher — each scored by the task's own test suite. 2.1 is a
+revision of 2.0 that fixes 28 tasks, so **2.0 and 2.1 numbers are not
+comparable**; cite the version with any result.
+
+Two harnesses stack, each owning what it is good at:
+
+| Layer | Owns |
+|-------|------|
+| [Mira](https://github.com/everruns/mira) (`mira` CLI) | the target matrix, sample/target selection, saved run folders, reporting — the same role it plays for [`swebench_verified`](../swebench_verified/) |
+| [Harbor](https://harborframework.com) (`harbor` CLI) | one case: build the task container, run the agent in it, run the task's verifier |
+
+`terminal_bench.py` is the Mira study; it shells out to `harbor run` per case and
+reads the reward back out of the trial's `result.json`. `harbor_yolop.py` is the
+Harbor **agent adapter** that puts yolop inside the container.
+
+## How yolop plugs into Harbor
+
+Harbor selects an agent with `--agent <module>:<Class>`, so the adapter is loaded
+by import path rather than being registered in Harbor's own agent map. yolop is a
+single static binary, not an npm/pip package, so `install()` **uploads a
+host-built binary** into the container instead of fetching a release.
+
+Two yolop features do the heavy lifting:
+
+- **`--trajectory-out` writes ATIF v1.7** — the same format Harbor consumes
+  (see [`knowledge/specs/trajectory.md`](../../knowledge/specs/trajectory.md)).
+  The adapter points it at `/logs/agent/trajectory.json`, declares
+  `SUPPORTS_ATIF`, and hands the document over unconverted. Token totals and
+  cost come from its `final_metrics`.
+- **`--session-dir` writes `events.jsonl` incrementally**, and `/logs/agent` is
+  bind-mounted from the host trial dir — so the host can watch cost as it
+  accrues and stop the run at `max_cost_usd`. yolop has no native dollar cap.
+
+The adapter also applies `prompt_autonomous.md` to every instruction by default
+(override with `--ak prompt_template_path=<path>`). Terminal-Bench instructions
+are written as if to a colleague — "please help me find them and merge them into
+master" — but there is nobody in the container to answer a follow-up, and grading
+looks only at the filesystem after the agent exits, so a run that stops to ask
+for confirmation scores zero with the work undone. The template says so.
+
+`worktrees = "off"` is written into an isolated `XDG_CONFIG_HOME` at install:
+Terminal-Bench containers are not git repos and the verifier reads the live
+filesystem, so edits must land in place rather than on a linked branch.
+
+### ABI: the binary must match the image
+
+Harbor **always** runs the agent inside the task's container, and Terminal-Bench
+images are mostly Debian bookworm (glibc 2.36) — older than a typical dev box, so
+a host glibc build will not start there. Build the static musl binary
+(`bootstrap.sh` does this):
+
+```bash
+cargo build --release --target x86_64-unknown-linux-musl
+```
+
+Point `TB_YOLOP_BIN` elsewhere to override it.
+
+## First run
+
+Two `easy` tasks, yolop · gpt-5.6-terra (via OpenRouter, so `cost_usd` is the
+real charge), run `20260730T205010Z-4dc1` — **2/2 resolved for $0.20**:
+
+| task | resolved | cost | wall | llm calls | tool calls |
+|---|---|---|---|---|---|
+| `fix-git` | ✓ | $0.091 | 73s | 13 | 16 |
+| `cobol-modernization` | ✓ | $0.106 | 85s | 16 | 20 |
+
+Two cents of signal, not a resolve rate — run the full 89 for a headline number.
+Both cases needed a fix that the run surfaced, and both are worth knowing about
+before reading any Terminal-Bench result:
+
+- **The instructions have no reader.** `fix-git` asks "please help me find them
+  and merge them into master"; yolop found the dangling commit, then stopped to
+  ask whether it should rewrite `master`. Correct behavior with a user present,
+  zero reward with none. `prompt_autonomous.md` (applied by default, see
+  [How yolop plugs into Harbor](#how-yolop-plugs-into-harbor)) states that
+  nothing reads the agent's output and that only the filesystem is graded.
+- **The verifier needs its own network trust.** Many tasks' `test.sh` fetches
+  `uv` before running the tests. The verifier phase inherits none of the agent's
+  environment, so behind a TLS-terminating proxy every task fails to *score* —
+  reported as a 0.0 reward that looks exactly like a wrong answer. `TB_CA_CERT`
+  now also configures the verifier (see [Environment knobs](#environment-knobs)).
+
+## What it measures
+
+Per `(task, config)` case, surfaced in the host's transcript/usage:
+
+- **success** — `resolved` (reward 1.0 = the task's tests all passed; Terminal-Bench is pass/fail per task)
+- **time** — `wall_time_s` (harness-measured, includes container build + verify)
+- **tokens** — input, output, `cache_read_tokens`; **cost** — `cost_usd` from yolop's own accounting
+- **loop shape** — `agent_steps`, `llm_calls`, `tool_calls`, per-tool `tools_used`
+- **stop_reason** — `completed` / `budget` / `timeout` / `error`
+- **config metadata** — agent, provider, model, reasoning effort, yolop version
+
+Samples carry `difficulty`, `category`, and the task's own keyword tags, so the
+host can break results down by any of them:
+
+```bash
+mira run --group-by difficulty       # resolve rate per difficulty tier
+mira run --group-by agent            # yolop vs terminus-2 vs claude-code vs codex
+mira run --tag easy                  # just the easy tier
+```
+
+A Harbor/Docker failure, a harness timeout, and a budget stop are all reported as
+**infra errors** (`error_kind`), so the host treats them as **N/A** and retries
+rather than counting them as the model failing the task.
+
+## Cost cap
+
+Two nested caps, because a terminal task can loop for its full agent timeout:
+
+- **Per case** — `max_cost_usd` in the matrix (default **$5**). The adapter
+  polls the in-flight `events.jsonl` from the host and `SIGINT`s yolop once the
+  cap is passed (`stop_reason: budget`). The verifier still runs against
+  whatever the agent had written to disk by then.
+- **Per run** — `TB_MAX_COST_USD`, a budget across *every* case in the run. The
+  study clamps each case's cap to what the run has left, and once the budget is
+  gone the remaining cases are skipped and reported N/A rather than started.
+
+```bash
+TB_MAX_COST_USD=5 doppler run -- mira run --preset smoke
+```
+
+## Setup
+
+```bash
+evals/terminal_bench/bootstrap.sh    # uv deps + yolop musl build + mira + task tree
+```
+
+`bootstrap.sh` is idempotent. Manual equivalent:
+
+```bash
+( cd ../.. && cargo build --release --target x86_64-unknown-linux-musl )
+brew install everruns/tap/mira           # the host CLI (prebuilt binary, recommended)
+# …or:  cargo binstall mira-cli  /  cargo install mira-cli --locked
+# Python deps need nothing — `uv run terminal_bench.py` installs mira-eval and
+# harbor from the file's PEP 723 header on first use.
+```
+
+Requires a running **Docker** daemon (every task is a container) and provider
+keys in the environment: `OPENAI_API_KEY` (yolop openai configs, `codex`,
+`terminus-2`), `ANTHROPIC_API_KEY` (yolop anthropic configs, `claude-code`). Use
+`doppler run --` to inject them. A config whose key is missing is reported
+`unavailable` and skipped, so a keyless run stays green.
+
+## Usage
+
+```bash
+cd evals/terminal_bench      # so the adjacent mira.toml is found; runs land in ./results
+
+# What the study advertises: the eval, its 89 samples, and the matrix of targets.
+mira list
+
+# Offline plumbing check — one task on the llmsim config: uploads the binary,
+# runs it, runs the verifier, with no API key. It will not solve the task, so a
+# 0.0 reward is the expected result. --dry-run skips the saved run folder.
+mira run --samples fix-git --targets llmsim --dry-run
+
+# Real run on two cheap tasks, capped at $5 across the whole run.
+TB_MAX_COST_USD=5 doppler run -- mira run --preset smoke
+
+# Whole benchmark, one config; an interrupted run resumes with --resume <run_id>.
+doppler run -- mira run --preset full --group-by difficulty
+```
+
+`mira run` selects like `cargo test` — `--samples <glob>`, `--tag easy`,
+`--targets <glob>` — and takes the cross-product of the chosen samples and
+targets.
+
+### Presets — named runs
+
+| Preset | Purpose | Samples | Targets |
+|--------|---------|---------|---------|
+| `smoke` | Integration check / validate a new config before a full run | `fix-git`, `cobol-modernization` | gpt-5.6-terra |
+| `compare` | yolop vs the other terminal agents on identical tasks | the `easy` tier | yolop ×2 + terminus-2 + claude-code + codex |
+| `full` | The headline number | all 89 | gpt-5.6-terra |
+
+### Environment knobs
+
+The Mira host cannot pass study CLI flags, so study-internal settings are read
+from the environment:
+
+| Variable | Effect |
+|----------|--------|
+| `TB_MAX_COST_USD` | whole-run USD budget across every case (unset = no cap) |
+| `TB_YOLOP_BIN` | yolop binary to upload (default: the musl release build) |
+| `TB_DATASET_DIR` | use a pre-downloaded task tree instead of `.cache/dataset/` |
+| `TB_AGENT_ENV` | comma-separated `KEY=VALUE` forwarded into the agent's environment |
+| `TB_VERIFIER_ENV` | the same, for the verifier phase (it inherits nothing from the agent) |
+| `TB_CA_CERT` | CA bundle to install in the container; also sets the verifier's trust vars |
+| `TB_JOB_TIMEOUT` | wall-clock cap on one `harbor run` (default 5400s) |
+| `TB_TIMEOUT_MULTIPLIER` | scale the task's own agent/verifier timeouts |
+| `TB_KEEP_JOBS=1` | keep Harbor job dirs under `.cache/jobs/` for debugging |
+
+`TB_AGENT_ENV` and `TB_CA_CERT` exist because the *sandbox*, not the benchmark,
+decides how a container reaches the model provider. On a box whose egress goes
+through a local TLS-terminating proxy, the container needs the proxy's address
+(it cannot reach a host-loopback listener) and its CA:
+
+```bash
+PROXY=http://172.17.0.1:44324      # reachable from the container, not 127.0.0.1
+TB_AGENT_ENV="HTTPS_PROXY=$PROXY,HTTP_PROXY=$PROXY" \
+TB_VERIFIER_ENV="HTTPS_PROXY=$PROXY,HTTP_PROXY=$PROXY" \
+TB_CA_CERT=/etc/ssl/corp-ca.crt \
+    doppler run -- mira run --preset smoke
+```
+
+Give the verifier the same treatment as the agent: many tasks' `test.sh` fetches
+`uv` before it can run the tests, and a verifier that cannot reach the network
+reports a 0.0 reward indistinguishable from a wrong answer.
+
+## Layout
+
+```
+evals/terminal_bench/
+  terminal_bench.py   # the Mira study: matrix, dataset, `harbor run` per case,
+                      #   result parsing, run-wide budget (PEP 723 inline deps)
+  harbor_yolop.py     # the Harbor agent adapter: upload yolop, run it, ATIF out,
+                      #   per-case cost cap
+  prompt_autonomous.md # instruction template: no user to ask, only disk is graded
+  mira.toml           # host config: [results].dir -> ./results, presets
+  bootstrap.sh        # uv deps + musl build + mira + task tree
+  tests/              # unit tests (no Docker, no network, no key)
+  results/            # mira run archives (<run_id>/)
+  .cache/             # gitignored: task tree, Harbor job dirs
+```
+
+## Extending
+
+- **New config:** add a `MATRIX` entry in `terminal_bench.py`. `agent: "yolop"`
+  routes to the adapter; any other value is passed to `harbor run --agent`
+  verbatim, so Harbor's built-in agents are targets without extra code.
+- **New yolop flag:** add a `CliFlag` to `harbor_yolop.Yolop.CLI_FLAGS` and pass
+  it per config as an `--ak <kwarg>=<value>`.
+- **A different Harbor dataset** (terminal-bench-pro, swebench-verified as
+  packaged by Harbor): a sibling study folder — `DATASET`/`DATASET_NAME` are the
+  only benchmark-specific constants, but the matrix and prompt framing differ
+  enough that a copy beats a flag.

--- a/evals/terminal_bench/bootstrap.sh
+++ b/evals/terminal_bench/bootstrap.sh
@@ -80,6 +80,15 @@ if have uv; then
     || echo "  ! dataset download failed; the study will retry on first run"
 fi
 
+# --- Control suite integrity ------------------------------------------------ #
+# The committed suite must reproduce from the dataset it was selected against; a
+# silent drift would make periodic runs incomparable to their own history.
+note "control-v1 suite"
+if have uv; then
+  ( cd "$STUDY_DIR" && uv run suites/select_control.py --check ) \
+    || echo "  ! control-v1.json does not reproduce; re-run suites/select_control.py"
+fi
+
 cat <<'EOF'
 
 [bootstrap] Done. Before running the matrix:
@@ -99,4 +108,7 @@ cat <<'EOF'
 
   Cheap real run, capped at $5 across the whole run:
     TB_MAX_COST_USD=5 doppler run -- mira run --preset smoke
+
+  The periodic regression run (8 fixed tasks, 3 easy / 3 medium / 2 hard):
+    TB_MAX_COST_USD=10 doppler run -- mira run --preset control --group-by difficulty
 EOF

--- a/evals/terminal_bench/bootstrap.sh
+++ b/evals/terminal_bench/bootstrap.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Bootstrap the terminal_bench benchmark environment.
+#
+# Installs everything needed to run the matrix: pre-warms the uv dependency
+# cache for the single-file study, builds the static musl yolop binary that gets
+# uploaded into task containers, installs the mira host CLI, and pre-downloads
+# the Terminal-Bench 2.1 task tree. Re-runnable / idempotent.
+#
+#   evals/terminal_bench/bootstrap.sh
+set -euo pipefail
+
+STUDY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$STUDY_DIR/../.." && pwd)"
+MUSL_TARGET="x86_64-unknown-linux-musl"
+
+have() { command -v "$1" >/dev/null 2>&1; }
+note() { printf '\n[bootstrap] %s\n' "$*"; }
+
+# --- Python deps (uv, inline) ----------------------------------------------- #
+# The study is a single file with PEP 723 inline deps (mira-eval + harbor);
+# `uv run terminal_bench.py` builds the ephemeral env on first use. Pre-warm it
+# so the first real run isn't slowed by dependency installation.
+note "Python deps via uv (inline PEP 723)"
+if have uv; then
+  ( cd "$STUDY_DIR" && echo '{"id":1,"method":"initialize"}' | uv run terminal_bench.py >/dev/null )
+else
+  echo "  ! uv not found; install it: https://docs.astral.sh/uv/  (curl -LsSf https://astral.sh/uv/install.sh | sh)"
+fi
+
+# --- yolop musl build ------------------------------------------------------- #
+# Harbor always runs the agent inside the task's container, and Terminal-Bench
+# images are mostly Debian bookworm (glibc 2.36) — older than a typical dev box,
+# so a host glibc build will not start there. A static musl binary runs in every
+# image, which is what the adapter uploads.
+note "yolop static build ($MUSL_TARGET)"
+if have cargo; then
+  if rustup target list --installed 2>/dev/null | grep -q "$MUSL_TARGET" \
+     || rustup target add "$MUSL_TARGET" 2>/dev/null; then
+    if have musl-gcc || { have apt-get && sudo apt-get install -y musl-tools >/dev/null 2>&1; }; then
+      ( cd "$REPO_DIR" && cargo build --release --quiet --target "$MUSL_TARGET" )
+    else
+      echo "  ! musl-tools not available; install it, or point TB_YOLOP_BIN at a binary"
+      echo "    built for the task image ABI"
+    fi
+  fi
+else
+  echo "  ! cargo not found; skipping yolop build (install Rust to benchmark yolop)"
+fi
+
+# --- Mira host CLI ---------------------------------------------------------- #
+# Require a MINIMUM version, not merely any `mira` on PATH: the 0.3.0 preset
+# `samples` key in mira.toml is silently ignored by older hosts, which then run
+# every task instead of the pinned ones. Keep this in lockstep with the
+# `mira-eval` SDK pinned in the study's PEP 723 deps.
+MIRA_MIN_VERSION="${MIRA_MIN_VERSION:-0.3.0}"
+note "mira host CLI (>= $MIRA_MIN_VERSION)"
+mira_version() { mira --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1; }
+version_ge() { [ "$(printf '%s\n%s\n' "$2" "$1" | sort -V | head -1)" = "$2" ]; }  # $1 >= $2
+if have mira && version_ge "$(mira_version)" "$MIRA_MIN_VERSION"; then
+  mira --version 2>&1 | head -1 || true
+elif have brew; then
+  brew install everruns/tap/mira || brew upgrade everruns/tap/mira \
+    || echo "  ! mira install failed; install/upgrade manually"
+elif have cargo-binstall && cargo binstall -y --force mira-cli; then
+  :
+elif have cargo; then
+  cargo install mira-cli --locked --force || echo "  ! mira install failed; install manually"
+else
+  echo "  ! no brew/cargo; install mira >= $MIRA_MIN_VERSION manually (brew install everruns/tap/mira)"
+fi
+
+# --- Terminal-Bench 2.1 task tree ------------------------------------------- #
+# The study downloads this on first use too; doing it here keeps the first real
+# run from paying for it (and surfaces a Harbor Hub outage before a paid run).
+note "Terminal-Bench 2.1 tasks"
+if have uv; then
+  ( cd "$STUDY_DIR" && uv run --with harbor harbor dataset download \
+      terminal-bench/terminal-bench-2-1 -o .cache/dataset >/dev/null \
+    && echo "  $(find .cache/dataset/terminal-bench-2-1 -maxdepth 1 -mindepth 1 -type d | wc -l) tasks cached" ) \
+    || echo "  ! dataset download failed; the study will retry on first run"
+fi
+
+cat <<'EOF'
+
+[bootstrap] Done. Before running the matrix:
+
+  Provider keys (export in the environment, e.g. via `doppler run --`):
+    OPENAI_API_KEY        # yolop openai configs, codex, terminus-2
+    ANTHROPIC_API_KEY     # yolop anthropic configs, claude-code
+
+  Docker daemon must be running (every task is a container).
+
+  Run from this study directory (so mira.toml is found, its default_launcher
+  drives the study, and runs save here):
+    cd evals/terminal_bench
+
+  Smoke test (offline, no API key — exercises upload/run/verify, solves nothing):
+    mira run --samples fix-git --targets llmsim --dry-run
+
+  Cheap real run, capped at $5 across the whole run:
+    TB_MAX_COST_USD=5 doppler run -- mira run --preset smoke
+EOF

--- a/evals/terminal_bench/harbor_yolop.py
+++ b/evals/terminal_bench/harbor_yolop.py
@@ -1,0 +1,396 @@
+"""harbor_yolop — a Harbor agent adapter that runs yolop inside a task container.
+
+[Harbor](https://harborframework.com) is the execution framework behind
+Terminal-Bench 2.x: it builds the task's container, runs an agent inside it,
+then runs the task's own verifier. Agents plug in as `BaseInstalledAgent`
+subclasses; Harbor selects one with `--agent <module>:<Class>`, so this file is
+loaded by import path rather than being registered in Harbor's own agent map:
+
+    PYTHONPATH=evals/terminal_bench harbor run \\
+        --agent harbor_yolop:Yolop --model openai/gpt-5.6-terra \\
+        -p <task-dir>
+
+yolop is a single static binary, not an npm/pip package, so `install()` uploads
+a host-built binary into the container instead of fetching a release. The image
+ABI is not the host's (Terminal-Bench images are mostly Debian bookworm,
+glibc 2.36, against a newer host), so point `YOLOP_BIN` at a static musl build:
+`cargo build --release --target x86_64-unknown-linux-musl`.
+
+Two yolop features do the heavy lifting here:
+
+* `--trajectory-out` writes the run as an ATIF v1.7 document, the format Harbor
+  itself consumes, so no bespoke event-log converter is needed — the adapter
+  points it at `/logs/agent/trajectory.json` and declares `SUPPORTS_ATIF`.
+* `--session-dir` writes an incrementally-flushed `events.jsonl`. `/logs/agent`
+  is bind-mounted from the host trial dir, so the host can watch the run's cost
+  as it accrues and stop it at `max_cost_usd` — yolop has no native dollar cap.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import shlex
+import uuid
+from pathlib import Path
+from typing import Any, override
+
+from harbor.agents.installed.base import (
+    BaseInstalledAgent,
+    CliFlag,
+    with_prompt_template,
+)
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+from harbor.utils.env import parse_bool_env_value
+
+# Everything the adapter owns inside the container lives here; `/logs/agent` is
+# reserved for artifacts the harness collects (trajectory, sessions).
+_INSTALL_DIR = "/installed-agent/yolop"
+_BIN_PATH = f"{_INSTALL_DIR}/yolop"
+_CONFIG_HOME = f"{_INSTALL_DIR}/config"
+# Deliberately outside the yolop dir: the container outlives the agent phase, so
+# the verifier can trust the same bundle. Exported for callers that build the
+# verifier's environment (see `TB_VERIFIER_ENV` in the study).
+CONTAINER_CA_PATH = "/installed-agent/ca-bundle.crt"
+_AGENT_LOGS = "/logs/agent"
+_SESSION_DIR = f"{_AGENT_LOGS}/sessions"
+_TRAJECTORY_PATH = f"{_AGENT_LOGS}/trajectory.json"
+_STDOUT_FILENAME = "yolop.txt"
+
+# Terminal-Bench instructions are written as if to a colleague ("please help me
+# find them and merge them into master"), but there is nobody in the container to
+# answer a follow-up, and grading looks only at the filesystem after the agent
+# exits. Without this framing yolop's headless run can legitimately stop to ask
+# for confirmation before a history-rewriting change and score zero with the work
+# undone. Overridable per config with `--ak prompt_template_path=<path>`.
+DEFAULT_PROMPT_TEMPLATE = Path(__file__).resolve().parent / "prompt_autonomous.md"
+
+# Provider -> the host env var whose value the in-container agent needs.
+_PROVIDER_KEYS = {
+    "anthropic": ["ANTHROPIC_API_KEY"],
+    "codex": ["OPENAI_API_KEY"],
+    "google": ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+    "openai": ["OPENAI_API_KEY"],
+    "openrouter": ["OPENROUTER_API_KEY"],
+    "custom": ["CUSTOM_API_KEY", "CUSTOM_BASE_URL"],
+}
+
+
+def session_id() -> str:
+    """A fresh yolop session id. yolop validates the shape (`session_` + 32 hex)."""
+    return f"session_{uuid.uuid4().hex}"
+
+
+def running_cost(session_log: Path) -> float | None:
+    """Cost accrued so far, read from a partially-written yolop `events.jsonl`.
+
+    Returns None while the log has no completed message yet, so a missing or
+    empty log reads as "unknown", never as "$0 spent". Actual cost is preferred
+    over the estimate, matching yolop's own accounting.
+    """
+    if not session_log.exists():
+        return None
+    total = 0.0
+    seen = False
+    with session_log.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue  # a half-written trailing line; the writer is still going
+            if event.get("type") != "output.message.completed":
+                continue
+            usage = (event.get("data") or {}).get("usage") or {}
+            actual = usage.get("actual_cost_usd")
+            total += float(
+                actual if actual is not None else (usage.get("estimated_cost_usd") or 0.0)
+            )
+            seen = True
+    return total if seen else None
+
+
+def _kill_command(signal: str) -> str:
+    """Signal the in-container yolop process, without depending on `pkill`.
+
+    Task images are minimal and many carry no `procps`, so the process table is
+    walked through `/proc` with tools every image has.
+    """
+    return (
+        'for proc in /proc/[0-9]*; do '
+        f'  if tr "\\0" " " < "$proc/cmdline" 2>/dev/null | grep -q {shlex.quote(_BIN_PATH)}; then '
+        f'    kill -{signal} "${{proc#/proc/}}" 2>/dev/null || true; '
+        "  fi; "
+        "done; true"
+    )
+
+
+class Yolop(BaseInstalledAgent):
+    """yolop, run headlessly (`-p`) inside the task container."""
+
+    SUPPORTS_ATIF: bool = True
+
+    CLI_FLAGS = [
+        CliFlag(
+            "reasoning_effort",
+            cli="--reasoning-effort",
+            type="str",
+            env_fallback="YOLOP_REASONING_EFFORT",
+        ),
+    ]
+
+    def __init__(
+        self,
+        logs_dir: Path,
+        binary_path: str | None = None,
+        ca_cert_path: str | None = None,
+        max_cost_usd: float | None = None,
+        sandbox: bool = False,
+        poll_s: float = 2.0,
+        *args,
+        **kwargs,
+    ):
+        # Resolved on the host: the binary and CA are uploaded, not fetched.
+        self._binary_path = Path(
+            binary_path or os.environ.get("YOLOP_BIN") or "target/release/yolop"
+        ).expanduser()
+        ca = ca_cert_path or os.environ.get("YOLOP_CA_CERT")
+        self._ca_cert_path = Path(ca).expanduser() if ca else None
+        # Harbor delivers `--ak key=value` kwargs as strings, so coerce rather
+        # than trust the annotation ("false" is a truthy str).
+        self._max_cost_usd = float(max_cost_usd) if max_cost_usd is not None else None
+        self._sandbox = parse_bool_env_value(sandbox, name="sandbox")
+        self._poll_s = float(poll_s)
+        self._session_id = session_id()
+        self._stop_reason = "completed"
+        kwargs.setdefault("prompt_template_path", DEFAULT_PROMPT_TEMPLATE)
+        super().__init__(logs_dir, *args, **kwargs)
+
+    @staticmethod
+    @override
+    def name() -> str:
+        return "yolop"
+
+    @override
+    def get_version_command(self) -> str | None:
+        return f"{_BIN_PATH} --version"
+
+    @override
+    def parse_version(self, stdout: str) -> str:
+        # `yolop --version` prints "yolop 0.13.0 (commit …, everruns-runtime …)";
+        # the trailing build detail is not the version.
+        match = re.search(r"\d+\.\d+\.\d+", stdout)
+        return match.group(0) if match else stdout.strip()
+
+    # -- install ------------------------------------------------------------ #
+    @override
+    async def install(self, environment: BaseEnvironment) -> None:
+        if not self._binary_path.exists():
+            raise RuntimeError(
+                f"yolop binary not found at {self._binary_path}. Build it "
+                "(`cargo build --release --target x86_64-unknown-linux-musl`) and pass "
+                "`--ak binary_path=<path>` or set YOLOP_BIN. The binary must match the "
+                "task image's ABI, so prefer the static musl build."
+            )
+        await self.exec_as_root(
+            environment, command=f"mkdir -p {_INSTALL_DIR} {_CONFIG_HOME}/yolop {_SESSION_DIR}"
+        )
+        await environment.upload_file(self._binary_path, _BIN_PATH)
+        # World-readable/executable: install runs as root, the agent as the task user.
+        await self.exec_as_root(environment, command=f"chmod 755 {_BIN_PATH}")
+
+        # yolop defaults to worktree mode. Terminal-Bench containers are not git
+        # repos and the verifier reads the live filesystem, so edits must land in
+        # place rather than on a linked branch.
+        settings = "worktrees = \"off\"\n"
+        await self.exec_as_root(
+            environment,
+            command=(
+                f"printf %s {shlex.quote(settings)} > {_CONFIG_HOME}/yolop/settings.toml && "
+                f"chmod -R 777 {_CONFIG_HOME} {_SESSION_DIR}"
+            ),
+        )
+
+        if self._ca_cert_path is not None:
+            if not self._ca_cert_path.exists():
+                raise RuntimeError(f"ca_cert_path does not exist: {self._ca_cert_path}")
+            await environment.upload_file(self._ca_cert_path, CONTAINER_CA_PATH)
+            await self.exec_as_root(environment, command=f"chmod 644 {CONTAINER_CA_PATH}")
+
+    # -- run ---------------------------------------------------------------- #
+    def _provider_and_model(self) -> tuple[str | None, str | None]:
+        """Split Harbor's `provider/model` convention into yolop's two flags.
+
+        A bare model name (no slash) leaves the provider unset, so yolop
+        auto-detects it from the environment.
+        """
+        if not self.model_name:
+            return None, None
+        if "/" in self.model_name:
+            provider, model = self.model_name.split("/", 1)
+            return provider, model
+        return None, self.model_name
+
+    def _run_env(self) -> dict[str, str]:
+        provider, _ = self._provider_and_model()
+        env: dict[str, str] = {"XDG_CONFIG_HOME": _CONFIG_HOME}
+        for key in _PROVIDER_KEYS.get(provider or "", []):
+            value = self._get_env(key)
+            if value:
+                env[key] = value
+        if self._ca_cert_path is not None:
+            # yolop's HTTP stack reads SSL_CERT_FILE; the others cover any tool
+            # the agent shells out to from inside the container.
+            env.update(
+                {
+                    "SSL_CERT_FILE": CONTAINER_CA_PATH,
+                    "REQUESTS_CA_BUNDLE": CONTAINER_CA_PATH,
+                    "CURL_CA_BUNDLE": CONTAINER_CA_PATH,
+                    "NODE_EXTRA_CA_CERTS": CONTAINER_CA_PATH,
+                }
+            )
+        return env
+
+    def _command(self, instruction: str) -> str:
+        provider, model = self._provider_and_model()
+        parts = [_BIN_PATH]
+        if provider:
+            parts += ["--provider", provider]
+        if model:
+            parts += ["--model", model]
+        if self._sandbox:
+            parts.append("--sandbox")
+        flags = self.build_cli_flags()
+        if flags:
+            parts.append(flags)
+        parts += [
+            "--session",
+            self._session_id,
+            "--session-dir",
+            _SESSION_DIR,
+            "--trajectory-out",
+            _TRAJECTORY_PATH,
+            "-p",
+            shlex.quote(instruction),
+        ]
+        # stdbuf keeps the tee'd copy current while the run is in flight.
+        return (
+            " ".join(parts)
+            + f" 2>&1 </dev/null | stdbuf -oL tee {_AGENT_LOGS}/{_STDOUT_FILENAME}"
+        )
+
+    @property
+    def _host_session_log(self) -> Path:
+        """`events.jsonl` as seen from the host (`/logs/agent` is bind-mounted)."""
+        return self.logs_dir / "sessions" / self._session_id / "events.jsonl"
+
+    async def _watch_budget(self, environment: BaseEnvironment) -> bool:
+        """Poll the in-flight cost and stop yolop once it passes the cap.
+
+        Returns True if the run was stopped. Cancelled by `run()` as soon as the
+        agent exec finishes, so a run that stays under the cap pays nothing but
+        a few file reads.
+        """
+        assert self._max_cost_usd is not None
+        while True:
+            await asyncio.sleep(self._poll_s)
+            try:
+                cost = running_cost(self._host_session_log)
+            except OSError:
+                cost = None  # log not readable yet (mount lag); try again
+            if cost is None or cost <= self._max_cost_usd:
+                continue
+            self.logger.warning(
+                f"yolop hit the cost cap (${cost:.2f} > ${self._max_cost_usd:.2f}); "
+                "stopping the run"
+            )
+            self._stop_reason = "budget"
+            # SIGINT first so yolop flushes its trajectory; SIGKILL is the backstop.
+            await environment.exec(command=_kill_command("INT"), user="root")
+            await asyncio.sleep(5)
+            await environment.exec(command=_kill_command("KILL"), user="root")
+            return True
+
+    @override
+    @with_prompt_template
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        command = self._command(instruction)
+        env = self._run_env()
+
+        agent_task = asyncio.ensure_future(
+            self.exec_as_agent(environment, command=command, env=env)
+        )
+        watcher = (
+            asyncio.ensure_future(self._watch_budget(environment))
+            if self._max_cost_usd is not None
+            else None
+        )
+        try:
+            await agent_task
+        except Exception:
+            # A run we stopped on budget exits non-zero by construction; that is a
+            # recorded outcome, not a harness failure, and the verifier still runs
+            # against whatever the agent had already written to disk.
+            if self._stop_reason != "budget":
+                raise
+        finally:
+            if watcher is not None:
+                watcher.cancel()
+                # Retrieve the cancellation (and any watcher failure) so the loop
+                # does not log an unretrieved-exception warning after the trial.
+                await asyncio.gather(watcher, return_exceptions=True)
+
+    # -- metrics ------------------------------------------------------------ #
+    @override
+    def populate_context_post_run(self, context: AgentContext) -> None:
+        trajectory_path = self.logs_dir / "trajectory.json"
+        if not trajectory_path.exists():
+            context.metadata = {"stop_reason": self._stop_reason}
+            return
+        try:
+            trajectory = json.loads(trajectory_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            context.metadata = {"stop_reason": self._stop_reason}
+            return
+
+        totals = trajectory.get("final_metrics") or {}
+        # ATIF `total_prompt_tokens` is the whole prompt including cache reads,
+        # which is exactly AgentContext's "input tokens including cache".
+        context.n_input_tokens = totals.get("total_prompt_tokens")
+        context.n_cache_tokens = totals.get("total_cached_tokens")
+        context.n_output_tokens = totals.get("total_completion_tokens")
+        context.cost_usd = totals.get("total_cost_usd")
+        context.metadata = {"stop_reason": self._stop_reason, **summarize(trajectory)}
+
+
+def summarize(trajectory: dict[str, Any]) -> dict[str, Any]:
+    """Loop-shape metrics ATIF records per step but does not total up."""
+    steps = trajectory.get("steps") or []
+    tools: dict[str, int] = {}
+    agent_steps = llm_calls = tool_calls = 0
+    for step in steps:
+        if step.get("source") != "agent":
+            continue
+        agent_steps += 1
+        llm_calls += int(step.get("llm_call_count") or 1)
+        for call in step.get("tool_calls") or []:
+            tool_calls += 1
+            name = call.get("function_name") or "unknown"
+            tools[name] = tools.get(name, 0) + 1
+    return {
+        "agent_steps": agent_steps,
+        "llm_calls": llm_calls,
+        "tool_calls": tool_calls,
+        "tools_used": tools,
+        "yolop_version": (trajectory.get("agent") or {}).get("version"),
+    }

--- a/evals/terminal_bench/mira.toml
+++ b/evals/terminal_bench/mira.toml
@@ -1,0 +1,53 @@
+# Mira host config for the terminal_bench eval study.
+#
+# The `mira` CLI finds this by walking up from the working directory, so any
+# `mira run` launched from inside evals/terminal_bench/ archives here. A
+# relative results dir resolves against THIS file's directory, so runs always
+# land in evals/terminal_bench/results/ regardless of the cwd.
+#
+# Layout per saved run: results/<run_id>/{report.json,report.html,meta.json}
+# (run_id = YYYYMMDDThhmmssZ-xxxx, sortable by time).
+
+# Named launcher: how `mira` starts this study. With `default_launcher` set, a
+# bare `mira list` / `mira run …` from this directory drives the study — no
+# `--uv terminal_bench.py` needed. Explicit launch flags still override it.
+default_launcher = "study"
+
+[launchers.study]
+uv = "terminal_bench.py"   # single-file PEP 723 study; uv installs inline deps
+
+[results]
+dir = "./results"
+
+# Stamp every saved run's meta.json `environment` block (git/box/CI captured
+# automatically; these are static labels for filtering runs later).
+[environment.labels]
+benchmark = "terminal-bench-2-1"
+
+# Named selection presets, applied with `mira run --preset NAME` (explicit flags
+# override). A preset only *subsets* the declared grid: `targets`/`samples`/
+# `evals` (each a glob, or a list of globs) plus `tag`. `--group-by` is not
+# selection, so pass it too. The README "Presets" table documents each one.
+
+# SMOKE — the two cheapest easy tasks on one config, for integration checks and
+# for validating a new model/config before committing to a full run. Pair it
+# with TB_MAX_COST_USD to bound the spend.
+#   TB_MAX_COST_USD=5 mira run --preset smoke
+[presets.smoke]
+samples = ["fix-git", "cobol-modernization"]
+targets = "openai-gpt-5.6-terra"
+
+# COMPARE — yolop against the other terminal agents on the same easy tasks, the
+# evidence for "how does yolop's harness bench against Terminus/Claude Code/Codex".
+#   mira run --preset compare --group-by agent
+[presets.compare]
+tag = "easy"
+targets = ["openai-gpt-5.6-terra", "anthropic-claude-opus-4.8", "terminus-2",
+           "claude-code-opus-4.8", "codex"]
+
+# FULL — the whole 89-task benchmark on one config; the headline number. Each
+# case saves as it lands, so an interrupted run resumes with
+# `mira run --resume <run_id>`.
+#   mira run --preset full --group-by difficulty
+[presets.full]
+targets = "openai-gpt-5.6-terra"

--- a/evals/terminal_bench/mira.toml
+++ b/evals/terminal_bench/mira.toml
@@ -37,6 +37,15 @@ benchmark = "terminal-bench-2-1"
 samples = ["fix-git", "cobol-modernization"]
 targets = "openai-gpt-5.6-terra"
 
+# CONTROL — the periodic regression set: the fixed 8-task `control-v1` suite
+# (3 easy / 3 medium / 2 hard, selected deterministically — see
+# suites/select_control.py) on the tracked config. This is the run to repeat on a
+# cadence; the whole 89 is for headline numbers, not for noticing movement.
+#   TB_MAX_COST_USD=10 mira run --preset control --group-by difficulty
+[presets.control]
+tag = "control-v1"
+targets = "openai-gpt-5.6-terra"
+
 # COMPARE — yolop against the other terminal agents on the same easy tasks, the
 # evidence for "how does yolop's harness bench against Terminus/Claude Code/Codex".
 #   mira run --preset compare --group-by agent

--- a/evals/terminal_bench/prompt_autonomous.md
+++ b/evals/terminal_bench/prompt_autonomous.md
@@ -1,0 +1,14 @@
+{{ instruction }}
+
+---
+
+You are running fully autonomously inside a container. There is no user to
+answer you: nothing you write is read by anyone, and the session ends as soon as
+you stop. Do not ask for confirmation, do not offer options, and do not stop to
+report a plan — make the call yourself and carry it out, including for changes
+that rewrite history or overwrite files.
+
+The task is graded after you exit by running the task's own tests against the
+container's filesystem. Only what is on disk when you stop counts; a correct
+description of what should be done scores zero. Before you stop, verify your
+work by actually running it.

--- a/evals/terminal_bench/results/20260730T205010Z-4dc1/cases/terminal_5fbench_2fcobol_2dmodernization_40openrouter_2dgpt_2d5_2e6_2dterra/result.json
+++ b/evals/terminal_bench/results/20260730T205010Z-4dc1/cases/terminal_5fbench_2fcobol_2dmodernization_40openrouter_2dgpt_2d5_2e6_2dterra/result.json
@@ -1,0 +1,84 @@
+{
+  "eval": "terminal_bench",
+  "sample": "cobol-modernization",
+  "target": "openrouter-gpt-5.6-terra",
+  "passed": true,
+  "aggregate": 1.0,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 1.0,
+      "pass": true,
+      "reason": "tests passed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=True",
+    "iterations": 16,
+    "tool_calls_count": 20,
+    "tool_calls": [
+      "write_session_title",
+      "write_todos",
+      "write_todos",
+      "write_todos",
+      "write_todos",
+      "list_directory",
+      "list_directory",
+      "list_directory",
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash"
+    ],
+    "usage": {
+      "input_tokens": 59973,
+      "output_tokens": 3336,
+      "cache_read_tokens": 109046,
+      "cost_usd": 0.10587485
+    },
+    "timing": {
+      "duration_ms": 85146
+    },
+    "metrics": {
+      "cache_read_tokens": 109046.0,
+      "llm_calls": 16.0,
+      "reward": 1.0,
+      "tool_calls": 20.0
+    },
+    "metadata": {
+      "agent": "yolop",
+      "category": "software-engineering",
+      "difficulty": "easy",
+      "exception": null,
+      "model": "openrouter/openai/gpt-5.6-terra",
+      "provider": "openrouter",
+      "reasoning_effort": null,
+      "resolved": true,
+      "reward": 1.0,
+      "stop_reason": "completed",
+      "tools_used": {
+        "bash": 7,
+        "list_directory": 3,
+        "read_file": 5,
+        "write_session_title": 1,
+        "write_todos": 4
+      },
+      "yolop_version": "0.13.0"
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260730T205010Z-4dc1/cases/terminal_5fbench_2ffix_2dgit_40openrouter_2dgpt_2d5_2e6_2dterra/result.json
+++ b/evals/terminal_bench/results/20260730T205010Z-4dc1/cases/terminal_5fbench_2ffix_2dgit_40openrouter_2dgpt_2d5_2e6_2dterra/result.json
@@ -1,0 +1,78 @@
+{
+  "eval": "terminal_bench",
+  "sample": "fix-git",
+  "target": "openrouter-gpt-5.6-terra",
+  "passed": true,
+  "aggregate": 1.0,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 1.0,
+      "pass": true,
+      "reason": "tests passed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=True",
+    "iterations": 17,
+    "tool_calls_count": 16,
+    "tool_calls": [
+      "write_session_title",
+      "write_todos",
+      "write_todos",
+      "write_todos",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash"
+    ],
+    "usage": {
+      "input_tokens": 54188,
+      "output_tokens": 2035,
+      "cache_read_tokens": 112684,
+      "cost_usd": 0.09120065
+    },
+    "timing": {
+      "duration_ms": 73489
+    },
+    "metrics": {
+      "cache_read_tokens": 112684.0,
+      "llm_calls": 17.0,
+      "reward": 1.0,
+      "tool_calls": 16.0
+    },
+    "metadata": {
+      "agent": "yolop",
+      "category": "software-engineering",
+      "difficulty": "easy",
+      "exception": null,
+      "model": "openrouter/openai/gpt-5.6-terra",
+      "provider": "openrouter",
+      "reasoning_effort": null,
+      "resolved": true,
+      "reward": 1.0,
+      "stop_reason": "completed",
+      "tools_used": {
+        "bash": 12,
+        "write_session_title": 1,
+        "write_todos": 3
+      },
+      "yolop_version": "0.13.0"
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260730T205010Z-4dc1/meta.json
+++ b/evals/terminal_bench/results/20260730T205010Z-4dc1/meta.json
@@ -1,0 +1,35 @@
+{
+  "format": 1,
+  "run_id": "20260730T205010Z-4dc1",
+  "study": "terminal_bench",
+  "study_version": "0.1.0",
+  "started_unix": 1785444610,
+  "finished_unix": 1785444769,
+  "environment": {
+    "git": {
+      "commit": "03d034fd609f5a5d9b8ede1e6a55a3d9b43f5e1c",
+      "branch": "claude/terminal-bench-2-1-eval-6skuc7",
+      "dirty": true
+    },
+    "os": "linux",
+    "arch": "x86_64",
+    "hostname": "vm",
+    "cpus": 4,
+    "mem_total_mib": 16075,
+    "mira_version": "0.5.0",
+    "labels": {
+      "benchmark": "terminal-bench-2-1"
+    }
+  },
+  "summary": {
+    "scored": 2,
+    "passed": 2,
+    "failed": 0,
+    "na": 0,
+    "skipped": 0,
+    "total_tokens": 119532,
+    "total_cost_usd": 0.19707550000000001,
+    "total_tool_calls": 36,
+    "total_duration_ms": 158635
+  }
+}

--- a/evals/terminal_bench/results/20260730T205010Z-4dc1/report.html
+++ b/evals/terminal_bench/results/20260730T205010Z-4dc1/report.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Mira eval report</title>
+<style>
+:root{color-scheme:light dark;--ok:#1a7f37;--bad:#cf222e;--warn:#9a6700;--mut:#57606a;--bg:#fff;--fg:#1f2328;--line:#d0d7de}
+@media(prefers-color-scheme:dark){:root{--bg:#0d1117;--fg:#e6edf3;--line:#30363d;--mut:#8b949e}}
+*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--fg);font:15px/1.5 -apple-system,Segoe UI,Roboto,sans-serif}
+main{max-width:960px;margin:0 auto;padding:2rem 1.25rem}
+h1{font-size:1.6rem;margin:0 0 1rem}h2{font-size:1.15rem;margin:2rem 0 .75rem;border-bottom:1px solid var(--line);padding-bottom:.25rem}
+.cards{display:flex;flex-wrap:wrap;gap:.75rem}
+.card{flex:1;min-width:96px;border:1px solid var(--line);border-radius:8px;padding:.75rem 1rem;text-align:center}
+.card b{display:block;font-size:1.5rem}.card span{color:var(--mut);font-size:.8rem;text-transform:uppercase;letter-spacing:.04em}
+.card.ok b{color:var(--ok)}.card.bad b{color:var(--bad)}.card.warn b{color:var(--warn)}
+table.matrix{border-collapse:collapse;width:100%}table.matrix th,table.matrix td{border:1px solid var(--line);padding:.4rem .6rem;text-align:center}
+table.matrix td:first-child,table.matrix th:first-child{text-align:left}
+.case{border:1px solid var(--line);border-radius:8px;margin:.5rem 0;padding:.25rem .75rem}
+.case summary{cursor:pointer;display:flex;gap:.6rem;align-items:center;flex-wrap:wrap}
+.case code{font-size:.92rem}.metrics{color:var(--mut);font-size:.8rem;margin-left:auto}
+.badge{font-size:.7rem;font-weight:700;padding:.1rem .4rem;border-radius:4px;color:#fff}
+.badge.pass{background:var(--ok)}.badge.fail{background:var(--bad)}.badge.skip{background:var(--mut)}.badge.na{background:var(--warn)}
+.scores{list-style:none;padding:0;margin:.5rem 0}.scores li{padding:.15rem 0}.scores li.pass{color:var(--ok)}.scores li.fail{color:var(--bad)}.scores li.na{color:var(--mut)}
+.tools,.meta{font-size:.85rem;color:var(--mut)}
+pre{background:rgba(127,127,127,.1);border-radius:6px;padding:.6rem .75rem;overflow:auto;font-size:.85rem;white-space:pre-wrap}
+pre.error{color:var(--bad)}a{color:#0969da}
+</style>
+</head>
+<body>
+<main>
+<h1>Mira eval report</h1>
+<section class="cards">
+<div class="card ok"><b>2/2</b><span>passed</span></div>
+<div class="card"><b>0</b><span>failed</span></div>
+<div class="card"><b>0</b><span>n/a</span></div>
+<div class="card"><b>0</b><span>skipped</span></div>
+<div class="card"><b>119532</b><span>tokens</span></div>
+<div class="card"><b>$0.1971</b><span>cost</span></div>
+</section>
+<h2>Matrix</h2>
+<table class="matrix">
+<thead><tr><th>eval</th><th>openrouter-gpt-5.6-terra</th></tr></thead>
+<tbody>
+<tr><td>terminal_bench</td><td>2/2</td></tr>
+</tbody>
+</table>
+<h2>Resolve rate by difficulty</h2>
+<table class="matrix">
+<thead><tr><th>difficulty</th><th>passed</th><th>scored</th><th>rate</th></tr></thead>
+<tbody>
+<tr><td>easy</td><td>2</td><td>2</td><td>100%</td></tr>
+</tbody>
+</table>
+<h2>Cases</h2>
+<details class="case pass">
+<summary><span class="badge pass">PASS</span> <code>terminal_bench/cobol-modernization@openrouter-gpt-5.6-terra</code><span class="metrics">63309 tok · $0.1059 · 85146ms · 20 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="pass">✓ <b>resolved</b> — tests passed</li>
+</ul>
+<p class="tools"><b>tools:</b> write_session_title, write_todos, write_todos, write_todos, write_todos, list_directory, list_directory, list_directory, read_file, read_file, read_file, read_file, read_file, bash, bash, bash, bash, bash, bash, bash</p>
+<p class="meta"><b>metrics:</b> cache_read_tokens=109046, llm_calls=16, reward=1, tool_calls=20</p>
+<p class="meta"><b>metadata:</b> agent=yolop, category=software-engineering, difficulty=easy, exception=null, model=openrouter/openai/gpt-5.6-terra, provider=openrouter, reasoning_effort=null, resolved=true, reward=1.0, stop_reason=completed, tools_used={"bash":7,"list_directory":3,"read_file":5,"write_session_title":1,"write_todos":4}, yolop_version=0.13.0</p>
+<pre class="response">resolved=True</pre>
+</details>
+<details class="case pass">
+<summary><span class="badge pass">PASS</span> <code>terminal_bench/fix-git@openrouter-gpt-5.6-terra</code><span class="metrics">56223 tok · $0.0912 · 73489ms · 16 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="pass">✓ <b>resolved</b> — tests passed</li>
+</ul>
+<p class="tools"><b>tools:</b> write_session_title, write_todos, write_todos, write_todos, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash</p>
+<p class="meta"><b>metrics:</b> cache_read_tokens=112684, llm_calls=17, reward=1, tool_calls=16</p>
+<p class="meta"><b>metadata:</b> agent=yolop, category=software-engineering, difficulty=easy, exception=null, model=openrouter/openai/gpt-5.6-terra, provider=openrouter, reasoning_effort=null, resolved=true, reward=1.0, stop_reason=completed, tools_used={"bash":12,"write_session_title":1,"write_todos":3}, yolop_version=0.13.0</p>
+<pre class="response">resolved=True</pre>
+</details>
+<script type="application/json" id="mira-data">
+{"cases":[{"aggregate":1.0,"eval":"terminal_bench","passed":true,"sample":"cobol-modernization","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":true,"reason":"tests passed","scorer":"resolved","value":1.0}],"skipped":false,"target":"openrouter-gpt-5.6-terra","transcript":{"final_response":"resolved=True","iterations":16,"metadata":{"agent":"yolop","category":"software-engineering","difficulty":"easy","exception":null,"model":"openrouter/openai/gpt-5.6-terra","provider":"openrouter","reasoning_effort":null,"resolved":true,"reward":1.0,"stop_reason":"completed","tools_used":{"bash":7,"list_directory":3,"read_file":5,"write_session_title":1,"write_todos":4},"yolop_version":"0.13.0"},"metrics":{"cache_read_tokens":109046.0,"llm_calls":16.0,"reward":1.0,"tool_calls":20.0},"timing":{"duration_ms":85146},"tool_calls":["write_session_title","write_todos","write_todos","write_todos","write_todos","list_directory","list_directory","list_directory","read_file","read_file","read_file","read_file","read_file","bash","bash","bash","bash","bash","bash","bash"],"tool_calls_count":20,"usage":{"cache_read_tokens":109046,"cost_usd":0.10587485,"input_tokens":59973,"output_tokens":3336}}},{"aggregate":1.0,"eval":"terminal_bench","passed":true,"sample":"fix-git","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":true,"reason":"tests passed","scorer":"resolved","value":1.0}],"skipped":false,"target":"openrouter-gpt-5.6-terra","transcript":{"final_response":"resolved=True","iterations":17,"metadata":{"agent":"yolop","category":"software-engineering","difficulty":"easy","exception":null,"model":"openrouter/openai/gpt-5.6-terra","provider":"openrouter","reasoning_effort":null,"resolved":true,"reward":1.0,"stop_reason":"completed","tools_used":{"bash":12,"write_session_title":1,"write_todos":3},"yolop_version":"0.13.0"},"metrics":{"cache_read_tokens":112684.0,"llm_calls":17.0,"reward":1.0,"tool_calls":16.0},"timing":{"duration_ms":73489},"tool_calls":["write_session_title","write_todos","write_todos","write_todos","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash"],"tool_calls_count":16,"usage":{"cache_read_tokens":112684,"cost_usd":0.09120065,"input_tokens":54188,"output_tokens":2035}}}],"groups":{"difficulty":{"easy":{"passed":2,"scored":2}}},"summary":{"failed":0,"na":0,"passed":2,"scored":2,"skipped":0,"total_cost_usd":0.19707550000000001,"total_duration_ms":158635,"total_tokens":119532,"total_tool_calls":36}}
+</script>
+</main>
+</body>
+</html>

--- a/evals/terminal_bench/results/20260730T205010Z-4dc1/report.json
+++ b/evals/terminal_bench/results/20260730T205010Z-4dc1/report.json
@@ -1,0 +1,185 @@
+{
+  "cases": [
+    {
+      "aggregate": 1.0,
+      "eval": "terminal_bench",
+      "passed": true,
+      "sample": "cobol-modernization",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": true,
+          "reason": "tests passed",
+          "scorer": "resolved",
+          "value": 1.0
+        }
+      ],
+      "skipped": false,
+      "target": "openrouter-gpt-5.6-terra",
+      "transcript": {
+        "final_response": "resolved=True",
+        "iterations": 16,
+        "metadata": {
+          "agent": "yolop",
+          "category": "software-engineering",
+          "difficulty": "easy",
+          "exception": null,
+          "model": "openrouter/openai/gpt-5.6-terra",
+          "provider": "openrouter",
+          "reasoning_effort": null,
+          "resolved": true,
+          "reward": 1.0,
+          "stop_reason": "completed",
+          "tools_used": {
+            "bash": 7,
+            "list_directory": 3,
+            "read_file": 5,
+            "write_session_title": 1,
+            "write_todos": 4
+          },
+          "yolop_version": "0.13.0"
+        },
+        "metrics": {
+          "cache_read_tokens": 109046.0,
+          "llm_calls": 16.0,
+          "reward": 1.0,
+          "tool_calls": 20.0
+        },
+        "timing": {
+          "duration_ms": 85146
+        },
+        "tool_calls": [
+          "write_session_title",
+          "write_todos",
+          "write_todos",
+          "write_todos",
+          "write_todos",
+          "list_directory",
+          "list_directory",
+          "list_directory",
+          "read_file",
+          "read_file",
+          "read_file",
+          "read_file",
+          "read_file",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash"
+        ],
+        "tool_calls_count": 20,
+        "usage": {
+          "cache_read_tokens": 109046,
+          "cost_usd": 0.10587485,
+          "input_tokens": 59973,
+          "output_tokens": 3336
+        }
+      }
+    },
+    {
+      "aggregate": 1.0,
+      "eval": "terminal_bench",
+      "passed": true,
+      "sample": "fix-git",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": true,
+          "reason": "tests passed",
+          "scorer": "resolved",
+          "value": 1.0
+        }
+      ],
+      "skipped": false,
+      "target": "openrouter-gpt-5.6-terra",
+      "transcript": {
+        "final_response": "resolved=True",
+        "iterations": 17,
+        "metadata": {
+          "agent": "yolop",
+          "category": "software-engineering",
+          "difficulty": "easy",
+          "exception": null,
+          "model": "openrouter/openai/gpt-5.6-terra",
+          "provider": "openrouter",
+          "reasoning_effort": null,
+          "resolved": true,
+          "reward": 1.0,
+          "stop_reason": "completed",
+          "tools_used": {
+            "bash": 12,
+            "write_session_title": 1,
+            "write_todos": 3
+          },
+          "yolop_version": "0.13.0"
+        },
+        "metrics": {
+          "cache_read_tokens": 112684.0,
+          "llm_calls": 17.0,
+          "reward": 1.0,
+          "tool_calls": 16.0
+        },
+        "timing": {
+          "duration_ms": 73489
+        },
+        "tool_calls": [
+          "write_session_title",
+          "write_todos",
+          "write_todos",
+          "write_todos",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash"
+        ],
+        "tool_calls_count": 16,
+        "usage": {
+          "cache_read_tokens": 112684,
+          "cost_usd": 0.09120065,
+          "input_tokens": 54188,
+          "output_tokens": 2035
+        }
+      }
+    }
+  ],
+  "groups": {
+    "difficulty": {
+      "easy": {
+        "passed": 2,
+        "scored": 2
+      }
+    }
+  },
+  "summary": {
+    "failed": 0,
+    "na": 0,
+    "passed": 2,
+    "scored": 2,
+    "skipped": 0,
+    "total_cost_usd": 0.19707550000000001,
+    "total_duration_ms": 158635,
+    "total_tokens": 119532,
+    "total_tool_calls": 36
+  }
+}

--- a/evals/terminal_bench/results/20260731T014824Z-3c1e/cases/terminal_5fbench_2fchess_2dbest_2dmove_40openai_2dgpt_2d5_2e6_2dterra/result.json
+++ b/evals/terminal_bench/results/20260731T014824Z-3c1e/cases/terminal_5fbench_2fchess_2dbest_2dmove_40openai_2dgpt_2d5_2e6_2dterra/result.json
@@ -1,0 +1,79 @@
+{
+  "eval": "terminal_bench",
+  "sample": "chess-best-move",
+  "target": "openai-gpt-5.6-terra",
+  "passed": false,
+  "aggregate": 0.5,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 0.0,
+      "pass": false,
+      "reason": "tests failed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=False",
+    "iterations": 18,
+    "tool_calls_count": 17,
+    "tool_calls": [
+      "write_session_title",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "read_file"
+    ],
+    "usage": {
+      "input_tokens": 31607,
+      "output_tokens": 6744,
+      "cache_read_tokens": 346719,
+      "cost_usd": 0.26685725
+    },
+    "timing": {
+      "duration_ms": 343633
+    },
+    "metrics": {
+      "cache_read_tokens": 346719.0,
+      "llm_calls": 18.0,
+      "reward": 0.0,
+      "tool_calls": 17.0
+    },
+    "metadata": {
+      "agent": "yolop",
+      "category": "games",
+      "difficulty": "medium",
+      "exception": null,
+      "model": "openai/gpt-5.6-terra",
+      "provider": "openai",
+      "reasoning_effort": null,
+      "resolved": false,
+      "reward": 0.0,
+      "stop_reason": "completed",
+      "tools_used": {
+        "bash": 15,
+        "read_file": 1,
+        "write_session_title": 1
+      },
+      "yolop_version": "0.13.0"
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260731T014824Z-3c1e/cases/terminal_5fbench_2fcobol_2dmodernization_40openai_2dgpt_2d5_2e6_2dterra/result.json
+++ b/evals/terminal_bench/results/20260731T014824Z-3c1e/cases/terminal_5fbench_2fcobol_2dmodernization_40openai_2dgpt_2d5_2e6_2dterra/result.json
@@ -1,0 +1,74 @@
+{
+  "eval": "terminal_bench",
+  "sample": "cobol-modernization",
+  "target": "openai-gpt-5.6-terra",
+  "passed": true,
+  "aggregate": 1.0,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 1.0,
+      "pass": true,
+      "reason": "tests passed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=True",
+    "iterations": 13,
+    "tool_calls_count": 12,
+    "tool_calls": [
+      "write_session_title",
+      "write_todos",
+      "write_todos",
+      "write_todos",
+      "write_todos",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash"
+    ],
+    "usage": {
+      "input_tokens": 24843,
+      "output_tokens": 5492,
+      "cache_read_tokens": 191687,
+      "cost_usd": 0.19240925000000003
+    },
+    "timing": {
+      "duration_ms": 108119
+    },
+    "metrics": {
+      "cache_read_tokens": 191687.0,
+      "llm_calls": 13.0,
+      "reward": 1.0,
+      "tool_calls": 12.0
+    },
+    "metadata": {
+      "agent": "yolop",
+      "category": "software-engineering",
+      "difficulty": "easy",
+      "exception": null,
+      "model": "openai/gpt-5.6-terra",
+      "provider": "openai",
+      "reasoning_effort": null,
+      "resolved": true,
+      "reward": 1.0,
+      "stop_reason": "completed",
+      "tools_used": {
+        "bash": 7,
+        "write_session_title": 1,
+        "write_todos": 4
+      },
+      "yolop_version": "0.13.0"
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260731T014824Z-3c1e/cases/terminal_5fbench_2fconfigure_2dgit_2dwebserver_40openai_2dgpt_2d5_2e6_2dterra/result.json
+++ b/evals/terminal_bench/results/20260731T014824Z-3c1e/cases/terminal_5fbench_2fconfigure_2dgit_2dwebserver_40openai_2dgpt_2d5_2e6_2dterra/result.json
@@ -1,0 +1,72 @@
+{
+  "eval": "terminal_bench",
+  "sample": "configure-git-webserver",
+  "target": "openai-gpt-5.6-terra",
+  "passed": false,
+  "aggregate": 0.5,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 0.0,
+      "pass": false,
+      "reason": "tests failed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=False",
+    "iterations": 11,
+    "tool_calls_count": 10,
+    "tool_calls": [
+      "write_session_title",
+      "write_todos",
+      "write_todos",
+      "write_todos",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash"
+    ],
+    "usage": {
+      "input_tokens": 22814,
+      "output_tokens": 3712,
+      "cache_read_tokens": 143290,
+      "cost_usd": 0.14853750000000002
+    },
+    "timing": {
+      "duration_ms": 116657
+    },
+    "metrics": {
+      "cache_read_tokens": 143290.0,
+      "llm_calls": 11.0,
+      "reward": 0.0,
+      "tool_calls": 10.0
+    },
+    "metadata": {
+      "agent": "yolop",
+      "category": "system-administration",
+      "difficulty": "hard",
+      "exception": null,
+      "model": "openai/gpt-5.6-terra",
+      "provider": "openai",
+      "reasoning_effort": null,
+      "resolved": false,
+      "reward": 0.0,
+      "stop_reason": "completed",
+      "tools_used": {
+        "bash": 6,
+        "write_session_title": 1,
+        "write_todos": 3
+      },
+      "yolop_version": "0.13.0"
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260731T014824Z-3c1e/cases/terminal_5fbench_2fcount_2ddataset_2dtokens_40openai_2dgpt_2d5_2e6_2dterra/result.json
+++ b/evals/terminal_bench/results/20260731T014824Z-3c1e/cases/terminal_5fbench_2fcount_2ddataset_2dtokens_40openai_2dgpt_2d5_2e6_2dterra/result.json
@@ -1,0 +1,72 @@
+{
+  "eval": "terminal_bench",
+  "sample": "count-dataset-tokens",
+  "target": "openai-gpt-5.6-terra",
+  "passed": true,
+  "aggregate": 1.0,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 1.0,
+      "pass": true,
+      "reason": "tests passed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=True",
+    "iterations": 11,
+    "tool_calls_count": 10,
+    "tool_calls": [
+      "write_session_title",
+      "write_todos",
+      "write_todos",
+      "write_todos",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash"
+    ],
+    "usage": {
+      "input_tokens": 18271,
+      "output_tokens": 2408,
+      "cache_read_tokens": 127710,
+      "cost_usd": 0.113725
+    },
+    "timing": {
+      "duration_ms": 164998
+    },
+    "metrics": {
+      "cache_read_tokens": 127710.0,
+      "llm_calls": 11.0,
+      "reward": 1.0,
+      "tool_calls": 10.0
+    },
+    "metadata": {
+      "agent": "yolop",
+      "category": "model-training",
+      "difficulty": "medium",
+      "exception": null,
+      "model": "openai/gpt-5.6-terra",
+      "provider": "openai",
+      "reasoning_effort": null,
+      "resolved": true,
+      "reward": 1.0,
+      "stop_reason": "completed",
+      "tools_used": {
+        "bash": 6,
+        "write_session_title": 1,
+        "write_todos": 3
+      },
+      "yolop_version": "0.13.0"
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260731T014824Z-3c1e/cases/terminal_5fbench_2ffix_2dcode_2dvulnerability_40openai_2dgpt_2d5_2e6_2dterra/result.json
+++ b/evals/terminal_bench/results/20260731T014824Z-3c1e/cases/terminal_5fbench_2ffix_2dcode_2dvulnerability_40openai_2dgpt_2d5_2e6_2dterra/result.json
@@ -1,0 +1,82 @@
+{
+  "eval": "terminal_bench",
+  "sample": "fix-code-vulnerability",
+  "target": "openai-gpt-5.6-terra",
+  "passed": true,
+  "aggregate": 1.0,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 1.0,
+      "pass": true,
+      "reason": "tests passed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=True",
+    "iterations": 13,
+    "tool_calls_count": 20,
+    "tool_calls": [
+      "write_session_title",
+      "write_todos",
+      "write_todos",
+      "write_todos",
+      "write_todos",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash"
+    ],
+    "usage": {
+      "input_tokens": 32520,
+      "output_tokens": 2474,
+      "cache_read_tokens": 236989,
+      "cost_usd": 0.17765724999999996
+    },
+    "timing": {
+      "duration_ms": 86147
+    },
+    "metrics": {
+      "cache_read_tokens": 236989.0,
+      "llm_calls": 13.0,
+      "reward": 1.0,
+      "tool_calls": 20.0
+    },
+    "metadata": {
+      "agent": "yolop",
+      "category": "security",
+      "difficulty": "hard",
+      "exception": null,
+      "model": "openai/gpt-5.6-terra",
+      "provider": "openai",
+      "reasoning_effort": null,
+      "resolved": true,
+      "reward": 1.0,
+      "stop_reason": "completed",
+      "tools_used": {
+        "bash": 15,
+        "write_session_title": 1,
+        "write_todos": 4
+      },
+      "yolop_version": "0.13.0"
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260731T014824Z-3c1e/cases/terminal_5fbench_2ffix_2dgit_40openai_2dgpt_2d5_2e6_2dterra/result.json
+++ b/evals/terminal_bench/results/20260731T014824Z-3c1e/cases/terminal_5fbench_2ffix_2dgit_40openai_2dgpt_2d5_2e6_2dterra/result.json
@@ -1,0 +1,77 @@
+{
+  "eval": "terminal_bench",
+  "sample": "fix-git",
+  "target": "openai-gpt-5.6-terra",
+  "passed": true,
+  "aggregate": 1.0,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 1.0,
+      "pass": true,
+      "reason": "tests passed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=True",
+    "iterations": 16,
+    "tool_calls_count": 15,
+    "tool_calls": [
+      "write_session_title",
+      "write_todos",
+      "write_todos",
+      "write_todos",
+      "write_todos",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash"
+    ],
+    "usage": {
+      "input_tokens": 21262,
+      "output_tokens": 2933,
+      "cache_read_tokens": 233438,
+      "cost_usd": 0.15550950000000002
+    },
+    "timing": {
+      "duration_ms": 100734
+    },
+    "metrics": {
+      "cache_read_tokens": 233438.0,
+      "llm_calls": 16.0,
+      "reward": 1.0,
+      "tool_calls": 15.0
+    },
+    "metadata": {
+      "agent": "yolop",
+      "category": "software-engineering",
+      "difficulty": "easy",
+      "exception": null,
+      "model": "openai/gpt-5.6-terra",
+      "provider": "openai",
+      "reasoning_effort": null,
+      "resolved": true,
+      "reward": 1.0,
+      "stop_reason": "completed",
+      "tools_used": {
+        "bash": 10,
+        "write_session_title": 1,
+        "write_todos": 4
+      },
+      "yolop_version": "0.13.0"
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260731T014824Z-3c1e/cases/terminal_5fbench_2fmodernize_2dscientific_2dstack_40openai_2dgpt_2d5_2e6_2dterra/result.json
+++ b/evals/terminal_bench/results/20260731T014824Z-3c1e/cases/terminal_5fbench_2fmodernize_2dscientific_2dstack_40openai_2dgpt_2d5_2e6_2dterra/result.json
@@ -1,0 +1,71 @@
+{
+  "eval": "terminal_bench",
+  "sample": "modernize-scientific-stack",
+  "target": "openai-gpt-5.6-terra",
+  "passed": true,
+  "aggregate": 1.0,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 1.0,
+      "pass": true,
+      "reason": "tests passed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=True",
+    "iterations": 10,
+    "tool_calls_count": 9,
+    "tool_calls": [
+      "write_session_title",
+      "write_todos",
+      "write_todos",
+      "write_todos",
+      "write_todos",
+      "bash",
+      "bash",
+      "bash",
+      "bash"
+    ],
+    "usage": {
+      "input_tokens": 14708,
+      "output_tokens": 1935,
+      "cache_read_tokens": 102205,
+      "cost_usd": 0.09134625
+    },
+    "timing": {
+      "duration_ms": 78228
+    },
+    "metrics": {
+      "cache_read_tokens": 102205.0,
+      "llm_calls": 10.0,
+      "reward": 1.0,
+      "tool_calls": 9.0
+    },
+    "metadata": {
+      "agent": "yolop",
+      "category": "scientific-computing",
+      "difficulty": "medium",
+      "exception": null,
+      "model": "openai/gpt-5.6-terra",
+      "provider": "openai",
+      "reasoning_effort": null,
+      "resolved": true,
+      "reward": 1.0,
+      "stop_reason": "completed",
+      "tools_used": {
+        "bash": 4,
+        "write_session_title": 1,
+        "write_todos": 4
+      },
+      "yolop_version": "0.13.0"
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260731T014824Z-3c1e/cases/terminal_5fbench_2foverfull_2dhbox_40openai_2dgpt_2d5_2e6_2dterra/result.json
+++ b/evals/terminal_bench/results/20260731T014824Z-3c1e/cases/terminal_5fbench_2foverfull_2dhbox_40openai_2dgpt_2d5_2e6_2dterra/result.json
@@ -1,0 +1,76 @@
+{
+  "eval": "terminal_bench",
+  "sample": "overfull-hbox",
+  "target": "openai-gpt-5.6-terra",
+  "passed": true,
+  "aggregate": 1.0,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 1.0,
+      "pass": true,
+      "reason": "tests passed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=True",
+    "iterations": 15,
+    "tool_calls_count": 14,
+    "tool_calls": [
+      "write_session_title",
+      "write_todos",
+      "write_todos",
+      "write_todos",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash"
+    ],
+    "usage": {
+      "input_tokens": 27384,
+      "output_tokens": 4670,
+      "cache_read_tokens": 236116,
+      "cost_usd": 0.19753900000000005
+    },
+    "timing": {
+      "duration_ms": 318508
+    },
+    "metrics": {
+      "cache_read_tokens": 236116.0,
+      "llm_calls": 15.0,
+      "reward": 1.0,
+      "tool_calls": 14.0
+    },
+    "metadata": {
+      "agent": "yolop",
+      "category": "debugging",
+      "difficulty": "easy",
+      "exception": null,
+      "model": "openai/gpt-5.6-terra",
+      "provider": "openai",
+      "reasoning_effort": null,
+      "resolved": true,
+      "reward": 1.0,
+      "stop_reason": "completed",
+      "tools_used": {
+        "bash": 10,
+        "write_session_title": 1,
+        "write_todos": 3
+      },
+      "yolop_version": "0.13.0"
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260731T014824Z-3c1e/meta.json
+++ b/evals/terminal_bench/results/20260731T014824Z-3c1e/meta.json
@@ -1,0 +1,35 @@
+{
+  "format": 1,
+  "run_id": "20260731T014824Z-3c1e",
+  "study": "terminal_bench",
+  "study_version": "0.1.0",
+  "started_unix": 1785462504,
+  "finished_unix": 0,
+  "environment": {
+    "git": {
+      "commit": "d871553a3d2fadd0da04de81d1a7c2b26e9b2116",
+      "branch": "claude/terminal-bench-2-1-eval-6skuc7",
+      "dirty": true
+    },
+    "os": "linux",
+    "arch": "x86_64",
+    "hostname": "vm",
+    "cpus": 4,
+    "mem_total_mib": 16075,
+    "mira_version": "0.5.0",
+    "labels": {
+      "benchmark": "terminal-bench-2-1"
+    }
+  },
+  "summary": {
+    "scored": 0,
+    "passed": 0,
+    "failed": 0,
+    "na": 0,
+    "skipped": 0,
+    "total_tokens": 0,
+    "total_cost_usd": 0.0,
+    "total_tool_calls": 0,
+    "total_duration_ms": 0
+  }
+}

--- a/evals/terminal_bench/results/20260731T014824Z-3c1e/meta.json
+++ b/evals/terminal_bench/results/20260731T014824Z-3c1e/meta.json
@@ -4,7 +4,7 @@
   "study": "terminal_bench",
   "study_version": "0.1.0",
   "started_unix": 1785462504,
-  "finished_unix": 0,
+  "finished_unix": 1785463822,
   "environment": {
     "git": {
       "commit": "d871553a3d2fadd0da04de81d1a7c2b26e9b2116",
@@ -22,14 +22,14 @@
     }
   },
   "summary": {
-    "scored": 0,
-    "passed": 0,
-    "failed": 0,
+    "scored": 8,
+    "passed": 6,
+    "failed": 2,
     "na": 0,
     "skipped": 0,
-    "total_tokens": 0,
-    "total_cost_usd": 0.0,
-    "total_tool_calls": 0,
-    "total_duration_ms": 0
+    "total_tokens": 223777,
+    "total_cost_usd": 1.3435810000000001,
+    "total_tool_calls": 107,
+    "total_duration_ms": 1317024
   }
 }

--- a/evals/terminal_bench/results/20260731T014824Z-3c1e/report.html
+++ b/evals/terminal_bench/results/20260731T014824Z-3c1e/report.html
@@ -1,0 +1,151 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Mira eval report</title>
+<style>
+:root{color-scheme:light dark;--ok:#1a7f37;--bad:#cf222e;--warn:#9a6700;--mut:#57606a;--bg:#fff;--fg:#1f2328;--line:#d0d7de}
+@media(prefers-color-scheme:dark){:root{--bg:#0d1117;--fg:#e6edf3;--line:#30363d;--mut:#8b949e}}
+*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--fg);font:15px/1.5 -apple-system,Segoe UI,Roboto,sans-serif}
+main{max-width:960px;margin:0 auto;padding:2rem 1.25rem}
+h1{font-size:1.6rem;margin:0 0 1rem}h2{font-size:1.15rem;margin:2rem 0 .75rem;border-bottom:1px solid var(--line);padding-bottom:.25rem}
+.cards{display:flex;flex-wrap:wrap;gap:.75rem}
+.card{flex:1;min-width:96px;border:1px solid var(--line);border-radius:8px;padding:.75rem 1rem;text-align:center}
+.card b{display:block;font-size:1.5rem}.card span{color:var(--mut);font-size:.8rem;text-transform:uppercase;letter-spacing:.04em}
+.card.ok b{color:var(--ok)}.card.bad b{color:var(--bad)}.card.warn b{color:var(--warn)}
+table.matrix{border-collapse:collapse;width:100%}table.matrix th,table.matrix td{border:1px solid var(--line);padding:.4rem .6rem;text-align:center}
+table.matrix td:first-child,table.matrix th:first-child{text-align:left}
+.case{border:1px solid var(--line);border-radius:8px;margin:.5rem 0;padding:.25rem .75rem}
+.case summary{cursor:pointer;display:flex;gap:.6rem;align-items:center;flex-wrap:wrap}
+.case code{font-size:.92rem}.metrics{color:var(--mut);font-size:.8rem;margin-left:auto}
+.badge{font-size:.7rem;font-weight:700;padding:.1rem .4rem;border-radius:4px;color:#fff}
+.badge.pass{background:var(--ok)}.badge.fail{background:var(--bad)}.badge.skip{background:var(--mut)}.badge.na{background:var(--warn)}
+.scores{list-style:none;padding:0;margin:.5rem 0}.scores li{padding:.15rem 0}.scores li.pass{color:var(--ok)}.scores li.fail{color:var(--bad)}.scores li.na{color:var(--mut)}
+.tools,.meta{font-size:.85rem;color:var(--mut)}
+pre{background:rgba(127,127,127,.1);border-radius:6px;padding:.6rem .75rem;overflow:auto;font-size:.85rem;white-space:pre-wrap}
+pre.error{color:var(--bad)}a{color:#0969da}
+</style>
+</head>
+<body>
+<main>
+<h1>Mira eval report</h1>
+<section class="cards">
+<div class="card bad"><b>6/8</b><span>passed</span></div>
+<div class="card"><b>2</b><span>failed</span></div>
+<div class="card"><b>0</b><span>n/a</span></div>
+<div class="card"><b>0</b><span>skipped</span></div>
+<div class="card"><b>223777</b><span>tokens</span></div>
+<div class="card"><b>$1.3436</b><span>cost</span></div>
+</section>
+<h2>Matrix</h2>
+<table class="matrix">
+<thead><tr><th>eval</th><th>openai-gpt-5.6-terra</th></tr></thead>
+<tbody>
+<tr><td>terminal_bench</td><td>6/8</td></tr>
+</tbody>
+</table>
+<h2>Resolve rate by difficulty</h2>
+<table class="matrix">
+<thead><tr><th>difficulty</th><th>passed</th><th>scored</th><th>rate</th></tr></thead>
+<tbody>
+<tr><td>easy</td><td>3</td><td>3</td><td>100%</td></tr>
+<tr><td>hard</td><td>1</td><td>2</td><td>50%</td></tr>
+<tr><td>medium</td><td>2</td><td>3</td><td>67%</td></tr>
+</tbody>
+</table>
+<h2>Cases</h2>
+<details class="case fail">
+<summary><span class="badge fail">FAIL</span> <code>terminal_bench/chess-best-move@openai-gpt-5.6-terra</code><span class="metrics">38351 tok · $0.2669 · 343633ms · 17 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="fail">✗ <b>resolved</b> — tests failed</li>
+</ul>
+<p class="tools"><b>tools:</b> write_session_title, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, read_file</p>
+<p class="meta"><b>metrics:</b> cache_read_tokens=346719, llm_calls=18, reward=0, tool_calls=17</p>
+<p class="meta"><b>metadata:</b> agent=yolop, category=games, difficulty=medium, exception=null, model=openai/gpt-5.6-terra, provider=openai, reasoning_effort=null, resolved=false, reward=0.0, stop_reason=completed, tools_used={"bash":15,"read_file":1,"write_session_title":1}, yolop_version=0.13.0</p>
+<pre class="response">resolved=False</pre>
+</details>
+<details class="case pass">
+<summary><span class="badge pass">PASS</span> <code>terminal_bench/cobol-modernization@openai-gpt-5.6-terra</code><span class="metrics">30335 tok · $0.1924 · 108119ms · 12 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="pass">✓ <b>resolved</b> — tests passed</li>
+</ul>
+<p class="tools"><b>tools:</b> write_session_title, write_todos, write_todos, write_todos, write_todos, bash, bash, bash, bash, bash, bash, bash</p>
+<p class="meta"><b>metrics:</b> cache_read_tokens=191687, llm_calls=13, reward=1, tool_calls=12</p>
+<p class="meta"><b>metadata:</b> agent=yolop, category=software-engineering, difficulty=easy, exception=null, model=openai/gpt-5.6-terra, provider=openai, reasoning_effort=null, resolved=true, reward=1.0, stop_reason=completed, tools_used={"bash":7,"write_session_title":1,"write_todos":4}, yolop_version=0.13.0</p>
+<pre class="response">resolved=True</pre>
+</details>
+<details class="case fail">
+<summary><span class="badge fail">FAIL</span> <code>terminal_bench/configure-git-webserver@openai-gpt-5.6-terra</code><span class="metrics">26526 tok · $0.1485 · 116657ms · 10 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="fail">✗ <b>resolved</b> — tests failed</li>
+</ul>
+<p class="tools"><b>tools:</b> write_session_title, write_todos, write_todos, write_todos, bash, bash, bash, bash, bash, bash</p>
+<p class="meta"><b>metrics:</b> cache_read_tokens=143290, llm_calls=11, reward=0, tool_calls=10</p>
+<p class="meta"><b>metadata:</b> agent=yolop, category=system-administration, difficulty=hard, exception=null, model=openai/gpt-5.6-terra, provider=openai, reasoning_effort=null, resolved=false, reward=0.0, stop_reason=completed, tools_used={"bash":6,"write_session_title":1,"write_todos":3}, yolop_version=0.13.0</p>
+<pre class="response">resolved=False</pre>
+</details>
+<details class="case pass">
+<summary><span class="badge pass">PASS</span> <code>terminal_bench/count-dataset-tokens@openai-gpt-5.6-terra</code><span class="metrics">20679 tok · $0.1137 · 164998ms · 10 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="pass">✓ <b>resolved</b> — tests passed</li>
+</ul>
+<p class="tools"><b>tools:</b> write_session_title, write_todos, write_todos, write_todos, bash, bash, bash, bash, bash, bash</p>
+<p class="meta"><b>metrics:</b> cache_read_tokens=127710, llm_calls=11, reward=1, tool_calls=10</p>
+<p class="meta"><b>metadata:</b> agent=yolop, category=model-training, difficulty=medium, exception=null, model=openai/gpt-5.6-terra, provider=openai, reasoning_effort=null, resolved=true, reward=1.0, stop_reason=completed, tools_used={"bash":6,"write_session_title":1,"write_todos":3}, yolop_version=0.13.0</p>
+<pre class="response">resolved=True</pre>
+</details>
+<details class="case pass">
+<summary><span class="badge pass">PASS</span> <code>terminal_bench/fix-code-vulnerability@openai-gpt-5.6-terra</code><span class="metrics">34994 tok · $0.1777 · 86147ms · 20 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="pass">✓ <b>resolved</b> — tests passed</li>
+</ul>
+<p class="tools"><b>tools:</b> write_session_title, write_todos, write_todos, write_todos, write_todos, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash</p>
+<p class="meta"><b>metrics:</b> cache_read_tokens=236989, llm_calls=13, reward=1, tool_calls=20</p>
+<p class="meta"><b>metadata:</b> agent=yolop, category=security, difficulty=hard, exception=null, model=openai/gpt-5.6-terra, provider=openai, reasoning_effort=null, resolved=true, reward=1.0, stop_reason=completed, tools_used={"bash":15,"write_session_title":1,"write_todos":4}, yolop_version=0.13.0</p>
+<pre class="response">resolved=True</pre>
+</details>
+<details class="case pass">
+<summary><span class="badge pass">PASS</span> <code>terminal_bench/fix-git@openai-gpt-5.6-terra</code><span class="metrics">24195 tok · $0.1555 · 100734ms · 15 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="pass">✓ <b>resolved</b> — tests passed</li>
+</ul>
+<p class="tools"><b>tools:</b> write_session_title, write_todos, write_todos, write_todos, write_todos, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash</p>
+<p class="meta"><b>metrics:</b> cache_read_tokens=233438, llm_calls=16, reward=1, tool_calls=15</p>
+<p class="meta"><b>metadata:</b> agent=yolop, category=software-engineering, difficulty=easy, exception=null, model=openai/gpt-5.6-terra, provider=openai, reasoning_effort=null, resolved=true, reward=1.0, stop_reason=completed, tools_used={"bash":10,"write_session_title":1,"write_todos":4}, yolop_version=0.13.0</p>
+<pre class="response">resolved=True</pre>
+</details>
+<details class="case pass">
+<summary><span class="badge pass">PASS</span> <code>terminal_bench/modernize-scientific-stack@openai-gpt-5.6-terra</code><span class="metrics">16643 tok · $0.0913 · 78228ms · 9 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="pass">✓ <b>resolved</b> — tests passed</li>
+</ul>
+<p class="tools"><b>tools:</b> write_session_title, write_todos, write_todos, write_todos, write_todos, bash, bash, bash, bash</p>
+<p class="meta"><b>metrics:</b> cache_read_tokens=102205, llm_calls=10, reward=1, tool_calls=9</p>
+<p class="meta"><b>metadata:</b> agent=yolop, category=scientific-computing, difficulty=medium, exception=null, model=openai/gpt-5.6-terra, provider=openai, reasoning_effort=null, resolved=true, reward=1.0, stop_reason=completed, tools_used={"bash":4,"write_session_title":1,"write_todos":4}, yolop_version=0.13.0</p>
+<pre class="response">resolved=True</pre>
+</details>
+<details class="case pass">
+<summary><span class="badge pass">PASS</span> <code>terminal_bench/overfull-hbox@openai-gpt-5.6-terra</code><span class="metrics">32054 tok · $0.1975 · 318508ms · 14 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="pass">✓ <b>resolved</b> — tests passed</li>
+</ul>
+<p class="tools"><b>tools:</b> write_session_title, write_todos, write_todos, write_todos, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash</p>
+<p class="meta"><b>metrics:</b> cache_read_tokens=236116, llm_calls=15, reward=1, tool_calls=14</p>
+<p class="meta"><b>metadata:</b> agent=yolop, category=debugging, difficulty=easy, exception=null, model=openai/gpt-5.6-terra, provider=openai, reasoning_effort=null, resolved=true, reward=1.0, stop_reason=completed, tools_used={"bash":10,"write_session_title":1,"write_todos":3}, yolop_version=0.13.0</p>
+<pre class="response">resolved=True</pre>
+</details>
+<script type="application/json" id="mira-data">
+{"cases":[{"aggregate":0.5,"eval":"terminal_bench","passed":false,"sample":"chess-best-move","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":false,"reason":"tests failed","scorer":"resolved","value":0.0}],"skipped":false,"target":"openai-gpt-5.6-terra","transcript":{"final_response":"resolved=False","iterations":18,"metadata":{"agent":"yolop","category":"games","difficulty":"medium","exception":null,"model":"openai/gpt-5.6-terra","provider":"openai","reasoning_effort":null,"resolved":false,"reward":0.0,"stop_reason":"completed","tools_used":{"bash":15,"read_file":1,"write_session_title":1},"yolop_version":"0.13.0"},"metrics":{"cache_read_tokens":346719.0,"llm_calls":18.0,"reward":0.0,"tool_calls":17.0},"timing":{"duration_ms":343633},"tool_calls":["write_session_title","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","read_file"],"tool_calls_count":17,"usage":{"cache_read_tokens":346719,"cost_usd":0.26685725,"input_tokens":31607,"output_tokens":6744}}},{"aggregate":1.0,"eval":"terminal_bench","passed":true,"sample":"cobol-modernization","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":true,"reason":"tests passed","scorer":"resolved","value":1.0}],"skipped":false,"target":"openai-gpt-5.6-terra","transcript":{"final_response":"resolved=True","iterations":13,"metadata":{"agent":"yolop","category":"software-engineering","difficulty":"easy","exception":null,"model":"openai/gpt-5.6-terra","provider":"openai","reasoning_effort":null,"resolved":true,"reward":1.0,"stop_reason":"completed","tools_used":{"bash":7,"write_session_title":1,"write_todos":4},"yolop_version":"0.13.0"},"metrics":{"cache_read_tokens":191687.0,"llm_calls":13.0,"reward":1.0,"tool_calls":12.0},"timing":{"duration_ms":108119},"tool_calls":["write_session_title","write_todos","write_todos","write_todos","write_todos","bash","bash","bash","bash","bash","bash","bash"],"tool_calls_count":12,"usage":{"cache_read_tokens":191687,"cost_usd":0.19240925000000003,"input_tokens":24843,"output_tokens":5492}}},{"aggregate":0.5,"eval":"terminal_bench","passed":false,"sample":"configure-git-webserver","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":false,"reason":"tests failed","scorer":"resolved","value":0.0}],"skipped":false,"target":"openai-gpt-5.6-terra","transcript":{"final_response":"resolved=False","iterations":11,"metadata":{"agent":"yolop","category":"system-administration","difficulty":"hard","exception":null,"model":"openai/gpt-5.6-terra","provider":"openai","reasoning_effort":null,"resolved":false,"reward":0.0,"stop_reason":"completed","tools_used":{"bash":6,"write_session_title":1,"write_todos":3},"yolop_version":"0.13.0"},"metrics":{"cache_read_tokens":143290.0,"llm_calls":11.0,"reward":0.0,"tool_calls":10.0},"timing":{"duration_ms":116657},"tool_calls":["write_session_title","write_todos","write_todos","write_todos","bash","bash","bash","bash","bash","bash"],"tool_calls_count":10,"usage":{"cache_read_tokens":143290,"cost_usd":0.14853750000000002,"input_tokens":22814,"output_tokens":3712}}},{"aggregate":1.0,"eval":"terminal_bench","passed":true,"sample":"count-dataset-tokens","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":true,"reason":"tests passed","scorer":"resolved","value":1.0}],"skipped":false,"target":"openai-gpt-5.6-terra","transcript":{"final_response":"resolved=True","iterations":11,"metadata":{"agent":"yolop","category":"model-training","difficulty":"medium","exception":null,"model":"openai/gpt-5.6-terra","provider":"openai","reasoning_effort":null,"resolved":true,"reward":1.0,"stop_reason":"completed","tools_used":{"bash":6,"write_session_title":1,"write_todos":3},"yolop_version":"0.13.0"},"metrics":{"cache_read_tokens":127710.0,"llm_calls":11.0,"reward":1.0,"tool_calls":10.0},"timing":{"duration_ms":164998},"tool_calls":["write_session_title","write_todos","write_todos","write_todos","bash","bash","bash","bash","bash","bash"],"tool_calls_count":10,"usage":{"cache_read_tokens":127710,"cost_usd":0.113725,"input_tokens":18271,"output_tokens":2408}}},{"aggregate":1.0,"eval":"terminal_bench","passed":true,"sample":"fix-code-vulnerability","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":true,"reason":"tests passed","scorer":"resolved","value":1.0}],"skipped":false,"target":"openai-gpt-5.6-terra","transcript":{"final_response":"resolved=True","iterations":13,"metadata":{"agent":"yolop","category":"security","difficulty":"hard","exception":null,"model":"openai/gpt-5.6-terra","provider":"openai","reasoning_effort":null,"resolved":true,"reward":1.0,"stop_reason":"completed","tools_used":{"bash":15,"write_session_title":1,"write_todos":4},"yolop_version":"0.13.0"},"metrics":{"cache_read_tokens":236989.0,"llm_calls":13.0,"reward":1.0,"tool_calls":20.0},"timing":{"duration_ms":86147},"tool_calls":["write_session_title","write_todos","write_todos","write_todos","write_todos","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash"],"tool_calls_count":20,"usage":{"cache_read_tokens":236989,"cost_usd":0.17765724999999996,"input_tokens":32520,"output_tokens":2474}}},{"aggregate":1.0,"eval":"terminal_bench","passed":true,"sample":"fix-git","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":true,"reason":"tests passed","scorer":"resolved","value":1.0}],"skipped":false,"target":"openai-gpt-5.6-terra","transcript":{"final_response":"resolved=True","iterations":16,"metadata":{"agent":"yolop","category":"software-engineering","difficulty":"easy","exception":null,"model":"openai/gpt-5.6-terra","provider":"openai","reasoning_effort":null,"resolved":true,"reward":1.0,"stop_reason":"completed","tools_used":{"bash":10,"write_session_title":1,"write_todos":4},"yolop_version":"0.13.0"},"metrics":{"cache_read_tokens":233438.0,"llm_calls":16.0,"reward":1.0,"tool_calls":15.0},"timing":{"duration_ms":100734},"tool_calls":["write_session_title","write_todos","write_todos","write_todos","write_todos","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash"],"tool_calls_count":15,"usage":{"cache_read_tokens":233438,"cost_usd":0.15550950000000002,"input_tokens":21262,"output_tokens":2933}}},{"aggregate":1.0,"eval":"terminal_bench","passed":true,"sample":"modernize-scientific-stack","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":true,"reason":"tests passed","scorer":"resolved","value":1.0}],"skipped":false,"target":"openai-gpt-5.6-terra","transcript":{"final_response":"resolved=True","iterations":10,"metadata":{"agent":"yolop","category":"scientific-computing","difficulty":"medium","exception":null,"model":"openai/gpt-5.6-terra","provider":"openai","reasoning_effort":null,"resolved":true,"reward":1.0,"stop_reason":"completed","tools_used":{"bash":4,"write_session_title":1,"write_todos":4},"yolop_version":"0.13.0"},"metrics":{"cache_read_tokens":102205.0,"llm_calls":10.0,"reward":1.0,"tool_calls":9.0},"timing":{"duration_ms":78228},"tool_calls":["write_session_title","write_todos","write_todos","write_todos","write_todos","bash","bash","bash","bash"],"tool_calls_count":9,"usage":{"cache_read_tokens":102205,"cost_usd":0.09134625,"input_tokens":14708,"output_tokens":1935}}},{"aggregate":1.0,"eval":"terminal_bench","passed":true,"sample":"overfull-hbox","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":true,"reason":"tests passed","scorer":"resolved","value":1.0}],"skipped":false,"target":"openai-gpt-5.6-terra","transcript":{"final_response":"resolved=True","iterations":15,"metadata":{"agent":"yolop","category":"debugging","difficulty":"easy","exception":null,"model":"openai/gpt-5.6-terra","provider":"openai","reasoning_effort":null,"resolved":true,"reward":1.0,"stop_reason":"completed","tools_used":{"bash":10,"write_session_title":1,"write_todos":3},"yolop_version":"0.13.0"},"metrics":{"cache_read_tokens":236116.0,"llm_calls":15.0,"reward":1.0,"tool_calls":14.0},"timing":{"duration_ms":318508},"tool_calls":["write_session_title","write_todos","write_todos","write_todos","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash"],"tool_calls_count":14,"usage":{"cache_read_tokens":236116,"cost_usd":0.19753900000000005,"input_tokens":27384,"output_tokens":4670}}}],"groups":{"difficulty":{"easy":{"passed":3,"scored":3},"hard":{"passed":1,"scored":2},"medium":{"passed":2,"scored":3}}},"summary":{"failed":2,"na":0,"passed":6,"scored":8,"skipped":0,"total_cost_usd":1.3435810000000001,"total_duration_ms":1317024,"total_tokens":223777,"total_tool_calls":107}}
+</script>
+</main>
+</body>
+</html>

--- a/evals/terminal_bench/results/20260731T014824Z-3c1e/report.json
+++ b/evals/terminal_bench/results/20260731T014824Z-3c1e/report.json
@@ -1,0 +1,634 @@
+{
+  "cases": [
+    {
+      "aggregate": 0.5,
+      "eval": "terminal_bench",
+      "passed": false,
+      "sample": "chess-best-move",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": false,
+          "reason": "tests failed",
+          "scorer": "resolved",
+          "value": 0.0
+        }
+      ],
+      "skipped": false,
+      "target": "openai-gpt-5.6-terra",
+      "transcript": {
+        "final_response": "resolved=False",
+        "iterations": 18,
+        "metadata": {
+          "agent": "yolop",
+          "category": "games",
+          "difficulty": "medium",
+          "exception": null,
+          "model": "openai/gpt-5.6-terra",
+          "provider": "openai",
+          "reasoning_effort": null,
+          "resolved": false,
+          "reward": 0.0,
+          "stop_reason": "completed",
+          "tools_used": {
+            "bash": 15,
+            "read_file": 1,
+            "write_session_title": 1
+          },
+          "yolop_version": "0.13.0"
+        },
+        "metrics": {
+          "cache_read_tokens": 346719.0,
+          "llm_calls": 18.0,
+          "reward": 0.0,
+          "tool_calls": 17.0
+        },
+        "timing": {
+          "duration_ms": 343633
+        },
+        "tool_calls": [
+          "write_session_title",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "read_file"
+        ],
+        "tool_calls_count": 17,
+        "usage": {
+          "cache_read_tokens": 346719,
+          "cost_usd": 0.26685725,
+          "input_tokens": 31607,
+          "output_tokens": 6744
+        }
+      }
+    },
+    {
+      "aggregate": 1.0,
+      "eval": "terminal_bench",
+      "passed": true,
+      "sample": "cobol-modernization",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": true,
+          "reason": "tests passed",
+          "scorer": "resolved",
+          "value": 1.0
+        }
+      ],
+      "skipped": false,
+      "target": "openai-gpt-5.6-terra",
+      "transcript": {
+        "final_response": "resolved=True",
+        "iterations": 13,
+        "metadata": {
+          "agent": "yolop",
+          "category": "software-engineering",
+          "difficulty": "easy",
+          "exception": null,
+          "model": "openai/gpt-5.6-terra",
+          "provider": "openai",
+          "reasoning_effort": null,
+          "resolved": true,
+          "reward": 1.0,
+          "stop_reason": "completed",
+          "tools_used": {
+            "bash": 7,
+            "write_session_title": 1,
+            "write_todos": 4
+          },
+          "yolop_version": "0.13.0"
+        },
+        "metrics": {
+          "cache_read_tokens": 191687.0,
+          "llm_calls": 13.0,
+          "reward": 1.0,
+          "tool_calls": 12.0
+        },
+        "timing": {
+          "duration_ms": 108119
+        },
+        "tool_calls": [
+          "write_session_title",
+          "write_todos",
+          "write_todos",
+          "write_todos",
+          "write_todos",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash"
+        ],
+        "tool_calls_count": 12,
+        "usage": {
+          "cache_read_tokens": 191687,
+          "cost_usd": 0.19240925000000003,
+          "input_tokens": 24843,
+          "output_tokens": 5492
+        }
+      }
+    },
+    {
+      "aggregate": 0.5,
+      "eval": "terminal_bench",
+      "passed": false,
+      "sample": "configure-git-webserver",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": false,
+          "reason": "tests failed",
+          "scorer": "resolved",
+          "value": 0.0
+        }
+      ],
+      "skipped": false,
+      "target": "openai-gpt-5.6-terra",
+      "transcript": {
+        "final_response": "resolved=False",
+        "iterations": 11,
+        "metadata": {
+          "agent": "yolop",
+          "category": "system-administration",
+          "difficulty": "hard",
+          "exception": null,
+          "model": "openai/gpt-5.6-terra",
+          "provider": "openai",
+          "reasoning_effort": null,
+          "resolved": false,
+          "reward": 0.0,
+          "stop_reason": "completed",
+          "tools_used": {
+            "bash": 6,
+            "write_session_title": 1,
+            "write_todos": 3
+          },
+          "yolop_version": "0.13.0"
+        },
+        "metrics": {
+          "cache_read_tokens": 143290.0,
+          "llm_calls": 11.0,
+          "reward": 0.0,
+          "tool_calls": 10.0
+        },
+        "timing": {
+          "duration_ms": 116657
+        },
+        "tool_calls": [
+          "write_session_title",
+          "write_todos",
+          "write_todos",
+          "write_todos",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash"
+        ],
+        "tool_calls_count": 10,
+        "usage": {
+          "cache_read_tokens": 143290,
+          "cost_usd": 0.14853750000000002,
+          "input_tokens": 22814,
+          "output_tokens": 3712
+        }
+      }
+    },
+    {
+      "aggregate": 1.0,
+      "eval": "terminal_bench",
+      "passed": true,
+      "sample": "count-dataset-tokens",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": true,
+          "reason": "tests passed",
+          "scorer": "resolved",
+          "value": 1.0
+        }
+      ],
+      "skipped": false,
+      "target": "openai-gpt-5.6-terra",
+      "transcript": {
+        "final_response": "resolved=True",
+        "iterations": 11,
+        "metadata": {
+          "agent": "yolop",
+          "category": "model-training",
+          "difficulty": "medium",
+          "exception": null,
+          "model": "openai/gpt-5.6-terra",
+          "provider": "openai",
+          "reasoning_effort": null,
+          "resolved": true,
+          "reward": 1.0,
+          "stop_reason": "completed",
+          "tools_used": {
+            "bash": 6,
+            "write_session_title": 1,
+            "write_todos": 3
+          },
+          "yolop_version": "0.13.0"
+        },
+        "metrics": {
+          "cache_read_tokens": 127710.0,
+          "llm_calls": 11.0,
+          "reward": 1.0,
+          "tool_calls": 10.0
+        },
+        "timing": {
+          "duration_ms": 164998
+        },
+        "tool_calls": [
+          "write_session_title",
+          "write_todos",
+          "write_todos",
+          "write_todos",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash"
+        ],
+        "tool_calls_count": 10,
+        "usage": {
+          "cache_read_tokens": 127710,
+          "cost_usd": 0.113725,
+          "input_tokens": 18271,
+          "output_tokens": 2408
+        }
+      }
+    },
+    {
+      "aggregate": 1.0,
+      "eval": "terminal_bench",
+      "passed": true,
+      "sample": "fix-code-vulnerability",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": true,
+          "reason": "tests passed",
+          "scorer": "resolved",
+          "value": 1.0
+        }
+      ],
+      "skipped": false,
+      "target": "openai-gpt-5.6-terra",
+      "transcript": {
+        "final_response": "resolved=True",
+        "iterations": 13,
+        "metadata": {
+          "agent": "yolop",
+          "category": "security",
+          "difficulty": "hard",
+          "exception": null,
+          "model": "openai/gpt-5.6-terra",
+          "provider": "openai",
+          "reasoning_effort": null,
+          "resolved": true,
+          "reward": 1.0,
+          "stop_reason": "completed",
+          "tools_used": {
+            "bash": 15,
+            "write_session_title": 1,
+            "write_todos": 4
+          },
+          "yolop_version": "0.13.0"
+        },
+        "metrics": {
+          "cache_read_tokens": 236989.0,
+          "llm_calls": 13.0,
+          "reward": 1.0,
+          "tool_calls": 20.0
+        },
+        "timing": {
+          "duration_ms": 86147
+        },
+        "tool_calls": [
+          "write_session_title",
+          "write_todos",
+          "write_todos",
+          "write_todos",
+          "write_todos",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash"
+        ],
+        "tool_calls_count": 20,
+        "usage": {
+          "cache_read_tokens": 236989,
+          "cost_usd": 0.17765724999999996,
+          "input_tokens": 32520,
+          "output_tokens": 2474
+        }
+      }
+    },
+    {
+      "aggregate": 1.0,
+      "eval": "terminal_bench",
+      "passed": true,
+      "sample": "fix-git",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": true,
+          "reason": "tests passed",
+          "scorer": "resolved",
+          "value": 1.0
+        }
+      ],
+      "skipped": false,
+      "target": "openai-gpt-5.6-terra",
+      "transcript": {
+        "final_response": "resolved=True",
+        "iterations": 16,
+        "metadata": {
+          "agent": "yolop",
+          "category": "software-engineering",
+          "difficulty": "easy",
+          "exception": null,
+          "model": "openai/gpt-5.6-terra",
+          "provider": "openai",
+          "reasoning_effort": null,
+          "resolved": true,
+          "reward": 1.0,
+          "stop_reason": "completed",
+          "tools_used": {
+            "bash": 10,
+            "write_session_title": 1,
+            "write_todos": 4
+          },
+          "yolop_version": "0.13.0"
+        },
+        "metrics": {
+          "cache_read_tokens": 233438.0,
+          "llm_calls": 16.0,
+          "reward": 1.0,
+          "tool_calls": 15.0
+        },
+        "timing": {
+          "duration_ms": 100734
+        },
+        "tool_calls": [
+          "write_session_title",
+          "write_todos",
+          "write_todos",
+          "write_todos",
+          "write_todos",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash"
+        ],
+        "tool_calls_count": 15,
+        "usage": {
+          "cache_read_tokens": 233438,
+          "cost_usd": 0.15550950000000002,
+          "input_tokens": 21262,
+          "output_tokens": 2933
+        }
+      }
+    },
+    {
+      "aggregate": 1.0,
+      "eval": "terminal_bench",
+      "passed": true,
+      "sample": "modernize-scientific-stack",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": true,
+          "reason": "tests passed",
+          "scorer": "resolved",
+          "value": 1.0
+        }
+      ],
+      "skipped": false,
+      "target": "openai-gpt-5.6-terra",
+      "transcript": {
+        "final_response": "resolved=True",
+        "iterations": 10,
+        "metadata": {
+          "agent": "yolop",
+          "category": "scientific-computing",
+          "difficulty": "medium",
+          "exception": null,
+          "model": "openai/gpt-5.6-terra",
+          "provider": "openai",
+          "reasoning_effort": null,
+          "resolved": true,
+          "reward": 1.0,
+          "stop_reason": "completed",
+          "tools_used": {
+            "bash": 4,
+            "write_session_title": 1,
+            "write_todos": 4
+          },
+          "yolop_version": "0.13.0"
+        },
+        "metrics": {
+          "cache_read_tokens": 102205.0,
+          "llm_calls": 10.0,
+          "reward": 1.0,
+          "tool_calls": 9.0
+        },
+        "timing": {
+          "duration_ms": 78228
+        },
+        "tool_calls": [
+          "write_session_title",
+          "write_todos",
+          "write_todos",
+          "write_todos",
+          "write_todos",
+          "bash",
+          "bash",
+          "bash",
+          "bash"
+        ],
+        "tool_calls_count": 9,
+        "usage": {
+          "cache_read_tokens": 102205,
+          "cost_usd": 0.09134625,
+          "input_tokens": 14708,
+          "output_tokens": 1935
+        }
+      }
+    },
+    {
+      "aggregate": 1.0,
+      "eval": "terminal_bench",
+      "passed": true,
+      "sample": "overfull-hbox",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": true,
+          "reason": "tests passed",
+          "scorer": "resolved",
+          "value": 1.0
+        }
+      ],
+      "skipped": false,
+      "target": "openai-gpt-5.6-terra",
+      "transcript": {
+        "final_response": "resolved=True",
+        "iterations": 15,
+        "metadata": {
+          "agent": "yolop",
+          "category": "debugging",
+          "difficulty": "easy",
+          "exception": null,
+          "model": "openai/gpt-5.6-terra",
+          "provider": "openai",
+          "reasoning_effort": null,
+          "resolved": true,
+          "reward": 1.0,
+          "stop_reason": "completed",
+          "tools_used": {
+            "bash": 10,
+            "write_session_title": 1,
+            "write_todos": 3
+          },
+          "yolop_version": "0.13.0"
+        },
+        "metrics": {
+          "cache_read_tokens": 236116.0,
+          "llm_calls": 15.0,
+          "reward": 1.0,
+          "tool_calls": 14.0
+        },
+        "timing": {
+          "duration_ms": 318508
+        },
+        "tool_calls": [
+          "write_session_title",
+          "write_todos",
+          "write_todos",
+          "write_todos",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash"
+        ],
+        "tool_calls_count": 14,
+        "usage": {
+          "cache_read_tokens": 236116,
+          "cost_usd": 0.19753900000000005,
+          "input_tokens": 27384,
+          "output_tokens": 4670
+        }
+      }
+    }
+  ],
+  "groups": {
+    "difficulty": {
+      "easy": {
+        "passed": 3,
+        "scored": 3
+      },
+      "hard": {
+        "passed": 1,
+        "scored": 2
+      },
+      "medium": {
+        "passed": 2,
+        "scored": 3
+      }
+    }
+  },
+  "summary": {
+    "failed": 2,
+    "na": 0,
+    "passed": 6,
+    "scored": 8,
+    "skipped": 0,
+    "total_cost_usd": 1.3435810000000001,
+    "total_duration_ms": 1317024,
+    "total_tokens": 223777,
+    "total_tool_calls": 107
+  }
+}

--- a/evals/terminal_bench/suites/control-v1.json
+++ b/evals/terminal_bench/suites/control-v1.json
@@ -1,0 +1,59 @@
+{
+  "name": "control-v1",
+  "description": "Periodic regression set: 3 easy / 3 medium / 2 hard Terminal-Bench 2.1 tasks, chosen deterministically by suites/select_control.py. Cheapest eligible task per tier, one per category, no GPU and <= 4 GiB.",
+  "quotas": {
+    "easy": 3,
+    "medium": 3,
+    "hard": 2
+  },
+  "tasks": [
+    {
+      "name": "overfull-hbox",
+      "difficulty": "easy",
+      "category": "debugging",
+      "agent_timeout_sec": 750.0
+    },
+    {
+      "name": "cobol-modernization",
+      "difficulty": "easy",
+      "category": "software-engineering",
+      "agent_timeout_sec": 900.0
+    },
+    {
+      "name": "fix-git",
+      "difficulty": "easy",
+      "category": "software-engineering",
+      "agent_timeout_sec": 900.0
+    },
+    {
+      "name": "modernize-scientific-stack",
+      "difficulty": "medium",
+      "category": "scientific-computing",
+      "agent_timeout_sec": 600.0
+    },
+    {
+      "name": "chess-best-move",
+      "difficulty": "medium",
+      "category": "games",
+      "agent_timeout_sec": 900.0
+    },
+    {
+      "name": "count-dataset-tokens",
+      "difficulty": "medium",
+      "category": "model-training",
+      "agent_timeout_sec": 900.0
+    },
+    {
+      "name": "configure-git-webserver",
+      "difficulty": "hard",
+      "category": "system-administration",
+      "agent_timeout_sec": 900.0
+    },
+    {
+      "name": "fix-code-vulnerability",
+      "difficulty": "hard",
+      "category": "security",
+      "agent_timeout_sec": 900.0
+    }
+  ]
+}

--- a/evals/terminal_bench/suites/select_control.py
+++ b/evals/terminal_bench/suites/select_control.py
@@ -1,0 +1,183 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
+"""Select (and verify) the `control-v1` suite — the periodic regression set.
+
+Terminal-Bench is 89 tasks and hours of wall clock; the control suite is the
+small, fixed subset run on a cadence to notice yolop moving. It is chosen by a
+deterministic rule, not by hand, so it can be re-derived and audited:
+
+1. **Eligible** tasks need no GPU and at most 4 GiB of memory, so the suite runs
+   concurrently on an ordinary box rather than serializing on the 8 GiB tasks.
+2. Within each difficulty tier, tasks are ordered by `(agent timeout, name)` —
+   cheapest first. A control suite is run often, so its cost is the constraint.
+3. Walking that order, a task is taken only if its **category is not already in
+   the suite**, until the tier's quota is met. Eight tasks cannot be
+   representative of 89; spreading them over distinct categories at least keeps
+   the suite from being a referendum on one kind of work.
+4. If diversity cannot fill a quota (there are only four `easy` tasks, three of
+   them `software-engineering`), the remainder is filled from the same order
+   with the category rule dropped.
+
+Tiers are ordered easy -> medium -> hard, and the "already in the suite" set is
+shared across tiers, so the harder tiers pick up categories the easy ones missed.
+
+    uv run suites/select_control.py            # rewrite control-v1.json
+    uv run suites/select_control.py --check    # verify the committed file
+
+Re-running on the same dataset reproduces the committed set exactly. Bump to
+`control-v2` rather than editing v1, so historical numbers stay comparable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+STUDY_DIR = HERE.parent
+SUITE_NAME = "control-v1"
+SUITE_PATH = HERE / f"{SUITE_NAME}.json"
+
+QUOTAS = {"easy": 3, "medium": 3, "hard": 2}
+MAX_MEMORY_MB = 4096
+
+
+@dataclass(frozen=True)
+class Candidate:
+    name: str
+    difficulty: str
+    category: str
+    timeout_sec: float
+    memory_mb: int
+    gpus: int
+
+    @property
+    def eligible(self) -> bool:
+        return self.gpus == 0 and self.memory_mb <= MAX_MEMORY_MB
+
+    @property
+    def order(self) -> tuple[float, str]:
+        return (self.timeout_sec, self.name)
+
+
+def load_candidates(dataset_dir: Path) -> list[Candidate]:
+    candidates: list[Candidate] = []
+    for path in sorted(dataset_dir.iterdir()):
+        config_path = path / "task.toml"
+        if not config_path.is_file():
+            continue
+        config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+        metadata = config.get("metadata") or {}
+        environment = config.get("environment") or {}
+        candidates.append(Candidate(
+            name=path.name,
+            difficulty=str(metadata.get("difficulty") or ""),
+            category=str(metadata.get("category") or ""),
+            timeout_sec=float((config.get("agent") or {}).get("timeout_sec") or 0.0),
+            memory_mb=int(environment.get("memory_mb") or 0),
+            gpus=int(environment.get("gpus") or 0),
+        ))
+    return candidates
+
+
+def select(candidates: list[Candidate]) -> list[Candidate]:
+    chosen: list[Candidate] = []
+    categories: set[str] = set()
+    for difficulty, quota in QUOTAS.items():
+        tier = sorted(
+            (c for c in candidates if c.difficulty == difficulty and c.eligible),
+            key=lambda c: c.order,
+        )
+        picked = [c for c in _take_distinct_categories(tier, quota, categories)]
+        if len(picked) < quota:  # only `easy` hits this: 4 tasks, 3 of one category
+            already = {c.name for c in picked}
+            picked += [c for c in tier if c.name not in already][: quota - len(picked)]
+        categories.update(c.category for c in picked)
+        chosen.extend(picked)
+    return chosen
+
+
+def _take_distinct_categories(tier: list[Candidate], quota: int,
+                              used: set[str]) -> list[Candidate]:
+    picked: list[Candidate] = []
+    seen = set(used)
+    for candidate in tier:
+        if len(picked) == quota:
+            break
+        if candidate.category in seen:
+            continue
+        picked.append(candidate)
+        seen.add(candidate.category)
+    return picked
+
+
+def build_suite(chosen: list[Candidate]) -> dict:
+    return {
+        "name": SUITE_NAME,
+        "description": (
+            "Periodic regression set: 3 easy / 3 medium / 2 hard Terminal-Bench 2.1 "
+            "tasks, chosen deterministically by suites/select_control.py. Cheapest "
+            "eligible task per tier, one per category, no GPU and <= 4 GiB."
+        ),
+        "quotas": QUOTAS,
+        "tasks": [
+            {
+                "name": c.name,
+                "difficulty": c.difficulty,
+                "category": c.category,
+                "agent_timeout_sec": c.timeout_sec,
+            }
+            for c in chosen
+        ],
+    }
+
+
+def dataset_dir() -> Path:
+    # Same resolution the study uses, so the selector sees the same tasks.
+    import os
+
+    override = os.environ.get("TB_DATASET_DIR")
+    if override:
+        return Path(override).expanduser().resolve()
+    return STUDY_DIR / ".cache" / "dataset" / "terminal-bench-2-1"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true",
+                        help="verify the committed suite instead of rewriting it")
+    args = parser.parse_args()
+
+    root = dataset_dir()
+    if not root.is_dir():
+        print(f"dataset not found at {root}; run bootstrap.sh first", file=sys.stderr)
+        return 2
+
+    suite = build_suite(select(load_candidates(root)))
+    rendered = json.dumps(suite, indent=2) + "\n"
+
+    if args.check:
+        if not SUITE_PATH.exists():
+            print(f"{SUITE_PATH} is missing", file=sys.stderr)
+            return 1
+        if SUITE_PATH.read_text(encoding="utf-8") != rendered:
+            print(f"{SUITE_PATH} is stale; re-run without --check", file=sys.stderr)
+            return 1
+        print(f"{SUITE_PATH.name} reproduces exactly ({len(suite['tasks'])} tasks)")
+        return 0
+
+    SUITE_PATH.write_text(rendered, encoding="utf-8")
+    print(f"wrote {SUITE_PATH} ({len(suite['tasks'])} tasks)")
+    for task in suite["tasks"]:
+        print(f"  {task['difficulty']:<7} {task['category']:<22} {task['name']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/terminal_bench/terminal_bench.py
+++ b/evals/terminal_bench/terminal_bench.py
@@ -29,8 +29,7 @@ too, so yolop can be compared against them on identical tasks and scorer.
     ./bootstrap.sh                                    # yolop musl build + mira + dataset
     mira list                                         # eval, samples, targets
     mira run --samples fix-git --targets llmsim       # offline plumbing check
-    doppler run -- mira run --samples fix-git,cobol-modernization \\
-        --targets openai-gpt-5.6-terra
+    TB_MAX_COST_USD=10 doppler run -- mira run --preset control   # the periodic run
 
 Study-internal knobs come from the environment (the Mira host cannot pass study
 CLI flags): `TB_YOLOP_BIN` (yolop binary to upload; default the musl build),
@@ -48,6 +47,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -229,6 +229,34 @@ def load_task(path: Path) -> Task:
         tags=[str(t) for t in (metadata.get("tags") or [])],
         agent_timeout_sec=float((config.get("agent") or {}).get("timeout_sec") or 0.0),
     )
+
+
+# ---- Suites — curated task subsets under suites/*.json, surfaced as sample tags
+# so a set can be selected with `mira run --tag <suite>`. ---------------------- #
+SUITES_DIR = HERE / "suites"
+_SAFE_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def load_suite(name: str) -> dict:
+    if not name or name in (".", "..") or not _SAFE_NAME.match(name):
+        raise SystemExit(f"invalid suite name {name!r}")
+    path = SUITES_DIR / f"{name}.json"
+    if not path.exists():
+        raise SystemExit(f"unknown suite {name!r}; available: {available_suites()}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def available_suites() -> list[str]:
+    return sorted(p.stem for p in SUITES_DIR.glob("*.json")) if SUITES_DIR.exists() else []
+
+
+def suite_membership() -> dict[str, list[str]]:
+    """task name -> the suites it belongs to."""
+    membership: dict[str, list[str]] = {}
+    for name in available_suites():
+        for task in load_suite(name).get("tasks", []):
+            membership.setdefault(task["name"], []).append(name)
+    return membership
 
 
 def load_tasks() -> list[Task]:
@@ -535,14 +563,17 @@ class Study:
         return build_transcript(task, case_spec, outcome, error_kind)
 
     def _build_samples(self) -> list[mira.Sample]:
+        membership = suite_membership()
         samples: list[mira.Sample] = []
         for task in self.tasks().values():
             tags = [t for t in (task.difficulty, task.category) if t]
             tags += [_sanitize(t) for t in task.tags]
+            tags += membership.get(task.name, [])
             samples.append(mira.Sample(
                 task.name, tags=tags,
                 metadata={"difficulty": task.difficulty, "category": task.category,
-                          "agent_timeout_sec": task.agent_timeout_sec},
+                          "agent_timeout_sec": task.agent_timeout_sec,
+                          "suites": membership.get(task.name, [])},
             ))
         return samples
 

--- a/evals/terminal_bench/terminal_bench.py
+++ b/evals/terminal_bench/terminal_bench.py
@@ -1,0 +1,614 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["mira-eval>=0.3.0", "harbor>=0.20.0"]
+# ///
+"""terminal_bench — a single-file Mira eval study for Terminal-Bench 2.1.
+
+[Terminal-Bench](https://www.tbench.ai) measures an agent's ability to finish
+real work in a terminal: 89 containerized tasks (compile a toolchain, recover a
+corrupted database, break a cipher) each scored by the task's own test suite.
+2.1 is a revision of 2.0 that fixes 28 tasks — same 89-task set, so 2.0 numbers
+are *not* comparable.
+
+Two harnesses stack here, each owning what it is good at:
+
+* **Mira** (`mira` host CLI) owns the target matrix, sample/target selection,
+  saved run folders, and reporting — the same role it plays for
+  `evals/swebench_verified`.
+* **Harbor** (`harbor` CLI, Terminal-Bench's own execution framework) owns one
+  case: building the task container, running the agent in it, and running the
+  task's verifier. This study shells out to `harbor run` per case and reads the
+  reward back out of the trial's `result.json`.
+
+yolop plugs into Harbor through `harbor_yolop.py` (an adapter alongside this
+file), which uploads a host-built yolop binary into the task container. Harbor's
+own agents (`terminus-2`, `claude-code`, `codex`, …) are available as targets
+too, so yolop can be compared against them on identical tasks and scorer.
+
+    cd evals/terminal_bench
+    ./bootstrap.sh                                    # yolop musl build + mira + dataset
+    mira list                                         # eval, samples, targets
+    mira run --samples fix-git --targets llmsim       # offline plumbing check
+    doppler run -- mira run --samples fix-git,cobol-modernization \\
+        --targets openai-gpt-5.6-terra
+
+Study-internal knobs come from the environment (the Mira host cannot pass study
+CLI flags): `TB_YOLOP_BIN` (yolop binary to upload; default the musl build),
+`TB_MAX_COST_USD` (whole-run USD budget across every case), `TB_DATASET_DIR`
+(pre-downloaded task tree), `TB_AGENT_ENV` / `TB_VERIFIER_ENV` (comma-separated
+`KEY=VALUE` passed into the agent's resp. the verifier's environment),
+`TB_CA_CERT` (CA bundle to install in the container, for sandboxes behind a
+TLS-terminating proxy), `TB_JOB_TIMEOUT`,
+`TB_TIMEOUT_MULTIPLIER`, `TB_KEEP_JOBS=1` (keep Harbor job dirs for debugging).
+
+stdout carries ONLY protocol JSON (one object per line); logs go to stderr.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import tomllib
+import uuid
+from collections import abc
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import mira  # the mira-eval SDK: protocol types + the stdio serve loop
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import harbor_yolop  # noqa: E402  the Harbor agent adapter (sibling module)
+
+STUDY_VERSION = "0.1.0"
+
+# The Harbor Hub dataset id. `harbor dataset download` resolves it against the
+# hub registry; the tasks land under <output-dir>/<DATASET_NAME>/<task>/.
+DATASET = "terminal-bench/terminal-bench-2-1"
+DATASET_NAME = "terminal-bench-2-1"
+N_TASKS = 89
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]  # evals/terminal_bench -> repo root
+CACHE_DIR = HERE / ".cache"
+# Container mode is the only mode: Harbor always runs the agent inside the task
+# image, so the uploaded binary must match that ABI. A static musl build runs in
+# every task image; the host glibc build generally does not.
+YOLOP_BIN = os.environ.get("TB_YOLOP_BIN") or str(
+    REPO_ROOT / "target/x86_64-unknown-linux-musl/release/yolop"
+)
+
+
+def log(msg: str) -> None:
+    print(f"[terminal_bench] {msg}", file=sys.stderr, flush=True)
+
+
+def _int(name: str, default: int) -> int:
+    try:
+        return int(os.environ[name])
+    except (KeyError, ValueError):
+        return default
+
+
+def _float(name: str, default: float | None) -> float | None:
+    try:
+        return float(os.environ[name])
+    except (KeyError, ValueError):
+        return default
+
+
+# ============================================================================ #
+# The config matrix (one entry = one Mira target). `agent:` is what Harbor is
+# told to run: `yolop` maps to the adapter import path, anything else is passed
+# to `harbor run --agent` verbatim (so Harbor's built-in agents are targets too).
+# ============================================================================ #
+YOLOP_AGENT_IMPORT_PATH = "harbor_yolop:Yolop"
+
+DEFAULTS: dict[str, Any] = {"max_cost_usd": 5.0}
+
+MATRIX: dict[str, dict[str, Any]] = {
+    # yolop x OpenAI (default provider)
+    "openai-gpt-5.6-terra": {"agent": "yolop", "model": "openai/gpt-5.6-terra"},
+    "openai-gpt-5.6-terra-high": {
+        "agent": "yolop", "model": "openai/gpt-5.6-terra", "reasoning_effort": "high",
+    },
+    "openai-gpt-5.5": {"agent": "yolop", "model": "openai/gpt-5.5"},
+    # The same model through OpenRouter. Worth its own target beyond redundancy:
+    # OpenRouter returns an inline price, so `cost_usd` (and the cap that reads
+    # it) is the real charge rather than yolop's price-table estimate.
+    "openrouter-gpt-5.6-terra": {"agent": "yolop", "model": "openrouter/openai/gpt-5.6-terra"},
+    # yolop x Anthropic (secondary provider)
+    "anthropic-claude-opus-4.8": {"agent": "yolop", "model": "anthropic/claude-opus-4-8"},
+    "anthropic-claude-sonnet-4.5": {"agent": "yolop", "model": "anthropic/claude-sonnet-4-5"},
+    # Offline plumbing check: exercises upload/run/verify with no API key. It
+    # will not solve anything, so a 0.0 reward here is the expected result.
+    "llmsim": {"agent": "yolop", "model": "llmsim/llmsim-yolop"},
+    # Harbor's own agents, for cross-agent comparison on identical tasks.
+    "terminus-2": {"agent": "terminus-2", "model": "openai/gpt-5.6-terra"},
+    "claude-code-opus-4.8": {"agent": "claude-code", "model": "anthropic/claude-opus-4-8"},
+    "codex": {"agent": "codex", "model": "openai/gpt-5.6-terra"},
+}
+
+# provider (the part before `/` in a model id) -> env var that makes it runnable.
+_PROVIDER_KEYS = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "google": "GEMINI_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+    "llmsim": None,
+}
+
+
+def provider_of(spec: dict) -> str:
+    model = spec.get("model") or ""
+    return model.split("/", 1)[0] if "/" in model else ""
+
+
+def config_available(spec: dict) -> bool:
+    """Whether a matrix config can run given the current environment."""
+    provider = provider_of(spec)
+    if provider == "llmsim":
+        return True
+    key = _PROVIDER_KEYS.get(provider)
+    return bool(os.environ.get(key)) if key else False
+
+
+def _target_metadata(spec: dict) -> dict[str, Any]:
+    cfg = {**DEFAULTS, **spec}
+    md: dict[str, Any] = {"agent": cfg.get("agent", "yolop"), "provider": provider_of(cfg)}
+    for key in ("model", "reasoning_effort", "max_cost_usd"):
+        if cfg.get(key) is not None:
+            md[key] = cfg[key]
+    return md
+
+
+# ============================================================================ #
+# Dataset — the 89 task directories, downloaded once with the harbor CLI and
+# cached. Each task's `task.toml` carries the metadata Mira tags samples with.
+# ============================================================================ #
+@dataclass
+class Task:
+    name: str
+    path: Path
+    difficulty: str = ""
+    category: str = ""
+    tags: list[str] = field(default_factory=list)
+    agent_timeout_sec: float = 0.0
+
+
+def harbor_bin() -> str:
+    """The `harbor` console script. `uv run` installs it next to the interpreter
+    from this file's PEP 723 deps, so prefer that over whatever is on PATH."""
+    local = Path(sys.executable).parent / "harbor"
+    if local.exists():
+        return str(local)
+    found = shutil.which("harbor")
+    if not found:
+        raise RuntimeError("harbor CLI not found; install it with `pip install harbor`")
+    return found
+
+
+def dataset_dir() -> Path:
+    """The task tree, downloading it on first use. `TB_DATASET_DIR` points at an
+    existing download (a shared cache, or a pinned copy)."""
+    override = os.environ.get("TB_DATASET_DIR")
+    if override:
+        return Path(override).expanduser().resolve()
+    root = CACHE_DIR / "dataset"
+    tasks_dir = root / DATASET_NAME
+    # A marker, not "the directory exists": `harbor dataset download` writes
+    # tasks as it fetches them, so an interrupted download leaves a partial tree
+    # that would otherwise be reused as a silently shrunken benchmark.
+    marker = root / f".{DATASET_NAME}.complete"
+    if marker.is_file() and tasks_dir.is_dir():
+        return tasks_dir
+    root.mkdir(parents=True, exist_ok=True)
+    log(f"downloading {DATASET} -> {tasks_dir}")
+    proc = subprocess.run(
+        [harbor_bin(), "dataset", "download", DATASET, "-o", str(root), "--overwrite"],
+        stdout=sys.stderr, stderr=subprocess.STDOUT,
+    )
+    if proc.returncode != 0 or not tasks_dir.is_dir():
+        raise RuntimeError(f"`harbor dataset download {DATASET}` failed (exit {proc.returncode})")
+    marker.write_text(DATASET, encoding="utf-8")
+    return tasks_dir
+
+
+def load_task(path: Path) -> Task:
+    config = tomllib.loads((path / "task.toml").read_text(encoding="utf-8"))
+    metadata = config.get("metadata") or {}
+    return Task(
+        name=path.name,
+        path=path,
+        difficulty=str(metadata.get("difficulty") or ""),
+        category=str(metadata.get("category") or ""),
+        tags=[str(t) for t in (metadata.get("tags") or [])],
+        agent_timeout_sec=float((config.get("agent") or {}).get("timeout_sec") or 0.0),
+    )
+
+
+def load_tasks() -> list[Task]:
+    root = dataset_dir()
+    tasks = [
+        load_task(path)
+        for path in sorted(root.iterdir())
+        if (path / "task.toml").is_file()
+    ]
+    if len(tasks) != N_TASKS:
+        # Not fatal — a filtered or pinned copy is a legitimate TB_DATASET_DIR —
+        # but a silent partial download would quietly shrink the benchmark.
+        log(f"warning: expected {N_TASKS} tasks, found {len(tasks)} in {root}")
+    return tasks
+
+
+# ============================================================================ #
+# Running one case — `harbor run` for a single (task, config), then read the
+# reward and usage back out of the trial's result.json.
+# ============================================================================ #
+@dataclass
+class TrialOutcome:
+    reward: float = 0.0
+    resolved: bool = False
+    wall_time_s: float = 0.0
+    input_tokens: int = 0
+    cache_tokens: int = 0
+    output_tokens: int = 0
+    cost_usd: float = 0.0
+    stop_reason: str = "completed"
+    agent_metadata: dict[str, Any] = field(default_factory=dict)
+    exception: str | None = None
+    error: str | None = None
+
+
+def _sanitize(value: str) -> str:
+    return "".join(c if c.isalnum() or c in "-._" else "_" for c in value)
+
+
+def _env_pairs(name: str) -> list[str]:
+    """Parse a `KEY=VALUE,KEY=VALUE` env knob into Harbor's repeated-flag form.
+
+    The sandbox a study runs in, not the benchmark, decides these (a proxy host,
+    a base URL), so they stay configuration rather than matrix entries.
+    """
+    raw = os.environ.get(name, "")
+    return [pair.strip() for pair in raw.split(",") if "=" in pair]
+
+
+def _verifier_env_pairs() -> list[str]:
+    """`TB_VERIFIER_ENV`, plus the CA the agent adapter already installed.
+
+    The verifier phase is a separate process from the agent and gets none of the
+    agent's environment — but many tasks' `test.sh` fetches something over the
+    network, so behind a TLS-terminating proxy it needs the same trust setup or
+    every task fails to *score* rather than failing on merit.
+    """
+    pairs = _env_pairs("TB_VERIFIER_ENV")
+    if os.environ.get("TB_CA_CERT"):
+        declared = {pair.split("=", 1)[0] for pair in pairs}
+        pairs += [
+            f"{var}={harbor_yolop.CONTAINER_CA_PATH}"
+            for var in ("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE",
+                        "NODE_EXTRA_CA_CERTS")
+            if var not in declared
+        ]
+    return pairs
+
+
+def build_command(task: Task, spec: dict, job_dir: Path, *, jobs_dir: Path) -> list[str]:
+    cfg = {**DEFAULTS, **spec}
+    agent = cfg.get("agent", "yolop")
+    cmd = [
+        harbor_bin(), "run",
+        "-p", str(task.path),
+        "--jobs-dir", str(jobs_dir),
+        "--job-name", job_dir.name,
+        "--agent", YOLOP_AGENT_IMPORT_PATH if agent == "yolop" else agent,
+        # Mira owns concurrency across cases; one Harbor job is one case, so its
+        # own trial concurrency stays at 1.
+        "-n", "1",
+        "--quiet",
+        "--yes",
+    ]
+    if cfg.get("model"):
+        cmd += ["--model", cfg["model"]]
+    if agent == "yolop":
+        cmd += ["--ak", f"binary_path={YOLOP_BIN}"]
+        if cfg.get("max_cost_usd") is not None:
+            cmd += ["--ak", f"max_cost_usd={cfg['max_cost_usd']}"]
+        if cfg.get("reasoning_effort"):
+            cmd += ["--ak", f"reasoning_effort={cfg['reasoning_effort']}"]
+        if os.environ.get("TB_CA_CERT"):
+            cmd += ["--ak", f"ca_cert_path={os.environ['TB_CA_CERT']}"]
+    for pair in _env_pairs("TB_AGENT_ENV"):
+        cmd += ["--ae", pair]
+    for pair in _verifier_env_pairs():
+        cmd += ["--ve", pair]
+    multiplier = _float("TB_TIMEOUT_MULTIPLIER", None)
+    if multiplier is not None:
+        cmd += ["--timeout-multiplier", str(multiplier)]
+    return cmd + list(cfg.get("extra_args") or [])
+
+
+def find_trial_result(job_dir: Path) -> Path | None:
+    """The single trial's result.json. One task x one target is one trial, but
+    its directory name carries a random suffix, so it is globbed, not named."""
+    candidates = sorted(job_dir.glob("*/result.json"))
+    return candidates[0] if candidates else None
+
+
+def parse_trial(path: Path) -> TrialOutcome:
+    result = json.loads(path.read_text(encoding="utf-8"))
+    outcome = TrialOutcome()
+
+    rewards = ((result.get("verifier_result") or {}).get("rewards")) or {}
+    # Terminal-Bench scores each task 1.0 (all tests passed) or 0.0. Harbor's
+    # reward map is open-ended, so read the canonical key and keep the rest in
+    # metadata rather than assuming this is the only one.
+    outcome.reward = float(rewards.get("reward") or 0.0)
+    outcome.resolved = outcome.reward >= 1.0
+
+    agent_result = result.get("agent_result") or {}
+    outcome.input_tokens = int(agent_result.get("n_input_tokens") or 0)
+    outcome.cache_tokens = int(agent_result.get("n_cache_tokens") or 0)
+    outcome.output_tokens = int(agent_result.get("n_output_tokens") or 0)
+    outcome.cost_usd = float(agent_result.get("cost_usd") or 0.0)
+    outcome.agent_metadata = agent_result.get("metadata") or {}
+    outcome.stop_reason = str(outcome.agent_metadata.get("stop_reason") or "completed")
+
+    exception = result.get("exception_info")
+    if exception:
+        outcome.exception = exception.get("exception_type")
+        outcome.error = (
+            f"{exception.get('exception_type')}: {exception.get('exception_message')}"
+        )
+    return outcome
+
+
+def run_case(task: Task, target: str, spec: dict, *, job_timeout: int,
+             keep_jobs: bool) -> TrialOutcome:
+    """One `harbor run`: build the container, run the agent, run the verifier."""
+    jobs_dir = CACHE_DIR / "jobs"
+    job_dir = jobs_dir / f"{_sanitize(target)}-{_sanitize(task.name)}-{uuid.uuid4().hex[:6]}"
+    cmd = build_command(task, spec, job_dir, jobs_dir=jobs_dir)
+
+    env = dict(os.environ)
+    # The adapter is imported by path from this directory by the harbor subprocess.
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, [str(HERE), env.get("PYTHONPATH")]))
+
+    log(f"{target}/{task.name}: {' '.join(cmd)}")
+    start = time.monotonic()
+    # Harbor's progress output is verbose and must not reach this process's
+    # stdout — that is the Mira protocol channel.
+    proc = subprocess.run(cmd, env=env, stdout=sys.stderr, stderr=subprocess.STDOUT,
+                          timeout=job_timeout)
+    elapsed = round(time.monotonic() - start, 3)
+
+    result_path = find_trial_result(job_dir)
+    if result_path is None:
+        outcome = TrialOutcome(
+            wall_time_s=elapsed, stop_reason="error",
+            error=f"harbor produced no trial result (exit {proc.returncode}) in {job_dir}",
+        )
+    else:
+        outcome = parse_trial(result_path)
+        outcome.wall_time_s = elapsed
+    if not keep_jobs:
+        shutil.rmtree(job_dir, ignore_errors=True)
+    return outcome
+
+
+# ============================================================================ #
+# The study — the Terminal-Bench-specific work behind the mira-eval SDK. The SDK
+# owns the stdio protocol loop; this class holds the task cache and the run-wide
+# budget, and exposes a subject `(sample, cx) -> mira.Transcript`.
+# ============================================================================ #
+def _resolved_scorer() -> mira.Scorer:
+    """The benchmark gate: did the task's own test suite pass?"""
+
+    def fn(_sample, transcript) -> mira.Score:
+        resolved = bool(transcript.metadata.get("resolved"))
+        return mira.make_score(
+            "resolved", 1.0 if resolved else 0.0, resolved,
+            "tests passed" if resolved else "tests failed",
+        )
+
+    return mira.scorer("resolved", fn)
+
+
+def build_transcript(task: Task, spec: dict, outcome: TrialOutcome,
+                     error_kind: str | None) -> mira.Transcript:
+    tools_used = outcome.agent_metadata.get("tools_used") or {}
+    tools = [name for name, count in tools_used.items() for _ in range(count)]
+    metrics: dict[str, float] = {
+        "reward": outcome.reward,
+        "tool_calls": float(outcome.agent_metadata.get("tool_calls") or 0),
+        "llm_calls": float(outcome.agent_metadata.get("llm_calls") or 0),
+        "cache_read_tokens": float(outcome.cache_tokens),
+    }
+    return mira.Transcript(
+        final_response=f"resolved={outcome.resolved}",
+        iterations=int(outcome.agent_metadata.get("agent_steps") or 0),
+        tool_calls_count=int(outcome.agent_metadata.get("tool_calls") or 0),
+        tool_calls=tools,
+        usage=mira.Usage(
+            # Harbor's n_input_tokens includes cache reads; Mira's does not.
+            input_tokens=max(outcome.input_tokens - outcome.cache_tokens, 0),
+            output_tokens=outcome.output_tokens,
+            cache_read_tokens=outcome.cache_tokens,
+            cost_usd=outcome.cost_usd,
+        ),
+        timing=mira.Timing(duration_ms=int(outcome.wall_time_s * 1000)),
+        metrics=metrics,
+        metadata={
+            "agent": spec.get("agent", "yolop"),
+            "provider": provider_of(spec),
+            "model": spec.get("model") or "",
+            "reasoning_effort": spec.get("reasoning_effort"),
+            "stop_reason": outcome.stop_reason,
+            "resolved": outcome.resolved,
+            "reward": outcome.reward,
+            "difficulty": task.difficulty,
+            "category": task.category,
+            "exception": outcome.exception,
+            "tools_used": tools_used,
+            "yolop_version": outcome.agent_metadata.get("yolop_version"),
+        },
+        error=outcome.error,
+        # Harbor/Docker failures and budget stops are surfaced as N/A by the
+        # SDK's scorer short-circuit rather than counted as the model failing.
+        error_kind=error_kind,
+    )
+
+
+class Study:
+    """Terminal-Bench study state: the task cache plus the run-wide USD budget."""
+
+    def __init__(self, *, max_cost_usd: float | None = None, job_timeout: int = 5400,
+                 keep_jobs: bool = False):
+        self.max_cost_usd = max_cost_usd
+        self.job_timeout = job_timeout
+        self.keep_jobs = keep_jobs
+        self._tasks: dict[str, Task] | None = None
+        self._spent_usd = 0.0
+
+    def tasks(self) -> dict[str, Task]:
+        if self._tasks is None:
+            self._tasks = {task.name: task for task in load_tasks()}
+        return self._tasks
+
+    @property
+    def spent_usd(self) -> float:
+        return round(self._spent_usd, 6)
+
+    def _budget_left(self) -> float | None:
+        if self.max_cost_usd is None:
+            return None
+        return self.max_cost_usd - self._spent_usd
+
+    def _subject(self, sample: mira.Sample, cx: mira.RunCx) -> mira.Transcript:
+        spec = MATRIX.get(cx.target)
+        if spec is None:
+            raise ValueError(f"unknown target/config: {cx.target!r}")
+        task = self.tasks().get(sample.id)
+        if task is None:
+            raise ValueError(f"unknown sample/task: {sample.id!r}")
+
+        # The run-wide cap is checked before a case starts: once the budget is
+        # gone, no further case is worth starting, and reporting the remaining
+        # cases as infra-N/A keeps them out of the resolve rate.
+        left = self._budget_left()
+        if left is not None and left <= 0:
+            log(f"budget exhausted (${self.spent_usd:.2f}); skipping {cx.target}/{task.name}")
+            return build_transcript(
+                task, spec,
+                TrialOutcome(stop_reason="budget",
+                             error=f"run budget ${self.max_cost_usd:.2f} exhausted "
+                                   f"(${self.spent_usd:.2f} spent)"),
+                error_kind="infra",
+            )
+
+        # Per-case cap: never let one case spend more than the run has left.
+        case_spec = dict(spec)
+        cap = {**DEFAULTS, **spec}.get("max_cost_usd")
+        if left is not None:
+            case_spec["max_cost_usd"] = min(left, cap) if cap is not None else left
+
+        try:
+            outcome = run_case(task, cx.target, case_spec, job_timeout=self.job_timeout,
+                               keep_jobs=self.keep_jobs)
+        except subprocess.TimeoutExpired:
+            outcome = TrialOutcome(stop_reason="timeout",
+                                   error=f"harbor run exceeded {self.job_timeout}s")
+        except Exception as exc:  # report, don't crash the study loop
+            log(f"case failed for {cx.target}/{task.name}: {exc}")
+            outcome = TrialOutcome(stop_reason="error", error=f"runner: {exc}")
+
+        self._spent_usd += outcome.cost_usd
+        if self.max_cost_usd is not None:
+            log(f"spent ${self.spent_usd:.2f} of ${self.max_cost_usd:.2f}")
+
+        error_kind = "infra" if outcome.stop_reason in ("error", "timeout") else None
+        return build_transcript(task, case_spec, outcome, error_kind)
+
+    def _build_samples(self) -> list[mira.Sample]:
+        samples: list[mira.Sample] = []
+        for task in self.tasks().values():
+            tags = [t for t in (task.difficulty, task.category) if t]
+            tags += [_sanitize(t) for t in task.tags]
+            samples.append(mira.Sample(
+                task.name, tags=tags,
+                metadata={"difficulty": task.difficulty, "category": task.category,
+                          "agent_timeout_sec": task.agent_timeout_sec},
+            ))
+        return samples
+
+    def _targets(self) -> list[mira.Target]:
+        return [
+            mira.target(
+                name, provider=provider_of(spec) or spec.get("agent", "yolop"),
+                available=config_available(spec), metadata=_target_metadata(spec),
+            )
+            for name, spec in MATRIX.items()
+        ]
+
+    def protocol(self) -> mira.Study:
+        study = mira.Study("terminal_bench", version=STUDY_VERSION)
+        study.add(mira.Eval(
+            name="terminal_bench",
+            subject=self._subject,
+            samples=_LazySamples(self),
+            targets=self._targets(),
+            scorers=[mira.succeeded(), _resolved_scorer()],
+            description="Solve Terminal-Bench 2.1 tasks; scored by each task's own tests",
+            metadata={"benchmark": DATASET_NAME},
+        ))
+        return study
+
+
+class _LazySamples(abc.Sequence):
+    """The study's samples, materialized (downloading the dataset) on first
+    access. Keeps `initialize` cheap and offline."""
+
+    def __init__(self, study: Study):
+        self._study = study
+        self._cache: list[mira.Sample] | None = None
+
+    def _materialized(self) -> list[mira.Sample]:
+        if self._cache is None:
+            self._cache = self._study._build_samples()
+        return self._cache
+
+    def __getitem__(self, index):
+        return self._materialized()[index]
+
+    def __len__(self) -> int:
+        return len(self._materialized())
+
+
+def _build_study() -> Study:
+    return Study(
+        max_cost_usd=_float("TB_MAX_COST_USD", None),
+        job_timeout=_int("TB_JOB_TIMEOUT", 5400),
+        keep_jobs=os.environ.get("TB_KEEP_JOBS", "") in ("1", "true", "yes"),
+    )
+
+
+def serve(study: Study | None = None) -> None:
+    """Build the study and run the SDK's stdio protocol loop until stdin closes."""
+    study = study or _build_study()
+    budget = f"${study.max_cost_usd:.2f}" if study.max_cost_usd is not None else "unset"
+    log(f"ready: study=terminal_bench dataset={DATASET} budget={budget}")
+    study.protocol().serve()
+
+
+def main() -> int:
+    serve()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/terminal_bench/tests/test_harbor_yolop.py
+++ b/evals/terminal_bench/tests/test_harbor_yolop.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 import json
-import re
 import sys
 import tempfile
 import unittest
+import unittest.mock as mock
 from pathlib import Path
-from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 

--- a/evals/terminal_bench/tests/test_harbor_yolop.py
+++ b/evals/terminal_bench/tests/test_harbor_yolop.py
@@ -1,0 +1,238 @@
+"""Unit tests for the Harbor yolop adapter (no Docker, no network, no API key)."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import harbor_yolop as hy  # noqa: E402
+
+
+def make_agent(tmp: Path, **kwargs) -> hy.Yolop:
+    kwargs.setdefault("model_name", "openai/gpt-5.6-terra")
+    kwargs.setdefault("binary_path", str(tmp / "yolop"))
+    return hy.Yolop(logs_dir=tmp, **kwargs)
+
+
+class TestSessionId(unittest.TestCase):
+    def test_shape_matches_what_yolop_accepts(self):
+        # yolop rejects any other shape: `session_` + 32 hex chars.
+        self.assertRegex(hy.session_id(), r"^session_[0-9a-f]{32}$")
+
+
+class TestCommand(unittest.TestCase):
+    def test_provider_and_model_are_split_on_the_slash(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = make_agent(Path(tmp))
+            command = agent._command("fix the repo")
+        self.assertIn("--provider openai", command)
+        self.assertIn("--model gpt-5.6-terra", command)
+        self.assertIn(f"--trajectory-out {hy._TRAJECTORY_PATH}", command)
+        self.assertIn("-p 'fix the repo'", command)
+
+    def test_bare_model_leaves_the_provider_to_autodetection(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = make_agent(Path(tmp), model_name="gpt-5.6-terra")
+            command = agent._command("go")
+        self.assertNotIn("--provider", command)
+        self.assertIn("--model gpt-5.6-terra", command)
+
+    def test_instruction_is_shell_quoted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = make_agent(Path(tmp))
+            command = agent._command("rm -rf /; echo $(whoami)")
+        # The whole instruction must land inside one quoted argument.
+        self.assertNotIn("; echo $(whoami)'", command.split("-p ", 1)[1].split("' ")[0])
+        self.assertIn("'rm -rf /; echo $(whoami)'", command)
+
+    def test_reasoning_effort_flag(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = make_agent(Path(tmp), reasoning_effort="high")
+            self.assertIn("--reasoning-effort high", agent._command("go"))
+
+    def test_sandbox_is_off_unless_asked_for(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertNotIn("--sandbox", make_agent(Path(tmp))._command("go"))
+            self.assertIn("--sandbox", make_agent(Path(tmp), sandbox=True)._command("go"))
+
+    def test_string_kwargs_from_harbor_are_coerced(self):
+        # `--ak sandbox=false` arrives as the string "false", which is truthy.
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = make_agent(Path(tmp), sandbox="false", max_cost_usd="2.5")
+        self.assertNotIn("--sandbox", agent._command("go"))
+        self.assertEqual(agent._max_cost_usd, 2.5)
+
+
+class TestPromptTemplate(unittest.TestCase):
+    def test_autonomy_framing_is_applied_by_default(self):
+        # Terminal-Bench instructions read like a request to a colleague, but
+        # nothing in the container can answer a follow-up question.
+        with tempfile.TemporaryDirectory() as tmp:
+            rendered = make_agent(Path(tmp)).render_instruction("merge my changes")
+        self.assertIn("merge my changes", rendered)
+        self.assertIn("no user", rendered)
+        self.assertNotEqual(rendered, "merge my changes")
+
+    def test_an_explicit_template_wins(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            template = Path(tmp) / "t.md"
+            template.write_text("ONLY: {{ instruction }}", encoding="utf-8")
+            agent = make_agent(Path(tmp), prompt_template_path=str(template))
+            self.assertEqual(agent.render_instruction("go"), "ONLY: go")
+
+
+class TestKillCommand(unittest.TestCase):
+    def test_walks_proc_instead_of_needing_pkill(self):
+        # Terminal-Bench images are minimal and many carry no procps.
+        command = hy._kill_command("INT")
+        self.assertNotIn("pkill", command)
+        self.assertIn("/proc/[0-9]*", command)
+        self.assertIn("kill -INT", command)
+        self.assertIn(hy._BIN_PATH, command)
+
+
+class TestRunEnv(unittest.TestCase):
+    def test_only_the_selected_provider_key_is_forwarded(self):
+        with tempfile.TemporaryDirectory() as tmp, \
+                mock.patch.dict("os.environ",
+                                {"OPENAI_API_KEY": "sk-o", "ANTHROPIC_API_KEY": "sk-a"},
+                                clear=True):
+            env = make_agent(Path(tmp))._run_env()
+        self.assertEqual(env["OPENAI_API_KEY"], "sk-o")
+        self.assertNotIn("ANTHROPIC_API_KEY", env)
+        # worktrees=off lives in the uploaded settings under this config home.
+        self.assertEqual(env["XDG_CONFIG_HOME"], hy._CONFIG_HOME)
+
+    def test_ca_cert_sets_every_trust_var(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ca = Path(tmp) / "ca.crt"
+            ca.write_text("x", encoding="utf-8")
+            env = make_agent(Path(tmp), ca_cert_path=str(ca))._run_env()
+        for var in ("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE",
+                    "NODE_EXTRA_CA_CERTS"):
+            self.assertEqual(env[var], hy.CONTAINER_CA_PATH)
+
+
+class TestRunningCost(unittest.TestCase):
+    def _log(self, tmp: Path, events: list[dict]) -> Path:
+        path = tmp / "events.jsonl"
+        path.write_text("\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8")
+        return path
+
+    def _usage(self, **usage) -> dict:
+        return {"type": "output.message.completed", "data": {"usage": usage}}
+
+    def test_missing_log_reads_as_unknown_not_zero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(hy.running_cost(Path(tmp) / "nope.jsonl"))
+
+    def test_empty_log_reads_as_unknown(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "events.jsonl"
+            path.write_text("", encoding="utf-8")
+            self.assertIsNone(hy.running_cost(path))
+
+    def test_actual_cost_wins_over_the_estimate(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._log(Path(tmp), [
+                self._usage(actual_cost_usd=0.5, estimated_cost_usd=9.0),
+                self._usage(estimated_cost_usd=0.25),
+            ])
+            self.assertAlmostEqual(hy.running_cost(path), 0.75)
+
+    def test_half_written_trailing_line_is_skipped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._log(Path(tmp), [self._usage(actual_cost_usd=1.0)])
+            with path.open("a", encoding="utf-8") as fh:
+                fh.write('{"type": "output.message.comp')  # writer still going
+            self.assertAlmostEqual(hy.running_cost(path), 1.0)
+
+
+class TestPostRun(unittest.TestCase):
+    TRAJECTORY = {
+        "schema_version": "ATIF-v1.7",
+        "agent": {"name": "yolop", "version": "0.13.0"},
+        "steps": [
+            {"step_id": 1, "source": "user", "message": "go"},
+            {"step_id": 2, "source": "agent", "message": "looking",
+             "llm_call_count": 1,
+             "tool_calls": [
+                 {"tool_call_id": "c1", "function_name": "run_terminal_cmd",
+                  "arguments": {"command": "ls"}},
+                 {"tool_call_id": "c2", "function_name": "read_file",
+                  "arguments": {"path": "a.txt"}},
+             ]},
+            {"step_id": 3, "source": "agent", "message": "done", "llm_call_count": 1},
+        ],
+        "final_metrics": {"total_prompt_tokens": 1000, "total_cached_tokens": 400,
+                          "total_completion_tokens": 200, "total_cost_usd": 0.25},
+    }
+
+    def test_totals_and_loop_shape_land_on_the_context(self):
+        from harbor.models.agent.context import AgentContext
+
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "trajectory.json").write_text(json.dumps(self.TRAJECTORY),
+                                                       encoding="utf-8")
+            agent = make_agent(Path(tmp))
+            context = AgentContext()
+            agent.populate_context_post_run(context)
+
+        self.assertEqual(context.n_input_tokens, 1000)
+        self.assertEqual(context.n_cache_tokens, 400)
+        self.assertEqual(context.n_output_tokens, 200)
+        self.assertEqual(context.cost_usd, 0.25)
+        self.assertEqual(context.metadata["agent_steps"], 2)
+        self.assertEqual(context.metadata["tool_calls"], 2)
+        self.assertEqual(context.metadata["tools_used"],
+                         {"run_terminal_cmd": 1, "read_file": 1})
+        self.assertEqual(context.metadata["stop_reason"], "completed")
+
+    def test_missing_trajectory_still_records_the_stop_reason(self):
+        from harbor.models.agent.context import AgentContext
+
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = make_agent(Path(tmp))
+            agent._stop_reason = "budget"
+            context = AgentContext()
+            agent.populate_context_post_run(context)
+
+        self.assertIsNone(context.cost_usd)
+        self.assertEqual(context.metadata, {"stop_reason": "budget"})
+
+    def test_yolop_trajectory_validates_as_harbor_atif(self):
+        # The adapter declares SUPPORTS_ATIF and hands Harbor yolop's own
+        # `--trajectory-out` document unconverted; this is that contract.
+        from harbor.models.trajectories import Trajectory
+
+        Trajectory.model_validate(self.TRAJECTORY)
+
+
+class TestInstall(unittest.TestCase):
+    def test_missing_binary_fails_with_a_build_hint(self):
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = make_agent(Path(tmp), binary_path=str(Path(tmp) / "absent"))
+            with self.assertRaises(RuntimeError) as caught:
+                asyncio.run(agent.install(mock.AsyncMock()))
+        self.assertIn("musl", str(caught.exception))
+
+
+class TestVersion(unittest.TestCase):
+    def test_version_is_parsed_from_the_yolop_banner(self):
+        # The banner carries build detail after the version, not just the version.
+        banner = "yolop 0.13.0 (commit 03d034fd609f, everruns-runtime 0.17.17)\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(make_agent(Path(tmp)).parse_version(banner), "0.13.0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/evals/terminal_bench/tests/test_study.py
+++ b/evals/terminal_bench/tests/test_study.py
@@ -203,6 +203,35 @@ class TestBudget(unittest.TestCase):
         self.assertNotIn("max_cost_usd", captured["spec"])
 
 
+class TestSuites(unittest.TestCase):
+    def test_control_v1_matches_its_declared_quotas(self):
+        suite = tb.load_suite("control-v1")
+        counts: dict[str, int] = {}
+        for task in suite["tasks"]:
+            counts[task["difficulty"]] = counts.get(task["difficulty"], 0) + 1
+        self.assertEqual(counts, suite["quotas"])
+
+    def test_control_v1_spreads_across_categories(self):
+        # Eight tasks cannot be representative of 89; distinct categories at
+        # least keep the suite from being a referendum on one kind of work.
+        tasks = tb.load_suite("control-v1")["tasks"]
+        categories = {task["category"] for task in tasks}
+        self.assertGreaterEqual(len(categories), len(tasks) - 1)
+
+    def test_membership_becomes_a_sample_tag(self):
+        study = tb.Study()
+        study._tasks = {"fix-git": make_task(), "nowhere": make_task("nowhere")}
+        samples = {sample.id: sample for sample in study._build_samples()}
+        self.assertIn("control-v1", samples["fix-git"].tags)
+        self.assertNotIn("control-v1", samples["nowhere"].tags)
+        self.assertEqual(samples["nowhere"].metadata["suites"], [])
+
+    def test_suite_names_are_validated(self):
+        for bad in ("", "..", "../../etc/passwd", "a/b"):
+            with self.assertRaises(SystemExit):
+                tb.load_suite(bad)
+
+
 class TestLoadTask(unittest.TestCase):
     def test_task_toml_metadata_becomes_sample_tags(self):
         import tempfile

--- a/evals/terminal_bench/tests/test_study.py
+++ b/evals/terminal_bench/tests/test_study.py
@@ -1,0 +1,251 @@
+"""Unit tests for the terminal_bench study (no Docker, no network, no API key).
+
+Run them from the study directory:
+
+    uv run --with mira-eval --with harbor -m unittest discover -s tests
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import terminal_bench as tb  # noqa: E402
+
+
+def make_task(name: str = "fix-git", **kwargs) -> tb.Task:
+    return tb.Task(name=name, path=Path("/tasks") / name,
+                   difficulty=kwargs.pop("difficulty", "easy"),
+                   category=kwargs.pop("category", "software-engineering"), **kwargs)
+
+
+class TestMatrix(unittest.TestCase):
+    def test_every_config_declares_an_agent_and_model(self):
+        for name, spec in tb.MATRIX.items():
+            self.assertIn("agent", spec, name)
+            self.assertIn("model", spec, name)
+
+    def test_provider_is_the_model_prefix(self):
+        self.assertEqual(tb.provider_of({"model": "openai/gpt-5.6-terra"}), "openai")
+        self.assertEqual(tb.provider_of({"model": "gpt-5.6-terra"}), "")
+
+    def test_llmsim_is_available_without_any_key(self):
+        with mock.patch.dict("os.environ", {}, clear=True):
+            self.assertTrue(tb.config_available(tb.MATRIX["llmsim"]))
+            self.assertFalse(tb.config_available(tb.MATRIX["openai-gpt-5.6-terra"]))
+
+    def test_openai_config_available_with_key(self):
+        with mock.patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}, clear=True):
+            self.assertTrue(tb.config_available(tb.MATRIX["openai-gpt-5.6-terra"]))
+
+
+class TestBuildCommand(unittest.TestCase):
+    def _command(self, spec: dict, env: dict | None = None) -> list[str]:
+        with mock.patch.dict("os.environ", env or {}, clear=True), \
+                mock.patch.object(tb, "harbor_bin", return_value="/bin/harbor"):
+            return tb.build_command(make_task(), spec, Path("/jobs/job1"),
+                                    jobs_dir=Path("/jobs"))
+
+    def test_yolop_config_uses_the_adapter_import_path(self):
+        cmd = self._command(tb.MATRIX["openai-gpt-5.6-terra"])
+        self.assertIn(tb.YOLOP_AGENT_IMPORT_PATH, cmd)
+        self.assertEqual(cmd[cmd.index("--model") + 1], "openai/gpt-5.6-terra")
+        self.assertIn("binary_path=" + tb.YOLOP_BIN, cmd)
+        self.assertIn("max_cost_usd=5.0", cmd)
+
+    def test_reasoning_effort_rides_as_an_agent_kwarg(self):
+        cmd = self._command(tb.MATRIX["openai-gpt-5.6-terra-high"])
+        self.assertIn("reasoning_effort=high", cmd)
+
+    def test_harbor_native_agent_is_passed_through(self):
+        cmd = self._command(tb.MATRIX["terminus-2"])
+        self.assertEqual(cmd[cmd.index("--agent") + 1], "terminus-2")
+        # Adapter-only kwargs must not leak onto a Harbor-native agent.
+        self.assertNotIn("--ak", cmd)
+
+    def test_agent_env_pairs_are_forwarded(self):
+        cmd = self._command(tb.MATRIX["llmsim"],
+                            env={"TB_AGENT_ENV": "HTTPS_PROXY=http://p:1, BAD, X=1"})
+        self.assertIn("HTTPS_PROXY=http://p:1", cmd)
+        self.assertIn("X=1", cmd)
+        self.assertNotIn("BAD", cmd)
+
+    def test_ca_cert_also_reaches_the_verifier(self):
+        # The verifier is a separate process from the agent, and many tasks'
+        # test.sh fetches over the network — without trust it fails to *score*.
+        cmd = self._command(tb.MATRIX["llmsim"], env={"TB_CA_CERT": "/host/ca.crt"})
+        self.assertIn("--ve", cmd)
+        self.assertIn(f"CURL_CA_BUNDLE={tb.harbor_yolop.CONTAINER_CA_PATH}", cmd)
+
+    def test_explicit_verifier_env_is_not_overridden(self):
+        cmd = self._command(tb.MATRIX["llmsim"],
+                            env={"TB_CA_CERT": "/host/ca.crt",
+                                 "TB_VERIFIER_ENV": "SSL_CERT_FILE=/mine.crt"})
+        self.assertIn("SSL_CERT_FILE=/mine.crt", cmd)
+        self.assertNotIn(f"SSL_CERT_FILE={tb.harbor_yolop.CONTAINER_CA_PATH}", cmd)
+
+    def test_no_verifier_env_without_the_knobs(self):
+        self.assertNotIn("--ve", self._command(tb.MATRIX["llmsim"]))
+
+
+class TestParseTrial(unittest.TestCase):
+    def _write(self, tmp: Path, payload: dict) -> Path:
+        path = tmp / "result.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return path
+
+    def test_reward_one_resolves(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(Path(tmp), {
+                "verifier_result": {"rewards": {"reward": 1.0}},
+                "agent_result": {"n_input_tokens": 1000, "n_cache_tokens": 400,
+                                 "n_output_tokens": 200, "cost_usd": 0.25,
+                                 "metadata": {"stop_reason": "completed", "tool_calls": 7,
+                                              "tools_used": {"run_terminal_cmd": 7}}},
+            })
+            outcome = tb.parse_trial(path)
+        self.assertTrue(outcome.resolved)
+        self.assertEqual(outcome.reward, 1.0)
+        self.assertEqual(outcome.cache_tokens, 400)
+        self.assertEqual(outcome.cost_usd, 0.25)
+        self.assertEqual(outcome.stop_reason, "completed")
+
+    def test_exception_is_surfaced(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(Path(tmp), {
+                "verifier_result": {"rewards": {"reward": 0.0}},
+                "exception_info": {"exception_type": "ApiRateLimitError",
+                                   "exception_message": "429"},
+            })
+            outcome = tb.parse_trial(path)
+        self.assertFalse(outcome.resolved)
+        self.assertEqual(outcome.exception, "ApiRateLimitError")
+        self.assertIn("429", outcome.error or "")
+
+    def test_missing_verifier_result_is_not_resolved(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(Path(tmp), {"agent_result": {}})
+            outcome = tb.parse_trial(path)
+        self.assertFalse(outcome.resolved)
+        self.assertEqual(outcome.reward, 0.0)
+
+
+class TestTranscript(unittest.TestCase):
+    def test_input_tokens_exclude_cache(self):
+        outcome = tb.TrialOutcome(reward=1.0, resolved=True, input_tokens=1000,
+                                  cache_tokens=400, output_tokens=200, cost_usd=0.25)
+        transcript = tb.build_transcript(make_task(), tb.MATRIX["openai-gpt-5.6-terra"],
+                                         outcome, None)
+        # Harbor counts cache reads inside n_input_tokens; Mira keeps them apart.
+        self.assertEqual(transcript.usage.input_tokens, 600)
+        self.assertEqual(transcript.usage.cache_read_tokens, 400)
+        self.assertTrue(transcript.metadata["resolved"])
+
+    def test_infra_error_kind_rides_through(self):
+        outcome = tb.TrialOutcome(stop_reason="error", error="runner: boom")
+        transcript = tb.build_transcript(make_task(), tb.MATRIX["llmsim"], outcome, "infra")
+        self.assertEqual(transcript.error_kind, "infra")
+        self.assertFalse(transcript.metadata["resolved"])
+
+
+class TestBudget(unittest.TestCase):
+    def test_case_cap_is_clamped_to_what_the_run_has_left(self):
+        study = tb.Study(max_cost_usd=1.0)
+        study._tasks = {"fix-git": make_task()}
+        captured: dict = {}
+
+        def fake_run_case(task, target, spec, **kwargs):
+            captured["spec"] = spec
+            return tb.TrialOutcome(reward=1.0, resolved=True, cost_usd=0.75)
+
+        with mock.patch.object(tb, "run_case", fake_run_case):
+            transcript = study._subject(mira_sample("fix-git"), run_cx("openai-gpt-5.6-terra"))
+
+        # The config's own cap is $5, but only $1 is budgeted for the whole run.
+        self.assertEqual(captured["spec"]["max_cost_usd"], 1.0)
+        self.assertTrue(transcript.metadata["resolved"])
+        self.assertEqual(study.spent_usd, 0.75)
+
+    def test_exhausted_budget_skips_the_case_as_infra(self):
+        study = tb.Study(max_cost_usd=1.0)
+        study._tasks = {"fix-git": make_task()}
+        study._spent_usd = 1.0
+
+        with mock.patch.object(tb, "run_case", side_effect=AssertionError("must not run")):
+            transcript = study._subject(mira_sample("fix-git"), run_cx("openai-gpt-5.6-terra"))
+
+        self.assertEqual(transcript.error_kind, "infra")
+        self.assertEqual(transcript.metadata["stop_reason"], "budget")
+
+    def test_no_budget_means_no_clamping(self):
+        study = tb.Study(max_cost_usd=None)
+        study._tasks = {"fix-git": make_task()}
+        captured: dict = {}
+
+        def fake_run_case(task, target, spec, **kwargs):
+            captured["spec"] = spec
+            return tb.TrialOutcome(cost_usd=9.0)
+
+        with mock.patch.object(tb, "run_case", fake_run_case):
+            study._subject(mira_sample("fix-git"), run_cx("openai-gpt-5.6-terra"))
+
+        self.assertNotIn("max_cost_usd", captured["spec"])
+
+
+class TestLoadTask(unittest.TestCase):
+    def test_task_toml_metadata_becomes_sample_tags(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            task_dir = Path(tmp) / "fix-git"
+            task_dir.mkdir()
+            (task_dir / "task.toml").write_text(
+                '[metadata]\ndifficulty = "easy"\ncategory = "system-administration"\n'
+                'tags = ["git", "recovery"]\n[agent]\ntimeout_sec = 900.0\n',
+                encoding="utf-8",
+            )
+            task = tb.load_task(task_dir)
+
+        self.assertEqual(task.difficulty, "easy")
+        self.assertEqual(task.category, "system-administration")
+        self.assertEqual(task.tags, ["git", "recovery"])
+        self.assertEqual(task.agent_timeout_sec, 900.0)
+
+        study = tb.Study()
+        study._tasks = {task.name: task}
+        sample = study._build_samples()[0]
+        self.assertEqual(sample.id, "fix-git")
+        for tag in ("easy", "system-administration", "git", "recovery"):
+            self.assertIn(tag, sample.tags)
+
+
+def mira_sample(sample_id: str):
+    import mira
+
+    return mira.Sample(sample_id)
+
+
+def run_cx(target: str):
+    """A minimal stand-in for the SDK's RunCx — the subject only reads `target`."""
+
+    class _Cx:
+        pass
+
+    cx = _Cx()
+    cx.target = target
+    return cx
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/evals/terminal_bench/tests/test_study.py
+++ b/evals/terminal_bench/tests/test_study.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 import json
 import sys
 import unittest
+import unittest.mock as mock
 from pathlib import Path
-from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -101,3 +101,12 @@ wording, formatting, and link fixes do not need entries.
 
 - Made the alternate-screen fullscreen renderer the default for interactive sessions.
 - Added `--inline` as the explicit opt-out for terminal-native scrollback.
+
+## 2026-07-30 — Terminal-Bench 2.1 eval study
+
+- Added `evals/terminal_bench/`: yolop on Terminal-Bench 2.1 (89 containerized
+  tasks), stacking the Mira host over Harbor — Mira owns the matrix and
+  reporting, Harbor owns the container, the agent run, and the task's verifier.
+- Realized the Harbor half of [Trajectory export](specs/trajectory.md): the
+  study's Harbor agent adapter hands `--trajectory-out` ATIF straight to Harbor
+  with no converter, so the export's stated consumer is now an actual one.


### PR DESCRIPTION
## What changed

Adds `evals/terminal_bench/` — a Mira eval study for **Terminal-Bench 2.1** (89 containerized terminal tasks, each scored by its own test suite), plus `control-v1`, the small fixed subset meant to be run on a cadence.

Two harnesses stack, each owning what it is good at:

- **Mira** owns the target matrix, sample/target selection, saved run folders, and reporting — the same role it plays for `evals/swebench_verified`.
- **Harbor**, Terminal-Bench's own execution framework, owns one case: building the task container, running the agent in it, and running the task's verifier.

`terminal_bench.py` is the study (shells out to `harbor run` per case, reads the reward back out of the trial's `result.json`). `harbor_yolop.py` is the Harbor **agent adapter** that puts yolop inside the container.

Two existing yolop features carried the integration:

- **`--trajectory-out` already emits ATIF v1.7**, the format Harbor consumes, so the adapter declares `SUPPORTS_ATIF` and hands the document over with no converter. Token totals and cost come from its `final_metrics`.
- **`--session-dir` flushes `events.jsonl` incrementally**, and `/logs/agent` is bind-mounted from the host trial dir, so the host watches cost as it accrues and stops the run at `max_cost_usd` — yolop has no native dollar cap.

Install uploads a **static musl** yolop binary: Harbor always runs the agent inside the task image, and those are mostly Debian bookworm (glibc 2.36), older than a typical host, so the glibc build will not start there.

Cost is capped twice — per case (`max_cost_usd`, default $5, enforced by the adapter's poller) and per run (`TB_MAX_COST_USD`, which clamps each case's cap to what the run has left and skips the remainder as N/A once exhausted).

### The control suite

The full 89 is hours of wall clock and real money, so it answers *what is the number* rather than *did yolop move*. `suites/control-v1.json` is the set for the second question: **3 easy / 3 medium / 2 hard**, selected deterministically by `suites/select_control.py` rather than hand-picked, so it can be re-derived and audited —

1. exclude anything needing a GPU or more than 4 GiB, so the suite runs concurrently on an ordinary box instead of serializing on the 8 GiB tasks;
2. order each tier by `(agent timeout, name)`, cheapest first, because a set run often is constrained by its cost;
3. take a task only if its category is not already in the suite.

Only `easy` needs the fallback — there are four easy tasks and three are `software-engineering`. Result: seven categories over eight tasks, every task at 900s or less. Membership rides as a sample tag (matching `swebench_verified`'s `tracking-v1`), so `--tag control-v1` selects it against any target; the `control` preset bundles it with the tracked config. `bootstrap.sh` verifies the committed JSON still reproduces from the dataset, since silent drift would make periodic runs incomparable to their own history.

## Why

yolop is benchmarked on SWE-bench Verified, which measures patching a Python repo from an issue. Terminal-Bench measures a different thing — finishing real work in a terminal — and it is where the terminal-agent field is currently compared. Having it as a sibling study means yolop can be tracked on it, and compared against Terminus/Claude Code/Codex on identical tasks and scorer, using the reporting we already have.

It also closes a loop the bundle already opened: `knowledge/specs/trajectory.md` names Harbor as the reason ATIF export exists. Until now that consumer was hypothetical.

## Before / After

**Before:** no Terminal-Bench coverage; ATIF export had no Harbor consumer in-tree.

**After** — `control-v1` baseline, yolop · gpt-5.6-terra (OpenAI), run `20260731T014824Z-3c1e`: **6/8 for $1.34**, 22 minutes wall clock.

```
── matrix (passed/scored) ──
  eval            openai-gpt-5.6-terra
  terminal_bench                   6/8

6 passed / 8 scored (2 failed, 0 n/a, 0 skipped)

── resolve rate by difficulty (passed/scored) ──
  easy        3/3  (100%)
  medium      2/3  (67%)
  hard        1/2  (50%)
```

Every case ran to its own completion — no timeout, no budget stop, no infra N/A — so both failures are model verdicts rather than harness artifacts. That distinction is the point of the two fixes below.

**Read the cost as a ceiling, not a charge.** Against the OpenAI endpoint yolop has no inline price and estimates from a price table billing full `prompt_tokens`, which on OpenAI *includes* cache reads — and cache reads dominate an agentic run. The same `cobol-modernization` case reads $0.192 here and $0.106 through OpenRouter, where the number is what the provider actually billed. `swebench_verified` documents the same effect; the README repeats the caveat next to the table so these are not read as cross-provider comparables.

### Two things the first runs surfaced

Both are handled in the study, and **before them the easy tasks scored 0/2**:

1. **The instructions have no reader.** `fix-git` asks *"please help me find them and merge them into master"*. yolop found the dangling commit, then stopped to ask whether it should rewrite `master` — correct behavior with a user present, zero reward with none, since grading looks only at the filesystem after the agent exits. `prompt_autonomous.md` states the situation and is applied to every instruction by default (`--ak prompt_template_path=` overrides).
2. **The verifier needs its own network trust.** The verifier phase inherits none of the agent's environment, and many tasks' `test.sh` fetches `uv` before it can run the tests. Behind a TLS-terminating egress proxy that meant *every* task failed to **score** — reported as a 0.0 reward indistinguishable from a wrong answer. `TB_CA_CERT` now also configures the verifier's trust vars, and `TB_VERIFIER_ENV` mirrors `TB_AGENT_ENV`.

Offline plumbing check (`mira run --samples fix-git --targets llmsim`) exercises upload → run → verify with no API key and correctly reports 0.0.

## Risk

- **Low.** Nothing under `src/` or `crates/` changed; no Rust was touched, so the shipped binary is unaffected.
- What can break: the study depends on external services it does not control — the Harbor Hub dataset registry, prebuilt task images on Docker Hub, and provider APIs. A dataset move or a Harbor CLI flag rename breaks runs, not the product. The dataset is resolved by name at `@latest`; pinning it is a follow-up.
- The adapter uploads a host-built binary, so a mismatched build fails the trial at install with an explicit message rather than silently.
- `ci.yml` gained a job. It is path-filtered to `evals/terminal_bench/**` and skipped otherwise, so it does not lengthen unrelated PRs.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

45 unit tests covering the matrix, command construction (including shell-quoting of the instruction), Harbor's string-typed `--ak` kwargs, cost parsing against half-written logs, ATIF-to-context mapping, the budget clamp, suite integrity, and the verifier-env wiring. They need no Docker, network, or API key — and they now **run in CI**, which they did not at first: `evals/` had one Python leg, path-filtered to `harness_basic`'s stdlib-only analyzers, so these 45 tests were unreachable. They get their own `uv` leg because, unlike the analyzers, they import the study's third-party deps.

## Knowledge

`knowledge/log.md` records the study and notes that the Harbor half of `knowledge/specs/trajectory.md` now has a real consumer. No concept added or changed: eval studies live outside the bundle (`evals/README.md` is their index, linked from `AGENTS.md`), and this adds no product behavior, policy, or constraint. `python3 scripts/validate_okf.py knowledge --check-links` is clean.

## Security

No product code changed. The study handles provider API keys, and does so by name rather than value: the adapter forwards only the selected provider's key into the container via Harbor's env plumbing, so secrets never appear in a command line. The instruction is `shlex.quote`d into the yolop invocation (covered by a test). Suite names are validated against a safe-name pattern before path joining (also covered). `TB_CA_CERT` installs an additional trust anchor inside the task container only — it does not disable verification anywhere, and it is opt-in for sandboxes whose egress is already TLS-terminated.

Terminal-Bench tasks are themselves adversarial-adjacent by design (some are security tasks) and run with `allow_internet = true` in a container the agent fully controls; that is the benchmark's model, unchanged here.

## Follow-ups

- **Pin the dataset version.** `harbor dataset download terminal-bench/terminal-bench-2-1` resolves `@latest`; a pinned digest would make saved runs reproducible against the exact task set that produced them. The study warns when the download is not 89 tasks, which catches truncation but not revision drift.
- **A full 89-task baseline.** Deliberately not in this PR. Extrapolating from `control-v1` is unsafe in one direction: the suite picks the *cheapest* task in each tier (600–900s budgets), while the full set includes 1800s–12000s tasks with no data behind them. Worth measuring one deliberately expensive hard task before quoting a full-run cost.
- **Investigate the two failures.** `chess-best-move` burned the most turns and money of the eight and still missed; `configure-git-webserver` was the *cheapest* case at 10 tool calls — it stopped early rather than exhausting anything, the same shape as the `fix-git` confirmation-stall, which may mean the autonomy framing does not fully cover "verify before you stop".
- **Session-log upload.** Same open integration point as `swebench_verified`: raw trajectories stay in `.cache/` and are not committed.