### PR TITLE
feat(config): add named profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ act of consent. MCP tools run autonomously like the rest of yolop's tools.
 | -------------------------- | -------------------------------------------------------------------- |
 | `-C, --cwd <PATH>`         | Workspace root (default: current dir)                                |
 | `--provider <P>`           | Force `anthropic`, `codex`, `openai`, `google`, `openrouter`, `ollama`, `custom`, or `llmsim` |
+| `--profile <NAME>`         | Overlay a named execution profile from the platform config directory |
 | `-m, --model <ID>`         | Override the model id for the chosen provider                        |
 | `-p, --print <PROMPT>`     | Run one prompt non-interactively and print the result                |
 | `--acp`                    | Speak the Agent Client Protocol over stdio (for editors like Zed)    |
@@ -357,8 +358,33 @@ and edit the file itself through the `get_config` / `set_config` tools or the
 `yolop-config` skill (e.g. "use anthropic by default", "store my OpenAI key").
 Unknown keys are ignored, so the format stays forward-compatible.
 
+Named profiles are sparse execution overlays stored under
+`<config_dir>/yolop/profiles/<name>.toml` and selected explicitly with
+`--profile <name>`. They can bundle provider/model choices, endpoint base URLs,
+soft and hard approval settings, sandbox mode, and worktree behavior without
+duplicating global settings:
+
+```toml
+# profiles/deep-review.toml
+default_provider = "openai"
+approval_mode = "protective"
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+worktrees = "always"
+
+[models]
+openai = "gpt-5.6 xhigh"
+```
+
+CLI and ACP live model choices override the selected profile; the profile
+overrides `settings.toml`. Credentials, MCP servers, capabilities, theme,
+attribution, and background-wake behavior remain global and are rejected in a
+profile. When a profile is active, `/setup` and `set_config` persist profileable
+changes back to that profile while credential changes still update the global
+settings file.
+
 **Provider resolution at startup:** `--provider` wins, then the saved
-`default_provider`, then auto-detect in the order **OpenAI → Codex → Anthropic →
+profile `default_provider`, then the global `default_provider`, then auto-detect in the order **OpenAI → Codex → Anthropic →
 OpenRouter → Google → Ollama → Custom** (first with a matching env var or saved
 credential), then a fall back to OpenAI's default with setup opened.
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,15 @@
 Significant changes to Yolop's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
+## 2026-07-31 — Named configuration profiles
+
+- [Configuration](specs/configuration.md) now defines explicit `--profile`
+  selection, sparse execution overlays above global settings, global-only
+  credential and structural keys, active-layer persistence, and profile
+  visibility. [ACP](specs/acp.md) records profile defaults below standard live
+  model selection, while [Presentation](specs/presentation.md) makes the active
+  profile part of safety status.
+
 ## 2026-07-30 — ACP model selection uses standard session configuration
 
 - [ACP integration](specs/acp.md) now exposes model and reasoning-effort choices

--- a/knowledge/specs/acp.md
+++ b/knowledge/specs/acp.md
@@ -57,6 +57,8 @@ Yolop uses ACP's standard session configuration mechanism for model selection. `
 - a `reasoning_effort` select option in the standard `thought_level` category when the selected model supports reasoning levels.
 
 Clients change either option with `session/set_config_option`. Yolop validates the selected provider, model, and reasoning effort, applies the change only to that live ACP session, and returns the complete refreshed `configOptions` list. Refreshing the full list allows clients to update dependent reasoning choices after the model changes. Invalid option IDs and unsupported values return ACP `InvalidParams`.
+When the process was launched with `--profile`, that profile supplies the
+initial model before any live ACP selection.
 
 ### Prompt content
 
@@ -100,10 +102,10 @@ vocabulary across every front end instead of an ACP-only taxonomy.
 
 - `session/new` and `session/load` responses carry a `modes` block listing the
   three levels (strictest first) with the current one selected.
-- `session/set_mode` maps the mode id back to a level and persists it. Because
-  yolop is a single-user CLI whose settings are shared across sessions, this
-  changes the level globally — exactly like `/setup approval` — rather than
-  per-session. An unknown mode id is rejected with `InvalidParams`.
+- `session/set_mode` maps the mode id back to a level and persists it. It writes
+  the selected profile when `--profile` is active and global settings otherwise,
+  exactly like `/setup approval`. An unknown mode id is rejected with
+  `InvalidParams`.
 - When the level changes out of band (the `set_approval_mode` tool, `/setup
   approval`), yolop emits a `current_mode_update` after the turn so the picker
   stays in sync.

--- a/knowledge/specs/configuration.md
+++ b/knowledge/specs/configuration.md
@@ -10,8 +10,9 @@ Status: v1 implemented.
 
 ## Why
 
-yolop's settings live in one TOML file (`settings.toml` in the platform config
-dir). Loading is deliberately tolerant — unknown keys are ignored, never fatal
+yolop's global settings live in `settings.toml` in the platform config dir.
+Optional named profiles live below `profiles/` and form a sparse execution
+layer above global settings. Global loading is deliberately tolerant — unknown keys are ignored, never fatal
 (see `Settings::from_table`) — so a user or another tool can add keys without
 breaking yolop. The cost of that tolerance is that the file carries no
 *semantics*: nothing tells the agent (or the user) what a key means, what type
@@ -60,6 +61,42 @@ switches, yolop may also query the provider's models API (when credentials
 exist) and fall back with a warning if the resolved model is no longer offered.
 Per-provider `models.<provider>` picks are always trusted.
 
+### Named execution profiles
+
+`--profile <name>` loads
+`<config_dir>/yolop/profiles/<name>.toml`. Profile selection is explicit for
+each process; it is never persisted and has no environment-variable selector.
+Names contain 1–64 lowercase ASCII letters, numbers, hyphens, or underscores,
+start with a letter or number, and are validated before constructing the path.
+
+Profiles are sparse overlays. Scalars replace the global value and provider
+maps merge by provider key. Resolution order is CLI or ACP live selection,
+selected profile, global settings, and finally credential auto-detection or
+built-in defaults. Provider-specific environment variables keep their existing
+precedence where read (credentials and `CUSTOM_BASE_URL`). ACP's standard
+`session/set_config_option` model and reasoning changes remain local to that ACP
+session.
+
+The profileable v1 keys are `default_provider`, `default_model`, `models`,
+`base_urls`, `approval_mode`, `approval_policy`, `sandbox_mode`, and
+`worktrees`. Credentials (`tokens`, `codex_auth`) and structural or personal
+settings (`mcp`, `capabilities`, `theme`, `attribution`, `proactive_wake`) are
+global-only and make a selected profile fail validation. Invalid known values
+also fail startup; unknown keys produce a warning and are ignored for forward
+compatibility.
+
+`SettingsStore` retains the global document and sparse profile separately and
+only returns their merged effective `Settings` snapshot. It never serializes
+that merged snapshot into a profile, so inherited credentials cannot leak into
+the profile file. Profileable writes from `/setup`, ACP mode selection, and
+`set_config` target the active profile; global-only writes always target
+`settings.toml`. Clearing a profile override removes it and reveals the global
+value.
+
+The active profile is printed at startup, returned by `get_config`, and
+included in the terminal-independent safety status. Missing or malformed
+profiles fail before session construction.
+
 ### Tools
 
 The `config` capability (`src/capabilities/config.rs`) exposes two tools backed
@@ -94,8 +131,8 @@ The surface is kept minimal: `current(key)` covers arbitrary reads, so a
 capability adds a typed getter only when it grows a real need rather than
 carrying speculative methods.
 
-`SettingsStore` implements `ConfigService`, so the single shared handle that
-backs writes also serves reads. Read-only capabilities take only an
+`SettingsStore` implements `ConfigService`, so the shared layered handle that
+backs writes also serves effective reads. Read-only capabilities take only an
 `Arc<dyn ConfigService>`; write-coupled capabilities hold both — reads go
 through the service handle, writes through the concrete `SettingsStore` — so the
 read/write split is explicit at the type level. `AttributionCapability` reads

--- a/knowledge/specs/presentation.md
+++ b/knowledge/specs/presentation.md
@@ -29,7 +29,7 @@ The model must expose structured values for:
 3. **Stream previews** — assistant and tool delta previews while a turn is
    active.
 4. **Session status** — every value shown in the status bar, including provider
-   and model, approval mode, goal state, background-task counts, token counts,
+   and model, active configuration profile, approval mode, goal state, background-task counts, token counts,
    current session, worktree state, and busy/idle state when present.
 
 The TUI may still own layout, colors, wrapping, scrollback anchoring, input
@@ -70,6 +70,11 @@ The interactive TUI exposes a bounded, turn-scoped agent status contribution.
 The agent may update or clear that value while working; the host clears it when
 the turn finishes. Host-owned runtime, safety, session, and workspace values
 remain authoritative and cannot be replaced by the agent contribution.
+
+When a named configuration profile is active, the safety status identifies it
+before the soft approval, sandbox, and hard approval-policy values. This keeps
+the selected execution bundle visible in compact and expanded layouts without
+conflating it with the provider or model name.
 
 `--print` and ACP may project the model differently, but shared semantics should
 come from the same presentation model rather than parallel ad hoc formatting.

--- a/src/capabilities/config.rs
+++ b/src/capabilities/config.rs
@@ -74,12 +74,18 @@ impl Capability for ConfigCapability {
         {
             return None;
         }
+        let profile = self
+            .settings
+            .active_profile_name()
+            .map(|name| format!(" Active profile: `{name}`."))
+            .unwrap_or_default();
         Some(format!(
             "<capability id=\"{}\">\nyolop's settings live at {}. Unknown keys are ignored, \
              never fatal. Provider/model and capability edits apply on the next run; use \
-             `/setup` to switch the live model now.\n</capability>",
+             `/setup` to switch the live model now.{}\n</capability>",
             self.id(),
-            self.settings.path().display()
+            self.settings.path().display(),
+            profile,
         ))
     }
 
@@ -185,6 +191,11 @@ impl Tool for GetConfigTool {
     async fn execute(&self, arguments: Value) -> ToolExecutionResult {
         let settings = self.settings.snapshot();
         let path = self.settings.path().display().to_string();
+        let active_profile = self.settings.active_profile_name();
+        let profile_path = self
+            .settings
+            .active_profile_path()
+            .map(|path| path.display().to_string());
 
         if let Some(key) = arguments.get("key").and_then(Value::as_str) {
             let key = key.trim();
@@ -200,6 +211,8 @@ impl Tool for GetConfigTool {
                         let field = target.field();
                         ToolExecutionResult::success(json!({
                             "settings_path": path,
+                            "active_profile": active_profile,
+                            "profile_path": profile_path,
                             "field": field_json(&settings, field),
                             "catalog": capability_catalog_list(&self.catalog),
                             "stored_overrides": overrides_to_json(&settings.capabilities),
@@ -236,6 +249,8 @@ impl Tool for GetConfigTool {
                         let field = target.field();
                         ToolExecutionResult::success(json!({
                             "settings_path": path,
+                            "active_profile": active_profile,
+                            "profile_path": profile_path,
                             "field": field_json(&settings, field),
                             "capability": catalog,
                             "stored_overrides": stored,
@@ -257,6 +272,9 @@ impl Tool for GetConfigTool {
                         entry["current"] = value;
                         ToolExecutionResult::success(json!({
                             "settings_path": path,
+                            "active_profile": active_profile,
+                            "profile_path": profile_path,
+                            "source": self.settings.source_for(&target),
                             "field": entry,
                         }))
                     }
@@ -267,6 +285,8 @@ impl Tool for GetConfigTool {
         let fields: Vec<Value> = schema().iter().map(|f| field_json(&settings, f)).collect();
         ToolExecutionResult::success(json!({
             "settings_path": path,
+            "active_profile": active_profile,
+            "profile_path": profile_path,
             "fields": fields,
             "note": "Set any key with `set_config`. Harness overrides: `set_config key=capabilities json=…`. \
                      Provider/model edits apply on the next run; use /setup to switch the live model now.",
@@ -279,6 +299,20 @@ impl Tool for GetConfigTool {
 struct SetConfigTool {
     settings: Arc<SettingsStore>,
     catalog: Arc<CapabilityCatalog>,
+}
+
+fn is_profileable_target(target: &KeyTarget) -> bool {
+    matches!(
+        target,
+        KeyTarget::DefaultProvider
+            | KeyTarget::DefaultModel
+            | KeyTarget::ApprovalMode
+            | KeyTarget::ApprovalPolicy
+            | KeyTarget::Worktrees
+            | KeyTarget::Sandbox
+            | KeyTarget::Model(_)
+            | KeyTarget::BaseUrl(_)
+    )
 }
 
 #[async_trait]
@@ -428,7 +462,11 @@ impl Tool for SetConfigTool {
                 "ok": true,
                 "key": key,
                 "message": message,
-                "settings_path": self.settings.path().display().to_string(),
+                "settings_path": if is_profileable_target(&target) {
+                    self.settings.active_config_path()
+                } else {
+                    self.settings.path().to_path_buf()
+                }.display().to_string(),
             })),
             Err(err) => ToolExecutionResult::tool_error(err),
         }
@@ -437,7 +475,12 @@ impl Tool for SetConfigTool {
 
 impl SetConfigTool {
     fn apply(&self, target: &KeyTarget, value: &str, clearing: bool) -> Result<String, String> {
-        let path = self.settings.path().display().to_string();
+        let path = if is_profileable_target(target) {
+            self.settings.active_config_path()
+        } else {
+            self.settings.path().to_path_buf()
+        };
+        let path = path.display().to_string();
         let saved = |what: String| format!("{what} (saved to {path})");
         let map_err = |e: anyhow::Error| format!("could not save settings: {e}");
 
@@ -503,6 +546,12 @@ impl SetConfigTool {
                 Ok(saved(format!("proactive_wake = {}", on_off(enabled))))
             }
             KeyTarget::ApprovalMode => {
+                if clearing {
+                    self.settings.clear_approval_mode().map_err(map_err)?;
+                    return Ok(saved(
+                        "cleared approval_mode; inherited/default value is active".to_string(),
+                    ));
+                }
                 let mode = ApprovalMode::parse(value).ok_or_else(|| {
                     "approval_mode expects protective, normal, or off".to_string()
                 })?;
@@ -513,6 +562,12 @@ impl SetConfigTool {
                 )))
             }
             KeyTarget::ApprovalPolicy => {
+                if clearing {
+                    self.settings.clear_approval_policy().map_err(map_err)?;
+                    return Ok(saved(
+                        "cleared approval_policy; inherited/default value is active".to_string(),
+                    ));
+                }
                 let policy = crate::config::ApprovalPolicy::parse(value).ok_or_else(|| {
                     "approval_policy expects untrusted, on-failure, on-request, or never"
                         .to_string()
@@ -525,10 +580,10 @@ impl SetConfigTool {
             }
             KeyTarget::Worktrees => {
                 if clearing {
-                    self.settings
-                        .set_worktrees_mode(crate::config::WorktreesMode::Auto)
-                        .map_err(map_err)?;
-                    return Ok(saved("cleared worktrees (default auto)".to_string()));
+                    self.settings.clear_worktrees_mode().map_err(map_err)?;
+                    return Ok(saved(
+                        "cleared worktrees; inherited/default value is active".to_string(),
+                    ));
                 }
                 let mode = crate::config::WorktreesMode::parse(value)
                     .ok_or_else(|| "worktrees expects auto, always, or off".to_string())?;
@@ -540,11 +595,9 @@ impl SetConfigTool {
             }
             KeyTarget::Sandbox => {
                 if clearing {
-                    self.settings
-                        .set_sandbox_mode(crate::config::SandboxMode::DangerFullAccess)
-                        .map_err(map_err)?;
+                    self.settings.clear_sandbox_mode().map_err(map_err)?;
                     return Ok(saved(
-                        "cleared sandbox_mode (default danger-full-access); applies next run"
+                        "cleared sandbox_mode; inherited/default value applies next run"
                             .to_string(),
                     ));
                 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -15,6 +15,7 @@
 pub mod capability_settings;
 pub mod hooks;
 pub mod mcp;
+pub mod profile;
 pub mod schema;
 pub mod service;
 
@@ -271,7 +272,7 @@ impl Default for Settings {
             approval_policy: ApprovalPolicy::OnRequest,
             proactive_wake: true,
             worktrees: WorktreesMode::Auto,
-            sandbox: SandboxMode::WorkspaceWrite,
+            sandbox: SandboxMode::DangerFullAccess,
             theme: None,
             mcp: McpSettings::default(),
             capabilities: Vec::new(),
@@ -594,6 +595,14 @@ pub fn load_from(path: &Path) -> Settings {
 /// created with mode 0o600 on Unix, so the resulting file is owner-only
 /// regardless of any prior file's permissions.
 fn save_to(path: &Path, settings: &Settings) -> Result<()> {
+    save_table_to(path, &settings.to_table())
+}
+
+fn save_profile_to(path: &Path, overlay: &profile::SettingsOverlay) -> Result<()> {
+    save_table_to(path, &overlay.to_table())
+}
+
+fn save_table_to(path: &Path, table: &Table) -> Result<()> {
     let parent = path
         .parent()
         .filter(|p| !p.as_os_str().is_empty())
@@ -601,7 +610,7 @@ fn save_to(path: &Path, settings: &Settings) -> Result<()> {
         .unwrap_or_else(|| PathBuf::from("."));
     std::fs::create_dir_all(&parent)
         .with_context(|| format!("create settings dir {}", parent.display()))?;
-    let toml_text = toml::to_string(&settings.to_table()).context("serialize settings")?;
+    let toml_text = toml::to_string(table).context("serialize settings")?;
 
     let file_name = path
         .file_name()
@@ -637,13 +646,27 @@ fn save_to(path: &Path, settings: &Settings) -> Result<()> {
     Ok(())
 }
 
-/// Thread-safe handle shared across capabilities. The cached `Settings`
-/// is the source of truth in memory; mutations flush to disk via an
-/// atomic temp-file + rename (see `save_to`), so readers and crashes
-/// never observe a partially written settings file.
+/// Thread-safe handle shared across capabilities. Global settings and an
+/// optional sparse profile stay separate in memory; snapshots merge them for
+/// reads, while mutations flush only their owning layer via atomic rename.
 pub struct SettingsStore {
     path: PathBuf,
-    inner: Mutex<Settings>,
+    inner: Mutex<SettingsState>,
+}
+
+struct SettingsState {
+    base: Settings,
+    profile: Option<profile::ActiveProfile>,
+}
+
+impl SettingsState {
+    fn effective(&self) -> Settings {
+        let mut settings = self.base.clone();
+        if let Some(profile) = &self.profile {
+            profile.overlay.apply_to(&mut settings);
+        }
+        settings
+    }
 }
 
 impl SettingsStore {
@@ -651,119 +674,274 @@ impl SettingsStore {
         let settings = load_from(&path);
         Self {
             path,
-            inner: Mutex::new(settings),
+            inner: Mutex::new(SettingsState {
+                base: settings,
+                profile: None,
+            }),
         }
     }
 
+    pub fn open_with_profile(path: PathBuf, profile_name: &str) -> Result<Self> {
+        let settings = load_from(&path);
+        let active_profile = profile::ActiveProfile::load(&path, profile_name)?;
+        Ok(Self {
+            path,
+            inner: Mutex::new(SettingsState {
+                base: settings,
+                profile: Some(active_profile),
+            }),
+        })
+    }
+
     pub fn snapshot(&self) -> Settings {
-        self.inner.lock().expect("settings lock poisoned").clone()
+        self.inner
+            .lock()
+            .expect("settings lock poisoned")
+            .effective()
     }
 
     pub fn path(&self) -> &Path {
         &self.path
     }
 
-    pub fn set_default_provider(&self, provider: Option<String>) -> Result<()> {
+    pub fn active_profile_name(&self) -> Option<String> {
+        self.inner
+            .lock()
+            .expect("settings lock poisoned")
+            .profile
+            .as_ref()
+            .map(|profile| profile.name.as_str().to_string())
+    }
+
+    pub fn active_profile_path(&self) -> Option<PathBuf> {
+        self.inner
+            .lock()
+            .expect("settings lock poisoned")
+            .profile
+            .as_ref()
+            .map(|profile| profile.path.clone())
+    }
+
+    pub fn active_config_path(&self) -> PathBuf {
+        self.active_profile_path()
+            .unwrap_or_else(|| self.path.clone())
+    }
+
+    pub fn source_for(&self, target: &schema::KeyTarget) -> String {
+        let guard = self.inner.lock().expect("settings lock poisoned");
+        let Some(active) = &guard.profile else {
+            return "global".to_string();
+        };
+        let overlay = &active.overlay;
+        let overridden = match target {
+            schema::KeyTarget::DefaultProvider => overlay.default_provider.is_some(),
+            schema::KeyTarget::DefaultModel => overlay.default_model.is_some(),
+            schema::KeyTarget::ApprovalMode => overlay.approval_mode.is_some(),
+            schema::KeyTarget::ApprovalPolicy => overlay.approval_policy.is_some(),
+            schema::KeyTarget::Worktrees => overlay.worktrees.is_some(),
+            schema::KeyTarget::Sandbox => overlay.sandbox.is_some(),
+            schema::KeyTarget::Model(provider) => overlay.models.contains_key(provider),
+            schema::KeyTarget::BaseUrl(provider) => overlay.base_urls.contains_key(provider),
+            _ => false,
+        };
+        if overridden {
+            format!("profile:{}", active.name.as_str())
+        } else {
+            "global".to_string()
+        }
+    }
+
+    pub fn profile_warnings(&self) -> Vec<String> {
+        self.inner
+            .lock()
+            .expect("settings lock poisoned")
+            .profile
+            .as_ref()
+            .map(|profile| profile.warnings.clone())
+            .unwrap_or_default()
+    }
+
+    fn update_profileable(
+        &self,
+        update_base: impl FnOnce(&mut Settings),
+        update_profile: impl FnOnce(&mut profile::SettingsOverlay),
+    ) -> Result<()> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
-        guard.default_provider = provider;
-        save_to(&self.path, &guard)
+        if let Some(active) = &mut guard.profile {
+            update_profile(&mut active.overlay);
+            save_profile_to(&active.path, &active.overlay)
+        } else {
+            update_base(&mut guard.base);
+            save_to(&self.path, &guard.base)
+        }
+    }
+
+    pub fn set_default_provider(&self, provider: Option<String>) -> Result<()> {
+        let base_provider = provider.clone();
+        self.update_profileable(
+            |settings| settings.default_provider = base_provider,
+            |profile| profile.default_provider = provider.map(Some),
+        )
     }
 
     pub fn set_attribution(&self, enabled: bool) -> Result<()> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
-        guard.attribution = enabled;
-        save_to(&self.path, &guard)
+        guard.base.attribution = enabled;
+        save_to(&self.path, &guard.base)
     }
 
     pub fn set_theme(&self, theme: Option<String>) -> Result<()> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
-        guard.theme = theme;
-        save_to(&self.path, &guard)
+        guard.base.theme = theme;
+        save_to(&self.path, &guard.base)
     }
 
     pub fn set_proactive_wake(&self, enabled: bool) -> Result<()> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
-        guard.proactive_wake = enabled;
-        save_to(&self.path, &guard)
+        guard.base.proactive_wake = enabled;
+        save_to(&self.path, &guard.base)
     }
 
     pub fn set_approval_mode(&self, mode: ApprovalMode) -> Result<()> {
-        let mut guard = self.inner.lock().expect("settings lock poisoned");
-        guard.approval_mode = mode;
-        save_to(&self.path, &guard)
+        self.update_profileable(
+            |settings| settings.approval_mode = mode,
+            |profile| profile.approval_mode = Some(mode),
+        )
+    }
+
+    pub fn clear_approval_mode(&self) -> Result<()> {
+        self.update_profileable(
+            |settings| settings.approval_mode = ApprovalMode::Normal,
+            |profile| profile.approval_mode = None,
+        )
     }
 
     pub fn set_approval_policy(&self, policy: ApprovalPolicy) -> Result<()> {
-        let mut guard = self.inner.lock().expect("settings lock poisoned");
-        guard.approval_policy = policy;
-        save_to(&self.path, &guard)
+        self.update_profileable(
+            |settings| settings.approval_policy = policy,
+            |profile| profile.approval_policy = Some(policy),
+        )
+    }
+
+    pub fn clear_approval_policy(&self) -> Result<()> {
+        self.update_profileable(
+            |settings| settings.approval_policy = ApprovalPolicy::OnRequest,
+            |profile| profile.approval_policy = None,
+        )
     }
 
     pub fn set_worktrees_mode(&self, mode: WorktreesMode) -> Result<()> {
-        let mut guard = self.inner.lock().expect("settings lock poisoned");
-        guard.worktrees = mode;
-        save_to(&self.path, &guard)
+        self.update_profileable(
+            |settings| settings.worktrees = mode,
+            |profile| profile.worktrees = Some(mode),
+        )
+    }
+
+    pub fn clear_worktrees_mode(&self) -> Result<()> {
+        self.update_profileable(
+            |settings| settings.worktrees = WorktreesMode::Auto,
+            |profile| profile.worktrees = None,
+        )
     }
 
     pub fn set_sandbox_mode(&self, mode: SandboxMode) -> Result<()> {
-        let mut guard = self.inner.lock().expect("settings lock poisoned");
-        guard.sandbox = mode;
-        save_to(&self.path, &guard)
+        self.update_profileable(
+            |settings| settings.sandbox = mode,
+            |profile| profile.sandbox = Some(mode),
+        )
+    }
+
+    pub fn clear_sandbox_mode(&self) -> Result<()> {
+        self.update_profileable(
+            |settings| settings.sandbox = SandboxMode::DangerFullAccess,
+            |profile| profile.sandbox = None,
+        )
     }
 
     pub fn set_token(&self, provider: String, token: String) -> Result<()> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
-        guard.tokens.insert(provider, token);
-        save_to(&self.path, &guard)
+        guard.base.tokens.insert(provider, token);
+        save_to(&self.path, &guard.base)
     }
 
     /// Returns whether a token was actually present before removal.
     pub fn clear_token(&self, provider: &str) -> Result<bool> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
-        let existed = guard.tokens.remove(provider).is_some();
-        save_to(&self.path, &guard)?;
+        let existed = guard.base.tokens.remove(provider).is_some();
+        save_to(&self.path, &guard.base)?;
         Ok(existed)
     }
 
     pub fn set_model(&self, provider: String, spec: String) -> Result<()> {
-        let mut guard = self.inner.lock().expect("settings lock poisoned");
-        guard.models.insert(provider, spec);
-        save_to(&self.path, &guard)
+        let base_provider = provider.clone();
+        let base_spec = spec.clone();
+        self.update_profileable(
+            |settings| {
+                settings.models.insert(base_provider, base_spec);
+            },
+            |profile| {
+                profile.models.insert(provider, Some(spec));
+            },
+        )
     }
 
     /// Returns whether a per-provider model was actually present before removal.
     pub fn clear_model(&self, provider: &str) -> Result<bool> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
-        let existed = guard.models.remove(provider).is_some();
-        save_to(&self.path, &guard)?;
+        let existed = if let Some(active) = &mut guard.profile {
+            let existed = active.overlay.models.remove(provider).is_some();
+            save_profile_to(&active.path, &active.overlay)?;
+            existed
+        } else {
+            let existed = guard.base.models.remove(provider).is_some();
+            save_to(&self.path, &guard.base)?;
+            existed
+        };
         Ok(existed)
     }
 
     /// Set or clear the global fallback model spec (`default_model`).
     pub fn set_default_model(&self, spec: Option<String>) -> Result<()> {
-        let mut guard = self.inner.lock().expect("settings lock poisoned");
-        guard.default_model = spec.filter(|s| !s.trim().is_empty());
-        save_to(&self.path, &guard)
+        let spec = spec.filter(|s| !s.trim().is_empty());
+        let base_spec = spec.clone();
+        self.update_profileable(
+            |settings| settings.default_model = base_spec,
+            |profile| profile.default_model = spec.map(Some),
+        )
     }
 
     pub fn set_base_url(&self, provider: String, url: String) -> Result<()> {
-        let mut guard = self.inner.lock().expect("settings lock poisoned");
-        guard.base_urls.insert(provider, url);
-        save_to(&self.path, &guard)
+        let base_provider = provider.clone();
+        let base_url = url.clone();
+        self.update_profileable(
+            |settings| {
+                settings.base_urls.insert(base_provider, base_url);
+            },
+            |profile| {
+                profile.base_urls.insert(provider, Some(url));
+            },
+        )
     }
 
     /// Returns whether a base URL was actually present before removal.
     pub fn clear_base_url(&self, provider: &str) -> Result<bool> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
-        let existed = guard.base_urls.remove(provider).is_some();
-        save_to(&self.path, &guard)?;
+        let existed = if let Some(active) = &mut guard.profile {
+            let existed = active.overlay.base_urls.remove(provider).is_some();
+            save_profile_to(&active.path, &active.overlay)?;
+            existed
+        } else {
+            let existed = guard.base.base_urls.remove(provider).is_some();
+            save_to(&self.path, &guard.base)?;
+            existed
+        };
         Ok(existed)
     }
 
     pub fn set_codex_auth(&self, auth: CodexAuth) -> Result<()> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
-        guard.codex_auth = Some(auth);
-        save_to(&self.path, &guard)
+        guard.base.codex_auth = Some(auth);
+        save_to(&self.path, &guard.base)
     }
 
     /// Re-read `[codex_auth]` from disk and adopt it into the in-memory cache.
@@ -774,38 +952,38 @@ impl SettingsStore {
     pub fn refresh_codex_auth_from_disk(&self) -> Option<CodexAuth> {
         let from_disk = load_from(&self.path).codex_auth;
         let mut guard = self.inner.lock().expect("settings lock poisoned");
-        guard.codex_auth = from_disk.clone();
+        guard.base.codex_auth = from_disk.clone();
         from_disk
     }
 
     /// Returns whether a Codex login was actually present before removal.
     pub fn clear_codex_auth(&self) -> Result<bool> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
-        let existed = guard.codex_auth.take().is_some();
-        save_to(&self.path, &guard)?;
+        let existed = guard.base.codex_auth.take().is_some();
+        save_to(&self.path, &guard.base)?;
         Ok(existed)
     }
 
     pub fn replace_mcp(&self, mcp: McpSettings) -> Result<()> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
-        guard.mcp = mcp;
-        save_to(&self.path, &guard)
+        guard.base.mcp = mcp;
+        save_to(&self.path, &guard.base)
     }
 
     /// Append a harness capability override to the ordered settings list.
     pub fn append_capability_override(&self, entry: CapabilityOverride) -> Result<usize> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
-        guard.capabilities.push(entry);
-        let index = guard.capabilities.len() - 1;
-        save_to(&self.path, &guard)?;
+        guard.base.capabilities.push(entry);
+        let index = guard.base.capabilities.len() - 1;
+        save_to(&self.path, &guard.base)?;
         Ok(index)
     }
 
     /// Drop every stored `[[capabilities]]` override.
     pub fn clear_capability_overrides(&self) -> Result<()> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
-        guard.capabilities.clear();
-        save_to(&self.path, &guard)
+        guard.base.capabilities.clear();
+        save_to(&self.path, &guard.base)
     }
 
     /// Enable or disable a capability by `ref`, idempotently. Enabling
@@ -818,6 +996,7 @@ impl SettingsStore {
     pub fn set_capability_enabled(&self, capability_ref: &str, enabled: bool) -> Result<bool> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
         let already: Vec<usize> = guard
+            .base
             .capabilities
             .iter()
             .enumerate()
@@ -825,10 +1004,14 @@ impl SettingsStore {
             .map(|(index, _)| index)
             .collect();
         let changed = if enabled {
-            if already.iter().any(|&i| !guard.capabilities[i].is_remove()) {
+            if already
+                .iter()
+                .any(|&i| !guard.base.capabilities[i].is_remove())
+            {
                 false
             } else {
                 guard
+                    .base
                     .capabilities
                     .push(CapabilityOverride::enable(capability_ref));
                 true
@@ -837,12 +1020,13 @@ impl SettingsStore {
             false
         } else {
             guard
+                .base
                 .capabilities
                 .retain(|entry| entry.capability_ref != capability_ref);
             true
         };
         if changed {
-            save_to(&self.path, &guard)?;
+            save_to(&self.path, &guard.base)?;
         }
         Ok(changed)
     }
@@ -860,16 +1044,18 @@ impl SettingsStore {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
         // The active (last non-remove) override for this ref, or a fresh one.
         let index = guard
+            .base
             .capabilities
             .iter()
             .rposition(|entry| entry.capability_ref == capability_ref && !entry.is_remove());
         let entry = match index {
-            Some(i) => &mut guard.capabilities[i],
+            Some(i) => &mut guard.base.capabilities[i],
             None => {
                 guard
+                    .base
                     .capabilities
                     .push(CapabilityOverride::enable(capability_ref));
-                guard.capabilities.last_mut().expect("just pushed")
+                guard.base.capabilities.last_mut().expect("just pushed")
             }
         };
         if !entry.config.is_object() {
@@ -878,7 +1064,7 @@ impl SettingsStore {
         if let serde_json::Value::Object(map) = &mut entry.config {
             map.insert(key.to_string(), value);
         }
-        save_to(&self.path, &guard)
+        save_to(&self.path, &guard.base)
     }
 }
 
@@ -933,6 +1119,56 @@ mod tests {
             reloaded.snapshot().default_provider.as_deref(),
             Some("anthropic")
         );
+    }
+
+    #[test]
+    fn active_profile_writes_only_profileable_values_to_profile() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let settings_path = tmp.path().join("settings.toml");
+        let profile_dir = tmp.path().join("profiles");
+        std::fs::create_dir_all(&profile_dir).unwrap();
+        let profile_path = profile_dir.join("review.toml");
+        std::fs::write(
+            &settings_path,
+            "default_provider = 'anthropic'\napproval_policy = 'untrusted'\n[tokens]\nopenai = 'global-secret'\n",
+        )
+        .unwrap();
+        std::fs::write(
+            &profile_path,
+            "default_provider = 'openai'\napproval_policy = 'never'\nfuture_setting = 'preserved'\n",
+        )
+        .unwrap();
+
+        let store = SettingsStore::open_with_profile(settings_path.clone(), "review").unwrap();
+        assert_eq!(store.snapshot().default_provider.as_deref(), Some("openai"));
+        assert_eq!(store.snapshot().approval_policy(), ApprovalPolicy::Never);
+        assert_eq!(
+            store.source_for(&schema::KeyTarget::DefaultProvider),
+            "profile:review"
+        );
+
+        store
+            .set_model("openai".to_string(), "gpt-5.6 high".to_string())
+            .unwrap();
+        store.clear_approval_policy().unwrap();
+        assert_eq!(
+            store.snapshot().approval_policy(),
+            ApprovalPolicy::Untrusted
+        );
+
+        let profile = std::fs::read_to_string(&profile_path).unwrap();
+        assert!(profile.contains("openai = \"gpt-5.6 high\""));
+        assert!(!profile.contains("global-secret"));
+        assert!(!profile.contains("tokens"));
+        assert!(!profile.contains("approval_policy"));
+        assert!(profile.contains("future_setting = \"preserved\""));
+        assert_eq!(
+            store.source_for(&schema::KeyTarget::ApprovalPolicy),
+            "global"
+        );
+        let base = std::fs::read_to_string(settings_path).unwrap();
+        assert!(base.contains("global-secret"));
+        assert!(!base.contains("gpt-5.6 high"));
     }
 
     #[test]

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -1,0 +1,371 @@
+use super::{ApprovalMode, ApprovalPolicy, SandboxMode, Settings, WorktreesMode};
+use crate::runtime::SUPPORTED_PROVIDERS;
+use anyhow::{Context, Result, bail};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use toml::{Table, Value};
+
+const PROFILEABLE_KEYS: &[&str] = &[
+    "default_provider",
+    "default_model",
+    "models",
+    "base_urls",
+    "approval_mode",
+    "approval_policy",
+    "worktrees",
+    "sandbox_mode",
+];
+
+const GLOBAL_ONLY_KEYS: &[&str] = &[
+    "tokens",
+    "codex_auth",
+    "theme",
+    "attribution",
+    "proactive_wake",
+    "mcp",
+    "capabilities",
+];
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProfileName(String);
+
+impl ProfileName {
+    pub fn parse(raw: &str) -> Result<Self> {
+        let valid = !raw.is_empty()
+            && raw.len() <= 64
+            && raw.bytes().enumerate().all(|(index, byte)| match byte {
+                b'a'..=b'z' | b'0'..=b'9' => true,
+                b'-' | b'_' => index > 0,
+                _ => false,
+            });
+        if !valid {
+            bail!(
+                "invalid profile name `{raw}`; expected 1-64 lowercase letters, numbers, hyphens, or underscores, starting with a letter or number"
+            );
+        }
+        Ok(Self(raw.to_string()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SettingsOverlay {
+    pub default_provider: Option<Option<String>>,
+    pub default_model: Option<Option<String>>,
+    pub models: BTreeMap<String, Option<String>>,
+    pub base_urls: BTreeMap<String, Option<String>>,
+    pub approval_mode: Option<ApprovalMode>,
+    pub approval_policy: Option<ApprovalPolicy>,
+    pub worktrees: Option<WorktreesMode>,
+    pub sandbox: Option<SandboxMode>,
+    unknown: Table,
+}
+
+impl SettingsOverlay {
+    pub fn apply_to(&self, settings: &mut Settings) {
+        if let Some(provider) = &self.default_provider {
+            settings.default_provider.clone_from(provider);
+        }
+        if let Some(model) = &self.default_model {
+            settings.default_model.clone_from(model);
+        }
+        apply_map(&mut settings.models, &self.models);
+        apply_map(&mut settings.base_urls, &self.base_urls);
+        if let Some(mode) = self.approval_mode {
+            settings.approval_mode = mode;
+        }
+        if let Some(policy) = self.approval_policy {
+            settings.approval_policy = policy;
+        }
+        if let Some(mode) = self.worktrees {
+            settings.worktrees = mode;
+        }
+        if let Some(mode) = self.sandbox {
+            settings.sandbox = mode;
+        }
+    }
+
+    pub fn from_table(table: &Table) -> Result<(Self, Vec<String>)> {
+        for key in GLOBAL_ONLY_KEYS {
+            if table.contains_key(*key) {
+                bail!("`{key}` is global-only and cannot be set in a profile");
+            }
+        }
+
+        let warnings = table
+            .keys()
+            .filter(|key| !PROFILEABLE_KEYS.contains(&key.as_str()))
+            .map(|key| format!("ignoring unknown profile key `{key}`"))
+            .collect();
+        let unknown = table
+            .iter()
+            .filter(|(key, _)| !PROFILEABLE_KEYS.contains(&key.as_str()))
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+
+        let default_provider = optional_string(table, "default_provider")?.map(Some);
+        let default_model = optional_string(table, "default_model")?.map(Some);
+        let models = optional_string_map(table, "models")?;
+        let base_urls = optional_string_map(table, "base_urls")?;
+        if let Some(Some(provider)) = &default_provider
+            && !SUPPORTED_PROVIDERS.contains(&provider.as_str())
+        {
+            bail!(
+                "`default_provider` expects one of {}; got `{provider}`",
+                SUPPORTED_PROVIDERS.join(", ")
+            );
+        }
+        for provider in models.keys().chain(base_urls.keys()) {
+            if !SUPPORTED_PROVIDERS.contains(&provider.as_str()) {
+                bail!(
+                    "unknown provider `{provider}` in profile table; expected one of {}",
+                    SUPPORTED_PROVIDERS.join(", ")
+                );
+            }
+        }
+        let approval_mode = optional_parsed(
+            table,
+            "approval_mode",
+            ApprovalMode::parse,
+            "protective, normal, or off",
+        )?;
+        let approval_policy = optional_parsed(
+            table,
+            "approval_policy",
+            ApprovalPolicy::parse,
+            "untrusted, on-failure, on-request, or never",
+        )?;
+        let worktrees = optional_parsed(
+            table,
+            "worktrees",
+            WorktreesMode::parse,
+            "auto, always, or off",
+        )?;
+        let sandbox = optional_parsed(
+            table,
+            "sandbox_mode",
+            SandboxMode::parse,
+            "read-only, workspace-write, or danger-full-access",
+        )?;
+
+        Ok((
+            Self {
+                default_provider,
+                default_model,
+                models,
+                base_urls,
+                approval_mode,
+                approval_policy,
+                worktrees,
+                sandbox,
+                unknown,
+            },
+            warnings,
+        ))
+    }
+
+    pub fn to_table(&self) -> Table {
+        let mut table = self.unknown.clone();
+        insert_optional_string(&mut table, "default_provider", &self.default_provider);
+        insert_optional_string(&mut table, "default_model", &self.default_model);
+        insert_map(&mut table, "models", &self.models);
+        insert_map(&mut table, "base_urls", &self.base_urls);
+        if let Some(mode) = self.approval_mode {
+            table.insert(
+                "approval_mode".to_string(),
+                Value::String(mode.as_str().to_string()),
+            );
+        }
+        if let Some(policy) = self.approval_policy {
+            table.insert(
+                "approval_policy".to_string(),
+                Value::String(policy.as_str().to_string()),
+            );
+        }
+        if let Some(mode) = self.worktrees {
+            table.insert(
+                "worktrees".to_string(),
+                Value::String(mode.as_str().to_string()),
+            );
+        }
+        if let Some(mode) = self.sandbox {
+            table.insert(
+                "sandbox_mode".to_string(),
+                Value::String(mode.as_str().to_string()),
+            );
+        }
+        table
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ActiveProfile {
+    pub name: ProfileName,
+    pub path: PathBuf,
+    pub overlay: SettingsOverlay,
+    pub warnings: Vec<String>,
+}
+
+impl ActiveProfile {
+    pub fn load(settings_path: &Path, raw_name: &str) -> Result<Self> {
+        let name = ProfileName::parse(raw_name)?;
+        let parent = settings_path.parent().unwrap_or_else(|| Path::new("."));
+        let path = parent
+            .join("profiles")
+            .join(format!("{}.toml", name.as_str()));
+        let text = std::fs::read_to_string(&path)
+            .with_context(|| format!("read profile `{}` from {}", name.as_str(), path.display()))?;
+        let table: Table = toml::from_str(&text)
+            .with_context(|| format!("parse profile `{}` at {}", name.as_str(), path.display()))?;
+        let (overlay, warnings) = SettingsOverlay::from_table(&table).with_context(|| {
+            format!("invalid profile `{}` at {}", name.as_str(), path.display())
+        })?;
+        Ok(Self {
+            name,
+            path,
+            overlay,
+            warnings,
+        })
+    }
+}
+
+fn optional_string(table: &Table, key: &str) -> Result<Option<String>> {
+    table
+        .get(key)
+        .map(|value| {
+            value
+                .as_str()
+                .filter(|value| !value.trim().is_empty())
+                .map(str::to_string)
+                .ok_or_else(|| anyhow::anyhow!("`{key}` must be a non-empty string"))
+        })
+        .transpose()
+}
+
+fn optional_string_map(table: &Table, key: &str) -> Result<BTreeMap<String, Option<String>>> {
+    let Some(value) = table.get(key) else {
+        return Ok(BTreeMap::new());
+    };
+    let entries = value
+        .as_table()
+        .ok_or_else(|| anyhow::anyhow!("`{key}` must be a table"))?;
+    entries
+        .iter()
+        .map(|(entry_key, value)| {
+            let value = value
+                .as_str()
+                .filter(|value| !value.trim().is_empty())
+                .map(str::to_string)
+                .ok_or_else(|| anyhow::anyhow!("`{key}.{entry_key}` must be a non-empty string"))?;
+            Ok((entry_key.clone(), Some(value)))
+        })
+        .collect()
+}
+
+fn optional_parsed<T: Copy>(
+    table: &Table,
+    key: &str,
+    parse: impl Fn(&str) -> Option<T>,
+    expected: &str,
+) -> Result<Option<T>> {
+    let Some(value) = table.get(key) else {
+        return Ok(None);
+    };
+    let raw = value
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("`{key}` must be a string"))?;
+    parse(raw)
+        .map(Some)
+        .ok_or_else(|| anyhow::anyhow!("`{key}` expects {expected}; got `{raw}`"))
+}
+
+fn apply_map(target: &mut BTreeMap<String, String>, overlay: &BTreeMap<String, Option<String>>) {
+    for (key, value) in overlay {
+        match value {
+            Some(value) => {
+                target.insert(key.clone(), value.clone());
+            }
+            None => {
+                target.remove(key);
+            }
+        }
+    }
+}
+
+fn insert_optional_string(table: &mut Table, key: &str, value: &Option<Option<String>>) {
+    if let Some(Some(value)) = value {
+        table.insert(key.to_string(), Value::String(value.clone()));
+    }
+}
+
+fn insert_map(table: &mut Table, key: &str, values: &BTreeMap<String, Option<String>>) {
+    let entries = values
+        .iter()
+        .filter_map(|(key, value)| value.as_ref().map(|value| (key.clone(), value.clone())))
+        .map(|(key, value)| (key, Value::String(value)))
+        .collect::<Table>();
+    if !entries.is_empty() {
+        table.insert(key.to_string(), Value::Table(entries));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_name_rejects_paths_and_case_ambiguity() {
+        for invalid in ["", "../fast", "Fast", "-fast", "fast.toml", "fast profile"] {
+            assert!(ProfileName::parse(invalid).is_err(), "accepted {invalid:?}");
+        }
+        assert_eq!(
+            ProfileName::parse("deep-review_2").unwrap().as_str(),
+            "deep-review_2"
+        );
+    }
+
+    #[test]
+    fn profile_is_sparse_and_rejects_global_credentials() {
+        let table: Table = toml::from_str(
+            "default_provider = 'openai'\napproval_policy = 'never'\nfuture_setting = 'preserved'\n[models]\nopenai = 'gpt-5.6 high'\n",
+        )
+        .unwrap();
+        let (overlay, warnings) = SettingsOverlay::from_table(&table).unwrap();
+        assert_eq!(warnings, ["ignoring unknown profile key `future_setting`"]);
+        assert_eq!(overlay.default_provider, Some(Some("openai".to_string())));
+        assert_eq!(overlay.approval_policy, Some(ApprovalPolicy::Never));
+        assert_eq!(overlay.models["openai"].as_deref(), Some("gpt-5.6 high"));
+        assert!(overlay.to_table().get("sandbox_mode").is_none());
+        assert_eq!(
+            overlay.to_table()["future_setting"].as_str(),
+            Some("preserved")
+        );
+
+        let credentials: Table = toml::from_str("[tokens]\nopenai = 'secret'\n").unwrap();
+        assert!(SettingsOverlay::from_table(&credentials).is_err());
+    }
+
+    #[test]
+    fn overlay_replaces_scalars_and_merges_provider_maps() {
+        let mut settings = Settings {
+            default_provider: Some("anthropic".to_string()),
+            models: BTreeMap::from([
+                ("anthropic".to_string(), "claude-sonnet".to_string()),
+                ("openai".to_string(), "gpt-base".to_string()),
+            ]),
+            ..Settings::default()
+        };
+        let overlay = SettingsOverlay {
+            default_provider: Some(Some("openai".to_string())),
+            models: BTreeMap::from([("openai".to_string(), Some("gpt-profile".to_string()))]),
+            ..SettingsOverlay::default()
+        };
+        overlay.apply_to(&mut settings);
+        assert_eq!(settings.default_provider.as_deref(), Some("openai"));
+        assert_eq!(settings.models["openai"], "gpt-profile");
+        assert_eq!(settings.models["anthropic"], "claude-sonnet");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,10 @@ struct Cli {
     #[arg(long, value_enum)]
     provider: Option<ProviderArg>,
 
+    /// Load a named execution profile from `<config_dir>/yolop/profiles/<name>.toml`.
+    #[arg(long, value_name = "NAME")]
+    profile: Option<String>,
+
     /// Override the model id
     #[arg(short, long)]
     model: Option<String>,
@@ -545,7 +549,19 @@ async fn async_main(crash_reporter: &crash_report::CrashReporter) -> Result<()> 
         );
         std::path::PathBuf::from("/dev/null/yolop/settings.toml")
     });
-    let settings = Arc::new(SettingsStore::open(settings_path));
+    let settings = Arc::new(match cli.profile.as_deref() {
+        Some(profile) => SettingsStore::open_with_profile(settings_path, profile)?,
+        None => SettingsStore::open(settings_path),
+    });
+    for warning in settings.profile_warnings() {
+        eprintln!("yolop: {warning}");
+    }
+    if let (Some(name), Some(path)) = (
+        settings.active_profile_name(),
+        settings.active_profile_path(),
+    ) {
+        eprintln!("yolop: profile `{name}` loaded from {}", path.display());
+    }
     let sandbox_mode_override = cli.sandbox.then_some(config::SandboxMode::WorkspaceWrite);
     let effective_sandbox_mode =
         sandbox_mode_override.unwrap_or_else(|| settings.snapshot().sandbox_mode());
@@ -1762,6 +1778,7 @@ mod tests {
             command: None,
             cwd: None,
             provider: Some(ProviderArg::Openrouter),
+            profile: None,
             model: Some("nvidia/nemotron-3-super-120b-a12b".to_string()),
             reasoning_effort: reasoning_effort.map(str::to_string),
             print: None,
@@ -1821,6 +1838,7 @@ mod tests {
             command: None,
             cwd: None,
             provider: None,
+            profile: None,
             model: None,
             reasoning_effort: None,
             print: None,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1048,20 +1048,13 @@ impl App {
         let sandbox = self
             .sandbox_mode_override
             .unwrap_or_else(|| settings.sandbox_mode());
-        let approval_mode = if sandbox == crate::config::SandboxMode::DangerFullAccess {
-            format!(
-                "{} · {} · UNSAFE HOST",
-                settings.approval_mode().as_str(),
-                settings.approval_policy().as_str()
-            )
-        } else {
-            format!(
-                "{} · {} · {}",
-                settings.approval_mode().as_str(),
-                sandbox.as_str(),
-                settings.approval_policy().as_str()
-            )
-        };
+        let profile = self.settings.active_profile_name();
+        let approval_mode = presentation::safety_status_label(
+            profile.as_deref(),
+            settings.approval_mode(),
+            sandbox,
+            settings.approval_policy(),
+        );
         PresentationState {
             stream_preview: self.stream_preview.clone(),
             busy: self.busy,

--- a/src/tui/presentation.rs
+++ b/src/tui/presentation.rs
@@ -6,6 +6,7 @@
 //! dependency so transcript wording and status values can be tested without a
 //! terminal buffer.
 
+use crate::config::{ApprovalMode, ApprovalPolicy, SandboxMode};
 use crate::tui::session_tasks_view::BackgroundCounts;
 use crate::tui::transcript::{Author, ChatLine, StreamKind, StreamPreview};
 use crate::version::VERSION_DETAILS;
@@ -204,6 +205,32 @@ impl PresentationState {
     pub(crate) fn activity_text(&self) -> Option<&str> {
         self.busy
             .then(|| self.turn_activity.as_deref().unwrap_or("thinking"))
+    }
+}
+
+pub(crate) fn safety_status_label(
+    profile: Option<&str>,
+    approval_mode: ApprovalMode,
+    sandbox: SandboxMode,
+    approval_policy: ApprovalPolicy,
+) -> String {
+    let safety = if sandbox == SandboxMode::DangerFullAccess {
+        format!(
+            "{} · {} · UNSAFE HOST",
+            approval_mode.as_str(),
+            approval_policy.as_str()
+        )
+    } else {
+        format!(
+            "{} · {} · {}",
+            approval_mode.as_str(),
+            sandbox.as_str(),
+            approval_policy.as_str()
+        )
+    };
+    match profile {
+        Some(profile) => format!("profile {profile} · {safety}"),
+        None => safety,
     }
 }
 
@@ -551,6 +578,19 @@ mod tests {
         // No extensions → no stray field.
         s.extension_status.clear();
         assert!(!flatten(s.status_lines()).contains("git-guard"));
+    }
+
+    #[test]
+    fn safety_status_identifies_the_active_profile() {
+        assert_eq!(
+            safety_status_label(
+                Some("deep-review"),
+                ApprovalMode::Protective,
+                SandboxMode::WorkspaceWrite,
+                ApprovalPolicy::OnRequest,
+            ),
+            "profile deep-review · protective · workspace-write · on-request"
+        );
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -302,9 +302,103 @@ fn help_flag_succeeds() {
     assert!(stdout.contains("--print"), "help output missing --print");
     assert!(stdout.contains("--image"), "help output missing --image");
     assert!(
+        stdout.contains("--profile"),
+        "help output missing --profile"
+    );
+    assert!(
         stdout.contains("--sandbox"),
         "help output missing --sandbox"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn named_profile_drives_real_print_run_without_copying_global_secrets() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config_root = if cfg!(target_os = "macos") {
+        tmp.path().join("Library/Application Support")
+    } else {
+        tmp.path().join(".config")
+    };
+    let yolop_config = config_root.join("yolop");
+    let profile_dir = yolop_config.join("profiles");
+    std::fs::create_dir_all(&profile_dir).expect("profile dir");
+    let base_path = yolop_config.join("settings.toml");
+    let profile_path = profile_dir.join("offline.toml");
+    std::fs::write(
+        &base_path,
+        "default_provider = 'anthropic'\n[tokens]\nopenai = 'global-secret'\n",
+    )
+    .expect("base settings");
+    std::fs::write(
+        &profile_path,
+        "default_provider = 'llmsim'\napproval_mode = 'protective'\n",
+    )
+    .expect("profile");
+
+    let output = Command::new(yolop_binary())
+        .args([
+            "--profile",
+            "offline",
+            "--session-dir",
+            tmp.path().join("sessions").to_str().unwrap(),
+            "-p",
+            "hi",
+        ])
+        .env("HOME", tmp.path())
+        .env("XDG_CONFIG_HOME", &config_root)
+        .env_remove("OPENAI_API_KEY")
+        .env_remove("ANTHROPIC_API_KEY")
+        .output()
+        .expect("spawn yolop with profile");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "profile run failed: stdout={stdout} stderr={stderr}"
+    );
+    assert!(stdout.contains("offline mode"), "stdout={stdout}");
+    assert!(
+        stderr.contains("profile `offline` loaded"),
+        "stderr={stderr}"
+    );
+    assert!(
+        std::fs::read_to_string(&base_path)
+            .unwrap()
+            .contains("global-secret")
+    );
+    assert!(
+        !std::fs::read_to_string(&profile_path)
+            .unwrap()
+            .contains("global-secret"),
+        "profile must never receive global credentials"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn missing_named_profile_fails_before_starting_a_session() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let output = Command::new(yolop_binary())
+        .args([
+            "--profile",
+            "missing",
+            "--session-dir",
+            tmp.path().join("sessions").to_str().unwrap(),
+            "-p",
+            "hi",
+        ])
+        .env("HOME", tmp.path())
+        .env("XDG_CONFIG_HOME", tmp.path().join(".config"))
+        .output()
+        .expect("spawn yolop with missing profile");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(stderr.contains("read profile `missing`"), "stderr={stderr}");
 }
 
 #[test]


### PR DESCRIPTION
## What changed

Adds explicit `--profile <name>` selection for sparse execution overlays stored in `<config_dir>/yolop/profiles/<name>.toml`. Profiles can bundle provider/model, endpoint, approval, sandbox, and worktree choices while credentials and structural settings remain global-only. Active profile identity is visible at startup, through `get_config`, and in TUI safety status. Profileable setup/config writes return to the active profile; global-only writes remain in `settings.toml`.

## Why

Yolop previously had one persistent settings scope, so changing task-specific model and safety bundles required editing shared global configuration. Named profiles make those bundles explicit and repeatable without duplicating credentials.

## Before / After

Before: `yolop -p "..."` could use only CLI overrides plus global `settings.toml`.

After: `yolop --profile deep-review -p "..."` loads the named overlay, reports its source on stderr, and preserves inherited global secrets outside the profile.

## Risk

- Medium
- Configuration reads and writes now pass through a layered store. Regression coverage verifies precedence, missing/malformed profile failure, path-safe names, active-layer writes, unknown-key preservation, and secret isolation.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated Configuration, ACP integration, Presentation, and the knowledge log.

## Security

Reviewed path traversal, secret boundaries, malformed input, file permissions, and serialization behavior. Profile names use a restricted ASCII filename grammar; credentials, OAuth data, MCP, and capabilities are rejected in profiles; merged settings are never serialized into a profile; writes retain atomic owner-only file creation. Unknown keys are preserved without being interpreted.

## Follow-ups

No follow-ups.