### PR TITLE
fix(runtime): preserve native workspace paths

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -697,7 +697,7 @@ impl CodingCliSessionFileStore {
 #[async_trait]
 impl SessionFileSystem for CodingCliSessionFileStore {
     fn is_mount_resolver(&self) -> bool {
-        false
+        true
     }
 
     fn display_root(&self) -> String {
@@ -5862,7 +5862,7 @@ mod tests {
 
         let workspace = tempfile::tempdir().expect("workspace");
         let session = tempfile::tempdir().expect("session");
-        let store = test_file_store(workspace.path(), session.path());
+        let store = MountFs::wrap_if_needed(test_file_store(workspace.path(), session.path()));
         let workspace_root = std::fs::canonicalize(workspace.path()).expect("canonical workspace");
         let narration = narrate_list_directory(
             &serde_json::json!({ "path": "/workspace/src" }),


### PR DESCRIPTION
## Summary

- mark Yolop's session file store as the native mount resolver
- prevent everruns from wrapping it in a default `/workspace`-aliasing mount
- exercise the real narration mount-resolution path in the regression test

## Testing

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo run --quiet -- --provider llmsim -p 'Reply with exactly: smoke-ok'`

## Security

- **TM-FS:** Reviewed. The change preserves Yolop's existing workspace/session/skills router and write blocklist; it removes an unnecessary wrapper without broadening filesystem access or changing path validation.
- **TM-TOOL:** Reviewed. No capability registration or tool schema changes.
- **TM-DEP:** No dependency changes.
- **TM-BASH / TM-LLM:** Not affected.

## Knowledge

No knowledge update required: this fixes an incorrect capability declaration in the existing filesystem architecture without changing intended behavior or policy.

## Follow-ups

No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
