### PR TITLE
fix(evals): retain terminal-bench trajectories

### DIFF
--- a/evals/terminal_bench/README.md
+++ b/evals/terminal_bench/README.md
@@ -270,7 +270,7 @@ from the environment:
 | `TB_CA_CERT` | CA bundle to install in the container; also sets the verifier's trust vars |
 | `TB_JOB_TIMEOUT` | wall-clock cap on one `harbor run` (default 5400s) |
 | `TB_TIMEOUT_MULTIPLIER` | scale the task's own agent/verifier timeouts |
-| `TB_KEEP_JOBS=1` | keep Harbor job dirs under `.cache/jobs/` for debugging |
+| `TB_KEEP_JOBS=0` | discard Harbor job dirs; by default trajectories and session events are retained under `.cache/jobs/` |
 
 `TB_AGENT_ENV` and `TB_CA_CERT` exist because the *sandbox*, not the benchmark,
 decides how a container reaches the model provider. On a box whose egress goes

--- a/evals/terminal_bench/harbor_yolop.py
+++ b/evals/terminal_bench/harbor_yolop.py
@@ -115,6 +115,32 @@ def running_cost(session_log: Path) -> float | None:
     return total if seen else None
 
 
+def effective_model_metadata(session_log: Path) -> dict[str, str]:
+    """Resolved provider settings from the latest completed model response."""
+    if not session_log.exists():
+        return {}
+    effective: dict[str, str] = {}
+    try:
+        log = session_log.open("r", encoding="utf-8")
+    except OSError:
+        return {}
+    with log:
+        for line in log:
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if event.get("type") != "output.message.completed":
+                continue
+            message = (event.get("data") or {}).get("message") or {}
+            metadata = message.get("metadata") or {}
+            for key in ("provider", "model", "reasoning_effort"):
+                value = metadata.get(key)
+                if value is not None:
+                    effective[key] = str(value)
+    return effective
+
+
 def _kill_command(signal: str) -> str:
     """Signal the in-container yolop process, without depending on `pkill`.
 
@@ -353,14 +379,18 @@ class Yolop(BaseInstalledAgent):
     # -- metrics ------------------------------------------------------------ #
     @override
     def populate_context_post_run(self, context: AgentContext) -> None:
+        metadata = {
+            "stop_reason": self._stop_reason,
+            **effective_model_metadata(self._host_session_log),
+        }
         trajectory_path = self.logs_dir / "trajectory.json"
         if not trajectory_path.exists():
-            context.metadata = {"stop_reason": self._stop_reason}
+            context.metadata = metadata
             return
         try:
             trajectory = json.loads(trajectory_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
-            context.metadata = {"stop_reason": self._stop_reason}
+            context.metadata = metadata
             return
 
         totals = trajectory.get("final_metrics") or {}
@@ -370,7 +400,7 @@ class Yolop(BaseInstalledAgent):
         context.n_cache_tokens = totals.get("total_cached_tokens")
         context.n_output_tokens = totals.get("total_completion_tokens")
         context.cost_usd = totals.get("total_cost_usd")
-        context.metadata = {"stop_reason": self._stop_reason, **summarize(trajectory)}
+        context.metadata = {**metadata, **summarize(trajectory)}
 
 
 def summarize(trajectory: dict[str, Any]) -> dict[str, Any]:

--- a/evals/terminal_bench/terminal_bench.py
+++ b/evals/terminal_bench/terminal_bench.py
@@ -38,7 +38,7 @@ CLI flags): `TB_YOLOP_BIN` (yolop binary to upload; default the musl build),
 `KEY=VALUE` passed into the agent's resp. the verifier's environment),
 `TB_CA_CERT` (CA bundle to install in the container, for sandboxes behind a
 TLS-terminating proxy), `TB_JOB_TIMEOUT`,
-`TB_TIMEOUT_MULTIPLIER`, `TB_KEEP_JOBS=1` (keep Harbor job dirs for debugging).
+`TB_TIMEOUT_MULTIPLIER`, `TB_KEEP_JOBS=0` (discard retained Harbor job dirs).
 
 stdout carries ONLY protocol JSON (one object per line); logs go to stderr.
 """
@@ -99,6 +99,18 @@ def _float(name: str, default: float | None) -> float | None:
         return float(os.environ[name])
     except (KeyError, ValueError):
         return default
+
+
+def _bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    normalized = raw.strip().lower()
+    if normalized in ("1", "true", "yes"):
+        return True
+    if normalized in ("0", "false", "no"):
+        return False
+    return default
 
 
 # ============================================================================ #
@@ -475,7 +487,13 @@ def build_transcript(task: Task, spec: dict, outcome: TrialOutcome,
             "agent": spec.get("agent", "yolop"),
             "provider": provider_of(spec),
             "model": spec.get("model") or "",
-            "reasoning_effort": spec.get("reasoning_effort"),
+            "reasoning_effort": outcome.agent_metadata.get("reasoning_effort"),
+            "provider_requested": provider_of(spec),
+            "model_requested": spec.get("model") or "",
+            "reasoning_effort_requested": spec.get("reasoning_effort"),
+            "provider_effective": outcome.agent_metadata.get("provider"),
+            "model_effective": outcome.agent_metadata.get("model"),
+            "reasoning_effort_effective": outcome.agent_metadata.get("reasoning_effort"),
             "stop_reason": outcome.stop_reason,
             "resolved": outcome.resolved,
             "reward": outcome.reward,
@@ -496,7 +514,7 @@ class Study:
     """Terminal-Bench study state: the task cache plus the run-wide USD budget."""
 
     def __init__(self, *, max_cost_usd: float | None = None, job_timeout: int = 5400,
-                 keep_jobs: bool = False):
+                 keep_jobs: bool = True):
         self.max_cost_usd = max_cost_usd
         self.job_timeout = job_timeout
         self.keep_jobs = keep_jobs
@@ -624,7 +642,7 @@ def _build_study() -> Study:
     return Study(
         max_cost_usd=_float("TB_MAX_COST_USD", None),
         job_timeout=_int("TB_JOB_TIMEOUT", 5400),
-        keep_jobs=os.environ.get("TB_KEEP_JOBS", "") in ("1", "true", "yes"),
+        keep_jobs=_bool("TB_KEEP_JOBS", True),
     )
 
 

--- a/evals/terminal_bench/tests/test_harbor_yolop.py
+++ b/evals/terminal_bench/tests/test_harbor_yolop.py
@@ -154,6 +154,38 @@ class TestRunningCost(unittest.TestCase):
             self.assertAlmostEqual(hy.running_cost(path), 1.0)
 
 
+class TestEffectiveModelMetadata(unittest.TestCase):
+    def test_latest_completed_response_values_are_reported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "events.jsonl"
+            events = [
+                {
+                    "type": "output.message.completed",
+                    "data": {"message": {"metadata": {
+                        "provider": "openai", "model": "gpt-5.6-terra",
+                        "reasoning_effort": "medium",
+                    }}},
+                },
+                {
+                    "type": "output.message.completed",
+                    "data": {"message": {"metadata": {
+                        "provider": "openai", "model": "gpt-5.6-terra",
+                        "reasoning_effort": "high",
+                    }}},
+                },
+            ]
+            path.write_text(
+                "\n".join(json.dumps(event) for event in events) + "\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(hy.effective_model_metadata(path), {
+                "provider": "openai",
+                "model": "gpt-5.6-terra",
+                "reasoning_effort": "high",
+            })
+
+
 class TestPostRun(unittest.TestCase):
     TRAJECTORY = {
         "schema_version": "ATIF-v1.7",
@@ -181,6 +213,14 @@ class TestPostRun(unittest.TestCase):
             (Path(tmp) / "trajectory.json").write_text(json.dumps(self.TRAJECTORY),
                                                        encoding="utf-8")
             agent = make_agent(Path(tmp))
+            agent._host_session_log.parent.mkdir(parents=True)
+            agent._host_session_log.write_text(json.dumps({
+                "type": "output.message.completed",
+                "data": {"message": {"metadata": {
+                    "provider": "openai", "model": "gpt-5.6-terra",
+                    "reasoning_effort": "medium",
+                }}},
+            }) + "\n", encoding="utf-8")
             context = AgentContext()
             agent.populate_context_post_run(context)
 
@@ -193,6 +233,9 @@ class TestPostRun(unittest.TestCase):
         self.assertEqual(context.metadata["tools_used"],
                          {"run_terminal_cmd": 1, "read_file": 1})
         self.assertEqual(context.metadata["stop_reason"], "completed")
+        self.assertEqual(context.metadata["provider"], "openai")
+        self.assertEqual(context.metadata["model"], "gpt-5.6-terra")
+        self.assertEqual(context.metadata["reasoning_effort"], "medium")
 
     def test_missing_trajectory_still_records_the_stop_reason(self):
         from harbor.models.agent.context import AgentContext

--- a/evals/terminal_bench/tests/test_study.py
+++ b/evals/terminal_bench/tests/test_study.py
@@ -152,6 +152,25 @@ class TestTranscript(unittest.TestCase):
         self.assertEqual(transcript.usage.cache_read_tokens, 400)
         self.assertTrue(transcript.metadata["resolved"])
 
+    def test_requested_and_effective_model_values_are_distinct(self):
+        outcome = tb.TrialOutcome(agent_metadata={
+            "provider": "openai",
+            "model": "gpt-5.6-terra",
+            "reasoning_effort": "medium",
+        })
+        transcript = tb.build_transcript(
+            make_task(), tb.MATRIX["openai-gpt-5.6-terra"], outcome, None,
+        )
+        self.assertEqual(transcript.metadata["provider_requested"], "openai")
+        self.assertEqual(
+            transcript.metadata["model_requested"], "openai/gpt-5.6-terra",
+        )
+        self.assertIsNone(transcript.metadata["reasoning_effort_requested"])
+        self.assertEqual(transcript.metadata["reasoning_effort_effective"], "medium")
+        self.assertEqual(transcript.metadata["reasoning_effort"], "medium")
+        self.assertEqual(transcript.metadata["model_effective"], "gpt-5.6-terra")
+        self.assertEqual(transcript.metadata["provider_effective"], "openai")
+
     def test_infra_error_kind_rides_through(self):
         outcome = tb.TrialOutcome(stop_reason="error", error="runner: boom")
         transcript = tb.build_transcript(make_task(), tb.MATRIX["llmsim"], outcome, "infra")
@@ -201,6 +220,20 @@ class TestBudget(unittest.TestCase):
             study._subject(mira_sample("fix-git"), run_cx("openai-gpt-5.6-terra"))
 
         self.assertNotIn("max_cost_usd", captured["spec"])
+
+
+class TestJobRetention(unittest.TestCase):
+    def test_harbor_jobs_are_kept_by_default(self):
+        with mock.patch.dict("os.environ", {}, clear=True):
+            self.assertTrue(tb._build_study().keep_jobs)
+
+    def test_harbor_jobs_can_be_discarded_explicitly(self):
+        with mock.patch.dict("os.environ", {"TB_KEEP_JOBS": "0"}, clear=True):
+            self.assertFalse(tb._build_study().keep_jobs)
+
+    def test_invalid_retention_value_does_not_discard_jobs(self):
+        with mock.patch.dict("os.environ", {"TB_KEEP_JOBS": "maybe"}, clear=True):
+            self.assertTrue(tb._build_study().keep_jobs)
 
 
 class TestSuites(unittest.TestCase):

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -150,3 +150,12 @@ wording, formatting, and link fixes do not need entries.
 - Realized the Harbor half of [Trajectory export](specs/trajectory.md): the
   study's Harbor agent adapter hands `--trajectory-out` ATIF straight to Harbor
   with no converter, so the export's stated consumer is now an actual one.
+
+## 2026-07-31 — Terminal-Bench trajectories retained
+
+- Terminal-Bench now keeps Harbor job directories by default so ATIF
+  trajectories and Yolop event logs survive result summarization; constrained
+  runs can opt out with `TB_KEEP_JOBS=0`.
+- Eval metadata now distinguishes matrix-requested provider settings from the
+  effective provider, model, and reasoning effort recorded on completed model
+  responses.

--- a/knowledge/specs/trajectory.md
+++ b/knowledge/specs/trajectory.md
@@ -30,6 +30,12 @@ reasoning, tool calls, and tool results keyed by `source_call_id`, token usage
 into per-step and final metrics). Export is best-effort and never fails the
 run.
 
+The Terminal-Bench study retains each Harbor job directory by default, including
+the ATIF trajectory and Yolop session event log. `TB_KEEP_JOBS=0` opts out when
+storage matters. Its result metadata records requested and effective provider,
+model, and reasoning-effort values separately; the effective values come from
+completed-response metadata in the session log.
+
 ## Non-goals
 
 - Not a replay or resume format — the per-session JSONL log stays the local


### PR DESCRIPTION
## What changed

Terminal-Bench keeps Harbor job directories by default, preserving each case's ATIF trajectory and Yolop event log under `.cache/jobs/`. Set `TB_KEEP_JOBS=0` to discard them.

Completed-response metadata is promoted into Harbor and Mira results. Reports now distinguish requested and effective provider, model, and reasoning effort; the legacy `reasoning_effort` field reports the effective value.

## Why

Mira's saved result previously preserved only the matrix override. With default model settings this produced `reasoning_effort=null`, even though Yolop actually used `medium`. The Harbor job containing the authoritative event metadata was then deleted by default, preventing later diagnosis.

## Before / After

Before:
- `reasoning_effort=null` when the matrix left effort unset
- Harbor jobs, ATIF trajectories, and session events deleted unless `TB_KEEP_JOBS=1`

After:
- `reasoning_effort_requested=null`
- `reasoning_effort_effective=medium` (for the observed GPT-5.6 Terra run)
- trajectories and events retained by default; `TB_KEEP_JOBS=0` opts out

End-to-end llmsim smoke completed the agent phase successfully and retained `trajectory.json`, `events.jsonl`, and result metadata with requested/effective provider and model values. Its expected task score was zero because llmsim does not solve benchmark tasks.

## Risk

- Medium: full 89-case runs now consume more local disk under the ignored `.cache/jobs/` directory.
- The opt-out is documented; invalid `TB_KEEP_JOBS` values fail safe by retaining artifacts.
- Effective values represent the latest completed model response; the retained event log remains authoritative for per-response changes.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

Validation:
- `uv run --with mira-eval --with harbor -m unittest discover -s tests` (50 passed)
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `python3 scripts/validate_okf.py knowledge --check-links`
- Terminal-Bench llmsim end-to-end smoke
- `cargo test --all-features`: all unit/integration tests passed except the unchanged local PTY color-capture test `gallery_paints_truecolor_and_braille`; GitHub Actions remains the merge authority

## Knowledge

Updated `knowledge/specs/trajectory.md` and `knowledge/log.md` with the retention and metadata contract.

## Security

Reviewed TM-FS, TM-LLM, and resource-exhaustion risks. Parsing is limited to the harness-owned session log and streams the file rather than loading it unbounded. No prompt, command, credential, or key handling changed, and no secret values are copied into result metadata. Default retention increases local cache usage intentionally and has a documented opt-out.

## Follow-ups

No follow-ups.
