### PR TITLE
fix(background): make long monitoring turn-free

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -167,3 +167,11 @@ wording, formatting, and link fixes do not need entries.
 - Eval metadata now distinguishes matrix-requested provider settings from the
   effective provider, model, and reasoning effort recorded on completed model
   responses.
+
+## 2026-07-31 — Durable monitoring without polling turns
+
+- [Background execution](specs/background.md) now defines semantic polling
+  detection across a bounded observation window, so heterogeneous status/task
+  cycles steer to one durable background watch without flagging one-off checks.
+- Background completions queued at one idle boundary are coalesced into one
+  TUI or ACP wake turn while retaining their durable task results.

--- a/knowledge/specs/background.md
+++ b/knowledge/specs/background.md
@@ -72,9 +72,11 @@ harness steers there at the three places poll loops start, on any repo:
   (CI, reviews, deploys) must not consume turns: detach one blocking watch,
   end the turn, let the completion wake continue — or `wait_task` it in
   one-shot mode, where there is no wake.
-- `progress_guard` classifies external-event probes (`gh pr checks`,
-  `gh run …`, bare/leading `sleep`) as *waiting* and, on consecutive repeats,
-  injects a warning that names `spawn_background` as the fix.
+- `progress_guard` classifies external-event and session-task probes
+  (`gh pr checks`, `gh run …`, `get_task`, bare/leading `sleep`) as *waiting*.
+  Four waiting signals in a bounded eight-observation window inject a warning
+  that names `spawn_background` as the fix. Mutations and validations clear the
+  window, so a legitimate one-off status check around real work stays quiet.
 - The `bash` tool's 120s-timeout error points foreground watches at
   `spawn_background` instead of leaving the model to fall back to
   sleep-and-recheck turns.
@@ -155,6 +157,9 @@ Yolop installs a platform store to close that gap (`crate::background_wake`):
 - Both frame the completion message as an `[automatic]` prompt
   (`frame_wake_prompt`): explicitly not a user message, pointing the model at the
   run's result before it continues.
+- Both coalesce completions already queued at the same idle boundary into one
+  automatic prompt. Result paths remain in that bounded prompt, and the durable
+  task registry remains authoritative if an unusually large burst is capped.
 - Opt-out: the `proactive_wake` setting (on by default) suppresses the auto-turn
   and surfaces a one-line notice instead.
 - `--print` is one-shot, so it does not auto-wake.

--- a/src/capabilities/progress_guard.rs
+++ b/src/capabilities/progress_guard.rs
@@ -22,7 +22,8 @@ const REPEATED_EXPLORATION_THRESHOLD: usize = 5;
 const ZERO_EVIDENCE_SEARCH_THRESHOLD: usize = 3;
 const TRUNCATED_EXPLORATION_THRESHOLD: usize = 2;
 const REPEATED_STATUS_THRESHOLD: usize = 3;
-const REPEATED_WAITING_THRESHOLD: usize = 3;
+const WAITING_WINDOW_SIZE: usize = 8;
+const WAITING_WINDOW_THRESHOLD: usize = 4;
 const SEMANTIC_HISTORY_LIMIT: usize = 512;
 const TRACKED_PATH_LIMIT: usize = 1024;
 
@@ -96,7 +97,7 @@ struct SessionProgress {
     validation_count: usize,
     repeated_status_count: usize,
     last_status_command: Option<String>,
-    repeated_waiting_count: usize,
+    recent_waiting: VecDeque<bool>,
     repeated_exploration_count: usize,
     last_exploration_signature: Option<String>,
     consecutive_zero_evidence_searches: usize,
@@ -138,10 +139,8 @@ impl SessionProgress {
             ToolClass::Waiting => {
                 self.exploration_since_progress += 1;
                 self.reset_result_streaks();
-                self.repeated_waiting_count += 1;
-                if self.repeated_waiting_count >= REPEATED_WAITING_THRESHOLD {
+                if self.observe_waiting_signal(true) {
                     self.warning_count += 1;
-                    self.repeated_waiting_count = 0;
                     return Some(
                         "progress_guard: repeated checks of an external event (CI run, PR checks/reviews) without other progress. Do not poll across turns: run one blocking watch detached via spawn_background (e.g. `gh pr checks --watch` or an `until <check>; do sleep 30; done` loop) and end the turn — completion wakes the agent. In one-shot mode, block on the spawned task with wait_task instead."
                             .to_string(),
@@ -152,7 +151,7 @@ impl SessionProgress {
             ToolClass::Status(command) => {
                 self.exploration_since_progress += 1;
                 self.reset_result_streaks();
-                self.repeated_waiting_count = 0;
+                self.observe_waiting_signal(false);
                 if self.last_status_command.as_deref() == Some(command.as_str()) {
                     self.repeated_status_count += 1;
                 } else {
@@ -171,7 +170,7 @@ impl SessionProgress {
             }
             ToolClass::Exploration => {
                 self.exploration_since_progress += 1;
-                self.repeated_waiting_count = 0;
+                self.observe_waiting_signal(false);
                 if let Some(warning) = self.result_warning(tool_call, result) {
                     return Some(warning);
                 }
@@ -181,10 +180,7 @@ impl SessionProgress {
                 self.exploration_warning()
             }
             ToolClass::Other => {
-                // The waiting counter is strictly consecutive (any other tool
-                // resets it) so legitimate one-off PR/CI checks between real
-                // work never accumulate into a false poll warning.
-                self.repeated_waiting_count = 0;
+                self.observe_waiting_signal(false);
                 self.reset_result_streaks();
                 None
             }
@@ -247,10 +243,33 @@ impl SessionProgress {
         self.exploration_since_progress = 0;
         self.repeated_status_count = 0;
         self.last_status_command = None;
-        self.repeated_waiting_count = 0;
+        self.recent_waiting.clear();
         self.repeated_exploration_count = 0;
         self.last_exploration_signature = None;
         self.reset_result_streaks();
+    }
+
+    fn observe_waiting_signal(&mut self, waiting: bool) -> bool {
+        // A bounded semantic window catches heterogeneous check/read/task-probe
+        // cycles while mutations and validations still clear it. Transparently
+        // moving an already-started shell process would risk replaying side
+        // effects and weakening one-shot cancellation, so the guard steers the
+        // next wait onto the existing durable background-task path instead.
+        self.recent_waiting.push_back(waiting);
+        if self.recent_waiting.len() > WAITING_WINDOW_SIZE {
+            self.recent_waiting.pop_front();
+        }
+        if self
+            .recent_waiting
+            .iter()
+            .filter(|waiting| **waiting)
+            .count()
+            >= WAITING_WINDOW_THRESHOLD
+        {
+            self.recent_waiting.clear();
+            return true;
+        }
+        false
     }
 
     fn advance_opaque_mutation(&mut self) {
@@ -456,6 +475,7 @@ fn classify_tool_call(tool_call: &ToolCall) -> ToolClass {
             ToolClass::Exploration
         }
         "write_file" | "edit_file" | "delete_file" | "ast_edit" => ToolClass::Mutation,
+        "get_task" | "list_tasks" => ToolClass::Waiting,
         "bash" => classify_bash_command(
             tool_call
                 .arguments
@@ -1413,6 +1433,7 @@ mod tests {
             "gh pr checks 42",
             "sleep 30 && gh pr checks 42",
             "gh run list --limit 1",
+            "gh pr view 42",
         ];
         for command in polls {
             last = result();
@@ -1435,14 +1456,84 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn interleaved_work_resets_waiting_counter() {
+    async fn semantic_polling_cycle_warns_across_heterogeneous_tools() {
+        let state = Arc::new(Mutex::new(ProgressGuardState::default()));
+        let hook = ProgressGuardHook { state };
+        let context = ToolContext::new(SessionId::new());
+        let cycle = [
+            call("bash", json!({ "command": "gh pr checks 42" })),
+            call("read_file", json!({ "path": "/tmp/synthetic-ci-note" })),
+            call("get_task", json!({ "task_id": "task_ci" })),
+            call("bash", json!({ "command": "gh run view 123" })),
+        ];
+        let mut warnings = Vec::new();
+
+        for tool_call in cycle.into_iter().cycle().take(8) {
+            let mut output = result();
+            hook.after_exec(
+                &tool_call,
+                &tool_def(&tool_call.name),
+                &mut output,
+                &context,
+            )
+            .await;
+            if let Some(warning) = output
+                .result
+                .as_ref()
+                .and_then(|value| value.get("progress_guard_warning"))
+                .and_then(Value::as_str)
+            {
+                warnings.push(warning.to_string());
+            }
+        }
+
+        assert!(
+            warnings
+                .iter()
+                .any(|warning| warning.contains("spawn_background")),
+            "a semantic polling cycle must be caught even when unrelated reads and task probes separate external checks: {warnings:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn one_off_task_and_ci_status_checks_do_not_warn() {
         let state = Arc::new(Mutex::new(ProgressGuardState::default()));
         let hook = ProgressGuardHook { state };
         let context = ToolContext::new(SessionId::new());
 
-        // Check CI, fix something, check again — legitimate, never a poll
-        // warning because the counter is strictly consecutive.
-        for _ in 0..(REPEATED_WAITING_THRESHOLD * 2) {
+        for tool_call in [
+            call("list_tasks", json!({})),
+            call("get_task", json!({ "task_id": "task_once" })),
+            call("bash", json!({ "command": "gh pr checks 42" })),
+        ] {
+            let mut output = result();
+            hook.after_exec(
+                &tool_call,
+                &tool_def(&tool_call.name),
+                &mut output,
+                &context,
+            )
+            .await;
+            assert!(
+                output
+                    .result
+                    .as_ref()
+                    .and_then(|value| value.get("progress_guard_warning"))
+                    .is_none(),
+                "a one-off status check is legitimate"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn interleaved_work_resets_waiting_window() {
+        let state = Arc::new(Mutex::new(ProgressGuardState::default()));
+        let hook = ProgressGuardHook { state };
+        let context = ToolContext::new(SessionId::new());
+
+        // Check CI, fix something, check again — legitimate, because real
+        // progress clears the semantic window.
+        for _ in 0..(WAITING_WINDOW_THRESHOLD * 2) {
             let mut check = result();
             hook.after_exec(
                 &call("bash", json!({ "command": "gh pr checks 42" })),

--- a/src/editor/acp/server.rs
+++ b/src/editor/acp/server.rs
@@ -41,7 +41,7 @@ use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use crate::capabilities::{ApprovalDecision, ToolApprover};
 use crate::config::{ApprovalMode, SettingsStore};
 use crate::exec::worktree::WorktreeManager;
-use crate::runtime::background_wake::{WakeReceiver, frame_wake_prompt};
+use crate::runtime::background_wake::{WakeReceiver, coalesce_pending_wakes, frame_wake_prompt};
 use crate::runtime::{BuiltRuntime, ModelState, RuntimeHandles};
 
 use super::bridge::{Translator, tool_kind};
@@ -673,6 +673,9 @@ fn spawn_background_wake_drain(
             }
             // Serialize with client prompts so two turns never overlap.
             let _turn = session.turn_lock.lock().await;
+            // Completions that accumulated while the foreground turn held the
+            // lock are one observation point, not separate model obligations.
+            let message = coalesce_pending_wakes(message, &mut wake_rx);
             if !session.settings.snapshot().proactive_wake_enabled() {
                 peer.session_update(
                     &session.acp_id,

--- a/src/runtime/background_wake.rs
+++ b/src/runtime/background_wake.rs
@@ -33,6 +33,42 @@ pub type WakeSender = mpsc::UnboundedSender<String>;
 /// Receiver half a host drains to react to finished background tasks.
 pub type WakeReceiver = mpsc::UnboundedReceiver<String>;
 
+const MAX_WAKE_BATCH_BYTES: usize = 32 * 1024;
+const MAX_WAKE_BATCH_MESSAGES: usize = 256;
+
+/// Drain the completions already queued for one idle host into one model turn.
+/// The task registry remains the durable source of truth when an unusually
+/// large burst exceeds the prompt cap.
+pub(crate) fn coalesce_pending_wakes(first: String, receiver: &mut WakeReceiver) -> String {
+    let mut messages = vec![first];
+    while messages.len() < MAX_WAKE_BATCH_MESSAGES
+        && let Ok(message) = receiver.try_recv()
+    {
+        messages.push(message);
+    }
+    let count = messages.len();
+    if count == 1 {
+        return messages.pop().expect("wake batch has first message");
+    }
+
+    let mut message = format!("{count} background tasks finished:");
+    let mut omitted = 0;
+    for (index, item) in messages.into_iter().enumerate() {
+        let section = format!("\n\n--- task {} ---\n{item}", index + 1);
+        if message.len() + section.len() <= MAX_WAKE_BATCH_BYTES {
+            message.push_str(&section);
+        } else {
+            omitted += 1;
+        }
+    }
+    if omitted > 0 {
+        message.push_str(&format!(
+            "\n\n{omitted} additional completion(s) omitted from this prompt; inspect list_tasks for their durable results."
+        ));
+    }
+    message
+}
+
 fn wake_routes() -> &'static Mutex<HashMap<SessionId, WakeSender>> {
     static ROUTES: OnceLock<Mutex<HashMap<SessionId, WakeSender>>> = OnceLock::new();
     ROUTES.get_or_init(|| Mutex::new(HashMap::new()))
@@ -109,7 +145,7 @@ impl Drop for WakeRunner {
 /// message and point the model at the run's result before it continues.
 pub fn frame_wake_prompt(message: &str) -> String {
     format!(
-        "[automatic] A background task you started has finished:\n\n{message}\n\nThis is not a \
+        "[automatic] Background work you started has finished:\n\n{message}\n\nThis is not a \
          user message. Read the run's result if useful (its `result_path`/`log_path` are session \
          files you can read), then continue the work it was for or report the result."
     )
@@ -321,5 +357,31 @@ mod tests {
             .expect("wake runner must scope schedule claims");
         assert!(routable.contains(&session_a));
         assert!(!routable.contains(&session_b));
+    }
+
+    #[test]
+    fn queued_completion_burst_coalesces_without_losing_results() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        tx.send("task_2 result_path=/results/2".to_string())
+            .unwrap();
+        tx.send("task_3 result_path=/results/3".to_string())
+            .unwrap();
+
+        let batch = coalesce_pending_wakes("task_1 result_path=/results/1".to_string(), &mut rx);
+
+        assert!(
+            batch.starts_with("3 background tasks finished"),
+            "three wakes should cost one model turn"
+        );
+        for result_path in ["/results/1", "/results/2", "/results/3"] {
+            assert!(
+                batch.contains(result_path),
+                "every queued result must be delivered in the coalesced prompt"
+            );
+        }
+        assert!(
+            rx.try_recv().is_err(),
+            "the burst must be drained exactly once"
+        );
     }
 }

--- a/src/testing/scenarios.rs
+++ b/src/testing/scenarios.rs
@@ -19,9 +19,10 @@
 //! specifically about the agent control flow.
 
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use everruns_core::llmsim_driver::{LlmSimConfig, OnExhausted, SimError, SimToolCall, SimTurn};
+use everruns_core::session_task::SessionTaskState;
 use serde_json::json;
 
 use crate::config::SettingsStore;
@@ -263,6 +264,76 @@ async fn scripted_spawn_background_runs_bash_detached() {
         .await
         .expect("read marker");
     assert_eq!(marker_text, "background-ok");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn predictable_long_command_returns_immediately_and_terminal_result_is_durable() {
+    let (runtime, _workspace) = build_scripted_runtime(LlmSimConfig::scripted(vec![
+        SimTurn::ToolCalls(vec![SimToolCall {
+            name: "spawn_background".to_string(),
+            arguments: json!({
+                "tool": "bash",
+                "args": { "command": "sleep 1; printf durable-result" },
+                "title": "synthetic long validation",
+                "signal_on_completion": false
+            }),
+            id: None,
+        }]),
+        SimTurn::Assistant("background validation started".to_string()),
+    ]))
+    .await;
+
+    let started = Instant::now();
+    let turn = run_single_turn(&runtime, "run the predictable long validation").await;
+    let foreground_elapsed = started.elapsed();
+    assert!(
+        turn.success,
+        "background launch turn must succeed: {turn:?}"
+    );
+    assert!(
+        foreground_elapsed < Duration::from_millis(750),
+        "the one-second command must not consume foreground time: {foreground_elapsed:?}"
+    );
+
+    let session_id = runtime.handles.session_id;
+    let task = runtime
+        .task_registry
+        .list(session_id, None)
+        .await
+        .expect("list real session tasks")
+        .into_iter()
+        .find(|task| task.kind == "background_tool")
+        .expect("spawn_background must create a session task");
+    let terminal = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let current = runtime
+                .task_registry
+                .get(session_id, &task.id)
+                .await
+                .expect("retrieve task while it runs")
+                .expect("task must remain retrievable");
+            if current.state.is_terminal() {
+                break current;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("background command should finish");
+
+    assert_eq!(terminal.state, SessionTaskState::Succeeded);
+    assert!(
+        terminal.result_path.is_some(),
+        "terminal result path is delivered"
+    );
+    let retrieved = runtime
+        .task_registry
+        .get(session_id, &task.id)
+        .await
+        .expect("retrieve completed task")
+        .expect("completed tasks must not disappear before wait_task/get_task");
+    assert_eq!(retrieved.id, task.id);
+    assert_eq!(retrieved.result_path, terminal.result_path);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -2528,6 +2528,10 @@ impl App {
         let Ok(message) = self.background_wake.try_recv() else {
             return false;
         };
+        let message = crate::runtime::background_wake::coalesce_pending_wakes(
+            message,
+            &mut self.background_wake,
+        );
         if !self.settings.snapshot().proactive_wake_enabled() {
             self.push_system(
                 "✓ background task finished — see /background (proactive wake off)".to_string(),
@@ -6325,6 +6329,33 @@ mod tests {
         assert!(
             app.lines.iter().any(|l| l.text.contains("waking")),
             "a notice explaining the auto-wake should be shown"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn proactive_wake_coalesces_queued_completions_into_one_turn() {
+        let mut test = app_with_llmsim().await;
+        let app = &mut test.app;
+        app.setup = None;
+        let tx = seed_background_wake(app, "task_1 result_path=/results/1");
+        tx.send("task_2 result_path=/results/2".to_string())
+            .unwrap();
+        tx.send("task_3 result_path=/results/3".to_string())
+            .unwrap();
+
+        assert!(app.maybe_wake_from_background_channel());
+        assert!(app.busy);
+        assert!(
+            app.lines
+                .iter()
+                .filter(|line| line.text.contains("waking"))
+                .count()
+                == 1,
+            "the host should present one wake notice"
+        );
+        assert!(
+            app.background_wake.try_recv().is_err(),
+            "queued completions must not create duplicate idle wakes"
         );
     }
 


### PR DESCRIPTION
## What changed

Long external validation now converges onto the existing durable background-task path without spending a model turn per poll or per queued completion.

- Detect heterogeneous monitoring cycles with a bounded semantic window: four wait/task signals within eight non-progress observations warn toward one `spawn_background` watch. Mutations and validations clear the window.
- Coalesce up to 256 already-queued completion signals into one bounded 32 KiB automatic wake prompt in both TUI and ACP hosts.
- Keep foreground/background shell timeout selection, output caps, sandboxing, cancellation, one-shot behavior, and existing host notices unchanged.

## Why

Observed sessions lost 24 minutes to twelve fixed 120-second foreground timeouts, produced 53 synthetic completion turns across sixteen sessions, and escaped consecutive-repeat guards by alternating heterogeneous probes. A terminal task could also become unavailable before its result was consumed.

Two owner-level options were evaluated:

1. Transparently hand an already-running foreground shell process to the task registry at timeout. This was rejected: the shell executor intentionally kills on future drop, and safe handoff would require process reattachment or replay semantics that could duplicate side effects and weaken one-shot cancellation.
2. Detect the semantic cycle before another wait, route it to the existing durable background primitive, and coalesce completions at the host idle boundary. This won because it preserves the established sandbox/process lifecycle while directly reducing polling and wake turns.

## Before / After

Deterministic synthetic regressions measure the changed behavior:

- Heterogeneous cycle: baseline consecutive logic emitted 0 warnings for an eight-observation `gh`/read/task-probe cycle; the semantic window now interrupts it with the durable-watch guidance.
- False-positive control: one `list_tasks`, one `get_task`, and one CI check emit 0 warnings; edits between checks clear the window.
- Wake burst: 3 queued completions previously implied 3 host/model wakes; now they produce 1 wake, deliver all 3 result paths, and leave 0 duplicate queued wakes.
- Foreground time: a synthetic 1-second command launched through the real `spawn_background` path returns the foreground turn in under 750 ms, then reaches `succeeded` asynchronously.
- Result delivery: the same real-path test retrieves the terminal task and unchanged `result_path` after completion.
- Live provider: Doppler/OpenAI used exactly one `spawn_background` and one `wait_task`, with no direct bash/list/get polling, and returned `durable-live-smoke`.

Validation:

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`: 993 unit tests passed; 51 integration tests passed. `fullscreen_enables_modified_key_reporting_after_entering_alternate_screen` failed and reproduced identically on a clean `origin/main` worktree, so it is unrelated to this diff.
- Focused progress-guard, wake, TUI, and real background/session-task tests pass.
- `python3 scripts/validate_okf.py knowledge --check-links`
- Doppler/OpenAI live-provider smoke through `spawn_background` + `wait_task`

## Risk

- Medium: the progress guard may steer a dense cluster of status probes earlier than before. The four-of-eight threshold and progress reset are covered by negative controls.
- Wake coalescing changes turn cardinality only for completions already queued at one idle boundary; every included result path remains in the prompt, and all task results remain durable in the registry.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated `Background execution` and the knowledge log with semantic polling-window and wake-coalescing policy.

## Security

- **TM-BASH:** reviewed sandbox inheritance, foreground/background timeouts, per-stream output caps, cancellation, and one-shot behavior. Execution code is unchanged; the real background/session-task test exercises the shared executor.
- **TM-LLM:** automatic completion prompts remain host-generated and are now bounded to 256 messages / 32 KiB per batch. Excess result details remain available from the durable task registry. No credentials or private session content are logged or persisted by this change.
- **TM-FS:** no filesystem permission or path handling changes. Result retrieval uses the existing session VFS/task registry.
- **TM-TOOL:** no new tools or capability registration. Existing task probes are classified only for progress guidance.
- **TM-DEP:** no dependency changes.
- Reviewed injection, data exposure, trust-boundary validation, and resource exhaustion; no findings requiring changes beyond the explicit batch count/size bounds.

## Follow-ups

No follow-ups.