### PR TITLE
feat(evals): run control-v1 on gpt-5.6-luna

### DIFF
--- a/evals/terminal_bench/README.md
+++ b/evals/terminal_bench/README.md
@@ -127,7 +127,47 @@ fast enough to repeat.
 | `configure-git-webserver` | hard | system-administration | 900s |
 | `fix-code-vulnerability` | hard | security | 900s |
 
-### Baseline
+### Baselines
+
+The tracked `control` preset uses yolop · **gpt-5.6-luna** (OpenAI). Run
+`20260801T001630Z-ec1b`, with the infrastructure-invalid `overfull-hbox` case
+replaced by CA-enabled run `20260801T004403Z-5be4`, resolved **5/8 for $0.55**
+in 29 minutes of summed case wall time. Every valid case used the model's
+effective default reasoning effort, `medium`; there were no timeouts or budget
+stops.
+
+| difficulty | resolved |
+|---|---|
+| easy | 3/3 |
+| medium | 1/3 |
+| hard | 1/2 |
+
+| task | | cost | wall | llm calls | tool calls |
+|---|---|---|---|---|---|
+| `cobol-modernization` | ✓ | $0.090 | 146s | 15 | 14 |
+| `fix-git` | ✓ | $0.068 | 153s | 16 | 23 |
+| `overfull-hbox` | ✓ | $0.090 | 301s | 17 | 20 |
+| `modernize-scientific-stack` | ✓ | $0.026 | 147s | 5 | 4 |
+| `count-dataset-tokens` | ✗ | $0.058 | 326s | 14 | 13 |
+| `chess-best-move` | ✗ | $0.088 | 173s | 14 | 13 |
+| `fix-code-vulnerability` | ✗ | $0.069 | 121s | 7 | 12 |
+| `configure-git-webserver` | ✓ | $0.063 | 347s | 12 | 11 |
+
+The initial `overfull-hbox` attempt never reached the model: that task image had
+no CA certificates, so reqwest failed during client construction. The
+replacement run supplied the host CA through `TB_CA_CERT` and passed. The three
+model failures have distinct causes in their retained trajectories:
+
+- `chess-best-move` could not interpret the board image directly, inferred the
+  pieces from pixel statistics, and wrote `g7f8`; the verifier requires both
+  `e2e4` and `g2g4`.
+- `count-dataset-tokens` calculated 63,841 reasoning tokens and 15,745 solution
+  tokens, but chose the reasoning-only value instead of their required 79,586
+  total.
+- `fix-code-vulnerability` fixed the CRLF injection and passed all 367 upstream
+  tests, but reported `CWE-113`; the benchmark requires `CWE-93`.
+
+The historical Terra baseline remains useful for comparison:
 
 yolop · **gpt-5.6-terra** (OpenAI), run `20260731T014824Z-3c1e` — **6/8 for
 $1.34**, 22 minutes wall clock, every case ran to its own completion (no
@@ -251,7 +291,7 @@ targets.
 | Preset | Purpose | Samples | Targets |
 |--------|---------|---------|---------|
 | `smoke` | Integration check / validate a new config before a full run | `fix-git`, `cobol-modernization` | gpt-5.6-terra |
-| `control` | The periodic regression run ([Control suite](#control-suite)) | 8 (`control-v1`) | gpt-5.6-terra |
+| `control` | The periodic regression run ([Control suite](#control-suite)) | 8 (`control-v1`) | gpt-5.6-luna |
 | `compare` | yolop vs the other terminal agents on identical tasks | the `easy` tier | yolop ×2 + terminus-2 + claude-code + codex |
 | `full` | The headline number | all 89 | gpt-5.6-terra |
 

--- a/evals/terminal_bench/mira.toml
+++ b/evals/terminal_bench/mira.toml
@@ -44,7 +44,7 @@ targets = "openai-gpt-5.6-terra"
 #   TB_MAX_COST_USD=10 mira run --preset control --group-by difficulty
 [presets.control]
 tag = "control-v1"
-targets = "openai-gpt-5.6-terra"
+targets = "openai-gpt-5.6-luna"
 
 # COMPARE — yolop against the other terminal agents on the same easy tasks, the
 # evidence for "how does yolop's harness bench against Terminus/Claude Code/Codex".

--- a/evals/terminal_bench/results/20260801T001630Z-ec1b/cases/terminal_5fbench_2fchess_2dbest_2dmove_40openai_2dgpt_2d5_2e6_2dluna/result.json
+++ b/evals/terminal_bench/results/20260801T001630Z-ec1b/cases/terminal_5fbench_2fchess_2dbest_2dmove_40openai_2dgpt_2d5_2e6_2dluna/result.json
@@ -1,0 +1,81 @@
+{
+  "eval": "terminal_bench",
+  "sample": "chess-best-move",
+  "target": "openai-gpt-5.6-luna",
+  "passed": false,
+  "aggregate": 0.5,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 0.0,
+      "pass": false,
+      "reason": "tests failed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=False",
+    "iterations": 14,
+    "tool_calls_count": 13,
+    "tool_calls": [
+      "write_session_title",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "read_file"
+    ],
+    "usage": {
+      "input_tokens": 24669,
+      "output_tokens": 7480,
+      "cache_read_tokens": 182814,
+      "cost_usd": 0.08783039999999999
+    },
+    "timing": {
+      "duration_ms": 173028
+    },
+    "metrics": {
+      "cache_read_tokens": 182814.0,
+      "llm_calls": 14.0,
+      "reward": 0.0,
+      "tool_calls": 13.0
+    },
+    "metadata": {
+      "agent": "yolop",
+      "category": "games",
+      "difficulty": "medium",
+      "exception": null,
+      "model": "openai/gpt-5.6-luna",
+      "model_effective": "gpt-5.6-luna",
+      "model_requested": "openai/gpt-5.6-luna",
+      "provider": "openai",
+      "provider_effective": "openai",
+      "provider_requested": "openai",
+      "reasoning_effort": "medium",
+      "reasoning_effort_effective": "medium",
+      "reasoning_effort_requested": null,
+      "resolved": false,
+      "reward": 0.0,
+      "stop_reason": "completed",
+      "tools_used": {
+        "bash": 11,
+        "read_file": 1,
+        "write_session_title": 1
+      },
+      "yolop_version": "0.13.0"
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260801T001630Z-ec1b/cases/terminal_5fbench_2fcobol_2dmodernization_40openai_2dgpt_2d5_2e6_2dluna/result.json
+++ b/evals/terminal_bench/results/20260801T001630Z-ec1b/cases/terminal_5fbench_2fcobol_2dmodernization_40openai_2dgpt_2d5_2e6_2dluna/result.json
@@ -1,0 +1,81 @@
+{
+  "eval": "terminal_bench",
+  "sample": "cobol-modernization",
+  "target": "openai-gpt-5.6-luna",
+  "passed": true,
+  "aggregate": 1.0,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 1.0,
+      "pass": true,
+      "reason": "tests passed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=True",
+    "iterations": 15,
+    "tool_calls_count": 14,
+    "tool_calls": [
+      "write_session_title",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash"
+    ],
+    "usage": {
+      "input_tokens": 27157,
+      "output_tokens": 6324,
+      "cache_read_tokens": 249069,
+      "cost_usd": 0.0900079
+    },
+    "timing": {
+      "duration_ms": 145691
+    },
+    "metrics": {
+      "cache_read_tokens": 249069.0,
+      "llm_calls": 15.0,
+      "reward": 1.0,
+      "tool_calls": 14.0
+    },
+    "metadata": {
+      "agent": "yolop",
+      "category": "software-engineering",
+      "difficulty": "easy",
+      "exception": null,
+      "model": "openai/gpt-5.6-luna",
+      "model_effective": "gpt-5.6-luna",
+      "model_requested": "openai/gpt-5.6-luna",
+      "provider": "openai",
+      "provider_effective": "openai",
+      "provider_requested": "openai",
+      "reasoning_effort": "medium",
+      "reasoning_effort_effective": "medium",
+      "reasoning_effort_requested": null,
+      "resolved": true,
+      "reward": 1.0,
+      "stop_reason": "completed",
+      "tools_used": {
+        "bash": 13,
+        "write_session_title": 1
+      },
+      "yolop_version": "0.13.0"
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260801T001630Z-ec1b/cases/terminal_5fbench_2fconfigure_2dgit_2dwebserver_40openai_2dgpt_2d5_2e6_2dluna/result.json
+++ b/evals/terminal_bench/results/20260801T001630Z-ec1b/cases/terminal_5fbench_2fconfigure_2dgit_2dwebserver_40openai_2dgpt_2d5_2e6_2dluna/result.json
@@ -1,0 +1,79 @@
+{
+  "eval": "terminal_bench",
+  "sample": "configure-git-webserver",
+  "target": "openai-gpt-5.6-luna",
+  "passed": true,
+  "aggregate": 1.0,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 1.0,
+      "pass": true,
+      "reason": "tests passed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=True",
+    "iterations": 12,
+    "tool_calls_count": 11,
+    "tool_calls": [
+      "write_session_title",
+      "list_directory",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash"
+    ],
+    "usage": {
+      "input_tokens": 29638,
+      "output_tokens": 3631,
+      "cache_read_tokens": 120684,
+      "cost_usd": 0.0634924
+    },
+    "timing": {
+      "duration_ms": 346537
+    },
+    "metrics": {
+      "cache_read_tokens": 120684.0,
+      "llm_calls": 12.0,
+      "reward": 1.0,
+      "tool_calls": 11.0
+    },
+    "metadata": {
+      "agent": "yolop",
+      "category": "system-administration",
+      "difficulty": "hard",
+      "exception": null,
+      "model": "openai/gpt-5.6-luna",
+      "model_effective": "gpt-5.6-luna",
+      "model_requested": "openai/gpt-5.6-luna",
+      "provider": "openai",
+      "provider_effective": "openai",
+      "provider_requested": "openai",
+      "reasoning_effort": "medium",
+      "reasoning_effort_effective": "medium",
+      "reasoning_effort_requested": null,
+      "resolved": true,
+      "reward": 1.0,
+      "stop_reason": "completed",
+      "tools_used": {
+        "bash": 9,
+        "list_directory": 1,
+        "write_session_title": 1
+      },
+      "yolop_version": "0.13.0"
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260801T001630Z-ec1b/cases/terminal_5fbench_2fcount_2ddataset_2dtokens_40openai_2dgpt_2d5_2e6_2dluna/result.json
+++ b/evals/terminal_bench/results/20260801T001630Z-ec1b/cases/terminal_5fbench_2fcount_2ddataset_2dtokens_40openai_2dgpt_2d5_2e6_2dluna/result.json
@@ -1,0 +1,80 @@
+{
+  "eval": "terminal_bench",
+  "sample": "count-dataset-tokens",
+  "target": "openai-gpt-5.6-luna",
+  "passed": false,
+  "aggregate": 0.5,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 0.0,
+      "pass": false,
+      "reason": "tests failed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=False",
+    "iterations": 14,
+    "tool_calls_count": 13,
+    "tool_calls": [
+      "write_session_title",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash"
+    ],
+    "usage": {
+      "input_tokens": 20118,
+      "output_tokens": 3290,
+      "cache_read_tokens": 177333,
+      "cost_usd": 0.0575913
+    },
+    "timing": {
+      "duration_ms": 325626
+    },
+    "metrics": {
+      "cache_read_tokens": 177333.0,
+      "llm_calls": 14.0,
+      "reward": 0.0,
+      "tool_calls": 13.0
+    },
+    "metadata": {
+      "agent": "yolop",
+      "category": "model-training",
+      "difficulty": "medium",
+      "exception": null,
+      "model": "openai/gpt-5.6-luna",
+      "model_effective": "gpt-5.6-luna",
+      "model_requested": "openai/gpt-5.6-luna",
+      "provider": "openai",
+      "provider_effective": "openai",
+      "provider_requested": "openai",
+      "reasoning_effort": "medium",
+      "reasoning_effort_effective": "medium",
+      "reasoning_effort_requested": null,
+      "resolved": false,
+      "reward": 0.0,
+      "stop_reason": "completed",
+      "tools_used": {
+        "bash": 12,
+        "write_session_title": 1
+      },
+      "yolop_version": "0.13.0"
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260801T001630Z-ec1b/cases/terminal_5fbench_2ffix_2dcode_2dvulnerability_40openai_2dgpt_2d5_2e6_2dluna/result.json
+++ b/evals/terminal_bench/results/20260801T001630Z-ec1b/cases/terminal_5fbench_2ffix_2dcode_2dvulnerability_40openai_2dgpt_2d5_2e6_2dluna/result.json
@@ -1,0 +1,81 @@
+{
+  "eval": "terminal_bench",
+  "sample": "fix-code-vulnerability",
+  "target": "openai-gpt-5.6-luna",
+  "passed": false,
+  "aggregate": 0.5,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 0.0,
+      "pass": false,
+      "reason": "tests failed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=False",
+    "iterations": 7,
+    "tool_calls_count": 12,
+    "tool_calls": [
+      "write_session_title",
+      "list_directory",
+      "grep_files",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash"
+    ],
+    "usage": {
+      "input_tokens": 43885,
+      "output_tokens": 1440,
+      "cache_read_tokens": 162514,
+      "cost_usd": 0.06877640000000002
+    },
+    "timing": {
+      "duration_ms": 120805
+    },
+    "metrics": {
+      "cache_read_tokens": 162514.0,
+      "llm_calls": 7.0,
+      "reward": 0.0,
+      "tool_calls": 12.0
+    },
+    "metadata": {
+      "agent": "yolop",
+      "category": "security",
+      "difficulty": "hard",
+      "exception": null,
+      "model": "openai/gpt-5.6-luna",
+      "model_effective": "gpt-5.6-luna",
+      "model_requested": "openai/gpt-5.6-luna",
+      "provider": "openai",
+      "provider_effective": "openai",
+      "provider_requested": "openai",
+      "reasoning_effort": "medium",
+      "reasoning_effort_effective": "medium",
+      "reasoning_effort_requested": null,
+      "resolved": false,
+      "reward": 0.0,
+      "stop_reason": "completed",
+      "tools_used": {
+        "bash": 9,
+        "grep_files": 1,
+        "list_directory": 1,
+        "write_session_title": 1
+      },
+      "yolop_version": "0.13.0"
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260801T001630Z-ec1b/cases/terminal_5fbench_2ffix_2dgit_40openai_2dgpt_2d5_2e6_2dluna/result.json
+++ b/evals/terminal_bench/results/20260801T001630Z-ec1b/cases/terminal_5fbench_2ffix_2dgit_40openai_2dgpt_2d5_2e6_2dluna/result.json
@@ -1,0 +1,91 @@
+{
+  "eval": "terminal_bench",
+  "sample": "fix-git",
+  "target": "openai-gpt-5.6-luna",
+  "passed": true,
+  "aggregate": 1.0,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 1.0,
+      "pass": true,
+      "reason": "tests passed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=True",
+    "iterations": 16,
+    "tool_calls_count": 23,
+    "tool_calls": [
+      "write_session_title",
+      "write_todos",
+      "write_todos",
+      "write_todos",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash"
+    ],
+    "usage": {
+      "input_tokens": 24103,
+      "output_tokens": 3084,
+      "cache_read_tokens": 256425,
+      "cost_usd": 0.0682495
+    },
+    "timing": {
+      "duration_ms": 152520
+    },
+    "metrics": {
+      "cache_read_tokens": 256425.0,
+      "llm_calls": 16.0,
+      "reward": 1.0,
+      "tool_calls": 23.0
+    },
+    "metadata": {
+      "agent": "yolop",
+      "category": "software-engineering",
+      "difficulty": "easy",
+      "exception": null,
+      "model": "openai/gpt-5.6-luna",
+      "model_effective": "gpt-5.6-luna",
+      "model_requested": "openai/gpt-5.6-luna",
+      "provider": "openai",
+      "provider_effective": "openai",
+      "provider_requested": "openai",
+      "reasoning_effort": "medium",
+      "reasoning_effort_effective": "medium",
+      "reasoning_effort_requested": null,
+      "resolved": true,
+      "reward": 1.0,
+      "stop_reason": "completed",
+      "tools_used": {
+        "bash": 19,
+        "write_session_title": 1,
+        "write_todos": 3
+      },
+      "yolop_version": "0.13.0"
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260801T001630Z-ec1b/cases/terminal_5fbench_2fmodernize_2dscientific_2dstack_40openai_2dgpt_2d5_2e6_2dluna/result.json
+++ b/evals/terminal_bench/results/20260801T001630Z-ec1b/cases/terminal_5fbench_2fmodernize_2dscientific_2dstack_40openai_2dgpt_2d5_2e6_2dluna/result.json
@@ -1,0 +1,71 @@
+{
+  "eval": "terminal_bench",
+  "sample": "modernize-scientific-stack",
+  "target": "openai-gpt-5.6-luna",
+  "passed": true,
+  "aggregate": 1.0,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 1.0,
+      "pass": true,
+      "reason": "tests passed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=True",
+    "iterations": 5,
+    "tool_calls_count": 4,
+    "tool_calls": [
+      "write_session_title",
+      "bash",
+      "bash",
+      "bash"
+    ],
+    "usage": {
+      "input_tokens": 13693,
+      "output_tokens": 1334,
+      "cache_read_tokens": 42692,
+      "cost_usd": 0.0259662
+    },
+    "timing": {
+      "duration_ms": 147027
+    },
+    "metrics": {
+      "cache_read_tokens": 42692.0,
+      "llm_calls": 5.0,
+      "reward": 1.0,
+      "tool_calls": 4.0
+    },
+    "metadata": {
+      "agent": "yolop",
+      "category": "scientific-computing",
+      "difficulty": "medium",
+      "exception": null,
+      "model": "openai/gpt-5.6-luna",
+      "model_effective": "gpt-5.6-luna",
+      "model_requested": "openai/gpt-5.6-luna",
+      "provider": "openai",
+      "provider_effective": "openai",
+      "provider_requested": "openai",
+      "reasoning_effort": "medium",
+      "reasoning_effort_effective": "medium",
+      "reasoning_effort_requested": null,
+      "resolved": true,
+      "reward": 1.0,
+      "stop_reason": "completed",
+      "tools_used": {
+        "bash": 3,
+        "write_session_title": 1
+      },
+      "yolop_version": "0.13.0"
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260801T001630Z-ec1b/cases/terminal_5fbench_2foverfull_2dhbox_40openai_2dgpt_2d5_2e6_2dluna/result.json
+++ b/evals/terminal_bench/results/20260801T001630Z-ec1b/cases/terminal_5fbench_2foverfull_2dhbox_40openai_2dgpt_2d5_2e6_2dluna/result.json
@@ -1,0 +1,62 @@
+{
+  "eval": "terminal_bench",
+  "sample": "overfull-hbox",
+  "target": "openai-gpt-5.6-luna",
+  "passed": false,
+  "aggregate": 0.0,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 0.0,
+      "pass": false,
+      "reason": "NonZeroAgentExitCodeError: Command failed (exit 101): /installed-agent/yolop/yolop --provider openai --model gpt-5.6-luna --session session_009c1b2c62434506a4896608e34f8bdd --session-dir /logs/agent/sessions --trajectory-out /logs/agent/trajectory.json -p 'Ensure that the LaTeX document main.tex compiles successfully using the installed TeX distribution and pdflatex compiler with no \"overfull hbox\" warnings. In doing so, the only edits you may make are to replace words in input.tex with their specified synonyms in synonyms.txt (each line specifies a family of allowed synonyms). Do not edit main.tex or synonyms.txt.\n\n\n---\n\nYou are running fully autonomously inside a container. There is no user to\nanswer you: nothing you write is read by anyone, and the session ends as soon as\nyou stop. Do not ask for confirmation, do not offer options, and do not stop to\nreport a plan — make the call yourself and carry it out, including for changes\nthat rewrite history or overwrite files.\n\nThe task is graded after you exit by running the task'\"'\"'s own tests against the\ncontainer'\"'\"'s filesystem. Only what is on disk when you stop counts; a correct\ndescription of what should be done scores zero. Before you stop, verify your\nwork by actually running it.' 2>&1 </dev/null | stdbuf -oL tee /logs/agent/yolop.txt\nstdout: \nthread 'yolop-main' (81) panicked at /Users/mykhailochalyi/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/reqwest-0.13.4/src/async_impl/client.rs:2507:38:\nClient::new(): reqwest::Error { kind: Builder, source: General(\"No CA certificates were loaded from the system\") }\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\nyolop: crash report written to /root/.local/share/yolop/crashes/2026-08-01T00-40-11Z-5068dd34-crash.log\n\nstderr: None"
+    },
+    {
+      "scorer": "resolved",
+      "value": 0.0,
+      "pass": false,
+      "reason": "tests failed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=False",
+    "iterations": 0,
+    "tool_calls_count": 0,
+    "usage": {
+      "input_tokens": 0,
+      "output_tokens": 0,
+      "cost_usd": 0.0
+    },
+    "timing": {
+      "duration_ms": 205433
+    },
+    "metrics": {
+      "cache_read_tokens": 0.0,
+      "llm_calls": 0.0,
+      "reward": 0.0,
+      "tool_calls": 0.0
+    },
+    "metadata": {
+      "agent": "yolop",
+      "category": "debugging",
+      "difficulty": "easy",
+      "exception": "NonZeroAgentExitCodeError",
+      "model": "openai/gpt-5.6-luna",
+      "model_effective": null,
+      "model_requested": "openai/gpt-5.6-luna",
+      "provider": "openai",
+      "provider_effective": null,
+      "provider_requested": "openai",
+      "reasoning_effort": null,
+      "reasoning_effort_effective": null,
+      "reasoning_effort_requested": null,
+      "resolved": false,
+      "reward": 0.0,
+      "stop_reason": "completed",
+      "tools_used": {},
+      "yolop_version": null
+    },
+    "error": "NonZeroAgentExitCodeError: Command failed (exit 101): /installed-agent/yolop/yolop --provider openai --model gpt-5.6-luna --session session_009c1b2c62434506a4896608e34f8bdd --session-dir /logs/agent/sessions --trajectory-out /logs/agent/trajectory.json -p 'Ensure that the LaTeX document main.tex compiles successfully using the installed TeX distribution and pdflatex compiler with no \"overfull hbox\" warnings. In doing so, the only edits you may make are to replace words in input.tex with their specified synonyms in synonyms.txt (each line specifies a family of allowed synonyms). Do not edit main.tex or synonyms.txt.\n\n\n---\n\nYou are running fully autonomously inside a container. There is no user to\nanswer you: nothing you write is read by anyone, and the session ends as soon as\nyou stop. Do not ask for confirmation, do not offer options, and do not stop to\nreport a plan — make the call yourself and carry it out, including for changes\nthat rewrite history or overwrite files.\n\nThe task is graded after you exit by running the task'\"'\"'s own tests against the\ncontainer'\"'\"'s filesystem. Only what is on disk when you stop counts; a correct\ndescription of what should be done scores zero. Before you stop, verify your\nwork by actually running it.' 2>&1 </dev/null | stdbuf -oL tee /logs/agent/yolop.txt\nstdout: \nthread 'yolop-main' (81) panicked at /Users/mykhailochalyi/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/reqwest-0.13.4/src/async_impl/client.rs:2507:38:\nClient::new(): reqwest::Error { kind: Builder, source: General(\"No CA certificates were loaded from the system\") }\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\nyolop: crash report written to /root/.local/share/yolop/crashes/2026-08-01T00-40-11Z-5068dd34-crash.log\n\nstderr: None"
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260801T001630Z-ec1b/meta.json
+++ b/evals/terminal_bench/results/20260801T001630Z-ec1b/meta.json
@@ -1,0 +1,34 @@
+{
+  "format": 1,
+  "run_id": "20260801T001630Z-ec1b",
+  "study": "terminal_bench",
+  "study_version": "0.1.0",
+  "started_unix": 1785543390,
+  "finished_unix": 1785545006,
+  "environment": {
+    "git": {
+      "commit": "f36b74f8e9ad005ed88833b3a122a0588510edc6",
+      "branch": "codex/control-v1-luna",
+      "dirty": true
+    },
+    "os": "macos",
+    "arch": "aarch64",
+    "hostname": "Mykhailos-Mac-mini.local",
+    "cpus": 12,
+    "mira_version": "0.3.0",
+    "labels": {
+      "benchmark": "terminal-bench-2-1"
+    }
+  },
+  "summary": {
+    "scored": 8,
+    "passed": 4,
+    "failed": 4,
+    "na": 0,
+    "skipped": 0,
+    "total_tokens": 209846,
+    "total_cost_usd": 0.46191410000000005,
+    "total_tool_calls": 90,
+    "total_duration_ms": 1616667
+  }
+}

--- a/evals/terminal_bench/results/20260801T001630Z-ec1b/report.html
+++ b/evals/terminal_bench/results/20260801T001630Z-ec1b/report.html
@@ -1,0 +1,193 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Mira eval report</title>
+<style>
+:root{color-scheme:light dark;--ok:#1a7f37;--bad:#cf222e;--warn:#9a6700;--mut:#57606a;--bg:#fff;--fg:#1f2328;--line:#d0d7de}
+@media(prefers-color-scheme:dark){:root{--bg:#0d1117;--fg:#e6edf3;--line:#30363d;--mut:#8b949e}}
+*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--fg);font:15px/1.5 -apple-system,Segoe UI,Roboto,sans-serif}
+main{max-width:960px;margin:0 auto;padding:2rem 1.25rem}
+h1{font-size:1.6rem;margin:0 0 1rem}h2{font-size:1.15rem;margin:2rem 0 .75rem;border-bottom:1px solid var(--line);padding-bottom:.25rem}
+.cards{display:flex;flex-wrap:wrap;gap:.75rem}
+.card{flex:1;min-width:96px;border:1px solid var(--line);border-radius:8px;padding:.75rem 1rem;text-align:center}
+.card b{display:block;font-size:1.5rem}.card span{color:var(--mut);font-size:.8rem;text-transform:uppercase;letter-spacing:.04em}
+.card.ok b{color:var(--ok)}.card.bad b{color:var(--bad)}.card.warn b{color:var(--warn)}
+table.matrix{border-collapse:collapse;width:100%}table.matrix th,table.matrix td{border:1px solid var(--line);padding:.4rem .6rem;text-align:center}
+table.matrix td:first-child,table.matrix th:first-child{text-align:left}
+.case{border:1px solid var(--line);border-radius:8px;margin:.5rem 0;padding:.25rem .75rem}
+.case summary{cursor:pointer;display:flex;gap:.6rem;align-items:center;flex-wrap:wrap}
+.case code{font-size:.92rem}.metrics{color:var(--mut);font-size:.8rem;margin-left:auto}
+.badge{font-size:.7rem;font-weight:700;padding:.1rem .4rem;border-radius:4px;color:#fff}
+.badge.pass{background:var(--ok)}.badge.fail{background:var(--bad)}.badge.skip{background:var(--mut)}.badge.na{background:var(--warn)}
+.scores{list-style:none;padding:0;margin:.5rem 0}.scores li{padding:.15rem 0}.scores li.pass{color:var(--ok)}.scores li.fail{color:var(--bad)}.scores li.na{color:var(--mut)}
+.tools,.meta{font-size:.85rem;color:var(--mut)}
+pre{background:rgba(127,127,127,.1);border-radius:6px;padding:.6rem .75rem;overflow:auto;font-size:.85rem;white-space:pre-wrap}
+pre.error{color:var(--bad)}a{color:#0969da}
+</style>
+</head>
+<body>
+<main>
+<h1>Mira eval report</h1>
+<section class="cards">
+<div class="card bad"><b>4/8</b><span>passed</span></div>
+<div class="card"><b>4</b><span>failed</span></div>
+<div class="card"><b>0</b><span>n/a</span></div>
+<div class="card"><b>0</b><span>skipped</span></div>
+<div class="card"><b>209846</b><span>tokens</span></div>
+<div class="card"><b>$0.4619</b><span>cost</span></div>
+</section>
+<h2>Matrix</h2>
+<table class="matrix">
+<thead><tr><th>eval</th><th>openai-gpt-5.6-luna</th></tr></thead>
+<tbody>
+<tr><td>terminal_bench</td><td>4/8</td></tr>
+</tbody>
+</table>
+<h2>Resolve rate by difficulty</h2>
+<table class="matrix">
+<thead><tr><th>difficulty</th><th>passed</th><th>scored</th><th>rate</th></tr></thead>
+<tbody>
+<tr><td>easy</td><td>2</td><td>3</td><td>67%</td></tr>
+<tr><td>hard</td><td>1</td><td>2</td><td>50%</td></tr>
+<tr><td>medium</td><td>1</td><td>3</td><td>33%</td></tr>
+</tbody>
+</table>
+<h2>Cases</h2>
+<details class="case fail">
+<summary><span class="badge fail">FAIL</span> <code>terminal_bench/chess-best-move@openai-gpt-5.6-luna</code><span class="metrics">32149 tok · $0.0878 · 173028ms · 13 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="fail">✗ <b>resolved</b> — tests failed</li>
+</ul>
+<p class="tools"><b>tools:</b> write_session_title, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, read_file</p>
+<p class="meta"><b>metrics:</b> cache_read_tokens=182814, llm_calls=14, reward=0, tool_calls=13</p>
+<p class="meta"><b>metadata:</b> agent=yolop, category=games, difficulty=medium, exception=null, model=openai/gpt-5.6-luna, model_effective=gpt-5.6-luna, model_requested=openai/gpt-5.6-luna, provider=openai, provider_effective=openai, provider_requested=openai, reasoning_effort=medium, reasoning_effort_effective=medium, reasoning_effort_requested=null, resolved=false, reward=0.0, stop_reason=completed, tools_used={"bash":11,"read_file":1,"write_session_title":1}, yolop_version=0.13.0</p>
+<pre class="response">resolved=False</pre>
+</details>
+<details class="case pass">
+<summary><span class="badge pass">PASS</span> <code>terminal_bench/cobol-modernization@openai-gpt-5.6-luna</code><span class="metrics">33481 tok · $0.0900 · 145691ms · 14 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="pass">✓ <b>resolved</b> — tests passed</li>
+</ul>
+<p class="tools"><b>tools:</b> write_session_title, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash</p>
+<p class="meta"><b>metrics:</b> cache_read_tokens=249069, llm_calls=15, reward=1, tool_calls=14</p>
+<p class="meta"><b>metadata:</b> agent=yolop, category=software-engineering, difficulty=easy, exception=null, model=openai/gpt-5.6-luna, model_effective=gpt-5.6-luna, model_requested=openai/gpt-5.6-luna, provider=openai, provider_effective=openai, provider_requested=openai, reasoning_effort=medium, reasoning_effort_effective=medium, reasoning_effort_requested=null, resolved=true, reward=1.0, stop_reason=completed, tools_used={"bash":13,"write_session_title":1}, yolop_version=0.13.0</p>
+<pre class="response">resolved=True</pre>
+</details>
+<details class="case pass">
+<summary><span class="badge pass">PASS</span> <code>terminal_bench/configure-git-webserver@openai-gpt-5.6-luna</code><span class="metrics">33269 tok · $0.0635 · 346537ms · 11 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="pass">✓ <b>resolved</b> — tests passed</li>
+</ul>
+<p class="tools"><b>tools:</b> write_session_title, list_directory, bash, bash, bash, bash, bash, bash, bash, bash, bash</p>
+<p class="meta"><b>metrics:</b> cache_read_tokens=120684, llm_calls=12, reward=1, tool_calls=11</p>
+<p class="meta"><b>metadata:</b> agent=yolop, category=system-administration, difficulty=hard, exception=null, model=openai/gpt-5.6-luna, model_effective=gpt-5.6-luna, model_requested=openai/gpt-5.6-luna, provider=openai, provider_effective=openai, provider_requested=openai, reasoning_effort=medium, reasoning_effort_effective=medium, reasoning_effort_requested=null, resolved=true, reward=1.0, stop_reason=completed, tools_used={"bash":9,"list_directory":1,"write_session_title":1}, yolop_version=0.13.0</p>
+<pre class="response">resolved=True</pre>
+</details>
+<details class="case fail">
+<summary><span class="badge fail">FAIL</span> <code>terminal_bench/count-dataset-tokens@openai-gpt-5.6-luna</code><span class="metrics">23408 tok · $0.0576 · 325626ms · 13 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="fail">✗ <b>resolved</b> — tests failed</li>
+</ul>
+<p class="tools"><b>tools:</b> write_session_title, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash</p>
+<p class="meta"><b>metrics:</b> cache_read_tokens=177333, llm_calls=14, reward=0, tool_calls=13</p>
+<p class="meta"><b>metadata:</b> agent=yolop, category=model-training, difficulty=medium, exception=null, model=openai/gpt-5.6-luna, model_effective=gpt-5.6-luna, model_requested=openai/gpt-5.6-luna, provider=openai, provider_effective=openai, provider_requested=openai, reasoning_effort=medium, reasoning_effort_effective=medium, reasoning_effort_requested=null, resolved=false, reward=0.0, stop_reason=completed, tools_used={"bash":12,"write_session_title":1}, yolop_version=0.13.0</p>
+<pre class="response">resolved=False</pre>
+</details>
+<details class="case fail">
+<summary><span class="badge fail">FAIL</span> <code>terminal_bench/fix-code-vulnerability@openai-gpt-5.6-luna</code><span class="metrics">45325 tok · $0.0688 · 120805ms · 12 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="fail">✗ <b>resolved</b> — tests failed</li>
+</ul>
+<p class="tools"><b>tools:</b> write_session_title, list_directory, grep_files, bash, bash, bash, bash, bash, bash, bash, bash, bash</p>
+<p class="meta"><b>metrics:</b> cache_read_tokens=162514, llm_calls=7, reward=0, tool_calls=12</p>
+<p class="meta"><b>metadata:</b> agent=yolop, category=security, difficulty=hard, exception=null, model=openai/gpt-5.6-luna, model_effective=gpt-5.6-luna, model_requested=openai/gpt-5.6-luna, provider=openai, provider_effective=openai, provider_requested=openai, reasoning_effort=medium, reasoning_effort_effective=medium, reasoning_effort_requested=null, resolved=false, reward=0.0, stop_reason=completed, tools_used={"bash":9,"grep_files":1,"list_directory":1,"write_session_title":1}, yolop_version=0.13.0</p>
+<pre class="response">resolved=False</pre>
+</details>
+<details class="case pass">
+<summary><span class="badge pass">PASS</span> <code>terminal_bench/fix-git@openai-gpt-5.6-luna</code><span class="metrics">27187 tok · $0.0682 · 152520ms · 23 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="pass">✓ <b>resolved</b> — tests passed</li>
+</ul>
+<p class="tools"><b>tools:</b> write_session_title, write_todos, write_todos, write_todos, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash</p>
+<p class="meta"><b>metrics:</b> cache_read_tokens=256425, llm_calls=16, reward=1, tool_calls=23</p>
+<p class="meta"><b>metadata:</b> agent=yolop, category=software-engineering, difficulty=easy, exception=null, model=openai/gpt-5.6-luna, model_effective=gpt-5.6-luna, model_requested=openai/gpt-5.6-luna, provider=openai, provider_effective=openai, provider_requested=openai, reasoning_effort=medium, reasoning_effort_effective=medium, reasoning_effort_requested=null, resolved=true, reward=1.0, stop_reason=completed, tools_used={"bash":19,"write_session_title":1,"write_todos":3}, yolop_version=0.13.0</p>
+<pre class="response">resolved=True</pre>
+</details>
+<details class="case pass">
+<summary><span class="badge pass">PASS</span> <code>terminal_bench/modernize-scientific-stack@openai-gpt-5.6-luna</code><span class="metrics">15027 tok · $0.0260 · 147027ms · 4 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="pass">✓ <b>resolved</b> — tests passed</li>
+</ul>
+<p class="tools"><b>tools:</b> write_session_title, bash, bash, bash</p>
+<p class="meta"><b>metrics:</b> cache_read_tokens=42692, llm_calls=5, reward=1, tool_calls=4</p>
+<p class="meta"><b>metadata:</b> agent=yolop, category=scientific-computing, difficulty=medium, exception=null, model=openai/gpt-5.6-luna, model_effective=gpt-5.6-luna, model_requested=openai/gpt-5.6-luna, provider=openai, provider_effective=openai, provider_requested=openai, reasoning_effort=medium, reasoning_effort_effective=medium, reasoning_effort_requested=null, resolved=true, reward=1.0, stop_reason=completed, tools_used={"bash":3,"write_session_title":1}, yolop_version=0.13.0</p>
+<pre class="response">resolved=True</pre>
+</details>
+<details class="case fail">
+<summary><span class="badge fail">FAIL</span> <code>terminal_bench/overfull-hbox@openai-gpt-5.6-luna</code><span class="metrics">0 tok · $0.0000 · 205433ms · 0 tool calls</span></summary>
+<ul class="scores">
+<li class="fail">✗ <b>succeeded</b> — NonZeroAgentExitCodeError: Command failed (exit 101): /installed-agent/yolop/yolop --provider openai --model gpt-5.6-luna --session session_009c1b2c62434506a4896608e34f8bdd --session-dir /logs/agent/sessions --trajectory-out /logs/agent/trajectory.json -p 'Ensure that the LaTeX document main.tex compiles successfully using the installed TeX distribution and pdflatex compiler with no "overfull hbox" warnings. In doing so, the only edits you may make are to replace words in input.tex with their specified synonyms in synonyms.txt (each line specifies a family of allowed synonyms). Do not edit main.tex or synonyms.txt.
+
+
+---
+
+You are running fully autonomously inside a container. There is no user to
+answer you: nothing you write is read by anyone, and the session ends as soon as
+you stop. Do not ask for confirmation, do not offer options, and do not stop to
+report a plan — make the call yourself and carry it out, including for changes
+that rewrite history or overwrite files.
+
+The task is graded after you exit by running the task'"'"'s own tests against the
+container'"'"'s filesystem. Only what is on disk when you stop counts; a correct
+description of what should be done scores zero. Before you stop, verify your
+work by actually running it.' 2&gt;&amp;1 &lt;/dev/null | stdbuf -oL tee /logs/agent/yolop.txt
+stdout:
+thread 'yolop-main' (81) panicked at /Users/mykhailochalyi/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/reqwest-0.13.4/src/async_impl/client.rs:2507:38:
+Client::new(): reqwest::Error { kind: Builder, source: General("No CA certificates were loaded from the system") }
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+yolop: crash report written to /root/.local/share/yolop/crashes/2026-08-01T00-40-11Z-5068dd34-crash.log
+
+stderr: None</li>
+<li class="fail">✗ <b>resolved</b> — tests failed</li>
+</ul>
+<p class="meta"><b>metrics:</b> cache_read_tokens=0, llm_calls=0, reward=0, tool_calls=0</p>
+<p class="meta"><b>metadata:</b> agent=yolop, category=debugging, difficulty=easy, exception=NonZeroAgentExitCodeError, model=openai/gpt-5.6-luna, model_effective=null, model_requested=openai/gpt-5.6-luna, provider=openai, provider_effective=null, provider_requested=openai, reasoning_effort=null, reasoning_effort_effective=null, reasoning_effort_requested=null, resolved=false, reward=0.0, stop_reason=completed, tools_used={}, yolop_version=null</p>
+<pre class="error">NonZeroAgentExitCodeError: Command failed (exit 101): /installed-agent/yolop/yolop --provider openai --model gpt-5.6-luna --session session_009c1b2c62434506a4896608e34f8bdd --session-dir /logs/agent/sessions --trajectory-out /logs/agent/trajectory.json -p 'Ensure that the LaTeX document main.tex compiles successfully using the installed TeX distribution and pdflatex compiler with no "overfull hbox" warnings. In doing so, the only edits you may make are to replace words in input.tex with their specified synonyms in synonyms.txt (each line specifies a family of allowed synonyms). Do not edit main.tex or synonyms.txt.
+
+
+---
+
+You are running fully autonomously inside a container. There is no user to
+answer you: nothing you write is read by anyone, and the session ends as soon as
+you stop. Do not ask for confirmation, do not offer options, and do not stop to
+report a plan — make the call yourself and carry it out, including for changes
+that rewrite history or overwrite files.
+
+The task is graded after you exit by running the task'"'"'s own tests against the
+container'"'"'s filesystem. Only what is on disk when you stop counts; a correct
+description of what should be done scores zero. Before you stop, verify your
+work by actually running it.' 2&gt;&amp;1 &lt;/dev/null | stdbuf -oL tee /logs/agent/yolop.txt
+stdout:
+thread 'yolop-main' (81) panicked at /Users/mykhailochalyi/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/reqwest-0.13.4/src/async_impl/client.rs:2507:38:
+Client::new(): reqwest::Error { kind: Builder, source: General("No CA certificates were loaded from the system") }
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+yolop: crash report written to /root/.local/share/yolop/crashes/2026-08-01T00-40-11Z-5068dd34-crash.log
+
+stderr: None</pre>
+<pre class="response">resolved=False</pre>
+</details>
+<script type="application/json" id="mira-data">
+{"cases":[{"aggregate":0.5,"eval":"terminal_bench","passed":false,"sample":"chess-best-move","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":false,"reason":"tests failed","scorer":"resolved","value":0.0}],"skipped":false,"target":"openai-gpt-5.6-luna","transcript":{"final_response":"resolved=False","iterations":14,"metadata":{"agent":"yolop","category":"games","difficulty":"medium","exception":null,"model":"openai/gpt-5.6-luna","model_effective":"gpt-5.6-luna","model_requested":"openai/gpt-5.6-luna","provider":"openai","provider_effective":"openai","provider_requested":"openai","reasoning_effort":"medium","reasoning_effort_effective":"medium","reasoning_effort_requested":null,"resolved":false,"reward":0.0,"stop_reason":"completed","tools_used":{"bash":11,"read_file":1,"write_session_title":1},"yolop_version":"0.13.0"},"metrics":{"cache_read_tokens":182814.0,"llm_calls":14.0,"reward":0.0,"tool_calls":13.0},"timing":{"duration_ms":173028},"tool_calls":["write_session_title","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","read_file"],"tool_calls_count":13,"usage":{"cache_read_tokens":182814,"cost_usd":0.08783039999999999,"input_tokens":24669,"output_tokens":7480}}},{"aggregate":1.0,"eval":"terminal_bench","passed":true,"sample":"cobol-modernization","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":true,"reason":"tests passed","scorer":"resolved","value":1.0}],"skipped":false,"target":"openai-gpt-5.6-luna","transcript":{"final_response":"resolved=True","iterations":15,"metadata":{"agent":"yolop","category":"software-engineering","difficulty":"easy","exception":null,"model":"openai/gpt-5.6-luna","model_effective":"gpt-5.6-luna","model_requested":"openai/gpt-5.6-luna","provider":"openai","provider_effective":"openai","provider_requested":"openai","reasoning_effort":"medium","reasoning_effort_effective":"medium","reasoning_effort_requested":null,"resolved":true,"reward":1.0,"stop_reason":"completed","tools_used":{"bash":13,"write_session_title":1},"yolop_version":"0.13.0"},"metrics":{"cache_read_tokens":249069.0,"llm_calls":15.0,"reward":1.0,"tool_calls":14.0},"timing":{"duration_ms":145691},"tool_calls":["write_session_title","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash"],"tool_calls_count":14,"usage":{"cache_read_tokens":249069,"cost_usd":0.0900079,"input_tokens":27157,"output_tokens":6324}}},{"aggregate":1.0,"eval":"terminal_bench","passed":true,"sample":"configure-git-webserver","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":true,"reason":"tests passed","scorer":"resolved","value":1.0}],"skipped":false,"target":"openai-gpt-5.6-luna","transcript":{"final_response":"resolved=True","iterations":12,"metadata":{"agent":"yolop","category":"system-administration","difficulty":"hard","exception":null,"model":"openai/gpt-5.6-luna","model_effective":"gpt-5.6-luna","model_requested":"openai/gpt-5.6-luna","provider":"openai","provider_effective":"openai","provider_requested":"openai","reasoning_effort":"medium","reasoning_effort_effective":"medium","reasoning_effort_requested":null,"resolved":true,"reward":1.0,"stop_reason":"completed","tools_used":{"bash":9,"list_directory":1,"write_session_title":1},"yolop_version":"0.13.0"},"metrics":{"cache_read_tokens":120684.0,"llm_calls":12.0,"reward":1.0,"tool_calls":11.0},"timing":{"duration_ms":346537},"tool_calls":["write_session_title","list_directory","bash","bash","bash","bash","bash","bash","bash","bash","bash"],"tool_calls_count":11,"usage":{"cache_read_tokens":120684,"cost_usd":0.0634924,"input_tokens":29638,"output_tokens":3631}}},{"aggregate":0.5,"eval":"terminal_bench","passed":false,"sample":"count-dataset-tokens","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":false,"reason":"tests failed","scorer":"resolved","value":0.0}],"skipped":false,"target":"openai-gpt-5.6-luna","transcript":{"final_response":"resolved=False","iterations":14,"metadata":{"agent":"yolop","category":"model-training","difficulty":"medium","exception":null,"model":"openai/gpt-5.6-luna","model_effective":"gpt-5.6-luna","model_requested":"openai/gpt-5.6-luna","provider":"openai","provider_effective":"openai","provider_requested":"openai","reasoning_effort":"medium","reasoning_effort_effective":"medium","reasoning_effort_requested":null,"resolved":false,"reward":0.0,"stop_reason":"completed","tools_used":{"bash":12,"write_session_title":1},"yolop_version":"0.13.0"},"metrics":{"cache_read_tokens":177333.0,"llm_calls":14.0,"reward":0.0,"tool_calls":13.0},"timing":{"duration_ms":325626},"tool_calls":["write_session_title","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash"],"tool_calls_count":13,"usage":{"cache_read_tokens":177333,"cost_usd":0.0575913,"input_tokens":20118,"output_tokens":3290}}},{"aggregate":0.5,"eval":"terminal_bench","passed":false,"sample":"fix-code-vulnerability","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":false,"reason":"tests failed","scorer":"resolved","value":0.0}],"skipped":false,"target":"openai-gpt-5.6-luna","transcript":{"final_response":"resolved=False","iterations":7,"metadata":{"agent":"yolop","category":"security","difficulty":"hard","exception":null,"model":"openai/gpt-5.6-luna","model_effective":"gpt-5.6-luna","model_requested":"openai/gpt-5.6-luna","provider":"openai","provider_effective":"openai","provider_requested":"openai","reasoning_effort":"medium","reasoning_effort_effective":"medium","reasoning_effort_requested":null,"resolved":false,"reward":0.0,"stop_reason":"completed","tools_used":{"bash":9,"grep_files":1,"list_directory":1,"write_session_title":1},"yolop_version":"0.13.0"},"metrics":{"cache_read_tokens":162514.0,"llm_calls":7.0,"reward":0.0,"tool_calls":12.0},"timing":{"duration_ms":120805},"tool_calls":["write_session_title","list_directory","grep_files","bash","bash","bash","bash","bash","bash","bash","bash","bash"],"tool_calls_count":12,"usage":{"cache_read_tokens":162514,"cost_usd":0.06877640000000002,"input_tokens":43885,"output_tokens":1440}}},{"aggregate":1.0,"eval":"terminal_bench","passed":true,"sample":"fix-git","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":true,"reason":"tests passed","scorer":"resolved","value":1.0}],"skipped":false,"target":"openai-gpt-5.6-luna","transcript":{"final_response":"resolved=True","iterations":16,"metadata":{"agent":"yolop","category":"software-engineering","difficulty":"easy","exception":null,"model":"openai/gpt-5.6-luna","model_effective":"gpt-5.6-luna","model_requested":"openai/gpt-5.6-luna","provider":"openai","provider_effective":"openai","provider_requested":"openai","reasoning_effort":"medium","reasoning_effort_effective":"medium","reasoning_effort_requested":null,"resolved":true,"reward":1.0,"stop_reason":"completed","tools_used":{"bash":19,"write_session_title":1,"write_todos":3},"yolop_version":"0.13.0"},"metrics":{"cache_read_tokens":256425.0,"llm_calls":16.0,"reward":1.0,"tool_calls":23.0},"timing":{"duration_ms":152520},"tool_calls":["write_session_title","write_todos","write_todos","write_todos","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash"],"tool_calls_count":23,"usage":{"cache_read_tokens":256425,"cost_usd":0.0682495,"input_tokens":24103,"output_tokens":3084}}},{"aggregate":1.0,"eval":"terminal_bench","passed":true,"sample":"modernize-scientific-stack","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":true,"reason":"tests passed","scorer":"resolved","value":1.0}],"skipped":false,"target":"openai-gpt-5.6-luna","transcript":{"final_response":"resolved=True","iterations":5,"metadata":{"agent":"yolop","category":"scientific-computing","difficulty":"medium","exception":null,"model":"openai/gpt-5.6-luna","model_effective":"gpt-5.6-luna","model_requested":"openai/gpt-5.6-luna","provider":"openai","provider_effective":"openai","provider_requested":"openai","reasoning_effort":"medium","reasoning_effort_effective":"medium","reasoning_effort_requested":null,"resolved":true,"reward":1.0,"stop_reason":"completed","tools_used":{"bash":3,"write_session_title":1},"yolop_version":"0.13.0"},"metrics":{"cache_read_tokens":42692.0,"llm_calls":5.0,"reward":1.0,"tool_calls":4.0},"timing":{"duration_ms":147027},"tool_calls":["write_session_title","bash","bash","bash"],"tool_calls_count":4,"usage":{"cache_read_tokens":42692,"cost_usd":0.0259662,"input_tokens":13693,"output_tokens":1334}}},{"aggregate":0.0,"eval":"terminal_bench","passed":false,"sample":"overfull-hbox","scores":[{"pass":false,"reason":"NonZeroAgentExitCodeError: Command failed (exit 101): /installed-agent/yolop/yolop --provider openai --model gpt-5.6-luna --session session_009c1b2c62434506a4896608e34f8bdd --session-dir /logs/agent/sessions --trajectory-out /logs/agent/trajectory.json -p 'Ensure that the LaTeX document main.tex compiles successfully using the installed TeX distribution and pdflatex compiler with no \"overfull hbox\" warnings. In doing so, the only edits you may make are to replace words in input.tex with their specified synonyms in synonyms.txt (each line specifies a family of allowed synonyms). Do not edit main.tex or synonyms.txt.\n\n\n---\n\nYou are running fully autonomously inside a container. There is no user to\nanswer you: nothing you write is read by anyone, and the session ends as soon as\nyou stop. Do not ask for confirmation, do not offer options, and do not stop to\nreport a plan — make the call yourself and carry it out, including for changes\nthat rewrite history or overwrite files.\n\nThe task is graded after you exit by running the task'\"'\"'s own tests against the\ncontainer'\"'\"'s filesystem. Only what is on disk when you stop counts; a correct\ndescription of what should be done scores zero. Before you stop, verify your\nwork by actually running it.' 2>&1 <\/dev/null | stdbuf -oL tee /logs/agent/yolop.txt\nstdout: \nthread 'yolop-main' (81) panicked at /Users/mykhailochalyi/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/reqwest-0.13.4/src/async_impl/client.rs:2507:38:\nClient::new(): reqwest::Error { kind: Builder, source: General(\"No CA certificates were loaded from the system\") }\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\nyolop: crash report written to /root/.local/share/yolop/crashes/2026-08-01T00-40-11Z-5068dd34-crash.log\n\nstderr: None","scorer":"succeeded","value":0.0},{"pass":false,"reason":"tests failed","scorer":"resolved","value":0.0}],"skipped":false,"target":"openai-gpt-5.6-luna","transcript":{"error":"NonZeroAgentExitCodeError: Command failed (exit 101): /installed-agent/yolop/yolop --provider openai --model gpt-5.6-luna --session session_009c1b2c62434506a4896608e34f8bdd --session-dir /logs/agent/sessions --trajectory-out /logs/agent/trajectory.json -p 'Ensure that the LaTeX document main.tex compiles successfully using the installed TeX distribution and pdflatex compiler with no \"overfull hbox\" warnings. In doing so, the only edits you may make are to replace words in input.tex with their specified synonyms in synonyms.txt (each line specifies a family of allowed synonyms). Do not edit main.tex or synonyms.txt.\n\n\n---\n\nYou are running fully autonomously inside a container. There is no user to\nanswer you: nothing you write is read by anyone, and the session ends as soon as\nyou stop. Do not ask for confirmation, do not offer options, and do not stop to\nreport a plan — make the call yourself and carry it out, including for changes\nthat rewrite history or overwrite files.\n\nThe task is graded after you exit by running the task'\"'\"'s own tests against the\ncontainer'\"'\"'s filesystem. Only what is on disk when you stop counts; a correct\ndescription of what should be done scores zero. Before you stop, verify your\nwork by actually running it.' 2>&1 <\/dev/null | stdbuf -oL tee /logs/agent/yolop.txt\nstdout: \nthread 'yolop-main' (81) panicked at /Users/mykhailochalyi/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/reqwest-0.13.4/src/async_impl/client.rs:2507:38:\nClient::new(): reqwest::Error { kind: Builder, source: General(\"No CA certificates were loaded from the system\") }\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\nyolop: crash report written to /root/.local/share/yolop/crashes/2026-08-01T00-40-11Z-5068dd34-crash.log\n\nstderr: None","final_response":"resolved=False","iterations":0,"metadata":{"agent":"yolop","category":"debugging","difficulty":"easy","exception":"NonZeroAgentExitCodeError","model":"openai/gpt-5.6-luna","model_effective":null,"model_requested":"openai/gpt-5.6-luna","provider":"openai","provider_effective":null,"provider_requested":"openai","reasoning_effort":null,"reasoning_effort_effective":null,"reasoning_effort_requested":null,"resolved":false,"reward":0.0,"stop_reason":"completed","tools_used":{},"yolop_version":null},"metrics":{"cache_read_tokens":0.0,"llm_calls":0.0,"reward":0.0,"tool_calls":0.0},"timing":{"duration_ms":205433},"tool_calls_count":0,"usage":{"cost_usd":0.0,"input_tokens":0,"output_tokens":0}}}],"groups":{"difficulty":{"easy":{"passed":2,"scored":3},"hard":{"passed":1,"scored":2},"medium":{"passed":1,"scored":3}}},"summary":{"failed":4,"na":0,"passed":4,"scored":8,"skipped":0,"total_cost_usd":0.46191410000000005,"total_duration_ms":1616667,"total_tokens":209846,"total_tool_calls":90}}
+</script>
+</main>
+</body>
+</html>

--- a/evals/terminal_bench/results/20260801T001630Z-ec1b/report.json
+++ b/evals/terminal_bench/results/20260801T001630Z-ec1b/report.json
@@ -1,0 +1,657 @@
+{
+  "cases": [
+    {
+      "aggregate": 0.5,
+      "eval": "terminal_bench",
+      "passed": false,
+      "sample": "chess-best-move",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": false,
+          "reason": "tests failed",
+          "scorer": "resolved",
+          "value": 0.0
+        }
+      ],
+      "skipped": false,
+      "target": "openai-gpt-5.6-luna",
+      "transcript": {
+        "final_response": "resolved=False",
+        "iterations": 14,
+        "metadata": {
+          "agent": "yolop",
+          "category": "games",
+          "difficulty": "medium",
+          "exception": null,
+          "model": "openai/gpt-5.6-luna",
+          "model_effective": "gpt-5.6-luna",
+          "model_requested": "openai/gpt-5.6-luna",
+          "provider": "openai",
+          "provider_effective": "openai",
+          "provider_requested": "openai",
+          "reasoning_effort": "medium",
+          "reasoning_effort_effective": "medium",
+          "reasoning_effort_requested": null,
+          "resolved": false,
+          "reward": 0.0,
+          "stop_reason": "completed",
+          "tools_used": {
+            "bash": 11,
+            "read_file": 1,
+            "write_session_title": 1
+          },
+          "yolop_version": "0.13.0"
+        },
+        "metrics": {
+          "cache_read_tokens": 182814.0,
+          "llm_calls": 14.0,
+          "reward": 0.0,
+          "tool_calls": 13.0
+        },
+        "timing": {
+          "duration_ms": 173028
+        },
+        "tool_calls": [
+          "write_session_title",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "read_file"
+        ],
+        "tool_calls_count": 13,
+        "usage": {
+          "cache_read_tokens": 182814,
+          "cost_usd": 0.08783039999999999,
+          "input_tokens": 24669,
+          "output_tokens": 7480
+        }
+      }
+    },
+    {
+      "aggregate": 1.0,
+      "eval": "terminal_bench",
+      "passed": true,
+      "sample": "cobol-modernization",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": true,
+          "reason": "tests passed",
+          "scorer": "resolved",
+          "value": 1.0
+        }
+      ],
+      "skipped": false,
+      "target": "openai-gpt-5.6-luna",
+      "transcript": {
+        "final_response": "resolved=True",
+        "iterations": 15,
+        "metadata": {
+          "agent": "yolop",
+          "category": "software-engineering",
+          "difficulty": "easy",
+          "exception": null,
+          "model": "openai/gpt-5.6-luna",
+          "model_effective": "gpt-5.6-luna",
+          "model_requested": "openai/gpt-5.6-luna",
+          "provider": "openai",
+          "provider_effective": "openai",
+          "provider_requested": "openai",
+          "reasoning_effort": "medium",
+          "reasoning_effort_effective": "medium",
+          "reasoning_effort_requested": null,
+          "resolved": true,
+          "reward": 1.0,
+          "stop_reason": "completed",
+          "tools_used": {
+            "bash": 13,
+            "write_session_title": 1
+          },
+          "yolop_version": "0.13.0"
+        },
+        "metrics": {
+          "cache_read_tokens": 249069.0,
+          "llm_calls": 15.0,
+          "reward": 1.0,
+          "tool_calls": 14.0
+        },
+        "timing": {
+          "duration_ms": 145691
+        },
+        "tool_calls": [
+          "write_session_title",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash"
+        ],
+        "tool_calls_count": 14,
+        "usage": {
+          "cache_read_tokens": 249069,
+          "cost_usd": 0.0900079,
+          "input_tokens": 27157,
+          "output_tokens": 6324
+        }
+      }
+    },
+    {
+      "aggregate": 1.0,
+      "eval": "terminal_bench",
+      "passed": true,
+      "sample": "configure-git-webserver",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": true,
+          "reason": "tests passed",
+          "scorer": "resolved",
+          "value": 1.0
+        }
+      ],
+      "skipped": false,
+      "target": "openai-gpt-5.6-luna",
+      "transcript": {
+        "final_response": "resolved=True",
+        "iterations": 12,
+        "metadata": {
+          "agent": "yolop",
+          "category": "system-administration",
+          "difficulty": "hard",
+          "exception": null,
+          "model": "openai/gpt-5.6-luna",
+          "model_effective": "gpt-5.6-luna",
+          "model_requested": "openai/gpt-5.6-luna",
+          "provider": "openai",
+          "provider_effective": "openai",
+          "provider_requested": "openai",
+          "reasoning_effort": "medium",
+          "reasoning_effort_effective": "medium",
+          "reasoning_effort_requested": null,
+          "resolved": true,
+          "reward": 1.0,
+          "stop_reason": "completed",
+          "tools_used": {
+            "bash": 9,
+            "list_directory": 1,
+            "write_session_title": 1
+          },
+          "yolop_version": "0.13.0"
+        },
+        "metrics": {
+          "cache_read_tokens": 120684.0,
+          "llm_calls": 12.0,
+          "reward": 1.0,
+          "tool_calls": 11.0
+        },
+        "timing": {
+          "duration_ms": 346537
+        },
+        "tool_calls": [
+          "write_session_title",
+          "list_directory",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash"
+        ],
+        "tool_calls_count": 11,
+        "usage": {
+          "cache_read_tokens": 120684,
+          "cost_usd": 0.0634924,
+          "input_tokens": 29638,
+          "output_tokens": 3631
+        }
+      }
+    },
+    {
+      "aggregate": 0.5,
+      "eval": "terminal_bench",
+      "passed": false,
+      "sample": "count-dataset-tokens",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": false,
+          "reason": "tests failed",
+          "scorer": "resolved",
+          "value": 0.0
+        }
+      ],
+      "skipped": false,
+      "target": "openai-gpt-5.6-luna",
+      "transcript": {
+        "final_response": "resolved=False",
+        "iterations": 14,
+        "metadata": {
+          "agent": "yolop",
+          "category": "model-training",
+          "difficulty": "medium",
+          "exception": null,
+          "model": "openai/gpt-5.6-luna",
+          "model_effective": "gpt-5.6-luna",
+          "model_requested": "openai/gpt-5.6-luna",
+          "provider": "openai",
+          "provider_effective": "openai",
+          "provider_requested": "openai",
+          "reasoning_effort": "medium",
+          "reasoning_effort_effective": "medium",
+          "reasoning_effort_requested": null,
+          "resolved": false,
+          "reward": 0.0,
+          "stop_reason": "completed",
+          "tools_used": {
+            "bash": 12,
+            "write_session_title": 1
+          },
+          "yolop_version": "0.13.0"
+        },
+        "metrics": {
+          "cache_read_tokens": 177333.0,
+          "llm_calls": 14.0,
+          "reward": 0.0,
+          "tool_calls": 13.0
+        },
+        "timing": {
+          "duration_ms": 325626
+        },
+        "tool_calls": [
+          "write_session_title",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash"
+        ],
+        "tool_calls_count": 13,
+        "usage": {
+          "cache_read_tokens": 177333,
+          "cost_usd": 0.0575913,
+          "input_tokens": 20118,
+          "output_tokens": 3290
+        }
+      }
+    },
+    {
+      "aggregate": 0.5,
+      "eval": "terminal_bench",
+      "passed": false,
+      "sample": "fix-code-vulnerability",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": false,
+          "reason": "tests failed",
+          "scorer": "resolved",
+          "value": 0.0
+        }
+      ],
+      "skipped": false,
+      "target": "openai-gpt-5.6-luna",
+      "transcript": {
+        "final_response": "resolved=False",
+        "iterations": 7,
+        "metadata": {
+          "agent": "yolop",
+          "category": "security",
+          "difficulty": "hard",
+          "exception": null,
+          "model": "openai/gpt-5.6-luna",
+          "model_effective": "gpt-5.6-luna",
+          "model_requested": "openai/gpt-5.6-luna",
+          "provider": "openai",
+          "provider_effective": "openai",
+          "provider_requested": "openai",
+          "reasoning_effort": "medium",
+          "reasoning_effort_effective": "medium",
+          "reasoning_effort_requested": null,
+          "resolved": false,
+          "reward": 0.0,
+          "stop_reason": "completed",
+          "tools_used": {
+            "bash": 9,
+            "grep_files": 1,
+            "list_directory": 1,
+            "write_session_title": 1
+          },
+          "yolop_version": "0.13.0"
+        },
+        "metrics": {
+          "cache_read_tokens": 162514.0,
+          "llm_calls": 7.0,
+          "reward": 0.0,
+          "tool_calls": 12.0
+        },
+        "timing": {
+          "duration_ms": 120805
+        },
+        "tool_calls": [
+          "write_session_title",
+          "list_directory",
+          "grep_files",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash"
+        ],
+        "tool_calls_count": 12,
+        "usage": {
+          "cache_read_tokens": 162514,
+          "cost_usd": 0.06877640000000002,
+          "input_tokens": 43885,
+          "output_tokens": 1440
+        }
+      }
+    },
+    {
+      "aggregate": 1.0,
+      "eval": "terminal_bench",
+      "passed": true,
+      "sample": "fix-git",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": true,
+          "reason": "tests passed",
+          "scorer": "resolved",
+          "value": 1.0
+        }
+      ],
+      "skipped": false,
+      "target": "openai-gpt-5.6-luna",
+      "transcript": {
+        "final_response": "resolved=True",
+        "iterations": 16,
+        "metadata": {
+          "agent": "yolop",
+          "category": "software-engineering",
+          "difficulty": "easy",
+          "exception": null,
+          "model": "openai/gpt-5.6-luna",
+          "model_effective": "gpt-5.6-luna",
+          "model_requested": "openai/gpt-5.6-luna",
+          "provider": "openai",
+          "provider_effective": "openai",
+          "provider_requested": "openai",
+          "reasoning_effort": "medium",
+          "reasoning_effort_effective": "medium",
+          "reasoning_effort_requested": null,
+          "resolved": true,
+          "reward": 1.0,
+          "stop_reason": "completed",
+          "tools_used": {
+            "bash": 19,
+            "write_session_title": 1,
+            "write_todos": 3
+          },
+          "yolop_version": "0.13.0"
+        },
+        "metrics": {
+          "cache_read_tokens": 256425.0,
+          "llm_calls": 16.0,
+          "reward": 1.0,
+          "tool_calls": 23.0
+        },
+        "timing": {
+          "duration_ms": 152520
+        },
+        "tool_calls": [
+          "write_session_title",
+          "write_todos",
+          "write_todos",
+          "write_todos",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash"
+        ],
+        "tool_calls_count": 23,
+        "usage": {
+          "cache_read_tokens": 256425,
+          "cost_usd": 0.0682495,
+          "input_tokens": 24103,
+          "output_tokens": 3084
+        }
+      }
+    },
+    {
+      "aggregate": 1.0,
+      "eval": "terminal_bench",
+      "passed": true,
+      "sample": "modernize-scientific-stack",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": true,
+          "reason": "tests passed",
+          "scorer": "resolved",
+          "value": 1.0
+        }
+      ],
+      "skipped": false,
+      "target": "openai-gpt-5.6-luna",
+      "transcript": {
+        "final_response": "resolved=True",
+        "iterations": 5,
+        "metadata": {
+          "agent": "yolop",
+          "category": "scientific-computing",
+          "difficulty": "medium",
+          "exception": null,
+          "model": "openai/gpt-5.6-luna",
+          "model_effective": "gpt-5.6-luna",
+          "model_requested": "openai/gpt-5.6-luna",
+          "provider": "openai",
+          "provider_effective": "openai",
+          "provider_requested": "openai",
+          "reasoning_effort": "medium",
+          "reasoning_effort_effective": "medium",
+          "reasoning_effort_requested": null,
+          "resolved": true,
+          "reward": 1.0,
+          "stop_reason": "completed",
+          "tools_used": {
+            "bash": 3,
+            "write_session_title": 1
+          },
+          "yolop_version": "0.13.0"
+        },
+        "metrics": {
+          "cache_read_tokens": 42692.0,
+          "llm_calls": 5.0,
+          "reward": 1.0,
+          "tool_calls": 4.0
+        },
+        "timing": {
+          "duration_ms": 147027
+        },
+        "tool_calls": [
+          "write_session_title",
+          "bash",
+          "bash",
+          "bash"
+        ],
+        "tool_calls_count": 4,
+        "usage": {
+          "cache_read_tokens": 42692,
+          "cost_usd": 0.0259662,
+          "input_tokens": 13693,
+          "output_tokens": 1334
+        }
+      }
+    },
+    {
+      "aggregate": 0.0,
+      "eval": "terminal_bench",
+      "passed": false,
+      "sample": "overfull-hbox",
+      "scores": [
+        {
+          "pass": false,
+          "reason": "NonZeroAgentExitCodeError: Command failed (exit 101): /installed-agent/yolop/yolop --provider openai --model gpt-5.6-luna --session session_009c1b2c62434506a4896608e34f8bdd --session-dir /logs/agent/sessions --trajectory-out /logs/agent/trajectory.json -p 'Ensure that the LaTeX document main.tex compiles successfully using the installed TeX distribution and pdflatex compiler with no \"overfull hbox\" warnings. In doing so, the only edits you may make are to replace words in input.tex with their specified synonyms in synonyms.txt (each line specifies a family of allowed synonyms). Do not edit main.tex or synonyms.txt.\n\n\n---\n\nYou are running fully autonomously inside a container. There is no user to\nanswer you: nothing you write is read by anyone, and the session ends as soon as\nyou stop. Do not ask for confirmation, do not offer options, and do not stop to\nreport a plan — make the call yourself and carry it out, including for changes\nthat rewrite history or overwrite files.\n\nThe task is graded after you exit by running the task'\"'\"'s own tests against the\ncontainer'\"'\"'s filesystem. Only what is on disk when you stop counts; a correct\ndescription of what should be done scores zero. Before you stop, verify your\nwork by actually running it.' 2>&1 </dev/null | stdbuf -oL tee /logs/agent/yolop.txt\nstdout: \nthread 'yolop-main' (81) panicked at /Users/mykhailochalyi/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/reqwest-0.13.4/src/async_impl/client.rs:2507:38:\nClient::new(): reqwest::Error { kind: Builder, source: General(\"No CA certificates were loaded from the system\") }\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\nyolop: crash report written to /root/.local/share/yolop/crashes/2026-08-01T00-40-11Z-5068dd34-crash.log\n\nstderr: None",
+          "scorer": "succeeded",
+          "value": 0.0
+        },
+        {
+          "pass": false,
+          "reason": "tests failed",
+          "scorer": "resolved",
+          "value": 0.0
+        }
+      ],
+      "skipped": false,
+      "target": "openai-gpt-5.6-luna",
+      "transcript": {
+        "error": "NonZeroAgentExitCodeError: Command failed (exit 101): /installed-agent/yolop/yolop --provider openai --model gpt-5.6-luna --session session_009c1b2c62434506a4896608e34f8bdd --session-dir /logs/agent/sessions --trajectory-out /logs/agent/trajectory.json -p 'Ensure that the LaTeX document main.tex compiles successfully using the installed TeX distribution and pdflatex compiler with no \"overfull hbox\" warnings. In doing so, the only edits you may make are to replace words in input.tex with their specified synonyms in synonyms.txt (each line specifies a family of allowed synonyms). Do not edit main.tex or synonyms.txt.\n\n\n---\n\nYou are running fully autonomously inside a container. There is no user to\nanswer you: nothing you write is read by anyone, and the session ends as soon as\nyou stop. Do not ask for confirmation, do not offer options, and do not stop to\nreport a plan — make the call yourself and carry it out, including for changes\nthat rewrite history or overwrite files.\n\nThe task is graded after you exit by running the task'\"'\"'s own tests against the\ncontainer'\"'\"'s filesystem. Only what is on disk when you stop counts; a correct\ndescription of what should be done scores zero. Before you stop, verify your\nwork by actually running it.' 2>&1 </dev/null | stdbuf -oL tee /logs/agent/yolop.txt\nstdout: \nthread 'yolop-main' (81) panicked at /Users/mykhailochalyi/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/reqwest-0.13.4/src/async_impl/client.rs:2507:38:\nClient::new(): reqwest::Error { kind: Builder, source: General(\"No CA certificates were loaded from the system\") }\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\nyolop: crash report written to /root/.local/share/yolop/crashes/2026-08-01T00-40-11Z-5068dd34-crash.log\n\nstderr: None",
+        "final_response": "resolved=False",
+        "iterations": 0,
+        "metadata": {
+          "agent": "yolop",
+          "category": "debugging",
+          "difficulty": "easy",
+          "exception": "NonZeroAgentExitCodeError",
+          "model": "openai/gpt-5.6-luna",
+          "model_effective": null,
+          "model_requested": "openai/gpt-5.6-luna",
+          "provider": "openai",
+          "provider_effective": null,
+          "provider_requested": "openai",
+          "reasoning_effort": null,
+          "reasoning_effort_effective": null,
+          "reasoning_effort_requested": null,
+          "resolved": false,
+          "reward": 0.0,
+          "stop_reason": "completed",
+          "tools_used": {},
+          "yolop_version": null
+        },
+        "metrics": {
+          "cache_read_tokens": 0.0,
+          "llm_calls": 0.0,
+          "reward": 0.0,
+          "tool_calls": 0.0
+        },
+        "timing": {
+          "duration_ms": 205433
+        },
+        "tool_calls_count": 0,
+        "usage": {
+          "cost_usd": 0.0,
+          "input_tokens": 0,
+          "output_tokens": 0
+        }
+      }
+    }
+  ],
+  "groups": {
+    "difficulty": {
+      "easy": {
+        "passed": 2,
+        "scored": 3
+      },
+      "hard": {
+        "passed": 1,
+        "scored": 2
+      },
+      "medium": {
+        "passed": 1,
+        "scored": 3
+      }
+    }
+  },
+  "summary": {
+    "failed": 4,
+    "na": 0,
+    "passed": 4,
+    "scored": 8,
+    "skipped": 0,
+    "total_cost_usd": 0.46191410000000005,
+    "total_duration_ms": 1616667,
+    "total_tokens": 209846,
+    "total_tool_calls": 90
+  }
+}

--- a/evals/terminal_bench/results/20260801T004403Z-5be4/cases/terminal_5fbench_2foverfull_2dhbox_40openai_2dgpt_2d5_2e6_2dluna/result.json
+++ b/evals/terminal_bench/results/20260801T004403Z-5be4/cases/terminal_5fbench_2foverfull_2dhbox_40openai_2dgpt_2d5_2e6_2dluna/result.json
@@ -1,0 +1,89 @@
+{
+  "eval": "terminal_bench",
+  "sample": "overfull-hbox",
+  "target": "openai-gpt-5.6-luna",
+  "passed": true,
+  "aggregate": 1.0,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 1.0,
+      "pass": true,
+      "reason": "tests passed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=True",
+    "iterations": 17,
+    "tool_calls_count": 20,
+    "tool_calls": [
+      "write_session_title",
+      "list_directory",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "read_file",
+      "read_file",
+      "read_file"
+    ],
+    "usage": {
+      "input_tokens": 29790,
+      "output_tokens": 5198,
+      "cache_read_tokens": 294038,
+      "cost_usd": 0.0903818
+    },
+    "timing": {
+      "duration_ms": 301177
+    },
+    "metrics": {
+      "cache_read_tokens": 294038.0,
+      "llm_calls": 17.0,
+      "reward": 1.0,
+      "tool_calls": 20.0
+    },
+    "metadata": {
+      "agent": "yolop",
+      "category": "debugging",
+      "difficulty": "easy",
+      "exception": null,
+      "model": "openai/gpt-5.6-luna",
+      "model_effective": "gpt-5.6-luna",
+      "model_requested": "openai/gpt-5.6-luna",
+      "provider": "openai",
+      "provider_effective": "openai",
+      "provider_requested": "openai",
+      "reasoning_effort": "medium",
+      "reasoning_effort_effective": "medium",
+      "reasoning_effort_requested": null,
+      "resolved": true,
+      "reward": 1.0,
+      "stop_reason": "completed",
+      "tools_used": {
+        "bash": 15,
+        "list_directory": 1,
+        "read_file": 3,
+        "write_session_title": 1
+      },
+      "yolop_version": "0.13.0"
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260801T004403Z-5be4/meta.json
+++ b/evals/terminal_bench/results/20260801T004403Z-5be4/meta.json
@@ -1,0 +1,34 @@
+{
+  "format": 1,
+  "run_id": "20260801T004403Z-5be4",
+  "study": "terminal_bench",
+  "study_version": "0.1.0",
+  "started_unix": 1785545043,
+  "finished_unix": 1785545344,
+  "environment": {
+    "git": {
+      "commit": "f36b74f8e9ad005ed88833b3a122a0588510edc6",
+      "branch": "codex/control-v1-luna",
+      "dirty": true
+    },
+    "os": "macos",
+    "arch": "aarch64",
+    "hostname": "Mykhailos-Mac-mini.local",
+    "cpus": 12,
+    "mira_version": "0.3.0",
+    "labels": {
+      "benchmark": "terminal-bench-2-1"
+    }
+  },
+  "summary": {
+    "scored": 1,
+    "passed": 1,
+    "failed": 0,
+    "na": 0,
+    "skipped": 0,
+    "total_tokens": 34988,
+    "total_cost_usd": 0.0903818,
+    "total_tool_calls": 20,
+    "total_duration_ms": 301177
+  }
+}

--- a/evals/terminal_bench/results/20260801T004403Z-5be4/report.html
+++ b/evals/terminal_bench/results/20260801T004403Z-5be4/report.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Mira eval report</title>
+<style>
+:root{color-scheme:light dark;--ok:#1a7f37;--bad:#cf222e;--warn:#9a6700;--mut:#57606a;--bg:#fff;--fg:#1f2328;--line:#d0d7de}
+@media(prefers-color-scheme:dark){:root{--bg:#0d1117;--fg:#e6edf3;--line:#30363d;--mut:#8b949e}}
+*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--fg);font:15px/1.5 -apple-system,Segoe UI,Roboto,sans-serif}
+main{max-width:960px;margin:0 auto;padding:2rem 1.25rem}
+h1{font-size:1.6rem;margin:0 0 1rem}h2{font-size:1.15rem;margin:2rem 0 .75rem;border-bottom:1px solid var(--line);padding-bottom:.25rem}
+.cards{display:flex;flex-wrap:wrap;gap:.75rem}
+.card{flex:1;min-width:96px;border:1px solid var(--line);border-radius:8px;padding:.75rem 1rem;text-align:center}
+.card b{display:block;font-size:1.5rem}.card span{color:var(--mut);font-size:.8rem;text-transform:uppercase;letter-spacing:.04em}
+.card.ok b{color:var(--ok)}.card.bad b{color:var(--bad)}.card.warn b{color:var(--warn)}
+table.matrix{border-collapse:collapse;width:100%}table.matrix th,table.matrix td{border:1px solid var(--line);padding:.4rem .6rem;text-align:center}
+table.matrix td:first-child,table.matrix th:first-child{text-align:left}
+.case{border:1px solid var(--line);border-radius:8px;margin:.5rem 0;padding:.25rem .75rem}
+.case summary{cursor:pointer;display:flex;gap:.6rem;align-items:center;flex-wrap:wrap}
+.case code{font-size:.92rem}.metrics{color:var(--mut);font-size:.8rem;margin-left:auto}
+.badge{font-size:.7rem;font-weight:700;padding:.1rem .4rem;border-radius:4px;color:#fff}
+.badge.pass{background:var(--ok)}.badge.fail{background:var(--bad)}.badge.skip{background:var(--mut)}.badge.na{background:var(--warn)}
+.scores{list-style:none;padding:0;margin:.5rem 0}.scores li{padding:.15rem 0}.scores li.pass{color:var(--ok)}.scores li.fail{color:var(--bad)}.scores li.na{color:var(--mut)}
+.tools,.meta{font-size:.85rem;color:var(--mut)}
+pre{background:rgba(127,127,127,.1);border-radius:6px;padding:.6rem .75rem;overflow:auto;font-size:.85rem;white-space:pre-wrap}
+pre.error{color:var(--bad)}a{color:#0969da}
+</style>
+</head>
+<body>
+<main>
+<h1>Mira eval report</h1>
+<section class="cards">
+<div class="card ok"><b>1/1</b><span>passed</span></div>
+<div class="card"><b>0</b><span>failed</span></div>
+<div class="card"><b>0</b><span>n/a</span></div>
+<div class="card"><b>0</b><span>skipped</span></div>
+<div class="card"><b>34988</b><span>tokens</span></div>
+<div class="card"><b>$0.0904</b><span>cost</span></div>
+</section>
+<h2>Matrix</h2>
+<table class="matrix">
+<thead><tr><th>eval</th><th>openai-gpt-5.6-luna</th></tr></thead>
+<tbody>
+<tr><td>terminal_bench</td><td>1/1</td></tr>
+</tbody>
+</table>
+<h2>Cases</h2>
+<details class="case pass">
+<summary><span class="badge pass">PASS</span> <code>terminal_bench/overfull-hbox@openai-gpt-5.6-luna</code><span class="metrics">34988 tok · $0.0904 · 301177ms · 20 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="pass">✓ <b>resolved</b> — tests passed</li>
+</ul>
+<p class="tools"><b>tools:</b> write_session_title, list_directory, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, bash, read_file, read_file, read_file</p>
+<p class="meta"><b>metrics:</b> cache_read_tokens=294038, llm_calls=17, reward=1, tool_calls=20</p>
+<p class="meta"><b>metadata:</b> agent=yolop, category=debugging, difficulty=easy, exception=null, model=openai/gpt-5.6-luna, model_effective=gpt-5.6-luna, model_requested=openai/gpt-5.6-luna, provider=openai, provider_effective=openai, provider_requested=openai, reasoning_effort=medium, reasoning_effort_effective=medium, reasoning_effort_requested=null, resolved=true, reward=1.0, stop_reason=completed, tools_used={"bash":15,"list_directory":1,"read_file":3,"write_session_title":1}, yolop_version=0.13.0</p>
+<pre class="response">resolved=True</pre>
+</details>
+<script type="application/json" id="mira-data">
+{"cases":[{"aggregate":1.0,"eval":"terminal_bench","passed":true,"sample":"overfull-hbox","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":true,"reason":"tests passed","scorer":"resolved","value":1.0}],"skipped":false,"target":"openai-gpt-5.6-luna","transcript":{"final_response":"resolved=True","iterations":17,"metadata":{"agent":"yolop","category":"debugging","difficulty":"easy","exception":null,"model":"openai/gpt-5.6-luna","model_effective":"gpt-5.6-luna","model_requested":"openai/gpt-5.6-luna","provider":"openai","provider_effective":"openai","provider_requested":"openai","reasoning_effort":"medium","reasoning_effort_effective":"medium","reasoning_effort_requested":null,"resolved":true,"reward":1.0,"stop_reason":"completed","tools_used":{"bash":15,"list_directory":1,"read_file":3,"write_session_title":1},"yolop_version":"0.13.0"},"metrics":{"cache_read_tokens":294038.0,"llm_calls":17.0,"reward":1.0,"tool_calls":20.0},"timing":{"duration_ms":301177},"tool_calls":["write_session_title","list_directory","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","bash","read_file","read_file","read_file"],"tool_calls_count":20,"usage":{"cache_read_tokens":294038,"cost_usd":0.0903818,"input_tokens":29790,"output_tokens":5198}}}],"summary":{"failed":0,"na":0,"passed":1,"scored":1,"skipped":0,"total_cost_usd":0.0903818,"total_duration_ms":301177,"total_tokens":34988,"total_tool_calls":20}}
+</script>
+</main>
+</body>
+</html>

--- a/evals/terminal_bench/results/20260801T004403Z-5be4/report.json
+++ b/evals/terminal_bench/results/20260801T004403Z-5be4/report.json
@@ -1,0 +1,104 @@
+{
+  "cases": [
+    {
+      "aggregate": 1.0,
+      "eval": "terminal_bench",
+      "passed": true,
+      "sample": "overfull-hbox",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": true,
+          "reason": "tests passed",
+          "scorer": "resolved",
+          "value": 1.0
+        }
+      ],
+      "skipped": false,
+      "target": "openai-gpt-5.6-luna",
+      "transcript": {
+        "final_response": "resolved=True",
+        "iterations": 17,
+        "metadata": {
+          "agent": "yolop",
+          "category": "debugging",
+          "difficulty": "easy",
+          "exception": null,
+          "model": "openai/gpt-5.6-luna",
+          "model_effective": "gpt-5.6-luna",
+          "model_requested": "openai/gpt-5.6-luna",
+          "provider": "openai",
+          "provider_effective": "openai",
+          "provider_requested": "openai",
+          "reasoning_effort": "medium",
+          "reasoning_effort_effective": "medium",
+          "reasoning_effort_requested": null,
+          "resolved": true,
+          "reward": 1.0,
+          "stop_reason": "completed",
+          "tools_used": {
+            "bash": 15,
+            "list_directory": 1,
+            "read_file": 3,
+            "write_session_title": 1
+          },
+          "yolop_version": "0.13.0"
+        },
+        "metrics": {
+          "cache_read_tokens": 294038.0,
+          "llm_calls": 17.0,
+          "reward": 1.0,
+          "tool_calls": 20.0
+        },
+        "timing": {
+          "duration_ms": 301177
+        },
+        "tool_calls": [
+          "write_session_title",
+          "list_directory",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "read_file",
+          "read_file",
+          "read_file"
+        ],
+        "tool_calls_count": 20,
+        "usage": {
+          "cache_read_tokens": 294038,
+          "cost_usd": 0.0903818,
+          "input_tokens": 29790,
+          "output_tokens": 5198
+        }
+      }
+    }
+  ],
+  "summary": {
+    "failed": 0,
+    "na": 0,
+    "passed": 1,
+    "scored": 1,
+    "skipped": 0,
+    "total_cost_usd": 0.0903818,
+    "total_duration_ms": 301177,
+    "total_tokens": 34988,
+    "total_tool_calls": 20
+  }
+}

--- a/evals/terminal_bench/terminal_bench.py
+++ b/evals/terminal_bench/terminal_bench.py
@@ -124,6 +124,7 @@ DEFAULTS: dict[str, Any] = {"max_cost_usd": 5.0}
 
 MATRIX: dict[str, dict[str, Any]] = {
     # yolop x OpenAI (default provider)
+    "openai-gpt-5.6-luna": {"agent": "yolop", "model": "openai/gpt-5.6-luna"},
     "openai-gpt-5.6-terra": {"agent": "yolop", "model": "openai/gpt-5.6-terra"},
     "openai-gpt-5.6-terra-high": {
         "agent": "yolop", "model": "openai/gpt-5.6-terra", "reasoning_effort": "high",

--- a/evals/terminal_bench/tests/test_study.py
+++ b/evals/terminal_bench/tests/test_study.py
@@ -13,6 +13,8 @@ import unittest
 import unittest.mock as mock
 from pathlib import Path
 
+import tomllib
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import terminal_bench as tb  # noqa: E402
@@ -42,6 +44,16 @@ class TestMatrix(unittest.TestCase):
     def test_openai_config_available_with_key(self):
         with mock.patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}, clear=True):
             self.assertTrue(tb.config_available(tb.MATRIX["openai-gpt-5.6-terra"]))
+
+    def test_control_preset_uses_luna(self):
+        config_path = Path(__file__).resolve().parents[1] / "mira.toml"
+        config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(config["presets"]["control"]["targets"], "openai-gpt-5.6-luna")
+        self.assertEqual(
+            tb.MATRIX["openai-gpt-5.6-luna"],
+            {"agent": "yolop", "model": "openai/gpt-5.6-luna"},
+        )
 
 
 class TestBuildCommand(unittest.TestCase):


### PR DESCRIPTION
## What changed

- Add `openai-gpt-5.6-luna` as a Terminal-Bench target and make it the tracked `control` preset target.
- Archive the complete `control-v1` run plus the CA-enabled replacement for the infrastructure-invalid `overfull-hbox` attempt.
- Document the corrected Luna baseline, effective reasoning effort, costs, and verifier-backed failure causes.

## Why

The periodic eight-task control suite needed a reproducible GPT-5.6 Luna configuration and baseline rather than an ad-hoc target wrapper.

## Before / After

Before: `mira run --preset control` selected GPT-5.6 Terra; Luna had no tracked matrix target.

After: the preset selects GPT-5.6 Luna. The corrected control result is 5/8 for $0.55 with effective reasoning effort `medium`: easy 3/3, medium 1/3, hard 1/2. The full archive scored 4/8 because `overfull-hbox` failed before its first model call in a task image with no CA certificates; the retained CA-enabled replacement passed and is archived separately.

## Risk

- Low: configuration, test, documentation, and generated eval reports only.
- The periodic control comparison now uses Luna; smoke, compare, and full remain on their existing targets.

## Validation

- `uv run --with mira-eval --with harbor -m unittest discover -s tests` — 51 passed.
- `uv run suites/select_control.py --check` — committed eight-task suite reproduced exactly.
- `TB_MAX_COST_USD=10 ... mira run --preset control --group-by difficulty` — all eight cases executed.
- `TB_CA_CERT=/etc/ssl/cert.pem ... mira run --samples overfull-hbox --targets openai-gpt-5.6-luna` — infrastructure replacement passed.
- Effective metadata checked across all eight valid cases: model `gpt-5.6-luna`, reasoning effort `medium`, stop reason `completed`.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered; this changes only the tracked eval preset
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

No knowledge update required — this changes the public eval matrix, baseline report, and preset rather than durable Yolop product behavior or architecture.

## Security

TM-LLM reviewed: the change selects a model identifier only; provider keys remain process-environment inputs and the archived reports were scanned for credential patterns with no findings. Existing per-case and run-wide cost caps remain unchanged. No filesystem, shell capability, or dependency changes.

## Follow-ups

- Make Yolop bootstrap public trust roots in certificate-less task images so `overfull-hbox` does not require an explicit `TB_CA_CERT` replacement run.