### PR TITLE
feat(skills): conversational skills.sh search and install

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,9 @@ yolop --provider llmsim -p "hi"         # offline demo, no API key required
   remember.
 - **Skills** — `SKILL.md` files discovered from workspace (`.agents/skills/`),
   global, ephemeral environment, and bundled scopes, exposed via `list_skills`,
-  `read_skill`, `write_skill`, and `activate_skill`. Skills installed after
-  startup are available immediately.
+  `read_skill`, `write_skill`, `activate_skill`, plus `search_skills` /
+  `install_skill` for the public skills.sh registry and `delete_skill` for
+  uninstall. Skills installed after startup are available immediately.
 - **OKF knowledge** — a bundled `okf` skill for the
   [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md):
   read, author, convert to, and

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,7 @@
 Significant changes to Yolop's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
+<<<<<<< HEAD
 ## 2026-08-01 — Owner evidence before non-obvious mutation
 
 - [System prompt composition](specs/system-prompt.md) now requires repository
@@ -21,6 +22,14 @@ wording, formatting, and link fixes do not need entries.
   result it needed.
 - Title and todo handling remains in runtime tools rather than a deterministic
   host side channel, preserving event replay and presentation ownership.
+=======
+## 2026-08-01 — Conversational skills.sh search and install
+
+- [Skills](specs/skills.md) and [Conversational control](specs/conversational-control.md)
+  now cover `search_skills` / `install_skill`: query the public skills.sh
+  registry, ask which match to install, and write the snapshot into workspace
+  or global scope without restarting.
+>>>>>>> e57d458 (feat(skills): add conversational skills.sh search and install)
 
 ## 2026-07-31 — Live agent sidebar and session-scoped transcripts
 

--- a/knowledge/specs/conversational-control.md
+++ b/knowledge/specs/conversational-control.md
@@ -64,7 +64,9 @@ command, an overlay confirmation, or a next-run-only settings write fail this ba
 | Model | `set_model` | `/model` overlay, `/setup model` |
 | Provider | `set_provider` | `/setup provider` |
 | Skills — list | `list_skills` (upstream) | system-prompt listing |
-| Skills — install/update | `write_skill` (upstream) | — |
+| Skills — search (skills.sh) | `search_skills` | — |
+| Skills — install from registry | `install_skill` | — |
+| Skills — install/update by content | `write_skill` (upstream) | — |
 | Skills — uninstall | `delete_skill` | — |
 | Settings (provider/model/tokens/urls/capabilities, next-run) | `get_config` / `set_config` | `/setup`, `yolop-config` skill |
 | Terminal/UI actions (help, tools, mcp, cwd, status, model, effort, clear, quit) | `run_yolop_command` (TUI only) | the slash commands themselves |
@@ -89,8 +91,9 @@ Notes:
 
 - This spec owns the conversational-control contract and the inventory above.
 - `crate::capabilities::host` owns `SetupController` and the `set_*` tools.
-- `crate::capabilities::skills` owns `delete_skill`; the upstream
-  `ScopedSkillsCapability` owns `list_skills` / `write_skill` (see [`skills.md`](./skills.md)).
+- `crate::capabilities::skills` owns `delete_skill`; `crate::capabilities::skill_registry`
+  owns `search_skills` / `install_skill`; the upstream `ScopedSkillsCapability`
+  owns `list_skills` / `write_skill` (see [`skills.md`](./skills.md)).
 - `crate::capabilities::config` owns `get_config` / `set_config` (see
   [`configuration.md`](./configuration.md)).
 - The command registry and `run_yolop_command` are owned by [`commands.md`](./commands.md).

--- a/knowledge/specs/skills.md
+++ b/knowledge/specs/skills.md
@@ -104,14 +104,23 @@ a labeled VFS root that yolop's file store maps to a **real on-disk directory**:
     so parallel processes do not race on the shared cache directory.
 11. **Management guidance is bundled.** Yolop ships a `skill-management` system
     skill that tells the agent how to inspect, install, search for, and upgrade
-    skills, including reconstructing `npx skill add ...` style installs by
+    skills. Prefer the yolop-owned `search_skills` / `install_skill` tools for
+    the public skills.sh registry (search → ask which to install → install).
+    Reconstruct `npx skill add ...` style installs that are not on skills.sh by
     fetching source files directly and writing them with `write_skill`.
-12. **User guide is bundled.** Yolop ships a `yolop` system skill from the
+12. **Registry search and install.** `search_skills` queries skills.sh and
+    returns structured matches (id, source, installs, URL). `install_skill`
+    downloads a skills.sh snapshot into a writable scope (`workspace` or
+    `global`), validates `SKILL.md` and relative paths, and makes the skill
+    available immediately. Both are conversational control surfaces (see
+    [`conversational-control.md`](./conversational-control.md)): present search
+    results and ask before installing. System skills remain read-only.
+13. **User guide is bundled.** Yolop ships a `yolop` system skill from the
     private bundled asset tree as the durable reference for slash commands,
     keyboard shortcuts, CLI flags, and session controls. `/help` in the TUI
     summarizes the live command registry and shortcuts; the skill carries the
     full guide for conversational help.
-13. **Environment skills are ephemeral.** An environment integration may mount
+14. **Environment skills are ephemeral.** An environment integration may mount
     a read-only, VFS-only skill scope for the current session. Herdr does this
     only when its inherited pane/socket contract is present. Precedence is
     workspace, global, environment, then system; the mount never writes any
@@ -125,7 +134,9 @@ a labeled VFS root that yolop's file store maps to a **real on-disk directory**:
 - `crate::capabilities::skills` owns the yolop wiring: the scope set, the
   host-path `SkillDirResolver`, the embedded system skills + materialization, the
   VFS-root constants the file store routes on, and the `SkillManagementCapability`
-  that contributes the `delete_skill` (uninstall) tool.
+  that contributes `search_skills`, `install_skill`, and `delete_skill`.
+- `crate::capabilities::skill_registry` owns the skills.sh HTTP client used by
+  `search_skills` / `install_skill`.
 - `crate::runtime` (`CodingCliSessionFileStore`) owns mapping the scope VFS roots
   to real on-disk directories.
 - `everruns_core::skill` owns the `SKILL.md` format, parsing, validation, and

--- a/src/bundled/system-skills/skill-management/SKILL.md
+++ b/src/bundled/system-skills/skill-management/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: skill-management
-description: Install, inspect, update, or search for Yolop skills in workspace and global scopes. Use when the user asks to manage skills, import a skill from a registry or GitHub, or upgrade skills.
+description: Install, inspect, update, or search for Yolop skills in workspace and global scopes. Use when the user asks to manage skills, find a skill for a task, import a skill from skills.sh or GitHub, or upgrade skills.
 user-invocable: true
 ---
 
 # Skill Management
 
-Use this skill when the user wants to customize Yolop with skills.
+Use this skill when the user wants to customize Yolop with skills — especially
+when they ask to *find* a skill for a task.
 
 ## Ground Rules
 
@@ -28,9 +29,36 @@ Use this skill when the user wants to customize Yolop with skills.
    workspace/local for project-specific behavior, global for cross-project
    behavior.
 
-## Install Or Modify
+## Search (conversational)
 
-Use `write_skill` with:
+When the user asks to find a skill for something:
+
+1. Call `search_skills` with a short query (and optional `owner`).
+2. Present the top matches: name, source repo, install count, and skills.sh URL.
+3. **Ask which skill to install** (and whether workspace or global) before
+   writing anything.
+4. Call `install_skill` with the chosen `install_source` / id from the search
+   result (`owner/repo/skillId`).
+5. Confirm with `list_skills` and offer to `activate_skill` when useful.
+
+Do not install on a guess. If search returns nothing useful, say so and offer
+the GitHub / web fallback below.
+
+## Install From Registry
+
+`install_skill` fetches a skills.sh snapshot and writes it into a writable
+scope:
+
+- `source`: `owner/repo/skillId`, `owner/repo@skill`, or a skills.sh URL
+- `scope`: `workspace` (default) or `global`
+- `overwrite`: defaults to true
+
+After install the skill is live — no restart.
+
+## Install Or Modify By Hand
+
+Use `write_skill` when you already have the `SKILL.md` (and optional files), or
+when the source is not on skills.sh:
 
 - `scope`: `workspace`/`local` or `global`
 - `name`: the skill directory name
@@ -40,26 +68,28 @@ Use `write_skill` with:
 `write_skill` validates the skill name, parses `SKILL.md`, rejects path
 traversal in bundled files, and writes the skill atomically.
 
-## Import From npx-Style Sources
+## Import From npx-Style Or GitHub Sources
 
-If the user mentions an `npx skill add ...` command, reconstruct the install
-without requiring `npx` or the package:
+If the user mentions an `npx skill add ...` command or a GitHub skill that
+`install_skill` cannot resolve:
 
-1. Identify the package, registry, or repository that command would fetch.
-2. Fetch the relevant `SKILL.md` and bundled files from the source.
-3. Preserve the upstream skill directory name unless the user asks to rename it.
-4. Install with `write_skill`.
-5. Call `list_skills` afterward and report the installed scope/path.
+1. Prefer `install_skill` with `owner/repo@skill` when the package is on
+   skills.sh.
+2. Otherwise identify the repository or files that command would fetch.
+3. Fetch the relevant `SKILL.md` and bundled files (`web_fetch` /
+   `free_web_search`).
+4. Preserve the upstream skill directory name unless the user asks to rename it.
+5. Install with `write_skill`.
+6. Call `list_skills` afterward and report the installed scope/path.
 
 If the source is ambiguous or private and cannot be fetched, ask for the exact
 repository, package, archive, or file contents.
 
-## Search
+## Search Fallback Order
 
-For public skills, search in this order:
-
-1. Known registry or site named by the user, such as `skills.sh`.
-2. GitHub repositories and paths containing `SKILL.md`.
+1. `search_skills` (skills.sh) — preferred.
+2. GitHub repositories and paths containing `SKILL.md` via `free_web_search` /
+   `web_fetch`.
 3. General web search for the skill topic plus `SKILL.md`.
 
 Prefer source URLs that expose the actual files. Do not install from a summary
@@ -70,9 +100,9 @@ page unless you can retrieve the real `SKILL.md` and any referenced files.
 For one skill:
 
 1. `read_skill` to capture the current scope, path, and any local changes.
-2. Fetch the current upstream version.
-3. Compare with the installed version when practical.
-4. Use `write_skill` to update the same scope.
+2. Prefer `install_skill` when the upstream is a known skills.sh source.
+3. Otherwise fetch the current upstream version and `write_skill`.
+4. Compare with the installed version when practical.
 5. `activate_skill` or `list_skills` to verify it loads.
 
 For all skills:
@@ -85,3 +115,8 @@ For all skills:
 
 Never silently overwrite a clearly user-customized skill with unrelated
 registry content. If the intended upstream is uncertain, ask first.
+
+## Uninstall
+
+Use `delete_skill` with `name` and `scope` (`workspace` or `global`). System
+skills cannot be deleted.

--- a/src/bundled/system-skills/yolop/SKILL.md
+++ b/src/bundled/system-skills/yolop/SKILL.md
@@ -116,7 +116,8 @@ yolop is an autonomous coding agent for the workspace it was started in.
 - **Background work** — detached shell commands with completion wakes
 - **Web** — `web_fetch`, `free_web_search`, and `duckduckgo_instant_answer`
 - **Memory** — durable cross-session notes via `remember` / `recall` / `forget`
-- **Skills** — `SKILL.md` packages in workspace, global, and bundled system scopes
+- **Skills** — `SKILL.md` packages in workspace, global, and bundled system scopes;
+  find/install from skills.sh via `search_skills` / `install_skill`
 - **MCP** — extra tools from `.mcp.json` / global `mcp.json`
 - **Hooks** — block, allow, or audit tool calls (see `yolop-hooks` skill)
 - **Goal loops** — `/goal` keeps working until an evaluator confirms the condition

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -26,6 +26,7 @@ pub(crate) mod progress_guard;
 pub(crate) mod repo_map;
 pub(crate) mod session_history;
 pub(crate) mod session_tasks_override;
+pub(crate) mod skill_registry;
 pub mod skills;
 pub(crate) mod tool_approval;
 pub(crate) mod tool_reveal;

--- a/src/capabilities/skill_registry.rs
+++ b/src/capabilities/skill_registry.rs
@@ -1029,4 +1029,46 @@ mod tests {
             "install_skill"
         );
     }
+
+    /// Live smoke against production skills.sh. Not part of default CI; run with
+    /// `cargo test -- --ignored live_skills_sh_search_and_install`.
+    #[tokio::test]
+    #[ignore = "hits production skills.sh"]
+    async fn live_skills_sh_search_and_install() {
+        let registry = SkillRegistryClient::production();
+        let search = SearchSkillsTool::new(registry.clone());
+        let search_out = match search
+            .execute(json!({"query": "find-skills", "limit": 3}))
+            .await
+        {
+            ToolExecutionResult::Success(v) => v,
+            other => panic!("live search failed: {other:?}"),
+        };
+        let first = &search_out["skills"][0];
+        let source = first["install_source"].as_str().expect("install_source");
+        assert!(source.contains('/'), "{source}");
+
+        let ws = tempfile::tempdir().unwrap();
+        let install = InstallSkillTool::new(
+            SkillDirs {
+                workspace: ws.path().to_path_buf(),
+                global: None,
+                system: None,
+            },
+            registry,
+        );
+        let install_out = match install
+            .execute(json!({"source": source, "scope": "workspace"}))
+            .await
+        {
+            ToolExecutionResult::Success(v) => v,
+            other => panic!("live install failed: {other:?}"),
+        };
+        let name = install_out["name"].as_str().expect("name");
+        assert!(
+            ws.path().join(name).join("SKILL.md").is_file(),
+            "expected installed skill at {}",
+            ws.path().join(name).display()
+        );
+    }
 }

--- a/src/capabilities/skill_registry.rs
+++ b/src/capabilities/skill_registry.rs
@@ -1,0 +1,1032 @@
+//! Conversational skills.sh registry search and install.
+//!
+//! Yolop already has local skill lifecycle tools (`list_skills`, `write_skill`,
+//! `delete_skill`). This module adds the missing discovery/install loop against
+//! the public [skills.sh](https://skills.sh) registry:
+//!
+//! - `search_skills` — `GET /api/search`
+//! - `install_skill` — `GET /api/download/{owner}/{repo}/{slug}` then write into
+//!   a writable scope (workspace or global)
+//!
+//! The agent should search, present options, ask which to install, then call
+//! `install_skill`. GitHub-style `owner/repo@skill` sources work when the
+//! registry has cached the snapshot; there is no separate GitHub clone path.
+
+use crate::capabilities::narration::stable_labeled;
+use crate::capabilities::skills::{SkillDirs, validate_skill_name};
+use async_trait::async_trait;
+use everruns_core::tool_narration::{ToolNarrationPhase, arg_str, truncate};
+use everruns_core::tool_types::ToolCall;
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::path::{Component, Path, PathBuf};
+use std::time::Duration;
+
+const USER_AGENT: &str = concat!(
+    "yolop/",
+    env!("CARGO_PKG_VERSION"),
+    " (+https://github.com/everruns/yolop)"
+);
+
+const DEFAULT_REGISTRY_BASE: &str = "https://skills.sh";
+const DEFAULT_SEARCH_LIMIT: usize = 8;
+const MAX_SEARCH_LIMIT: usize = 25;
+/// Registry snapshots can be larger than agent-authored `write_skill` payloads;
+/// keep a hard cap so a bad response cannot fill the disk.
+const MAX_INSTALL_FILES: usize = 200;
+const MAX_SKILL_FILE_BYTES: usize = 1024 * 1024;
+const MAX_INSTALL_TOTAL_BYTES: usize = 10 * 1024 * 1024;
+const FETCH_TIMEOUT_SECS: u64 = 20;
+
+#[derive(Clone, Debug)]
+pub(crate) struct SkillRegistryClient {
+    client: Client,
+    base_url: String,
+}
+
+impl SkillRegistryClient {
+    pub(crate) fn production() -> Self {
+        Self::with_base_url(DEFAULT_REGISTRY_BASE.to_string())
+    }
+
+    pub(crate) fn with_base_url(base_url: String) -> Self {
+        let client = Client::builder()
+            .user_agent(USER_AGENT)
+            .timeout(Duration::from_secs(FETCH_TIMEOUT_SECS))
+            .build()
+            .expect("skills registry HTTP client should build");
+        Self {
+            client,
+            base_url: base_url.trim_end_matches('/').to_string(),
+        }
+    }
+
+    async fn search(
+        &self,
+        query: &str,
+        limit: usize,
+        owner: Option<&str>,
+    ) -> Result<SkillSearchResponse, String> {
+        let mut url = format!(
+            "{}/api/search?q={}&limit={}",
+            self.base_url,
+            urlencoding::encode(query),
+            limit
+        );
+        if let Some(owner) = owner.filter(|o| !o.is_empty()) {
+            url.push_str("&owner=");
+            url.push_str(&urlencoding::encode(owner));
+        }
+        let response = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|err| format!("skills.sh search failed: {err}"))?;
+        if !response.status().is_success() {
+            return Err(format!(
+                "skills.sh search returned HTTP {}",
+                response.status()
+            ));
+        }
+        response
+            .json::<SkillSearchResponse>()
+            .await
+            .map_err(|err| format!("skills.sh search response was not valid JSON: {err}"))
+    }
+
+    async fn download(
+        &self,
+        owner: &str,
+        repo: &str,
+        slug: &str,
+    ) -> Result<SkillDownloadResponse, String> {
+        let url = format!(
+            "{}/api/download/{}/{}/{}",
+            self.base_url,
+            urlencoding::encode(owner),
+            urlencoding::encode(repo),
+            urlencoding::encode(slug)
+        );
+        let response = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|err| format!("skills.sh download failed: {err}"))?;
+        if response.status().as_u16() == 404 {
+            return Err(format!(
+                "skills.sh has no cached snapshot for `{owner}/{repo}/{slug}`"
+            ));
+        }
+        if !response.status().is_success() {
+            return Err(format!(
+                "skills.sh download returned HTTP {}",
+                response.status()
+            ));
+        }
+        response
+            .json::<SkillDownloadResponse>()
+            .await
+            .map_err(|err| format!("skills.sh download response was not valid JSON: {err}"))
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct SkillSearchResponse {
+    query: String,
+    #[serde(default)]
+    #[serde(rename = "searchType")]
+    search_type: Option<String>,
+    #[serde(default)]
+    skills: Vec<SkillSearchHit>,
+    #[serde(default)]
+    count: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+struct SkillSearchHit {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default, rename = "skillId")]
+    skill_id: Option<String>,
+    name: String,
+    #[serde(default)]
+    installs: Option<u64>,
+    #[serde(default)]
+    source: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SkillDownloadResponse {
+    #[serde(default)]
+    files: Vec<SkillDownloadFile>,
+    #[serde(default)]
+    hash: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SkillDownloadFile {
+    path: String,
+    contents: String,
+}
+
+/// Parsed install source: GitHub owner/repo plus skill slug for skills.sh.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedSkillSource {
+    owner: String,
+    repo: String,
+    slug: String,
+}
+
+fn to_skill_slug(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    let mut last_dash = false;
+    for ch in name.chars() {
+        let lower = ch.to_ascii_lowercase();
+        if lower.is_ascii_alphanumeric() {
+            out.push(lower);
+            last_dash = false;
+        } else if matches!(lower, ' ' | '_' | '-') && !out.is_empty() && !last_dash {
+            out.push('-');
+            last_dash = true;
+        }
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+    out
+}
+
+fn parse_skill_source(source: &str, skill: Option<&str>) -> Result<ParsedSkillSource, String> {
+    let raw = source.trim();
+    if raw.is_empty() {
+        return Err("'source' is required".to_string());
+    }
+
+    let mut owned = raw.to_string();
+    for prefix in [
+        "https://www.skills.sh/",
+        "http://www.skills.sh/",
+        "https://skills.sh/",
+        "http://skills.sh/",
+        "https://github.com/",
+        "http://github.com/",
+        "github.com/",
+    ] {
+        if let Some(stripped) = owned.strip_prefix(prefix) {
+            owned = stripped.to_string();
+            break;
+        }
+    }
+    owned = owned.trim_matches('/').to_string();
+    if let Some((path, _)) = owned.split_once('?') {
+        owned = path.to_string();
+    }
+    if let Some((path, _)) = owned.split_once('#') {
+        owned = path.to_string();
+    }
+    // Drop optional `/tree/<ref>/...` noise from GitHub URLs when present.
+    if let Some(idx) = owned.find("/tree/") {
+        let owner_repo = owned[..idx].to_string();
+        let after = owned[idx + "/tree/".len()..].to_string();
+        let mut parts = after.splitn(2, '/');
+        let _ref = parts.next();
+        owned = if let Some(subpath) = parts.next() {
+            let skill_seg = subpath
+                .trim_end_matches('/')
+                .rsplit('/')
+                .find(|p| !p.is_empty() && !p.eq_ignore_ascii_case("SKILL.md"))
+                .unwrap_or(subpath);
+            format!("{owner_repo}/{skill_seg}")
+        } else {
+            owner_repo
+        };
+    }
+
+    // owner/repo@skill
+    if let Some((left, right)) = owned.split_once('@') {
+        let (owner, repo) = split_owner_repo(left)?;
+        let slug = skill_slug_from(right, skill)?;
+        return Ok(ParsedSkillSource { owner, repo, slug });
+    }
+
+    let segments: Vec<&str> = owned.split('/').filter(|s| !s.is_empty()).collect();
+    match segments.as_slice() {
+        [owner, repo] => {
+            let slug = skill
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(to_skill_slug)
+                .ok_or_else(|| {
+                    "source `owner/repo` requires a skill name — pass `skill` or use `owner/repo@skill`"
+                        .to_string()
+                })?;
+            Ok(ParsedSkillSource {
+                owner: (*owner).to_string(),
+                repo: (*repo).to_string(),
+                slug,
+            })
+        }
+        [owner, repo, skill_id] => Ok(ParsedSkillSource {
+            owner: (*owner).to_string(),
+            repo: (*repo).to_string(),
+            slug: skill_slug_from(skill_id, skill)?,
+        }),
+        [owner, repo, rest @ ..] if !rest.is_empty() => {
+            // skills.sh ids are owner/repo/skillId; tolerate deeper paths by
+            // taking the final segment as the skill id.
+            let skill_id = rest.last().expect("rest non-empty");
+            Ok(ParsedSkillSource {
+                owner: (*owner).to_string(),
+                repo: (*repo).to_string(),
+                slug: skill_slug_from(skill_id, skill)?,
+            })
+        }
+        _ => Err(format!(
+            "unrecognized skill source `{source}`; expected `owner/repo/skill`, `owner/repo@skill`, or a skills.sh URL"
+        )),
+    }
+}
+
+fn split_owner_repo(value: &str) -> Result<(String, String), String> {
+    let parts: Vec<&str> = value.split('/').filter(|s| !s.is_empty()).collect();
+    match parts.as_slice() {
+        [owner, repo] => Ok(((*owner).to_string(), (*repo).to_string())),
+        _ => Err(format!("expected `owner/repo` before `@`, got `{value}`")),
+    }
+}
+
+fn skill_slug_from(primary: &str, override_skill: Option<&str>) -> Result<String, String> {
+    let chosen = override_skill
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(primary.trim());
+    if chosen.is_empty() {
+        return Err("skill name is empty".to_string());
+    }
+    let slug = to_skill_slug(chosen);
+    if slug.is_empty() {
+        return Err(format!("skill name `{chosen}` has no usable slug"));
+    }
+    Ok(slug)
+}
+
+fn validate_relative_skill_path(raw: &str) -> Result<PathBuf, String> {
+    if raw.trim().is_empty() || raw.contains('\\') {
+        return Err(format!("invalid skill file path `{raw}`"));
+    }
+    let path = PathBuf::from(raw);
+    if path.is_absolute() {
+        return Err(format!("invalid skill file path `{raw}`"));
+    }
+    for component in path.components() {
+        if !matches!(component, Component::Normal(_)) {
+            return Err(format!("invalid skill file path `{raw}`"));
+        }
+    }
+    Ok(path)
+}
+
+#[derive(Debug)]
+struct PreparedInstall {
+    name: String,
+    skill_md: String,
+    files: Vec<(PathBuf, String)>,
+    hash: Option<String>,
+}
+
+fn prepare_install_files(download: SkillDownloadResponse) -> Result<PreparedInstall, String> {
+    if download.files.is_empty() {
+        return Err("skills.sh download returned no files".to_string());
+    }
+    if download.files.len() > MAX_INSTALL_FILES {
+        return Err(format!(
+            "skills.sh snapshot has too many files ({}; max {MAX_INSTALL_FILES})",
+            download.files.len()
+        ));
+    }
+
+    let mut total = 0usize;
+    let mut skill_md: Option<(PathBuf, String)> = None;
+    let mut extras: Vec<(PathBuf, String)> = Vec::new();
+
+    for file in download.files {
+        total = total.saturating_add(file.contents.len());
+        if total > MAX_INSTALL_TOTAL_BYTES {
+            return Err(format!(
+                "skills.sh snapshot exceeds the {MAX_INSTALL_TOTAL_BYTES} byte install limit"
+            ));
+        }
+        if file.contents.len() > MAX_SKILL_FILE_BYTES {
+            return Err(format!(
+                "file `{}` exceeds the {MAX_SKILL_FILE_BYTES} byte limit",
+                file.path
+            ));
+        }
+        let path = validate_relative_skill_path(&file.path)?;
+        if path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.eq_ignore_ascii_case("SKILL.md"))
+            && path.components().count() == 1
+        {
+            if skill_md.is_some() {
+                return Err("skills.sh snapshot contains multiple root SKILL.md files".to_string());
+            }
+            skill_md = Some((path, file.contents));
+        } else {
+            // Nested SKILL.md copies are treated as ordinary bundled files.
+            extras.push((path, file.contents));
+        }
+    }
+
+    let Some((_path, skill_md_content)) = skill_md else {
+        return Err("skills.sh snapshot is missing a root SKILL.md".to_string());
+    };
+
+    let parsed = everruns_core::skill::parse_skill_md(&skill_md_content)
+        .map_err(|errors| format!("Invalid SKILL.md from registry: {}", errors.join(", ")))?;
+    validate_skill_name(&parsed.name)?;
+
+    Ok(PreparedInstall {
+        name: parsed.name,
+        skill_md: skill_md_content,
+        files: extras,
+        hash: download.hash,
+    })
+}
+
+fn write_skill_install(
+    target_dir: &Path,
+    skill_md: &str,
+    files: &[(PathBuf, String)],
+    overwrite: bool,
+) -> Result<(), String> {
+    if target_dir.exists() {
+        if !overwrite {
+            return Err(format!(
+                "`{}` already exists; pass overwrite=true to replace it",
+                target_dir.display()
+            ));
+        }
+        if !target_dir.join("SKILL.md").is_file() {
+            return Err(format!(
+                "`{}` exists but is not a skill (no SKILL.md); refusing to overwrite",
+                target_dir.display()
+            ));
+        }
+    }
+
+    let parent = target_dir.parent().ok_or_else(|| {
+        format!(
+            "skill install path `{}` has no parent directory",
+            target_dir.display()
+        )
+    })?;
+    std::fs::create_dir_all(parent)
+        .map_err(|err| format!("failed to create skills directory: {err}"))?;
+
+    let staging = parent.join(format!(
+        ".yolop-skill-install-{}-{}",
+        target_dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("skill"),
+        std::process::id()
+    ));
+    if staging.exists() {
+        std::fs::remove_dir_all(&staging)
+            .map_err(|err| format!("failed to clear staging directory: {err}"))?;
+    }
+    std::fs::create_dir_all(&staging)
+        .map_err(|err| format!("failed to create staging directory: {err}"))?;
+
+    let write_all = || -> Result<(), String> {
+        std::fs::write(staging.join("SKILL.md"), skill_md)
+            .map_err(|err| format!("failed to write SKILL.md: {err}"))?;
+        for (rel, content) in files {
+            let dest = staging.join(rel);
+            if let Some(dir) = dest.parent() {
+                std::fs::create_dir_all(dir)
+                    .map_err(|err| format!("failed to create `{}`: {err}", dir.display()))?;
+            }
+            std::fs::write(&dest, content)
+                .map_err(|err| format!("failed to write `{}`: {err}", rel.display()))?;
+        }
+        Ok(())
+    };
+
+    if let Err(err) = write_all() {
+        let _ = std::fs::remove_dir_all(&staging);
+        return Err(err);
+    }
+
+    if target_dir.exists() {
+        std::fs::remove_dir_all(target_dir).map_err(|err| {
+            let _ = std::fs::remove_dir_all(&staging);
+            format!("failed to replace existing skill: {err}")
+        })?;
+    }
+
+    std::fs::rename(&staging, target_dir).map_err(|err| {
+        let _ = std::fs::remove_dir_all(&staging);
+        format!("failed to finalize skill install: {err}")
+    })?;
+    Ok(())
+}
+
+pub(crate) struct SearchSkillsTool {
+    registry: SkillRegistryClient,
+}
+
+impl SearchSkillsTool {
+    pub(crate) fn new(registry: SkillRegistryClient) -> Self {
+        Self { registry }
+    }
+}
+
+#[async_trait]
+impl Tool for SearchSkillsTool {
+    fn narrate(
+        &self,
+        tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        let _ = locale;
+        let detail = arg_str(&tool_call.arguments, &["query"]).map(|q| truncate(q, 48));
+        Some(stable_labeled("Search skills", detail, phase))
+    }
+
+    fn name(&self) -> &str {
+        "search_skills"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Search skills")
+    }
+
+    fn description(&self) -> &str {
+        "Search the public skills.sh registry for installable agent skills. \
+         Use when the user asks to find a skill for a task. Present the top \
+         matches (name, source, installs, skills.sh URL) and ask which one to \
+         install before calling `install_skill`. For sources outside skills.sh, \
+         fall back to `free_web_search` / `web_fetch` and `write_skill`."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "What the skill should help with (topic, tool, or task)."
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum results to return (1–25). Defaults to 8.",
+                    "minimum": 1,
+                    "maximum": 25
+                },
+                "owner": {
+                    "type": "string",
+                    "description": "Optional GitHub owner/org to restrict results (e.g. `vercel-labs`)."
+                }
+            },
+            "required": ["query"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let query = arguments
+            .get("query")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .trim();
+        if query.len() < 2 {
+            return ToolExecutionResult::tool_error(
+                "'query' must be at least 2 characters".to_string(),
+            );
+        }
+        let limit = arguments
+            .get("limit")
+            .and_then(Value::as_u64)
+            .map(|n| n as usize)
+            .unwrap_or(DEFAULT_SEARCH_LIMIT)
+            .clamp(1, MAX_SEARCH_LIMIT);
+        let owner = arguments
+            .get("owner")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+
+        match self.registry.search(query, limit, owner).await {
+            Ok(response) => {
+                let skills: Vec<Value> = response
+                    .skills
+                    .into_iter()
+                    .map(|hit| {
+                        let id = hit
+                            .id
+                            .clone()
+                            .or_else(|| {
+                                hit.source.as_ref().map(|source| {
+                                    format!(
+                                        "{source}/{}",
+                                        hit.skill_id
+                                            .clone()
+                                            .unwrap_or_else(|| to_skill_slug(&hit.name))
+                                    )
+                                })
+                            })
+                            .unwrap_or_else(|| hit.name.clone());
+                        let url = format!("https://skills.sh/{id}");
+                        json!({
+                            "id": id,
+                            "skill_id": hit.skill_id,
+                            "name": hit.name,
+                            "installs": hit.installs,
+                            "source": hit.source,
+                            "url": url,
+                            "install_source": id,
+                        })
+                    })
+                    .collect();
+                ToolExecutionResult::success(json!({
+                    "query": response.query,
+                    "search_type": response.search_type,
+                    "count": response.count.unwrap_or(skills.len()),
+                    "skills": skills,
+                    "registry": "skills.sh",
+                    "message": "Present these options to the user and ask which skill to install before calling install_skill.",
+                }))
+            }
+            Err(err) => ToolExecutionResult::tool_error(err),
+        }
+    }
+}
+
+pub(crate) struct InstallSkillTool {
+    dirs: SkillDirs,
+    registry: SkillRegistryClient,
+}
+
+impl InstallSkillTool {
+    pub(crate) fn new(dirs: SkillDirs, registry: SkillRegistryClient) -> Self {
+        Self { dirs, registry }
+    }
+
+    fn base_for(&self, scope: &str) -> Result<PathBuf, String> {
+        match scope {
+            "workspace" => Ok(self.dirs.workspace.clone()),
+            "global" => self
+                .dirs
+                .global
+                .clone()
+                .ok_or_else(|| "no global skills directory is configured".to_string()),
+            "system" => Err("system skills are read-only and cannot be installed into".to_string()),
+            other => Err(format!(
+                "unknown scope `{other}`; expected `workspace` or `global`"
+            )),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for InstallSkillTool {
+    fn narrate(
+        &self,
+        tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        let _ = locale;
+        let detail = arg_str(&tool_call.arguments, &["source"])
+            .or_else(|| arg_str(&tool_call.arguments, &["skill"]))
+            .map(|s| truncate(s, 48));
+        Some(stable_labeled("Install skill", detail, phase))
+    }
+
+    fn name(&self) -> &str {
+        "install_skill"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Install skill")
+    }
+
+    fn description(&self) -> &str {
+        "Install a skill from the skills.sh registry into the workspace or global \
+         scope. Prefer sources returned by `search_skills` (`owner/repo/skillId` or \
+         `owner/repo@skill`). Ask the user which skill to install first. After \
+         install the skill is available immediately via `list_skills` / \
+         `activate_skill` — no restart. For non-registry sources, fetch files and \
+         use `write_skill` instead."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "string",
+                    "description": "Registry id (`owner/repo/skillId`), `owner/repo@skill`, skills.sh URL, or GitHub `owner/repo` (with `skill`)."
+                },
+                "skill": {
+                    "type": "string",
+                    "description": "Skill name/slug when `source` is only `owner/repo`."
+                },
+                "scope": {
+                    "type": "string",
+                    "description": "Writable scope to install into.",
+                    "enum": ["workspace", "global"],
+                    "default": "workspace"
+                },
+                "overwrite": {
+                    "type": "boolean",
+                    "description": "Replace an existing skill with the same name. Defaults to true.",
+                    "default": true
+                }
+            },
+            "required": ["source"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let source = arguments
+            .get("source")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .trim();
+        let skill = arguments
+            .get("skill")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+        let parsed = match parse_skill_source(source, skill) {
+            Ok(parsed) => parsed,
+            Err(err) => return ToolExecutionResult::tool_error(err),
+        };
+        let scope = arguments
+            .get("scope")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or("workspace");
+        let overwrite = arguments
+            .get("overwrite")
+            .and_then(Value::as_bool)
+            .unwrap_or(true);
+
+        let base = match self.base_for(scope) {
+            Ok(base) => base,
+            Err(err) => return ToolExecutionResult::tool_error(err),
+        };
+
+        let download = match self
+            .registry
+            .download(&parsed.owner, &parsed.repo, &parsed.slug)
+            .await
+        {
+            Ok(download) => download,
+            Err(err) => return ToolExecutionResult::tool_error(err),
+        };
+
+        let prepared = match prepare_install_files(download) {
+            Ok(prepared) => prepared,
+            Err(err) => return ToolExecutionResult::tool_error(err),
+        };
+
+        let target = base.join(&prepared.name);
+        let name_for_write = prepared.name.clone();
+        let skill_md_for_write = prepared.skill_md.clone();
+        let files_for_write = prepared.files.clone();
+        let hash = prepared.hash.clone();
+        let files_written = files_for_write.len() + 1;
+        let target_for_write = target.clone();
+        let outcome = tokio::task::spawn_blocking(move || {
+            write_skill_install(
+                &target_for_write,
+                &skill_md_for_write,
+                &files_for_write,
+                overwrite,
+            )
+        })
+        .await;
+
+        match outcome {
+            Ok(Ok(())) => ToolExecutionResult::success(json!({
+                "success": true,
+                "name": name_for_write,
+                "scope": scope,
+                "path": target.display().to_string(),
+                "source": format!("{}/{}/{}", parsed.owner, parsed.repo, parsed.slug),
+                "files_written": files_written,
+                "hash": hash,
+                "url": format!(
+                    "https://skills.sh/{}/{}/{}",
+                    parsed.owner, parsed.repo, parsed.slug
+                ),
+                "message": format!(
+                    "installed `{name_for_write}` into the {scope} scope; activate with activate_skill or /{name_for_write} if user-invocable"
+                ),
+            })),
+            Ok(Err(message)) => ToolExecutionResult::tool_error(message),
+            Err(join_err) => {
+                ToolExecutionResult::tool_error(format!("install task failed: {join_err}"))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slugifies_skill_names() {
+        assert_eq!(
+            to_skill_slug("vercel-react-best-practices"),
+            "vercel-react-best-practices"
+        );
+        assert_eq!(to_skill_slug("Find Skills"), "find-skills");
+        assert_eq!(to_skill_slug("  Foo_Bar!! "), "foo-bar");
+    }
+
+    #[test]
+    fn parses_common_source_forms() {
+        assert_eq!(
+            parse_skill_source("vercel-labs/agent-skills/vercel-react-best-practices", None)
+                .unwrap(),
+            ParsedSkillSource {
+                owner: "vercel-labs".into(),
+                repo: "agent-skills".into(),
+                slug: "vercel-react-best-practices".into(),
+            }
+        );
+        assert_eq!(
+            parse_skill_source("vercel-labs/skills@find-skills", None).unwrap(),
+            ParsedSkillSource {
+                owner: "vercel-labs".into(),
+                repo: "skills".into(),
+                slug: "find-skills".into(),
+            }
+        );
+        assert_eq!(
+            parse_skill_source("https://skills.sh/vercel-labs/skills/find-skills", None).unwrap(),
+            ParsedSkillSource {
+                owner: "vercel-labs".into(),
+                repo: "skills".into(),
+                slug: "find-skills".into(),
+            }
+        );
+        assert_eq!(
+            parse_skill_source("vercel-labs/skills", Some("find-skills")).unwrap(),
+            ParsedSkillSource {
+                owner: "vercel-labs".into(),
+                repo: "skills".into(),
+                slug: "find-skills".into(),
+            }
+        );
+        assert!(parse_skill_source("vercel-labs/skills", None).is_err());
+    }
+
+    #[test]
+    fn prepare_install_rejects_traversal_and_missing_skill_md() {
+        let err = prepare_install_files(SkillDownloadResponse {
+            files: vec![SkillDownloadFile {
+                path: "../escape.md".into(),
+                contents: "nope".into(),
+            }],
+            hash: None,
+        })
+        .unwrap_err();
+        assert!(err.contains("invalid skill file path"), "{err}");
+
+        let err = prepare_install_files(SkillDownloadResponse {
+            files: vec![SkillDownloadFile {
+                path: "README.md".into(),
+                contents: "hi".into(),
+            }],
+            hash: None,
+        })
+        .unwrap_err();
+        assert!(err.contains("missing a root SKILL.md"), "{err}");
+    }
+
+    #[test]
+    fn prepare_install_accepts_valid_snapshot() {
+        let prepared = prepare_install_files(SkillDownloadResponse {
+            files: vec![
+                SkillDownloadFile {
+                    path: "SKILL.md".into(),
+                    contents: "---\nname: find-skills\ndescription: Find skills\n---\nBody\n"
+                        .into(),
+                },
+                SkillDownloadFile {
+                    path: "notes/README.md".into(),
+                    contents: "extra".into(),
+                },
+            ],
+            hash: Some("abc".into()),
+        })
+        .unwrap();
+        assert_eq!(prepared.name, "find-skills");
+        assert!(prepared.skill_md.contains("name: find-skills"));
+        assert_eq!(prepared.files.len(), 1);
+        assert_eq!(prepared.hash.as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn write_skill_install_is_atomic_and_overwrite_safe() {
+        let root = tempfile::tempdir().unwrap();
+        let target = root.path().join("find-skills");
+        write_skill_install(
+            &target,
+            "---\nname: find-skills\ndescription: Find skills\n---\nv1\n",
+            &[(PathBuf::from("extra.txt"), "one".into())],
+            true,
+        )
+        .unwrap();
+        assert_eq!(
+            std::fs::read_to_string(target.join("extra.txt")).unwrap(),
+            "one"
+        );
+
+        write_skill_install(
+            &target,
+            "---\nname: find-skills\ndescription: Find skills\n---\nv2\n",
+            &[],
+            true,
+        )
+        .unwrap();
+        assert!(
+            !target.join("extra.txt").exists(),
+            "overwrite should replace the whole skill directory"
+        );
+        assert!(
+            std::fs::read_to_string(target.join("SKILL.md"))
+                .unwrap()
+                .contains("v2")
+        );
+
+        let err = write_skill_install(
+            &target,
+            "---\nname: find-skills\ndescription: Find skills\n---\nv3\n",
+            &[],
+            false,
+        )
+        .unwrap_err();
+        assert!(err.contains("already exists"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn search_and_install_tools_hit_registry_entrypoint() {
+        let server = tiny_http::Server::http("127.0.0.1:0").expect("test server");
+        let base_url = format!("http://{}", server.server_addr());
+        let server_thread = std::thread::spawn(move || {
+            for request in server.incoming_requests().take(2) {
+                let url = request.url().to_string();
+                let body = if url.starts_with("/api/search") {
+                    r#"{
+                      "query":"find",
+                      "searchType":"fuzzy",
+                      "count":1,
+                      "skills":[{
+                        "id":"vercel-labs/skills/find-skills",
+                        "skillId":"find-skills",
+                        "name":"find-skills",
+                        "installs":42,
+                        "source":"vercel-labs/skills"
+                      }]
+                    }"#
+                } else if url.starts_with("/api/download/") {
+                    r#"{
+                      "hash":"deadbeef",
+                      "files":[
+                        {"path":"SKILL.md","contents":"---\nname: find-skills\ndescription: Find skills\nuser-invocable: true\n---\nBody\n"},
+                        {"path":"hint.txt","contents":"tip"}
+                      ]
+                    }"#
+                } else {
+                    "{}"
+                };
+                request
+                    .respond(tiny_http::Response::from_string(body))
+                    .expect("respond");
+            }
+        });
+
+        let registry = SkillRegistryClient::with_base_url(base_url);
+        let search = SearchSkillsTool::new(registry.clone());
+        let search_result = search.execute(json!({"query": "find", "limit": 5})).await;
+        let search_out = match search_result {
+            ToolExecutionResult::Success(v) => v,
+            other => panic!("search should succeed: {other:?}"),
+        };
+        assert_eq!(search_out["skills"][0]["name"], "find-skills");
+        assert_eq!(
+            search_out["skills"][0]["install_source"],
+            "vercel-labs/skills/find-skills"
+        );
+        assert!(
+            search_out["message"]
+                .as_str()
+                .unwrap()
+                .contains("ask which skill to install")
+        );
+
+        let ws = tempfile::tempdir().unwrap();
+        let install = InstallSkillTool::new(
+            SkillDirs {
+                workspace: ws.path().to_path_buf(),
+                global: None,
+                system: None,
+            },
+            registry,
+        );
+        let install_result = install
+            .execute(json!({
+                "source": "vercel-labs/skills/find-skills",
+                "scope": "workspace"
+            }))
+            .await;
+        server_thread.join().expect("server thread");
+        let install_out = match install_result {
+            ToolExecutionResult::Success(v) => v,
+            other => panic!("install should succeed: {other:?}"),
+        };
+        assert_eq!(install_out["name"], "find-skills");
+        assert_eq!(install_out["files_written"], 2);
+        assert!(ws.path().join("find-skills").join("SKILL.md").is_file());
+        assert_eq!(
+            std::fs::read_to_string(ws.path().join("find-skills/hint.txt")).unwrap(),
+            "tip"
+        );
+    }
+
+    #[test]
+    fn tool_names_are_stable() {
+        let dirs = SkillDirs {
+            workspace: PathBuf::from("/ws/.agents/skills"),
+            global: None,
+            system: None,
+        };
+        let registry = SkillRegistryClient::with_base_url("http://127.0.0.1:9".into());
+        assert_eq!(
+            SearchSkillsTool::new(registry.clone()).name(),
+            "search_skills"
+        );
+        assert_eq!(
+            InstallSkillTool::new(dirs, registry).name(),
+            "install_skill"
+        );
+    }
+}

--- a/src/capabilities/skills.rs
+++ b/src/capabilities/skills.rs
@@ -356,11 +356,15 @@ pub(crate) const SKILL_MANAGEMENT_CAPABILITY_ID: &str = "yolop_skill_management"
 /// of shelling out to `rm`.
 pub(crate) struct SkillManagementCapability {
     dirs: SkillDirs,
+    registry: crate::capabilities::skill_registry::SkillRegistryClient,
 }
 
 impl SkillManagementCapability {
     pub(crate) fn new(dirs: SkillDirs) -> Self {
-        Self { dirs }
+        Self {
+            dirs,
+            registry: crate::capabilities::skill_registry::SkillRegistryClient::production(),
+        }
     }
 }
 
@@ -373,7 +377,7 @@ impl Capability for SkillManagementCapability {
         "Skill Management"
     }
     fn description(&self) -> &str {
-        "Uninstall workspace or global skills (delete_skill)."
+        "Search skills.sh, install registry skills, and uninstall workspace/global skills."
     }
     fn status(&self) -> CapabilityStatus {
         CapabilityStatus::Available
@@ -382,15 +386,23 @@ impl Capability for SkillManagementCapability {
         Some("Examples")
     }
     fn system_prompt_addition(&self) -> Option<&str> {
-        // `delete_skill`'s description already states the scope argument, that
-        // system skills are read-only, and that install/update go through
-        // `write_skill`.
+        // Tool descriptions already cover search → ask → install, and that
+        // system skills are read-only.
         None
     }
     fn tools(&self) -> Vec<Box<dyn Tool>> {
-        vec![Box::new(DeleteSkillTool {
-            dirs: self.dirs.clone(),
-        })]
+        vec![
+            Box::new(crate::capabilities::skill_registry::SearchSkillsTool::new(
+                self.registry.clone(),
+            )),
+            Box::new(crate::capabilities::skill_registry::InstallSkillTool::new(
+                self.dirs.clone(),
+                self.registry.clone(),
+            )),
+            Box::new(DeleteSkillTool {
+                dirs: self.dirs.clone(),
+            }),
+        ]
     }
 }
 
@@ -421,8 +433,8 @@ impl DeleteSkillTool {
 }
 
 /// A skill name must be a single, plain path component — no separators, no `.`
-/// or `..`. This keeps `delete_skill` from escaping the scope directory.
-fn validate_skill_name(name: &str) -> Result<(), String> {
+/// or `..`. This keeps skill install/uninstall from escaping the scope directory.
+pub(crate) fn validate_skill_name(name: &str) -> Result<(), String> {
     if name.is_empty() {
         return Err("'name' is required".to_string());
     }
@@ -767,7 +779,7 @@ mod tests {
     // ---------- delete_skill ----------
 
     #[test]
-    fn skill_management_capability_exposes_delete_skill() {
+    fn skill_management_capability_exposes_search_install_delete() {
         let dirs = SkillDirs {
             workspace: PathBuf::from("/ws/.agents/skills"),
             global: None,
@@ -779,15 +791,17 @@ mod tests {
             .iter()
             .map(|t| t.name().to_string())
             .collect();
-        assert!(
-            names.iter().any(|n| n == "delete_skill"),
-            "delete_skill should be exposed: {names:?}"
-        );
-        // Uninstall guidance belongs to the tool, not to a per-turn prompt block:
-        // the description is already in context whenever the tool is offered.
+        for expected in ["search_skills", "install_skill", "delete_skill"] {
+            assert!(
+                names.iter().any(|n| n == expected),
+                "{expected} should be exposed: {names:?}"
+            );
+        }
+        // Guidance belongs to the tools, not to a per-turn prompt block:
+        // the descriptions are already in context whenever the tools are offered.
         assert!(
             capability.system_prompt_addition().is_none(),
-            "skill removal guidance lives in `delete_skill`'s description"
+            "skill management guidance lives in the tool descriptions"
         );
         let description = capability
             .tools()

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -931,9 +931,12 @@ const YOLOP_NEVER_DEFER_TOOLS: &[&str] = &[
     "spawn_agent",
     "write_todos",
     "write_session_title",
-    // Skill activation is a routing tool with required arguments; hiding its
-    // tiny schema makes malformed calls like activate_skill({}) more likely.
+    // Skill activation/search/install are routing tools with required arguments;
+    // hiding their schemas makes malformed calls more likely and adds friction
+    // to the conversational "find a skill → install it" loop.
     "activate_skill",
+    "search_skills",
+    "install_skill",
     "run_yolop_command",
     // LSP tools exist only when the optional `lsp` capability is enabled
     // (absent names are ignored by the allowlist). When they exist, stub
@@ -2885,6 +2888,7 @@ pub async fn build_with_options(
     //   * skills               — discovers SKILL.md across workspace / global /
     //                            environment / system scopes via the session file store;
     //                            list_skills + activate_skill + read/write_skill
+    //   * skill_management     — search_skills / install_skill (skills.sh) + delete_skill
     //
     // Non-filesystem, but useful for a coding agent:
     //   * repo_map            - on-demand multi-language symbol map for broad codebase orientation
@@ -2927,8 +2931,9 @@ pub async fn build_with_options(
     // Herdr contributes a conditional, read-only skill mount. Outside a Herdr
     // pane it has no mounts and the reporter is inert.
     capabilities.register(HerdrCapability::new(herdr.is_active()));
-    // yolop-owned skill uninstall (`delete_skill`); the upstream capability has
-    // no removal. Shares the same resolved scope directories.
+    // yolop-owned skill registry + uninstall (`search_skills`, `install_skill`,
+    // `delete_skill`); the upstream capability has list/activate/read/write only.
+    // Shares the same resolved scope directories.
     capabilities.register(crate::capabilities::skills::SkillManagementCapability::new(
         skill_dirs.clone(),
     ));
@@ -4946,13 +4951,14 @@ mod tests {
     }
 
     // The live-config tools (`set_provider` / `set_model` / `set_reasoning_effort`)
-    // and `delete_skill` are registered via SetupCapability / SkillManagementCapability
+    // and skill management tools (`search_skills` / `install_skill` / `delete_skill`)
+    // are registered via SetupCapability / SkillManagementCapability
     // in `build_with_options`. Because ToolSearchCapability defers the long tail
-    // behind `tool_search`, they are not in the immediate `runtime_agent.tools`
-    // snapshot, so their presence is asserted at the capability level
-    // (`capabilities::host::tests::setup_capability_exposes_live_config_tools`,
-    // `capabilities::skills::tests::skill_management_capability_exposes_delete_skill`)
-    // and their behavior by the SetupController / DeleteSkillTool unit tests.
+    // behind `tool_search`, only the never-defer allowlist keeps search/install
+    // schemas loaded; `delete_skill` remains deferred. Presence is asserted at
+    // the capability level
+    // (`capabilities::skills::tests::skill_management_capability_exposes_search_install_delete`)
+    // and behavior by the SkillRegistry / DeleteSkillTool unit tests.
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn setup_url_and_custom_model_persist_through_settings() {
@@ -6602,6 +6608,36 @@ mod tests {
                 hints: ToolHints::default(),
                 full_parameters: None,
             }),
+            ToolDefinition::Builtin(BuiltinTool {
+                name: "search_skills".to_string(),
+                display_name: None,
+                description: "search skills".to_string(),
+                parameters: serde_json::json!({
+                    "type": "object",
+                    "properties": { "query": { "type": "string" } },
+                    "required": ["query"]
+                }),
+                policy: ToolPolicy::Auto,
+                category: None,
+                deferrable: DeferrablePolicy::Automatic,
+                hints: ToolHints::default(),
+                full_parameters: None,
+            }),
+            ToolDefinition::Builtin(BuiltinTool {
+                name: "install_skill".to_string(),
+                display_name: None,
+                description: "install skill".to_string(),
+                parameters: serde_json::json!({
+                    "type": "object",
+                    "properties": { "source": { "type": "string" } },
+                    "required": ["source"]
+                }),
+                policy: ToolPolicy::Auto,
+                category: None,
+                deferrable: DeferrablePolicy::Automatic,
+                hints: ToolHints::default(),
+                full_parameters: None,
+            }),
             fake_tool("write_session_title"),
         ];
         tools
@@ -6632,6 +6668,21 @@ mod tests {
             activate_skill.parameters().get("properties").is_some(),
             "activate_skill must keep its full schema so models pass the required name field"
         );
+
+        for name in ["search_skills", "install_skill"] {
+            assert!(
+                YOLOP_NEVER_DEFER_TOOLS.contains(&name),
+                "{name} must stay on the never-defer allowlist"
+            );
+            let tool = transformed
+                .iter()
+                .find(|tool| tool.name() == name)
+                .unwrap_or_else(|| panic!("{name} definition"));
+            assert!(
+                tool.parameters().get("properties").is_some(),
+                "{name} must keep its full schema for the conversational find→install loop"
+            );
+        }
 
         let write_session_title = transformed
             .iter()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed
Yolop can now search the public skills.sh registry and install a chosen skill conversationally:

- `search_skills` queries skills.sh and returns structured matches (id, source, installs, URL)
- `install_skill` downloads a skills.sh snapshot into workspace or global scope, validates `SKILL.md`/paths, and hot-loads without restart
- `/skill-management` guidance updated to: search → present options → ask → install
- Both tools stay on the never-defer allowlist so the find→install loop does not need a `tool_search` round-trip

## Why
Users asking “find a skill for X” previously relied on prompt-only web search plus `write_skill`. That was unreliable. skills.sh already exposes search and download APIs; Yolop now uses them as first-class conversational tools.

## Before / After
**Before:** Agent had to invent a fetch plan via `free_web_search` / `web_fetch` and reconstruct installs with `write_skill`.

**After:**
```text
search_skills query="react performance"
→ present matches + ask which to install
install_skill source="vercel-labs/agent-skills/vercel-react-best-practices"
→ skill available via list_skills / activate_skill immediately
```

Validated with unit tests (mocked registry), an ignored live skills.sh smoke (`live_skills_sh_search_and_install`), and `--provider llmsim` binary smoke.

## Risk
- Low / Medium
- Depends on skills.sh availability; failures surface as tool errors and fall back to the existing `write_skill` path in guidance
- Install writes third-party skill content into workspace/global dirs (same trust model as `write_skill`, with path traversal and size bounds)

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (additive tools; pre-1.0)
- [x] Knowledge concepts updated

## Knowledge
Updated `knowledge/specs/skills.md`, `knowledge/specs/conversational-control.md`, and `knowledge/log.md`.

## Security
- **TM-FS:** Install writes only under resolved workspace/global skill dirs; rejects path traversal, absolute paths, and non-skill overwrite targets; atomic staging + rename; size caps (200 files, 1MB/file, 10MB total).
- **TM-TOOL:** New tools registered on existing `SkillManagementCapability`; no write-blocklist bypass outside skill scopes.
- **TM-DEP:** No new crates; uses existing `reqwest` + `urlencoding`.
- **TM-LLM:** No key handling changes; public registry only.

## Follow-ups
- No dedicated GitHub clone fallback when skills.sh has no cached snapshot (guidance still points to `web_fetch` + `write_skill`).
- No `yolop skill` CLI surface yet (extensions/MCP have CLI; skills remain conversational-first).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d26b5572-f899-46e7-9af1-2012cc41270c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d26b5572-f899-46e7-9af1-2012cc41270c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

