### PR TITLE
fix(mcp): expose reload to conversation

### DIFF
--- a/src/capabilities/client_commands.rs
+++ b/src/capabilities/client_commands.rs
@@ -35,7 +35,8 @@ commands: `/help`, `/tools`, `/mcp`, `/cwd`, `/status [compact|expanded|toggle]`
 The TUI may expose other slash commands, but only use `run_yolop_command` for this listed
 client-command set. When the user asks for one of these terminal
 actions — for example "exit", "clear the screen", "show tools", "switch model",
-"log in to an MCP server" (`/mcp login <name>`), or "expand the status bar" —
+"reload MCP servers" (`/mcp reload`), "log in to an MCP server"
+(`/mcp login <name>`), or "expand the status bar" —
 call `run_yolop_command` with the command and arguments; do not merely tell the
 user to type the slash command, and do not invent a manager window. The tool
 result includes the host's response text (server lists, tool lists, OAuth URLs).
@@ -262,7 +263,8 @@ impl Tool for RunYolopCommandTool {
     fn description(&self) -> &str {
         "Execute an interactive yolop slash command on behalf of a natural-language user request. \
          Use this when the user asks to exit, clear the transcript, show help/tools/MCP/cwd, \
-         show or change the status layout, or open/switch model or reasoning effort. Accepts command names with or without the leading \
+         reload MCP servers (`command: mcp`, `arguments: reload`), show or change the status \
+         layout, or open/switch model or reasoning effort. Accepts command names with or without the leading \
          slash; `exit` is accepted as an alias for `quit`."
     }
 
@@ -280,7 +282,7 @@ impl Tool for RunYolopCommandTool {
                 },
                 "arguments": {
                     "type": "string",
-                    "description": "Optional command arguments, e.g. a model id for /model or level for /effort."
+                    "description": "Optional command arguments, e.g. `reload` for /mcp, a model id for /model, or a level for /effort."
                 }
             },
             "required": ["command"],
@@ -613,6 +615,26 @@ mod tests {
             ui.take(),
             vec![UiCommand::SetStatusLayout {
                 arg: Some("expanded".to_string())
+            }]
+        );
+    }
+
+    /// MCP reload is directly callable from conversation; the host receives the
+    /// same typed command as interactive `/mcp reload` and returns its report.
+    #[tokio::test]
+    async fn run_yolop_command_dispatches_mcp_reload() {
+        let ui = Arc::new(RecordingUi::default());
+        let tool = RunYolopCommandTool { ui: ui.clone() };
+
+        let result = tool
+            .execute(json!({ "command": "mcp", "arguments": "reload" }))
+            .await;
+
+        assert!(result.is_success(), "tool should succeed: {result:?}");
+        assert_eq!(
+            ui.take(),
+            vec![UiCommand::ManageMcp {
+                arg: Some("reload".into()),
             }]
         );
     }


### PR DESCRIPTION
## Summary

- make the conversational client-command prompt explicitly advertise MCP reload
- document the exact `run_yolop_command` arguments for `/mcp reload`
- add a regression test proving the conversational tool dispatches the existing typed MCP reload command

## Why

Yolop already routed `run_yolop_command` with `command: mcp` and `arguments: reload` to the same implementation as interactive `/mcp reload`, but the capability description did not make that path discoverable. The agent could therefore ask the user to type the slash command instead of reloading MCP servers itself.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (923 passed; 1 ignored)
- `cargo run -- --provider llmsim -p 'hi'`
- OpenAI smoke attempted, but unavailable locally because neither Doppler project configuration nor `OPENAI_API_KEY` is present

## Security

Reviewed TM-LLM and TM-TOOL. This changes only trusted built-in capability instructions and dispatch test coverage; it adds no new command execution, inputs, credentials, filesystem access, dependency, or capability registration. The existing typed `UiCommand::ManageMcp` boundary remains unchanged.

## Knowledge

No knowledge update required: the durable MCP and command specs already state that conversational `/mcp reload` is supported; this change aligns capability discoverability with that documented behavior.

## Follow-ups

No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
