### PR TITLE
feat(evals): add claude sonnet 5 targets

### DIFF
--- a/evals/terminal_bench/README.md
+++ b/evals/terminal_bench/README.md
@@ -131,10 +131,14 @@ fast enough to repeat.
 
 The tracked `control` preset remains yolop · **gpt-5.6-terra** (OpenAI), keeping
 the periodic signal continuous. Luna is a first-class matrix target for explicit
-comparisons:
+comparisons. Claude Sonnet 5 is available through Anthropic directly and through
+OpenRouter:
 
 ```bash
 mira run --preset control --targets openai-gpt-5.6-luna --group-by difficulty
+mira run --preset control --targets anthropic-claude-sonnet-5 --group-by difficulty
+# Same model through OpenRouter; useful when comparing provider routing/costs.
+mira run --preset control --targets openrouter-claude-sonnet-5 --group-by difficulty
 ```
 
 This comparison uses Terra run `20260731T014824Z-3c1e` and Luna run
@@ -261,8 +265,9 @@ brew install everruns/tap/mira           # the host CLI (prebuilt binary, recomm
 
 Requires a running **Docker** daemon (every task is a container) and provider
 keys in the environment: `OPENAI_API_KEY` (yolop openai configs, `codex`,
-`terminus-2`), `ANTHROPIC_API_KEY` (yolop anthropic configs, `claude-code`). Use
-`doppler run --` to inject them. A config whose key is missing is reported
+`terminus-2`), `ANTHROPIC_API_KEY` (yolop anthropic configs, `claude-code`), and
+`OPENROUTER_API_KEY` (OpenRouter targets). Use `doppler run --` to inject them.
+A config whose key is missing is reported
 `unavailable` and skipped, so a keyless run stays green.
 
 ## Usage

--- a/evals/terminal_bench/terminal_bench.py
+++ b/evals/terminal_bench/terminal_bench.py
@@ -134,7 +134,11 @@ MATRIX: dict[str, dict[str, Any]] = {
     # OpenRouter returns an inline price, so `cost_usd` (and the cap that reads
     # it) is the real charge rather than yolop's price-table estimate.
     "openrouter-gpt-5.6-terra": {"agent": "yolop", "model": "openrouter/openai/gpt-5.6-terra"},
+    "openrouter-claude-sonnet-5": {
+        "agent": "yolop", "model": "openrouter/anthropic/claude-sonnet-5",
+    },
     # yolop x Anthropic (secondary provider)
+    "anthropic-claude-sonnet-5": {"agent": "yolop", "model": "anthropic/claude-sonnet-5"},
     "anthropic-claude-opus-4.8": {"agent": "yolop", "model": "anthropic/claude-opus-4-8"},
     "anthropic-claude-sonnet-4.5": {"agent": "yolop", "model": "anthropic/claude-sonnet-4-5"},
     # Offline plumbing check: exercises upload/run/verify with no API key. It

--- a/evals/terminal_bench/tests/test_study.py
+++ b/evals/terminal_bench/tests/test_study.py
@@ -55,6 +55,16 @@ class TestMatrix(unittest.TestCase):
             {"agent": "yolop", "model": "openai/gpt-5.6-luna"},
         )
 
+    def test_sonnet_5_targets_are_selectable(self):
+        self.assertEqual(
+            tb.MATRIX["anthropic-claude-sonnet-5"],
+            {"agent": "yolop", "model": "anthropic/claude-sonnet-5"},
+        )
+        self.assertEqual(
+            tb.MATRIX["openrouter-claude-sonnet-5"],
+            {"agent": "yolop", "model": "openrouter/anthropic/claude-sonnet-5"},
+        )
+
 
 class TestBuildCommand(unittest.TestCase):
     def _command(self, spec: dict, env: dict | None = None) -> list[str]:


### PR DESCRIPTION
## What changed

Adds Claude Sonnet 5 as selectable Terminal-Bench targets through Anthropic direct and OpenRouter. Terra remains the control preset default. Documents both explicit control-v1 commands and the required OpenRouter key.

## Why

Maintainers need to compare the fixed control-v1 suite across Terra, Luna, and Claude Sonnet 5 without changing the tracked control default.

## Before / After

Before, the matrix stopped at Claude Sonnet 4.5. After, `mira run --preset control --targets anthropic-claude-sonnet-5` and `--targets openrouter-claude-sonnet-5` select the canonical `claude-sonnet-5` model.

Evidence:
- 52 Terminal-Bench unit tests pass.
- `control-v1.json` reproduces exactly with 8 tasks.
- Anthropic direct smoke `20260801T031453Z-e9a8`: fix-git passed with effective effort high and retained trajectory.
- OpenRouter smoke `20260801T035253Z-f945`: fix-git passed with retained trajectory.
- Full comparison attempted; provider billing limits interrupted the remaining cases, so no incomplete result is published.

## Risk

- Low.
- A typo in a target label or provider-qualified model ID could make the target unavailable; focused matrix tests and live smokes cover both routes.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered; existing targets and presets are unchanged
- [x] No knowledge update required; this extends the eval matrix and its public study guide without changing product architecture or policy

## Knowledge

No knowledge update required — the durable eval workflow is unchanged; the study README owns its target catalog.

## Security

No security-relevant code changes. The change only adds model-selection metadata, tests, and documentation; existing provider-key environment handling, filesystem boundaries, shell execution, and capability registration are unchanged.

## Follow-ups

- Complete and publish the eight-case Sonnet 5 comparison after Anthropic or OpenRouter credits are replenished; both configured routes currently return billing errors.