### PR TITLE
feat(tui): render Mermaid and HTML markdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,7 +1640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3304,7 +3304,19 @@ dependencies = [
  "html5ever 0.27.0",
  "markup5ever 0.12.1",
  "tendril 0.4.3",
- "xml5ever",
+ "xml5ever 0.18.1",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.39.0+unofficial"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ac010f19d6c4af81eeb4018a39d7a115de9d285af45c126a4ac02e6fc5716b7"
+dependencies = [
+ "html5ever 0.39.0",
+ "markup5ever 0.39.0",
+ "tendril 0.5.1",
+ "xml5ever 0.39.0",
 ]
 
 [[package]]
@@ -3791,7 +3803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4502,7 +4514,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4544,7 +4556,7 @@ dependencies = [
  "anyhow",
  "clap",
  "html5ever 0.27.0",
- "markup5ever_rcdom",
+ "markup5ever_rcdom 0.3.0",
  "rquickjs",
  "scraper",
  "similar 2.7.0",
@@ -5041,7 +5053,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5109,7 +5121,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5698,6 +5710,7 @@ dependencies = [
  "parking_lot",
  "phf_shared 0.13.1",
  "precomputed-hash",
+ "serde",
 ]
 
 [[package]]
@@ -5863,7 +5876,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6667,9 +6680,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuika"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19d29f435a03a089f7a3842bbfc5b2b3a01fc4758cea0bb34bc9f6f0df99333"
+checksum = "342a82ee8016637ca1ac001a442e10cba08cd30230d9984f9a7d039b5c4d9c70"
 dependencies = [
  "crossterm",
  "pulldown-cmark",
@@ -6682,9 +6695,9 @@ dependencies = [
 
 [[package]]
 name = "tuika-codeformatters"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0091249e75f39c03aedb69555341d3ffb662c4693428d8b60b67497a64b585d7"
+checksum = "100174a0ba5b7ef8187403c4546682bfd16ddb70e3f0c458c73b10f2b386e730"
 dependencies = [
  "ratatui",
  "tree-sitter",
@@ -6706,10 +6719,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "tuika-mermaid"
-version = "0.1.1"
+name = "tuika-html"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38fbe4d52e3e8e791d9d1f08b67d15b2d139c7542042306690638a590dc1acf1"
+checksum = "11da3a2774cc913e90af87307f38152a9f26af10d5094f8fe70a34aaf228e9ea"
+dependencies = [
+ "html5ever 0.39.0",
+ "markup5ever_rcdom 0.39.0+unofficial",
+ "ratatui-core",
+ "tuika",
+]
+
+[[package]]
+name = "tuika-mermaid"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0077b474ae88da6606a63a4b3bfe837f658e35029d4d8cf37971b959292a75e"
 dependencies = [
  "mmdflux",
  "ratatui-core",
@@ -7301,7 +7326,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7641,6 +7666,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xml5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab627f34ff61b80d756180d556f9c68801d836d271b3b8c094504ceca69d221"
+dependencies = [
+ "log",
+ "markup5ever 0.39.0",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7738,6 +7773,7 @@ dependencies = [
  "tree-sitter-zig",
  "tuika",
  "tuika-codeformatters",
+ "tuika-html",
  "tuika-mermaid",
  "urlencoding",
  "vt100",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,17 +69,15 @@ toml = "1"
 textwrap = "0.16"
 # The TUI toolkit behind both renderers. It lives in its own repository
 # (everruns/tuika) and is consumed from crates.io like any other dependency;
-# yolop gets no special treatment there. 0.6 is the release that carries the
-# split-footer screen mode the `--inline` renderer is built on.
-tuika = "0.6.0"
+# yolop gets no special treatment there.
+tuika = "0.7.0"
+# Optional structured-markdown renderers stay outside tuika core. Mermaid
+# fences become terminal diagrams; safe block HTML becomes styled text.
+tuika-mermaid = "0.2.0"
+tuika-html = "0.1.0"
 # Tree-sitter Highlighter impl for tuika's CodeBlock/Markdown; owns the grammar
-# deps so tuika core stays dependency-light. Published from the tuika repo, and
-# released with it — 0.3.1 is the 0.6-compatible one.
-tuika-codeformatters = "0.3.1"
-# FencedBlockRenderer impl that turns ```mermaid fences into Unicode diagrams
-# via mmdflux; keeps diagram layout out of tuika core. Published from the tuika
-# repo; 0.1.1 is the 0.6-compatible one.
-tuika-mermaid = "0.1.1"
+# deps so tuika core stays dependency-light. Published from the tuika repo.
+tuika-codeformatters = "0.4.0"
 tokio = { version = "1.52", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tree-sitter = "0.26"

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,11 @@
 Significant changes to Yolop's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
+## 2026-08-01 — Tuika structured-markdown renderers
+
+- [Tuika](specs/tuika.md) now records the HTML companion renderer and the
+  current structured-markdown renderer API alongside Mermaid diagrams.
+
 ## 2026-08-01 — Conversational skills.sh search and install
 
 - [Skills](specs/skills.md) and [Conversational control](specs/conversational-control.md)

--- a/knowledge/specs/tuika.md
+++ b/knowledge/specs/tuika.md
@@ -23,15 +23,17 @@ than a one-line convenience.
 
 ## What
 
-Yolop depends on three crates from crates.io:
+Yolop depends on four crates from crates.io:
 
 - `tuika` — the toolkit. Version-pinned like any other dependency, with no path
   override.
 - `tuika-codeformatters` — the tree-sitter `Highlighter` implementation. Kept
   separate upstream so tuika core stays grammar-free.
-- `tuika-mermaid` — the `FencedBlockRenderer` that turns ` ```mermaid ` fences
+- `tuika-mermaid` — the `MarkdownBlockRenderer` that turns ` ```mermaid ` fences
   into Unicode cell diagrams. Kept separate upstream so tuika core takes on no
   diagram engine.
+- `tuika-html` — the safe block-HTML renderer. It maps supported semantic HTML
+  to styled terminal text and ignores unsafe elements and attributes.
 
 ## Screen modes
 
@@ -94,9 +96,9 @@ it receives, or a modifier-click opens the browser twice. See
 - **A yolop-only feature does not belong upstream.** If a proposed tuika change
   only makes sense for yolop, the right shape is a new seam (a trait, a state
   type, a callback) that yolop fills in.
-- **The companion crates move with tuika.** `tuika-codeformatters` and
-  `tuika-mermaid` pin a compatible `tuika` range, so bumping one usually means
-  bumping all three.
+- **The companion crates move with tuika.** `tuika-codeformatters`,
+  `tuika-mermaid`, and `tuika-html` pin a compatible `tuika` range, so bumping
+  one usually means bumping the full set.
 - **A fenced block that does not fit is not painted.** A companion renderer may
   lay content out at its natural size and ignore the offered width;
   `tuika-mermaid` does. The transcript falls back to the themed code block

--- a/src/main.rs
+++ b/src/main.rs
@@ -1046,7 +1046,6 @@ pub(crate) fn hyperlink_policy() -> LinkPolicy {
 /// and a loader on the alternate screen, and drives the terminal's native
 /// OSC 9;4 progress indicator while running. Quits on `q`/`Esc`/`Ctrl-C`.
 fn run_tuika_gallery() -> Result<()> {
-    use std::ops::ControlFlow;
     use std::time::Duration;
 
     // Route through the same hyperlink-aware backend as the main TUI so the
@@ -1061,18 +1060,20 @@ fn run_tuika_gallery() -> Result<()> {
         // default, and split-footer mode is for hosts that publish scrollback.
         ..tuika::RunnerConfig::default()
     });
+    let mut state = ();
     runner.run_with_backend(
         &theme,
         backend,
-        |frame| build_gallery(frame, &theme),
-        |event| match event {
-            tuika::Event::Key(key)
+        &mut state,
+        |_state, frame| build_gallery(frame, &theme),
+        |_state, signal| match signal {
+            tuika::Signal::Event(tuika::Event::Key(key))
                 if matches!(key.code, tuika::KeyCode::Esc | tuika::KeyCode::Char('q'))
                     || (key.ctrl && matches!(key.code, tuika::KeyCode::Char('c'))) =>
             {
-                ControlFlow::Break(())
+                tuika::UpdateResult::Exit
             }
-            _ => ControlFlow::Continue(()),
+            _ => tuika::UpdateResult::Dirty,
         },
     )?;
     progress.clear();

--- a/src/tui/fullscreen.rs
+++ b/src/tui/fullscreen.rs
@@ -469,7 +469,7 @@ fn draw_setup_picker(f: &mut Frame, area: Rect, picker: render::SetupPicker) {
         viewport,
     } = picker;
     let mut state = SelectState::new();
-    state.select(selected);
+    state.select(Some(selected));
     let mut list = SelectList::new(options, &state);
     if let Some(rows) = viewport {
         list = list.viewport(rows);

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -33,7 +33,8 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, oneshot};
-use tuika::components::{ScrollState, TextInputEvent, TextInputState};
+use tuika::InputOutcome;
+use tuika::components::{ScrollState, TextInputState};
 use tuika::keymap::Dispatch;
 use tuika::mouse::{SelectionRange, selected_text, word_at};
 use tuika::term::hyperlink::BufferLink;
@@ -1952,8 +1953,11 @@ impl App {
                 .composer
                 .handle_enter(key.modifiers == KeyModifiers::SHIFT)
             {
-                TextInputEvent::Changed => {}
-                TextInputEvent::Submit => self.submit_input().await,
+                InputOutcome::Submitted => self.submit_input().await,
+                InputOutcome::Ignored
+                | InputOutcome::Consumed
+                | InputOutcome::Changed
+                | InputOutcome::Cancelled => {}
             },
             KeyCode::Tab => {
                 if !self.busy
@@ -1994,7 +1998,7 @@ impl App {
     /// the event itself (component-driven input) after translation from crossterm.
     fn composer_edit_key(&mut self, key: KeyEvent) {
         if let Some(event) = tuika::translate_event(CrosstermEvent::Key(key)) {
-            self.composer.handle(&event);
+            let _ = self.composer.handle(&event);
         }
     }
 
@@ -3898,6 +3902,62 @@ mod tests {
         assert!(
             has_keyword_color,
             "rust fence should be syntax-highlighted: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn mermaid_fence_renders_as_terminal_diagram() {
+        let mut lines: Vec<Line> = Vec::new();
+        append_markdown_lines(
+            &mut lines,
+            "",
+            Style::default(),
+            "```mermaid\nflowchart LR\nA --> B\n```",
+            80,
+        );
+        let text: String = lines
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .map(|span| span.content.as_ref())
+            .collect();
+
+        assert!(
+            text.contains('A') && text.contains('B'),
+            "diagram labels: {text:?}"
+        );
+        assert!(
+            !text.contains("flowchart LR"),
+            "source should become a diagram: {text:?}"
+        );
+    }
+
+    #[test]
+    fn safe_html_block_renders_as_styled_text() {
+        let mut lines: Vec<Line> = Vec::new();
+        append_markdown_lines(
+            &mut lines,
+            "",
+            Style::default(),
+            "<p>Hello <strong>terminal</strong></p><script>alert(1)</script>",
+            80,
+        );
+        let spans: Vec<&Span> = lines.iter().flat_map(|line| line.spans.iter()).collect();
+        let terminal = spans
+            .iter()
+            .find(|span| span.content.contains("terminal"))
+            .expect("HTML text should render");
+
+        assert!(
+            terminal.style.add_modifier.contains(Modifier::BOLD),
+            "strong HTML should render bold: {lines:?}"
+        );
+        assert!(
+            spans.iter().all(|span| !span.content.contains("<strong>")),
+            "safe HTML markup should not render literally: {lines:?}"
+        );
+        assert!(
+            spans.iter().all(|span| !span.content.contains("alert(1)")),
+            "unsafe HTML content should be ignored: {lines:?}"
         );
     }
 

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1761,21 +1761,18 @@ pub(crate) fn diff_line_style(line: &str) -> Style {
 /// half a box, no way to read the rest. Falling back to `None` there hands the
 /// block back to tuika's themed code block, which keeps the Mermaid source
 /// itself on screen.
-struct MermaidFencedBlocks;
+struct MermaidBlocks;
 
-impl tuika::components::markdown::FencedBlockRenderer for MermaidFencedBlocks {
+impl tuika::components::MarkdownBlockRenderer for MermaidBlocks {
     fn render(
         &self,
-        language: &str,
-        source: &str,
-        width: u16,
-        theme: &tuika::style::Theme,
+        block: tuika::components::MarkdownBlock<'_>,
+        context: tuika::components::MarkdownBlockContext<'_>,
     ) -> Option<Vec<Line<'static>>> {
-        let rendered =
-            tuika_mermaid::MermaidRenderer::new().render(language, source, width, theme)?;
+        let rendered = tuika_mermaid::MermaidRenderer::new().render(block, context)?;
         rendered
             .iter()
-            .all(|line| line_width(line) <= width as usize)
+            .all(|line| line_width(line) <= context.width as usize)
             .then_some(rendered)
     }
 }
@@ -1784,9 +1781,11 @@ impl tuika::components::markdown::FencedBlockRenderer for MermaidFencedBlocks {
 /// renderer + tree-sitter code highlighting (see the `tuika` and
 /// `tuika-codeformatters` crates).
 ///
-/// ` ```mermaid ` fences go through [`MermaidFencedBlocks`], which paints them
-/// as Unicode cell diagrams; unsupported, malformed, or too-wide diagrams keep
-/// the ordinary code-block fallback so the source stays readable.
+/// ` ```mermaid ` fences go through [`MermaidBlocks`], which paints them as
+/// Unicode cell diagrams; unsupported, malformed, or too-wide diagrams keep the
+/// ordinary code-block fallback so the source stays readable. Safe block HTML
+/// is rendered as styled terminal text; unsafe elements and attributes are
+/// ignored by `tuika-html`.
 ///
 /// The tuika renderer word-wraps prose and lays code/tables out to a width; we
 /// render at `inner_width` minus the header prefix, then prepend the header to
@@ -1812,14 +1811,18 @@ pub(crate) fn append_markdown_lines<'a>(
     // Keeping it permanently underlined masks Ghostty's clickability feedback.
     sheet.link = tuika::style::StyleBundle::new().fg(theme.code.link);
     let highlighter = tuika_codeformatters::TreeSitterHighlighter::new();
-    let mermaid = MermaidFencedBlocks;
-    let (rendered, md_links) = tuika::components::markdown::to_linked_lines_with_renderer(
+    let mermaid = MermaidBlocks;
+    let html = tuika_html::HtmlRenderer::new();
+    let renderers = tuika::components::Renderers::new()
+        .renderer(&mermaid)
+        .renderer(&html);
+    let (rendered, md_links) = tuika::components::markdown::to_linked_lines_with(
         text,
         width,
         &theme,
         &sheet,
         tuika::highlight::CodeHighlighter::With(&highlighter),
-        &mermaid,
+        renderers,
     );
 
     let base_line = lines.len() as u16;

--- a/src/tui/setup.rs
+++ b/src/tui/setup.rs
@@ -16,17 +16,17 @@ use super::*;
 /// (see the `draw_setup_picker` note in `fullscreen.rs`).
 fn select_up(selected: usize) -> usize {
     let mut state = tuika::components::SelectState::new();
-    state.select(selected);
+    state.select(Some(selected));
     state.move_up();
-    state.selected()
+    state.selected().unwrap_or(0)
 }
 
 /// Step a picker selection down one row, clamping at the last of `len` rows.
 fn select_down(selected: usize, len: usize) -> usize {
     let mut state = tuika::components::SelectState::new();
-    state.select(selected);
+    state.select(Some(selected));
     state.move_down(len);
-    state.selected()
+    state.selected().unwrap_or(0)
 }
 
 impl App {


### PR DESCRIPTION
## What changed

- Bumps Tuika from 0.6 to 0.7 and updates `tuika-codeformatters` to its compatible 0.4 release.
- Renders Mermaid fences as Unicode terminal diagrams, preserving the readable source fallback when a diagram is invalid or wider than the transcript.
- Renders supported safe block HTML as styled terminal text through `tuika-html`.
- Migrates Yolop's small Tuika API call sites to the 0.7 interfaces.

## Why

Assistant responses increasingly contain structured Markdown. Yolop already used Tuika for Markdown and code highlighting, but diagrams and HTML were shown as source rather than using Tuika's new companion renderers.

## Before / After

Before: Mermaid fences appeared as code and block HTML was not rendered semantically.

After: Mermaid fences produce terminal-native diagrams and safe HTML such as `<strong>` produces styled text. Unsafe HTML content is ignored; overwide or malformed diagrams retain source fallback.

## Risk

- Medium
- The Tuika major pre-1.0 dependency bump changes input, selection, runner, and Markdown renderer APIs. Existing full test coverage and focused renderer tests exercise the migrated surfaces.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered — Yolop is pre-1.0 and the behavior is additive; source fallback is retained.
- [x] Knowledge concepts updated

## Knowledge

Updated `knowledge/specs/tuika.md` and `knowledge/log.md` with the four-crate composition and structured-Markdown renderer behavior.

## Security

- **TM-DEP:** Added `tuika-html` from the same upstream Tuika repository and moved Tuika companion crates together to compatible releases. It is required for safe semantic HTML-to-terminal rendering.
- **TM-LLM:** HTML and Mermaid in model output remain display-only. `tuika-html` ignores unsafe elements and attributes; a focused test verifies script content is omitted.
- **TM-TOOL / TM-FS / TM-BASH:** No capability, filesystem, shell execution, key handling, or prompt-construction changes.
- Resource bounds: Mermaid output is accepted only when every rendered line fits the transcript width; otherwise the existing source fallback is used.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `python3 scripts/validate_okf.py knowledge --check-links`
- `cargo run -- --provider llmsim -p 'Reply with a short Mermaid flowchart and a safe HTML paragraph containing bold text'`

## Follow-ups

No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
