### PR TITLE
fix(deps): revert toml and schemars to fix repo-map-bounded nightly regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ dependencies = [
  "futures-concurrency",
  "rustc-hash",
  "rustix",
- "schemars 1.2.2",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "shell-words",
@@ -111,7 +111,7 @@ checksum = "d5c231915b4ab578c722eca2d1bd7df4d300bfd6cac3b8e9f0d1e3ddc95b187c"
 dependencies = [
  "anyhow",
  "derive_more",
- "schemars 1.2.2",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "serde_with",
@@ -1995,7 +1995,7 @@ dependencies = [
  "rakers",
  "rand 0.10.2",
  "reqwest 0.13.4",
- "schemars 1.2.2",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -5198,9 +5198,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -5211,14 +5211,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2 1.0.107",
  "quote 1.0.47",
  "serde_derive_internals",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5337,13 +5337,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.30.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2 1.0.107",
  "quote 1.0.47",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5394,7 +5394,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.2",
+ "schemars 1.2.1",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -6184,9 +6184,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
@@ -7796,7 +7796,7 @@ dependencies = [
 name = "yolop-yep"
 version = "0.3.0"
 dependencies = [
- "schemars 1.2.2",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
 ]


### PR DESCRIPTION
## What changed

Reverts `toml` (1.1.4+spec-1.1.0 → 1.1.3+spec-1.1.0) and `schemars` (1.2.2 → 1.2.1)
to the versions in place before dependabot PR #501. `landlock` stays at 0.4.7 —
it is confirmed not the cause (see below).

## Why

The nightly [Search Efficiency Eval](https://github.com/everruns/yolop/actions/workflows/search-efficiency-eval.yml)
has failed 3 nights running (Jul 31, Aug 1, Aug 2), each time on the same two
focused cases regressing to a 0% candidate pass rate against the preserved
baseline: `repo-map-bounded` and `zero-result-search-recovery`.

Bisected with targeted `workflow_dispatch` runs of `search-efficiency-eval.yml`
against throwaway branches at specific commits:

- The regression is fully reproducible starting at
  [c119733](https://github.com/everruns/yolop/commit/c119733118b6b36f50e17218df428410b8b6264b)
  (#501: `toml` 1.1.3→1.1.4, `landlock` 0.4.5→0.4.7, `schemars` 1.2.1→1.2.2) and
  does not reproduce at its parent commit (`2d3f1b5`, last green nightly).
- A follow-up run with **only `landlock` reverted** to 0.4.5 (toml/schemars still
  bumped) still failed identically on both cases — ruling landlock out.
- A follow-up run with **`toml`+`schemars` reverted** (this PR's diff, landlock
  still bumped) fixed `repo-map-bounded` (now 67%, clears the 67% bar) but
  **`zero-result-search-recovery` still failed**.
- A final run with **all three fully reverted** (exact pre-#501 versions, on top
  of current `main`) still left `zero-result-search-recovery` failing (67%→0%),
  while `repo-map-bounded` stayed fixed.

So this PR's revert is a confirmed, evidenced fix for `repo-map-bounded`, but
**`zero-result-search-recovery` is a separate, still-unresolved regression that
does not correlate with PR #501 at all** — reverting all three dependencies to
their pre-bump state does not restore it. That check's candidate assertion
requires the app's own `progress_guard` capability to fire a warning
(`progress_guard_warnings >= 1`); `src/capabilities/progress_guard.rs` hasn't
changed across this commit range, and even the frozen baseline binary only hit
67% (not 100%) on this case in the last run, which points toward live-model
behavioral variance on the `openai/gpt-5.5` endpoint rather than a code
regression in this repo. See Follow-ups.

## Before / After

Before (candidate build from `main`, e.g. run
[30752315411](https://github.com/everruns/yolop/actions/runs/30752315411)):
```
Regression gates:
- repo-map-bounded: candidate focused pass rate 33% < 67%
- zero-result-search-recovery: correctness regressed 100% -> 0%
- zero-result-search-recovery: candidate focused pass rate 0% < 67%
```

After (candidate build from this branch, run
[30755186967](https://github.com/everruns/yolop/actions/runs/30755186967)):
```
repo-map-bounded: pass 0%->67%; tools 2->3; ...
Regression gates:
- zero-result-search-recovery: correctness regressed 67% -> 0%
- zero-result-search-recovery: candidate focused pass rate 0% < 67%
```

`repo-map-bounded` no longer appears in the gate failures. The nightly will
still show red because of `zero-result-search-recovery` until that separate
issue is resolved.

## Risk

- Low. Pure dependency-version revert (`Cargo.lock` only), no application code
  changes. `cargo build --release`, `cargo fmt --check`, `cargo clippy
  --all-targets --all-features -- -D warnings`, and `cargo test --all-features`
  all pass locally, plus an offline `--provider llmsim` smoke test.
- What can break: reverting `toml`/`schemars` forgoes their upstream fixes
  (toml: datetime preservation in `Value` deserialization; schemars: `syn` 3
  migration in the derive macro) until dependabot re-proposes them — low risk
  since neither fix is required by any code in this repo today.

## Checklist

- [x] Tests added or updated — n/a, dependency-version-only change; existing
      suite plus the search-efficiency eval itself is the regression coverage.
- [x] Backward compatibility considered — pure downgrade to previously-shipped
      versions.
- [x] Knowledge concepts updated, or no update required with a reason — see
      Knowledge below.

## Knowledge

No knowledge update required — this reverts a dependency bump back to its
prior, already-documented state; no durable behavior, architecture, or policy
changed.

## Security

No security-relevant code changes — `Cargo.lock` only, reverting two
dependencies to versions that were already running in production before
2026-07-30. `landlock` (TM-BASH sandbox dependency) is intentionally left at
the newer 0.4.7, since it's confirmed unrelated to this regression and its
newer ABI support is a net-positive.

## Follow-ups

- `zero-result-search-recovery` nightly failure remains unresolved. It doesn't
  correlate with PR #501 (fails identically with all three dependencies fully
  reverted). Needs a maintainer look at whether this is `openai/gpt-5.5`
  behavioral drift (the frozen baseline binary itself only hit 67% pass in the
  latest run, suggesting genuine live-model variance rather than a yolop code
  regression) or something else in the ~260 commits since the eval's pinned
  baseline commit (`67e3d798`, quite old) that a 3-trial focused run can't
  cleanly isolate. Not filing a public issue per current process; flagging here
  for the maintainer's triage.
- Two scratch branches used for bisection during this investigation
  (`bisect/nightly-search-eval-deps-bump`, `test/full-revert-501`) are pushed to
  the remote but not merged; safe to delete once this PR is reviewed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGjDirw746wTJUkCKJ8wMh)_