### PR TITLE
feat(runtime): expose live model context

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,14 @@
 Significant changes to Yolop's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
+## 2026-08-03 — Cache-stable live model context
+
+- [System prompt composition](specs/system-prompt.md) now exposes the effective
+  provider, model, and reasoning effort through prompt-only conversation
+  annotations on the first turn and when the values change. Stable message-id
+  placement preserves provider prompt-cache prefixes; compaction and rewind
+  re-emit the current state when they remove the last marker.
+
 ## 2026-08-01 — Tuika structured-markdown renderers
 
 - [Tuika](specs/tuika.md) now records the HTML companion renderer and the

--- a/knowledge/specs/system-prompt.md
+++ b/knowledge/specs/system-prompt.md
@@ -102,6 +102,27 @@ resize and cost the cached prefix that `AGENTS.md`'s placement exists to
 protect. A capability that only holds at some widths still advertises `true`;
 degrading gracefully at the narrow end is the renderer's job, not the prompt's.
 
+### Live model identity rides the conversation, not the prefix
+
+The effective provider, model, and reasoning effort can change while a session
+is open through ACP configuration or Yolop's live-config tools. The provider
+receives reasoning effort as a request control, but that control is not visible
+to the model as conversation content; asking the model which effort it uses can
+therefore produce an answer based on stale dialogue.
+
+`model_runtime_context` adds a trusted `<runtime_context>` annotation to the
+prompt-facing view of the newest user message on the first turn and whenever
+one of those values changes. Stored messages and rendered transcripts remain
+untouched. Each annotation is retained against its stable message id in later
+model views, so unchanged turns extend the same provider-cache prefix instead
+of rewriting the system prompt. If compaction or checkpoint rewind removes the
+last annotated message, the capability re-emits the current values on the
+newest surviving user message.
+
+The request control remains present on every turn; only the model-visible
+annotation is change-triggered. This separates execution correctness from
+conversational awareness.
+
 ### Judgement yields to measurement
 
 Judgment over ritual applies here as it does everywhere

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -21,6 +21,7 @@ pub(crate) mod mcp;
 pub(crate) mod memory;
 pub(crate) mod model_discovery;
 pub(crate) mod model_ranking;
+pub(crate) mod model_runtime_context;
 pub(crate) mod narration;
 pub(crate) mod progress_guard;
 pub(crate) mod repo_map;
@@ -58,6 +59,9 @@ pub(crate) use host::{
     SETUP_CAPABILITY_ID, SetupCapability,
 };
 pub(crate) use lsp::LspCapability;
+pub(crate) use model_runtime_context::{
+    MODEL_RUNTIME_CONTEXT_CAPABILITY_ID, ModelRuntimeContextCapability,
+};
 pub(crate) use progress_guard::{PROGRESS_GUARD_CAPABILITY_ID, ProgressGuardCapability};
 pub(crate) use repo_map::{REPO_MAP_CAPABILITY_ID, RepoMapCapability};
 pub(crate) use session_history::{SESSION_HISTORY_CAPABILITY_ID, SessionHistoryCapability};

--- a/src/capabilities/model_runtime_context.rs
+++ b/src/capabilities/model_runtime_context.rs
@@ -1,0 +1,220 @@
+//! Cache-stable, model-visible context for the live provider selection.
+
+use std::sync::{Arc, Mutex, RwLock};
+
+use async_trait::async_trait;
+use everruns_core::capabilities::{
+    Capability, CapabilityStatus, ModelViewContext, ModelViewProvider,
+};
+use everruns_core::message::{ContentPart, Message, MessageRole};
+use everruns_core::typed_id::MessageId;
+use serde_json::Value;
+
+use crate::runtime::ProviderChoice;
+
+pub(crate) const MODEL_RUNTIME_CONTEXT_CAPABILITY_ID: &str = "model_runtime_context";
+
+/// Adds effective model settings to the prompt-facing view only when they
+/// change. Stored messages and rendered transcripts remain untouched.
+pub(crate) struct ModelRuntimeContextCapability {
+    provider: Arc<RwLock<ProviderChoice>>,
+}
+
+impl ModelRuntimeContextCapability {
+    pub(crate) fn new(provider: Arc<RwLock<ProviderChoice>>) -> Self {
+        Self { provider }
+    }
+}
+
+#[async_trait]
+impl Capability for ModelRuntimeContextCapability {
+    fn id(&self) -> &str {
+        MODEL_RUNTIME_CONTEXT_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Model Runtime Context"
+    }
+
+    fn description(&self) -> &str {
+        "Tells the model which provider, model, and reasoning effort are active when they change."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Core")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(
+            "Conversation messages may carry a <runtime_context> block added by the host. Its latest values are authoritative for the active provider, model, and reasoning effort. It is not part of what the user wrote; never repeat the block in replies.",
+        )
+    }
+
+    fn model_view_provider(&self) -> Option<Arc<dyn ModelViewProvider>> {
+        Some(Arc::new(ModelRuntimeContextProvider {
+            provider: self.provider.clone(),
+            annotations: Mutex::new(Vec::new()),
+        }))
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ModelRuntimeContext {
+    provider: String,
+    model: String,
+    reasoning_effort: Option<String>,
+}
+
+impl ModelRuntimeContext {
+    fn from_provider(provider: &ProviderChoice) -> Self {
+        Self {
+            provider: provider.provider_name().to_string(),
+            model: provider.model_id().to_string(),
+            reasoning_effort: provider.reasoning_effort().map(str::to_string),
+        }
+    }
+}
+
+struct ModelRuntimeContextProvider {
+    provider: Arc<RwLock<ProviderChoice>>,
+    annotations: Mutex<Vec<(MessageId, ModelRuntimeContext)>>,
+}
+
+impl ModelViewProvider for ModelRuntimeContextProvider {
+    fn apply_model_view(
+        &self,
+        mut messages: Vec<Message>,
+        _config: &Value,
+        _context: &ModelViewContext<'_>,
+    ) -> Vec<Message> {
+        let current = ModelRuntimeContext::from_provider(
+            &self.provider.read().expect("provider lock poisoned"),
+        );
+        let mut annotations = self
+            .annotations
+            .lock()
+            .expect("model runtime context lock poisoned");
+
+        // Compaction and checkpoint rewind can remove an earlier marker. Drop
+        // annotations whose stored messages are no longer in the model view so
+        // the current state is re-emitted on the newest surviving user message.
+        annotations.retain(|(id, _)| messages.iter().any(|message| message.id == *id));
+        let latest = messages.iter().rev().find_map(|message| {
+            annotations
+                .iter()
+                .find(|(id, _)| *id == message.id)
+                .map(|(_, context)| context)
+        });
+        if latest != Some(&current)
+            && let Some(message) = messages
+                .iter()
+                .rev()
+                .find(|message| message.role == MessageRole::User)
+        {
+            if let Some((_, context)) = annotations.iter_mut().find(|(id, _)| *id == message.id) {
+                *context = current.clone();
+            } else {
+                annotations.push((message.id, current.clone()));
+            }
+        }
+
+        for message in &mut messages {
+            if let Some((_, context)) = annotations.iter().find(|(id, _)| *id == message.id) {
+                message
+                    .content
+                    .insert(0, ContentPart::text(render(context)));
+            }
+        }
+        messages
+    }
+
+    /// After compaction masking and message timestamps, so the marker is a
+    /// separate leading content part and never alters stored transcript text.
+    fn priority(&self) -> i32 {
+        110
+    }
+}
+
+fn render(context: &ModelRuntimeContext) -> String {
+    format!(
+        "<runtime_context>\n  <provider>{}</provider>\n  <model>{}</model>\n  <reasoning_effort>{}</reasoning_effort>\n</runtime_context>",
+        html_escape::encode_text(&context.provider),
+        html_escape::encode_text(&context.model),
+        html_escape::encode_text(context.reasoning_effort.as_deref().unwrap_or("none")),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::typed_id::SessionId;
+
+    fn markers(message: &Message) -> Vec<&str> {
+        message
+            .content
+            .iter()
+            .filter_map(ContentPart::as_text)
+            .filter(|text| text.starts_with("<runtime_context>"))
+            .collect()
+    }
+
+    #[test]
+    fn added_only_on_change_and_after_history_loss() {
+        let provider = Arc::new(RwLock::new(ProviderChoice::OpenAi {
+            model: "gpt-5.6-sol".to_string(),
+            reasoning_effort: Some("low".to_string()),
+        }));
+        let view = ModelRuntimeContextCapability::new(provider.clone())
+            .model_view_provider()
+            .expect("runtime context model view");
+        let context = ModelViewContext {
+            session_id: SessionId::new(),
+            prior_usage: None,
+        };
+        let first = Message::user("first");
+        let second = Message::user("second");
+
+        let initial = view.apply_model_view(vec![first.clone()], &Value::Null, &context);
+        assert!(markers(&initial[0])[0].contains("<reasoning_effort>low</reasoning_effort>"));
+        assert_eq!(
+            first.text(),
+            Some("first"),
+            "stored message stays untouched"
+        );
+
+        let unchanged =
+            view.apply_model_view(vec![first.clone(), second.clone()], &Value::Null, &context);
+        assert_eq!(markers(&unchanged[0]).len(), 1);
+        assert!(markers(&unchanged[1]).is_empty());
+
+        *provider.write().expect("provider lock") = ProviderChoice::OpenAi {
+            model: "gpt-5.6-sol".to_string(),
+            reasoning_effort: Some("high".to_string()),
+        };
+        let changed =
+            view.apply_model_view(vec![first.clone(), second.clone()], &Value::Null, &context);
+        assert!(markers(&changed[0])[0].contains("<reasoning_effort>low</reasoning_effort>"));
+        assert!(markers(&changed[1])[0].contains("<reasoning_effort>high</reasoning_effort>"));
+
+        let surviving = Message::user("surviving history");
+        let rebuilt = view.apply_model_view(vec![surviving.clone()], &Value::Null, &context);
+        assert!(markers(&rebuilt[0])[0].contains("<reasoning_effort>high</reasoning_effort>"));
+        assert_eq!(surviving.text(), Some("surviving history"));
+    }
+
+    #[test]
+    fn escapes_config_values() {
+        let rendered = render(&ModelRuntimeContext {
+            provider: "custom".to_string(),
+            model: "model</model><injected>".to_string(),
+            reasoning_effort: Some("high & deliberate".to_string()),
+        });
+
+        assert!(rendered.contains("<model>model&lt;/model&gt;&lt;injected&gt;</model>"));
+        assert!(rendered.contains("<reasoning_effort>high &amp; deliberate</reasoning_effort>"));
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -24,7 +24,8 @@ use crate::capabilities::{
     CodingCliEnvironmentCapability, ConfigCapability, ContextCostControlCapability,
     ENVIRONMENT_CONTEXT_CAPABILITY_ID, EnvironmentContextRegistry, GOAL_CAPABILITY_ID,
     GoalCapability, HERDR_CAPABILITY_ID, HOOKS_CAPABILITY_ID, HerdrCapability, HooksCapability,
-    LspCapability, PROGRESS_GUARD_CAPABILITY_ID, ProgressGuardCapability, REPO_MAP_CAPABILITY_ID,
+    LspCapability, MODEL_RUNTIME_CONTEXT_CAPABILITY_ID, ModelRuntimeContextCapability,
+    PROGRESS_GUARD_CAPABILITY_ID, ProgressGuardCapability, REPO_MAP_CAPABILITY_ID,
     RepoMapCapability, SESSION_HISTORY_CAPABILITY_ID, SETUP_CAPABILITY_ID,
     SessionHistoryCapability, SetupCapability, USER_ASK_CAPABILITY_ID, UserAskCapability,
     WorktreeCapability,
@@ -2099,6 +2100,7 @@ fn default_coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabi
         // without deferral.
         AgentCapabilityConfig::new(TOOL_REVEAL_CAPABILITY_ID),
         AgentCapabilityConfig::new(TOOL_OUTPUT_PERSISTENCE_CAPABILITY_ID),
+        AgentCapabilityConfig::new(MODEL_RUNTIME_CONTEXT_CAPABILITY_ID),
         AgentCapabilityConfig::new(SESSION_TASKS_CAPABILITY_ID),
         // A two-level 4×4 swarm has 20 live descendants (four coordinators and
         // sixteen workers). Keep that useful topology inside the default bound
@@ -3137,6 +3139,7 @@ pub async fn build_with_options(
     capabilities.register(crate::capabilities::FreeSearchCapability::new());
     capabilities.register(WebFetchCapability::from_env());
     capabilities.register(MessageMetadataCapability);
+    capabilities.register(ModelRuntimeContextCapability::new(provider_state.clone()));
     capabilities.register(CodingCliEnvironmentCapability::new(
         repo_root.clone().unwrap_or_else(|| canonical_root.clone()),
         shared_workspace_root.clone(),
@@ -4059,6 +4062,73 @@ mod tests {
                         && prompt.contains("Piggyback title, todo, and status updates")
                 }))
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn real_turn_exposes_model_runtime_context_without_persisting_it() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+        let messages = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let options = BuildOptions {
+            llmsim_override: Some(
+                LlmSimConfig::fixed("done").with_message_capture(messages.clone()),
+            ),
+            ..BuildOptions::default()
+        };
+        let built = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Sim,
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            options,
+        )
+        .await
+        .expect("build runtime");
+
+        let result = built
+            .handles
+            .run_checkpointed_turn("hello", built.model.input_message("hello"))
+            .await
+            .expect("run turn");
+        assert!(result.success);
+
+        let provider_text = {
+            let captured = messages.lock().expect("captured messages");
+            captured
+                .first()
+                .and_then(|call| {
+                    call.iter().find(|message| {
+                        message.role == everruns_core::LlmMessageRole::User
+                            && message.content_as_text().contains("<runtime_context>")
+                    })
+                })
+                .expect("provider-visible runtime context")
+                .content_as_text()
+        };
+        assert!(provider_text.contains("<provider>llmsim</provider>"));
+        assert!(provider_text.contains("<model>llmsim-yolop</model>"));
+        assert!(provider_text.contains("<reasoning_effort>none</reasoning_effort>"));
+
+        let events = built
+            .handles
+            .runtime
+            .events()
+            .await
+            .expect("runtime events");
+        let stored_input = events
+            .iter()
+            .find_map(|event| match &event.data {
+                everruns_core::EventData::InputMessage(data) => Some(&data.message),
+                _ => None,
+            })
+            .expect("stored input message");
+        assert_eq!(stored_input.text(), Some("hello"));
+        assert!(!stored_input.content.iter().any(|part| {
+            part.as_text()
+                .is_some_and(|text| text.contains("<runtime_context>"))
+        }));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## What changed
Yolop now tells the model which provider, model, and reasoning effort are active. The prompt-only runtime marker is emitted on the first turn, when the live selection changes, and after compaction or rewind removes the last marker. Stored messages and rendered transcripts remain unchanged.

Markers stay attached to stable message ids in later model views, preserving the provider prompt-cache prefix on unchanged turns. Request-level reasoning controls continue to be sent on every turn.

## Why
ACP correctly propagated a selected reasoning effort to the provider, but the model could not see that out-of-band control and could answer from stale conversation state.

## Before / After
Before: after changing ACP reasoning effort from low to high, the provider response metadata recorded high while the model answered that it was still using low.

After: a live Codex smoke at high effort answered `Provider: codex · Model: gpt-5.6-sol · Reasoning effort: high`.

## Risk
- Medium: this changes provider-visible prompt construction and cache behavior.
- Model ids are XML-escaped before entering the annotation. Change markers are model-view-only and are covered across unchanged turns, live changes, history loss, and a real runtime turn.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered; this is additive prompt context and Yolop is pre-1.0
- [x] Knowledge concepts updated

## Knowledge
Updated `knowledge/specs/system-prompt.md` and `knowledge/log.md` with the cache-stable live-context contract.

## Security
- TM-LLM reviewed: provider/model values are XML-escaped, no credentials enter the marker, and stored transcripts remain untouched.
- TM-FS, TM-BASH, TM-TOOL: no changes to filesystem access, shell execution, or tool authorization.
- TM-DEP: no dependency changes.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (1015 unit tests, 52 integration tests, 1 parallel integration test, 5 Tuika PTY tests passed)
- `python3 scripts/validate_okf.py knowledge --check-links`
- Live Codex provider smoke at high reasoning effort

Doppler was not configured for this worktree (`You must specify a project`), so the live smoke used the saved Codex login instead.

## Follow-ups
No follow-ups.