### PR TITLE
fix(models): defer persistence until successful turn

### DIFF
--- a/knowledge/specs/conversational-control.md
+++ b/knowledge/specs/conversational-control.md
@@ -39,7 +39,9 @@ command, an overlay confirmation, or a next-run-only settings write fail this ba
    Adding a tool must not fork the logic — it shares the command's code path so
    validation, persistence, and live application are identical. (`SetupController` is
    the reference: `/setup`, the model picker overlay, and the `set_*` tools all call
-   its `change_*` methods.)
+   its `change_*` methods.) Model selection applies immediately but is persisted only
+   after that model completes a successful turn, so an inaccessible or unsupported
+   model does not become the next session's default.
 
 3. **Errors are recoverable.** A bad argument (unknown effort, unknown provider,
    missing skill) returns a tool error whose message names the valid options or the

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -533,6 +533,8 @@ pub(crate) struct SetupCapability {
     pub(crate) config: Arc<dyn ConfigService>,
     /// …and writes provider/token/model choices through the concrete store.
     pub(crate) settings: Arc<SettingsStore>,
+    /// Model choice awaiting proof that the next model turn succeeds.
+    pub(crate) pending_model_choice: Arc<RwLock<Option<ProviderChoice>>>,
 }
 
 impl SetupCapability {
@@ -546,6 +548,7 @@ impl SetupCapability {
             provider_store: self.provider_store.clone(),
             config: self.config.clone(),
             settings: self.settings.clone(),
+            pending_model_choice: self.pending_model_choice.clone(),
         }
     }
 }
@@ -562,6 +565,7 @@ pub(crate) struct SetupController {
     provider_store: Arc<dyn RuntimeProviderStore>,
     config: Arc<dyn ConfigService>,
     settings: Arc<SettingsStore>,
+    pending_model_choice: Arc<RwLock<Option<ProviderChoice>>>,
 }
 
 #[async_trait]
@@ -863,11 +867,16 @@ impl SetupController {
             return Ok(failed_result(format!("setup model failed: {err}")));
         }
         let label = next.label();
-        let persist_note = self.persist_model_choice(&next);
-        *self.provider.write().expect("provider lock poisoned") = next;
+        *self.provider.write().expect("provider lock poisoned") = next.clone();
+        *self
+            .pending_model_choice
+            .write()
+            .expect("pending model lock poisoned") = Some(next);
         Ok(CommandResult {
             success: true,
-            message: format!("setup model changed: {label}{persist_note}"),
+            message: format!(
+                "setup model changed: {label}; applies to this session until a turn succeeds"
+            ),
             error_code: None,
             error_fields: None,
         })
@@ -875,15 +884,30 @@ impl SetupController {
 
     /// Persist a model switch: the provider preference and the
     /// provider-relative `model [effort]` spec, so both survive a restart
-    /// (the model picker promises "future sessions"). Best-effort — a failed
-    /// save is reported in the message but never blocks the in-session
-    /// switch.
-    fn persist_model_choice(&self, next: &ProviderChoice) -> String {
+    /// (the model picker promises "future sessions"). A failed save is kept
+    /// pending so a later successful turn can retry it.
+    pub(crate) fn persist_pending_model_choice(
+        settings: &SettingsStore,
+        pending_model_choice: &RwLock<Option<ProviderChoice>>,
+    ) -> String {
+        let mut pending = pending_model_choice
+            .write()
+            .expect("pending model lock poisoned");
+        let Some(next) = pending.as_ref() else {
+            return String::new();
+        };
+        let warning = Self::persist_model_choice(settings, next);
+        if warning.is_empty() {
+            pending.take();
+        }
+        warning
+    }
+
+    fn persist_model_choice(settings: &SettingsStore, next: &ProviderChoice) -> String {
         let provider_name = next.provider_name().to_string();
-        let result = self
-            .settings
+        let result = settings
             .set_default_provider(Some(provider_name.clone()))
-            .and_then(|()| self.settings.set_model(provider_name, next.model_spec()));
+            .and_then(|()| settings.set_model(provider_name, next.model_spec()));
         match result {
             Ok(()) => String::new(),
             Err(err) => format!(" (warning: settings not saved: {err})"),
@@ -962,7 +986,7 @@ impl SetupController {
             Err(err) => return Ok(failed_result(format!("setup effort failed: {err}"))),
         };
         let label = next.label();
-        let persist_note = self.persist_model_choice(&next);
+        let persist_note = Self::persist_model_choice(&self.settings, &next);
         *self.provider.write().expect("provider lock poisoned") = next;
         Ok(CommandResult {
             success: true,
@@ -1498,6 +1522,7 @@ mod tests {
             provider_store: Arc::new(StubProviderStore),
             config: settings.clone(),
             settings,
+            pending_model_choice: Arc::new(RwLock::new(None)),
         };
         (controller, provider, dir)
     }
@@ -1528,6 +1553,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn model_choice_is_persisted_only_after_a_successful_turn() {
+        let (controller, _provider, _dir) = test_controller(ProviderChoice::OpenAi {
+            model: "gpt-5.5".to_string(),
+            reasoning_effort: None,
+        });
+
+        controller
+            .change_model("gpt-5.4")
+            .await
+            .expect("change model");
+        let before = controller.settings.snapshot();
+        assert_eq!(before.models.get("openai"), None);
+        assert_eq!(before.default_provider, None);
+
+        let warning = SetupController::persist_pending_model_choice(
+            &controller.settings,
+            &controller.pending_model_choice,
+        );
+        assert!(warning.is_empty(), "unexpected warning: {warning}");
+        let after = controller.settings.snapshot();
+        assert_eq!(
+            after.models.get("openai").map(String::as_str),
+            Some("gpt-5.4 none")
+        );
+        assert_eq!(after.default_provider.as_deref(), Some("openai"));
+    }
+
+    #[tokio::test]
     async fn set_model_tool_switches_model_and_optional_effort() {
         let (controller, provider, _dir) = test_controller(ProviderChoice::OpenAi {
             model: "gpt-5.5".to_string(),
@@ -1554,6 +1607,7 @@ mod tests {
             provider_store: controller.provider_store.clone(),
             config: controller.config.clone(),
             settings: controller.settings.clone(),
+            pending_model_choice: controller.pending_model_choice.clone(),
         };
         let names: Vec<String> = capability
             .tools()

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -89,6 +89,7 @@ use everruns_runtime::{
     SessionBuilder, WriteBlocklistFileStore,
 };
 
+use crate::capabilities::host::SetupController;
 use crate::exec::workspace_host::WorkspaceHost;
 use crate::exec::worktree::{WorktreeManager, detect_repo_root, restore_worktree_from_metadata};
 use crate::runtime::session_log::{
@@ -2276,6 +2277,8 @@ pub struct BuiltRuntime {
 #[derive(Clone)]
 pub struct RuntimeHandles {
     pub runtime: Arc<InProcessRuntime>,
+    settings: Arc<SettingsStore>,
+    pending_model_choice: Arc<RwLock<Option<ProviderChoice>>>,
     pub session_id: SessionId,
     /// Typed handle to the JSONL event emitter. The runtime sees it
     /// through the `EventBus` trait object; we keep a direct reference
@@ -2319,6 +2322,15 @@ impl RuntimeHandles {
         let result = self.runtime.run_turn(self.session_id, input).await;
         let success = result.as_ref().is_ok_and(|turn| turn.success);
         checkpoint.finish(success)?;
+        if success {
+            let warning = SetupController::persist_pending_model_choice(
+                &self.settings,
+                &self.pending_model_choice,
+            );
+            if !warning.is_empty() {
+                tracing::warn!("{warning}");
+            }
+        }
         self.checkpoints.apply_queued_confirmation().await;
         Ok(result?)
     }
@@ -3178,11 +3190,13 @@ pub async fn build_with_options(
     });
     // `/setup` (below) is the capability-sourced slash command. It implements
     // `Capability::execute_command` end to end.
+    let pending_model_choice = Arc::new(RwLock::new(None));
     capabilities.register(SetupCapability {
         provider: provider_state.clone(),
         provider_store: provider_store.clone(),
         config: settings.clone(),
         settings: settings.clone(),
+        pending_model_choice: pending_model_choice.clone(),
     });
     // Schema-described, human-friendly config editing (`get_config` /
     // `set_config`, including `key=capabilities`) plus an always-on pointer
@@ -3441,6 +3455,8 @@ pub async fn build_with_options(
     Ok(BuiltRuntime {
         handles: RuntimeHandles {
             runtime,
+            settings: settings.clone(),
+            pending_model_choice,
             session_id,
             events: event_bus_typed,
             checkpoints,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -9684,7 +9684,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn setup_model_picker_preset_selection_applies_and_persists() {
+    async fn setup_model_picker_preset_selection_applies_without_persisting() {
         let mut fixture = app_with_llmsim().await;
         let app = &mut fixture.app;
         app.lines.clear();
@@ -9721,11 +9721,10 @@ mod tests {
             "completion line should report the picked model: {:?}",
             app.lines
         );
-        // The pick persists, so the next run restores it (see
-        // pick_provider_applies_saved_model_for_saved_provider in main.rs).
+        // Persistence waits until the selected model completes a turn.
         let snapshot = app.settings.snapshot();
         assert_eq!(snapshot.default_provider.as_deref(), Some("openai"));
-        assert_eq!(snapshot.model_for("openai"), Some("gpt-5.4 none"));
+        assert_eq!(snapshot.model_for("openai"), None);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1581,7 +1581,7 @@ fn tui_browser_login_can_be_cancelled_after_browser_closes() {
 /// Drive the real TUI binary through the whole model-selection flow:
 /// `/setup` → quick-select a provider that is already connected (saved key)
 /// → the wizard jumps straight to the model picker → quick-select a preset
-/// model → the switch is announced and persisted to settings.toml.
+/// model → the switch is announced but remains unpersisted until a turn succeeds.
 #[test]
 fn tui_setup_selects_model_for_connected_provider_in_real_pty() {
     let mut tui = spawn_tui_llmsim_with_settings(
@@ -1646,8 +1646,8 @@ fn tui_setup_selects_model_for_connected_provider_in_real_pty() {
         "provider switch should persist: {settings}"
     );
     assert!(
-        settings.contains("openai = \"gpt-5.4 none\""),
-        "picked model should persist under [models]: {settings}"
+        !settings.contains("openai = \"gpt-5.4 none\""),
+        "picked model should not persist before a successful turn: {settings}"
     );
 
     tui.write_input(b"\x03\x03");


### PR DESCRIPTION
## Summary

- defer persistence of a newly selected model until it completes a successful turn
- keep inaccessible or unsupported model selections from becoming the next session default
- retry settings persistence after a later successful turn if writing settings fails

## Test plan

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features capabilities::host::tests`
- `cargo test --all-features setup_model_picker_preset_selection_applies_without_persisting`
- `cargo test --all-features predictable_long_command_returns_immediately_and_terminal_result_is_durable`
- `python3 scripts/validate_okf.py knowledge --check-links`
- attempted `cargo run -- --provider llmsim -p "reply with ok"`; build did not finish inside the 120-second local command limit
- full `cargo test --all-features` otherwise passed but hit the known timing-sensitive `predictable_long_command_returns_immediately_and_terminal_result_is_durable`; its isolated rerun passed

## Security

Reviewed TM-LLM and TM-TOOL. The change only delays writing an already validated provider/model selection; it adds no prompt construction, key handling, capability registration, filesystem path, shell execution, dependency, or unbounded-resource behavior.

## Knowledge

Updated `knowledge/specs/conversational-control.md` to document that model selections become durable only after a successful turn.

## Follow-ups

No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
