### PR TITLE
fix(evals): exclude bookkeeping from search budgets

### DIFF
--- a/evals/harness_basic/README.md
+++ b/evals/harness_basic/README.md
@@ -148,8 +148,11 @@ the shared owner, unchanged-reuse responses, session useful-match recall/extra
 matches, and session-search result bytes. Orchestration cases additionally report
 `tool_emitting_model_calls`, `single_tool_model_calls`,
 `batched_tool_model_calls`, `mean_tool_batch_width`, `max_tool_batch_width`,
-`max_read_file_batch_width`, `bookkeeping_tool_calls`, and
-`standalone_bookkeeping_rounds`. `cumulative_input_tokens` sums uncached,
+`max_read_file_batch_width`, `bookkeeping_tool_calls`,
+`standalone_bookkeeping_rounds`, `task_tool_calls`, and `task_llm_calls`. The
+task counters exclude bookkeeping tools and bookkeeping-only model rounds so
+automatic title and status maintenance do not consume focused task budgets.
+`cumulative_input_tokens` sums uncached,
 cache-read, and cache-creation input so fewer repeated rounds remain visible
 even when provider caching makes billable input look small. All cases also
 expose metadata (`provider`, `model`, `effort`,

--- a/evals/harness_basic/src/main.rs
+++ b/evals/harness_basic/src/main.rs
@@ -618,8 +618,8 @@ fn zero_result_search_sample() -> Sample {
                 "metric_at_least": {"progress_guard_warnings": 1.0},
                 "metric_at_most": {
                     "calls_after_progress_warning": 1.0,
-                    "tool_calls": 4.0,
-                    "llm_calls": 5.0
+                    "task_tool_calls": 4.0,
+                    "task_llm_calls": 5.0
                 },
                 "metric_equals": {"duplicate_exploration_calls": 0.0}
             },
@@ -1613,6 +1613,21 @@ struct Mined {
     session_result_bytes: u64,
 }
 
+// Bookkeeping-only rounds are tracked independently from the work an eval asks
+// the agent to perform. This keeps product features such as automatic session
+// titles from consuming a task's search or reasoning budget.
+fn task_tool_calls(mined: &Mined) -> u64 {
+    mined
+        .total_model_emitted_tool_calls
+        .saturating_sub(mined.bookkeeping_tool_calls)
+}
+
+fn task_llm_calls(mined: &Mined) -> u64 {
+    mined
+        .llm_calls
+        .saturating_sub(mined.standalone_bookkeeping_rounds)
+}
+
 #[derive(Default)]
 struct WorkspaceTrajectory {
     current_hashes: BTreeMap<String, String>,
@@ -2407,6 +2422,8 @@ async fn run_yolop(sample: Sample, cx: RunCx) -> Transcript {
         t.error = Some(format!("no events at {}", events_path.display()));
         stop_reason = "error";
     }
+    let task_tool_calls = task_tool_calls(&mined);
+    let task_llm_calls = task_llm_calls(&mined);
 
     t.final_response = mined.final_response;
     t.iterations = mined.iterations as usize;
@@ -2456,6 +2473,10 @@ async fn run_yolop(sample: Sample, cx: RunCx) -> Transcript {
         "bookkeeping_tool_calls".into(),
         mined.bookkeeping_tool_calls as f64,
     );
+    t.metrics
+        .insert("task_tool_calls".into(), task_tool_calls as f64);
+    t.metrics
+        .insert("task_llm_calls".into(), task_llm_calls as f64);
     t.metrics
         .insert("tool_calls".into(), t.tool_calls_count as f64);
     t.metrics.insert("turns".into(), mined.turns as f64);
@@ -2787,6 +2808,8 @@ mod tests {
         assert_eq!(m.max_read_file_batch_width, 2);
         assert_eq!(m.bookkeeping_tool_calls, 2);
         assert_eq!(m.standalone_bookkeeping_rounds, 1);
+        assert_eq!(task_tool_calls(&m), 2);
+        assert_eq!(task_llm_calls(&m), 2);
     }
 
     #[test]
@@ -3050,6 +3073,29 @@ mod tests {
         transcript.metrics.insert("warnings".into(), 0.0);
         let score = checks_scorer().score(&sample, &transcript).await;
         assert!(!score.pass);
+    }
+
+    #[tokio::test]
+    async fn zero_result_search_budget_ignores_standalone_bookkeeping() {
+        let mut transcript = graded_transcript();
+        transcript.final_response = "GUARD-203".into();
+        transcript
+            .metadata
+            .insert("binary".into(), json!("candidate"));
+        transcript.metrics.extend([
+            ("progress_guard_warnings".into(), 1.0),
+            ("calls_after_progress_warning".into(), 1.0),
+            ("duplicate_exploration_calls".into(), 0.0),
+            ("tool_calls".into(), 5.0),
+            ("llm_calls".into(), 6.0),
+            ("task_tool_calls".into(), 4.0),
+            ("task_llm_calls".into(), 5.0),
+        ]);
+
+        let score = checks_scorer()
+            .score(&zero_result_search_sample(), &transcript)
+            .await;
+        assert!(score.pass, "{}", score.reason);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

Adds task-focused tool and model-call metrics that exclude bookkeeping tools and bookkeeping-only model rounds. The `zero-result-search-recovery` case now applies its existing 4-tool / 5-call efficiency budget to substantive task work while retaining raw totals and dedicated bookkeeping metrics.

## Why

The nightly search-efficiency monitor was reporting a 0% candidate pass rate even though every candidate trial emitted the progress warning, recovered to `GUARD-203`, and used the intended four searches. Automatic `write_session_title` maintenance added one tool and one model round to the raw totals, causing a false regression.

## Before / After

Before, the August 5 candidate trajectories scored 0/3 because their raw totals were 5 tools / 6 model calls.

After, the same archived trajectories resolve to 4 task tools / 5 task model calls and satisfy the unchanged search-efficiency budget. Raw 5/6 totals remain available for overall cost analysis.

## Risk

- Low.
- Incorrect bookkeeping classification could undercount focused task work. The calculation subtracts only the existing bookkeeping tool set and only subtracts model calls when the entire round is bookkeeping.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

No knowledge update required — this corrects eval accounting and documents the new metrics in the eval README; product behavior and maintainer policy are unchanged.

## Security

No security-relevant runtime code changes. Reviewed TM-FS, TM-BASH, TM-LLM, TM-TOOL, and TM-DEP: the change only derives numeric eval metrics from existing event data, adds no I/O or trust boundary, handles no keys, registers no capability, and adds no dependency.

## Follow-ups

No follow-ups.