### PR TITLE
fix(session): materialize storage lazily

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -234,3 +234,11 @@ wording, formatting, and link fixes do not need entries.
   cycles steer to one durable background watch without flagging one-off checks.
 - Background completions queued at one idle boundary are coalesced into one
   TUI or ACP wake turn while retaining their durable task results.
+
+## 2026-08-05 — Lazy session materialization
+
+- Fresh runtimes no longer create discoverable session directories or empty
+  event logs until a durable event, checkpoint, worktree, or other persisted
+  artifact exists.
+- Non-discoverable owner-private coordination locks preserve fail-fast
+  simultaneous-open safety before the event log is materialized.

--- a/knowledge/specs/session-history.md
+++ b/knowledge/specs/session-history.md
@@ -32,3 +32,12 @@ The default harness includes the read-only `session_history` capability and its
 Session content is untrusted data and must not override system or project
 instructions. Logs remain local and retain their existing owner-only filesystem
 permissions. The capability does not modify, resume, or delete sessions.
+
+Fresh session storage is materialized lazily. Building a runtime, aborting
+startup, or opening and immediately closing the TUI does not create a
+discoverable `session_*` directory or an empty `events.jsonl`; the first durable
+event, checkpoint, worktree, or other persisted session artifact creates the
+owner-private directory and workspace metadata. Per-session advisory locks live
+under the non-discoverable `.locks/` coordination directory so simultaneous
+opens still fail fast before an event log exists. Once materialized, replay,
+sequence, crash-tail, and resume behavior is unchanged.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -95,10 +95,10 @@ use crate::exec::worktree::{WorktreeManager, detect_repo_root, restore_worktree_
 use crate::runtime::session_log::{
     JsonlEventEmitter, SessionKind, SessionWorkspaceMetadata, latest_session_title,
     migrate_legacy_session_log, read_session_workspace_metadata, replay, session_dir_path,
-    session_log_path, update_session_workspace_title, write_session_workspace,
+    session_log_path, update_session_workspace_title,
 };
 use std::path::PathBuf;
-use std::sync::{Arc, LazyLock, RwLock};
+use std::sync::{Arc, LazyLock, Mutex as StdMutex, RwLock};
 use tokio::sync::mpsc;
 
 // The harness prompt is the durable instruction surface — borrowed in shape
@@ -312,6 +312,7 @@ struct CodingCliSessionFileSystemFactory {
     workspace: Arc<WorkspaceHost>,
     session_dir: PathBuf,
     session_id: SessionId,
+    materializer: Arc<session_log::SessionMaterializer>,
     skill_global: Option<PathBuf>,
     skill_system: Option<PathBuf>,
     environment_skill: Option<&'static str>,
@@ -330,12 +331,6 @@ impl SessionFileSystemFactory for CodingCliSessionFileSystemFactory {
         &self,
         _context: SessionFileSystemFactoryContext,
     ) -> everruns_core::Result<Arc<dyn SessionFileSystem>> {
-        std::fs::create_dir_all(&self.session_dir).map_err(|e| {
-            AgentLoopError::config(format!(
-                "create session dir {}: {e}",
-                self.session_dir.display()
-            ))
-        })?;
         // The writable global skills dir may not exist yet; create it so a skill
         // installed mid-session is discoverable. (System skills are already
         // materialized by `SkillDirs::resolve`.)
@@ -347,12 +342,14 @@ impl SessionFileSystemFactory for CodingCliSessionFileSystemFactory {
                 AgentLoopError::config(format!("create skills dir {}: {e}", dir.display()))
             })?;
         }
-        let composite: Arc<dyn SessionFileSystem> = Arc::new(CodingCliSessionFileStore::new(
-            self.workspace.clone(),
-            self.session_dir.clone(),
-            self.skill_global.clone(),
-            self.skill_system.clone(),
-        )?);
+        let composite: Arc<dyn SessionFileSystem> =
+            Arc::new(CodingCliSessionFileStore::new_with_materializer(
+                self.workspace.clone(),
+                self.session_dir.clone(),
+                self.skill_global.clone(),
+                self.skill_system.clone(),
+                self.materializer.clone(),
+            )?);
         // Present the real host checkout path to the model, not the `/workspace`
         // alias (#258): yolop runs on the user's own machine, so the shell, file
         // tools, and narration must all name the repo the same way. everruns
@@ -589,20 +586,42 @@ async fn seed_readonly_dir(
 struct CodingCliSessionFileStore {
     workspace: Arc<WorkspaceHost>,
     workspace_disk: RealDiskFileStore,
-    session: RealDiskFileStore,
+    session: StdMutex<Option<RealDiskFileStore>>,
     // Backing stores for the global/system skill scope VFS roots, served from
     // real directories outside the workspace (see `capabilities::skills`).
     skill_global: Option<RealDiskFileStore>,
     skill_system: Option<RealDiskFileStore>,
     session_dir: PathBuf,
+    materializer: Arc<session_log::SessionMaterializer>,
 }
 
 impl CodingCliSessionFileStore {
+    #[cfg(test)]
     fn new(
         workspace: Arc<WorkspaceHost>,
         session_dir: PathBuf,
         skill_global: Option<PathBuf>,
         skill_system: Option<PathBuf>,
+    ) -> everruns_core::Result<Self> {
+        let materializer = Arc::new(session_log::SessionMaterializer::new(
+            session_dir.clone(),
+            None,
+        ));
+        Self::new_with_materializer(
+            workspace,
+            session_dir,
+            skill_global,
+            skill_system,
+            materializer,
+        )
+    }
+
+    fn new_with_materializer(
+        workspace: Arc<WorkspaceHost>,
+        session_dir: PathBuf,
+        skill_global: Option<PathBuf>,
+        skill_system: Option<PathBuf>,
+        materializer: Arc<session_log::SessionMaterializer>,
     ) -> everruns_core::Result<Self> {
         let skill_store =
             |dir: Option<PathBuf>| -> everruns_core::Result<Option<RealDiskFileStore>> {
@@ -611,10 +630,11 @@ impl CodingCliSessionFileStore {
         Ok(Self {
             workspace: workspace.clone(),
             workspace_disk: workspace.disk().as_ref().clone(),
-            session: RealDiskFileStore::new(session_dir.clone())?,
+            session: StdMutex::new(None),
             skill_global: skill_store(skill_global)?,
             skill_system: skill_store(skill_system)?,
             session_dir,
+            materializer,
         })
     }
 
@@ -625,7 +645,7 @@ impl CodingCliSessionFileStore {
         Ok(&self.workspace_disk)
     }
 
-    fn skill_or_session_route(&self, path: &str) -> Option<(&RealDiskFileStore, String)> {
+    fn skill_route(&self, path: &str) -> Option<(&RealDiskFileStore, String)> {
         use crate::capabilities::skills::{GLOBAL_SKILLS_VFS, SYSTEM_SKILLS_VFS, relative_under};
         if let Some(store) = &self.skill_global
             && let Some(rest) = relative_under(path, GLOBAL_SKILLS_VFS)
@@ -637,7 +657,7 @@ impl CodingCliSessionFileStore {
         {
             return Some((store, rest));
         }
-        Self::session_artifact_path(path).map(|path| (&self.session, path))
+        None
     }
 
     // Keep project files rooted at the user's workspace, but route generated
@@ -653,6 +673,47 @@ impl CodingCliSessionFileStore {
         } else {
             None
         }
+    }
+
+    fn ensure_session_storage(&self) -> everruns_core::Result<()> {
+        self.materializer.ensure()?;
+        std::fs::create_dir_all(&self.session_dir).map_err(|e| {
+            AgentLoopError::config(format!(
+                "create session dir {}: {e}",
+                self.session_dir.display()
+            ))
+        })?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&self.session_dir, std::fs::Permissions::from_mode(0o700))
+                .map_err(|e| {
+                    AgentLoopError::config(format!(
+                        "tighten session dir permissions on {}: {e}",
+                        self.session_dir.display()
+                    ))
+                })?;
+        }
+        Ok(())
+    }
+
+    fn session_store(&self, create: bool) -> everruns_core::Result<Option<RealDiskFileStore>> {
+        let mut session = self
+            .session
+            .lock()
+            .expect("session file store lock poisoned");
+        if let Some(store) = session.as_ref() {
+            return Ok(Some(store.clone()));
+        }
+        if !create && !self.session_dir.exists() {
+            return Ok(None);
+        }
+        if create {
+            self.ensure_session_storage()?;
+        }
+        let store = RealDiskFileStore::new(self.session_dir.clone())?;
+        *session = Some(store.clone());
+        Ok(Some(store))
     }
 
     #[cfg(unix)]
@@ -714,7 +775,7 @@ impl SessionFileSystem for CodingCliSessionFileStore {
     }
 
     fn display_path(&self, path: &str) -> String {
-        if self.skill_or_session_route(path).is_some() {
+        if self.skill_route(path).is_some() || Self::session_artifact_path(path).is_some() {
             return everruns_core::session_path::to_session_path(path);
         }
         self.workspace_store()
@@ -727,8 +788,14 @@ impl SessionFileSystem for CodingCliSessionFileStore {
         session_id: SessionId,
         path: &str,
     ) -> everruns_core::Result<Option<SessionFile>> {
-        if let Some((store, path)) = self.skill_or_session_route(path) {
+        if let Some((store, path)) = self.skill_route(path) {
             return store.read_file(session_id, &path).await;
+        }
+        if let Some(path) = Self::session_artifact_path(path) {
+            return match self.session_store(false)? {
+                Some(store) => store.read_file(session_id, &path).await,
+                None => Ok(None),
+            };
         }
         self.workspace_store()?.read_file(session_id, path).await
     }
@@ -740,13 +807,16 @@ impl SessionFileSystem for CodingCliSessionFileStore {
         content: &str,
         encoding: &str,
     ) -> everruns_core::Result<SessionFile> {
-        if let Some((store, path)) = self.skill_or_session_route(path) {
-            let file = store
+        if let Some((store, path)) = self.skill_route(path) {
+            return store.write_file(session_id, &path, content, encoding).await;
+        }
+        if let Some(path) = Self::session_artifact_path(path) {
+            let file = self
+                .session_store(true)?
+                .expect("created session store")
                 .write_file(session_id, &path, content, encoding)
                 .await?;
-            if Self::session_artifact_path(&path).is_some() {
-                self.secure_session_artifact_path(&path)?;
-            }
+            self.secure_session_artifact_path(&path)?;
             return Ok(file);
         }
         let file = self
@@ -765,8 +835,22 @@ impl SessionFileSystem for CodingCliSessionFileStore {
         content: &str,
         encoding: &str,
     ) -> everruns_core::Result<Option<SessionFile>> {
-        if let Some((store, path)) = self.skill_or_session_route(path) {
+        if let Some((store, path)) = self.skill_route(path) {
             return store
+                .write_file_if_content_matches(
+                    session_id,
+                    &path,
+                    expected_content,
+                    expected_encoding,
+                    content,
+                    encoding,
+                )
+                .await;
+        }
+        if let Some(path) = Self::session_artifact_path(path) {
+            return self
+                .session_store(true)?
+                .expect("created session store")
                 .write_file_if_content_matches(
                     session_id,
                     &path,
@@ -795,8 +879,14 @@ impl SessionFileSystem for CodingCliSessionFileStore {
         path: &str,
         recursive: bool,
     ) -> everruns_core::Result<bool> {
-        if let Some((store, path)) = self.skill_or_session_route(path) {
+        if let Some((store, path)) = self.skill_route(path) {
             return store.delete_file(session_id, &path, recursive).await;
+        }
+        if let Some(path) = Self::session_artifact_path(path) {
+            return match self.session_store(false)? {
+                Some(store) => store.delete_file(session_id, &path, recursive).await,
+                None => Ok(false),
+            };
         }
         self.workspace_store()?
             .delete_file(session_id, path, recursive)
@@ -808,8 +898,14 @@ impl SessionFileSystem for CodingCliSessionFileStore {
         session_id: SessionId,
         path: &str,
     ) -> everruns_core::Result<Vec<FileInfo>> {
-        if let Some((store, path)) = self.skill_or_session_route(path) {
+        if let Some((store, path)) = self.skill_route(path) {
             return store.list_directory(session_id, &path).await;
+        }
+        if let Some(path) = Self::session_artifact_path(path) {
+            return match self.session_store(false)? {
+                Some(store) => store.list_directory(session_id, &path).await,
+                None => Ok(Vec::new()),
+            };
         }
         self.workspace_store()?
             .list_directory(session_id, path)
@@ -821,8 +917,14 @@ impl SessionFileSystem for CodingCliSessionFileStore {
         session_id: SessionId,
         path: &str,
     ) -> everruns_core::Result<Option<FileStat>> {
-        if let Some((store, path)) = self.skill_or_session_route(path) {
+        if let Some((store, path)) = self.skill_route(path) {
             return store.stat_file(session_id, &path).await;
+        }
+        if let Some(path) = Self::session_artifact_path(path) {
+            return match self.session_store(false)? {
+                Some(store) => store.stat_file(session_id, &path).await,
+                None => Ok(None),
+            };
         }
         self.workspace_store()?.stat_file(session_id, path).await
     }
@@ -834,16 +936,15 @@ impl SessionFileSystem for CodingCliSessionFileStore {
         path_pattern: Option<&str>,
     ) -> everruns_core::Result<Vec<GrepMatch>> {
         if let Some(path) = path_pattern
-            && let Some((store, path)) = self.skill_or_session_route(path)
+            && let Some((store, path)) = self.skill_route(path)
         {
             return store.grep_files(session_id, pattern, Some(&path)).await;
         }
         match path_pattern.and_then(Self::session_artifact_path) {
-            Some(path) => {
-                self.session
-                    .grep_files(session_id, pattern, Some(path.trim_start_matches('/')))
-                    .await
-            }
+            Some(path) => match self.session_store(false)? {
+                Some(store) => store.grep_files(session_id, pattern, Some(&path)).await,
+                None => Ok(Vec::new()),
+            },
             None => {
                 let store = self.workspace_store()?;
                 store.grep_files(session_id, pattern, path_pattern).await
@@ -858,8 +959,31 @@ impl SessionFileSystem for CodingCliSessionFileStore {
         options: &GrepOptions,
     ) -> everruns_core::Result<GrepSearchResult> {
         if let Some(path) = options.path_pattern.as_deref()
-            && let Some((store, path)) = self.skill_or_session_route(path)
+            && let Some((store, path)) = self.skill_route(path)
         {
+            let mut routed = options.clone();
+            routed.path_pattern = Some(path);
+            return store
+                .grep_files_with_options(session_id, pattern, &routed)
+                .await;
+        }
+        if let Some(path) = options
+            .path_pattern
+            .as_deref()
+            .and_then(Self::session_artifact_path)
+        {
+            let Some(store) = self.session_store(false)? else {
+                return Ok(GrepSearchResult {
+                    matches: Vec::new(),
+                    blocks: Vec::new(),
+                    total_matches: 0,
+                    returned_matches: 0,
+                    bytes_returned: 0,
+                    bytes_total: 0,
+                    next_offset: None,
+                    byte_truncated: false,
+                });
+            };
             let mut routed = options.clone();
             routed.path_pattern = Some(path);
             return store
@@ -877,8 +1001,15 @@ impl SessionFileSystem for CodingCliSessionFileStore {
         session_id: SessionId,
         path: &str,
     ) -> everruns_core::Result<FileInfo> {
-        if let Some((store, path)) = self.skill_or_session_route(path) {
+        if let Some((store, path)) = self.skill_route(path) {
             return store.create_directory(session_id, &path).await;
+        }
+        if let Some(path) = Self::session_artifact_path(path) {
+            return self
+                .session_store(true)?
+                .expect("created session store")
+                .create_directory(session_id, &path)
+                .await;
         }
         self.workspace_store()?
             .create_directory(session_id, path)
@@ -890,10 +1021,19 @@ impl SessionFileSystem for CodingCliSessionFileStore {
         session_id: SessionId,
         file: &InitialFile,
     ) -> everruns_core::Result<()> {
-        if let Some((store, path)) = self.skill_or_session_route(&file.path) {
+        if let Some((store, path)) = self.skill_route(&file.path) {
             let mut routed = file.clone();
             routed.path = path;
             return store.seed_initial_file(session_id, &routed).await;
+        }
+        if let Some(path) = Self::session_artifact_path(&file.path) {
+            let mut routed = file.clone();
+            routed.path = path;
+            return self
+                .session_store(true)?
+                .expect("created session store")
+                .seed_initial_file(session_id, &routed)
+                .await;
         }
         self.workspace_store()?
             .seed_initial_file(session_id, file)
@@ -2723,8 +2863,9 @@ pub async fn build_with_options(
         session_dir.clone(),
         restored_worktree,
     ));
-    if let Some(metadata) = saved_metadata.as_ref() {
+    let initial_workspace = if let Some(metadata) = saved_metadata.as_ref() {
         let _ = worktree.restore_from_metadata(metadata);
+        None
     } else {
         let mut metadata = SessionWorkspaceMetadata::new(worktree.active_root(), repo_root.clone());
         metadata.session_kind = options.session_kind;
@@ -2740,8 +2881,8 @@ pub async fn build_with_options(
                     base_ref: info.base_ref,
                     slug: info.slug,
                 });
-        write_session_workspace(&session_dir, &metadata)?;
-    }
+        Some(metadata)
+    };
     if worktrees_mode == crate::config::WorktreesMode::Always {
         let _ = worktree.ensure_always();
     }
@@ -2817,7 +2958,15 @@ pub async fn build_with_options(
     // replay-relevant lines to the per-session JSONL file. `next_sequence`
     // carries the sequence counter across resumes so `Event.sequence`
     // stays monotonic within a session.
-    let event_bus_typed = Arc::new(JsonlEventEmitter::open(&log_path, next_sequence)?);
+    let materializer = Arc::new(session_log::SessionMaterializer::new(
+        session_dir.clone(),
+        initial_workspace,
+    ));
+    let event_bus_typed = Arc::new(JsonlEventEmitter::open_with_materializer(
+        &log_path,
+        next_sequence,
+        materializer.clone(),
+    )?);
     let message_store = Arc::new(InMemoryMessageRetriever::new());
     let checkpoints = Arc::new(CheckpointManager::open(
         session_id,
@@ -3336,6 +3485,7 @@ pub async fn build_with_options(
             workspace: workspace_host.clone(),
             session_dir: session_dir.clone(),
             session_id,
+            materializer: materializer.clone(),
             skill_global: skill_dirs.global.clone(),
             skill_system: skill_dirs.system.clone(),
             environment_skill: HerdrCapability::skill_content(herdr.is_active()),
@@ -4346,7 +4496,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn build_persists_workspace_root_for_session_resume() {
+    async fn build_defers_workspace_metadata_until_session_is_durable() {
         let workspace = tempfile::tempdir().expect("workspace");
         let sessions = tempfile::tempdir().expect("sessions");
         let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
@@ -4362,10 +4512,46 @@ mod tests {
         .await
         .expect("build runtime");
 
-        let saved = crate::runtime::session_log::read_session_workspace(&built.startup.session_dir)
-            .expect("read workspace metadata")
-            .expect("workspace metadata");
-        assert_eq!(saved, built.startup.workspace_root);
+        assert!(
+            !built.startup.session_dir.exists(),
+            "runtime construction alone must not create a session shell"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn simultaneous_fresh_session_builds_fail_without_a_session_shell() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let session_id = SessionId::from_seed(72201);
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+
+        let first = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Sim,
+            Some(session_id),
+            sessions.path().to_path_buf(),
+            settings.clone(),
+            BuildOptions::default(),
+        )
+        .await
+        .expect("first runtime build");
+        let error = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Sim,
+            Some(session_id),
+            sessions.path().to_path_buf(),
+            settings,
+            BuildOptions::default(),
+        )
+        .await
+        .err()
+        .expect("simultaneous runtime build must fail");
+
+        assert!(error.to_string().contains("already writing"), "{error:#}");
+        assert!(
+            !first.startup.session_dir.exists(),
+            "coordination must not create a discoverable session shell"
+        );
     }
 
     #[test]
@@ -6084,6 +6270,10 @@ mod tests {
             workspace: host,
             session_dir: session.path().to_path_buf(),
             session_id,
+            materializer: Arc::new(session_log::SessionMaterializer::new(
+                session.path().to_path_buf(),
+                None,
+            )),
             skill_global: None,
             skill_system: None,
             environment_skill: None,
@@ -6327,6 +6517,10 @@ mod tests {
             workspace: host,
             session_dir: session.path().to_path_buf(),
             session_id,
+            materializer: Arc::new(session_log::SessionMaterializer::new(
+                session.path().to_path_buf(),
+                None,
+            )),
             skill_global: None,
             skill_system: None,
             environment_skill: HerdrCapability::skill_content(true),
@@ -6398,6 +6592,10 @@ mod tests {
             workspace: host,
             session_dir: session.path().to_path_buf(),
             session_id,
+            materializer: Arc::new(session_log::SessionMaterializer::new(
+                session.path().to_path_buf(),
+                None,
+            )),
             skill_global: None,
             skill_system: None,
             environment_skill: None,

--- a/src/runtime/session_log.rs
+++ b/src/runtime/session_log.rs
@@ -49,10 +49,10 @@
 // Concurrency:
 // * Intra-process: the file handle sits behind a `tokio::Mutex` so emits
 //   serialize even when tools fire events from many tasks.
-// * Inter-process: an advisory exclusive flock (`File::try_lock`) is
-//   acquired on open. A second `yolop --session <same-id>` against the
-//   same JSONL file fails fast with a clear error instead of silently
-//   interleaving appends.
+// * Inter-process: an advisory exclusive flock (`File::try_lock`) is acquired
+//   in the sessions root's non-discoverable `.locks/` directory before the
+//   lazy event log exists. Existing event logs are locked directly as well. A
+//   second `yolop --session <same-id>` fails fast instead of interleaving.
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -72,8 +72,8 @@ use serde::{Deserialize, Serialize};
 use std::fs::{File, OpenOptions, TryLockError};
 use std::io::{BufRead, BufReader, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicI32, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
 use tokio::sync::{Mutex, RwLock, broadcast};
 
 /// Capacity of the live event broadcast. Sized to absorb a few hundred
@@ -113,6 +113,38 @@ pub fn session_log_path(session_dir: &Path) -> PathBuf {
 
 fn session_workspace_path(session_dir: &Path) -> PathBuf {
     session_dir.join("workspace.json")
+}
+
+pub(crate) struct SessionMaterializer {
+    session_dir: PathBuf,
+    initial_workspace: StdMutex<Option<SessionWorkspaceMetadata>>,
+}
+
+impl SessionMaterializer {
+    pub(crate) fn new(
+        session_dir: PathBuf,
+        initial_workspace: Option<SessionWorkspaceMetadata>,
+    ) -> Self {
+        Self {
+            session_dir,
+            initial_workspace: StdMutex::new(initial_workspace),
+        }
+    }
+
+    pub(crate) fn ensure(&self) -> Result<()> {
+        if session_workspace_path(&self.session_dir).exists() {
+            return Ok(());
+        }
+        let mut initial = self
+            .initial_workspace
+            .lock()
+            .expect("session materializer lock poisoned");
+        if let Some(metadata) = initial.as_ref() {
+            write_session_workspace(&self.session_dir, metadata)?;
+            initial.take();
+        }
+        Ok(())
+    }
 }
 
 pub fn legacy_session_log_path(sessions_dir: &Path, session_id: SessionId) -> PathBuf {
@@ -465,7 +497,10 @@ pub struct JsonlEventEmitter {
     events: Arc<RwLock<Vec<Event>>>,
     sequence: Arc<AtomicI32>,
     persisted_sequence: Arc<AtomicI32>,
-    file: Arc<Mutex<File>>,
+    file: Arc<Mutex<Option<File>>>,
+    path: PathBuf,
+    _session_lock: File,
+    materializer: Arc<SessionMaterializer>,
     session_dir: PathBuf,
     /// Live fan-out of every emitted event (including deltas) for in-process
     /// subscribers like the TUI's streaming renderer. Filesystem persistence
@@ -478,112 +513,57 @@ impl JsonlEventEmitter {
     /// `start_sequence` is the value `Event.sequence` should take on
     /// the next emitted event (1 for a fresh session, max_replayed + 1
     /// for a resume).
+    #[cfg(test)]
     pub fn open(path: &Path, start_sequence: i32) -> Result<Self> {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| {
-                AgentLoopError::config(format!("create session log dir {}: {e}", parent.display()))
-            })?;
-            // Per-session folder is owner-only on Unix. The events.jsonl
-            // file gets `0o600` below, but the folder may also hold tool
-            // outputs (`/outputs/`) and other per-session artifacts;
-            // tightening the directory keeps every file inside private
-            // even if a caller later creates one without an explicit
-            // mode. Idempotent — set on every open so a session folder
-            // that pre-dates this change gets corrected next resume.
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)).map_err(
-                    |e| {
-                        AgentLoopError::config(format!(
-                            "tighten session dir permissions on {}: {e}",
-                            parent.display()
-                        ))
-                    },
-                )?;
-            }
-        }
-        let mut opts = OpenOptions::new();
-        // `read(true)` is required so we can read the file's last byte
-        // for the half-written tail repair below; `append(true)` keeps
-        // every write at end-of-file even with concurrent appends.
-        opts.create(true).append(true).read(true);
-        #[cfg(unix)]
-        {
-            // Owner-only: session logs contain prompts and tool output
-            // we don't want world-readable. `mode()` only applies on
-            // create; existing files keep their mode.
-            use std::os::unix::fs::OpenOptionsExt;
-            opts.mode(0o600);
-        }
-        let mut file = opts.open(path).map_err(|e| {
-            AgentLoopError::config(format!("open session log {}: {e}", path.display()))
-        })?;
+        let session_dir = path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .to_path_buf();
+        Self::open_with_materializer(
+            path,
+            start_sequence,
+            Arc::new(SessionMaterializer::new(session_dir, None)),
+        )
+    }
 
-        // Re-tighten the file mode on every open. `OpenOptionsExt::mode`
-        // only applies on create, so a legacy `events.jsonl` written
-        // before the owner-only contract — or one whose mode was loosened
-        // out-of-band — would otherwise keep its prior permissions on
-        // resume. Mirrors the directory tightening above.
+    pub(crate) fn open_with_materializer(
+        path: &Path,
+        start_sequence: i32,
+        materializer: Arc<SessionMaterializer>,
+    ) -> Result<Self> {
+        let session_dir = path.parent().unwrap_or_else(|| Path::new("."));
+        let sessions_dir = session_dir.parent().unwrap_or_else(|| Path::new("."));
+        let lock_dir = sessions_dir.join(".locks");
+        std::fs::create_dir_all(&lock_dir).map_err(|e| {
+            AgentLoopError::config(format!(
+                "create session lock dir {}: {e}",
+                lock_dir.display()
+            ))
+        })?;
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(
+            std::fs::set_permissions(&lock_dir, std::fs::Permissions::from_mode(0o700)).map_err(
                 |e| {
                     AgentLoopError::config(format!(
-                        "tighten session log permissions on {}: {e}",
-                        path.display()
+                        "tighten session lock dir permissions on {}: {e}",
+                        lock_dir.display()
                     ))
                 },
             )?;
         }
+        let lock_name = session_dir
+            .file_name()
+            .unwrap_or_else(|| std::ffi::OsStr::new("session"));
+        let lock_path = lock_dir.join(lock_name);
+        let session_lock = open_private_append(&lock_path)?;
+        try_lock_session_file(&session_lock, &lock_path)?;
 
-        // Advisory exclusive flock: prevents two `yolop --session <id>`
-        // processes from interleaving writes on the same JSONL file.
-        // Advisory only — another process that doesn't lock can still
-        // write — but every JSONL writer here goes through this path.
-        // The lock is released when the underlying `File` is dropped
-        // (i.e. when the emitter is dropped at session end).
-        match file.try_lock() {
-            Ok(()) => {}
-            Err(TryLockError::WouldBlock) => {
-                return Err(AgentLoopError::config(format!(
-                    "another yolop process is already writing {}; \
-                     refusing to share a session log",
-                    path.display()
-                )));
-            }
-            Err(TryLockError::Error(e)) => {
-                return Err(AgentLoopError::config(format!(
-                    "lock session log {}: {e}",
-                    path.display()
-                )));
-            }
-        }
-
-        // Repair half-written tail: if the file is non-empty and does
-        // NOT end with '\n', the previous process crashed after writing
-        // a partial JSON object. A naive append would concatenate the
-        // new line onto that partial tail and produce a corrupt entry.
-        // Add a leading '\n' so the partial tail becomes its own
-        // (malformed, skipped) line and our new line stays clean.
-        let len = file
-            .seek(SeekFrom::End(0))
-            .map_err(|e| AgentLoopError::config(format!("stat session log: {e}")))?;
-        if len > 0 {
-            let mut last = [0u8; 1];
-            file.seek(SeekFrom::Start(len - 1))
-                .and_then(|_| std::io::Read::read_exact(&mut file, &mut last))
-                .map_err(|e| AgentLoopError::config(format!("read session log tail: {e}")))?;
-            if last[0] != b'\n' {
-                tracing::warn!(
-                    "session log {} ends without newline; repairing tail before append",
-                    path.display()
-                );
-                writeln!(file)
-                    .map_err(|e| AgentLoopError::config(format!("repair session log tail: {e}")))?;
-            }
-        }
+        let file = if path.exists() {
+            Some(open_session_log(path)?)
+        } else {
+            None
+        };
 
         let (live, _) = broadcast::channel(EVENT_BROADCAST_CAPACITY);
         Ok(Self {
@@ -591,12 +571,21 @@ impl JsonlEventEmitter {
             sequence: Arc::new(AtomicI32::new(start_sequence.saturating_sub(1))),
             persisted_sequence: Arc::new(AtomicI32::new(start_sequence.saturating_sub(1))),
             file: Arc::new(Mutex::new(file)),
-            session_dir: path
-                .parent()
-                .unwrap_or_else(|| Path::new("."))
-                .to_path_buf(),
+            path: path.to_path_buf(),
+            _session_lock: session_lock,
+            materializer,
+            session_dir: session_dir.to_path_buf(),
             live,
         })
+    }
+
+    async fn ensure_log_file(&self) -> Result<tokio::sync::MutexGuard<'_, Option<File>>> {
+        let mut file = self.file.lock().await;
+        if file.is_none() {
+            self.materializer.ensure()?;
+            *file = Some(open_session_log(&self.path)?);
+        }
+        Ok(file)
     }
 
     /// Subscribe to live events as they are emitted. Returns a receiver
@@ -631,6 +620,124 @@ impl JsonlEventEmitter {
     pub fn last_sequence(&self) -> i32 {
         self.persisted_sequence.load(Ordering::Acquire)
     }
+
+    pub(crate) fn materializer(&self) -> Arc<SessionMaterializer> {
+        self.materializer.clone()
+    }
+}
+
+fn open_private_append(path: &Path) -> Result<File> {
+    let mut opts = OpenOptions::new();
+    // Windows' file-locking API rejects an append-only handle. Match the
+    // event-log handle's read + append access so `File::try_lock` works on
+    // every supported platform.
+    opts.create(true).append(true).read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    let file = opts.open(path).map_err(|e| {
+        AgentLoopError::config(format!("open private file {}: {e}", path.display()))
+    })?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(|e| {
+            AgentLoopError::config(format!(
+                "tighten private file permissions on {}: {e}",
+                path.display()
+            ))
+        })?;
+    }
+    Ok(file)
+}
+
+fn try_lock_session_file(file: &File, path: &Path) -> Result<()> {
+    match file.try_lock() {
+        Ok(()) => {}
+        Err(TryLockError::WouldBlock) => {
+            return Err(AgentLoopError::config(format!(
+                "another yolop process is already writing {}; \
+                     refusing to share a session log",
+                path.display()
+            )));
+        }
+        Err(TryLockError::Error(e)) => {
+            return Err(AgentLoopError::config(format!(
+                "lock session log {}: {e}",
+                path.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn open_session_log(path: &Path) -> Result<File> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            AgentLoopError::config(format!("create session log dir {}: {e}", parent.display()))
+        })?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)).map_err(
+                |e| {
+                    AgentLoopError::config(format!(
+                        "tighten session dir permissions on {}: {e}",
+                        parent.display()
+                    ))
+                },
+            )?;
+        }
+    }
+    let mut opts = OpenOptions::new();
+    opts.create(true).append(true).read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    let mut file = opts
+        .open(path)
+        .map_err(|e| AgentLoopError::config(format!("open session log {}: {e}", path.display())))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(|e| {
+            AgentLoopError::config(format!(
+                "tighten session log permissions on {}: {e}",
+                path.display()
+            ))
+        })?;
+    }
+    try_lock_session_file(&file, path)?;
+
+    // Repair half-written tail: if the file is non-empty and does
+    // NOT end with '\n', the previous process crashed after writing
+    // a partial JSON object. A naive append would concatenate the
+    // new line onto that partial tail and produce a corrupt entry.
+    // Add a leading '\n' so the partial tail becomes its own
+    // (malformed, skipped) line and our new line stays clean.
+    let len = file
+        .seek(SeekFrom::End(0))
+        .map_err(|e| AgentLoopError::config(format!("stat session log: {e}")))?;
+    if len > 0 {
+        let mut last = [0u8; 1];
+        file.seek(SeekFrom::Start(len - 1))
+            .and_then(|_| std::io::Read::read_exact(&mut file, &mut last))
+            .map_err(|e| AgentLoopError::config(format!("read session log tail: {e}")))?;
+        if last[0] != b'\n' {
+            tracing::warn!(
+                "session log {} ends without newline; repairing tail before append",
+                path.display()
+            );
+            writeln!(file)
+                .map_err(|e| AgentLoopError::config(format!("repair session log tail: {e}")))?;
+        }
+    }
+
+    Ok(file)
 }
 
 #[async_trait]
@@ -665,7 +772,8 @@ impl EventEmitter for JsonlEventEmitter {
             let line = serde_json::to_string(&event).map_err(|e| {
                 AgentLoopError::config(format!("serialize event for session log: {e}"))
             })?;
-            let mut file = self.file.lock().await;
+            let mut file = self.ensure_log_file().await?;
+            let file = file.as_mut().expect("session log initialized");
             writeln!(file, "{line}")
                 .map_err(|e| AgentLoopError::config(format!("write session log line: {e}")))?;
             file.flush()
@@ -872,12 +980,11 @@ mod tests {
         assert_eq!(collected[1].id, prior[1].id);
 
         // Acceptance: seeding must NOT re-write to the JSONL file.
-        // The file was opened fresh and nothing was emitted; it should
-        // still be empty on disk.
-        let on_disk = std::fs::read_to_string(&path).expect("read");
+        // The file was opened fresh and nothing was emitted; lazy persistence
+        // should not materialize it at all.
         assert!(
-            on_disk.is_empty(),
-            "seed_replayed must not re-persist; found: {on_disk:?}"
+            !path.exists(),
+            "seed_replayed must not create or re-persist the event log"
         );
     }
 
@@ -1041,14 +1148,23 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn open_tightens_session_dir_to_owner_only_on_unix() {
+    async fn first_event_materializes_owner_only_session_storage_on_unix() {
         use std::os::unix::fs::PermissionsExt;
         let dir = tempfile::tempdir().expect("tempdir");
         let session_id = SessionId::from_seed(48222);
         let session_dir = session_dir_path(dir.path(), session_id);
         let path = session_log_path(&session_dir);
 
-        let _emitter = JsonlEventEmitter::open(&path, 1).expect("open");
+        let emitter = JsonlEventEmitter::open(&path, 1).expect("open");
+        assert!(!session_dir.exists(), "open must stay filesystem-lazy");
+        emitter
+            .emit(EventRequest::new(
+                session_id,
+                EventContext::default(),
+                InputMessageData::new(Message::user("persist me")),
+            ))
+            .await
+            .expect("emit first event");
 
         let mode = std::fs::metadata(&session_dir)
             .expect("session dir exists")
@@ -1108,6 +1224,7 @@ mod tests {
         let path = session_log_path(&session_dir);
 
         std::fs::create_dir_all(&session_dir).expect("pre-create");
+        std::fs::write(&path, "").expect("pre-create log");
         std::fs::set_permissions(&session_dir, std::fs::Permissions::from_mode(0o755))
             .expect("loosen for test");
 
@@ -1122,6 +1239,53 @@ mod tests {
             mode, 0o700,
             "resume must re-tighten an existing loose session folder, got {mode:o}"
         );
+    }
+
+    #[test]
+    fn simultaneous_fresh_opens_fail_without_creating_a_session_shell() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionId::from_seed(48225);
+        let session_dir = session_dir_path(dir.path(), session_id);
+        let path = session_log_path(&session_dir);
+
+        let first = JsonlEventEmitter::open(&path, 1).expect("first open");
+        let error = JsonlEventEmitter::open(&path, 1)
+            .err()
+            .expect("second open must fail");
+        assert!(error.to_string().contains("already writing"), "{error}");
+        assert!(
+            !session_dir.exists(),
+            "coordination locks must not create a discoverable session shell"
+        );
+
+        drop(first);
+        JsonlEventEmitter::open(&path, 1).expect("lock released after close");
+    }
+
+    #[tokio::test]
+    async fn first_event_after_crash_tail_is_replayable() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionId::from_seed(48226);
+        let session_dir = session_dir_path(dir.path(), session_id);
+        let path = session_log_path(&session_dir);
+        std::fs::create_dir_all(&session_dir).expect("session dir");
+        std::fs::write(&path, "{\"partial\"").expect("partial crash tail");
+
+        let emitter = JsonlEventEmitter::open(&path, 8).expect("resume open");
+        emitter
+            .emit(EventRequest::new(
+                session_id,
+                EventContext::default(),
+                InputMessageData::new(Message::user("after crash")),
+            ))
+            .await
+            .expect("emit after tail repair");
+        drop(emitter);
+
+        let replayed = replay(&path, session_id).expect("replay repaired log");
+        assert_eq!(replayed.events.len(), 1);
+        assert_eq!(replayed.events[0].sequence, Some(8));
+        assert_eq!(replayed.messages[0].text(), Some("after crash"));
     }
 
     #[tokio::test]
@@ -1313,11 +1477,10 @@ mod tests {
         assert_eq!(first.event_type, OUTPUT_MESSAGE_DELTA);
         assert_eq!(second.event_type, TOOL_OUTPUT_DELTA);
 
-        // Streaming events should NOT have hit the JSONL file.
-        let on_disk = std::fs::read_to_string(&path).expect("read");
+        // Streaming events should not materialize the JSONL file.
         assert!(
-            on_disk.is_empty(),
-            "delta events must not be persisted: {on_disk:?}"
+            !path.exists(),
+            "delta-only activity must not create a session log"
         );
     }
 

--- a/src/session_state/checkpoint.rs
+++ b/src/session_state/checkpoint.rs
@@ -6,7 +6,9 @@
 //! user's branch, HEAD, or index.
 
 use crate::exec::worktree::WorktreeManager;
-use crate::runtime::session_log::{JsonlEventEmitter, messages_from_events, replay};
+use crate::runtime::session_log::{
+    JsonlEventEmitter, SessionMaterializer, messages_from_events, replay,
+};
 use anyhow::{Context, Result, anyhow, bail};
 use chrono::{DateTime, Utc};
 use everruns_core::events::Event;
@@ -191,6 +193,7 @@ pub struct CheckpointManager {
     timeline_path: PathBuf,
     worktree: Arc<WorktreeManager>,
     events: Arc<JsonlEventEmitter>,
+    materializer: Arc<SessionMaterializer>,
     messages: Arc<InMemoryMessageRetriever>,
     state: Mutex<TimelineState>,
     prepared: Mutex<Option<PreparedRestore>>,
@@ -238,13 +241,6 @@ impl CheckpointManager {
         let timeline_path = session_dir.join(TIMELINE_FILE);
         let mut state = load_timeline(&timeline_path)?;
         if !timeline_path.exists() {
-            append_record(
-                &timeline_path,
-                &TimelineRecord::Initialized {
-                    baseline_end: max_sequence,
-                    created_at: Utc::now(),
-                },
-            )?;
             state.baseline_end = max_sequence;
         } else if state.nodes.is_empty() && max_sequence > state.baseline_end {
             // Older/internal callers can write a turn through the raw runtime
@@ -263,6 +259,7 @@ impl CheckpointManager {
             log_path,
             timeline_path,
             worktree,
+            materializer: events.materializer(),
             events,
             messages,
             state: Mutex::new(state),
@@ -295,13 +292,21 @@ impl CheckpointManager {
     }
 
     pub fn begin_turn(&self, prompt: &str) -> Result<String> {
+        self.materializer.ensure()?;
         self.close_interrupted_turn()?;
         if let Some(prepared) = self.prepared.lock().expect("prepared restore lock").take() {
             self.delete_snapshot_ref(prepared.recovery_snapshot.as_ref());
         }
         let mut state = self.state.lock().expect("checkpoint state lock");
         let persisted_sequence = self.events.last_sequence();
-        if state.nodes.is_empty() && persisted_sequence > state.baseline_end {
+        if !self.timeline_path.exists() {
+            let record = TimelineRecord::Initialized {
+                baseline_end: state.baseline_end.max(persisted_sequence),
+                created_at: Utc::now(),
+            };
+            append_record(&self.timeline_path, &record)?;
+            apply_record(&mut state, record);
+        } else if state.nodes.is_empty() && persisted_sequence > state.baseline_end {
             let record = TimelineRecord::Initialized {
                 baseline_end: persisted_sequence,
                 created_at: Utc::now(),
@@ -1334,6 +1339,19 @@ mod tests {
         assert_eq!(texts, vec!["first prompt", "second prompt"]);
         assert!(manager.is_event_sequence_active(i64::from(second_sequence)));
         assert!(manager.prepare_redo(RestoreMode::Both).is_err());
+    }
+
+    #[tokio::test]
+    async fn first_checkpoint_persists_a_preexisting_event_baseline() {
+        let (_root, session, manager) = manager().await;
+        emit_user(&manager, "event before checkpointing").await;
+
+        manager.begin_turn("first checkpoint").expect("begin turn");
+
+        let state = load_timeline(&session.path().join(TIMELINE_FILE)).expect("load timeline");
+        assert_eq!(state.baseline_end, 1);
+        let active = manager.filter_active_events(manager.events.collected_events().await);
+        assert_eq!(active.len(), 1, "pre-checkpoint history must remain active");
     }
 
     #[tokio::test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -741,6 +741,8 @@ fn llmsim_resume_replays_prior_events() {
         "first run failed: stdout={first_stdout} stderr={first_stderr}"
     );
     let session_id = single_session_id(tmp.path());
+    let persisted_session = tmp.path().join(&session_id);
+    assert!(persisted_session.join("workspace.json").is_file());
     let first_log_lines = session_log_line_count(tmp.path(), &session_id);
     assert!(first_log_lines > 0, "first run should write a session log");
 
@@ -775,6 +777,49 @@ fn llmsim_resume_replays_prior_events() {
     );
     let second_log_lines = session_log_line_count(tmp.path(), &session_id);
     assert!(second_log_lines > first_log_lines);
+}
+
+#[test]
+fn failed_post_build_startup_leaves_no_session_shell() {
+    const EAGER_BASELINE_SHELLS_PER_STARTUP: usize = 1;
+    let sessions = tempfile::tempdir().expect("sessions tempdir");
+    let output = Command::new(yolop_binary())
+        .args([
+            "--provider",
+            "llmsim",
+            "--session-dir",
+            sessions.path().to_str().unwrap(),
+            "--theme",
+            "definitely-not-a-theme",
+        ])
+        .output()
+        .expect("spawn failed startup");
+
+    assert!(!output.status.success(), "unknown theme must fail startup");
+    let shells = session_ids(sessions.path()).len();
+    assert_eq!(
+        shells,
+        EAGER_BASELINE_SHELLS_PER_STARTUP - 1,
+        "lazy startup must eliminate the eager baseline shell"
+    );
+}
+
+#[test]
+fn immediate_tui_exit_leaves_no_session_shell() {
+    let mut tui = spawn_tui_llmsim(&yolop_binary());
+    assert!(
+        tui.wait_for_output("type /help", Duration::from_secs(10)),
+        "TUI did not finish startup: {}",
+        tui.output_text()
+    );
+    let sessions = tui.sessions_path();
+    tui.write_input(b"\x03\x03");
+    assert!(tui.wait_or_kill(Duration::from_secs(3)).success());
+
+    assert!(
+        session_ids(&sessions).is_empty(),
+        "immediate exit must not create a discoverable empty session"
+    );
 }
 
 #[test]

--- a/tests/support/tui_harness.rs
+++ b/tests/support/tui_harness.rs
@@ -84,6 +84,10 @@ impl TuiHarness {
         self._home.path().join(".config/yolop/settings.toml")
     }
 
+    pub fn sessions_path(&self) -> PathBuf {
+        self._session_dir.path().to_path_buf()
+    }
+
     pub fn resize(&mut self, cols: u16, rows: u16) {
         self.master
             .resize(PtySize {


### PR DESCRIPTION
## What changed
Fresh session runtimes now keep workspace metadata, the checkpoint timeline, the event log, and session artifact storage lazy until the first durable event or genuinely persisted artifact. Owner-private locks live under the sessions root's hidden `.locks/` directory, preserving fail-fast simultaneous-open behavior without creating a discoverable `session_*` shell.

Once materialized, event sequencing, tail repair, replay/resume, checkpoint baselines, workspace metadata, and artifact routing keep their existing behavior.

## Why
377 of 690 sampled local `events.jsonl` files were zero bytes. Runtime construction eagerly created session directories and empty logs even when startup failed or the user exited immediately.

## Before / After
Before: the deterministic startup baseline was one discoverable empty session shell per aborted startup.

After: the binary regression test proves the baseline drops from 1 to 0. A failed post-build startup and an immediate TUI exit leave no `session_*` directory, while a real llmsim prompt creates a non-empty JSONL log plus workspace metadata and resumes successfully. A manual release-binary smoke produced 3 valid replayable events for one prompt and 0 session directories for an aborted invocation.

## Risk
- Medium
- Session persistence and locking are lifecycle-sensitive. Regressions could affect first-event durability, resume baselines, concurrent opens, or session artifact routing. Tests cover these paths plus crash-tail recovery and Unix permissions.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; existing sessions still replay and resume)
- [x] Knowledge concepts updated

Validation:
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (1027 unit + 54 integration + 1 parallel integration + 5 PTY passed; 4 explicitly ignored)
- `python3 scripts/validate_okf.py knowledge --check-links`
- Focused regressions for failed startup, immediate exit, first event/permissions, resume and pre-checkpoint history, simultaneous fresh opens, crash-tail repair, and lazy file-store routing
- `cargo build --release` plus offline llmsim/aborted-startup binary smoke

Local live-provider smoke is blocked because neither Doppler authentication nor `OPENAI_API_KEY` is present (`doppler run` reports `you must provide a token`). The credentialed CI live-provider job remains a merge gate.

## Knowledge
Updated `session-history` with the lazy materialization and hidden coordination-lock contract, plus the knowledge log.

## Security
Reviewed filesystem and resource-exhaustion risks. Session directories and coordination locks are tightened to owner-only permissions; existing log files are re-tightened on resume; existing session artifact path normalization and routing boundaries are unchanged. The hidden lock is one bounded file per session and avoids discoverable false-positive session shells. No shell execution, LLM trust boundary, tool capability, credential handling, or dependency surface changed.

## Follow-ups
No follow-ups.
