### PR TITLE
feat(runtime): continue incomplete user tasks

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,14 @@
 Significant changes to Yolop's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
+## 2026-08-05 — Default bounded task completion
+
+- [User ask](specs/user-ask.md) is now the default host completion safety net
+  across TUI, `--print`, and ACP. Cheap deterministic evidence closes trivial,
+  failed, blocked, and background-waiting turns; only ambiguous tool-using
+  candidate finals pay for semantic evaluation. In-progress work continues from
+  compact state inside six-turn, 64k-token, and ten-minute budgets.
+
 ## 2026-08-05 — Compact background completion handoffs
 
 - Automatic background-completion turns now replace the provider-visible parent

--- a/knowledge/specs/acp.md
+++ b/knowledge/specs/acp.md
@@ -161,8 +161,10 @@ refresh any state-sensitive command UI.
 
 `session/prompt` resolves with:
 
-- `end_turn` — the turn completed (success, or a recoverable failure whose
-  error text is also streamed as an `agent_message_chunk`).
+- `end_turn` — the tracked user ask reached achieved, blocked, failed,
+  waiting-on-background, or the bounded continuation budget. In-progress turns
+  are continued and streamed before the original prompt resolves. Recoverable
+  failure text is streamed as an `agent_message_chunk`.
 - `cancelled` — a `session/cancel` arrived, or the turn task was dropped.
 
 The runtime does not expose token-limit or refusal outcomes distinctly, so

--- a/knowledge/specs/background.md
+++ b/knowledge/specs/background.md
@@ -171,6 +171,9 @@ Yolop installs a platform store to close that gap (`crate::background_wake`):
   remain durable and queryable through `query_history`, task tools, and session
   file reads. If task resolution, summary validation, or handoff decoding fails,
   the provider view falls back to ordinary full history rather than guessing.
+- Automatic prompts never replace the tracked user ask or reset its completion
+  budget. A tool-using turn with active detached work is classified
+  waiting-on-background; the eventual wake resumes that same ask.
 - Both coalesce completions already queued at the same idle boundary into one
   automatic prompt in notification order. All resolved task snapshots share
   one bounded handoff; a mixed or unusually large burst falls back safely and

--- a/knowledge/specs/user-ask.md
+++ b/knowledge/specs/user-ask.md
@@ -6,8 +6,7 @@ description: Defines the user ask — request tracking and turn-end validation c
 
 # User ask — request tracking and turn-end validation
 
-Status: implemented in yolop (`yolop_user_ask` capability). **Disabled by default** —
-enable via `[[capabilities]]` in `settings.toml` or `set_config key=capabilities`.
+Status: implemented in yolop (`yolop_user_ask` capability) and enabled by default.
 
 ## Why
 
@@ -16,16 +15,15 @@ over several turns. The agent needs a durable record of the current request,
 independent of `/goal` completion loops, so it can stay aligned and the host can
 judge whether the latest turn actually addressed what was asked.
 
-`/goal` is for autonomous multi-turn work toward a verifiable end state with
-auto-continuation. User ask is lighter: one tracked request per session, revision
-history when the user pivots, and a post-turn evaluator that reports achieved,
-blocked, or in progress — without starting another turn automatically.
+`/goal` remains the explicit user-authored completion condition. User ask is the
+default safety net: one tracked request per session, revision history on pivots,
+and selective bounded continuation when a turn stops without finishing.
 
 ## Behavior
 
 | Surface | Effect |
 | --- | --- |
-| User message (TUI / `--print`) | Host records the message as the active user ask (superseding the previous ask in revision history). |
+| User message (TUI / `--print` / ACP) | Host records the message as the active user ask (superseding the previous ask in revision history). |
 | `set_user_ask` tool | Agent records or replaces the tracked ask (for refinement or when the user pivots in conversation). |
 | `clear_user_ask` tool | Clears the tracked ask when the user abandons the request. |
 | `/ask <text>` | Set or replace the tracked ask manually. |
@@ -33,61 +31,69 @@ blocked, or in progress — without starting another turn automatically.
 | `/ask clear` | Clear the tracked ask (`stop`, `off`, `reset`, `none`, `cancel` are aliases). |
 | `/clear` | Also clears the tracked user ask (new conversation). |
 
-After each agent turn while a user ask is active:
+After each agent turn while a user ask is active, every host applies the same
+cheap deterministic gate. A successful no-tool final is achieved without an
+evaluator call. Tool/commentary activity with no final is in progress and
+continues automatically. Active detached work is waiting-on-background and does
+not consume turns; its wake continues the same actual ask. Provider errors,
+refusals, and cancellation become failed or blocked and never retry blindly.
 
-1. The host calls an internal evaluator through `CommandHost::completion` — no
-   tools, nothing extra persisted beyond the evaluation result.
-2. The evaluator returns JSON
-   `{"outcome": "achieved"|"blocked"|"in_progress", "reason": "..."}` judged only
-   from the conversation transcript.
-3. The host surfaces the result as a system message (`user ask achieved`, `user ask
-   blocked`, or `user ask in progress`).
-4. Achieved and blocked outcomes deactivate the ask; a new user message starts a
-   fresh ask. In-progress keeps the ask active for the next turn.
+A tool-using turn that produced a candidate final is semantically ambiguous, so
+only then the host calls the tool-less evaluator through `CommandHost::completion`.
+It returns `achieved`, `blocked`, `failed`, `waiting_on_background`, or
+`in_progress`. In-progress work continues from a compact automatic prompt.
 
-Unlike `/goal`, there is no auto-continuation loop.
+Automatic work is capped per user ask at six agent turns, 64,000 provider-reported
+tokens, and ten minutes. Exhaustion leaves the ask active for an explicit user
+resume. A fresh user message resets the budget; automatic wakes do not. Achieved,
+blocked, and failed deactivate the ask. Waiting remains active for its wake.
 
-## Enabling
+## Configuration
 
-Off the default harness. Opt in with:
+The capability is on by default. It can be removed from the harness with:
 
 ```toml
 [[capabilities]]
 ref = "yolop_user_ask"
+enabled = false
 ```
 
-Or conversationally via `set_config key=capabilities json={"ref":"yolop_user_ask"}`.
-Takes effect on the next run.
+The ordinary capability override path takes effect on the next run.
 
 ## System prompt
 
-The capability contributes a `<capability id="yolop_user_ask">` block each turn
-with the current ask, optional revision history, and last evaluation. It instructs
-the model to call `set_user_ask` when the user changes direction.
+An inactive tracker contributes no system-prompt text. While active, it contributes
+only the current compact ask and last evaluation; revision history stays available
+through `/ask` instead of bloating each prompt. Tool schemas remain discoverable
+through the ordinary tool-search path.
 
 ## Hosts
 
 | Host | Support |
 | --- | --- |
-| Interactive TUI | Records user prompts, end-of-turn evaluation, `? ask (N)` status indicator. |
-| `--print` | Records the prompt, evaluates after the turn. |
-| ACP | Tools and `/ask` are listed; end-of-turn evaluation requires the TUI/print host today. |
+| Interactive TUI | Streams each bounded continuation, surfaces state, and shows `? ask (N)`. |
+| `--print` | Runs bounded continuations synchronously; waiting work remains one-shot and requires resume/wake in a live host. |
+| ACP | Streams the same continuation loop; prompt resolves only at a terminal/waiting/budget state. |
 
 ## Persistence
 
 Active asks are stored in `<session_dir>/user_ask.json` so a resumed session
-(`--session`) restores the ask. Evaluated-turn counters reset on resume.
+(`--session`) restores the actual ask and pivot history. Host continuation budgets
+restart on process resume.
 
 ## Independence from `/goal`
 
 - Separate store, capability id, tools, and evaluator.
 - Either capability can be disabled in `[[capabilities]]` without affecting the other.
-- `/goal` may auto-continue turns; user ask only records and evaluates.
+- `/goal` uses the user's explicit completion condition; default continuation uses
+  the latest conversational ask and a smaller fixed budget.
 
 ## Ownership
 
 - `UserAskCapability` and `UserAskStore` live in yolop (`src/capabilities/user_ask.rs`,
   `src/session_state/user_ask.rs`).
+- The shared deterministic gate and budgets live in
+  `src/session_state/task_completion.rs`; hosts own only streaming/projection.
 - Evaluator calls use upstream `CommandHost::completion` (everruns-core).
 
 ## Related

--- a/src/capabilities/context_cost_control.rs
+++ b/src/capabilities/context_cost_control.rs
@@ -89,12 +89,26 @@ fn compact_background_wake_view(messages: Vec<Message>) -> Vec<Message> {
     }
 
     let prefix = &messages[..wake_index];
-    let Some(active_ask) = prefix
-        .iter()
-        .rev()
-        .find(|message| message.role == MessageRole::User && !is_handoff_message(message))
-        .and_then(Message::text)
+    let Some(active_ask) = handoff
+        .active_ask
+        .as_deref()
         .map(|value| truncate(value, MAX_ACTIVE_ASK_BYTES))
+        .or_else(|| {
+            prefix
+                .iter()
+                .rev()
+                .find(|message| {
+                    message.role == MessageRole::User
+                        && !is_handoff_message(message)
+                        && !message.metadata.as_ref().is_some_and(|metadata| {
+                            metadata.contains_key(
+                                crate::session_state::task_completion::CONTINUATION_METADATA_KEY,
+                            )
+                        })
+                })
+                .and_then(Message::text)
+                .map(|value| truncate(value, MAX_ACTIVE_ASK_BYTES))
+        })
     else {
         return messages;
     };
@@ -273,6 +287,7 @@ mod tests {
             HANDOFF_METADATA_KEY.to_string(),
             serde_json::to_value(WakeHandoff {
                 version: 1,
+                active_ask: None,
                 active_goal: Some("ship after green CI".to_string()),
                 tasks,
                 omitted_tasks: 0,
@@ -369,6 +384,7 @@ mod tests {
 
         let missing_summary = WakeHandoff {
             version: 1,
+            active_ask: None,
             active_goal: None,
             tasks: vec![],
             omitted_tasks: 0,

--- a/src/capabilities/user_ask.rs
+++ b/src/capabilities/user_ask.rs
@@ -123,13 +123,12 @@ impl Capability for UserAskCapability {
     }
 
     async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
-        Some(system_prompt_block(&self.store.status(self.session_id)))
+        let block = system_prompt_block(&self.store.status(self.session_id));
+        (!block.is_empty()).then_some(block)
     }
 
     fn system_prompt_preview(&self) -> Option<String> {
-        Some(system_prompt_block(
-            &crate::session_state::user_ask::UserAskStatus { active: None },
-        ))
+        None
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {

--- a/src/editor/acp/mod.rs
+++ b/src/editor/acp/mod.rs
@@ -273,10 +273,31 @@ mod tests {
         Fut: Future<Output = agent_client_protocol::Result<T>> + Send + 'static,
         T: Send + 'static,
     {
+        with_sdk_client_completion(config, false, op).await
+    }
+
+    async fn with_sdk_client_completion<T, F, Fut>(
+        config: LlmSimConfig,
+        completion_tracking: bool,
+        op: F,
+    ) -> T
+    where
+        F: FnOnce(SdkClient) -> Fut + Send + 'static,
+        Fut: Future<Output = agent_client_protocol::Result<T>> + Send + 'static,
+        T: Send + 'static,
+    {
         let (client_w, agent_r) = tokio::io::duplex(64 * 1024);
         let (agent_w, client_r) = tokio::io::duplex(64 * 1024);
         let sessions = tempfile::tempdir().expect("sessions tempdir").keep();
         let settings = Arc::new(SettingsStore::open(sessions.join("settings.toml")));
+        if !completion_tracking {
+            settings
+                .set_capability_enabled(
+                    crate::session_state::user_ask::USER_ASK_CAPABILITY_ID,
+                    false,
+                )
+                .expect("disable completion tracking for unrelated ACP fixture");
+        }
         let factory = Arc::new(ScriptedFactory {
             config,
             sessions_dir: sessions,
@@ -370,7 +391,7 @@ mod tests {
     }
 
     async fn next_json(reader: &mut Lines<BufReader<DuplexStream>>) -> Value {
-        let line = tokio::time::timeout(Duration::from_secs(15), reader.next_line())
+        let line = tokio::time::timeout(Duration::from_secs(30), reader.next_line())
             .await
             .expect("timed out")
             .expect("read line")
@@ -1035,6 +1056,110 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn completion_tracking_pivot_survives_acp_session_resume() {
+        let sessions = tempfile::tempdir().expect("sessions tempdir");
+        let sessions_dir = sessions.path().to_path_buf();
+        let cwd = tempfile::tempdir().expect("cwd tempdir").keep();
+        let (mut first_w, mut first_reader, first_server) =
+            start_raw_server(fixed(""), sessions_dir.clone());
+        send_json(
+            &mut first_w,
+            json!({ "jsonrpc": "2.0", "id": 0, "method": "initialize", "params": { "protocolVersion": 1 } }),
+        )
+        .await;
+        collect_until_response_id(&mut first_reader, 0).await;
+        send_json(
+            &mut first_w,
+            json!({ "jsonrpc": "2.0", "id": 1, "method": "session/new", "params": { "cwd": cwd.to_str().unwrap(), "mcpServers": [] } }),
+        )
+        .await;
+        let (new_session, _) = collect_until_response_id(&mut first_reader, 1).await;
+        let session_id = new_session["result"]["sessionId"]
+            .as_str()
+            .expect("sessionId")
+            .to_string();
+
+        for (id, prompt) in [
+            (2, "original unfinished ask"),
+            (3, "pivoted unfinished ask"),
+        ] {
+            send_json(
+                &mut first_w,
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "method": "session/prompt",
+                    "params": { "sessionId": session_id, "prompt": [{ "type": "text", "text": prompt }] },
+                }),
+            )
+            .await;
+            let (_, updates) = collect_until_response_id(&mut first_reader, id).await;
+            assert!(
+                update_texts(&updates, "agent_message_chunk")
+                    .iter()
+                    .any(|text| text.contains("budget exhausted")),
+                "unfinished ask should stop at the host budget: {updates:?}"
+            );
+        }
+
+        drop(first_w);
+        drop(first_reader);
+        tokio::time::timeout(Duration::from_secs(10), first_server)
+            .await
+            .expect("first server must stop")
+            .expect("first server joins")
+            .expect("first server returns Ok");
+
+        let (mut second_w, mut second_reader, second_server) =
+            start_raw_server(fixed("unused"), sessions_dir);
+        send_json(
+            &mut second_w,
+            json!({ "jsonrpc": "2.0", "id": 10, "method": "initialize", "params": { "protocolVersion": 1 } }),
+        )
+        .await;
+        collect_until_response_id(&mut second_reader, 10).await;
+        send_json(
+            &mut second_w,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 11,
+                "method": "session/load",
+                "params": { "sessionId": session_id, "cwd": cwd.to_str().unwrap(), "mcpServers": [] },
+            }),
+        )
+        .await;
+        collect_until_response_id(&mut second_reader, 11).await;
+        send_json(
+            &mut second_w,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 12,
+                "method": "session/prompt",
+                "params": { "sessionId": session_id, "prompt": [{ "type": "text", "text": "/ask" }] },
+            }),
+        )
+        .await;
+        let (_, ask_updates) = collect_until_response_id(&mut second_reader, 12).await;
+        let ask_text = serde_json::to_string(&ask_updates).expect("serialize ask updates");
+        assert!(
+            ask_text.contains("pivoted unfinished ask"),
+            "resumed tracker must retain the actual pivoted ask: {ask_updates:?}"
+        );
+        assert!(
+            !ask_text.contains("ask: original unfinished ask"),
+            "superseded ask must not resume as current: {ask_updates:?}"
+        );
+
+        drop(second_w);
+        drop(second_reader);
+        tokio::time::timeout(Duration::from_secs(10), second_server)
+            .await
+            .expect("second server must stop")
+            .expect("second server joins")
+            .expect("second server returns Ok");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn full_handshake_then_prompt_streams_text_and_ends_turn() {
         let run = with_sdk_client(fixed("hello from acp"), |client| async move {
             let mut session = client.new_session().await?;
@@ -1274,6 +1399,125 @@ mod tests {
             run.updates
         );
         assert!(run.assistant_text().contains("tool done"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn default_completion_gate_continues_tool_only_stop_to_one_final() {
+        use everruns_core::llmsim_driver::OnExhausted;
+
+        let config = LlmSimConfig::scripted(vec![
+            SimTurn::ToolCalls(vec![SimToolCall {
+                name: "bash".to_string(),
+                arguments: json!({ "command": "true" }),
+                id: None,
+            }]),
+            SimTurn::Assistant(String::new()),
+            SimTurn::Assistant("verified final".to_string()),
+        ])
+        .with_on_exhausted(OnExhausted::Error);
+        let run = with_sdk_client_completion(config, true, |client| async move {
+            let mut session = client.new_session().await?;
+            let _ = collect_available_commands(&mut session).await?;
+            SdkClient::prompt(&mut session, "run the check and report the result").await
+        })
+        .await;
+
+        assert_eq!(run.stop_reason, StopReason::EndTurn);
+        assert!(run.assistant_text().contains("verified final"));
+        assert_eq!(run.assistant_text().matches("verified final").count(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn trivial_exact_reply_uses_one_generation_and_no_evaluator() {
+        use everruns_core::llmsim_driver::OnExhausted;
+
+        let config = LlmSimConfig::scripted(vec![SimTurn::Assistant("exact".to_string())])
+            .with_on_exhausted(OnExhausted::Error);
+        let run = with_sdk_client_completion(config, true, |client| async move {
+            let mut session = client.new_session().await?;
+            let _ = collect_available_commands(&mut session).await?;
+            SdkClient::prompt(&mut session, "reply exactly: exact").await
+        })
+        .await;
+
+        assert_eq!(run.assistant_text(), "exact");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn tool_using_final_pays_one_bounded_semantic_evaluator_call() {
+        use everruns_core::llmsim_driver::OnExhausted;
+
+        // Baseline trivial fixture above consumes one scripted generation.
+        // This mutation fixture consumes two agent-loop generations plus
+        // exactly one evaluator generation; exhaustion makes any regression
+        // beyond that explicit three-call budget fail.
+        let config = LlmSimConfig::scripted(vec![
+            SimTurn::ToolCalls(vec![SimToolCall {
+                name: "bash".to_string(),
+                arguments: json!({ "command": "true" }),
+                id: None,
+            }]),
+            SimTurn::Assistant("candidate final".to_string()),
+            SimTurn::Assistant(r#"{"outcome":"achieved","reason":"validated"}"#.to_string()),
+        ])
+        .with_on_exhausted(OnExhausted::Error);
+        let run = with_sdk_client_completion(config, true, |client| async move {
+            let mut session = client.new_session().await?;
+            let _ = collect_available_commands(&mut session).await?;
+            SdkClient::prompt(&mut session, "make and validate the change").await
+        })
+        .await;
+
+        assert_eq!(run.assistant_text(), "candidate final");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn permanent_provider_failure_is_failed_without_continuation() {
+        use everruns_core::llmsim_driver::{OnExhausted, SimError};
+
+        let config = LlmSimConfig::scripted(vec![SimTurn::Error(SimError::Other(
+            "permanent provider failure".to_string(),
+        ))])
+        .with_on_exhausted(OnExhausted::Error);
+        let run = with_sdk_client_completion(config, true, |client| async move {
+            let mut session = client.new_session().await?;
+            let _ = collect_available_commands(&mut session).await?;
+            SdkClient::prompt(&mut session, "do the work").await
+        })
+        .await;
+
+        assert!(run.assistant_text().contains("task failed"));
+        assert!(!run.assistant_text().contains("budget exhausted"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn clarification_is_blocked_and_not_auto_continued() {
+        use everruns_core::llmsim_driver::OnExhausted;
+
+        let config = LlmSimConfig::scripted(vec![SimTurn::Assistant(
+            "I need the target path. Which file should I edit?".to_string(),
+        )])
+        .with_on_exhausted(OnExhausted::Error);
+        let run = with_sdk_client_completion(config, true, |client| async move {
+            let mut session = client.new_session().await?;
+            let _ = collect_available_commands(&mut session).await?;
+            SdkClient::prompt(&mut session, "edit the file").await
+        })
+        .await;
+
+        assert!(run.assistant_text().contains("task blocked"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn empty_reply_loop_stops_at_host_budget() {
+        let run = with_sdk_client_completion(LlmSimConfig::fixed(""), true, |client| async move {
+            let mut session = client.new_session().await?;
+            let _ = collect_available_commands(&mut session).await?;
+            SdkClient::prompt(&mut session, "finish this").await
+        })
+        .await;
+
+        assert!(run.assistant_text().contains("budget exhausted"));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1564,7 +1808,10 @@ mod tests {
         assert!(candidate_text.contains("validate compact wake"));
         assert!(candidate_text.contains("succeeded"));
         assert!(candidate_text.contains("result.json"));
-        assert!(candidate_text.contains("run the requested validation"));
+        assert!(
+            candidate_text.contains("run the requested validation"),
+            "compact wake lost the tracked ask: {candidate_text}"
+        );
         assert!(!candidate_text.contains("LONG_PARENT_HISTORY_MARKER"));
 
         let durable_events = std::fs::read_to_string(session_dir.join("events.jsonl"))

--- a/src/editor/acp/server.rs
+++ b/src/editor/acp/server.rs
@@ -43,6 +43,8 @@ use crate::config::{ApprovalMode, SettingsStore};
 use crate::exec::worktree::WorktreeManager;
 use crate::runtime::background_wake::{WakeReceiver, coalesce_pending_wakes, frame_wake_prompt};
 use crate::runtime::{BuiltRuntime, ModelState, RuntimeHandles};
+use crate::session_state::task_completion::{CompletionBudget, GateDecision};
+use crate::session_state::user_ask::{AskOutcome, UserAskStore};
 
 use super::bridge::{Translator, tool_kind};
 use super::modes;
@@ -251,6 +253,10 @@ struct Session {
     last_mode: StdMutex<ApprovalMode>,
     /// Retained for the ACP session lifetime so due local schedules keep polling.
     _schedule_runner: everruns_local::LocalScheduleRunnerHandle,
+    user_ask_store: Arc<UserAskStore>,
+    user_ask_enabled: bool,
+    task_registry: Arc<dyn everruns_core::session_task::SessionTaskRegistry>,
+    completion_budget: StdMutex<CompletionBudget>,
     /// Serializes turns for this session. Both a client prompt and a background
     /// wake turn take it, so two `run_turn`s never overlap.
     turn_lock: tokio::sync::Mutex<()>,
@@ -617,6 +623,9 @@ fn register_session<F: RuntimeFactory>(
 ) -> String {
     let acp_id = built.handles.session_id.to_string();
     let commands = built.startup.capability_commands.clone();
+    let user_ask_store = built.user_ask_store.clone();
+    let user_ask_enabled = built.user_ask_enabled;
+    let task_registry = built.task_registry.clone();
     let session = Arc::new(Session {
         acp_id: acp_id.clone(),
         handles: built.handles,
@@ -628,6 +637,10 @@ fn register_session<F: RuntimeFactory>(
         settings: built.settings,
         goal_store: built.goal_store,
         _schedule_runner: built.schedule_runner,
+        user_ask_store,
+        user_ask_enabled,
+        task_registry,
+        completion_budget: StdMutex::new(CompletionBudget::default()),
         turn_lock: tokio::sync::Mutex::new(()),
     });
     server
@@ -677,11 +690,17 @@ fn spawn_background_wake_drain(
             let _turn = session.turn_lock.lock().await;
             // Completions that accumulated while the foreground turn held the
             // lock are one observation point, not separate model obligations.
-            let message = coalesce_pending_wakes(message, &mut wake_rx).with_active_goal(
-                session
-                    .goal_store
-                    .active_condition(session.handles.session_id),
-            );
+            let message = coalesce_pending_wakes(message, &mut wake_rx)
+                .with_active_goal(
+                    session
+                        .goal_store
+                        .active_condition(session.handles.session_id),
+                )
+                .with_active_ask(
+                    session
+                        .user_ask_store
+                        .active_text(session.handles.session_id),
+                );
             if !session.settings.snapshot().proactive_wake_enabled() {
                 peer.session_update(
                     &session.acp_id,
@@ -817,7 +836,17 @@ async fn handle_prompt<F: RuntimeFactory>(
     // reuse it under its own guard.
     let _turn = session.turn_lock.lock().await;
     let mode_peer = peer.clone();
-    let stop_reason = match parse_command_prompt(&prompt) {
+    let parsed_command = parse_command_prompt(&prompt);
+    if parsed_command.is_none() && session.user_ask_enabled {
+        if let Err(err) = session
+            .user_ask_store
+            .record_user_prompt(session.handles.session_id, &prompt)
+        {
+            tracing::warn!(%err, "acp: record user ask failed");
+        }
+        session.completion_budget.lock().unwrap().reset();
+    }
+    let stop_reason = match parsed_command {
         Some(command) => run_slash_command(peer, session.clone(), command).await,
         None => run_prompt(peer, session.clone(), prompt, input).await,
     };
@@ -1155,9 +1184,47 @@ fn prompt_image_parts(blocks: &[protocol::ContentBlock]) -> Vec<ContentPart> {
 async fn run_prompt(
     peer: Arc<Peer>,
     session: Arc<Session>,
+    mut prompt: String,
+    mut input: InputMessage,
+) -> StopReason {
+    loop {
+        let (stop, result) = run_prompt_once(peer.clone(), session.clone(), prompt, input).await;
+        if stop == StopReason::Cancelled {
+            return stop;
+        }
+        let Some(result) = result else {
+            if session.user_ask_enabled
+                && session.user_ask_store.is_active(session.handles.session_id)
+            {
+                let evaluation = crate::session_state::task_completion::evaluation_for_state(
+                    crate::session_state::task_completion::CompletionState::Failed,
+                );
+                let _ = session
+                    .user_ask_store
+                    .record_evaluation(session.handles.session_id, &evaluation);
+                peer.session_update(
+                    &session.acp_id,
+                    SessionUpdate::AgentMessageChunk(protocol::text_chunk("task failed")),
+                );
+            }
+            return stop;
+        };
+        let Some(next) = completion_followup(&peer, &session, &result).await else {
+            return stop;
+        };
+        prompt = next;
+        input = crate::session_state::task_completion::tag_continuation(
+            session.model.input_message(prompt.clone()),
+        );
+    }
+}
+
+async fn run_prompt_once(
+    peer: Arc<Peer>,
+    session: Arc<Session>,
     prompt: String,
     input: InputMessage,
-) -> StopReason {
+) -> (StopReason, Option<everruns_runtime::TurnResult>) {
     let handles = session.handles.clone();
     let session_id = handles.session_id;
     let acp_id = session.acp_id.clone();
@@ -1219,7 +1286,7 @@ async fn run_prompt(
         // remaining events are ignored.
         turn.abort();
         handles.report_herdr_state(crate::capabilities::herdr::HerdrState::Idle);
-        return StopReason::Cancelled;
+        return (StopReason::Cancelled, None);
     }
 
     let outcome = turn.await;
@@ -1230,9 +1297,9 @@ async fn run_prompt(
         );
     }
     match outcome {
-        Ok(Ok(result)) if result.success => StopReason::EndTurn,
+        Ok(Ok(result)) if result.success => (StopReason::EndTurn, Some(result)),
         Ok(Ok(result)) => {
-            if let Some(error) = result.error {
+            if let Some(error) = &result.error {
                 peer.session_update(
                     &acp_id,
                     SessionUpdate::AgentMessageChunk(protocol::text_chunk(format!(
@@ -1240,7 +1307,7 @@ async fn run_prompt(
                     ))),
                 );
             }
-            StopReason::EndTurn
+            (StopReason::EndTurn, Some(result))
         }
         Ok(Err(err)) => {
             peer.session_update(
@@ -1249,9 +1316,111 @@ async fn run_prompt(
                     "turn failed: {err}"
                 ))),
             );
-            StopReason::EndTurn
+            (StopReason::EndTurn, None)
         }
-        Err(_) => StopReason::Cancelled,
+        Err(_) => (StopReason::Cancelled, None),
+    }
+}
+
+async fn completion_followup(
+    peer: &Arc<Peer>,
+    session: &Arc<Session>,
+    result: &everruns_runtime::TurnResult,
+) -> Option<String> {
+    let session_id = session.handles.session_id;
+    if !session.user_ask_enabled || !session.user_ask_store.is_active(session_id) {
+        return None;
+    }
+    let tokens = session.handles.turn_tokens(result.turn_id).await;
+    if !session
+        .completion_budget
+        .lock()
+        .unwrap()
+        .observe_turn(tokens)
+    {
+        peer.session_update(
+            &session.acp_id,
+            SessionUpdate::AgentMessageChunk(protocol::text_chunk(
+                "user ask budget exhausted; send another prompt to resume",
+            )),
+        );
+        return None;
+    }
+    let has_background = session
+        .task_registry
+        .list(session_id, None)
+        .await
+        .unwrap_or_default()
+        .iter()
+        .any(|task| !task.state.is_terminal());
+
+    let evaluation = match crate::session_state::task_completion::gate_turn(result, has_background)
+    {
+        GateDecision::Evaluate => {
+            let command = session
+                .handles
+                .runtime
+                .execute_command(
+                    session_id,
+                    ExecuteCommandRequest {
+                        name: "ask".to_string(),
+                        arguments: Some(
+                            crate::session_state::user_ask::USER_ASK_EVALUATE_ARG.to_string(),
+                        ),
+                        controls: None,
+                    },
+                )
+                .await
+                .ok()?;
+            if !command.success {
+                return None;
+            }
+            crate::session_state::user_ask::parse_evaluation_response(&command.message).ok()?
+        }
+        GateDecision::Conclusive(state) => {
+            let evaluation = crate::session_state::task_completion::evaluation_for_state(state);
+            if session
+                .user_ask_store
+                .record_evaluation(session_id, &evaluation)
+                .is_err()
+            {
+                return None;
+            }
+            evaluation
+        }
+    };
+
+    match evaluation.outcome {
+        AskOutcome::InProgress => Some(crate::session_state::task_completion::continuation_prompt(
+            &evaluation.reason,
+        )),
+        AskOutcome::Blocked => {
+            session
+                .handles
+                .report_herdr_state(crate::capabilities::herdr::HerdrState::Blocked);
+            peer.session_update(
+                &session.acp_id,
+                SessionUpdate::AgentMessageChunk(protocol::text_chunk("task blocked")),
+            );
+            None
+        }
+        AskOutcome::Failed => {
+            peer.session_update(
+                &session.acp_id,
+                SessionUpdate::AgentMessageChunk(protocol::text_chunk("task failed")),
+            );
+            None
+        }
+        AskOutcome::WaitingOnBackground => {
+            peer.session_update(
+                &session.acp_id,
+                SessionUpdate::AgentMessageChunk(protocol::text_chunk(
+                    "task waiting on background",
+                )),
+            );
+            None
+        }
+        AskOutcome::Achieved => None,
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1486,6 +1486,7 @@ async fn run_print_mode(
         goal_store,
         user_ask_store,
         user_ask_enabled,
+        task_registry,
         worktree,
         ..
     } = runtime;
@@ -1521,33 +1522,100 @@ async fn run_print_mode(
         eprintln!("user ask: {err}");
     }
 
-    let turn = collect_print_turn(&handles, &worktree, &model, trimmed, images).await?;
-    print_final_output(&turn.output);
-    if !turn.result.success {
-        write_trajectory_if_requested(&handles, &model, trajectory_out.as_deref()).await;
-        std::process::exit(1);
-    }
-    if user_ask_enabled && user_ask_store.is_active(handles.session_id) {
-        let evaluation = handles
-            .runtime
-            .execute_command(
-                handles.session_id,
-                ExecuteCommandRequest {
-                    name: "ask".to_string(),
-                    arguments: Some(session_state::user_ask::USER_ASK_EVALUATE_ARG.to_string()),
-                    controls: None,
-                },
-            )
-            .await?;
-        if evaluation.success {
-            if let Ok(parsed) =
-                session_state::user_ask::parse_evaluation_response(&evaluation.message)
-                && parsed.outcome == session_state::user_ask::AskOutcome::Blocked
+    let mut prompt = trimmed.to_string();
+    let mut turn_images = images;
+    let mut automatic = false;
+    let mut budget = session_state::task_completion::CompletionBudget::default();
+    loop {
+        let turn =
+            match collect_print_turn(&handles, &worktree, &model, &prompt, turn_images, automatic)
+                .await
             {
-                handles.report_herdr_state(capabilities::herdr::HerdrState::Blocked);
+                Ok(turn) => turn,
+                Err(err) => {
+                    if user_ask_enabled && user_ask_store.is_active(handles.session_id) {
+                        let evaluation = session_state::task_completion::evaluation_for_state(
+                            session_state::task_completion::CompletionState::Failed,
+                        );
+                        user_ask_store.record_evaluation(handles.session_id, &evaluation)?;
+                    }
+                    return Err(err);
+                }
+            };
+        print_final_output(&turn.output);
+        if !turn.result.success {
+            if user_ask_enabled && user_ask_store.is_active(handles.session_id) {
+                let evaluation = session_state::task_completion::evaluation_for_state(
+                    session_state::task_completion::CompletionState::Failed,
+                );
+                user_ask_store.record_evaluation(handles.session_id, &evaluation)?;
+                eprintln!(
+                    "{}",
+                    session_state::user_ask::evaluation_status_message(&evaluation)
+                );
             }
-        } else {
-            eprintln!("user ask evaluation failed: {}", evaluation.message);
+            write_trajectory_if_requested(&handles, &model, trajectory_out.as_deref()).await;
+            std::process::exit(1);
+        }
+        if !user_ask_enabled || !user_ask_store.is_active(handles.session_id) {
+            break;
+        }
+
+        let tokens = handles.turn_tokens(turn.result.turn_id).await;
+        if !budget.observe_turn(tokens) {
+            eprintln!("user ask budget exhausted; use --session to resume");
+            break;
+        }
+        let has_background = task_registry
+            .list(handles.session_id, None)
+            .await
+            .unwrap_or_default()
+            .iter()
+            .any(|task| !task.state.is_terminal());
+        let (outcome, reason) =
+            match session_state::task_completion::gate_turn(&turn.result, has_background) {
+                session_state::task_completion::GateDecision::Conclusive(state) => {
+                    let evaluation = session_state::task_completion::evaluation_for_state(state);
+                    user_ask_store.record_evaluation(handles.session_id, &evaluation)?;
+                    (evaluation.outcome, evaluation.reason)
+                }
+                session_state::task_completion::GateDecision::Evaluate => {
+                    let evaluation = handles
+                        .runtime
+                        .execute_command(
+                            handles.session_id,
+                            ExecuteCommandRequest {
+                                name: "ask".to_string(),
+                                arguments: Some(
+                                    session_state::user_ask::USER_ASK_EVALUATE_ARG.to_string(),
+                                ),
+                                controls: None,
+                            },
+                        )
+                        .await?;
+                    if !evaluation.success {
+                        eprintln!("user ask evaluation failed: {}", evaluation.message);
+                        break;
+                    }
+                    let parsed =
+                        session_state::user_ask::parse_evaluation_response(&evaluation.message)?;
+                    (parsed.outcome, parsed.reason)
+                }
+            };
+
+        match outcome {
+            session_state::user_ask::AskOutcome::InProgress => {
+                prompt = session_state::task_completion::continuation_prompt(&reason);
+                turn_images = Vec::new();
+                automatic = true;
+            }
+            session_state::user_ask::AskOutcome::Blocked => {
+                handles.report_herdr_state(capabilities::herdr::HerdrState::Blocked);
+                break;
+            }
+            session_state::user_ask::AskOutcome::Achieved
+            | session_state::user_ask::AskOutcome::Failed
+            | session_state::user_ask::AskOutcome::WaitingOnBackground => break,
         }
     }
     write_trajectory_if_requested(&handles, &model, trajectory_out.as_deref()).await;
@@ -1592,7 +1660,8 @@ async fn run_print_goal(
     };
 
     loop {
-        let turn = collect_print_turn(handles, worktree, model, &turn_prompt, vec![]).await?;
+        let turn =
+            collect_print_turn(handles, worktree, model, &turn_prompt, vec![], false).await?;
         if !turn.result.success {
             print_final_output(&turn.output);
             return Ok(false);
@@ -1639,6 +1708,7 @@ async fn collect_print_turn(
     model: &runtime::ModelState,
     prompt: &str,
     images: Vec<ContentPart>,
+    automatic: bool,
 ) -> Result<PrintTurn> {
     if let Err(err) = worktree.ensure_before_turn(prompt) {
         eprintln!("worktree: {err}");
@@ -1650,7 +1720,10 @@ async fn collect_print_turn(
         .map(|m| m.len())
         .unwrap_or(0);
 
-    let input = model.input_message_with_images(prompt, images);
+    let mut input = model.input_message_with_images(prompt, images);
+    if automatic {
+        input = session_state::task_completion::tag_continuation(input);
+    }
     let result = handles.run_checkpointed_turn(prompt, input).await?;
     if let Some(notice) = handles.checkpoints.take_notice() {
         eprintln!("{notice}");

--- a/src/runtime/background_wake.rs
+++ b/src/runtime/background_wake.rs
@@ -62,6 +62,8 @@ pub(crate) struct TaskHandoff {
 pub(crate) struct WakeHandoff {
     pub version: u8,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_ask: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub active_goal: Option<String>,
     pub tasks: Vec<TaskHandoff>,
     #[serde(default, skip_serializing_if = "is_zero")]
@@ -91,6 +93,13 @@ impl WakeMessage {
         }
         self
     }
+
+    pub(crate) fn with_active_ask(mut self, ask: Option<String>) -> Self {
+        if let Some(handoff) = self.handoff.as_mut() {
+            handoff.active_ask = ask.map(|value| truncate_field(&value));
+        }
+        self
+    }
 }
 
 /// Drain the completions already queued for one idle host into one model turn.
@@ -117,6 +126,7 @@ pub(crate) fn coalesce_pending_wakes(
     let mut task_bytes = 0usize;
     let mut omitted_tasks = 0usize;
     let mut compact = true;
+    let mut active_ask = None;
     let mut active_goal = None;
     for (index, item) in messages.into_iter().enumerate() {
         let section = format!("\n\n--- task {} ---\n{}", index + 1, item.raw);
@@ -127,6 +137,7 @@ pub(crate) fn coalesce_pending_wakes(
         }
         match item.handoff {
             Some(handoff) => {
+                active_ask = active_ask.or(handoff.active_ask);
                 active_goal = active_goal.or(handoff.active_goal);
                 omitted_tasks = omitted_tasks.saturating_add(handoff.omitted_tasks);
                 for task in handoff.tasks {
@@ -151,6 +162,7 @@ pub(crate) fn coalesce_pending_wakes(
         raw,
         handoff: compact.then_some(WakeHandoff {
             version: 1,
+            active_ask,
             active_goal,
             tasks,
             omitted_tasks,
@@ -265,6 +277,7 @@ impl WakeRunner {
             raw: truncate_bytes(content, MAX_WAKE_BATCH_BYTES),
             handoff: task.and_then(task_handoff).map(|task| WakeHandoff {
                 version: 1,
+                active_ask: None,
                 active_goal,
                 tasks: vec![task],
                 omitted_tasks: 0,
@@ -740,6 +753,7 @@ mod tests {
             raw: "completion".to_string(),
             handoff: Some(WakeHandoff {
                 version: 1,
+                active_ask: None,
                 active_goal: None,
                 tasks: vec![task],
                 omitted_tasks: 0,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2128,6 +2128,9 @@ fn default_coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabi
         // `/btw` — ephemeral side question, answered out-of-band with the
         // session's context (upstream `BtwCapability`).
         AgentCapabilityConfig::new(BTW_CAPABILITY_ID),
+        // Host-side completion tracking is cheap while inactive and prevents
+        // tool/commentary-only turns from silently ending a user request.
+        AgentCapabilityConfig::new(USER_ASK_CAPABILITY_ID),
         // `/goal` — keep working across turns until a model-evaluated condition holds.
         AgentCapabilityConfig::new(GOAL_CAPABILITY_ID),
         // Soft approval: injects spoken-consent guidance for critical actions,
@@ -2235,7 +2238,7 @@ pub struct BuiltRuntime {
     pub model: ModelState,
     pub goal_store: Arc<GoalStore>,
     pub user_ask_store: Arc<UserAskStore>,
-    /// Whether `yolop_user_ask` is on the session harness (off by default).
+    /// Whether `yolop_user_ask` is on the session harness (on by default).
     pub user_ask_enabled: bool,
     pub worktree: Arc<WorktreeManager>,
     /// Settings store shared with the runtime capabilities. The TUI uses it
@@ -2333,6 +2336,31 @@ impl RuntimeHandles {
         }
         self.checkpoints.apply_queued_confirmation().await;
         Ok(result?)
+    }
+
+    /// Provider-reported tokens consumed by one agent turn. Completion gates
+    /// use the durable event stream so TUI, print, and ACP share one budget
+    /// accounting rule.
+    pub(crate) async fn turn_tokens(&self, turn_id: everruns_core::typed_id::TurnId) -> u64 {
+        self.runtime
+            .events()
+            .await
+            .unwrap_or_default()
+            .iter()
+            .filter(|event| event.context.turn_id == Some(turn_id))
+            .filter_map(|event| match &event.data {
+                everruns_core::events::EventData::LlmGeneration(data) => {
+                    data.metadata.usage.as_ref()
+                }
+                _ => None,
+            })
+            .map(|usage| {
+                u64::from(usage.input_tokens)
+                    + u64::from(usage.output_tokens)
+                    + u64::from(usage.cache_read_tokens.unwrap_or(0))
+                    + u64::from(usage.cache_creation_tokens.unwrap_or(0))
+            })
+            .sum()
     }
 
     /// Re-read the merged MCP server config (global settings + workspace
@@ -4753,12 +4781,12 @@ mod tests {
     }
 
     #[test]
-    fn coding_harness_excludes_user_ask_by_default() {
+    fn coding_harness_enables_user_ask_by_default() {
         let ids = coding_harness_capabilities(false, None, &Settings::default());
         assert!(
-            !ids.iter()
+            ids.iter()
                 .any(|cap| cap.capability_id() == USER_ASK_CAPABILITY_ID),
-            "user ask should be opt-in via settings"
+            "user ask completion tracking should be on by default"
         );
     }
 

--- a/src/runtime/session.rs
+++ b/src/runtime/session.rs
@@ -65,6 +65,10 @@ impl Session {
         self.handles.report_herdr_state(state);
     }
 
+    pub(crate) async fn turn_tokens(&self, turn_id: everruns_core::typed_id::TurnId) -> u64 {
+        self.handles.turn_tokens(turn_id).await
+    }
+
     /// Re-read the merged MCP server config and swap it into the live session
     /// so add / remove / enable / disable apply on the next turn without a
     /// restart. Returns the sorted names now active. See
@@ -183,7 +187,7 @@ impl Session {
                 Ok(m) => m.len(),
                 Err(e) => {
                     let _ = tx.send(TurnEvent::Failed(format!("load history: {e}")));
-                    let _ = tx.send(TurnEvent::Done);
+                    let _ = tx.send(TurnEvent::Done(None));
                     return;
                 }
             };
@@ -263,7 +267,7 @@ impl Session {
                     author: Author::System,
                     text: "turn cancelled".into(),
                 }]));
-                let _ = tx.send(TurnEvent::Done);
+                let _ = tx.send(TurnEvent::Done(None));
                 return;
             }
 
@@ -291,7 +295,7 @@ impl Session {
                 Ok(result) => result,
                 Err(e) => {
                     let _ = tx.send(TurnEvent::Failed(format!("turn task: {e}")));
-                    let _ = tx.send(TurnEvent::Done);
+                    let _ = tx.send(TurnEvent::Done(None));
                     return;
                 }
             };
@@ -299,7 +303,7 @@ impl Session {
                 Ok(r) => r,
                 Err(e) => {
                     let _ = tx.send(TurnEvent::Failed(format!("{e}")));
-                    let _ = tx.send(TurnEvent::Done);
+                    let _ = tx.send(TurnEvent::Done(None));
                     return;
                 }
             };
@@ -315,11 +319,11 @@ impl Session {
             if out.is_empty() && !response.response.is_empty() {
                 out.push(ChatLine {
                     author: Author::Assistant,
-                    text: response.response,
+                    text: response.response.clone(),
                 });
             }
             if !response.success
-                && let Some(err) = response.error
+                && let Some(err) = &response.error
             {
                 out.push(ChatLine {
                     author: Author::System,
@@ -327,7 +331,7 @@ impl Session {
                 });
             }
             let _ = tx.send(TurnEvent::Lines(out));
-            let _ = tx.send(TurnEvent::Done);
+            let _ = tx.send(TurnEvent::Done(Some(response)));
         });
 
         TurnHandle {
@@ -373,7 +377,7 @@ impl Session {
                     }]));
                 }
             }
-            let _ = tx.send(TurnEvent::Done);
+            let _ = tx.send(TurnEvent::Done(None));
         });
 
         TurnHandle {

--- a/src/session_state/mod.rs
+++ b/src/session_state/mod.rs
@@ -6,4 +6,5 @@
 pub mod atif;
 pub mod checkpoint;
 pub mod goal;
+pub mod task_completion;
 pub mod user_ask;

--- a/src/session_state/task_completion.rs
+++ b/src/session_state/task_completion.rs
@@ -1,0 +1,230 @@
+//! Cheap end-of-turn completion gate shared by TUI, print, and ACP hosts.
+
+use std::time::{Duration, Instant};
+
+use everruns_core::turn::TurnStopReason;
+
+pub(crate) const MAX_TASK_TURNS: u32 = 6;
+pub(crate) const MAX_TASK_TOKENS: u64 = 64_000;
+pub(crate) const MAX_TASK_ELAPSED: Duration = Duration::from_secs(10 * 60);
+pub(crate) const CONTINUATION_TAG: &str = "automatic_task_continuation";
+pub(crate) const CONTINUATION_METADATA_KEY: &str = "yolop.task_continuation";
+
+pub(crate) fn tag_continuation(
+    mut input: everruns_core::message_retriever::InputMessage,
+) -> everruns_core::message_retriever::InputMessage {
+    input.tags.push(CONTINUATION_TAG.to_string());
+    input.metadata.get_or_insert_default().insert(
+        CONTINUATION_METADATA_KEY.to_string(),
+        serde_json::Value::Bool(true),
+    );
+    input
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CompletionState {
+    Achieved,
+    Blocked,
+    Failed,
+    WaitingOnBackground,
+    InProgress,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum GateDecision {
+    Conclusive(CompletionState),
+    /// Tool-using work produced a candidate final answer. Mutations and
+    /// multi-step work are ambiguous enough to justify semantic evaluation.
+    Evaluate,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct CompletionBudget {
+    started: Instant,
+    turns: u32,
+    tokens: u64,
+}
+
+impl Default for CompletionBudget {
+    fn default() -> Self {
+        Self {
+            started: Instant::now(),
+            turns: 0,
+            tokens: 0,
+        }
+    }
+}
+
+impl CompletionBudget {
+    pub(crate) fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    pub(crate) fn observe_turn(&mut self, tokens: u64) -> bool {
+        self.turns = self.turns.saturating_add(1);
+        self.tokens = self.tokens.saturating_add(tokens);
+        self.turns <= MAX_TASK_TURNS
+            && self.tokens <= MAX_TASK_TOKENS
+            && self.started.elapsed() <= MAX_TASK_ELAPSED
+    }
+
+    #[cfg(test)]
+    pub(crate) fn usage(&self) -> (u32, u64) {
+        (self.turns, self.tokens)
+    }
+}
+
+pub(crate) fn gate_turn(
+    result: &everruns_runtime::TurnResult,
+    has_active_background: bool,
+) -> GateDecision {
+    if !result.success {
+        return GateDecision::Conclusive(match result.stop_reason {
+            TurnStopReason::Cancelled => CompletionState::Blocked,
+            _ => CompletionState::Failed,
+        });
+    }
+
+    match result.stop_reason {
+        TurnStopReason::Error | TurnStopReason::Refusal => {
+            return GateDecision::Conclusive(CompletionState::Failed);
+        }
+        TurnStopReason::Cancelled => {
+            return GateDecision::Conclusive(CompletionState::Blocked);
+        }
+        TurnStopReason::MaxTokens | TurnStopReason::MaxTurnRequests => {
+            return GateDecision::Conclusive(CompletionState::InProgress);
+        }
+        TurnStopReason::EndTurn => {}
+    }
+
+    if has_active_background && result.tool_calls_count > 0 {
+        return GateDecision::Conclusive(CompletionState::WaitingOnBackground);
+    }
+
+    if result.response.trim().is_empty() {
+        return GateDecision::Conclusive(CompletionState::InProgress);
+    }
+
+    let normalized = result.response.trim().to_ascii_lowercase();
+    if normalized.ends_with('?')
+        && ["need", "which", "what", "could you", "please provide"]
+            .iter()
+            .any(|marker| normalized.contains(marker))
+    {
+        return GateDecision::Conclusive(CompletionState::Blocked);
+    }
+
+    if result.tool_calls_count == 0 {
+        GateDecision::Conclusive(CompletionState::Achieved)
+    } else {
+        GateDecision::Evaluate
+    }
+}
+
+pub(crate) fn continuation_prompt(reason: &str) -> String {
+    let reason = reason.trim();
+    if reason.is_empty() {
+        "[automatic] Continue the active user request from the compact conversation state. Make concrete progress and provide exactly one final answer when finished.".to_string()
+    } else {
+        format!(
+            "[automatic] Continue the active user request from the compact conversation state. {reason} Make concrete progress and provide exactly one final answer when finished."
+        )
+    }
+}
+
+pub(crate) fn evaluation_for_state(
+    state: CompletionState,
+) -> crate::session_state::user_ask::UserAskEvaluation {
+    use crate::session_state::user_ask::AskOutcome;
+    let (outcome, reason) = match state {
+        CompletionState::Achieved => (AskOutcome::Achieved, "final answer delivered"),
+        CompletionState::Blocked => (
+            AskOutcome::Blocked,
+            "turn was cancelled or needs user input",
+        ),
+        CompletionState::Failed => (AskOutcome::Failed, "turn ended with a permanent failure"),
+        CompletionState::WaitingOnBackground => (
+            AskOutcome::WaitingOnBackground,
+            "detached work is still running",
+        ),
+        CompletionState::InProgress => {
+            (AskOutcome::InProgress, "turn ended without a final answer")
+        }
+    };
+    crate::session_state::user_ask::UserAskEvaluation {
+        outcome,
+        reason: reason.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::typed_id::TurnId;
+
+    fn result(response: &str, tools: usize, success: bool) -> everruns_runtime::TurnResult {
+        everruns_runtime::TurnResult {
+            response: response.to_string(),
+            iterations: 1,
+            tool_calls_count: tools,
+            success,
+            error: (!success).then(|| "permanent provider error".to_string()),
+            stop_reason: if success {
+                TurnStopReason::EndTurn
+            } else {
+                TurnStopReason::Error
+            },
+            turn_id: TurnId::new(),
+        }
+    }
+
+    #[test]
+    fn trivial_final_is_achieved_without_evaluator() {
+        assert_eq!(
+            gate_turn(&result("hello", 0, true), false),
+            GateDecision::Conclusive(CompletionState::Achieved)
+        );
+    }
+
+    #[test]
+    fn tool_only_turn_continues_unless_background_is_running() {
+        assert_eq!(
+            gate_turn(&result("", 1, true), false),
+            GateDecision::Conclusive(CompletionState::InProgress)
+        );
+        assert_eq!(
+            gate_turn(&result("", 1, true), true),
+            GateDecision::Conclusive(CompletionState::WaitingOnBackground)
+        );
+    }
+
+    #[test]
+    fn tool_using_candidate_final_warrants_semantic_evaluation() {
+        assert_eq!(
+            gate_turn(&result("done", 1, true), false),
+            GateDecision::Evaluate
+        );
+    }
+
+    #[test]
+    fn permanent_failure_never_continues() {
+        assert_eq!(
+            gate_turn(&result("", 0, false), false),
+            GateDecision::Conclusive(CompletionState::Failed)
+        );
+    }
+
+    #[test]
+    fn budget_is_strict_for_turns_and_tokens() {
+        let mut budget = CompletionBudget::default();
+        for _ in 0..MAX_TASK_TURNS {
+            assert!(budget.observe_turn(1));
+        }
+        assert!(!budget.observe_turn(1));
+
+        budget.reset();
+        assert!(!budget.observe_turn(MAX_TASK_TOKENS + 1));
+        assert_eq!(budget.usage(), (1, MAX_TASK_TOKENS + 1));
+    }
+}

--- a/src/session_state/user_ask.rs
+++ b/src/session_state/user_ask.rs
@@ -2,7 +2,7 @@
 //!
 //! Records what the user is asking for, allows updates when they change direction,
 //! and evaluates after each turn whether the ask was achieved, blocked, or still
-//! in progress. Independent of `/goal` — no auto-continuation loop.
+//! in progress. The default host completion gate may selectively continue it.
 
 use anyhow::{Context, Result, bail};
 use everruns_core::command::{CommandExecutionContext, ExecuteCommandRequest};
@@ -21,6 +21,7 @@ pub(crate) const USER_ASK_EVALUATE_ARG: &str = "\x00evaluate";
 
 pub(crate) const MAX_USER_ASK_LEN: usize = 4_000;
 pub(crate) const MAX_USER_ASK_REVISIONS: usize = 8;
+const MAX_EVALUATION_REASON_CHARS: usize = 1_000;
 
 const USER_ASK_FILE: &str = "user_ask.json";
 
@@ -30,11 +31,13 @@ transcript below. You cannot run commands or read files independently — judge 
 only what the agent has already surfaced in the conversation.\n\
 \n\
 Respond with exactly one JSON object and no other text:\n\
-{\"outcome\": \"achieved\"|\"blocked\"|\"in_progress\", \"reason\": \"short explanation\"}\n\
+{\"outcome\": \"achieved\"|\"blocked\"|\"failed\"|\"waiting_on_background\"|\"in_progress\", \"reason\": \"short explanation\"}\n\
 \n\
 - `achieved`: the user's request is clearly satisfied from the transcript.\n\
 - `blocked`: the agent hit a blocker that needs user input, permission, or an \
 external dependency before work can continue.\n\
+- `failed`: a permanent error ended the work; retrying will not help.\n\
+- `waiting_on_background`: detached work is running and its completion will wake the agent.\n\
 - `in_progress`: work is underway but not finished and no hard blocker is evident.";
 
 const CLEAR_ALIASES: &[&str] = &["clear", "stop", "off", "reset", "none", "cancel"];
@@ -44,6 +47,8 @@ const CLEAR_ALIASES: &[&str] = &["clear", "stop", "off", "reset", "none", "cance
 pub(crate) enum AskOutcome {
     Achieved,
     Blocked,
+    Failed,
+    WaitingOnBackground,
     InProgress,
 }
 
@@ -52,6 +57,8 @@ impl AskOutcome {
         match value.trim().to_ascii_lowercase().as_str() {
             "achieved" | "done" | "complete" | "completed" => Some(Self::Achieved),
             "blocked" | "blocker" | "stuck" => Some(Self::Blocked),
+            "failed" | "failure" | "permanent_error" => Some(Self::Failed),
+            "waiting_on_background" | "waiting" | "background" => Some(Self::WaitingOnBackground),
             "in_progress" | "in-progress" | "progress" | "ongoing" | "pending" => {
                 Some(Self::InProgress)
             }
@@ -63,6 +70,8 @@ impl AskOutcome {
         match self {
             Self::Achieved => "achieved",
             Self::Blocked => "blocked",
+            Self::Failed => "failed",
+            Self::WaitingOnBackground => "waiting_on_background",
             Self::InProgress => "in_progress",
         }
     }
@@ -276,7 +285,7 @@ impl UserAskStore {
         runtime.persisted.last_reason = Some(evaluation.reason.clone());
         if matches!(
             evaluation.outcome,
-            AskOutcome::Achieved | AskOutcome::Blocked
+            AskOutcome::Achieved | AskOutcome::Blocked | AskOutcome::Failed
         ) {
             runtime.persisted.active = false;
         }
@@ -351,25 +360,7 @@ pub(crate) fn format_status(status: &UserAskStatus) -> String {
 
 pub(crate) fn system_prompt_block(status: &UserAskStatus) -> String {
     let Some(active) = &status.active else {
-        return "<capability id=\"yolop_user_ask\">\n\
-When the user states or changes what they want, call `set_user_ask` with a concise \
-summary of their request. The host also records raw user messages, but refine or \
-replace the tracked ask when the user pivots or clarifies. Use `clear_user_ask` only \
-when the user explicitly abandons the request.\n\
-After each turn the host evaluates whether the ask was achieved, blocked, or still \
-in progress — keep working until achieved or a blocker is clear.\n\
-</capability>"
-            .to_string();
-    };
-    let revisions = if active.revisions.is_empty() {
-        String::new()
-    } else {
-        let lines: Vec<String> = active
-            .revisions
-            .iter()
-            .map(|revision| format!("- {}", revision.text))
-            .collect();
-        format!("\nPrevious asks (superseded):\n{}\n", lines.join("\n"))
+        return String::new();
     };
     let evaluation = active
         .last_reason
@@ -387,7 +378,6 @@ in progress — keep working until achieved or a blocker is clear.\n\
         "<capability id=\"yolop_user_ask\">\n\
 Track and satisfy the user's request. Call `set_user_ask` when they change direction; \
 `clear_user_ask` only when they abandon it.\n\
-{revisions}\
 Current user ask: {}\n\
 {evaluation}\
 </capability>",
@@ -469,7 +459,7 @@ pub(crate) fn parse_evaluation_response(text: &str) -> everruns_core::Result<Use
     }
     Ok(UserAskEvaluation {
         outcome: AskOutcome::InProgress,
-        reason: trimmed.to_string(),
+        reason: bounded_reason(trimmed),
     })
 }
 
@@ -491,9 +481,13 @@ fn parse_evaluation_value(value: &serde_json::Value) -> everruns_core::Result<Us
         .get("reason")
         .and_then(serde_json::Value::as_str)
         .unwrap_or_default()
-        .trim()
-        .to_string();
+        .trim();
+    let reason = bounded_reason(reason);
     Ok(UserAskEvaluation { outcome, reason })
+}
+
+fn bounded_reason(reason: &str) -> String {
+    reason.chars().take(MAX_EVALUATION_REASON_CHARS).collect()
 }
 
 pub(crate) fn evaluation_result_message(evaluation: &UserAskEvaluation) -> String {
@@ -508,6 +502,10 @@ pub(crate) fn evaluation_status_message(evaluation: &UserAskEvaluation) -> Strin
     match evaluation.outcome {
         AskOutcome::Achieved => format!("user ask achieved: {}", evaluation.reason),
         AskOutcome::Blocked => format!("user ask blocked: {}", evaluation.reason),
+        AskOutcome::Failed => format!("user ask failed: {}", evaluation.reason),
+        AskOutcome::WaitingOnBackground => {
+            format!("user ask waiting on background: {}", evaluation.reason)
+        }
         AskOutcome::InProgress => format!("user ask in progress: {}", evaluation.reason),
     }
 }
@@ -563,6 +561,34 @@ mod tests {
     }
 
     #[test]
+    fn resumed_store_restores_actual_ask_and_pivot_history() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionId::new();
+        let store = UserAskStore::open(dir.path().to_path_buf());
+        store
+            .record_user_prompt(session_id, "wait for CI then merge")
+            .expect("record original ask");
+
+        let resumed = UserAskStore::open(dir.path().to_path_buf());
+        resumed.load_session(session_id).expect("resume ask");
+        assert_eq!(
+            resumed.active_text(session_id).as_deref(),
+            Some("wait for CI then merge")
+        );
+        resumed
+            .record_user_prompt(session_id, "do not merge; only report CI")
+            .expect("record pivot");
+        let active = resumed.status(session_id).active.expect("active pivot");
+        assert_eq!(active.text, "do not merge; only report CI");
+        assert_eq!(active.revisions[0].text, "wait for CI then merge");
+    }
+
+    #[test]
+    fn inactive_tracking_adds_no_system_prompt_text() {
+        assert!(system_prompt_block(&UserAskStatus { active: None }).is_empty());
+    }
+
+    #[test]
     fn evaluation_marks_achieved_inactive() {
         let dir = tempfile::tempdir().expect("tempdir");
         let store = UserAskStore::open(dir.path().to_path_buf());
@@ -594,7 +620,9 @@ mod tests {
             active: Some(PersistedUserAsk {
                 text: "upgrade dependencies".into(),
                 active: true,
-                revisions: Vec::new(),
+                revisions: vec![AskRevision {
+                    text: "obsolete request must stay out of the prompt".into(),
+                }],
                 evaluated_turns: 0,
                 last_outcome: None,
                 last_reason: None,
@@ -602,5 +630,6 @@ mod tests {
         });
         assert!(block.contains("upgrade dependencies"));
         assert!(block.contains("set_user_ask"));
+        assert!(!block.contains("obsolete request"));
     }
 }

--- a/src/testing/streaming.rs
+++ b/src/testing/streaming.rs
@@ -277,7 +277,7 @@ async fn session_run_turn_emits_lines_and_finishes_with_done() {
                 }
             }
             Ok(Some(TurnEvent::Failed(err))) => failure = Some(err),
-            Ok(Some(TurnEvent::Done)) => {
+            Ok(Some(TurnEvent::Done(_))) => {
                 saw_done = true;
                 break;
             }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -264,6 +264,7 @@ pub struct App {
     goal_store: Arc<GoalStore>,
     user_ask_store: Arc<UserAskStore>,
     user_ask_enabled: bool,
+    completion_budget: crate::session_state::task_completion::CompletionBudget,
     worktree: Arc<WorktreeManager>,
     workspace_host: Arc<crate::exec::workspace_host::WorkspaceHost>,
     /// Images from `--image` / `-i` on the CLI, consumed on the first turn.
@@ -657,6 +658,7 @@ impl App {
             goal_store,
             user_ask_store,
             user_ask_enabled,
+            completion_budget: Default::default(),
             worktree: runtime.worktree,
             workspace_host: runtime.workspace_host,
             pending_images,
@@ -1498,7 +1500,7 @@ impl App {
                     self.context_used_tokens = Some(used);
                     return Ok(());
                 }
-                Ok(TurnEvent::Done) => {
+                Ok(TurnEvent::Done(result)) => {
                     self.finish_busy();
                     if let Some(notice) = self.session.take_checkpoint_notice() {
                         self.refresh_after_checkpoint_restore(notice).await;
@@ -1517,12 +1519,17 @@ impl App {
                         return Ok(());
                     }
                     self.after_turn_goal_check().await;
-                    self.after_turn_user_ask_check().await;
+                    if !self.busy {
+                        self.after_turn_user_ask_check(result).await;
+                    }
                     return Ok(());
                 }
                 Ok(TurnEvent::Failed(err)) => {
                     self.finish_busy();
                     self.push_system(format!("turn failed: {err}"));
+                    self.record_completion_state(
+                        crate::session_state::task_completion::CompletionState::Failed,
+                    );
                     self.start_next_queued_turn();
                     return Ok(());
                 }
@@ -2440,13 +2447,6 @@ impl App {
         let image_count = self.pending_images.len();
         let display = crate::tui::input::image_input::user_display_text(&display_text, image_count);
         self.push_user(display.clone());
-        if self.user_ask_enabled
-            && let Err(err) = self
-                .user_ask_store
-                .record_user_prompt(self.session.session_id(), &text)
-        {
-            self.push_system(format!("user ask: {err}"));
-        }
         let images = std::mem::take(&mut self.pending_images);
         if self.busy {
             self.queued_messages.push_back(QueuedMessage {
@@ -2455,6 +2455,7 @@ impl App {
                 images,
             });
         } else {
+            self.begin_user_request(&text);
             self.start_turn_with_images(text, images);
         }
     }
@@ -2635,7 +2636,8 @@ impl App {
             message,
             &mut self.background_wake,
         )
-        .with_active_goal(self.goal_store.active_condition(self.session.session_id()));
+        .with_active_goal(self.goal_store.active_condition(self.session.session_id()))
+        .with_active_ask(self.user_ask_store.active_text(self.session.session_id()));
         if !self.settings.snapshot().proactive_wake_enabled() {
             self.push_system(
                 "✓ background task finished — see /background (proactive wake off)".to_string(),
@@ -3239,8 +3241,39 @@ impl App {
         let Some(message) = self.queued_messages.pop_front() else {
             return false;
         };
+        self.begin_user_request(&message.prompt);
         self.start_turn_with_images(message.prompt, message.images);
         true
+    }
+
+    fn begin_user_request(&mut self, prompt: &str) {
+        self.completion_budget.reset();
+        if self.user_ask_enabled
+            && let Err(err) = self
+                .user_ask_store
+                .record_user_prompt(self.session.session_id(), prompt)
+        {
+            self.push_system(format!("user ask: {err}"));
+        }
+    }
+
+    fn record_completion_state(
+        &mut self,
+        state: crate::session_state::task_completion::CompletionState,
+    ) {
+        let session_id = self.session.session_id();
+        if !self.user_ask_enabled || !self.user_ask_store.is_active(session_id) {
+            return;
+        }
+        let evaluation = crate::session_state::task_completion::evaluation_for_state(state);
+        if let Err(err) = self
+            .user_ask_store
+            .record_evaluation(session_id, &evaluation)
+        {
+            self.push_system(format!("user ask: {err}"));
+            return;
+        }
+        self.push_system(evaluation_status_message(&evaluation));
     }
 
     fn maybe_start_goal_turn(&mut self) {
@@ -3297,12 +3330,52 @@ impl App {
         self.start_turn(prompt);
     }
 
-    async fn after_turn_user_ask_check(&mut self) {
+    async fn after_turn_user_ask_check(&mut self, result: Option<everruns_runtime::TurnResult>) {
         if !self.user_ask_enabled {
             return;
         }
         let session_id = self.session.session_id();
         if !self.user_ask_store.is_active(session_id) {
+            return;
+        }
+        let Some(result) = result else { return };
+        let tokens = self.session.turn_tokens(result.turn_id).await;
+        if !self.completion_budget.observe_turn(tokens) {
+            self.push_system("user ask budget exhausted; send a message to resume".into());
+            return;
+        }
+        let has_background = self
+            .task_registry
+            .list(session_id, None)
+            .await
+            .unwrap_or_default()
+            .iter()
+            .any(|task| !task.state.is_terminal());
+        if let crate::session_state::task_completion::GateDecision::Conclusive(state) =
+            crate::session_state::task_completion::gate_turn(&result, has_background)
+        {
+            let evaluation = crate::session_state::task_completion::evaluation_for_state(state);
+            let outcome = evaluation.outcome;
+            let reason = evaluation.reason.clone();
+            if let Err(err) = self
+                .user_ask_store
+                .record_evaluation(session_id, &evaluation)
+            {
+                self.push_system(format!("user ask: {err}"));
+                return;
+            }
+            self.push_system(evaluation_status_message(&evaluation));
+            match outcome {
+                AskOutcome::InProgress => {
+                    let prompt =
+                        crate::session_state::task_completion::continuation_prompt(&reason);
+                    self.start_continuation_turn(prompt);
+                }
+                AskOutcome::Blocked => self
+                    .session
+                    .report_herdr_state(crate::capabilities::herdr::HerdrState::Blocked),
+                AskOutcome::Achieved | AskOutcome::Failed | AskOutcome::WaitingOnBackground => {}
+            }
             return;
         }
         let result = match self
@@ -3332,6 +3405,11 @@ impl App {
                 .report_herdr_state(crate::capabilities::herdr::HerdrState::Blocked);
         }
         self.push_system(evaluation_status_message(&evaluation));
+        if evaluation.outcome == AskOutcome::InProgress {
+            let prompt =
+                crate::session_state::task_completion::continuation_prompt(&evaluation.reason);
+            self.start_continuation_turn(prompt);
+        }
     }
 
     /// Dispatch a capability-provided slash command.
@@ -3438,6 +3516,13 @@ impl App {
     fn start_turn(&mut self, prompt: String) {
         let images = std::mem::take(&mut self.pending_images);
         self.start_turn_with_images(prompt, images);
+    }
+
+    fn start_continuation_turn(&mut self, prompt: String) {
+        let input = crate::session_state::task_completion::tag_continuation(
+            self.model.input_message(prompt.clone()),
+        );
+        self.start_turn_input(prompt, input);
     }
 
     fn start_turn_with_images(&mut self, prompt: String, images: Vec<ContentPart>) {
@@ -6405,6 +6490,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn blocked_completion_state_is_in_presentation_transcript() {
+        use everruns_core::turn::TurnStopReason;
+        use everruns_core::typed_id::TurnId;
+
+        let mut test = app_with_llmsim().await;
+        let session_id = test.app.session.session_id();
+        test.app
+            .user_ask_store
+            .record_user_prompt(session_id, "edit the file")
+            .expect("record ask");
+        test.app
+            .after_turn_user_ask_check(Some(everruns_runtime::TurnResult {
+                response: "I need the path. Which file should I edit?".to_string(),
+                iterations: 1,
+                tool_calls_count: 0,
+                success: true,
+                error: None,
+                stop_reason: TurnStopReason::EndTurn,
+                turn_id: TurnId::new(),
+            }))
+            .await;
+
+        assert!(test.app.lines.iter().any(|line| {
+            line.author == Author::System && line.text.contains("user ask blocked")
+        }));
+        assert!(!test.app.busy, "blocked state must not auto-continue");
+    }
+
+    #[tokio::test]
     async fn completed_session_task_refresh_is_applied_without_panicking() {
         let mut test = app_with_llmsim().await;
         let mut expected = crate::tui::session_tasks_view::TaskTree::default();
@@ -7058,7 +7172,7 @@ mod tests {
                         Ok(TurnEvent::ContextUsed(used)) => {
                             self.context_used_tokens = Some(used);
                         }
-                        Ok(TurnEvent::Done) => {
+                        Ok(TurnEvent::Done(_)) => {
                             self.finish_busy();
                             self.start_next_queued_turn();
                         }
@@ -8228,6 +8342,13 @@ mod tests {
         app.submit_input().await;
 
         assert_eq!(app.queued_messages.len(), 2);
+        assert_eq!(
+            app.user_ask_store
+                .active_text(app.session.session_id())
+                .as_deref(),
+            Some("first turn"),
+            "queued pivots must not replace the ask before their turn starts"
+        );
         assert!(app.input_text().is_empty());
         assert!(app.busy, "queueing must not interrupt the active turn");
 

--- a/src/tui/transcript.rs
+++ b/src/tui/transcript.rs
@@ -69,7 +69,7 @@ pub(crate) enum TurnEvent {
     /// Prompt tokens the latest LLM generation consumed — the current fill of
     /// the model's context window. Replaces (not accumulates) the prior value.
     ContextUsed(u32),
-    Done,
+    Done(Option<everruns_runtime::TurnResult>),
     Failed(String),
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1039,7 +1039,7 @@ fn fullscreen_enables_modified_key_reporting_after_entering_alternate_screen() {
         },
     );
     assert!(
-        tui.wait_for_output("Enter to send", Duration::from_secs(3)),
+        tui.wait_for_output("Enter to send", Duration::from_secs(5)),
         "TUI did not render the composer: {}",
         tui.output_text()
     );
@@ -2474,6 +2474,46 @@ fn openai_print_smoke() {
         "expected `pong` in stdout: {stdout}"
     );
     assert!(!stdout.contains("success="), "unexpected footer: {stdout}");
+}
+
+#[test]
+fn openai_multistep_completion_smoke() {
+    let Some(_) = live_key_or_skip("OPENAI_API_KEY") else {
+        return;
+    };
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let session_dir = tmp.path().join("sessions");
+    let proof = tmp.path().join("completion-proof.txt");
+    let output = Command::new(yolop_binary())
+        .current_dir(tmp.path())
+        .args([
+            "--provider",
+            "openai",
+            "--session-dir",
+            session_dir.to_str().unwrap(),
+            "-p",
+            "Use the shell to create completion-proof.txt containing exactly `verified`, read it back to verify the contents, then finish with the exact final answer: task complete",
+        ])
+        .output()
+        .expect("spawn multistep yolop --provider openai");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !output.status.success() && looks_provider_quota_exhausted(&format!("{stdout}{stderr}")) {
+        eprintln!("skipping live test: OpenAI quota exhausted");
+        return;
+    }
+    assert!(
+        output.status.success(),
+        "yolop multistep smoke failed: stdout={stdout} stderr={stderr}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&proof).expect("completion proof file"),
+        "verified"
+    );
+    assert!(
+        stdout.to_lowercase().contains("task complete"),
+        "expected verified final answer in stdout: {stdout}"
+    );
 }
 
 /// Model used by the live OpenRouter smoke tests. Defaults to a Nemotron 3


### PR DESCRIPTION
## What changed
Yolop now tracks the current user request by default and applies one shared end-of-turn completion gate across TUI, `--print`, and ACP. Tool/commentary-only stops continue automatically from compact state, while achieved, blocked, failed, and background-waiting work terminate explicitly. Continuation is bounded to six agent turns, 64k provider-reported tokens, and ten minutes.

Trivial final replies stay deterministic and pay no evaluator call. Tool-using candidate finals use one semantic evaluation because mutation and multi-step completion are ambiguous. Automatic continuation messages are host-tagged so compact background wakeups retain the real user ask rather than a continuation prompt.

## Why
Observed sessions included user turns that ended after commentary or tool activity without a final answer and without a recorded provider failure. The existing user-ask tracker was opt-in, so the default host path could silently treat those turns as complete.

## Before / After
Before: a successful runtime turn with an empty final response could end the user turn; all tracked asks paid semantic evaluation; background wake races could lose the actual ask.

After: empty/tool-only stops continue to one final response within strict budgets; exact trivial replies use one generation and zero evaluator calls; the mutation fixture uses exactly two agent-loop generations plus one evaluator generation. Exhaustion-backed fixtures make any extra model call fail. A live OpenAI smoke creates and verifies a file before accepting the final answer.

## Risk
- Medium
- Host turn termination changes across TUI, print, and ACP. Bounded loop tests cover duplicate finals, permanent failures, blocked prompts, background waits/wakes, pivots, resume, and exhaustion.
- User ask state is persisted per session; prompt contribution is absent while inactive and excludes superseded revisions.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered; Yolop is pre-1.0 and explicit capability disable remains available
- [x] Knowledge concepts updated

## Knowledge
Updated `user-ask`, `acp`, and `background`, plus the knowledge log, to define default tracking, terminal states, host semantics, continuation budgets, and wake retention.

## Security
Reviewed TM-FS, TM-BASH, TM-LLM, TM-TOOL, and TM-DEP. This adds no dependency, shell authority, filesystem bypass, secret handling, or new destructive operation. Evaluator reasons are capped at 1,000 characters; asks and revision history keep existing bounds; automatic loops have turn/token/time caps; host-only continuation metadata cannot be forged by prompt text; task-authored wake content remains untrusted data.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `python3 scripts/validate_okf.py knowledge --check-links`
- Offline `llmsim` print smoke
- Focused ACP, TUI, background-wake, and compact-context suites
- Local live smoke could not start because this shell has no Doppler project configuration; the required same-repository CI live-smoke job supplies `DOPPLER_TOKEN`, sets `YOLOP_REQUIRE_LIVE_TESTS=1`, and hard-fails if OpenAI credentials are absent.

## Follow-ups
No follow-ups.