### PR TITLE
feat(runtime): compact context from cumulative cost

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -219,7 +219,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1439,7 +1439,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1640,7 +1640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1691,9 +1691,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.19"
+version = "0.17.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf546adaf284c281a807e93a5320419e095cd960f06681fcc97051a4ff760ea"
+checksum = "2c64c5c9dc834c368ef58a519af6057170d59898f1832497bac36930315a8159"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1709,9 +1709,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.19"
+version = "0.17.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6afb891f32f45b97a0bec8c051d0a50d414e71f0c033f7e95113b0e7662bfe6"
+checksum = "a707c1ea91a00907d7c374697ba87479259394a6e0b3dfdd93d67a5b3c924126"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -1756,9 +1756,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.19"
+version = "0.17.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7254a90e7bdfa34897c0ddc46ad989f22614d1c942b00d4a1c85da4fa9a9cc"
+checksum = "975a396124387a581b761f56af6f35cde3abea660f7b403a5863ad04ca2b2b5f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1773,9 +1773,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.19"
+version = "0.17.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e32f2ea96e057f564fd269e9042dc4bb5e2f7ae705a1ad4773281d468297a84"
+checksum = "fa3db9a459681785e1f7957ad323023517f1a07bf3294101674b083d139784be"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1789,9 +1789,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.19"
+version = "0.17.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c785d00c726092156e95908bfdceb9383d4a17a3f1b94bc19bb5a19c7247b46"
+checksum = "15753faec7aafe618f999e7cb06ff2c61f2727d8a697684db932a9dd2b83289b"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1803,9 +1803,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.19"
+version = "0.17.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4295a1e49596cbcec4962de17060f8a75aa45b0a729e2406925ee0694bc505af"
+checksum = "43fe1c7522c51e3185433e6c39158762ca610e69b0e9a8efa5879b97b9031483"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1827,9 +1827,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.19"
+version = "0.17.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c9281a5cf00221505f340e8d77924b63099cd0edc3f1282ef3788541c66fd4"
+checksum = "5a7d3808718fd36963382eabeac88c162e72da1aa00a8611261d5486460cf3be"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1842,9 +1842,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.19"
+version = "0.17.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b99334b3b842a9e64f4276e24ef25a7106ec352901b135e91858fbc77ea042ac"
+checksum = "296bae9a7d1b2f60628be5d1174aa8f4dcc050e3c1e03f2b06970af6325db171"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1858,9 +1858,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.19"
+version = "0.17.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cad5d23f913fb469545c25433009fd6f35e439b5eeae096513f53821e9b56ad"
+checksum = "f9e204bd31f57e49dab2e09918bcf34044d0280853ab562b3ee57b0b99e6fef4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1872,9 +1872,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-provider"
-version = "0.17.19"
+version = "0.17.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0c07b1a24a0b5dfca3e3c8391c04a47bde09b020885d10fc2e3969280ef925"
+checksum = "77d6ba9c24f528e53b305170d66cca9c4a2e01928a2bf0d9a37240fb2311d90e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1900,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.19"
+version = "0.17.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87c37b85b05a4a1ee262e61da6a18aab8327c4d4bed8c1e1551bf7f74517d721"
+checksum = "454576d37ea267d7a58db8a3a5e3c931f98e6abd810a8a7be923e88c253e1555"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3502,7 +3502,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3803,7 +3803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4514,7 +4514,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5053,7 +5053,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5121,7 +5121,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5633,7 +5633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5876,7 +5876,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5909,7 +5909,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7326,7 +7326,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,20 +102,20 @@ tree-sitter-zig = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-everruns-anthropic = "0.17.19"
-everruns-core = "0.17.19"
-everruns-openai = "0.17.19"
+everruns-anthropic = "0.17.21"
+everruns-core = "0.17.21"
+everruns-openai = "0.17.21"
 # OpenRouter's first-class driver was split out of everruns-openai into its own
 # crate in 0.13.0; register it alongside openai to keep DriverId::OpenRouter.
-everruns-openrouter = "0.17.19"
-everruns-local = "0.17.19"
-everruns-mcp = { version = "0.17.19", features = ["stdio"] }
+everruns-openrouter = "0.17.21"
+everruns-local = "0.17.21"
+everruns-mcp = { version = "0.17.21", features = ["stdio"] }
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (knowledge/specs/mcp.md, upstream runtime-mcp.md D2).
-everruns-runtime = { version = "0.17.19", features = ["mcp-stdio"] }
-everruns-integrations-duckduckgo = "0.17.19"
-everruns-integrations-parallel = "0.17.19"
-everruns-integrations-daytona = "0.17.19"
+everruns-runtime = { version = "0.17.21", features = ["mcp-stdio"] }
+everruns-integrations-duckduckgo = "0.17.21"
+everruns-integrations-parallel = "0.17.21"
+everruns-integrations-daytona = "0.17.21"
 arboard = { version = "3", features = ["wayland-data-control"] }
 futures = "0.3"
 html-escape = "0.2"

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,17 @@
 Significant changes to Yolop's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
+## 2026-08-05 — Cumulative-cost context checkpoints
+
+- [Checkpointing](specs/checkpointing.md) now defines cumulative uncached input
+  and accumulated raw tool-result bytes as early proactive-compaction signals.
+  Cost pressure shares the existing durable replacement, history retrieval,
+  rewind lineage, retry bounds, and failure fallback; a marginal prompt floor
+  keeps short follow-ups out of the compaction path.
+- Active turns now admit already-persisted event boundaries for durable context
+  checkpoints while rejecting future boundaries, so proactive replacement can
+  install before the turn closes without weakening rewind lineage.
+
 ## 2026-08-05 — Default bounded task completion
 
 - [User ask](specs/user-ask.md) is now the default host completion safety net

--- a/knowledge/specs/checkpointing.md
+++ b/knowledge/specs/checkpointing.md
@@ -133,6 +133,23 @@ event sequence, format version, and provider-opaque replacement to
 latest compatible checkpoint on the active timeline plus raw messages after its
 source boundary. The raw events are never rewritten or deleted.
 
+Proactive replacement is triggered by either context-window pressure or prompt
+cost pressure. Cost pressure combines bounded cumulative uncached input with
+the saturating byte count of raw tool results accumulated since the compatible
+checkpoint, and requires a non-trivial current prompt so short follow-ups do not
+compact unnecessarily. Both triggers use the same provider-native replacement,
+lineage-aware retry watermark, suffix re-arming, and atomic failure fallback;
+there is no cost-only checkpoint format or replay path. Cold bulky evidence can
+therefore leave the live model view while remaining lossless and retrievable
+through `query_history`, with the active raw suffix retaining recent asks,
+decisions, edits, and validation.
+
+A durable model-context checkpoint may use an event boundary already persisted
+inside the currently open turn. That pending turn is the active head extension
+until completion, but the timeline rejects boundaries beyond the event log's
+current maximum; finishing, rewinding, and redoing then apply the ordinary
+closed-node lineage rules.
+
 Rewind and redo select checkpoints by the active timeline. A checkpoint on an
 abandoned suffix remains append-only data but cannot shadow the latest surviving
 ancestor. Installation is monotonic for each provider/model/version, and a

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -7387,6 +7387,14 @@ mod tests {
         assert_eq!(compaction.config["strategy"], "auto");
         assert_eq!(compaction.config["proactive"], true);
         assert_eq!(compaction.config["budget_percent"], serde_json::json!(0.85));
+        let config: everruns_core::capabilities::CompactionConfig =
+            serde_json::from_value(compaction.config.clone()).expect("valid compaction config");
+        assert_eq!(
+            config.cost_control.compact_after_tool_result_bytes,
+            256 * 1024
+        );
+        assert_eq!(config.cost_control.compact_min_input_tokens, 8 * 1024);
+        assert_eq!(config.cost_control.max_uncached_input_tokens, 100_000);
     }
 
     #[test]

--- a/src/session_state/checkpoint.rs
+++ b/src/session_state/checkpoint.rs
@@ -287,6 +287,9 @@ impl CheckpointManager {
         let Ok(sequence) = i32::try_from(sequence) else {
             return false;
         };
+        if sequence > self.events.last_sequence() {
+            return false;
+        }
         let state = self.state.lock().expect("checkpoint state lock");
         event_sequence_is_active(&state, sequence)
     }
@@ -903,10 +906,16 @@ fn event_sequence_is_active(state: &TimelineState, sequence: i32) -> bool {
     if sequence <= state.baseline_end {
         return true;
     }
+    if state.pending.as_ref().is_some_and(|id| {
+        state.nodes.get(id).is_some_and(|node| {
+            sequence >= node.event_start && node.event_end.is_none_or(|end| sequence <= end)
+        })
+    }) {
+        return true;
+    }
     active_path(state).into_iter().any(|id| {
         state.nodes.get(&id).is_some_and(|node| {
-            node.event_end
-                .is_some_and(|end| sequence >= node.event_start && sequence <= end)
+            sequence >= node.event_start && node.event_end.is_none_or(|end| sequence <= end)
         })
     })
 }
@@ -1272,6 +1281,33 @@ mod tests {
             ))
             .await
             .expect("emit user");
+    }
+
+    #[tokio::test]
+    async fn current_turn_event_boundary_is_active_before_turn_finishes() {
+        let (_root, _session, manager) = manager().await;
+        let current = manager.begin_turn("current prompt").expect("checkpoint");
+        emit_user(&manager, "current prompt").await;
+        let current_sequence = manager
+            .events
+            .collected_events()
+            .await
+            .into_iter()
+            .filter_map(|event| event.sequence)
+            .max()
+            .expect("current turn event sequence");
+
+        assert!(
+            manager.is_event_sequence_active(i64::from(current_sequence)),
+            "durable context checkpoints must be installable during the active turn"
+        );
+        assert!(
+            !manager.is_event_sequence_active(i64::from(current_sequence) + 1),
+            "an open turn must not make a future event boundary active"
+        );
+        manager
+            .finish_turn(&current, true)
+            .expect("finish current turn");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed
Yolop now consumes everruns-runtime 0.17.21, which proactively creates the existing durable provider-native context checkpoint when cumulative uncached input or raw tool-result bytes become costly, even below the 85% window threshold. Short prompts stay out of the compaction path.

The host now also accepts an already-persisted source boundary inside the currently open turn. This lets the runtime atomically install the proactive checkpoint before turn completion while preserving the existing rewind/redo lineage rules and rejecting future event boundaries.

Raw `events.jsonl` history remains lossless and `query_history`-retrievable; recent asks, decisions, edits, validation, and the active suffix remain in the live model view.

Upstream implementation and feature proof: everruns/everruns#2933. Published release: v0.17.21.

## Why
313 useful local sessions processed about 564M input tokens versus 3.0M output tokens and stored about 111 MB of tool results. The largest session accumulated 37.2M input tokens without crossing the native 85%-of-window trigger or producing a non-empty checkpoint. Window occupancy alone therefore did not control repeated prompt cost.

## Before / After
Deterministic upstream A/B long-tool fixture:

- Baseline model-view prompt: 293,520 bytes
- Candidate after checkpoint: 56 bytes
- Reduction: 99%+ (reported as 100% rounded)
- Task-success sentinel: unchanged (`true`)

The real ReasonAtom feature suite crosses the cumulative budget below 85% occupancy and verifies raw history stays intact/queryable, then covers short-turn non-activation, resume/checkpoint compatibility, rewind/rearm behavior, and provider-compaction failure fallback.

Live OpenAI smoke (`gpt-5.6-sol`, medium) completed a 20-tool coding trajectory:

- Triggered at 14,756 estimated input tokens and 267,147 raw tool-result bytes, below the native occupancy threshold
- Installed one durable checkpoint and completed with `LIVE_COST_SMOKE_OK`
- Preserved a 446 KB raw event log alongside an 8 KB checkpoint ledger
- Resumed the same session with `LIVE_COST_RESUME_OK`
- The trivial resume appended raw events without producing another checkpoint

Local validation after rebasing onto current `origin/main`:

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (1,119 passing across unit/integration/PTY groups; expected live/toolchain ignores only)
- `python3 scripts/validate_okf.py knowledge --check-links` (37 concepts, 0 errors)
- Offline `llmsim` print smoke
- Live-provider activation, completion, and resume smoke through Doppler

## Risk
- Medium
- Runtime compaction timing changes for long/costly sessions. The trigger reuses the existing checkpoint format, provider-native compactor, retry watermark, failure fallback, and query-history path.
- The host boundary fix is limited to the pending turn and rejects any sequence beyond the persisted event log maximum.
- Pre-1.0 compatibility considered: no persisted format was changed; old sessions without cost metadata retain the existing fallback behavior.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge
Updated `knowledge/specs/checkpointing.md` and `knowledge/log.md` for cumulative-cost triggers, lossless retrieval, bounded retry/rearm semantics, and active-turn event boundaries.

## Security
Reviewed TM-DEP, TM-LLM, TM-DOS, and checkpoint lineage/storage risks:

- All public everruns crates move in lockstep to published crates.io 0.17.21 artifacts with registry checksums; no git dependency or new dependency is introduced.
- Tool-result and token counters are saturating/bounded upstream; the minimum current-prompt floor avoids compaction amplification on trivial turns.
- Provider-opaque checkpoint payloads keep their existing durable storage path and are not copied into public events or logs; raw events remain append-only.
- Pending-turn activation is checked under the timeline lock and capped by the event store latest sequence, so it cannot authorize a future or abandoned boundary.
- No new credentials, network endpoints, command execution, authorization, or user-controlled path handling.

## Follow-ups
No follow-ups.