### PR TITLE
feat(models): search provider catalogs conversationally

### DIFF
--- a/knowledge/specs/commands.md
+++ b/knowledge/specs/commands.md
@@ -56,7 +56,7 @@ The runtime's `execute_command` can only return a `CommandResult` string; it has
 no way to clear a transcript or open an overlay. Rather than add a second,
 non-capability command path in the host, yolop injects a host UI port
 (`HostUi`) into the capability at construction — the same dependency-injection
-pattern `SetupCapability` already uses for its settings/provider stores. The
+pattern `ModelsCapability` already uses for its settings/provider stores. The
 capability requests an effect (`UiCommand`); the host — the only thing that can
 — performs it. This keeps all commands in one registry, keeps them pluggable
 (remove the capability and its commands disappear from the UI; swap it and they
@@ -85,7 +85,7 @@ portable case ever arises.
    is the shared contract between client capabilities and the host — a genuinely
    new on-screen effect is a host change, not a drop-in.
 4. **Natural-language dispatch.** In the interactive TUI, the same client
-   capability exposes a model-facing `run_yolop_command` tool and a prompt
+   capability exposes a model-facing `run_command` tool and a prompt
    contribution listing the terminal commands. When the user asks for a
    terminal-side action in ordinary prose (for example, "exit"), the model
    invokes that tool; the tool emits the same `UiCommand` as the slash-command

--- a/knowledge/specs/configuration.md
+++ b/knowledge/specs/configuration.md
@@ -139,7 +139,7 @@ read/write split is explicit at the type level. `AttributionCapability` reads
 whether attribution is enabled through the service; `ApprovalCapability` reads
 its soft-approval paranoia level through `ConfigService::approval_mode()` each
 turn; the `config` capability's `get_config` reads single values through
-`ConfigService::current`; and `SetupCapability` reads provider/token/model state
+`ConfigService::current`; and `ModelsCapability` reads provider/token/model state
 through its config handle while persisting `/setup` changes through the store.
 `approval_mode` is also a first-class schema key, so `get_config`/`set_config`
 manage it alongside everything else.

--- a/knowledge/specs/conversational-control.md
+++ b/knowledge/specs/conversational-control.md
@@ -63,7 +63,7 @@ command, an overlay confirmation, or a next-run-only settings write fail this ba
 | Surface | Conversational tool | Front-ends sharing the logic |
 |---|---|---|
 | Reasoning effort | `set_reasoning_effort` | `/effort` overlay, `/setup effort` |
-| Model | `set_model` | `/model` overlay, `/setup model` |
+| Model | `search_models` / `set_model` | `/model` overlay, `/setup model` |
 | Provider | `set_provider` | `/setup provider` |
 | Skills — list | `list_skills` (upstream) | system-prompt listing |
 | Skills — search (skills.sh) | `search_skills` | — |
@@ -71,16 +71,19 @@ command, an overlay confirmation, or a next-run-only settings write fail this ba
 | Skills — install/update by content | `write_skill` (upstream) | — |
 | Skills — uninstall | `delete_skill` | — |
 | Settings (provider/model/tokens/urls/capabilities, next-run) | `get_config` / `set_config` | `/setup`, `yolop-config` skill |
-| Terminal/UI actions (help, tools, mcp, cwd, status, model, effort, clear, quit) | `run_yolop_command` (TUI only) | the slash commands themselves |
+| Terminal/UI actions (help, tools, mcp, cwd, status, model, effort, clear, quit) | `run_command` (TUI only) | the slash commands themselves |
 
 Notes:
 
 - `set_model` / `set_provider` / `set_reasoning_effort` apply to the live session; the
   `/model` and `/effort` overlays still exist for humans, but the agent no longer
   needs them (it does not pre-seed an overlay the user must confirm).
+- `search_models` queries usable providers through the runtime driver registry and
+  returns provider-qualified matches. `set_model` rejects a partial name when it
+  matches discovered models but is not an exact ID for the current provider.
 - `set_config` is intentionally next-run for provider/model edits — it edits the
   settings file. The *live* equivalents are the `set_*` tools above.
-- `run_yolop_command` is gated to the interactive TUI because its effects (clearing
+- `run_command` is gated to the interactive TUI because its effects (clearing
   the transcript, quitting) only exist there; see [`commands.md`](./commands.md).
 
 ## Known gap
@@ -98,7 +101,7 @@ Notes:
   owns `list_skills` / `write_skill` (see [`skills.md`](./skills.md)).
 - `crate::capabilities::config` owns `get_config` / `set_config` (see
   [`configuration.md`](./configuration.md)).
-- The command registry and `run_yolop_command` are owned by [`commands.md`](./commands.md).
+- The command registry and `run_command` are owned by [`commands.md`](./commands.md).
 
 ## Related
 

--- a/knowledge/specs/mcp.md
+++ b/knowledge/specs/mcp.md
@@ -94,7 +94,7 @@ browser is invisible), and the wait runs in the background so the event loop is
 not blocked. The token endpoint and client id are persisted alongside the tokens
 so refresh is self-contained. Because credentials are resolved per turn, a fresh
 login takes effect on the next message — no restart (composes with live reload
-above). Agent-driven `/mcp` and `/tools` via `run_yolop_command` return the
+above). Agent-driven `/mcp` and `/tools` via `run_command` return the
 host's response text in the tool result; `/tools` includes live discovered
 `mcp_*` names from the session's scoped servers.
 

--- a/knowledge/specs/tool-search.md
+++ b/knowledge/specs/tool-search.md
@@ -45,7 +45,7 @@ vendor was deleted and yolop now consumes upstream directly:
    schemas and common work needs no `tool_search` round-trip: the file/shell
    tools (`read_file`, `write_file`, `edit_file`, `list_directory`,
    `grep_files`, `bash`), the planning tool (`write_todos`), plus
-   `run_yolop_command` (the client-command dispatch tool, which requires a
+   `run_command` (the client-command dispatch tool, which requires a
    `command` argument and so must never be called against a stub). Yolop does
    not own those tool definitions (they come from `FileSystemCapability`,
    `StatelessTodoListCapability`, yolop's `bash` tool, and the

--- a/scripts/repro-mcp-activation.sh
+++ b/scripts/repro-mcp-activation.sh
@@ -21,7 +21,7 @@ echo "Expected gap: no transcript line carries the authorize URL before wait_for
 echo "== repro: /tools uses frozen startup.tool_names ==" | tee "$OUT/02-tools-frozen.txt"
 rg -n "ShowTools|startup.tool_names" "$ROOT/src/tui/mod.rs" | tee -a "$OUT/02-tools-frozen.txt"
 
-echo "== repro: run_yolop_command queues without host output ==" | tee "$OUT/03-queued.txt"
+echo "== repro: run_command queues without host output ==" | tee "$OUT/03-queued.txt"
 rg -n "queued for the interactive terminal host|ManageMcp" \
   "$ROOT/src/capabilities/client_commands.rs" \
   "$ROOT/src/tui/host_ui.rs" | tee -a "$OUT/03-queued.txt"

--- a/src/bundled/system-skills/yolop/SKILL.md
+++ b/src/bundled/system-skills/yolop/SKILL.md
@@ -28,7 +28,7 @@ the following; `--print` and ACP omit the terminal-only client commands.
 ### Terminal client commands
 
 These act on the TUI itself (clear transcript, open overlays, quit). The agent
-can also run them via `run_yolop_command` when the user asks in plain language.
+can also run them via `run_command` when the user asks in plain language.
 
 | Command | Description |
 | --- | --- |
@@ -159,6 +159,6 @@ When the user asks what yolop can do or how to use it:
 1. Summarize the relevant section from this skill (commands, shortcuts, or
    features — match what they asked).
 2. For the **live** command or tool list, prefer `/help`, `/tools`, or
-   `run_yolop_command` / `list_skills` rather than guessing.
+   `run_command` / `list_skills` rather than guessing.
 3. Point power users at `README.md` and `knowledge/specs/` for protocol and configuration
    depth; keep conversational answers short.

--- a/src/capabilities/client_commands.rs
+++ b/src/capabilities/client_commands.rs
@@ -29,15 +29,15 @@ use std::sync::Arc;
 pub(crate) const CLIENT_COMMANDS_CAPABILITY_ID: &str = "yolop_client_commands";
 
 pub(crate) const CLIENT_COMMANDS_PROMPT: &str = r#"<capability id="yolop_client_commands">
-For natural-language requests, `run_yolop_command` can perform these TUI client
+For natural-language requests, `run_command` can perform these TUI client
 commands: `/help`, `/tools`, `/mcp`, `/cwd`, `/status [compact|expanded|toggle]`,
 `/model [id]`, `/effort [level]`, `/clear`, and `/quit` (`/exit` is an alias).
-The TUI may expose other slash commands, but only use `run_yolop_command` for this listed
+The TUI may expose other slash commands, but only use `run_command` for this listed
 client-command set. When the user asks for one of these terminal
 actions — for example "exit", "clear the screen", "show tools", "switch model",
 "reload MCP servers" (`/mcp reload`), "log in to an MCP server"
 (`/mcp login <name>`), or "expand the status bar" —
-call `run_yolop_command` with the command and arguments; do not merely tell the
+call `run_command` with the command and argument array; do not merely tell the
 user to type the slash command, and do not invent a manager window. The tool
 result includes the host's response text (server lists, tool lists, OAuth URLs).
 Use `set_status` for a concise live description of meaningful turn progress.
@@ -82,7 +82,7 @@ impl Capability for ClientCommandsCapability {
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
         vec![
-            Box::new(RunYolopCommandTool {
+            Box::new(RunCommandTool {
                 ui: self.ui.clone(),
             }),
             Box::new(SetStatusTool {
@@ -168,7 +168,7 @@ fn ui_command_for(name: &str, arg: Option<String>) -> Option<UiCommand> {
     }
 }
 
-struct RunYolopCommandTool {
+struct RunCommandTool {
     ui: Arc<dyn HostUi>,
 }
 
@@ -239,7 +239,7 @@ impl Tool for SetStatusTool {
 }
 
 #[async_trait]
-impl Tool for RunYolopCommandTool {
+impl Tool for RunCommandTool {
     fn narrate(
         &self,
         tool_call: &ToolCall,
@@ -253,7 +253,7 @@ impl Tool for RunYolopCommandTool {
     }
 
     fn name(&self) -> &str {
-        "run_yolop_command"
+        "run_command"
     }
 
     fn display_name(&self) -> Option<&str> {
@@ -263,7 +263,7 @@ impl Tool for RunYolopCommandTool {
     fn description(&self) -> &str {
         "Execute an interactive yolop slash command on behalf of a natural-language user request. \
          Use this when the user asks to exit, clear the transcript, show help/tools/MCP/cwd, \
-         reload MCP servers (`command: mcp`, `arguments: reload`), show or change the status \
+         reload MCP servers (`command: mcp`, `args: [reload]`), show or change the status \
          layout, or open/switch model or reasoning effort. Accepts command names with or without the leading \
          slash; `exit` is accepted as an alias for `quit`."
     }
@@ -280,9 +280,10 @@ impl Tool for RunYolopCommandTool {
                         "/help", "/tools", "/mcp", "/cwd", "/status", "/model", "/effort", "/clear", "/quit", "/exit"
                     ]
                 },
-                "arguments": {
-                    "type": "string",
-                    "description": "Optional command arguments, e.g. `reload` for /mcp, a model id for /model, or a level for /effort."
+                "args": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Ordered command arguments, e.g. [`reload`] for /mcp or [`openai/gpt-5.4`] for /model."
                 }
             },
             "required": ["command"],
@@ -302,12 +303,23 @@ impl Tool for RunYolopCommandTool {
                 "shell commands must be typed directly as !shell <command> or /shell <command>",
             );
         }
-        let arg = arguments
-            .get("arguments")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(str::to_string);
+        let args = match arguments.get("args") {
+            None => Vec::new(),
+            Some(Value::Array(args)) => {
+                let mut parsed = Vec::with_capacity(args.len());
+                for value in args {
+                    let Some(value) = value.as_str() else {
+                        return ToolExecutionResult::tool_error("'args' must contain only strings");
+                    };
+                    parsed.push(value.to_string());
+                }
+                parsed
+            }
+            Some(_) => {
+                return ToolExecutionResult::tool_error("'args' must be an array of strings");
+            }
+        };
+        let arg = (!args.is_empty()).then(|| args.join(" "));
 
         let Some(command) = ui_command_for(name, arg.clone()) else {
             return ToolExecutionResult::tool_error(format!("unknown yolop command: /{stripped}"));
@@ -347,7 +359,7 @@ impl Tool for RunYolopCommandTool {
     }
 }
 
-/// Whether `run_yolop_command` should wait for host transcript lines.
+/// Whether `run_command` should wait for host transcript lines.
 fn command_awaits_host_reply(name: &str) -> bool {
     matches!(name, "mcp" | "tools" | "help" | "cwd")
 }
@@ -436,10 +448,10 @@ mod tests {
         let capability = ClientCommandsCapability::new(ui);
         let prompt = capability.system_prompt_addition().expect("prompt");
 
-        assert!(prompt.contains("run_yolop_command"));
+        assert!(prompt.contains("run_command"));
         assert!(prompt.contains("TUI client"));
         // The prompt wraps this guidance across two lines — check each side.
-        assert!(prompt.contains("only use `run_yolop_command` for this listed"));
+        assert!(prompt.contains("only use `run_command` for this listed"));
         assert!(prompt.contains("client-command set"));
         assert!(prompt.contains("/quit"));
         assert!(prompt.contains("/exit"));
@@ -447,16 +459,16 @@ mod tests {
     }
 
     #[test]
-    fn run_yolop_command_narration_includes_command() {
+    fn run_command_narration_includes_command() {
         use everruns_core::tool_narration::ToolNarrationPhase;
         use everruns_core::tool_types::ToolCall;
 
-        let tool = RunYolopCommandTool {
+        let tool = RunCommandTool {
             ui: Arc::new(RecordingUi::default()),
         };
         let tool_call = ToolCall {
             id: "call-1".to_string(),
-            name: "run_yolop_command".to_string(),
+            name: "run_command".to_string(),
             arguments: json!({ "command": "/model" }),
         };
 
@@ -497,8 +509,8 @@ mod tests {
     }
 
     #[test]
-    fn run_yolop_command_schema_accepts_slashed_aliases() {
-        let tool = RunYolopCommandTool {
+    fn run_command_schema_accepts_slashed_aliases() {
+        let tool = RunCommandTool {
             ui: Arc::new(RecordingUi::default()),
         };
         let schema = tool.parameters_schema();
@@ -513,9 +525,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_yolop_command_exit_alias_queues_quit() {
+    async fn run_command_exit_alias_queues_quit() {
         let ui = Arc::new(RecordingUi::default());
-        let tool = RunYolopCommandTool { ui: ui.clone() };
+        let tool = RunCommandTool { ui: ui.clone() };
 
         let result = tool.execute(json!({ "command": "/exit" })).await;
 
@@ -562,14 +574,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_yolop_command_rejects_shell_dispatch() {
+    async fn run_command_rejects_shell_dispatch() {
         let ui = Arc::new(RecordingUi::default());
-        let tool = RunYolopCommandTool { ui: ui.clone() };
+        let tool = RunCommandTool { ui: ui.clone() };
 
         let result = tool
             .execute(json!({
                 "command": "shell",
-                "arguments": "echo should-not-run"
+                "args": ["echo", "should-not-run"]
             }))
             .await;
 
@@ -578,14 +590,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_yolop_command_preserves_model_argument() {
+    async fn run_command_preserves_model_argument() {
         let ui = Arc::new(RecordingUi::default());
-        let tool = RunYolopCommandTool { ui: ui.clone() };
+        let tool = RunCommandTool { ui: ui.clone() };
 
         let result = tool
             .execute(json!({
                 "command": "model",
-                "arguments": "openai/gpt-5.4"
+                "args": ["openai/gpt-5.4"]
             }))
             .await;
 
@@ -599,14 +611,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_yolop_command_preserves_status_layout_argument() {
+    async fn run_command_preserves_status_layout_argument() {
         let ui = Arc::new(RecordingUi::default());
-        let tool = RunYolopCommandTool { ui: ui.clone() };
+        let tool = RunCommandTool { ui: ui.clone() };
 
         let result = tool
             .execute(json!({
                 "command": "status",
-                "arguments": "expanded"
+                "args": ["expanded"]
             }))
             .await;
 
@@ -622,12 +634,12 @@ mod tests {
     /// MCP reload is directly callable from conversation; the host receives the
     /// same typed command as interactive `/mcp reload` and returns its report.
     #[tokio::test]
-    async fn run_yolop_command_dispatches_mcp_reload() {
+    async fn run_command_dispatches_mcp_reload() {
         let ui = Arc::new(RecordingUi::default());
-        let tool = RunYolopCommandTool { ui: ui.clone() };
+        let tool = RunCommandTool { ui: ui.clone() };
 
         let result = tool
-            .execute(json!({ "command": "mcp", "arguments": "reload" }))
+            .execute(json!({ "command": "mcp", "args": ["reload"] }))
             .await;
 
         assert!(result.is_success(), "tool should succeed: {result:?}");
@@ -639,16 +651,14 @@ mod tests {
         );
     }
 
-    /// `run_yolop_command` for `/mcp` returns the host listing so the agent
+    /// `run_command` for `/mcp` returns the host listing so the agent
     /// can act conversationally (login/reload) without inventing a manager window.
     #[tokio::test]
-    async fn repro_run_yolop_command_mcp_returns_host_output() {
+    async fn repro_run_command_mcp_returns_host_output() {
         let ui = Arc::new(RecordingUi::default());
-        let tool = RunYolopCommandTool { ui: ui.clone() };
+        let tool = RunCommandTool { ui: ui.clone() };
 
-        let result = tool
-            .execute(json!({ "command": "mcp", "arguments": "" }))
-            .await;
+        let result = tool.execute(json!({ "command": "mcp", "args": [] })).await;
         assert!(result.is_success(), "tool should succeed: {result:?}");
 
         let payload = match result {

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -1,6 +1,7 @@
 // Host/example capabilities for yolop: local environment context, bash, and
 // TUI-facing slash commands that mutate this process's provider selection.
 
+use crate::capabilities::model_discovery::search_configured_models;
 use crate::capabilities::narration::stable_labeled;
 use crate::config::service::ConfigService;
 use crate::config::{ApprovalMode, SettingsStore};
@@ -508,7 +509,7 @@ fn format_shell_output(value: &serde_json::Value) -> String {
 // that wizard mutate runtime state without exposing `/provider`, `/token`, and
 // `/model` as separate commands.
 
-pub(crate) const SETUP_CAPABILITY_ID: &str = "yolop_setup";
+pub(crate) const MODELS_CAPABILITY_ID: &str = "models";
 
 /// Providers that meaningfully consume an API token. `llmsim` is excluded
 /// (no key needed); `ollama` and `custom` are included for completeness even
@@ -526,7 +527,7 @@ const TOKEN_PROVIDERS: &[&str] = &[
 /// settings (vs. a compiled-in default with env override).
 const BASE_URL_PROVIDERS: &[&str] = &["custom"];
 
-pub(crate) struct SetupCapability {
+pub(crate) struct ModelsCapability {
     pub(crate) provider: Arc<RwLock<ProviderChoice>>,
     pub(crate) provider_store: Arc<dyn RuntimeProviderStore>,
     /// Reads current configuration through the shared config service…
@@ -537,7 +538,7 @@ pub(crate) struct SetupCapability {
     pub(crate) pending_model_choice: Arc<RwLock<Option<ProviderChoice>>>,
 }
 
-impl SetupCapability {
+impl ModelsCapability {
     /// The shared, cloneable handle the `/setup` command and the model-facing
     /// `set_*` tools both drive. Everything that mutates the live provider/model
     /// lives on [`SetupController`] so the slash command and the agent tools
@@ -554,7 +555,7 @@ impl SetupCapability {
 }
 
 /// Live provider/model/effort controller. Holds the same handles as
-/// [`SetupCapability`] and owns every mutation (`change_provider`,
+/// [`ModelsCapability`] and owns every mutation (`change_provider`,
 /// `change_model`, `change_effort`, tokens, urls, attribution, approval). The
 /// slash command (`execute_command`) and the agent-facing `set_*` tools both
 /// call these methods, so a natural-language request and a typed `/setup`
@@ -569,15 +570,15 @@ pub(crate) struct SetupController {
 }
 
 #[async_trait]
-impl Capability for SetupCapability {
+impl Capability for ModelsCapability {
     fn id(&self) -> &str {
-        SETUP_CAPABILITY_ID
+        MODELS_CAPABILITY_ID
     }
     fn name(&self) -> &str {
-        "Coding CLI Setup"
+        "Models"
     }
     fn description(&self) -> &str {
-        "Configure provider, API key, and model."
+        "Discover and control models, providers, reasoning, and provider credentials."
     }
     fn status(&self) -> CapabilityStatus {
         CapabilityStatus::Available
@@ -586,7 +587,7 @@ impl Capability for SetupCapability {
         Some("Examples")
     }
     fn system_prompt_addition(&self) -> Option<&str> {
-        Some(SETUP_TOOLS_PROMPT)
+        Some(MODELS_PROMPT)
     }
     fn commands(&self) -> Vec<CommandDescriptor> {
         vec![CommandDescriptor {
@@ -606,6 +607,9 @@ impl Capability for SetupCapability {
         vec![
             Box::new(SetReasoningEffortTool {
                 controller: self.controller(),
+            }),
+            Box::new(SearchModelsTool {
+                settings: self.settings.clone(),
             }),
             Box::new(SetModelTool {
                 controller: self.controller(),
@@ -658,11 +662,10 @@ impl Capability for SetupCapability {
 // Discovery, not how-to: without this the model does not know it may retune the
 // live session at all. When to escalate effort, and not thrashing the model
 // mid-task, are judgement calls left to the model.
-pub(crate) const SETUP_TOOLS_PROMPT: &str = "<capability id=\"yolop_setup\">\n\
-    You can reconfigure the live session yourself when it helps the task: \
-    `set_reasoning_effort`, `set_model`, and `set_provider` all apply on the next \
-    turn of this session — no restart. Effort levels are model-specific; if one is \
-    unknown, `set_reasoning_effort` returns the accepted values.\n\
+pub(crate) const MODELS_PROMPT: &str = "<capability id=\"models\">\n\
+    `set_reasoning_effort`, `set_model`, and `set_provider` apply next turn. For partial \
+    model names, call `search_models`, show ambiguous matches, and never guess an ID. \
+    Unknown effort levels return accepted values.\n\
     </capability>";
 
 fn setup_command_arg() -> CommandArg {
@@ -1303,6 +1306,38 @@ impl Tool for SetReasoningEffortTool {
     }
 }
 
+struct SearchModelsTool {
+    settings: Arc<SettingsStore>,
+}
+
+#[async_trait]
+impl Tool for SearchModelsTool {
+    fn name(&self) -> &str {
+        "search_models"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Search models")
+    }
+    fn description(&self) -> &str {
+        "Search model IDs and display names across all currently usable providers. Use this before set_model for a partial or unqualified model name."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({"type":"object","properties":{"query":{"type":"string"}},"required":["query"],"additionalProperties":false})
+    }
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let Some(query) = arguments.get("query").and_then(Value::as_str) else {
+            return ToolExecutionResult::tool_error("missing required string 'query'");
+        };
+        if query.trim().is_empty() {
+            return ToolExecutionResult::tool_error("'query' must not be empty");
+        }
+        let result = search_configured_models(&self.settings.snapshot(), query).await;
+        ToolExecutionResult::success(
+            json!({"query":query,"matches":result.matches.into_iter().map(|item| json!({"provider":item.provider,"model":item.model_id,"display_name":item.display_name})).collect::<Vec<_>>(),"providers_searched":result.providers_searched,"provider_errors":result.provider_errors}),
+        )
+    }
+}
+
 struct SetModelTool {
     controller: SetupController,
 }
@@ -1328,9 +1363,7 @@ impl Tool for SetModelTool {
         Some("Set model")
     }
     fn description(&self) -> &str {
-        "Switch the model used for this session. Applies on the next turn — no restart. The id is \
-         resolved against the current provider; an optional reasoning effort can be set at the same \
-         time. Avoid switching mid-task unless it clearly helps."
+        "Switch to an exact model ID for the current provider. For a partial name, call search_models first; never pass an unresolved fragment."
     }
     fn parameters_schema(&self) -> Value {
         json!({
@@ -1354,6 +1387,31 @@ impl Tool for SetModelTool {
             Ok(value) => value,
             Err(err) => return err,
         };
+        let search = search_configured_models(&self.controller.settings.snapshot(), model).await;
+        let current_provider = self
+            .controller
+            .provider
+            .read()
+            .expect("provider lock poisoned")
+            .provider_name()
+            .to_string();
+        let exact_current = search
+            .matches
+            .iter()
+            .any(|item| item.provider == current_provider && item.model_id == model);
+        if !search.matches.is_empty() && !exact_current {
+            let choices = search
+                .matches
+                .iter()
+                .take(20)
+                .map(|item| format!("{}: {}", item.provider, item.model_id))
+                .collect::<Vec<_>>()
+                .join(", ");
+            return ToolExecutionResult::tool_error(format!(
+                "`{model}` is not an exact model ID for provider `{current_provider}`. Matching models: {choices}. Select an exact result; call set_provider first for another provider."
+            ));
+        }
+
         // `change_model` accepts the `model [reasoning-effort]` spec the
         // `/setup model` command takes, so join the optional effort onto it.
         let spec = match arguments.get("reasoning_effort").and_then(Value::as_str) {
@@ -1426,7 +1484,7 @@ impl Tool for SetProviderTool {
     }
 }
 
-impl SetupCapability {
+impl ModelsCapability {
     /// True when no provider preference is saved and no API token is set —
     /// either via env var or in the settings file. Used by the TUI at
     /// startup to auto-open the wizard on a fresh install.
@@ -1600,9 +1658,9 @@ mod tests {
     }
 
     #[test]
-    fn setup_capability_exposes_live_config_tools() {
+    fn models_capability_exposes_live_config_tools() {
         let (controller, _provider, _dir) = test_controller(ProviderChoice::Sim);
-        let capability = SetupCapability {
+        let capability = ModelsCapability {
             provider: controller.provider.clone(),
             provider_store: controller.provider_store.clone(),
             config: controller.config.clone(),
@@ -1614,10 +1672,15 @@ mod tests {
             .iter()
             .map(|t| t.name().to_string())
             .collect();
-        for expected in ["set_reasoning_effort", "set_model", "set_provider"] {
+        for expected in [
+            "set_reasoning_effort",
+            "search_models",
+            "set_model",
+            "set_provider",
+        ] {
             assert!(
                 names.iter().any(|n| n == expected),
-                "{expected} should be exposed by SetupCapability: {names:?}"
+                "{expected} should be exposed by ModelsCapability: {names:?}"
             );
         }
         // The agent is told these tools exist so it uses them instead of asking
@@ -1625,6 +1688,7 @@ mod tests {
         let prompt = capability.system_prompt_addition().expect("setup prompt");
         assert!(prompt.contains("set_reasoning_effort"));
         assert!(prompt.contains("set_model"));
+        assert!(prompt.contains("search_models"));
         assert!(prompt.contains("set_provider"));
     }
 
@@ -1658,7 +1722,7 @@ mod tests {
             std::env::remove_var("CUSTOM_API_KEY");
         }
         let settings = crate::config::Settings::default();
-        assert!(SetupCapability::needs_onboarding(&settings));
+        assert!(ModelsCapability::needs_onboarding(&settings));
     }
 
     #[test]
@@ -1678,12 +1742,12 @@ mod tests {
             std::env::set_var("CUSTOM_API_KEY", "sk-orphan");
         }
         let settings = crate::config::Settings::default();
-        assert!(SetupCapability::needs_onboarding(&settings));
+        assert!(ModelsCapability::needs_onboarding(&settings));
 
         unsafe {
             std::env::set_var("CUSTOM_BASE_URL", "http://localhost:8000/v1");
         }
-        assert!(!SetupCapability::needs_onboarding(&settings));
+        assert!(!ModelsCapability::needs_onboarding(&settings));
         unsafe {
             std::env::remove_var("CUSTOM_BASE_URL");
             std::env::remove_var("CUSTOM_API_KEY");
@@ -1696,7 +1760,7 @@ mod tests {
             default_provider: Some("anthropic".to_string()),
             ..Default::default()
         };
-        assert!(!SetupCapability::needs_onboarding(&settings));
+        assert!(!ModelsCapability::needs_onboarding(&settings));
     }
 
     #[test]
@@ -1708,7 +1772,7 @@ mod tests {
             tokens,
             ..Default::default()
         };
-        assert!(!SetupCapability::needs_onboarding(&settings));
+        assert!(!ModelsCapability::needs_onboarding(&settings));
     }
 
     #[test]

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -56,7 +56,7 @@ pub(crate) use hooks::{HOOKS_CAPABILITY_ID, HooksCapability};
 pub(crate) use host::{
     CODING_BASH_CAPABILITY_ID, ClientUiContext, CodingBashCapability,
     CodingCliEnvironmentCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID, EnvironmentContextRegistry,
-    SETUP_CAPABILITY_ID, SetupCapability,
+    MODELS_CAPABILITY_ID, ModelsCapability,
 };
 pub(crate) use lsp::LspCapability;
 pub(crate) use model_runtime_context::{

--- a/src/capabilities/model_discovery.rs
+++ b/src/capabilities/model_discovery.rs
@@ -8,7 +8,7 @@
 // names and descriptions even when the provider's API returns bare ids.
 
 use crate::config::Settings;
-use crate::runtime::ProviderChoice;
+use crate::runtime::{ProviderChoice, SUPPORTED_PROVIDERS};
 use anyhow::{Context, Result, anyhow};
 use everruns_core::DriverId;
 use everruns_core::driver_registry::{DiscoveredModel, DriverRegistry, ProviderConfig};
@@ -247,6 +247,101 @@ async fn list_openai_compatible_models(
         })
         .collect();
     Ok(Some(models))
+}
+
+fn provider_is_usable(settings: &Settings, provider: &str) -> bool {
+    match provider {
+        "llmsim" | "ollama" => true,
+        "custom" => crate::runtime::custom_base_url(settings).is_some(),
+        "codex" => provider_env_present("codex") || settings.has_codex_auth(),
+        _ => provider_env_present(provider) || settings.has_token(provider),
+    }
+}
+
+fn provider_env_present(provider: &str) -> bool {
+    let names: &[&str] = match provider {
+        "openai" => &["OPENAI_API_KEY"],
+        "codex" => &["CODEX_ACCESS_TOKEN"],
+        "anthropic" => &["ANTHROPIC_API_KEY"],
+        "google" => &["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+        "openrouter" => &["OPENROUTER_API_KEY"],
+        "ollama" => &["OLLAMA_BASE_URL", "OLLAMA_API_KEY"],
+        "custom" => &["CUSTOM_API_KEY"],
+        _ => &[],
+    };
+    names.iter().any(|name| {
+        std::env::var(name)
+            .map(|value| !value.is_empty())
+            .unwrap_or(false)
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ModelSearchMatch {
+    pub(crate) provider: String,
+    pub(crate) model_id: String,
+    pub(crate) display_name: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct ModelSearchResult {
+    pub(crate) matches: Vec<ModelSearchMatch>,
+    pub(crate) providers_searched: Vec<String>,
+    pub(crate) provider_errors: Vec<String>,
+}
+
+/// Search driver-provided model catalogs across every currently usable provider.
+/// A provider failure is isolated so successful catalogs still contribute results.
+pub(crate) async fn search_configured_models(
+    settings: &Settings,
+    query: &str,
+) -> ModelSearchResult {
+    let needle = query.trim().to_lowercase();
+    let mut result = ModelSearchResult::default();
+    if needle.is_empty() {
+        return result;
+    }
+    for provider_name in SUPPORTED_PROVIDERS {
+        if !provider_is_usable(settings, provider_name) {
+            continue;
+        }
+        let choice = match ProviderChoice::default_for_provider_name(provider_name) {
+            Ok(choice) => choice,
+            Err(error) => {
+                result
+                    .provider_errors
+                    .push(format!("{provider_name}: {error}"));
+                continue;
+            }
+        };
+        result.providers_searched.push((*provider_name).to_string());
+        match discover_provider_models(&choice, settings).await {
+            Ok(Some(models)) => result
+                .matches
+                .extend(models.into_iter().filter_map(|model| {
+                    let display_name = model.display_name.clone();
+                    let display = display_name.as_deref().unwrap_or("");
+                    (model.model_id.to_lowercase().contains(&needle)
+                        || display.to_lowercase().contains(&needle))
+                    .then(|| ModelSearchMatch {
+                        provider: (*provider_name).to_string(),
+                        model_id: model.model_id,
+                        display_name,
+                    })
+                })),
+            Ok(None) => {}
+            Err(error) => result
+                .provider_errors
+                .push(format!("{provider_name}: {error}")),
+        }
+    }
+    result
+        .matches
+        .sort_by(|a, b| (&a.provider, &a.model_id).cmp(&(&b.provider, &b.model_id)));
+    result
+        .matches
+        .dedup_by(|a, b| a.provider == b.provider && a.model_id == b.model_id);
+    result
 }
 
 #[cfg(test)]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -24,11 +24,11 @@ use crate::capabilities::{
     CodingCliEnvironmentCapability, ConfigCapability, ContextCostControlCapability,
     ENVIRONMENT_CONTEXT_CAPABILITY_ID, EnvironmentContextRegistry, GOAL_CAPABILITY_ID,
     GoalCapability, HERDR_CAPABILITY_ID, HOOKS_CAPABILITY_ID, HerdrCapability, HooksCapability,
-    LspCapability, MODEL_RUNTIME_CONTEXT_CAPABILITY_ID, ModelRuntimeContextCapability,
-    PROGRESS_GUARD_CAPABILITY_ID, ProgressGuardCapability, REPO_MAP_CAPABILITY_ID,
-    RepoMapCapability, SESSION_HISTORY_CAPABILITY_ID, SETUP_CAPABILITY_ID,
-    SessionHistoryCapability, SetupCapability, USER_ASK_CAPABILITY_ID, UserAskCapability,
-    WorktreeCapability,
+    LspCapability, MODEL_RUNTIME_CONTEXT_CAPABILITY_ID, MODELS_CAPABILITY_ID,
+    ModelRuntimeContextCapability, ModelsCapability, PROGRESS_GUARD_CAPABILITY_ID,
+    ProgressGuardCapability, REPO_MAP_CAPABILITY_ID, RepoMapCapability,
+    SESSION_HISTORY_CAPABILITY_ID, SessionHistoryCapability, USER_ASK_CAPABILITY_ID,
+    UserAskCapability, WorktreeCapability,
 };
 use crate::config::capability_settings::{CapabilityCatalog, apply_capability_settings};
 use crate::config::mcp::McpConfigStore;
@@ -1079,7 +1079,7 @@ const YOLOP_NEVER_DEFER_TOOLS: &[&str] = &[
     "activate_skill",
     "search_skills",
     "install_skill",
-    "run_yolop_command",
+    "run_command",
     // LSP tools exist only when the optional `lsp` capability is enabled
     // (absent names are ignored by the allowlist). When they exist, stub
     // schemas behind `tool_search` add enough friction that models fall back
@@ -2258,7 +2258,7 @@ fn default_coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabi
             WEB_FETCH_CAPABILITY_ID,
             serde_json::json!({ "enable_file_download": true }),
         ),
-        AgentCapabilityConfig::new(SETUP_CAPABILITY_ID),
+        AgentCapabilityConfig::new(MODELS_CAPABILITY_ID),
         AgentCapabilityConfig::new(CONFIG_CAPABILITY_ID),
         AgentCapabilityConfig::new(CONNECTORS_CAPABILITY_ID),
         AgentCapabilityConfig::new(crate::extensions::manage::EXTENSIONS_CAPABILITY_ID),
@@ -2632,7 +2632,7 @@ impl StartupInfo {
 
 #[derive(Clone)]
 pub struct ModelState {
-    /// Shared with [`crate::capabilities::SetupCapability`] so a successful `/setup`
+    /// Shared with [`crate::capabilities::ModelsCapability`] so a successful `/setup`
     /// invocation through `runtime.execute_command` immediately updates the
     /// banner label.
     provider: Arc<RwLock<ProviderChoice>>,
@@ -3067,7 +3067,7 @@ pub async fn build_with_options(
     let local_backends = local_backends.with_platform_runner(wake_runner);
     let backends = local_backends.runtime_backends;
     // Shared between `ModelState` (for banner labels) and
-    // `SetupCapability` (which mutates it on a successful `/setup`).
+    // `ModelsCapability` (which mutates it on a successful `/setup`).
     let provider_state = Arc::new(RwLock::new(provider.clone()));
     let provider_store = backends.provider_store.clone();
 
@@ -3373,7 +3373,7 @@ pub async fn build_with_options(
     // `/setup` (below) is the capability-sourced slash command. It implements
     // `Capability::execute_command` end to end.
     let pending_model_choice = Arc::new(RwLock::new(None));
-    capabilities.register(SetupCapability {
+    capabilities.register(ModelsCapability {
         provider: provider_state.clone(),
         provider_store: provider_store.clone(),
         config: settings.clone(),
@@ -3476,7 +3476,7 @@ pub async fn build_with_options(
     everruns_openrouter::register_driver(&mut driver_registry);
     crate::drivers::codex::register_driver(&mut driver_registry, settings.clone());
     let settings_snapshot = settings.snapshot();
-    let mut setup_recommended = SetupCapability::needs_onboarding(&settings_snapshot);
+    let mut setup_recommended = ModelsCapability::needs_onboarding(&settings_snapshot);
     let default_model = match &provider {
         ProviderChoice::Anthropic { .. }
         | ProviderChoice::OpenAi { .. }
@@ -5442,7 +5442,7 @@ mod tests {
 
     // The live-config tools (`set_provider` / `set_model` / `set_reasoning_effort`)
     // and skill management tools (`search_skills` / `install_skill` / `delete_skill`)
-    // are registered via SetupCapability / SkillManagementCapability
+    // are registered via ModelsCapability / SkillManagementCapability
     // in `build_with_options`. Because ToolSearchCapability defers the long tail
     // behind `tool_search`, only the never-defer allowlist keeps search/install
     // schemas loaded; `delete_skill` remains deferred. Presence is asserted at
@@ -7547,7 +7547,7 @@ mod tests {
         use crate::capabilities::attribution::yolop_attribution_prompt;
         use crate::capabilities::background::BACKGROUND_SYSTEM_PROMPT;
         use crate::capabilities::client_commands::CLIENT_COMMANDS_PROMPT;
-        use crate::capabilities::host::SETUP_TOOLS_PROMPT;
+        use crate::capabilities::host::MODELS_PROMPT;
         use crate::config::ApprovalMode;
 
         // Current total is 5,657; the headroom is deliberately thin.
@@ -7559,7 +7559,7 @@ mod tests {
             ("approval", approval.len()),
             ("background", BACKGROUND_SYSTEM_PROMPT.len()),
             ("client_commands", CLIENT_COMMANDS_PROMPT.len()),
-            ("setup", SETUP_TOOLS_PROMPT.len()),
+            ("setup", MODELS_PROMPT.len()),
             ("attribution", yolop_attribution_prompt().len()),
         ];
 

--- a/src/testing/scenarios.rs
+++ b/src/testing/scenarios.rs
@@ -151,7 +151,7 @@ async fn scripted_prompt_command_tool_queues_quit_ui_command() {
     let (mut runtime, _ws) = build_scripted_runtime_with_workspace_and_options(
         LlmSimConfig::scripted(vec![
             SimTurn::ToolCalls(vec![SimToolCall {
-                name: "run_yolop_command".to_string(),
+                name: "run_command".to_string(),
                 arguments: json!({ "command": "exit" }),
                 id: None,
             }]),

--- a/src/tui/host_ui.rs
+++ b/src/tui/host_ui.rs
@@ -10,7 +10,7 @@
 //! forwards a typed [`UiCommand`] to the terminal event loop over a channel.
 //! The loop is the only thing that can perform the effect, so it applies it.
 //!
-//! Agent-facing tools ([`crate::capabilities::client_commands::RunYolopCommandTool`])
+//! Agent-facing tools ([`crate::capabilities::client_commands::RunCommandTool`])
 //! use [`HostUi::request`] so the host can return the transcript lines it
 //! produced — making `/mcp` and `/tools` conversational instead of
 //! fire-and-forget.
@@ -102,7 +102,7 @@ pub trait HostUi: Send + Sync {
     fn send(&self, command: UiCommand);
 
     /// Apply `command` and return the system transcript lines the host produced.
-    /// Used by `run_yolop_command` so the agent sees `/mcp` / `/tools` output.
+    /// Used by `run_command` so the agent sees `/mcp` / `/tools` output.
     fn request(&self, command: UiCommand) -> oneshot::Receiver<Vec<String>>;
 }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -213,7 +213,7 @@ pub struct App {
     sandbox_approval_rx: crate::sandbox_approval::ApprovalReceiver,
     pending_sandbox_approval: Option<PendingSandboxApproval>,
     /// Settings store shared with the runtime (same instance
-    /// `SetupCapability` writes). Used to resolve credentials when querying
+    /// `ModelsCapability` writes). Used to resolve credentials when querying
     /// provider models APIs and to show per-provider connection status in
     /// the setup overlay.
     settings: Arc<crate::config::SettingsStore>,
@@ -2701,7 +2701,7 @@ impl App {
     /// declare commands and request effects, the host performs them.
     ///
     /// Returns the system transcript lines produced while applying the command
-    /// so agent-facing `HostUi::request` callers (e.g. `run_yolop_command`) can
+    /// so agent-facing `HostUi::request` callers (e.g. `run_command`) can
     /// surface `/mcp` / `/tools` output conversationally.
     async fn apply_ui_command(&mut self, command: UiCommand) -> Vec<String> {
         let clearing = matches!(&command, UiCommand::ClearTranscript);


### PR DESCRIPTION
## Summary
- add driver-backed model search across every usable provider
- expose `search_models` with safe exact-ID enforcement before `set_model`
- rename the capability to the noun-based `models` ID
- rename `run_yolop_command` to `run_command` and accept structured `args[]`
- document the conversational model-control contract

## User Impact
A request such as “use luna model” now searches configured provider catalogs and presents provider-qualified choices instead of changing the session to an invalid literal `luna` model.

## Testing
- `cargo test client_commands --all-features`
- `cargo test capabilities::host --all-features`
- `cargo test runtime::tests::always_on_capability_prompts_within_budget --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `python3 scripts/validate_okf.py knowledge --check-links`
- live smoke: `doppler run --project everruns-dev --config dev -- cargo run -- --provider openai --model gpt-5.2 -p "use luna model"`
- full `cargo test --all-features` completed except one timing-sensitive scenario; its exact rerun passed

## Security
- **TM-LLM / TM-TOOL:** model discovery remains read-only and uses runtime drivers; credentials stay inside provider configuration and are never returned
- provider failures are isolated and only provider/model metadata is exposed
- `set_model` rejects discovered partial IDs and leaves the active model unchanged
- no filesystem, shell, dependency, or infrastructure behavior changed

## Knowledge
Updated command, configuration, conversational-control, MCP, and tool-search concepts for `run_command`, the `models` capability, and model-search behavior.

## Follow-ups
No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
