### PR TITLE
fix(runtime): recover interrupted provider turns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,9 +1691,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.21"
+version = "0.17.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c64c5c9dc834c368ef58a519af6057170d59898f1832497bac36930315a8159"
+checksum = "76462bebdf37c94747b8d94fa0547fbd6f28b15f0a475093da9c2f9f319ec856"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1709,9 +1709,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.21"
+version = "0.17.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a707c1ea91a00907d7c374697ba87479259394a6e0b3dfdd93d67a5b3c924126"
+checksum = "7ac5957d24870f985d4d0f5d090edc6ac943ffd74c93d0243be76b5b509db9c1"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -1746,6 +1746,7 @@ dependencies = [
  "similar 3.1.1",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-opentelemetry",
@@ -1756,9 +1757,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.21"
+version = "0.17.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "975a396124387a581b761f56af6f35cde3abea660f7b403a5863ad04ca2b2b5f"
+checksum = "cdae003ba3e9a61f851b63147a6186526b1ca8d2384239421e331da96d1a2bb4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1773,9 +1774,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.21"
+version = "0.17.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3db9a459681785e1f7957ad323023517f1a07bf3294101674b083d139784be"
+checksum = "dca42a43f7be36c152f6b7691171d43f72ac29bededfd475ce04bdc4b31c6d81"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1789,9 +1790,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.21"
+version = "0.17.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15753faec7aafe618f999e7cb06ff2c61f2727d8a697684db932a9dd2b83289b"
+checksum = "9f3e651904d2f74f4da41c28be3c37b18f3f95afd64df7f29565dfe2ae5ce13f"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1803,9 +1804,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.21"
+version = "0.17.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fe1c7522c51e3185433e6c39158762ca610e69b0e9a8efa5879b97b9031483"
+checksum = "110244f532549556ba454a1a53b40f16c040413d8f0d2e2083c17ee2bb915145"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1827,9 +1828,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.21"
+version = "0.17.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7d3808718fd36963382eabeac88c162e72da1aa00a8611261d5486460cf3be"
+checksum = "718a12085773ed21a8ee01fef281c9db03c87f3100c8b13971f2af4e841b7a25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1842,9 +1843,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.21"
+version = "0.17.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "296bae9a7d1b2f60628be5d1174aa8f4dcc050e3c1e03f2b06970af6325db171"
+checksum = "be65a5d4af067f51cb2ef7492348cb2c85e6a4b58b677b19900f5e2ad5cd209d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1858,9 +1859,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.21"
+version = "0.17.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e204bd31f57e49dab2e09918bcf34044d0280853ab562b3ee57b0b99e6fef4"
+checksum = "b2af9f0042bbbf4934511c0a05f7abf6036bdf980b5476b79b60b08ef1720681"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1872,9 +1873,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-provider"
-version = "0.17.21"
+version = "0.17.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d6ba9c24f528e53b305170d66cca9c4a2e01928a2bf0d9a37240fb2311d90e"
+checksum = "329f7663db42528a5ac2d5144009da545df4fdea56a25790e8650590d17a38ed"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1900,9 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.21"
+version = "0.17.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "454576d37ea267d7a58db8a3a5e3c931f98e6abd810a8a7be923e88c253e1555"
+checksum = "b61fb61bea6fc1f05aa1981a67efccd34ec2705d6ab5d62c407de07b056941ac"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,20 +102,20 @@ tree-sitter-zig = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-everruns-anthropic = "0.17.21"
-everruns-core = "0.17.21"
-everruns-openai = "0.17.21"
+everruns-anthropic = "0.17.22"
+everruns-core = "0.17.22"
+everruns-openai = "0.17.22"
 # OpenRouter's first-class driver was split out of everruns-openai into its own
 # crate in 0.13.0; register it alongside openai to keep DriverId::OpenRouter.
-everruns-openrouter = "0.17.21"
-everruns-local = "0.17.21"
-everruns-mcp = { version = "0.17.21", features = ["stdio"] }
+everruns-openrouter = "0.17.22"
+everruns-local = "0.17.22"
+everruns-mcp = { version = "0.17.22", features = ["stdio"] }
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (knowledge/specs/mcp.md, upstream runtime-mcp.md D2).
-everruns-runtime = { version = "0.17.21", features = ["mcp-stdio"] }
-everruns-integrations-duckduckgo = "0.17.21"
-everruns-integrations-parallel = "0.17.21"
-everruns-integrations-daytona = "0.17.21"
+everruns-runtime = { version = "0.17.22", features = ["mcp-stdio"] }
+everruns-integrations-duckduckgo = "0.17.22"
+everruns-integrations-parallel = "0.17.22"
+everruns-integrations-daytona = "0.17.22"
 arboard = { version = "3", features = ["wayland-data-control"] }
 futures = "0.3"
 html-escape = "0.2"

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,15 @@
 Significant changes to Yolop's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
+## 2026-08-05 — Bounded provider-turn recovery
+
+- Provider stalls, transport failures, overload, and retryable server failures
+  recover inside the active everruns reason phase under shared attempt and time
+  budgets, preserving completed tool outputs and checkpoint identity.
+- Yolop serializes single-use Codex token rotation across driver instances and
+  rejects models absent from an available provider catalog before persisting the
+  ask.
+
 ## 2026-08-05 — Cumulative-cost context checkpoints
 
 - [Checkpointing](specs/checkpointing.md) now defines cumulative uncached input
@@ -13,7 +22,6 @@ wording, formatting, and link fixes do not need entries.
 - Active turns now admit already-persisted event boundaries for durable context
   checkpoints while rejecting future boundaries, so proactive replacement can
   install before the turn closes without weakening rewind lineage.
-
 ## 2026-08-05 — Default bounded task completion
 
 - [User ask](specs/user-ask.md) is now the default host completion safety net

--- a/knowledge/specs/checkpointing.md
+++ b/knowledge/specs/checkpointing.md
@@ -165,11 +165,17 @@ describes which event ranges form the active branch.
 
 On a new turn, Yolop:
 
-1. creates and flushes the checkpoint;
-2. records its parent as the current conversation head;
-3. runs the turn and appends events normally;
-4. records the turn's final sequence and status;
-5. advances the active head.
+1. validates the requested model when its provider exposes model discovery;
+2. creates and flushes the checkpoint;
+3. records its parent as the current conversation head;
+4. runs the turn and appends events normally;
+5. records the turn's final sequence and status;
+6. advances the active head.
+
+A failed model preflight does not create a checkpoint or append the ask. Once a
+provider request begins, everruns-runtime owns bounded transient recovery inside
+the active reason phase. Retries reuse the persisted ask and completed tool
+outputs; they never create another checkpoint or re-run a completed tool.
 
 On resume, Yolop validates the timeline, walks parents from the active head, and
 replays only those event ranges into the event bus, message store, and transcript.

--- a/knowledge/specs/configuration.md
+++ b/knowledge/specs/configuration.md
@@ -57,9 +57,12 @@ key is still read (and accepted as an alias) so pre-rename settings files keep
 working. `default_model` is applied as a cross-provider fallback in
 `ProviderChoice::resolve_for_settings`, but only when the model id is
 recognized for the active provider. At startup and on `/setup provider`
-switches, yolop may also query the provider's models API (when credentials
-exist) and fall back with a warning if the resolved model is no longer offered.
-Per-provider `models.<provider>` picks are always trusted.
+switches, yolop may also query the provider's models API when credentials
+exist. Before a turn is checkpointed or sent, Yolop validates the selected model
+once per process against that API when it is available. Unavailable models fail
+without persisting the ask, so the user can select an advertised model and
+submit the same turn. Providers without discovery support (including custom
+compatible endpoints) continue without preflight.
 
 ### Named execution profiles
 

--- a/src/drivers/codex.rs
+++ b/src/drivers/codex.rs
@@ -8,7 +8,7 @@ use everruns_core::driver_registry::{
     ProviderMetadata, ProviderOpaqueContext,
 };
 use everruns_core::driver_registry::{DiscoveredModel, DriverRegistry};
-use everruns_core::error::{AgentLoopError, Result as EverrunsResult};
+use everruns_core::error::{AgentLoopError, LlmErrorKind, Result as EverrunsResult};
 use everruns_core::tool_types::{ToolCall, ToolDefinition};
 use everruns_core::{
     CompactContent, CompactContentPart, CompactOutputItem, CompactRequest, CompactResponse,
@@ -63,15 +63,18 @@ pub struct CodexChatDriver {
     client: reqwest::Client,
     responses_url: String,
     tokens: Arc<tokio::sync::Mutex<CodexTokens>>,
+    refresh_gate: Arc<tokio::sync::Mutex<()>>,
     auth_store: Option<Arc<dyn CodexAuthStore>>,
 }
 
 pub fn register_driver(registry: &mut DriverRegistry, settings: Arc<SettingsStore>) {
     let auth_store: Arc<dyn CodexAuthStore> = settings;
+    let refresh_gate = Arc::new(tokio::sync::Mutex::new(()));
     registry.register_external(CODEX_DRIVER_ID, move |config| {
-        Box::new(CodexChatDriver::from_config(
+        Box::new(CodexChatDriver::from_config_with_refresh_gate(
             config,
             Some(auth_store.clone()),
+            refresh_gate.clone(),
         ))
     });
 }
@@ -81,7 +84,11 @@ pub(crate) fn model_profile(model_id: &str) -> Option<ModelProfile> {
 }
 
 impl CodexChatDriver {
-    fn from_config(config: &DriverConfig, auth_store: Option<Arc<dyn CodexAuthStore>>) -> Self {
+    fn from_config_with_refresh_gate(
+        config: &DriverConfig,
+        auth_store: Option<Arc<dyn CodexAuthStore>>,
+        refresh_gate: Arc<tokio::sync::Mutex<()>>,
+    ) -> Self {
         let access_token = config
             .api_key
             .clone()
@@ -109,18 +116,28 @@ impl CodexChatDriver {
                 account_id,
                 email,
             })),
+            refresh_gate,
             auth_store,
         }
     }
 
     async fn token_snapshot(&self) -> EverrunsResult<CodexTokens> {
+        self.refresh_tokens_with(|refresh_token| async move {
+            crate::auth::codex::refresh_with_token(&refresh_token).await
+        })
+        .await
+    }
+
+    async fn refresh_tokens_with<F, Fut>(&self, refresh: F) -> EverrunsResult<CodexTokens>
+    where
+        F: Fn(String) -> Fut,
+        Fut: Future<Output = anyhow::Result<CodexAuth>>,
+    {
+        // Refresh tokens are single-use. Factories can create multiple driver
+        // instances, so serialize the disk reload + rotation across all of them.
+        let _refresh_guard = self.refresh_gate.lock().await;
         let mut guard = self.tokens.lock().await;
-        ensure_fresh_tokens(
-            &mut guard,
-            self.auth_store.as_deref(),
-            |refresh_token| async move { crate::auth::codex::refresh_with_token(&refresh_token).await },
-        )
-        .await?;
+        ensure_fresh_tokens(&mut guard, self.auth_store.as_deref(), refresh).await?;
         Ok(guard.clone())
     }
 }
@@ -143,7 +160,8 @@ where
     Fut: Future<Output = anyhow::Result<CodexAuth>>,
 {
     if tokens.access_token.is_empty() {
-        return Err(AgentLoopError::llm(
+        return Err(AgentLoopError::llm_kind(
+            LlmErrorKind::Authentication,
             "Codex provider requires a saved OAuth access token",
         ));
     }
@@ -169,9 +187,7 @@ where
         Err(err) if crate::auth::codex::is_refresh_token_reused(&err) => {
             recover_from_refresh_token_reused(tokens, store, refresh, &refresh_token).await
         }
-        Err(err) => Err(AgentLoopError::llm(format!(
-            "Codex token refresh failed: {err:#}"
-        ))),
+        Err(err) => Err(classified_refresh_error(&err)),
     }
 }
 
@@ -203,9 +219,7 @@ where
                     // Fall through to clear + re-auth message.
                 }
                 Err(err) => {
-                    return Err(AgentLoopError::llm(format!(
-                        "Codex token refresh failed: {err:#}"
-                    )));
+                    return Err(classified_refresh_error(&err));
                 }
             }
         }
@@ -213,7 +227,27 @@ where
             tracing::warn!(error = %clear_err, "failed to clear invalid Codex auth");
         }
     }
-    Err(AgentLoopError::llm(REAUTH_MESSAGE))
+    Err(AgentLoopError::llm_kind(
+        LlmErrorKind::Authentication,
+        REAUTH_MESSAGE,
+    ))
+}
+
+fn classified_refresh_error(error: &anyhow::Error) -> AgentLoopError {
+    let message = format!("{error:#}");
+    let lower = message.to_ascii_lowercase();
+    let kind = if lower.contains("(429") {
+        LlmErrorKind::RateLimited
+    } else if lower.contains("refresh codex token")
+        || ["(500", "(502", "(503", "(504"]
+            .iter()
+            .any(|status| lower.contains(status))
+    {
+        LlmErrorKind::Unavailable
+    } else {
+        LlmErrorKind::Authentication
+    };
+    AgentLoopError::llm_kind(kind, format!("Codex token refresh failed: {message}"))
 }
 
 fn adopt_disk_auth(tokens: &mut CodexTokens, store: &dyn CodexAuthStore) {
@@ -1070,6 +1104,7 @@ mod tests {
                 account_id: Some("account-test".to_string()),
                 email: None,
             })),
+            refresh_gate: Arc::new(tokio::sync::Mutex::new(())),
             auth_store: None,
         }
     }
@@ -1281,6 +1316,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn shared_refresh_gate_prevents_duplicate_single_use_rotation() {
+        let store = Arc::new(MemoryAuthStore::default());
+        store
+            .save(CodexAuth {
+                access_token: "access-old".to_string(),
+                refresh_token: Some("refresh-once".to_string()),
+                expires_at: Some(crate::auth::codex::now_epoch_millis() - 1_000),
+                account_id: Some("acc".to_string()),
+                email: Some("user@example.com".to_string()),
+            })
+            .unwrap();
+        let auth_store: Arc<dyn CodexAuthStore> = store.clone();
+        let refresh_gate = Arc::new(tokio::sync::Mutex::new(()));
+        let make_driver = || CodexChatDriver {
+            client: reqwest::Client::new(),
+            responses_url: CODEX_RESPONSES_URL.to_string(),
+            tokens: Arc::new(tokio::sync::Mutex::new(expired_tokens("refresh-once"))),
+            refresh_gate: refresh_gate.clone(),
+            auth_store: Some(auth_store.clone()),
+        };
+        let first = make_driver();
+        let second = make_driver();
+        let refresh_calls = Arc::new(StdMutex::new(0usize));
+
+        let first_calls = refresh_calls.clone();
+        let second_calls = refresh_calls.clone();
+        let (first_result, second_result) = tokio::join!(
+            first.refresh_tokens_with(move |_refresh_token| {
+                let calls = first_calls.clone();
+                async move {
+                    *calls.lock().expect("calls") += 1;
+                    tokio::task::yield_now().await;
+                    Ok(CodexAuth {
+                        access_token: "access-new".to_string(),
+                        refresh_token: Some("refresh-next".to_string()),
+                        expires_at: Some(crate::auth::codex::now_epoch_millis() + 3_600_000),
+                        account_id: Some("acc".to_string()),
+                        email: None,
+                    })
+                }
+            }),
+            second.refresh_tokens_with(move |_refresh_token| {
+                let calls = second_calls.clone();
+                async move {
+                    *calls.lock().expect("calls") += 1;
+                    Ok(CodexAuth {
+                        access_token: "unexpected-second-refresh".to_string(),
+                        refresh_token: Some("unexpected".to_string()),
+                        expires_at: Some(crate::auth::codex::now_epoch_millis() + 3_600_000),
+                        account_id: Some("acc".to_string()),
+                        email: None,
+                    })
+                }
+            })
+        );
+
+        assert_eq!(*refresh_calls.lock().unwrap(), 1);
+        assert_eq!(first_result.unwrap().access_token, "access-new");
+        assert_eq!(second_result.unwrap().access_token, "access-new");
+        assert_eq!(store.load_from_disk().unwrap().access_token, "access-new");
+    }
+
+    #[tokio::test]
     async fn refresh_token_reused_recovers_from_disk_winner() {
         // First load looks like memory (stale); after reuse failure the disk
         // has another process's winner that no longer needs refresh.
@@ -1358,8 +1456,35 @@ mod tests {
 
         assert!(err.to_string().contains("/setup"));
         assert!(err.to_string().contains("refresh token already used"));
+        assert_eq!(err.llm_error_kind(), Some(LlmErrorKind::Authentication));
         assert!(store.load_from_disk().is_none());
         assert_eq!(*store.clears.lock().unwrap(), 1);
+    }
+
+    #[test]
+    fn refresh_failures_keep_transient_and_permanent_classification() {
+        let unavailable = classified_refresh_error(&anyhow::anyhow!(
+            "Codex token refresh failed (503 Service Unavailable)"
+        ));
+        let rate_limited = classified_refresh_error(&anyhow::anyhow!(
+            "Codex token refresh failed (429 Too Many Requests)"
+        ));
+        let authentication = classified_refresh_error(&anyhow::anyhow!(
+            "Codex token refresh failed (401 Unauthorized)"
+        ));
+
+        assert_eq!(
+            unavailable.llm_error_kind(),
+            Some(LlmErrorKind::Unavailable)
+        );
+        assert_eq!(
+            rate_limited.llm_error_kind(),
+            Some(LlmErrorKind::RateLimited)
+        );
+        assert_eq!(
+            authentication.llm_error_kind(),
+            Some(LlmErrorKind::Authentication)
+        );
     }
 
     #[test]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -97,9 +97,10 @@ use crate::runtime::session_log::{
     migrate_legacy_session_log, read_session_workspace_metadata, replay, session_dir_path,
     session_log_path, update_session_workspace_title,
 };
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::{Arc, LazyLock, Mutex as StdMutex, RwLock};
-use tokio::sync::mpsc;
+use tokio::sync::{RwLock as AsyncRwLock, mpsc};
 
 // The harness prompt is the durable instruction surface — borrowed in shape
 // from `crates/server/src/harnesses/coding_container.rs` and trimmed for
@@ -2638,6 +2639,8 @@ pub struct ModelState {
     provider: Arc<RwLock<ProviderChoice>>,
     provider_store: Arc<dyn RuntimeProviderStore>,
     settings: Settings,
+    driver_registry: DriverRegistry,
+    validated_models: Arc<AsyncRwLock<HashSet<(String, String)>>>,
 }
 
 impl ModelState {
@@ -2645,12 +2648,56 @@ impl ModelState {
         provider: Arc<RwLock<ProviderChoice>>,
         provider_store: Arc<dyn RuntimeProviderStore>,
         settings: Settings,
+        driver_registry: DriverRegistry,
     ) -> Self {
         Self {
             provider,
             provider_store,
             settings,
+            driver_registry,
+            validated_models: Arc::new(AsyncRwLock::new(HashSet::new())),
         }
+    }
+
+    /// Reject a model the provider's discovery API does not advertise before
+    /// the runtime persists or sends the next user turn. Providers without a
+    /// models API remain supported, and successful checks are cached per
+    /// process/model so tool continuations do not add network round trips.
+    pub(crate) async fn validate_model_available(&self) -> Result<()> {
+        let resolved = self
+            .provider_store
+            .get_default_model()
+            .await?
+            .ok_or_else(|| anyhow!("no provider model is configured; run `/setup`"))?;
+        let provider_name = resolved.provider_type.to_string();
+        let model_id = resolved.model.clone();
+        let cache_key = (provider_name.clone(), model_id.clone());
+        if self.validated_models.read().await.contains(&cache_key) {
+            return Ok(());
+        }
+        if !self.driver_registry.has_driver(&resolved.provider_type) {
+            // Runtime-builder-owned drivers (notably llmsim) and compatible
+            // custom providers do not expose discovery through this registry.
+            self.validated_models.write().await.insert(cache_key);
+            return Ok(());
+        }
+
+        let config = everruns_core::llm_conversions::provider_config_from_resolved_model(&resolved);
+        let driver = self.driver_registry.create_chat_driver(&config)?;
+        let discovered = tokio::time::timeout(std::time::Duration::from_secs(10), driver.list_models())
+            .await
+            .map_err(|_| anyhow!("{provider_name} model availability check timed out; the turn was not started and is safe to resume"))??;
+
+        if let Some(models) = discovered
+            && !models.iter().any(|model| model.model_id == model_id)
+        {
+            return Err(anyhow!(
+                "model `{model_id}` is not available from {provider_name}; choose an advertised model and resume the turn"
+            ));
+        }
+
+        self.validated_models.write().await.insert(cache_key);
+        Ok(())
     }
 
     pub fn provider_label(&self) -> String {
@@ -3513,6 +3560,7 @@ pub async fn build_with_options(
             base_url: None,
         },
     };
+    let model_driver_registry = driver_registry.clone();
 
     let platform = PlatformDefinition::builder()
         .capability_registry(capabilities)
@@ -3669,7 +3717,12 @@ pub async fn build_with_options(
             disabled_hook_contribution_count,
             hook_configured,
         },
-        model: ModelState::new(provider_state, provider_store, settings_snapshot),
+        model: ModelState::new(
+            provider_state,
+            provider_store,
+            settings_snapshot,
+            model_driver_registry,
+        ),
         settings,
         sandbox_mode_override: options.sandbox_mode_override,
         ui_rx,

--- a/src/runtime/session.rs
+++ b/src/runtime/session.rs
@@ -173,6 +173,7 @@ impl Session {
     /// attach provenance metadata without letting display text forge it.
     pub fn run_turn_input(&self, prompt: String, input: InputMessage) -> TurnHandle {
         let handles = self.handles.clone();
+        let model = self.model.clone();
         let (tx, rx) = mpsc::unbounded_channel::<TurnEvent>();
         let (cancel_tx, mut cancel_rx) = oneshot::channel::<()>();
 
@@ -183,6 +184,13 @@ impl Session {
 
         tokio::spawn(async move {
             let session_id = handles.session_id;
+            if let Err(error) = model.validate_model_available().await {
+                let _ = tx.send(TurnEvent::Failed(format!(
+                    "model availability check: {error:#}"
+                )));
+                let _ = tx.send(TurnEvent::Done(None));
+                return;
+            }
             let before = match handles.runtime.messages(session_id).await {
                 Ok(m) => m.len(),
                 Err(e) => {
@@ -443,7 +451,13 @@ fn route_catch_up_events(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
+    use everruns_core::driver_registry::{
+        ChatDriver, DiscoveredModel, LlmCallConfig, LlmMessage, LlmResponseStream,
+    };
     use everruns_core::events::{EventContext, ToolCompletedData};
+    use everruns_core::{DriverId, error::Result as EverrunsResult};
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
     fn catch_up_routes_only_the_active_session() {
@@ -483,5 +497,88 @@ mod tests {
         assert_eq!(emitted.len(), 1, "foreign event ids are not claimed");
         assert!(lines.iter().any(|line| line.contains("Root")));
         assert!(lines.iter().all(|line| !line.contains("Child")));
+    }
+
+    #[tokio::test]
+    async fn unavailable_discovered_model_fails_before_turn_is_persisted_or_sent() {
+        struct ModelListingDriver {
+            chat_calls: Arc<AtomicUsize>,
+        }
+
+        #[async_trait]
+        impl ChatDriver for ModelListingDriver {
+            async fn chat_completion_stream(
+                &self,
+                _messages: Vec<LlmMessage>,
+                _config: &LlmCallConfig,
+            ) -> EverrunsResult<LlmResponseStream> {
+                self.chat_calls.fetch_add(1, Ordering::SeqCst);
+                panic!("unavailable model must be rejected before provider send")
+            }
+
+            async fn list_models(&self) -> EverrunsResult<Option<Vec<DiscoveredModel>>> {
+                Ok(Some(vec![DiscoveredModel {
+                    model_id: "different-model".to_string(),
+                    display_name: None,
+                    created_at: None,
+                    owned_by: None,
+                    discovered_profile: None,
+                }]))
+            }
+        }
+
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(crate::config::SettingsStore::open(
+            sessions.path().join("settings.toml"),
+        ));
+        let built = crate::runtime::build_with_options(
+            workspace.path().to_path_buf(),
+            crate::runtime::ProviderChoice::Sim,
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            crate::runtime::BuildOptions::default(),
+        )
+        .await
+        .expect("build runtime");
+        let chat_calls = Arc::new(AtomicUsize::new(0));
+        let mut model = built.model;
+        let captured_calls = chat_calls.clone();
+        model
+            .driver_registry
+            .register_or_replace(DriverId::LlmSim, move |_config| {
+                Box::new(ModelListingDriver {
+                    chat_calls: captured_calls.clone(),
+                })
+            });
+        let runtime = built.handles.runtime.clone();
+        let session_id = built.handles.session_id;
+        let session = Session::new(built.handles, model);
+
+        let mut turn = session.run_turn("keep this ask".to_string(), Vec::new());
+        let mut failure = None;
+        while let Some(event) = turn.events.recv().await {
+            match event {
+                TurnEvent::Failed(message) => failure = Some(message),
+                TurnEvent::Done(_) => break,
+                _ => {}
+            }
+        }
+
+        assert_eq!(chat_calls.load(Ordering::SeqCst), 0);
+        assert!(
+            failure
+                .as_deref()
+                .is_some_and(|message| message.contains("not available"))
+        );
+        assert!(
+            runtime
+                .messages(session_id)
+                .await
+                .expect("messages")
+                .is_empty(),
+            "the rejected ask must remain resumable instead of entering history"
+        );
     }
 }


### PR DESCRIPTION
## What changed

Interrupted provider turns now recover automatically under the released Everruns v0.17.22 runtime. Transient stalls, transport failures, overload, and retryable 5xx responses use bounded recovery while permanent authentication, quota, model, and invalid-request failures remain fast and resumable.

Yolop additionally serializes Codex OAuth refresh rotation across driver instances and validates discoverable provider models before checkpointing or sending a turn. Completed tool outputs and the active ask retain their existing checkpoint identity; recovery does not replay completed mutations.

## Why

Observed production evidence contained 62 model/runtime-failed user turns and no same-turn recovery. The failure mix included stalls, overload/5xx responses, token-refresh races, unsupported models, and missing provider tool-output continuation state.

The retry/continuation mechanism belongs in everruns-runtime, so it was landed upstream in everruns/everruns#2937, released as v0.17.22 in everruns/everruns#2940, and consumed here through published crates in lockstep.

## Before / After

Before: the deterministic injected transient baseline stopped after its first provider failure; concurrent Codex drivers could race a single-use refresh token; an unavailable discoverable model could enter turn persistence before failing.

After: the real runtime turn loop completes after injected transient failures with 10 ms then 20 ms bounded backoff, fails permanent classes without retry, reconstructs interrupted state, repairs one locally recoverable missing-tool-output continuation, and proves completed side-effecting tools run once. Two independently constructed Codex drivers perform one refresh rotation, and unavailable discoverable models cause zero provider sends and leave message history empty.

Live proof returned `recovery-live-ok` through Yolop's OpenAI print entry point. The offline llmsim print entry point also completed successfully.

## Risk

- Medium
- Provider preflight adds one cached models request for providers that expose discovery; a discovery timeout leaves the ask unpersisted and safe to resume.
- Retry budgets and exactly-once tool-output preservation are owned and feature-tested in the upstream runtime. Providers without discovery, including custom compatible endpoints and llmsim, bypass preflight.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered — Yolop is pre-1.0; providers without discovery retain existing behavior
- [x] Knowledge concepts updated

Validation:

- `cargo test -p everruns-runtime --test turn_recovery_test --all-features -- --nocapture`
- `cargo test shared_refresh_gate_prevents_duplicate_single_use_rotation --all-features`
- `cargo test unavailable_discovered_model_fails_before_turn_is_persisted_or_sent --all-features`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `python3 scripts/validate_okf.py knowledge --check-links`
- `cargo run -- --provider llmsim -p ...`
- `doppler run --project yolop --config ci -- cargo run -- --provider openai -p ...`

## Knowledge

Updated `checkpointing` with preflight/recovery ownership and exactly-once persistence guarantees, `configuration` with discoverable-model validation behavior, and the durable knowledge log.

## Security

Reviewed the final Yolop and upstream diffs against TM-LLM and TM-DOS. Retry classification does not weaken permanent authentication/quota/invalid-request failures, attempt and elapsed-time budgets bound amplification, completed mutation outputs are reused rather than re-executed, provider continuation repair is limited to a locally recoverable missing-output case, model discovery uses the already configured provider/credentials, and token rotation is serialized without logging secrets. No new unsafe data path or authorization bypass was introduced.

## Follow-ups

No follow-ups.
