### PR TITLE
chore(ship): prompt for PR evidence in the ship skill

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -78,6 +78,10 @@ justification.
 Write the body around functional change and impact — what changed, why, how it
 was validated, notable risks — using
 [`.github/pull_request_template.md`](../../../.github/pull_request_template.md).
+
+Attach a Before / After with proof a reviewer can check — CLI output or a terminal
+recording (asciinema/VHS) of the agent run, and screenshots for any TUI change.
+State explicitly when a change has no observable behavior.
 Two sections are never omitted: **Security** (above) and **Follow-ups**
 (everything deferred, one line of rationale each, or "No follow-ups."). Default
 to implementing in-scope work rather than deferring it.


### PR DESCRIPTION
## What changed

The `/ship` skill's PR-and-merge section now prompts for **evidence in the PR body** — a Before / After with proof a reviewer can check: CLI output or a **terminal recording (asciinema/VHS) of the agent run**, and screenshots for any TUI change. It complements the existing "functional change and impact" framing.

## Why

The ship flow already gathers validation, but the skill didn't tell the agent to attach that proof to the PR. Reviewers benefit from seeing the change work, not reading that it does.

## Before / After

Docs/skill-guidance only — no runtime behavior changes.

- **Before:** the PR-and-merge section framed the body around functional change/impact but named no evidence.
- **After:** adds a paragraph — attach a Before / After with proof (CLI output or a terminal recording; TUI screenshots), and state when there's no observable behavior.

## Risk

- Low
- Skill/docs only; no source, config, or CI logic touched.

## Checklist

- [x] Tests added or updated — N/A (skill/docs only)
- [x] Backward compatibility considered — no code paths affected

---
_Generated by [Claude Code](https://claude.ai/code/session_013LSB82Db25Rf3tVPqWb1JQ)_