### PR TITLE
refactor(runtime): adopt upstream tool approval

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,15 @@
 Significant changes to Yolop's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
+## 2026-08-06 — Upstream interactive approval and cancellation
+
+- ACP tool gating now delegates risk classification, permission decisions, and
+  remembered answers to `everruns-core`; Yolop retains only the adapter that
+  supplies its mutable central approval level on every call.
+- ACP cancellation now awaits runtime task teardown before returning, allowing
+  active tools' cooperative `ToolContext` cancellation tokens to reach detached
+  child work before the client continues.
+
 ## 2026-08-05 — Bounded provider-turn recovery
 
 - Provider stalls, transport failures, overload, and retryable server failures

--- a/knowledge/specs/acp.md
+++ b/knowledge/specs/acp.md
@@ -172,10 +172,12 @@ The runtime does not expose token-limit or refusal outcomes distinctly, so
 
 ### Permissions
 
-The session mode (approval level) drives a hard gate. Before a tool runs, a
-native pre-tool hook (`src/capabilities/tool_approval.rs`) checks whether the
-current level requires approval for that tool, classified by the runtime's own
-`ToolHints`:
+The session mode (approval level) drives a hard gate. Before a tool runs, the
+upstream `everruns-core` tool-approval capability checks whether the current
+level requires approval for that tool, classified by the runtime's own
+`ToolHints`. Yolop's thin adapter supplies the live central setting on every
+call so `session/set_mode`, `/setup approval`, and `set_approval_mode` take
+effect without rebuilding the session:
 
 - `off` — never asks; tools run autonomously (unchanged behaviour).
 - `normal` — asks before `destructive` or `open_world` (outward-facing) tools.
@@ -281,5 +283,7 @@ same way.
   runtime's `ContentPart` has no audio variant, so there is no path to forward
   it to the model even if advertised. Embedded/linked **resource** context and
   image content are supported (see Prompt content); MCP-server pass-through too.
-- In-flight turn interruption beyond abandoning the task — the runtime has no
-  mid-turn cancellation hook yet.
+- Provider calls stop when their turn task is aborted. Active tools additionally
+  receive the runtime's cooperative `ToolContext` cancellation token; Yolop
+  awaits task teardown before returning ACP's `cancelled` stop reason so
+  detached child work observes cancellation before the client continues.

--- a/knowledge/specs/approval.md
+++ b/knowledge/specs/approval.md
@@ -13,6 +13,11 @@ Yolop also has a hard shell `approval_policy`. It composes with
 and fails closed in non-interactive hosts. This specification remains focused
 on the separate soft-approval layer.
 
+ACP also composes this guidance with the upstream `everruns-core` interactive
+tool-approval capability. Yolop supplies the central `approval_mode` live on
+each call, while upstream owns tool-risk classification, permission decisions,
+and remembered allow/reject answers.
+
 ## Why
 
 A coding agent runs tools that touch the real host: it writes files, deletes

--- a/src/capabilities/tool_approval.rs
+++ b/src/capabilities/tool_approval.rs
@@ -1,118 +1,36 @@
-//! Hard tool-approval gate — the enforcement half of yolop's approval levels.
+//! Live-config adapter for the upstream interactive tool-approval gate.
 //!
-//! Where [`approval`](super::approval) *asks the model* to pause for spoken
-//! consent (prompt engineering), this capability *blocks the tool* until a host
-//! actually approves it. It contributes a native [`PreToolUseHook`] that, for
-//! tools the current [`ApprovalMode`] deems risky, calls out to a
-//! [`ToolApprover`] (the ACP client's `session/request_permission`) and turns
-//! the answer into a `Continue`/`Block` decision. The turn genuinely suspends
-//! until the approver responds.
-//!
-//! Only hosts that can service an interactive prompt register it: the ACP
-//! server wires a client-backed [`ToolApprover`]; the TUI and `--print` leave
-//! it off and keep the soft-approval guidance alone.
+//! `everruns-core` owns risk classification, remembered answers, and approval
+//! decisions. Yolop adds one host concern: `approval_mode` is mutable central
+//! configuration, so the upstream hook must receive a fresh config for every
+//! call instead of capturing the session-start value.
 
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use everruns_core::atoms::{PreToolUseDecision, PreToolUseHook};
-use everruns_core::capabilities::{Capability, CapabilityStatus};
+use everruns_core::capabilities::{
+    Capability, CapabilityStatus, ToolApprovalCapability as UpstreamToolApprovalCapability,
+};
 use everruns_core::tool_types::{ToolCall, ToolDefinition};
 use everruns_core::traits::ToolContext;
-use everruns_core::typed_id::SessionId;
 
-use crate::config::ApprovalMode;
 use crate::config::service::ConfigService;
 
-pub(crate) const TOOL_APPROVAL_CAPABILITY_ID: &str = "yolop_tool_approval";
+pub(crate) use everruns_core::capabilities::TOOL_APPROVAL_CAPABILITY_ID;
+pub(crate) use everruns_core::capabilities::{ApprovalDecision, ToolApprover};
 
-/// A host that can interactively approve or reject a tool call. The ACP server
-/// backs this with `session/request_permission`; other hosts do not register
-/// the gate at all.
-#[async_trait]
-pub trait ToolApprover: Send + Sync {
-    /// Ask the host to approve `tool_call`. Blocks the turn until it answers.
-    async fn approve(
-        &self,
-        session_id: SessionId,
-        tool_call: &ToolCall,
-        tool_def: &ToolDefinition,
-    ) -> ApprovalDecision;
-}
-
-/// A host's answer to an approval request.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ApprovalDecision {
-    /// Allow this call.
-    Allow,
-    /// Allow this call and stop asking for this tool this session.
-    AllowAlways,
-    /// Reject this call.
-    Reject,
-    /// Reject this call and keep rejecting this tool this session.
-    RejectAlways,
-    /// The turn was cancelled while the request was pending.
-    Cancelled,
-    /// The host could not be asked (unsupported or transport error). The gate
-    /// falls back to allowing, so a client without a permission UI keeps working
-    /// autonomously rather than deadlocking every mutating tool.
-    Unavailable,
-}
-
-/// How risky a tool is, derived from the runtime's [`ToolHints`] annotations
-/// rather than by guessing from names.
-///
-/// [`ToolHints`]: everruns_core::tool_types::ToolHints
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ToolRisk {
-    /// Declares `readonly` — never gated.
-    ReadOnly,
-    /// Changes state but is not flagged destructive/outward (writes, edits, or
-    /// an un-annotated tool: fail safe by treating unknown as mutating).
-    Mutating,
-    /// Declares `destructive` or `open_world` (deletes, force-push, publish,
-    /// network side effects).
-    Destructive,
-}
-
-fn classify(tool_def: &ToolDefinition) -> ToolRisk {
-    let hints = tool_def.hints();
-    if hints.readonly == Some(true) {
-        ToolRisk::ReadOnly
-    } else if hints.destructive == Some(true) || hints.open_world == Some(true) {
-        ToolRisk::Destructive
-    } else {
-        ToolRisk::Mutating
-    }
-}
-
-/// Whether a tool of the given risk needs approval at the given level. Mirrors
-/// the soft-approval prose in [`super::approval`]: `off` never asks, `normal`
-/// asks before destructive/outward actions, `protective` asks before any
-/// state change.
-fn requires_approval(mode: ApprovalMode, risk: ToolRisk) -> bool {
-    match mode {
-        ApprovalMode::Off => false,
-        ApprovalMode::Normal => matches!(risk, ToolRisk::Destructive),
-        ApprovalMode::Protective => !matches!(risk, ToolRisk::ReadOnly),
-    }
-}
-
-/// Registers the [`ToolApprovalHook`]. Holds the hook so a single cache (of
-/// "always" answers) is shared across the session's turns.
+/// Delegates approval policy to everruns-core while resolving Yolop's live mode.
 pub struct ToolApprovalCapability {
-    hook: Arc<ToolApprovalHook>,
+    upstream: Arc<UpstreamToolApprovalCapability>,
+    config: Arc<dyn ConfigService>,
 }
 
 impl ToolApprovalCapability {
     pub fn new(approver: Arc<dyn ToolApprover>, config: Arc<dyn ConfigService>) -> Self {
         Self {
-            hook: Arc::new(ToolApprovalHook {
-                approver,
-                config,
-                remembered: Mutex::new(HashMap::new()),
-            }),
+            upstream: Arc::new(UpstreamToolApprovalCapability::new(approver)),
+            config,
         }
     }
 }
@@ -122,177 +40,133 @@ impl Capability for ToolApprovalCapability {
     fn id(&self) -> &str {
         TOOL_APPROVAL_CAPABILITY_ID
     }
+
     fn name(&self) -> &str {
         "Tool Approval Gate"
     }
+
     fn description(&self) -> &str {
-        "Blocks risky tools behind an interactive host approval, tuned by the approval level."
+        "Blocks risky tools behind an interactive host approval, tuned by the live approval mode."
     }
+
     fn status(&self) -> CapabilityStatus {
         CapabilityStatus::Available
     }
+
     fn category(&self) -> Option<&str> {
         Some("Safety")
     }
 
+    fn is_guardrail(&self) -> bool {
+        true
+    }
+
     fn pre_tool_use_hooks(&self) -> Vec<Arc<dyn PreToolUseHook>> {
-        vec![self.hook.clone()]
+        vec![Arc::new(LiveApprovalHook {
+            upstream: self.upstream.clone(),
+            config: self.config.clone(),
+        })]
     }
 }
 
-struct ToolApprovalHook {
-    approver: Arc<dyn ToolApprover>,
-    /// Read live each call so a `session/set_mode` (or `/setup approval`) takes
-    /// effect on the very next tool.
+struct LiveApprovalHook {
+    upstream: Arc<UpstreamToolApprovalCapability>,
     config: Arc<dyn ConfigService>,
-    /// "Allow always" / "reject always" answers, keyed by (session, tool name).
-    /// `true` = remembered allow, `false` = remembered reject.
-    remembered: Mutex<HashMap<(SessionId, String), bool>>,
-}
-
-impl ToolApprovalHook {
-    fn block(tool_call: ToolCall, reason: &str) -> PreToolUseDecision {
-        PreToolUseDecision::Block {
-            reason: reason.to_string(),
-            user_message: Some(format!("Denied `{}` — {reason}.", tool_call.name)),
-            tool_call,
-        }
-    }
 }
 
 #[async_trait]
-impl PreToolUseHook for ToolApprovalHook {
+impl PreToolUseHook for LiveApprovalHook {
     async fn before_exec(
         &self,
         tool_call: ToolCall,
         tool_def: &ToolDefinition,
         context: &ToolContext,
     ) -> PreToolUseDecision {
-        let mode = self.config.approval_mode();
-        if !requires_approval(mode, classify(tool_def)) {
-            return PreToolUseDecision::Continue(tool_call);
-        }
-
-        let key = (context.session_id, tool_call.name.clone());
-        if let Some(&allowed) = self.remembered.lock().unwrap().get(&key) {
-            return if allowed {
-                PreToolUseDecision::Continue(tool_call)
-            } else {
-                Self::block(tool_call, "rejected earlier this session")
-            };
-        }
-
-        match self
-            .approver
-            .approve(context.session_id, &tool_call, tool_def)
-            .await
-        {
-            ApprovalDecision::Allow | ApprovalDecision::Unavailable => {
-                PreToolUseDecision::Continue(tool_call)
-            }
-            ApprovalDecision::AllowAlways => {
-                self.remembered.lock().unwrap().insert(key, true);
-                PreToolUseDecision::Continue(tool_call)
-            }
-            ApprovalDecision::Reject => Self::block(tool_call, "rejected by user"),
-            ApprovalDecision::RejectAlways => {
-                self.remembered.lock().unwrap().insert(key, false);
-                Self::block(tool_call, "rejected by user")
-            }
-            ApprovalDecision::Cancelled => Self::block(tool_call, "turn cancelled"),
-        }
+        let config = serde_json::json!({ "mode": self.config.approval_mode().as_str() });
+        let hook = self
+            .upstream
+            .pre_tool_use_hooks_with_config(&config)
+            .into_iter()
+            .next()
+            .expect("upstream tool approval capability always contributes one hook");
+        hook.before_exec(tool_call, tool_def, context).await
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use everruns_core::tool_types::{BuiltinTool, ToolHints};
+    use everruns_core::typed_id::SessionId;
     use serde_json::json;
 
-    fn tool_with(hints: ToolHints) -> ToolDefinition {
+    use super::*;
+    use crate::config::{ApprovalMode, SettingsStore};
+
+    struct RejectingApprover {
+        asked: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl ToolApprover for RejectingApprover {
+        async fn approve(
+            &self,
+            _session_id: SessionId,
+            _tool_call: &ToolCall,
+            _tool_def: &ToolDefinition,
+        ) -> ApprovalDecision {
+            self.asked.fetch_add(1, Ordering::Relaxed);
+            ApprovalDecision::Reject
+        }
+    }
+
+    fn destructive_tool() -> ToolDefinition {
         ToolDefinition::Builtin(BuiltinTool {
-            name: "t".to_string(),
+            name: "publish".to_string(),
             display_name: None,
             description: String::new(),
             parameters: json!({}),
             policy: Default::default(),
             category: None,
             deferrable: Default::default(),
-            hints,
+            hints: ToolHints::default().with_destructive(true),
             full_parameters: None,
         })
     }
 
-    #[test]
-    fn classify_reads_hints() {
-        assert_eq!(
-            classify(&tool_with(ToolHints {
-                readonly: Some(true),
-                ..Default::default()
-            })),
-            ToolRisk::ReadOnly
-        );
-        assert_eq!(
-            classify(&tool_with(ToolHints {
-                destructive: Some(true),
-                ..Default::default()
-            })),
-            ToolRisk::Destructive
-        );
-        assert_eq!(
-            classify(&tool_with(ToolHints {
-                open_world: Some(true),
-                ..Default::default()
-            })),
-            ToolRisk::Destructive
-        );
-        // Un-annotated tools fail safe as mutating (gated in protective).
-        assert_eq!(
-            classify(&tool_with(ToolHints::default())),
-            ToolRisk::Mutating
-        );
-        // `readonly` wins over `open_world`: a read-only network tool (e.g. web
-        // search, which sets both) is never gated, not treated as outward.
-        assert_eq!(
-            classify(&tool_with(ToolHints {
-                readonly: Some(true),
-                open_world: Some(true),
-                ..Default::default()
-            })),
-            ToolRisk::ReadOnly
-        );
+    fn call(id: &str) -> ToolCall {
+        ToolCall {
+            id: id.to_string(),
+            name: "publish".to_string(),
+            arguments: json!({}),
+        }
     }
 
-    #[test]
-    fn policy_matches_approval_semantics() {
-        // Off never gates.
-        for risk in [
-            ToolRisk::ReadOnly,
-            ToolRisk::Mutating,
-            ToolRisk::Destructive,
-        ] {
-            assert!(!requires_approval(ApprovalMode::Off, risk));
-        }
-        // Normal gates destructive/outward only.
-        assert!(!requires_approval(ApprovalMode::Normal, ToolRisk::ReadOnly));
-        assert!(!requires_approval(ApprovalMode::Normal, ToolRisk::Mutating));
-        assert!(requires_approval(
-            ApprovalMode::Normal,
-            ToolRisk::Destructive
+    #[tokio::test]
+    async fn delegates_policy_to_upstream_and_reads_mode_live() {
+        let temp = tempfile::tempdir().unwrap();
+        let settings = Arc::new(SettingsStore::open(temp.path().join("settings.toml")));
+        let approver = Arc::new(RejectingApprover {
+            asked: AtomicUsize::new(0),
+        });
+        let capability = ToolApprovalCapability::new(approver.clone(), settings.clone());
+        let hook = capability.pre_tool_use_hooks().pop().unwrap();
+        let context = ToolContext::new(SessionId::new());
+
+        assert!(matches!(
+            hook.before_exec(call("call-1"), &destructive_tool(), &context)
+                .await,
+            PreToolUseDecision::Block { .. }
         ));
-        // Protective gates anything that changes state.
-        assert!(!requires_approval(
-            ApprovalMode::Protective,
-            ToolRisk::ReadOnly
+        assert_eq!(approver.asked.load(Ordering::Relaxed), 1);
+
+        settings.set_approval_mode(ApprovalMode::Off).unwrap();
+        assert!(matches!(
+            hook.before_exec(call("call-2"), &destructive_tool(), &context)
+                .await,
+            PreToolUseDecision::Continue(_)
         ));
-        assert!(requires_approval(
-            ApprovalMode::Protective,
-            ToolRisk::Mutating
-        ));
-        assert!(requires_approval(
-            ApprovalMode::Protective,
-            ToolRisk::Destructive
-        ));
+        assert_eq!(approver.asked.load(Ordering::Relaxed), 1);
     }
 }

--- a/src/editor/acp/server.rs
+++ b/src/editor/acp/server.rs
@@ -1281,10 +1281,11 @@ async fn run_prompt_once(
     drain_events(&peer, &handles, events_before, &mut translator, &acp_id).await;
 
     if cancelled {
-        // run_turn has no in-flight cancellation hook; abandon the task and
-        // report cancelled. The runtime may finish in the background but its
-        // remaining events are ignored.
+        // Dropping the runtime's active act future cancels its per-tool
+        // ToolContext token. Await teardown before replying so child work has
+        // observed cooperative cancellation when the client sees `cancelled`.
         turn.abort();
+        let _ = turn.await;
         handles.report_herdr_state(crate::capabilities::herdr::HerdrState::Idle);
         return (StopReason::Cancelled, None);
     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3581,7 +3581,7 @@ pub async fn build_with_options(
     // only from the *resolved* capability set.
     if options.tool_approver.is_some() {
         harness_capabilities.push(AgentCapabilityConfig::new(
-            crate::capabilities::tool_approval::TOOL_APPROVAL_CAPABILITY_ID,
+            everruns_core::capabilities::TOOL_APPROVAL_CAPABILITY_ID,
         ));
     }
     let user_ask_enabled = harness_capabilities


### PR DESCRIPTION
## What changed

Yolop now delegates interactive tool-risk classification, approval decisions, and remembered allow/reject answers to the `everruns-core` 0.17.22 capability. A small host adapter preserves Yolop’s live central `approval_mode`, so ACP mode changes still affect the next tool call without rebuilding the session.

ACP cancellation now awaits aborted runtime-task teardown before returning `cancelled`, guaranteeing the runtime’s cooperative `ToolContext` cancellation token has fired for active child work.

## Why

The runtime release promoted Yolop’s approval implementation into the shared core and added cooperative tool cancellation. Keeping a parallel policy engine would drift from upstream and miss future fixes.

## Before / After

Before: Yolop owned 200+ lines of duplicated approval policy and ACP returned as soon as it requested turn abortion.

After: the focused hook test proves a destructive call is rejected through upstream policy in `normal`, then immediately allowed through the same live hook after switching to `off`. The ACP cancellation path now awaits the aborted turn before reporting completion. There is no user-facing wording or UI change.

Live-provider proof: `doppler run --project yolop --config ci -- cargo run -- --provider openai -p "Reply exactly: runtime-adoption-ok"` returned `runtime-adoption-ok`.

## Risk

- Low
- Approval registration or live mode propagation could regress; focused adapter and 58 ACP tests cover both the runtime hook and host protocol path.
- Cancellation now waits for task teardown, which may add a bounded scheduling delay but prevents child work from outliving the client-visible cancellation boundary.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; existing approval behavior preserved)
- [x] Knowledge concepts updated

## Knowledge

Updated `approval` and `ACP` concepts plus the knowledge log to record upstream policy ownership and cooperative cancellation semantics.

## Security

Reviewed TM-TOOL, TM-BASH, TM-DEP, TM-FS, and TM-LLM. Upstream receives only the canonical `off|normal|protective` mode; no untrusted metadata or secrets cross the adapter. The approval fallback and remembered-answer scope are unchanged. Awaiting aborted-task teardown strengthens bounded shell/tool execution by ensuring cooperative cancellation is observed. No filesystem, prompt/key-handling, or dependency-family changes; all `everruns-*` crates remain aligned at 0.17.22.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (1,062 unit + 61 integration/PTY passed; 4 ignored)
- `python3 scripts/validate_okf.py knowledge --check-links`
- focused live OpenAI smoke above

## Follow-ups

No follow-ups.