### PR TITLE
refactor(runtime): adopt everruns 0.17.23 primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,9 +1691,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.22"
+version = "0.17.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76462bebdf37c94747b8d94fa0547fbd6f28b15f0a475093da9c2f9f319ec856"
+checksum = "2d11f03ff2efaaa5a134a1123971ae31cda326facddfdb0b7748cf88e4cfdaec"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1709,9 +1709,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.22"
+version = "0.17.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ac5957d24870f985d4d0f5d090edc6ac943ffd74c93d0243be76b5b509db9c1"
+checksum = "90969374fcbeba28ea7134ec0ca9f74bdedfedd52e5fd8653df395bd8ce7ad28"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -1741,6 +1741,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "serde_yaml",
  "sha2 0.11.0",
  "similar 3.1.1",
@@ -1757,9 +1758,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.22"
+version = "0.17.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdae003ba3e9a61f851b63147a6186526b1ca8d2384239421e331da96d1a2bb4"
+checksum = "57675a7afb201d5b4c39d9b82a1441d647824b17b8be2ed5f4e1ea7c43f5e81f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1774,9 +1775,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.22"
+version = "0.17.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca42a43f7be36c152f6b7691171d43f72ac29bededfd475ce04bdc4b31c6d81"
+checksum = "f4f519ddfa06bd05d105565f08a4583d3b553ceadabbde100addf85e49f233d1"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1790,9 +1791,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.22"
+version = "0.17.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3e651904d2f74f4da41c28be3c37b18f3f95afd64df7f29565dfe2ae5ce13f"
+checksum = "faa253e18f2867753dbac023c7a7af47dcf1a66a7f7b68cea2a1a7d8d15bde48"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1804,9 +1805,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.22"
+version = "0.17.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110244f532549556ba454a1a53b40f16c040413d8f0d2e2083c17ee2bb915145"
+checksum = "556c2cf2f6834956f566076e8e4ba32191cb793e885f501025675422760ffa59"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1828,24 +1829,26 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.22"
+version = "0.17.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718a12085773ed21a8ee01fef281c9db03c87f3100c8b13971f2af4e841b7a25"
+checksum = "c0e5fca91f7ee022bedbf71c43c449371eca88632d4f5d4d48b3742c1bfd362a"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
  "everruns-core",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.22"
+version = "0.17.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be65a5d4af067f51cb2ef7492348cb2c85e6a4b58b677b19900f5e2ad5cd209d"
+checksum = "04767aea7ceffa3e5ebe41431d2f6ccb63a4087b88b2aac1dc84c3d9448c9137"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1859,9 +1862,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.22"
+version = "0.17.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2af9f0042bbbf4934511c0a05f7abf6036bdf980b5476b79b60b08ef1720681"
+checksum = "3ee554ad8ab1cf5f8aba63627ef3180a06e9ea32db4510ca0c4eef1238a65a36"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1873,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-provider"
-version = "0.17.22"
+version = "0.17.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329f7663db42528a5ac2d5144009da545df4fdea56a25790e8650590d17a38ed"
+checksum = "41d3a1a92bf898e7079d006af687efbec9009b6a4b37efbe5d5447199097d533"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1901,9 +1904,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.22"
+version = "0.17.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b61fb61bea6fc1f05aa1981a67efccd34ec2705d6ab5d62c407de07b056941ac"
+checksum = "7eb04dbe1581d84c8edc79996e97f764eba46a790b349374ec29517bf18d9e45"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,20 +102,20 @@ tree-sitter-zig = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-everruns-anthropic = "0.17.22"
-everruns-core = "0.17.22"
-everruns-openai = "0.17.22"
+everruns-anthropic = "0.17.23"
+everruns-core = "0.17.23"
+everruns-openai = "0.17.23"
 # OpenRouter's first-class driver was split out of everruns-openai into its own
 # crate in 0.13.0; register it alongside openai to keep DriverId::OpenRouter.
-everruns-openrouter = "0.17.22"
-everruns-local = "0.17.22"
-everruns-mcp = { version = "0.17.22", features = ["stdio"] }
+everruns-openrouter = "0.17.23"
+everruns-local = "0.17.23"
+everruns-mcp = { version = "0.17.23", features = ["stdio"] }
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (knowledge/specs/mcp.md, upstream runtime-mcp.md D2).
-everruns-runtime = { version = "0.17.22", features = ["mcp-stdio"] }
-everruns-integrations-duckduckgo = "0.17.22"
-everruns-integrations-parallel = "0.17.22"
-everruns-integrations-daytona = "0.17.22"
+everruns-runtime = { version = "0.17.23", features = ["mcp-stdio"] }
+everruns-integrations-duckduckgo = "0.17.23"
+everruns-integrations-parallel = "0.17.23"
+everruns-integrations-daytona = "0.17.23"
 arboard = { version = "3", features = ["wayland-data-control"] }
 futures = "0.3"
 html-escape = "0.2"

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,21 @@
 Significant changes to Yolop's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
+## 2026-08-07 — Shared completion and host wake routing
+
+- [User ask](specs/user-ask.md) now delegates deterministic turn completion and
+  continuation budgets to `everruns-core`; Yolop retains ask-specific tagging,
+  prompts, evaluation projection, and host streaming.
+- [Background execution](specs/background.md) now delegates live-session route
+  ownership and retryable closed-route handling to `everruns-local`; Yolop's
+  inner runner retains authenticated task handoffs, wake coalescing, and
+  synchronous child-session turns.
+- [MCP](specs/mcp.md) now delegates OAuth discovery, dynamic registration,
+  PKCE, resource binding, callback-issuer validation, code exchange, and
+  serialized token refresh to the shared Everruns client. Yolop retains the
+  loopback callback host, connection-file adapter, environment fallback, and
+  explicit loopback egress exception.
+
 ## 2026-08-06 — Upstream interactive approval and cancellation
 
 - ACP tool gating now delegates risk classification, permission decisions, and

--- a/knowledge/specs/background.md
+++ b/knowledge/specs/background.md
@@ -53,15 +53,16 @@ For delayed or recurring work, `spawn_background` accepts a `schedule` instead
 of starting the wrapped tool immediately. Everruns persists the monitor and its
 payload in the local SQLite store. Yolop starts one `LocalScheduleRunner` per
 live host session; when a schedule becomes due, the runner sends the stored
-monitor prompt through the same `WakeRunner` used by background completions.
+monitor prompt through the same upstream `HostRoutedRunner` used by background
+completions.
 The resulting turn starts the wrapped tool, and that tool's eventual completion
 produces the ordinary second wake. The TUI and ACP session objects retain the
 runner handle for their lifetimes, preventing polling from outliving its host.
-Before each poll, `WakeRunner` reports the live session routes in this process;
-`everruns-local` scopes claims to that set. This prevents inactive sessions'
-overdue schedules from being claimed and rejected on every poll. Delivery is
-still routed by `SessionId`, and a route that closes after the claim rejects the
-wake so the occurrence remains durable and retryable.
+Before each poll, `everruns-local::WakeRoutes` reports the live session routes
+in this process; the local scheduler scopes claims to that set. This prevents
+inactive sessions' overdue schedules from being claimed and rejected on every
+poll. Delivery is still routed by `SessionId`, and a route that closes after the
+claim rejects the wake so the occurrence remains durable and retryable.
 
 ### Steering (poll-proofing)
 
@@ -141,12 +142,12 @@ and background completions.
 
 Yolop installs a platform store to close that gap (`crate::background_wake`):
 
-- `runtime.rs` wires a `LocalPlatformStore` backed by a `WakeRunner` via
-  `LocalBackends::with_platform_runner`. For a session with a live terminal host,
-  the runner hands the message to that host over an unbounded channel
-  (`BuiltRuntime::background_wake`) so it can stream the turn normally. For a
-  child sub-agent with no terminal host, it runs the turn synchronously through
-  the in-process runtime.
+- `runtime.rs` wires a `LocalPlatformStore` backed by
+  `everruns-local::HostRoutedRunner` via `LocalBackends::with_platform_runner`.
+  The upstream route registry hands live-host messages to Yolop's enrichment
+  bridge and then `BuiltRuntime::background_wake`, so the host can stream the
+  turn normally. Its inner Yolop runner resolves authenticated task handoffs and
+  runs child sub-agent turns synchronously when no live host owns the session.
 - The runner's `routable_session_ids` exposes only currently registered wake
   routes, which bounds local schedule claims to sessions this host process can
   actually wake.

--- a/knowledge/specs/mcp.md
+++ b/knowledge/specs/mcp.md
@@ -91,10 +91,13 @@ server offers it → authorization code + PKCE (RFC 7636) through the browser wi
 a loopback redirect. The authorize URL is printed in the transcript before the
 host waits on the callback (so fullscreen and inline both stay usable if the
 browser is invisible), and the wait runs in the background so the event loop is
-not blocked. The token endpoint and client id are persisted alongside the tokens
-so refresh is self-contained. Because credentials are resolved per turn, a fresh
-login takes effect on the next message — no restart (composes with live reload
-above). Agent-driven `/mcp` and `/tools` via `run_command` return the
+not blocked. The token is bound to the MCP server through the OAuth `resource`
+indicator, and callback issuer validation prevents mix-up attacks. The token
+endpoint and client id are persisted alongside the tokens so refresh is
+self-contained; refreshes are serialized and re-read under the lock so rotated
+refresh tokens cannot be spent concurrently. Because credentials are resolved
+per turn, a fresh login takes effect on the next message — no restart (composes
+with live reload above). Agent-driven `/mcp` and `/tools` via `run_command` return the
 host's response text in the tool result; `/tools` includes live discovered
 `mcp_*` names from the session's scoped servers.
 
@@ -104,11 +107,11 @@ host's response text in the tool result; `/tools` includes live discovered
 - **stdio** spawns local processes the user explicitly listed in their own
   `.mcp.json`. Authoring that file is the act of consent, mirroring how other
   MCP clients treat a project-scoped server list.
-- **OAuth** discovery/token calls go to the authorization server advertised by
-  the (user-configured) MCP server. Discovered endpoints must be `https`
-  (loopback may use `http`), bounding downgrade to plaintext. The user
-  configuring the server URL is the act of consent; yolop is a local CLI on the
-  user's own network.
+- **OAuth** discovery/token calls use `everruns-core`'s egress-bound OAuth
+  client. Public endpoints require DNS-pinned SSRF validation and discovered
+  endpoints must be `https`. Literal loopback endpoints may use `http` because
+  the user explicitly configured the local MCP server; Yolop's transport
+  adapter limits that exception to loopback hosts.
 - **No per-call approval**: MCP tools run autonomously like the rest of yolop's
   tools; the standing guardrail is the write blocklist on filesystem writes.
 
@@ -127,7 +130,7 @@ host's response text in the tool result; `/tools` includes live discovered
 | Wiring into the session | `src/runtime/mod.rs` (`session_mcp_servers`, `StartupInfo.mcp_server_names`) |
 | `/mcp` command (list/reload/enable/disable/remove) | `src/capabilities/client_commands.rs`, `src/tui/host_ui.rs`, `src/tui/mod.rs` |
 | Live reload seam | `src/runtime/mod.rs` (`RuntimeHandles::reload_mcp_servers`), `src/runtime/session.rs` |
-| OAuth login (discovery, DCR, PKCE) | `src/auth/mcp_oauth_login.rs` |
-| OAuth token storage | `src/auth/mcp_oauth.rs` (connection store) |
-| Auth provider (stored token + refresh, env fallback) | `src/runtime/mod.rs` (`StoredMcpAuthProvider`) |
+| OAuth protocol (discovery, DCR, PKCE, exchange, refresh) | upstream `everruns-core::oauth`, `everruns-mcp::oauth` |
+| OAuth loopback host, token storage, egress adapter | `src/auth/mcp_oauth_login.rs`, `src/auth/mcp_oauth.rs` |
+| Auth policy (stored token, env fallback) | `src/runtime/mod.rs` (`StoredMcpAuthProvider`) |
 | Client / transports / executor | upstream `everruns-mcp`, `everruns-runtime` (`mcp-stdio` feature) |

--- a/knowledge/specs/user-ask.md
+++ b/knowledge/specs/user-ask.md
@@ -92,8 +92,10 @@ restart on process resume.
 
 - `UserAskCapability` and `UserAskStore` live in yolop (`src/capabilities/user_ask.rs`,
   `src/session_state/user_ask.rs`).
-- The shared deterministic gate and budgets live in
-  `src/session_state/task_completion.rs`; hosts own only streaming/projection.
+- The deterministic gate and three-axis continuation budget live in
+  `everruns-core::turn_completion`. Yolop's `src/session_state/task_completion.rs`
+  adapts runtime turn results and owns continuation tagging, prompts, and ask
+  projection; hosts own streaming.
 - Evaluator calls use upstream `CommandHost::completion` (everruns-core).
 
 ## Related

--- a/src/auth/mcp_oauth.rs
+++ b/src/auth/mcp_oauth.rs
@@ -1,16 +1,16 @@
-//! Persistence for user-scoped MCP OAuth tokens.
-//!
-//! Tokens minted by the interactive login flow (`crate::auth::mcp_oauth_login`) are
-//! stored in the shared [`ConnectionStore`] under a stable `mcp-oauth:<id>`
-//! connection id, alongside just enough of the authorization-server contract
-//! (`token_endpoint`, `client_id`, optional `client_secret`) to refresh the
-//! access token later without re-reading MCP config or re-running discovery.
-//! [`crate::runtime::StoredMcpAuthProvider`] reads them back per request.
+//! Yolop persistence and transport adapters for Everruns' shared MCP OAuth.
 
 use crate::connectors::{ConnectionStore, StoredConnection};
-use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
+use async_trait::async_trait;
+use everruns_core::egress::{
+    DirectEgressService, EgressRequest, EgressResponse, EgressResult, EgressService,
+    EgressStreamResponse,
+};
+use everruns_mcp::oauth::McpTokenStore;
 use std::collections::BTreeMap;
+use std::sync::Arc;
+
+pub(crate) type McpOAuthTokenSet = everruns_core::oauth::TokenSet;
 
 const KIND_FIELD: &str = "kind";
 const KIND_OAUTH: &str = "oauth";
@@ -23,40 +23,6 @@ const TOKEN_ENDPOINT_FIELD: &str = "token_endpoint";
 const CLIENT_ID_FIELD: &str = "client_id";
 const CLIENT_SECRET_FIELD: &str = "client_secret";
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct McpOAuthTokenSet {
-    pub(crate) access_token: String,
-    pub(crate) refresh_token: Option<String>,
-    #[serde(default = "default_token_type")]
-    pub(crate) token_type: String,
-    pub(crate) expires_at: Option<DateTime<Utc>>,
-    pub(crate) scope: Option<String>,
-    /// Authorization-server token endpoint, retained so a refresh is
-    /// self-contained (no config re-read / re-discovery).
-    pub(crate) token_endpoint: Option<String>,
-    /// OAuth client id used at login (from dynamic registration or config).
-    pub(crate) client_id: Option<String>,
-    /// Client secret, only for confidential clients that were issued one.
-    pub(crate) client_secret: Option<String>,
-}
-
-impl McpOAuthTokenSet {
-    /// True once `expires_at` has arrived. A `now` at or past the expiry is
-    /// treated as expired so we refresh before the token is rejected.
-    pub(crate) fn is_expired(&self, now: DateTime<Utc>) -> bool {
-        self.expires_at.is_some_and(|expires_at| expires_at <= now)
-    }
-
-    /// The `Authorization` header value this token set contributes.
-    pub(crate) fn authorization_value(&self) -> String {
-        format!("{} {}", self.token_type, self.access_token)
-    }
-}
-
-fn default_token_type() -> String {
-    "Bearer".to_string()
-}
-
 pub(crate) fn connection_id(provider_id: &str) -> String {
     format!("mcp-oauth:{provider_id}")
 }
@@ -66,87 +32,148 @@ pub(crate) fn save_tokens(
     provider_id: &str,
     tokens: McpOAuthTokenSet,
 ) -> anyhow::Result<()> {
-    store.save(&connection_id(provider_id), tokens.into())
+    store.save(&connection_id(provider_id), encode_tokens(tokens))
 }
 
 pub(crate) fn load_tokens(store: &ConnectionStore, provider_id: &str) -> Option<McpOAuthTokenSet> {
     store
         .get(&connection_id(provider_id))
-        .and_then(|connection| connection.try_into().ok())
+        .and_then(|connection| decode_tokens(connection).ok())
 }
 
-impl From<McpOAuthTokenSet> for StoredConnection {
-    fn from(tokens: McpOAuthTokenSet) -> Self {
-        let mut fields = BTreeMap::new();
-        fields.insert(KIND_FIELD.to_string(), KIND_OAUTH.to_string());
-        fields.insert(ACCESS_TOKEN_FIELD.to_string(), tokens.access_token);
-        if let Some(refresh_token) = tokens.refresh_token {
-            fields.insert(REFRESH_TOKEN_FIELD.to_string(), refresh_token);
-        }
-        fields.insert(TOKEN_TYPE_FIELD.to_string(), tokens.token_type);
-        if let Some(expires_at) = tokens.expires_at {
-            fields.insert(EXPIRES_AT_FIELD.to_string(), expires_at.to_rfc3339());
-        }
-        if let Some(scope) = tokens.scope {
-            fields.insert(SCOPE_FIELD.to_string(), scope);
-        }
-        if let Some(token_endpoint) = tokens.token_endpoint {
-            fields.insert(TOKEN_ENDPOINT_FIELD.to_string(), token_endpoint);
-        }
-        if let Some(client_id) = tokens.client_id {
-            fields.insert(CLIENT_ID_FIELD.to_string(), client_id);
-        }
-        if let Some(client_secret) = tokens.client_secret {
-            fields.insert(CLIENT_SECRET_FIELD.to_string(), client_secret);
-        }
-        StoredConnection {
-            fields,
-            metadata: None,
-        }
+fn encode_tokens(tokens: McpOAuthTokenSet) -> StoredConnection {
+    let mut fields = BTreeMap::new();
+    fields.insert(KIND_FIELD.to_string(), KIND_OAUTH.to_string());
+    fields.insert(ACCESS_TOKEN_FIELD.to_string(), tokens.access_token);
+    if let Some(value) = tokens.refresh_token {
+        fields.insert(REFRESH_TOKEN_FIELD.to_string(), value);
+    }
+    fields.insert(TOKEN_TYPE_FIELD.to_string(), tokens.token_type);
+    if let Some(value) = tokens.expires_at {
+        fields.insert(EXPIRES_AT_FIELD.to_string(), value.to_rfc3339());
+    }
+    if let Some(value) = tokens.scope {
+        fields.insert(SCOPE_FIELD.to_string(), value);
+    }
+    if let Some(value) = tokens.token_endpoint {
+        fields.insert(TOKEN_ENDPOINT_FIELD.to_string(), value);
+    }
+    if let Some(value) = tokens.client_id {
+        fields.insert(CLIENT_ID_FIELD.to_string(), value);
+    }
+    if let Some(value) = tokens.client_secret {
+        fields.insert(CLIENT_SECRET_FIELD.to_string(), value);
+    }
+    StoredConnection {
+        fields,
+        metadata: None,
     }
 }
 
-impl TryFrom<StoredConnection> for McpOAuthTokenSet {
-    type Error = ();
-
-    fn try_from(connection: StoredConnection) -> Result<Self, Self::Error> {
-        if connection.fields.get(KIND_FIELD).map(String::as_str) != Some(KIND_OAUTH) {
-            return Err(());
-        }
-        let non_empty = |field: &str| {
-            connection
-                .fields
-                .get(field)
-                .filter(|value| !value.trim().is_empty())
-                .cloned()
-        };
-        let access_token = non_empty(ACCESS_TOKEN_FIELD).ok_or(())?;
-        let token_type = non_empty(TOKEN_TYPE_FIELD).unwrap_or_else(default_token_type);
-        let expires_at = connection
+fn decode_tokens(connection: StoredConnection) -> Result<McpOAuthTokenSet, ()> {
+    if connection.fields.get(KIND_FIELD).map(String::as_str) != Some(KIND_OAUTH) {
+        return Err(());
+    }
+    let non_empty = |field: &str| {
+        connection
             .fields
-            .get(EXPIRES_AT_FIELD)
-            .map(|raw| DateTime::parse_from_rfc3339(raw).map(|dt| dt.with_timezone(&Utc)))
-            .transpose()
-            .map_err(|_| ())?;
-        Ok(Self {
-            access_token,
-            refresh_token: non_empty(REFRESH_TOKEN_FIELD),
-            token_type,
-            expires_at,
-            scope: non_empty(SCOPE_FIELD),
-            token_endpoint: non_empty(TOKEN_ENDPOINT_FIELD),
-            client_id: non_empty(CLIENT_ID_FIELD),
-            client_secret: non_empty(CLIENT_SECRET_FIELD),
+            .get(field)
+            .filter(|value| !value.trim().is_empty())
+            .cloned()
+    };
+    let access_token = non_empty(ACCESS_TOKEN_FIELD).ok_or(())?;
+    let expires_at = connection
+        .fields
+        .get(EXPIRES_AT_FIELD)
+        .map(|raw| {
+            chrono::DateTime::parse_from_rfc3339(raw).map(|dt| dt.with_timezone(&chrono::Utc))
         })
+        .transpose()
+        .map_err(|_| ())?;
+    Ok(McpOAuthTokenSet {
+        access_token,
+        refresh_token: non_empty(REFRESH_TOKEN_FIELD),
+        token_type: non_empty(TOKEN_TYPE_FIELD).unwrap_or_else(|| "Bearer".to_string()),
+        expires_at,
+        scope: non_empty(SCOPE_FIELD),
+        token_endpoint: non_empty(TOKEN_ENDPOINT_FIELD),
+        client_id: non_empty(CLIENT_ID_FIELD),
+        client_secret: non_empty(CLIENT_SECRET_FIELD),
+    })
+}
+
+/// Adapts Yolop's synchronous connection file to the shared OAuth token store.
+#[derive(Clone)]
+pub(crate) struct ConnectionTokenStore {
+    store: Arc<ConnectionStore>,
+}
+
+impl ConnectionTokenStore {
+    pub(crate) fn new(store: Arc<ConnectionStore>) -> Self {
+        Self { store }
     }
+}
+
+#[async_trait]
+impl McpTokenStore for ConnectionTokenStore {
+    async fn load(&self, server_name: &str) -> anyhow::Result<Option<McpOAuthTokenSet>> {
+        Ok(load_tokens(&self.store, server_name))
+    }
+
+    async fn save(&self, server_name: &str, tokens: &McpOAuthTokenSet) -> anyhow::Result<()> {
+        save_tokens(&self.store, server_name, tokens.clone())
+    }
+}
+
+/// The shared OAuth client requires DNS pinning for discovered public endpoints.
+/// Literal loopback URLs are the one local-CLI exception: users explicitly
+/// configure them and the upstream URL validator already limits plaintext HTTP
+/// to loopback hosts.
+struct YolopMcpOAuthEgress {
+    direct: DirectEgressService,
+}
+
+impl Default for YolopMcpOAuthEgress {
+    fn default() -> Self {
+        Self {
+            direct: DirectEgressService::for_runtime_traffic_from_env(),
+        }
+    }
+}
+
+fn allow_configured_loopback(mut request: EgressRequest) -> EgressRequest {
+    let is_loopback = reqwest::Url::parse(&request.url)
+        .ok()
+        .is_some_and(|url| matches!(url.host_str(), Some("localhost" | "127.0.0.1" | "::1")));
+    if is_loopback {
+        request.dns_pinning_required = false;
+    }
+    request
+}
+
+#[async_trait]
+impl EgressService for YolopMcpOAuthEgress {
+    async fn send(&self, request: EgressRequest) -> EgressResult<EgressResponse> {
+        self.direct.send(allow_configured_loopback(request)).await
+    }
+
+    async fn send_stream(&self, request: EgressRequest) -> EgressResult<EgressStreamResponse> {
+        self.direct
+            .send_stream(allow_configured_loopback(request))
+            .await
+    }
+}
+
+pub(crate) fn oauth_egress() -> Arc<dyn EgressService> {
+    Arc::new(YolopMcpOAuthEgress::default())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::TimeZone;
+    use chrono::{TimeZone, Utc};
 
-    fn sample(expires_at: Option<DateTime<Utc>>) -> McpOAuthTokenSet {
+    fn sample(expires_at: Option<chrono::DateTime<Utc>>) -> McpOAuthTokenSet {
         McpOAuthTokenSet {
             access_token: "access".to_string(),
             refresh_token: Some("refresh".to_string()),
@@ -160,25 +187,16 @@ mod tests {
     }
 
     #[test]
-    fn round_trips_oauth_tokens_with_refresh_metadata() {
+    fn round_trips_upstream_oauth_tokens_with_refresh_metadata() {
         let tmp = tempfile::tempdir().expect("tmp");
         let store = ConnectionStore::open(tmp.path().join("connections.toml"));
         let expires_at = Utc.with_ymd_and_hms(2030, 1, 2, 3, 4, 5).unwrap();
         save_tokens(&store, "parallel", sample(Some(expires_at))).expect("save tokens");
 
-        let raw = store.get("mcp-oauth:parallel").expect("stored raw");
-        assert_eq!(raw.fields.get("kind").map(String::as_str), Some("oauth"));
-        assert_eq!(
-            raw.fields.get("token_endpoint").map(String::as_str),
-            Some("https://as.example/token")
-        );
-
         let loaded = load_tokens(&store, "parallel").expect("loaded tokens");
         assert_eq!(loaded.access_token, "access");
         assert_eq!(loaded.refresh_token.as_deref(), Some("refresh"));
         assert_eq!(loaded.expires_at, Some(expires_at));
-        assert_eq!(loaded.scope.as_deref(), Some("search"));
-        assert_eq!(loaded.client_id.as_deref(), Some("client-123"));
         assert_eq!(loaded.authorization_value(), "Bearer access");
     }
 
@@ -188,14 +206,6 @@ mod tests {
             fields: BTreeMap::from([("api_key".to_string(), "secret".to_string())]),
             metadata: None,
         };
-        assert!(McpOAuthTokenSet::try_from(connection).is_err());
-    }
-
-    #[test]
-    fn detects_expired_tokens_at_boundary() {
-        let expires_at = Utc.with_ymd_and_hms(2030, 1, 2, 3, 4, 5).unwrap();
-        let tokens = sample(Some(expires_at));
-        assert!(!tokens.is_expired(expires_at - chrono::TimeDelta::seconds(1)));
-        assert!(tokens.is_expired(expires_at));
+        assert!(decode_tokens(connection).is_err());
     }
 }

--- a/src/auth/mcp_oauth_login.rs
+++ b/src/auth/mcp_oauth_login.rs
@@ -1,133 +1,20 @@
-//! Interactive OAuth login for remote (HTTP) MCP servers.
-//!
-//! Implements the MCP authorization handshake against a server's own
-//! authorization server, discovered at runtime rather than hand-configured:
-//!
-//! 1. **Protected-resource metadata** (RFC 9728) at the server origin points to
-//!    its authorization server(s); we fall back to treating the server origin
-//!    as the issuer when the document is absent.
-//! 2. **Authorization-server metadata** (RFC 8414 / OpenID discovery) yields the
-//!    `authorization`/`token`/`registration` endpoints.
-//! 3. **Dynamic client registration** (RFC 7591) mints a public client when the
-//!    server advertises a registration endpoint and no `client_id` is
-//!    configured.
-//! 4. **Authorization code + PKCE** (RFC 7636) runs through the browser with a
-//!    loopback redirect (RFC 8252), and the code is exchanged for tokens.
-//!
-//! The resulting [`McpOAuthTokenSet`] carries the token endpoint and client id
-//! so [`refresh`] (and the runtime auth provider) can renew the access token
-//! without re-discovering anything.
+//! Interactive loopback host for Everruns' shared MCP OAuth client.
 
 use crate::auth::mcp_oauth::McpOAuthTokenSet;
 use anyhow::{Context, Result, anyhow};
-use chrono::{Duration, Utc};
-use reqwest::Url;
-use serde::Deserialize;
+use everruns_core::oauth::RegisteredClient;
 use std::collections::HashMap;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
 const CALLBACK_PATH: &str = "/callback";
-const CLIENT_NAME: &str = "yolop";
-/// Refresh a little before the hard expiry so a token is renewed before the
-/// server would reject it.
-const REFRESH_SKEW: Duration = Duration::seconds(60);
 
-/// Authorization-server endpoints resolved via discovery.
-#[derive(Debug, Clone)]
-pub(crate) struct OAuthEndpoints {
-    pub authorization_endpoint: String,
-    pub token_endpoint: String,
-    pub registration_endpoint: Option<String>,
-    pub scopes_supported: Option<Vec<String>>,
-}
-
-/// The OAuth client used for a login — either configured or dynamically
-/// registered.
-#[derive(Debug, Clone)]
-struct OAuthClient {
-    client_id: String,
-    client_secret: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct ProtectedResourceMetadata {
-    #[serde(default)]
-    authorization_servers: Vec<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct AuthServerMetadata {
-    authorization_endpoint: String,
-    token_endpoint: String,
-    #[serde(default)]
-    registration_endpoint: Option<String>,
-    #[serde(default)]
-    scopes_supported: Option<Vec<String>>,
-}
-
-#[derive(Debug, Deserialize)]
-struct RegistrationResponse {
-    client_id: String,
-    #[serde(default)]
-    client_secret: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct TokenResponse {
-    access_token: String,
-    #[serde(default)]
-    refresh_token: Option<String>,
-    #[serde(default)]
-    token_type: Option<String>,
-    #[serde(default)]
-    expires_in: Option<i64>,
-    #[serde(default)]
-    scope: Option<String>,
-}
-
-fn http_client() -> Result<reqwest::Client> {
-    reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(30))
-        .build()
-        .context("build OAuth HTTP client")
-}
-
-/// Guard against pointing the browser / token calls at a plaintext or
-/// non-HTTP(S) endpoint. Loopback stays allowed over HTTP so a locally hosted
-/// authorization server (and the test suite) works without TLS.
-fn require_secure(url: &str, what: &str) -> Result<Url> {
-    let parsed = Url::parse(url).with_context(|| format!("parse {what} URL: {url}"))?;
-    let is_loopback = matches!(parsed.host_str(), Some("localhost" | "127.0.0.1" | "::1"));
-    match parsed.scheme() {
-        "https" => Ok(parsed),
-        "http" if is_loopback => Ok(parsed),
-        other => Err(anyhow!(
-            "{what} must use https (got {other} for a non-loopback host): {url}"
-        )),
-    }
-}
-
-/// Prepared interactive login: discovery + DCR + PKCE are done, the authorize
-/// URL is ready to show the user, and [`complete_login`] waits on the loopback
-/// callback then exchanges the code. Splitting prepare from complete lets the
-/// TUI print the URL (and keep the event loop alive) in both fullscreen and
-/// inline modes before blocking on the browser.
 pub(crate) struct PreparedLogin {
     pub authorize_url: String,
     listener: TcpListener,
-    state: String,
-    verifier: String,
-    redirect_uri: String,
-    endpoints: OAuthEndpoints,
-    oauth_client: OAuthClient,
-    scope: Option<String>,
+    oauth: everruns_mcp::oauth::PreparedLogin,
 }
 
-/// Run the full interactive login for `mcp_url`, returning tokens ready to
-/// persist. Convenience wrapper around [`prepare_login`] + open browser +
-/// [`complete_login`] for callers that do not need to surface the authorize
-/// URL first.
 #[allow(dead_code)]
 pub(crate) async fn login(
     mcp_url: &str,
@@ -139,19 +26,11 @@ pub(crate) async fn login(
     complete_login(prepared).await
 }
 
-/// Discover, register, and build the authorize URL without opening a browser or
-/// waiting on the callback. The caller should show [`PreparedLogin::authorize_url`]
-/// then call [`complete_login`].
 pub(crate) async fn prepare_login(
     mcp_url: &str,
     configured_client_id: Option<&str>,
     scope: Option<&str>,
 ) -> Result<PreparedLogin> {
-    let client = http_client()?;
-    let endpoints = discover_endpoints(&client, mcp_url).await?;
-
-    // Bind the loopback callback first so its port is part of the redirect_uri
-    // we register and send to the authorization endpoint.
     let listener = TcpListener::bind(("127.0.0.1", 0))
         .await
         .context("bind loopback OAuth callback")?;
@@ -160,348 +39,51 @@ pub(crate) async fn prepare_login(
         .context("resolve callback port")?
         .port();
     let redirect_uri = format!("http://127.0.0.1:{port}{CALLBACK_PATH}");
-
-    let oauth_client = match configured_client_id {
-        Some(client_id) => OAuthClient {
-            client_id: client_id.to_string(),
-            client_secret: None,
-        },
-        None => register_client(&client, &endpoints, &redirect_uri).await?,
-    };
-
-    let verifier = crate::auth::oauth_flow::random_pkce_verifier();
-    let challenge = crate::auth::oauth_flow::pkce_challenge(&verifier);
-    let state = crate::auth::oauth_flow::random_token(32);
-    let scope = scope
-        .map(str::to_string)
-        .or_else(|| endpoints.scopes_supported.as_ref().map(|s| s.join(" ")));
-
-    let auth_url = authorize_url(
-        &endpoints,
-        &oauth_client.client_id,
+    let configured_client = configured_client_id.map(|client_id| RegisteredClient {
+        client_id: client_id.to_string(),
+        client_secret: None,
+    });
+    let egress = crate::auth::mcp_oauth::oauth_egress();
+    let oauth = everruns_mcp::oauth::prepare_login(
+        egress.as_ref(),
+        mcp_url,
         &redirect_uri,
-        &challenge,
-        &state,
-        scope.as_deref(),
-    )?;
-    Ok(PreparedLogin {
-        authorize_url: auth_url.to_string(),
-        listener,
-        state,
-        verifier,
-        redirect_uri,
-        endpoints,
-        oauth_client,
+        "yolop",
+        configured_client,
         scope,
+    )
+    .await?;
+    Ok(PreparedLogin {
+        authorize_url: oauth.authorization_url.clone(),
+        listener,
+        oauth,
     })
 }
 
-/// Wait for the authorize redirect on the prepared loopback listener and
-/// exchange the code for tokens.
 pub(crate) async fn complete_login(prepared: PreparedLogin) -> Result<McpOAuthTokenSet> {
-    let PreparedLogin {
-        listener,
+    let Callback {
+        code,
         state,
-        verifier,
-        redirect_uri,
-        endpoints,
-        oauth_client,
-        scope,
-        ..
-    } = prepared;
-    let client = http_client()?;
-    let code = wait_for_callback(listener, &state).await?;
-    exchange_code(
-        &client,
-        &endpoints,
-        &oauth_client,
+        issuer,
+    } = wait_for_callback(prepared.listener, &prepared.oauth.state).await?;
+    let egress = crate::auth::mcp_oauth::oauth_egress();
+    everruns_mcp::oauth::complete_login(
+        egress.as_ref(),
+        &prepared.oauth,
         &code,
-        &verifier,
-        &redirect_uri,
-        scope.as_deref(),
+        &state,
+        issuer.as_deref(),
     )
     .await
 }
 
-/// Discover the authorization-server endpoints for an MCP server URL.
-pub(crate) async fn discover_endpoints(
-    client: &reqwest::Client,
-    mcp_url: &str,
-) -> Result<OAuthEndpoints> {
-    let server = require_secure(mcp_url, "MCP server")?;
-    let origin = origin_of(&server);
-
-    // RFC 9728: protected-resource metadata advertises the issuer(s).
-    let issuer = match fetch_json::<ProtectedResourceMetadata>(
-        client,
-        &join_well_known(&origin, "oauth-protected-resource"),
-    )
-    .await?
-    {
-        Some(prm) => prm
-            .authorization_servers
-            .into_iter()
-            .next()
-            .unwrap_or_else(|| origin.clone()),
-        None => origin.clone(),
-    };
-    let issuer = require_secure(&issuer, "authorization server")?;
-    let issuer_origin = origin_of(&issuer);
-
-    // RFC 8414 first, then OpenID Connect discovery as a fallback.
-    for suffix in ["oauth-authorization-server", "openid-configuration"] {
-        if let Some(meta) =
-            fetch_json::<AuthServerMetadata>(client, &join_well_known(&issuer_origin, suffix))
-                .await?
-        {
-            // Validate the endpoints before handing them to the browser / token
-            // exchange so discovery can't downgrade us to plaintext.
-            require_secure(&meta.authorization_endpoint, "authorization endpoint")?;
-            require_secure(&meta.token_endpoint, "token endpoint")?;
-            if let Some(reg) = &meta.registration_endpoint {
-                require_secure(reg, "registration endpoint")?;
-            }
-            return Ok(OAuthEndpoints {
-                authorization_endpoint: meta.authorization_endpoint,
-                token_endpoint: meta.token_endpoint,
-                registration_endpoint: meta.registration_endpoint,
-                scopes_supported: meta.scopes_supported,
-            });
-        }
-    }
-
-    Err(anyhow!(
-        "no OAuth authorization-server metadata found for {issuer_origin} \
-         (looked under /.well-known/oauth-authorization-server and /openid-configuration)"
-    ))
+struct Callback {
+    code: String,
+    state: String,
+    issuer: Option<String>,
 }
 
-/// Register a public client via RFC 7591 dynamic client registration.
-async fn register_client(
-    client: &reqwest::Client,
-    endpoints: &OAuthEndpoints,
-    redirect_uri: &str,
-) -> Result<OAuthClient> {
-    let registration_endpoint = endpoints.registration_endpoint.as_deref().ok_or_else(|| {
-        anyhow!(
-            "server does not support dynamic client registration; \
-             configure `oauth_client_id` for this MCP server"
-        )
-    })?;
-    let body = serde_json::json!({
-        "client_name": CLIENT_NAME,
-        "redirect_uris": [redirect_uri],
-        "grant_types": ["authorization_code", "refresh_token"],
-        "response_types": ["code"],
-        "token_endpoint_auth_method": "none",
-    });
-    let response = client
-        .post(registration_endpoint)
-        .json(&body)
-        .send()
-        .await
-        .context("register OAuth client")?;
-    if !response.status().is_success() {
-        let status = response.status();
-        let text = response.text().await.unwrap_or_default();
-        return Err(anyhow!(
-            "dynamic client registration failed ({status}): {text}"
-        ));
-    }
-    let parsed: RegistrationResponse = response
-        .json()
-        .await
-        .context("parse client registration response")?;
-    Ok(OAuthClient {
-        client_id: parsed.client_id,
-        client_secret: parsed.client_secret,
-    })
-}
-
-fn authorize_url(
-    endpoints: &OAuthEndpoints,
-    client_id: &str,
-    redirect_uri: &str,
-    challenge: &str,
-    state: &str,
-    scope: Option<&str>,
-) -> Result<Url> {
-    let mut url =
-        Url::parse(&endpoints.authorization_endpoint).context("parse authorization endpoint")?;
-    url.query_pairs_mut()
-        .append_pair("response_type", "code")
-        .append_pair("client_id", client_id)
-        .append_pair("redirect_uri", redirect_uri)
-        .append_pair("code_challenge", challenge)
-        .append_pair("code_challenge_method", "S256")
-        .append_pair("state", state);
-    if let Some(scope) = scope {
-        url.query_pairs_mut().append_pair("scope", scope);
-    }
-    Ok(url)
-}
-
-/// Exchange an authorization code for tokens, folding in the refresh metadata.
-async fn exchange_code(
-    client: &reqwest::Client,
-    endpoints: &OAuthEndpoints,
-    oauth_client: &OAuthClient,
-    code: &str,
-    verifier: &str,
-    redirect_uri: &str,
-    scope: Option<&str>,
-) -> Result<McpOAuthTokenSet> {
-    let mut form = vec![
-        ("grant_type", "authorization_code"),
-        ("code", code),
-        ("redirect_uri", redirect_uri),
-        ("client_id", oauth_client.client_id.as_str()),
-        ("code_verifier", verifier),
-    ];
-    if let Some(secret) = &oauth_client.client_secret {
-        form.push(("client_secret", secret.as_str()));
-    }
-    let token: TokenResponse = post_token(client, &endpoints.token_endpoint, &form).await?;
-    Ok(token_set(
-        token,
-        &endpoints.token_endpoint,
-        oauth_client,
-        None,
-        scope,
-    ))
-}
-
-/// Renew an access token from a stored token set. Preserves the client id,
-/// token endpoint, and (when the server omits a rotated one) the refresh token.
-pub(crate) async fn refresh(tokens: &McpOAuthTokenSet) -> Result<McpOAuthTokenSet> {
-    let token_endpoint = tokens
-        .token_endpoint
-        .as_deref()
-        .ok_or_else(|| anyhow!("stored token has no token endpoint to refresh against"))?;
-    let refresh_token = tokens
-        .refresh_token
-        .as_deref()
-        .ok_or_else(|| anyhow!("stored token has no refresh token"))?;
-    let client_id = tokens
-        .client_id
-        .as_deref()
-        .ok_or_else(|| anyhow!("stored token has no client id to refresh with"))?;
-    require_secure(token_endpoint, "token endpoint")?;
-
-    let client = http_client()?;
-    let mut form = vec![
-        ("grant_type", "refresh_token"),
-        ("refresh_token", refresh_token),
-        ("client_id", client_id),
-    ];
-    if let Some(secret) = tokens.client_secret.as_deref() {
-        form.push(("client_secret", secret));
-    }
-    let token: TokenResponse = post_token(&client, token_endpoint, &form).await?;
-    let oauth_client = OAuthClient {
-        client_id: client_id.to_string(),
-        client_secret: tokens.client_secret.clone(),
-    };
-    Ok(token_set(
-        token,
-        token_endpoint,
-        &oauth_client,
-        tokens.refresh_token.clone(),
-        tokens.scope.as_deref(),
-    ))
-}
-
-/// Whether a token set should be refreshed before use (expired or within the
-/// refresh skew of expiry). A set without a refresh token is never eligible.
-pub(crate) fn needs_refresh(tokens: &McpOAuthTokenSet) -> bool {
-    tokens.refresh_token.is_some() && tokens.is_expired(Utc::now() + REFRESH_SKEW)
-}
-
-async fn post_token(
-    client: &reqwest::Client,
-    token_endpoint: &str,
-    form: &[(&str, &str)],
-) -> Result<TokenResponse> {
-    let response = client
-        .post(token_endpoint)
-        .form(form)
-        .send()
-        .await
-        .context("call token endpoint")?;
-    if !response.status().is_success() {
-        let status = response.status();
-        let text = response.text().await.unwrap_or_default();
-        return Err(anyhow!("token endpoint returned {status}: {text}"));
-    }
-    response.json().await.context("parse token response")
-}
-
-fn token_set(
-    token: TokenResponse,
-    token_endpoint: &str,
-    oauth_client: &OAuthClient,
-    fallback_refresh: Option<String>,
-    fallback_scope: Option<&str>,
-) -> McpOAuthTokenSet {
-    let expires_at = token
-        .expires_in
-        .filter(|seconds| *seconds > 0)
-        .map(|seconds| Utc::now() + Duration::seconds(seconds));
-    McpOAuthTokenSet {
-        access_token: token.access_token,
-        refresh_token: token.refresh_token.or(fallback_refresh),
-        token_type: token.token_type.unwrap_or_else(|| "Bearer".to_string()),
-        expires_at,
-        scope: token.scope.or_else(|| fallback_scope.map(str::to_string)),
-        token_endpoint: Some(token_endpoint.to_string()),
-        client_id: Some(oauth_client.client_id.clone()),
-        client_secret: oauth_client.client_secret.clone(),
-    }
-}
-
-/// `scheme://host[:port]` of a URL (no path), used as the well-known base.
-fn origin_of(url: &Url) -> String {
-    let scheme = url.scheme();
-    let host = url.host_str().unwrap_or_default();
-    match url.port() {
-        Some(port) => format!("{scheme}://{host}:{port}"),
-        None => format!("{scheme}://{host}"),
-    }
-}
-
-fn join_well_known(origin: &str, suffix: &str) -> String {
-    format!("{origin}/.well-known/{suffix}")
-}
-
-/// GET a JSON document, returning `None` on 404 (metadata simply absent) and an
-/// error on transport failures or malformed JSON.
-async fn fetch_json<T: for<'de> Deserialize<'de>>(
-    client: &reqwest::Client,
-    url: &str,
-) -> Result<Option<T>> {
-    let response = client
-        .get(url)
-        .header("Accept", "application/json")
-        .send()
-        .await
-        .with_context(|| format!("GET {url}"))?;
-    if response.status() == reqwest::StatusCode::NOT_FOUND {
-        return Ok(None);
-    }
-    if !response.status().is_success() {
-        return Err(anyhow!("GET {url} returned {}", response.status()));
-    }
-    let parsed = response
-        .json::<T>()
-        .await
-        .with_context(|| format!("parse JSON from {url}"))?;
-    Ok(Some(parsed))
-}
-
-/// Serve the loopback redirect until the authorization server redirects back
-/// with a matching `state`, returning the authorization code. Rejects
-/// mismatched state and surfaces `error` responses.
-async fn wait_for_callback(listener: TcpListener, expected_state: &str) -> Result<String> {
+async fn wait_for_callback(listener: TcpListener, expected_state: &str) -> Result<Callback> {
     loop {
         let (mut socket, _) = listener.accept().await.context("accept OAuth callback")?;
         let request = read_request_line(&mut socket).await?;
@@ -509,15 +91,16 @@ async fn wait_for_callback(listener: TcpListener, expected_state: &str) -> Resul
             .split_whitespace()
             .nth(1)
             .ok_or_else(|| anyhow!("invalid OAuth callback request"))?;
-        let parsed =
-            Url::parse(&format!("http://127.0.0.1{path}")).context("parse OAuth callback URL")?;
+        let parsed = reqwest::Url::parse(&format!("http://127.0.0.1{path}"))
+            .context("parse OAuth callback URL")?;
         let params: HashMap<_, _> = parsed.query_pairs().into_owned().collect();
 
         if parsed.path() != CALLBACK_PATH {
             write_response(&mut socket, "404 Not Found", "Unexpected callback path.").await?;
             continue;
         }
-        if params.get("state").map(String::as_str) != Some(expected_state) {
+        let state = params.get("state").cloned().unwrap_or_default();
+        if state != expected_state {
             write_response(
                 &mut socket,
                 "400 Bad Request",
@@ -538,7 +121,11 @@ async fn wait_for_callback(listener: TcpListener, expected_state: &str) -> Resul
                 "MCP login complete. You can return to the terminal.",
             )
             .await?;
-            return Ok(code.clone());
+            return Ok(Callback {
+                code: code.clone(),
+                state,
+                issuer: params.get("iss").cloned(),
+            });
         }
         write_response(
             &mut socket,
@@ -572,11 +159,6 @@ async fn write_response(socket: &mut TcpStream, status: &str, message: &str) -> 
         .context("write OAuth callback response")
 }
 
-/// A hand-rolled loopback OAuth authorization server for tests: serves the
-/// discovery documents, dynamic client registration, and token endpoints so the
-/// non-browser parts of the login flow (and the runtime auth provider) can be
-/// exercised end-to-end without a real provider. Shared with `runtime`'s
-/// provider tests.
 #[cfg(test)]
 pub(crate) mod test_support {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -587,8 +169,6 @@ pub(crate) mod test_support {
     }
 
     impl MockOAuthServer {
-        /// Start the server on an ephemeral loopback port and spawn its accept
-        /// loop. The task runs until the process exits (fine for tests).
         pub(crate) async fn start() -> Self {
             let listener = TcpListener::bind(("127.0.0.1", 0))
                 .await
@@ -614,7 +194,7 @@ pub(crate) mod test_support {
                         let path = it.next().unwrap_or_default();
                         let body = request
                             .split_once("\r\n\r\n")
-                            .map(|(_, b)| b.to_string())
+                            .map(|(_, body)| body.to_string())
                             .unwrap_or_default();
                         let json = route(method, path, &body, &base);
                         let response = match json {
@@ -622,10 +202,7 @@ pub(crate) mod test_support {
                                 "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
                                 body.len()
                             ),
-                            None => {
-                                "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
-                                    .to_string()
-                            }
+                            None => "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".to_string(),
                         };
                         let _ = socket.write_all(response.as_bytes()).await;
                     });
@@ -637,24 +214,18 @@ pub(crate) mod test_support {
 
     fn route(method: &str, path: &str, body: &str, base: &str) -> Option<String> {
         match (method, path) {
-            ("GET", "/.well-known/oauth-protected-resource") => {
-                Some(format!(r#"{{"authorization_servers":["{base}"]}}"#))
-            }
+            ("GET", "/.well-known/oauth-protected-resource") => Some(format!(
+                r#"{{"resource":"{base}/mcp","authorization_servers":["{base}"]}}"#
+            )),
             ("GET", "/.well-known/oauth-authorization-server") => Some(format!(
-                r#"{{"authorization_endpoint":"{base}/authorize","token_endpoint":"{base}/token","registration_endpoint":"{base}/register","scopes_supported":["read"]}}"#
+                r#"{{"issuer":"{base}","authorization_endpoint":"{base}/authorize","token_endpoint":"{base}/token","registration_endpoint":"{base}/register","scopes_supported":["read"]}}"#
             )),
             ("POST", "/register") => Some(r#"{"client_id":"dcr-client-1"}"#.to_string()),
             ("POST", "/token") => {
                 if body.contains("grant_type=refresh_token") {
-                    Some(
-                        r#"{"access_token":"access-2","refresh_token":"refresh-2","token_type":"Bearer","expires_in":3600}"#
-                            .to_string(),
-                    )
+                    Some(r#"{"access_token":"access-2","refresh_token":"refresh-2","token_type":"Bearer","expires_in":3600}"#.to_string())
                 } else {
-                    Some(
-                        r#"{"access_token":"access-1","refresh_token":"refresh-1","token_type":"Bearer","expires_in":3600,"scope":"read"}"#
-                            .to_string(),
-                    )
+                    Some(r#"{"access_token":"access-1","refresh_token":"refresh-1","token_type":"Bearer","expires_in":3600,"scope":"read"}"#.to_string())
                 }
             }
             _ => None,
@@ -686,160 +257,18 @@ mod tests {
         server.await.unwrap();
         let mut response = String::new();
         browser.read_to_string(&mut response).await.unwrap();
-
         assert!(response.starts_with("HTTP/1.1 200 OK\r\n"));
-        assert!(response.contains("Content-Type: text/html; charset=utf-8"));
-        assert!(response.contains("<svg"));
         assert!(response.contains("MCP server is connected."));
-        assert!(response.contains("Your terminal is already warming up the keyboard."));
     }
 
     #[tokio::test]
-    async fn discovers_endpoints_via_protected_resource_metadata() {
+    async fn upstream_login_preparation_discovers_registers_and_binds_resource() {
         let server = MockOAuthServer::start().await;
-        let client = http_client().unwrap();
-        let endpoints = discover_endpoints(&client, &format!("{}/mcp", server.base))
+        let prepared = prepare_login(&format!("{}/mcp", server.base), None, Some("read"))
             .await
-            .expect("discover");
-        assert_eq!(
-            endpoints.authorization_endpoint,
-            format!("{}/authorize", server.base)
-        );
-        assert_eq!(endpoints.token_endpoint, format!("{}/token", server.base));
-        assert_eq!(
-            endpoints.registration_endpoint.as_deref(),
-            Some(format!("{}/register", server.base).as_str())
-        );
-        assert_eq!(
-            endpoints.scopes_supported.as_deref(),
-            Some(["read".to_string()].as_slice())
-        );
-    }
-
-    #[tokio::test]
-    async fn full_flow_minus_browser_registers_and_exchanges() {
-        let server = MockOAuthServer::start().await;
-        let client = http_client().unwrap();
-        let endpoints = discover_endpoints(&client, &format!("{}/mcp", server.base))
-            .await
-            .expect("discover");
-        let oauth_client = register_client(&client, &endpoints, "http://127.0.0.1:9/callback")
-            .await
-            .expect("register");
-        assert_eq!(oauth_client.client_id, "dcr-client-1");
-
-        let tokens = exchange_code(
-            &client,
-            &endpoints,
-            &oauth_client,
-            "auth-code",
-            "verifier",
-            "http://127.0.0.1:9/callback",
-            Some("read"),
-        )
-        .await
-        .expect("exchange");
-        assert_eq!(tokens.access_token, "access-1");
-        assert_eq!(tokens.refresh_token.as_deref(), Some("refresh-1"));
-        assert_eq!(
-            tokens.token_endpoint.as_deref(),
-            Some(format!("{}/token", server.base).as_str())
-        );
-        assert_eq!(tokens.client_id.as_deref(), Some("dcr-client-1"));
-        assert!(tokens.expires_at.is_some(), "expires_in yields an expiry");
-    }
-
-    #[tokio::test]
-    async fn refresh_mints_new_access_token_and_preserves_metadata() {
-        let server = MockOAuthServer::start().await;
-        let tokens = McpOAuthTokenSet {
-            access_token: "access-1".to_string(),
-            refresh_token: Some("refresh-1".to_string()),
-            token_type: "Bearer".to_string(),
-            expires_at: Some(Utc::now() - Duration::seconds(1)),
-            scope: Some("read".to_string()),
-            token_endpoint: Some(format!("{}/token", server.base)),
-            client_id: Some("dcr-client-1".to_string()),
-            client_secret: None,
-        };
-        let refreshed = refresh(&tokens).await.expect("refresh");
-        assert_eq!(refreshed.access_token, "access-2");
-        assert_eq!(refreshed.refresh_token.as_deref(), Some("refresh-2"));
-        assert_eq!(refreshed.client_id.as_deref(), Some("dcr-client-1"));
-        assert_eq!(
-            refreshed.token_endpoint.as_deref(),
-            Some(format!("{}/token", server.base).as_str())
-        );
-    }
-
-    #[test]
-    fn require_secure_allows_https_and_loopback_http() {
-        assert!(require_secure("https://mcp.example.com/mcp", "s").is_ok());
-        assert!(require_secure("http://127.0.0.1:8080/mcp", "s").is_ok());
-        assert!(require_secure("http://localhost/mcp", "s").is_ok());
-        assert!(require_secure("http://mcp.example.com/mcp", "s").is_err());
-        assert!(require_secure("ftp://mcp.example.com", "s").is_err());
-    }
-
-    #[test]
-    fn origin_strips_path_and_keeps_port() {
-        let url = Url::parse("https://as.example.com:8443/tenant/authorize").unwrap();
-        assert_eq!(origin_of(&url), "https://as.example.com:8443");
-        let url = Url::parse("https://as.example.com/authorize").unwrap();
-        assert_eq!(origin_of(&url), "https://as.example.com");
-    }
-
-    #[test]
-    fn authorize_url_carries_pkce_and_state() {
-        let endpoints = OAuthEndpoints {
-            authorization_endpoint: "https://as.example.com/authorize".to_string(),
-            token_endpoint: "https://as.example.com/token".to_string(),
-            registration_endpoint: None,
-            scopes_supported: None,
-        };
-        let url = authorize_url(
-            &endpoints,
-            "client-1",
-            "http://127.0.0.1:9999/callback",
-            "challenge-xyz",
-            "state-abc",
-            Some("read write"),
-        )
-        .unwrap();
-        let pairs: HashMap<_, _> = url.query_pairs().into_owned().collect();
-        assert_eq!(pairs.get("response_type").map(String::as_str), Some("code"));
-        assert_eq!(pairs.get("client_id").map(String::as_str), Some("client-1"));
-        assert_eq!(
-            pairs.get("code_challenge_method").map(String::as_str),
-            Some("S256")
-        );
-        assert_eq!(
-            pairs.get("code_challenge").map(String::as_str),
-            Some("challenge-xyz")
-        );
-        assert_eq!(pairs.get("state").map(String::as_str), Some("state-abc"));
-        assert_eq!(pairs.get("scope").map(String::as_str), Some("read write"));
-    }
-
-    #[test]
-    fn needs_refresh_only_when_expiring_with_refresh_token() {
-        let mut tokens = McpOAuthTokenSet {
-            access_token: "a".to_string(),
-            refresh_token: Some("r".to_string()),
-            token_type: "Bearer".to_string(),
-            expires_at: Some(Utc::now() + Duration::seconds(300)),
-            scope: None,
-            token_endpoint: Some("https://as.example/token".to_string()),
-            client_id: Some("c".to_string()),
-            client_secret: None,
-        };
-        assert!(!needs_refresh(&tokens), "fresh token is not refreshed");
-        tokens.expires_at = Some(Utc::now() + Duration::seconds(10));
-        assert!(needs_refresh(&tokens), "near-expiry token is refreshed");
-        tokens.refresh_token = None;
-        assert!(
-            !needs_refresh(&tokens),
-            "no refresh token -> cannot refresh"
-        );
+            .expect("prepare login");
+        assert!(prepared.authorize_url.contains("client_id=dcr-client-1"));
+        assert!(prepared.authorize_url.contains("code_challenge="));
+        assert!(prepared.authorize_url.contains("resource="));
     }
 }

--- a/src/runtime/background_wake.rs
+++ b/src/runtime/background_wake.rs
@@ -8,11 +8,10 @@
 //! reached the yolop agent.
 //!
 //! yolop installs a [`LocalPlatformStore`](everruns_local::LocalPlatformStore)
-//! backed by [`WakeRunner`]. For a live host session the runner routes the
-//! completion message to the host's unbounded channel; the host (TUI event loop
-//! or ACP session loop) runs it as an ordinary streamed turn when idle. Child
-//! sub-agent sessions have no terminal host, so the same runner creates and
-//! drives those turns synchronously through the in-process runtime.
+//! backed by Everruns' [`HostRoutedRunner`](everruns_local::HostRoutedRunner).
+//! Its inner [`WakeRunner`] enriches host wakes with Yolop's authenticated task
+//! handoff and drives child sessions synchronously through the in-process
+//! runtime.
 
 use async_trait::async_trait;
 use everruns_core::error::{AgentLoopError, Result};
@@ -23,7 +22,7 @@ use everruns_core::session::Session;
 use everruns_core::session_task::{SessionTask, SessionTaskRegistry};
 use everruns_core::typed_id::{AgentId, HarnessId, SessionId};
 use everruns_core::{TaskTransition, wake_text_for};
-use everruns_local::LocalSessionRunner;
+use everruns_local::{HostRoutedRunner, LocalSessionRunner, WakeRoutes};
 use everruns_runtime::{InProcessRuntime, RuntimeSessionStore, SessionBuilder};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -34,9 +33,45 @@ use tokio::sync::{Mutex as AsyncMutex, mpsc};
 /// Sender half of a session's wake channel. The `LocalPlatformStore`'s
 /// `send_message` pushes a background-completion message here; the host drains
 /// the paired [`WakeReceiver`] and runs a turn.
+#[cfg(test)]
 pub type WakeSender = mpsc::UnboundedSender<WakeMessage>;
 /// Receiver half a host drains to react to finished background tasks.
-pub type WakeReceiver = mpsc::UnboundedReceiver<WakeMessage>;
+pub struct WakeReceiver {
+    inner: mpsc::UnboundedReceiver<WakeMessage>,
+    _route: Option<HostWakeRoute>,
+}
+
+impl WakeReceiver {
+    pub async fn recv(&mut self) -> Option<WakeMessage> {
+        self.inner.recv().await
+    }
+
+    pub fn try_recv(&mut self) -> std::result::Result<WakeMessage, mpsc::error::TryRecvError> {
+        self.inner.try_recv()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn unrouted(inner: mpsc::UnboundedReceiver<WakeMessage>) -> Self {
+        Self {
+            inner,
+            _route: None,
+        }
+    }
+}
+
+/// Owns one upstream host route and the task that enriches its raw messages.
+pub struct HostWakeRoute {
+    routes: WakeRoutes,
+    session_id: SessionId,
+    bridge: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for HostWakeRoute {
+    fn drop(&mut self) {
+        self.routes.unregister(self.session_id);
+        self.bridge.abort();
+    }
+}
 
 const MAX_WAKE_BATCH_BYTES: usize = 32 * 1024;
 const MAX_WAKE_BATCH_MESSAGES: usize = 256;
@@ -170,19 +205,9 @@ pub(crate) fn coalesce_pending_wakes(
     }
 }
 
-fn wake_routes() -> &'static Mutex<HashMap<SessionId, WakeSender>> {
-    static ROUTES: OnceLock<Mutex<HashMap<SessionId, WakeSender>>> = OnceLock::new();
-    ROUTES.get_or_init(|| Mutex::new(HashMap::new()))
-}
-
 /// Local platform runner for host wakes and child sub-agent sessions.
-///
-/// Every terminal-host session registers a wake sender for its lifetime.
-/// Messages targeting one of those sessions are queued for the host. All other
-/// messages target child sessions and run synchronously through `runtime`.
+/// Host routing itself is owned by Everruns' [`HostRoutedRunner`].
 pub struct WakeRunner {
-    session_id: SessionId,
-    wake_tx: WakeSender,
     runtime: Arc<OnceLock<Weak<InProcessRuntime>>>,
     sessions: Arc<dyn RuntimeSessionStore>,
     tasks: Option<Arc<dyn SessionTaskRegistry>>,
@@ -191,19 +216,11 @@ pub struct WakeRunner {
 
 impl WakeRunner {
     pub fn new(
-        session_id: SessionId,
-        wake_tx: WakeSender,
         runtime: Arc<OnceLock<Weak<InProcessRuntime>>>,
         sessions: Arc<dyn RuntimeSessionStore>,
         tasks: Option<Arc<dyn SessionTaskRegistry>>,
     ) -> Self {
-        wake_routes()
-            .lock()
-            .unwrap()
-            .insert(session_id, wake_tx.clone());
         Self {
-            session_id,
-            wake_tx,
             runtime,
             sessions,
             tasks,
@@ -286,15 +303,34 @@ impl WakeRunner {
     }
 }
 
-impl Drop for WakeRunner {
-    fn drop(&mut self) {
-        let mut routes = wake_routes().lock().unwrap();
-        if routes
-            .get(&self.session_id)
-            .is_some_and(|current| current.same_channel(&self.wake_tx))
-        {
-            routes.remove(&self.session_id);
+/// Register a live host session with Everruns' route registry and translate
+/// raw route messages into Yolop's authenticated wake representation.
+pub fn register_host_route(
+    runner: Arc<HostRoutedRunner<WakeRunner>>,
+    session_id: SessionId,
+) -> WakeReceiver {
+    let routes = runner.routes().clone();
+    let mut raw = routes.register(session_id);
+    let (wake_tx, wake_rx) = mpsc::unbounded_channel();
+    let bridge_runner = runner.clone();
+    let bridge = tokio::spawn(async move {
+        while let Some(content) = raw.recv().await {
+            let wake = bridge_runner
+                .inner()
+                .wake_message(session_id, &content)
+                .await;
+            if wake_tx.send(wake).is_err() {
+                break;
+            }
         }
+    });
+    WakeReceiver {
+        inner: wake_rx,
+        _route: Some(HostWakeRoute {
+            routes,
+            session_id,
+            bridge,
+        }),
     }
 }
 
@@ -437,29 +473,11 @@ fn is_zero(value: &usize) -> bool {
 #[async_trait]
 impl LocalSessionRunner for WakeRunner {
     async fn routable_session_ids(&self) -> Result<Option<Vec<SessionId>>> {
-        Ok(Some(
-            wake_routes().lock().unwrap().keys().copied().collect(),
-        ))
+        Ok(Some(Vec::new()))
     }
 
     async fn send_message(&self, session_id: SessionId, content: &str) -> Result<()> {
         let wake = self.wake_message(session_id, content).await;
-        let sender = wake_routes().lock().unwrap().get(&session_id).cloned();
-        if let Some(sender) = sender {
-            return sender.send(wake).map_err(|_| {
-                let mut routes = wake_routes().lock().unwrap();
-                if routes
-                    .get(&session_id)
-                    .is_some_and(|current| current.same_channel(&sender))
-                {
-                    routes.remove(&session_id);
-                }
-                AgentLoopError::tool(format!(
-                    "session {session_id} wake receiver is closed; wake remains retryable"
-                ))
-            });
-        }
-
         if self.sessions.get_session(session_id).await?.is_none() {
             return Err(AgentLoopError::session_not_found(session_id));
         }
@@ -580,41 +598,32 @@ mod tests {
     };
     use everruns_runtime::RuntimeBackends;
 
-    fn runner(session_id: SessionId, tx: WakeSender) -> WakeRunner {
+    fn runner() -> WakeRunner {
         let backends = RuntimeBackends::in_memory();
-        WakeRunner::new(
-            session_id,
-            tx,
-            Arc::new(OnceLock::new()),
-            backends.session_store,
-            None,
-        )
+        WakeRunner::new(Arc::new(OnceLock::new()), backends.session_store, None)
     }
 
     #[tokio::test]
-    async fn routes_wakes_to_the_target_session() {
-        let session_a = SessionId::from_seed(910_001);
-        let session_b = SessionId::from_seed(910_002);
-        let (tx_a, mut rx_a) = mpsc::unbounded_channel();
-        let (tx_b, mut rx_b) = mpsc::unbounded_channel();
-        let runner_a = runner(session_a, tx_a);
-        let _runner_b = runner(session_b, tx_b);
+    async fn upstream_router_delivers_an_enriched_host_wake() {
+        let session_id = SessionId::from_seed(910_001);
+        let runner = Arc::new(HostRoutedRunner::new(runner(), WakeRoutes::new()));
+        let mut wakes = register_host_route(runner.clone(), session_id);
 
-        runner_a
-            .send_message(session_b, "for b")
+        runner
+            .send_message(session_id, "for host")
             .await
-            .expect("route to active session b");
+            .expect("route to active host");
 
-        assert_eq!(rx_b.recv().await.map(|wake| wake.raw), Some("for b".into()));
-        assert!(rx_a.try_recv().is_err());
+        assert_eq!(
+            wakes.recv().await.map(|wake| wake.raw),
+            Some("for host".into())
+        );
     }
 
     #[tokio::test]
     async fn inactive_session_wakes_remain_retryable() {
-        let active = SessionId::from_seed(910_003);
         let inactive = SessionId::from_seed(910_004);
-        let (tx, _rx) = mpsc::unbounded_channel();
-        let runner = runner(active, tx);
+        let runner = runner();
 
         let error = runner
             .send_message(inactive, "later")
@@ -628,12 +637,11 @@ mod tests {
     async fn reports_only_live_host_sessions_as_routable() {
         let session_a = SessionId::from_seed(910_005);
         let session_b = SessionId::from_seed(910_006);
-        let (tx_a, _rx_a) = mpsc::unbounded_channel();
-        let (tx_b, _rx_b) = mpsc::unbounded_channel();
-        let runner_a = runner(session_a, tx_a);
-        let runner_b = runner(session_b, tx_b);
+        let runner = Arc::new(HostRoutedRunner::new(runner(), WakeRoutes::new()));
+        let rx_a = register_host_route(runner.clone(), session_a);
+        let rx_b = register_host_route(runner.clone(), session_b);
 
-        let routable = runner_a
+        let routable = runner
             .routable_session_ids()
             .await
             .expect("read routable sessions")
@@ -641,19 +649,21 @@ mod tests {
         assert!(routable.contains(&session_a));
         assert!(routable.contains(&session_b));
 
-        drop(runner_b);
-        let routable = runner_a
+        drop(rx_b);
+        let routable = runner
             .routable_session_ids()
             .await
             .expect("read routable sessions after route closes")
             .expect("wake runner must scope schedule claims");
         assert!(routable.contains(&session_a));
         assert!(!routable.contains(&session_b));
+        drop(rx_a);
     }
 
     #[test]
     fn queued_completion_burst_coalesces_without_losing_results() {
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut rx = WakeReceiver::unrouted(rx);
         tx.send(WakeMessage::unstructured("task_2 result_path=/results/2"))
             .unwrap();
         tx.send(WakeMessage::unstructured("task_3 result_path=/results/3"))
@@ -759,7 +769,8 @@ mod tests {
                 omitted_tasks: 0,
             }),
         };
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut rx = WakeReceiver::unrouted(rx);
         tx.send(structured(second)).unwrap();
         let batch = coalesce_pending_wakes(structured(first), &mut rx);
         let ids = batch

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -167,14 +167,17 @@ fn env_key_prefix(value: &str) -> String {
 /// environment-provided bearer credentials. The stored connection is keyed by
 /// the server's `oauth_provider_id` when set, otherwise its name.
 pub(crate) struct StoredMcpAuthProvider {
-    connections: Arc<ConnectionStore>,
+    oauth: everruns_mcp::oauth::OAuthAuthProvider<crate::auth::mcp_oauth::ConnectionTokenStore>,
     env: EnvMcpAuthProvider,
 }
 
 impl StoredMcpAuthProvider {
     pub(crate) fn new(connections: Arc<ConnectionStore>) -> Self {
         Self {
-            connections,
+            oauth: everruns_mcp::oauth::OAuthAuthProvider::new(
+                crate::auth::mcp_oauth::ConnectionTokenStore::new(connections),
+                crate::auth::mcp_oauth::oauth_egress(),
+            ),
             env: EnvMcpAuthProvider,
         }
     }
@@ -191,43 +194,15 @@ impl McpAuthProvider for StoredMcpAuthProvider {
         request: &McpAuthRequest<'_>,
     ) -> anyhow::Result<Option<McpCredential>> {
         let key = Self::provider_key(request);
-        let Some(tokens) = crate::auth::mcp_oauth::load_tokens(&self.connections, key) else {
-            // No stored OAuth token for this server: fall back to env vars.
-            return self.env.authorization(request).await;
+        let keyed_request = McpAuthRequest {
+            server_name: key,
+            auth_mode: request.auth_mode.clone(),
+            oauth_provider_id: None,
         };
-
-        let tokens = if crate::auth::mcp_oauth_login::needs_refresh(&tokens) {
-            match crate::auth::mcp_oauth_login::refresh(&tokens).await {
-                Ok(refreshed) => {
-                    if let Err(err) = crate::auth::mcp_oauth::save_tokens(
-                        &self.connections,
-                        key,
-                        refreshed.clone(),
-                    ) {
-                        tracing::warn!(
-                            provider = key,
-                            %err,
-                            "failed to persist refreshed MCP OAuth token"
-                        );
-                    }
-                    refreshed
-                }
-                Err(err) => {
-                    tracing::warn!(
-                        provider = key,
-                        %err,
-                        "MCP OAuth token refresh failed; using the existing token"
-                    );
-                    tokens
-                }
-            }
-        } else {
-            tokens
-        };
-
-        Ok(Some(McpCredential::authorization(
-            tokens.authorization_value(),
-        )))
+        match self.oauth.authorization(&keyed_request).await? {
+            Some(credential) => Ok(Some(credential)),
+            None => self.env.authorization(request).await,
+        }
     }
 }
 
@@ -3084,15 +3059,17 @@ pub async fn build_with_options(
     // Install the local platform seam. Host-session messages are queued onto
     // `background_wake`; child sub-agent messages run synchronously through the
     // in-process runtime once it has been built below.
-    let (background_wake_tx, background_wake_rx) = mpsc::unbounded_channel();
     let runtime_cell = Arc::new(std::sync::OnceLock::new());
-    let wake_runner = Arc::new(crate::runtime::background_wake::WakeRunner::new(
-        session_id,
-        background_wake_tx,
-        runtime_cell.clone(),
-        local_backends.runtime_backends.session_store.clone(),
-        Some(task_registry.clone()),
+    let wake_runner = Arc::new(everruns_local::HostRoutedRunner::new(
+        crate::runtime::background_wake::WakeRunner::new(
+            runtime_cell.clone(),
+            local_backends.runtime_backends.session_store.clone(),
+            Some(task_registry.clone()),
+        ),
+        everruns_local::WakeRoutes::new(),
     ));
+    let background_wake_rx =
+        crate::runtime::background_wake::register_host_route(wake_runner.clone(), session_id);
     let schedule_runner = local_backends
         .start_schedule_runner(wake_runner.clone())
         .context("start everruns-local schedule runner")?;

--- a/src/session_state/task_completion.rs
+++ b/src/session_state/task_completion.rs
@@ -1,12 +1,8 @@
-//! Cheap end-of-turn completion gate shared by TUI, print, and ACP hosts.
+//! Yolop policy around Everruns' shared end-of-turn completion gate.
 
-use std::time::{Duration, Instant};
-
-use everruns_core::turn::TurnStopReason;
-
-pub(crate) const MAX_TASK_TURNS: u32 = 6;
-pub(crate) const MAX_TASK_TOKENS: u64 = 64_000;
-pub(crate) const MAX_TASK_ELAPSED: Duration = Duration::from_secs(10 * 60);
+pub(crate) use everruns_core::turn_completion::{
+    CompletionState, ContinuationBudget as CompletionBudget, GateDecision,
+};
 pub(crate) const CONTINUATION_TAG: &str = "automatic_task_continuation";
 pub(crate) const CONTINUATION_METADATA_KEY: &str = "yolop.task_continuation";
 
@@ -21,105 +17,17 @@ pub(crate) fn tag_continuation(
     input
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum CompletionState {
-    Achieved,
-    Blocked,
-    Failed,
-    WaitingOnBackground,
-    InProgress,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum GateDecision {
-    Conclusive(CompletionState),
-    /// Tool-using work produced a candidate final answer. Mutations and
-    /// multi-step work are ambiguous enough to justify semantic evaluation.
-    Evaluate,
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct CompletionBudget {
-    started: Instant,
-    turns: u32,
-    tokens: u64,
-}
-
-impl Default for CompletionBudget {
-    fn default() -> Self {
-        Self {
-            started: Instant::now(),
-            turns: 0,
-            tokens: 0,
-        }
-    }
-}
-
-impl CompletionBudget {
-    pub(crate) fn reset(&mut self) {
-        *self = Self::default();
-    }
-
-    pub(crate) fn observe_turn(&mut self, tokens: u64) -> bool {
-        self.turns = self.turns.saturating_add(1);
-        self.tokens = self.tokens.saturating_add(tokens);
-        self.turns <= MAX_TASK_TURNS
-            && self.tokens <= MAX_TASK_TOKENS
-            && self.started.elapsed() <= MAX_TASK_ELAPSED
-    }
-
-    #[cfg(test)]
-    pub(crate) fn usage(&self) -> (u32, u64) {
-        (self.turns, self.tokens)
-    }
-}
-
 pub(crate) fn gate_turn(
     result: &everruns_runtime::TurnResult,
     has_active_background: bool,
 ) -> GateDecision {
-    if !result.success {
-        return GateDecision::Conclusive(match result.stop_reason {
-            TurnStopReason::Cancelled => CompletionState::Blocked,
-            _ => CompletionState::Failed,
-        });
-    }
-
-    match result.stop_reason {
-        TurnStopReason::Error | TurnStopReason::Refusal => {
-            return GateDecision::Conclusive(CompletionState::Failed);
-        }
-        TurnStopReason::Cancelled => {
-            return GateDecision::Conclusive(CompletionState::Blocked);
-        }
-        TurnStopReason::MaxTokens | TurnStopReason::MaxTurnRequests => {
-            return GateDecision::Conclusive(CompletionState::InProgress);
-        }
-        TurnStopReason::EndTurn => {}
-    }
-
-    if has_active_background && result.tool_calls_count > 0 {
-        return GateDecision::Conclusive(CompletionState::WaitingOnBackground);
-    }
-
-    if result.response.trim().is_empty() {
-        return GateDecision::Conclusive(CompletionState::InProgress);
-    }
-
-    let normalized = result.response.trim().to_ascii_lowercase();
-    if normalized.ends_with('?')
-        && ["need", "which", "what", "could you", "please provide"]
-            .iter()
-            .any(|marker| normalized.contains(marker))
-    {
-        return GateDecision::Conclusive(CompletionState::Blocked);
-    }
-
-    if result.tool_calls_count == 0 {
-        GateDecision::Conclusive(CompletionState::Achieved)
-    } else {
-        GateDecision::Evaluate
-    }
+    everruns_core::turn_completion::gate_turn(&everruns_core::turn_completion::TurnSummary {
+        success: result.success,
+        stop_reason: result.stop_reason,
+        response: &result.response,
+        tool_calls_count: result.tool_calls_count,
+        has_active_background,
+    })
 }
 
 pub(crate) fn continuation_prompt(reason: &str) -> String {
@@ -161,6 +69,7 @@ pub(crate) fn evaluation_for_state(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use everruns_core::turn::TurnStopReason;
     use everruns_core::typed_id::TurnId;
 
     fn result(response: &str, tools: usize, success: bool) -> everruns_runtime::TurnResult {
@@ -218,13 +127,14 @@ mod tests {
     #[test]
     fn budget_is_strict_for_turns_and_tokens() {
         let mut budget = CompletionBudget::default();
-        for _ in 0..MAX_TASK_TURNS {
+        for _ in 0..everruns_core::turn_completion::DEFAULT_MAX_CONTINUATION_TURNS {
             assert!(budget.observe_turn(1));
         }
         assert!(!budget.observe_turn(1));
 
         budget.reset();
-        assert!(!budget.observe_turn(MAX_TASK_TOKENS + 1));
-        assert_eq!(budget.usage(), (1, MAX_TASK_TOKENS + 1));
+        let over_limit = everruns_core::turn_completion::DEFAULT_MAX_CONTINUATION_TOKENS + 1;
+        assert!(!budget.observe_turn(over_limit));
+        assert_eq!(budget.usage(), (1, over_limit));
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -6599,7 +6599,7 @@ mod tests {
         message: &str,
     ) -> crate::runtime::background_wake::WakeSender {
         let (tx, rx) = mpsc::unbounded_channel();
-        app.background_wake = rx;
+        app.background_wake = crate::runtime::background_wake::WakeReceiver::unrouted(rx);
         tx.send(crate::runtime::background_wake::WakeMessage::unstructured(
             message,
         ))


### PR DESCRIPTION
## What changed

Bumps every `everruns-*` crate from 0.17.22 to 0.17.23 and adopts the new shared host primitives:

- turn completion classification and the three-axis continuation budget now come from `everruns-core`
- live-session wake ownership and retryable closed-route handling now come from `everruns-local`
- MCP OAuth discovery, DCR, PKCE, resource binding, callback issuer validation, exchange, and serialized refresh now come from `everruns-core` / `everruns-mcp`

Yolop retains its host-specific ask projection, authenticated wake handoff/coalescing, synchronous child turns, connection-file persistence, environment credential fallback, and loopback callback host. The migration removes 639 net lines of duplicate protocol and policy code.

## Why

Everruns 0.17.23 promoted behavior Yolop previously owned into reusable runtime APIs. Adopting those owners avoids policy drift and picks up resource-bound MCP tokens, issuer validation, and refresh serialization while keeping Yolop-specific host behavior intact.

## Before / After

No terminal wording or layout changes.

Before: Yolop locally classified turn completion, owned the live wake-route registry, and implemented the MCP OAuth protocol and refresh path.

After: focused tests drive the same Yolop entry points through the upstream implementations. Live OpenAI proof used a real tool loop to read `Cargo.toml` and returned exactly `0.17.23`.

## Risk

- Medium
- Wake-route lifetime mistakes could suppress background callbacks; ACP completion and scheduled-wake end-to-end tests cover both paths.
- OAuth migration could affect login, refresh, or credential fallback; loopback discovery/DCR/resource-binding, persisted refresh, fresh-token, and no-token/env tests cover those paths.
- Completion policy drift could change continuation decisions; adapter tests cover trivial, tool-only, background-waiting, evaluator, failure, and budget cases.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered — pre-1.0; existing host behavior and stored token shape are preserved
- [x] Knowledge concepts updated

## Knowledge

Updated `user-ask`, `background`, and `mcp`, plus the knowledge log, to record upstream ownership and the retained Yolop adapters.

## Security

Reviewed **TM-DEP, TM-LLM, TM-TOOL, TM-BASH, and TM-FS**.

- TM-DEP: no new crates; every direct and transitive `everruns-*` crate resolves to 0.17.23.
- TM-LLM: OAuth credentials retain the existing connection-store shape and are never logged. Public discovery and token calls now use DNS-pinned egress; only explicitly configured loopback hosts bypass public-address pinning, and plaintext remains limited by the upstream URL validator to loopback.
- TM-TOOL: host routing delegates only session-id/message delivery. Yolop still authenticates task handoffs from the durable registry, bounds/coalesces wake payloads, and serializes child turns.
- TM-BASH/TM-FS: no shell execution or filesystem boundary changed; timeouts, output caps, and write blocklists are untouched.

No findings remain.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` — 1,055 unit + 61 integration/PTY passed; 4 ignored
- `python3 scripts/validate_okf.py knowledge --check-links` — 37 concepts, 0 errors
- Offline binary smoke: `cargo run -- --provider llmsim -p "Reply exactly: offline-runtime-ok"`
- Live provider/tool-loop smoke: `doppler run --project yolop --config ci -- cargo run -- --provider openai -p "Use your tools to read Cargo.toml and reply with exactly the everruns-runtime version value."` → `0.17.23`

## Follow-ups

No follow-ups.