### PR TITLE
chore(release): prepare v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,42 @@ mechanical `### What's Changed` list of merged PRs.
 Releases are cut via [`/release`](./.agents/skills/release/SKILL.md), which
 tags the version and publishes to crates.io and the Homebrew tap.
 
+## [0.15.0] - 2026-08-06
+
+### Highlights
+
+- Models now receive cache-stable live provider, model, and reasoning-effort context, and provider catalogs can be searched conversationally before a selection is persisted.
+- Long-running tasks continue automatically under bounded completion budgets, with cumulative-cost compaction, stronger progress checkpoints, and compact background-completion handoffs.
+- Repository context loads asynchronously at startup, keeping the composer responsive while branch and workspace details arrive in the background.
+- Interrupted provider turns recover without losing completed tool work, while lazy session storage avoids creating empty session state.
+- Yolop now shares completion, wake routing, interactive approval, cancellation, and MCP OAuth primitives with Everruns 0.17.23, reducing duplicated policy while preserving host behavior.
+
+### Breaking Changes
+
+- No intentional breaking changes. The minor version reflects the new model-context, conversational discovery, bounded continuation, and startup capabilities added since v0.14.0.
+
+### What's Changed
+
+* refactor(runtime): adopt everruns 0.17.23 primitives ([#544](https://github.com/everruns/yolop/pull/544)) by @chaliy
+* refactor(runtime): adopt upstream tool approval ([#543](https://github.com/everruns/yolop/pull/543)) by @chaliy
+* chore(ship): prompt for PR evidence in the ship skill ([#542](https://github.com/everruns/yolop/pull/542)) by @chaliy
+* fix(runtime): recover interrupted provider turns ([#541](https://github.com/everruns/yolop/pull/541)) by @chaliy
+* feat(models): search provider catalogs conversationally ([#540](https://github.com/everruns/yolop/pull/540)) by @chaliy
+* perf(runtime): shape first-turn tool disclosure ([#539](https://github.com/everruns/yolop/pull/539)) by @chaliy
+* feat(runtime): compact context from cumulative cost ([#538](https://github.com/everruns/yolop/pull/538)) by @chaliy
+* feat(runtime): continue incomplete user tasks ([#537](https://github.com/everruns/yolop/pull/537)) by @chaliy
+* fix(agent): enforce progress checkpoints ([#536](https://github.com/everruns/yolop/pull/536)) by @chaliy
+* fix(session): materialize storage lazily ([#535](https://github.com/everruns/yolop/pull/535)) by @chaliy
+* fix(background): compact completion wake context ([#534](https://github.com/everruns/yolop/pull/534)) by @chaliy
+* fix(evals): exclude bookkeeping from search budgets ([#533](https://github.com/everruns/yolop/pull/533)) by @chaliy
+* feat(tui): add async repository startup pulse ([#532](https://github.com/everruns/yolop/pull/532)) by @chaliy
+* fix(models): defer persistence until successful turn ([#531](https://github.com/everruns/yolop/pull/531)) by @chaliy
+* chore(deps): bump the cargo-minor-and-patch group across 1 directory with 4 updates ([#530](https://github.com/everruns/yolop/pull/530)) by @dependabot[bot]
+* feat(runtime): expose live model context ([#528](https://github.com/everruns/yolop/pull/528)) by @chaliy
+* fix(deps): revert toml and schemars to fix repo-map-bounded nightly regression ([#526](https://github.com/everruns/yolop/pull/526)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/yolop/compare/v0.14.0...v0.15.0
+
 ## [0.14.0] - 2026-08-03
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7704,7 +7704,7 @@ dependencies = [
 
 [[package]]
 name = "yolop"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "yolop"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 authors = ["Everruns <support@everruns.com>"]
 license = "MIT"


### PR DESCRIPTION
## [0.15.0] - 2026-08-06

### Highlights

- Models now receive cache-stable live provider, model, and reasoning-effort context, and provider catalogs can be searched conversationally before a selection is persisted.
- Long-running tasks continue automatically under bounded completion budgets, with cumulative-cost compaction, stronger progress checkpoints, and compact background-completion handoffs.
- Repository context loads asynchronously at startup, keeping the composer responsive while branch and workspace details arrive in the background.
- Interrupted provider turns recover without losing completed tool work, while lazy session storage avoids creating empty session state.
- Yolop now shares completion, wake routing, interactive approval, cancellation, and MCP OAuth primitives with Everruns 0.17.23, reducing duplicated policy while preserving host behavior.

### Breaking Changes

- No intentional breaking changes. The minor version reflects the new model-context, conversational discovery, bounded continuation, and startup capabilities added since v0.14.0.

### What's Changed

* refactor(runtime): adopt everruns 0.17.23 primitives ([#544](https://github.com/everruns/yolop/pull/544)) by @chaliy
* refactor(runtime): adopt upstream tool approval ([#543](https://github.com/everruns/yolop/pull/543)) by @chaliy
* chore(ship): prompt for PR evidence in the ship skill ([#542](https://github.com/everruns/yolop/pull/542)) by @chaliy
* fix(runtime): recover interrupted provider turns ([#541](https://github.com/everruns/yolop/pull/541)) by @chaliy
* feat(models): search provider catalogs conversationally ([#540](https://github.com/everruns/yolop/pull/540)) by @chaliy
* perf(runtime): shape first-turn tool disclosure ([#539](https://github.com/everruns/yolop/pull/539)) by @chaliy
* feat(runtime): compact context from cumulative cost ([#538](https://github.com/everruns/yolop/pull/538)) by @chaliy
* feat(runtime): continue incomplete user tasks ([#537](https://github.com/everruns/yolop/pull/537)) by @chaliy
* fix(agent): enforce progress checkpoints ([#536](https://github.com/everruns/yolop/pull/536)) by @chaliy
* fix(session): materialize storage lazily ([#535](https://github.com/everruns/yolop/pull/535)) by @chaliy
* fix(background): compact completion wake context ([#534](https://github.com/everruns/yolop/pull/534)) by @chaliy
* fix(evals): exclude bookkeeping from search budgets ([#533](https://github.com/everruns/yolop/pull/533)) by @chaliy
* feat(tui): add async repository startup pulse ([#532](https://github.com/everruns/yolop/pull/532)) by @chaliy
* fix(models): defer persistence until successful turn ([#531](https://github.com/everruns/yolop/pull/531)) by @chaliy
* chore(deps): bump the cargo-minor-and-patch group across 1 directory with 4 updates ([#530](https://github.com/everruns/yolop/pull/530)) by @dependabot[bot]
* feat(runtime): expose live model context ([#528](https://github.com/everruns/yolop/pull/528)) by @chaliy
* fix(deps): revert toml and schemars to fix repo-map-bounded nightly regression ([#526](https://github.com/everruns/yolop/pull/526)) by @chaliy

**Full Changelog**: https://github.com/everruns/yolop/compare/v0.14.0...v0.15.0

## Publish-readiness

- Main CI and CodeQL are green at release base ab206f5.
- cargo fmt --check passed.
- cargo clippy --all-targets --all-features -- -D warnings passed.
- cargo test --all-features passed: 1,116 passed, 4 ignored.
- python3 scripts/validate_okf.py knowledge --check-links passed: 37 concepts, 0 errors.
- cargo publish --dry-run --allow-dirty -p yolop-yep passed; yolop-yep 0.3.0 is unchanged and already published.
- cargo publish --dry-run --allow-dirty -p yolop passed; the packaged v0.15.0 crate compiled successfully.
- crates.io currently serves yolop 0.14.0, below the proposed 0.15.0.
- Cargo.toml and Cargo.lock both read 0.15.0.
- The TUI renderer did not change, so the manual terminal matrix is not required.

## Post-merge verification

- [ ] release.yml succeeds and creates GitHub release v0.15.0.
- [ ] publish.yml succeeds.
- [ ] cli-binaries.yml succeeds with all binaries and checksums attached.
- [ ] crates.io serves yolop 0.15.0.
- [ ] everruns/homebrew-tap Formula/yolop.rb points at v0.15.0.
