### PR TITLE
fix(acp): expose only connected models

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,14 @@ session, and sends turns; yolop streams back assistant text, reasoning, tool
 calls, and plans. Editors can also load an existing session with `session/load`,
 replaying the same persisted history used by CLI `--session`.
 
+ACP model pickers list only providers that are currently connected. A stale
+saved provider no longer prevents session creation: yolop starts with another
+usable provider (or local `llmsim`) and updates the picker live after `/setup`
+or authentication changes. Clients that support ACP authentication can launch
+Yolop's browser-based ChatGPT/Codex sign-in directly from the agent UI. API-key
+providers must receive their keys through the ACP process environment; Yolop
+does not accept secrets through ACP prompt text.
+
 To set up Zed:
 
 ```bash

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,16 @@
 Significant changes to Yolop's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
+## 2026-08-07 — Connected ACP model catalog and authentication
+
+- ACP session creation now falls back from a stale disconnected preference to
+  a usable provider, exposes only connected providers, advertises agent-handled
+  Codex browser authentication, and pushes standard `config_option_update`
+  notifications after authentication or `/setup` changes.
+- The cross-provider `default_model` setting was removed. Durable model choices
+  are provider-scoped under `models.<provider>`; connection state determines
+  which choices ACP exposes.
+
 ## 2026-08-07 — Shared completion and host wake routing
 
 - [User ask](specs/user-ask.md) now delegates deterministic turn completion and

--- a/knowledge/specs/acp.md
+++ b/knowledge/specs/acp.md
@@ -35,7 +35,7 @@ ACP protocol version: **1** (integer).
 | Method | Direction | Behaviour |
 |--------|-----------|-----------|
 | `initialize` | client → agent | Negotiates protocol version and advertises agent capabilities. Echoes the client's version when supported, else advertises v1. |
-| `authenticate` | client → agent | No-op success: credentials come from the environment/settings the process already inherits, so `authMethods` is empty. |
+| `authenticate` | client → agent | Runs an advertised agent-handled login. Yolop currently advertises browser-based ChatGPT/Codex OAuth; API-key providers continue to use inherited environment variables or `/setup token`. |
 | `session/new` | client → agent | Builds a fresh runtime rooted at the client-supplied `cwd`; returns the everruns session id as the ACP `sessionId`. |
 | `session/load` | client → agent | Rehydrates an existing yolop JSONL session for the supplied `sessionId` and `cwd`, replays persisted conversation history as `session/update` notifications, and then returns success. |
 | `session/prompt` | client → agent | Runs one turn, or executes a recognised `/command`; streams `session/update`s, and resolves a `stopReason`. |
@@ -56,9 +56,26 @@ Yolop uses ACP's standard session configuration mechanism for model selection. `
 - a `model` select option in the standard `model` category;
 - a `reasoning_effort` select option in the standard `thought_level` category when the selected model supports reasoning levels.
 
-Clients change either option with `session/set_config_option`. Yolop validates the selected provider, model, and reasoning effort, applies the change only to that live ACP session, and returns the complete refreshed `configOptions` list. Refreshing the full list allows clients to update dependent reasoning choices after the model changes. Invalid option IDs and unsupported values return ACP `InvalidParams`.
+The model list contains only currently usable providers; a stale preference is
+never presented as a connected model. If the preferred provider is unusable,
+ACP starts with another usable provider and falls back to local `llmsim` when
+none is connected. Session creation therefore never fails only because a saved
+provider lost its credentials, while one-shot print mode remains fail-fast.
+
+Clients change either option with `session/set_config_option`. Yolop validates the selected provider, model, and reasoning effort, applies the change only to that live ACP session, and returns the complete refreshed `configOptions` list. After authentication or a `/setup` command changes provider connectivity or selection, Yolop also pushes ACP's standard `config_option_update` to every affected open session. Invalid option IDs and unsupported values return ACP `InvalidParams`.
 When the process was launched with `--profile`, that profile supplies the
 initial model before any live ACP selection.
+
+### Authentication
+
+`initialize.authMethods` advertises `codex_browser`, an agent-handled method
+that opens the ChatGPT OAuth flow and stores the resulting refreshable Codex
+credentials in Yolop settings. `authenticate` rejects unknown method ids. A
+successful login refreshes open sessions' model options, so clients can expose
+the newly connected Codex models without restarting the ACP process. Stable ACP
+does not define secure API-key entry; those providers remain connectable only
+through the agent process environment. Yolop rejects `/setup token` over ACP
+without echoing or persisting the supplied value.
 
 ### Prompt content
 

--- a/knowledge/specs/configuration.md
+++ b/knowledge/specs/configuration.md
@@ -40,7 +40,6 @@ Keys are addressed the way a human would name them:
 | Key                       | Type   | Meaning                                                        |
 |---------------------------|--------|----------------------------------------------------------------|
 | `default_provider`        | text   | Provider used when no `--provider` flag is given; takes precedence over env auto-detection. |
-| `default_model`           | text   | Global fallback model spec for the active provider when no per-provider pick exists; only applied when the id is recognized for that provider. |
 | `models.<provider>`       | text   | Per-provider model spec, survives provider switches.           |
 | `tokens.<provider>`       | secret | Provider API token (owner-only on disk; env vars override).    |
 | `base_urls.<provider>`    | text   | Endpoint base URL (used by the `custom` provider).             |
@@ -54,9 +53,8 @@ Keys are addressed the way a human would name them:
 
 `default_provider` is persisted under that name on disk; the legacy `provider`
 key is still read (and accepted as an alias) so pre-rename settings files keep
-working. `default_model` is applied as a cross-provider fallback in
-`ProviderChoice::resolve_for_settings`, but only when the model id is
-recognized for the active provider. At startup and on `/setup provider`
+working. Model preferences are provider-scoped; a disconnected provider's
+preference is never treated as a usable active model. At startup and on `/setup provider`
 switches, yolop may also query the provider's models API when credentials
 exist. Before a turn is checkpointed or sent, Yolop validates the selected model
 once per process against that API when it is available. Unavailable models fail
@@ -80,7 +78,7 @@ precedence where read (credentials and `CUSTOM_BASE_URL`). ACP's standard
 `session/set_config_option` model and reasoning changes remain local to that ACP
 session.
 
-The profileable v1 keys are `default_provider`, `default_model`, `models`,
+The profileable v1 keys are `default_provider`, `models`,
 `base_urls`, `approval_mode`, `approval_policy`, `sandbox_mode`, and
 `worktrees`. Credentials (`tokens`, `codex_auth`) and structural or personal
 settings (`mcp`, `capabilities`, `theme`, `attribution`, `proactive_wake`) are

--- a/src/bundled/system-skills/yolop-config/SKILL.md
+++ b/src/bundled/system-skills/yolop-config/SKILL.md
@@ -36,7 +36,7 @@ Call `set_config` with a `key` and a `value` for scalar settings:
 
 - `set_config key=default_provider value=anthropic` — the default provider when
   neither `--provider` nor an env credential forces a choice.
-- `set_config key=default_model value="claude-sonnet-4-5"` — global fallback
+- `set_config key=models.anthropic value="claude-sonnet-4-5"` — provider preference
   model for the active provider. A per-provider pick wins over it.
 - `set_config key=models.openai value="gpt-5.5 high"` — remember a model for one
   provider (survives provider switches). The spec is `model [reasoning-effort]`.

--- a/src/capabilities/config.rs
+++ b/src/capabilities/config.rs
@@ -24,9 +24,7 @@ use crate::config::capability_settings::{
 use crate::config::schema::{KeyTarget, ValueKind, known_keys, parse_key, schema};
 use crate::config::service::{ConfigService, current_value, scoped_current};
 use crate::config::{ApprovalMode, Settings, SettingsStore};
-use crate::runtime::{
-    ProviderChoice, SUPPORTED_PROVIDERS, coding_harness_defaults, resolve_for_settings,
-};
+use crate::runtime::{SUPPORTED_PROVIDERS, coding_harness_defaults, resolve_for_settings};
 use async_trait::async_trait;
 use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
 use everruns_core::tool_narration::ToolNarrationPhase;
@@ -182,7 +180,7 @@ impl Tool for GetConfigTool {
             "properties": {
                 "key": {
                     "type": "string",
-                    "description": "Optional single key to describe, e.g. `default_model` or `models.anthropic`."
+                    "description": "Optional single key to describe, e.g. `default_provider` or `models.anthropic`."
                 }
             },
             "additionalProperties": false
@@ -305,7 +303,6 @@ fn is_profileable_target(target: &KeyTarget) -> bool {
     matches!(
         target,
         KeyTarget::DefaultProvider
-            | KeyTarget::DefaultModel
             | KeyTarget::ApprovalMode
             | KeyTarget::ApprovalPolicy
             | KeyTarget::Worktrees
@@ -508,23 +505,6 @@ impl SetConfigTool {
                     .unwrap_or_else(|err| format!("→ next run: could not resolve model: {err}"));
                 Ok(saved(format!(
                     "default_provider = {provider}; applies on the next run (use /setup to switch now)\n{preview}"
-                )))
-            }
-            KeyTarget::DefaultModel => {
-                if clearing {
-                    self.settings.set_default_model(None).map_err(map_err)?;
-                    return Ok(saved("cleared default_model".to_string()));
-                }
-                self.settings
-                    .set_default_model(Some(value.to_string()))
-                    .map_err(map_err)?;
-                let preview_provider =
-                    ProviderChoice::preview_provider_name(&self.settings.snapshot());
-                let preview = resolve_for_settings(&preview_provider, &self.settings.snapshot())
-                    .map(|resolved| resolved.next_run_preview())
-                    .unwrap_or_else(|err| format!("→ next run: could not resolve model: {err}"));
-                Ok(saved(format!(
-                    "default_model = {value}; applies on the next run (use /setup to switch now)\n{preview}"
                 )))
             }
             KeyTarget::Attribution => {
@@ -777,7 +757,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn set_config_persists_default_provider_and_model() {
+    async fn set_config_persists_default_provider_and_per_provider_model() {
         let (_tmp, settings) = store();
         let tool = set_config_tool(settings.clone());
 
@@ -797,33 +777,12 @@ mod tests {
             Some("anthropic")
         );
 
-        // Alias `model` routes to default_model.
-        tool.execute(json!({ "key": "model", "value": "claude-opus-4-5" }))
+        tool.execute(json!({ "key": "models.anthropic", "value": "claude-opus-4-5" }))
             .await;
-        assert_eq!(settings.snapshot().default_model(), Some("claude-opus-4-5"));
-    }
-
-    #[tokio::test]
-    async fn set_config_warns_when_default_model_mismatches_provider() {
-        let (_tmp, settings) = store();
-        settings
-            .set_default_model(Some("gpt-5.5".to_string()))
-            .expect("seed default_model");
-        let tool = set_config_tool(settings.clone());
-
-        let r = tool
-            .execute(json!({ "key": "default_provider", "value": "anthropic" }))
-            .await;
-        match &r {
-            ToolExecutionResult::Success(msg) => {
-                let text = msg.to_string();
-                assert!(
-                    text.contains("default_model") && text.contains("ignored"),
-                    "{text}"
-                );
-            }
-            other => panic!("expected success, got {other:?}"),
-        }
+        assert_eq!(
+            settings.snapshot().model_for("anthropic"),
+            Some("claude-opus-4-5")
+        );
     }
 
     #[tokio::test]

--- a/src/capabilities/model_discovery.rs
+++ b/src/capabilities/model_discovery.rs
@@ -249,9 +249,10 @@ async fn list_openai_compatible_models(
     Ok(Some(models))
 }
 
-fn provider_is_usable(settings: &Settings, provider: &str) -> bool {
+pub(crate) fn provider_is_usable(settings: &Settings, provider: &str) -> bool {
     match provider {
-        "llmsim" | "ollama" => true,
+        "llmsim" => true,
+        "ollama" => provider_env_present("ollama") || settings.has_token("ollama"),
         "custom" => crate::runtime::custom_base_url(settings).is_some(),
         "codex" => provider_env_present("codex") || settings.has_codex_auth(),
         _ => provider_env_present(provider) || settings.has_token(provider),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -225,10 +225,6 @@ pub struct Settings {
     /// `model [effort]` form `/setup model` accepts. Lets a model pick
     /// survive restarts and provider switches.
     pub models: BTreeMap<String, String>,
-    /// Global fallback model spec applied to the active provider when no
-    /// per-provider `[models]` entry exists. Provider-relative, same form as
-    /// `[models]` (`gpt-5.5 high`). A per-provider pick always wins over this.
-    pub default_model: Option<String>,
     /// Endpoint base URLs keyed by provider. Today only `custom` (the
     /// generic OpenAI-compatible provider) writes here.
     pub base_urls: BTreeMap<String, String>,
@@ -264,7 +260,6 @@ impl Default for Settings {
             default_provider: None,
             tokens: BTreeMap::new(),
             models: BTreeMap::new(),
-            default_model: None,
             base_urls: BTreeMap::new(),
             codex_auth: None,
             attribution: true,
@@ -287,10 +282,6 @@ impl Settings {
         let default_provider = table
             .get("default_provider")
             .or_else(|| table.get("provider"))
-            .and_then(Value::as_str)
-            .map(str::to_string);
-        let default_model = table
-            .get("default_model")
             .and_then(Value::as_str)
             .map(str::to_string);
         let attribution = table
@@ -345,7 +336,6 @@ impl Settings {
             default_provider,
             tokens: string_map("tokens"),
             models: string_map("models"),
-            default_model,
             base_urls: string_map("base_urls"),
             codex_auth,
             attribution,
@@ -364,9 +354,6 @@ impl Settings {
         let mut table = Table::new();
         if let Some(p) = &self.default_provider {
             table.insert("default_provider".to_string(), Value::String(p.clone()));
-        }
-        if let Some(m) = &self.default_model {
-            table.insert("default_model".to_string(), Value::String(m.clone()));
         }
         if !self.attribution {
             table.insert("attribution".to_string(), Value::Boolean(false));
@@ -451,10 +438,6 @@ impl Settings {
 
     pub fn model_for(&self, provider: &str) -> Option<&str> {
         self.models.get(provider).map(String::as_str)
-    }
-
-    pub fn default_model(&self) -> Option<&str> {
-        self.default_model.as_deref()
     }
 
     pub fn base_url_for(&self, provider: &str) -> Option<&str> {
@@ -735,7 +718,6 @@ impl SettingsStore {
         let overlay = &active.overlay;
         let overridden = match target {
             schema::KeyTarget::DefaultProvider => overlay.default_provider.is_some(),
-            schema::KeyTarget::DefaultModel => overlay.default_model.is_some(),
             schema::KeyTarget::ApprovalMode => overlay.approval_mode.is_some(),
             schema::KeyTarget::ApprovalPolicy => overlay.approval_policy.is_some(),
             schema::KeyTarget::Worktrees => overlay.worktrees.is_some(),
@@ -898,16 +880,6 @@ impl SettingsStore {
             existed
         };
         Ok(existed)
-    }
-
-    /// Set or clear the global fallback model spec (`default_model`).
-    pub fn set_default_model(&self, spec: Option<String>) -> Result<()> {
-        let spec = spec.filter(|s| !s.trim().is_empty());
-        let base_spec = spec.clone();
-        self.update_profileable(
-            |settings| settings.default_model = base_spec,
-            |profile| profile.default_model = spec.map(Some),
-        )
     }
 
     pub fn set_base_url(&self, provider: String, url: String) -> Result<()> {
@@ -1564,37 +1536,6 @@ Authorization = "Bearer ${LINEAR_API_KEY}"
             Some("http://localhost:8000/v1")
         );
         assert!(reloaded.snapshot().model_for("anthropic").is_none());
-    }
-
-    #[test]
-    fn default_model_roundtrips_and_clears() {
-        let tmp = tempfile::tempdir().expect("tmp");
-        let path = tmp.path().join("settings.toml");
-        let store = SettingsStore::open(path.clone());
-        assert!(store.snapshot().default_model().is_none());
-
-        store
-            .set_default_model(Some("claude-sonnet-4-5".to_string()))
-            .expect("save default model");
-        let on_disk = std::fs::read_to_string(&path).expect("read");
-        assert!(
-            on_disk.contains("default_model = \"claude-sonnet-4-5\""),
-            "expected default_model key, got: {on_disk}"
-        );
-
-        let reloaded = SettingsStore::open(path.clone());
-        assert_eq!(
-            reloaded.snapshot().default_model(),
-            Some("claude-sonnet-4-5")
-        );
-
-        // Empty/whitespace clears, and the key drops out of the TOML.
-        reloaded
-            .set_default_model(Some("  ".to_string()))
-            .expect("clear");
-        assert!(reloaded.snapshot().default_model().is_none());
-        let on_disk = std::fs::read_to_string(&path).expect("read");
-        assert!(!on_disk.contains("default_model"), "got: {on_disk}");
     }
 
     #[test]

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -7,7 +7,6 @@ use toml::{Table, Value};
 
 const PROFILEABLE_KEYS: &[&str] = &[
     "default_provider",
-    "default_model",
     "models",
     "base_urls",
     "approval_mode",
@@ -54,7 +53,6 @@ impl ProfileName {
 #[derive(Clone, Debug, Default)]
 pub struct SettingsOverlay {
     pub default_provider: Option<Option<String>>,
-    pub default_model: Option<Option<String>>,
     pub models: BTreeMap<String, Option<String>>,
     pub base_urls: BTreeMap<String, Option<String>>,
     pub approval_mode: Option<ApprovalMode>,
@@ -68,9 +66,6 @@ impl SettingsOverlay {
     pub fn apply_to(&self, settings: &mut Settings) {
         if let Some(provider) = &self.default_provider {
             settings.default_provider.clone_from(provider);
-        }
-        if let Some(model) = &self.default_model {
-            settings.default_model.clone_from(model);
         }
         apply_map(&mut settings.models, &self.models);
         apply_map(&mut settings.base_urls, &self.base_urls);
@@ -107,7 +102,6 @@ impl SettingsOverlay {
             .collect();
 
         let default_provider = optional_string(table, "default_provider")?.map(Some);
-        let default_model = optional_string(table, "default_model")?.map(Some);
         let models = optional_string_map(table, "models")?;
         let base_urls = optional_string_map(table, "base_urls")?;
         if let Some(Some(provider)) = &default_provider
@@ -154,7 +148,6 @@ impl SettingsOverlay {
         Ok((
             Self {
                 default_provider,
-                default_model,
                 models,
                 base_urls,
                 approval_mode,
@@ -170,7 +163,6 @@ impl SettingsOverlay {
     pub fn to_table(&self) -> Table {
         let mut table = self.unknown.clone();
         insert_optional_string(&mut table, "default_provider", &self.default_provider);
-        insert_optional_string(&mut table, "default_model", &self.default_model);
         insert_map(&mut table, "models", &self.models);
         insert_map(&mut table, "base_urls", &self.base_urls);
         if let Some(mode) = self.approval_mode {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -97,20 +97,6 @@ pub fn schema() -> &'static [ConfigField] {
             provider_scoped: false,
         },
         ConfigField {
-            key: "default_model",
-            aliases: &["model"],
-            title: "Default model",
-            description: "Global fallback model spec applied to the active provider when that \
-                          provider has no per-provider entry under `models`. Provider-relative, \
-                          same `model [reasoning-effort]` form `/setup model` accepts. A \
-                          per-provider `models.<provider>` pick always wins over this. Applied \
-                          only when the model id is recognized for the active provider.",
-            kind: ValueKind::Text,
-            default: Some("the active provider's built-in default model"),
-            examples: &["claude-sonnet-4-5", "gpt-5.5 high", "gemini-2.5-pro"],
-            provider_scoped: false,
-        },
-        ConfigField {
             key: "models",
             aliases: &["model_for"],
             title: "Per-provider model",
@@ -270,7 +256,6 @@ pub fn schema() -> &'static [ConfigField] {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum KeyTarget {
     DefaultProvider,
-    DefaultModel,
     Attribution,
     ApprovalMode,
     ApprovalPolicy,
@@ -298,7 +283,6 @@ impl KeyTarget {
     pub fn field(&self) -> &'static ConfigField {
         let key = match self {
             KeyTarget::DefaultProvider => "default_provider",
-            KeyTarget::DefaultModel => "default_model",
             KeyTarget::Attribution => "attribution",
             KeyTarget::ApprovalMode => "approval_mode",
             KeyTarget::ApprovalPolicy => "approval_policy",
@@ -354,7 +338,6 @@ pub fn parse_key(input: &str) -> Result<KeyTarget, String> {
 
     match head {
         "default_provider" | "provider" => scalar(KeyTarget::DefaultProvider),
-        "default_model" | "model" => scalar(KeyTarget::DefaultModel),
         "attribution" => scalar(KeyTarget::Attribution),
         "approval_mode" | "approval" => scalar(KeyTarget::ApprovalMode),
         "approval_policy" | "sandbox_approval" => scalar(KeyTarget::ApprovalPolicy),
@@ -406,8 +389,6 @@ mod tests {
             parse_key("default_provider").unwrap(),
             KeyTarget::DefaultProvider
         );
-        assert_eq!(parse_key("model").unwrap(), KeyTarget::DefaultModel);
-        assert_eq!(parse_key("default_model").unwrap(), KeyTarget::DefaultModel);
         assert_eq!(parse_key("approval").unwrap(), KeyTarget::ApprovalMode);
         assert_eq!(parse_key("approval_mode").unwrap(), KeyTarget::ApprovalMode);
     }
@@ -431,7 +412,7 @@ mod tests {
     #[test]
     fn scalar_key_rejects_provider_segment() {
         assert!(parse_key("attribution.openai").is_err());
-        assert!(parse_key("default_model.openai").is_err());
+        assert!(parse_key("default_provider.openai").is_err());
     }
 
     #[test]
@@ -446,6 +427,7 @@ mod tests {
 
     #[test]
     fn unknown_key_lists_known_keys() {
+        assert!(parse_key("default_model").is_err());
         let err = parse_key("frobnicate").unwrap_err();
         assert!(err.contains("default_provider"));
         assert!(err.contains("tokens.<provider>"));
@@ -464,7 +446,6 @@ mod tests {
     fn every_target_maps_to_a_field() {
         for target in [
             KeyTarget::DefaultProvider,
-            KeyTarget::DefaultModel,
             KeyTarget::Attribution,
             KeyTarget::ApprovalMode,
             KeyTarget::Model("openai".into()),

--- a/src/config/service.rs
+++ b/src/config/service.rs
@@ -65,10 +65,6 @@ pub(crate) fn current_value(settings: &Settings, target: &KeyTarget) -> Value {
             .clone()
             .map(Value::String)
             .unwrap_or(Value::Null),
-        KeyTarget::DefaultModel => settings
-            .default_model()
-            .map(|s| Value::String(s.to_string()))
-            .unwrap_or(Value::Null),
         KeyTarget::Attribution => Value::Bool(settings.attribution_enabled()),
         KeyTarget::ApprovalMode => Value::String(settings.approval_mode().as_str().to_string()),
         KeyTarget::ApprovalPolicy => Value::String(settings.approval_policy().as_str().to_string()),

--- a/src/editor/acp/mod.rs
+++ b/src/editor/acp/mod.rs
@@ -28,6 +28,7 @@ use crate::capabilities::ClientUiContext;
 use crate::config::{SandboxMode, SettingsStore};
 use crate::runtime::session_log::{legacy_session_log_path, session_dir_path, session_log_path};
 use crate::runtime::{BuildOptions, BuiltRuntime, ProviderChoice, build_with_options};
+use agent_client_protocol::schema::v1::{AuthMethod, AuthMethodAgent};
 use everruns_core::ScopedMcpServers;
 use everruns_core::typed_id::SessionId as RuntimeSessionId;
 
@@ -50,6 +51,21 @@ impl RuntimeFactory for ConfigRuntimeFactory {
         let session_dir = session_dir_path(&self.sessions_dir, session_id);
         session_log_path(&session_dir).exists()
             || legacy_session_log_path(&self.sessions_dir, session_id).exists()
+    }
+
+    fn auth_methods(&self) -> Vec<AuthMethod> {
+        vec![AuthMethod::Agent(
+            AuthMethodAgent::new("codex_browser", "Sign in with ChatGPT")
+                .description("Open a browser to connect the Codex provider."),
+        )]
+    }
+
+    async fn authenticate(&self, method_id: &str) -> Result<()> {
+        if method_id != "codex_browser" {
+            anyhow::bail!("unknown authentication method `{method_id}`");
+        }
+        let auth = crate::auth::codex::login_with_browser().await?;
+        self.settings.set_codex_auth(auth)
     }
 
     async fn build(
@@ -129,6 +145,22 @@ mod tests {
             let session_dir = session_dir_path(&self.sessions_dir, session_id);
             session_log_path(&session_dir).exists()
                 || legacy_session_log_path(&self.sessions_dir, session_id).exists()
+        }
+
+        fn auth_methods(&self) -> Vec<AuthMethod> {
+            vec![AuthMethod::Agent(AuthMethodAgent::new(
+                "test_connect_openai",
+                "Connect OpenAI for tests",
+            ))]
+        }
+
+        async fn authenticate(&self, method_id: &str) -> Result<()> {
+            anyhow::ensure!(
+                method_id == "test_connect_openai",
+                "unknown test auth method"
+            );
+            self.settings
+                .set_token("openai".to_string(), "test-token".to_string())
         }
 
         async fn build(
@@ -426,9 +458,21 @@ mod tests {
         Lines<BufReader<DuplexStream>>,
         tokio::task::JoinHandle<Result<()>>,
     ) {
+        let settings = Arc::new(SettingsStore::open(sessions_dir.join("settings.toml")));
+        start_raw_server_with_settings(config, sessions_dir, settings)
+    }
+
+    fn start_raw_server_with_settings(
+        config: LlmSimConfig,
+        sessions_dir: PathBuf,
+        settings: Arc<SettingsStore>,
+    ) -> (
+        DuplexStream,
+        Lines<BufReader<DuplexStream>>,
+        tokio::task::JoinHandle<Result<()>>,
+    ) {
         let (client_w, agent_r) = tokio::io::duplex(64 * 1024);
         let (agent_w, client_r) = tokio::io::duplex(64 * 1024);
-        let settings = Arc::new(SettingsStore::open(sessions_dir.join("settings.toml")));
         let factory = Arc::new(ScriptedFactory {
             config,
             sessions_dir,
@@ -788,6 +832,9 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn standard_config_options_select_the_live_session_model() {
         let sessions = tempfile::tempdir().expect("sessions tempdir");
+        SettingsStore::open(sessions.path().join("settings.toml"))
+            .set_token("ollama".to_string(), "local".to_string())
+            .expect("mark Ollama configured");
         let (mut w, mut reader, _server) =
             start_raw_server(fixed("unused"), sessions.path().to_path_buf());
         send_json(
@@ -871,6 +918,196 @@ mod tests {
         .await;
         let (invalid, _) = collect_until_response_id(&mut reader, 3).await;
         assert_eq!(invalid["error"]["code"], -32602);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn setup_credential_change_pushes_refreshed_model_options() {
+        let sessions = tempfile::tempdir().expect("sessions tempdir");
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+        let (mut w, mut reader, _server) = start_raw_server_with_settings(
+            fixed("unused"),
+            sessions.path().to_path_buf(),
+            settings.clone(),
+        );
+        send_json(
+            &mut w,
+            json!({ "jsonrpc": "2.0", "id": 0, "method": "initialize", "params": { "protocolVersion": 1 } }),
+        )
+        .await;
+        collect_until_response_id(&mut reader, 0).await;
+
+        let cwd = tempfile::tempdir().expect("cwd tempdir").keep();
+        send_json(
+            &mut w,
+            json!({ "jsonrpc": "2.0", "id": 1, "method": "session/new", "params": { "cwd": cwd, "mcpServers": [] } }),
+        )
+        .await;
+        let (new_session, _) = collect_until_response_id(&mut reader, 1).await;
+        let session_id = new_session["result"]["sessionId"]
+            .as_str()
+            .expect("sessionId");
+        let initial_options = new_session["result"]["configOptions"][0]["options"]
+            .as_array()
+            .expect("initial model options");
+        assert!(
+            !initial_options.iter().any(|option| option["value"]
+                .as_str()
+                .is_some_and(|value| value.starts_with("openai:"))),
+            "disconnected OpenAI must not be advertised"
+        );
+
+        settings
+            .set_token("openai".to_string(), "test-token".to_string())
+            .expect("connect OpenAI outside the ACP prompt channel");
+        send_json(
+            &mut w,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/prompt",
+                "params": {
+                    "sessionId": session_id,
+                    "prompt": [{ "type": "text", "text": "/setup status" }]
+                }
+            }),
+        )
+        .await;
+        let (_, updates) = collect_until_response_id(&mut reader, 2).await;
+        let refreshed = updates
+            .iter()
+            .filter_map(|message| message.get("params")?.get("update"))
+            .find(|update| update["sessionUpdate"] == "config_option_update")
+            .expect("config_option_update after credential change");
+        let model = refreshed["configOptions"]
+            .as_array()
+            .expect("refreshed options")
+            .iter()
+            .find(|option| option["id"] == "model")
+            .expect("model config option");
+        assert!(
+            model["options"]
+                .as_array()
+                .expect("model choices")
+                .iter()
+                .any(|option| option["value"]
+                    .as_str()
+                    .is_some_and(|value| value.starts_with("openai:"))),
+            "connected OpenAI must be advertised after the settings change: {model}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn setup_token_is_rejected_without_echoing_the_secret() {
+        let sessions = tempfile::tempdir().expect("sessions tempdir");
+        let (mut w, mut reader, _server) =
+            start_raw_server(fixed("unused"), sessions.path().to_path_buf());
+        send_json(
+            &mut w,
+            json!({ "jsonrpc": "2.0", "id": 0, "method": "initialize", "params": { "protocolVersion": 1 } }),
+        )
+        .await;
+        collect_until_response_id(&mut reader, 0).await;
+        let cwd = tempfile::tempdir().expect("cwd tempdir").keep();
+        send_json(
+            &mut w,
+            json!({ "jsonrpc": "2.0", "id": 1, "method": "session/new", "params": { "cwd": cwd, "mcpServers": [] } }),
+        )
+        .await;
+        let (new_session, _) = collect_until_response_id(&mut reader, 1).await;
+        let session_id = new_session["result"]["sessionId"]
+            .as_str()
+            .expect("sessionId");
+
+        send_json(
+            &mut w,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/prompt",
+                "params": {
+                    "sessionId": session_id,
+                    "prompt": [{ "type": "text", "text": "/setup token openai top-secret" }]
+                }
+            }),
+        )
+        .await;
+        let (_, updates) = collect_until_response_id(&mut reader, 2).await;
+        let serialized = serde_json::to_string(&updates).expect("updates serialize");
+        assert!(serialized.contains("cannot be entered over ACP"));
+        assert!(!serialized.contains("top-secret"));
+        let settings_file =
+            std::fs::read_to_string(sessions.path().join("settings.toml")).unwrap_or_default();
+        assert!(!settings_file.contains("top-secret"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn authenticate_refreshes_model_options_for_open_sessions() {
+        let sessions = tempfile::tempdir().expect("sessions tempdir");
+        let (mut w, mut reader, _server) =
+            start_raw_server(fixed("unused"), sessions.path().to_path_buf());
+        send_json(
+            &mut w,
+            json!({ "jsonrpc": "2.0", "id": 0, "method": "initialize", "params": { "protocolVersion": 1 } }),
+        )
+        .await;
+        let (initialize, _) = collect_until_response_id(&mut reader, 0).await;
+        assert_eq!(
+            initialize["result"]["authMethods"][0]["id"],
+            "test_connect_openai"
+        );
+
+        let cwd = tempfile::tempdir().expect("cwd tempdir").keep();
+        send_json(
+            &mut w,
+            json!({ "jsonrpc": "2.0", "id": 1, "method": "session/new", "params": { "cwd": cwd, "mcpServers": [] } }),
+        )
+        .await;
+        let (new_session, _) = collect_until_response_id(&mut reader, 1).await;
+        let session_id = new_session["result"]["sessionId"]
+            .as_str()
+            .expect("sessionId");
+
+        send_json(
+            &mut w,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "authenticate",
+                "params": { "methodId": "unknown" }
+            }),
+        )
+        .await;
+        let (unknown, _) = collect_until_response_id(&mut reader, 2).await;
+        assert_eq!(unknown["error"]["code"], -32602);
+
+        send_json(
+            &mut w,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "authenticate",
+                "params": { "methodId": "test_connect_openai" }
+            }),
+        )
+        .await;
+        collect_until_response_id(&mut reader, 3).await;
+        let update = next_json(&mut reader).await;
+        let refreshed = update
+            .get("params")
+            .filter(|params| {
+                params["sessionId"] == session_id
+                    && params["update"]["sessionUpdate"] == "config_option_update"
+            })
+            .expect("open session receives config option refresh after authentication");
+        assert!(
+            refreshed["update"]["configOptions"][0]["options"]
+                .as_array()
+                .expect("model choices")
+                .iter()
+                .any(|option| option["value"]
+                    .as_str()
+                    .is_some_and(|value| value.starts_with("openai:")))
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/editor/acp/protocol.rs
+++ b/src/editor/acp/protocol.rs
@@ -7,10 +7,10 @@ pub use agent_client_protocol::schema::ProtocolVersion;
 #[cfg(test)]
 pub(crate) use agent_client_protocol::schema::v1::ImageContent;
 pub use agent_client_protocol::schema::v1::{
-    AgentCapabilities, AuthenticateRequest as AuthenticateParams,
+    AgentCapabilities, AuthMethod, AuthenticateRequest as AuthenticateParams,
     AuthenticateResponse as AuthenticateResult, AvailableCommand, AvailableCommandInput,
-    AvailableCommandsUpdate, CancelNotification, Content, ContentBlock, ContentChunk,
-    CurrentModeUpdate, EmbeddedResource, EmbeddedResourceResource,
+    AvailableCommandsUpdate, CancelNotification, ConfigOptionUpdate, Content, ContentBlock,
+    ContentChunk, CurrentModeUpdate, EmbeddedResource, EmbeddedResourceResource,
     InitializeRequest as InitializeParams, InitializeResponse as InitializeResult,
     LoadSessionRequest as LoadSessionParams, LoadSessionResponse as LoadSessionResult,
     McpCapabilities, McpServer, NewSessionRequest as NewSessionParams,

--- a/src/editor/acp/server.rs
+++ b/src/editor/acp/server.rs
@@ -49,11 +49,11 @@ use crate::session_state::user_ask::{AskOutcome, UserAskStore};
 use super::bridge::{Translator, tool_kind};
 use super::modes;
 use super::protocol::{
-    self, AgentCapabilities, AuthenticateParams, AuthenticateResult, AvailableCommand,
-    AvailableCommandInput, CurrentModeUpdate, InitializeParams, InitializeResult,
-    LoadSessionParams, LoadSessionResult, McpCapabilities, McpServer, NewSessionParams,
-    NewSessionResult, PermissionOption, PermissionOptionKind, PromptCapabilities, PromptParams,
-    PromptResult, RequestPermissionOutcome, RequestPermissionParams, SessionConfigId,
+    self, AgentCapabilities, AuthMethod, AuthenticateParams, AuthenticateResult, AvailableCommand,
+    AvailableCommandInput, ConfigOptionUpdate, CurrentModeUpdate, InitializeParams,
+    InitializeResult, LoadSessionParams, LoadSessionResult, McpCapabilities, McpServer,
+    NewSessionParams, NewSessionResult, PermissionOption, PermissionOptionKind, PromptCapabilities,
+    PromptParams, PromptResult, RequestPermissionOutcome, RequestPermissionParams, SessionConfigId,
     SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOption,
     SessionNotification, SessionUpdate, SetSessionConfigOptionRequest,
     SetSessionConfigOptionResponse, SetSessionModeParams, SetSessionModeResult, StopReason,
@@ -70,6 +70,14 @@ const TURN_POLL_INTERVAL: Duration = Duration::from_millis(150);
 #[async_trait]
 pub trait RuntimeFactory: Send + Sync + 'static {
     fn session_exists(&self, session_id: RuntimeSessionId) -> bool;
+
+    fn auth_methods(&self) -> Vec<AuthMethod> {
+        Vec::new()
+    }
+
+    async fn authenticate(&self, method_id: &str) -> Result<()> {
+        anyhow::bail!("unknown authentication method `{method_id}`")
+    }
 
     async fn build(
         &self,
@@ -296,6 +304,10 @@ impl<F: RuntimeFactory> Server<F> {
     fn session(&self, id: &str) -> Option<Arc<Session>> {
         self.sessions.lock().unwrap().get(id).cloned()
     }
+
+    fn sessions(&self) -> Vec<Arc<Session>> {
+        self.sessions.lock().unwrap().values().cloned().collect()
+    }
 }
 
 /// Run the ACP agent over the given byte streams until the client closes its
@@ -345,14 +357,47 @@ where
         .builder()
         .name("yolop")
         .on_receive_request(
-            async |params: InitializeParams, responder, _cx| {
-                responder.respond(handle_initialize(params))
+            {
+                let server = server.clone();
+                async move |params: InitializeParams, responder, _cx| {
+                    responder.respond(handle_initialize(params, server.factory.auth_methods()))
+                }
             },
             agent_client_protocol::on_receive_request!(),
         )
         .on_receive_request(
-            async |_params: AuthenticateParams, responder, _cx| {
-                responder.respond(AuthenticateResult::new())
+            {
+                let server = server.clone();
+                let next_tool_id = next_tool_id.clone();
+                async move |params: AuthenticateParams, responder, cx| {
+                    let method_id = params.method_id.to_string();
+                    if !server
+                        .factory
+                        .auth_methods()
+                        .iter()
+                        .any(|method| method.id().to_string() == method_id)
+                    {
+                        responder.respond_with_error(invalid_params(format!(
+                            "unknown authentication method `{method_id}`"
+                        )))?;
+                        return Ok(());
+                    }
+                    match server.factory.authenticate(&method_id).await {
+                        Ok(()) => {
+                            responder.respond(AuthenticateResult::new())?;
+                            let peer = Peer {
+                                cx: cx.clone(),
+                                next_id: next_tool_id.clone(),
+                            };
+                            for session in server.sessions() {
+                                emit_config_options(&peer, &session);
+                            }
+                        }
+                        Err(err) => responder
+                            .respond_with_error(internal_error(format!("authenticate: {err}")))?,
+                    }
+                    Ok(())
+                }
             },
             agent_client_protocol::on_receive_request!(),
         )
@@ -511,34 +556,36 @@ fn value_mentions_broken_pipe(value: &Value) -> bool {
     }
 }
 
-fn handle_initialize(params: InitializeParams) -> InitializeResult {
+fn handle_initialize(params: InitializeParams, auth_methods: Vec<AuthMethod>) -> InitializeResult {
     // Echo a supported version: honour the client's request when it is one we
     // speak, otherwise advertise our own.
     let version = match params.protocol_version {
         v if v == protocol::PROTOCOL_VERSION => v,
         _ => protocol::PROTOCOL_VERSION,
     };
-    InitializeResult::new(version).agent_capabilities(
-        AgentCapabilities::new()
-            .load_session(true)
-            .prompt_capabilities(
-                PromptCapabilities::new()
-                    .image(true)
-                    .audio(false)
-                    .embedded_context(true),
-            )
-            // Client-configured MCP servers: `http` is advertised; the `stdio`
-            // transport is mandatory for all agents and needs no flag. `sse` is
-            // not advertised (the runtime has no SSE transport).
-            .mcp_capabilities(McpCapabilities::new().http(true))
-            .meta(protocol::meta(json!({
-                "yolop.dev/acp": {
-                    "commandMetadata": true,
-                    "commandArgSuggestions": true,
-                    "commandToolLifecycle": true
-                }
-            }))),
-    )
+    InitializeResult::new(version)
+        .auth_methods(auth_methods)
+        .agent_capabilities(
+            AgentCapabilities::new()
+                .load_session(true)
+                .prompt_capabilities(
+                    PromptCapabilities::new()
+                        .image(true)
+                        .audio(false)
+                        .embedded_context(true),
+                )
+                // Client-configured MCP servers: `http` is advertised; the `stdio`
+                // transport is mandatory for all agents and needs no flag. `sse` is
+                // not advertised (the runtime has no SSE transport).
+                .mcp_capabilities(McpCapabilities::new().http(true))
+                .meta(protocol::meta(json!({
+                    "yolop.dev/acp": {
+                        "commandMetadata": true,
+                        "commandArgSuggestions": true,
+                        "commandToolLifecycle": true
+                    }
+                }))),
+        )
 }
 
 async fn handle_new_session<F: RuntimeFactory>(
@@ -895,6 +942,15 @@ fn emit_mode_change_if_needed(peer: &Peer, session: &Session) {
     }
 }
 
+fn emit_config_options(peer: &Peer, session: &Session) {
+    peer.session_update(
+        &session.acp_id,
+        SessionUpdate::ConfigOptionUpdate(ConfigOptionUpdate::new(session_config_options(
+            &session.model,
+        ))),
+    );
+}
+
 async fn respond_prompt<F: RuntimeFactory>(
     server: &Arc<Server<F>>,
     peer: Arc<Peer>,
@@ -1034,6 +1090,15 @@ async fn run_slash_command(
     let name = command.name;
     let args = command.args;
     let title = command.title;
+    if name == "setup" && args.split_whitespace().next() == Some("token") {
+        peer.session_update(
+            &session.acp_id,
+            SessionUpdate::AgentMessageChunk(protocol::text_chunk(
+                "API keys cannot be entered over ACP because the protocol does not provide secure secret input; configure the provider key in the agent process environment",
+            )),
+        );
+        return StopReason::EndTurn;
+    }
     let commands = session.commands.lock().unwrap().clone();
     let Some(descriptor) = commands.iter().find(|c| c.name == name).cloned() else {
         peer.session_update(
@@ -1123,6 +1188,7 @@ async fn run_slash_command(
                 )),
             );
             refresh_available_commands(&peer, &session).await;
+            emit_config_options(&peer, &session);
             StopReason::EndTurn
         }
         CommandSource::Skill => {
@@ -1449,6 +1515,23 @@ async fn drain_events(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn initialize_advertises_agent_handled_authentication() {
+        let result = handle_initialize(
+            InitializeParams::new(protocol::PROTOCOL_VERSION),
+            vec![AuthMethod::Agent(
+                agent_client_protocol::schema::v1::AuthMethodAgent::new(
+                    "codex_browser",
+                    "Sign in with ChatGPT",
+                ),
+            )],
+        );
+
+        let value = serde_json::to_value(result).expect("serialize initialize response");
+        assert_eq!(value["authMethods"][0]["id"], "codex_browser");
+        assert_eq!(value["authMethods"][0]["name"], "Sign in with ChatGPT");
+    }
 
     #[test]
     fn prompt_image_parts_preserve_acp_inline_images() {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1345,22 +1345,12 @@ impl ProviderChoice {
             Provider::Sim => Ok(Self::Sim),
         }
     }
-
-    /// Provider name used when previewing config changes before the next run.
-    pub fn preview_provider_name(settings: &Settings) -> String {
-        settings.default_provider.clone().unwrap_or_else(|| {
-            Self::from_env_or_settings(settings)
-                .provider_name()
-                .to_string()
-        })
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ModelResolutionSource {
     ProviderDefault,
     PerProviderModel,
-    DefaultModel,
     EnvOverride,
 }
 
@@ -1379,9 +1369,6 @@ impl ResolvedProviderChoice {
                 let provider = self.choice.provider_name();
                 format!("→ next run: {label} (from models.{provider})")
             }
-            ModelResolutionSource::DefaultModel => {
-                format!("→ next run: {label} (from default_model)")
-            }
             ModelResolutionSource::EnvOverride => {
                 format!("→ next run: {label} (EVERRUNS_CLI_MODEL env)")
             }
@@ -1398,55 +1385,10 @@ impl ResolvedProviderChoice {
     }
 }
 
-fn bare_model_id_from_spec(spec: &str) -> &str {
-    spec.split_whitespace().next().unwrap_or(spec)
-}
-
-fn driver_id_for_provider_name(provider: &str) -> Option<DriverId> {
-    Provider::from_name(provider).and_then(Provider::driver_id)
-}
-
-/// Whether a bare model id plausibly belongs to the given provider. Used to
-/// gate the cross-provider `default_model` fallback so an OpenAI pick is not
-/// silently applied after switching to Anthropic.
-pub fn model_compatible_with_provider(model_id: &str, provider: &str) -> bool {
-    match provider {
-        "openrouter" | "ollama" | "custom" => true,
-        "llmsim" => model_id == "llmsim-yolop",
-        "anthropic" | "openai" | "google" => {
-            let bare = model_id.strip_suffix("[1m]").unwrap_or(model_id);
-            if ProviderChoice::model_suggestions_for_provider(provider)
-                .iter()
-                .any(|s| bare_model_id_from_spec(s) == bare)
-            {
-                return true;
-            }
-            if let Some(driver) = driver_id_for_provider_name(provider)
-                && get_model_profile(&driver, bare).is_some()
-            {
-                return true;
-            }
-            match provider {
-                "anthropic" => bare.starts_with("claude-"),
-                "openai" => {
-                    bare.starts_with("gpt-")
-                        || bare.starts_with("o1")
-                        || bare.starts_with("o3")
-                        || bare.starts_with("o4")
-                        || bare.starts_with("codex")
-                }
-                "google" => bare.starts_with("gemini-"),
-                _ => false,
-            }
-        }
-        _ => false,
-    }
-}
-
 /// Resolve a provider plus its model from persisted settings.
 ///
-/// Priority: `EVERRUNS_CLI_MODEL` env → `models.<provider>` → compatible
-/// `default_model` → the provider's built-in default.
+/// Priority: `EVERRUNS_CLI_MODEL` env → `models.<provider>` → the provider's
+/// built-in default.
 pub fn resolve_for_settings(provider: &str, settings: &Settings) -> Result<ResolvedProviderChoice> {
     let base = ProviderChoice::default_for_provider_name(provider)?;
     let base_label = base.label();
@@ -1472,35 +1414,6 @@ pub fn resolve_for_settings(provider: &str, settings: &Settings) -> Result<Resol
                 source: ModelResolutionSource::ProviderDefault,
                 notes: vec![format!(
                     "ignored models.{provider_name} \"{spec}\": {err}; using {base_label}"
-                )],
-            }),
-        };
-    }
-
-    if let Some(spec) = settings.default_model() {
-        let model_id = bare_model_id_from_spec(spec);
-        if !model_compatible_with_provider(model_id, provider_name) {
-            return Ok(ResolvedProviderChoice {
-                choice: base,
-                source: ModelResolutionSource::ProviderDefault,
-                notes: vec![format!(
-                    "default_model \"{spec}\" ignored for {provider_name} (not a recognized \
-                     {provider_name} model); using {base_label}"
-                )],
-            });
-        }
-        return match base.resolve_model_spec(spec) {
-            Ok(choice) => Ok(ResolvedProviderChoice {
-                choice,
-                source: ModelResolutionSource::DefaultModel,
-                notes: vec![],
-            }),
-            Err(err) => Ok(ResolvedProviderChoice {
-                choice: base,
-                source: ModelResolutionSource::ProviderDefault,
-                notes: vec![format!(
-                    "default_model \"{spec}\" ignored for {provider_name}: {err}; using \
-                     {base_label}"
                 )],
             }),
         };
@@ -2598,7 +2511,7 @@ pub struct ModelState {
     /// banner label.
     provider: Arc<RwLock<ProviderChoice>>,
     provider_store: Arc<dyn RuntimeProviderStore>,
-    settings: Settings,
+    settings: Arc<SettingsStore>,
     driver_registry: DriverRegistry,
     validated_models: Arc<AsyncRwLock<HashSet<(String, String)>>>,
 }
@@ -2607,7 +2520,7 @@ impl ModelState {
     fn new(
         provider: Arc<RwLock<ProviderChoice>>,
         provider_store: Arc<dyn RuntimeProviderStore>,
-        settings: Settings,
+        settings: Arc<SettingsStore>,
         driver_registry: DriverRegistry,
     ) -> Self {
         Self {
@@ -2711,26 +2624,26 @@ impl ModelState {
             .ok_or_else(|| anyhow!("model selection must be `provider:model`"))?;
         let selected =
             ProviderChoice::default_for_provider_name(provider)?.resolve_model_spec(model)?;
-        let resolved = selected.model_with_provider(&self.settings)?;
+        let resolved = selected.model_with_provider(&self.settings.snapshot())?;
         self.provider_store.set_default_model(resolved).await?;
         *self.provider.write().expect("provider lock poisoned") = selected;
         Ok(())
     }
 
     pub(crate) fn model_options(&self) -> Vec<(String, String, String)> {
-        const PROVIDERS: &[&str] = &[
-            "openai",
-            "anthropic",
-            "google",
-            "openrouter",
-            "codex",
-            "ollama",
-            "llmsim",
-        ];
+        let settings = self.settings.snapshot();
         let current = self.provider.read().expect("provider lock poisoned");
-        let mut options = PROVIDERS
+        let mut options = SUPPORTED_PROVIDERS
             .iter()
-            .filter_map(|provider| ProviderChoice::default_for_provider_name(provider).ok())
+            .filter(|provider| {
+                crate::capabilities::model_discovery::provider_is_usable(&settings, provider)
+            })
+            .filter_map(|provider| {
+                resolve_for_settings(provider, &settings)
+                    .ok()
+                    .map(|resolved| resolved.choice)
+            })
+            .filter(|choice| !choice.model_id().trim().is_empty())
             .map(|choice| {
                 (
                     format!("{}:{}", choice.provider_name(), choice.model_id()),
@@ -2744,6 +2657,11 @@ impl ModelState {
             current.model_id().to_owned(),
             current.provider_name().to_owned(),
         );
+        // The installed session model remains usable even if its credential is
+        // later removed from persistent settings; the runtime already owns the
+        // resolved credential for this session. Startup never installs a stale
+        // disconnected provider in ACP, so the current option is connection
+        // truth rather than a persisted preference.
         if !options.iter().any(|option| option.0 == current_option.0) {
             options.push(current_option);
         }
@@ -2757,7 +2675,7 @@ impl ModelState {
             .expect("provider lock poisoned")
             .clone();
         let selected = current.resolve_model_spec(&format!("{} {effort}", current.model_id()))?;
-        let resolved = selected.model_with_provider(&self.settings)?;
+        let resolved = selected.model_with_provider(&self.settings.snapshot())?;
         self.provider_store.set_default_model(resolved).await?;
         *self.provider.write().expect("provider lock poisoned") = selected;
         Ok(())
@@ -3489,34 +3407,80 @@ pub async fn build_with_options(
     crate::drivers::codex::register_driver(&mut driver_registry, settings.clone());
     let settings_snapshot = settings.snapshot();
     let mut setup_recommended = ModelsCapability::needs_onboarding(&settings_snapshot);
-    let default_model = match &provider {
+    let active_provider = provider_state
+        .read()
+        .expect("provider lock poisoned")
+        .clone();
+    let default_model = match &active_provider {
         ProviderChoice::Anthropic { .. }
         | ProviderChoice::OpenAi { .. }
         | ProviderChoice::Codex { .. }
         | ProviderChoice::Google { .. }
         | ProviderChoice::OpenRouter { .. }
         | ProviderChoice::Ollama { .. }
-        | ProviderChoice::Custom { .. } => match provider.model_with_provider(&settings_snapshot) {
-            Ok(model) => model,
-            Err(err) if matches!(options.client_ui, ClientUiContext::Tui) => {
-                // Preferred provider is set but credentials are missing
-                // (e.g. Codex login cleared after refresh_token_reused).
-                // Interactive sessions open `/setup` instead of exiting.
-                tracing::warn!(
-                    error = %err,
-                    provider = provider.provider_name(),
-                    "provider credentials missing; opening setup"
-                );
-                setup_recommended = true;
-                provider.model_without_stored_key()
-            }
-            Err(_) if setup_recommended => provider.model_without_stored_key(),
-            Err(err) => {
-                return Err(err.context(
+        | ProviderChoice::Custom { .. } => {
+            match active_provider.model_with_provider(&settings_snapshot) {
+                Ok(model) => model,
+                Err(err) if matches!(options.client_ui, ClientUiContext::Acp) => {
+                    // ACP must return a session before the client can present its
+                    // model picker. Never install a disconnected provider as the
+                    // live runtime model: choose another usable provider, with the
+                    // always-local simulator as the final fallback.
+                    let fallback = SUPPORTED_PROVIDERS
+                        .iter()
+                        .filter(|name| **name != active_provider.provider_name())
+                        .filter(|name| {
+                            crate::capabilities::model_discovery::provider_is_usable(
+                                &settings_snapshot,
+                                name,
+                            )
+                        })
+                        .filter_map(|name| resolve_for_settings(name, &settings_snapshot).ok())
+                        .filter(|resolved| !resolved.choice.model_id().trim().is_empty())
+                        .find_map(|resolved| {
+                            resolved
+                                .choice
+                                .model_with_provider(&settings_snapshot)
+                                .ok()
+                                .map(|model| (resolved.choice, model))
+                        })
+                        .unwrap_or_else(|| {
+                            let choice = ProviderChoice::Sim;
+                            let model = choice
+                                .model_with_provider(&settings_snapshot)
+                                .expect("llmsim provider is always available");
+                            (choice, model)
+                        });
+                    tracing::warn!(
+                        error = %err,
+                        provider = active_provider.provider_name(),
+                        fallback = fallback.0.provider_name(),
+                        "provider unavailable; starting ACP with a usable fallback"
+                    );
+                    setup_recommended = true;
+                    *provider_state.write().expect("provider lock poisoned") = fallback.0;
+                    fallback.1
+                }
+                Err(err) if matches!(options.client_ui, ClientUiContext::Tui) => {
+                    // Preferred provider is set but credentials are missing
+                    // (e.g. Codex login cleared after refresh_token_reused).
+                    // Interactive sessions open `/setup` instead of exiting.
+                    tracing::warn!(
+                        error = %err,
+                        provider = active_provider.provider_name(),
+                        "provider credentials missing; opening setup"
+                    );
+                    setup_recommended = true;
+                    active_provider.model_without_stored_key()
+                }
+                Err(_) if setup_recommended => active_provider.model_without_stored_key(),
+                Err(err) => {
+                    return Err(err.context(
                     "provider credentials missing; run `yolop` interactively and complete /setup",
                 ));
+                }
             }
-        },
+        }
         ProviderChoice::Sim => ResolvedModel {
             model: "llmsim-yolop".into(),
             provider_type: DriverId::LlmSim,
@@ -3685,7 +3649,7 @@ pub async fn build_with_options(
         model: ModelState::new(
             provider_state,
             provider_store,
-            settings_snapshot,
+            settings.clone(),
             model_driver_registry,
         ),
         settings,
@@ -3964,6 +3928,9 @@ mod tests {
         settings
             .set_default_provider(Some("codex".to_string()))
             .expect("save provider");
+        settings
+            .set_base_url("custom".to_string(), "http://localhost:8000/v1".to_string())
+            .expect("save incomplete custom endpoint");
 
         let built = build_with_options(
             workspace.path().to_path_buf(),
@@ -3988,6 +3955,59 @@ mod tests {
             "missing Codex login should recommend setup"
         );
         assert_eq!(built.model.provider_name(), "codex");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[allow(clippy::await_holding_lock)]
+    async fn acp_build_exposes_model_configuration_when_default_credentials_missing() {
+        let _guard = crate::testing::test_env::lock();
+        unsafe {
+            std::env::remove_var("CODEX_ACCESS_TOKEN");
+            std::env::remove_var("OPENAI_API_KEY");
+            std::env::remove_var("ANTHROPIC_API_KEY");
+        }
+
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+        settings
+            .set_default_provider(Some("codex".to_string()))
+            .expect("save provider");
+
+        let built = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Codex {
+                model: "gpt-5.5".to_string(),
+                reasoning_effort: None,
+            },
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            BuildOptions {
+                client_ui: ClientUiContext::Acp,
+                ..BuildOptions::default()
+            },
+        )
+        .await
+        .expect("ACP must build far enough to expose model configuration");
+
+        assert!(built.startup.setup_recommended);
+        assert_eq!(built.model.provider_name(), "llmsim");
+        assert!(
+            built
+                .model
+                .model_options()
+                .iter()
+                .any(|(id, _, _)| id == "llmsim:llmsim-yolop")
+        );
+        assert!(
+            !built
+                .model
+                .model_options()
+                .iter()
+                .any(|(_, _, provider)| provider == "codex"),
+            "disconnected providers must not be exposed to ACP"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -5919,55 +5939,6 @@ mod tests {
     }
 
     #[test]
-    fn resolve_for_settings_falls_back_to_global_default_model() {
-        let _guard = crate::testing::test_env::lock();
-        unsafe {
-            std::env::remove_var("EVERRUNS_CLI_MODEL");
-        }
-        let mut settings = Settings {
-            default_model: Some("claude-opus-4-5".to_string()),
-            ..Default::default()
-        };
-
-        // No per-provider entry, so the global default_model is applied.
-        let anthropic = resolve_for_settings("anthropic", &settings)
-            .expect("resolve")
-            .choice;
-        assert_eq!(anthropic.label(), "anthropic/claude-opus-4-5 medium");
-
-        // A per-provider pick still wins over the global default.
-        settings
-            .models
-            .insert("anthropic".to_string(), "claude-haiku-4-5".to_string());
-        let anthropic = resolve_for_settings("anthropic", &settings)
-            .expect("resolve")
-            .choice;
-        assert_eq!(anthropic.label(), "anthropic/claude-haiku-4-5 medium");
-    }
-
-    #[test]
-    fn resolve_for_settings_ignores_cross_provider_default_model() {
-        let _guard = crate::testing::test_env::lock();
-        unsafe {
-            std::env::remove_var("EVERRUNS_CLI_MODEL");
-        }
-        let settings = Settings {
-            default_provider: Some("anthropic".to_string()),
-            default_model: Some("gpt-5.5".to_string()),
-            ..Default::default()
-        };
-
-        let resolved = resolve_for_settings("anthropic", &settings).expect("resolve");
-        assert_eq!(resolved.choice.label(), "anthropic/claude-opus-4-8 high");
-        assert_eq!(resolved.source, ModelResolutionSource::ProviderDefault);
-        assert!(
-            resolved.notes.iter().any(|n| n.contains("default_model")),
-            "expected warning about ignored default_model, got {:?}",
-            resolved.notes
-        );
-    }
-
-    #[test]
     fn resolve_for_settings_uses_per_provider_model() {
         let _guard = crate::testing::test_env::lock();
         unsafe {
@@ -5984,17 +5955,21 @@ mod tests {
     }
 
     #[test]
-    fn model_compatible_with_provider_rejects_obvious_mismatches() {
-        assert!(model_compatible_with_provider(
-            "claude-opus-4-5",
-            "anthropic"
-        ));
-        assert!(model_compatible_with_provider("gpt-5.5", "openai"));
-        assert!(!model_compatible_with_provider("gpt-5.5", "anthropic"));
-        assert!(model_compatible_with_provider(
-            "anthropic/claude-sonnet-4-5",
-            "openrouter"
-        ));
+    fn legacy_global_default_model_is_not_resolution_state() {
+        let _guard = crate::testing::test_env::lock();
+        unsafe {
+            std::env::remove_var("EVERRUNS_CLI_MODEL");
+        }
+        let table: toml::Table =
+            toml::from_str("default_provider = 'anthropic'\ndefault_model = 'claude-haiku-4-5'\n")
+                .expect("legacy settings parse");
+        let settings = Settings::from_table(&table);
+
+        let resolved = resolve_for_settings("anthropic", &settings).expect("resolve");
+
+        assert_eq!(resolved.source, ModelResolutionSource::ProviderDefault);
+        assert_ne!(resolved.choice.model_id(), "claude-haiku-4-5");
+        assert!(!Settings::to_table(&settings).contains_key("default_model"));
     }
 
     #[test]
@@ -6002,11 +5977,11 @@ mod tests {
         let resolved = ResolvedProviderChoice {
             choice: ProviderChoice::default_for_provider_name("anthropic").unwrap(),
             source: ModelResolutionSource::ProviderDefault,
-            notes: vec!["default_model \"gpt-5.5\" ignored for anthropic".to_string()],
+            notes: vec!["ignored invalid models.anthropic value".to_string()],
         };
         let preview = resolved.next_run_preview();
         assert!(preview.contains("provider default"));
-        assert!(preview.contains("default_model"));
+        assert!(preview.contains("models.anthropic"));
     }
 
     #[test]


### PR DESCRIPTION
## What changed

ACP sessions now start even when the saved provider is disconnected, select another usable provider (or local llmsim), and expose only connected providers in standard model config options.

Yolop now advertises agent-handled ChatGPT/Codex browser authentication and pushes standard config_option_update notifications after authentication or setup changes. The cross-provider default_model setting is removed in favor of models.<provider> preferences. ACP rejects /setup token so secrets cannot enter protocol prompt/tool output.

## Why

Paseo model discovery failed with Internal error when Yolop had a stale OpenAI default but no OpenAI credential. The agent failed session/new before the client could render the model selector, and its catalog mixed connected and disconnected providers.

## Before / After

Before:

```text
paseo provider models yolop --json
PROVIDER_ERROR: Internal error

build runtime: provider credentials missing; run yolop interactively and complete /setup
```

After (direct binary ACP handshake):

```json
{
  "authMethods": ["codex_browser"],
  "currentValue": "codex:gpt-5.3-codex",
  "models": ["codex:gpt-5.3-codex", "llmsim:llmsim-yolop"]
}
```

A wire-level regression test also proves a stale credentialless Codex preference starts on llmsim and does not expose Codex.

## Risk

- Medium: changes ACP startup/model-catalog behavior and removes the pre-1.0 global default_model setting.
- Existing provider-scoped models.<provider> preferences remain supported. Legacy default_model is ignored and disappears on the next global settings write.
- Browser OAuth is bounded by the existing ten-minute authentication timeout.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated ACP and configuration specifications plus the durable knowledge log. Updated the bundled configuration skill and public README.

## Security

Reviewed TM-FS, TM-BASH, TM-LLM, TM-TOOL, and TM-DEP.

- No filesystem-tool, shell-execution, capability-registration, or dependency changes.
- Codex OAuth uses the existing owner-only settings store; credentials are neither logged nor returned over ACP.
- /setup token is rejected over ACP without echoing or persisting the supplied value, with wire-level regression coverage.
- Authentication remains bounded by the existing OAuth timeout.

## Validation

- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features (1,056 unit passed, 3 ignored; 55 integration passed, 1 ignored; parallel and Tuika suites passed)
- cargo build --release --all-features
- python3 scripts/validate_okf.py knowledge --check-links
- Direct target/debug/yolop --acp handshake: codex + llmsim only, codex_browser advertised
- Doppler-backed live OpenAI print smoke: ACP-SMOKE

## Follow-ups

- Secure API-key entry remains environment-only until stable ACP defines a secret-input authentication method; prompt-based token entry is intentionally rejected.