### PR TITLE
fix(runtime): align stall recovery budget with watchdog

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,15 @@
 Significant changes to Yolop's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
+## 2026-08-08 — Provider stall recovery budget and failure UX
+
+- [Checkpointing](specs/checkpointing.md) now records that Yolop installs a
+  stall liveness window with an elapsed recovery budget large enough for full
+  stall retries (upstream's default elapsed budget is shorter than one window).
+- [User ask](specs/user-ask.md) now classifies provider/runtime failures as
+  failed before charging the continuation budget, so a stall never surfaces as
+  "budget exhausted".
+
 ## 2026-08-07 — Connected ACP model catalog and authentication
 
 - ACP session creation now falls back from a stale disconnected preference to

--- a/knowledge/specs/checkpointing.md
+++ b/knowledge/specs/checkpointing.md
@@ -174,8 +174,11 @@ On a new turn, Yolop:
 
 A failed model preflight does not create a checkpoint or append the ask. Once a
 provider request begins, everruns-runtime owns bounded transient recovery inside
-the active reason phase. Retries reuse the persisted ask and completed tool
-outputs; they never create another checkpoint or re-run a completed tool.
+the active reason phase. Yolop installs a stall liveness window and a recovery
+elapsed budget large enough to absorb full stall retries (upstream's default
+elapsed budget is shorter than one stall window). Retries reuse the persisted ask
+and completed tool outputs; they never create another checkpoint or re-run a
+completed tool.
 
 On resume, Yolop validates the timeline, walks parents from the active head, and
 replays only those event ranges into the event bus, message store, and transcript.

--- a/knowledge/specs/user-ask.md
+++ b/knowledge/specs/user-ask.md
@@ -47,6 +47,8 @@ Automatic work is capped per user ask at six agent turns, 64,000 provider-report
 tokens, and ten minutes. Exhaustion leaves the ask active for an explicit user
 resume. A fresh user message resets the budget; automatic wakes do not. Achieved,
 blocked, and failed deactivate the ask. Waiting remains active for its wake.
+Provider/runtime failures are classified as failed before the continuation budget
+is charged, so a stall or transport error never surfaces as "budget exhausted".
 
 ## Configuration
 

--- a/src/editor/acp/server.rs
+++ b/src/editor/acp/server.rs
@@ -1398,6 +1398,17 @@ async fn completion_followup(
     if !session.user_ask_enabled || !session.user_ask_store.is_active(session_id) {
         return None;
     }
+    if let Some(evaluation) = crate::session_state::task_completion::failed_turn_evaluation(result)
+    {
+        let _ = session
+            .user_ask_store
+            .record_evaluation(session_id, &evaluation);
+        peer.session_update(
+            &session.acp_id,
+            SessionUpdate::AgentMessageChunk(protocol::text_chunk("task failed")),
+        );
+        return None;
+    }
     let tokens = session.handles.turn_tokens(result.turn_id).await;
     if !session
         .completion_budget

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2766,12 +2766,11 @@ pub struct BuildOptions {
     /// interactive prompt (the TUI, `--print`) leave it `None`.
     pub tool_approver: Option<Arc<dyn crate::capabilities::ToolApprover>>,
     /// Override the provider stream-stall liveness window. Tests inject a short
-    /// bound under `tokio::time` pause; production leaves this `None` and uses
-    /// [`PROVIDER_STALL_TIMEOUT`].
+    /// bound; production leaves this `None` and uses [`PROVIDER_STALL_TIMEOUT`].
     pub provider_stall_timeout: Option<Duration>,
-    /// Override the bounded provider-recovery policy. Tests pair a short
-    /// elapsed budget with a paused clock; production leaves this `None` and
-    /// uses [`provider_recovery_config`].
+    /// Override the bounded provider-recovery policy. Tests inject a short
+    /// elapsed budget; production leaves this `None` and uses
+    /// [`provider_recovery_config`].
     pub provider_retry_config: Option<everruns_core::LlmRetryConfig>,
 }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -100,7 +100,33 @@ use crate::runtime::session_log::{
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::{Arc, LazyLock, Mutex as StdMutex, RwLock};
+use std::time::Duration;
 use tokio::sync::{RwLock as AsyncRwLock, mpsc};
+
+/// Default no-output stream-liveness window. Matches everruns-core's Reason
+/// atom default and the provider reconnect first-item bound so silent HTTP 200
+/// responses fail at the same budget everywhere.
+pub(crate) const PROVIDER_STALL_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Bounded recovery for transient provider failures, including stream stalls.
+///
+/// Upstream's default `max_retry_elapsed` is 30s — shorter than one stall
+/// window — so a recovered attempt is clipped and usually stalls again
+/// immediately. Keep SDK-shaped retry counts/backoff, but give the elapsed
+/// budget enough room for `max_retries` full stall windows plus backoff.
+pub(crate) fn provider_recovery_config() -> everruns_core::LlmRetryConfig {
+    let max_retries = 2;
+    everruns_core::LlmRetryConfig {
+        max_retries,
+        initial_backoff: Duration::from_secs(1),
+        max_backoff: Duration::from_secs(60),
+        backoff_multiplier: 2.0,
+        jitter_factor: 0.25,
+        max_retry_elapsed: PROVIDER_STALL_TIMEOUT
+            .saturating_mul(max_retries)
+            .saturating_add(Duration::from_secs(60)),
+    }
+}
 
 // The harness prompt is the durable instruction surface — borrowed in shape
 // from `crates/server/src/harnesses/coding_container.rs` and trimmed for
@@ -2739,6 +2765,14 @@ pub struct BuildOptions {
     /// registered and enforces the current approval level; hosts without an
     /// interactive prompt (the TUI, `--print`) leave it `None`.
     pub tool_approver: Option<Arc<dyn crate::capabilities::ToolApprover>>,
+    /// Override the provider stream-stall liveness window. Tests inject a short
+    /// bound under `tokio::time` pause; production leaves this `None` and uses
+    /// [`PROVIDER_STALL_TIMEOUT`].
+    pub provider_stall_timeout: Option<Duration>,
+    /// Override the bounded provider-recovery policy. Tests pair a short
+    /// elapsed budget with a paused clock; production leaves this `None` and
+    /// uses [`provider_recovery_config`].
+    pub provider_retry_config: Option<everruns_core::LlmRetryConfig>,
 }
 
 impl Default for BuildOptions {
@@ -2752,6 +2786,8 @@ impl Default for BuildOptions {
             client_ui: ClientUiContext::None,
             client_mcp_servers: ScopedMcpServers::new(),
             tool_approver: None,
+            provider_stall_timeout: None,
+            provider_retry_config: None,
         }
     }
 }
@@ -3593,6 +3629,20 @@ pub async fn build_with_options(
         .with_model("llmsim-yolop")
     });
     builder = builder.llm_sim(llmsim_config);
+    // EVE-806 / production stalls: everruns recovers silent streams when the
+    // elapsed retry budget can absorb full stall windows. Yolop always installs
+    // that aligned policy (tests may override both knobs via BuildOptions).
+    builder = builder
+        .provider_stall_timeout(
+            options
+                .provider_stall_timeout
+                .unwrap_or(PROVIDER_STALL_TIMEOUT),
+        )
+        .provider_retry_config(
+            options
+                .provider_retry_config
+                .unwrap_or_else(provider_recovery_config),
+        );
     let runtime = Arc::new(builder.build().await?);
     runtime_cell
         .set(Arc::downgrade(&runtime))
@@ -4195,6 +4245,127 @@ mod tests {
                 .expect("read workspace metadata")
                 .expect("workspace metadata present");
         assert_eq!(metadata.title.as_deref(), Some("Automatic session titles"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn provider_stream_stall_recovers_through_yolop_runtime_builder() {
+        use everruns_core::llmsim_driver::SimTurn;
+
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+        let options = BuildOptions {
+            llmsim_override: Some(LlmSimConfig::scripted(vec![
+                SimTurn::StreamStall,
+                SimTurn::Assistant("recovered after stall".to_string()),
+            ])),
+            provider_stall_timeout: Some(Duration::from_millis(50)),
+            provider_retry_config: Some(everruns_core::LlmRetryConfig {
+                max_retries: 2,
+                initial_backoff: Duration::from_millis(10),
+                max_backoff: Duration::from_millis(40),
+                backoff_multiplier: 2.0,
+                jitter_factor: 0.0,
+                // Must cover a full stall window after the first failure; the
+                // upstream default of 30s is fine for wall-clock rate limits
+                // but too short once the stall watchdog uses the same budget.
+                max_retry_elapsed: Duration::from_millis(500),
+            }),
+            ..BuildOptions::default()
+        };
+        let built = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Sim,
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            options,
+        )
+        .await
+        .expect("build runtime");
+
+        let result = built
+            .handles
+            .run_checkpointed_turn(
+                "survive the stall",
+                built.model.input_message("survive the stall"),
+            )
+            .await
+            .expect("run turn");
+
+        assert!(result.success, "stall should recover: {result:?}");
+        assert_eq!(result.response, "recovered after stall");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn misaligned_retry_budget_fails_a_recoverable_stream_stall() {
+        use everruns_core::llmsim_driver::SimTurn;
+
+        // Prove the production bug class: when max_retry_elapsed is shorter
+        // than the stall window, the first recovery attempt is clipped and the
+        // turn dies instead of completing on the scripted follow-up response.
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+        let options = BuildOptions {
+            llmsim_override: Some(LlmSimConfig::scripted(vec![
+                SimTurn::StreamStall,
+                SimTurn::StreamStall,
+                SimTurn::Assistant("should not run".to_string()),
+            ])),
+            provider_stall_timeout: Some(Duration::from_millis(80)),
+            provider_retry_config: Some(everruns_core::LlmRetryConfig {
+                max_retries: 2,
+                initial_backoff: Duration::from_millis(10),
+                max_backoff: Duration::from_millis(40),
+                backoff_multiplier: 2.0,
+                jitter_factor: 0.0,
+                max_retry_elapsed: Duration::from_millis(20),
+            }),
+            ..BuildOptions::default()
+        };
+        let built = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Sim,
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            options,
+        )
+        .await
+        .expect("build runtime");
+
+        let result = built
+            .handles
+            .run_checkpointed_turn(
+                "budget too small",
+                built.model.input_message("budget too small"),
+            )
+            .await
+            .expect("run turn");
+
+        assert!(!result.success, "clipped recovery must fail: {result:?}");
+        assert!(
+            result
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("provider stream stall")
+                    || error.contains("time budget exhausted")),
+            "{result:?}"
+        );
+    }
+
+    #[test]
+    fn provider_recovery_budget_covers_full_stall_retries() {
+        let config = provider_recovery_config();
+        assert_eq!(config.max_retries, 2);
+        assert!(
+            config.max_retry_elapsed >= PROVIDER_STALL_TIMEOUT.saturating_mul(config.max_retries),
+            "elapsed budget {:?} must cover {} full {} stall windows",
+            config.max_retry_elapsed,
+            config.max_retries,
+            PROVIDER_STALL_TIMEOUT.as_secs()
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/session_state/task_completion.rs
+++ b/src/session_state/task_completion.rs
@@ -66,6 +66,19 @@ pub(crate) fn evaluation_for_state(
     }
 }
 
+/// Provider/runtime failures are terminal for the ask and must not consume the
+/// continuation budget. Spec: user-ask.md — "Provider errors … become failed
+/// … and never retry blindly." Checking this before `observe_turn` also stops
+/// ACP/TUI from appending a misleading "budget exhausted" line after a stall.
+pub(crate) fn failed_turn_evaluation(
+    result: &everruns_runtime::TurnResult,
+) -> Option<crate::session_state::user_ask::UserAskEvaluation> {
+    if result.success {
+        return None;
+    }
+    Some(evaluation_for_state(CompletionState::Failed))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -121,6 +134,16 @@ mod tests {
         assert_eq!(
             gate_turn(&result("", 0, false), false),
             GateDecision::Conclusive(CompletionState::Failed)
+        );
+    }
+
+    #[test]
+    fn failed_turn_evaluation_skips_successful_turns() {
+        assert!(failed_turn_evaluation(&result("ok", 0, true)).is_none());
+        let failed = failed_turn_evaluation(&result("", 0, false)).expect("failed");
+        assert_eq!(
+            failed.outcome,
+            crate::session_state::user_ask::AskOutcome::Failed
         );
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -3339,6 +3339,24 @@ impl App {
             return;
         }
         let Some(result) = result else { return };
+        if let Some(evaluation) =
+            crate::session_state::task_completion::failed_turn_evaluation(&result)
+        {
+            let outcome = evaluation.outcome;
+            if let Err(err) = self
+                .user_ask_store
+                .record_evaluation(session_id, &evaluation)
+            {
+                self.push_system(format!("user ask: {err}"));
+                return;
+            }
+            self.push_system(evaluation_status_message(&evaluation));
+            if matches!(outcome, AskOutcome::Blocked) {
+                self.session
+                    .report_herdr_state(crate::capabilities::herdr::HerdrState::Blocked);
+            }
+            return;
+        }
         let tokens = self.session.turn_tokens(result.turn_id).await;
         if !self.completion_budget.observe_turn(tokens) {
             self.push_system("user ask budget exhausted; send a message to resume".into());

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -3342,7 +3342,6 @@ impl App {
         if let Some(evaluation) =
             crate::session_state::task_completion::failed_turn_evaluation(&result)
         {
-            let outcome = evaluation.outcome;
             if let Err(err) = self
                 .user_ask_store
                 .record_evaluation(session_id, &evaluation)
@@ -3351,10 +3350,6 @@ impl App {
                 return;
             }
             self.push_system(evaluation_status_message(&evaluation));
-            if matches!(outcome, AskOutcome::Blocked) {
-                self.session
-                    .report_herdr_state(crate::capabilities::herdr::HerdrState::Blocked);
-            }
             return;
         }
         let tokens = self.session.turn_tokens(result.turn_id).await;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Provider stream stalls (`provider stream stall: no tokens for 120s`) now recover through Yolop's runtime builder with an elapsed retry budget large enough for full stall windows. ACP and TUI classify provider/runtime failures as failed *before* charging the user-ask continuation budget, so a stall no longer appends a misleading "budget exhausted" line.

## Why

Everruns recovers silent streams, but its default `max_retry_elapsed` (30s) is shorter than the 120s stall watchdog. After the first stall, the next attempt was clipped and usually stalled again — matching the ~6 minute fatal turns users still see. Host follow-up also charged the ask budget on failed turns, concatenating "user ask budget exhausted" onto the stall error.

## Before / After

**Before:** a silent stream could exhaust recovery with truncated retries and surface `turn error: … provider stream stall … user ask budget exhausted`.

**After:** Yolop installs a 120s stall window with `max_retry_elapsed` covering two full windows plus backoff; scripted `StreamStall` → assistant recovery succeeds through `build_with_options`, and a deliberately misaligned budget still fails as expected. Failed turns record ask failure without the budget message.

Evidence:
- Feature tests: `provider_stream_stall_recovers_through_yolop_runtime_builder`, `misaligned_retry_budget_fails_a_recoverable_stream_stall`, `provider_recovery_budget_covers_full_stall_retries`, `failed_turn_evaluation_skips_successful_turns`
- Offline smoke: `cargo run -- --provider llmsim -p "reply with exactly: stall-recovery-smoke-ok"` → binary starts and completes a turn
- CI: Format + Clippy, Build + Tests + Offline Smoke, Live Provider Smoke (Doppler), sandbox contracts, Windows, CodeQL

## Risk

- Medium — recovery can wait longer on a truly hung provider (up to two full stall windows after the first). Permanent auth/quota/invalid-request failures remain fail-fast.
- Hosts now skip continuation-budget accounting on unsuccessful turns; successful turns keep the existing six-turn / 64k / ten-minute caps.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered — Yolop is pre-1.0
- [x] Knowledge concepts updated

## Knowledge

Updated `checkpointing`, `user-ask`, and `knowledge/log.md`.

## Security

Reviewed against TM-LLM / TM-DOS. Retry amplification stays bounded by attempt count and an explicit elapsed budget sized to the stall window; permanent auth/quota/invalid-request failures remain non-retryable. No new credential, egress, filesystem, or shell surface.

## Follow-ups

No follow-ups. Mid-stream stalls after partial thinking remain non-retryable by upstream EVE-806 design; that needs an everruns change if production still sees thinking-then-silence aborts.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb83b687-9d6f-4ab5-8fc8-6b892cdfa3e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb83b687-9d6f-4ab5-8fc8-6b892cdfa3e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

