### PR TITLE
feat(acp): list provider model catalogs

### DIFF
--- a/src/editor/acp/server.rs
+++ b/src/editor/acp/server.rs
@@ -390,7 +390,7 @@ where
                                 next_id: next_tool_id.clone(),
                             };
                             for session in server.sessions() {
-                                emit_config_options(&peer, &session);
+                                emit_config_options(&peer, &session).await;
                             }
                         }
                         Err(err) => responder
@@ -612,7 +612,7 @@ async fn handle_new_session<F: RuntimeFactory>(
 
     Ok(NewSessionResult::new(acp_id)
         .modes(modes::session_mode_state(mode))
-        .config_options(session_config_options(&session.model)))
+        .config_options(session_config_options(&session.model).await))
 }
 
 async fn handle_load_session<F: RuntimeFactory>(
@@ -658,7 +658,7 @@ async fn handle_load_session<F: RuntimeFactory>(
     Ok((
         LoadSessionResult::new()
             .modes(modes::session_mode_state(mode))
-            .config_options(session_config_options(&session.model)),
+            .config_options(session_config_options(&session.model).await),
         session.acp_id.clone(),
     ))
 }
@@ -795,9 +795,10 @@ async fn replay_session_history(
 const MODEL_CONFIG_ID: &str = "model";
 const REASONING_EFFORT_CONFIG_ID: &str = "reasoning_effort";
 
-fn session_config_options(model: &ModelState) -> Vec<SessionConfigOption> {
+async fn session_config_options(model: &ModelState) -> Vec<SessionConfigOption> {
     let model_options = model
         .model_options()
+        .await
         .into_iter()
         .map(|(value, name, group)| {
             SessionConfigSelectOption::new(value, format!("{group}: {name}"))
@@ -860,9 +861,9 @@ async fn apply_set_config_option<F: RuntimeFactory>(
     }
     .map_err(|err| invalid_params(err.to_string()))?;
 
-    Ok(SetSessionConfigOptionResponse::new(session_config_options(
-        &session.model,
-    )))
+    Ok(SetSessionConfigOptionResponse::new(
+        session_config_options(&session.model).await,
+    ))
 }
 
 async fn handle_prompt<F: RuntimeFactory>(
@@ -942,12 +943,12 @@ fn emit_mode_change_if_needed(peer: &Peer, session: &Session) {
     }
 }
 
-fn emit_config_options(peer: &Peer, session: &Session) {
+async fn emit_config_options(peer: &Peer, session: &Session) {
     peer.session_update(
         &session.acp_id,
-        SessionUpdate::ConfigOptionUpdate(ConfigOptionUpdate::new(session_config_options(
-            &session.model,
-        ))),
+        SessionUpdate::ConfigOptionUpdate(ConfigOptionUpdate::new(
+            session_config_options(&session.model).await,
+        )),
     );
 }
 
@@ -1188,7 +1189,7 @@ async fn run_slash_command(
                 )),
             );
             refresh_available_commands(&peer, &session).await;
-            emit_config_options(&peer, &session);
+            emit_config_options(&peer, &session).await;
             StopReason::EndTurn
         }
         CommandSource::Skill => {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2656,41 +2656,72 @@ impl ModelState {
         Ok(())
     }
 
-    pub(crate) fn model_options(&self) -> Vec<(String, String, String)> {
+    fn push_model_option(
+        options: &mut Vec<(String, String, String)>,
+        provider: &str,
+        model: &str,
+        name: &str,
+    ) {
+        let value = format!("{provider}:{model}");
+        if options.iter().any(|(existing, _, _)| existing == &value) {
+            return;
+        }
+        options.push((value, name.to_string(), provider.to_string()));
+    }
+
+    pub(crate) async fn model_options(&self) -> Vec<(String, String, String)> {
         let settings = self.settings.snapshot();
-        let current = self.provider.read().expect("provider lock poisoned");
-        let mut options = SUPPORTED_PROVIDERS
-            .iter()
-            .filter(|provider| {
-                crate::capabilities::model_discovery::provider_is_usable(&settings, provider)
-            })
-            .filter_map(|provider| {
-                resolve_for_settings(provider, &settings)
-                    .ok()
-                    .map(|resolved| resolved.choice)
-            })
-            .filter(|choice| !choice.model_id().trim().is_empty())
-            .map(|choice| {
-                (
-                    format!("{}:{}", choice.provider_name(), choice.model_id()),
-                    choice.model_id().to_owned(),
-                    choice.provider_name().to_owned(),
-                )
-            })
-            .collect::<Vec<_>>();
-        let current_option = (
-            format!("{}:{}", current.provider_name(), current.model_id()),
-            current.model_id().to_owned(),
-            current.provider_name().to_owned(),
-        );
+        let current = self
+            .provider
+            .read()
+            .expect("provider lock poisoned")
+            .clone();
+        let mut options = Vec::new();
+
+        for provider in SUPPORTED_PROVIDERS.iter().copied().filter(|provider| {
+            crate::capabilities::model_discovery::provider_is_usable(&settings, provider)
+        }) {
+            let Ok(resolved) = resolve_for_settings(provider, &settings) else {
+                continue;
+            };
+            Self::push_model_option(
+                &mut options,
+                provider,
+                resolved.choice.model_id(),
+                resolved.choice.model_id(),
+            );
+
+            for model in ProviderChoice::model_suggestions_for_provider(provider) {
+                Self::push_model_option(&mut options, provider, model, model);
+            }
+
+            if let Ok(Ok(Some(discovered))) = tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                crate::capabilities::model_discovery::discover_provider_models(
+                    &resolved.choice,
+                    &settings,
+                ),
+            )
+            .await
+            {
+                for model in discovered {
+                    let name = model.display_name.as_deref().unwrap_or(&model.model_id);
+                    Self::push_model_option(&mut options, provider, &model.model_id, name);
+                }
+            }
+        }
+
         // The installed session model remains usable even if its credential is
         // later removed from persistent settings; the runtime already owns the
         // resolved credential for this session. Startup never installs a stale
         // disconnected provider in ACP, so the current option is connection
         // truth rather than a persisted preference.
-        if !options.iter().any(|option| option.0 == current_option.0) {
-            options.push(current_option);
-        }
+        Self::push_model_option(
+            &mut options,
+            current.provider_name(),
+            current.model_id(),
+            current.model_id(),
+        );
         options
     }
 
@@ -4042,20 +4073,38 @@ mod tests {
 
         assert!(built.startup.setup_recommended);
         assert_eq!(built.model.provider_name(), "llmsim");
+        let options = built.model.model_options().await;
+        assert!(options.iter().any(|(id, _, _)| id == "llmsim:llmsim-yolop"));
         assert!(
-            built
-                .model
-                .model_options()
+            !options.iter().any(|(_, _, provider)| provider == "codex"),
+            "disconnected providers must not be exposed to ACP"
+        );
+    }
+
+    #[test]
+    fn curated_acp_model_options_include_terra_and_luna_without_duplicates() {
+        let mut options = Vec::new();
+        for model in ProviderChoice::model_suggestions_for_provider("codex") {
+            ModelState::push_model_option(&mut options, "codex", model, model);
+        }
+        ModelState::push_model_option(&mut options, "codex", "gpt-5.6-terra", "Terra");
+
+        assert!(
+            options
                 .iter()
-                .any(|(id, _, _)| id == "llmsim:llmsim-yolop")
+                .any(|(id, _, provider)| { id == "codex:gpt-5.6-terra" && provider == "codex" })
         );
         assert!(
-            !built
-                .model
-                .model_options()
+            options
                 .iter()
-                .any(|(_, _, provider)| provider == "codex"),
-            "disconnected providers must not be exposed to ACP"
+                .any(|(id, _, provider)| { id == "codex:gpt-5.6-luna" && provider == "codex" })
+        );
+        assert_eq!(
+            options
+                .iter()
+                .filter(|(id, _, _)| id == "codex:gpt-5.6-terra")
+                .count(),
+            1
         );
     }
 


### PR DESCRIPTION
## Summary

- populate ACP's model selector from each connected provider's curated and discovered model catalog
- retain configured and current models while deduplicating provider-qualified IDs
- bound live discovery to five seconds and fall back without blocking ACP sessions

## Why

ACP previously advertised only one resolved model per provider, so valid catalog models such as Terra and Luna were missing from the selector.

## Before / After

**Before:** A connected Codex provider exposed only its resolved default model in ACP.

**After:** The same provider exposes its curated catalog, including `gpt-5.6-terra` and `gpt-5.6-luna`; providers with live discovery also expose discovered models. Disconnected providers remain hidden.

Proof: `curated_acp_model_options_include_terra_and_luna_without_duplicates` exercises the selector's catalog merge, while `model_options_only_include_usable_providers` verifies connection filtering.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- focused Terra/Luna, disconnected-provider, ACP credential-refresh, and YEP SDK tests
- `cargo test --all-features` was run; three environment/timing-sensitive tests failed, and the command-timing failure reproduces unchanged on a clean `origin/main` worktree. Relevant failures pass individually.

## Risk

Low to medium. ACP session creation now performs provider discovery, but each request is capped at five seconds and errors/timeouts retain curated and configured options.

## Security

- **TM-LLM:** Provider credentials continue through existing settings/discovery paths and are neither logged nor persisted by this change.
- **TM-TOOL:** No capability registration changes.
- **TM-FS / TM-BASH / TM-DEP:** No filesystem, shell execution, or dependency changes.
- Resource exhaustion is bounded with a five-second timeout per usable provider; failed discovery degrades to local catalog data.

## Knowledge

No knowledge update required: this aligns ACP with the existing model catalog/discovery architecture and changes no durable policy or terminology.

## Follow-ups

No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
