### PR TITLE
feat(providers): add Meta Model API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,9 +1705,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.24"
+version = "0.17.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a87c34a3d9dbd5fd03471973d42f6fbcabaebbefe0147afab796c3a45eb32e3a"
+checksum = "4ebfbea1be46ad77232a277cb38f0892dc8d7a1f869e89be21f3b0ce3ac87cf6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1723,9 +1723,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.24"
+version = "0.17.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29dd3587a55c264aa70d94c5d9b3ce068b88392ef6a4ac930ddebc2e818deeb0"
+checksum = "737ece66441939876ba4f0d7b0d5d38a5e7d23d3ef2753c48561cc84e258185a"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -1772,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-engine"
-version = "0.17.24"
+version = "0.17.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20757b1752435f44683331d63fe037e8e1c966f4811a4c9640987a92122aa3ac"
+checksum = "9bba611ee9f70791327cd9f9895b0415d0be3bf22b6f3bc5056b3233e8b13085"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -1784,9 +1784,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.24"
+version = "0.17.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5b206562d53fb8faf52023e3e60a719e5a378fc3e02de660534550cfde733d9"
+checksum = "833fec187c3d11e687fcc44c60bcb96cb32e2b0faa6fa6d1ba482fb0e526f31a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1801,9 +1801,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.24"
+version = "0.17.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24fcc5fb053a383425e568201277d5cc1e3566660d50453dbd35b937d4465"
+checksum = "8d814c6aa390240c8ee59657a7fad1b7ae7a418017d21df20ed60a757cfecdf6"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1817,9 +1817,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.24"
+version = "0.17.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e222d04789b09fc44ba2e047af90e3d1eefb3a79abf486a5207d56e00499374d"
+checksum = "c669f429f47d1d7a2adb62baaf5ba10ca49bda25c54eb3bdbd4e5eb690ecb87a"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1831,9 +1831,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.24"
+version = "0.17.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390f3a15cdb0f42ed6184990571fb6944c51c9bcf0da27cf291da48ee05d6a8c"
+checksum = "930d22d7a621830b695fee63da4d064560fda8a517a6492ebd31cb63cc8dac07"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1856,9 +1856,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.24"
+version = "0.17.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfba8147cf7e0f1abec2dbef322251a9f380de1d5bf15083b96bba3a1fb8c7c6"
+checksum = "b652208a3ef0aeb37eb1b700c0c18871b2e9444c43dcc4290c4791466fca15ab"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1872,10 +1872,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "everruns-openai"
-version = "0.17.24"
+name = "everruns-meta"
+version = "0.17.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e607c57364d0546f167abc4b2877ba626ec49bfd74395370afbaf7999dc9e6"
+checksum = "8b502af18612441478363b21027b8d30a8ec20a105e35b045d76468eb1a82a05"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "everruns-provider",
+ "reqwest 0.13.4",
+ "serde",
+]
+
+[[package]]
+name = "everruns-openai"
+version = "0.17.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52786590a0b5052c9f2ebbf12d7b8da7fb7a5645cdca4d2a80dde8e2e290b1e4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1889,9 +1902,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.24"
+version = "0.17.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92a1203c68fb907a963288fd174c2b5396077723902737be25ba63e93a7382e"
+checksum = "51640ebdc362f0346714657427acf8f0c2dd3b185351a4d3c4233414b184e9f0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1903,9 +1916,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-platform"
-version = "0.17.24"
+version = "0.17.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7c2798ab517dc1b49ae9d76a535aa7efb557321058b62d6ba6d629befb068c"
+checksum = "a3d946bd552df5560e2138d74d41ab7d3bd92abb7c3d2ece8c8b94783207b054"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1920,9 +1933,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-provider"
-version = "0.17.24"
+version = "0.17.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384a6c5f3d9e0d5b3e18ad4ad34d19ba2b047af088a0bdc4dfee133d66fe16f9"
+checksum = "d089f7c6c3cdcce30257bde874ed8d3ec3cbba8811f1623af96c4c8c6a27c01c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1948,9 +1961,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.24"
+version = "0.17.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92c21841fec34432fb0614eeced943450d97fa6c6c9eee76c2dfb364cc25a9e"
+checksum = "dc9daec13759b8c089eb87788b7c0ebb7b617a7cf3cf862bd0ea0d35d6003364"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7822,6 +7835,7 @@ dependencies = [
  "everruns-integrations-parallel",
  "everruns-local",
  "everruns-mcp",
+ "everruns-meta",
  "everruns-openai",
  "everruns-openrouter",
  "everruns-platform",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,24 +110,25 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # transports, the driver registry). Adopting it today would collapse two of nine
 # dependencies and route the rest through escape hatches. Revisit when the
 # facade promotes provider registration, MCP, and capability wiring.
-everruns-anthropic = "0.17.24"
-everruns-core = "0.17.24"
+everruns-anthropic = "0.17.25"
+everruns-core = "0.17.25"
 # The identity/platform family (PlatformStore and friends) moved out of
 # everruns-core into its own crate in 0.17.24; yolop implements PlatformStore
 # to route background-task wakes (src/runtime/background_wake.rs).
-everruns-platform = "0.17.24"
-everruns-openai = "0.17.24"
+everruns-platform = "0.17.25"
+everruns-openai = "0.17.25"
+everruns-meta = "0.17.25"
 # OpenRouter's first-class driver was split out of everruns-openai into its own
 # crate in 0.13.0; register it alongside openai to keep DriverId::OpenRouter.
-everruns-openrouter = "0.17.24"
-everruns-local = "0.17.24"
-everruns-mcp = { version = "0.17.24", features = ["stdio"] }
+everruns-openrouter = "0.17.25"
+everruns-local = "0.17.25"
+everruns-mcp = { version = "0.17.25", features = ["stdio"] }
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (knowledge/specs/mcp.md, upstream runtime-mcp.md D2).
-everruns-runtime = { version = "0.17.24", features = ["mcp-stdio"] }
-everruns-integrations-duckduckgo = "0.17.24"
-everruns-integrations-parallel = "0.17.24"
-everruns-integrations-daytona = "0.17.24"
+everruns-runtime = { version = "0.17.25", features = ["mcp-stdio"] }
+everruns-integrations-duckduckgo = "0.17.25"
+everruns-integrations-parallel = "0.17.25"
+everruns-integrations-daytona = "0.17.25"
 arboard = { version = "3", features = ["wayland-data-control"] }
 futures = "0.3"
 html-escape = "0.2"

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ yolop --provider llmsim -p "hi"         # offline demo, no API key required
 | OpenAI     | `OPENAI_API_KEY`                      | `gpt-5.6-sol`     |
 | Codex subscription | browser/device ChatGPT login or `CODEX_ACCESS_TOKEN` | `gpt-5.6-sol` |
 | Anthropic  | `ANTHROPIC_API_KEY`                   | `claude-opus-4-8` |
+| Meta Model API | `MODEL_API_KEY`                   | `muse-spark-1.2`  |
 | OpenRouter | `OPENROUTER_API_KEY`                  | `openai/gpt-5.6-sol` |
 | Google     | `GEMINI_API_KEY` / `GOOGLE_API_KEY`   | `gemini-2.5-flash` |
 | Ollama     | `OLLAMA_BASE_URL` / `OLLAMA_API_KEY`  | `llama3.2`        |
@@ -317,7 +318,7 @@ act of consent. MCP tools run autonomously like the rest of yolop's tools.
 | Flag                       | Description                                                          |
 | -------------------------- | -------------------------------------------------------------------- |
 | `-C, --cwd <PATH>`         | Workspace root (default: current dir)                                |
-| `--provider <P>`           | Force `anthropic`, `codex`, `openai`, `google`, `openrouter`, `ollama`, `custom`, or `llmsim` |
+| `--provider <P>`           | Force `anthropic`, `meta`, `codex`, `openai`, `google`, `openrouter`, `ollama`, `custom`, or `llmsim` |
 | `--profile <NAME>`         | Overlay a named execution profile from the platform config directory |
 | `-m, --model <ID>`         | Override the model id for the chosen provider                        |
 | `-p, --print <PROMPT>`     | Run one prompt non-interactively and print the result                |
@@ -345,7 +346,8 @@ act of consent. MCP tools run autonomously like the rest of yolop's tools.
 | `OPENAI_API_KEY`                    | Select OpenAI unless `--provider` overrides                  |
 | `CODEX_ACCESS_TOKEN`                | Select Codex subscription auth                               |
 | `ANTHROPIC_API_KEY`                 | Select Anthropic when OpenAI is not configured               |
-| `OPENROUTER_API_KEY`                | Select OpenRouter when OpenAI/Anthropic are not configured   |
+| `MODEL_API_KEY`                     | Select Meta Model API when earlier providers are not configured |
+| `OPENROUTER_API_KEY`                | Select OpenRouter when earlier providers are not configured  |
 | `GEMINI_API_KEY` / `GOOGLE_API_KEY` | Select Google Gemini via its OpenAI-compatible endpoint      |
 | `OLLAMA_BASE_URL`                   | Select Ollama, defaults to `http://localhost:11434/v1`       |
 | `CUSTOM_BASE_URL`                   | Select the custom OpenAI-compatible endpoint                 |
@@ -398,7 +400,7 @@ changes back to that profile while credential changes still update the global
 settings file.
 
 **Provider resolution at startup:** `--provider` wins, then the saved
-profile `default_provider`, then the global `default_provider`, then auto-detect in the order **OpenAI → Codex → Anthropic →
+profile `default_provider`, then the global `default_provider`, then auto-detect in the order **OpenAI → Codex → Anthropic → Meta →
 OpenRouter → Google → Ollama → Custom** (first with a matching env var or saved
 credential), then a fall back to OpenAI's default with setup opened.
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,12 @@
 Significant changes to Yolop's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
+## 2026-08-09 — Meta Model API provider
+
+- Yolop adopts the Everruns 0.17.25 family and registers `everruns-meta` as the
+  first-class `meta` provider. `MODEL_API_KEY` enables Muse Spark 1.2 and its
+  Contributor profile through CLI, setup, settings, and model discovery.
+
 ## 2026-08-09 — Everruns 0.17.24 adoption; upstream example is no longer a mirror
 
 - [Maintenance](specs/maintenance.md) no longer treats `examples/coding-cli` as a

--- a/knowledge/specs/configuration.md
+++ b/knowledge/specs/configuration.md
@@ -62,6 +62,11 @@ without persisting the ask, so the user can select an advertised model and
 submit the same turn. Providers without discovery support (including custom
 compatible endpoints) continue without preflight.
 
+Meta Model API is a first-class `meta` provider backed by `everruns-meta`, not a
+generic compatible endpoint. It reads `MODEL_API_KEY`, defaults to
+`muse-spark-1.2`, and exposes both the standard and
+`muse-spark-1.2-contributor` published profiles.
+
 ### Named execution profiles
 
 `--profile <name>` loads

--- a/src/capabilities/model_discovery.rs
+++ b/src/capabilities/model_discovery.rs
@@ -51,6 +51,7 @@ pub(crate) async fn discover_provider_models(
 
     let mut registry = DriverRegistry::new();
     everruns_anthropic::register_driver(&mut registry);
+    everruns_meta::register_driver(&mut registry);
     everruns_openai::register_driver(&mut registry);
     everruns_openrouter::register_driver(&mut registry);
     let driver = registry.create_chat_driver(&config)?;
@@ -290,6 +291,7 @@ fn provider_env_present(provider: &str) -> bool {
         "openai" => &["OPENAI_API_KEY"],
         "codex" => &["CODEX_ACCESS_TOKEN"],
         "anthropic" => &["ANTHROPIC_API_KEY"],
+        "meta" => &["MODEL_API_KEY"],
         "google" => &["GEMINI_API_KEY", "GOOGLE_API_KEY"],
         "openrouter" => &["OPENROUTER_API_KEY"],
         "ollama" => &["OLLAMA_BASE_URL", "OLLAMA_API_KEY"],

--- a/src/main.rs
+++ b/src/main.rs
@@ -320,6 +320,7 @@ struct ZedIntoArgs {
 #[derive(clap::ValueEnum, Debug, Clone, Copy)]
 enum ProviderArg {
     Anthropic,
+    Meta,
     Codex,
     Openai,
     Google,
@@ -334,6 +335,7 @@ enum ProviderArg {
 fn provider_name_for_arg(arg: ProviderArg) -> &'static str {
     match arg {
         ProviderArg::Anthropic => "anthropic",
+        ProviderArg::Meta => "meta",
         ProviderArg::Codex => "codex",
         ProviderArg::Openai => "openai",
         ProviderArg::Google => "google",
@@ -404,6 +406,16 @@ fn pick_provider(cli: &Cli, settings: &SettingsStore) -> (ProviderChoice, Vec<St
             },
             effort,
         ) => ProviderChoice::Anthropic {
+            model,
+            reasoning_effort: effort.or(reasoning_effort),
+        },
+        (
+            ProviderChoice::Meta {
+                model,
+                reasoning_effort,
+            },
+            effort,
+        ) => ProviderChoice::Meta {
             model,
             reasoning_effort: effort.or(reasoning_effort),
         },

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1052,6 +1052,7 @@ impl SessionFileSystem for CodingCliSessionFileStore {
 const DEFAULT_OPENAI_MODEL: &str = "gpt-5.6-sol";
 const DEFAULT_CODEX_MODEL: &str = "gpt-5.6-sol";
 const DEFAULT_ANTHROPIC_MODEL: &str = "claude-opus-4-8";
+const DEFAULT_META_MODEL: &str = "muse-spark-1.2";
 const DEFAULT_GOOGLE_MODEL: &str = "gemini-2.5-flash";
 // Gemini exposes an OpenAI-compatible surface at this base URL, driven through
 // `everruns_openai`. (OpenRouter has its own first-class driver since
@@ -1087,6 +1088,10 @@ const YOLOP_NEVER_DEFER_TOOLS: &[&str] = &[
 #[derive(Clone, Debug)]
 pub enum ProviderChoice {
     Anthropic {
+        model: String,
+        reasoning_effort: Option<String>,
+    },
+    Meta {
         model: String,
         reasoning_effort: Option<String>,
     },
@@ -1144,6 +1149,7 @@ pub enum Provider {
     OpenAi,
     Codex,
     Anthropic,
+    Meta,
     Google,
     OpenRouter,
     Ollama,
@@ -1153,10 +1159,11 @@ pub enum Provider {
 
 impl Provider {
     /// Every provider, in the user-visible suggestion order.
-    pub const ALL: [Provider; 8] = [
+    pub const ALL: [Provider; 9] = [
         Provider::OpenAi,
         Provider::Codex,
         Provider::Anthropic,
+        Provider::Meta,
         Provider::Google,
         Provider::OpenRouter,
         Provider::Ollama,
@@ -1170,6 +1177,7 @@ impl Provider {
             Provider::OpenAi => "openai",
             Provider::Codex => "codex",
             Provider::Anthropic => "anthropic",
+            Provider::Meta => "meta",
             Provider::Google => "google",
             Provider::OpenRouter => "openrouter",
             Provider::Ollama => "ollama",
@@ -1193,6 +1201,7 @@ impl Provider {
     pub fn driver_id(self) -> Option<DriverId> {
         match self {
             Provider::Anthropic => Some(DriverId::Anthropic),
+            Provider::Meta => Some(DriverId::Meta),
             Provider::OpenAi | Provider::Google => Some(DriverId::OpenAI),
             Provider::OpenRouter => Some(DriverId::OpenRouter),
             Provider::Codex | Provider::Ollama | Provider::Custom | Provider::Sim => None,
@@ -1207,6 +1216,7 @@ pub const SUPPORTED_PROVIDERS: &[&str] = &[
     Provider::OpenAi.as_str(),
     Provider::Codex.as_str(),
     Provider::Anthropic.as_str(),
+    Provider::Meta.as_str(),
     Provider::Google.as_str(),
     Provider::OpenRouter.as_str(),
     Provider::Ollama.as_str(),
@@ -1228,6 +1238,9 @@ impl ProviderChoice {
         }
         if env_non_empty("ANTHROPIC_API_KEY").is_some() || settings.has_token("anthropic") {
             return Self::default_anthropic();
+        }
+        if env_non_empty("MODEL_API_KEY").is_some() || settings.has_token("meta") {
+            return Self::default_meta();
         }
         if env_non_empty("OPENROUTER_API_KEY").is_some() || settings.has_token("openrouter") {
             return Self::default_openrouter();
@@ -1286,6 +1299,14 @@ impl ProviderChoice {
         }
     }
 
+    fn default_meta() -> Self {
+        let model = env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_META_MODEL);
+        Self::Meta {
+            reasoning_effort: default_reasoning_effort(&DriverId::Meta, &model),
+            model,
+        }
+    }
+
     fn default_google() -> Self {
         let model = env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_GOOGLE_MODEL);
         Self::Google {
@@ -1336,6 +1357,7 @@ impl ProviderChoice {
     pub fn provider(&self) -> Provider {
         match self {
             Self::Anthropic { .. } => Provider::Anthropic,
+            Self::Meta { .. } => Provider::Meta,
             Self::OpenAi { .. } => Provider::OpenAi,
             Self::Codex { .. } => Provider::Codex,
             Self::Google { .. } => Provider::Google,
@@ -1365,6 +1387,7 @@ impl ProviderChoice {
             Provider::OpenAi => Ok(Self::default_openai()),
             Provider::Codex => Ok(Self::default_codex()),
             Provider::Anthropic => Ok(Self::default_anthropic()),
+            Provider::Meta => Ok(Self::default_meta()),
             Provider::Google => Ok(Self::default_google()),
             Provider::OpenRouter => Ok(Self::default_openrouter()),
             Provider::Ollama => Ok(Self::default_ollama()),
@@ -1460,6 +1483,7 @@ impl ProviderChoice {
     pub fn model_id(&self) -> &str {
         match self {
             Self::Anthropic { model, .. }
+            | Self::Meta { model, .. }
             | Self::OpenAi { model, .. }
             | Self::Codex { model, .. }
             | Self::Google { model, .. }
@@ -1506,6 +1530,9 @@ impl ProviderChoice {
                 reasoning_effort, ..
             }
             | Self::Anthropic {
+                reasoning_effort, ..
+            }
+            | Self::Meta {
                 reasoning_effort, ..
             }
             | Self::Codex {
@@ -1574,6 +1601,7 @@ impl ProviderChoice {
                 "claude-fable-5[1m]",
                 "claude-opus-4-8[1m]",
             ],
+            "meta" => &["muse-spark-1.2", "muse-spark-1.2-contributor"],
             "google" => &["gemini-2.5-flash", "gemini-2.5-pro"],
             "openrouter" => &[
                 "openai/gpt-5.6-sol",
@@ -1613,6 +1641,14 @@ impl ProviderChoice {
                 let reasoning_effort =
                     self.resolve_model_reasoning_effort(&model, reasoning_effort)?;
                 Ok(Self::Anthropic {
+                    model,
+                    reasoning_effort,
+                })
+            }
+            Self::Meta { .. } => {
+                let reasoning_effort =
+                    self.resolve_model_reasoning_effort(&model, reasoning_effort)?;
+                Ok(Self::Meta {
                     model,
                     reasoning_effort,
                 })
@@ -1765,6 +1801,17 @@ impl ProviderChoice {
                     base_url: None,
                 })
             }
+            ProviderChoice::Meta { model, .. } => {
+                let key = resolve_token(settings, "meta", &["MODEL_API_KEY"])
+                    .ok_or_else(|| anyhow!("MODEL_API_KEY not set (and no token stored)"))?;
+                Ok(ResolvedModel {
+                    model: model.clone(),
+                    provider_type: DriverId::Meta,
+                    provider_metadata: None,
+                    api_key: Some(key),
+                    base_url: None,
+                })
+            }
             ProviderChoice::OpenAi { model, .. } => {
                 let key = resolve_token(settings, "openai", &["OPENAI_API_KEY"])
                     .ok_or_else(|| anyhow!("OPENAI_API_KEY not set (and no token stored)"))?;
@@ -1887,6 +1934,13 @@ impl ProviderChoice {
             ProviderChoice::Anthropic { model, .. } => ResolvedModel {
                 model: model.clone(),
                 provider_type: DriverId::Anthropic,
+                provider_metadata: None,
+                api_key: None,
+                base_url: None,
+            },
+            ProviderChoice::Meta { model, .. } => ResolvedModel {
+                model: model.clone(),
+                provider_type: DriverId::Meta,
                 provider_metadata: None,
                 api_key: None,
                 base_url: None,
@@ -3470,6 +3524,7 @@ pub async fn build_with_options(
 
     let mut driver_registry = DriverRegistry::new();
     everruns_anthropic::register_driver(&mut driver_registry);
+    everruns_meta::register_driver(&mut driver_registry);
     everruns_openai::register_driver(&mut driver_registry);
     // OpenRouter moved to its own crate in everruns 0.13.0; register its
     // first-class DriverId::OpenRouter driver here (was bundled with openai).
@@ -3483,6 +3538,7 @@ pub async fn build_with_options(
         .clone();
     let default_model = match &active_provider {
         ProviderChoice::Anthropic { .. }
+        | ProviderChoice::Meta { .. }
         | ProviderChoice::OpenAi { .. }
         | ProviderChoice::Codex { .. }
         | ProviderChoice::Google { .. }
@@ -5968,6 +6024,9 @@ mod tests {
         let anthropic = ProviderChoice::default_for_provider_name("anthropic").unwrap();
         assert_eq!(anthropic.label(), "anthropic/claude-opus-4-8 high");
 
+        let meta = ProviderChoice::default_for_provider_name("meta").unwrap();
+        assert_eq!(meta.label(), "meta/muse-spark-1.2");
+
         let google = ProviderChoice::default_for_provider_name("google").unwrap();
         assert_eq!(google.label(), "google/gemini-2.5-flash");
 
@@ -6000,6 +6059,7 @@ mod tests {
 
         // Driver mapping matches the previous hand-written table.
         assert_eq!(Provider::Anthropic.driver_id(), Some(DriverId::Anthropic));
+        assert_eq!(Provider::Meta.driver_id(), Some(DriverId::Meta));
         assert_eq!(Provider::OpenAi.driver_id(), Some(DriverId::OpenAI));
         assert_eq!(Provider::Google.driver_id(), Some(DriverId::OpenAI));
         assert_eq!(Provider::OpenRouter.driver_id(), Some(DriverId::OpenRouter));
@@ -6016,6 +6076,7 @@ mod tests {
             std::env::remove_var("OPENAI_API_KEY");
             std::env::remove_var("CODEX_ACCESS_TOKEN");
             std::env::remove_var("ANTHROPIC_API_KEY");
+            std::env::remove_var("MODEL_API_KEY");
             std::env::remove_var("OPENROUTER_API_KEY");
             std::env::remove_var("GEMINI_API_KEY");
             std::env::remove_var("GOOGLE_API_KEY");
@@ -6035,6 +6096,7 @@ mod tests {
         unsafe {
             std::env::remove_var("OPENAI_API_KEY");
             std::env::remove_var("ANTHROPIC_API_KEY");
+            std::env::remove_var("MODEL_API_KEY");
             std::env::remove_var("OPENROUTER_API_KEY");
             std::env::remove_var("GEMINI_API_KEY");
             std::env::remove_var("GOOGLE_API_KEY");
@@ -6345,6 +6407,44 @@ mod tests {
         };
         let model = provider.model_with_provider(&settings).unwrap();
         assert_eq!(model.api_key, Some("stored-anth-key".to_string()));
+    }
+
+    #[test]
+    fn meta_uses_first_class_driver_and_model_api_key() {
+        let _guard = crate::testing::test_env::lock();
+        unsafe {
+            std::env::set_var("MODEL_API_KEY", "test-meta-key");
+        }
+        let provider = ProviderChoice::default_for_provider_name("meta").unwrap();
+
+        let model = provider.model_with_provider(&Settings::default()).unwrap();
+        unsafe {
+            std::env::remove_var("MODEL_API_KEY");
+        }
+
+        assert_eq!(model.model, "muse-spark-1.2");
+        assert_eq!(model.provider_type, DriverId::Meta);
+        assert_eq!(model.api_key.as_deref(), Some("test-meta-key"));
+        assert_eq!(
+            provider.model_without_stored_key().provider_type,
+            DriverId::Meta
+        );
+    }
+
+    #[test]
+    fn meta_suggestions_include_standard_and_contributor_profiles() {
+        let suggestions = ProviderChoice::model_suggestions_for_provider("meta");
+        assert_eq!(
+            suggestions,
+            &["muse-spark-1.2", "muse-spark-1.2-contributor"]
+        );
+
+        for model in suggestions {
+            assert!(
+                get_model_profile(&DriverId::Meta, model).is_some(),
+                "missing published Meta profile for {model}"
+            );
+        }
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -489,6 +489,11 @@ const PROVIDER_OPTIONS: &[ProviderOption] = &[
         hint: "Claude",
     },
     ProviderOption {
+        name: "meta",
+        label: "Meta Model API",
+        hint: "Muse models",
+    },
+    ProviderOption {
         name: "google",
         label: "Google Gemini",
         hint: "Gemini models",
@@ -9420,6 +9425,7 @@ mod tests {
         let rendered = setup_overlay_text(app);
         assert!(rendered.iter().any(|line| line.contains("Set Up Yolop")));
         assert!(rendered.iter().any(|line| line.contains("OpenAI")));
+        assert!(rendered.iter().any(|line| line.contains("Meta Model API")));
         assert!(
             rendered
                 .iter()

--- a/src/tui/setup.rs
+++ b/src/tui/setup.rs
@@ -141,6 +141,7 @@ impl App {
             "openai" => &["OPENAI_API_KEY"],
             "codex" => &["CODEX_ACCESS_TOKEN"],
             "anthropic" => &["ANTHROPIC_API_KEY"],
+            "meta" => &["MODEL_API_KEY"],
             "google" => &["GEMINI_API_KEY", "GOOGLE_API_KEY"],
             "openrouter" => &["OPENROUTER_API_KEY"],
             "ollama" => &["OLLAMA_BASE_URL", "OLLAMA_API_KEY"],
@@ -386,6 +387,18 @@ impl App {
                     spec: Some("claude-fable-5".to_string()),
                     label: "claude-fable-5".to_string(),
                     hint: "most powerful Claude model".to_string(),
+                },
+            ],
+            "meta" => vec![
+                ModelOption {
+                    spec: Some("muse-spark-1.2".to_string()),
+                    label: "muse-spark-1.2".to_string(),
+                    hint: "full Muse Spark model".to_string(),
+                },
+                ModelOption {
+                    spec: Some("muse-spark-1.2-contributor".to_string()),
+                    label: "muse-spark-1.2-contributor".to_string(),
+                    hint: "lower-cost contributor model".to_string(),
                 },
             ],
             "google" => vec![

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -43,6 +43,33 @@ fn yolop_binary() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_yolop"))
 }
 
+#[test]
+fn meta_provider_requires_model_api_key_from_real_binary() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config_root = tmp.path().join(".config");
+    let output = Command::new(yolop_binary())
+        .args([
+            "--provider",
+            "meta",
+            "--session-dir",
+            tmp.path().to_str().unwrap(),
+            "-p",
+            "hi",
+        ])
+        .env("HOME", tmp.path())
+        .env("XDG_CONFIG_HOME", &config_root)
+        .env_remove("MODEL_API_KEY")
+        .output()
+        .expect("spawn yolop with Meta provider");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success(), "stderr={stderr}");
+    assert!(
+        stderr.contains("API key is required"),
+        "Meta provider should reach its registered driver: {stderr}"
+    );
+}
+
 #[cfg(target_os = "linux")]
 fn run_linux_sandbox_worker(
     cwd: &Path,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -44,7 +44,7 @@ fn yolop_binary() -> PathBuf {
 }
 
 #[test]
-fn meta_provider_requires_model_api_key_from_real_binary() {
+fn meta_provider_reaches_credential_boundary_from_real_binary() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let config_root = tmp.path().join(".config");
     let output = Command::new(yolop_binary())
@@ -65,8 +65,8 @@ fn meta_provider_requires_model_api_key_from_real_binary() {
 
     assert!(!output.status.success(), "stderr={stderr}");
     assert!(
-        stderr.contains("API key is required"),
-        "Meta provider should reach its registered driver: {stderr}"
+        stderr.contains("MODEL_API_KEY not set") || stderr.contains("API key is required"),
+        "Meta provider should reach credential resolution or its registered driver: {stderr}"
     );
 }
 


### PR DESCRIPTION
## What changed

Yolop now supports Meta Model API as a first-class `meta` provider. Users can select it with `--provider meta` or `/setup`, authenticate with `MODEL_API_KEY` or a saved token, and choose Muse Spark 1.2 or its Contributor profile. The Everruns dependency family moves together to 0.17.25 and registers the published `everruns-meta` driver for turns and model discovery.

## Why

Everruns 0.17.25 publishes the dedicated Meta driver and Muse profiles, so Yolop no longer needs to wait on upstream packaging before exposing the provider.

## Before / After

Before: `--provider meta` was rejected because Meta was not a supported provider.

After: `yolop --help` lists `meta`; the real binary accepts `--provider meta` and reaches the registered driver/credential boundary. `/setup` shows “Meta Model API” with standard and Contributor Muse choices.

Validation:

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (1,070 unit, 57 integration, 1 parallel integration, 5 PTY tests)
- `python3 scripts/validate_okf.py knowledge --check-links`
- `cargo build --release`
- Live OpenAI provider smoke through Doppler: `provider-smoke-ok`

## Risk

- Medium: adds a provider and upgrades the lockstep Everruns family from 0.17.24 to 0.17.25.
- Provider selection order changes only when `MODEL_API_KEY` or a saved Meta token exists.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated `knowledge/specs/configuration.md` and `knowledge/log.md` with the first-class Meta provider, credential, defaults, and profiles.

## Security

- TM-LLM: `MODEL_API_KEY` follows the existing environment/saved-token resolution path and is never emitted to logs, session events, labels, or discovery metadata.
- TM-DEP: all `everruns-*` crates move together to 0.17.25; `everruns-meta` is the upstream first-party driver needed for `DriverId::Meta`. The lockfile contains no unrelated dependency additions.
- TM-FS / TM-BASH / TM-TOOL: no filesystem policy, shell execution, or capability permission changes.
- Reviewed provider/model inputs for injection and unbounded work; they remain data passed through existing validated provider and discovery paths.

## Follow-ups

- Add `MODEL_API_KEY` to the Yolop Doppler project and run a direct hosted Meta smoke. The key is currently absent; the published upstream driver live tests, Yolop driver/profile tests, real-binary credential-boundary test, and a live provider runtime smoke cover this PR meanwhile.