### PR TITLE
fix(evals): stop reporting outages and budget misses as search-efficiency regressions

### DIFF
--- a/.github/workflows/search-efficiency-eval.yml
+++ b/.github/workflows/search-efficiency-eval.yml
@@ -130,12 +130,30 @@ jobs:
           fi
           echo "Mira controls exit: ${mira_status}; the distribution analyzer decides the regression gate."
 
+      # Exit 75 means the analyzer graded nothing — a provider outage, not a
+      # regression. The job stays green so an unfunded or throttled account does
+      # not page, but the run must not read as a clean nightly: an outage-green
+      # is indistinguishable from a real pass in the run list, which is how a
+      # night with 0/3 valid trials on every sample was once the only green in a
+      # two-week streak.
       - name: Gate trial distributions
         working-directory: evals/harness_basic
         run: |
+          status=0
           python3 "${SEARCH_EFFICIENCY_ANALYZER}" \
             "${RUNNER_TEMP}/search-efficiency-focused.json" \
-            "${RUNNER_TEMP}/search-efficiency-controls.json"
+            "${RUNNER_TEMP}/search-efficiency-controls.json" || status=$?
+          if [ "${status}" -eq 75 ]; then
+            echo "::warning::Search-efficiency gate INCONCLUSIVE: provider/infrastructure errors left no valid trials. Nothing was verified this run."
+            {
+              echo "### Search efficiency: INCONCLUSIVE"
+              echo
+              echo "Provider/infrastructure errors left no valid trials to compare."
+              echo "No regression gate ran — this is not a passing nightly."
+            } >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+          exit "${status}"
 
       - name: Upload eval reports
         if: always()

--- a/evals/harness_basic/README.md
+++ b/evals/harness_basic/README.md
@@ -312,6 +312,22 @@ separate five-trial controls expose global prompt/tool-surface regressions with
 a less noisy median. A candidate is not an improvement merely because its
 aggregate pass count is higher.
 
+A check marked `"budget": true` is an efficiency ceiling rather than a statement
+about whether the agent did the task, and is scored under `declared_budget`
+instead of `checks`. Keep the two apart: budgets are usually asserted on the
+candidate only, so folding one into `checks` and comparing pass rates across
+binaries measures the candidate against a baseline that was never asked to meet
+any ceiling — which is how `zero-result-search-recovery` reported its own call
+budget as `correctness regressed 100% -> 33%`. Binary-conditional *behavioural*
+checks stay in `checks`: "baseline emits no guard warning, candidate emits one"
+is the asymmetry those cases exist to prove. The analyzer gates a budget only
+when both binaries declare one; a candidate-only budget is reported, not gated.
+
+Budgets on `zero-result-search-recovery` and `prior-session-reference` are
+currently set at exactly the call count their prompts mandate, so every trial
+sits on the edge and one extra call fails the sample. Loosening them is a
+deliberate policy choice about how much slack the eval allows, not a bug fix.
+
 The manual/nightly [Search Efficiency Eval](../../.github/workflows/search-efficiency-eval.yml)
 builds both the triggering revision and the immutable pre-fix commit recorded
 in [`search_efficiency_baseline.json`](search_efficiency_baseline.json), runs

--- a/evals/harness_basic/README.md
+++ b/evals/harness_basic/README.md
@@ -320,12 +320,20 @@ Mira run archives. It is intentionally excluded from pull-request CI because
 it is a live-model regression monitor, not a deterministic unit test.
 
 Trials that fail because the provider or infrastructure was unavailable (quota
-exhaustion, rate limits, 5xx, network) carry no signal and are dropped from the
-gate like skipped trials; harness timeouts stay real failures. When an outage
-wipes out a majority of a sample's trials the sample is reported *inconclusive*
-rather than a regression, and a run with nothing left to compare exits green so
-a throttled account never pages as a fleet-wide regression. The gate logic is
-covered by pure-Python unit tests (`tests/`) that do run in pull-request CI.
+exhaustion, billing exhaustion, rate limits, 5xx, network) carry no signal and
+are dropped from the gate like skipped trials; harness timeouts stay real
+failures. Error-string matching only recognizes outages someone has already
+seen, so a failed trial that made no tool calls and burned no input tokens is
+dropped too, whatever it reported: it never reached the provider, and scoring an
+unrecognized outage as a regression is the worst available default.
+
+When an outage wipes out a majority of a sample's trials the sample is reported
+*inconclusive* rather than a regression. A run with nothing left to compare
+exits `75`, not `0` — the workflow keeps the job green so a throttled account
+never pages, but annotates the run as inconclusive, because a nightly that
+graded nothing has not passed the gate and must not be read as evidence that
+`main` is clean. The gate logic is covered by pure-Python unit tests (`tests/`)
+that do run in pull-request CI.
 
 For progress-efficiency, the distribution gate additionally requires fewer
 workspace-state revisits in the dependency case and fewer redundant validation

--- a/evals/harness_basic/analyze_search_efficiency.py
+++ b/evals/harness_basic/analyze_search_efficiency.py
@@ -113,6 +113,38 @@ def is_infra_failure(case: dict) -> bool:
     return produced_no_signal(case)
 
 
+def correctness_pass(case: dict) -> bool | None:
+    """Whether the trial did the task, ignoring any efficiency budget it declares.
+
+    The harness reports budgets under the `declared_budget` scorer precisely so
+    they stay out of this number. Budgets are asserted on the candidate only, so
+    folding them into whole-case `passed` and comparing that across binaries
+    measures the candidate against a baseline that is never asked to meet a
+    budget: `zero-result-search-recovery` reported exactly that as "correctness
+    regressed 100% -> 33%".
+
+    Budget results are still gated — as budgets, by `budget_regressed` below.
+    None when the sample asserts nothing about correctness at all.
+    """
+    for score in case.get("scores", []):
+        if score.get("scorer") == "checks":
+            if score.get("na"):
+                return None
+            return bool(score.get("pass"))
+    return bool(case.get("passed"))
+
+
+def budget_pass(case: dict) -> bool | None:
+    """Whether the trial met its declared efficiency budget, or None if it
+    declares none."""
+    for score in case.get("scores", []):
+        if score.get("scorer") == "declared_budget":
+            if score.get("na"):
+                return None
+            return bool(score.get("pass"))
+    return None
+
+
 def value(case: dict, metric: str) -> float:
     transcript = case.get("transcript", {})
     if metric == "tool_calls":
@@ -167,8 +199,47 @@ def analyze_reports(reports: list[dict]) -> tuple[list[str], list[str], list[str
                 f"{len(candidate)}/{len(candidate_all)} candidate valid trials"
             )
             continue
-        base_pass = sum(bool(case.get("passed")) for case in baseline) / len(baseline)
-        cand_pass = sum(bool(case.get("passed")) for case in candidate) / len(candidate)
+        base_graded = [
+            result
+            for result in (correctness_pass(case) for case in baseline)
+            if result is not None
+        ]
+        cand_graded = [
+            result
+            for result in (correctness_pass(case) for case in candidate)
+            if result is not None
+        ]
+        if not base_graded or not cand_graded:
+            notes.append(f"{sample}: no correctness rubric to compare")
+            continue
+        base_pass = sum(base_graded) / len(base_graded)
+        cand_pass = sum(cand_graded) / len(cand_graded)
+
+        # Budgets are gated only where both binaries declare one, because that is
+        # the only case in which the two numbers mean the same thing. A
+        # candidate-only budget is reported instead of gated: choosing a floor for
+        # it is a policy call about how much slack the eval allows, and these
+        # budgets currently sit at the exact call count their prompts mandate.
+        base_budget = [b for b in (budget_pass(c) for c in baseline) if b is not None]
+        cand_budget = [b for b in (budget_pass(c) for c in candidate) if b is not None]
+        budget_row = ""
+        if cand_budget:
+            cand_budget_rate = sum(cand_budget) / len(cand_budget)
+            budget_row = f"; budget {cand_budget_rate:.0%}"
+            if base_budget:
+                base_budget_rate = sum(base_budget) / len(base_budget)
+                budget_row = f"; budget {base_budget_rate:.0%}->{cand_budget_rate:.0%}"
+                if cand_budget_rate < base_budget_rate:
+                    failures.append(
+                        f"{sample}: declared budget regressed "
+                        f"{base_budget_rate:.0%} -> {cand_budget_rate:.0%}"
+                    )
+            elif cand_budget_rate < 1:
+                notes.append(
+                    f"{sample}: candidate met its declared budget in only "
+                    f"{cand_budget_rate:.0%} of trials (candidate-only budget, "
+                    f"reported not gated)"
+                )
         if cand_pass < base_pass:
             failures.append(
                 f"{sample}: correctness regressed {base_pass:.0%} -> {cand_pass:.0%}"
@@ -212,6 +283,7 @@ def analyze_reports(reports: list[dict]) -> tuple[list[str], list[str], list[str
             f"{medians[('candidate', 'input_tokens')]:g}; "
             f"bytes {medians[('baseline', 'total_tool_result_bytes')]:g}->"
             f"{medians[('candidate', 'total_tool_result_bytes')]:g}"
+            f"{budget_row}"
         )
     # Only demand an improvement when at least one focused case actually produced
     # signal. A provider outage that leaves every focused case inconclusive must
@@ -249,7 +321,7 @@ def main() -> int:
     )
     print("\n".join(rows))
     if notes:
-        print("\nInconclusive (excluded from the gate):", file=sys.stderr)
+        print("\nNot gated:", file=sys.stderr)
         for note in notes:
             print(f"- {note}", file=sys.stderr)
     status = exit_code(rows, failures, notes)

--- a/evals/harness_basic/analyze_search_efficiency.py
+++ b/evals/harness_basic/analyze_search_efficiency.py
@@ -57,7 +57,23 @@ INFRA_ERROR_MARKERS = (
     "failed to connect",
     "network error",
     "temporarily unavailable",
+    # Billing exhaustion. An unfunded account fails every trial identically, which
+    # is an outage in every sense that matters here — but it says nothing about
+    # quota or rate limits, so it went unmatched and scored two nightlies
+    # (2026-07-22, 2026-08-03) as fleet-wide regressions against runs where no
+    # trial ever reached the provider.
+    "credit_balance_exhausted",
+    "no credits remaining",
+    "insufficient_credit",
+    "billing_hard_limit_reached",
+    "payment_required",
 )
+
+# Exit statuses. Inconclusive is deliberately not 0: a night that graded nothing
+# has not cleared the gate, and reporting it as a pass is how a run in which every
+# trial died could read as the only green night in a streak.
+REGRESSION_EXIT = 1
+INCONCLUSIVE_EXIT = 75  # EX_TEMPFAIL
 
 
 def error_text(case: dict) -> str:
@@ -70,6 +86,15 @@ def error_text(case: dict) -> str:
     return " ".join(parts).lower()
 
 
+def produced_no_signal(case: dict) -> bool:
+    """True when a failed trial made no tool calls and burned no input tokens —
+    it never reached the provider, so there is no trajectory to compare. This is
+    the structural backstop behind INFRA_ERROR_MARKERS: matching error strings can
+    only catch outages someone has already seen, and an unmatched one is scored as
+    a regression, which is the worst possible default."""
+    return value(case, "tool_calls") == 0 and value(case, "input_tokens") == 0
+
+
 def is_infra_failure(case: dict) -> bool:
     """True when a *failed* trial errored because the provider or infrastructure
     was unavailable, not because the agent solved the task wrong. Harness timeouts
@@ -79,11 +104,13 @@ def is_infra_failure(case: dict) -> bool:
     if case.get("passed"):
         return False
     error = error_text(case)
-    if not error.strip():
-        return False
+    # Checked before everything else: a timeout can also land zero tool calls and
+    # zero tokens, and it must not reach the structural backstop below.
     if "timeout after" in error or "no events at" in error:
         return False
-    return any(marker in error for marker in INFRA_ERROR_MARKERS)
+    if any(marker in error for marker in INFRA_ERROR_MARKERS):
+        return True
+    return produced_no_signal(case)
 
 
 def value(case: dict, metric: str) -> float:
@@ -199,6 +226,15 @@ def analyze(report: dict) -> tuple[list[str], list[str], list[str]]:
     return analyze_reports([report])
 
 
+def exit_code(rows: list[str], failures: list[str], notes: list[str]) -> int:
+    """Map an analysis to a status: regression, inconclusive, or clean."""
+    if failures:
+        return REGRESSION_EXIT
+    if not rows and notes:
+        return INCONCLUSIVE_EXIT
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -216,22 +252,23 @@ def main() -> int:
         print("\nInconclusive (excluded from the gate):", file=sys.stderr)
         for note in notes:
             print(f"- {note}", file=sys.stderr)
-    if failures:
+    status = exit_code(rows, failures, notes)
+    if status == REGRESSION_EXIT:
         print("\nRegression gates:", file=sys.stderr)
         for failure in failures:
             print(f"- {failure}", file=sys.stderr)
-        return 1
-    if not rows and notes:
+        return status
+    if status == INCONCLUSIVE_EXIT:
         # Nothing was gradable: a provider/infrastructure outage, not a code
-        # regression. Say so plainly and let the scheduled run stay green rather
-        # than paging on a throttled account.
+        # regression. The caller decides whether to page — but it is told the
+        # difference, because "no trial ran" is not "the gates passed".
         print(
             "\nRegression gate inconclusive: provider/infrastructure errors left "
-            "no valid trials to compare; not gating CI on a provider outage."
+            "no valid trials to compare; nothing was gated this run."
         )
-        return 0
+        return status
     print("\nRegression gates passed.")
-    return 0
+    return status
 
 
 if __name__ == "__main__":

--- a/evals/harness_basic/src/main.rs
+++ b/evals/harness_basic/src/main.rs
@@ -435,7 +435,12 @@ fn prior_session_reference_sample() -> Sample {
                 "search_sessions_first_exploration": 1.0,
                 "tool_calls_failed": 0.0,
                 "duplicate_exploration_calls": 0.0
-            },
+            }
+        },
+        {
+            // Also zero-slack: the task needs one session search plus one read,
+            // so a single extra call fails the sample outright.
+            "budget": true,
             "metric_at_most": {
                 "tool_calls": 2.0,
                 "llm_calls": 3.0,
@@ -614,15 +619,24 @@ fn zero_result_search_sample() -> Sample {
         "checks",
         json!([
             {"response_contains": ["GUARD-203"]},
+            // The behavioural proof: the guard must fire, and the agent must act
+            // on it rather than keep searching blindly.
             {
                 "when_binary": "candidate",
                 "metric_at_least": {"progress_guard_warnings": 1.0},
+                "metric_equals": {"duplicate_exploration_calls": 0.0}
+            },
+            // The efficiency ceiling. Note the prompt mandates three zero-result
+            // searches plus one recovery search — exactly task_tool_calls — so
+            // this budget has no slack and every trial sits on its edge.
+            {
+                "when_binary": "candidate",
+                "budget": true,
                 "metric_at_most": {
                     "calls_after_progress_warning": 1.0,
                     "task_tool_calls": 4.0,
                     "task_llm_calls": 5.0
-                },
-                "metric_equals": {"duplicate_exploration_calls": 0.0}
+                }
             },
             {
                 "when_binary": "baseline",
@@ -1382,20 +1396,66 @@ fn dataset() -> Dataset {
 /// Grades each sample against its own `checks` metadata (file contents captured
 /// from the workdir after the run, and/or the final response). N/A — not a
 /// failure — on samples that declare no checks.
+/// True for checks a sample marks `"budget": true` — efficiency ceilings (call
+/// counts, bytes) rather than statements about whether the agent did the task.
+///
+/// These are scored apart from correctness because the two are compared
+/// differently: correctness is compared *across binaries*, and a budget usually
+/// is not, since budgets are asserted on the candidate only. Folding a
+/// candidate-only ceiling into the same pass/fail as the task assertions is what
+/// reported `zero-result-search-recovery` busting its own call budget as
+/// "correctness regressed 100% -> 33%" against a baseline that is never asked to
+/// meet any budget at all.
+///
+/// Behavioural proofs stay in `checks` even when binary-conditional: "baseline
+/// emits no guard warning, candidate emits one" is the asymmetry these cases
+/// exist to demonstrate, not an artifact.
+fn is_budget_check(spec: &Value) -> bool {
+    spec.get("budget").and_then(Value::as_bool).unwrap_or(false)
+}
+
 fn checks_scorer() -> Box<dyn Scorer> {
     scorer("checks", |sample, t| {
         let Some(specs) = sample.metadata.get("checks").and_then(Value::as_array) else {
             return Score::na("checks", "sample declares no checks");
         };
+        let correctness: Vec<&Value> = specs.iter().filter(|s| !is_budget_check(s)).collect();
+        if correctness.is_empty() {
+            return Score::na("checks", "sample declares only budget checks");
+        }
         let mut passed = 0usize;
         let mut failures: Vec<String> = Vec::new();
-        for spec in specs {
+        for spec in correctness {
             run_check(spec, t, &mut passed, &mut failures);
         }
         if failures.is_empty() {
             Score::pass("checks", format!("{passed} check(s) passed"))
         } else {
             Score::fail("checks", failures.join("; "))
+        }
+    })
+}
+
+/// Grades a sample's declared efficiency budgets, separately from correctness.
+/// N/A on samples that declare none.
+fn declared_budget_scorer() -> Box<dyn Scorer> {
+    scorer("declared_budget", |sample, t| {
+        let Some(specs) = sample.metadata.get("checks").and_then(Value::as_array) else {
+            return Score::na("declared_budget", "sample declares no checks");
+        };
+        let budgets: Vec<&Value> = specs.iter().filter(|s| is_budget_check(s)).collect();
+        if budgets.is_empty() {
+            return Score::na("declared_budget", "sample declares no budget checks");
+        }
+        let mut passed = 0usize;
+        let mut failures: Vec<String> = Vec::new();
+        for spec in budgets {
+            run_check(spec, t, &mut passed, &mut failures);
+        }
+        if failures.is_empty() {
+            Score::pass("declared_budget", format!("{passed} budget(s) met"))
+        } else {
+            Score::fail("declared_budget", failures.join("; "))
         }
     })
 }
@@ -1712,6 +1772,19 @@ struct Mined {
 // Bookkeeping-only rounds are tracked independently from the work an eval asks
 // the agent to perform. This keeps product features such as automatic session
 // titles from consuming a task's search or reasoning budget.
+/// Runtime-mandated meta-calls that are not task progress. The agent does not
+/// choose to make these, so charging them to a task budget measures the runtime,
+/// not the trajectory. `progress_checkpoint` joined this set when the progress
+/// guard began *requiring* a checkpoint after it warns: without the exemption a
+/// case that budgets exactly the calls its prompt mandates fails the moment the
+/// guard fires, which is the behaviour the case exists to reward.
+fn is_bookkeeping_tool(name: &str) -> bool {
+    matches!(
+        name,
+        "write_session_title" | "write_todos" | "set_status" | "progress_checkpoint"
+    )
+}
+
 fn task_tool_calls(mined: &Mined) -> u64 {
     mined
         .total_model_emitted_tool_calls
@@ -2096,12 +2169,7 @@ fn parse_events(jsonl: &str) -> Mined {
                         m.max_read_file_batch_width = m.max_read_file_batch_width.max(read_width);
                         let bookkeeping = tool_names
                             .iter()
-                            .filter(|name| {
-                                matches!(
-                                    **name,
-                                    "write_session_title" | "write_todos" | "set_status"
-                                )
-                            })
+                            .filter(|name| is_bookkeeping_tool(name))
                             .count() as u64;
                         m.bookkeeping_tool_calls += bookkeeping;
                         if bookkeeping == width {
@@ -2136,7 +2204,10 @@ fn parse_events(jsonl: &str) -> Mined {
                     .and_then(Value::as_str)
                     .unwrap_or("unknown");
                 m.tool_calls.push(name.to_string());
-                if saw_progress_warning {
+                // The mandatory checkpoint lands after the warning by definition;
+                // counting it here would consume the whole post-warning allowance
+                // before the agent can make its recovery call.
+                if saw_progress_warning && !is_bookkeeping_tool(name) {
                     m.calls_after_progress_warning += 1;
                 }
                 let result_bytes = data
@@ -2786,6 +2857,7 @@ fn basic_coding() -> Eval {
         .axis("effort", EFFORTS.iter().copied())
         .scorer(succeeded())
         .scorer(checks_scorer())
+        .scorer(declared_budget_scorer())
         // Guardrails, not the comparison itself: the per-case numbers (turns,
         // tool calls, tokens, cost) surface in the report for A/B reading.
         .scorer(turns_budget_scorer())
@@ -3221,6 +3293,10 @@ mod tests {
         transcript.metrics.insert("warnings".into(), 0.0);
         let score = checks_scorer().score(&sample, &transcript).await;
         assert!(!score.pass);
+
+        // Binary-conditional behavioural checks are correctness, not budget.
+        let budget = declared_budget_scorer().score(&sample, &transcript).await;
+        assert!(budget.na, "{}", budget.reason);
     }
 
     #[tokio::test]
@@ -3244,6 +3320,104 @@ mod tests {
             .score(&zero_result_search_sample(), &transcript)
             .await;
         assert!(score.pass, "{}", score.reason);
+    }
+
+    #[tokio::test]
+    async fn zero_result_search_budget_ignores_required_progress_checkpoint() {
+        // The progress guard *requires* a progress_checkpoint call once it fires.
+        // Charging that call to the task budget makes the candidate pay for a
+        // call the runtime forced on it: the case mandates three zero-result
+        // searches plus one recovery search, exactly the task_tool_calls budget,
+        // so a mandatory extra call fails the sample by construction.
+        let mut transcript = graded_transcript();
+        transcript.final_response = "GUARD-203".into();
+        transcript
+            .metadata
+            .insert("binary".into(), json!("candidate"));
+        transcript.metrics.extend([
+            ("progress_guard_warnings".into(), 1.0),
+            // The checkpoint and the recovery search both land after the warning.
+            ("calls_after_progress_warning".into(), 1.0),
+            ("duplicate_exploration_calls".into(), 0.0),
+            ("tool_calls".into(), 5.0),
+            ("llm_calls".into(), 6.0),
+            ("task_tool_calls".into(), 4.0),
+            ("task_llm_calls".into(), 5.0),
+        ]);
+
+        let score = checks_scorer()
+            .score(&zero_result_search_sample(), &transcript)
+            .await;
+        assert!(score.pass, "{}", score.reason);
+    }
+
+    #[test]
+    fn progress_checkpoint_is_bookkeeping_not_task_work() {
+        assert!(is_bookkeeping_tool("progress_checkpoint"));
+        assert!(is_bookkeeping_tool("write_todos"));
+        assert!(!is_bookkeeping_tool("grep_files"));
+        assert!(!is_bookkeeping_tool("read_file"));
+    }
+
+    #[tokio::test]
+    async fn busted_budget_does_not_fail_correctness() {
+        // The agent found the target, the guard fired, and it did not re-search
+        // blindly — it just took more calls than the ceiling allows. That is a
+        // budget result, not a correctness one, and must not read as a
+        // correctness regression against a baseline held to no budget.
+        let mut transcript = graded_transcript();
+        transcript.final_response = "GUARD-203".into();
+        transcript
+            .metadata
+            .insert("binary".into(), json!("candidate"));
+        transcript.metrics.extend([
+            ("progress_guard_warnings".into(), 1.0),
+            ("calls_after_progress_warning".into(), 1.0),
+            ("duplicate_exploration_calls".into(), 0.0),
+            ("task_tool_calls".into(), 9.0),
+            ("task_llm_calls".into(), 9.0),
+        ]);
+        let sample = zero_result_search_sample();
+
+        let correctness = checks_scorer().score(&sample, &transcript).await;
+        let budget = declared_budget_scorer().score(&sample, &transcript).await;
+
+        assert!(correctness.pass, "correctness: {}", correctness.reason);
+        assert!(!budget.pass, "budget should fail");
+    }
+
+    #[tokio::test]
+    async fn behavioural_proof_stays_in_correctness_when_binary_conditional() {
+        // "candidate emits a guard warning" is the asymmetry the case exists to
+        // demonstrate. It must stay in `checks`, or the eval loses the very
+        // signal that distinguishes the fixed binary from the pre-fix one.
+        let mut transcript = graded_transcript();
+        transcript.final_response = "GUARD-203".into();
+        transcript
+            .metadata
+            .insert("binary".into(), json!("candidate"));
+        transcript.metrics.extend([
+            ("progress_guard_warnings".into(), 0.0),
+            ("calls_after_progress_warning".into(), 0.0),
+            ("duplicate_exploration_calls".into(), 0.0),
+            ("task_tool_calls".into(), 4.0),
+            ("task_llm_calls".into(), 5.0),
+        ]);
+
+        let score = checks_scorer()
+            .score(&zero_result_search_sample(), &transcript)
+            .await;
+        assert!(!score.pass, "guard never fired; correctness must fail");
+    }
+
+    #[tokio::test]
+    async fn samples_without_budget_checks_report_no_budget_score() {
+        let sample =
+            Sample::new("plain", "x").meta("checks", json!([{"response_contains": ["x"]}]));
+        let score = declared_budget_scorer()
+            .score(&sample, &graded_transcript())
+            .await;
+        assert!(score.na, "{}", score.reason);
     }
 
     #[test]

--- a/evals/harness_basic/tests/test_analyze_search_efficiency.py
+++ b/evals/harness_basic/tests/test_analyze_search_efficiency.py
@@ -8,7 +8,25 @@ analyzer = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(analyzer)
 
 
-def case(sample, binary, passed, tools=1, tokens=100, failures=0, error=None):
+def scores(checks=None, budget=None):
+    """Score list as the harness emits it: `checks` grades whether the agent did
+    the task, `declared_budget` grades the efficiency ceiling separately."""
+    emitted = []
+    if checks is not None:
+        emitted.append(
+            {"scorer": "checks", "pass": checks}
+            if checks is not NA
+            else {"scorer": "checks", "pass": False, "na": True}
+        )
+    if budget is not None:
+        emitted.append({"scorer": "declared_budget", "pass": budget})
+    return emitted
+
+
+NA = object()
+
+
+def case(sample, binary, passed, tools=1, tokens=100, failures=0, error=None, scored=None):
     transcript = {
         "tool_calls_count": tools,
         "metrics": {
@@ -21,12 +39,15 @@ def case(sample, binary, passed, tools=1, tokens=100, failures=0, error=None):
     }
     if error is not None:
         transcript["error"] = error
-    return {
+    built = {
         "sample": sample,
         "passed": passed,
         "params": {"binary": binary},
         "transcript": transcript,
     }
+    if scored is not None:
+        built["scores"] = scored
+    return built
 
 
 QUOTA_ERROR = (
@@ -156,6 +177,72 @@ class AnalyzeTests(unittest.TestCase):
         self.assertTrue(
             any("candidate focused pass rate" in failure for failure in failures)
         )
+
+    def test_candidate_only_budget_is_not_a_correctness_regression(self):
+        # The real zero-result-search-recovery shape: baseline answers two
+        # assertions and passes, candidate answers six and busts its own budget.
+        # Both cleared the rubric they share, so this is not a regression — it was
+        # reported as "correctness regressed 100% -> 33%" for two weeks.
+        cases = []
+        for index, sample in enumerate(sorted(analyzer.FOCUSED)):
+            # One focused case improves, as on a real night, so the separate
+            # "some case improved" gate is satisfied and cannot mask this result.
+            base_ok = index != 0
+            for _ in range(3):
+                cases.append(
+                    case(
+                        sample, "baseline", base_ok, tools=5, scored=scores(checks=base_ok)
+                    )
+                )
+                cases.append(
+                    case(
+                        sample,
+                        "candidate",
+                        False,
+                        tools=5,
+                        scored=scores(checks=True, budget=False),
+                    )
+                )
+        cases += control_cases()
+        _, failures, notes = analyzer.analyze_reports([{"cases": cases}])
+        self.assertEqual(failures, [])
+        # Not gated, but not silent either.
+        self.assertTrue(any("declared budget" in note for note in notes))
+
+    def test_shared_rubric_failure_still_regresses(self):
+        # The budget split must not blunt the gate: when the candidate fails the
+        # rubric both binaries answer, that is still a correctness regression.
+        cases = []
+        for sample in sorted(analyzer.FOCUSED):
+            for _ in range(3):
+                cases.append(
+                    case(sample, "baseline", True, tools=5, scored=scores(checks=True))
+                )
+                cases.append(
+                    case(
+                        sample,
+                        "candidate",
+                        False,
+                        tools=5,
+                        scored=scores(checks=False, budget=True),
+                    )
+                )
+        cases += control_cases()
+        _, failures, _ = analyzer.analyze_reports([{"cases": cases}])
+        self.assertTrue(any("correctness regressed" in failure for failure in failures))
+
+    def test_sample_with_no_shared_rubric_is_reported_not_compared(self):
+        cases = []
+        for sample in sorted(analyzer.FOCUSED):
+            for _ in range(3):
+                for binary in ("baseline", "candidate"):
+                    cases.append(
+                        case(sample, binary, False, tools=5, scored=scores(checks=NA))
+                    )
+        cases += control_cases()
+        _, failures, notes = analyzer.analyze_reports([{"cases": cases}])
+        self.assertEqual(failures, [])
+        self.assertTrue(all("no correctness rubric" in note for note in notes))
 
     def test_billing_outage_is_inconclusive_not_regression(self):
         # Provider billing exhaustion wipes out both binaries exactly like a quota

--- a/evals/harness_basic/tests/test_analyze_search_efficiency.py
+++ b/evals/harness_basic/tests/test_analyze_search_efficiency.py
@@ -34,6 +34,14 @@ QUOTA_ERROR = (
     "You exceeded your current quota, please check your plan and billing details."
 )
 
+# Verbatim shape of the 2026-08-03 and 2026-07-22 nightlies, where every trial
+# died on provider billing and the gate scored the dead run as a fleet-wide
+# regression because no marker matched.
+CREDIT_ERROR = (
+    "yolop exit 1: turn error: LLM error: credit_balance_exhausted: "
+    "You have no credits remaining. Add credits to continue."
+)
+
 
 def focused_cases():
     cases = []
@@ -62,18 +70,22 @@ def control_cases(candidate_passed=True, candidate_tokens=100, trials=5):
     return cases
 
 
-def outage_cases():
-    """Every focused and control trial fails with a provider quota error — the
-    shape of a full provider outage (baseline and candidate both wiped out)."""
+def outage_cases(error=QUOTA_ERROR, tools=1, tokens=100):
+    """Every focused and control trial fails with a provider error — the shape of
+    a full provider outage (baseline and candidate both wiped out)."""
     cases = []
     for sample in sorted(analyzer.FOCUSED):
         for _ in range(3):
             for binary in ("baseline", "candidate"):
-                cases.append(case(sample, binary, False, error=QUOTA_ERROR))
+                cases.append(
+                    case(sample, binary, False, tools=tools, tokens=tokens, error=error)
+                )
     for sample in sorted(analyzer.CONTROLS):
         for _ in range(5):
             for binary in ("baseline", "candidate"):
-                cases.append(case(sample, binary, False, error=QUOTA_ERROR))
+                cases.append(
+                    case(sample, binary, False, tools=tools, tokens=tokens, error=error)
+                )
     return cases
 
 
@@ -143,6 +155,57 @@ class AnalyzeTests(unittest.TestCase):
         self.assertEqual(notes, [])
         self.assertTrue(
             any("candidate focused pass rate" in failure for failure in failures)
+        )
+
+    def test_billing_outage_is_inconclusive_not_regression(self):
+        # Provider billing exhaustion wipes out both binaries exactly like a quota
+        # outage. The 2026-08-03 nightly reported eight gate violations against a
+        # run in which not one trial ever reached the provider.
+        rows, failures, notes = analyzer.analyze({"cases": outage_cases(CREDIT_ERROR)})
+        self.assertEqual(failures, [])
+        self.assertEqual(rows, [])
+        self.assertEqual(len(notes), len(analyzer.EXPECTED_SAMPLES))
+
+    def test_trials_that_never_ran_are_inconclusive_without_error_text(self):
+        # Structural backstop for outage strings no marker anticipates: a failed
+        # trial with no tool calls and no input tokens never reached the provider,
+        # so it carries no signal even when the report exposes no error at all.
+        rows, failures, notes = analyzer.analyze(
+            {"cases": outage_cases(error=None, tools=0, tokens=0)}
+        )
+        self.assertEqual(failures, [])
+        self.assertEqual(rows, [])
+        self.assertEqual(len(notes), len(analyzer.EXPECTED_SAMPLES))
+
+    def test_timeout_stays_a_real_failure_even_with_no_signal(self):
+        # A harness timeout can also land zero tool calls and zero tokens, but it
+        # is a finding about the agent under test — the structural backstop must
+        # not launder it into an inconclusive dropout.
+        self.assertFalse(
+            analyzer.is_infra_failure(
+                case(
+                    "repo-map-bounded",
+                    "candidate",
+                    False,
+                    tools=0,
+                    tokens=0,
+                    error="timeout after 300s",
+                )
+            )
+        )
+
+    def test_inconclusive_run_does_not_exit_as_a_pass(self):
+        # A night in which nothing was gradable must be distinguishable from a
+        # night that actually cleared the gates: 2026-07-30 was the streak's only
+        # green, and every one of its samples had 0/3 valid trials.
+        _, failures, notes = analyzer.analyze({"cases": outage_cases(CREDIT_ERROR)})
+        self.assertEqual(
+            analyzer.exit_code([], failures, notes), analyzer.INCONCLUSIVE_EXIT
+        )
+        self.assertNotEqual(analyzer.INCONCLUSIVE_EXIT, 0)
+        self.assertEqual(analyzer.exit_code(["add-fn: ..."], [], []), 0)
+        self.assertEqual(
+            analyzer.exit_code(["add-fn: ..."], ["boom"], []), analyzer.REGRESSION_EXIT
         )
 
     def test_harness_timeout_is_not_treated_as_infra(self):


### PR DESCRIPTION
## What changed

The nightly Search Efficiency Eval reported three things as regressions that are not regressions.

**Provider outages.** `INFRA_ERROR_MARKERS` had no entry for billing exhaustion, so a run in which every trial died on `credit_balance_exhausted` was scored as a fleet-wide regression. Billing markers are added, and backed by a structural check that does not depend on recognizing an error string: a failed trial with no tool calls and no input tokens never reached the provider, so it carries no signal whatever it reported. Timeouts and empty-event runs keep their precedence and stay real failures.

**Outage-greens.** A run with nothing left to compare exited `0`, indistinguishable from a clean night. It now exits `75`; the workflow keeps the job green so a throttled account never pages, but annotates the run as inconclusive.

**Budget misses reported as correctness.** Checks marked `"budget": true` now score under a new `declared_budget` scorer instead of `checks`, and the analyzer compares correctness on the `checks` score. A budget is gated only where both binaries declare one; a candidate-only budget is reported rather than gated. Binary-conditional *behavioural* checks stay in `checks` — "baseline emits no guard warning, candidate emits one" is the asymmetry those cases exist to prove.

**A mandatory tool call charged to the agent.** The progress guard now requires a `progress_checkpoint` call once it warns, but bookkeeping classification only exempted `write_session_title`, `write_todos` and `set_status`. The checkpoint was charged to `task_tool_calls`, and — because it lands after the warning by definition — consumed the entire `calls_after_progress_warning` allowance before the agent could make its recovery call.

## Why

The nightly has been red almost every night since 2026-08-01 and was triaged three times (#93, #324, #352) as model variance. Reading the analyzer's printed tables out of 13 nightly job logs shows otherwise:

- **2026-07-22 and 2026-08-03** were total billing outages — every trial `credit_balance_exhausted`, `tools 0->0`, `tokens 0->0` — reported as seven correctness regressions plus `no focused case improved over baseline`.
- **2026-07-30**, the only green in the streak, had `0/3 valid trials` on every sample. It was green because nothing ran.
- **`zero-result-search-recovery`** grades baseline against two assertions and candidate against six. Its `correctness regressed 100% -> 33%` was the candidate busting a call budget the baseline is never asked to meet.

So the streak was a mix of billing artifacts, rubric mismatches, and a real signal nobody could see through the noise. This change removes the first two so the third is legible.

## Before / After

Replaying the 2026-08-03 report shape (every trial `credit_balance_exhausted`, 0 tools, 0 tokens):

**Before** — verbatim from the 2026-08-03 job log:

```
Regression gates:
- add-fn: ordinary control did not pass every trial
- find-constant: ordinary control did not pass every trial
- grep-files-nested-glob: candidate focused pass rate 0% < 67%
- missing-rg-recovery: candidate focused pass rate 0% < 67%
- prior-session-reference: candidate focused pass rate 0% < 67%
- repo-map-bounded: candidate focused pass rate 0% < 67%
- zero-result-search-recovery: candidate focused pass rate 0% < 67%
- no focused case improved over baseline
```
exit 1 — job red.

**After** — same input through the new analyzer:

```
Not gated:
- add-fn: inconclusive — provider/infra errors left 0/5 baseline and 0/5 candidate valid trials
- find-constant: inconclusive — provider/infra errors left 0/5 baseline and 0/5 candidate valid trials
- grep-files-nested-glob: inconclusive — provider/infra errors left 0/3 baseline and 0/3 candidate valid trials
- missing-rg-recovery: inconclusive — provider/infra errors left 0/3 baseline and 0/3 candidate valid trials
- prior-session-reference: inconclusive — provider/infra errors left 0/3 baseline and 0/3 candidate valid trials
- repo-map-bounded: inconclusive — provider/infra errors left 0/3 baseline and 0/3 candidate valid trials
- zero-result-search-recovery: inconclusive — provider/infra errors left 0/3 baseline and 0/3 candidate valid trials

Regression gate inconclusive: provider/infrastructure errors left no valid trials to compare; nothing was gated this run.
```
exit 75 — job green, annotated inconclusive, not counted as a pass.

The budget split is covered by unit tests rather than CLI output: a candidate that finds the target, fires the guard, does not re-search, and merely exceeds the call ceiling now passes `checks` and fails `declared_budget`, producing a reported note instead of `correctness regressed`.

## Risk

- **Low**
- The gate becomes less strict in one specific way: a candidate-only budget miss no longer fails CI, it is reported. That is deliberate — choosing a floor for a candidate-only budget is a policy call, and these budgets currently sit at exactly the call count their prompts mandate, so every trial rides the edge. Left for a follow-up.
- Mitigated against over-correction: `test_shared_rubric_failure_still_regresses` asserts a candidate failing the shared rubric is still a correctness regression, and `behavioural_proof_stays_in_correctness_when_binary_conditional` asserts the guard-fired proof did not leak into the budget score.
- No product code changes; the nightly is excluded from PR CI, so this lands unexercised by CI beyond the unit tests.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

No knowledge update required — the search-efficiency gate is documented in `evals/harness_basic/README.md`, which sits outside the OKF bundle (`evals/` are outside the Cargo workspace and are linked from `AGENTS.md` separately). No concept's intent, architecture, policy, constraints, or terminology changed. The README is updated in this change to describe the outage semantics, the `"budget": true` marker, and the zero-slack budgets.

## Security

No security-relevant code changes — the diff is confined to the eval harness, its analyzer, its tests, and the nightly workflow; no product code, no new dependencies.

Reviewed against the concentrated categories anyway:
- **TM-FS / TM-BASH / TM-TOOL** — untouched. No capability registration, no filesystem or shell paths, no change to `tools.rs` or the bounded execution model.
- **TM-LLM** — untouched. No prompt construction or key handling; the analyzer reads only CI-produced report JSON.
- **TM-DEP** — no new crates or version moves.
- Trust boundary reviewed: the analyzer parses CI-generated report JSON and the new structural check reads numeric metrics only, with no unbounded iteration. The workflow addition writes fixed strings to `$GITHUB_STEP_SUMMARY` and echoes no secrets or provider error text.

## Follow-ups

- **Budget slack.** `zero-result-search-recovery` (`task_tool_calls <= 4`) and `prior-session-reference` (`tool_calls <= 2`) are set at exactly the calls their prompts mandate, so ordinary ±1 variance flips the sample. Loosening them trades sensitivity for stability and is a deliberate policy call, deferred to the maintainers.
- **`add-fn` control degradation.** Median tool calls went 4 → 6-8 from the 2026-08-06 nightly onward, with `candidate introduced command/tool failures` firing for the first time on 8/6-8/8. `add-fn` is a trivial edit that should never trigger the progress guard, so this may be a too-eager trigger condition that would affect real sessions, not just the eval. Not investigated here; it is a product question, not a gate question.
- **Analyzer thresholds.** The 10% control rule applies to integer medians of 4-6, and `tool_calls_failed` uses strict `>` on a 3-sample median. Worth revisiting once a few nights of outage-clean history exist to calibrate against, rather than guessing now.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sg4WX8cKNwBiKyeTgj1HSQ)_