### PR TITLE
fix(evals): stop declared_budget vacuously passing binaries it never checked

### DIFF
--- a/evals/harness_basic/src/main.rs
+++ b/evals/harness_basic/src/main.rs
@@ -1424,9 +1424,18 @@ fn checks_scorer() -> Box<dyn Scorer> {
             return Score::na("checks", "sample declares only budget checks");
         }
         let mut passed = 0usize;
+        let mut applied = 0usize;
         let mut failures: Vec<String> = Vec::new();
         for spec in correctness {
-            run_check(spec, t, &mut passed, &mut failures);
+            if run_check(spec, t, &mut passed, &mut failures) {
+                applied += 1;
+            }
+        }
+        if applied == 0 {
+            return Score::na(
+                "checks",
+                "no correctness checks apply to this binary/harness",
+            );
         }
         if failures.is_empty() {
             Score::pass("checks", format!("{passed} check(s) passed"))
@@ -1448,9 +1457,18 @@ fn declared_budget_scorer() -> Box<dyn Scorer> {
             return Score::na("declared_budget", "sample declares no budget checks");
         }
         let mut passed = 0usize;
+        let mut applied = 0usize;
         let mut failures: Vec<String> = Vec::new();
         for spec in budgets {
-            run_check(spec, t, &mut passed, &mut failures);
+            if run_check(spec, t, &mut passed, &mut failures) {
+                applied += 1;
+            }
+        }
+        if applied == 0 {
+            return Score::na(
+                "declared_budget",
+                "no budget checks apply to this binary/harness",
+            );
         }
         if failures.is_empty() {
             Score::pass("declared_budget", format!("{passed} budget(s) met"))
@@ -1514,12 +1532,17 @@ fn ast_edit_used_scorer() -> Box<dyn Scorer> {
     })
 }
 
-fn run_check(spec: &Value, t: &Transcript, passed: &mut usize, failures: &mut Vec<String>) {
+/// Runs one check spec against a transcript, returning whether it applied.
+/// A `when_binary`/`when_harness` mismatch means this transcript is not the
+/// audience for the check at all — it returns `false` without touching
+/// `passed`/`failures`, so callers can tell "applied and passed" apart from
+/// "did not apply here" instead of reading the latter as a vacuous pass.
+fn run_check(spec: &Value, t: &Transcript, passed: &mut usize, failures: &mut Vec<String>) -> bool {
     for (condition, metadata_key) in [("when_binary", "binary"), ("when_harness", "harness")] {
         if let Some(expected) = spec.get(condition).and_then(Value::as_str)
             && t.metadata.get(metadata_key).and_then(Value::as_str) != Some(expected)
         {
-            return;
+            return false;
         }
     }
     let strings = |key: &str| -> Vec<&str> {
@@ -1531,7 +1554,7 @@ fn run_check(spec: &Value, t: &Transcript, passed: &mut usize, failures: &mut Ve
     if let Some(path) = spec.get("file").and_then(Value::as_str) {
         let Some(contents) = t.files.get(path) else {
             failures.push(format!("no such file: {path}"));
-            return;
+            return true;
         };
         for needle in strings("contains") {
             if contents.contains(needle) {
@@ -1634,6 +1657,7 @@ fn run_check(spec: &Value, t: &Transcript, passed: &mut usize, failures: &mut Ve
             failures.push(format!("metric {key} {actual} != {expected}"));
         }
     }
+    true
 }
 
 // ============================================================================
@@ -3416,6 +3440,31 @@ mod tests {
             Sample::new("plain", "x").meta("checks", json!([{"response_contains": ["x"]}]));
         let score = declared_budget_scorer()
             .score(&sample, &graded_transcript())
+            .await;
+        assert!(score.na, "{}", score.reason);
+    }
+
+    #[tokio::test]
+    async fn candidate_only_budget_is_na_on_baseline_not_a_vacuous_pass() {
+        // zero-result-search-recovery's budget check is `when_binary: candidate`
+        // only. On a baseline transcript it must not apply to that binary — and
+        // must not apply, silently, to a vacuous "0 budget(s) met" pass either.
+        // A vacuous pass reads to the nightly analyzer as "baseline also declares
+        // and meets this budget", which turned a single candidate trial missing
+        // its own budget into a fabricated cross-binary regression.
+        let mut transcript = graded_transcript();
+        transcript.final_response = "GUARD-203".into();
+        transcript
+            .metadata
+            .insert("binary".into(), json!("baseline"));
+        transcript.metrics.extend([
+            ("progress_guard_warnings".into(), 0.0),
+            ("task_tool_calls".into(), 9.0),
+            ("task_llm_calls".into(), 9.0),
+        ]);
+
+        let score = declared_budget_scorer()
+            .score(&zero_result_search_sample(), &transcript)
             .await;
         assert!(score.na, "{}", score.reason);
     }


### PR DESCRIPTION
## What changed
`run_check` now reports whether a check spec actually applied to a transcript (its `when_binary`/`when_harness` condition matched), instead of only reporting pass/fail. `checks_scorer` and `declared_budget_scorer` now return N/A when *none* of their specs applied to a given binary/harness, instead of silently reporting a vacuous pass.

## Why
`zero-result-search-recovery`'s budget check is scoped `when_binary: candidate` only — baseline is never meant to be held to it. But `run_check` returned early on a `when_binary` mismatch without touching `passed`/`failures`, so `declared_budget_scorer` read "0 budget(s) met, 0 failures" as a **pass** for baseline, rather than not applicable.

That fabricated a 100% baseline budget rate every night. Tonight's [Search Efficiency Eval run](https://github.com/everruns/yolop/actions/runs/31363565908) compared it against candidate's real rate (one of three trials missed its own budget → 67%) and reported it as a cross-binary regression, even though baseline was never actually graded on that budget. This is the same class of bug #553 fixed for the outage/budget-vs-correctness cases, just on the `when_binary`-scoped path instead.

## Before / After
Before: `declared_budget_scorer` on a baseline transcript for `zero-result-search-recovery` → `Score::pass("declared_budget", "0 budget(s) met")`.
After: same input → `Score::na("declared_budget", "no budget checks apply to this binary/harness")`.

New test `candidate_only_budget_is_na_on_baseline_not_a_vacuous_pass` pins this down; all 34 existing `harness_basic` unit tests and all 15 `analyze_search_efficiency.py` tests still pass.

## Risk
- Low
- Scoped to `evals/harness_basic`'s scorer internals (not the yolop binary or main Cargo workspace). Could in theory mask a scorer that's supposed to trivially pass when no specs apply, but no such sample exists today — `checks_scorer`/`declared_budget_scorer` already treat "declares none of this kind at all" as N/A, this just extends that to "declares some, but none apply to this transcript."

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

No knowledge update required — bug fix in eval scorer internals (`evals/harness_basic`), not durable yolop behavior, architecture, or policy.

## Security

No security-relevant code changed — this touches only eval scoring logic used to grade nightly A/B trial transcripts.

## Follow-ups

No follow-ups.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AjYYXFymveAL1LM5i9KhUX)_