### PR TITLE
fix(runtime): hide blocked completion status

### DIFF
--- a/src/editor/acp/mod.rs
+++ b/src/editor/acp/mod.rs
@@ -1742,7 +1742,11 @@ mod tests {
         })
         .await;
 
-        assert!(run.assistant_text().contains("task blocked"));
+        assert_eq!(
+            run.assistant_text(),
+            "I need the target path. Which file should I edit?",
+            "ACP must preserve the clarification without appending host status"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/editor/acp/server.rs
+++ b/src/editor/acp/server.rs
@@ -1477,10 +1477,6 @@ async fn completion_followup(
             session
                 .handles
                 .report_herdr_state(crate::capabilities::herdr::HerdrState::Blocked);
-            peer.session_update(
-                &session.acp_id,
-                SessionUpdate::AgentMessageChunk(protocol::text_chunk("task blocked")),
-            );
             None
         }
         AskOutcome::Failed => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1561,10 +1561,11 @@ async fn run_print_mode(
                     session_state::task_completion::CompletionState::Failed,
                 );
                 user_ask_store.record_evaluation(handles.session_id, &evaluation)?;
-                eprintln!(
-                    "{}",
+                if let Some(message) =
                     session_state::user_ask::evaluation_status_message(&evaluation)
-                );
+                {
+                    eprintln!("{message}");
+                }
             }
             write_trajectory_if_requested(&handles, &model, trajectory_out.as_deref()).await;
             std::process::exit(1);

--- a/src/runtime/session.rs
+++ b/src/runtime/session.rs
@@ -271,10 +271,6 @@ impl Session {
             if cancelled {
                 handles.report_herdr_state(crate::capabilities::herdr::HerdrState::Idle);
                 let _ = tx.send(TurnEvent::Stream(None));
-                let _ = tx.send(TurnEvent::Lines(vec![ChatLine {
-                    author: Author::System,
-                    text: "turn cancelled".into(),
-                }]));
                 let _ = tx.send(TurnEvent::Done(None));
                 return;
             }
@@ -580,6 +576,54 @@ mod tests {
                 .expect("messages")
                 .is_empty(),
             "the rejected ask must remain resumable instead of entering history"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelling_agent_turn_finishes_without_host_transcript_status() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(crate::config::SettingsStore::open(
+            sessions.path().join("settings.toml"),
+        ));
+        let built = crate::runtime::build_with_options(
+            workspace.path().to_path_buf(),
+            crate::runtime::ProviderChoice::Sim,
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            crate::runtime::BuildOptions::default(),
+        )
+        .await
+        .expect("build runtime");
+        let session = Session::new(built.handles, built.model);
+
+        let mut turn = session.run_turn("keep working".to_string(), Vec::new());
+        turn.cancel.send(()).expect("cancel turn");
+
+        let mut transcript = Vec::new();
+        let mut completed = false;
+        while let Some(event) = turn.events.recv().await {
+            match event {
+                TurnEvent::Lines(lines) => transcript.extend(lines),
+                TurnEvent::Done(None) => {
+                    completed = true;
+                    break;
+                }
+                TurnEvent::Done(Some(result)) => {
+                    panic!("cancelled turn unexpectedly completed: {result:?}")
+                }
+                _ => {}
+            }
+        }
+
+        assert!(
+            completed,
+            "cancelled turn must still reach its terminal event"
+        );
+        assert!(
+            transcript.is_empty(),
+            "cancelled turn must not add host status to the transcript: {transcript:?}"
         );
     }
 }

--- a/src/session_state/user_ask.rs
+++ b/src/session_state/user_ask.rs
@@ -498,15 +498,18 @@ pub(crate) fn evaluation_result_message(evaluation: &UserAskEvaluation) -> Strin
     .to_string()
 }
 
-pub(crate) fn evaluation_status_message(evaluation: &UserAskEvaluation) -> String {
+pub(crate) fn evaluation_status_message(evaluation: &UserAskEvaluation) -> Option<String> {
     match evaluation.outcome {
-        AskOutcome::Achieved => format!("user ask achieved: {}", evaluation.reason),
-        AskOutcome::Blocked => format!("user ask blocked: {}", evaluation.reason),
-        AskOutcome::Failed => format!("user ask failed: {}", evaluation.reason),
-        AskOutcome::WaitingOnBackground => {
-            format!("user ask waiting on background: {}", evaluation.reason)
-        }
-        AskOutcome::InProgress => format!("user ask in progress: {}", evaluation.reason),
+        AskOutcome::Achieved => Some(format!("user ask achieved: {}", evaluation.reason)),
+        // The assistant's clarification is already the visible handoff to the user.
+        // Repeating blocked state as host-authored transcript copy only adds noise.
+        AskOutcome::Blocked => None,
+        AskOutcome::Failed => Some(format!("user ask failed: {}", evaluation.reason)),
+        AskOutcome::WaitingOnBackground => Some(format!(
+            "user ask waiting on background: {}",
+            evaluation.reason
+        )),
+        AskOutcome::InProgress => Some(format!("user ask in progress: {}", evaluation.reason)),
     }
 }
 
@@ -612,6 +615,26 @@ mod tests {
         .expect("parse");
         assert_eq!(evaluation.outcome, AskOutcome::Blocked);
         assert!(evaluation.reason.contains("API key"));
+    }
+
+    #[test]
+    fn evaluation_status_message_suppresses_only_blocked() {
+        for (outcome, expected) in [
+            (AskOutcome::Achieved, Some("user ask achieved: reason")),
+            (AskOutcome::Blocked, None),
+            (AskOutcome::Failed, Some("user ask failed: reason")),
+            (
+                AskOutcome::WaitingOnBackground,
+                Some("user ask waiting on background: reason"),
+            ),
+            (AskOutcome::InProgress, Some("user ask in progress: reason")),
+        ] {
+            let evaluation = UserAskEvaluation {
+                outcome,
+                reason: "reason".into(),
+            };
+            assert_eq!(evaluation_status_message(&evaluation).as_deref(), expected);
+        }
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1257,6 +1257,15 @@ impl App {
         });
     }
 
+    fn push_evaluation_status(
+        &mut self,
+        evaluation: &crate::session_state::user_ask::UserAskEvaluation,
+    ) {
+        if let Some(message) = evaluation_status_message(evaluation) {
+            self.push_system(message);
+        }
+    }
+
     /// Refresh the memoized full-screen transcript wrapping for `width` and
     /// return the total wrapped-line count.
     ///
@@ -3278,7 +3287,7 @@ impl App {
             self.push_system(format!("user ask: {err}"));
             return;
         }
-        self.push_system(evaluation_status_message(&evaluation));
+        self.push_evaluation_status(&evaluation);
     }
 
     fn maybe_start_goal_turn(&mut self) {
@@ -3354,7 +3363,7 @@ impl App {
                 self.push_system(format!("user ask: {err}"));
                 return;
             }
-            self.push_system(evaluation_status_message(&evaluation));
+            self.push_evaluation_status(&evaluation);
             return;
         }
         let tokens = self.session.turn_tokens(result.turn_id).await;
@@ -3382,7 +3391,7 @@ impl App {
                 self.push_system(format!("user ask: {err}"));
                 return;
             }
-            self.push_system(evaluation_status_message(&evaluation));
+            self.push_evaluation_status(&evaluation);
             match outcome {
                 AskOutcome::InProgress => {
                     let prompt =
@@ -3422,7 +3431,7 @@ impl App {
             self.session
                 .report_herdr_state(crate::capabilities::herdr::HerdrState::Blocked);
         }
-        self.push_system(evaluation_status_message(&evaluation));
+        self.push_evaluation_status(&evaluation);
         if evaluation.outcome == AskOutcome::InProgress {
             let prompt =
                 crate::session_state::task_completion::continuation_prompt(&evaluation.reason);
@@ -6508,7 +6517,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn blocked_completion_state_is_in_presentation_transcript() {
+    async fn blocked_completion_state_stops_without_presentation_status() {
         use everruns_core::turn::TurnStopReason;
         use everruns_core::typed_id::TurnId;
 
@@ -6530,9 +6539,15 @@ mod tests {
             }))
             .await;
 
-        assert!(test.app.lines.iter().any(|line| {
-            line.author == Author::System && line.text.contains("user ask blocked")
-        }));
+        assert!(
+            test.app.lines.is_empty(),
+            "blocked completion must not add host status to the presentation transcript: {:?}",
+            test.app.lines
+        );
+        assert!(
+            !test.app.user_ask_store.is_active(session_id),
+            "blocked completion must remain persisted as terminal"
+        );
         assert!(!test.app.busy, "blocked state must not auto-continue");
     }
 


### PR DESCRIPTION
## What changed

Clarification questions and cancelled agent turns now stop cleanly without appending host-authored status copy to the user transcript. The internal blocked outcome, persistence, Herdr reporting, cancellation teardown, and no-auto-continuation behavior are unchanged.

ACP likewise preserves the assistant's clarification as-is instead of appending `task blocked`. Failed, achieved, waiting-on-background, in-progress, budget, and provider/runtime failure reporting remain intact.

## Why

The default user-ask completion gate classified an ordinary follow-up question as blocked and surfaced the implementation detail as `user ask blocked: turn was cancelled or needs user input`. That line is misleading and duplicates the assistant's actual handoff to the user.

## Before / After

Before:

```text
assistant › I need the target path. Which file should I edit?
system › user ask blocked: turn was cancelled or needs user input
```

After:

```text
assistant › I need the target path. Which file should I edit?
```

Proof: the terminal-independent TUI completion test asserts that the presentation transcript receives no host line while the ask becomes terminal and no continuation starts. The ACP end-to-end prompt test asserts the client receives exactly the assistant clarification. A cancellation-path test asserts the turn still reaches its terminal event without adding transcript copy.

## Risk

- Low
- Risk is limited to completion-status presentation across TUI, print-mode helper use, and ACP. Tests pin every non-blocked status message and preserve permanent provider-failure reporting.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered; Yolop is pre-1.0 and internal completion semantics are unchanged
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

No knowledge update required — the durable user-ask and presentation specs define terminal states and the terminal-independent model, but do not specify this host-generated copy. The behavioral decision is documented beside the presentation helper.

## Security

Reviewed TM-FS, TM-BASH, TM-LLM, TM-TOOL, and TM-DEP. The change adds no authority, filesystem or shell behavior, prompt/key handling, tool registration, dependency, loop, or unbounded data path. It only suppresses host-authored completion transcript entries; genuine runtime/provider errors remain visible.

## Validation

- `cargo test blocked --all-features --quiet`
- `cargo test cancelling_agent_turn_finishes_without_host_transcript_status --all-features --quiet`
- `cargo test permanent_provider_failure_is_failed_without_continuation --all-features --quiet`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --quiet` — 1,072 unit, 57 integration, 1 parallel integration, and 5 Tuika PTY tests passed
- `cargo run --quiet -- --provider llmsim -p "Ask me which file to edit before doing anything."`
- Local live OpenAI smoke could not start because this isolated checkout has no Doppler project configuration (`You must specify a project`). The same-repository `Live Provider Smoke (Doppler)` CI job requires `DOPPLER_TOKEN`, sets `YOLOP_REQUIRE_LIVE_TESTS=1`, and must pass before merge.

## Follow-ups

No follow-ups.
