### PR TITLE
feat(user-ask): make tracking experimental opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ yolop --provider llmsim -p "hi"         # offline demo, no API key required
 - **Goal loops** — `/goal <condition>` keeps working across turns until a
   separate evaluator model confirms the condition; `/goal clear` stops early.
   Works in `--print` mode too.
+- **User-ask tracking** *(experimental, off by default)* — records the current
+  request across turns and applies bounded completion checks. Enable with
+  `[[capabilities]] ref = "yolop_user_ask"` in `settings.toml`.
 - **Planning** — `write_todos` keeps multi-step tasks on track, and loop
   detection stops the model from retrying the same failing tool call.
 - **One-shot mode** — `--print` runs a single prompt non-interactively, for

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,13 @@
 Significant changes to Yolop's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
+## 2026-08-12 — User-ask tracking becomes experimental opt-in
+
+- [User ask](specs/user-ask.md) is no longer part of the default harness. The
+  registered `yolop_user_ask` capability remains available through an explicit
+  `[[capabilities]]` settings override while the completion behavior is
+  experimental.
+
 ## 2026-08-11 — Fullscreen mouse selection survives Ctrl and Ctrl+C copies
 
 - [Presentation](specs/presentation.md) records that fullscreen drag-select is

--- a/knowledge/specs/user-ask.md
+++ b/knowledge/specs/user-ask.md
@@ -6,7 +6,7 @@ description: Defines the user ask — request tracking and turn-end validation c
 
 # User ask — request tracking and turn-end validation
 
-Status: implemented in yolop (`yolop_user_ask` capability) and enabled by default.
+Status: experimental and opt-in through the `yolop_user_ask` capability.
 
 ## Why
 
@@ -15,9 +15,10 @@ over several turns. The agent needs a durable record of the current request,
 independent of `/goal` completion loops, so it can stay aligned and the host can
 judge whether the latest turn actually addressed what was asked.
 
-`/goal` remains the explicit user-authored completion condition. User ask is the
-default safety net: one tracked request per session, revision history on pivots,
-and selective bounded continuation when a turn stops without finishing.
+`/goal` remains the explicit user-authored completion condition. When enabled,
+user ask provides a completion safety net: one tracked request per session,
+revision history on pivots, and selective bounded continuation when a turn stops
+without finishing.
 
 ## Behavior
 
@@ -52,15 +53,19 @@ is charged, so a stall or transport error never surfaces as "budget exhausted".
 
 ## Configuration
 
-The capability is on by default. It can be removed from the harness with:
+The capability is experimental and off by default. Enable it in `settings.toml`
+with:
 
 ```toml
 [[capabilities]]
 ref = "yolop_user_ask"
-enabled = false
+enabled = true
 ```
 
-The ordinary capability override path takes effect on the next run.
+The ordinary capability override path takes effect on the next run. The
+capability remains registered while disabled, so it is discoverable through
+`get_config key=capabilities` and can be enabled conversationally with
+`set_config`.
 
 ## System prompt
 
@@ -86,9 +91,10 @@ restart on process resume.
 ## Independence from `/goal`
 
 - Separate store, capability id, tools, and evaluator.
-- Either capability can be disabled in `[[capabilities]]` without affecting the other.
-- `/goal` uses the user's explicit completion condition; default continuation uses
-  the latest conversational ask and a smaller fixed budget.
+- Either capability can be enabled or disabled in `[[capabilities]]` without
+  affecting the other.
+- `/goal` uses the user's explicit completion condition; opt-in user ask
+  continuation uses the latest conversational ask and a smaller fixed budget.
 
 ## Ownership
 

--- a/src/capabilities/user_ask.rs
+++ b/src/capabilities/user_ask.rs
@@ -1,7 +1,8 @@
-//! `yolop_user_ask` — track the user's request and validate it after each turn.
+//! Experimental `yolop_user_ask` — track the user's request and validate it
+//! after each turn.
 //!
 //! Independent of `/goal`: records what the user wants, allows updates when they
-//! pivot, and runs a tool-less evaluator at turn end. Does not auto-continue turns.
+//! pivot, and runs a tool-less evaluator at turn end. Hosts own bounded continuation.
 
 use crate::capabilities::narration::stable_labeled;
 use crate::session_state::user_ask::{
@@ -34,11 +35,11 @@ impl Capability for UserAskCapability {
     }
 
     fn name(&self) -> &str {
-        "User ask"
+        "User ask (experimental)"
     }
 
     fn description(&self) -> &str {
-        "Track the user's request across turns and evaluate whether it was achieved."
+        "Experimental request tracking across turns with end-of-turn completion evaluation."
     }
 
     fn status(&self) -> CapabilityStatus {

--- a/src/editor/acp/mod.rs
+++ b/src/editor/acp/mod.rs
@@ -322,13 +322,13 @@ mod tests {
         let (agent_w, client_r) = tokio::io::duplex(64 * 1024);
         let sessions = tempfile::tempdir().expect("sessions tempdir").keep();
         let settings = Arc::new(SettingsStore::open(sessions.join("settings.toml")));
-        if !completion_tracking {
+        if completion_tracking {
             settings
                 .set_capability_enabled(
                     crate::session_state::user_ask::USER_ASK_CAPABILITY_ID,
-                    false,
+                    true,
                 )
-                .expect("disable completion tracking for unrelated ACP fixture");
+                .expect("enable completion tracking for ACP fixture");
         }
         let factory = Arc::new(ScriptedFactory {
             config,
@@ -1297,8 +1297,12 @@ mod tests {
         let sessions = tempfile::tempdir().expect("sessions tempdir");
         let sessions_dir = sessions.path().to_path_buf();
         let cwd = tempfile::tempdir().expect("cwd tempdir").keep();
+        let settings = Arc::new(SettingsStore::open(sessions_dir.join("settings.toml")));
+        settings
+            .set_capability_enabled(crate::session_state::user_ask::USER_ASK_CAPABILITY_ID, true)
+            .expect("enable completion tracking");
         let (mut first_w, mut first_reader, first_server) =
-            start_raw_server(fixed(""), sessions_dir.clone());
+            start_raw_server_with_settings(fixed(""), sessions_dir.clone(), settings);
         send_json(
             &mut first_w,
             json!({ "jsonrpc": "2.0", "id": 0, "method": "initialize", "params": { "protocolVersion": 1 } }),
@@ -1639,7 +1643,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn default_completion_gate_continues_tool_only_stop_to_one_final() {
+    async fn opt_in_completion_gate_continues_tool_only_stop_to_one_final() {
         use everruns_core::llmsim_driver::OnExhausted;
 
         let config = LlmSimConfig::scripted(vec![

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2226,9 +2226,6 @@ fn default_coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabi
         // `/btw` — ephemeral side question, answered out-of-band with the
         // session's context (upstream `BtwCapability`).
         AgentCapabilityConfig::new(BTW_CAPABILITY_ID),
-        // Host-side completion tracking is cheap while inactive and prevents
-        // tool/commentary-only turns from silently ending a user request.
-        AgentCapabilityConfig::new(USER_ASK_CAPABILITY_ID),
         // `/goal` — keep working across turns until a model-evaluated condition holds.
         AgentCapabilityConfig::new(GOAL_CAPABILITY_ID),
         // Soft approval: injects spoken-consent guidance for critical actions,
@@ -2336,7 +2333,7 @@ pub struct BuiltRuntime {
     pub model: ModelState,
     pub goal_store: Arc<GoalStore>,
     pub user_ask_store: Arc<UserAskStore>,
-    /// Whether `yolop_user_ask` is on the session harness (on by default).
+    /// Whether the experimental `yolop_user_ask` capability was enabled.
     pub user_ask_enabled: bool,
     pub worktree: Arc<WorktreeManager>,
     /// Settings store shared with the runtime capabilities. The TUI uses it
@@ -3414,6 +3411,8 @@ pub async fn build_with_options(
     });
     let user_ask_store = Arc::new(UserAskStore::open(session_dir.clone()));
     user_ask_store.load_session(session_id)?;
+    // Registered for catalog discovery and explicit settings opt-in, but kept
+    // off the default harness while completion tracking remains experimental.
     capabilities.register(UserAskCapability {
         store: user_ask_store.clone(),
         session_id,
@@ -5405,6 +5404,36 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn user_ask_command_is_not_registered_by_default() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+
+        let built = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Sim,
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            BuildOptions::default(),
+        )
+        .await
+        .expect("build runtime");
+
+        assert!(!built.user_ask_enabled);
+        let commands = built
+            .handles
+            .runtime
+            .list_commands(built.handles.session_id)
+            .await
+            .expect("commands");
+        assert!(
+            commands.iter().all(|command| command.name != "ask"),
+            "/ask should require the experimental capability opt-in"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn user_ask_command_is_registered_when_enabled_in_settings() {
         use crate::config::capability_settings::CapabilityOverride;
 
@@ -5473,12 +5502,12 @@ mod tests {
     }
 
     #[test]
-    fn coding_harness_enables_user_ask_by_default() {
+    fn coding_harness_does_not_enable_experimental_user_ask_by_default() {
         let ids = coding_harness_capabilities(false, None, &Settings::default());
         assert!(
-            ids.iter()
+            !ids.iter()
                 .any(|cap| cap.capability_id() == USER_ASK_CAPABILITY_ID),
-            "user ask completion tracking should be on by default"
+            "experimental user ask completion tracking should require opt-in"
         );
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -6618,7 +6618,7 @@ mod tests {
         use everruns_core::turn::TurnStopReason;
         use everruns_core::typed_id::TurnId;
 
-        let mut test = app_with_llmsim().await;
+        let mut test = app_with_llmsim_and_user_ask().await;
         let session_id = test.app.session.session_id();
         test.app
             .user_ask_store
@@ -6672,11 +6672,27 @@ mod tests {
     }
 
     async fn app_with_llmsim() -> TestApp {
+        app_with_llmsim_capabilities(false).await
+    }
+
+    async fn app_with_llmsim_and_user_ask() -> TestApp {
+        app_with_llmsim_capabilities(true).await
+    }
+
+    async fn app_with_llmsim_capabilities(user_ask: bool) -> TestApp {
         let workspace = tempfile::tempdir().expect("workspace tempdir");
         let sessions = tempfile::tempdir().expect("sessions tempdir");
         let settings = std::sync::Arc::new(crate::config::SettingsStore::open(
             sessions.path().join("settings.toml"),
         ));
+        if user_ask {
+            settings
+                .set_capability_enabled(
+                    crate::session_state::user_ask::USER_ASK_CAPABILITY_ID,
+                    true,
+                )
+                .expect("enable user ask for TUI fixture");
+        }
         let runtime = crate::runtime::build_with_options(
             workspace.path().to_path_buf(),
             crate::runtime::ProviderChoice::Sim,
@@ -8453,7 +8469,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn busy_composer_queues_messages_for_fifo_delivery() {
-        let mut fixture = app_with_llmsim().await;
+        let mut fixture = app_with_llmsim_and_user_ask().await;
         let app = &mut fixture.app;
         app.setup = None;
         app.lines.clear();


### PR DESCRIPTION
## What changed

- Removed `yolop_user_ask` from the default coding harness.
- Kept the capability registered and discoverable so users can opt in through `[[capabilities]]` settings.
- Labeled the capability experimental and updated ACP/TUI fixtures to enable it explicitly when testing completion tracking.
- Documented the experimental opt-in in the README and user-ask knowledge specification.

## Why

User-ask tracking and its automatic completion behavior are not ready to be part of every Yolop session. Making the capability experimental avoids exposing its tools and continuation semantics unless a user deliberately enables them.

## Before / After

Before: a default runtime included `yolop_user_ask`, advertised `/ask` and its tools, and applied completion tracking automatically.

After: a default runtime omits `/ask` and reports `user_ask_enabled = false`; this runtime-level proof passes:

```text
test runtime::tests::user_ask_command_is_not_registered_by_default ... ok
test runtime::tests::user_ask_command_is_registered_when_enabled_in_settings ... ok
```

The live OpenAI runtime smoke also completed successfully:

```text
$ doppler run --project yolop --config ci -- target/debug/yolop --provider openai --session-dir /private/tmp/yolop-user-ask-smoke-sessions -p "Reply exactly: USER_ASK_DEFAULT_OFF_SMOKE_OK"
USER_ASK_DEFAULT_OFF_SMOKE_OK
```

## Risk

- Medium: default sessions no longer receive automatic user-ask completion tracking, so a tool/commentary-only provider turn will not be continued by this feature.
- The behavior is intentional and reversible per user by enabling `yolop_user_ask`; the enabled path remains covered across runtime, ACP, and TUI tests.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

Validation:

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (1,137 tests passed)
- `python3 scripts/validate_okf.py knowledge --check-links`
- Live OpenAI provider smoke through Doppler

## Knowledge

Updated `knowledge/specs/user-ask.md` and `knowledge/log.md`; updated the public README with the opt-in instructions.

## Security

- TM-TOOL reviewed: the default capability/tool surface is reduced. `yolop_user_ask` stays in the registered catalog and opt-in still uses the existing validated capability override path.
- TM-FS, TM-BASH, TM-LLM, and TM-DEP are unaffected: no filesystem policy, shell execution, prompt/key handling, or dependency changes.
- No injection, data-exposure, validation-boundary, or resource-exhaustion issues found in the changed surface.

## Follow-ups

No follow-ups.
