### PR TITLE
chore(deps): bump tuika to 0.8.0 with matching satellite crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -219,7 +219,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -272,9 +272,9 @@ checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "ast-grep-core"
-version = "0.45.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f378c151f97e66921165bcfd962793cb85f86a7453bb20598913292c96a09f1"
+checksum = "dc04b01428d8ff8e2c22f888a69115af6e3921b5c20f99d85d3bc838cc2b6f18"
 dependencies = [
  "bit-set 0.11.1",
  "regex",
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "ast-grep-language"
-version = "0.45.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ac3b94d4adab9542f0b690d2ebe6885893bed074906673ba92230e5fcfb0e0"
+checksum = "d9ebe4f04dceadc722936dbdf5819ce05bba78507ae81aa34781d94e4e7bd840"
 dependencies = [
  "ast-grep-core",
  "ignore",
@@ -422,9 +422,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2 1.0.107",
  "quote 1.0.47",
@@ -537,9 +537,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -555,7 +555,7 @@ checksum = "ace171a860c49083fbb7dd7fe6ebda7c6535aa24cdcf396b9edd9c71c4dd1d37"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bigdecimal",
  "bitflags 2.13.1",
  "bzip2",
@@ -904,9 +904,9 @@ checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -914,9 +914,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1453,7 +1453,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1654,7 +1654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1731,7 +1731,7 @@ dependencies = [
  "a2a-lf",
  "anyhow",
  "async-trait",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bashkit",
  "bytes",
  "chrono",
@@ -1939,7 +1939,7 @@ checksum = "d089f7c6c3cdcce30257bde874ed8d3ec3cbba8811f1623af96c4c8c6a27c01c"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bytes",
  "chrono",
  "eventsource-stream",
@@ -2834,9 +2834,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.31"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8a7b8211e695a1d0cd91cace480d4d0bd57667ab10277cc412c5f7f4884f83"
+checksum = "00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -3594,7 +3594,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3895,7 +3895,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4606,7 +4606,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4910,9 +4910,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5145,7 +5145,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5213,7 +5213,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5747,7 +5747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5990,7 +5990,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6023,7 +6023,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6565,9 +6565,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.11"
+version = "0.26.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
+checksum = "83c567a8e18ae93f20982c90370b16fd24023aeaf52f6052b96957ab253a0fec"
 dependencies = [
  "cc",
  "regex",
@@ -6737,9 +6737,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-scala"
-version = "0.26.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5a4a7ff23a55474ce6a741d52aaeca7a82fe9421bb982b86e98c6ac8629397"
+checksum = "24e0ab4505990bfe30051761d40a7bf4033ce5a81c9eda9e20e987a5cdc84826"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -6794,9 +6794,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuika"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "342a82ee8016637ca1ac001a442e10cba08cd30230d9984f9a7d039b5c4d9c70"
+checksum = "3df8ce9b27d3a5e4541ead23a9c187a2923b5c33a8dad162e390d5817f902523"
 dependencies = [
  "crossterm",
  "pulldown-cmark",
@@ -6809,9 +6809,9 @@ dependencies = [
 
 [[package]]
 name = "tuika-codeformatters"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100174a0ba5b7ef8187403c4546682bfd16ddb70e3f0c458c73b10f2b386e730"
+checksum = "ca76bf36ab565bba6b0530d86b7573c5169827d06d06d85968451c17baebefb7"
 dependencies = [
  "ratatui",
  "tree-sitter",
@@ -6834,9 +6834,9 @@ dependencies = [
 
 [[package]]
 name = "tuika-html"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11da3a2774cc913e90af87307f38152a9f26af10d5094f8fe70a34aaf228e9ea"
+checksum = "aa712e61a5a2a039dc0620efdc23bc93f184f64f5bc7a8aff39397f21217eb53"
 dependencies = [
  "html5ever 0.39.0",
  "markup5ever_rcdom 0.39.0+unofficial",
@@ -6846,9 +6846,9 @@ dependencies = [
 
 [[package]]
 name = "tuika-mermaid"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0077b474ae88da6606a63a4b3bfe837f658e35029d4d8cf37971b959292a75e"
+checksum = "e0b44ac0edd2f8dd94cea82479857d9a5afc47fcef7d76a7854d3b7be853426a"
 dependencies = [
  "mmdflux",
  "ratatui-core",
@@ -7440,7 +7440,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7822,7 +7822,7 @@ dependencies = [
  "ast-grep-core",
  "ast-grep-language",
  "async-trait",
- "base64 0.23.0",
+ "base64 0.23.1",
  "chrono",
  "clap",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ textwrap = "0.16"
 # The TUI toolkit behind both renderers. It lives in its own repository
 # (everruns/tuika) and is consumed from crates.io like any other dependency;
 # yolop gets no special treatment there.
-tuika = "0.7.0"
+tuika = "0.8.0"
 # Optional structured-markdown renderers stay outside tuika core. Mermaid
 # fences become terminal diagrams; safe block HTML becomes styled text.
 tuika-mermaid = "0.2.0"


### PR DESCRIPTION
## What changed
Bumps `tuika` 0.7.0 → 0.8.0 together with the satellite crates that must move in lockstep (`tuika-codeformatters` 0.4.1, `tuika-mermaid` 0.2.1, `tuika-html` 0.1.1), plus the unrelated patch bumps bundled in dependabot's `cargo-minor-and-patch` group (ast-grep-core/language, async-trait, base64, clap, ignore, tree-sitter, tree-sitter-scala). No functional/behavior change — dependency versions only.

Supersedes dependabot's #559 and #560, which each fail CI when applied alone.

## Why
`tuika-codeformatters` 0.4.1 (and the other satellites) require `tuika` 0.8. Dependabot split the family across two PRs — #560 bumped `tuika` alone, #559 bumped the satellites alone — and each leaves two incompatible `tuika` versions in the dependency graph, which fails to compile:

```
error[E0277]: the trait bound `tuika_codeformatters::TreeSitterHighlighter: tuika::highlight::Highlighter` is not satisfied
  --> src/main.rs:1126:57
note: there are multiple different versions of crate `tuika` in the dependency graph
```

Bumping the whole family together in one `cargo update` resolves it.

## Before / After
No observable behavior change — this is a dependency-version-only bump (Cargo.toml/Cargo.lock). Evidence is build/test success rather than a before/after CLI diff:
- `cargo build --all-features`: succeeds (previously failed to compile with the partial bump, per #559/#560 CI logs above)
- `cargo test --all-features`: 1065 + 58 + 1 + 5 tests, 0 failed

## Risk
- Low
- What can break: tuika 0.8.0 adds new components (AppShell, KeyedTable, SelectionScreen, etc.) but yolop doesn't use them yet; the full test suite (including `tests/tuika_pty.rs` PTY-driven rendering tests) passed unchanged, so no rendering regression was observed locally.

## Checklist
- [x] Tests added or updated — n/a, dependency bump only; existing suite re-verified
- [x] Backward compatibility considered — yolop is pre-1.0, tuika is a normal crates.io dependency
- [x] Knowledge concepts updated, or no update required with a reason — see Knowledge

## Knowledge
No knowledge update required — routine dependency bump, no behavior/architecture/policy change.

## Security
No security-relevant code changes — this only updates `Cargo.toml`/`Cargo.lock` pins for existing dependencies to versions dependabot already proposed independently; no new crates, no code touched.

## Follow-ups
No follow-ups.