### PR TITLE
chore(release): prepare v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,41 @@ mechanical `### What's Changed` list of merged PRs.
 Releases are cut via [`/release`](./.agents/skills/release/SKILL.md), which
 tags the version and publishes to crates.io and the Homebrew tap.
 
+## [0.15.1] - 2026-08-15
+
+### Highlights
+
+- Model selection is honest about what is reachable: ACP exposes only connected models, duplicate model names resolve uniquely, and provider model catalogs are listable over ACP.
+- The Meta Model API joins the supported providers.
+- Long-running turns behave better under stress — stall recovery shares the watchdog's budget, blocked completion status stays hidden, and workspace grep scans stream instead of buffering.
+- Terminal selection survives Ctrl and Ctrl+C, on tuika 0.8.0 with matching satellite crates.
+- Skill management (`search_skills` / `install_skill` / `delete_skill`) is now actually enabled in the coding harness, matching what the docs already promised.
+
+### Breaking Changes
+
+- None. `feat` commits in this release are additive (a new provider, a new ACP listing, an opt-in experimental flag), so the release is cut as a patch.
+
+### What's Changed
+
+* fix(skills): enable skill management in the coding harness ([#564](https://github.com/everruns/yolop/pull/564)) by @chaliy
+* chore(deps): bump tuika to 0.8.0 with matching satellite crates ([#563](https://github.com/everruns/yolop/pull/563)) by @chaliy
+* feat(user-ask): make tracking experimental opt-in ([#562](https://github.com/everruns/yolop/pull/562)) by @chaliy
+* fix(runtime): stream workspace grep scans ([#561](https://github.com/everruns/yolop/pull/561)) by @chaliy
+* fix(tui): keep mouse selection through Ctrl and Ctrl+C ([#557](https://github.com/everruns/yolop/pull/557)) by @chaliy
+* fix(runtime): hide blocked completion status ([#556](https://github.com/everruns/yolop/pull/556)) by @chaliy
+* fix(ci): recognize OpenAI credit exhaustion and re-pin stale eval baseline ([#555](https://github.com/everruns/yolop/pull/555)) by @chaliy
+* fix(evals): stop declared_budget vacuously passing binaries it never checked ([#554](https://github.com/everruns/yolop/pull/554)) by @chaliy
+* fix(evals): stop reporting outages and budget misses as search-efficiency regressions ([#553](https://github.com/everruns/yolop/pull/553)) by @chaliy
+* feat(providers): add Meta Model API ([#552](https://github.com/everruns/yolop/pull/552)) by @chaliy
+* chore(deps): adopt everruns 0.17.24 ([#551](https://github.com/everruns/yolop/pull/551)) by @chaliy
+* feat(acp): list provider model catalogs ([#550](https://github.com/everruns/yolop/pull/550)) by @chaliy
+* fix(mcp): recognize conversational restart requests ([#549](https://github.com/everruns/yolop/pull/549)) by @chaliy
+* fix(runtime): align stall recovery budget with watchdog ([#548](https://github.com/everruns/yolop/pull/548)) by @chaliy
+* fix(models): resolve unique model names ([#547](https://github.com/everruns/yolop/pull/547)) by @chaliy
+* fix(acp): expose only connected models ([#546](https://github.com/everruns/yolop/pull/546)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/yolop/compare/v0.15.0...v0.15.1
+
 ## [0.15.0] - 2026-08-06
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7814,7 +7814,7 @@ dependencies = [
 
 [[package]]
 name = "yolop"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "yolop"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2024"
 authors = ["Everruns <support@everruns.com>"]
 license = "MIT"


### PR DESCRIPTION
## What changed

Cuts **v0.15.1** — 16 merged PRs since `v0.15.0`. Bumps `version` in `Cargo.toml` (and the matching `Cargo.lock` entry) and adds the changelog section below. No source changes.

`yolop-yep` stays at `0.3.0`: its API and the wire protocol are untouched since `v0.15.0` (`git diff v0.15.0..HEAD -- crates/yolop-yep/` is empty), and `0.3.0` is already live on crates.io, so `publish.yml` will skip it.

### Changelog section

## [0.15.1] - 2026-08-15

### Highlights

- Model selection is honest about what is reachable: ACP exposes only connected models, duplicate model names resolve uniquely, and provider model catalogs are listable over ACP.
- The Meta Model API joins the supported providers.
- Long-running turns behave better under stress — stall recovery shares the watchdog's budget, blocked completion status stays hidden, and workspace grep scans stream instead of buffering.
- Terminal selection survives Ctrl and Ctrl+C, on tuika 0.8.0 with matching satellite crates.
- Skill management (`search_skills` / `install_skill` / `delete_skill`) is now actually enabled in the coding harness, matching what the docs already promised.

### Breaking Changes

- None. `feat` commits in this release are additive (a new provider, a new ACP listing, an opt-in experimental flag), so the release is cut as a patch.

### What's Changed

* fix(skills): enable skill management in the coding harness ([#564](https://github.com/everruns/yolop/pull/564)) by @chaliy
* chore(deps): bump tuika to 0.8.0 with matching satellite crates ([#563](https://github.com/everruns/yolop/pull/563)) by @chaliy
* feat(user-ask): make tracking experimental opt-in ([#562](https://github.com/everruns/yolop/pull/562)) by @chaliy
* fix(runtime): stream workspace grep scans ([#561](https://github.com/everruns/yolop/pull/561)) by @chaliy
* fix(tui): keep mouse selection through Ctrl and Ctrl+C ([#557](https://github.com/everruns/yolop/pull/557)) by @chaliy
* fix(runtime): hide blocked completion status ([#556](https://github.com/everruns/yolop/pull/556)) by @chaliy
* fix(ci): recognize OpenAI credit exhaustion and re-pin stale eval baseline ([#555](https://github.com/everruns/yolop/pull/555)) by @chaliy
* fix(evals): stop declared_budget vacuously passing binaries it never checked ([#554](https://github.com/everruns/yolop/pull/554)) by @chaliy
* fix(evals): stop reporting outages and budget misses as search-efficiency regressions ([#553](https://github.com/everruns/yolop/pull/553)) by @chaliy
* feat(providers): add Meta Model API ([#552](https://github.com/everruns/yolop/pull/552)) by @chaliy
* chore(deps): adopt everruns 0.17.24 ([#551](https://github.com/everruns/yolop/pull/551)) by @chaliy
* feat(acp): list provider model catalogs ([#550](https://github.com/everruns/yolop/pull/550)) by @chaliy
* fix(mcp): recognize conversational restart requests ([#549](https://github.com/everruns/yolop/pull/549)) by @chaliy
* fix(runtime): align stall recovery budget with watchdog ([#548](https://github.com/everruns/yolop/pull/548)) by @chaliy
* fix(models): resolve unique model names ([#547](https://github.com/everruns/yolop/pull/547)) by @chaliy
* fix(acp): expose only connected models ([#546](https://github.com/everruns/yolop/pull/546)) by @chaliy

**Full Changelog**: https://github.com/everruns/yolop/compare/v0.15.0...v0.15.1

## Why

Ship the 16 merged PRs since `v0.15.0` to crates.io and the Homebrew tap.

**Version choice — flagged for the reviewer.** The unreleased set contains three `feat` commits (#550 ACP catalog listing, #552 Meta Model API provider, #562 experimental user-ask opt-in). Under the release spec's versioning rules ("MINOR: new features, new tools, new providers") that reads as `v0.16.0`, and that was the proposed version. The maintainer chose `v0.15.1` instead; all three additions are additive with no breakage, so the patch level is safe, just conservative relative to the spec's letter. Say the word and this can be re-cut as `v0.16.0`.

## Before / After

No observable behavior change from this PR itself — it is a version bump plus a changelog entry. The behavior changes belong to the 16 PRs listed above, each of which shipped its own evidence.

## Publish-readiness

| Check | Result |
|---|---|
| History complete (not shallow) | `git fetch --unshallow` ran; `v0.1.0` resolves, 534 commits reachable |
| `cargo fmt --check` | clean |
| `cargo clippy --all-targets --all-features -- -D warnings` | clean |
| `cargo test --all-features` | 1131 passed, 0 failed, 0 ignored (1067 + 58 + 5 + 1) |
| `python3 scripts/validate_okf.py knowledge --check-links` | 37 concepts, 0 errors |
| `cargo publish --dry-run -p yolop-yep` | packaged + verified (`0.3.0` already live, so CI will skip it) |
| `cargo publish --dry-run -p yolop` | packaged + verified at `0.15.1` — passes locally because `yolop-yep 0.3.0` is already on crates.io |
| crates.io currently serves | `yolop = "0.15.0"`, `yolop-yep = "0.3.0"` — both below/equal as expected, `0.15.1 > 0.15.0` |
| `Cargo.toml` / `Cargo.lock` agree | both read `0.15.1` (lock refreshed via `cargo update -p yolop`) |

## Risk

- **Low.** No source changes; the publish path is proven by both dry-runs, and no new library version needs to go live first.
- What can break: `release.yml` requires the commit subject `chore(release): prepare v0.15.1` to reach `main` intact — **squash-merge with that exact subject**, or the tag never gets cut. Homebrew formula regeneration in `cli-binaries.yml` depends on `DOPPLER_TOKEN` / `HOMEBREW_TAP_GITHUB_TOKEN`; a stale token shows up as a green crates.io publish with a stale tap.

## Checklist
- [x] Tests added or updated — n/a for a version bump; the full suite was run and is green
- [x] Backward compatibility considered — no API, CLI, or config changes; `yolop-yep` wire protocol untouched
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

No knowledge update required — the 16 PRs in this release each updated their affected concepts and `knowledge/log.md` as they landed (most recently the 2026-08-14 registry-skill entry). A version bump carries no durable behavior, intent, architecture, or policy change of its own.

## Manual terminal matrix

The TUI renderer changed this cycle (tuika 0.8.0 in #563, mouse selection in #557), so per the release spec this is a **human** walk before merge. The automated protocol layer is green — `tests/tuika_pty.rs` passes all 5 (alt-screen, OSC 9;4, OSC 8 on and off, truecolor/Braille, resize) — but emulator painting is not something an agent can verify here.

- [ ] Ghostty
- [ ] iTerm2
- [ ] WezTerm
- [ ] Kitty
- [ ] Windows Terminal
- [ ] Konsole
- [ ] tmux

## Post-merge verification

Unchecked; to be filled in during monitoring after merge.

- [ ] `release.yml` green — tag `v0.15.1` and GitHub Release created
- [ ] `publish.yml` green — `yolop 0.15.1` published (`yolop-yep 0.3.0` skipped as already live)
- [ ] `cli-binaries.yml` green — three target tarballs + `.sha256` attached to the release
- [ ] crates.io serves `0.15.1` (`cargo search yolop --limit 1`)
- [ ] `everruns/homebrew-tap` `Formula/yolop.rb` download URL points at `v0.15.1`

## Security

No security-relevant code changed — this PR touches only `CHANGELOG.md`, the `version` field in `Cargo.toml`, and the corresponding `Cargo.lock` entry. No dependency versions move, no new network or filesystem surface, no credential handling. The release secrets (`CARGO_REGISTRY_TOKEN`, `DOPPLER_TOKEN`, and the tap-scoped `HOMEBREW_TAP_GITHUB_TOKEN`) stay in CI and are never read by this branch.

## Follow-ups

- If the maintainer prefers the spec's letter over the conservative patch, re-cut as `v0.16.0` before merging — after merge it would need a fresh release.

Auto-merge deliberately not enabled: the release spec requires a human to read the changelog and click squash.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkWEmwTWN5AYHEAYnswfsW)_