### PR TITLE
fix(ollama): use literal loopback default

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ act of consent. MCP tools run autonomously like the rest of yolop's tools.
 | `MODEL_API_KEY`                     | Select Meta Model API when earlier providers are not configured |
 | `OPENROUTER_API_KEY`                | Select OpenRouter when earlier providers are not configured  |
 | `GEMINI_API_KEY` / `GOOGLE_API_KEY` | Select Google Gemini via its OpenAI-compatible endpoint      |
-| `OLLAMA_BASE_URL`                   | Select Ollama, defaults to `http://localhost:11434/v1`       |
+| `OLLAMA_BASE_URL`                   | Select Ollama, defaults to `http://127.0.0.1:11434/v1`       |
 | `CUSTOM_BASE_URL`                   | Select the custom OpenAI-compatible endpoint                 |
 | `EVERRUNS_CLI_MODEL`                | Override the auto-selected default model                     |
 | `EVERRUNS_CLI_REASONING_EFFORT`     | Reasoning effort override when the model profile supports it  |

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1196,7 +1196,7 @@ const DEFAULT_GOOGLE_BASE_URL: &str = "https://generativelanguage.googleapis.com
 const DEFAULT_OPENROUTER_MODEL: &str = "openai/gpt-5.6-sol";
 const DEFAULT_OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
 const DEFAULT_OLLAMA_MODEL: &str = "llama3.2";
-const DEFAULT_OLLAMA_BASE_URL: &str = "http://localhost:11434/v1";
+const DEFAULT_OLLAMA_BASE_URL: &str = "http://127.0.0.1:11434/v1";
 const DEFAULT_OLLAMA_API_KEY: &str = "ollama";
 // Generic OpenAI-compatible servers usually ignore the bearer token, but the
 // OpenAI client requires one — same trick as Ollama's placeholder key.
@@ -6576,6 +6576,23 @@ mod tests {
         assert_eq!(
             provider.model_without_stored_key().provider_type,
             DriverId::OpenRouter
+        );
+    }
+
+    #[test]
+    fn ollama_provider_resolution_uses_literal_loopback_url() {
+        let _guard = crate::testing::test_env::lock();
+        unsafe {
+            std::env::remove_var("OLLAMA_BASE_URL");
+        }
+
+        let provider = resolve_for_settings("ollama", &Settings::default())
+            .expect("resolve Ollama")
+            .choice;
+
+        assert_eq!(
+            provider.model_without_stored_key().base_url.as_deref(),
+            Some("http://127.0.0.1:11434/v1")
         );
     }
 


### PR DESCRIPTION
## What changed
Ollama now defaults to `http://127.0.0.1:11434/v1`, so `--provider ollama` works with the runtime private-network guard and needs no environment override.

## Why
The previous `localhost` default can resolve to IPv6 `::1`. The provider HTTP safety check rejects hostname resolution to private/internal addresses, while a literal loopback endpoint is intentionally allowed for local providers.

## Before / After
Before: a local Ollama request failed with `Provider HTTP client blocked: hostname resolves to private/internal address host=localhost resolved_ip=::1`.

After: `cargo run -- --provider ollama -m qwen3-coder:30b --sandbox ...` completed a tool-use smoke and returned the worktree directory without setting `OLLAMA_BASE_URL`.

## Risk
- Low
- Existing `OLLAMA_BASE_URL` overrides are unchanged; only the built-in local default changes from a hostname to its IPv4 loopback address.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge
No knowledge update required — the concrete provider default is documented in README and this does not change architecture or policy.

## Security
Reviewed TM-LLM and provider-network boundaries. Literal loopback removes DNS ambiguity and remains local-only. No credentials, prompts, tools, filesystem or shell authority, dependencies, or remote endpoints changed.

## Follow-ups
No follow-ups.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features -- --skip predictable_long_command_returns_immediately_and_terminal_result_is_durable`
- Targeted regression test and live Ollama tool-use smoke

The skipped timing test also fails on untouched `origin/main` in this machine environment; all remaining tests pass. The Doppler-wrapped live smoke could not start because this worktree has no Doppler project/fallback configuration, so the local-provider smoke was run directly.