### PR TITLE
feat(auth): add OpenRouter PKCE browser login

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ yolop --provider llmsim -p "hi"         # offline demo, no API key required
 | Codex subscription | browser/device ChatGPT login or `CODEX_ACCESS_TOKEN` | `gpt-5.6-sol` |
 | Anthropic  | `ANTHROPIC_API_KEY`                   | `claude-opus-4-8` |
 | Meta Model API | `MODEL_API_KEY`                   | `muse-spark-1.2`  |
-| OpenRouter | `OPENROUTER_API_KEY`                  | `openai/gpt-5.6-sol` |
+| OpenRouter | browser PKCE login or `OPENROUTER_API_KEY` | `openai/gpt-5.6-sol` |
 | Google     | `GEMINI_API_KEY` / `GOOGLE_API_KEY`   | `gemini-2.5-flash` |
 | Ollama     | `OLLAMA_BASE_URL` / `OLLAMA_API_KEY`  | `llama3.2`        |
 | Custom     | `CUSTOM_BASE_URL` (+ optional `CUSTOM_API_KEY`) | — (set via `/setup`) |
@@ -205,8 +205,10 @@ yolop --provider llmsim -p "hi"         # offline demo, no API key required
 
 Pick explicitly with `--provider`, override the model with `-m/--model`. **Codex
 subscription** signs in through ChatGPT and uses the Codex backend directly.
-**Custom** is any OpenAI-compatible Chat Completions endpoint (vLLM, llama.cpp,
-LM Studio, hosted gateways, …).
+**OpenRouter** can mint a user-controlled API key through the same `/setup`
+browser login, or you can paste/`OPENROUTER_API_KEY` as before. **Custom** is
+any OpenAI-compatible Chat Completions endpoint (vLLM, llama.cpp, LM Studio,
+hosted gateways, …).
 
 ### Git attribution
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,14 @@
 Significant changes to Yolop's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
+## 2026-08-14 — OpenRouter PKCE browser login
+
+- [Configuration](specs/configuration.md) records that OpenRouter can mint a
+  user-controlled API key through PKCE browser login, stored as
+  `tokens.openrouter` like a pasted key.
+- [ACP](specs/acp.md) advertises `openrouter_browser` alongside `codex_browser`
+  so editors can connect OpenRouter without a pre-set environment variable.
+
 ## 2026-08-12 — Streaming workspace grep
 
 - [Sandboxing](specs/sandboxing.md) records that broad structured grep streams

--- a/knowledge/specs/acp.md
+++ b/knowledge/specs/acp.md
@@ -35,7 +35,7 @@ ACP protocol version: **1** (integer).
 | Method | Direction | Behaviour |
 |--------|-----------|-----------|
 | `initialize` | client → agent | Negotiates protocol version and advertises agent capabilities. Echoes the client's version when supported, else advertises v1. |
-| `authenticate` | client → agent | Runs an advertised agent-handled login. Yolop currently advertises browser-based ChatGPT/Codex OAuth; API-key providers continue to use inherited environment variables or `/setup token`. |
+| `authenticate` | client → agent | Runs an advertised agent-handled login. Yolop currently advertises browser-based ChatGPT/Codex OAuth and OpenRouter PKCE login; other API-key providers continue to use inherited environment variables or `/setup token`. |
 | `session/new` | client → agent | Builds a fresh runtime rooted at the client-supplied `cwd`; returns the everruns session id as the ACP `sessionId`. |
 | `session/load` | client → agent | Rehydrates an existing yolop JSONL session for the supplied `sessionId` and `cwd`, replays persisted conversation history as `session/update` notifications, and then returns success. |
 | `session/prompt` | client → agent | Runs one turn, or executes a recognised `/command`; streams `session/update`s, and resolves a `stopReason`. |
@@ -68,14 +68,16 @@ initial model before any live ACP selection.
 
 ### Authentication
 
-`initialize.authMethods` advertises `codex_browser`, an agent-handled method
-that opens the ChatGPT OAuth flow and stores the resulting refreshable Codex
-credentials in Yolop settings. `authenticate` rejects unknown method ids. A
-successful login refreshes open sessions' model options, so clients can expose
-the newly connected Codex models without restarting the ACP process. Stable ACP
-does not define secure API-key entry; those providers remain connectable only
-through the agent process environment. Yolop rejects `/setup token` over ACP
-without echoing or persisting the supplied value.
+`initialize.authMethods` advertises `codex_browser` and `openrouter_browser`,
+agent-handled methods that open a browser OAuth flow. Codex stores refreshable
+ChatGPT credentials in Yolop settings; OpenRouter exchanges the PKCE code for a
+user-controlled API key stored as `tokens.openrouter`. `authenticate` rejects
+unknown method ids. A successful login refreshes open sessions' model options,
+so clients can expose the newly connected provider's models without restarting
+the ACP process. Stable ACP does not define secure API-key entry; remaining
+key-based providers stay connectable only through the agent process
+environment. Yolop rejects `/setup token` over ACP without echoing or persisting
+the supplied value.
 
 ### Prompt content
 

--- a/knowledge/specs/configuration.md
+++ b/knowledge/specs/configuration.md
@@ -41,7 +41,7 @@ Keys are addressed the way a human would name them:
 |---------------------------|--------|----------------------------------------------------------------|
 | `default_provider`        | text   | Provider used when no `--provider` flag is given; takes precedence over env auto-detection. |
 | `models.<provider>`       | text   | Per-provider model spec, survives provider switches.           |
-| `tokens.<provider>`       | secret | Provider API token (owner-only on disk; env vars override).    |
+| `tokens.<provider>`       | secret | Provider API token (owner-only on disk; env vars override). OpenRouter PKCE browser login stores the minted key as `tokens.openrouter`. |
 | `base_urls.<provider>`    | text   | Endpoint base URL (used by the `custom` provider).             |
 | `approval_mode`           | text   | Soft-approval paranoia level (`protective` / `normal` / `off`). |
 | `approval_policy`         | text   | Hard shell approval policy (`untrusted` / `on-failure` / `on-request` / `never`). |

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,9 +1,10 @@
 //! Provider and MCP authentication flows.
 //!
 //! Token minting, storage, and the interactive OAuth login handshakes shared
-//! by the Codex provider and remote MCP servers.
+//! by the Codex provider, OpenRouter, and remote MCP servers.
 
 pub mod codex;
 pub mod mcp_oauth;
 pub mod mcp_oauth_login;
 pub mod oauth_flow;
+pub mod openrouter;

--- a/src/auth/openrouter.rs
+++ b/src/auth/openrouter.rs
@@ -1,0 +1,364 @@
+//! OpenRouter PKCE login.
+//!
+//! OpenRouter's OAuth is not a refreshable access-token grant: there is no
+//! client id or secret. The user authorizes at `openrouter.ai/auth`, the
+//! loopback callback receives a short-lived code, and `POST /api/v1/auth/keys`
+//! exchanges that code for a user-controlled API key. Yolop stores the key as
+//! `tokens.openrouter` (same as a pasted `OPENROUTER_API_KEY`).
+
+use anyhow::{Context, Result, anyhow};
+use reqwest::Url;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+const AUTHORIZE_URL: &str = "https://openrouter.ai/auth";
+const KEYS_URL: &str = "https://openrouter.ai/api/v1/auth/keys";
+const CALLBACK_PATH: &str = "/auth/callback";
+const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+const USER_AUTH_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+
+#[derive(Debug, Deserialize)]
+struct KeyResponse {
+    key: String,
+}
+
+pub(crate) struct PreparedLogin {
+    pub authorize_url: String,
+    listener: TcpListener,
+    verifier: String,
+    keys_url: String,
+}
+
+/// Interactive browser login against the production OpenRouter endpoints.
+pub async fn login_with_browser() -> Result<String> {
+    let prepared = prepare_login().await?;
+    crate::auth::oauth_flow::open_browser(&prepared.authorize_url)?;
+    complete_login(prepared).await
+}
+
+pub(crate) async fn prepare_login() -> Result<PreparedLogin> {
+    prepare_login_at(AUTHORIZE_URL, KEYS_URL).await
+}
+
+pub(crate) async fn prepare_login_at(authorize_url: &str, keys_url: &str) -> Result<PreparedLogin> {
+    let listener = TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .context("bind OpenRouter OAuth callback")?;
+    let port = listener
+        .local_addr()
+        .context("resolve OpenRouter callback port")?
+        .port();
+    let redirect_uri = format!("http://127.0.0.1:{port}{CALLBACK_PATH}");
+    let verifier = crate::auth::oauth_flow::random_pkce_verifier();
+    let challenge = crate::auth::oauth_flow::pkce_challenge(&verifier);
+    let mut url = Url::parse(authorize_url).context("parse OpenRouter authorize URL")?;
+    url.query_pairs_mut()
+        .append_pair("callback_url", &redirect_uri)
+        .append_pair("code_challenge", &challenge)
+        .append_pair("code_challenge_method", "S256");
+    Ok(PreparedLogin {
+        authorize_url: url.to_string(),
+        listener,
+        verifier,
+        keys_url: keys_url.to_string(),
+    })
+}
+
+pub(crate) async fn complete_login(prepared: PreparedLogin) -> Result<String> {
+    let code = tokio::time::timeout(USER_AUTH_TIMEOUT, wait_for_callback(prepared.listener))
+        .await
+        .map_err(|_| anyhow!("OpenRouter browser login timed out"))??;
+    exchange_code_at(&prepared.keys_url, &code, &prepared.verifier).await
+}
+
+async fn exchange_code_at(keys_url: &str, code: &str, verifier: &str) -> Result<String> {
+    let client = reqwest::Client::builder()
+        .timeout(HTTP_TIMEOUT)
+        .build()
+        .context("build OpenRouter auth HTTP client")?;
+    let response = client
+        .post(keys_url)
+        .json(&serde_json::json!({
+            "code": code,
+            "code_verifier": verifier,
+            "code_challenge_method": "S256",
+        }))
+        .send()
+        .await
+        .context("exchange OpenRouter OAuth code")?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(anyhow!(
+            "OpenRouter OAuth exchange failed ({status}): {body}"
+        ));
+    }
+    let parsed: KeyResponse = response
+        .json()
+        .await
+        .context("parse OpenRouter API key response")?;
+    if parsed.key.is_empty() {
+        return Err(anyhow!("OpenRouter OAuth exchange returned an empty key"));
+    }
+    Ok(parsed.key)
+}
+
+async fn wait_for_callback(listener: TcpListener) -> Result<String> {
+    loop {
+        let (mut socket, _) = listener
+            .accept()
+            .await
+            .context("accept OpenRouter OAuth callback")?;
+        let request = read_request_line(&mut socket).await?;
+        let path = request
+            .split_whitespace()
+            .nth(1)
+            .ok_or_else(|| anyhow!("invalid OpenRouter OAuth callback request"))?;
+        let parsed = Url::parse(&format!("http://127.0.0.1{path}"))
+            .context("parse OpenRouter OAuth callback URL")?;
+        let params: HashMap<_, _> = parsed.query_pairs().into_owned().collect();
+
+        if parsed.path() != CALLBACK_PATH {
+            write_response(&mut socket, "404 Not Found", "Unexpected callback path.").await?;
+            continue;
+        }
+        if let Some(error) = params.get("error") {
+            let message = format!("Authorization failed: {error}.");
+            write_response(&mut socket, "400 Bad Request", &message).await?;
+            return Err(anyhow!(
+                "OpenRouter authorization server returned error: {error}"
+            ));
+        }
+        if let Some(code) = params.get("code") {
+            if code.is_empty() {
+                write_response(
+                    &mut socket,
+                    "400 Bad Request",
+                    "Callback had an empty authorization code.",
+                )
+                .await?;
+                return Err(anyhow!("OpenRouter OAuth callback had an empty code"));
+            }
+            write_response(
+                &mut socket,
+                "200 OK",
+                "OpenRouter login complete. You can return to the terminal.",
+            )
+            .await?;
+            return Ok(code.clone());
+        }
+        write_response(
+            &mut socket,
+            "400 Bad Request",
+            "Callback had no authorization code.",
+        )
+        .await?;
+    }
+}
+
+async fn read_request_line(socket: &mut TcpStream) -> Result<String> {
+    let mut buffer = vec![0u8; 8192];
+    let n = socket
+        .read(&mut buffer)
+        .await
+        .context("read OpenRouter OAuth callback")?;
+    let request = String::from_utf8_lossy(&buffer[..n]);
+    Ok(request.lines().next().unwrap_or_default().to_string())
+}
+
+async fn write_response(socket: &mut TcpStream, status: &str, message: &str) -> Result<()> {
+    let body = crate::auth::oauth_flow::callback_page(status, message, "OpenRouter");
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    socket
+        .write_all(response.as_bytes())
+        .await
+        .context("write OpenRouter OAuth callback response")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpStream;
+
+    struct MockKeysServer {
+        base: String,
+        received: std::sync::Arc<tokio::sync::Mutex<Option<String>>>,
+    }
+
+    impl MockKeysServer {
+        async fn start(status: u16, body: &str) -> Self {
+            let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+            let port = listener.local_addr().unwrap().port();
+            let base = format!("http://127.0.0.1:{port}");
+            let received = std::sync::Arc::new(tokio::sync::Mutex::new(None));
+            let received_for_task = received.clone();
+            let body = body.to_string();
+            tokio::spawn(async move {
+                loop {
+                    let Ok((mut socket, _)) = listener.accept().await else {
+                        break;
+                    };
+                    let mut buf = vec![0u8; 8192];
+                    let Ok(n) = socket.read(&mut buf).await else {
+                        continue;
+                    };
+                    let request = String::from_utf8_lossy(&buf[..n]).to_string();
+                    *received_for_task.lock().await = Some(request.clone());
+                    let response = format!(
+                        "HTTP/1.1 {status} {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                        if (200..300).contains(&status) {
+                            "OK"
+                        } else {
+                            "Error"
+                        },
+                        body.len()
+                    );
+                    let _ = socket.write_all(response.as_bytes()).await;
+                }
+            });
+            Self { base, received }
+        }
+
+        fn keys_url(&self) -> String {
+            format!("{}/api/v1/auth/keys", self.base)
+        }
+    }
+
+    fn callback_url(prepared: &PreparedLogin) -> Url {
+        let authorize = Url::parse(&prepared.authorize_url).unwrap();
+        let params: HashMap<_, _> = authorize.query_pairs().into_owned().collect();
+        Url::parse(params.get("callback_url").expect("callback_url")).unwrap()
+    }
+
+    async fn get(url: &str) -> String {
+        let parsed = Url::parse(url).unwrap();
+        let mut stream = TcpStream::connect(format!(
+            "{}:{}",
+            parsed.host_str().unwrap(),
+            parsed.port().unwrap()
+        ))
+        .await
+        .unwrap();
+        let path = match parsed.query() {
+            Some(query) => format!("{}?{query}", parsed.path()),
+            None => parsed.path().to_string(),
+        };
+        let request =
+            format!("GET {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n");
+        stream.write_all(request.as_bytes()).await.unwrap();
+        let mut response = String::new();
+        stream.read_to_string(&mut response).await.unwrap();
+        response
+    }
+
+    #[tokio::test]
+    async fn prepare_login_builds_pkce_authorize_url() {
+        let prepared = prepare_login_at("https://openrouter.ai/auth", KEYS_URL)
+            .await
+            .unwrap();
+        let url = Url::parse(&prepared.authorize_url).unwrap();
+        let params: HashMap<_, _> = url.query_pairs().into_owned().collect();
+        assert_eq!(url.scheme(), "https");
+        assert_eq!(url.host_str(), Some("openrouter.ai"));
+        assert_eq!(url.path(), "/auth");
+        assert_eq!(
+            params.get("code_challenge_method").map(String::as_str),
+            Some("S256")
+        );
+        let expected_challenge = crate::auth::oauth_flow::pkce_challenge(&prepared.verifier);
+        assert_eq!(
+            params.get("code_challenge").map(String::as_str),
+            Some(expected_challenge.as_str())
+        );
+        let callback = Url::parse(params.get("callback_url").expect("callback_url")).unwrap();
+        assert_eq!(callback.host_str(), Some("127.0.0.1"));
+        assert_eq!(callback.path(), CALLBACK_PATH);
+    }
+
+    #[tokio::test]
+    async fn complete_login_exchanges_callback_code_for_api_key() {
+        let server =
+            MockKeysServer::start(200, r#"{"key":"sk-or-test-key","user_id":"user_123"}"#).await;
+        let prepared = prepare_login_at("https://openrouter.ai/auth", &server.keys_url())
+            .await
+            .unwrap();
+        let callback = callback_url(&prepared);
+        let hit = format!("{callback}?code=auth-code-1");
+        let browser = tokio::spawn(async move { get(&hit).await });
+        let key = complete_login(prepared).await.expect("exchange");
+        let page = browser.await.unwrap();
+        assert_eq!(key, "sk-or-test-key");
+        assert!(page.contains("HTTP/1.1 200 OK"));
+        assert!(page.contains("OpenRouter is connected."));
+        let request = server.received.lock().await.clone().expect("keys POST");
+        assert!(request.starts_with("POST /api/v1/auth/keys"));
+        assert!(request.contains("\"code\":\"auth-code-1\""));
+        assert!(request.contains("\"code_challenge_method\":\"S256\""));
+        assert!(request.contains("\"code_verifier\":"));
+    }
+
+    #[tokio::test]
+    async fn complete_login_rejects_authorization_error() {
+        let server = MockKeysServer::start(200, r#"{"key":"unused"}"#).await;
+        let prepared = prepare_login_at("https://openrouter.ai/auth", &server.keys_url())
+            .await
+            .unwrap();
+        let callback = callback_url(&prepared);
+        let hit = format!("{callback}?error=access_denied");
+        let browser = tokio::spawn(async move { get(&hit).await });
+        let error = complete_login(prepared).await.expect_err("denied");
+        let page = browser.await.unwrap();
+        assert!(error.to_string().contains("access_denied"), "got: {error}");
+        assert!(page.contains("HTTP/1.1 400 Bad Request"));
+    }
+
+    #[tokio::test]
+    async fn exchange_surfaces_openrouter_error_body() {
+        let err = exchange_code_at(
+            &MockKeysServer::start(403, r#"{"error":"Invalid code or code_verifier"}"#)
+                .await
+                .keys_url(),
+            "stale-code",
+            "verifier",
+        )
+        .await
+        .expect_err("403");
+        let message = err.to_string();
+        assert!(message.contains("403"), "got: {message}");
+        assert!(
+            message.contains("Invalid code or code_verifier"),
+            "got: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn callback_page_is_branded_for_openrouter() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            write_response(
+                &mut socket,
+                "200 OK",
+                "OpenRouter login complete. You can return to the terminal.",
+            )
+            .await
+            .unwrap();
+        });
+
+        let mut browser = TcpStream::connect(address).await.unwrap();
+        server.await.unwrap();
+        let mut response = String::new();
+        browser.read_to_string(&mut response).await.unwrap();
+        assert!(response.contains("OpenRouter is connected."));
+        assert!(response.contains("<svg"));
+    }
+}

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -117,7 +117,8 @@ pub fn schema() -> &'static [ConfigField] {
             title: "Provider API token",
             description: "API token for a provider, stored owner-only (0o600). Environment \
                           variables (OPENAI_API_KEY, ANTHROPIC_API_KEY, …) always override the \
-                          stored value. Addressed as `tokens.<provider>`.",
+                          stored value. OpenRouter browser login mints a key into \
+                          `tokens.openrouter`. Addressed as `tokens.<provider>`.",
             kind: ValueKind::Secret,
             default: None,
             examples: &["tokens.openai = sk-…", "tokens.anthropic = …"],

--- a/src/editor/acp/mod.rs
+++ b/src/editor/acp/mod.rs
@@ -34,6 +34,19 @@ use everruns_core::typed_id::SessionId as RuntimeSessionId;
 
 pub use server::{RuntimeFactory, serve};
 
+pub(crate) fn advertised_auth_methods() -> Vec<AuthMethod> {
+    vec![
+        AuthMethod::Agent(
+            AuthMethodAgent::new("codex_browser", "Sign in with ChatGPT")
+                .description("Open a browser to connect the Codex provider."),
+        ),
+        AuthMethod::Agent(
+            AuthMethodAgent::new("openrouter_browser", "Sign in with OpenRouter")
+                .description("Open a browser to create an OpenRouter API key."),
+        ),
+    ]
+}
+
 /// Production [`RuntimeFactory`]: builds a real provider-backed runtime rooted
 /// at the client-supplied `cwd` for each `session/new`. The provider, settings,
 /// and session-log directory come from the CLI invocation and are shared
@@ -54,18 +67,21 @@ impl RuntimeFactory for ConfigRuntimeFactory {
     }
 
     fn auth_methods(&self) -> Vec<AuthMethod> {
-        vec![AuthMethod::Agent(
-            AuthMethodAgent::new("codex_browser", "Sign in with ChatGPT")
-                .description("Open a browser to connect the Codex provider."),
-        )]
+        advertised_auth_methods()
     }
 
     async fn authenticate(&self, method_id: &str) -> Result<()> {
-        if method_id != "codex_browser" {
-            anyhow::bail!("unknown authentication method `{method_id}`");
+        match method_id {
+            "codex_browser" => {
+                let auth = crate::auth::codex::login_with_browser().await?;
+                self.settings.set_codex_auth(auth)
+            }
+            "openrouter_browser" => {
+                let key = crate::auth::openrouter::login_with_browser().await?;
+                self.settings.set_token("openrouter".to_string(), key)
+            }
+            _ => anyhow::bail!("unknown authentication method `{method_id}`"),
         }
-        let auth = crate::auth::codex::login_with_browser().await?;
-        self.settings.set_codex_auth(auth)
     }
 
     async fn build(

--- a/src/editor/acp/server.rs
+++ b/src/editor/acp/server.rs
@@ -1528,17 +1528,14 @@ mod tests {
     fn initialize_advertises_agent_handled_authentication() {
         let result = handle_initialize(
             InitializeParams::new(protocol::PROTOCOL_VERSION),
-            vec![AuthMethod::Agent(
-                agent_client_protocol::schema::v1::AuthMethodAgent::new(
-                    "codex_browser",
-                    "Sign in with ChatGPT",
-                ),
-            )],
+            super::super::advertised_auth_methods(),
         );
 
         let value = serde_json::to_value(result).expect("serialize initialize response");
         assert_eq!(value["authMethods"][0]["id"], "codex_browser");
         assert_eq!(value["authMethods"][0]["name"], "Sign in with ChatGPT");
+        assert_eq!(value["authMethods"][1]["id"], "openrouter_browser");
+        assert_eq!(value["authMethods"][1]["name"], "Sign in with OpenRouter");
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -186,6 +186,12 @@ pub struct App {
     codex_login_tx: mpsc::UnboundedSender<CodexLoginEvent>,
     codex_login_rx: mpsc::UnboundedReceiver<CodexLoginEvent>,
     next_codex_login_id: u64,
+    /// OpenRouter PKCE login is the same shape as Codex browser login: a
+    /// background task plus a wait overlay so the TUI stays responsive.
+    openrouter_login: Option<PendingOpenRouterLogin>,
+    openrouter_login_tx: mpsc::UnboundedSender<OpenRouterLoginEvent>,
+    openrouter_login_rx: mpsc::UnboundedReceiver<OpenRouterLoginEvent>,
+    next_openrouter_login_id: u64,
     /// Background MCP OAuth login (browser + loopback), parallel to Codex so
     /// the event loop stays alive in both fullscreen and inline modes.
     mcp_login: Option<PendingMcpLogin>,
@@ -391,6 +397,9 @@ pub(crate) enum SetupStep {
         method: CodexLoginMethod,
         device_code: Option<(String, String)>,
     },
+    OpenRouterLogin {
+        selected: usize,
+    },
     TokenInput {
         provider: String,
         token: String,
@@ -415,6 +424,11 @@ pub(crate) enum CodexLoginMethod {
 }
 
 struct PendingCodexLogin {
+    id: u64,
+    task: tokio::task::JoinHandle<()>,
+}
+
+struct PendingOpenRouterLogin {
     id: u64,
     task: tokio::task::JoinHandle<()>,
 }
@@ -454,6 +468,14 @@ enum CodexLoginEvent {
         id: u64,
         selected: usize,
         result: Result<crate::config::CodexAuth, String>,
+    },
+}
+
+enum OpenRouterLoginEvent {
+    Finished {
+        id: u64,
+        selected: usize,
+        result: Result<String, String>,
     },
 }
 
@@ -595,6 +617,8 @@ impl App {
         let session = Session::new(runtime.handles, runtime.model.clone());
         let (models_tx, models_rx) = mpsc::unbounded_channel::<ModelDiscovery>();
         let (codex_login_tx, codex_login_rx) = mpsc::unbounded_channel::<CodexLoginEvent>();
+        let (openrouter_login_tx, openrouter_login_rx) =
+            mpsc::unbounded_channel::<OpenRouterLoginEvent>();
         let (mcp_login_tx, mcp_login_rx) = mpsc::unbounded_channel::<McpLoginEvent>();
         let mut app = Self {
             session,
@@ -626,6 +650,10 @@ impl App {
             codex_login_tx,
             codex_login_rx,
             next_codex_login_id: 0,
+            openrouter_login: None,
+            openrouter_login_tx,
+            openrouter_login_rx,
+            next_openrouter_login_id: 0,
             mcp_login: None,
             mcp_login_tx,
             mcp_login_rx,
@@ -1663,6 +1691,9 @@ impl App {
         if self.apply_codex_login_events().await {
             return Ok(());
         }
+        if self.apply_openrouter_login_events().await {
+            return Ok(());
+        }
         if self.apply_mcp_login_events() {
             return Ok(());
         }
@@ -1928,6 +1959,7 @@ impl App {
                 GlobalAction::Interrupt => self.handle_ctrl_c(),
                 GlobalAction::Quit => {
                     self.abort_codex_login();
+                    self.abort_openrouter_login();
                     self.abort_mcp_login();
                     self.should_quit = true;
                 }
@@ -3218,6 +3250,7 @@ impl App {
 
         if self.ctrl_c_pending_exit() {
             self.abort_codex_login();
+            self.abort_openrouter_login();
             self.abort_mcp_login();
             self.ctrl_c_exit = true;
             self.should_quit = true;
@@ -9669,6 +9702,91 @@ mod tests {
                 error: Some(ref error),
             }) if provider == "codex" && error == "Codex sign-in canceled"
         ));
+    }
+
+    #[test]
+    fn openrouter_credential_options_lead_with_browser_login() {
+        let options = App::credential_options("openrouter");
+        assert_eq!(options[0].id, CredentialAction::BrowserLogin);
+        assert_eq!(options[0].label, "Sign in with browser");
+        assert!(
+            options
+                .iter()
+                .any(|option| option.id == CredentialAction::PasteKey)
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn setup_openrouter_login_wait_can_be_cancelled() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        let task = tokio::spawn(std::future::pending());
+        app.openrouter_login = Some(PendingOpenRouterLogin { id: 3, task });
+        app.setup = Some(SetupStep::OpenRouterLogin { selected: 0 });
+
+        let rendered = setup_overlay_text(app);
+        assert!(
+            rendered
+                .iter()
+                .any(|line| line.contains("Sign in to OpenRouter")),
+            "wait overlay should name OpenRouter: {rendered:?}"
+        );
+
+        app.handle_setup_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
+            .await;
+
+        assert!(app.openrouter_login.is_none());
+        assert!(matches!(
+            app.setup,
+            Some(SetupStep::Credential {
+                ref provider,
+                selected: 0,
+                error: Some(ref error),
+            }) if provider == "openrouter" && error == "OpenRouter sign-in canceled"
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn setup_openrouter_login_stores_key_without_echoing_it() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        let task = tokio::spawn(std::future::pending());
+        app.openrouter_login = Some(PendingOpenRouterLogin { id: 9, task });
+        app.setup = Some(SetupStep::OpenRouterLogin { selected: 0 });
+        app.openrouter_login_tx
+            .send(OpenRouterLoginEvent::Finished {
+                id: 9,
+                selected: 0,
+                result: Ok("sk-or-secret-login-key".into()),
+            })
+            .expect("send login result");
+
+        assert!(app.apply_openrouter_login_events().await);
+        assert_eq!(
+            app.settings.snapshot().token_for("openrouter"),
+            Some("sk-or-secret-login-key")
+        );
+        let transcript = app
+            .lines
+            .iter()
+            .map(|line| line.text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            !transcript.contains("sk-or-secret-login-key"),
+            "OAuth key must not land in the transcript: {transcript}"
+        );
+        assert!(
+            matches!(
+                app.setup,
+                Some(SetupStep::PickModel { ref provider, .. }) if provider == "openrouter"
+            ) || matches!(
+                app.setup,
+                Some(SetupStep::Credential { ref provider, .. }) if provider == "openrouter"
+            ),
+            "login should advance to model pick or return to credentials: {:?}",
+            app.setup
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -973,6 +973,18 @@ pub(crate) fn setup_overlay_content(app: &App) -> (Vec<Line<'static>>, Option<(u
             lines.push(Line::from(""));
             lines.push(setup_footer("Esc cancel · Ctrl+C twice exit"));
         }
+        Some(SetupStep::OpenRouterLogin { .. }) => {
+            lines.push(setup_title("Sign in to OpenRouter"));
+            lines.push(setup_hint(
+                "Waiting for the browser to finish authentication.",
+            ));
+            lines.push(Line::from(""));
+            lines.push(setup_hint(
+                "If the browser was closed, cancel here and try again.",
+            ));
+            lines.push(Line::from(""));
+            lines.push(setup_footer("Esc cancel · Ctrl+C twice exit"));
+        }
         Some(SetupStep::TokenInput {
             provider,
             token,

--- a/src/tui/setup.rs
+++ b/src/tui/setup.rs
@@ -235,6 +235,37 @@ impl App {
                 },
             ];
         }
+        if provider == "openrouter" {
+            return vec![
+                CredentialOption {
+                    id: CredentialAction::BrowserLogin,
+                    label: "Sign in with browser".to_string(),
+                    hint: "opens OpenRouter in your browser".to_string(),
+                },
+                CredentialOption {
+                    id: CredentialAction::UseEnv,
+                    label: "Use OPENROUTER_API_KEY from environment".to_string(),
+                    hint: Self::detected_env_var(provider)
+                        .map(|name| format!("{name} detected"))
+                        .unwrap_or_else(|| "not detected yet".to_string()),
+                },
+                CredentialOption {
+                    id: CredentialAction::PasteKey,
+                    label: "Paste API key".to_string(),
+                    hint: "saved to settings.toml".to_string(),
+                },
+                CredentialOption {
+                    id: CredentialAction::Skip,
+                    label: "Skip for now".to_string(),
+                    hint: "leave setup unchanged".to_string(),
+                },
+                CredentialOption {
+                    id: CredentialAction::ClearSaved,
+                    label: "Clear saved key".to_string(),
+                    hint: "remove this provider token".to_string(),
+                },
+            ];
+        }
         let env_names = Self::provider_env_names(provider);
         // The custom endpoint treats a key as optional: most local servers
         // accept any bearer token, so the first option proceeds with the env
@@ -636,6 +667,11 @@ impl App {
                     self.cancel_codex_login(selected);
                 }
             }
+            SetupStep::OpenRouterLogin { selected } => {
+                if key.code == KeyCode::Esc {
+                    self.cancel_openrouter_login(selected);
+                }
+            }
             SetupStep::TokenInput {
                 provider, token, ..
             } => {
@@ -918,12 +954,11 @@ impl App {
                     }
                 }
             }
-            CredentialAction::BrowserLogin => {
-                if provider != "codex" {
-                    return;
-                }
-                self.start_codex_login(CodexLoginMethod::Browser, selected);
-            }
+            CredentialAction::BrowserLogin => match provider.as_str() {
+                "codex" => self.start_codex_login(CodexLoginMethod::Browser, selected),
+                "openrouter" => self.start_openrouter_login(selected),
+                _ => {}
+            },
             CredentialAction::DeviceLogin => {
                 if provider != "codex" {
                     return;
@@ -1035,6 +1070,42 @@ impl App {
         }
     }
 
+    fn start_openrouter_login(&mut self, selected: usize) {
+        if self.openrouter_login.is_some() {
+            return;
+        }
+        self.next_openrouter_login_id = self.next_openrouter_login_id.wrapping_add(1);
+        let id = self.next_openrouter_login_id;
+        let tx = self.openrouter_login_tx.clone();
+        let task = tokio::spawn(async move {
+            let result = crate::auth::openrouter::login_with_browser()
+                .await
+                .map_err(|error| error.to_string());
+            let _ = tx.send(OpenRouterLoginEvent::Finished {
+                id,
+                selected,
+                result,
+            });
+        });
+        self.openrouter_login = Some(PendingOpenRouterLogin { id, task });
+        self.setup = Some(SetupStep::OpenRouterLogin { selected });
+    }
+
+    fn cancel_openrouter_login(&mut self, selected: usize) {
+        self.abort_openrouter_login();
+        self.setup = Some(SetupStep::Credential {
+            provider: "openrouter".to_string(),
+            selected,
+            error: Some("OpenRouter sign-in canceled".to_string()),
+        });
+    }
+
+    pub(crate) fn abort_openrouter_login(&mut self) {
+        if let Some(login) = self.openrouter_login.take() {
+            login.task.abort();
+        }
+    }
+
     pub(crate) fn abort_mcp_login(&mut self) {
         if let Some(login) = self.mcp_login.take() {
             login.task.abort();
@@ -1094,6 +1165,51 @@ impl App {
                     }
                 }
                 _ => {}
+            }
+        }
+        applied
+    }
+
+    pub(crate) async fn apply_openrouter_login_events(&mut self) -> bool {
+        let mut applied = false;
+        while let Ok(event) = self.openrouter_login_rx.try_recv() {
+            let OpenRouterLoginEvent::Finished {
+                id,
+                selected,
+                result,
+            } = event;
+            if self.openrouter_login.as_ref().map(|login| login.id) != Some(id) {
+                continue;
+            }
+            self.openrouter_login = None;
+            applied = true;
+            match result {
+                Ok(key) => {
+                    if let Err(error) = self.settings.set_token("openrouter".to_string(), key) {
+                        self.setup = Some(SetupStep::Credential {
+                            provider: "openrouter".to_string(),
+                            selected,
+                            error: Some(error.to_string()),
+                        });
+                    } else if let Err(error) =
+                        self.run_setup_command(Some("provider openrouter")).await
+                    {
+                        self.setup = Some(SetupStep::Credential {
+                            provider: "openrouter".to_string(),
+                            selected,
+                            error: Some(error),
+                        });
+                    } else {
+                        self.open_model_step("openrouter");
+                    }
+                }
+                Err(error) => {
+                    self.setup = Some(SetupStep::Credential {
+                        provider: "openrouter".to_string(),
+                        selected,
+                        error: Some(error),
+                    });
+                }
             }
         }
         applied


### PR DESCRIPTION
## What changed
OpenRouter can now be connected with a browser login. `/setup` offers **Sign in with browser** for OpenRouter, and ACP advertises `openrouter_browser` next to Codex. The PKCE flow mints a user-controlled API key and stores it as `tokens.openrouter` (same as a pasted `OPENROUTER_API_KEY`). Env still wins.

## Why
OpenRouter already had a first-class driver, but the only way to authenticate was to paste or export a key. Codex already had browser OAuth; OpenRouter's documented PKCE flow is the matching path so a user can connect without copying secrets around.

## Before / After
**Before:** OpenRouter setup only offered env / paste / skip / clear.

**After:**
- `/setup` → OpenRouter → **Sign in with browser** opens `openrouter.ai/auth`, waits on a loopback callback, exchanges the code at `/api/v1/auth/keys`, stores the key, then continues to model pick.
- ACP `initialize.authMethods` includes `openrouter_browser`.
- Pasted keys and `OPENROUTER_API_KEY` still work.

Proof a reviewer can check:
- `complete_login_exchanges_callback_code_for_api_key` drives prepare → loopback `?code=` → POST keys exchange against a local mock and asserts the minted key.
- `setup_openrouter_login_stores_key_without_echoing_it` persists the key through the TUI event path and asserts it never appears in the transcript.
- `initialize_advertises_agent_handled_authentication` asserts both `codex_browser` and `openrouter_browser`.
- Smoke: `cargo run -- --provider llmsim -p "hi"` starts and completes (offline). A live OpenRouter browser handshake needs an interactive account and was not run here.

## Risk
- Low / Medium
- A failed or canceled login leaves the user on the credential panel; an existing stored OpenRouter key is unchanged unless the exchange succeeds. Binding `127.0.0.1` with an ephemeral port can conflict with a local firewall that blocks loopback callbacks (same class of issue as MCP OAuth).

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated [configuration.md](knowledge/specs/configuration.md), [acp.md](knowledge/specs/acp.md), and [knowledge/log.md](knowledge/log.md). README provider table now mentions browser login.

## Security

- **TM-LLM** — the minted key is written only through `SettingsStore::set_token` (existing owner-only `0o600` settings file). It is not passed through `/setup token <key>` (which would put the secret in a command string) and must not appear in the transcript (covered by test). Env `OPENROUTER_API_KEY` still overrides stored tokens.
- **PKCE** — S256 challenge/verifier, loopback bind on `127.0.0.1` with an ephemeral port, 10-minute user timeout, 30-second HTTP timeout. OpenRouter does not use a client secret; the verifier is the proof of possession.
- **TM-DEP** — no new crates; reuses `reqwest`, existing PKCE helpers, and the shared OAuth callback page.

No findings that needed a code change beyond storing the key through the existing secret path.

## Follow-ups

- Live interactive OpenRouter browser handshake is not in CI — it needs a real OpenRouter account and a desktop browser. Manual `/setup` sign-in is the remaining smoke.
- No device-code path: OpenRouter's PKCE docs only describe the browser callback flow.

Made with [Cursor](https://cursor.com)