### PR TITLE
chore(knowledge): add manual test scenarios collection

### DIFF
--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -59,3 +59,8 @@ and [`docs/`](../docs/); it must not link back into this internal bundle.
 - [Release](specs/release.md) — publishing crates and Homebrew releases.
 - [Documentation](specs/documentation.md) — public/internal documentation contract.
 - [Agent context](specs/agent-context.md) — how AGENTS.md, knowledge, and skills are layered.
+
+## Verification
+
+- [Manual test scenarios](test-scenarios/index.md) — flows verified by hand because
+  the automated suite cannot reach them.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,19 @@
 Significant changes to Yolop's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
+## 2026-08-14 — Manual test scenarios collection
+
+- Added [manual test scenarios](test-scenarios/index.md), a home for flows the
+  automated suite cannot reach — live provider, network, or a judgement about
+  what the terminal actually shows. Scenarios supplement the shipping bar's
+  automated-test requirement; they never replace it.
+- First scenario covers installing a skills.sh skill mid-session and rendering
+  its Mermaid answer as a terminal diagram.
+- [Release](specs/release.md) now draws its smoke paths from the collection:
+  impact analysis picks which scenarios a cut walks, so a release stops
+  improvising a smoke path. The manual terminal matrix stays in the release
+  spec, which owns the gate requiring it.
+
 ## 2026-08-14 — OpenRouter PKCE browser login
 
 - [Configuration](specs/configuration.md) records that OpenRouter can mint a
@@ -10,6 +23,17 @@ wording, formatting, and link fixes do not need entries.
   `tokens.openrouter` like a pasted key.
 - [ACP](specs/acp.md) advertises `openrouter_browser` alongside `codex_browser`
   so editors can connect OpenRouter without a pre-set environment variable.
+
+## 2026-08-14 — Registry skill install reaches real sessions
+
+- `search_skills` / `install_skill` / `delete_skill` were registered but never
+  enabled in the default coding harness, so no session ever exposed them while
+  [Skills](specs/skills.md) and the README documented them. The harness now
+  enables `yolop_skill_management`, and the cold-start guard asserts the three
+  tools reach the assembled session rather than only the capability.
+- Tool descriptions are provider-visible even when schemas are deferred, so the
+  three registry tools dropped the workflow prose the skill-management skill
+  already owns.
 
 ## 2026-08-12 — Streaming workspace grep
 
@@ -394,27 +418,3 @@ wording, formatting, and link fixes do not need entries.
   artifact exists.
 - Non-discoverable owner-private coordination locks preserve fail-fast
   simultaneous-open safety before the event log is materialized.
-
-## 2026-08-14 — Registry skill install reaches real sessions
-
-- `search_skills` / `install_skill` / `delete_skill` were registered but never
-  enabled in the default coding harness, so no session ever exposed them while
-  [Skills](specs/skills.md) and the README documented them. The harness now
-  enables `yolop_skill_management`, and the cold-start guard asserts the three
-  tools reach the assembled session rather than only the capability.
-- Tool descriptions are provider-visible even when schemas are deferred, so the
-  three registry tools dropped the workflow prose the skill-management skill
-  already owns.
-
-## 2026-08-14 — Manual test scenarios collection
-
-- Added [manual test scenarios](test-scenarios/index.md), a home for flows the
-  automated suite cannot reach — live provider, network, or a judgement about
-  what the terminal actually shows. Scenarios supplement the shipping bar's
-  automated-test requirement; they never replace it.
-- First scenario covers installing a skills.sh skill mid-session and rendering
-  its Mermaid answer as a terminal diagram.
-- [Release](specs/release.md) now draws its smoke paths from the collection:
-  impact analysis picks which scenarios a cut walks, so a release stops
-  improvising a smoke path. The manual terminal matrix stays in the release
-  spec, which owns the gate requiring it.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -405,3 +405,12 @@ wording, formatting, and link fixes do not need entries.
 - Tool descriptions are provider-visible even when schemas are deferred, so the
   three registry tools dropped the workflow prose the skill-management skill
   already owns.
+
+## 2026-08-14 — Manual test scenarios collection
+
+- Added [manual test scenarios](test-scenarios/index.md), a home for flows the
+  automated suite cannot reach — live provider, network, or a judgement about
+  what the terminal actually shows. Scenarios supplement the shipping bar's
+  automated-test requirement; they never replace it.
+- First scenario covers installing a skills.sh skill mid-session and rendering
+  its Mermaid answer as a terminal diagram.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -414,3 +414,7 @@ wording, formatting, and link fixes do not need entries.
   automated-test requirement; they never replace it.
 - First scenario covers installing a skills.sh skill mid-session and rendering
   its Mermaid answer as a terminal diagram.
+- [Release](specs/release.md) now draws its smoke paths from the collection:
+  impact analysis picks which scenarios a cut walks, so a release stops
+  improvising a smoke path. The manual terminal matrix stays in the release
+  spec, which owns the gate requiring it.

--- a/knowledge/specs/release.md
+++ b/knowledge/specs/release.md
@@ -163,6 +163,13 @@ The agent verifies before opening the release PR:
 - [ ] `X.Y.Z` is greater than the latest crates.io version.
 - [ ] Manual terminal matrix walked (see below) if the TUI renderer changed.
 
+Which end-to-end paths to smoke follows from what the release changed. Work out
+that impact from the commits since the previous tag, then draw the paths from
+[manual test scenarios](../test-scenarios/index.md) — each one already states a
+setup and acceptance criteria, so a release walks a known path instead of
+improvising a new one per cut. A release whose impact no scenario covers is a
+gap in the collection worth filling rather than a reason to skip the smoke.
+
 ## Manual Terminal Matrix
 
 The automated tests cover the *protocol* the terminal renderer emits — the

--- a/knowledge/test-scenarios/index.md
+++ b/knowledge/test-scenarios/index.md
@@ -1,0 +1,47 @@
+# Manual test scenarios
+
+Scenarios a person or agent runs by hand against a real Yolop build, kept here
+because the automated suite cannot reach them. Each one names an observable
+outcome and the acceptance criteria that decide pass or fail.
+
+A scenario earns a place here only when `cargo test` cannot own it. The usual
+reasons are a live provider, network access, a real terminal, or a judgement
+call about what the screen looks like. Anything that a test could assert belongs
+in a test instead — see [`shipping.md`](../specs/shipping.md), which still
+requires an automated test for every behavior change. These scenarios are
+additional coverage, never a substitute.
+
+## Scenarios
+
+| Scenario | Area | Needs |
+| --- | --- | --- |
+| [Install a registry skill and render its diagram](skill-install-mermaid-render.md) | Skills, transcript rendering | Live provider, network |
+
+## Running one
+
+Build first (`cargo build`), then follow the scenario's Setup and Steps exactly.
+Record the result as pass or fail against the acceptance criteria — not against
+whether the run "looked fine". A scenario that passes for the wrong reason is
+worse than one that fails.
+
+Where a scenario has known-benign variation — a model wording things
+differently, a diagram laid out differently — it says so under Expected
+variation. Treat anything outside that as a failure worth reporting.
+
+## Adding one
+
+Name the file for the outcome it verifies, not the feature it touches, and give
+it OKF frontmatter with `type: Test Scenario`. Cover these sections:
+
+- **Purpose** — the outcome under test, and why an automated test cannot own it.
+- **Preconditions** — credentials, network, platform, terminal size.
+- **Setup** — commands that put the workspace in a known state. Point at a
+  checked-in fixture script rather than restating steps; a script stays true,
+  prose drifts.
+- **Steps** — what the operator types, verbatim.
+- **Acceptance criteria** — each one independently checkable, phrased so two
+  people would agree on pass or fail.
+- **Expected variation** and **Known failure modes** — what is benign, and what
+  looks like a product bug but is not.
+
+Then add a row to the table above.

--- a/knowledge/test-scenarios/index.md
+++ b/knowledge/test-scenarios/index.md
@@ -17,6 +17,22 @@ additional coverage, never a substitute.
 | --- | --- | --- |
 | [Install a registry skill and render its diagram](skill-install-mermaid-render.md) | Skills, transcript rendering | Live provider, network |
 
+## Related manual checks
+
+Not every manual check belongs here. Two live elsewhere because another concept
+owns when they run:
+
+- The [manual terminal matrix](../specs/release.md#manual-terminal-matrix) —
+  walking `yolop tuika-gallery` across real emulators — stays in the release
+  spec, which owns the pre-release gate that requires it.
+- [`surfaces.md`](../../.agents/skills/maintenance/surfaces.md) carries the
+  commands a maintenance pass runs by hand. It checks repository health, not
+  product behavior.
+
+[Release](../specs/release.md#pre-release-checklist) draws its smoke paths from
+the scenarios below, so keeping them current is what keeps a release cut from
+improvising one.
+
 ## Running one
 
 Build first (`cargo build`), then follow the scenario's Setup and Steps exactly.

--- a/knowledge/test-scenarios/skill-install-mermaid-render.md
+++ b/knowledge/test-scenarios/skill-install-mermaid-render.md
@@ -1,0 +1,117 @@
+---
+type: Test Scenario
+title: Install a registry skill and render its diagram
+description: Verifies that a skills.sh skill installs mid-session and that a Mermaid fence from it paints as a terminal diagram.
+---
+
+# Install a registry skill and render its diagram
+
+## Purpose
+
+One session must be able to install a skill it does not have and immediately
+answer with it, and a Mermaid fence in that answer must paint as a diagram
+rather than as source.
+
+Neither half is reachable from `cargo test`. The install needs the live
+[skills.sh](https://skills.sh) registry over the network, and the answer needs a
+live provider — a simulated one will not choose to call `search_skills`. The
+rendering half is asserted in unit tests at fixed widths
+(`markdown_mermaid_fence_renders_as_a_diagram`), but only a real terminal shows
+whether a real model's diagram fits the transcript it actually gets.
+
+## Preconditions
+
+- `cargo build` has run; `target/debug/yolop` exists.
+- A live provider is authenticated. `ANTHROPIC_API_KEY` via `doppler run` is the
+  reference setup.
+- Outbound network access to `skills.sh`.
+- A terminal at least 150 columns wide. Below roughly 120 the diagram is
+  expected to fall back to source — see Known failure modes.
+
+## Setup
+
+Run the checked-in fixture, which writes a disposable source-only project to
+`/tmp/yolop-show-me-orbit` and removes any previously installed copy of the
+skill:
+
+```bash
+docs/features/show-me/demo-setup.sh
+```
+
+Start the agent against it:
+
+```bash
+doppler run -- target/debug/yolop -C /tmp/yolop-show-me-orbit --provider anthropic
+```
+
+## Steps
+
+1. Ask for the skill by name:
+
+   > Find a skill called show-me in the skills registry and install the
+   > humanlayer one into this workspace.
+
+2. In the same session, ask it to explain the fixture visually:
+
+   > Use the show-me skill: how does a repository deletion request flow through
+   > this service? Answer with one mermaid sequence diagram over Client, HTTP,
+   > Shard, Workflow, Tokens and Git. Keep the labels short.
+
+## Acceptance criteria
+
+**Skill installed**
+
+1. The transcript shows a `search_skills` call followed by an `install_skill`
+   call. A `write_skill` call instead means the registry tools were unreachable
+   and the model fell back to fetching files by hand — that is a failure of this
+   scenario even though the skill ends up on disk.
+2. `/tmp/yolop-show-me-orbit/.agents/skills/show-me/SKILL.md` exists after the
+   first turn.
+3. Its contents match what the registry serves, byte for byte:
+
+   ```bash
+   sha256sum /tmp/yolop-show-me-orbit/.agents/skills/show-me/SKILL.md
+   curl -sS https://skills.sh/api/download/humanlayer/skills/show-me \
+     | python3 -c "import hashlib,json,sys; print(hashlib.sha256([f for f in json.load(sys.stdin)['files'] if f['path']=='SKILL.md'][0]['contents'].encode()).hexdigest())"
+   ```
+
+4. The skill is used in the second turn without restarting the session.
+
+**Mermaid diagram rendered**
+
+5. The second answer paints participant boxes and lifelines with box-drawing
+   characters (`─`, `│`, `>`), with each participant name inside a box.
+6. The literal text `sequenceDiagram` does not appear in the transcript. Seeing
+   it means the fence fell back to a source code block.
+7. The diagram sits in the transcript under the `agent ›` gutter, not spilling
+   past the right edge or wrapping mid-box.
+
+## Expected variation
+
+The model chooses its own participants, message labels, and prose. Step counts
+and wording differ run to run, and the diagram may include return arrows one run
+and not the next. None of that fails the scenario — criteria 5 through 7 are
+about the render, not the content.
+
+The registry install count reported by `search_skills` changes over time, and
+other `show-me` skills from other owners appear in the results. Only
+`humanlayer/skills/show-me` matters.
+
+## Known failure modes
+
+- **Diagram appears as source.** Usually the transcript-width guard, not a bug:
+  Yolop falls back to the code block when any rendered line is wider than the
+  transcript, so a diagram with long participant aliases and full argument lists
+  can need over 200 columns. Widen the terminal or ask for shorter labels and
+  re-run before reporting it. See [`tuika.md`](../specs/tuika.md).
+- **Model invents steps the fixture does not contain.** A model failure, not a
+  Yolop one. Worth noting in the result, but it does not fail criteria 5–7.
+- **Install reports success but no tool call is visible.** Check whether the
+  transcript was scrolled; tool rows are collapsed in some layouts.
+
+## Related
+
+- [`skills.md`](../specs/skills.md) — scopes, precedence, and the registry tools.
+- [`tuika.md`](../specs/tuika.md) — the rendering seam this exercises.
+- [Registry skills and Mermaid diagrams](../../docs/features/show-me/show-me.md)
+  — the public guide, whose recording is this scenario run once.


### PR DESCRIPTION
## What changed

Manual verification gets a home. `knowledge/test-scenarios/` collects flows a
person or agent runs by hand, each stating a setup and acceptance criteria that
decide pass or fail. The first scenario covers installing a skills.sh skill
mid-session and rendering its Mermaid answer as a terminal diagram.

A release now draws its smoke paths from that collection: impact analysis over
the commits since the previous tag picks which scenarios a cut walks, instead of
each cut improvising one.

## Why

Flows needing a live provider, network access, or a judgement about what the
terminal actually paints cannot be reached from `cargo test`. They were verified
ad hoc, so the acceptance criteria lived in whoever ran them last — and the
`/release` smoke had no stated source for which paths to walk.

## Before / After

No behavior change; this is documentation. The observable difference is that
manual verification has one stated shape and one place to look:

```
before: knowledge/specs/*.md            (concepts only)
        release smoke path              chosen fresh per cut
after:  knowledge/test-scenarios/       index + scenarios, each with criteria
        release smoke path              picked from scenarios by impact
```

The scenario's mechanical steps were rehearsed end to end before committing —
fixture setup, a live install turn, then acceptance criteria 2 and 3 verbatim:

```console
$ docs/features/show-me/demo-setup.sh          # SETUP OK, clean start confirmed
$ doppler run -- target/debug/yolop -C /tmp/yolop-show-me-orbit --provider anthropic \
    -p "Find a skill called show-me ... install the humanlayer one"
  Source: humanlayer/skills/show-me   Scope: workspace   Path: .agents/skills/show-me

$ sha256sum /tmp/yolop-show-me-orbit/.agents/skills/show-me/SKILL.md
bea6da70a58096730b9aeb0bae293ddf4726103a98efc9ce13c481619942a810
$ curl -sS https://skills.sh/api/download/humanlayer/skills/show-me | …
bea6da70a58096730b9aeb0bae293ddf4726103a98efc9ce13c481619942a810
```

The rendering half of the scenario is the flow captured in
[`docs/features/show-me/`](docs/features/show-me/show-me.md), landed in #564.

## Risk

- Low
- Markdown only; no Rust file is touched, so no runtime behavior can change.
- The one way this bites is drift: a scenario that stops matching the product is
  worse than no scenario. The index states the bar for belonging, and the
  release checklist now depends on the collection, which is what should keep it
  current.

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

Tests are not added: the change is documentation with no behavior to drive.
`python3 scripts/validate_okf.py knowledge --check-links` (38 concepts, 0
errors) and the public-docs boundary grep are the lints that gate it, and both
pass. Per [`shipping.md`](knowledge/specs/shipping.md) § Constraints, a
docs-only change may skip code tests with the choice justified.

## Knowledge

This change *is* knowledge. Added `test-scenarios/index.md` and the first
scenario, listed the collection under a new Verification section in
`knowledge/index.md`, and pointed
[`release.md`](knowledge/specs/release.md) § Pre-Release Checklist at it.

The manual terminal matrix stays in `release.md`, which owns the pre-release
gate that requires it; the collection links to it rather than claiming it, so
each check keeps one owner. `surfaces.md` is likewise named and scoped as
repository health, not product behavior.

`knowledge/log.md` also gets an ordering fix: the log reads newest-first, but
both of today's entries had been appended to the end, landing them among
2026-08-05 material.

## Security

No security-relevant code changes — Markdown only, no runtime, configuration,
or dependency surface touched.

## Follow-ups

- [`shipping.md`](knowledge/specs/shipping.md) outcome 6 also mandates a smoke
  test, and `/ship` runs far more often than `/release`, so the same pointer
  would likely pay off more there. Deferred deliberately: the ownership call was
  scoped to release, and extending it is a separate decision.
- The collection has one scenario. It is worth adding a second before the shape
  in the index hardens, since one example is thin evidence that the section
  headings generalize.
- An older ordering wrinkle remains near the end of `knowledge/log.md`
  (2026-07-31 sits above 2026-08-05). Pre-existing on `main` and left alone to
  keep this diff readable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01StzR8uXo7iQccF1VDnfS5U)_