### PR TITLE
test(tuika): gate the tmux gallery render on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,31 @@ jobs:
       - name: Build
         run: cargo build --locked --all-targets
 
+      - name: Install tmux
+        run: sudo apt-get update && sudo apt-get install -y tmux
+
+      # `tuika_pty` asserts the bytes yolop *emits*, parsed by the vt100 crate.
+      # This asserts what a real, independent terminal implementation *paints*
+      # from those bytes. Same recipe as the nightly job's tmux leg, run per-PR
+      # so a renderer regression surfaces at review time rather than up to a day
+      # later — and so a release can cite a run against its own commit.
+      - name: Gallery renders under tmux
+        env:
+          TERM: tmux-256color
+          YOLOP_HYPERLINKS: "1"
+        run: |
+          set -euo pipefail
+          BIN="$PWD/target/debug/yolop"
+          tmux -f /dev/null new-session -d -x 120 -y 40 -s gallery "$BIN tuika-gallery"
+          sleep 4
+          tmux capture-pane -t gallery -p > capture.txt || true
+          tmux send-keys -t gallery q || true
+          sleep 1
+          tmux kill-server 2>/dev/null || true
+          echo "----- capture -----"
+          cat capture.txt
+          bash scripts/assert-gallery.sh capture.txt
+
       - name: Unit and integration tests with coverage
         # The live provider tests skip themselves here (no API keys and
         # YOLOP_REQUIRE_LIVE_TESTS unset); they run in the `live-smoke` job below.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
               - 'rust-toolchain.toml'
               - '**/build.rs'
               - '.github/workflows/ci.yml'
+              # The tmux gallery gate runs in this job; a change that weakens
+              # the assertion must re-run it even with no Rust touched.
+              - 'scripts/assert-gallery.sh'
             docs:
               - '**/*.md'
             # The regression-gate analyzers under harness_basic are pure Python

--- a/.github/workflows/nightly-terminals.yml
+++ b/.github/workflows/nightly-terminals.yml
@@ -5,9 +5,10 @@ name: Nightly Terminals
 # this runs `yolop tuika-gallery` inside *real* terminal emulators nightly to
 # check how they actually interpret those bytes.
 #
-# Maturity differs by leg (see knowledge/specs/release.md § Manual Terminal Matrix):
+# Maturity differs by leg (see knowledge/specs/release.md § Terminal Verification):
 #   - tmux (Linux): text-capture via `capture-pane`, asserted — a regression
-#     here fails the nightly.
+#     here fails the nightly. `ci.yml` runs this same capture per-PR, so the
+#     nightly leg is a scheduled re-check rather than the only gate.
 #   - kitty / iTerm2 / Windows Terminal: GPU- or OS-locked GUI terminals driven
 #     best-effort. They capture text and/or a screenshot as build artifacts for
 #     human inspection and do not fail the nightly yet (`continue-on-error`).
@@ -70,7 +71,7 @@ jobs:
           cat capture.txt
 
       - name: Assert the gallery rendered
-        run: bash scripts/nightly-assert-gallery.sh capture.txt
+        run: bash scripts/assert-gallery.sh capture.txt
 
       - name: Upload capture
         if: always()
@@ -110,7 +111,7 @@ jobs:
 
       - name: Assert (non-fatal)
         run: |
-          bash scripts/nightly-assert-gallery.sh capture.txt \
+          bash scripts/assert-gallery.sh capture.txt \
             || echo "::warning::kitty capture did not pass assertions (best-effort leg)"
 
       - name: Upload capture + screenshot
@@ -170,7 +171,7 @@ jobs:
 
       - name: Assert (non-fatal)
         run: |
-          bash scripts/nightly-assert-gallery.sh capture.txt \
+          bash scripts/assert-gallery.sh capture.txt \
             || echo "::warning::iTerm2 capture did not pass assertions (best-effort leg)"
 
       - name: Upload capture + screenshot

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,22 @@
 Significant changes to Yolop's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
+## 2026-08-15 — Terminal verification split into tiers
+
+- The release spec's "Manual Terminal Matrix" became
+  [Terminal Verification](specs/release.md#terminal-verification), organized by
+  what actually checks each row: asserted per PR, best-effort nightly, or human.
+  Presenting one undifferentiated checklist led a release to report rows as
+  unverified that CI had already gated on the same commit, and invited humans to
+  re-walk them.
+- The tmux gallery capture moved from nightly-only to `ci.yml`'s `Build + Tests`
+  job, so a real terminal implementation checks the render on every PR and a
+  release can cite a run against its own commit. `scripts/nightly-assert-gallery.sh`
+  lost its `nightly-` prefix accordingly; the nightly leg keeps running as a
+  scheduled re-check.
+- The human tier now lists GUI emulators only. tmux left the manual list because
+  a machine gates it.
+
 ## 2026-08-14 — Layered tool-call shape enforcement and repair
 
 - Added [tool-call shape enforcement](specs/tool-calling.md): compatible Codex

--- a/knowledge/specs/release.md
+++ b/knowledge/specs/release.md
@@ -161,7 +161,8 @@ The agent verifies before opening the release PR:
 - [ ] `cargo publish --dry-run` succeeds for each library crate (`-p yolop` is
       validated by CI once they are live — see § Agent Steps).
 - [ ] `X.Y.Z` is greater than the latest crates.io version.
-- [ ] Manual terminal matrix walked (see below) if the TUI renderer changed.
+- [ ] Terminal verification current (see below) if the TUI renderer changed —
+      Tier 1 green on the release commit, Tier 3 walked by a human.
 
 Which end-to-end paths to smoke follows from what the release changed. Work out
 that impact from the commits since the previous tag, then draw the paths from
@@ -170,19 +171,53 @@ setup and acceptance criteria, so a release walks a known path instead of
 improvising a new one per cut. A release whose impact no scenario covers is a
 gap in the collection worth filling rather than a reason to skip the smoke.
 
-## Manual Terminal Matrix
+## Terminal Verification
 
-The automated tests cover the *protocol* the terminal renderer emits — the
-`tests/tuika_pty.rs` PTY smoke drives the real binary and asserts alternate-screen
-enter/exit, OSC 9;4 progress, OSC 8 hyperlinks, 24-bit truecolor SGR, and Braille
-glyphs. What they cannot verify is how a specific emulator actually *paints* those
-bytes. This is a manual checklist to walk before a release when the TUI renderer
-changed, not a record of verified results — tick a box only after confirming it
-yourself.
+Terminal behavior is checked at three tiers. They are documented together
+because the failure mode is reporting the whole matrix as "unverified" when two
+of the tiers are already green: that invites a human to re-walk what a machine
+gates on every PR, and it buries the rows nobody actually checked.
 
-Run `cargo run -- tuika-gallery` in each terminal and check alt-screen
-enter/exit, Braille/wide glyphs, truecolor, mouse-wheel scroll, and — with
-`YOLOP_HYPERLINKS=1` — that the footer URL is a clickable OSC 8 link:
+### Tier 1 — asserted on every PR
+
+The `Build + Tests` job in `ci.yml` runs both of these for any change touching
+Rust, so they are green on the release commit before the release PR is cut.
+
+| Check | What it proves |
+|-------|----------------|
+| `tests/tuika_pty.rs` | Drives the real binary under a PTY and asserts against a `vt100` reference terminal: alternate-screen enter/exit, OSC 9;4 progress set **and** cleared, OSC 8 hyperlinks present when enabled and absent when not, a 24-bit truecolor RGB cell in the grid, a Braille glyph in the grid, and survival across a resize. |
+| tmux gallery capture | Runs `yolop tuika-gallery` inside real tmux at 120×40 under `TERM=tmux-256color`, gated by `scripts/assert-gallery.sh`: box chrome, a real Braille glyph, and the footer URL. This is an independent implementation *interpreting* the bytes, where `tuika_pty` parses them with a reference crate. |
+
+A release PR cites the CI run for these rows. It does not list them as
+unverified, and it does not ask a human to walk them.
+
+### Tier 2 — best-effort nightly
+
+`.github/workflows/nightly-terminals.yml` drives GUI emulators on a schedule and
+on `workflow_dispatch`. Being nightly, it can lag the commit being released —
+dispatch it against the tag when a cut needs the evidence fresh.
+
+| Leg | Runner | Capture | Status |
+|-----|--------|---------|--------|
+| kitty | Linux (Xvfb, software GL) | remote-control text + screenshot | Best-effort — captured as an artifact; assertion is a warning, not a failure. |
+| iTerm2 | macOS | AppleScript session text + `screencapture` | Best-effort — artifact for inspection. |
+| Windows Terminal | Windows | screenshot | Best-effort — artifact for inspection. |
+
+Promote a leg to Tier 1 once its capture is proven stable on the runner. The
+best-effort legs are `continue-on-error`, so a flaky GUI runner never reports the
+nightly red on its own.
+
+### Tier 3 — the human walk
+
+What no tier above reaches: how a specific GUI emulator *paints* the bytes. Walk
+this before a release when the TUI renderer changed. It is a checklist, not a
+record of results — tick a box only after confirming it yourself, and leave it
+unticked rather than inferring it from a green CI run.
+
+Run `cargo run -- tuika-gallery` in each terminal and check truecolor fidelity,
+wide and Braille glyph shaping, mouse-wheel scroll, and — with
+`YOLOP_HYPERLINKS=1` — that the footer URL is a clickable OSC 8 link with the
+surrounding text, colors, and wrapping undamaged:
 
 - [ ] Ghostty
 - [ ] iTerm2
@@ -190,7 +225,12 @@ enter/exit, Braille/wide glyphs, truecolor, mouse-wheel scroll, and — with
 - [ ] Kitty
 - [ ] Windows Terminal
 - [ ] Konsole
-- [ ] tmux (truecolor needs `Tc`/`RGB` in `terminal-overrides`)
+
+tmux is deliberately absent: Tier 1 gates it per PR. Walk it by hand only when
+changing tmux-specific behavior, where truecolor needs `Tc`/`RGB` in
+`terminal-overrides`.
+
+### Terminal capability reference
 
 **Native OSC 9;4 progress** support is a fixed property of each terminal (not
 something to re-verify per release). Terminals that render it: **Ghostty** (bar
@@ -207,31 +247,7 @@ still auto-linkified) text, so emitting it is safe everywhere. Unlike OSC 9;4,
 this one *is* worth re-checking, because it writes styled spans straight to the
 terminal: confirm the link is clickable **and** that surrounding text, colors,
 and wrapping are undamaged. In yolop it is opt-in (`YOLOP_HYPERLINKS=1`),
-default-off until this matrix is walked — that is what the checkbox above
-verifies.
-
-### Nightly cross-terminal job
-
-`.github/workflows/nightly-terminals.yml` runs `yolop tuika-gallery` inside real
-terminal emulators on a nightly schedule (and on `workflow_dispatch`), narrowing
-how much of the matrix a human has to walk. In-repo tests already prove yolop
-emits the right bytes (`tests/tuika_pty.rs` asserts the protocol and the parsed
-vt100 grid); the nightly checks how emulators *interpret* those bytes. Legs
-differ in maturity:
-
-| Leg | Runner | Capture | Status |
-|-----|--------|---------|--------|
-| tmux | Linux | `capture-pane` text | **Asserted** — `scripts/nightly-assert-gallery.sh` gates the job on the box chrome, a real Braille glyph, and the footer URL. |
-| kitty | Linux (Xvfb, software GL) | remote-control text + screenshot | Best-effort — captured as an artifact; assertion is a warning, not a failure. |
-| iTerm2 | macOS | AppleScript session text + `screencapture` | Best-effort — artifact for inspection. |
-| Windows Terminal | Windows | screenshot | Best-effort — artifact for inspection. |
-
-A green **tmux** leg means the "alt-screen / Braille / layout / footer" rows are
-already verified in a real emulator, so the manual walk reduces to the
-per-emulator painting the best-effort legs only screenshot. Promote a best-effort
-leg to asserting once its capture is proven stable on the runner. The best-effort
-legs are `continue-on-error`, so a flaky GUI runner never reports the nightly red
-on its own.
+default-off until Tier 3 is walked — that is what the checkboxes above verify.
 
 ## Post-Release Verification
 

--- a/knowledge/test-scenarios/index.md
+++ b/knowledge/test-scenarios/index.md
@@ -22,9 +22,9 @@ additional coverage, never a substitute.
 Not every manual check belongs here. Two live elsewhere because another concept
 owns when they run:
 
-- The [manual terminal matrix](../specs/release.md#manual-terminal-matrix) —
-  walking `yolop tuika-gallery` across real emulators — stays in the release
-  spec, which owns the pre-release gate that requires it.
+- The human tier of [terminal verification](../specs/release.md#terminal-verification)
+  — walking `yolop tuika-gallery` across real GUI emulators — stays in the
+  release spec, which owns the pre-release gate that requires it.
 - [`surfaces.md`](../../.agents/skills/maintenance/surfaces.md) carries the
   commands a maintenance pass runs by hand. It checks repository health, not
   product behavior.

--- a/scripts/assert-gallery.sh
+++ b/scripts/assert-gallery.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 # Assert that a captured terminal screen shows `yolop tuika-gallery` rendered
-# correctly. Used by the nightly cross-terminal workflow's text-capture legs
-# (tmux, kitty) to turn a real emulator's on-screen text into a pass/fail gate.
+# correctly — turning a real terminal's on-screen text into a pass/fail gate.
 #
-# Usage: assert_gallery.sh <capture-file>
+# Used by CI's per-PR tmux capture (Tier 1 of the release spec's terminal
+# verification) and by the nightly cross-terminal workflow's text-capture legs
+# (tmux, kitty).
+#
+# Usage: assert-gallery.sh <capture-file>
 set -euo pipefail
 
 capture="${1:?usage: assert_gallery.sh <capture-file>}"


### PR DESCRIPTION
## What changed

Terminal verification is now organized by **what actually checks each row**, and the tmux gallery capture moved from nightly-only to per-PR CI.

- `ci.yml` — the `Build + Tests` job now runs `yolop tuika-gallery` inside real tmux (120×40, `TERM=tmux-256color`, `YOLOP_HYPERLINKS=1`) and gates on `scripts/assert-gallery.sh`. It reuses the binary the job already built; cost is `apt-get install tmux` plus a ~5s capture.
- `knowledge/specs/release.md` — "Manual Terminal Matrix" became "Terminal Verification", split into three tiers: asserted per PR, best-effort nightly, and the human walk. The human checklist drops from seven rows to six.
- `scripts/nightly-assert-gallery.sh` → `scripts/assert-gallery.sh`, since CI is now a caller alongside the nightly job. All three nightly references updated.
- `nightly-terminals.yml` and `knowledge/test-scenarios/index.md` — pointer and anchor updates to match.

## Why

Cutting v0.15.1 surfaced this. The release PR reported the terminal matrix as unwalked — all seven rows — while `tests/tuika_pty.rs` had asserted five of them on that exact commit, minutes earlier, in the same CI run the PR was citing for everything else.

The spec was the cause: one undifferentiated list headed "manual checklist to walk before a release" reads as seven human rows, so that is how it gets reported. That is wrong in both directions — it asks a human to re-walk what a machine already gates, and it buries the rows genuinely nobody checked among rows that are green.

Splitting by verification tier makes the distinction structural rather than something each release has to rediscover. Moving tmux into CI then closes the remaining gap: it was already automatable on a Linux runner, it just ran nightly, so a release could not cite a run against its own commit.

### Coverage this adds

`tuika_pty` asserts the bytes yolop *emits*, parsed by the `vt100` crate. The tmux step asserts what an independent real implementation *paints* from those bytes:

| Row | `tuika_pty` | tmux capture |
|---|---|---|
| alt-screen enter/exit | asserted | box chrome on screen |
| Braille glyphs | grid cell | grid cell (U+2800 block) |
| 24-bit truecolor | RGB cell | — text capture is colorless |
| OSC 9;4 set/clear | asserted | — |
| OSC 8 on/off | both | footer URL text |
| resize | asserted | — |

Narrow but real: a second implementation, and a per-PR signal instead of per-night.

## Before / After

**Before** — the tmux render was checked only by the nightly job, so a renderer regression could sit up to a day before surfacing, and a release cut between nightlies had no run to cite.

**After** — `Build + Tests` fails on the same regression at review time. Local rehearsal of the exact step added, at `v0.15.1`:

```
$ bash scripts/assert-gallery.sh capture.txt
gallery rendered correctly in the captured terminal output
```

The capture shows box chrome, Braille spinner glyphs (`⠋`, `⠠`), progress bars at 25/60/100%, highlighted markdown, and the footer URL.

**Negative-tested**, so the gate is not vacuous — this repo has prior art there (#554):

| Input | Result |
|---|---|
| empty capture | fails as expected |
| all four required strings, no Braille glyph | fails as expected |

## Risk

- **Low.** No source changes; CI-only plus documentation. The added step runs after `Build`, before coverage, and cannot affect the coverage numbers.
- What can break: the step uses a fixed `sleep 4` before capturing, inherited from the nightly leg. A very slow runner could capture a half-painted first frame and fail spuriously. The nightly leg has run on this timing without flaking, but if it does prove flaky here the fix is a retry-until-chrome-appears loop rather than a longer sleep.
- `apt-get update && apt-get install -y tmux` adds a network dependency to a previously network-free job.

## Checklist
- [x] Tests added or updated — adds a per-PR terminal render gate; negative-tested against empty and Braille-less captures
- [x] Backward compatibility considered — no product surface touched; the renamed script has both callers updated
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated [`knowledge/specs/release.md`](knowledge/specs/release.md) (§ Terminal Verification, and the pre-release checklist line that points at it) and [`knowledge/test-scenarios/index.md`](knowledge/test-scenarios/index.md) for the renamed section and anchor. Added a `knowledge/log.md` entry.

No `knowledge/index.md` change — no concept was added, removed, renamed, or reclassified; the restructuring is within an existing concept. `validate_okf.py --check-links` passes at 38 concepts, 0 errors.

This keeps the ownership boundary #568 drew: the terminal gate stays in the release spec, and the test-scenarios collection continues to point at it rather than absorbing it.

## Security

No security-relevant code changed. CI additions are a package install and a local process capture; no secrets are read by the new step, and it runs in the existing unprivileged job. The renamed script is unchanged in behavior.

## Follow-ups

- The kitty leg is the next promotion candidate to Tier 1 — it already text-captures via remote control, and its assertion currently runs as a warning. Promote once its capture is proven stable on the runner.
- Truecolor and OSC 8 clickability remain human-only; `capture-pane` is colorless. Reaching those automatically would need a screenshot-diffing leg, which is a larger piece of work than this.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkWEmwTWN5AYHEAYnswfsW)_