### PR TITLE
fix(acp): recover provider authentication

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,13 @@
 Significant changes to Yolop's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
+## 2026-08-14 — ACP authentication recovery through setup
+
+- [ACP](specs/acp.md) now routes Codex authentication failures to `/setup` and
+  API-key failures to the secure environment/restart path; plain `/setup`
+  selects the active provider's advertised login, refreshes open sessions, and
+  invalid Codex credentials are cleared before the user signs in again.
+
 ## 2026-08-14 — Manual test scenarios collection
 
 - Added [manual test scenarios](test-scenarios/index.md), a home for flows the

--- a/knowledge/specs/acp.md
+++ b/knowledge/specs/acp.md
@@ -77,7 +77,14 @@ so clients can expose the newly connected provider's models without restarting
 the ACP process. Stable ACP does not define secure API-key entry; remaining
 key-based providers stay connectable only through the agent process
 environment. Yolop rejects `/setup token` over ACP without echoing or persisting
-the supplied value.
+the supplied value. Plain `/setup` and `/setup login` run the active provider's
+advertised login, or ask the user to choose a method when the active provider
+has none. This gives failed Codex and OpenRouter sessions an in-conversation
+recovery path even when the client does not expose its own authentication
+control. Codex authentication failures point to that command instead of generic
+support copy, while other API-key failures explain ACP's secure-input boundary
+and the environment/restart path. Invalid Codex credentials are cleared before
+reauthentication.
 
 ### Prompt content
 
@@ -143,7 +150,7 @@ notifications. The mapping is a pure, per-turn state machine
 | Runtime event | ACP update |
 |---------------|-----------|
 | assistant text delta | `agent_message_chunk` (incremental) |
-| completed assistant message, when no deltas streamed | `agent_message_chunk` (whole text) — covers providers that don't stream |
+| completed assistant message, when no deltas streamed | `agent_message_chunk` (whole text) — covers providers that don't stream; provider-authentication failures use ACP `/setup` recovery copy |
 | extended-thinking delta | `agent_thought_chunk` |
 | provider-curated reasoning summary | `agent_thought_chunk` (displayable reasoning; segments separated by blank lines) |
 | completed assistant commentary with tool calls, when no deltas streamed | `agent_message_chunk` before the tool activity |
@@ -170,8 +177,8 @@ can activate the skill.
 
 ACP v1 command input only standardises an unstructured `input.hint`. yolop also
 adds compatible extension metadata under `_meta["yolop.dev/command"]` so richer
-clients can render command argument suggestions (for example `/setup status`,
-`/setup provider openai`, or `/setup effort high`). Standard clients ignore
+clients can render command argument suggestions (for example `/setup login`,
+`/setup status`, `/setup provider openai`, or `/setup effort high`). Standard clients ignore
 this metadata and still see the command name, description, and hint. After a
 system command runs, yolop re-emits `available_commands_update` so clients can
 refresh any state-sensitive command UI.

--- a/src/drivers/codex.rs
+++ b/src/drivers/codex.rs
@@ -15,6 +15,7 @@ use everruns_core::{
     DriverId, ModelProfile, get_model_profile,
 };
 use futures::StreamExt;
+use reqwest::StatusCode;
 use reqwest::header::{HeaderMap, HeaderValue};
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -24,7 +25,8 @@ use std::sync::{Arc, Mutex};
 pub const CODEX_DRIVER_ID: &str = "openai-codex";
 const CODEX_RESPONSES_URL: &str = "https://chatgpt.com/backend-api/codex/responses";
 const CODEX_BETA_HEADER: &str = "responses=experimental";
-const REAUTH_MESSAGE: &str = "Codex login is no longer valid (refresh token already used). Run `/setup` and sign in with Codex again.";
+const REAUTH_MESSAGE: &str =
+    "Codex login is no longer valid. Run `/setup` and sign in with Codex again.";
 
 /// Host-side Codex OAuth storage. Reload must hit disk so another process that
 /// already rotated the refresh token is visible before we call `/oauth/token`.
@@ -250,6 +252,30 @@ fn classified_refresh_error(error: &anyhow::Error) -> AgentLoopError {
     AgentLoopError::llm_kind(kind, format!("Codex token refresh failed: {message}"))
 }
 
+fn codex_response_error(
+    operation: &str,
+    status: StatusCode,
+    body: String,
+    store: Option<&dyn CodexAuthStore>,
+) -> AgentLoopError {
+    let kind = LlmErrorKind::from_provider_status(status.as_u16(), &body);
+    if status == StatusCode::UNAUTHORIZED {
+        if let Some(store) = store
+            && let Err(clear_err) = store.clear()
+        {
+            tracing::warn!(error = %clear_err, "failed to clear invalid Codex auth");
+        }
+        return AgentLoopError::llm_kind(LlmErrorKind::Authentication, REAUTH_MESSAGE);
+    }
+    if kind == LlmErrorKind::Authentication {
+        return AgentLoopError::llm_kind(
+            kind,
+            "Codex access was denied. Run `/setup` to sign in again, or choose another provider.",
+        );
+    }
+    AgentLoopError::llm_kind(kind, format!("Codex {operation} error ({status}): {body}"))
+}
+
 fn adopt_disk_auth(tokens: &mut CodexTokens, store: &dyn CodexAuthStore) {
     let Some(disk) = store.load_from_disk() else {
         return;
@@ -348,9 +374,11 @@ impl ChatDriver for CodexChatDriver {
         let status = response.status();
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
-            return Err(AgentLoopError::llm_kind(
-                everruns_core::error::LlmErrorKind::from_provider_status(status.as_u16(), &body),
-                format!("Codex API error ({status}): {body}"),
+            return Err(codex_response_error(
+                "API",
+                status,
+                body,
+                self.auth_store.as_deref(),
             ));
         }
 
@@ -425,9 +453,11 @@ impl ChatDriver for CodexChatDriver {
         let status = response.status();
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
-            return Err(AgentLoopError::llm_kind(
-                everruns_core::error::LlmErrorKind::from_provider_status(status.as_u16(), &body),
-                format!("Codex compact API error ({status}): {body}"),
+            return Err(codex_response_error(
+                "compact API",
+                status,
+                body,
+                self.auth_store.as_deref(),
             ));
         }
 
@@ -1455,8 +1485,35 @@ mod tests {
         .expect_err("must fail");
 
         assert!(err.to_string().contains("/setup"));
-        assert!(err.to_string().contains("refresh token already used"));
+        assert!(err.to_string().contains("login is no longer valid"));
         assert_eq!(err.llm_error_kind(), Some(LlmErrorKind::Authentication));
+        assert!(store.load_from_disk().is_none());
+        assert_eq!(*store.clears.lock().unwrap(), 1);
+    }
+
+    #[test]
+    fn invalidated_api_token_clears_auth_and_asks_for_setup() {
+        let store = MemoryAuthStore::default();
+        store
+            .save(CodexAuth {
+                access_token: "invalidated-access".to_string(),
+                refresh_token: Some("invalidated-refresh".to_string()),
+                expires_at: None,
+                account_id: Some("acc".to_string()),
+                email: Some("user@example.com".to_string()),
+            })
+            .unwrap();
+
+        let err = codex_response_error(
+            "API",
+            StatusCode::UNAUTHORIZED,
+            r#"{"error":{"code":"token_invalidated"}}"#.to_string(),
+            Some(&store),
+        );
+
+        assert_eq!(err.llm_error_kind(), Some(LlmErrorKind::Authentication));
+        assert!(err.to_string().contains("/setup"));
+        assert!(!err.to_string().contains("token_invalidated"));
         assert!(store.load_from_disk().is_none());
         assert_eq!(*store.clears.lock().unwrap(), 1);
     }

--- a/src/editor/acp/bridge.rs
+++ b/src/editor/acp/bridge.rs
@@ -101,9 +101,11 @@ impl Translator {
                 if data.message.role != MessageRole::Agent {
                     return Vec::new();
                 }
-                let mut updates = data
-                    .message
-                    .text()
+                let recovery_message = (data.error_code.as_deref()
+                    == Some(everruns_core::user_facing_error_codes::PROVIDER_MISCONFIGURED))
+                .then(|| provider_authentication_message(data.error_fields.as_ref()));
+                let mut updates = recovery_message
+                    .or_else(|| data.message.text())
                     .map(str::trim)
                     .filter(|text| !text.is_empty())
                     .map(|text| vec![SessionUpdate::AgentMessageChunk(protocol::text_chunk(text))])
@@ -228,6 +230,25 @@ impl Translator {
                 updates
             }
             _ => Vec::new(),
+        }
+    }
+}
+
+fn provider_authentication_message(
+    fields: Option<&everruns_core::user_facing_error::UserFacingErrorFields>,
+) -> &'static str {
+    let provider = fields
+        .and_then(|fields| fields.get("provider"))
+        .and_then(Value::as_str);
+    match provider {
+        Some("codex" | "openai-codex") => {
+            "Codex authentication failed. Run `/setup` to sign in again, or choose another connected model."
+        }
+        Some("openrouter") => {
+            "OpenRouter authentication failed. Run `/setup` to sign in again, or choose another connected model."
+        }
+        _ => {
+            "AI provider authentication failed. API keys cannot be entered securely over ACP; update the provider credentials in the agent process environment and restart it, or choose another connected model."
         }
     }
 }
@@ -419,6 +440,53 @@ mod tests {
                 "full answer"
             ))]
         );
+    }
+
+    #[test]
+    fn provider_authentication_failure_points_to_acp_setup() {
+        let mut t = Translator::new();
+        let updates = t.on_event(&event(EventData::OutputMessageCompleted(
+            OutputMessageCompletedData {
+                message: Message::assistant(
+                    "There is a misconfiguration with the AI provider. Please contact support.",
+                ),
+                metadata: None,
+                usage: None,
+                error_code: Some(
+                    everruns_core::user_facing_error_codes::PROVIDER_MISCONFIGURED.to_string(),
+                ),
+                error_fields: Some(std::collections::BTreeMap::from([(
+                    "provider".to_string(),
+                    json!("openai-codex"),
+                )])),
+                error_disclosure: None,
+            },
+        )));
+
+        assert_eq!(
+            updates,
+            vec![SessionUpdate::AgentMessageChunk(protocol::text_chunk(
+                "Codex authentication failed. Run `/setup` to sign in again, or choose another connected model."
+            ))]
+        );
+    }
+
+    #[test]
+    fn api_key_authentication_failure_explains_acp_secret_boundary() {
+        let fields = std::collections::BTreeMap::from([("provider".to_string(), json!("openai"))]);
+
+        assert!(
+            provider_authentication_message(Some(&fields))
+                .contains("cannot be entered securely over ACP")
+        );
+    }
+
+    #[test]
+    fn openrouter_authentication_failure_points_to_acp_setup() {
+        let fields =
+            std::collections::BTreeMap::from([("provider".to_string(), json!("openrouter"))]);
+
+        assert!(provider_authentication_message(Some(&fields)).contains("Run `/setup`"));
     }
 
     #[test]

--- a/src/editor/acp/mod.rs
+++ b/src/editor/acp/mod.rs
@@ -1473,7 +1473,8 @@ mod tests {
             .as_array()
             .expect("setup suggestions");
         assert!(
-            suggestions.iter().any(|s| s == "status")
+            suggestions.iter().any(|s| s == "login")
+                && suggestions.iter().any(|s| s == "status")
                 && suggestions.iter().any(|s| s == "provider openai"),
             "expected setup choices in command metadata, got: {setup:?}"
         );
@@ -1514,6 +1515,67 @@ mod tests {
             "slash command should not invoke the model"
         );
         assert!(!run.updates_of_kind("available_commands_update").is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn plain_setup_runs_advertised_acp_authentication() {
+        let run = with_sdk_client(fixed("model should not run"), |client| async move {
+            let mut session = client.new_session().await?;
+            let _ = collect_available_commands(&mut session).await?;
+            SdkClient::prompt(&mut session, "/setup").await
+        })
+        .await;
+
+        assert_eq!(run.stop_reason, StopReason::EndTurn);
+        let completed = run
+            .updates_of_kind("tool_call_update")
+            .into_iter()
+            .find(|update| update["status"] == "completed")
+            .expect("completed setup login");
+        assert_eq!(completed["rawOutput"]["success"], true);
+        assert!(
+            completed["content"][0]["content"]["text"]
+                .as_str()
+                .is_some_and(|text| text.contains("Authentication refreshed")),
+            "expected authentication recovery output, got: {completed:?}"
+        );
+        let config_update = run
+            .updates_of_kind("config_option_update")
+            .into_iter()
+            .next()
+            .expect("model options refreshed after setup login");
+        assert!(
+            config_update["configOptions"][0]["options"]
+                .as_array()
+                .expect("model options")
+                .iter()
+                .any(|option| option["value"]
+                    .as_str()
+                    .is_some_and(|value| value.starts_with("openai:"))),
+            "authenticated provider must become selectable: {config_update:?}"
+        );
+        assert!(!run.assistant_text().contains("model should not run"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn provider_authentication_failure_has_actionable_recovery() {
+        use everruns_core::llmsim_driver::SimError;
+
+        let config = LlmSimConfig::scripted(vec![SimTurn::Error(SimError::Authentication)]);
+        let run = with_sdk_client(config, |client| async move {
+            let mut session = client.new_session().await?;
+            let _ = collect_available_commands(&mut session).await?;
+            SdkClient::prompt(&mut session, "continue the task").await
+        })
+        .await;
+
+        let text = run.assistant_text();
+        assert!(
+            text.contains("authentication failed")
+                && text.contains("cannot be entered securely over ACP"),
+            "expected actionable authentication recovery, got: {text}"
+        );
+        assert!(!text.contains("contact support"));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/editor/acp/server.rs
+++ b/src/editor/acp/server.rs
@@ -895,7 +895,7 @@ async fn handle_prompt<F: RuntimeFactory>(
         session.completion_budget.lock().unwrap().reset();
     }
     let stop_reason = match parsed_command {
-        Some(command) => run_slash_command(peer, session.clone(), command).await,
+        Some(command) => run_slash_command(server, peer, session.clone(), command).await,
         None => run_prompt(peer, session.clone(), prompt, input).await,
     };
     // A level changed mid-turn (the `set_approval_mode` tool, `/setup approval`)
@@ -1021,11 +1021,15 @@ fn command_meta(command: &CommandDescriptor) -> Option<serde_json::Map<String, V
         "yolop.dev/command": {
             "source": source,
             "args": command.args.iter().map(|arg| {
+                let mut suggestions = arg.suggestions.clone();
+                if command.name == "setup" && !suggestions.iter().any(|value| value == "login") {
+                    suggestions.insert(0, "login".to_string());
+                }
                 json!({
                     "name": arg.name,
                     "description": arg.description,
                     "required": arg.required,
-                    "suggestions": arg.suggestions,
+                    "suggestions": suggestions,
                 })
             }).collect::<Vec<_>>()
         }
@@ -1083,7 +1087,8 @@ fn parse_shell_shortcut(rest: &str) -> ParsedCommand {
     }
 }
 
-async fn run_slash_command(
+async fn run_slash_command<F: RuntimeFactory>(
+    server: &Arc<Server<F>>,
     peer: Arc<Peer>,
     session: Arc<Session>,
     command: ParsedCommand,
@@ -1091,6 +1096,11 @@ async fn run_slash_command(
     let name = command.name;
     let args = command.args;
     let title = command.title;
+    if name == "setup"
+        && let Some(stop_reason) = run_setup_login(server, &peer, &session, &args).await
+    {
+        return stop_reason;
+    }
     if name == "setup" && args.split_whitespace().next() == Some("token") {
         peer.session_update(
             &session.acp_id,
@@ -1202,6 +1212,129 @@ async fn run_slash_command(
             run_prompt(peer, session, text, input).await
         }
     }
+}
+
+/// ACP has no secure generic setup form, but it does have agent-handled auth
+/// methods. Treat plain `/setup` as the host's guided entry point, selecting
+/// the current provider's method when several are advertised, and expose
+/// `/setup login` as the explicit form.
+fn select_setup_auth_method(
+    methods: &[AuthMethod],
+    requested: Option<&str>,
+    active_provider: &str,
+) -> std::result::Result<Option<String>, String> {
+    let available = methods
+        .iter()
+        .map(|method| method.id().to_string())
+        .collect::<Vec<_>>();
+    if let Some(id) = requested {
+        return available
+            .contains(&id.to_string())
+            .then(|| Some(id.to_string()))
+            .ok_or_else(|| {
+                format!(
+                    "unknown authentication method `{id}`; available: {}",
+                    available.join(", ")
+                )
+            });
+    }
+
+    let active_method_id = format!("{active_provider}_browser");
+    if available.contains(&active_method_id) {
+        return Ok(Some(active_method_id));
+    }
+    if let [method_id] = available.as_slice() {
+        return Ok(Some(method_id.clone()));
+    }
+    Ok(None)
+}
+
+async fn run_setup_login<F: RuntimeFactory>(
+    server: &Arc<Server<F>>,
+    peer: &Arc<Peer>,
+    session: &Arc<Session>,
+    args: &str,
+) -> Option<StopReason> {
+    let mut parts = args.split_whitespace();
+    let requested = match parts.next() {
+        None => None,
+        Some("login" | "reauthenticate") => parts.next(),
+        Some(_) => return None,
+    };
+    let methods = server.factory.auth_methods();
+    if methods.is_empty() {
+        return None;
+    }
+    let method_id =
+        match select_setup_auth_method(&methods, requested, &session.model.provider_name()) {
+            Ok(Some(method_id)) => method_id,
+            Err(message) => {
+                peer.session_update(
+                    &session.acp_id,
+                    SessionUpdate::AgentMessageChunk(protocol::text_chunk(message)),
+                );
+                return Some(StopReason::EndTurn);
+            }
+            Ok(None) => {
+                peer.session_update(
+                    &session.acp_id,
+                    SessionUpdate::AgentMessageChunk(protocol::text_chunk(format!(
+                        "choose an authentication method with `/setup login <method>`: {}",
+                        methods
+                            .iter()
+                            .map(|method| method.id().to_string())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ))),
+                );
+                return Some(StopReason::EndTurn);
+            }
+        };
+
+    let tool_call_id = format!("command_{}", peer.next_id.fetch_add(1, Ordering::Relaxed));
+    peer.session_update(
+        &session.acp_id,
+        SessionUpdate::ToolCall(
+            ToolCall::new(tool_call_id.clone(), "/setup login")
+                .kind(ToolKind::Execute)
+                .status(ToolCallStatus::InProgress)
+                .raw_input(json!({
+                    "command": "setup",
+                    "arguments": "login",
+                    "source": "system",
+                    "authenticationMethod": method_id,
+                })),
+        ),
+    );
+
+    let result = server.factory.authenticate(&method_id).await;
+    let (success, message) = match &result {
+        Ok(()) => (
+            true,
+            "Authentication refreshed. Retry your request.".to_string(),
+        ),
+        Err(err) => (false, format!("Authentication failed: {err}")),
+    };
+    peer.session_update(
+        &session.acp_id,
+        SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+            tool_call_id,
+            ToolCallUpdateFields::new()
+                .status(if success {
+                    ToolCallStatus::Completed
+                } else {
+                    ToolCallStatus::Failed
+                })
+                .content(vec![protocol::content(message.clone())])
+                .raw_output(json!({ "success": success, "message": message })),
+        )),
+    );
+    if success {
+        for open_session in server.sessions() {
+            emit_config_options(peer, &open_session).await;
+        }
+    }
+    Some(StopReason::EndTurn)
 }
 
 fn command_title(prefix: &str, name: &str, args: &str) -> String {
@@ -1536,6 +1669,20 @@ mod tests {
         assert_eq!(value["authMethods"][0]["name"], "Sign in with ChatGPT");
         assert_eq!(value["authMethods"][1]["id"], "openrouter_browser");
         assert_eq!(value["authMethods"][1]["name"], "Sign in with OpenRouter");
+    }
+
+    #[test]
+    fn setup_authentication_prefers_the_active_provider() {
+        let methods = super::super::advertised_auth_methods();
+
+        assert_eq!(
+            select_setup_auth_method(&methods, None, "codex").unwrap(),
+            Some("codex_browser".to_string())
+        );
+        assert_eq!(
+            select_setup_auth_method(&methods, None, "openrouter").unwrap(),
+            Some("openrouter_browser".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What changed

ACP sessions now turn provider authentication failures into actionable recovery instead of the generic “contact support” message. `/setup` and `/setup login` invoke the active provider's advertised browser login, report progress through ACP tool updates, and refresh model options for every open session after success.

Codex HTTP 401 responses clear invalid stored authentication and return a sanitized `/setup` instruction. OpenRouter authentication failures use the same ACP recovery path; API-key providers explain ACP's secure-input boundary and the environment/restart path. `/setup token` remains rejected without echoing credentials.

## Why

An invalidated Codex token currently appears in ACP as an AI-provider misconfiguration with no way to recover in conversation. Users need to be able to reauthenticate through `/setup`, while secret-bearing API-key setup must remain outside ACP.

## Before / After

Before:

```text
There is a misconfiguration with the AI provider. Please contact support.
```

After, for Codex:

```text
Codex authentication failed. Run `/setup` to sign in again, or choose another connected model.
```

The ACP integration test `plain_setup_runs_advertised_acp_authentication` drives the real command entry point and verifies successful authentication plus refreshed model options. Provider-failure tests verify that support copy and provider error bodies do not leak.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test editor::acp --all-features` — 68 passed
- `cargo test drivers::codex --all-features` — 19 passed
- `cargo test --all-features -- --skip testing::scenarios::predictable_long_command_returns_immediately_and_terminal_result_is_durable` — 1,154 passed across all targets
- `python3 scripts/validate_okf.py knowledge --check-links` — 38 concepts, 0 errors

The excluded unchanged macOS timing assertion also fails in isolation because a one-second command consumes about 993 ms against its 750 ms ceiling. A separate session-lock concurrency flake from the first full run passed in isolation and in the complete rerun. Local live-provider smoke was unavailable because this worktree has no Doppler project/token or provider keys; the configured Doppler-backed CI smoke remains the merge gate.

## Risk

- Low
- Authentication errors could select the wrong recovery copy or `/setup` could select the wrong browser method when multiple methods are advertised. Unit and ACP end-to-end coverage exercise provider mapping, active-provider selection, command execution, secret rejection, and session refresh.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered — pre-1.0; existing ACP authentication methods and `/setup token` rejection are preserved
- [x] Knowledge concepts updated

## Knowledge

Updated `knowledge/specs/acp.md` and `knowledge/log.md` with the recovery contract and secure-input boundary.

## Security

Reviewed against TM-LLM. ACP continues to reject token entry and never places credentials in command input, output, or session messages. Codex 401 bodies are replaced with sanitized guidance, invalid stored credentials are cleared, and clear failures are logged without secrets. No dependencies or network trust boundaries changed.

## Follow-ups

No follow-ups.
