### PR TITLE
fix(tools): repair malformed tool call arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7847,6 +7847,7 @@ dependencies = [
  "image",
  "include_dir",
  "inventory",
+ "jsonschema",
  "landlock",
  "libc",
  "portable-pty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ tar = "0.4"
 # `.worktreeinclude` matching for copying ignored local files into worktrees.
 ignore = "0.4"
 include_dir = "0.7"
+jsonschema = { version = "0.49.2", default-features = false }
 rand = "0.10"
 ratatui = "0.30.2"
 # Already in the tree via the everruns driver crates; used directly only for

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -31,6 +31,7 @@ and [`docs/`](../docs/); it must not link back into this internal bundle.
 - [Session history](specs/session-history.md) — discovery of earlier sessions.
 - [Session titles](specs/session-titles.md) — automatic conversation titles.
 - [Skills](specs/skills.md) — reusable instruction packs.
+- [Tool calling](specs/tool-calling.md) — argument shape enforcement and bounded repair.
 - [Tool search](specs/tool-search.md) — deferred capability loading.
 - [Worktrees](specs/worktrees.md) — isolated Git workspace behavior.
 - [Yolop framing](specs/yolop.md) — requests addressed to Yolop itself.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,16 @@
 Significant changes to Yolop's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
+## 2026-08-14 — Layered tool-call shape enforcement and repair
+
+- Added [tool-call shape enforcement](specs/tool-calling.md): compatible Codex
+  schemas request strict generation, every provider is guarded by full-schema
+  pre-execution validation, and Everruns' bounded `tool_call_repair` is enabled
+  for one corrective attempt.
+- [Progress guard](specs/progress-guard.md) keeps `progress_checkpoint` eager and
+  makes array shapes explicit, while [tool search](specs/tool-search.md) records
+  the mandatory transition as part of the static eager profile.
+
 ## 2026-08-14 — ACP authentication recovery through setup
 
 - [ACP](specs/acp.md) now routes Codex authentication failures to `/setup` and

--- a/knowledge/specs/progress-guard.md
+++ b/knowledge/specs/progress-guard.md
@@ -34,6 +34,13 @@ tool can execute. The checkpoint is bounded and structured:
 - one next decisive action, classified as mutation, validation, or no-change
   diagnosis.
 
+Because the gate can make this tool the only permitted exploration transition,
+`progress_checkpoint` is never deferred: its full schema remains in the
+provider-visible tool set. Container descriptions explicitly require JSON
+arrays for `facts` and `missing_evidence`. Calls that still misshape a field are
+blocked before the checkpoint executor and receive the structured correction
+defined by [tool-call shape enforcement](tool-calling.md).
+
 An accepted checkpoint resets the exploration tranche and unlocks exploration.
 Submitting the same checkpoint again on unchanged state is rejected. Mutation
 or validation clears the gate directly, so the guard cannot trap a decisive

--- a/knowledge/specs/system-prompt.md
+++ b/knowledge/specs/system-prompt.md
@@ -200,11 +200,11 @@ would make session replay diverge from live execution.
 
 The stable prompt and tool catalogue always disclose every capability name and
 description. Only parameter schemas are progressive: the first-turn profile
-keeps repository discovery and bookkeeping schemas eager, while mutation,
-background, release/control, and specialized schemas load through
-`tool_search`. An explicitly enabled host profile may add eager schemas (LSP is
-the measured case), and extension manifests may opt individual tools out of
-deferral.
+keeps repository discovery, bookkeeping, and the mandatory progress-checkpoint
+transition eager, while mutation, background, release/control, and specialized
+schemas load through `tool_search`. An explicitly enabled host profile may add
+eager schemas (LSP is the measured case), and extension manifests may opt
+individual tools out of deferral.
 
 This policy is static for a host/session. A model classifier must not rewrite
 the system prefix from the wording of each new task; that would make cache
@@ -212,12 +212,12 @@ behavior volatile and could trap a turn in an incapable profile. Deferred tools
 remain discoverable and executable after reveal on every provider, including
 providers that require registered structured-call schemas.
 
-The composition regression records the pre-change baseline and candidate
-through the assembled runtime entry point. On the default 62-tool surface, the
-stable prompt stayed at 12,888 bytes, provider-visible tool definitions fell
-from 28,901 to 21,701 bytes (24.9%), and parameter schemas fell from 13,414 to
-6,214 bytes (53.7%). The gate requires at least 24% and 53% reductions
-respectively without prompt growth.
+The composition regression records the undeferred baseline and candidate
+through the assembled runtime entry point. On the current default surface, the
+stable prompt remains capped at 12,888 bytes, provider-visible tool definitions
+must fall by at least 24%, and parameter schemas by at least 50%. Keeping the
+mandatory checkpoint schema eager intentionally spends part of the schema
+savings so a host-required transition can never depend on schema discovery.
 
 ### The budget is a test
 

--- a/knowledge/specs/tool-calling.md
+++ b/knowledge/specs/tool-calling.md
@@ -1,0 +1,62 @@
+---
+type: Architecture Specification
+title: Tool-call shape enforcement and repair
+description: Defines layered prevention, validation, and bounded recovery for malformed model-authored tool calls.
+---
+
+# Tool-call shape enforcement and repair
+
+Status: implemented in Yolop's default coding harness.
+
+## Contract
+
+Tool arguments are untrusted model output. A provider accepting a request does
+not authorize execution, and provider-side structured generation is an
+optimization rather than the validation boundary. Yolop applies these layers:
+
+1. Tool schemas use closed objects, required fields, concrete item types, and
+   short descriptions that state error-prone container shapes. A tool required
+   by a host transition keeps its full schema loaded.
+2. The Codex Responses driver sends `strict: true` only when the advertised
+   schema fits OpenAI's Structured Outputs subset: the root is an object, every
+   object is closed, every property is required, and only known-supported
+   schema constructs occur. Deferred stubs, optional properties, and unknown
+   constructs stay best-effort (`strict: false`). Other providers retain their
+   existing driver behavior.
+3. Everruns' `tool_call_repair` capability performs bounded deterministic
+   salvage and allows one corrective re-prompt for calls it cannot salvage.
+4. Immediately before execution, Yolop validates every call against the tool's
+   full authoritative JSON Schema, including when the provider saw a deferred
+   stub. The first error blocks only that call and returns JSON containing the
+   trusted path, expected shape, received JSON type, and one-retry instruction.
+5. Individual executors retain semantic validation as defense in depth.
+
+## Diagnostic safety and bounds
+
+Validation diagnostics never include argument values or model-authored unknown
+property names. They expose JSON types and schema-authored shape metadata only,
+so credentials or user data in a malformed value are not copied into the
+transcript. Expected shapes are depth- and property-bounded, one error is
+reported per call, diagnostics are capped at 8 KiB, arguments over 1 MiB are
+rejected before execution, and compiled validators use a bounded cache.
+
+An invalid trusted schema is logged and skips the pre-execution layer for that
+tool rather than disabling execution globally; the executor remains the final
+boundary. This is a configuration defect, not a model-repair opportunity.
+
+## Provider boundary
+
+Yolop owns the Codex OAuth Responses driver and can emit its strictness flag
+directly. The shared `everruns-openai` Chat Completions adapter does not yet
+carry per-tool strictness metadata, so OpenAI API-key sessions currently rely
+on the provider-independent validation and repair layers. Strict propagation in
+that shared adapter belongs upstream; Yolop must not fork the provider crate to
+paper over the ownership boundary.
+
+## Evidence
+
+Focused tests cover strict-compatible and fallback serialization, full-schema
+validation behind a deferred stub, value-free structured corrections, valid
+pass-through, eager checkpoint disclosure, and default harness wiring. The
+feature smoke deliberately asks a live provider to call a typed tool before a
+synthetic acknowledgement.

--- a/knowledge/specs/tool-search.md
+++ b/knowledge/specs/tool-search.md
@@ -40,9 +40,10 @@ vendor was deleted and yolop now consumes upstream directly:
    *registered* definition and the model can pass real arguments. Tool execution
    always uses the real tools; only the advertised schema changes.
 
-2. **Static host-shaped eager profile.** Yolop passes only first-turn repository
-   discovery (`read_file`, `list_directory`, `grep_files`) and bookkeeping
-   (`write_todos`, `write_session_title`) to
+2. **Static host-shaped eager profile.** Yolop passes first-turn repository
+   discovery (`read_file`, `list_directory`, `grep_files`), bookkeeping
+   (`write_todos`, `write_session_title`), and the mandatory progress-guard
+   transition (`progress_checkpoint`) to
    `ToolSearchCapability::new().with_never_defer([...])`. Mutation, shell,
    background, release/control, skills, session history, web, and other
    specialized tools keep their names and descriptions visible but reveal their

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -30,6 +30,7 @@ pub(crate) mod session_tasks_override;
 pub(crate) mod skill_registry;
 pub mod skills;
 pub(crate) mod tool_approval;
+pub(crate) mod tool_argument_validation;
 pub(crate) mod tool_reveal;
 pub(crate) mod user_ask;
 pub(crate) mod worktree_cmd;
@@ -66,6 +67,9 @@ pub(crate) use progress_guard::{PROGRESS_GUARD_CAPABILITY_ID, ProgressGuardCapab
 pub(crate) use repo_map::{REPO_MAP_CAPABILITY_ID, RepoMapCapability};
 pub(crate) use session_history::{SESSION_HISTORY_CAPABILITY_ID, SessionHistoryCapability};
 pub(crate) use tool_approval::{ApprovalDecision, ToolApprovalCapability, ToolApprover};
+pub(crate) use tool_argument_validation::{
+    TOOL_ARGUMENT_VALIDATION_CAPABILITY_ID, ToolArgumentValidationCapability,
+};
 pub(crate) use user_ask::UserAskCapability;
 pub(crate) use worktree_cmd::WorktreeCapability;
 

--- a/src/capabilities/progress_guard.rs
+++ b/src/capabilities/progress_guard.rs
@@ -9,7 +9,7 @@ use everruns_core::atoms::{
     PostToolExecHook, PostToolExecHookPriority, PreToolUseDecision, PreToolUseHook,
 };
 use everruns_core::capabilities::{Capability, CapabilityStatus};
-use everruns_core::tool_types::{ToolCall, ToolDefinition, ToolResult};
+use everruns_core::tool_types::{DeferrablePolicy, ToolCall, ToolDefinition, ToolResult};
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
 use everruns_core::typed_id::SessionId;
@@ -709,7 +709,7 @@ impl Tool for ProgressCheckpointTool {
     }
 
     fn description(&self) -> &str {
-        "Submit the bounded trajectory checkpoint required by progress_guard before further exploration. State concise facts already established, one current hypothesis, the specific missing evidence, and one decisive next action. Use only when progress_guard requires it."
+        "Submit the bounded trajectory checkpoint required by progress_guard before further exploration. Pass facts and missing_evidence as JSON arrays of strings, hypothesis as one string, and next_decisive_action as an object with kind and description. Use only when progress_guard requires it."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -718,18 +718,26 @@ impl Tool for ProgressCheckpointTool {
             "properties": {
                 "facts": {
                     "type": "array",
+                    "description": "Established facts as a JSON array of 1 to 8 concise strings; do not pass one combined string.",
                     "minItems": 1,
                     "maxItems": 8,
                     "items": { "type": "string", "minLength": 1, "maxLength": 300 }
                 },
-                "hypothesis": { "type": "string", "minLength": 1, "maxLength": 600 },
+                "hypothesis": {
+                    "type": "string",
+                    "description": "The single current hypothesis that best explains the evidence.",
+                    "minLength": 1,
+                    "maxLength": 600
+                },
                 "missing_evidence": {
                     "type": "array",
+                    "description": "Evidence still needed as a JSON array of up to 6 strings; use [] when none remains, never a single string.",
                     "maxItems": 6,
                     "items": { "type": "string", "minLength": 1, "maxLength": 300 }
                 },
                 "next_decisive_action": {
                     "type": "object",
+                    "description": "Exactly one next transition: a mutation, validation, or explicit no-change decision.",
                     "properties": {
                         "kind": {
                             "type": "string",
@@ -744,6 +752,12 @@ impl Tool for ProgressCheckpointTool {
             "required": ["facts", "hypothesis", "missing_evidence", "next_decisive_action"],
             "additionalProperties": false
         })
+    }
+
+    fn deferrable_policy(&self) -> DeferrablePolicy {
+        // The progress gate can require this tool without allowing tool_search;
+        // its authoritative schema must therefore remain callable at all times.
+        DeferrablePolicy::Never
     }
 
     async fn execute(&self, arguments: Value) -> ToolExecutionResult {
@@ -1284,6 +1298,30 @@ mod tests {
                 "description": format!("validate {label}")
             }
         })
+    }
+
+    #[test]
+    fn checkpoint_schema_is_always_loaded_and_self_describing() {
+        let tool = ProgressCheckpointTool;
+        let schema = tool.parameters_schema();
+
+        assert_eq!(tool.deferrable_policy(), DeferrablePolicy::Never);
+        for field in [
+            "facts",
+            "hypothesis",
+            "missing_evidence",
+            "next_decisive_action",
+        ] {
+            assert!(
+                schema["properties"][field]["description"].is_string(),
+                "{field} needs a model-facing shape description"
+            );
+        }
+        assert_eq!(schema["properties"]["missing_evidence"]["type"], "array");
+        assert_eq!(
+            schema["properties"]["missing_evidence"]["items"]["type"],
+            "string"
+        );
     }
 
     #[tokio::test]

--- a/src/capabilities/tool_argument_validation.rs
+++ b/src/capabilities/tool_argument_validation.rs
@@ -1,0 +1,492 @@
+//! Provider-independent validation for model-authored tool arguments.
+//!
+//! Provider constrained decoding is helpful but cannot be the execution
+//! boundary: not every provider supports it, and deferred tools advertise a
+//! permissive stub. This hook validates against the authoritative full schema
+//! immediately before execution and returns a compact, value-free correction.
+
+use async_trait::async_trait;
+use everruns_core::atoms::{PreToolUseDecision, PreToolUseHook};
+use everruns_core::capabilities::{Capability, CapabilityStatus};
+use everruns_core::tool_types::{ToolCall, ToolDefinition};
+use everruns_core::traits::ToolContext;
+use jsonschema::error::ValidationErrorKind;
+use jsonschema::{Draft, Validator};
+use serde_json::{Map, Value, json};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+pub(crate) const TOOL_ARGUMENT_VALIDATION_CAPABILITY_ID: &str = "yolop_tool_argument_validation";
+const VALIDATOR_CACHE_LIMIT: usize = 128;
+const EXPECTED_SHAPE_DEPTH: usize = 3;
+const EXPECTED_OBJECT_PROPERTIES: usize = 32;
+const MAX_ARGUMENT_BYTES: usize = 1024 * 1024;
+const MAX_DIAGNOSTIC_BYTES: usize = 8 * 1024;
+const MAX_DIAGNOSTIC_STRING_CHARS: usize = 300;
+
+pub(crate) struct ToolArgumentValidationCapability;
+
+#[async_trait]
+impl Capability for ToolArgumentValidationCapability {
+    fn id(&self) -> &str {
+        TOOL_ARGUMENT_VALIDATION_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Tool Argument Validation"
+    }
+
+    fn description(&self) -> &str {
+        "Validates tool arguments against their full JSON Schema before execution and returns structured correction guidance."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Guardrails")
+    }
+
+    fn is_guardrail(&self) -> bool {
+        true
+    }
+
+    fn pre_tool_use_hooks(&self) -> Vec<Arc<dyn PreToolUseHook>> {
+        vec![Arc::new(ToolArgumentValidationHook::default())]
+    }
+}
+
+#[derive(Default)]
+struct ToolArgumentValidationHook {
+    validators: Mutex<HashMap<[u8; 32], Arc<Validator>>>,
+}
+
+impl ToolArgumentValidationHook {
+    fn validator(&self, schema: &Value) -> Result<Arc<Validator>, String> {
+        let encoded = serde_json::to_vec(schema).map_err(|error| error.to_string())?;
+        let key: [u8; 32] = Sha256::digest(encoded).into();
+        if let Some(validator) = self
+            .validators
+            .lock()
+            .expect("tool validator cache lock")
+            .get(&key)
+            .cloned()
+        {
+            return Ok(validator);
+        }
+
+        let validator = Arc::new(
+            Validator::options()
+                .with_draft(Draft::Draft202012)
+                .build(schema)
+                .map_err(|error| error.to_string())?,
+        );
+        let mut cache = self.validators.lock().expect("tool validator cache lock");
+        // Extension-provided schemas can vary. Bound persistent memory while
+        // still validating one-off schemas with the locally compiled value.
+        if cache.len() < VALIDATOR_CACHE_LIMIT {
+            cache.insert(key, validator.clone());
+        }
+        Ok(validator)
+    }
+}
+
+#[async_trait]
+impl PreToolUseHook for ToolArgumentValidationHook {
+    async fn before_exec(
+        &self,
+        tool_call: ToolCall,
+        tool_def: &ToolDefinition,
+        _context: &ToolContext,
+    ) -> PreToolUseDecision {
+        if serde_json::to_vec(&tool_call.arguments)
+            .is_ok_and(|arguments| arguments.len() > MAX_ARGUMENT_BYTES)
+        {
+            return PreToolUseDecision::Block {
+                reason: oversized_argument_diagnostic(tool_def.name(), &tool_call.arguments),
+                tool_call,
+                user_message: None,
+            };
+        }
+        let schema = tool_def.full_parameters();
+        let validator = match self.validator(schema) {
+            Ok(validator) => validator,
+            Err(error) => {
+                // Tool definitions are trusted host/extension configuration. A
+                // broken schema must be observable without disabling the tool;
+                // its executor remains the final validation boundary.
+                tracing::warn!(
+                    tool = tool_def.name(),
+                    error = %error,
+                    "skipping pre-execution validation for invalid tool schema"
+                );
+                return PreToolUseDecision::Continue(tool_call);
+            }
+        };
+
+        let Some(error) = validator.iter_errors(&tool_call.arguments).next() else {
+            return PreToolUseDecision::Continue(tool_call);
+        };
+        let reason = validation_diagnostic(tool_def.name(), schema, &tool_call.arguments, &error);
+        PreToolUseDecision::Block {
+            tool_call,
+            reason,
+            user_message: None,
+        }
+    }
+}
+
+fn validation_diagnostic(
+    tool_name: &str,
+    root_schema: &Value,
+    arguments: &Value,
+    error: &jsonschema::ValidationError<'_>,
+) -> String {
+    let mut path = error.instance_path().as_str().to_string();
+    let mut missing = false;
+    if let ValidationErrorKind::Required { property } = error.kind()
+        && let Some(property) = property.as_str()
+    {
+        path.push('/');
+        path.push_str(&escape_pointer_segment(property));
+        missing = true;
+    }
+    let (safe_path, target_schema) = schema_at_instance_path(root_schema, &path);
+    let received = if missing {
+        "missing"
+    } else {
+        arguments
+            .pointer(&safe_path)
+            .map(json_type)
+            .unwrap_or("missing")
+    };
+
+    let diagnostic = json!({
+        "error": "invalid_tool_arguments",
+        "tool": truncate_chars(tool_name, 128),
+        "path": if safe_path.is_empty() { "/".to_string() } else { truncate_chars(&safe_path, 512) },
+        "message": validation_message(error.kind()),
+        "expected": expected_shape(target_schema, 0),
+        "received": received,
+        "retryable": true,
+        "correction": "Correct the arguments to the expected shape and call this tool once more."
+    });
+    let encoded = serde_json::to_string(&diagnostic)
+        .expect("validation diagnostic contains only JSON values");
+    if encoded.len() <= MAX_DIAGNOSTIC_BYTES {
+        return encoded;
+    }
+    serde_json::to_string(&json!({
+        "error": "invalid_tool_arguments",
+        "tool": truncate_chars(tool_name, 128),
+        "path": if safe_path.is_empty() { "/".to_string() } else { truncate_chars(&safe_path, 512) },
+        "message": validation_message(error.kind()),
+        "expected": { "type": schema_type(target_schema) },
+        "received": received,
+        "retryable": true,
+        "correction": "Correct the arguments to the expected shape and call this tool once more."
+    }))
+    .expect("compact validation diagnostic contains only JSON values")
+}
+
+fn oversized_argument_diagnostic(tool_name: &str, arguments: &Value) -> String {
+    serde_json::to_string(&json!({
+        "error": "tool_arguments_too_large",
+        "tool": truncate_chars(tool_name, 128),
+        "path": "/",
+        "message": "tool arguments exceed the 1 MiB validation limit",
+        "received": json_type(arguments),
+        "retryable": false,
+        "correction": "Reduce the argument payload before calling this tool again."
+    }))
+    .expect("oversized diagnostic contains only JSON values")
+}
+
+fn validation_message(kind: &ValidationErrorKind) -> &'static str {
+    match kind {
+        ValidationErrorKind::Required { .. } => "a required argument is missing",
+        ValidationErrorKind::Type { .. } => "an argument has the wrong JSON type",
+        ValidationErrorKind::AdditionalProperties { .. } => {
+            "the object contains an unsupported argument"
+        }
+        ValidationErrorKind::Enum { .. } => "an argument is not one of the allowed values",
+        ValidationErrorKind::MinItems { .. } => "an array has too few items",
+        ValidationErrorKind::MaxItems { .. } => "an array has too many items",
+        ValidationErrorKind::MinLength { .. } => "a string is too short",
+        ValidationErrorKind::MaxLength { .. } => "a string is too long",
+        _ => "the arguments do not match the tool schema",
+    }
+}
+
+/// Follow only schema-declared properties and array indices. If an input path
+/// contains an unknown key, stop at its trusted parent so the diagnostic never
+/// reflects model-authored property names.
+fn schema_at_instance_path<'a>(schema: &'a Value, path: &str) -> (String, &'a Value) {
+    let mut current = schema;
+    let mut safe_segments = Vec::new();
+    for raw in path
+        .split('/')
+        .skip(1)
+        .filter(|segment| !segment.is_empty())
+    {
+        let segment = raw.replace("~1", "/").replace("~0", "~");
+        if current.get("type").and_then(Value::as_str) == Some("array")
+            && segment.parse::<usize>().is_ok()
+        {
+            let Some(items) = current.get("items") else {
+                break;
+            };
+            current = items;
+            safe_segments.push(segment);
+            continue;
+        }
+        let Some(property) = current
+            .get("properties")
+            .and_then(Value::as_object)
+            .and_then(|properties| properties.get(&segment))
+        else {
+            break;
+        };
+        current = property;
+        safe_segments.push(segment);
+    }
+    let safe_path = safe_segments
+        .iter()
+        .map(|segment| format!("/{}", escape_pointer_segment(segment)))
+        .collect::<String>();
+    (safe_path, current)
+}
+
+fn expected_shape(schema: &Value, depth: usize) -> Value {
+    if depth >= EXPECTED_SHAPE_DEPTH {
+        return json!({ "type": schema_type(schema) });
+    }
+    let mut shape = Map::new();
+    shape.insert("type".to_string(), Value::String(schema_type(schema)));
+    for keyword in [
+        "minItems",
+        "maxItems",
+        "minLength",
+        "maxLength",
+        "minimum",
+        "maximum",
+    ] {
+        if let Some(value) = schema.get(keyword) {
+            shape.insert(keyword.to_string(), value.clone());
+        }
+    }
+    if let Some(description) = schema.get("description").and_then(Value::as_str) {
+        shape.insert(
+            "description".to_string(),
+            Value::String(truncate_chars(description, MAX_DIAGNOSTIC_STRING_CHARS)),
+        );
+    }
+    if let Some(values) = schema.get("enum").and_then(Value::as_array) {
+        shape.insert(
+            "enum".to_string(),
+            Value::Array(values.iter().take(32).map(bounded_schema_value).collect()),
+        );
+    }
+    if let Some(items) = schema.get("items") {
+        shape.insert("items".to_string(), expected_shape(items, depth + 1));
+    }
+    if let Some(required) = schema.get("required").and_then(Value::as_array) {
+        shape.insert(
+            "required".to_string(),
+            Value::Array(required.iter().take(32).map(bounded_schema_value).collect()),
+        );
+    }
+    if let Some(properties) = schema.get("properties").and_then(Value::as_object) {
+        let properties = properties
+            .iter()
+            .take(EXPECTED_OBJECT_PROPERTIES)
+            .map(|(name, property)| {
+                (
+                    truncate_chars(name, MAX_DIAGNOSTIC_STRING_CHARS),
+                    expected_shape(property, depth + 1),
+                )
+            })
+            .collect();
+        shape.insert("properties".to_string(), Value::Object(properties));
+    }
+    Value::Object(shape)
+}
+
+fn schema_type(schema: &Value) -> String {
+    match schema.get("type") {
+        Some(Value::String(value)) => truncate_chars(value, 64),
+        Some(Value::Array(values)) => values
+            .iter()
+            .filter_map(Value::as_str)
+            .take(8)
+            .collect::<Vec<_>>()
+            .join(" | "),
+        _ if schema.get("anyOf").is_some() => "anyOf".to_string(),
+        _ => "schema".to_string(),
+    }
+}
+
+fn bounded_schema_value(value: &Value) -> Value {
+    match value {
+        Value::String(value) => Value::String(truncate_chars(value, MAX_DIAGNOSTIC_STRING_CHARS)),
+        Value::Null | Value::Bool(_) | Value::Number(_) => value.clone(),
+        Value::Array(_) | Value::Object(_) => Value::String(schema_type(value)),
+    }
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    let mut chars = value.chars();
+    let truncated = chars.by_ref().take(max_chars).collect::<String>();
+    if chars.next().is_some() {
+        format!("{truncated}…")
+    } else {
+        truncated
+    }
+}
+
+fn json_type(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(number) if number.is_i64() || number.is_u64() => "integer",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+fn escape_pointer_segment(segment: &str) -> String {
+    segment.replace('~', "~0").replace('/', "~1")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::tool_types::{BuiltinTool, DeferrablePolicy, ToolHints, ToolPolicy};
+    use everruns_core::typed_id::SessionId;
+
+    fn checkpoint_schema() -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "missing_evidence": {
+                    "type": "array",
+                    "description": "Evidence still needed as an array of strings.",
+                    "maxItems": 6,
+                    "items": { "type": "string" }
+                }
+            },
+            "required": ["missing_evidence"],
+            "additionalProperties": false
+        })
+    }
+
+    fn tool_definition(parameters: Value, full_parameters: Option<Value>) -> ToolDefinition {
+        ToolDefinition::Builtin(BuiltinTool {
+            name: "progress_checkpoint".to_string(),
+            display_name: None,
+            description: "test".to_string(),
+            parameters,
+            policy: ToolPolicy::Auto,
+            category: None,
+            deferrable: DeferrablePolicy::Automatic,
+            hints: ToolHints::default(),
+            full_parameters,
+        })
+    }
+
+    fn call(arguments: Value) -> ToolCall {
+        ToolCall {
+            id: "call-1".to_string(),
+            name: "progress_checkpoint".to_string(),
+            arguments,
+        }
+    }
+
+    #[tokio::test]
+    async fn wrong_type_is_blocked_with_structured_value_free_correction() {
+        let hook = ToolArgumentValidationHook::default();
+        let secret = "still need private-token-value";
+        let decision = hook
+            .before_exec(
+                call(json!({ "missing_evidence": secret })),
+                &tool_definition(checkpoint_schema(), None),
+                &ToolContext::new(SessionId::new()),
+            )
+            .await;
+
+        let PreToolUseDecision::Block { reason, .. } = decision else {
+            panic!("malformed arguments must be blocked");
+        };
+        let diagnostic: Value = serde_json::from_str(&reason).expect("structured correction");
+        assert_eq!(diagnostic["error"], "invalid_tool_arguments");
+        assert_eq!(diagnostic["path"], "/missing_evidence");
+        assert_eq!(diagnostic["expected"]["type"], "array");
+        assert_eq!(diagnostic["expected"]["items"]["type"], "string");
+        assert_eq!(diagnostic["received"], "string");
+        assert_eq!(diagnostic["retryable"], true);
+        assert!(!reason.contains(secret), "diagnostic must not echo values");
+    }
+
+    #[tokio::test]
+    async fn validation_uses_full_schema_when_advertised_schema_is_deferred() {
+        let hook = ToolArgumentValidationHook::default();
+        let definition = tool_definition(
+            json!({ "type": "object", "additionalProperties": true }),
+            Some(checkpoint_schema()),
+        );
+
+        let decision = hook
+            .before_exec(
+                call(json!({ "missing_evidence": "one string" })),
+                &definition,
+                &ToolContext::new(SessionId::new()),
+            )
+            .await;
+
+        assert!(matches!(decision, PreToolUseDecision::Block { .. }));
+    }
+
+    #[tokio::test]
+    async fn valid_arguments_continue_unchanged() {
+        let hook = ToolArgumentValidationHook::default();
+        let original = call(json!({ "missing_evidence": ["one check"] }));
+        let decision = hook
+            .before_exec(
+                original.clone(),
+                &tool_definition(checkpoint_schema(), None),
+                &ToolContext::new(SessionId::new()),
+            )
+            .await;
+
+        let PreToolUseDecision::Continue(actual) = decision else {
+            panic!("valid arguments must continue");
+        };
+        assert_eq!(actual.arguments, original.arguments);
+    }
+
+    #[tokio::test]
+    async fn oversized_arguments_are_blocked_without_echoing_content() {
+        let hook = ToolArgumentValidationHook::default();
+        let marker = "private-oversized-value";
+        let decision = hook
+            .before_exec(
+                call(json!({
+                    "missing_evidence": [format!("{marker}{}", "x".repeat(MAX_ARGUMENT_BYTES))]
+                })),
+                &tool_definition(checkpoint_schema(), None),
+                &ToolContext::new(SessionId::new()),
+            )
+            .await;
+
+        let PreToolUseDecision::Block { reason, .. } = decision else {
+            panic!("oversized arguments must be blocked");
+        };
+        assert!(reason.contains("tool_arguments_too_large"));
+        assert!(!reason.contains(marker));
+        assert!(reason.len() <= MAX_DIAGNOSTIC_BYTES);
+    }
+}

--- a/src/drivers/codex.rs
+++ b/src/drivers/codex.rs
@@ -578,6 +578,7 @@ struct CodexTool {
     name: String,
     description: String,
     parameters: Value,
+    strict: bool,
 }
 
 #[derive(Clone, Default)]
@@ -774,13 +775,136 @@ fn repair_unpaired_function_items(input: Vec<CodexInputItem>) -> Vec<CodexInputI
 fn convert_tools(tools: &[ToolDefinition]) -> Vec<CodexTool> {
     tools
         .iter()
-        .map(|tool| CodexTool {
-            r#type: "function".to_string(),
-            name: tool.name().to_string(),
-            description: tool.description().to_string(),
-            parameters: sanitize_parameters(tool.parameters()),
+        .map(|tool| {
+            let parameters = sanitize_parameters(tool.parameters());
+            CodexTool {
+                r#type: "function".to_string(),
+                name: tool.name().to_string(),
+                description: tool.description().to_string(),
+                strict: openai_strict_schema_compatible(&parameters),
+                parameters,
+            }
         })
         .collect()
+}
+
+/// OpenAI strict tool schemas require closed objects with every property named
+/// in `required`. Stay conservative: an unsupported construct falls back to the
+/// provider's ordinary best-effort decoding and the host validator remains the
+/// authoritative execution boundary.
+fn openai_strict_schema_compatible(schema: &Value) -> bool {
+    fn visit(schema: &Value, depth: usize, property_count: &mut usize) -> bool {
+        if depth > 10 {
+            return false;
+        }
+        let Some(object) = schema.as_object() else {
+            return false;
+        };
+        const SUPPORTED: &[&str] = &[
+            "$defs",
+            "$ref",
+            "additionalProperties",
+            "anyOf",
+            "const",
+            "description",
+            "enum",
+            "exclusiveMaximum",
+            "exclusiveMinimum",
+            "format",
+            "items",
+            "maxItems",
+            "maxLength",
+            "maxProperties",
+            "maximum",
+            "minItems",
+            "minLength",
+            "minProperties",
+            "minimum",
+            "multipleOf",
+            "pattern",
+            "properties",
+            "required",
+            "title",
+            "type",
+            "uniqueItems",
+        ];
+        if object.keys().any(|key| !SUPPORTED.contains(&key.as_str())) {
+            return false;
+        }
+
+        if object.get("type").and_then(Value::as_str) == Some("object") {
+            if object.get("additionalProperties") != Some(&Value::Bool(false)) {
+                return false;
+            }
+            let Some(properties) = object.get("properties").and_then(Value::as_object) else {
+                return false;
+            };
+            let Some(required_values) = object.get("required").and_then(Value::as_array) else {
+                return false;
+            };
+            let required = required_values
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<std::collections::HashSet<_>>();
+            if required.len() != required_values.len()
+                || required.len() != properties.len()
+                || properties
+                    .keys()
+                    .any(|key| !required.contains(key.as_str()))
+            {
+                return false;
+            }
+            *property_count += properties.len();
+            if *property_count > 5_000
+                || properties
+                    .values()
+                    .any(|property| !visit(property, depth + 1, property_count))
+            {
+                return false;
+            }
+        }
+
+        if object
+            .get("items")
+            .is_some_and(|child| !visit(child, depth + 1, property_count))
+        {
+            return false;
+        }
+        if let Some(any_of) = object.get("anyOf") {
+            let Some(children) = any_of.as_array() else {
+                return false;
+            };
+            if children.is_empty()
+                || children
+                    .iter()
+                    .any(|child| !visit(child, depth + 1, property_count))
+            {
+                return false;
+            }
+        }
+        if let Some(definitions) = object.get("$defs") {
+            let Some(definitions) = definitions.as_object() else {
+                return false;
+            };
+            if definitions
+                .values()
+                .any(|child| !visit(child, depth + 1, property_count))
+            {
+                return false;
+            }
+        }
+        true
+    }
+
+    // This byte bound is stricter than OpenAI's 120k aggregate limit for
+    // schema-authored names/enum/const strings and is cheap to establish.
+    if schema.get("type").and_then(Value::as_str) != Some("object")
+        || !serde_json::to_vec(schema).is_ok_and(|encoded| encoded.len() <= 120_000)
+    {
+        return false;
+    }
+    let mut property_count = 0;
+    visit(schema, 1, &mut property_count)
 }
 
 fn sanitize_parameters(params: &Value) -> Value {
@@ -1082,6 +1206,9 @@ fn metadata_extra_i64(metadata: &ProviderMetadata, key: &str) -> Option<i64> {
 mod tests {
     use super::*;
     use everruns_core::driver_registry::{LlmMessage, LlmMessageRole};
+    use everruns_core::tool_types::{
+        BuiltinTool, DeferrablePolicy, ToolDefinition, ToolHints, ToolPolicy,
+    };
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::sync::Mutex as StdMutex;
@@ -1137,6 +1264,74 @@ mod tests {
             refresh_gate: Arc::new(tokio::sync::Mutex::new(())),
             auth_store: None,
         }
+    }
+
+    fn tool_with_schema(name: &str, parameters: Value) -> ToolDefinition {
+        ToolDefinition::Builtin(BuiltinTool {
+            name: name.to_string(),
+            display_name: None,
+            description: "test tool".to_string(),
+            parameters,
+            policy: ToolPolicy::Auto,
+            category: None,
+            deferrable: DeferrablePolicy::Automatic,
+            hints: ToolHints::default(),
+            full_parameters: None,
+        })
+    }
+
+    #[test]
+    fn compatible_tool_schema_requests_strict_decoding() {
+        let tools = convert_tools(&[tool_with_schema(
+            "checkpoint",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "missing_evidence": {
+                        "type": "array",
+                        "items": { "type": "string" }
+                    }
+                },
+                "required": ["missing_evidence"],
+                "additionalProperties": false
+            }),
+        )]);
+        let wire = serde_json::to_value(tools).expect("serialize tools");
+
+        assert_eq!(wire[0]["strict"], true);
+    }
+
+    #[test]
+    fn permissive_or_optional_tool_schema_does_not_request_strict_decoding() {
+        let tools = convert_tools(&[
+            tool_with_schema(
+                "deferred",
+                serde_json::json!({ "type": "object", "additionalProperties": true }),
+            ),
+            tool_with_schema(
+                "optional",
+                serde_json::json!({
+                    "type": "object",
+                    "properties": { "value": { "type": "string" } },
+                    "required": [],
+                    "additionalProperties": false
+                }),
+            ),
+            tool_with_schema(
+                "malformed",
+                serde_json::json!({
+                    "type": "object",
+                    "properties": "not-an-object",
+                    "required": [],
+                    "additionalProperties": false
+                }),
+            ),
+        ]);
+        let wire = serde_json::to_value(tools).expect("serialize tools");
+
+        assert_eq!(wire[0]["strict"], false);
+        assert_eq!(wire[1]["strict"], false);
+        assert_eq!(wire[2]["strict"], false);
     }
 
     fn serve_one_json_response(response_body: &'static str) -> (String, mpsc::Receiver<String>) {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -27,8 +27,9 @@ use crate::capabilities::{
     LspCapability, MODEL_RUNTIME_CONTEXT_CAPABILITY_ID, MODELS_CAPABILITY_ID,
     ModelRuntimeContextCapability, ModelsCapability, PROGRESS_GUARD_CAPABILITY_ID,
     ProgressGuardCapability, REPO_MAP_CAPABILITY_ID, RepoMapCapability,
-    SESSION_HISTORY_CAPABILITY_ID, SessionHistoryCapability, USER_ASK_CAPABILITY_ID,
-    UserAskCapability, WorktreeCapability,
+    SESSION_HISTORY_CAPABILITY_ID, SessionHistoryCapability,
+    TOOL_ARGUMENT_VALIDATION_CAPABILITY_ID, ToolArgumentValidationCapability,
+    USER_ASK_CAPABILITY_ID, UserAskCapability, WorktreeCapability,
 };
 use crate::config::capability_settings::{CapabilityCatalog, apply_capability_settings};
 use crate::config::mcp::McpConfigStore;
@@ -54,9 +55,10 @@ use everruns_core::capabilities::{
     SESSION_STORAGE_CAPABILITY_ID, SESSION_TASKS_CAPABILITY_ID, SKILLS_CAPABILITY_ID,
     STATELESS_TODO_LIST_CAPABILITY_ID, SUBAGENTS_CAPABILITY_ID, ScopedSkillsCapability,
     SessionCapability, SessionStorageCapability, StatelessTodoListCapability, SubagentCapability,
-    TOOL_OUTPUT_PERSISTENCE_CAPABILITY_ID, TOOL_SEARCH_CAPABILITY_ID,
-    ToolOutputPersistenceCapability, ToolSearchCapability, USER_HOOKS_CAPABILITY_ID,
-    UserHooksCapability, WEB_FETCH_CAPABILITY_ID, WebFetchCapability,
+    TOOL_CALL_REPAIR_CAPABILITY_ID, TOOL_OUTPUT_PERSISTENCE_CAPABILITY_ID,
+    TOOL_SEARCH_CAPABILITY_ID, ToolCallRepairCapability, ToolOutputPersistenceCapability,
+    ToolSearchCapability, USER_HOOKS_CAPABILITY_ID, UserHooksCapability, WEB_FETCH_CAPABILITY_ID,
+    WebFetchCapability,
 };
 use everruns_core::command::CommandDescriptor;
 use everruns_core::driver_registry::{DriverRegistry, ProviderMetadata};
@@ -1207,6 +1209,9 @@ const YOLOP_NEVER_DEFER_TOOLS: &[&str] = &[
     "grep_files",
     "write_todos",
     "write_session_title",
+    // progress_guard can make this the only allowed transition, so the model
+    // must never need tool_search to recover its argument shape.
+    "progress_checkpoint",
     // LSP tools exist only when the optional `lsp` capability is enabled
     // (absent names are ignored by the allowlist). Enabling that host profile
     // is an explicit task-shaped signal, and the LSP adoption eval showed that
@@ -2326,6 +2331,11 @@ fn default_coding_harness_capabilities(client_commands: bool) -> Vec<AgentCapabi
         AgentCapabilityConfig::new(CONTEXT_COST_CONTROL_CAPABILITY_ID),
         AgentCapabilityConfig::new(STATELESS_TODO_LIST_CAPABILITY_ID),
         AgentCapabilityConfig::new(LOOP_DETECTION_CAPABILITY_ID),
+        AgentCapabilityConfig::new(TOOL_ARGUMENT_VALIDATION_CAPABILITY_ID),
+        AgentCapabilityConfig::with_config(
+            TOOL_CALL_REPAIR_CAPABILITY_ID,
+            serde_json::json!({ "max_reprompts": 1 }),
+        ),
         AgentCapabilityConfig::new(PROGRESS_GUARD_CAPABILITY_ID),
         AgentCapabilityConfig::new(PROMPT_CACHING_CAPABILITY_ID),
         // Provider-agnostic deferred tool loading. Core tools stay fully
@@ -3487,6 +3497,8 @@ pub async fn build_with_options(
     capabilities.register(ContextCostControlCapability);
     capabilities.register(StatelessTodoListCapability);
     capabilities.register(LoopDetectionCapability);
+    capabilities.register(ToolArgumentValidationCapability);
+    capabilities.register(ToolCallRepairCapability);
     capabilities.register(PromptCachingCapability::new());
     // Provider-agnostic deferred tool loading (upstream `everruns-core`, 0.11.0+).
     // Defers the long tail behind a `tool_search` tool and restores real schemas
@@ -4158,6 +4170,22 @@ mod tests {
     }
 
     #[test]
+    fn default_harness_enables_bounded_tool_call_validation_and_repair() {
+        let caps = default_coding_harness_capabilities(false);
+        let validation = caps
+            .iter()
+            .find(|capability| capability.capability_id() == "yolop_tool_argument_validation")
+            .expect("host-side tool argument validation must be enabled");
+        let repair = caps
+            .iter()
+            .find(|capability| capability.capability_id() == "tool_call_repair")
+            .expect("upstream tool-call repair must be enabled");
+
+        assert_eq!(validation.config, serde_json::json!({}));
+        assert_eq!(repair.config, serde_json::json!({ "max_reprompts": 1 }));
+    }
+
+    #[test]
     fn harness_prompt_leaves_project_files_framing_to_the_capability() {
         // The agent_instructions capability owns the <agent-instructions>
         // framing, so the base prompt must not hardcode project-file rules.
@@ -4492,6 +4520,88 @@ mod tests {
                 .expect("read workspace metadata")
                 .expect("workspace metadata present");
         assert_eq!(metadata.title.as_deref(), Some("Automatic session titles"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn real_turn_blocks_misshaped_arguments_then_accepts_one_correction() {
+        use everruns_core::events::EventData;
+        use everruns_core::llmsim_driver::{SimToolCall, SimTurn};
+
+        let workspace = tempfile::tempdir().expect("workspace");
+        std::fs::write(workspace.path().join("evidence.txt"), "confirmed\n")
+            .expect("seed evidence");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+        let options = BuildOptions {
+            llmsim_override: Some(LlmSimConfig::scripted(vec![
+                SimTurn::ToolCalls(vec![SimToolCall {
+                    name: "read_file".to_string(),
+                    arguments: serde_json::json!({
+                        "path": ["private-value-must-not-echo"]
+                    }),
+                    id: None,
+                }]),
+                SimTurn::ToolCalls(vec![SimToolCall {
+                    name: "read_file".to_string(),
+                    arguments: serde_json::json!({ "path": "evidence.txt" }),
+                    id: None,
+                }]),
+                SimTurn::Assistant("Correction accepted.".to_string()),
+            ])),
+            ..BuildOptions::default()
+        };
+        let built = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Sim,
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            options,
+        )
+        .await
+        .expect("build runtime");
+
+        let result = built
+            .handles
+            .run_checkpointed_turn(
+                "Exercise tool argument correction.",
+                built
+                    .model
+                    .input_message("Exercise tool argument correction."),
+            )
+            .await
+            .expect("run correction turn");
+        assert!(result.success, "correction turn: {result:?}");
+        assert_eq!(result.tool_calls_count, 2);
+
+        let events = built
+            .handles
+            .runtime
+            .events()
+            .await
+            .expect("runtime events");
+        let completed = events
+            .iter()
+            .filter_map(|event| match &event.data {
+                EventData::ToolCompleted(data) if data.tool_name == "read_file" => Some(data),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(completed.len(), 2);
+        let error = completed[0].error.as_deref().expect("validation error");
+        assert!(error.contains("invalid_tool_arguments"), "{error}");
+        assert!(error.contains("\"path\":\"/path\""), "{error}");
+        assert!(!error.contains("private-value-must-not-echo"));
+        assert!(
+            completed[1].success,
+            "corrected call should execute: {:?}",
+            completed[1].error
+        );
+        assert!(events.iter().any(|event| matches!(
+            &event.data,
+            EventData::ToolCallRepaired(data)
+                if data.tool_name == "read_file" && data.outcome == "re-prompt"
+        )));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -7698,6 +7808,7 @@ mod tests {
             "grep_files",
             "write_todos",
             "write_session_title",
+            "progress_checkpoint",
         ];
         let deferred = [
             "write_file",
@@ -7989,8 +8100,8 @@ mod tests {
             "provider-visible tool bytes must fall by at least 24%: {tool_definition_bytes} vs {BASELINE_TOOL_DEFINITION_BYTES}"
         );
         assert!(
-            schema_bytes * 100 <= BASELINE_SCHEMA_BYTES * 47,
-            "schema bytes must fall by at least 53%: {schema_bytes} vs {BASELINE_SCHEMA_BYTES}"
+            schema_bytes * 100 <= BASELINE_SCHEMA_BYTES * 50,
+            "schema bytes must fall by at least 50%: {schema_bytes} vs {BASELINE_SCHEMA_BYTES}"
         );
     }
 


### PR DESCRIPTION
## What changed

- keep `progress_checkpoint` fully described and callable when the progress gate requires it;
- request strict function arguments from the Codex Responses backend only for schemas inside OpenAI's supported strict subset;
- validate every provider's model-authored arguments against the full authoritative JSON Schema immediately before execution;
- return one bounded, machine-readable correction without echoing argument values, and enable Everruns' one-attempt `tool_call_repair` recovery;
- document the layered tool-call contract and the intentional cold-start schema-budget tradeoff.

## Why

The progress guard could require `progress_checkpoint` while tool search had replaced its schema with a permissive stub. A model could then emit a plausible but misshaped call, such as a string for `missing_evidence`, and receive only a generic tool failure. Provider constrained decoding helps where available, but it cannot protect every provider or the execution boundary.

## Before / After

Before: `missing_evidence: "what remains"` reached the checkpoint executor and surfaced `missing_evidence must be an array` as a generic tool error.

After: the checkpoint array shapes stay visible; compatible Codex schemas use `strict: true`; malformed calls are blocked before execution with JSON containing the trusted path, expected shape, received JSON type, and retry guidance. A corrected call succeeds on the next model step. The runtime feature test observes both `tool_call_repair` outcome `re-prompt` and the successful corrected call.

Keeping the mandatory checkpoint eager changes the default cold-start schema reduction from the previous 53% floor to a measured 50.5%; the regression floor is now 50%.

## Risk

- Medium
- Pre-execution validation applies to every tool. Invalid trusted schemas log and fall through to the executor, while argument payloads over 1 MiB are blocked. Diagnostics are value-free and capped at 8 KiB; the compiled-validator cache is capped at 128 entries.
- Codex requests now include `strict`; incompatible, optional, permissive, malformed, or unsupported schemas explicitly use `strict: false`.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered — Yolop is pre-1.0; valid calls are unchanged and invalid calls now fail earlier with structured guidance
- [x] Knowledge concepts updated

Validation:

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `python3 scripts/validate_okf.py knowledge --check-links`
- `cargo test --all-features -- --skip predictable_long_command_returns_immediately_and_terminal_result_is_durable` — 1,099 unit, 57 integration, 1 parallel integration, and 5 PTY tests passed
- the skipped timing test also fails unchanged `origin/main` in an isolated worktree (1.40s versus its 750ms bound), so it is not introduced by this branch
- live Codex OAuth smoke called `write_todos` with synthetic data and returned `TOOL_SHAPE_SMOKE_OK`

## Knowledge

Added `tool-calling.md`; updated progress guard, tool search, system prompt composition, the knowledge index, and the knowledge log.

## Security

Reviewed model-authored arguments as untrusted input. Validation occurs before side effects against full schemas, including deferred tools. Error output excludes argument values and unknown model-authored keys. Arguments, diagnostics, schema-shape rendering, and the validator cache are bounded. Invalid trusted schemas do not create a global denial of service; execution falls back to each tool's existing validation boundary.

## Follow-ups

- Add per-tool strictness propagation to the shared upstream `everruns-openai` Chat Completions adapter. Yolop owns the Codex Responses driver but should not fork the shared provider crate; API-key OpenAI sessions are protected by the provider-independent validation and repair layers meanwhile.
