### PR TITLE
chore(deps): bump tuika to 0.9 and companion crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -219,7 +219,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1453,7 +1453,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1654,7 +1654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3509,9 +3509,9 @@ dependencies = [
 
 [[package]]
 name = "mmdflux"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc3d57274846e2bab54eeb7e77e5418c76b8ea3e3ef4c5808daf73e1e68b89a6"
+checksum = "c78ba54627b01d793871184731714c11b41796326207c1fb8fd378e118800721"
 dependencies = [
  "pest",
  "pest_derive",
@@ -3594,7 +3594,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3895,7 +3895,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4606,7 +4606,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5145,7 +5145,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5213,7 +5213,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5747,7 +5747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5990,7 +5990,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6023,7 +6023,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6794,9 +6794,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuika"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df8ce9b27d3a5e4541ead23a9c187a2923b5c33a8dad162e390d5817f902523"
+checksum = "60cab8af397e3adbb2ce6b8332f786aefde23a7772e102e603726be450f6fcee"
 dependencies = [
  "crossterm",
  "pulldown-cmark",
@@ -6809,9 +6809,9 @@ dependencies = [
 
 [[package]]
 name = "tuika-codeformatters"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca76bf36ab565bba6b0530d86b7573c5169827d06d06d85968451c17baebefb7"
+checksum = "2ffda969ca27726ab0dc390492bd377abcf60db210a67e449100be15932da09f"
 dependencies = [
  "ratatui",
  "tree-sitter",
@@ -6834,9 +6834,9 @@ dependencies = [
 
 [[package]]
 name = "tuika-html"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa712e61a5a2a039dc0620efdc23bc93f184f64f5bc7a8aff39397f21217eb53"
+checksum = "cce2e679d1f8c26110ed09e967c2150580510d725cc961b5b87460768001708d"
 dependencies = [
  "html5ever 0.39.0",
  "markup5ever_rcdom 0.39.0+unofficial",
@@ -6846,9 +6846,9 @@ dependencies = [
 
 [[package]]
 name = "tuika-mermaid"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0b44ac0edd2f8dd94cea82479857d9a5afc47fcef7d76a7854d3b7be853426a"
+checksum = "a6fd512d4916f4f0dbee1cf8dea859a7b0c8edf2bd8bea668f125fd8fac82acb"
 dependencies = [
  "mmdflux",
  "ratatui-core",
@@ -7440,7 +7440,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,14 +71,14 @@ textwrap = "0.16"
 # The TUI toolkit behind both renderers. It lives in its own repository
 # (everruns/tuika) and is consumed from crates.io like any other dependency;
 # yolop gets no special treatment there.
-tuika = "0.8.0"
+tuika = "0.9.0"
 # Optional structured-markdown renderers stay outside tuika core. Mermaid
 # fences become terminal diagrams; safe block HTML becomes styled text.
-tuika-mermaid = "0.2.0"
-tuika-html = "0.1.0"
+tuika-mermaid = "0.3.0"
+tuika-html = "0.1.2"
 # Tree-sitter Highlighter impl for tuika's CodeBlock/Markdown; owns the grammar
 # deps so tuika core stays dependency-light. Published from the tuika repo.
-tuika-codeformatters = "0.4.0"
+tuika-codeformatters = "0.4.2"
 tokio = { version = "1.52", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tree-sitter = "0.26"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1072,21 +1072,25 @@ fn run_tuika_gallery() -> Result<()> {
         // default, and split-footer mode is for hosts that publish scrollback.
         ..tuika::RunnerConfig::default()
     });
+    // The gallery has no state of its own, so the closure seam (`from_fn`) is
+    // cheaper than naming an `Application` type for a unit state.
     let mut state = ();
     runner.run_with_backend(
         &theme,
         backend,
-        &mut state,
-        |_state, frame| build_gallery(frame, &theme),
-        |_state, signal| match signal {
-            tuika::Signal::Event(tuika::Event::Key(key))
-                if matches!(key.code, tuika::KeyCode::Esc | tuika::KeyCode::Char('q'))
-                    || (key.ctrl && matches!(key.code, tuika::KeyCode::Char('c'))) =>
-            {
-                tuika::UpdateResult::Exit
-            }
-            _ => tuika::UpdateResult::Dirty,
-        },
+        tuika::runner::from_fn(
+            &mut state,
+            |_state, frame| build_gallery(frame, &theme),
+            |_state, signal| match signal {
+                tuika::Signal::Event(tuika::Event::Key(key))
+                    if matches!(key.code, tuika::KeyCode::Esc | tuika::KeyCode::Char('q'))
+                        || (key.ctrl && matches!(key.code, tuika::KeyCode::Char('c'))) =>
+                {
+                    tuika::UpdateResult::Exit
+                }
+                _ => tuika::UpdateResult::Dirty,
+            },
+        ),
     )?;
     progress.clear();
     Ok(())


### PR DESCRIPTION
## What changed

Moves the TUI toolkit forward: `tuika` 0.8.0 → 0.9.0, `tuika-mermaid` 0.2.0 → 0.3.0, `tuika-html` 0.1.0 → 0.1.2, `tuika-codeformatters` 0.4.0 → 0.4.2 (plus `mmdflux` 2.6.0 → 2.6.1 transitively).

tuika 0.9 collapses the runner's `state` + `view` + `update` argument triple into a single `FrameSource` seam. The only affected call site is the hidden `tuika-gallery` demo, which has no state of its own, so it adapts through the closure seam (`tuika::runner::from_fn`) rather than naming an `Application` type for a unit state. No other host code needed changes.

No user-visible behavior change.

## Why

Keep the toolkit dependency current so future work can build on the 0.9 runner surface, and pick up the companion-crate patch releases. The companion crates pin a compatible `tuika` range, so they move together with the core bump.

## Before / After

No observable behavior change — this is a dependency bump plus a call-shape adaptation. The evidence is that the existing PTY coverage of the changed code path still passes against the new runner:

```
$ cargo test --all-features
test result: ok. 1092 passed; 0 failed   (unit)
test result: ok. 58 passed; 0 failed     (integration)
test result: ok. 5 passed; 0 failed      (tests/tuika_pty.rs)
test result: ok. 1 passed; 0 failed      (parallel_integration)
```

`tests/tuika_pty.rs` drives the real `yolop tuika-gallery` binary under a PTY and is the direct feature test for the rewritten call: alt-screen entry/exit, OSC 9;4 native progress, OSC 8 hyperlink emission (both enabled and disabled), truecolor + braille painting, and resize all still pass.

Smoke test, offline:

```
$ cargo run -- --provider llmsim -p "hi"
I'm running in offline mode (llmsim — no API key set). ...
```

The live-provider smoke ran in CI rather than locally — this environment has no Doppler credentials — and the **Live Provider Smoke (Doppler)** job passed on this branch.

Also verified `ratatui` still resolves to a single version across yolop and the toolkit, per `knowledge/specs/tuika.md`:

```
$ cargo tree -i ratatui
ratatui v0.30.2
├── tuika-codeformatters v0.4.2
└── yolop v0.15.1
```

`cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` are clean.

## Risk

- Low
- A toolkit minor bump can shift rendering details that assertions don't cover. The PTY gallery suite covers the protocol-level surface (alt screen, progress, hyperlinks, truecolor, resize); pixel-level layout drift in the transcript would not be caught by tests and would show up in manual terminal checks.

## Checklist
- [x] Tests added or updated — existing `tests/tuika_pty.rs` already covers the changed call path; no new test needed for a call-shape adaptation with no behavior change.
- [x] Backward compatibility considered — yolop is pre-1.0 and this changes no public surface; the breaking change is inbound from tuika and absorbed at the single call site.
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

`No knowledge update required` — `knowledge/specs/tuika.md` describes the yolop/tuika split and the companion-crates-move-together rule, both of which this change follows rather than changes. It pins no versions and does not document the runner's argument shape, so nothing in the bundle went stale.

## Security

**TM-DEP** is the only relevant category. No new crates are introduced — four existing toolkit dependencies from the same upstream (`everruns/tuika`) move to newer published versions, plus one transitive patch bump. Nothing else applies: no change to `tools.rs` or the bounded shell execution model (**TM-BASH**), no change to the write blocklist or workspace read boundary (**TM-FS**), no change to prompt construction or key handling (**TM-LLM**), and no new capability registration (**TM-TOOL**). The one source edit rewrites a demo call site's argument shape and introduces no new input, parsing, or unbounded work.

## Follow-ups

`No follow-ups.`