### PR TITLE
chore(release): prepare v0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,33 @@ mechanical `### What's Changed` list of merged PRs.
 Releases are cut via [`/release`](./.agents/skills/release/SKILL.md), which
 tags the version and publishes to crates.io and the Homebrew tap.
 
+## [0.15.2] - 2026-08-15
+
+### Highlights
+
+- OpenRouter can be authenticated from the browser: `--provider openrouter` runs a PKCE login instead of requiring a hand-pasted key.
+- Terra and Luna model variants join the OpenAI and Codex selectors, listed ahead of Sol.
+- Malformed tool calls no longer reach execution — every provider's model-authored arguments are validated against the authoritative JSON Schema first, and `progress_checkpoint` stays callable when the progress gate demands it.
+- ACP recovers provider authentication mid-session rather than stalling on an expired credential.
+- The tmux gallery render is now gated on every PR by a real terminal implementation, so the release spec's terminal matrix reserves the human walk for GUI emulators.
+
+### Breaking Changes
+
+- None. The `feat` commits in this release are additive — a new browser login path for an existing provider and new entries in the model selectors — so nothing that worked on 0.15.1 changes behavior and the release is cut as a patch.
+
+### What's Changed
+
+* chore(deps): bump tuika to 0.9 and companion crates ([#573](https://github.com/everruns/yolop/pull/573)) by @chaliy
+* fix(tools): repair malformed tool call arguments ([#572](https://github.com/everruns/yolop/pull/572)) by @chaliy
+* feat(models): add Terra and Luna variants ([#571](https://github.com/everruns/yolop/pull/571)) by @chaliy
+* fix(acp): recover provider authentication ([#570](https://github.com/everruns/yolop/pull/570)) by @chaliy
+* test(tuika): gate the tmux gallery render on every PR ([#569](https://github.com/everruns/yolop/pull/569)) by @chaliy
+* chore(knowledge): add manual test scenarios collection ([#568](https://github.com/everruns/yolop/pull/568)) by @chaliy
+* feat(auth): add OpenRouter PKCE browser login ([#567](https://github.com/everruns/yolop/pull/567)) by @chaliy
+* fix(ollama): use literal loopback default ([#566](https://github.com/everruns/yolop/pull/566)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/yolop/compare/v0.15.1...v0.15.2
+
 ## [0.15.1] - 2026-08-15
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7814,7 +7814,7 @@ dependencies = [
 
 [[package]]
 name = "yolop"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "yolop"
-version = "0.15.1"
+version = "0.15.2"
 edition = "2024"
 authors = ["Everruns <support@everruns.com>"]
 license = "MIT"


### PR DESCRIPTION
## What changed

Cuts yolop **v0.15.2**. Bumps `version` in `Cargo.toml` (and the matching
`Cargo.lock` entry) from 0.15.1 to 0.15.2 and adds the `[0.15.2]` changelog
section. `yolop-yep` is untouched by this release window, so it stays at 0.3.0
and `publish.yml` will skip it as already live.

Cut as a **patch**. The window carries two `feat` commits, but both are purely
additive — a new browser login path for a provider that already existed, and new
entries in the model selectors — so no user-visible behavior changes, following
the same call made for 0.15.1.

## Why

Eight PRs have merged to `main` since v0.15.1 — an OpenRouter PKCE login, Terra
and Luna model variants, tool-argument validation, ACP auth recovery, and the
per-PR tmux gallery gate — and none of them are on crates.io or the Homebrew tap
yet.

## Before / After

**Before:** crates.io serves `yolop = "0.15.1"`; the tap formula points at
`v0.15.1`.

**After (post-merge, via CI):** tag `v0.15.2`, a GitHub Release with binaries for
the three CLI targets, `yolop 0.15.2` on crates.io, and the tap formula pointing
at `v0.15.2`.

No source behavior changes in this PR itself — it is a version bump plus
changelog.

## Release notes

### Highlights

- OpenRouter can be authenticated from the browser: `--provider openrouter` runs a PKCE login instead of requiring a hand-pasted key.
- Terra and Luna model variants join the OpenAI and Codex selectors, listed ahead of Sol.
- Malformed tool calls no longer reach execution — every provider's model-authored arguments are validated against the authoritative JSON Schema first, and `progress_checkpoint` stays callable when the progress gate demands it.
- ACP recovers provider authentication mid-session rather than stalling on an expired credential.
- The tmux gallery render is now gated on every PR by a real terminal implementation, so the release spec's terminal matrix reserves the human walk for GUI emulators.

### Breaking Changes

- None. The `feat` commits in this release are additive — a new browser login path for an existing provider and new entries in the model selectors — so nothing that worked on 0.15.1 changes behavior and the release is cut as a patch.

### What's Changed

* chore(deps): bump tuika to 0.9 and companion crates ([#573](https://github.com/everruns/yolop/pull/573)) by @chaliy
* fix(tools): repair malformed tool call arguments ([#572](https://github.com/everruns/yolop/pull/572)) by @chaliy
* feat(models): add Terra and Luna variants ([#571](https://github.com/everruns/yolop/pull/571)) by @chaliy
* fix(acp): recover provider authentication ([#570](https://github.com/everruns/yolop/pull/570)) by @chaliy
* test(tuika): gate the tmux gallery render on every PR ([#569](https://github.com/everruns/yolop/pull/569)) by @chaliy
* chore(knowledge): add manual test scenarios collection ([#568](https://github.com/everruns/yolop/pull/568)) by @chaliy
* feat(auth): add OpenRouter PKCE browser login ([#567](https://github.com/everruns/yolop/pull/567)) by @chaliy
* fix(ollama): use literal loopback default ([#566](https://github.com/everruns/yolop/pull/566)) by @chaliy

**Full Changelog**: https://github.com/everruns/yolop/compare/v0.15.1...v0.15.2

## Publish-readiness

| Check | Result |
|-------|--------|
| `cargo fmt --check` | clean |
| `cargo clippy --all-targets --all-features -- -D warnings` | clean |
| `cargo test --all-features` | 1157 passed, 0 failed, 0 ignored |
| `python3 scripts/validate_okf.py knowledge --check-links` | 39 concepts, 0 errors |
| `cargo run -- --provider llmsim -p "hi"` | responds, exit 0 |
| `cargo publish --dry-run -p yolop-yep` | packaged 11 files, verified, upload aborted for dry run |
| crates.io currently serves | `yolop = "0.15.1"`, `yolop-yep = "0.3.0"` |
| `Cargo.toml` / `Cargo.lock` agree | both read `0.15.2` |

`cargo publish --dry-run -p yolop` is not run locally — it resolves `yolop-yep`
from crates.io, and CI validates yolop's own publish after the SDK step. Here the
SDK is unchanged at 0.3.0 and already live, so `publish.yml` will skip it and go
straight to `yolop`.

Commit history was verified against a full (un-shallowed) clone: 8 commits
between `v0.15.1` and `main`, all 8 listed above.

## Terminal verification

Tier 1 is green on the release base commit `785ad54` — CI run
[31868550110](https://github.com/everruns/yolop/actions/runs/31868550110) covers
both `tests/tuika_pty.rs` and the tmux gallery capture, and both also pass
locally on this branch.

This window touched the renderer (tuika 0.9's `FrameSource` migration, plus
`src/tui/` changes), so per the release spec the Tier 3 GUI walk is a reviewer
task before merge — an agent cannot tick these:

- [ ] Ghostty
- [ ] iTerm2
- [ ] WezTerm
- [ ] Kitty
- [ ] Windows Terminal
- [ ] Konsole

## Post-merge verification

- [ ] `release.yml` succeeds — tag `v0.15.2` and GitHub Release created
- [ ] `publish.yml` succeeds — `yolop 0.15.2` published (`yolop-yep` skipped, already live)
- [ ] `cli-binaries.yml` succeeds — three target tarballs + `.sha256` on the release
- [ ] crates.io serves `yolop = "0.15.2"`
- [ ] `everruns/homebrew-tap` `Formula/yolop.rb` downloads from `v0.15.2`

## Risk

- Low
- The failure mode is a half-published release: crates.io green while the tap
  lags or fails. Post-merge verification above checks both registries
  independently rather than trusting green workflows, and a failure rolls
  forward via hotfix per the spec.

## Checklist

- [x] Tests added or updated — none needed; no source change, existing suite is the gate
- [x] Backward compatibility considered — additive release, no breaking changes
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

No knowledge update required — durable knowledge for every commit in this window
was updated in its own PR (`knowledge/log.md`, `specs/acp.md`,
`specs/tool-calling.md`, `specs/release.md`, `specs/system-prompt.md`,
`test-scenarios/`), and a version bump plus changelog entry carries no durable
knowledge of its own.

## Security

No security-relevant code changed — this PR edits `Cargo.toml`, `Cargo.lock`, and
`CHANGELOG.md` only. Publishing credentials (`CARGO_REGISTRY_TOKEN`,
`DOPPLER_TOKEN` → `HOMEBREW_TAP_GITHUB_TOKEN`) stay in CI; nothing in this branch
reads or transports them.

## Follow-ups

No follow-ups.

Do not enable auto-merge — the changelog needs a human read before the squash.