### PR TITLE
fix(tui): keep tracing off owned terminal rows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,8 @@ its split-footer mode. See [Tuika](#tuika).
   `YOLOP_REQUIRE_LIVE_TESTS`. CI's live-smoke job sets that flag, which turns a
   missing key into a hard failure so a misconfigured secret cannot report green.
 
-`RUST_LOG` is honored for the tracing layer (stderr).
+`RUST_LOG` is honored for the tracing layer: stderr outside the interactive TUI,
+private rotating files under `<data_dir>/yolop/logs/` inside it.
 
 ## Checks
 

--- a/README.md
+++ b/README.md
@@ -343,7 +343,10 @@ act of consent. MCP tools run autonomously like the rest of yolop's tools.
 | `yolop into zed`   | Configure yolop as a custom ACP agent in Zed    |
 | `yolop mcp …`      | Manage MCP servers (see [MCP servers](#mcp-servers)) |
 
-`RUST_LOG` is honored for the underlying tracing layer (writes to stderr).
+`RUST_LOG` is honored for the underlying tracing layer. Non-interactive modes
+write traces to stderr. Interactive sessions keep terminal rendering clean and
+write traces to private, rotating files under `<data_dir>/yolop/logs/` (the five
+most recent files are retained, capped at 4 MiB each).
 
 ### Provider env vars
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,12 @@
 Significant changes to Yolop's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
+## 2026-08-15 — Interactive tracing no longer corrupts terminal frames
+
+- Fullscreen and inline renderers now route `RUST_LOG` diagnostics to private,
+  bounded files under the platform data directory instead of stderr. CLI,
+  `--print`, and ACP behavior is unchanged.
+
 ## 2026-08-15 — Terminal verification split into tiers
 
 - The release spec's "Manual Terminal Matrix" became

--- a/knowledge/specs/presentation.md
+++ b/knowledge/specs/presentation.md
@@ -65,6 +65,13 @@ exits. A published entry is never repainted, so anything that changes during a
 turn belongs in the pinned rows, and an entry the pinned rows still show must
 not also be published — a transcript entry appears once, never twice.
 
+Neither interactive renderer permits tracing output to inherit stderr: an
+asynchronous diagnostic would bypass the layout and overwrite owned terminal
+rows. `RUST_LOG` output is written without ANSI styling to owner-only rotating
+files under the platform data directory's `yolop/logs/` folder; command,
+`--print`, and ACP modes continue to write tracing output to stderr. At most
+five interactive trace files are retained, capped at 4 MiB each.
+
 Transcript links use OSC 8 targets and leave activation to the terminal
 emulator, including its platform-native modifier (`Ctrl` on Linux, `Command` on
 macOS). The fullscreen host must not also launch the URL from the reported mouse

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,10 +43,43 @@ use ratatui::{Terminal, TerminalOptions};
 use runtime::{BuiltRuntime, ProviderChoice, ResolvedProviderChoice, resolve_for_settings};
 use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use tracing_subscriber::fmt::writer::BoxMakeWriter;
 use tui::{App, COMPOSER_VIEWPORT_HEIGHT};
 use tuika::term::capabilities::Capabilities;
 use tuika::term::hyperlink::{HyperlinkBackend, LinkPolicy};
+
+const MAX_INTERACTIVE_TRACE_LOGS: usize = 5;
+const MAX_INTERACTIVE_TRACE_BYTES: u64 = 4 * 1024 * 1024;
+
+struct BoundedTraceWriter {
+    file: std::fs::File,
+    remaining: u64,
+}
+
+impl BoundedTraceWriter {
+    fn new(file: std::fs::File, max_bytes: u64) -> Self {
+        Self {
+            file,
+            remaining: max_bytes,
+        }
+    }
+}
+
+impl Write for BoundedTraceWriter {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        let writable = bytes.len().min(self.remaining as usize);
+        self.file.write_all(&bytes[..writable])?;
+        self.remaining -= writable as u64;
+        // Once capped, consume later trace events without growing the file or
+        // surfacing write failures into the application being diagnosed.
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.file.flush()
+    }
+}
 
 #[derive(Parser, Debug)]
 #[command(
@@ -537,15 +570,17 @@ fn join_worker<T>(
 }
 
 async fn async_main(crash_reporter: &crash_report::CrashReporter) -> Result<()> {
+    let cli = Cli::parse();
+    let interactive = uses_interactive_renderer(&cli);
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("error")),
         )
-        .with_writer(io::stderr)
+        .with_ansi(!interactive)
+        .with_writer(trace_writer(interactive))
         .init();
 
-    let cli = Cli::parse();
     if let Some(command) = cli.command {
         return run_command(command);
     }
@@ -677,6 +712,87 @@ async fn async_main(crash_reporter: &crash_report::CrashReporter) -> Result<()> 
     }
     let pending_images = tui::input::image_input::load_image_parts(&cli.images)?;
     run_tui(runtime, pending_images, cli.trajectory_out, !cli.inline).await
+}
+
+fn uses_interactive_renderer(cli: &Cli) -> bool {
+    (cli.command.is_none() && cli.print.is_none() && !cli.acp)
+        || matches!(cli.command.as_ref(), Some(Commands::TuikaGallery))
+}
+
+fn trace_writer(interactive: bool) -> BoxMakeWriter {
+    if !interactive {
+        return BoxMakeWriter::new(io::stderr);
+    }
+    let Some(data_dir) = dirs::data_dir() else {
+        eprintln!("yolop: no platform data dir resolvable — interactive tracing is disabled");
+        return BoxMakeWriter::new(io::sink);
+    };
+    let trace_dir = data_dir.join("yolop").join("logs");
+    match open_interactive_trace_log(&trace_dir) {
+        Ok((file, _path)) => BoxMakeWriter::new(Mutex::new(BoundedTraceWriter::new(
+            file,
+            MAX_INTERACTIVE_TRACE_BYTES,
+        ))),
+        Err(err) => {
+            eprintln!(
+                "yolop: cannot open interactive trace log in {}: {err}",
+                trace_dir.display()
+            );
+            BoxMakeWriter::new(io::sink)
+        }
+    }
+}
+
+fn open_interactive_trace_log(dir: &Path) -> io::Result<(std::fs::File, PathBuf)> {
+    let timestamp = chrono::Utc::now().format("%Y-%m-%dT%H-%M-%S%.6fZ");
+    open_interactive_trace_log_at(dir, &timestamp.to_string(), std::process::id())
+}
+
+fn open_interactive_trace_log_at(
+    dir: &Path,
+    timestamp: &str,
+    process_id: u32,
+) -> io::Result<(std::fs::File, PathBuf)> {
+    std::fs::create_dir_all(dir)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))?;
+    }
+
+    let path = dir.join(format!("{timestamp}-{process_id}-trace.log"));
+    let mut options = std::fs::OpenOptions::new();
+    options.create_new(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let file = options.open(&path)?;
+    prune_interactive_trace_logs(dir, MAX_INTERACTIVE_TRACE_LOGS);
+    Ok((file, path))
+}
+
+fn prune_interactive_trace_logs(dir: &Path, keep: usize) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut logs = entries
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.is_file()
+                && path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.ends_with("-trace.log"))
+        })
+        .collect::<Vec<_>>();
+    logs.sort();
+    let remove_count = logs.len().saturating_sub(keep);
+    for path in logs.into_iter().take(remove_count) {
+        let _ = std::fs::remove_file(path);
+    }
 }
 
 fn resolve_workspace_root(
@@ -1793,6 +1909,90 @@ mod tests {
     use super::*;
     use std::ffi::OsString;
     use std::process::Command;
+
+    #[test]
+    fn trace_routing_follows_terminal_ownership() {
+        let tui = Cli::try_parse_from(["yolop", "--provider", "llmsim"]).expect("parse TUI");
+        let gallery = Cli::try_parse_from(["yolop", "tuika-gallery"]).expect("parse TUI gallery");
+        let print = Cli::try_parse_from(["yolop", "--provider", "llmsim", "-p", "hi"])
+            .expect("parse print mode");
+        let command = Cli::try_parse_from(["yolop", "version"]).expect("parse command");
+
+        assert!(uses_interactive_renderer(&tui));
+        assert!(uses_interactive_renderer(&gallery));
+        assert!(!uses_interactive_renderer(&print));
+        assert!(!uses_interactive_renderer(&command));
+    }
+
+    #[test]
+    fn interactive_trace_logs_are_private_and_bounded() {
+        let dir = tempfile::tempdir().expect("trace tempdir");
+        for index in 0..MAX_INTERACTIVE_TRACE_LOGS {
+            std::fs::write(
+                dir.path().join(format!("2026-08-14-{index:02}-trace.log")),
+                b"old",
+            )
+            .expect("write old trace log");
+        }
+
+        let (file, path) =
+            open_interactive_trace_log_at(dir.path(), "2026-08-15T07-00-49.403905Z", 42)
+                .expect("open interactive trace log");
+        drop(file);
+
+        let trace_logs = std::fs::read_dir(dir.path())
+            .expect("read trace directory")
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.ends_with("-trace.log"))
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(trace_logs.len(), MAX_INTERACTIVE_TRACE_LOGS);
+        assert!(path.exists());
+        assert!(!dir.path().join("2026-08-14-00-trace.log").exists());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(dir.path())
+                    .expect("trace directory metadata")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o700
+            );
+            assert_eq!(
+                std::fs::metadata(path)
+                    .expect("trace metadata")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+    }
+
+    #[test]
+    fn interactive_trace_log_stops_growing_at_its_byte_limit() {
+        let dir = tempfile::tempdir().expect("trace tempdir");
+        let (file, path) =
+            open_interactive_trace_log_at(dir.path(), "2026-08-15T07-00-49.403905Z", 43)
+                .expect("open interactive trace log");
+        let mut writer = BoundedTraceWriter::new(file, 4);
+
+        writer
+            .write_all(b"warning one")
+            .expect("write first warning");
+        writer
+            .write_all(b"warning two")
+            .expect("discard warning past cap");
+        writer.flush().expect("flush trace log");
+
+        assert_eq!(std::fs::read(path).expect("read trace log"), b"warn");
+    }
 
     #[test]
     fn worker_join_preserves_original_panic_payload() {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1427,9 +1427,15 @@ fn tui_starts_when_emulator_answers_only_the_first_cursor_query() {
 
 #[test]
 fn tui_exits_cleanly_when_emulator_stops_answering_cursor_queries() {
-    let mut tui = spawn_tui_llmsim(&yolop_binary());
+    let mut tui = spawn_tui_llmsim_with(
+        &yolop_binary(),
+        TuiSpawnOptions {
+            rust_log: Some("warn".to_string()),
+            ..TuiSpawnOptions::default()
+        },
+    );
     assert!(
-        tui.wait_for_output("type /help", Duration::from_secs(3)),
+        tui.wait_for_output("type /help", Duration::from_secs(5)),
         "TUI did not render startup banner: {}",
         tui.output_text()
     );
@@ -1450,6 +1456,21 @@ fn tui_exits_cleanly_when_emulator_stops_answering_cursor_queries() {
             .contains("Continue with yolop --provider llmsim"),
         "cleanup should still print continuation hint: {}",
         tui.output_text()
+    );
+
+    let terminal_output = strip_ansi(&tui.output_text());
+    assert!(
+        !terminal_output.contains("footer teardown failed"),
+        "tracing must not overwrite the TUI or leak into terminal output: {terminal_output}"
+    );
+    let traces = std::fs::read_dir(tui.trace_logs_path())
+        .expect("read interactive trace logs")
+        .filter_map(Result::ok)
+        .map(|entry| std::fs::read_to_string(entry.path()).expect("read interactive trace log"))
+        .collect::<String>();
+    assert!(
+        traces.contains("footer teardown failed"),
+        "the terminal-safe trace log should retain the teardown warning: {traces}"
     );
 }
 

--- a/tests/support/tui_harness.rs
+++ b/tests/support/tui_harness.rs
@@ -40,6 +40,8 @@ pub struct TuiSpawnOptions {
     pub workspace: Option<PathBuf>,
     /// Enable shell sandboxing for this process.
     pub sandbox: bool,
+    /// Tracing filter passed to the spawned binary.
+    pub rust_log: Option<String>,
 }
 
 impl Default for TuiSpawnOptions {
@@ -53,6 +55,7 @@ impl Default for TuiSpawnOptions {
             inline: true,
             workspace: None,
             sandbox: false,
+            rust_log: None,
         }
     }
 }
@@ -86,6 +89,19 @@ impl TuiHarness {
 
     pub fn sessions_path(&self) -> PathBuf {
         self._session_dir.path().to_path_buf()
+    }
+
+    /// Directory where an interactive child writes tracing output.
+    pub fn trace_logs_path(&self) -> PathBuf {
+        #[cfg(target_os = "macos")]
+        {
+            self._home
+                .path()
+                .join("Library/Application Support/yolop/logs")
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        self._home.path().join(".local/share/yolop/logs")
     }
 
     pub fn resize(&mut self, cols: u16, rows: u16) {
@@ -255,6 +271,9 @@ pub fn spawn_tui_llmsim_with_settings(
     cmd.env("XDG_CONFIG_HOME", home.path().join(".config"));
     cmd.env("XDG_DATA_HOME", home.path().join(".local/share"));
     cmd.env("TERM", "xterm-256color");
+    if let Some(rust_log) = options.rust_log {
+        cmd.env("RUST_LOG", rust_log);
+    }
     if let Some(prefix) = options.path_prefix {
         let inherited = std::env::var_os("PATH").unwrap_or_default();
         let path =


### PR DESCRIPTION
## What changed

Interactive fullscreen, inline, and gallery sessions no longer write tracing diagnostics to stderr while they own terminal rows. `RUST_LOG` output now goes to private rotating files under the platform data directory; five files are retained and each is capped at 4 MiB. Commands, `--print`, and ACP keep their existing stderr behavior.

## Why

Asynchronous warnings bypassed Tuika's layout and painted directly over the composer and status rows, corrupting the interface.

## Before / After

**Before:** runtime warnings such as `scoped MCP tool discovery failed` were emitted over the active TUI frame.

**After:** the real-binary PTY regression deliberately triggers `footer teardown failed`, verifies the warning is absent from terminal output, and verifies the same warning is retained in the private trace log.

## Risk

- Low.
- Risk is limited to tracing destination selection and local trace-file lifecycle. Non-interactive output behavior is covered separately and unchanged.
- Trace storage is bounded to five owner-only files of at most 4 MiB each.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated `knowledge/specs/presentation.md` and `knowledge/log.md`; synchronized `README.md` and `AGENTS.md` with the new tracing destination and retention policy.

## Security

- **TM-FS:** trace directory/file permissions are asserted as `0700`/`0600` on Unix; retention and per-file byte limits bound disk use. Workspace containment and blocklists are untouched.
- **TM-LLM:** no prompt or credential handling changed. Traces remain subject to the existing no-secret logging invariant and are no longer exposed on-screen.
- **TM-BASH / TM-TOOL / TM-DEP:** no shell execution, capability registration, or dependency changes.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features -- --skip testing::scenarios::predictable_long_command_returns_immediately_and_terminal_result_is_durable` (1104 unit, 57 integration, 1 parallel integration, 5 PTY passed)
- `cargo test --test integration tui_exits_cleanly_when_emulator_stops_answering_cursor_queries`
- `python3 scripts/validate_okf.py knowledge --check-links`
- Local live-provider smoke could not run because this worktree has no Doppler project/token or provider key; credentialed CI supplies the live smoke.

## Follow-ups

- Investigate the existing host-sensitive one-second background-command timing assertion separately; it reproduces unchanged on this host and is unrelated to tracing.
