### PR TITLE
docs(changelog): record #575 in the 0.15.2 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ tags the version and publishes to crates.io and the Homebrew tap.
 - Malformed tool calls no longer reach execution — every provider's model-authored arguments are validated against the authoritative JSON Schema first, and `progress_checkpoint` stays callable when the progress gate demands it.
 - ACP recovers provider authentication mid-session rather than stalling on an expired credential.
 - The tmux gallery render is now gated on every PR by a real terminal implementation, so the release spec's terminal matrix reserves the human walk for GUI emulators.
+- Tracing output no longer scribbles over terminal rows the TUI owns.
 
 ### Breaking Changes
 
@@ -26,6 +27,7 @@ tags the version and publishes to crates.io and the Homebrew tap.
 
 ### What's Changed
 
+* fix(tui): keep tracing off owned terminal rows ([#575](https://github.com/everruns/yolop/pull/575)) by @chaliy
 * chore(deps): bump tuika to 0.9 and companion crates ([#573](https://github.com/everruns/yolop/pull/573)) by @chaliy
 * fix(tools): repair malformed tool call arguments ([#572](https://github.com/everruns/yolop/pull/572)) by @chaliy
 * feat(models): add Terra and Luna variants ([#571](https://github.com/everruns/yolop/pull/571)) by @chaliy


### PR DESCRIPTION
## What changed

Adds `fix(tui): keep tracing off owned terminal rows` (#575) to the `[0.15.2]`
changelog section — one line in `### What's Changed` and a matching highlight
bullet.

## Why

#575 merged to `main` after the release branch for v0.15.2 was cut, so the commit
shipped inside the `v0.15.2` tag but never made it into the changelog section
that `release.yml` turned into the release notes. The release spec requires every
commit since the previous tag to appear in the section for the release that
carries it, so the section under-reports what 0.15.2 actually contains.

Recorded against 0.15.2 rather than deferred to the next release, because that is
the version users are installing it with.

## Before / After

**Before:** the `[0.15.2]` section lists 8 PRs (#566–#573); #575 appears nowhere
despite being in the tag.

**After:** the section lists 9, newest-first ordering preserved, and the
highlights mention the fix.

No code changes — `CHANGELOG.md` only, so no observable runtime behavior changes.

## Risk

- Low
- Documentation-only. Worst case is a wording nit in a released section.

## Checklist

- [x] Tests added or updated — not applicable, documentation only
- [x] Backward compatibility considered — no code changes
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

No knowledge update required — this corrects a changelog entry. The underlying
process rule (every commit since the previous tag appears in the section) is
already stated in `knowledge/specs/release.md`; nothing about it changed.

## Security

No security-relevant code changed — `CHANGELOG.md` only.

## Follow-ups

The v0.15.2 GitHub Release body still carries the pre-correction notes; it will
be updated to match once this merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CftRGoUGe7SqRCZeuKwmUt)_