### PR TITLE
feat(editor): add Buzz ACP harness setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,16 @@ That adds a custom ACP agent server to `~/.config/zed/settings.json` using the
 current yolop executable (preserving any existing `env` on re-run). Then pick
 **yolop** in Zed's agent panel.
 
+To set up Buzz Desktop:
+
+```bash
+yolop into buzz
+```
+
+That adds a custom harness under Buzz's application data directory using the
+current yolop executable and `--acp`. Re-running updates the managed fields while
+preserving any custom `env` values and extension fields.
+
 ## MCP servers
 
 Yolop pulls in extra tools from MCP servers — remote (Streamable **HTTP**) and
@@ -341,6 +351,7 @@ act of consent. MCP tools run autonomously like the rest of yolop's tools.
 | ------------------ | ----------------------------------------------- |
 | `yolop version`    | Print yolop, commit, and runtime versions       |
 | `yolop into zed`   | Configure yolop as a custom ACP agent in Zed    |
+| `yolop into buzz`  | Configure yolop as a custom ACP harness in Buzz |
 | `yolop mcp …`      | Manage MCP servers (see [MCP servers](#mcp-servers)) |
 
 `RUST_LOG` is honored for the underlying tracing layer. Non-interactive modes

--- a/knowledge/specs/acp.md
+++ b/knowledge/specs/acp.md
@@ -265,6 +265,27 @@ The binary itself is smoke-tested over real OS pipes in
 (`acp_openai_handshake_smoke`, which skips itself when no API key is present)
 documents the live path.
 
+### Real-life testing in Buzz Desktop
+
+Register the current yolop executable as a custom Buzz ACP harness:
+
+```bash
+yolop into buzz
+```
+
+This writes `yolop.json` below Buzz's platform application-data
+`custom_harnesses` directory and launches yolop with `--acp`. The generated
+JSON follows Buzz's `CustomHarnessConfig` contract: `id`, `label`, `command`,
+`args`, `env`, `installInstructionsUrl`, and `installHint`. The path and schema
+are sourced from Buzz's loader and validator at commit
+[`d8281b9`](https://github.com/block/buzz/blob/d8281b9c93395f15d55091b131bb2747a0a3da8a/desktop/src-tauri/src/managed_agents/custom_harnesses.rs#L11-L64).
+Buzz's Tauri identifier is `xyz.block.buzz.app`, which determines the platform
+application-data directory.
+
+Re-running updates Yolop-owned fields while preserving user `env` values and
+unknown extension fields. Pass `--force` to replace the whole document. Restart
+Buzz Desktop after changing the harness so it is rediscovered.
+
 ### Real-life testing in an editor
 
 Configure Zed to launch yolop as a custom agent:

--- a/src/editor/into.rs
+++ b/src/editor/into.rs
@@ -20,6 +20,14 @@ pub struct PaseoIntoOptions {
 }
 
 #[derive(Debug)]
+pub struct BuzzIntoOptions {
+    pub harness_path: Option<PathBuf>,
+    pub agent_name: String,
+    pub command: PathBuf,
+    pub force: bool,
+}
+
+#[derive(Debug)]
 pub struct ZedIntoResult {
     pub settings_path: PathBuf,
     pub agent_name: String,
@@ -30,6 +38,14 @@ pub struct ZedIntoResult {
 #[derive(Debug)]
 pub struct PaseoIntoResult {
     pub settings_path: PathBuf,
+    pub agent_name: String,
+    pub command: String,
+    pub status: IntoStatus,
+}
+
+#[derive(Debug)]
+pub struct BuzzIntoResult {
+    pub harness_path: PathBuf,
     pub agent_name: String,
     pub command: String,
     pub status: IntoStatus,
@@ -74,7 +90,7 @@ pub fn into_zed(options: ZedIntoOptions) -> Result<ZedIntoResult> {
 
     if status != IntoStatus::Unchanged {
         let rendered = render_settings(&root, existing_text.as_deref(), "Zed")?;
-        write_file_atomically(&settings_path, rendered.as_bytes())?;
+        write_file_atomically(&settings_path, rendered.as_bytes(), "Zed settings")?;
     }
 
     Ok(ZedIntoResult {
@@ -123,7 +139,7 @@ pub fn into_paseo(options: PaseoIntoOptions) -> Result<PaseoIntoResult> {
 
     if status != IntoStatus::Unchanged {
         let rendered = render_settings(&root, existing_text.as_deref(), "Paseo")?;
-        write_file_atomically(&settings_path, rendered.as_bytes())?;
+        write_file_atomically(&settings_path, rendered.as_bytes(), "Paseo settings")?;
     }
 
     Ok(PaseoIntoResult {
@@ -131,6 +147,75 @@ pub fn into_paseo(options: PaseoIntoOptions) -> Result<PaseoIntoResult> {
         agent_name: options.agent_name,
         command,
         status,
+    })
+}
+
+pub fn into_buzz(options: BuzzIntoOptions) -> Result<BuzzIntoResult> {
+    if options.agent_name.trim().is_empty() {
+        bail!("agent harness name cannot be empty");
+    }
+
+    let harness_path = options
+        .harness_path
+        .unwrap_or_else(|| default_buzz_harness_path(&options.agent_name));
+    let command = path_to_json_string(&options.command)?;
+    let desired = buzz_harness(&options.agent_name, &command);
+    let existing_text = read_optional_settings(&harness_path, "Buzz")?;
+    let (root, status) = match existing_text.as_deref() {
+        None => (desired, IntoStatus::Created),
+        Some(text) => {
+            let mut current = parse_settings_or_empty(Some(text), &harness_path, "Buzz")?;
+            if current == desired {
+                (current, IntoStatus::Unchanged)
+            } else if options.force {
+                (desired, IntoStatus::Updated)
+            } else {
+                let before = current.clone();
+                let current_object = current.as_object_mut().context(
+                    "Buzz custom harness must be a JSON object; re-run with --force to replace it",
+                )?;
+                let desired_object = desired
+                    .as_object()
+                    .expect("desired Buzz harness is an object");
+                for (key, value) in desired_object {
+                    if key != "env" {
+                        current_object.insert(key.clone(), value.clone());
+                    }
+                }
+                if !current_object.contains_key("env") {
+                    current_object.insert("env".to_string(), json!({}));
+                }
+                let status = if current == before {
+                    IntoStatus::Unchanged
+                } else {
+                    IntoStatus::Updated
+                };
+                (current, status)
+            }
+        }
+    };
+
+    if status != IntoStatus::Unchanged {
+        let rendered = render_settings(&root, None, "Buzz")?;
+        write_file_atomically(&harness_path, rendered.as_bytes(), "Buzz custom harness")?;
+    }
+
+    Ok(BuzzIntoResult {
+        harness_path,
+        agent_name: options.agent_name,
+        command,
+        status,
+    })
+}
+
+fn buzz_harness(agent_name: &str, command: &str) -> Value {
+    json!({
+        "name": agent_name,
+        "display_name": agent_name,
+        "description": "Yolop coding agent",
+        "command": command,
+        "args": ["--acp"],
+        "env": {}
     })
 }
 
@@ -198,6 +283,14 @@ fn merge_agent_server(
     } else {
         IntoStatus::Unchanged
     })
+}
+
+fn default_buzz_harness_path(agent_name: &str) -> PathBuf {
+    let base = dirs::data_dir()
+        .unwrap_or_else(|| dirs::config_dir().unwrap_or_else(|| PathBuf::from(".")));
+    base.join("xyz.block.buzz.app")
+        .join("custom_harnesses")
+        .join(format!("{agent_name}.json"))
 }
 
 fn default_paseo_settings_path() -> PathBuf {
@@ -403,16 +496,16 @@ fn strip_trailing_commas(text: &str) -> String {
     out
 }
 
-fn write_file_atomically(path: &Path, content: &[u8]) -> Result<()> {
+fn write_file_atomically(path: &Path, content: &[u8], description: &str) -> Result<()> {
     let parent = path
         .parent()
         .filter(|p| !p.as_os_str().is_empty())
         .unwrap_or_else(|| Path::new("."));
     std::fs::create_dir_all(parent)
-        .with_context(|| format!("create Zed settings dir {}", parent.display()))?;
+        .with_context(|| format!("create {description} dir {}", parent.display()))?;
     let file_name = path
         .file_name()
-        .with_context(|| format!("Zed settings path has no file name: {}", path.display()))?;
+        .with_context(|| format!("{description} path has no file name: {}", path.display()))?;
     let mut tmp_name = std::ffi::OsString::from(".");
     tmp_name.push(file_name);
     tmp_name.push(format!(".tmp.{}", std::process::id()));
@@ -424,11 +517,11 @@ fn write_file_atomically(path: &Path, content: &[u8]) -> Result<()> {
             .create(true)
             .truncate(true)
             .open(&tmp_path)
-            .with_context(|| format!("open temp Zed settings {}", tmp_path.display()))?;
+            .with_context(|| format!("open temp {description} {}", tmp_path.display()))?;
         file.write_all(content)
-            .with_context(|| format!("write temp Zed settings {}", tmp_path.display()))?;
+            .with_context(|| format!("write temp {description} {}", tmp_path.display()))?;
         file.sync_all()
-            .with_context(|| format!("sync temp Zed settings {}", tmp_path.display()))?;
+            .with_context(|| format!("sync temp {description} {}", tmp_path.display()))?;
         Ok(())
     })();
     if let Err(err) = write_result {
@@ -438,7 +531,7 @@ fn write_file_atomically(path: &Path, content: &[u8]) -> Result<()> {
     #[cfg(windows)]
     if path.exists() {
         std::fs::remove_file(path)
-            .with_context(|| format!("remove existing Zed settings {}", path.display()))?;
+            .with_context(|| format!("remove existing {description} {}", path.display()))?;
     }
     std::fs::rename(&tmp_path, path)
         .with_context(|| format!("rename {} -> {}", tmp_path.display(), path.display()))?;
@@ -465,6 +558,64 @@ mod tests {
             command: PathBuf::from(command),
             force,
         })
+    }
+
+    fn into_buzz_at(path: PathBuf, command: &str, force: bool) -> Result<BuzzIntoResult> {
+        into_buzz(BuzzIntoOptions {
+            harness_path: Some(path),
+            agent_name: "yolop".to_string(),
+            command: PathBuf::from(command),
+            force,
+        })
+    }
+
+    #[test]
+    fn buzz_into_creates_custom_harness() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("custom_harnesses/yolop.json");
+
+        let result = into_buzz_at(path.clone(), "/bin/yolop", false).expect("into");
+
+        assert_eq!(result.status, IntoStatus::Created);
+        let value: Value = serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        assert_eq!(
+            value,
+            json!({
+                "name": "yolop",
+                "display_name": "yolop",
+                "description": "Yolop coding agent",
+                "command": "/bin/yolop",
+                "args": ["--acp"],
+                "env": {}
+            })
+        );
+    }
+
+    #[test]
+    fn buzz_into_updates_managed_fields_and_preserves_env_and_extensions() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("yolop.json");
+        std::fs::write(&path, r#"{"name":"old","display_name":"Old","description":"Old","command":"old","args":["old"],"env":{"API_KEY":"keep"},"icon":"keep"}"#).unwrap();
+
+        let result = into_buzz_at(path.clone(), "/bin/yolop", false).expect("into");
+
+        assert_eq!(result.status, IntoStatus::Updated);
+        let value: Value = serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        assert_eq!(value["command"], "/bin/yolop");
+        assert_eq!(value["args"], json!(["--acp"]));
+        assert_eq!(value["env"]["API_KEY"], "keep");
+        assert_eq!(value["icon"], "keep");
+    }
+
+    #[test]
+    fn buzz_into_is_idempotent_with_user_env() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("yolop.json");
+        std::fs::write(&path, r#"{"name":"yolop","display_name":"yolop","description":"Yolop coding agent","command":"/bin/yolop","args":["--acp"],"env":{"API_KEY":"keep"}}"#).unwrap();
+
+        let result = into_buzz_at(path, "/bin/yolop", false).expect("into");
+
+        assert_eq!(result.status, IntoStatus::Unchanged);
     }
 
     #[test]

--- a/src/editor/into.rs
+++ b/src/editor/into.rs
@@ -215,8 +215,8 @@ fn buzz_harness(agent_name: &str, command: &str) -> Value {
         "command": command,
         "args": ["--acp"],
         "env": {},
-        "installInstructionsUrl": "https://github.com/everruns/yolop#install",
-        "installHint": "Install Yolop, then run `yolop into buzz`."
+        "installInstructionsUrl": "https://everruns.com/yolop",
+        "installHint": "brew install everruns/tap/yolop"
     })
 }
 
@@ -587,8 +587,8 @@ mod tests {
                 "command": "/bin/yolop",
                 "args": ["--acp"],
                 "env": {},
-                "installInstructionsUrl": "https://github.com/everruns/yolop#install",
-                "installHint": "Install Yolop, then run `yolop into buzz`."
+                "installInstructionsUrl": "https://everruns.com/yolop",
+                "installHint": "brew install everruns/tap/yolop"
             })
         );
     }
@@ -613,7 +613,7 @@ mod tests {
     fn buzz_into_is_idempotent_with_user_env() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let path = tmp.path().join("yolop.json");
-        std::fs::write(&path, r#"{"id":"yolop","label":"yolop","command":"/bin/yolop","args":["--acp"],"env":{"API_KEY":"keep"},"installInstructionsUrl":"https://github.com/everruns/yolop#install","installHint":"Install Yolop, then run `yolop into buzz`."}"#).unwrap();
+        std::fs::write(&path, r#"{"id":"yolop","label":"yolop","command":"/bin/yolop","args":["--acp"],"env":{"API_KEY":"keep"},"installInstructionsUrl":"https://everruns.com/yolop","installHint":"brew install everruns/tap/yolop"}"#).unwrap();
 
         let result = into_buzz_at(path, "/bin/yolop", false).expect("into");
 

--- a/src/editor/into.rs
+++ b/src/editor/into.rs
@@ -20,6 +20,14 @@ pub struct PaseoIntoOptions {
 }
 
 #[derive(Debug)]
+pub struct BuzzIntoOptions {
+    pub harness_path: Option<PathBuf>,
+    pub agent_name: String,
+    pub command: PathBuf,
+    pub force: bool,
+}
+
+#[derive(Debug)]
 pub struct ZedIntoResult {
     pub settings_path: PathBuf,
     pub agent_name: String,
@@ -30,6 +38,14 @@ pub struct ZedIntoResult {
 #[derive(Debug)]
 pub struct PaseoIntoResult {
     pub settings_path: PathBuf,
+    pub agent_name: String,
+    pub command: String,
+    pub status: IntoStatus,
+}
+
+#[derive(Debug)]
+pub struct BuzzIntoResult {
+    pub harness_path: PathBuf,
     pub agent_name: String,
     pub command: String,
     pub status: IntoStatus,
@@ -74,7 +90,7 @@ pub fn into_zed(options: ZedIntoOptions) -> Result<ZedIntoResult> {
 
     if status != IntoStatus::Unchanged {
         let rendered = render_settings(&root, existing_text.as_deref(), "Zed")?;
-        write_file_atomically(&settings_path, rendered.as_bytes())?;
+        write_file_atomically(&settings_path, rendered.as_bytes(), "Zed settings")?;
     }
 
     Ok(ZedIntoResult {
@@ -123,7 +139,7 @@ pub fn into_paseo(options: PaseoIntoOptions) -> Result<PaseoIntoResult> {
 
     if status != IntoStatus::Unchanged {
         let rendered = render_settings(&root, existing_text.as_deref(), "Paseo")?;
-        write_file_atomically(&settings_path, rendered.as_bytes())?;
+        write_file_atomically(&settings_path, rendered.as_bytes(), "Paseo settings")?;
     }
 
     Ok(PaseoIntoResult {
@@ -131,6 +147,76 @@ pub fn into_paseo(options: PaseoIntoOptions) -> Result<PaseoIntoResult> {
         agent_name: options.agent_name,
         command,
         status,
+    })
+}
+
+pub fn into_buzz(options: BuzzIntoOptions) -> Result<BuzzIntoResult> {
+    if options.agent_name.trim().is_empty() {
+        bail!("agent harness name cannot be empty");
+    }
+
+    let harness_path = options
+        .harness_path
+        .unwrap_or_else(|| default_buzz_harness_path(&options.agent_name));
+    let command = path_to_json_string(&options.command)?;
+    let desired = buzz_harness(&options.agent_name, &command);
+    let existing_text = read_optional_settings(&harness_path, "Buzz")?;
+    let (root, status) = match existing_text.as_deref() {
+        None => (desired, IntoStatus::Created),
+        Some(text) => {
+            let mut current = parse_settings_or_empty(Some(text), &harness_path, "Buzz")?;
+            if current == desired {
+                (current, IntoStatus::Unchanged)
+            } else if options.force {
+                (desired, IntoStatus::Updated)
+            } else {
+                let before = current.clone();
+                let current_object = current.as_object_mut().context(
+                    "Buzz custom harness must be a JSON object; re-run with --force to replace it",
+                )?;
+                let desired_object = desired
+                    .as_object()
+                    .expect("desired Buzz harness is an object");
+                for (key, value) in desired_object {
+                    if key != "env" {
+                        current_object.insert(key.clone(), value.clone());
+                    }
+                }
+                if !current_object.contains_key("env") {
+                    current_object.insert("env".to_string(), json!({}));
+                }
+                let status = if current == before {
+                    IntoStatus::Unchanged
+                } else {
+                    IntoStatus::Updated
+                };
+                (current, status)
+            }
+        }
+    };
+
+    if status != IntoStatus::Unchanged {
+        let rendered = render_settings(&root, None, "Buzz")?;
+        write_file_atomically(&harness_path, rendered.as_bytes(), "Buzz custom harness")?;
+    }
+
+    Ok(BuzzIntoResult {
+        harness_path,
+        agent_name: options.agent_name,
+        command,
+        status,
+    })
+}
+
+fn buzz_harness(agent_name: &str, command: &str) -> Value {
+    json!({
+        "id": agent_name,
+        "label": agent_name,
+        "command": command,
+        "args": ["--acp"],
+        "env": {},
+        "installInstructionsUrl": "https://github.com/everruns/yolop#install",
+        "installHint": "Install Yolop, then run `yolop into buzz`."
     })
 }
 
@@ -198,6 +284,14 @@ fn merge_agent_server(
     } else {
         IntoStatus::Unchanged
     })
+}
+
+fn default_buzz_harness_path(agent_name: &str) -> PathBuf {
+    let base = dirs::data_dir()
+        .unwrap_or_else(|| dirs::config_dir().unwrap_or_else(|| PathBuf::from(".")));
+    base.join("xyz.block.buzz.app")
+        .join("custom_harnesses")
+        .join(format!("{agent_name}.json"))
 }
 
 fn default_paseo_settings_path() -> PathBuf {
@@ -403,16 +497,16 @@ fn strip_trailing_commas(text: &str) -> String {
     out
 }
 
-fn write_file_atomically(path: &Path, content: &[u8]) -> Result<()> {
+fn write_file_atomically(path: &Path, content: &[u8], description: &str) -> Result<()> {
     let parent = path
         .parent()
         .filter(|p| !p.as_os_str().is_empty())
         .unwrap_or_else(|| Path::new("."));
     std::fs::create_dir_all(parent)
-        .with_context(|| format!("create Zed settings dir {}", parent.display()))?;
+        .with_context(|| format!("create {description} dir {}", parent.display()))?;
     let file_name = path
         .file_name()
-        .with_context(|| format!("Zed settings path has no file name: {}", path.display()))?;
+        .with_context(|| format!("{description} path has no file name: {}", path.display()))?;
     let mut tmp_name = std::ffi::OsString::from(".");
     tmp_name.push(file_name);
     tmp_name.push(format!(".tmp.{}", std::process::id()));
@@ -424,11 +518,11 @@ fn write_file_atomically(path: &Path, content: &[u8]) -> Result<()> {
             .create(true)
             .truncate(true)
             .open(&tmp_path)
-            .with_context(|| format!("open temp Zed settings {}", tmp_path.display()))?;
+            .with_context(|| format!("open temp {description} {}", tmp_path.display()))?;
         file.write_all(content)
-            .with_context(|| format!("write temp Zed settings {}", tmp_path.display()))?;
+            .with_context(|| format!("write temp {description} {}", tmp_path.display()))?;
         file.sync_all()
-            .with_context(|| format!("sync temp Zed settings {}", tmp_path.display()))?;
+            .with_context(|| format!("sync temp {description} {}", tmp_path.display()))?;
         Ok(())
     })();
     if let Err(err) = write_result {
@@ -438,7 +532,7 @@ fn write_file_atomically(path: &Path, content: &[u8]) -> Result<()> {
     #[cfg(windows)]
     if path.exists() {
         std::fs::remove_file(path)
-            .with_context(|| format!("remove existing Zed settings {}", path.display()))?;
+            .with_context(|| format!("remove existing {description} {}", path.display()))?;
     }
     std::fs::rename(&tmp_path, path)
         .with_context(|| format!("rename {} -> {}", tmp_path.display(), path.display()))?;
@@ -465,6 +559,65 @@ mod tests {
             command: PathBuf::from(command),
             force,
         })
+    }
+
+    fn into_buzz_at(path: PathBuf, command: &str, force: bool) -> Result<BuzzIntoResult> {
+        into_buzz(BuzzIntoOptions {
+            harness_path: Some(path),
+            agent_name: "yolop".to_string(),
+            command: PathBuf::from(command),
+            force,
+        })
+    }
+
+    #[test]
+    fn buzz_into_creates_custom_harness() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("custom_harnesses/yolop.json");
+
+        let result = into_buzz_at(path.clone(), "/bin/yolop", false).expect("into");
+
+        assert_eq!(result.status, IntoStatus::Created);
+        let value: Value = serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        assert_eq!(
+            value,
+            json!({
+                "id": "yolop",
+                "label": "yolop",
+                "command": "/bin/yolop",
+                "args": ["--acp"],
+                "env": {},
+                "installInstructionsUrl": "https://github.com/everruns/yolop#install",
+                "installHint": "Install Yolop, then run `yolop into buzz`."
+            })
+        );
+    }
+
+    #[test]
+    fn buzz_into_updates_managed_fields_and_preserves_env_and_extensions() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("yolop.json");
+        std::fs::write(&path, r#"{"id":"old","label":"Old","command":"old","args":["old"],"env":{"API_KEY":"keep"},"icon":"keep","installInstructionsUrl":"old","installHint":"old"}"#).unwrap();
+
+        let result = into_buzz_at(path.clone(), "/bin/yolop", false).expect("into");
+
+        assert_eq!(result.status, IntoStatus::Updated);
+        let value: Value = serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        assert_eq!(value["command"], "/bin/yolop");
+        assert_eq!(value["args"], json!(["--acp"]));
+        assert_eq!(value["env"]["API_KEY"], "keep");
+        assert_eq!(value["icon"], "keep");
+    }
+
+    #[test]
+    fn buzz_into_is_idempotent_with_user_env() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("yolop.json");
+        std::fs::write(&path, r#"{"id":"yolop","label":"yolop","command":"/bin/yolop","args":["--acp"],"env":{"API_KEY":"keep"},"installInstructionsUrl":"https://github.com/everruns/yolop#install","installHint":"Install Yolop, then run `yolop into buzz`."}"#).unwrap();
+
+        let result = into_buzz_at(path, "/bin/yolop", false).expect("into");
+
+        assert_eq!(result.status, IntoStatus::Unchanged);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -330,10 +330,19 @@ struct IntoCommand {
 
 #[derive(Subcommand, Debug)]
 enum IntoTarget {
+    /// Configure Buzz Desktop to launch yolop as a custom ACP harness.
+    Buzz(BuzzIntoArgs),
     /// Configure Paseo to launch yolop as a custom ACP provider.
     Paseo(PaseoIntoArgs),
     /// Configure Zed to launch yolop as a custom ACP agent.
     Zed(ZedIntoArgs),
+}
+
+#[derive(Args, Debug)]
+struct BuzzIntoArgs {
+    /// Replace the custom harness instead of preserving its env/extra fields.
+    #[arg(long)]
+    force: bool,
 }
 
 #[derive(Args, Debug)]
@@ -1065,6 +1074,35 @@ fn run_command(command: Commands) -> Result<()> {
             script,
         } => exec::sandbox::run_linux_worker(&cwd, &temp, mode, &script),
         Commands::Into(into) => match into.target {
+            IntoTarget::Buzz(args) => {
+                let command = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("yolop"));
+                let result = editor::into::into_buzz(editor::into::BuzzIntoOptions {
+                    harness_path: None,
+                    agent_name: "yolop".to_string(),
+                    command,
+                    force: args.force,
+                })?;
+                match result.status {
+                    editor::into::IntoStatus::Unchanged => println!(
+                        "yolop: Buzz already has `{}` configured at {}",
+                        result.agent_name,
+                        result.harness_path.display()
+                    ),
+                    editor::into::IntoStatus::Created => println!(
+                        "yolop: added `{}` custom harness to {}",
+                        result.agent_name,
+                        result.harness_path.display()
+                    ),
+                    editor::into::IntoStatus::Updated => println!(
+                        "yolop: updated `{}` custom harness in {}",
+                        result.agent_name,
+                        result.harness_path.display()
+                    ),
+                }
+                println!("yolop: Buzz command: {} --acp", result.command);
+                println!("yolop: restart Buzz Desktop to reload this configuration");
+                Ok(())
+            }
             IntoTarget::Paseo(args) => {
                 let command = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("yolop"));
                 let result = editor::into::into_paseo(editor::into::PaseoIntoOptions {


### PR DESCRIPTION
## Problem

Yolop exposes ACP through `yolop --acp`, but Buzz Desktop users had to create a custom harness JSON manually. The first revision of this PR incorrectly inferred that JSON shape from a stale local file; this revision is based on Buzz's authoritative loader and validator.

## Approach

- Add `yolop into buzz` beside the existing Zed and Paseo integration commands.
- Write a per-harness file in Buzz's platform application-data `custom_harnesses` directory.
- Emit Buzz's required `CustomHarnessConfig` fields: `id`, `label`, `command`, `args`, `env`, `installInstructionsUrl`, and `installHint`.
- Preserve user `env` values and unknown extension fields on normal reruns; support complete replacement with `--force`.
- Document the behavior and its authoritative source in `knowledge/specs/acp.md` and the README.

Authoritative integration contract: [`block/buzz@d8281b9`, `custom_harnesses.rs`](https://github.com/block/buzz/blob/d8281b9c93395f15d55091b131bb2747a0a3da8a/desktop/src-tauri/src/managed_agents/custom_harnesses.rs#L11-L64).

## Non-goals

- Managing Buzz agent identities or global agent configuration.
- Launching or restarting Buzz Desktop.
- Managing secrets beyond preserving existing harness `env` entries.

## Validation

- [x] `cargo test editor::into::tests`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Isolated-`HOME` smoke test generated JSON and asserted every Buzz-required field with `jq`.
- [x] Independent re-review against the downloaded authoritative Buzz source found no remaining issue.
- [ ] Full `cargo test` is green locally (one existing timing assertion missed by 4 ms in the full run and passed when rerun alone).
- [ ] CI green after the corrected push.

## Risk

- Low and localized to the new `into buzz` branch and shared atomic JSON writer.
- The default application-data path comes from `dirs::data_dir()` plus Buzz's Tauri identifier (`xyz.block.buzz.app`), matching Buzz's own `app_data_dir()` storage.
- Existing custom values are retained unless `--force` is explicit.

## Rollback

Revert this PR. Users can remove the generated `custom_harnesses/yolop.json`; no other Buzz configuration is changed.


## Screenshot

![Buzz Desktop showing the Yolop harness](https://everruns.communities.buzz.xyz/media/11e04d2b338712b8f636fe1b58c14ee6817d8196585ec1cadc069cc4b1a0728f.png)

Produced by [yolop](https://everruns.com/yolop)