### PR TITLE
chore(agents): record the no-em-dash prose convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,10 @@ defines how this repository organizes what agents read.
 Telegraph, keep updates short and factual. Fix root causes; when you are still
 stuck after reading the code, ask with short options.
 
+Prose in this repository, `knowledge/`, docs, commit messages, and PR bodies
+alike, uses no em-dashes: a comma, colon, or separate sentence says the same
+thing without the AI tell. `knowledge/log.md` headings are `## DATE, Title`.
+
 ## Layout
 
 A Cargo workspace of two packages; root `cargo test` / `cargo clippy` cover


### PR DESCRIPTION
## What changed

Writes down a convention the repository already follows but never stated: prose carries
no em-dashes, and `knowledge/log.md` headings are `## DATE, Title`.

One paragraph in `AGENTS.md`, beside the existing voice guidance.

## Why

#577 applied this across 55 files, replacing em-dashes with commas in both headings and
mid-sentence prose. Nothing recorded it, so the rule is invisible until it bites.

It bit while rebasing #582: a new `knowledge/log.md` entry written in the old style
collided with the reformatted headings, and the convention had to be reverse-engineered
from the diff of #577. A contributor who does not happen to touch `log.md` would not
discover it at all, and would simply write prose that a reviewer then has to correct.

`AGENTS.md` is read on every turn, which is exactly when the rule is needed.

## Before / After

Reverse-engineering the rule from a conflict, versus reading it:

```
Before: git show 37187ba -- knowledge/log.md
        -## 2026-08-15 — Interactive tracing no longer corrupts terminal frames
        +## 2026-08-15, Interactive tracing no longer corrupts terminal frames

After:  AGENTS.md, read every turn:
        "Prose in this repository, `knowledge/`, docs, commit messages, and PR
         bodies alike, uses no em-dashes ... `knowledge/log.md` headings are
         `## DATE, Title`."
```

No behavior change: documentation only.

## Risk

- **Low**
- Documentation only. No code, configuration, or dependency changes, and nothing
  executable is touched.

## Checklist

- [ ] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

Tests are not applicable: the change adds three lines of prose to `AGENTS.md` and alters
no behavior. Per `knowledge/specs/shipping.md`, docs-only changes with no behavior change
are exempt with stated justification.

## Knowledge

`No knowledge update required` for the concept bundle.

Placement was deliberate. `knowledge/specs/documentation.md` looks like the obvious home
but scopes itself to the public-versus-internal boundary, information architecture, links,
guides, captures, and enforcement, and carries no prose-style section. The convention also
governs commit messages and PR bodies, which that spec does not cover, so `AGENTS.md`,
which already owns voice and commit conventions, is the correct layer. `knowledge/log.md`
is unchanged: this records an existing convention rather than making a decision.

Validated with `python3 scripts/validate_okf.py knowledge --check-links`: 40 concepts,
0 errors.

## Security

No security-relevant code changes. The diff is three lines of prose in a contributor
guidance file, touching no code, configuration, dependency, or infrastructure.

## Follow-ups

`No follow-ups.`


---
_Generated by [Claude Code](https://claude.ai/code/session_01EPe3ertCMNqSifwimmnab2)_