### PR TITLE
feat(config): let a profile carry capabilities, MCP, skills, and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,28 +416,53 @@ Unknown keys are ignored, so the format stays forward-compatible.
 
 Named profiles are sparse execution overlays stored under
 `<config_dir>/yolop/profiles/<name>.toml` and selected explicitly with
-`--profile <name>`. They can bundle provider/model choices, endpoint base URLs,
-soft and hard approval settings, sandbox mode, and worktree behavior without
-duplicating global settings:
+`--profile <name>`. A profile bundles provider/model choices, endpoint base
+URLs, approval and sandbox settings, worktree behavior, the harness capability
+set (which is also how extensions are enabled or disabled), MCP servers, extra
+skills, and standing instructions, so one profile can define a purpose-built
+agent without duplicating global settings:
 
 ```toml
-# profiles/deep-review.toml
+# profiles/triage.toml
 default_provider = "openai"
-approval_mode = "protective"
-approval_policy = "on-request"
-sandbox_mode = "workspace-write"
-worktrees = "always"
+approval_policy = "never"
+sandbox_mode = "read-only"
+instructions_file = "triage/INSTRUCTIONS.md"
 
 [models]
 openai = "gpt-5.6 xhigh"
+
+# Only these MCP servers, not the global set.
+mcp_mode = "replace"
+
+[mcp.servers.inbox]
+type = "http"
+url = "https://inbox.example/mcp"
+
+# Turn an extension on for this profile and a default capability off.
+[[capabilities]]
+ref = "ext:triage"
+
+[[capabilities]]
+ref = "yolop_skill_management"
+enabled = false
 ```
 
+Structural keys layer by default: `[[capabilities]]` entries run after the
+global ones and `[mcp.servers.<name>]` entries merge by name. Set
+`capabilities_mode = "replace"` or `mcp_mode = "replace"` when the profile
+should be the whole set. `instructions` (inline) and `instructions_file` are
+appended to the system prompt. Skills in `profiles/<name>/skills/` (or a
+`skills_dir` you name) become a scope ranked between the workspace and global
+ones. Paths resolve relative to the profiles directory.
+
 CLI and ACP live model choices override the selected profile; the profile
-overrides `settings.toml`. Credentials, MCP servers, capabilities, theme,
-attribution, and background-wake behavior remain global and are rejected in a
-profile. When a profile is active, `/setup` and `set_config` persist profileable
-changes back to that profile while credential changes still update the global
-settings file.
+overrides `settings.toml`. Credentials, theme, attribution, and background-wake
+behavior remain global and are rejected in a profile. When a profile is active,
+`/setup`, `set_config`, and extension enable/disable persist back to that
+profile while credential changes still update the global settings file.
+Workspace `.mcp.json` still overlays a profile's servers by name, and `yolop
+mcp` / `/mcp` writes stay scoped to global settings or the workspace file.
 
 **Provider resolution at startup:** `--provider` wins, then the saved
 profile `default_provider`, then the global `default_provider`, then auto-detect in the order **OpenAI → Codex → Anthropic → Meta →

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,25 @@
 Significant changes to Yolop's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
+## 2026-08-18, Profiles carry a whole agent, not just execution settings
+
+- [Configuration](specs/configuration.md): profiles gained `capabilities`,
+  `mcp`, `instructions` / `instructions_file`, and `skills_dir`, with
+  `capabilities_mode` / `mcp_mode` to replace the global set instead of layering
+  on it. Only credentials and personal settings (`tokens`, `codex_auth`,
+  `theme`, `attribution`, `proactive_wake`) stay global-only.
+- The reason for the change: v1 profiles could switch provider and paranoia
+  level but not define an agent with a job, so a purpose-built agent (triage,
+  review, release duty) meant a second config directory. Everything that decides
+  what an agent can do is now selectable per run.
+- Follow-on effects recorded in the neighbouring specs: extension enablement is
+  a `[[capabilities]]` entry, so it became per-profile for free
+  ([extensions](specs/extensions.md)); skills gained a profile scope between
+  workspace and global ([skills](specs/skills.md)); MCP gained a profile scope
+  between global and workspace ([mcp](specs/mcp.md)); and a profile's standing
+  instructions are the one operator-owned prompt seam
+  ([system prompt](specs/system-prompt.md)).
+
 ## 2026-08-16, In-process inference provider (experimental)
 
 - Added [Local inference](specs/local-inference.md): a `local` provider that

--- a/knowledge/specs/configuration.md
+++ b/knowledge/specs/configuration.md
@@ -83,13 +83,54 @@ precedence where read (credentials and `CUSTOM_BASE_URL`). ACP's standard
 `session/set_config_option` model and reasoning changes remain local to that ACP
 session.
 
-The profileable v1 keys are `default_provider`, `models`,
-`base_urls`, `approval_mode`, `approval_policy`, `sandbox_mode`, and
-`worktrees`. Credentials (`tokens`, `codex_auth`) and structural or personal
-settings (`mcp`, `capabilities`, `theme`, `attribution`, `proactive_wake`) are
-global-only and make a selected profile fail validation. Invalid known values
-also fail startup; unknown keys produce a warning and are ignored for forward
-compatibility.
+The profileable keys are `default_provider`, `models`, `base_urls`,
+`approval_mode`, `approval_policy`, `sandbox_mode`, `worktrees`,
+`capabilities`, `capabilities_mode`, `mcp`, `mcp_mode`, `instructions`,
+`instructions_file`, and `skills_dir`. Credentials (`tokens`, `codex_auth`) and
+personal settings (`theme`, `attribution`, `proactive_wake`) are global-only and
+make a selected profile fail validation. Invalid known values also fail startup;
+unknown keys produce a warning and are ignored for forward compatibility.
+
+### A profile is the unit of a purpose-built agent
+
+v1 profiles overlaid *execution* settings only, which was enough to switch
+provider or paranoia level but not to define an agent with a job. The keys above
+close that gap, because everything that decides what an agent can do is now
+selectable per run:
+
+- **`capabilities`**, the same ordered `[[capabilities]]` list global settings
+  carry, applied after the global entries. Since an installed extension's
+  enablement *is* a `[[capabilities]]` entry, this is also how a profile turns
+  extensions on and off. `capabilities_mode = "replace"` makes the profile's
+  list the whole set, for an agent whose tool surface must not drift with the
+  user's global preferences.
+- **`mcp`**, `[mcp.servers.<name>]` entries merged by name over the global ones,
+  or the whole set under `mcp_mode = "replace"`. Precedence is unchanged
+  otherwise: workspace `.mcp.json` still overlays the result, and an ACP
+  client's `session/new` servers still win over both.
+- **`instructions`** (inline) and **`instructions_file`**, appended to the
+  harness system prompt after `system.md` and the capability blocks. This is the
+  standing job of the profile, not a durable user preference; the boundary with
+  memory and `AGENTS.md` below still holds.
+- **`skills_dir`**, an extra skills scope, defaulting to
+  `profiles/<name>/skills/` when that directory exists. It ranks between the
+  workspace and global scopes: a profile is chosen per run, so it outranks the
+  user's global skills but never the repository's own. See
+  [skills](skills.md).
+
+Relative `instructions_file` and `skills_dir` paths resolve against the
+`profiles/` directory, so a profile is a `.toml` file plus an optional sibling
+directory of its assets. A named `instructions_file` that cannot be read fails
+startup rather than silently dropping the job it describes.
+
+Writes follow the same rule as the v1 keys: with a profile active, capability
+enable/disable and capability config land in the profile, and disabling
+something the global layer (or the harness default) turns on records an explicit
+`enabled = false` mask rather than editing global settings. `instructions_file`
+and `skills_dir` are pointers, so a write carries them through verbatim instead
+of rewriting the path or inlining the file. `yolop mcp` and `/mcp` remain
+scope-explicit (global settings or workspace `.mcp.json`); a profile's servers
+are edited in the profile file.
 
 `SettingsStore` retains the global document and sparse profile separately and
 only returns their merged effective `Settings` snapshot. It never serializes

--- a/knowledge/specs/extensions.md
+++ b/knowledge/specs/extensions.md
@@ -395,7 +395,11 @@ contribution diff before anything runs.
 
 An enabled extension is one harness entry, `[[capabilities]]
 ref = "ext:<name>"`, so enable/disable/configure/validate ride the existing
-overrides, catalog, and `set_config` tools unchanged. The declared
+overrides, catalog, and `set_config` tools unchanged. Enablement is therefore
+per-layer for free: a named profile carrying `[[capabilities]]` decides which
+extensions its runs get, and `/extensions enable|disable` writes into the active
+profile when one is selected (see [configuration](configuration.md)).
+Installation stays global, one copy per user. The declared
 `config_schema` plugs into `CapabilityCatalog` validation exactly like a
 built-in's.
 

--- a/knowledge/specs/mcp.md
+++ b/knowledge/specs/mcp.md
@@ -29,7 +29,14 @@ path, so MCP tools flow through the same agent loop as the built-in tools.
 - **Configuration**: a `.mcp.json` file using the `mcpServers` object shape.
   Two scopes are read and merged (`merge_scoped_mcp_servers`):
   - **global**: `<config_dir>/yolop/mcp.json` (e.g. `~/.config/yolop/mcp.json`)
-  - **workspace**: `<workspace_root>/.mcp.json`, overrides global by name.
+    and `[mcp.servers.<name>]` in `settings.toml`
+  - **profile**: `[mcp.servers.<name>]` in the selected `--profile`, merged by
+    name over global, or the whole set under `mcp_mode = "replace"`. See
+    [configuration](configuration.md). `yolop mcp` and `/mcp` writes stay
+    scope-explicit (global or workspace); a profile's servers are edited in the
+    profile file.
+  - **workspace**: `<workspace_root>/.mcp.json`, overrides global and profile by
+    name.
   A malformed file warns and is skipped rather than failing startup.
   - **ACP client**: servers passed in `session/new` `mcpServers` (see
     `knowledge/specs/acp.md`) overlay both file scopes for that session, so a

--- a/knowledge/specs/skills.md
+++ b/knowledge/specs/skills.md
@@ -18,8 +18,8 @@ That capability owns discovery, precedence, the skills tools (`list_skills`,
 substitution, all driven strictly through the session `SessionFileSystem`. yolop
 supplies only the embedder-specific glue (`crate::capabilities::skills`):
 
-1. **The scope set and writability**: workspace, global, environment, and
-   system (below), passed as `SkillScope`s with labeled **VFS roots** (never
+1. **The scope set and writability**: workspace, profile, global, environment,
+   and system (below), passed as `SkillScope`s with labeled **VFS roots** (never
    host paths).
 2. **A host-path `SkillDirResolver`**: so `${SKILL_DIR}` and the displayed paths
    expand to real on-disk paths the host `bash` tool can read. (The core default
@@ -48,16 +48,22 @@ a labeled VFS root that yolop's file store maps to a **real on-disk directory**:
 1. **Workspace**: `<workspace>/.agents/skills/<name>/` (VFS `/.agents/skills`).
    Lives in the project under version control; ships with the repo it belongs to.
    Writable.
-2. **Global**: `~/.agents/skills/<name>/` (VFS
+2. **Profile**: the active `--profile`'s skills directory, `skills_dir` or the
+   conventional `<config_dir>/yolop/profiles/<name>/skills/` (VFS
+   `/.yolop/profile-skills`). Present only while that profile is selected.
+   Writable. A profile is chosen per run, so it outranks the user's global
+   skills and never the repository's own; see
+   [configuration](configuration.md).
+3. **Global**: `~/.agents/skills/<name>/` (VFS
    `/.yolop/global-skills`), installed once per user and shared across every
    workspace. Writable. Overridable with `YOLOP_GLOBAL_SKILLS_DIR`. The prior
    `<config_dir>/yolop/skills/` root is imported temporarily for compatibility;
    existing primary entries are never overwritten.
-3. **Environment**: optional, integration-owned skills mounted into the
+4. **Environment**: optional, integration-owned skills mounted into the
    session-only VFS (VFS `/.yolop/environment-skills`). Always read-only and
    never materialized on disk. Herdr currently contributes this scope when its
    inherited environment contract is valid.
-4. **System**: pre-packed inside the yolop binary and materialized once to
+5. **System**: pre-packed inside the yolop binary and materialized once to
    `<data_dir>/yolop/system-skills/<name>/` (VFS `/.yolop/system-skills`). Always
    available, **read-only**. Overridable with `YOLOP_SYSTEM_SKILLS_DIR` (used
    verbatim, no materialization).
@@ -67,8 +73,8 @@ a labeled VFS root that yolop's file store maps to a **real on-disk directory**:
 1. **Merge.** `list_skills` and the system-prompt listing see skills from all
    active scopes as one set; each entry is tagged with its scope.
 2. **Precedence.** When the same skill directory name exists in more than one
-   scope, the most specific wins: workspace shadows global, which shadows
-   environment, which shadows system.
+   scope, the most specific wins: workspace shadows profile, which shadows
+   global, which shadows environment, which shadows system.
    Discovery de-duplicates by directory name in that order; `activate_skill`
    resolves the same way.
 3. **Usable paths.** Disk-backed scopes expand `${SKILL_DIR}` to paths the host
@@ -123,7 +129,7 @@ a labeled VFS root that yolop's file store maps to a **real on-disk directory**:
 14. **Environment skills are ephemeral.** An environment integration may mount
     a read-only, VFS-only skill scope for the current session. Herdr does this
     only when its inherited pane/socket contract is present. Precedence is
-    workspace, global, environment, then system; the mount never writes any
+    workspace, profile, global, environment, then system; the mount never writes any
     skill directory.
 
 ## Ownership Boundary

--- a/knowledge/specs/system-prompt.md
+++ b/knowledge/specs/system-prompt.md
@@ -243,6 +243,21 @@ Tool-round orchestration uses the four binary arms in the
 `orchestration-efficiency` preset: unchanged baseline, provider preference
 only, prompt policy only, and the combined candidate.
 
+### A profile may add a standing job
+
+A named profile's `instructions` / `instructions_file`
+([configuration](configuration.md)) are appended once, right after `system.md`,
+under a `## Profile instructions` heading and ahead of the capability blocks'
+per-turn contributions. That is the one seam where the operator, not a
+capability, adds prompt text: a profile exists to make yolop a particular agent
+for a run (triage, review, release duty), and that job cannot be expressed by
+any capability's own block. It stays subject to the same budget discipline as
+`system.md`, since it is paid on every turn of that profile's sessions.
+
+Project policy still belongs in `AGENTS.md` and durable user preference in
+memory. The distinguishing question is lifetime: an instruction that should
+apply whenever *this repository* is open is not a profile instruction.
+
 ## Non-goals
 
 - No per-model prompt variants. Composition is uniform across providers; when a

--- a/src/bundled/system-skills/yolop-config/SKILL.md
+++ b/src/bundled/system-skills/yolop-config/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: yolop-config
-description: View and change yolop's own configuration, default provider and model, per-provider API tokens and models, endpoint base URLs, attribution, and harness capabilities. Use when the user asks to configure yolop, set a default provider/model, store an API key, point at a custom endpoint, enable/disable capabilities, or asks "what is your config / what can you configure".
+description: View and change yolop's own configuration, default provider and model, per-provider API tokens and models, endpoint base URLs, attribution, harness capabilities, and named --profile overlays. Use when the user asks to configure yolop, set a default provider/model, store an API key, point at a custom endpoint, enable/disable capabilities, set up a profile, or asks "what is your config / what can you configure".
 user-invocable: true
 ---
 
@@ -76,6 +76,25 @@ Tool equivalents:
 Provider and model edits are persisted and take effect on the **next run**. To
 switch the *live* model in the current session, use the interactive `/setup`
 command instead.
+
+## Named profiles
+
+`yolop --profile <name>` loads `profiles/<name>.toml` next to `settings.toml` as
+a sparse overlay for that run. Profiles are how one machine hosts several
+purpose-built agents: besides provider, model, approval, sandbox, and worktree
+settings, a profile can carry its own `[[capabilities]]` (which is also how
+extensions are enabled or disabled), `[mcp.servers.<name>]`, `instructions` /
+`instructions_file` appended to the system prompt, and a `skills_dir`
+(defaulting to `profiles/<name>/skills/`). Set `capabilities_mode = "replace"`
+or `mcp_mode = "replace"` when the profile's set should be the only one.
+
+Credentials and personal settings (`tokens`, `codex_auth`, `theme`,
+`attribution`, `proactive_wake`) are global-only and make a profile fail to
+load. While a profile is active, `set_config` and `/setup` write profileable
+keys into it and credentials into `settings.toml`; `get_config` reports which
+layer each value came from. Profiles are edited as files, so use the file tools
+for a profile's `instructions_file` or its skills, and `set_config` for its
+keys.
 
 ## Related surfaces
 

--- a/src/capabilities/skill_registry.rs
+++ b/src/capabilities/skill_registry.rs
@@ -987,6 +987,7 @@ mod tests {
             SkillDirs {
                 workspace: ws.path().to_path_buf(),
                 global: None,
+                profile: None,
                 system: None,
             },
             registry,
@@ -1016,6 +1017,7 @@ mod tests {
         let dirs = SkillDirs {
             workspace: PathBuf::from("/ws/.agents/skills"),
             global: None,
+            profile: None,
             system: None,
         };
         let registry = SkillRegistryClient::with_base_url("http://127.0.0.1:9".into());
@@ -1057,6 +1059,7 @@ mod tests {
             SkillDirs {
                 workspace: ws.path().to_path_buf(),
                 global: None,
+                profile: None,
                 system: None,
             },
             registry,

--- a/src/capabilities/skills.rs
+++ b/src/capabilities/skills.rs
@@ -6,20 +6,21 @@
 // vendors it. This module keeps only the yolop-specific glue the core
 // capability cannot own:
 //
-//   * the three scopes and where each maps on the *host* disk,
+//   * the scope set and where each maps on the *host* disk,
 //   * a `SkillDirResolver` so `${SKILL_DIR}` expands to a real host path the
 //     `bash` tool can read (the core default keeps it in the VFS),
 //   * the system skills pre-packed in the binary and materialized once.
 //
 // The capability discovers/reads/writes strictly through the session
 // `SessionFileSystem`. yolop's file store (`CodingCliSessionFileStore`) maps the
-// three scope VFS roots onto the real directories below, so the capability never
+// disk-backed scope VFS roots onto the real directories below, so the capability never
 // touches a host path directly — the host mapping lives behind the file store,
 // not in the capability's configuration.
 //
-// Scopes (precedence: workspace > global > system; the core capability de-dups
-// by skill directory name, so a nearer scope shadows a farther one):
+// Scopes (precedence: workspace > profile > global > system; the core capability
+// de-dups by skill directory name, so a nearer scope shadows a farther one):
 //   * workspace — `<workspace>/.agents/skills`           (writable)
+//   * profile   — the active `--profile`'s skills dir    (writable; only while selected)
 //   * global    — `~/.agents/skills`                     (writable; override: YOLOP_GLOBAL_SKILLS_DIR)
 //   * system    — pre-packed, materialized once          (read-only; override: YOLOP_SYSTEM_SKILLS_DIR)
 
@@ -48,6 +49,9 @@ pub const WORKSPACE_SKILLS_VFS: &str = "/.agents/skills";
 /// Synthetic VFS root for the global scope, routed by the file store to the
 /// user's global skills directory (outside the workspace).
 pub const GLOBAL_SKILLS_VFS: &str = "/.yolop/global-skills";
+/// Synthetic VFS root for the active profile's skills directory, routed by the
+/// file store to `profiles/<name>/skills` (or the profile's `skills_dir`).
+pub const PROFILE_SKILLS_VFS: &str = "/.yolop/profile-skills";
 /// Synthetic VFS root for the system scope, routed by the file store to the
 /// materialized system skills directory.
 pub const SYSTEM_SKILLS_VFS: &str = "/.yolop/system-skills";
@@ -82,6 +86,8 @@ pub struct SkillDirs {
     pub workspace: PathBuf,
     /// Global skills directory, or `None` when no home directory exists.
     pub global: Option<PathBuf>,
+    /// The active profile's skills directory, when a profile contributes one.
+    pub profile: Option<PathBuf>,
     /// Materialized system skills directory, or `None` when unavailable.
     pub system: Option<PathBuf>,
 }
@@ -89,7 +95,7 @@ pub struct SkillDirs {
 impl SkillDirs {
     /// Resolve the workspace/global/system directories for `workspace_root`.
     /// Materializes the embedded system skills as a side effect (idempotent).
-    pub fn resolve(workspace_root: &Path) -> Self {
+    pub fn resolve(workspace_root: &Path, profile: Option<PathBuf>) -> Self {
         let global = global_skills_dir();
         if let (Some(primary), Some(legacy)) = (&global, legacy_global_skills_dir())
             && primary != &legacy
@@ -105,6 +111,7 @@ impl SkillDirs {
         Self {
             workspace: workspace_root.join(".agents").join("skills"),
             global,
+            profile,
             system: system_skills_dir(),
         }
     }
@@ -130,6 +137,11 @@ pub fn skills_config(
     extensions: &[(String, PathBuf)],
 ) -> SkillsConfig {
     let mut scopes = vec![SkillScope::new("workspace", WORKSPACE_SKILLS_VFS, true)];
+    // Between workspace and global: a profile is chosen per run, so its skills
+    // should win over the user's global set but never over the repo's own.
+    if dirs.profile.is_some() {
+        scopes.push(SkillScope::new("profile", PROFILE_SKILLS_VFS, true));
+    }
     if dirs.global.is_some() {
         scopes.push(SkillScope::new("global", GLOBAL_SKILLS_VFS, true));
     }
@@ -181,6 +193,7 @@ impl HostSkillDirResolver {
         }
         match label {
             "global" => self.dirs.global.clone(),
+            "profile" => self.dirs.profile.clone(),
             // Environment skills are VFS-only and contain no shell-side assets.
             // Keep their display/substitution path honest instead of pretending
             // they exist in a writable workspace or global directory.
@@ -617,6 +630,7 @@ mod tests {
         let dirs = SkillDirs {
             workspace: PathBuf::from("/ws/.agents/skills"),
             global: None,
+            profile: None,
             system: Some(PathBuf::from("/data/sys")),
         };
         let cfg = skills_config(&dirs, false, &[]);
@@ -641,10 +655,35 @@ mod tests {
     }
 
     #[test]
+    fn profile_scope_ranks_between_workspace_and_global() {
+        let dirs = SkillDirs {
+            workspace: PathBuf::from("/ws/.agents/skills"),
+            global: Some(PathBuf::from("/home/.agents/skills")),
+            profile: Some(PathBuf::from("/cfg/yolop/profiles/triage/skills")),
+            system: Some(PathBuf::from("/data/sys")),
+        };
+        let cfg = skills_config(&dirs, false, &[]);
+        let labels: Vec<&str> = cfg.scopes.iter().map(|s| s.label.as_str()).collect();
+        assert_eq!(labels, vec!["workspace", "profile", "global", "system"]);
+        let scope = cfg
+            .scopes
+            .iter()
+            .find(|s| s.label == "profile")
+            .expect("profile scope");
+        assert!(scope.writable, "a profile owns its skills");
+        assert_eq!(scope.vfs_root, PROFILE_SKILLS_VFS);
+        assert_eq!(
+            PathBuf::from(cfg.resolver.skill_dir(scope, "triage-intake")),
+            PathBuf::from("/cfg/yolop/profiles/triage/skills").join("triage-intake")
+        );
+    }
+
+    #[test]
     fn extension_scopes_are_read_only_and_routed() {
         let dirs = SkillDirs {
             workspace: PathBuf::from("/ws/.agents/skills"),
             global: None,
+            profile: None,
             system: None,
         };
         let ext = vec![(
@@ -671,6 +710,7 @@ mod tests {
         let dirs = SkillDirs {
             workspace: PathBuf::from("/ws/.agents/skills"),
             global: Some(PathBuf::from("/cfg/yolop/skills")),
+            profile: None,
             system: Some(PathBuf::from("/data/sys")),
         };
         let r = HostSkillDirResolver {
@@ -781,6 +821,7 @@ mod tests {
         let dirs = SkillDirs {
             workspace: PathBuf::from("/ws/.agents/skills"),
             global: None,
+            profile: None,
             system: None,
         };
         let capability = SkillManagementCapability::new(dirs);
@@ -821,6 +862,7 @@ mod tests {
             dirs: SkillDirs {
                 workspace: workspace.to_path_buf(),
                 global: global.map(Path::to_path_buf),
+                profile: None,
                 system: None,
             },
         }

--- a/src/config/mcp.rs
+++ b/src/config/mcp.rs
@@ -1,4 +1,4 @@
-use crate::config::{SettingsStore, default_settings_path};
+use crate::config::{Settings, SettingsStore, default_settings_path};
 use everruns_core::{ScopedMcpServer, ScopedMcpServers};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value as JsonValue;
@@ -224,10 +224,11 @@ pub(crate) fn global_mcp_config_path() -> Option<PathBuf> {
     default_settings_path().map(|path| path.with_file_name(MCP_CONFIG_FILE))
 }
 
-pub(crate) fn load_mcp_servers(workspace_root: &Path) -> ScopedMcpServers {
-    let mut servers = default_settings_path()
-        .map(|path| enabled_servers(SettingsStore::open(path).snapshot().mcp))
-        .unwrap_or_default();
+/// Merge the effective settings' MCP servers (global plus the active profile's
+/// overlay, already resolved in `settings`) with the legacy global `mcp.json`
+/// and the workspace `.mcp.json`, in that precedence order.
+pub(crate) fn load_mcp_servers(settings: &Settings, workspace_root: &Path) -> ScopedMcpServers {
+    let mut servers = enabled_servers(settings.mcp.clone());
 
     for (name, server) in load_global_mcp_legacy().into_iter() {
         servers.entry(name).or_insert(server);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -252,6 +252,13 @@ pub struct Settings {
     pub mcp: McpSettings,
     /// Ordered harness capability overrides (`[[capabilities]]` in settings.toml).
     pub capabilities: Vec<CapabilityOverride>,
+    /// Extra system-prompt text contributed by the active profile. Profile-only:
+    /// never parsed from, nor written to, `settings.toml`; standing instructions
+    /// for every session belong in memory or `AGENTS.md`, not global settings.
+    pub instructions: Option<String>,
+    /// Extra skills directory contributed by the active profile. Profile-only,
+    /// for the same reason.
+    pub skills_dir: Option<PathBuf>,
 }
 
 impl Default for Settings {
@@ -271,6 +278,8 @@ impl Default for Settings {
             theme: None,
             mcp: McpSettings::default(),
             capabilities: Vec::new(),
+            instructions: None,
+            skills_dir: None,
         }
     }
 }
@@ -347,6 +356,8 @@ impl Settings {
             theme,
             mcp: parse_mcp_settings(table),
             capabilities: parse_capabilities_table(table),
+            instructions: None,
+            skills_dir: None,
         }
     }
 
@@ -724,6 +735,8 @@ impl SettingsStore {
             schema::KeyTarget::Sandbox => overlay.sandbox.is_some(),
             schema::KeyTarget::Model(provider) => overlay.models.contains_key(provider),
             schema::KeyTarget::BaseUrl(provider) => overlay.base_urls.contains_key(provider),
+            schema::KeyTarget::Capabilities => !overlay.capabilities.is_empty(),
+            schema::KeyTarget::Mcp => !overlay.mcp.servers.is_empty(),
             _ => false,
         };
         if overridden {
@@ -942,18 +955,32 @@ impl SettingsStore {
         save_to(&self.path, &guard.base)
     }
 
-    /// Append a harness capability override to the ordered settings list.
+    /// Append a harness capability override to the ordered list of the active
+    /// layer: the profile when one is selected, global settings otherwise.
+    /// Returns the entry's index within that layer.
     pub fn append_capability_override(&self, entry: CapabilityOverride) -> Result<usize> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
+        if let Some(active) = &mut guard.profile {
+            active.overlay.capabilities.push(entry);
+            let index = active.overlay.capabilities.len() - 1;
+            save_profile_to(&active.path, &active.overlay)?;
+            return Ok(index);
+        }
         guard.base.capabilities.push(entry);
         let index = guard.base.capabilities.len() - 1;
         save_to(&self.path, &guard.base)?;
         Ok(index)
     }
 
-    /// Drop every stored `[[capabilities]]` override.
+    /// Drop every `[[capabilities]]` override stored in the active layer. With
+    /// a profile selected this clears the profile's list and reveals the global
+    /// one; it never edits global settings behind the profile's back.
     pub fn clear_capability_overrides(&self) -> Result<()> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
+        if let Some(active) = &mut guard.profile {
+            active.overlay.capabilities.clear();
+            return save_profile_to(&active.path, &active.overlay);
+        }
         guard.base.capabilities.clear();
         save_to(&self.path, &guard.base)
     }
@@ -967,6 +994,9 @@ impl SettingsStore {
     /// override list.
     pub fn set_capability_enabled(&self, capability_ref: &str, enabled: bool) -> Result<bool> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
+        if guard.profile.is_some() {
+            return self.set_capability_enabled_in_profile(&mut guard, capability_ref, enabled);
+        }
         let already: Vec<usize> = guard
             .base
             .capabilities
@@ -1014,6 +1044,21 @@ impl SettingsStore {
         value: serde_json::Value,
     ) -> Result<()> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
+        if let Some(active) = &mut guard.profile {
+            let overrides = &mut active.overlay.capabilities;
+            let index = overrides
+                .iter()
+                .rposition(|entry| entry.capability_ref == capability_ref && !entry.is_remove());
+            let entry = match index {
+                Some(i) => &mut overrides[i],
+                None => {
+                    overrides.push(CapabilityOverride::enable(capability_ref));
+                    overrides.last_mut().expect("just pushed")
+                }
+            };
+            set_config_key(entry, key, value);
+            return save_profile_to(&active.path, &active.overlay);
+        }
         // The active (last non-remove) override for this ref, or a fresh one.
         let index = guard
             .base
@@ -1030,13 +1075,70 @@ impl SettingsStore {
                 guard.base.capabilities.last_mut().expect("just pushed")
             }
         };
-        if !entry.config.is_object() {
-            entry.config = serde_json::Value::Object(serde_json::Map::new());
-        }
-        if let serde_json::Value::Object(map) = &mut entry.config {
-            map.insert(key.to_string(), value);
-        }
+        set_config_key(entry, key, value);
         save_to(&self.path, &guard.base)
+    }
+
+    /// Profile-layer counterpart of [`Self::set_capability_enabled`]. Enabling
+    /// adds an entry to the profile; disabling drops the profile's entries and,
+    /// unless the capability was enabled by this profile alone, records an
+    /// explicit `enabled = false` so the global entry (or the harness default)
+    /// is masked for this profile only.
+    fn set_capability_enabled_in_profile(
+        &self,
+        guard: &mut SettingsState,
+        capability_ref: &str,
+        enabled: bool,
+    ) -> Result<bool> {
+        let global_enables = guard
+            .base
+            .capabilities
+            .iter()
+            .any(|entry| entry.capability_ref == capability_ref && !entry.is_remove());
+        let active = guard.profile.as_mut().expect("profile layer");
+        let global_enables =
+            global_enables && active.overlay.capabilities_mode != profile::ListMode::Replace;
+        let overrides = &mut active.overlay.capabilities;
+        let profile_enables = overrides
+            .iter()
+            .any(|entry| entry.capability_ref == capability_ref && !entry.is_remove());
+        let profile_removes = overrides
+            .iter()
+            .any(|entry| entry.capability_ref == capability_ref && entry.is_remove());
+        let changed = if enabled {
+            if profile_enables && !profile_removes {
+                false
+            } else {
+                overrides.retain(|entry| entry.capability_ref != capability_ref);
+                overrides.push(CapabilityOverride::enable(capability_ref));
+                true
+            }
+        } else {
+            let had_entries = profile_enables || profile_removes;
+            overrides.retain(|entry| entry.capability_ref != capability_ref);
+            // Dropping a profile-local enable is enough only when nothing
+            // outside the profile turns the capability on.
+            let mask_needed = global_enables || !profile_enables;
+            if mask_needed && !profile_removes {
+                overrides.push(CapabilityOverride::remove(capability_ref));
+                true
+            } else {
+                had_entries
+            }
+        };
+        if changed {
+            save_profile_to(&active.path, &active.overlay)?;
+        }
+        Ok(changed)
+    }
+}
+
+fn set_config_key(entry: &mut CapabilityOverride, key: &str, value: serde_json::Value) {
+    if !entry.config.is_object() {
+        entry.config = serde_json::Value::Object(serde_json::Map::new());
+    }
+    if let serde_json::Value::Object(map) = &mut entry.config {
+        map.insert(key.to_string(), value);
     }
 }
 
@@ -1044,6 +1146,78 @@ impl SettingsStore {
 mod tests {
     use super::*;
     use everruns_core::McpServerAuthMode;
+
+    fn store_with_profile(dir: &Path, name: &str, body: &str) -> SettingsStore {
+        let profiles = dir.join("profiles");
+        std::fs::create_dir_all(&profiles).expect("profiles dir");
+        std::fs::write(profiles.join(format!("{name}.toml")), body).expect("profile");
+        SettingsStore::open_with_profile(dir.join("settings.toml"), name).expect("open")
+    }
+
+    #[test]
+    fn capability_writes_land_in_the_active_profile() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let dir = tmp.path();
+        // Global enables an extension; the profile turns it off for its runs.
+        let global = SettingsStore::open(dir.join("settings.toml"));
+        global
+            .set_capability_enabled("ext:notes", true)
+            .expect("enable globally");
+
+        let store = store_with_profile(dir, "triage", "approval_policy = 'never'\n");
+        assert!(
+            store
+                .set_capability_enabled("ext:notes", false)
+                .expect("disable")
+        );
+        assert!(
+            store
+                .set_capability_enabled("ext:triage", true)
+                .expect("enable")
+        );
+        let effective = store.snapshot();
+        let masked = effective
+            .capability_overrides_for("ext:notes")
+            .into_iter()
+            .map(|(_, entry)| entry.is_remove())
+            .collect::<Vec<_>>();
+        assert_eq!(masked, [false, true], "profile masks the global entry");
+        assert!(
+            effective
+                .capability_overrides_for("ext:triage")
+                .iter()
+                .any(|(_, entry)| !entry.is_remove())
+        );
+
+        // Global settings are untouched; the profile file carries both edits.
+        let global_only = SettingsStore::open(dir.join("settings.toml")).snapshot();
+        assert_eq!(global_only.capabilities.len(), 1);
+        assert!(!global_only.capabilities[0].is_remove());
+        let written = std::fs::read_to_string(dir.join("profiles").join("triage.toml"))
+            .expect("read profile");
+        assert!(written.contains("ext:triage"), "{written}");
+        assert!(written.contains("approval_policy"), "{written}");
+    }
+
+    #[test]
+    fn profile_capability_config_never_touches_global_settings() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let dir = tmp.path();
+        let store = store_with_profile(dir, "triage", "");
+        store
+            .set_capability_config("ext:triage", "queue", serde_json::json!("inbox"))
+            .expect("write config");
+        assert_eq!(
+            store.snapshot().capabilities[0].config["queue"],
+            serde_json::json!("inbox")
+        );
+        assert!(
+            SettingsStore::open(dir.join("settings.toml"))
+                .snapshot()
+                .capabilities
+                .is_empty()
+        );
+    }
 
     #[test]
     fn set_capability_config_creates_override_and_persists() {

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -1,4 +1,8 @@
-use super::{ApprovalMode, ApprovalPolicy, SandboxMode, Settings, WorktreesMode};
+use super::mcp::McpSettings;
+use super::{
+    ApprovalMode, ApprovalPolicy, CapabilityOverride, SandboxMode, Settings, WorktreesMode,
+    capabilities_to_toml, mcp_settings_to_table, parse_capabilities_table, parse_mcp_settings,
+};
 use crate::runtime::SUPPORTED_PROVIDERS;
 use anyhow::{Context, Result, bail};
 use std::collections::BTreeMap;
@@ -13,6 +17,31 @@ const PROFILEABLE_KEYS: &[&str] = &[
     "approval_policy",
     "worktrees",
     "sandbox_mode",
+    "capabilities",
+    "capabilities_mode",
+    "mcp",
+    "mcp_mode",
+    "instructions",
+    "instructions_file",
+    "skills_dir",
+];
+
+/// The subset of [`PROFILEABLE_KEYS`] that [`SettingsOverlay::to_table`]
+/// regenerates from parsed state. Everything else recognized (the instruction
+/// and skills pointers) is carried through verbatim, alongside keys yolop does
+/// not know, so a write never rewrites a path or inlines a file's contents.
+const REWRITTEN_KEYS: &[&str] = &[
+    "default_provider",
+    "models",
+    "base_urls",
+    "approval_mode",
+    "approval_policy",
+    "worktrees",
+    "sandbox_mode",
+    "capabilities",
+    "capabilities_mode",
+    "mcp",
+    "mcp_mode",
 ];
 
 const GLOBAL_ONLY_KEYS: &[&str] = &[
@@ -21,8 +50,6 @@ const GLOBAL_ONLY_KEYS: &[&str] = &[
     "theme",
     "attribution",
     "proactive_wake",
-    "mcp",
-    "capabilities",
 ];
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -50,6 +77,36 @@ impl ProfileName {
     }
 }
 
+/// How a profile's structural list combines with the global one.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ListMode {
+    /// Profile entries are layered on top of the global ones.
+    #[default]
+    Merge,
+    /// The profile's entries are the whole set; global ones are ignored.
+    Replace,
+}
+
+impl ListMode {
+    /// `append`/`merge` and `replace` both read naturally depending on whether
+    /// the key is an ordered list (`capabilities`) or a map (`mcp`), so accept
+    /// either spelling for either key.
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "merge" | "append" | "layer" => Some(Self::Merge),
+            "replace" | "only" | "exclusive" => Some(Self::Replace),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Merge => "merge",
+            Self::Replace => "replace",
+        }
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct SettingsOverlay {
     pub default_provider: Option<Option<String>>,
@@ -59,6 +116,23 @@ pub struct SettingsOverlay {
     pub approval_policy: Option<ApprovalPolicy>,
     pub worktrees: Option<WorktreesMode>,
     pub sandbox: Option<SandboxMode>,
+    /// Harness capability overrides applied after the global ones (or instead
+    /// of them under [`ListMode::Replace`]). This is also how a profile enables
+    /// or disables an installed extension, whose enablement *is* a
+    /// `[[capabilities]]` entry.
+    pub capabilities: Vec<CapabilityOverride>,
+    pub capabilities_mode: ListMode,
+    /// MCP servers merged by name over the global ones (or instead of them
+    /// under [`ListMode::Replace`]). Workspace `.mcp.json` still overlays the
+    /// result, so a repo can still override a profile server by name.
+    pub mcp: McpSettings,
+    pub mcp_mode: ListMode,
+    /// Extra system-prompt text appended after `system.md` and the capability
+    /// blocks, for a profile that gives the agent a standing job.
+    pub instructions: Option<String>,
+    /// Extra skills scope, resolved to a host directory. Ranks between the
+    /// workspace and global scopes.
+    pub skills_dir: Option<PathBuf>,
     unknown: Table,
 }
 
@@ -81,9 +155,29 @@ impl SettingsOverlay {
         if let Some(mode) = self.sandbox {
             settings.sandbox = mode;
         }
+        if self.capabilities_mode == ListMode::Replace {
+            settings.capabilities.clear();
+        }
+        settings
+            .capabilities
+            .extend(self.capabilities.iter().cloned());
+        if self.mcp_mode == ListMode::Replace {
+            settings.mcp.servers.clear();
+        }
+        for (name, entry) in &self.mcp.servers {
+            settings.mcp.servers.insert(name.clone(), entry.clone());
+        }
+        if let Some(instructions) = &self.instructions {
+            settings.instructions = Some(instructions.clone());
+        }
+        if let Some(dir) = &self.skills_dir {
+            settings.skills_dir = Some(dir.clone());
+        }
     }
 
-    pub fn from_table(table: &Table) -> Result<(Self, Vec<String>)> {
+    /// Parse a profile document. `base_dir` is the directory holding the
+    /// profile file; `instructions_file` and `skills_dir` resolve against it.
+    pub fn from_table(table: &Table, base_dir: &Path) -> Result<(Self, Vec<String>)> {
         for key in GLOBAL_ONLY_KEYS {
             if table.contains_key(*key) {
                 bail!("`{key}` is global-only and cannot be set in a profile");
@@ -97,7 +191,7 @@ impl SettingsOverlay {
             .collect();
         let unknown = table
             .iter()
-            .filter(|(key, _)| !PROFILEABLE_KEYS.contains(&key.as_str()))
+            .filter(|(key, _)| !REWRITTEN_KEYS.contains(&key.as_str()))
             .map(|(key, value)| (key.clone(), value.clone()))
             .collect();
 
@@ -144,6 +238,30 @@ impl SettingsOverlay {
             SandboxMode::parse,
             "read-only, workspace-write, or danger-full-access",
         )?;
+        let capabilities = parse_capabilities_table(table);
+        if table.contains_key("capabilities") && capabilities.is_empty() {
+            bail!("`capabilities` must be an array of tables, each with a `ref`");
+        }
+        let capabilities_mode = optional_parsed(
+            table,
+            "capabilities_mode",
+            ListMode::parse,
+            "merge (default) or replace",
+        )?
+        .unwrap_or_default();
+        let mcp = parse_mcp_settings(table);
+        if table.contains_key("mcp") && mcp.servers.is_empty() {
+            bail!("`mcp` must be a table of `[mcp.servers.<name>]` entries");
+        }
+        let mcp_mode = optional_parsed(
+            table,
+            "mcp_mode",
+            ListMode::parse,
+            "merge (default) or replace",
+        )?
+        .unwrap_or_default();
+        let instructions = load_instructions(table, base_dir)?;
+        let skills_dir = optional_string(table, "skills_dir")?.map(|raw| resolve(base_dir, &raw));
 
         Ok((
             Self {
@@ -154,6 +272,12 @@ impl SettingsOverlay {
                 approval_policy,
                 worktrees,
                 sandbox,
+                capabilities,
+                capabilities_mode,
+                mcp,
+                mcp_mode,
+                instructions,
+                skills_dir,
                 unknown,
             },
             warnings,
@@ -189,6 +313,29 @@ impl SettingsOverlay {
                 Value::String(mode.as_str().to_string()),
             );
         }
+        if let Value::Array(items) = capabilities_to_toml(&self.capabilities)
+            && !items.is_empty()
+        {
+            table.insert("capabilities".to_string(), Value::Array(items));
+        }
+        if self.capabilities_mode != ListMode::default() {
+            table.insert(
+                "capabilities_mode".to_string(),
+                Value::String(self.capabilities_mode.as_str().to_string()),
+            );
+        }
+        if !self.mcp.servers.is_empty() {
+            table.insert(
+                "mcp".to_string(),
+                Value::Table(mcp_settings_to_table(&self.mcp)),
+            );
+        }
+        if self.mcp_mode != ListMode::default() {
+            table.insert(
+                "mcp_mode".to_string(),
+                Value::String(self.mcp_mode.as_str().to_string()),
+            );
+        }
         table
     }
 }
@@ -212,9 +359,20 @@ impl ActiveProfile {
             .with_context(|| format!("read profile `{}` from {}", name.as_str(), path.display()))?;
         let table: Table = toml::from_str(&text)
             .with_context(|| format!("parse profile `{}` at {}", name.as_str(), path.display()))?;
-        let (overlay, warnings) = SettingsOverlay::from_table(&table).with_context(|| {
-            format!("invalid profile `{}` at {}", name.as_str(), path.display())
-        })?;
+        let base_dir = parent.join("profiles");
+        let (mut overlay, warnings) =
+            SettingsOverlay::from_table(&table, &base_dir).with_context(|| {
+                format!("invalid profile `{}` at {}", name.as_str(), path.display())
+            })?;
+        // Convention over configuration: `profiles/<name>/skills/` is the
+        // profile's skills scope when it exists, so a profile directory needs
+        // no `skills_dir` key to carry skills.
+        if overlay.skills_dir.is_none() {
+            let conventional = base_dir.join(name.as_str()).join("skills");
+            if conventional.is_dir() {
+                overlay.skills_dir = Some(conventional);
+            }
+        }
         Ok(Self {
             name,
             path,
@@ -222,6 +380,44 @@ impl ActiveProfile {
             warnings,
         })
     }
+}
+
+/// Resolve a profile-relative path against the profiles directory; absolute
+/// paths (and `~`) are taken as given.
+fn resolve(base_dir: &Path, raw: &str) -> PathBuf {
+    if let Some(rest) = raw.strip_prefix("~/")
+        && let Some(home) = dirs::home_dir()
+    {
+        return home.join(rest);
+    }
+    let path = PathBuf::from(raw);
+    if path.is_absolute() {
+        path
+    } else {
+        base_dir.join(path)
+    }
+}
+
+/// Inline `instructions` plus the contents of `instructions_file`, in that
+/// order. A named file that cannot be read fails the profile rather than
+/// silently dropping the standing job it describes.
+fn load_instructions(table: &Table, base_dir: &Path) -> Result<Option<String>> {
+    let mut blocks = Vec::new();
+    if let Some(inline) = optional_string(table, "instructions")? {
+        blocks.push(inline.trim_end().to_string());
+    }
+    if let Some(raw) = optional_string(table, "instructions_file")? {
+        let path = resolve(base_dir, &raw);
+        let text = std::fs::read_to_string(&path)
+            .with_context(|| format!("read `instructions_file` {}", path.display()))?;
+        blocks.push(text.trim_end().to_string());
+    }
+    let joined = blocks
+        .into_iter()
+        .filter(|block| !block.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    Ok((!joined.is_empty()).then_some(joined))
 }
 
 fn optional_string(table: &Table, key: &str) -> Result<Option<String>> {
@@ -325,7 +521,8 @@ mod tests {
             "default_provider = 'openai'\napproval_policy = 'never'\nfuture_setting = 'preserved'\n[models]\nopenai = 'gpt-5.6 high'\n",
         )
         .unwrap();
-        let (overlay, warnings) = SettingsOverlay::from_table(&table).unwrap();
+        let (overlay, warnings) =
+            SettingsOverlay::from_table(&table, Path::new("/nonexistent")).unwrap();
         assert_eq!(warnings, ["ignoring unknown profile key `future_setting`"]);
         assert_eq!(overlay.default_provider, Some(Some("openai".to_string())));
         assert_eq!(overlay.approval_policy, Some(ApprovalPolicy::Never));
@@ -337,7 +534,7 @@ mod tests {
         );
 
         let credentials: Table = toml::from_str("[tokens]\nopenai = 'secret'\n").unwrap();
-        assert!(SettingsOverlay::from_table(&credentials).is_err());
+        assert!(SettingsOverlay::from_table(&credentials, Path::new("/nonexistent")).is_err());
     }
 
     #[test]
@@ -359,5 +556,119 @@ mod tests {
         assert_eq!(settings.default_provider.as_deref(), Some("openai"));
         assert_eq!(settings.models["openai"], "gpt-profile");
         assert_eq!(settings.models["anthropic"], "claude-sonnet");
+    }
+
+    #[test]
+    fn capabilities_layer_by_default_and_replace_on_request() {
+        let table: Table = toml::from_str(
+            "[[capabilities]]\nref = 'ext:triage'\n\n[[capabilities]]\nref = 'yolop_lsp'\nenabled = false\n",
+        )
+        .unwrap();
+        let (overlay, warnings) =
+            SettingsOverlay::from_table(&table, Path::new("/nonexistent")).unwrap();
+        assert!(warnings.is_empty());
+        let mut settings = Settings {
+            capabilities: vec![CapabilityOverride::enable("ext:notes")],
+            ..Settings::default()
+        };
+        overlay.apply_to(&mut settings);
+        let refs: Vec<_> = settings
+            .capabilities
+            .iter()
+            .map(|entry| entry.capability_ref.as_str())
+            .collect();
+        assert_eq!(refs, ["ext:notes", "ext:triage", "yolop_lsp"]);
+        assert!(settings.capabilities[2].is_remove());
+
+        let replacing: Table =
+            toml::from_str("capabilities_mode = 'replace'\n[[capabilities]]\nref = 'ext:triage'\n")
+                .unwrap();
+        let (overlay, _) =
+            SettingsOverlay::from_table(&replacing, Path::new("/nonexistent")).unwrap();
+        let mut settings = Settings {
+            capabilities: vec![CapabilityOverride::enable("ext:notes")],
+            ..Settings::default()
+        };
+        overlay.apply_to(&mut settings);
+        assert_eq!(settings.capabilities.len(), 1);
+        assert_eq!(settings.capabilities[0].capability_ref, "ext:triage");
+        // Both survive a write back to disk.
+        let round_tripped = overlay.to_table();
+        assert_eq!(round_tripped["capabilities_mode"].as_str(), Some("replace"));
+        assert!(round_tripped["capabilities"].as_array().is_some());
+    }
+
+    #[test]
+    fn mcp_servers_merge_by_name_or_replace_the_global_set() {
+        let table: Table = toml::from_str(
+            "[mcp.servers.linear]\ntype = 'http'\nurl = 'https://profile.example/mcp'\n",
+        )
+        .unwrap();
+        let (overlay, _) = SettingsOverlay::from_table(&table, Path::new("/nonexistent")).unwrap();
+        let mut settings = Settings::default();
+        settings.mcp.servers.insert(
+            "notes".to_string(),
+            toml::from_str::<Table>("type = 'http'\nurl = 'https://global.example/mcp'\n")
+                .unwrap()
+                .try_into()
+                .unwrap(),
+        );
+        overlay.apply_to(&mut settings);
+        assert_eq!(
+            settings.mcp.servers.keys().collect::<Vec<_>>(),
+            ["linear", "notes"]
+        );
+
+        let replacing: Table = toml::from_str(
+            "mcp_mode = 'replace'\n[mcp.servers.linear]\ntype = 'http'\nurl = 'https://profile.example/mcp'\n",
+        )
+        .unwrap();
+        let (overlay, _) =
+            SettingsOverlay::from_table(&replacing, Path::new("/nonexistent")).unwrap();
+        overlay.apply_to(&mut settings);
+        assert_eq!(settings.mcp.servers.keys().collect::<Vec<_>>(), ["linear"]);
+    }
+
+    #[test]
+    fn instructions_and_skills_resolve_against_the_profiles_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path();
+        std::fs::write(base.join("triage.md"), "Route incoming work.\n").unwrap();
+        let table: Table = toml::from_str(
+            "instructions = 'You are the triage agent.'\ninstructions_file = 'triage.md'\nskills_dir = 'triage/skills'\n",
+        )
+        .unwrap();
+        let (overlay, warnings) = SettingsOverlay::from_table(&table, base).unwrap();
+        assert!(warnings.is_empty());
+        assert_eq!(
+            overlay.instructions.as_deref(),
+            Some("You are the triage agent.\n\nRoute incoming work.")
+        );
+        assert_eq!(
+            overlay.skills_dir.as_deref(),
+            Some(base.join("triage").join("skills").as_path())
+        );
+        // Pointers are carried through verbatim, never rewritten or inlined.
+        let written = overlay.to_table();
+        assert_eq!(written["instructions_file"].as_str(), Some("triage.md"));
+        assert_eq!(written["skills_dir"].as_str(), Some("triage/skills"));
+        assert!(written["instructions"].as_str().is_some());
+
+        let missing: Table = toml::from_str("instructions_file = 'absent.md'\n").unwrap();
+        assert!(SettingsOverlay::from_table(&missing, base).is_err());
+    }
+
+    #[test]
+    fn profile_directory_supplies_skills_without_a_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = tmp.path();
+        let profiles = config.join("profiles");
+        std::fs::create_dir_all(profiles.join("triage").join("skills")).unwrap();
+        std::fs::write(profiles.join("triage.toml"), "approval_policy = 'never'\n").unwrap();
+        let active = ActiveProfile::load(&config.join("settings.toml"), "triage").unwrap();
+        assert_eq!(
+            active.overlay.skills_dir.as_deref(),
+            Some(profiles.join("triage").join("skills").as_path())
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,10 @@ struct Cli {
     #[arg(long, value_enum)]
     provider: Option<ProviderArg>,
 
-    /// Load a named execution profile from `<config_dir>/yolop/profiles/<name>.toml`.
+    /// Load a named profile from `<config_dir>/yolop/profiles/<name>.toml`: an
+    /// overlay of provider, model, approval, sandbox, and worktree settings plus
+    /// the profile's own capabilities, extensions, MCP servers, skills, and
+    /// system-prompt instructions.
     #[arg(long, value_name = "NAME")]
     profile: Option<String>,
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -357,6 +357,7 @@ struct CodingCliSessionFileSystemFactory {
     session_id: SessionId,
     materializer: Arc<session_log::SessionMaterializer>,
     skill_global: Option<PathBuf>,
+    skill_profile: Option<PathBuf>,
     skill_system: Option<PathBuf>,
     environment_skill: Option<&'static str>,
     /// `(name, skills_dir)` for enabled extensions contributing skills; each is
@@ -377,9 +378,13 @@ impl SessionFileSystemFactory for CodingCliSessionFileSystemFactory {
         // The writable global skills dir may not exist yet; create it so a skill
         // installed mid-session is discoverable. (System skills are already
         // materialized by `SkillDirs::resolve`.)
-        for dir in [self.skill_global.as_ref(), self.skill_system.as_ref()]
-            .into_iter()
-            .flatten()
+        for dir in [
+            self.skill_global.as_ref(),
+            self.skill_profile.as_ref(),
+            self.skill_system.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
         {
             std::fs::create_dir_all(dir).map_err(|e| {
                 AgentLoopError::config(format!("create skills dir {}: {e}", dir.display()))
@@ -390,6 +395,7 @@ impl SessionFileSystemFactory for CodingCliSessionFileSystemFactory {
                 self.workspace.clone(),
                 self.session_dir.clone(),
                 self.skill_global.clone(),
+                self.skill_profile.clone(),
                 self.skill_system.clone(),
                 self.materializer.clone(),
             )?);
@@ -770,6 +776,7 @@ struct CodingCliSessionFileStore {
     // Backing stores for the global/system skill scope VFS roots, served from
     // real directories outside the workspace (see `capabilities::skills`).
     skill_global: Option<RealDiskFileStore>,
+    skill_profile: Option<RealDiskFileStore>,
     skill_system: Option<RealDiskFileStore>,
     session_dir: PathBuf,
     materializer: Arc<session_log::SessionMaterializer>,
@@ -781,6 +788,7 @@ impl CodingCliSessionFileStore {
         workspace: Arc<WorkspaceHost>,
         session_dir: PathBuf,
         skill_global: Option<PathBuf>,
+        skill_profile: Option<PathBuf>,
         skill_system: Option<PathBuf>,
     ) -> everruns_provider::error::Result<Self> {
         let materializer = Arc::new(session_log::SessionMaterializer::new(
@@ -791,6 +799,7 @@ impl CodingCliSessionFileStore {
             workspace,
             session_dir,
             skill_global,
+            skill_profile,
             skill_system,
             materializer,
         )
@@ -800,6 +809,7 @@ impl CodingCliSessionFileStore {
         workspace: Arc<WorkspaceHost>,
         session_dir: PathBuf,
         skill_global: Option<PathBuf>,
+        skill_profile: Option<PathBuf>,
         skill_system: Option<PathBuf>,
         materializer: Arc<session_log::SessionMaterializer>,
     ) -> everruns_provider::error::Result<Self> {
@@ -812,6 +822,7 @@ impl CodingCliSessionFileStore {
             workspace_disk: workspace.disk().as_ref().clone(),
             session: StdMutex::new(None),
             skill_global: skill_store(skill_global)?,
+            skill_profile: skill_store(skill_profile)?,
             skill_system: skill_store(skill_system)?,
             session_dir,
             materializer,
@@ -826,9 +837,16 @@ impl CodingCliSessionFileStore {
     }
 
     fn skill_route(&self, path: &str) -> Option<(&RealDiskFileStore, String)> {
-        use crate::capabilities::skills::{GLOBAL_SKILLS_VFS, SYSTEM_SKILLS_VFS, relative_under};
+        use crate::capabilities::skills::{
+            GLOBAL_SKILLS_VFS, PROFILE_SKILLS_VFS, SYSTEM_SKILLS_VFS, relative_under,
+        };
         if let Some(store) = &self.skill_global
             && let Some(rest) = relative_under(path, GLOBAL_SKILLS_VFS)
+        {
+            return Some((store, rest));
+        }
+        if let Some(store) = &self.skill_profile
+            && let Some(rest) = relative_under(path, PROFILE_SKILLS_VFS)
         {
             return Some((store, rest));
         }
@@ -2743,7 +2761,8 @@ impl RuntimeHandles {
     /// servers are discovered cold on the next turn and removed ones simply
     /// drop out of the tool set. Returns the sorted names now active.
     pub async fn reload_mcp_servers(&self) -> anyhow::Result<Vec<String>> {
-        let servers = crate::config::mcp::load_mcp_servers(&self.workspace_root);
+        let servers =
+            crate::config::mcp::load_mcp_servers(&self.settings.snapshot(), &self.workspace_root);
         let mut session = self
             .session_store
             .get_session(self.session_id)
@@ -3372,7 +3391,11 @@ pub async fn build_with_options(
     // (this also
     // materializes the embedded system skills). Shared by the skills capability
     // config and the file-store factory's scope routing.
-    let skill_dirs = crate::capabilities::skills::SkillDirs::resolve(&effective_root);
+    // The active profile may contribute a fourth, profile-scoped directory.
+    let skill_dirs = crate::capabilities::skills::SkillDirs::resolve(
+        &effective_root,
+        settings.snapshot().skills_dir.clone(),
+    );
 
     // Read-only skills contributed by enabled extensions (D4: only a declaring,
     // enabled extension's `skills/` loads). Computed here so it feeds both the
@@ -3393,7 +3416,8 @@ pub async fn build_with_options(
     // MCP servers from global settings and workspace `.mcp.json`, merged. Loading is
     // best-effort per scope: a malformed file is warned about and skipped, so
     // it never sinks the session or masks the other scope.
-    let mut mcp_servers: ScopedMcpServers = crate::config::mcp::load_mcp_servers(&canonical_root);
+    let mut mcp_servers: ScopedMcpServers =
+        crate::config::mcp::load_mcp_servers(&settings.snapshot(), &canonical_root);
     // Client-supplied servers (ACP `session/new` `mcpServers`) overlay the
     // file-based config: a name present in both resolves to the client's entry,
     // matching the "the editor configured this for the agent" expectation.
@@ -4038,6 +4062,7 @@ pub async fn build_with_options(
             session_id,
             materializer: materializer.clone(),
             skill_global: skill_dirs.global.clone(),
+            skill_profile: skill_dirs.profile.clone(),
             skill_system: skill_dirs.system.clone(),
             environment_skill: HerdrCapability::skill_content(herdr.is_active()),
             extension_skills: extension_skill_scopes.clone(),
@@ -4067,7 +4092,14 @@ pub async fn build_with_options(
         .any(|cap| cap.capability_id() == USER_ASK_CAPABILITY_ID);
     let session_mcp_servers = mcp_servers.clone();
 
-    let mut harness_builder = HarnessBuilder::new("yolop", SYSTEM_PROMPT)
+    // A profile's `instructions` ride after `system.md` so a profile can give
+    // the agent a standing job (triage, review, release duty) without editing
+    // the shipped prompt or the repository's AGENTS.md.
+    let harness_prompt = match settings_snapshot.instructions.as_deref() {
+        Some(extra) => format!("{SYSTEM_PROMPT}\n\n## Profile instructions\n\n{extra}\n"),
+        None => SYSTEM_PROMPT.to_string(),
+    };
+    let mut harness_builder = HarnessBuilder::new("yolop", harness_prompt)
         .metadata_entry("app", "yolop")
         .metadata_entry("yolop_version", env!("CARGO_PKG_VERSION"))
         .metadata_entry(
@@ -4454,7 +4486,8 @@ mod tests {
             .expect("workspace host"),
         );
         let composite: Arc<dyn SessionFileSystem> = Arc::new(
-            CodingCliSessionFileStore::new(host, session.to_path_buf(), None, None).expect("store"),
+            CodingCliSessionFileStore::new(host, session.to_path_buf(), None, None, None)
+                .expect("store"),
         );
         // Match production (`build`): backend-native display so tests exercise the
         // real host-path presentation (#258), not the `/workspace` alias.
@@ -7251,8 +7284,14 @@ mod tests {
         );
         let store: Arc<dyn SessionFileSystem> = Arc::new(
             MountFs::new(Arc::new(
-                CodingCliSessionFileStore::new(host, session.path().to_path_buf(), None, None)
-                    .expect("store"),
+                CodingCliSessionFileStore::new(
+                    host,
+                    session.path().to_path_buf(),
+                    None,
+                    None,
+                    None,
+                )
+                .expect("store"),
             ))
             .with_backend_display(),
         );
@@ -7470,6 +7509,7 @@ mod tests {
                 None,
             )),
             skill_global: None,
+            skill_profile: None,
             skill_system: None,
             environment_skill: None,
             extension_skills: Vec::new(),
@@ -7550,6 +7590,7 @@ mod tests {
                 None,
             )),
             skill_global: None,
+            skill_profile: None,
             skill_system: None,
             environment_skill: None,
             extension_skills: Vec::new(),
@@ -7657,6 +7698,7 @@ mod tests {
             host,
             session.path().to_path_buf(),
             Some(global.path().to_path_buf()),
+            None,
             Some(system.path().to_path_buf()),
         )
         .expect("store");
@@ -7717,6 +7759,7 @@ mod tests {
         let dirs = SkillDirs {
             workspace: workspace.path().join(".agents").join("skills"),
             global: None,
+            profile: None,
             system: Some(system.path().to_path_buf()),
         };
         let host = Arc::new(
@@ -7730,6 +7773,7 @@ mod tests {
             CodingCliSessionFileStore::new(
                 host,
                 session.path().to_path_buf(),
+                None,
                 None,
                 Some(system.path().to_path_buf()),
             )
@@ -7789,6 +7833,7 @@ mod tests {
                 None,
             )),
             skill_global: None,
+            skill_profile: None,
             skill_system: None,
             environment_skill: HerdrCapability::skill_content(true),
             extension_skills: Vec::new(),
@@ -7864,6 +7909,7 @@ mod tests {
                 None,
             )),
             skill_global: None,
+            skill_profile: None,
             skill_system: None,
             environment_skill: None,
             extension_skills: vec![("demo".to_string(), skills_dir.clone())],
@@ -8332,6 +8378,88 @@ mod tests {
              ({DEFAULT_TOOL_SEARCH_THRESHOLD}) for deferred loading to activate; \
              if the surface shrinks, lower the threshold via \
              ToolSearchCapability::with_threshold (or DEFAULT_TOOL_SEARCH_THRESHOLD)"
+        );
+    }
+
+    /// A profile is the unit that shapes a whole run: its instructions ride in
+    /// the system prompt, and its `[[capabilities]]` and `[mcp.servers]` entries
+    /// shape the tool set. That is what makes a purpose-built agent (triage,
+    /// review) a profile rather than a fork of settings.toml.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn profile_shapes_prompt_capabilities_skills_and_mcp() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let profiles = sessions.path().join("profiles");
+        std::fs::create_dir_all(&profiles).expect("profiles dir");
+        std::fs::write(
+            profiles.join("triage.toml"),
+            format!(
+                "instructions = 'Route incoming work to the right session.'\n\n\
+                 [mcp.servers.triage-inbox]\n\
+                 type = 'http'\n\
+                 url = 'https://inbox.example/mcp'\n\n\
+                 [[capabilities]]\n\
+                 ref = '{}'\n\
+                 enabled = false\n",
+                crate::capabilities::skills::SKILL_MANAGEMENT_CAPABILITY_ID
+            ),
+        )
+        .expect("write profile");
+        let skill = profiles.join("triage").join("skills").join("intake");
+        std::fs::create_dir_all(&skill).expect("skill dir");
+        std::fs::write(
+            skill.join("SKILL.md"),
+            "---\nname: intake\ndescription: Classify incoming work.\n---\n\nClassify, then route.\n",
+        )
+        .expect("write skill");
+        let settings = Arc::new(
+            SettingsStore::open_with_profile(sessions.path().join("settings.toml"), "triage")
+                .expect("open profile"),
+        );
+        let built = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Sim,
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            BuildOptions::default(),
+        )
+        .await
+        .expect("build runtime");
+        let context = built
+            .handles
+            .runtime
+            .load_context(built.handles.session_id)
+            .await
+            .expect("assemble context");
+
+        assert!(
+            context
+                .runtime_agent
+                .system_prompt
+                .contains("Route incoming work to the right session."),
+            "profile instructions are part of the prompt"
+        );
+        assert!(
+            !context
+                .runtime_agent
+                .tools
+                .iter()
+                .any(|tool| tool.name() == "search_skills"),
+            "a profile `enabled = false` entry masks the capability's tools"
+        );
+        assert!(
+            context.runtime_agent.system_prompt.contains("intake"),
+            "the profile's skills directory is a discoverable scope"
+        );
+        assert!(
+            built
+                .startup
+                .mcp_server_names
+                .iter()
+                .any(|name| name == "triage-inbox"),
+            "profile MCP servers join the session: {:?}",
+            built.startup.mcp_server_names
         );
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -2984,7 +2984,10 @@ impl App {
     /// invisible), best-effort opens the browser, and completes in the
     /// background — same pattern as Codex login.
     async fn mcp_login(&mut self, name: &str) {
-        let servers = crate::config::mcp::load_mcp_servers(&self.startup.workspace_root);
+        let servers = crate::config::mcp::load_mcp_servers(
+            &self.settings.snapshot(),
+            &self.startup.workspace_root,
+        );
         let Some(server) = servers.get(name) else {
             self.push_system(format!(
                 "MCP server `{name}` is not configured or is disabled; add it and run `/mcp reload` first"


### PR DESCRIPTION
## What changed

`--profile <name>` now selects a whole agent, not just execution settings. A profile file can carry, in addition to the existing provider/model/approval/sandbox/worktree keys:

- **`capabilities`** / **`capabilities_mode`**: the same ordered `[[capabilities]]` list global settings carry, applied after the global entries, or replacing them entirely under `capabilities_mode = "replace"`. An installed extension's enablement *is* a `[[capabilities]]` entry, so this is also how a profile turns extensions on and off, and `/extensions enable|disable` now writes into the active profile.
- **`mcp`** / **`mcp_mode`**: `[mcp.servers.<name>]` entries merged by name over the global set, or the whole set under `mcp_mode = "replace"`. Workspace `.mcp.json` still overlays the result, and an ACP client's `session/new` servers still win over both.
- **`instructions`** / **`instructions_file`**: appended to the harness system prompt after `system.md`, under a `## Profile instructions` heading, so a profile can give the agent a standing job.
- **`skills_dir`**: an extra skills scope, defaulting to `profiles/<name>/skills/` when that directory exists. It ranks between the workspace and global scopes, because a profile is chosen per run: it outranks the user's global skills, never the repository's own.

Credentials and personal settings (`tokens`, `codex_auth`, `theme`, `attribution`, `proactive_wake`) stay global-only and still fail a profile that sets them.

Relative `instructions_file` / `skills_dir` paths resolve against the `profiles/` directory, so a profile is a `.toml` file plus an optional sibling directory of its assets. A named `instructions_file` that cannot be read fails startup rather than silently dropping the job it describes. Writes follow the existing rule: with a profile active, capability enable/disable and capability config land in the profile, and disabling something the global layer (or the harness default) turns on records an explicit `enabled = false` mask instead of editing global settings. Pointer keys are carried through verbatim on write, never rewritten or inlined.

Two deliberate limits, both documented: workspace `.mcp.json` still overrides a profile server by name, and `yolop mcp` / `/mcp` writes stay scope-explicit (global settings or workspace file), so a profile's servers are edited in the profile file.

## Why

v1 profiles overlaid execution settings only. That was enough to switch provider or paranoia level, but not to define an agent with a job: a purpose-built agent (triage, review, release duty) needed its own tool surface, its own MCP servers, its own skills, and its own standing instructions, which meant a second config directory instead of a profile. Everything that decides what an agent can do is now selectable per run.

## Before / After

Same profile file in both runs:

```toml
# profiles/triage.toml
approval_policy = "never"
sandbox_mode = "read-only"
instructions_file = "triage/INSTRUCTIONS.md"

[mcp.servers.inbox]
type = "http"
url = "https://inbox.example/mcp"

[[capabilities]]
ref = "yolop_skill_management"
enabled = false
```

**Before** (`origin/main`):

```
$ yolop --provider llmsim --profile triage -p "hi"
Error: invalid profile `triage` at /tmp/.../yolop/profiles/triage.toml

Caused by:
    `mcp` is global-only and cannot be set in a profile
```

(Removing `[mcp.servers.inbox]` moves the same failure onto `capabilities`.)

**After** (this branch):

```
$ yolop --provider llmsim --profile triage -p "hi"
yolop: profile `triage` loaded from /tmp/.../yolop/profiles/triage.toml
I'm running in offline mode (llmsim — no API key set). Set ANTHROPIC_API_KEY or OPENAI_API_KEY for real responses.
```

The observable effects on the assembled session are asserted in `runtime::tests::profile_shapes_prompt_capabilities_skills_and_mcp`, which builds a real runtime from a profile and checks all four surfaces at once: the instructions appear in `runtime_agent.system_prompt`, the masked capability's `search_skills` tool is gone from `runtime_agent.tools`, a skill in `profiles/<name>/skills/` is discoverable through the VFS routing, and `triage-inbox` is in `startup.mcp_server_names`.

## Risk

- Low / Medium
- `SkillDirs::resolve` and `load_mcp_servers` changed signature to take the profile-resolved values; `load_mcp_servers` previously re-opened global settings on its own and so could never have seen a profile. Both are crate-internal.
- With no profile selected, every path is unchanged: `Settings::instructions` / `skills_dir` are `None`, the harness prompt is `SYSTEM_PROMPT` verbatim, and the capability/MCP write paths take their original branch.
- Behavior change for existing users: profiles that previously failed to load because they set `mcp` or `capabilities` now load and take effect. That was the point, but it is a semantic change for anyone relying on the rejection.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated: [configuration](knowledge/specs/configuration.md) (the profileable key set and the new "a profile is the unit of a purpose-built agent" section), [skills](knowledge/specs/skills.md) (profile scope and precedence), [mcp](knowledge/specs/mcp.md) (profile scope between global and workspace), [extensions](knowledge/specs/extensions.md) (per-profile enablement falls out of D5), [system prompt](knowledge/specs/system-prompt.md) (the one operator-owned prompt seam and its boundary with `AGENTS.md` and memory), plus a `knowledge/log.md` entry. The `yolop-config` bundled skill and README gained the profile documentation.

## Security

Reviewed against the concentrated categories:

- **TM-FS**: `skills_dir` and `instructions_file` accept absolute paths and `~`, and the profile skills scope is writable. Both come from the user's own config directory, the same trust level as `settings.toml` (which already holds API tokens), and the profile *name* remains path-validated as before. Writes through the new scope still pass through `WriteBlocklistFileStore`, so `.git/`, `target/`, `node_modules/` and friends stay protected at any depth. Reads are unchanged.
- **TM-LLM**: `instructions` reach the system prompt from a local operator-authored file. No credential material is read, logged, or written to session JSONL by this path. The text is unbounded in size, exactly like `AGENTS.md` today; a very large file inflates every turn of that profile's sessions, which is the operator's own choice and visible in their own config.
- **TM-TOOL**: profile `[[capabilities]]` entries flow through the same `apply_capability_settings` path as global ones, so an unknown or malformed ref behaves identically to a hand-edited global entry. Capability config written through `set_config` is still validated by the catalog. New capabilities are not introduced.
- **TM-BASH**: untouched.
- **TM-DEP**: no new dependencies.

No injection surface is added: nothing here builds a shell command or a URL from profile input; MCP server entries reuse the existing parser and its `${VAR}` expansion rules.

## Follow-ups

- No live-provider smoke run: this environment has no Doppler and no provider keys, so validation used `--provider llmsim` (the offline smoke test AGENTS.md prescribes) plus the runtime test above, which inspects the assembled prompt and tool set directly. The change is config wiring, not agent-loop behavior.
- Cross-session orchestration (a triage agent that lists live sessions, dispatches work to them, and is woken when one finishes) is the motivating use case and is *not* in this PR. It needs a session registry with liveness, a dispatch tool, and a wake path back into the dispatching session, riding the existing `background_wake` seam. Worth its own spec.
- `/mcp` and `yolop mcp` still write global or workspace only. Adding a profile write scope is straightforward but changes a scope-explicit CLI surface, so it is deferred until the file-editing workflow proves insufficient.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V37g4acvBDXPPjo8CsNz7d)_