### PR TITLE
feat(extensions): add attached control CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,10 @@ yolop --provider llmsim -p "hi"         # offline demo, no API key required
 - **Extensions**: installable capability packages that add tools, prompt
   guidance, MCP servers, and hooks without rebuilding yolop, over the yolop
   extension protocol (YEP). Install from crates.io with no Rust toolchain, a git
-  URL, or a local path; author one with the
+  URL, or a local path with `yolop extensions`; direct foreground invocations
+  from a running Yolop session also update that session without exposing
+  management tools to the model. The built-in `/extensions` command uses the
+  same grammar inside interactive clients. Author one with the
   [`yolop-yep`](./crates/yolop-yep) SDK. See
   [docs/extensions.md](./docs/extensions.md).
 - **MCP servers**: extra tools from local (stdio) or remote (HTTP)

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -35,17 +35,24 @@ config dir, so a repository never carries agent-specific machinery:
 **1. Install**: the fastest way is from **crates.io**, toolchain-free (no
 cargo or rustc needed, yolop fetches and unpacks the `.crate` itself):
 
-```
-install_extension source="crates.io:yolop-extension-lsp"     # or a bare "lsp"
-install_extension source="crates.io:yolop-extension-lsp@0.2.0"  # pin a version
+```bash
+yolop extensions install crates.io:yolop-extension-lsp       # or a bare "lsp"
+yolop extensions install crates.io:yolop-extension-lsp@0.2.0 # pin a version
 ```
 
 You can also install from a **git URL** (`https://…[@rev]`) or a **local
-path**, or just drop the package directory in place by hand. yolop has
-`install_extension` / `list_extensions` / `enable_extension` /
-`doctor_extension` tools, so "install and enable `yolop-extension-lsp`" works
-conversationally. Installs are pinned in `extensions.lock` (source + resolved
-version + content hash) so a later reinstall can flag a changed grant.
+path**, or just drop the package directory in place by hand. Use `yolop
+extensions --help` to discover list/install/enable/disable/remove/reload/doctor,
+secret setup, and scaffolding. Extension administration is a CLI surface, not a
+set of model tools, so its schemas do not consume model context. Installs are
+pinned in `extensions.lock` (source + resolved version + content hash) so a
+later reinstall can flag a changed grant.
+
+In an interactive client, `/extensions` is the command form of the same
+capability: `/extensions` lists packages and `/extensions enable <name>` uses
+the same action implementation as `yolop extensions enable <name>`. The
+top-level `yolop extensions` command and its help are contributed by that
+capability as well, rather than maintained in a separate CLI command table.
 
 **2. Enable**: installing does not activate. Turn an extension on by adding it
 to your harness in `~/.config/yolop/settings.toml`:
@@ -55,7 +62,18 @@ to your harness in `~/.config/yolop/settings.toml`:
 ref = "ext:<name>"
 ```
 
-(or run `enable_extension`). Changes take effect on the next session.
+(or run `yolop extensions enable <name>`). A detached invocation persists the
+choice for sessions. When the command is invoked directly through a running
+Yolop session's foreground Bash, Yolop also applies enable/disable to that
+session for the next turn. `reload` is session-only and reports an error when
+run detached. Installing a new manifest still requires a new session before it
+can be enabled because the host registers extension packages at startup.
+
+The attached path is deliberately narrow: invoke `yolop extensions ...`
+directly, without a pipeline, redirection, command substitution, or background
+operator. Yolop spawns its exact executable with anonymous pipes for one typed
+request; it does not publish a socket, endpoint, token, or control environment
+variable to general shell commands.
 
 **3. Use**: start yolop; the extension's tools and prompt are available. To
 watch it connect:
@@ -153,8 +171,8 @@ extension can do.
 ### Naming & distribution
 
 Name a crate `yolop-extension-<name>` so it's discoverable on crates.io under a
-common prefix, and so the bare-name install shorthand (`install_extension
-source="lsp"` → `yolop-extension-lsp`) resolves it.
+common prefix, and so the bare-name install shorthand (`yolop extensions
+install lsp` → `yolop-extension-lsp`) resolves it.
 
 **Publishing to crates.io.** Include `plugin.json` in the published package so
 yolop can read it straight from the `.crate` tarball, no build step:
@@ -164,8 +182,8 @@ yolop can read it straight from the `.crate` tarball, no build step:
 include = ["src/**", "plugin.json", "README.md"]
 ```
 
-`cargo publish`, and users install with `install_extension
-source="crates.io:yolop-extension-<name>"`. yolop resolves the version through
+`cargo publish`, and users install with `yolop extensions install
+crates.io:yolop-extension-<name>`. yolop resolves the version through
 the crates.io **sparse index**, downloads the tarball from the CDN, verifies
 its SHA-256 against the index, and unpacks it, all without cargo or rustc.
 Because a published crate ships source, the manifest's
@@ -188,6 +206,6 @@ Both are generated from the `yolop-yep` types (`cargo run -p yolop-yep
 
 > **Status.** The mechanism is implemented through hooks, the `yolop-yep`
 > SDK ([published on crates.io](https://crates.io/crates/yolop-yep)), a
-> `doctor_extension` conformance check, toolchain-free **crates.io installs**
-> (`install_extension source="crates.io:yolop-extension-<name>"`), and
+> `yolop extensions doctor` conformance check, toolchain-free **crates.io installs**
+> (`yolop extensions install crates.io:yolop-extension-<name>`), and
 > language-neutral **`meta.json` + `schema.json`** wire artifacts.

--- a/docs/features/sandboxing/sandboxing.md
+++ b/docs/features/sandboxing/sandboxing.md
@@ -19,6 +19,14 @@ The same policy covers every Yolop shell entry point:
 - the `/shell` command; and
 - the TUI `!shell` shortcut.
 
+One narrow exception is not an arbitrary shell command: a direct foreground
+`yolop extensions ...` invocation is recognized as typed administration of the
+current session. It still passes shell approval policy, then uses the exact
+running Yolop executable and anonymous one-request pipes. No endpoint or control
+environment variable is exported, and pipelines, redirects, substitutions,
+quoted commands, and background jobs are never attached. Those forms continue
+through the ordinary sandbox.
+
 The modes are:
 
 | Mode | Shell access |

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,23 @@
 Significant changes to Yolop's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
+## 2026-08-17, One-shot attached extension administration
+
+- Replaced model-visible extension management tools with the `yolop extensions`
+  CLI while retaining extension-contributed tools and commands.
+- Added a versioned, resource-tagged internal control plane over anonymous
+  one-request child pipes. Direct foreground commands can reconcile the current
+  session without publishing an endpoint or ambient shell capability.
+- Made attached administration an optional capability facet; the built-in
+  extension capability owns its CLI action grammar, `/extensions` command,
+  control execution, and rendering while contributing no model tools.
+- Made the top-level CLI itself capability-contributed: `CliCapability`
+  supplies the Clap command and typed decoder, and the root binary assembles
+  registered contributions without an extension-specific enum or dispatcher.
+- Seeded enabled extensions at the session layer so attached disable is
+  reversible; detached operations remain global and reload requires a live
+  session.
+
 ## 2026-08-16, In-process inference provider (experimental)
 
 - Added [Local inference](specs/local-inference.md): a `local` provider that

--- a/knowledge/specs/extensions.md
+++ b/knowledge/specs/extensions.md
@@ -10,10 +10,12 @@ Status: **phases 1–3 implemented** in `src/extensions/`.
 Phase 1: protocol core, transport-generic client, persistent process
 manager, package discovery, `ExtensionCapability` adapter,
 `[[capabilities]]` enablement, manifest clamp, never-defer wiring.
-Phase 2: the always-on `extensions` capability with
-`install`/`list`/`enable`/`disable`/`remove` tools, `extensions.lock`
+Phase 2: the `yolop extensions` CLI with
+`install`/`list`/`enable`/`disable`/`remove` operations, `extensions.lock`
 content-hash pinning, install from git URL and local path, and the
-`ext:<name>` enable/disable write path.
+`ext:<name>` enable/disable write path. Management is not exposed as model
+tools. The built-in `ExtensionsCapability` retains `/extensions`, while
+extension-contributed tools and commands are unchanged.
 Phase 3: contributed MCP servers, a `yolop.mcpServers` manifest facet
 (stdio/http), surfaced through `Capability::mcp_servers()` and merged into
 scoped MCP config for enabled extensions, name-prefixed `<ext>__<server>`
@@ -47,18 +49,18 @@ A `cargo test` drift guard (run under CI's `--all-features` coverage job) fails
 if either committed file is stale, so the wire surface can't change without the
 artifacts changing. A non-Rust author reads them to discover and validate the
 wire format.
-Conformance: `doctor_extension` (surfaced as `/extensions doctor`) spawns an
+Conformance: `yolop extensions doctor <name>` spawns an
 installed extension's server, runs the `initialize` handshake, and grades it
 against the manifest, protocol-version compatibility, the D4 tool clamp
 (a widened tool is a hard fail; an unserved manifest tool a warning), and
 prompt-facet consistency, returning per-check pass/warn/fail. It is the
 runtime dual of the CI schema/drift guards: authors validate a server before
 shipping without booting a whole session.
-Self-writing: `scaffold_extension` generates a ready-to-edit package, a
+Self-writing: `yolop extensions scaffold` generates a ready-to-edit package, a
 `plugin.json` declaring the requested facets (`tools`, `hooks`, `prompt`) plus
 a self-contained capability server whose only author-editable boundaries are the
 `handle_*` bodies. The skeleton is correct by construction: it installs via
-`install_extension source=<dir>` and passes `doctor_extension` before any logic
+`yolop extensions install <dir>` and passes `yolop extensions doctor <name>` before any logic
 is written, so authoring collapses to filling in handlers. The server is a
 single executable under the package `bin/` (resolved via the `bin/`-on-PATH
 rule the runtime already uses; the exec bit survives the install copy), so no
@@ -82,7 +84,7 @@ into a `SetExtensionStatus` `UiCommand`, then `App.extension_status`, then
 `PresentationState`. It renders in the inline TUI (`status_contributions` /
 `expanded_status_lines`) and the full-screen renderer (`app/fullscreen.rs`); it
 is a no-op in `--print`/ACP, where the sink is `None` and the push only logs.
-`scaffold_extension status=true` emits an `emit_status(text)` helper; the
+`yolop extensions scaffold --status` emits an `emit_status(text)` helper; the
 acceptance, a self-authored char-counter that pushes to the sink, is covered
 by `scaffolded_status_extension_pushes_to_the_sink`. ACP has no status surface
 today, so extension status is intentionally TUI-only for now.
@@ -94,7 +96,7 @@ declaring extension's `skills/` is seeded into a read-only in-memory mount at
 mutated through the VFS) and added as a read-only `SkillScope` (label
 `ext:<name>`) in `skills_config`. Loading follows the MCP-contribution rule
 (enabled extensions only) and is host-side, no server or wire involvement.
-`scaffold_extension skills=true` writes a starter `skills/<name>/SKILL.md`;
+`yolop extensions scaffold --skills` writes a starter `skills/<name>/SKILL.md`;
 `extension_contributed_skill_is_visible_and_read_only` covers the mount.
 Slash commands: an extension declares `commands` in its manifest; `ExtensionCapability`
 implements the `Capability` `commands()`/`execute_command()` boundaries, so the
@@ -102,7 +104,7 @@ commands flow into `runtime.list_commands` → the palette automatically. Each i
 registered namespaced (`<ext>:<name>`) so it can never shadow a built-in, and
 invoking it sends `command/execute` (host→server) with `{name, arguments}`; the
 server's `CommandExecuteResult { success, message }` becomes the `CommandResult`
-shown to the user. `scaffold_extension commands=[…]` generates a
+shown to the user. `yolop extensions scaffold --command <name>` generates a
 `handle_command` boundary in all three templates. Covered by
 `scaffolded_extension_serves_a_slash_command`.
 ui/ask: an extension that declares `ui_ask` (the D4 opt-in) may send a `ui/ask`
@@ -128,12 +130,12 @@ redacted, `ExtensionSecrets`, keyed `ext:<name>`), **never** in `settings.toml`,
 and reach the server as injected env only (`capability.rs` strips any `secret`
 key from `initialize.config`). The `secret` marker decouples the concept from the
 location: moving credentials to a keychain later changes only `secrets.rs`. Agent
-leak-protection is threefold: entry is out-of-band via `set_extension_secret`
+leak-protection is threefold: entry is out-of-band via `yolop extensions secret set`
 (and setup-on-enable), which prompts the *user* through the `ui/ask` surface,
 the agent triggers it but supplies no value and is refused if it passes one; all
-agent-facing reads (`list_extensions`) report a field's `set`/`unset` status,
+CLI reads (`yolop extensions list --json`) report a field's `set`/`unset` status,
 never its value; and a redacting `Secret` newtype keeps values out of logs. On
-`enable_extension`, every required field that is unset is prompted for (setup on
+`yolop extensions enable`, every required field that is unset is prompted for (setup on
 enable), dispatched by `ConfigField::kind`: `secret` → masked entry stored in the
 credential store; an `enum` field → a **selector**; otherwise free text, both
 persisted to capability config (`SettingsStore::set_capability_config`). The kind
@@ -172,7 +174,7 @@ configured by the same environment variables Logfire's onboarding checklist uses
 (`LOGFIRE_TOKEN`, `LOGFIRE_ENDPOINT`, `OTEL_SERVICE_NAME`). Covered by
 `trace_events_are_forwarded_to_a_declaring_server`; a non-declaring extension
 gets no forwarder (`non_declaring_extension_has_no_trace_process`).
-Live reload: `reload_extension name=<name>` restarts an already-enabled
+Live reload: `yolop extensions reload <name>` restarts an already-enabled
 extension's *server process* in place, so implementation edits take effect
 mid-session without a yolop restart, the self-writing inner loop. Each
 `ExtensionCapability` publishes its live `ExtensionProcess` into a shared
@@ -187,28 +189,28 @@ and can never widen it. A manifest change (a new tool, a changed schema) still
 requires a restart, the enabled-capability set is fixed for the session
 because `everruns-core` builds the harness once with no live-reconfigure boundary.
 Covered by `reload_respawns_the_server_with_edited_code`.
-Hot-enable: `everruns-runtime` grew a live-reconfigure boundary
+Attached control: `everruns-runtime` grew a live-reconfigure boundary
 (`InProcessRuntime::activate_capability`/`deactivate_capability` →
-`CapabilityDelta`, EVE-795), so enabling a *new* extension no longer waits for
-the next session. `enable_extension`/`disable_extension` still persist the
-`ext:<name>` override to settings, and in the TUI they also push a
+`CapabilityDelta`, EVE-795). `yolop extensions enable|disable` persists the
+`ext:<name>` override to settings, and when invoked directly through the TUI's
+foreground Bash it also pushes a
 `SetExtensionActive` `UiCommand`; the `App` answers it by calling
 `Session::activate_capability`/`deactivate_capability`, which mutate the
 session-scoped capability overlay. The runtime reassembles prompt, tools, hooks,
 commands, and contributed MCP servers from that overlay on the next reason/act
-boundary, so the extension is live on the **next turn**: no restart. The
-capability lands on the session overlay (distinct from the harness layer a
-startup-enabled extension rides), so it can be live-deactivated too; disabling
-one that was active from session start rides the harness layer and only settings
-can drop it (next session). Refused with no live session (`--print`/ACP), where
-enable/disable persist for the next run. Covered by
+boundary, so a registered extension is live on the **next turn**: no restart.
+Enabled extensions are seeded at the session layer, including at startup, so
+disable is reversible in the same session. Installing a new package remains a
+global operation and its manifest is registered on the next session. Detached
+enable/disable persist for the next run; reload is refused without an attached
+session. Covered by
 `enable_disable_emit_live_activation_when_wired`.
 Later, the full `yolop-extension-lsp` control-plane extraction (gated on
 `evals/lsp_integration` parity to retire the built-in),
 `workspace/changed`,
 providers, remain design-of-record below.
-Toolchain-free crates.io install is now wired: `install_extension
-source="crates.io:yolop-extension-<name>[@ver]"` (or the bare-`<name>`
+Toolchain-free crates.io install is now wired: `yolop extensions install
+crates.io:yolop-extension-<name>[@ver]` (or the bare-`<name>`
 shorthand) resolves the version through the crates.io **sparse index**
 (`index.crates.io`), downloads the `.crate` from the static CDN, verifies its
 SHA-256 against the index `cksum`, and unpacks the gzip'd tar, no cargo/rustc.
@@ -224,6 +226,41 @@ progress surfaces through the tracing layer until the TUI grows a live
 boundary.
 
 ## Why
+
+### Administration and the attached control plane
+
+Extension administration uses the ordinary `yolop extensions` CLI in both
+contexts. Outside a session it operates on global installed state and settings.
+Inside a running TUI, a conservative direct foreground invocation is attached
+to that session, so enable/disable reconcile the live session and reload can
+restart its process.
+
+The attachment is an internal `control/v1` plane, not YEP. YEP remains the
+host↔extension data plane. The control envelope is versioned and resource-tagged.
+An ordinary `Capability` may implement the optional `ControlCapability` facet,
+declaring its CLI route, read-only operations, typed action execution, and
+rendering. `ControlRegistry` routes only to registered facets, so MCP, skills,
+or configuration can opt in without growing transport branches. The same
+`ExtensionsCapability` instance owns `/extensions` and its attached control
+resource while returning no model tools. Its `CliCapability` facet contributes
+the complete top-level `clap::Command` and converts `ArgMatches` into that same
+typed control request. The binary assembles registered CLI facets into its root
+command and has no static `Extensions` command variant or dispatch branch.
+For each eligible command the parent launches its exact current
+executable and grants only anonymous stdin/stdout pipes. The child sends one
+bounded request and accepts one response; both ends close on completion,
+cancellation, or timeout. No listener, filesystem socket, port, token,
+`YOLOP_CONTROL_ENDPOINT`, or ambient shell environment is created. Pipelines,
+redirection, quoting, substitutions, and background execution receive no
+attachment and run as ordinary shell commands. Attached failure never falls
+back to detached global mutation.
+
+The Bash description provides the discovery hint; the capability-contributed
+Clap definition remains the canonical grammar and `yolop extensions --help`
+the detailed catalog. `/extensions` parses that same action grammar.
+Model-visible extension management tools are
+intentionally absent, while the management command and commands contributed by
+enabled extension packages remain in the capability command registry.
 
 Yolop's unit of functionality is the everruns **capability**: one `Capability`
 implementation contributes tools, system-prompt text, config schema, hooks,
@@ -560,7 +597,7 @@ shape:
   reaches the artifact (and a minor bump) only when promoted. Open
   vocabularies (capability tokens, `capability_params`, metadata maps)
   extend without any bump at all.
-- **Conformance harness in the product**: `/extensions doctor <cmd>` drives
+- **Conformance harness in the product**: `yolop extensions doctor <name>` drives
   a server through handshake, tool call, streaming, cancellation, and
   config push, validating every message against the committed schema, the
   runtime dual of the CI guards, pointed at third-party servers.
@@ -757,7 +794,7 @@ the protocol and the SDK.
    `tool/call` + `tool/update` + `cancel`, `shutdown`; wire types +
    schema-gen + `schema/yep/v1/` with CI `--check` and a conformance
    corpus; the `ExtensionCapability` adapter; the `yolop-extension`
-   reference crate; `/extensions doctor`. Exit: a hand-built server passes
+   reference crate; `yolop extensions doctor`. Exit: a hand-built server passes
    conformance and its tools stream in the TUI.
 2. **Packaging + trust.** Global-scope discovery, `extensions.lock`,
    `/extensions` verbs, manifest-clamps-handshake enforcement,

--- a/knowledge/specs/sandboxing.md
+++ b/knowledge/specs/sandboxing.md
@@ -23,6 +23,15 @@ Every shell entry point uses one shared `SandboxProvider` boundary:
 - the `/shell` command; and
 - the TUI `!shell` shortcut.
 
+A direct foreground `yolop extensions ...` invocation is a special typed host
+broker, not arbitrary shell execution. It passes the same shell approval policy
+first, then the host invokes its exact Yolop executable with anonymous pipes for
+one versioned control request. It receives no general shell environment
+capability and cannot be composed into a pipeline, redirection, substitution,
+or background job. The broker exposes no listener or persistent endpoint and
+closes both pipes after the response. All other commands, including composed
+Yolop commands, continue through `SandboxProvider` normally.
+
 Structured file tools remain in Yolop's trusted host broker. They are rooted at
 the active `WorkspaceHost` and retain the existing protected-path checks. System,
 global, workspace, and extension skills also keep their existing read-only
@@ -262,6 +271,8 @@ provider smoke.
 - structured file tools and trusted Git worktree/checkpoint operations use
   their own host-side boundaries;
 - hooks use Bashkit virtual execution rather than the native shell provider;
+- the one-shot attached Yolop administration broker is a typed host boundary,
+  not a sandbox escape available to arbitrary child processes;
 - LSP, MCP, and extension server processes are configured control-plane
   processes and are not automatically moved into this shell sandbox; and
 - resource controls are the existing wall-clock/output limits, not yet cgroup

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -366,6 +366,7 @@ pub(crate) struct CodingBashCapability {
     pub(crate) expose_command: bool,
     pub(crate) approval_policy: crate::config::ApprovalPolicy,
     pub(crate) approval_gate: Arc<crate::sandbox_approval::ApprovalGate>,
+    pub(crate) control: Option<Arc<dyn crate::control::ControlService>>,
 }
 
 #[async_trait]
@@ -392,12 +393,15 @@ impl Capability for CodingBashCapability {
         None
     }
     fn tools(&self) -> Vec<Box<dyn Tool>> {
-        vec![Box::new(BashTool::with_policy(
-            self.workspace.clone(),
-            self.sandbox.clone(),
-            self.approval_policy,
-            self.approval_gate.clone(),
-        ))]
+        vec![Box::new(
+            BashTool::with_policy(
+                self.workspace.clone(),
+                self.sandbox.clone(),
+                self.approval_policy,
+                self.approval_gate.clone(),
+            )
+            .with_control(self.control.clone()),
+        )]
     }
     fn commands(&self) -> Vec<CommandDescriptor> {
         if !self.expose_command {
@@ -441,6 +445,7 @@ impl Capability for CodingBashCapability {
             self.approval_policy,
             self.approval_gate.clone(),
         )
+        .with_control(self.control.clone())
         .execute(json!({ "command": command, "output": "normal" }))
         .await;
         Ok(shell_command_result(result))

--- a/src/control.rs
+++ b/src/control.rs
@@ -1,0 +1,597 @@
+//! One-shot attached CLI control plane.
+//!
+//! This is intentionally separate from YEP: YEP is the host↔extension data
+//! plane, while this module lets a directly invoked Yolop CLI ask its parent
+//! Yolop session to mutate live state. There is no listening socket, endpoint
+//! path, token, or inherited general-shell environment. For one conservative
+//! foreground invocation the host spawns its exact executable with anonymous
+//! stdin/stdout pipes, accepts one versioned request, replies once, and closes.
+
+use async_trait::async_trait;
+use clap::{ArgMatches, Command};
+use everruns_core::Capability;
+use everruns_core::ToolExecutionResult;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::path::Path;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+
+pub const CONTROL_VERSION: u32 = 1;
+const MAX_CONTROL_FRAME_BYTES: usize = 64 * 1024;
+const CONTROL_TIMEOUT: Duration = Duration::from_secs(120);
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ControlRequest {
+    pub version: u32,
+    pub resource: String,
+    pub action: Value,
+}
+
+impl ControlRequest {
+    pub fn new(resource: impl Into<String>, action: impl Serialize) -> serde_json::Result<Self> {
+        Ok(Self {
+            version: CONTROL_VERSION,
+            resource: resource.into(),
+            action: serde_json::to_value(action)?,
+        })
+    }
+}
+
+/// A capability-owned control route exposed through a direct `yolop` CLI
+/// invocation. Read-only operations may cross a contained Bash boundary
+/// without approval; every other operation is treated as consequential.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ControlRoute {
+    pub resource: &'static str,
+    pub cli_subcommand: &'static str,
+    pub read_only_operations: &'static [&'static str],
+}
+
+/// Optional control-plane facet for an ordinary runtime capability.
+///
+/// Keeping this as an adjunct to `Capability` lets MCP, skills, configuration,
+/// or another administrative domain opt in without adding model tools or a
+/// resource-specific branch to the transport.
+#[async_trait]
+pub trait ControlCapability: Capability {
+    fn control_route(&self) -> ControlRoute;
+    async fn execute_control(&self, action: &Value) -> ToolExecutionResult;
+    fn render_control(&self, action: &Value, response: &ControlResponse) -> String;
+}
+
+/// Capability facet for contributing a top-level Yolop CLI command.
+///
+/// The command definition and its conversion into the typed control envelope
+/// live together. The root binary only assembles registered contributions; it
+/// has no resource-specific command variant or dispatch branch.
+#[async_trait]
+pub trait CliCapability: ControlCapability {
+    fn cli_command(&self) -> Command;
+    fn control_request_from_cli(&self, matches: &ArgMatches) -> anyhow::Result<ControlRequest>;
+    async fn execute_cli(&self, request: &ControlRequest) -> anyhow::Result<()>;
+}
+
+pub struct CliInvocation {
+    capability: Arc<dyn CliCapability>,
+    pub request: ControlRequest,
+}
+
+impl CliInvocation {
+    pub async fn execute(self) -> anyhow::Result<()> {
+        self.capability.execute_cli(&self.request).await
+    }
+}
+
+#[derive(Default)]
+pub struct CliRegistry {
+    capabilities: HashMap<String, Arc<dyn CliCapability>>,
+}
+
+impl CliRegistry {
+    pub fn register<C>(&mut self, capability: Arc<C>) -> anyhow::Result<()>
+    where
+        C: CliCapability + 'static,
+    {
+        let name = capability.cli_command().get_name().to_string();
+        let route = capability.control_route();
+        if name != route.cli_subcommand {
+            anyhow::bail!(
+                "CLI command `{name}` does not match control route `{}`",
+                route.cli_subcommand
+            );
+        }
+        if self.capabilities.contains_key(&name) {
+            anyhow::bail!("duplicate contributed CLI command `{name}`");
+        }
+        self.capabilities.insert(name, capability);
+        Ok(())
+    }
+
+    pub fn augment(&self, mut root: Command) -> anyhow::Result<Command> {
+        let mut names = self.capabilities.keys().collect::<Vec<_>>();
+        names.sort();
+        for name in names {
+            if root
+                .get_subcommands()
+                .any(|command| command.get_name() == name)
+            {
+                anyhow::bail!("contributed CLI command `{name}` shadows a built-in command");
+            }
+            root = root.subcommand(self.capabilities[name].cli_command());
+        }
+        Ok(root)
+    }
+
+    pub fn invocation(&self, matches: &ArgMatches) -> anyhow::Result<Option<CliInvocation>> {
+        let Some((name, submatches)) = matches.subcommand() else {
+            return Ok(None);
+        };
+        let Some(capability) = self.capabilities.get(name) else {
+            return Ok(None);
+        };
+        Ok(Some(CliInvocation {
+            request: capability.control_request_from_cli(submatches)?,
+            capability: capability.clone(),
+        }))
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ControlResponse {
+    pub version: u32,
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl ControlResponse {
+    pub fn success(value: Value) -> Self {
+        Self {
+            version: CONTROL_VERSION,
+            ok: true,
+            value: Some(value),
+            error: None,
+        }
+    }
+
+    pub fn error(error: impl Into<String>) -> Self {
+        Self {
+            version: CONTROL_VERSION,
+            ok: false,
+            value: None,
+            error: Some(error.into()),
+        }
+    }
+
+    pub fn from_tool_result(result: ToolExecutionResult) -> Self {
+        match result {
+            ToolExecutionResult::Success(value)
+            | ToolExecutionResult::SuccessWithImages { result: value, .. } => Self::success(value),
+            ToolExecutionResult::ToolError(error) => Self::error(error),
+            ToolExecutionResult::InternalError(_) => {
+                Self::error("administration failed internally")
+            }
+            ToolExecutionResult::ConnectionRequired { provider } => {
+                Self::error(format!("connection `{provider}` is required"))
+            }
+        }
+    }
+
+    pub fn render_default(&self) -> String {
+        if !self.ok {
+            return self
+                .error
+                .clone()
+                .unwrap_or_else(|| "control request failed".to_string());
+        }
+        let value = self.value.as_ref().unwrap_or(&Value::Null);
+        serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+    }
+}
+
+#[async_trait]
+pub trait ControlService: Send + Sync {
+    fn route(&self, cli_subcommand: &str) -> Option<ControlRoute>;
+    async fn execute(&self, request: ControlRequest) -> ControlResponse;
+    fn render(&self, request: &ControlRequest, response: &ControlResponse) -> String;
+}
+
+#[derive(Default)]
+pub struct ControlRegistry {
+    resources: HashMap<String, Arc<dyn ControlCapability>>,
+    routes: HashMap<String, String>,
+}
+
+impl ControlRegistry {
+    pub fn register<C>(&mut self, capability: Arc<C>) -> anyhow::Result<()>
+    where
+        C: ControlCapability + 'static,
+    {
+        let route = capability.control_route();
+        if self.resources.contains_key(route.resource) {
+            anyhow::bail!("duplicate control resource `{}`", route.resource);
+        }
+        if self.routes.contains_key(route.cli_subcommand) {
+            anyhow::bail!("duplicate control CLI route `{}`", route.cli_subcommand);
+        }
+        self.routes
+            .insert(route.cli_subcommand.to_string(), route.resource.to_string());
+        self.resources
+            .insert(route.resource.to_string(), capability);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ControlService for ControlRegistry {
+    fn route(&self, cli_subcommand: &str) -> Option<ControlRoute> {
+        self.routes
+            .get(cli_subcommand)
+            .and_then(|resource| self.resources.get(resource))
+            .map(|capability| capability.control_route())
+    }
+
+    async fn execute(&self, request: ControlRequest) -> ControlResponse {
+        if request.version != CONTROL_VERSION {
+            return ControlResponse::error(format!(
+                "unsupported control protocol version {}; expected {CONTROL_VERSION}",
+                request.version
+            ));
+        }
+        let Some(capability) = self.resources.get(&request.resource) else {
+            return ControlResponse::error(format!(
+                "control resource `{}` is not available in this session",
+                request.resource
+            ));
+        };
+        ControlResponse::from_tool_result(capability.execute_control(&request.action).await)
+    }
+
+    fn render(&self, request: &ControlRequest, response: &ControlResponse) -> String {
+        self.resources
+            .get(&request.resource)
+            .map(|capability| capability.render_control(&request.action, response))
+            .unwrap_or_else(|| response.render_default())
+    }
+}
+
+pub struct AttachedCommandOutput {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+}
+
+/// Return argv only for the deliberately narrow direct-invocation grammar.
+/// Shell composition and quoting run as ordinary shell commands without an
+/// attached channel, so a capability cannot leak into pipelines/backgrounds.
+fn direct_control_args(
+    command: &str,
+    service: &dyn ControlService,
+) -> Option<(ControlRoute, Vec<OsString>)> {
+    if command.len() > 8192
+        || command.chars().any(|c| {
+            matches!(
+                c,
+                '|' | '&' | ';' | '<' | '>' | '`' | '\n' | '\r' | '\\' | '\'' | '"'
+            )
+        })
+        || command.contains("$(")
+    {
+        return None;
+    }
+    let words = command.split_ascii_whitespace().collect::<Vec<_>>();
+    if words.len() < 3 || Path::new(words[0]).file_name().and_then(|v| v.to_str()) != Some("yolop")
+    {
+        return None;
+    }
+    let route = service.route(words[1])?;
+    Some((
+        route,
+        words.into_iter().skip(1).map(OsString::from).collect(),
+    ))
+}
+
+/// Typed administration other than a list crosses the arbitrary-shell
+/// sandbox boundary into a host broker and therefore needs an explicit shell
+/// approval whenever containment is enabled.
+pub fn requires_host_approval(command: &str, service: &dyn ControlService) -> bool {
+    let Some((route, args)) = direct_control_args(command, service) else {
+        return false;
+    };
+    !args
+        .get(1)
+        .and_then(|value| value.to_str())
+        .is_some_and(|operation| route.read_only_operations.contains(&operation))
+}
+
+/// Invoke the exact running Yolop executable as a one-shot protocol client.
+/// `None` means this is not an eligible direct control command and the caller
+/// should execute it through the ordinary shell.
+pub async fn invoke_attached(
+    command: &str,
+    service: Arc<dyn ControlService>,
+) -> Option<AttachedCommandOutput> {
+    let (_, args) = direct_control_args(command, service.as_ref())?;
+    Some(
+        match tokio::time::timeout(CONTROL_TIMEOUT, invoke_attached_inner(args, service)).await {
+            Ok(Ok(output)) => output,
+            Ok(Err(error)) => AttachedCommandOutput {
+                stdout: String::new(),
+                stderr: format!("attached control failed: {error}\n"),
+                exit_code: 1,
+            },
+            Err(_) => AttachedCommandOutput {
+                stdout: String::new(),
+                stderr: "attached control timed out\n".to_string(),
+                exit_code: 1,
+            },
+        },
+    )
+}
+
+async fn invoke_attached_inner(
+    args: Vec<OsString>,
+    service: Arc<dyn ControlService>,
+) -> anyhow::Result<AttachedCommandOutput> {
+    let executable = std::env::current_exe()?;
+    let mut child = tokio::process::Command::new(executable)
+        .arg("--__attached-control-child")
+        .args(args)
+        .env_clear()
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()?;
+
+    let stdout = child.stdout.take().expect("piped stdout");
+    let reader = BufReader::new(stdout);
+    let mut reader = reader.take((MAX_CONTROL_FRAME_BYTES + 1) as u64);
+    let mut frame = Vec::new();
+    reader.read_until(b'\n', &mut frame).await?;
+    if frame.len() > MAX_CONTROL_FRAME_BYTES {
+        anyhow::bail!("control request exceeded {MAX_CONTROL_FRAME_BYTES} bytes");
+    }
+    if frame.is_empty() {
+        let stderr = child.stderr.take().expect("piped stderr");
+        let stderr = BufReader::new(stderr);
+        let mut stderr = stderr.take((MAX_CONTROL_FRAME_BYTES + 1) as u64);
+        let mut message = String::new();
+        stderr.read_to_string(&mut message).await?;
+        anyhow::bail!("child produced no control request: {}", message.trim());
+    }
+    let request: ControlRequest = serde_json::from_slice(&frame)?;
+    let response = service.execute(request.clone()).await;
+
+    let mut stdin = child.stdin.take().expect("piped stdin");
+    let mut reply = serde_json::to_vec(&response)?;
+    reply.push(b'\n');
+    stdin.write_all(&reply).await?;
+    stdin.shutdown().await?;
+    let status = child.wait().await?;
+    if !status.success() {
+        anyhow::bail!("control child rejected the host response");
+    }
+
+    let rendered = service.render(&request, &response);
+    Ok(if response.ok {
+        AttachedCommandOutput {
+            stdout: format!("{rendered}\n"),
+            stderr: String::new(),
+            exit_code: 0,
+        }
+    } else {
+        AttachedCommandOutput {
+            stdout: String::new(),
+            stderr: format!("{rendered}\n"),
+            exit_code: 1,
+        }
+    })
+}
+
+/// Child half of the anonymous pipe handshake. It emits exactly one bounded
+/// request and accepts exactly one version-matched response.
+pub async fn run_control_child(request: ControlRequest) -> anyhow::Result<()> {
+    let mut frame = serde_json::to_vec(&request)?;
+    if frame.len() > MAX_CONTROL_FRAME_BYTES {
+        anyhow::bail!("control request exceeded {MAX_CONTROL_FRAME_BYTES} bytes");
+    }
+    frame.push(b'\n');
+    let mut stdout = tokio::io::stdout();
+    stdout.write_all(&frame).await?;
+    stdout.flush().await?;
+
+    let reader = BufReader::new(tokio::io::stdin());
+    let mut reader = reader.take((MAX_CONTROL_FRAME_BYTES + 1) as u64);
+    let mut reply = Vec::new();
+    reader.read_until(b'\n', &mut reply).await?;
+    if reply.len() > MAX_CONTROL_FRAME_BYTES {
+        anyhow::bail!("control response exceeded {MAX_CONTROL_FRAME_BYTES} bytes");
+    }
+    let response: ControlResponse = serde_json::from_slice(&reply)?;
+    if response.version != CONTROL_VERSION {
+        anyhow::bail!(
+            "control response version {} does not match {CONTROL_VERSION}",
+            response.version
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestControlCapability;
+
+    #[async_trait]
+    impl Capability for TestControlCapability {
+        fn id(&self) -> &str {
+            "extensions"
+        }
+
+        fn name(&self) -> &str {
+            "Extensions"
+        }
+
+        fn description(&self) -> &str {
+            "Test extension administration."
+        }
+    }
+
+    #[async_trait]
+    impl ControlCapability for TestControlCapability {
+        fn control_route(&self) -> ControlRoute {
+            ControlRoute {
+                resource: "extensions",
+                cli_subcommand: "extensions",
+                read_only_operations: &["list"],
+            }
+        }
+
+        async fn execute_control(&self, action: &Value) -> ToolExecutionResult {
+            ToolExecutionResult::Success(action.clone())
+        }
+
+        fn render_control(&self, _action: &Value, response: &ControlResponse) -> String {
+            response.render_default()
+        }
+    }
+
+    #[async_trait]
+    impl CliCapability for TestControlCapability {
+        fn cli_command(&self) -> Command {
+            Command::new("extensions")
+                .subcommand(Command::new("enable").arg(clap::Arg::new("name").required(true)))
+        }
+
+        fn control_request_from_cli(&self, matches: &ArgMatches) -> anyhow::Result<ControlRequest> {
+            let (operation, matches) = matches.subcommand().expect("operation");
+            ControlRequest::new(
+                "extensions",
+                serde_json::json!({
+                    "operation": operation,
+                    "name": matches.get_one::<String>("name"),
+                }),
+            )
+            .map_err(Into::into)
+        }
+
+        async fn execute_cli(&self, _request: &ControlRequest) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn service() -> ControlRegistry {
+        let mut service = ControlRegistry::default();
+        service.register(Arc::new(TestControlCapability)).unwrap();
+        service
+    }
+
+    #[test]
+    fn only_plain_foreground_extension_invocations_are_attached() {
+        let service = service();
+        assert!(direct_control_args("yolop extensions list", &service).is_some());
+        assert!(
+            direct_control_args("/usr/local/bin/yolop extensions enable demo", &service).is_some()
+        );
+        assert!(direct_control_args("yolop extensions enable demo | cat", &service).is_none());
+        assert!(direct_control_args("yolop extensions enable demo &", &service).is_none());
+        assert!(direct_control_args("yolop extensions enable 'demo'", &service).is_none());
+        assert!(direct_control_args("yolop mcp list", &service).is_none());
+        assert!(!requires_host_approval("yolop extensions list", &service));
+        assert!(requires_host_approval(
+            "yolop extensions doctor demo",
+            &service
+        ));
+        assert!(requires_host_approval(
+            "yolop extensions enable demo",
+            &service
+        ));
+    }
+
+    #[test]
+    fn request_round_trips_as_versioned_resource_envelope() {
+        let request = ControlRequest::new(
+            "extensions",
+            serde_json::json!({ "operation": "enable", "name": "demo" }),
+        )
+        .unwrap();
+        let encoded = serde_json::to_string(&request).unwrap();
+        assert!(encoded.contains("\"version\":1"));
+        assert!(encoded.contains("\"resource\":\"extensions\""));
+        assert_eq!(
+            serde_json::from_str::<ControlRequest>(&encoded).unwrap(),
+            request
+        );
+    }
+
+    #[tokio::test]
+    async fn registry_routes_requests_to_the_declaring_capability() {
+        let service = service();
+        let request = ControlRequest::new(
+            "extensions",
+            serde_json::json!({ "operation": "enable", "name": "demo" }),
+        )
+        .unwrap();
+        let response = service.execute(request.clone()).await;
+        assert!(response.ok);
+        assert_eq!(response.value, Some(request.action));
+
+        let unavailable = service
+            .execute(ControlRequest::new("mcp", serde_json::json!({})).unwrap())
+            .await;
+        assert!(!unavailable.ok);
+        assert!(
+            unavailable
+                .error
+                .as_deref()
+                .unwrap_or_default()
+                .contains("not available")
+        );
+    }
+
+    #[test]
+    fn registries_reject_duplicate_capability_routes() {
+        let mut control = ControlRegistry::default();
+        control.register(Arc::new(TestControlCapability)).unwrap();
+        assert!(
+            control
+                .register(Arc::new(TestControlCapability))
+                .unwrap_err()
+                .to_string()
+                .contains("duplicate control resource")
+        );
+
+        let mut cli = CliRegistry::default();
+        cli.register(Arc::new(TestControlCapability)).unwrap();
+        assert!(
+            cli.register(Arc::new(TestControlCapability))
+                .unwrap_err()
+                .to_string()
+                .contains("duplicate contributed CLI command")
+        );
+    }
+
+    #[test]
+    fn cli_registry_contributes_and_decodes_the_capability_command() {
+        let mut registry = CliRegistry::default();
+        registry.register(Arc::new(TestControlCapability)).unwrap();
+        let matches = registry
+            .augment(Command::new("yolop").subcommand(Command::new("version")))
+            .unwrap()
+            .try_get_matches_from(["yolop", "extensions", "enable", "demo"])
+            .unwrap();
+        let invocation = registry.invocation(&matches).unwrap().unwrap();
+        assert_eq!(invocation.request.resource, "extensions");
+        assert_eq!(invocation.request.action["operation"], "enable");
+        assert_eq!(invocation.request.action["name"], "demo");
+    }
+}

--- a/src/exec/tools.rs
+++ b/src/exec/tools.rs
@@ -51,6 +51,7 @@ pub struct BashTool {
     sandbox: Arc<dyn SandboxProvider>,
     approval_policy: ApprovalPolicy,
     approval_gate: Arc<ApprovalGate>,
+    control: Option<Arc<dyn crate::control::ControlService>>,
     foreground_timeout_secs: u64,
     background_timeout_secs: u64,
     max_output_bytes: usize,
@@ -113,10 +114,19 @@ impl BashTool {
             sandbox,
             approval_policy,
             approval_gate,
+            control: None,
             foreground_timeout_secs: 120,
             background_timeout_secs: 24 * 60 * 60,
             max_output_bytes: 1024 * 1024,
         }
+    }
+
+    pub(crate) fn with_control(
+        mut self,
+        control: Option<Arc<dyn crate::control::ControlService>>,
+    ) -> Self {
+        self.control = control;
+        self
     }
 
     fn timeout_secs(&self, background: bool) -> u64 {
@@ -143,6 +153,25 @@ impl BashTool {
         let timeout = Duration::from_secs(timeout_secs);
         let max_bytes = self.max_output_bytes;
         let sandbox_mode = sandbox.mode();
+
+        // Attached administration is deliberately foreground-only. The
+        // recognizer rejects shell composition, then the exact running Yolop
+        // executable exchanges one typed request over anonymous pipes. No
+        // endpoint or capability reaches the ordinary shell environment.
+        if sink.is_none()
+            && let Some(control) = &self.control
+            && let Some(output) = crate::control::invoke_attached(command, control.clone()).await
+        {
+            return Ok(BashRunOutput {
+                stdout_text: output.stdout,
+                stderr_text: output.stderr,
+                exit_code: output.exit_code,
+                out_truncated: false,
+                err_truncated: false,
+                duration: Duration::ZERO,
+                sandbox_mode,
+            });
+        }
 
         if let Some(sink) = &sink {
             let _ = sink.status("Running bash command").await;
@@ -270,6 +299,33 @@ impl BashTool {
         request_full_access: bool,
         justification: Option<&str>,
     ) -> Result<BashRunOutput, ToolExecutionResult> {
+        if sink.is_none()
+            && self.control.is_some()
+            && self.sandbox.mode() != SandboxMode::DangerFullAccess
+            && crate::control::requires_host_approval(
+                command,
+                self.control.as_ref().expect("checked above").as_ref(),
+            )
+        {
+            if self.approval_policy == ApprovalPolicy::Never {
+                return Err(ToolExecutionResult::tool_error(
+                    "approval_policy=never forbids attached administration outside the shell sandbox",
+                ));
+            }
+            self.request_approval(
+                command,
+                justification
+                    .filter(|value| !value.trim().is_empty())
+                    .unwrap_or(
+                        "typed Yolop administration writes or executes outside the arbitrary-shell sandbox",
+                    )
+                    .to_string(),
+                false,
+            )
+            .await?;
+            return self.run_command(command, sink, &self.sandbox).await;
+        }
+
         if self.sandbox.mode() == SandboxMode::DangerFullAccess {
             if self.approval_policy == ApprovalPolicy::Untrusted && !trusted_command(command) {
                 self.request_approval(
@@ -394,7 +450,8 @@ impl Tool for BashTool {
              relative to it, or chain within one call (`cd sub; cmd`). Captures \
              stdout/stderr with configurable verbosity. 120s timeout; run commands \
              that wait on external events (CI runs, deploys) detached via \
-             `spawn_background` instead."
+             `spawn_background` instead. Invoke `yolop extensions ...` directly \
+             (without shell composition) to administer the current session."
         }
         #[cfg(not(windows))]
         {
@@ -405,7 +462,8 @@ impl Tool for BashTool {
              it, or chain within one call (`cd sub && cmd`). Captures stdout/stderr \
              with configurable verbosity. 120s timeout; run commands that wait on \
              external events (CI runs, deploys) detached via `spawn_background` \
-             instead."
+             instead. Invoke `yolop extensions ...` directly (without shell \
+             composition) to administer the current session."
         }
     }
     fn parameters_schema(&self) -> Value {

--- a/src/extensions/manage.rs
+++ b/src/extensions/manage.rs
@@ -1,8 +1,8 @@
-//! The `extensions` capability: the management surface for installing,
-//! listing, enabling, and removing extension packages. Distinct from the
-//! per-package `ext:<name>` capabilities — this one is always on the default
-//! harness (like `connectors`) and owns the verbs. Tools so both the user
-//! and the model can drive setup; a thin `/extensions` command mirrors them.
+//! Extension administration shared by the standalone CLI and the running host.
+//!
+//! Administration deliberately is not exposed as model tools. A direct
+//! foreground `yolop extensions ...` invocation can cross the attached control
+//! boundary, while ordinary CLI invocations mutate global state.
 
 use super::client::AskSink;
 use super::manager::LiveProcessRegistry;
@@ -13,18 +13,232 @@ use super::secrets::{ExtensionSecrets, Secret};
 use super::store::{self, CrateFetcher, GitRunner, Source, SystemCrateFetcher, SystemGit};
 use crate::capabilities::narration::stable_labeled;
 use crate::config::SettingsStore;
+use crate::control::{
+    CliCapability, ControlCapability, ControlRequest, ControlResponse, ControlRoute,
+};
 use crate::tui::host_ui::{UiCommand, UiRequest};
 use async_trait::async_trait;
+use clap::{Args, CommandFactory, FromArgMatches, Parser, Subcommand};
 use everruns_core::Capability;
+use everruns_core::command::{
+    CommandArg, CommandDescriptor, CommandExecutionContext, CommandResult, CommandSource,
+    ExecuteCommandRequest,
+};
 use everruns_core::tool_narration::{ToolNarrationPhase, arg_str, truncate};
 use everruns_core::{Tool, ToolExecutionResult};
 use everruns_provider::ToolCall;
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
 
 pub const EXTENSIONS_CAPABILITY_ID: &str = "extensions";
+const EXTENSIONS_COMMAND_NAME: &str = "extensions";
+
+#[derive(Subcommand, Debug)]
+enum ExtensionCommand {
+    /// List installed extensions.
+    List {
+        /// Emit the full machine-readable result.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Install an extension without enabling it.
+    Install { source: String },
+    /// Remove an installed extension and its persisted enablement/secrets.
+    Remove { name: String },
+    /// Persist enablement and apply it to the attached session when present.
+    Enable { name: String },
+    /// Persist disablement and apply it to the attached session when present.
+    Disable { name: String },
+    /// Restart an extension server in the attached session.
+    Reload { name: String },
+    /// Probe an installed extension's YEP conformance.
+    Doctor { name: String },
+    /// Prompt for and store an extension secret.
+    Secret(ExtensionSecretArgs),
+    /// Create a new extension package skeleton.
+    Scaffold {
+        name: String,
+        #[arg(long, default_value = "")]
+        description: String,
+        #[arg(long, default_value = "python")]
+        language: String,
+        #[arg(long = "tool")]
+        tools: Vec<String>,
+        #[arg(long = "command")]
+        commands: Vec<String>,
+        #[arg(long)]
+        prompt: Option<String>,
+        #[arg(long)]
+        status: bool,
+        #[arg(long)]
+        skills: bool,
+        #[arg(long)]
+        dir: Option<PathBuf>,
+    },
+}
+
+#[derive(Args, Debug)]
+pub struct ExtensionSecretArgs {
+    #[command(subcommand)]
+    command: ExtensionSecretCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum ExtensionSecretCommand {
+    /// Prompt for a secret field; the value is never accepted as an argument.
+    Set { name: String, field: String },
+}
+
+#[derive(Parser)]
+#[command(
+    name = "extensions",
+    about = "Manage Yolop extensions. A direct invocation from Yolop's foreground Bash updates the current session as well as persisted state",
+    disable_help_subcommand = true
+)]
+struct ExtensionCommandLine {
+    #[command(subcommand)]
+    command: ExtensionCommand,
+}
+
+/// Version-independent extension operations carried by the internal control
+/// plane. The wire envelope owns protocol versioning; this enum owns the
+/// extension domain vocabulary.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "operation", rename_all = "snake_case")]
+pub enum ExtensionAction {
+    List {
+        json: bool,
+    },
+    Install {
+        source: String,
+    },
+    Remove {
+        name: String,
+    },
+    Enable {
+        name: String,
+    },
+    Disable {
+        name: String,
+    },
+    Reload {
+        name: String,
+    },
+    Doctor {
+        name: String,
+    },
+    SetSecret {
+        name: String,
+        field: String,
+    },
+    Scaffold {
+        name: String,
+        description: String,
+        language: String,
+        tools: Vec<String>,
+        commands: Vec<String>,
+        prompt: Option<String>,
+        status: bool,
+        skills: bool,
+        dir: Option<PathBuf>,
+    },
+}
+
+impl ExtensionAction {
+    fn from_command(command: ExtensionCommand) -> Self {
+        match command {
+            ExtensionCommand::List { json } => Self::List { json },
+            ExtensionCommand::Install { source } => Self::Install { source },
+            ExtensionCommand::Remove { name } => Self::Remove { name },
+            ExtensionCommand::Enable { name } => Self::Enable { name },
+            ExtensionCommand::Disable { name } => Self::Disable { name },
+            ExtensionCommand::Reload { name } => Self::Reload { name },
+            ExtensionCommand::Doctor { name } => Self::Doctor { name },
+            ExtensionCommand::Secret(args) => match args.command {
+                ExtensionSecretCommand::Set { name, field } => Self::SetSecret { name, field },
+            },
+            ExtensionCommand::Scaffold {
+                name,
+                description,
+                language,
+                tools,
+                commands,
+                prompt,
+                status,
+                skills,
+                dir,
+            } => Self::Scaffold {
+                name,
+                description,
+                language,
+                tools,
+                commands,
+                prompt,
+                status,
+                skills,
+                dir,
+            },
+        }
+    }
+
+    fn parse_command(arguments: Option<&str>) -> Result<Self, String> {
+        let arguments = arguments.unwrap_or("").trim();
+        if arguments.is_empty() {
+            return Ok(Self::List { json: false });
+        }
+        let argv = std::iter::once("extensions").chain(arguments.split_ascii_whitespace());
+        ExtensionCommandLine::try_parse_from(argv)
+            .map(|parsed| Self::from_command(parsed.command))
+            .map_err(|error| error.to_string())
+    }
+
+    fn control_request(self) -> ControlRequest {
+        ControlRequest::new(EXTENSIONS_CAPABILITY_ID, self)
+            .expect("extension control actions are serializable")
+    }
+
+    fn verb_and_arguments(&self) -> (Verb, Value) {
+        match self {
+            Self::List { .. } => (Verb::List, json!({})),
+            Self::Install { source } => (Verb::Install, json!({ "source": source })),
+            Self::Remove { name } => (Verb::Remove, json!({ "name": name })),
+            Self::Enable { name } => (Verb::Enable, json!({ "name": name })),
+            Self::Disable { name } => (Verb::Disable, json!({ "name": name })),
+            Self::Reload { name } => (Verb::Reload, json!({ "name": name })),
+            Self::Doctor { name } => (Verb::Doctor, json!({ "name": name })),
+            Self::SetSecret { name, field } => {
+                (Verb::SetSecret, json!({ "name": name, "field": field }))
+            }
+            Self::Scaffold {
+                name,
+                description,
+                language,
+                tools,
+                commands,
+                prompt,
+                status,
+                skills,
+                dir,
+            } => (
+                Verb::Scaffold,
+                json!({
+                    "name": name,
+                    "description": description,
+                    "language": language,
+                    "tools": tools.iter().map(|name| json!({ "name": name })).collect::<Vec<_>>(),
+                    "commands": commands,
+                    "prompt": prompt,
+                    "status": status,
+                    "skills": skills,
+                    "dir": dir,
+                }),
+            ),
+        }
+    }
+}
 
 pub struct ExtensionsCapability {
     extensions_dir: PathBuf,
@@ -32,14 +246,15 @@ pub struct ExtensionsCapability {
     settings: Arc<SettingsStore>,
     git: Arc<dyn GitRunner>,
     crates: Arc<dyn CrateFetcher>,
-    /// Live server processes, so `reload_extension` can restart one in place.
+    /// Live server processes, so `yolop extensions reload` can restart one in place.
     live_processes: LiveProcessRegistry,
     /// UI-command sink (the TUI's `ui_rx`) used to activate/deactivate an
     /// extension on the live session after enable/disable; `None` in
     /// `--print`/ACP, where enable/disable only persists for the next session.
     ui_tx: Option<UnboundedSender<UiRequest>>,
-    /// Per-extension secret store (for `set_extension_secret` and the redacted
-    /// config status in `list_extensions`). `None` in tests without secrets.
+    /// Per-extension secret store (for `yolop extensions secret set` and the
+    /// redacted config status in `yolop extensions list`). `None` in tests
+    /// without secrets.
     secrets: Option<ExtensionSecrets>,
     /// Prompt surface for interactive secret entry; `None` refuses it (headless).
     ask_sink: Option<AskSink>,
@@ -66,8 +281,8 @@ impl ExtensionsCapability {
         }
     }
 
-    /// Wire the secret store so `set_extension_secret` can persist credentials
-    /// and `list_extensions` can report their (redacted) set/unset status.
+    /// Wire the secret store so the CLI can persist credentials and report
+    /// their redacted set/unset status.
     pub fn with_secrets(mut self, secrets: ExtensionSecrets) -> Self {
         self.secrets = Some(secrets);
         self
@@ -77,6 +292,46 @@ impl ExtensionsCapability {
     pub fn with_ask_sink(mut self, ask_sink: Option<AskSink>) -> Self {
         self.ask_sink = ask_sink;
         self
+    }
+
+    fn context(&self) -> Arc<ManageCtx> {
+        Arc::new(ManageCtx {
+            extensions_dir: self.extensions_dir.clone(),
+            workspace_root: self.workspace_root.clone(),
+            settings: self.settings.clone(),
+            git: self.git.clone(),
+            crates: self.crates.clone(),
+            live_processes: self.live_processes.clone(),
+            ui_tx: self.ui_tx.clone(),
+            secrets: self.secrets.clone(),
+            ask_sink: self.ask_sink.clone(),
+        })
+    }
+
+    pub async fn execute_action(&self, action: &ExtensionAction) -> ToolExecutionResult {
+        let (verb, arguments) = action.verb_and_arguments();
+        ManageTool::new(self.context(), verb)
+            .execute(arguments)
+            .await
+    }
+
+    #[cfg(test)]
+    fn management_tools(&self) -> Vec<Box<dyn Tool>> {
+        let ctx = self.context();
+        [
+            Verb::Scaffold,
+            Verb::List,
+            Verb::Install,
+            Verb::Remove,
+            Verb::Enable,
+            Verb::Disable,
+            Verb::Reload,
+            Verb::SetSecret,
+            Verb::Doctor,
+        ]
+        .into_iter()
+        .map(|verb| Box::new(ManageTool::new(ctx.clone(), verb)) as Box<dyn Tool>)
+        .collect()
     }
 }
 
@@ -91,8 +346,8 @@ impl Capability for ExtensionsCapability {
     }
 
     fn description(&self) -> &str {
-        "Install, list, enable, and remove yolop extensions — capability-level \
-         packages served over the extension protocol."
+        "Extension packages served over the extension protocol. Administration is available \
+         through `yolop extensions ...`."
     }
 
     fn category(&self) -> Option<&str> {
@@ -108,29 +363,147 @@ impl Capability for ExtensionsCapability {
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
-        let ctx = Arc::new(ManageCtx {
-            extensions_dir: self.extensions_dir.clone(),
-            workspace_root: self.workspace_root.clone(),
-            settings: self.settings.clone(),
-            git: self.git.clone(),
-            crates: self.crates.clone(),
-            live_processes: self.live_processes.clone(),
-            ui_tx: self.ui_tx.clone(),
-            secrets: self.secrets.clone(),
-            ask_sink: self.ask_sink.clone(),
-        });
-        vec![
-            Box::new(ManageTool::new(ctx.clone(), Verb::Scaffold)),
-            Box::new(ManageTool::new(ctx.clone(), Verb::List)),
-            Box::new(ManageTool::new(ctx.clone(), Verb::Install)),
-            Box::new(ManageTool::new(ctx.clone(), Verb::Remove)),
-            Box::new(ManageTool::new(ctx.clone(), Verb::Enable)),
-            Box::new(ManageTool::new(ctx.clone(), Verb::Disable)),
-            Box::new(ManageTool::new(ctx.clone(), Verb::Reload)),
-            Box::new(ManageTool::new(ctx.clone(), Verb::SetSecret)),
-            Box::new(ManageTool::new(ctx, Verb::Doctor)),
-        ]
+        Vec::new()
     }
+
+    fn commands(&self) -> Vec<CommandDescriptor> {
+        vec![CommandDescriptor {
+            name: EXTENSIONS_COMMAND_NAME.to_string(),
+            description: "Manage extension packages using the `yolop extensions` grammar."
+                .to_string(),
+            source: CommandSource::System,
+            args: vec![CommandArg {
+                name: "operation".to_string(),
+                description: "CLI-style operation and arguments; omit to list extensions."
+                    .to_string(),
+                required: false,
+                suggestions: vec![
+                    "list".to_string(),
+                    "enable".to_string(),
+                    "disable".to_string(),
+                    "reload".to_string(),
+                    "doctor".to_string(),
+                ],
+            }],
+        }]
+    }
+
+    async fn execute_command(
+        &self,
+        request: &ExecuteCommandRequest,
+        _ctx: &CommandExecutionContext,
+    ) -> everruns_provider::error::Result<CommandResult> {
+        if request.name != EXTENSIONS_COMMAND_NAME {
+            return Err(everruns_provider::error::AgentLoopError::config(format!(
+                "{} cannot execute /{}",
+                self.id(),
+                request.name
+            )));
+        }
+        let action = ExtensionAction::parse_command(request.arguments.as_deref())
+            .map_err(everruns_provider::error::AgentLoopError::config)?;
+        let response = ControlResponse::from_tool_result(self.execute_action(&action).await);
+        Ok(CommandResult {
+            success: response.ok,
+            message: render_extension_response(&action, &response),
+            error_code: None,
+            error_fields: None,
+        })
+    }
+}
+
+#[async_trait]
+impl ControlCapability for ExtensionsCapability {
+    fn control_route(&self) -> ControlRoute {
+        ControlRoute {
+            resource: EXTENSIONS_CAPABILITY_ID,
+            cli_subcommand: EXTENSIONS_CAPABILITY_ID,
+            read_only_operations: &["list"],
+        }
+    }
+
+    async fn execute_control(&self, action: &Value) -> ToolExecutionResult {
+        let action = match serde_json::from_value::<ExtensionAction>(action.clone()) {
+            Ok(action) => action,
+            Err(error) => {
+                return ToolExecutionResult::ToolError(format!(
+                    "invalid extension control action: {error}"
+                ));
+            }
+        };
+        self.execute_action(&action).await
+    }
+
+    fn render_control(&self, action: &Value, response: &ControlResponse) -> String {
+        serde_json::from_value::<ExtensionAction>(action.clone())
+            .map(|action| render_extension_response(&action, response))
+            .unwrap_or_else(|_| response.render_default())
+    }
+}
+
+#[async_trait]
+impl CliCapability for ExtensionsCapability {
+    fn cli_command(&self) -> clap::Command {
+        ExtensionCommandLine::command()
+    }
+
+    fn control_request_from_cli(
+        &self,
+        matches: &clap::ArgMatches,
+    ) -> anyhow::Result<ControlRequest> {
+        let parsed = ExtensionCommandLine::from_arg_matches(matches)?;
+        Ok(ExtensionAction::from_command(parsed.command).control_request())
+    }
+
+    async fn execute_cli(&self, request: &ControlRequest) -> anyhow::Result<()> {
+        let action = serde_json::from_value::<ExtensionAction>(request.action.clone())?;
+        if matches!(action, ExtensionAction::Reload { .. }) {
+            anyhow::bail!(
+                "extension reload requires a running Yolop session; invoke it directly through that session's Bash"
+            );
+        }
+        let response = ControlResponse::from_tool_result(self.execute_action(&action).await);
+        let rendered = self.render_control(&request.action, &response);
+        if response.ok {
+            println!("{rendered}");
+            Ok(())
+        } else {
+            anyhow::bail!(rendered)
+        }
+    }
+}
+
+fn render_extension_response(action: &ExtensionAction, response: &ControlResponse) -> String {
+    if !response.ok {
+        return response.render_default();
+    }
+    let value = response.value.as_ref().unwrap_or(&Value::Null);
+    if !matches!(action, ExtensionAction::List { json: false }) {
+        return response.render_default();
+    }
+    let Some(items) = value.get("extensions").and_then(Value::as_array) else {
+        return response.render_default();
+    };
+    if items.is_empty() {
+        return "No extensions installed.".to_string();
+    }
+    let mut lines = Vec::with_capacity(items.len() + 1);
+    lines.push(format!("{:<24} {:<10} {}", "NAME", "STATE", "VERSION"));
+    for item in items {
+        let name = item.get("name").and_then(Value::as_str).unwrap_or("?");
+        let state = if item
+            .get("enabled")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            "enabled"
+        } else {
+            "disabled"
+        };
+        let version = item.get("version").and_then(Value::as_str).unwrap_or("-");
+        lines.push(format!("{name:<24} {state:<10} {version}"));
+    }
+    lines.join("\n")
 }
 
 struct ManageCtx {
@@ -276,8 +649,8 @@ impl ManageTool {
                     "files": out.files,
                     "build": out.build,
                     "next": format!(
-                        "Edit the handler bodies in {}, then {build_step}install_extension \
-                         source={} → doctor_extension name={name} → enable_extension name={name} \
+                        "Edit the handler bodies in {}, then {build_step}`yolop extensions install \
+                         {}` → `yolop extensions doctor {name}` → `yolop extensions enable {name}` \
                          (next session).",
                         out.edit.display(),
                         out.dir.display(),
@@ -382,7 +755,7 @@ impl ManageTool {
                     "content_hash": installed.content_hash,
                     "grant_changed": installed.previous_hash.is_some(),
                     "note": format!(
-                        "Installed but not enabled. Run enable_extension name={} to add it to the harness.",
+                        "Installed but not enabled. Run `yolop extensions enable {}` to enable it.",
                         m.name
                     ),
                 }))
@@ -411,7 +784,7 @@ impl ManageTool {
         }
     }
 
-    fn toggle(&self, args: &Value, enable: bool) -> ToolExecutionResult {
+    async fn toggle(&self, args: &Value, enable: bool) -> ToolExecutionResult {
         let Some(name) = args.get("name").and_then(Value::as_str) else {
             return ToolExecutionResult::ToolError("`name` is required".into());
         };
@@ -421,7 +794,7 @@ impl ManageTool {
                 .any(|pkg| pkg.manifest.name == name)
         {
             return ToolExecutionResult::ToolError(format!(
-                "no extension named `{name}` is installed; install_extension first"
+                "no extension named `{name}` is installed; run `yolop extensions install` first"
             ));
         }
         let cap_id = extension_capability_id(name);
@@ -431,19 +804,41 @@ impl ManageTool {
                 // session to mutate (the TUI). The App answers on `ui_rx` by
                 // calling activate/deactivate_capability, so the extension's
                 // tools/prompt/hooks land on the next turn — no restart.
-                let live = self
-                    .ctx
-                    .ui_tx
-                    .as_ref()
-                    .map(|tx| {
-                        tx.send(UiRequest::fire(UiCommand::SetExtensionActive {
-                            capability_id: cap_id.clone(),
-                            name: name.to_string(),
-                            activate: enable,
-                        }))
-                        .is_ok()
-                    })
-                    .unwrap_or(false);
+                let live = if let Some(tx) = &self.ctx.ui_tx {
+                    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+                    if tx
+                        .send(UiRequest {
+                            command: UiCommand::SetExtensionActive {
+                                capability_id: cap_id.clone(),
+                                name: name.to_string(),
+                                activate: enable,
+                            },
+                            reply: Some(reply_tx),
+                        })
+                        .is_err()
+                    {
+                        false
+                    } else {
+                        // The TUI event loop replies only after the runtime
+                        // overlay mutation completes. This prevents a queued
+                        // request from being reported as live when activation
+                        // actually failed (for example, a package installed
+                        // after this session registered its manifests).
+                        tokio::time::timeout(std::time::Duration::from_secs(10), reply_rx)
+                            .await
+                            .ok()
+                            .and_then(Result::ok)
+                            .is_some_and(|messages| {
+                                messages.is_empty()
+                                    || messages.iter().any(|message| {
+                                        message.contains("for this session")
+                                            && message.contains("effective on the next turn")
+                                    })
+                            })
+                    }
+                } else {
+                    false
+                };
                 let note = if live {
                     "Applying to the running session now; effective on the next turn (and \
                      persisted for future sessions)."
@@ -603,7 +998,7 @@ impl ManageTool {
     /// text) that isn't set yet. Best-effort — with no prompt surface the
     /// extension still enables and stays inert until configured.
     async fn enable(&self, args: &Value) -> ToolExecutionResult {
-        let result = self.toggle(args, true);
+        let result = self.toggle(args, true).await;
         if !matches!(result, ToolExecutionResult::Success(_)) {
             return result;
         }
@@ -686,7 +1081,7 @@ impl ManageTool {
             })),
             None => ToolExecutionResult::ToolError(format!(
                 "extension `{name}` is not enabled this session, so it has no running server to \
-                 reload; enable_extension name={name} and restart yolop to load it"
+                 reload; run `yolop extensions enable {name}` and restart yolop to load it"
             )),
         }
     }
@@ -897,7 +1292,7 @@ impl Tool for ManageTool {
             Verb::Install => self.install(&arguments).await,
             Verb::Remove => self.remove(&arguments),
             Verb::Enable => self.enable(&arguments).await,
-            Verb::Disable => self.toggle(&arguments, false),
+            Verb::Disable => self.toggle(&arguments, false).await,
             Verb::Reload => self.reload(&arguments).await,
             Verb::SetSecret => self.set_secret(&arguments).await,
             Verb::Doctor => self.doctor(&arguments).await,
@@ -943,10 +1338,46 @@ mod tests {
     }
 
     #[test]
+    fn management_capability_contributes_command_but_no_model_tools() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (capability, _, _) = capability(tmp.path());
+        assert!(Capability::tools(&capability).is_empty());
+        let commands = Capability::commands(&capability);
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].name, "extensions");
+    }
+
+    #[test]
+    fn extension_command_uses_the_cli_action_grammar() {
+        assert_eq!(
+            ExtensionAction::parse_command(Some("enable demo")).unwrap(),
+            ExtensionAction::Enable {
+                name: "demo".to_string()
+            }
+        );
+        assert_eq!(
+            ExtensionAction::parse_command(None).unwrap(),
+            ExtensionAction::List { json: false }
+        );
+        assert!(ExtensionAction::parse_command(Some("unknown demo")).is_err());
+
+        let tmp = tempfile::tempdir().unwrap();
+        let (capability, _, _) = capability(tmp.path());
+        let matches = capability
+            .cli_command()
+            .try_get_matches_from(["extensions", "enable", "demo"])
+            .unwrap();
+        let request = capability.control_request_from_cli(&matches).unwrap();
+        assert_eq!(request.resource, "extensions");
+        assert_eq!(request.action["operation"], "enable");
+        assert_eq!(request.action["name"], "demo");
+    }
+
+    #[test]
     fn manage_tool_narration_names_action_and_extension() {
         let tmp = tempfile::tempdir().unwrap();
         let (cap, _, _) = capability(tmp.path());
-        let mut tools = cap.tools();
+        let mut tools = cap.management_tools();
         let tool = tools.remove(4);
         let call = ToolCall {
             id: "call-1".into(),
@@ -969,7 +1400,7 @@ mod tests {
     async fn scaffold_then_install_flow() {
         let tmp = tempfile::tempdir().unwrap();
         let (cap, _settings, _ext_dir) = capability(tmp.path());
-        let tools = cap.tools();
+        let tools = cap.management_tools();
         let get = |name: &str| tools.iter().find(|t| t.name() == name).unwrap();
 
         // Scaffold a hook extension into an explicit parent dir.
@@ -1009,7 +1440,7 @@ mod tests {
     async fn scaffold_rejects_no_contributions() {
         let tmp = tempfile::tempdir().unwrap();
         let (cap, _s, _e) = capability(tmp.path());
-        let tools = cap.tools();
+        let tools = cap.management_tools();
         let scaffold = tools
             .iter()
             .find(|t| t.name() == "scaffold_extension")
@@ -1026,7 +1457,7 @@ mod tests {
         let src = tmp.path().join("src");
         seed_package(&src, "echo");
         let (cap, settings, _ext_dir) = capability(tmp.path());
-        let tools = cap.tools();
+        let tools = cap.management_tools();
         let get = |name: &str| tools.iter().find(|t| t.name() == name).unwrap();
 
         // install
@@ -1113,7 +1544,7 @@ mod tests {
         let src = tmp.path().join("src");
         seed_secret_package(&src, "logfire");
         let (cap, _settings, _ext_dir) = capability(tmp.path());
-        let tools = cap.tools();
+        let tools = cap.management_tools();
         let get = |name: &str| tools.iter().find(|t| t.name() == name).unwrap();
         get("install_extension")
             .execute(json!({ "source": src.to_str().unwrap() }))
@@ -1174,7 +1605,7 @@ mod tests {
             secrets: Some(secrets.clone()),
             ask_sink: None,
         };
-        let tools = cap.tools();
+        let tools = cap.management_tools();
         let get = |name: &str| tools.iter().find(|t| t.name() == name).unwrap();
         get("install_extension")
             .execute(json!({ "source": src.to_str().unwrap() }))
@@ -1266,7 +1697,7 @@ mod tests {
             secrets: Some(secrets.clone()),
             ask_sink: Some(ask),
         };
-        let tools = cap.tools();
+        let tools = cap.management_tools();
         let get = |name: &str| tools.iter().find(|t| t.name() == name).unwrap();
         get("install_extension")
             .execute(json!({ "source": src.to_str().unwrap() }))
@@ -1298,7 +1729,7 @@ mod tests {
         let src = tmp.path().join("src");
         seed_package(&src, "echo");
         let (cap, _settings, _ext_dir) = capability(tmp.path());
-        let tools = cap.tools();
+        let tools = cap.management_tools();
         let get = |name: &str| tools.iter().find(|t| t.name() == name).unwrap();
         get("install_extension")
             .execute(json!({ "source": src.to_str().unwrap() }))
@@ -1344,13 +1775,29 @@ mod tests {
             secrets: None,
             ask_sink: None,
         };
-        let tools = cap.tools();
+        let tools = cap.management_tools();
         let get = |name: &str| tools.iter().find(|t| t.name() == name).unwrap();
         get("install_extension")
             .execute(json!({ "source": src.to_str().unwrap() }))
             .await;
 
-        // enable persists AND signals live activation on the UI channel.
+        let ui = tokio::spawn(async move {
+            let mut commands = Vec::new();
+            for _ in 0..2 {
+                let request = ui_rx.recv().await.unwrap();
+                commands.push(request.command);
+                request
+                    .reply
+                    .unwrap()
+                    .send(vec![
+                        "extension applied for this session; effective on the next turn.".into(),
+                    ])
+                    .unwrap();
+            }
+            commands
+        });
+
+        // enable persists AND waits for confirmed live activation from the UI.
         match get("enable_extension")
             .execute(json!({"name": "echo"}))
             .await
@@ -1358,26 +1805,30 @@ mod tests {
             ToolExecutionResult::Success(v) => assert_eq!(v["live"], true),
             other => panic!("{other:?}"),
         }
-        assert_eq!(
-            ui_rx.try_recv().unwrap().command,
-            UiCommand::SetExtensionActive {
-                capability_id: "ext:echo".into(),
-                name: "echo".into(),
-                activate: true,
-            }
-        );
 
         // disable signals deactivation.
-        get("disable_extension")
+        match get("disable_extension")
             .execute(json!({"name": "echo"}))
-            .await;
+            .await
+        {
+            ToolExecutionResult::Success(v) => assert_eq!(v["live"], true),
+            other => panic!("{other:?}"),
+        }
+        let commands = ui.await.unwrap();
         assert_eq!(
-            ui_rx.try_recv().unwrap().command,
-            UiCommand::SetExtensionActive {
-                capability_id: "ext:echo".into(),
-                name: "echo".into(),
-                activate: false,
-            }
+            commands,
+            vec![
+                UiCommand::SetExtensionActive {
+                    capability_id: "ext:echo".into(),
+                    name: "echo".into(),
+                    activate: true,
+                },
+                UiCommand::SetExtensionActive {
+                    capability_id: "ext:echo".into(),
+                    name: "echo".into(),
+                    activate: false,
+                },
+            ]
         );
     }
 }

--- a/src/extensions/scaffold.rs
+++ b/src/extensions/scaffold.rs
@@ -11,7 +11,7 @@
 //! JSON-RPC server:
 //! - **Python** / **Node.js** (`typescript`): single-file, dependency-free,
 //!   zero-build — the executable server lives directly in `bin/`, so the
-//!   package installs and passes `doctor_extension` immediately.
+//!   package installs and passes `yolop extensions doctor` immediately.
 //! - **Rust**: a `serde_json`-only crate. Compiled, so it carries a `build`
 //!   step ([`Scaffolded::build`]) that produces the binary into `bin/` before
 //!   install — the one difference from the zero-build path.
@@ -332,10 +332,10 @@ Speaks the yolop extension protocol: newline-delimited JSON-RPC over stdio.
 stdout carries ONLY protocol JSON — write any logs to stderr via log(). This
 file has no third-party dependencies.
 
-To author: edit the handle_* bodies below, then from yolop:
-  install_extension source=<this package directory>
-  doctor_extension  name={name}
-  enable_extension  name={name}    # takes effect on the next session
+To author: edit the handle_* bodies below, then run:
+  yolop extensions install <this package directory>
+  yolop extensions doctor {name}
+  yolop extensions enable {name}    # takes effect on the next session
 """
 
 import json
@@ -515,10 +515,10 @@ fn node_server(req: &ScaffoldRequest) -> String {
 // stdout carries ONLY protocol JSON — write any logs to stderr via log(). No
 // third-party dependencies.
 //
-// To author: edit the handle* bodies below, then from yolop:
-//   install_extension source=<this package directory>
-//   doctor_extension  name={name}
-//   enable_extension  name={name}    // takes effect on the next session
+// To author: edit the handle* bodies below, then run:
+//   yolop extensions install <this package directory>
+//   yolop extensions doctor {name}
+//   yolop extensions enable {name}    // takes effect on the next session
 
 const readline = require("readline");
 
@@ -680,12 +680,12 @@ fn readme(req: &ScaffoldRequest, server_name: &str, build: &Option<String>) -> S
          - `plugin.json` — the manifest: the contributions yolop approves at install.\n\
          {layout}\n\n\
          ## Author\n\n\
-         {edit}, then from yolop:\n\n\
+         {edit}, then run:\n\n\
          {build_block}\
          ```\n\
-         install_extension source=<this directory>\n\
-         doctor_extension  name={name}\n\
-         enable_extension  name={name}\n\
+         yolop extensions install <this directory>\n\
+         yolop extensions doctor {name}\n\
+         yolop extensions enable {name}\n\
          ```\n\n\
          Enabling takes effect on the next session.\n",
         name = req.name,
@@ -750,11 +750,11 @@ fn rust_main(req: &ScaffoldRequest) -> String {
 //! stdout carries ONLY protocol JSON — write any logs to stderr. Depends only
 //! on `serde_json`.
 //!
-//! To author: edit the handle_* bodies below, then from yolop:
+//! To author: edit the handle_* bodies below, then run:
 //!   cargo build --release   # then copy target/release/{name}-server to bin/
-//!   install_extension source=<this package directory>
-//!   doctor_extension  name={name}
-//!   enable_extension  name={name}    // takes effect on the next session
+//!   yolop extensions install <this package directory>
+//!   yolop extensions doctor {name}
+//!   yolop extensions enable {name}    // takes effect on the next session
 
 use serde_json::{{Value, json}};
 use std::io::{{BufRead, Write}};

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod auth;
 mod capabilities;
 mod config;
 mod connectors;
+mod control;
 mod crash_report;
 mod drivers;
 mod editor;
@@ -28,7 +29,7 @@ use anyhow::{Context, Result};
 // LTO/dead-code elimination when we register capabilities explicitly.
 extern crate everruns_integrations_daytona;
 extern crate everruns_integrations_parallel;
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, CommandFactory, FromArgMatches, Parser, Subcommand};
 use config::SettingsStore;
 use config::mcp::{McpConfigScope, McpConfigStore};
 use crossterm::event::{
@@ -91,6 +92,11 @@ impl Write for BoundedTraceWriter {
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
+
+    /// Internal one-shot control-plane child. The parent supplies anonymous
+    /// pipes; this flag is never a public session-selection mechanism.
+    #[arg(long = "__attached-control-child", hide = true)]
+    attached_control_child: bool,
 
     /// Workspace root the agent operates inside (default: current dir)
     #[arg(short = 'C', long = "cwd")]
@@ -629,7 +635,23 @@ fn join_worker<T>(
 }
 
 async fn async_main(crash_reporter: &crash_report::CrashReporter) -> Result<()> {
-    let cli = Cli::parse();
+    let cli_registry = detached_cli_registry()?;
+    let mut matches = cli_registry.augment(Cli::command())?.get_matches();
+    if let Some(invocation) = cli_registry.invocation(&matches)? {
+        tracing_subscriber::fmt()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("error")),
+            )
+            .with_ansi(true)
+            .with_writer(trace_writer(false))
+            .init();
+        if matches.get_flag("attached_control_child") {
+            return control::run_control_child(invocation.request).await;
+        }
+        return invocation.execute().await;
+    }
+    let cli = Cli::from_arg_matches_mut(&mut matches)?;
     let interactive = uses_interactive_renderer(&cli);
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -640,8 +662,12 @@ async fn async_main(crash_reporter: &crash_report::CrashReporter) -> Result<()> 
         .with_writer(trace_writer(interactive))
         .init();
 
+    if cli.attached_control_child {
+        anyhow::bail!("attached control accepts only a contributed CLI capability command");
+    }
+
     if let Some(command) = cli.command {
-        return run_command(command);
+        return run_command(command).await;
     }
 
     // Fall back to an unwritable scratch path when no platform config dir
@@ -1176,7 +1202,7 @@ fn run_worktree_command(command: WorktreeCommand) -> Result<()> {
     }
 }
 
-fn run_command(command: Commands) -> Result<()> {
+async fn run_command(command: Commands) -> Result<()> {
     match command {
         Commands::Version => {
             println!("{}", version::VERSION_LINE);
@@ -1293,6 +1319,139 @@ fn run_command(command: Commands) -> Result<()> {
                 Ok(())
             }
         },
+    }
+}
+
+fn detached_cli_registry() -> Result<control::CliRegistry> {
+    // CLI metadata must remain available even in stripped-down environments
+    // with no platform config directory. Operations against these fallbacks
+    // still fail visibly if they need to persist state.
+    let fallback = PathBuf::from("/dev/null/yolop");
+    let settings_path =
+        config::default_settings_path().unwrap_or_else(|| fallback.join("settings.toml"));
+    let extensions_dir =
+        extensions::extensions_dir().unwrap_or_else(|| fallback.join("extensions"));
+    let connections_path =
+        connectors::default_connections_path().unwrap_or_else(|| fallback.join("connections.toml"));
+    let settings = Arc::new(SettingsStore::open(settings_path));
+    let secrets = extensions::ExtensionSecrets::new(Arc::new(connectors::ConnectionStore::open(
+        connections_path,
+    )));
+    let workspace = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let capability = Arc::new(
+        extensions::ExtensionsCapability::new(
+            extensions_dir,
+            workspace,
+            settings,
+            extensions::LiveProcessRegistry::default(),
+            None,
+        )
+        .with_secrets(secrets)
+        .with_ask_sink(Some(terminal_extension_ask_sink())),
+    );
+    let mut registry = control::CliRegistry::default();
+    registry.register(capability)?;
+    Ok(registry)
+}
+
+fn terminal_extension_ask_sink() -> extensions::AskSink {
+    Arc::new(|params| {
+        Box::pin(async move {
+            tokio::task::spawn_blocking(move || terminal_extension_ask(params))
+                .await
+                .unwrap_or_else(|_| extensions::protocol::UiAskResult {
+                    answer: String::new(),
+                    cancelled: true,
+                })
+        })
+    })
+}
+
+fn terminal_extension_ask(
+    params: extensions::protocol::UiAskParams,
+) -> extensions::protocol::UiAskResult {
+    use crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers, read};
+
+    if !io::stdin().is_terminal() || !io::stderr().is_terminal() {
+        eprintln!("yolop: interactive extension setup requires a terminal");
+        return extensions::protocol::UiAskResult {
+            answer: String::new(),
+            cancelled: true,
+        };
+    }
+    eprint!("{}", params.prompt);
+    if !params.options.is_empty() {
+        eprint!(" [{}]", params.options.join("/"));
+    }
+    eprint!(": ");
+    let _ = io::stderr().flush();
+
+    if !params.secret {
+        let mut answer = String::new();
+        let cancelled = io::stdin().read_line(&mut answer).is_err();
+        return extensions::protocol::UiAskResult {
+            answer: answer.trim().to_string(),
+            cancelled,
+        };
+    }
+
+    struct RawModeGuard;
+    impl Drop for RawModeGuard {
+        fn drop(&mut self) {
+            let _ = disable_raw_mode();
+        }
+    }
+    if enable_raw_mode().is_err() {
+        eprintln!("could not enable masked terminal input");
+        return extensions::protocol::UiAskResult {
+            answer: String::new(),
+            cancelled: true,
+        };
+    }
+    let _guard = RawModeGuard;
+    let mut answer = String::new();
+    loop {
+        let Ok(Event::Key(key)) = read() else {
+            continue;
+        };
+        if key.kind != KeyEventKind::Press {
+            continue;
+        }
+        match key.code {
+            KeyCode::Enter => {
+                eprintln!();
+                return extensions::protocol::UiAskResult {
+                    answer,
+                    cancelled: false,
+                };
+            }
+            KeyCode::Esc => {
+                eprintln!();
+                return extensions::protocol::UiAskResult {
+                    answer: String::new(),
+                    cancelled: true,
+                };
+            }
+            KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                eprintln!();
+                return extensions::protocol::UiAskResult {
+                    answer: String::new(),
+                    cancelled: true,
+                };
+            }
+            KeyCode::Backspace => {
+                if answer.pop().is_some() {
+                    eprint!("\u{8} \u{8}");
+                    let _ = io::stderr().flush();
+                }
+            }
+            KeyCode::Char(ch) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                answer.push(ch);
+                eprint!("*");
+                let _ = io::stderr().flush();
+            }
+            _ => {}
+        }
     }
 }
 
@@ -2225,6 +2384,7 @@ mod tests {
     fn cli_with_reasoning_effort(reasoning_effort: Option<&str>) -> Cli {
         Cli {
             command: None,
+            attached_control_child: false,
             cwd: None,
             provider: Some(ProviderArg::Openrouter),
             profile: None,
@@ -2314,6 +2474,7 @@ mod tests {
         let settings = SettingsStore::open(path);
         let cli = Cli {
             command: None,
+            attached_control_child: false,
             cwd: None,
             provider: None,
             profile: None,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2600,6 +2600,19 @@ fn coding_harness_capabilities(
     caps
 }
 
+fn take_session_extension_capabilities(caps: &mut Vec<CapabilityRef>) -> Vec<CapabilityRef> {
+    let mut extensions = Vec::new();
+    caps.retain(|capability| {
+        if capability.capability_id().starts_with("ext:") {
+            extensions.push(capability.clone());
+            false
+        } else {
+            true
+        }
+    });
+    extensions
+}
+
 // ---------- runtime wiring result ----------
 
 pub struct BuiltRuntime {
@@ -2677,6 +2690,9 @@ pub struct RuntimeHandles {
     pub(crate) sandbox: Arc<dyn SandboxProvider>,
     pub(crate) sandbox_approval_gate: Arc<crate::sandbox_approval::ApprovalGate>,
     pub(crate) approval_policy: crate::config::ApprovalPolicy,
+    /// One-shot typed control service exposed only to conservative direct
+    /// foreground Yolop CLI invocations from this session's Bash surface.
+    pub(crate) control: Option<Arc<dyn crate::control::ControlService>>,
     /// Best-effort local lifecycle bridge when this process runs in Herdr.
     pub(crate) herdr: crate::capabilities::herdr::HerdrReporter,
 }
@@ -2782,10 +2798,9 @@ impl RuntimeHandles {
             .await?)
     }
 
-    /// Deactivate a capability from the live session overlay. Succeeds only for
-    /// one activated *this session*; an extension enabled at startup rides the
-    /// harness layer and cannot be removed by a session-scoped op (its disable
-    /// takes effect next session via settings).
+    /// Deactivate a capability from the live session overlay. Enabled
+    /// extensions are seeded into this layer at startup so attached disable is
+    /// reversible in the current session.
     pub async fn deactivate_capability(
         &self,
         capability_id: &str,
@@ -3672,11 +3687,13 @@ pub async fn build_with_options(
     // `reload_extension` can restart one in place mid-session (self-writing
     // iteration) without a yolop restart.
     let live_processes = crate::extensions::LiveProcessRegistry::default();
+    let mut session_control: Option<Arc<dyn crate::control::ControlService>> = None;
     // Per-extension secrets ride the shared credential store (`connections.toml`,
     // 0600), keyed `ext:<name>` — never `settings.toml`. Injected as env at
     // spawn; never surfaced to the agent.
     let extension_secrets = crate::extensions::ExtensionSecrets::new(connections.clone());
     let mut extension_never_defer: Vec<String> = Vec::new();
+    let mut extension_mcp_server_names: Vec<String> = Vec::new();
     // Trace-facet extensions, captured here and started once `session_id` and
     // the event broadcast exist (below). Observe-only agentic-trace export.
     let mut trace_forwarders: Vec<crate::extensions::trace::TraceForwarder> = Vec::new();
@@ -3684,9 +3701,9 @@ pub async fn build_with_options(
         let settings_snapshot = settings.snapshot();
         for package in crate::extensions::discover_extensions(&ext_dir) {
             // An extension's contributed MCP servers (D1) apply only when the
-            // extension is enabled in the harness — merged into scoped MCP
-            // config so the runtime's own client discovers them, exactly like
-            // `.mcp.json`. Workspace `.mcp.json` still overrides by name.
+            // extension is enabled. The runtime collects them from the live
+            // capability overlay, so attached disable removes them too;
+            // explicit workspace `.mcp.json` still overrides by name.
             let overrides = settings_snapshot.capability_overrides_for(
                 &crate::extensions::extension_capability_id(&package.manifest.name),
             );
@@ -3707,13 +3724,8 @@ pub async fn build_with_options(
                     .with_secrets(extension_secrets.clone())
                     .with_environment_context(environment_context.clone());
             if enabled {
-                let contributed = capability.contributed_mcp_servers();
-                if !contributed.is_empty() {
-                    mcp_servers = everruns_core::mcp_server::merge_scoped_mcp_servers(
-                        &contributed,
-                        &mcp_servers,
-                    );
-                }
+                extension_mcp_server_names
+                    .extend(capability.contributed_mcp_servers().keys().cloned());
                 // Forward the session event stream to an enabled `trace`
                 // extension (the process is shared with its other facets via
                 // `ext_config`); started below once the session id exists.
@@ -3727,11 +3739,11 @@ pub async fn build_with_options(
             extension_never_defer.extend(capability.never_defer_tools());
             capabilities.register(capability);
         }
-        // The always-on management surface (install/list/enable/remove/reload).
-        // Hand it the UI-command sink so enable/disable can activate the
-        // capability on the live session (TUI only); `None` elsewhere.
+        // Extension administration stays outside the model harness. Hand its
+        // shared service the UI-command sink so attached enable/disable can
+        // activate the capability live (TUI only); `None` elsewhere.
         let manage_ui_tx = matches!(options.client_ui, ClientUiContext::Tui).then(|| ui_tx.clone());
-        capabilities.register(
+        let management = Arc::new(
             crate::extensions::ExtensionsCapability::new(
                 ext_dir,
                 effective_root.clone(),
@@ -3744,11 +3756,17 @@ pub async fn build_with_options(
             // surface (TUI only); `None` elsewhere refuses interactive setup.
             .with_ask_sink(ask_sink.clone()),
         );
+        let mut control = crate::control::ControlRegistry::default();
+        control.register(management.clone())?;
+        session_control = Some(Arc::new(control));
+        capabilities.register_arc(management);
     }
     // Server name list for `/mcp` and StartupInfo, computed after extension
     // contributions are merged so provider-provenance entries show up too.
     let mut mcp_server_names: Vec<String> = mcp_servers.keys().cloned().collect();
+    mcp_server_names.extend(extension_mcp_server_names);
     mcp_server_names.sort();
+    mcp_server_names.dedup();
     capabilities.register(InfinityContextCapability);
     capabilities.register(CompactionCapability);
     capabilities.register(ContextCostControlCapability);
@@ -3899,6 +3917,7 @@ pub async fn build_with_options(
         expose_command: !options.client_commands,
         approval_policy,
         approval_gate: sandbox_approval_gate.clone(),
+        control: session_control.clone(),
     });
     // `background` — the `/background` command listing this session's everruns
     // tasks. Detached work runs through everruns `spawn_background` (which wraps
@@ -4054,6 +4073,13 @@ pub async fn build_with_options(
         hook_capability_config,
         &settings_snapshot,
     );
+    // Enabled extensions live at the session layer, not the harness layer.
+    // That makes the runtime's activate/deactivate overlay genuinely
+    // reversible for an attached `yolop extensions enable|disable` command.
+    // The capabilities are still registered above; only their ownership layer
+    // changes. Newly installed manifests require a new session to register.
+    let session_extension_capabilities =
+        take_session_extension_capabilities(&mut harness_capabilities);
     // Resolve the hard approval gate only when a host supplied an approver
     // (ACP): registering it above is not enough — its pre-tool hook is collected
     // only from the *resolved* capability set.
@@ -4097,6 +4123,7 @@ pub async fn build_with_options(
         .agent(agent_id)
         .id(session_id)
         .title(session_title)
+        .capabilities(session_extension_capabilities)
         .mcp_servers(session_mcp_servers)
         .tag("example")
         .tag("coding");
@@ -4180,6 +4207,7 @@ pub async fn build_with_options(
             sandbox: sandbox.clone(),
             sandbox_approval_gate,
             approval_policy,
+            control: session_control,
             herdr,
         },
         startup: StartupInfo {
@@ -4228,6 +4256,30 @@ mod tests {
     use std::sync::Mutex;
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn enabled_extensions_are_owned_by_the_reversible_session_layer() {
+        let mut harness = vec![
+            CapabilityRef::new("yolop_bash"),
+            CapabilityRef::new("ext:demo"),
+            CapabilityRef::new("ext:other"),
+        ];
+        let session = take_session_extension_capabilities(&mut harness);
+        assert_eq!(
+            harness
+                .iter()
+                .map(|capability| capability.capability_id())
+                .collect::<Vec<_>>(),
+            vec!["yolop_bash"]
+        );
+        assert_eq!(
+            session
+                .iter()
+                .map(|capability| capability.capability_id())
+                .collect::<Vec<_>>(),
+            vec!["ext:demo", "ext:other"]
+        );
+    }
 
     #[test]
     fn env_token_names_prefers_oauth_provider_then_server_specific_keys() {
@@ -4765,6 +4817,54 @@ mod tests {
             "retired DuckDuckGo tool name must not remain: {:?}",
             built.startup.tool_names
         );
+        for retired_management_tool in [
+            "scaffold_extension",
+            "list_extensions",
+            "install_extension",
+            "remove_extension",
+            "enable_extension",
+            "disable_extension",
+            "reload_extension",
+            "set_extension_secret",
+            "doctor_extension",
+        ] {
+            assert!(
+                !built
+                    .startup
+                    .tool_names
+                    .contains(&retired_management_tool.to_string()),
+                "extension administration belongs to the CLI, not model tools: {:?}",
+                built.startup.tool_names
+            );
+        }
+        assert!(
+            built
+                .startup
+                .capability_commands
+                .iter()
+                .any(|command| command.name == "extensions"),
+            "the extension capability must retain /extensions: {:?}",
+            built
+                .startup
+                .capability_commands
+                .iter()
+                .map(|command| command.name.as_str())
+                .collect::<Vec<_>>()
+        );
+        let extensions = built
+            .handles
+            .runtime
+            .execute_command(
+                built.handles.session_id,
+                ExecuteCommandRequest {
+                    name: "extensions".to_string(),
+                    arguments: None,
+                    controls: None,
+                },
+            )
+            .await
+            .expect("execute /extensions through the runtime registry");
+        assert!(extensions.success, "{}", extensions.message);
         assert!(
             built
                 .handles

--- a/src/runtime/session.rs
+++ b/src/runtime/session.rs
@@ -356,6 +356,7 @@ impl Session {
         let sandbox = self.handles.sandbox.clone();
         let approval_gate = self.handles.sandbox_approval_gate.clone();
         let approval_policy = self.handles.approval_policy;
+        let control = self.handles.control.clone();
 
         tokio::spawn(async move {
             let tool = BashTool::with_policy(
@@ -363,7 +364,8 @@ impl Session {
                 sandbox,
                 approval_policy,
                 approval_gate,
-            );
+            )
+            .with_control(control);
             let run = tool.execute(serde_json::json!({
                 "command": command,
                 // Direct shell output is not persisted through a tool-call

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -44,6 +44,94 @@ fn yolop_binary() -> PathBuf {
 }
 
 #[test]
+fn extensions_cli_installs_and_lists_without_model_tools() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config_root = tmp.path().join("config");
+    let extensions_dir = config_root.join("yolop/extensions");
+    let source = tmp.path().join("demo-source");
+    std::fs::create_dir_all(&source).unwrap();
+    std::fs::write(
+        source.join("plugin.json"),
+        serde_json::json!({
+            "name": "demo",
+            "description": "CLI smoke extension.",
+            "version": "0.1.0",
+            "yolop": {
+                "protocol_version": "1.0",
+                "capabilityServer": { "command": "demo" },
+                "tools": [{ "name": "ping", "description": "Ping." }]
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let install = Command::new(yolop_binary())
+        .args(["extensions", "install"])
+        .arg(&source)
+        .env("HOME", tmp.path())
+        .env("XDG_CONFIG_HOME", &config_root)
+        .env("YOLOP_EXTENSIONS_DIR", &extensions_dir)
+        .output()
+        .expect("install extension through CLI");
+    assert!(
+        install.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&install.stderr)
+    );
+
+    let list = Command::new(yolop_binary())
+        .args(["extensions", "list", "--json"])
+        .env("HOME", tmp.path())
+        .env("XDG_CONFIG_HOME", &config_root)
+        .env("YOLOP_EXTENSIONS_DIR", &extensions_dir)
+        .output()
+        .expect("list extensions through CLI");
+    assert!(list.status.success());
+    let value: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
+    assert_eq!(value["extensions"][0]["name"], "demo");
+}
+
+#[test]
+fn extension_reload_is_rejected_without_an_attached_session() {
+    let output = Command::new(yolop_binary())
+        .args(["extensions", "reload", "demo"])
+        .output()
+        .expect("run detached reload");
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("requires a running Yolop session"));
+}
+
+#[test]
+fn attached_control_child_exchanges_one_versioned_pipe_request() {
+    use std::io::{BufRead, BufReader};
+    use std::process::Stdio;
+
+    let mut child = Command::new(yolop_binary())
+        .args(["--__attached-control-child", "extensions", "enable", "demo"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn attached control child");
+    let mut request = String::new();
+    BufReader::new(child.stdout.take().unwrap())
+        .read_line(&mut request)
+        .unwrap();
+    let request: serde_json::Value = serde_json::from_str(&request).unwrap();
+    assert_eq!(request["version"], 1);
+    assert_eq!(request["resource"], "extensions");
+    assert_eq!(request["action"]["operation"], "enable");
+
+    writeln!(
+        child.stdin.take().unwrap(),
+        "{}",
+        serde_json::json!({ "version": 1, "ok": true, "value": { "enabled": true } })
+    )
+    .unwrap();
+    assert!(child.wait().unwrap().success());
+}
+
+#[test]
 fn meta_provider_reaches_credential_boundary_from_real_binary() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let config_root = tmp.path().join(".config");
@@ -1111,7 +1199,7 @@ fn fullscreen_enables_modified_key_reporting_after_entering_alternate_screen() {
         },
     );
     assert!(
-        tui.wait_for_output("Enter to send", Duration::from_secs(5)),
+        tui.wait_for_output("Enter to send", Duration::from_secs(10)),
         "TUI did not render the composer: {}",
         tui.output_text()
     );
@@ -1969,6 +2057,36 @@ fn tui_bang_shell_runs_shell_without_model_turn() {
         "double Ctrl-C should exit cleanly, got {status:?}: {}",
         tui.output_text()
     );
+}
+
+#[test]
+fn tui_bang_yolop_extensions_uses_attached_control() {
+    let mut tui = spawn_tui_llmsim(&yolop_binary());
+    assert!(
+        tui.wait_for_output("type /help", Duration::from_secs(10)),
+        "TUI did not render startup banner: {}",
+        tui.output_text()
+    );
+
+    tui.write_input(b"!yolop extensions list\r");
+    assert!(
+        tui.wait_for_output("shell exited with code 0", Duration::from_secs(5)),
+        "attached extension control did not complete: {}",
+        tui.output_text()
+    );
+    assert!(
+        tui.wait_for_output("No extensions installed.", Duration::from_secs(3)),
+        "attached control response should render in the TUI: {}",
+        tui.output_text()
+    );
+    let transcript = strip_ansi(&tui.output_text());
+    assert!(
+        !transcript.contains("offline mode"),
+        "attached control should not invoke a model turn: {transcript}"
+    );
+
+    tui.write_input(b"\x03\x03");
+    assert!(tui.wait_or_kill(Duration::from_secs(3)).success());
 }
 
 #[test]


### PR DESCRIPTION
## What changed

- Replaced model-visible extension administration tools with a capability-contributed `yolop extensions` CLI while retaining `/extensions` and commands/tools contributed by installed extensions.
- Added a generic, versioned attached-control registry. A direct foreground Yolop command from the running session uses the exact current executable and one-shot anonymous pipes so enable, disable, and reload affect the current session.
- Kept detached install, list, remove, enable, disable, doctor, secret, and scaffold operations global. Detached reload is rejected because it has no live process to restart.
- Made startup-enabled extensions session-layer capabilities so attached disable is reversible on the next turn.
- Updated generated scaffold guidance, public docs, sandbox documentation, and durable extension architecture knowledge.

## Why

Extension management tools consumed model context and exposed administrative operations as model-callable tools. The ordinary CLI is a better discovery and automation surface, but session-scoped operations still need a narrow way to reach the current Yolop process. Capability-contributed CLI metadata keeps command grammar, typed control decoding, execution, and help owned by the capability instead of duplicated in the root binary.

## Before / After

Before, `origin/main` had no root extensions command:

```text
$ yolop extensions --help
error: unrecognized subcommand 'extensions'
```

After, the capability contributes its complete CLI surface:

```text
$ yolop extensions --help
Usage: yolop extensions <COMMAND>

Commands:
  list      List installed extensions
  install   Install an extension without enabling it
  remove    Remove an installed extension and its persisted enablement/secrets
  enable    Persist enablement and apply it to the attached session when present
  disable   Persist disablement and apply it to the attached session when present
  reload    Restart an extension server in the attached session
  doctor    Probe an installed extension's YEP conformance
  secret    Prompt for and store an extension secret
  scaffold  Create a new extension package skeleton

$ yolop extensions list
No extensions installed.
```

Live-provider smoke asked OpenAI to invoke `yolop extensions list` through Bash. The agent completed the attached command and reported `No extensions installed.`

## Risk

- **Medium.** This changes extension administration, Bash routing, capability layering, and root CLI assembly.
- A parser or registry regression could route a command incorrectly, bypass the intended shell path, or leave live and persisted extension state inconsistent.
- Mitigations: attachment accepts only direct foreground commands with no quoting/composition; consequential actions retain shell approval; the child inherits no environment; request and response frames are capped at 64 KiB; the process is killed on drop and times out after 120 seconds; duplicate CLI/control routes fail closed; attached failure never falls back to detached mutation.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered: Yolop is pre-1.0; removal of model management tools is intentional, while `/extensions` and extension-contributed surfaces remain
- [x] Knowledge concepts updated

Validation:

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (1,215 tests across unit, integration, parallel, and PTY suites)
- `cargo build --release --all-features`
- `python3 scripts/validate_okf.py knowledge --check-links`
- Detached `yolop extensions --help` and `list` release-binary smokes
- Attached `!yolop extensions list` PTY smoke
- Live OpenAI agent-loop smoke through Doppler

## Knowledge

Updated `knowledge/specs/extensions.md`, `knowledge/specs/sandboxing.md`, and `knowledge/log.md` to record capability-contributed CLI assembly, attached-control ownership and transport, live-session semantics, approval boundaries, and the removal of model administration tools.

## Security

- **TM-BASH:** Reviewed direct-command recognition, shell injection/composition, approval behavior, timeouts, process cleanup, and output limits. Only a plain foreground registered Yolop subcommand attaches; pipelines, redirects, substitutions, quoting, and background jobs remain ordinary sandboxed shell commands. Consequential actions require approval when containment is active.
- **TM-TOOL:** The extension management capability contributes no model tools. CLI and control registries reject duplicate command/resource routes, and only explicitly registered capability facets are dispatchable.
- **TM-FS:** Install, remove, scaffold, settings, and credential writes continue through existing extension stores and validated paths. Attached control does not add a filesystem socket or endpoint.
- **TM-LLM:** No endpoint token or control environment variable enters model context. The one-shot child uses an empty environment, and extension secret values remain user-prompted and redacted.
- **TM-DEP:** No dependencies added.

No unresolved security findings.

## Follow-ups

No follow-ups.
