### PR TITLE
chore(deps): take everruns-builtins 0.18.1 and pin platform to 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2185,12 +2185,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "everruns-a2ui"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311c7d9867482efaf0199d17e510c9c8589ed8396648eef90926b02def0f9496"
-
-[[package]]
 name = "everruns-anthropic"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2210,16 +2204,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-builtins"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d68163ff7caa64270e2a92a1e585833d67ec45913f53da4f5b67e901d5400d8"
+checksum = "d058e7860618183c9e76523af9e47759fb4f8a5ef99d91e6933fb1b854392684"
 dependencies = [
  "async-trait",
  "chrono",
- "everruns-a2ui",
  "everruns-capability",
  "everruns-core",
- "everruns-openui",
  "everruns-provider",
  "serde",
  "serde_json",
@@ -2539,12 +2531,6 @@ dependencies = [
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "everruns-openui"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f974706396a3ef1d9f19c5c2d41374b496069aa02b39f75c09b3eb39c3fb5283"
 
 [[package]]
 name = "everruns-platform"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,12 @@ everruns-core = "0.18.0"
 # The identity/platform family (PlatformStore and friends) moved out of
 # everruns-core into its own crate in 0.17.24; yolop implements PlatformStore
 # to route background-task wakes (src/runtime/background_wake.rs).
-everruns-platform = "0.18.0"
+# Pinned exactly: platform 0.18.1 requires everruns-host ^0.19.0, but
+# everruns-local 0.18.0 still pins host ^0.18.0 and has not been republished
+# for 0.19. Taking 0.18.1 resolves two copies of everruns-host, and
+# everruns-local then fails to compile against the newer session-store traits.
+# Drop the `=` once everruns-local is released against host 0.19.
+everruns-platform = "=0.18.0"
 everruns-openai = "0.18.0"
 everruns-meta = "0.18.0"
 # OpenRouter's first-class driver was split out of everruns-openai into its own
@@ -159,7 +164,7 @@ everruns-host = { version = "0.18.0", features = ["mcp-stdio"] }
 # #3182 completed the library boundary cleanup: driver/model/provider types
 # and the built-in capabilities left everruns-core for their own crates.
 everruns-provider = "0.18.0"
-everruns-builtins = "0.18.0"
+everruns-builtins = "0.18.1"
 everruns-capability = "0.18.0"
 everruns-session-services = "0.18.0"
 everruns-http = "0.18.0"


### PR DESCRIPTION
## What changed

Bumps `everruns-builtins` to 0.18.1, which also drops `everruns-a2ui` and
`everruns-openui` from the dependency graph.

Pins `everruns-platform` to exactly 0.18.0 rather than a caret, and records why in the
manifest.

**The rest of the family cannot move yet.** `everruns-host` and `everruns-mcp` are
published at 0.19.0 and `everruns-platform` at 0.18.1, but `everruns-local` 0.18.0 still
requires `everruns-host ^0.18.0` and has not been republished for 0.19. Taking any of them
resolves two copies of `everruns-host`, and `everruns-local` then fails to compile because
its `RuntimeSessionStore` impl does not satisfy the newer `SessionMutator` bound.

## Why

Keeping the `everruns-*` versions in lockstep with crates.io is yolop's standing
maintenance obligation, so this takes what can be taken.

The pin is the part worth reviewing. `everruns-platform` 0.18.1 requires host ^0.19.0 and
is selected by a plain caret, so **`cargo update` today produces a broken build** with no
manifest change to explain it. That is a live trap, not a hypothetical: it is how this bump
was discovered. The `=` pin carries both the reason and the condition for lifting it.

## Before / After

Attempting the full bump to host 0.19.0:

```
error[E0277]: the trait bound `LocalSessionStore: SessionMutator` is not satisfied
   --> everruns-local-0.18.0/src/session_store.rs:285:30
285 | impl RuntimeSessionStore for LocalSessionStore {
error: could not compile `everruns-local` (lib)
```

Resolved graph, before the pin and after:

```
Before: everruns-host: ['0.18.0', '0.19.0']   <- two copies, via platform 0.18.1
After:  everruns-host: ['0.18.0']             <- duplicates: NONE
```

No behavior change: `everruns-builtins` 0.18.1 is a patch release, and the graph is
otherwise identical minus two dropped crates.

## Risk

- **Low**
- Patch-level dependency bump with no API change to reconcile; the compiler covers it.
- The pin is the only judgement call. It trades "automatically take platform 0.18.1" for
  "keep a build that compiles". It is explicitly temporary, and the manifest states the
  condition for removing it: `everruns-local` released against host 0.19.

## Checklist

- [ ] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

No new tests: this is a dependency bump with no behavior change, and the existing suite is
the regression check. It passes in full, including the capability surface that
`everruns-builtins` provides.

## Knowledge

`No knowledge update required.`

The blocked-version state is transient upstream detail, and `AGENTS.md` keeps transient
status out of the bundle. The durable version of this lesson is already recorded in
`knowledge/specs/maintenance.md`, which states that `everruns-*` versions move together and
that mismatched versions are a soft API break. This is that rule being applied, not a new
one. The specific reason for the pin lives beside the dependency in `Cargo.toml`, which is
where a maintainer looks when deciding whether to lift it.

## Validation

- `cargo test --all-features`: 1161 unit, 63 integration, 5 pty, 1 doc, all passing
- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`: clean
- `cargo package`: succeeds
- `cargo metadata`: no duplicate `everruns-*` versions in the resolved graph
- Live smoke through Doppler: `--provider anthropic` with a tool-calling turn that reads a
  file and reports its contents
- Offline smoke: `--provider llmsim`

## Follow-ups

- **Revisit once `everruns-local` is released against host 0.19.** That unblocks
  `everruns-host` 0.19.0, `everruns-mcp` 0.19.0, and `everruns-platform` 0.18.1 together,
  and the `=` pin on platform should be reverted to a caret in the same change. Worth
  raising upstream alongside the outstanding `everruns-test-support` item from #582, since
  both are the same class of problem: a crate left behind by a partial release.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EPe3ertCMNqSifwimmnab2)_