### PR TITLE
feat(acp): opt-in loopback setup page for editor clients

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,11 +31,6 @@ default = []
 # artifacts turn it on instead — see .github/workflows/cli-binaries.yml, which
 # builds the release binaries (and therefore the Homebrew formula) with it.
 local-inference = ["dep:mistralrs", "dep:hf-hub"]
-# Experimental loopback setup page for ACP clients (`--acp`). Off by default:
-# it binds a local HTTP listener and renders a credential form in the browser,
-# a surface the default build should not carry until the flow has proven itself
-# in real editors. See knowledge/specs/acp.md.
-acp-setup-page = []
 
 [dependencies]
 agent-client-protocol = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,11 @@ default = []
 # artifacts turn it on instead — see .github/workflows/cli-binaries.yml, which
 # builds the release binaries (and therefore the Homebrew formula) with it.
 local-inference = ["dep:mistralrs", "dep:hf-hub"]
+# Experimental loopback setup page for ACP clients (`--acp`). Off by default:
+# it binds a local HTTP listener and renders a credential form in the browser,
+# a surface the default build should not carry until the flow has proven itself
+# in real editors. See knowledge/specs/acp.md.
+acp-setup-page = []
 
 [dependencies]
 agent-client-protocol = "2.0.0"

--- a/README.md
+++ b/README.md
@@ -286,6 +286,15 @@ Yolop's browser-based ChatGPT/Codex sign-in directly from the agent UI. API-key
 providers must receive their keys through the ACP process environment; Yolop
 does not accept secrets through ACP prompt text.
 
+An experimental build flag, `cargo install yolop --features acp-setup-page`,
+adds a second route for those providers: an extra ACP authentication method that
+opens a short-lived setup page on `127.0.0.1`, where an API key, a custom
+endpoint, or a model can be entered in the browser instead of the editor. The
+key goes straight into yolop's settings, never through the editor or the session
+log. Sessions started with nothing connected also get a link to that page. It is
+off in default builds, and it needs the editor to be on the same machine as
+yolop.
+
 To set up Zed:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -286,14 +286,16 @@ Yolop's browser-based ChatGPT/Codex sign-in directly from the agent UI. API-key
 providers must receive their keys through the ACP process environment; Yolop
 does not accept secrets through ACP prompt text.
 
-An experimental build flag, `cargo install yolop --features acp-setup-page`,
-adds a second route for those providers: an extra ACP authentication method that
-opens a short-lived setup page on `127.0.0.1`, where an API key, a custom
-endpoint, or a model can be entered in the browser instead of the editor. The
-key goes straight into yolop's settings, never through the editor or the session
-log. Sessions started with nothing connected also get a link to that page. It is
-off in default builds, and it needs the editor to be on the same machine as
-yolop.
+An experimental opt-in adds a second route for those providers: an extra ACP
+authentication method that opens a short-lived setup page on `127.0.0.1`, where
+an API key, a custom endpoint, or a model can be entered in the browser instead
+of the editor. The key goes straight into yolop's settings, never through the
+editor or the session log. Sessions started with nothing connected also get a
+link to that page. Turn it on for one run with `yolop --acp --acp-setup-page`,
+or for every launch by setting `acp_setup_page` (ask yolop to turn it on, or use
+`/yolop-config`). Editors own the spawn arguments, so the setting is usually the
+practical one. It is off by
+default, and it needs the editor to be on the same machine as yolop.
 
 To set up Zed:
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -51,11 +51,14 @@ wording, formatting, and link fixes do not need entries.
 
 ## 2026-08-18, Loopback setup page for ACP clients (experimental)
 
-- [ACP](specs/acp.md) gained a `local_setup_page` authentication method behind
-  the `acp-setup-page` feature: agent-handled auth is the one place the protocol
-  hands an agent control for an out-of-band flow, so a loopback browser form now
-  carries the credential input ACP cannot express. Off by default; the listener
-  is a surface the default build should not carry yet.
+- [ACP](specs/acp.md) gained an opt-in `local_setup_page` authentication method:
+  agent-handled auth is the one place the protocol hands an agent control for an
+  out-of-band flow, so a loopback browser form now carries the credential input
+  ACP cannot express. Off by default, enabled per run with `--acp-setup-page` or
+  per user with the `acp_setup_page` setting.
+- Records why the gate is runtime rather than a Cargo feature: the page pulls in
+  no dependencies, so a build flag would only keep it out of the release
+  binaries, which is where the feedback that decides its future would come from.
 - Records why the no-provider hint exists: without a link posted at
   `session/new`, an editor with no key in its environment gets an llmsim-only
   session and no way to fix it from the client.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -49,6 +49,17 @@ wording, formatting, and link fixes do not need entries.
   reversible; detached operations remain global and reload requires a live
   session.
 
+## 2026-08-18, Loopback setup page for ACP clients (experimental)
+
+- [ACP](specs/acp.md) gained a `local_setup_page` authentication method behind
+  the `acp-setup-page` feature: agent-handled auth is the one place the protocol
+  hands an agent control for an out-of-band flow, so a loopback browser form now
+  carries the credential input ACP cannot express. Off by default; the listener
+  is a surface the default build should not carry yet.
+- Records why the no-provider hint exists: without a link posted at
+  `session/new`, an editor with no key in its environment gets an llmsim-only
+  session and no way to fix it from the client.
+
 ## 2026-08-16, In-process inference provider (experimental)
 
 - Added [Local inference](specs/local-inference.md): a `local` provider that

--- a/knowledge/specs/acp.md
+++ b/knowledge/specs/acp.md
@@ -86,6 +86,47 @@ support copy, while other API-key failures explain ACP's secure-input boundary
 and the environment/restart path. Invalid Codex credentials are cleared before
 reauthentication.
 
+### Local setup page (feature `acp-setup-page`, off by default)
+
+Stable ACP has no secure input surface: the client owns every field, and the
+only agent-initiated ask is `session/request_permission`, a fixed option list.
+Providers that need an API key, a base URL, or a custom model spec therefore
+have no in-conversation path. What ACP does have is agent-handled
+authentication, where `authenticate` hands control to the agent for an
+out-of-band flow. The `acp-setup-page` feature generalises that past OAuth.
+
+- `initialize.authMethods` gains `local_setup_page`, "Open the yolop setup
+  page". `authenticate` binds a loopback listener, opens the browser at
+  `http://127.0.0.1:<port>/setup?t=<token>`, and resolves once the form is
+  submitted, so the client's own authenticating state tracks the real flow.
+- The form writes provider, API key, base URL, and model into the same settings
+  the TUI overlay writes, then makes that provider the default. The credential
+  goes over loopback into the settings store, never through the ACP transcript
+  or the session log. A submission that leaves the provider still unusable keeps
+  what it wrote but does not become the default: the form says what is missing,
+  judged by the same predicate that builds the ACP model list.
+- Plain `/setup` and `/setup login` fall back to this method when the active
+  provider advertises no browser login of its own, and `/setup token` points at
+  it instead of at the environment.
+- Trust boundary, matching the OAuth callback listeners in `src/auth/`: loopback
+  bind only, an unguessable per-page token, a `Host` check so a hostile page
+  cannot drive it by DNS rebinding, and teardown once a provider is saved or
+  after ten minutes.
+
+When no provider is connected at all, `session/new` also posts the page URL as
+an `agent_message_chunk`. Without it, a client with no key in its environment
+gets a silently `llmsim`-only session and no way to fix it from the editor.
+Environment-provided keys count as connected, so a configured host is never
+nagged. When the page saves, open sessions receive `config_option_update` with
+the newly usable models.
+
+The feature is off in default builds: it opens a local HTTP listener and renders
+a credential form, a surface that should not ship by default until the flow has
+proven itself in real clients. Remote clients are the standing limit, the same
+one the OAuth flows have: if the editor is not on the machine running yolop, the
+browser opens in the wrong place, and the environment/restart path remains the
+answer.
+
 ### Prompt content
 
 `promptCapabilities` advertises `image: true` and `embeddedContext: true`
@@ -230,6 +271,7 @@ src/editor/acp/
   protocol.rs   # SDK-backed ACP schema shim plus yolop helpers
   bridge.rs     # pure runtime-event → session/update translation (Translator)
   server.rs     # SDK transport/dispatch wiring, session map, turn streaming
+  setup_page.rs # loopback provider form (feature `acp-setup-page`)
 ```
 
 Concurrency model in `server::serve`:

--- a/knowledge/specs/acp.md
+++ b/knowledge/specs/acp.md
@@ -86,7 +86,7 @@ support copy, while other API-key failures explain ACP's secure-input boundary
 and the environment/restart path. Invalid Codex credentials are cleared before
 reauthentication.
 
-### Local setup page (feature `acp-setup-page`, off by default)
+### Local setup page (opt-in, off by default)
 
 Stable ACP has no secure input surface: the client owns every field, and the
 only agent-initiated ask is `session/request_permission`, a fixed option list.
@@ -94,6 +94,13 @@ Providers that need an API key, a base URL, or a custom model spec therefore
 have no in-conversation path. What ACP does have is agent-handled
 authentication, where `authenticate` hands control to the agent for an
 out-of-band flow. The `acp-setup-page` feature generalises that past OAuth.
+
+Turn it on with `yolop --acp --acp-setup-page` for one run, or with the
+`acp_setup_page` setting (through `set_config`, see
+`knowledge/specs/configuration.md`) for every launch. The setting is what matters
+in practice: the editor owns the spawn arguments, so a flag means editing the
+client's agent config. With the page off, nothing binds
+a listener and the method is never advertised.
 
 - `initialize.authMethods` gains `local_setup_page`, "Open the yolop setup
   page". `authenticate` binds a loopback listener, opens the browser at
@@ -120,12 +127,12 @@ Environment-provided keys count as connected, so a configured host is never
 nagged. When the page saves, open sessions receive `config_option_update` with
 the newly usable models.
 
-The feature is off in default builds: it opens a local HTTP listener and renders
-a credential form, a surface that should not ship by default until the flow has
-proven itself in real clients. Remote clients are the standing limit, the same
-one the OAuth flows have: if the editor is not on the machine running yolop, the
-browser opens in the wrong place, and the environment/restart path remains the
-answer.
+The gate is runtime rather than a Cargo feature on purpose. The page adds no
+dependencies, so a compile-time gate would buy nothing but would keep it out of
+the release binaries, which is exactly the population whose feedback decides
+whether it ships on. Remote clients are the standing limit, the same one the
+OAuth flows have: if the editor is not on the machine running yolop, the browser
+opens in the wrong place, and the environment/restart path remains the answer.
 
 ### Prompt content
 
@@ -271,7 +278,7 @@ src/editor/acp/
   protocol.rs   # SDK-backed ACP schema shim plus yolop helpers
   bridge.rs     # pure runtime-event → session/update translation (Translator)
   server.rs     # SDK transport/dispatch wiring, session map, turn streaming
-  setup_page.rs # loopback provider form (feature `acp-setup-page`)
+  setup_page.rs # loopback provider form (opt-in, see above)
 ```
 
 Concurrency model in `server::serve`:

--- a/knowledge/specs/configuration.md
+++ b/knowledge/specs/configuration.md
@@ -47,6 +47,7 @@ Keys are addressed the way a human would name them:
 | `approval_policy`         | text   | Hard shell approval policy (`untrusted` / `on-failure` / `on-request` / `never`). |
 | `attribution`             | bool   | Commit/PR attribution on/off.                                  |
 | `proactive_wake`          | bool   | Auto-start a turn when a background task finishes (TUI); on by default. |
+| `acp_setup_page`          | bool   | Offer the loopback provider setup page to ACP clients; off by default (see [ACP](acp.md)). |
 | `worktrees`               | text   | Worktree isolation (`auto` / `always` / `off`).             |
 | `sandbox_mode`            | text   | Shell containment (`read-only` / `workspace-write` / `danger-full-access`). |
 | `capabilities`            | list   | Ordered `[[capabilities]]` harness overrides; `capabilities.<ref>` for schema metadata. |

--- a/knowledge/specs/configuration.md
+++ b/knowledge/specs/configuration.md
@@ -88,9 +88,10 @@ The profileable keys are `default_provider`, `models`, `base_urls`,
 `approval_mode`, `approval_policy`, `sandbox_mode`, `worktrees`,
 `capabilities`, `capabilities_mode`, `mcp`, `mcp_mode`, `instructions`,
 `instructions_file`, and `skills_dir`. Credentials (`tokens`, `codex_auth`) and
-personal settings (`theme`, `attribution`, `proactive_wake`) are global-only and
-make a selected profile fail validation. Invalid known values also fail startup;
-unknown keys produce a warning and are ignored for forward compatibility.
+personal settings (`theme`, `attribution`, `proactive_wake`, `acp_setup_page`)
+are global-only and make a selected profile fail validation. Invalid known
+values also fail startup; unknown keys produce a warning and are ignored for
+forward compatibility.
 
 ### A profile is the unit of a purpose-built agent
 

--- a/src/capabilities/config.rs
+++ b/src/capabilities/config.rs
@@ -525,6 +525,18 @@ impl SetConfigTool {
                 self.settings.set_proactive_wake(enabled).map_err(map_err)?;
                 Ok(saved(format!("proactive_wake = {}", on_off(enabled))))
             }
+            KeyTarget::AcpSetupPage => {
+                // `clear` reverts to the default (off), keeping settings.toml sparse.
+                if clearing {
+                    self.settings.set_acp_setup_page(false).map_err(map_err)?;
+                    return Ok(saved("cleared acp_setup_page (default off)".to_string()));
+                }
+                let enabled = parse_on_off(value).ok_or_else(|| {
+                    "acp_setup_page expects on/off (true/false, yes/no)".to_string()
+                })?;
+                self.settings.set_acp_setup_page(enabled).map_err(map_err)?;
+                Ok(saved(format!("acp_setup_page = {}", on_off(enabled))))
+            }
             KeyTarget::ApprovalMode => {
                 if clearing {
                     self.settings.clear_approval_mode().map_err(map_err)?;

--- a/src/capabilities/model_discovery.rs
+++ b/src/capabilities/model_discovery.rs
@@ -301,6 +301,15 @@ pub(crate) fn provider_is_usable(settings: &Settings, provider: &str) -> bool {
     }
 }
 
+/// Whether any real provider is connected. `llmsim` is excluded: it always
+/// answers, but it is the offline stand-in rather than a provider the user
+/// signed in to, so a workspace with nothing but `llmsim` still needs setup.
+pub(crate) fn any_provider_connected(settings: &Settings) -> bool {
+    crate::runtime::SUPPORTED_PROVIDERS
+        .iter()
+        .any(|provider| *provider != "llmsim" && provider_is_usable(settings, provider))
+}
+
 /// Whether the `local` spec this workspace would actually run is downloaded.
 ///
 /// Resolves through the same path the runtime uses, so a saved `[models].local`

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -240,6 +240,11 @@ pub struct Settings {
     /// Whether the TUI auto-starts a turn when a background task finishes while
     /// idle (proactive wake). On by default; disable for a quieter session.
     pub proactive_wake: bool,
+    /// Whether `--acp` offers the loopback provider setup page: an extra ACP
+    /// authentication method, and a link posted when a session opens with no
+    /// provider connected. Off by default; the page binds a local HTTP
+    /// listener, so it is opt-in per user rather than always live.
+    pub acp_setup_page: bool,
     /// Git worktree isolation for code changes (`auto`, `always`, `off`).
     pub worktrees: WorktreesMode,
     /// Sandbox boundary for arbitrary shell commands.
@@ -273,6 +278,7 @@ impl Default for Settings {
             approval_mode: ApprovalMode::Normal,
             approval_policy: ApprovalPolicy::OnRequest,
             proactive_wake: true,
+            acp_setup_page: false,
             worktrees: WorktreesMode::Auto,
             sandbox: SandboxMode::DangerFullAccess,
             theme: None,
@@ -311,6 +317,10 @@ impl Settings {
             .get("proactive_wake")
             .and_then(Value::as_bool)
             .unwrap_or(true);
+        let acp_setup_page = table
+            .get("acp_setup_page")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
         let worktrees = table
             .get("worktrees")
             .and_then(Value::as_str)
@@ -351,6 +361,7 @@ impl Settings {
             approval_mode,
             approval_policy,
             proactive_wake,
+            acp_setup_page,
             worktrees,
             sandbox,
             theme,
@@ -372,6 +383,10 @@ impl Settings {
         // Only persist when disabled so settings.toml stays sparse.
         if !self.proactive_wake {
             table.insert("proactive_wake".to_string(), Value::Boolean(false));
+        }
+        // Off by default, so only an opt-in is worth writing.
+        if self.acp_setup_page {
+            table.insert("acp_setup_page".to_string(), Value::Boolean(true));
         }
         // Only persist a non-default level so settings.toml stays sparse.
         if self.approval_mode != ApprovalMode::Normal {
@@ -479,6 +494,10 @@ impl Settings {
 
     pub fn proactive_wake_enabled(&self) -> bool {
         self.proactive_wake
+    }
+
+    pub fn acp_setup_page_enabled(&self) -> bool {
+        self.acp_setup_page
     }
 
     pub fn worktrees_mode(&self) -> WorktreesMode {
@@ -794,6 +813,12 @@ impl SettingsStore {
     pub fn set_proactive_wake(&self, enabled: bool) -> Result<()> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
         guard.base.proactive_wake = enabled;
+        save_to(&self.path, &guard.base)
+    }
+
+    pub fn set_acp_setup_page(&self, enabled: bool) -> Result<()> {
+        let mut guard = self.inner.lock().expect("settings lock poisoned");
+        guard.base.acp_setup_page = enabled;
         save_to(&self.path, &guard.base)
     }
 
@@ -1385,6 +1410,26 @@ mod tests {
             !SettingsStore::open(path)
                 .snapshot()
                 .proactive_wake_enabled()
+        );
+    }
+
+    #[test]
+    fn acp_setup_page_defaults_off_and_round_trips_when_enabled() {
+        let settings = Settings::from_table(&Table::new());
+        assert!(!settings.acp_setup_page_enabled());
+        // Default stays out of the file to keep it sparse.
+        assert!(!settings.to_table().contains_key("acp_setup_page"));
+
+        let tmp = tempfile::tempdir().expect("tmp");
+        let path = tmp.path().join("settings.toml");
+        let store = SettingsStore::open(path.clone());
+        store.set_acp_setup_page(true).expect("save");
+        assert!(store.snapshot().acp_setup_page_enabled());
+        // Survives a reopen.
+        assert!(
+            SettingsStore::open(path)
+                .snapshot()
+                .acp_setup_page_enabled()
         );
     }
 

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -50,6 +50,7 @@ const GLOBAL_ONLY_KEYS: &[&str] = &[
     "theme",
     "attribution",
     "proactive_wake",
+    "acp_setup_page",
 ];
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -535,6 +536,13 @@ mod tests {
 
         let credentials: Table = toml::from_str("[tokens]\nopenai = 'secret'\n").unwrap();
         assert!(SettingsOverlay::from_table(&credentials, Path::new("/nonexistent")).is_err());
+
+        // Host-local settings are global-only too: the ACP setup page binds a
+        // listener on this machine, so it is not part of an agent's job.
+        let host_local: Table = toml::from_str("acp_setup_page = true\n").unwrap();
+        let error = SettingsOverlay::from_table(&host_local, Path::new("/nonexistent"))
+            .expect_err("acp_setup_page is global-only");
+        assert!(error.to_string().contains("acp_setup_page"), "got: {error}");
     }
 
     #[test]

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -174,6 +174,19 @@ pub fn schema() -> &'static [ConfigField] {
             provider_scoped: false,
         },
         ConfigField {
+            key: "acp_setup_page",
+            aliases: &["setup_page"],
+            title: "ACP setup page",
+            description: "When on, `yolop --acp` offers a provider setup page served on \
+                          localhost: an extra ACP authentication method, plus a link posted when \
+                          a session opens with no provider connected. Lets an editor connect an \
+                          API-key provider, which ACP itself has no secure way to ask for.",
+            kind: ValueKind::Bool,
+            default: Some("off"),
+            examples: &["on", "off"],
+            provider_scoped: false,
+        },
+        ConfigField {
             key: "worktrees",
             aliases: &[],
             title: "Git worktree isolation",
@@ -262,6 +275,8 @@ pub enum KeyTarget {
     ApprovalMode,
     ApprovalPolicy,
     ProactiveWake,
+    /// Loopback provider setup page for ACP clients.
+    AcpSetupPage,
     Worktrees,
     Sandbox,
     /// Interactive TUI color theme.
@@ -289,6 +304,7 @@ impl KeyTarget {
             KeyTarget::ApprovalMode => "approval_mode",
             KeyTarget::ApprovalPolicy => "approval_policy",
             KeyTarget::ProactiveWake => "proactive_wake",
+            KeyTarget::AcpSetupPage => "acp_setup_page",
             KeyTarget::Worktrees => "worktrees",
             KeyTarget::Sandbox => "sandbox_mode",
             KeyTarget::Theme => "theme",
@@ -344,6 +360,7 @@ pub fn parse_key(input: &str) -> Result<KeyTarget, String> {
         "approval_mode" | "approval" => scalar(KeyTarget::ApprovalMode),
         "approval_policy" | "sandbox_approval" => scalar(KeyTarget::ApprovalPolicy),
         "proactive_wake" | "background_wake" | "wake" => scalar(KeyTarget::ProactiveWake),
+        "acp_setup_page" | "setup_page" => scalar(KeyTarget::AcpSetupPage),
         "worktrees" | "worktree" => scalar(KeyTarget::Worktrees),
         "sandbox_mode" | "sandbox" | "containment" => scalar(KeyTarget::Sandbox),
         "theme" => scalar(KeyTarget::Theme),

--- a/src/config/service.rs
+++ b/src/config/service.rs
@@ -69,6 +69,7 @@ pub(crate) fn current_value(settings: &Settings, target: &KeyTarget) -> Value {
         KeyTarget::ApprovalMode => Value::String(settings.approval_mode().as_str().to_string()),
         KeyTarget::ApprovalPolicy => Value::String(settings.approval_policy().as_str().to_string()),
         KeyTarget::ProactiveWake => Value::Bool(settings.proactive_wake_enabled()),
+        KeyTarget::AcpSetupPage => Value::Bool(settings.acp_setup_page_enabled()),
         KeyTarget::Worktrees => Value::String(settings.worktrees_mode().as_str().to_string()),
         KeyTarget::Sandbox => Value::String(settings.sandbox_mode().as_str().to_string()),
         KeyTarget::Theme => settings

--- a/src/editor/acp/mod.rs
+++ b/src/editor/acp/mod.rs
@@ -17,7 +17,6 @@ mod bridge;
 mod modes;
 mod protocol;
 mod server;
-#[cfg(feature = "acp-setup-page")]
 mod setup_page;
 
 use std::path::PathBuf;
@@ -36,13 +35,15 @@ use everruns_provider::typed_id::SessionId as RuntimeSessionId;
 
 pub use server::{RuntimeFactory, serve};
 
-/// Id of the agent-handled method that opens the loopback setup page. Present
-/// only in `acp-setup-page` builds; `server` treats it as the generic fallback
-/// for providers with no browser login of their own.
+/// Id of the agent-handled method that opens the loopback setup page.
+/// Advertised only when the page is enabled; `server` then treats it as the
+/// generic fallback for providers with no browser login of their own.
 pub(crate) const SETUP_PAGE_AUTH_METHOD: &str = "local_setup_page";
 
-pub(crate) fn advertised_auth_methods() -> Vec<AuthMethod> {
-    #[allow(unused_mut)]
+/// `setup_page` mirrors the `--acp-setup-page` flag and the `acp_setup_page`
+/// setting. With it off the method is never advertised and no listener is ever
+/// bound, so the default ACP surface is unchanged.
+pub(crate) fn advertised_auth_methods(setup_page: bool) -> Vec<AuthMethod> {
     let mut methods = vec![
         AuthMethod::Agent(
             AuthMethodAgent::new("codex_browser", "Sign in with ChatGPT")
@@ -53,13 +54,14 @@ pub(crate) fn advertised_auth_methods() -> Vec<AuthMethod> {
                 .description("Open a browser to create an OpenRouter API key."),
         ),
     ];
-    #[cfg(feature = "acp-setup-page")]
-    methods.push(AuthMethod::Agent(
-        AuthMethodAgent::new(SETUP_PAGE_AUTH_METHOD, "Open the yolop setup page")
-            .description(
-                "Open a page served on localhost to connect a provider with an API key, a custom endpoint, or a model.",
-            ),
-    ));
+    if setup_page {
+        methods.push(AuthMethod::Agent(
+            AuthMethodAgent::new(SETUP_PAGE_AUTH_METHOD, "Open the yolop setup page")
+                .description(
+                    "Open a page served on localhost to connect a provider with an API key, a custom endpoint, or a model.",
+                ),
+        ));
+    }
     methods
 }
 
@@ -72,8 +74,8 @@ struct ConfigRuntimeFactory {
     settings: Arc<SettingsStore>,
     sessions_dir: PathBuf,
     sandbox_mode_override: Option<SandboxMode>,
-    #[cfg(feature = "acp-setup-page")]
-    setup_page: setup_page::SetupPageService,
+    /// `None` when the setup page is off, so nothing can bind a listener.
+    setup_page: Option<setup_page::SetupPageService>,
 }
 
 #[async_trait]
@@ -85,7 +87,7 @@ impl RuntimeFactory for ConfigRuntimeFactory {
     }
 
     fn auth_methods(&self) -> Vec<AuthMethod> {
-        advertised_auth_methods()
+        advertised_auth_methods(self.setup_page.is_some())
     }
 
     async fn authenticate(&self, method_id: &str) -> Result<()> {
@@ -98,46 +100,40 @@ impl RuntimeFactory for ConfigRuntimeFactory {
                 let key = crate::auth::openrouter::login_with_browser().await?;
                 self.settings.set_token("openrouter".to_string(), key)
             }
-            #[cfg(feature = "acp-setup-page")]
-            SETUP_PAGE_AUTH_METHOD => self.setup_page.run_to_completion().await.map(|_| ()),
+            SETUP_PAGE_AUTH_METHOD if self.setup_page.is_some() => self
+                .setup_page
+                .as_ref()
+                .expect("checked by the guard")
+                .run_to_completion()
+                .await
+                .map(|_| ()),
             _ => anyhow::bail!("unknown authentication method `{method_id}`"),
         }
     }
 
     async fn setup_page_url(&self) -> Option<String> {
-        #[cfg(feature = "acp-setup-page")]
-        {
-            match self.setup_page.url().await {
-                Ok(url) => Some(url),
-                Err(err) => {
-                    tracing::warn!(%err, "acp: could not start the setup page");
-                    None
-                }
+        match self.setup_page.as_ref()?.url().await {
+            Ok(url) => Some(url),
+            Err(err) => {
+                tracing::warn!(%err, "acp: could not start the setup page");
+                None
             }
-        }
-        #[cfg(not(feature = "acp-setup-page"))]
-        {
-            None
         }
     }
 
     async fn wait_for_setup_page(&self) -> bool {
-        #[cfg(feature = "acp-setup-page")]
-        {
-            match self.setup_page.wait().await {
-                Ok(summary) => {
-                    tracing::info!(%summary, "acp: setup page connected a provider");
-                    true
-                }
-                Err(err) => {
-                    tracing::debug!(%err, "acp: setup page closed without saving");
-                    false
-                }
+        let Some(page) = self.setup_page.as_ref() else {
+            return false;
+        };
+        match page.wait().await {
+            Ok(summary) => {
+                tracing::info!(%summary, "acp: setup page connected a provider");
+                true
             }
-        }
-        #[cfg(not(feature = "acp-setup-page"))]
-        {
-            false
+            Err(err) => {
+                tracing::debug!(%err, "acp: setup page closed without saving");
+                false
+            }
         }
     }
 
@@ -174,11 +170,11 @@ pub async fn run_stdio(
     settings: Arc<SettingsStore>,
     sessions_dir: PathBuf,
     sandbox_mode_override: Option<SandboxMode>,
+    setup_page: bool,
 ) -> Result<()> {
     let factory = Arc::new(ConfigRuntimeFactory {
         provider,
-        #[cfg(feature = "acp-setup-page")]
-        setup_page: setup_page::SetupPageService::new(settings.clone()),
+        setup_page: setup_page.then(|| setup_page::SetupPageService::new(settings.clone())),
         settings,
         sessions_dir,
         sandbox_mode_override,
@@ -323,7 +319,7 @@ mod tests {
 
     /// Like [`ScriptedFactory`], but advertising a loopback setup page so the
     /// no-provider hint has something to link to. Stands in for an
-    /// `acp-setup-page` build without binding a real port.
+    /// run with the page enabled without binding a real port.
     struct SetupHintFactory {
         inner: ScriptedFactory,
         url: String,

--- a/src/editor/acp/mod.rs
+++ b/src/editor/acp/mod.rs
@@ -17,6 +17,8 @@ mod bridge;
 mod modes;
 mod protocol;
 mod server;
+#[cfg(feature = "acp-setup-page")]
+mod setup_page;
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -34,8 +36,14 @@ use everruns_provider::typed_id::SessionId as RuntimeSessionId;
 
 pub use server::{RuntimeFactory, serve};
 
+/// Id of the agent-handled method that opens the loopback setup page. Present
+/// only in `acp-setup-page` builds; `server` treats it as the generic fallback
+/// for providers with no browser login of their own.
+pub(crate) const SETUP_PAGE_AUTH_METHOD: &str = "local_setup_page";
+
 pub(crate) fn advertised_auth_methods() -> Vec<AuthMethod> {
-    vec![
+    #[allow(unused_mut)]
+    let mut methods = vec![
         AuthMethod::Agent(
             AuthMethodAgent::new("codex_browser", "Sign in with ChatGPT")
                 .description("Open a browser to connect the Codex provider."),
@@ -44,7 +52,15 @@ pub(crate) fn advertised_auth_methods() -> Vec<AuthMethod> {
             AuthMethodAgent::new("openrouter_browser", "Sign in with OpenRouter")
                 .description("Open a browser to create an OpenRouter API key."),
         ),
-    ]
+    ];
+    #[cfg(feature = "acp-setup-page")]
+    methods.push(AuthMethod::Agent(
+        AuthMethodAgent::new(SETUP_PAGE_AUTH_METHOD, "Open the yolop setup page")
+            .description(
+                "Open a page served on localhost to connect a provider with an API key, a custom endpoint, or a model.",
+            ),
+    ));
+    methods
 }
 
 /// Production [`RuntimeFactory`]: builds a real provider-backed runtime rooted
@@ -56,6 +72,8 @@ struct ConfigRuntimeFactory {
     settings: Arc<SettingsStore>,
     sessions_dir: PathBuf,
     sandbox_mode_override: Option<SandboxMode>,
+    #[cfg(feature = "acp-setup-page")]
+    setup_page: setup_page::SetupPageService,
 }
 
 #[async_trait]
@@ -80,7 +98,46 @@ impl RuntimeFactory for ConfigRuntimeFactory {
                 let key = crate::auth::openrouter::login_with_browser().await?;
                 self.settings.set_token("openrouter".to_string(), key)
             }
+            #[cfg(feature = "acp-setup-page")]
+            SETUP_PAGE_AUTH_METHOD => self.setup_page.run_to_completion().await.map(|_| ()),
             _ => anyhow::bail!("unknown authentication method `{method_id}`"),
+        }
+    }
+
+    async fn setup_page_url(&self) -> Option<String> {
+        #[cfg(feature = "acp-setup-page")]
+        {
+            match self.setup_page.url().await {
+                Ok(url) => Some(url),
+                Err(err) => {
+                    tracing::warn!(%err, "acp: could not start the setup page");
+                    None
+                }
+            }
+        }
+        #[cfg(not(feature = "acp-setup-page"))]
+        {
+            None
+        }
+    }
+
+    async fn wait_for_setup_page(&self) -> bool {
+        #[cfg(feature = "acp-setup-page")]
+        {
+            match self.setup_page.wait().await {
+                Ok(summary) => {
+                    tracing::info!(%summary, "acp: setup page connected a provider");
+                    true
+                }
+                Err(err) => {
+                    tracing::debug!(%err, "acp: setup page closed without saving");
+                    false
+                }
+            }
+        }
+        #[cfg(not(feature = "acp-setup-page"))]
+        {
+            false
         }
     }
 
@@ -120,6 +177,8 @@ pub async fn run_stdio(
 ) -> Result<()> {
     let factory = Arc::new(ConfigRuntimeFactory {
         provider,
+        #[cfg(feature = "acp-setup-page")]
+        setup_page: setup_page::SetupPageService::new(settings.clone()),
         settings,
         sessions_dir,
         sandbox_mode_override,
@@ -262,6 +321,37 @@ mod tests {
         }
     }
 
+    /// Like [`ScriptedFactory`], but advertising a loopback setup page so the
+    /// no-provider hint has something to link to. Stands in for an
+    /// `acp-setup-page` build without binding a real port.
+    struct SetupHintFactory {
+        inner: ScriptedFactory,
+        url: String,
+    }
+
+    #[async_trait]
+    impl RuntimeFactory for SetupHintFactory {
+        fn session_exists(&self, session_id: RuntimeSessionId) -> bool {
+            self.inner.session_exists(session_id)
+        }
+
+        async fn setup_page_url(&self) -> Option<String> {
+            Some(self.url.clone())
+        }
+
+        async fn build(
+            &self,
+            cwd: PathBuf,
+            resume_session_id: Option<RuntimeSessionId>,
+            client_mcp_servers: ScopedMcpServers,
+            tool_approver: Option<Arc<dyn crate::capabilities::ToolApprover>>,
+        ) -> Result<BuiltRuntime> {
+            self.inner
+                .build(cwd, resume_session_id, client_mcp_servers, tool_approver)
+                .await
+        }
+    }
+
     struct SdkClient {
         cx: ConnectionTo<Agent>,
         init: InitializeResponse,
@@ -334,8 +424,6 @@ mod tests {
         Fut: Future<Output = agent_client_protocol::Result<T>> + Send + 'static,
         T: Send + 'static,
     {
-        let (client_w, agent_r) = tokio::io::duplex(64 * 1024);
-        let (agent_w, client_r) = tokio::io::duplex(64 * 1024);
         let sessions = tempfile::tempdir().expect("sessions tempdir").keep();
         let settings = Arc::new(SettingsStore::open(sessions.join("settings.toml")));
         if completion_tracking {
@@ -351,6 +439,20 @@ mod tests {
             sessions_dir: sessions,
             settings,
         });
+        with_factory(factory, op).await
+    }
+
+    /// Drive `serve` over duplex pipes with an arbitrary factory. Shared by the
+    /// scripted-runtime fixtures and by tests that need a factory of their own.
+    async fn with_factory<T, Fa, F, Fut>(factory: Arc<Fa>, op: F) -> T
+    where
+        Fa: RuntimeFactory,
+        F: FnOnce(SdkClient) -> Fut + Send + 'static,
+        Fut: Future<Output = agent_client_protocol::Result<T>> + Send + 'static,
+        T: Send + 'static,
+    {
+        let (client_w, agent_r) = tokio::io::duplex(64 * 1024);
+        let (agent_w, client_r) = tokio::io::duplex(64 * 1024);
         tokio::spawn(async move {
             let _ = serve(agent_r, agent_w, factory).await;
         });
@@ -396,6 +498,42 @@ mod tests {
                     return Err(agent_client_protocol::Error::internal_error()
                         .data("timed out waiting for prompt update"));
                 }
+            }
+        }
+    }
+
+    /// Whether the session emits the no-provider setup link. Returns as soon as
+    /// the link arrives, or once the stream goes quiet.
+    async fn collect_setup_hint(
+        session: &mut agent_client_protocol::ActiveSession<'static, Agent>,
+        url: &str,
+    ) -> bool {
+        let deadline = Duration::from_secs(3);
+        loop {
+            let update = match tokio::time::timeout(deadline, session.read_update()).await {
+                Ok(Ok(SessionMessage::SessionMessage(dispatch))) => {
+                    let Ok(message) = dispatch.to_untyped_message() else {
+                        continue;
+                    };
+                    if message.method() != "session/update" {
+                        continue;
+                    }
+                    let Ok(notification) =
+                        serde_json::from_value::<SessionNotification>(message.params().clone())
+                    else {
+                        continue;
+                    };
+                    notification.update
+                }
+                Ok(Ok(_)) => continue,
+                Ok(Err(_)) | Err(_) => return false,
+            };
+            if let SessionUpdate::AgentMessageChunk(chunk) = update
+                && serde_json::to_value(&chunk)
+                    .map(|value| value.to_string().contains(url))
+                    .unwrap_or(false)
+            {
+                return true;
             }
         }
     }
@@ -1515,6 +1653,38 @@ mod tests {
             "slash command should not invoke the model"
         );
         assert!(!run.updates_of_kind("available_commands_update").is_empty());
+    }
+
+    /// The client cannot type an API key, so a session opened with nothing
+    /// connected would silently be an llmsim session. The expectation follows
+    /// the machine: a host with a provider key in its environment is already
+    /// connected and must not be nagged, one without it must get the link.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_session_with_no_connected_provider_is_offered_the_setup_page() {
+        let sessions = tempfile::tempdir().expect("sessions tempdir").keep();
+        let settings = Arc::new(SettingsStore::open(sessions.join("settings.toml")));
+        let expected =
+            !crate::capabilities::model_discovery::any_provider_connected(&settings.snapshot());
+        let url = "http://127.0.0.1:65000/setup?t=hint-test".to_string();
+        let factory = Arc::new(SetupHintFactory {
+            inner: ScriptedFactory {
+                config: LlmSimConfig::fixed("hi"),
+                sessions_dir: sessions,
+                settings,
+            },
+            url: url.clone(),
+        });
+
+        let offered = with_factory(factory, |client| async move {
+            let mut session = client.new_session().await?;
+            Ok(collect_setup_hint(&mut session, &url).await)
+        })
+        .await;
+
+        assert_eq!(
+            offered, expected,
+            "setup link should be offered exactly when no provider is connected"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/editor/acp/server.rs
+++ b/src/editor/acp/server.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
-use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use std::time::Duration;
 
 use agent_client_protocol::{Agent, Client, ConnectionTo, Lines, Responder};
@@ -70,6 +70,18 @@ const TURN_POLL_INTERVAL: Duration = Duration::from_millis(150);
 #[async_trait]
 pub trait RuntimeFactory: Send + Sync + 'static {
     fn session_exists(&self, session_id: RuntimeSessionId) -> bool;
+
+    /// URL of a live loopback setup page, when this build serves one (the
+    /// `acp-setup-page` feature). `None` disables the no-provider hint.
+    async fn setup_page_url(&self) -> Option<String> {
+        None
+    }
+
+    /// Resolve once the live setup page finishes; `true` when it connected a
+    /// provider, so open sessions should refresh their model options.
+    async fn wait_for_setup_page(&self) -> bool {
+        false
+    }
 
     fn auth_methods(&self) -> Vec<AuthMethod> {
         Vec::new()
@@ -298,6 +310,9 @@ struct Server<F: RuntimeFactory> {
     /// connection and hold the session open while a later `serve` loads the same
     /// session id from disk — a data race on the session's on-disk state.
     poller_handles: StdMutex<Vec<JoinHandle<()>>>,
+    /// Whether a task is already awaiting the loopback setup page, so several
+    /// sessions opened with nothing connected share one watcher.
+    setup_page_watch: AtomicBool,
 }
 
 impl<F: RuntimeFactory> Server<F> {
@@ -324,6 +339,7 @@ where
         sessions: StdMutex::new(HashMap::new()),
         shutdown: shutdown_rx,
         poller_handles: StdMutex::new(Vec::new()),
+        setup_page_watch: AtomicBool::new(false),
     });
     let next_tool_id = Arc::new(AtomicI64::new(1));
     let (eof_tx, eof_rx) = oneshot::channel::<()>();
@@ -417,6 +433,7 @@ where
                             if let Some(session) = server.session(&session_id) {
                                 let commands = session.commands.lock().unwrap().clone();
                                 notify_available_commands(&peer, &session_id, &commands);
+                                offer_setup_page(&server, &peer, &session).await;
                             }
                         }
                         Err(err) => responder.respond_with_error(err)?,
@@ -1100,11 +1117,19 @@ async fn run_slash_command<F: RuntimeFactory>(
         return stop_reason;
     }
     if name == "setup" && args.split_whitespace().next() == Some("token") {
+        let setup_page_offered = server
+            .factory
+            .auth_methods()
+            .iter()
+            .any(|method| method.id().to_string() == super::SETUP_PAGE_AUTH_METHOD);
+        let guidance = if setup_page_offered {
+            "API keys cannot be entered over ACP because the protocol does not provide secure secret input; run `/setup login` to open the local setup page instead"
+        } else {
+            "API keys cannot be entered over ACP because the protocol does not provide secure secret input; configure the provider key in the agent process environment"
+        };
         peer.session_update(
             &session.acp_id,
-            SessionUpdate::AgentMessageChunk(protocol::text_chunk(
-                "API keys cannot be entered over ACP because the protocol does not provide secure secret input; configure the provider key in the agent process environment",
-            )),
+            SessionUpdate::AgentMessageChunk(protocol::text_chunk(guidance)),
         );
         return StopReason::EndTurn;
     }
@@ -1241,6 +1266,14 @@ fn select_setup_auth_method(
     if available.contains(&active_method_id) {
         return Ok(Some(active_method_id));
     }
+    // The setup page covers every provider, so it is the right default once the
+    // active provider has no login of its own.
+    if available
+        .iter()
+        .any(|id| id == super::SETUP_PAGE_AUTH_METHOD)
+    {
+        return Ok(Some(super::SETUP_PAGE_AUTH_METHOD.to_string()));
+    }
     if let [method_id] = available.as_slice() {
         return Ok(Some(method_id.clone()));
     }
@@ -1333,6 +1366,56 @@ async fn run_setup_login<F: RuntimeFactory>(
         }
     }
     Some(StopReason::EndTurn)
+}
+
+/// With nothing connected, an ACP session can only run the offline `llmsim`
+/// model, and the protocol gives the client no way to type an API key. Post the
+/// local setup page so the conversation itself carries a way out. Builds without
+/// the `acp-setup-page` feature serve no page, so this is a no-op there.
+async fn offer_setup_page<F: RuntimeFactory>(
+    server: &Arc<Server<F>>,
+    peer: &Arc<Peer>,
+    session: &Arc<Session>,
+) {
+    if crate::capabilities::model_discovery::any_provider_connected(&session.settings.snapshot()) {
+        return;
+    }
+    let Some(url) = server.factory.setup_page_url().await else {
+        return;
+    };
+    peer.session_update(
+        &session.acp_id,
+        SessionUpdate::AgentMessageChunk(protocol::text_chunk(format!(
+            "No AI provider is connected, so this session can only run the offline `llmsim` model. \
+             Open {url} to connect one, then pick its model in this client."
+        ))),
+    );
+    // One watcher per process, not per session: the page writes global settings,
+    // and every open session is refreshed when it saves.
+    if server.setup_page_watch.swap(true, Ordering::Relaxed) {
+        return;
+    }
+    tokio::spawn({
+        let server = server.clone();
+        let peer = peer.clone();
+        let mut shutdown = server.shutdown.clone();
+        async move {
+            // The page outlives a turn by design (it waits on a human), so the
+            // watcher also drops out on teardown. Otherwise it would hold the
+            // session map open for the page's whole lifetime, and a later
+            // `serve` could load the same session id from disk underneath it.
+            let connected = tokio::select! {
+                connected = server.factory.wait_for_setup_page() => connected,
+                _ = shutdown.wait_for(|done| *done) => false,
+            };
+            server.setup_page_watch.store(false, Ordering::Relaxed);
+            if connected {
+                for session in server.sessions() {
+                    emit_config_options(&peer, &session).await;
+                }
+            }
+        }
+    });
 }
 
 fn command_title(prefix: &str, name: &str, args: &str) -> String {

--- a/src/editor/acp/server.rs
+++ b/src/editor/acp/server.rs
@@ -71,8 +71,9 @@ const TURN_POLL_INTERVAL: Duration = Duration::from_millis(150);
 pub trait RuntimeFactory: Send + Sync + 'static {
     fn session_exists(&self, session_id: RuntimeSessionId) -> bool;
 
-    /// URL of a live loopback setup page, when this build serves one (the
-    /// `acp-setup-page` feature). `None` disables the no-provider hint.
+    /// URL of a live loopback setup page, when this run serves one (the
+    /// `--acp-setup-page` flag or the `acp_setup_page` setting). `None`
+    /// disables the no-provider hint.
     async fn setup_page_url(&self) -> Option<String> {
         None
     }
@@ -1370,8 +1371,8 @@ async fn run_setup_login<F: RuntimeFactory>(
 
 /// With nothing connected, an ACP session can only run the offline `llmsim`
 /// model, and the protocol gives the client no way to type an API key. Post the
-/// local setup page so the conversation itself carries a way out. Builds without
-/// the `acp-setup-page` feature serve no page, so this is a no-op there.
+/// local setup page so the conversation itself carries a way out. A run with the
+/// page turned off serves no URL, so this is a no-op there.
 async fn offer_setup_page<F: RuntimeFactory>(
     server: &Arc<Server<F>>,
     peer: &Arc<Peer>,
@@ -1742,7 +1743,7 @@ mod tests {
     fn initialize_advertises_agent_handled_authentication() {
         let result = handle_initialize(
             InitializeParams::new(protocol::PROTOCOL_VERSION),
-            super::super::advertised_auth_methods(),
+            super::super::advertised_auth_methods(false),
         );
 
         let value = serde_json::to_value(result).expect("serialize initialize response");
@@ -1750,11 +1751,37 @@ mod tests {
         assert_eq!(value["authMethods"][0]["name"], "Sign in with ChatGPT");
         assert_eq!(value["authMethods"][1]["id"], "openrouter_browser");
         assert_eq!(value["authMethods"][1]["name"], "Sign in with OpenRouter");
+        assert_eq!(
+            value["authMethods"].as_array().map(Vec::len),
+            Some(2),
+            "the setup page must not be advertised when it is off"
+        );
+    }
+
+    /// The page covers every provider, so it is the fallback once the active
+    /// provider has no login of its own. It only exists when enabled.
+    #[test]
+    fn setup_page_is_the_fallback_method_only_when_enabled() {
+        let with_page = super::super::advertised_auth_methods(true);
+        assert_eq!(
+            select_setup_auth_method(&with_page, None, "openai").unwrap(),
+            Some(super::super::SETUP_PAGE_AUTH_METHOD.to_string())
+        );
+        assert_eq!(
+            select_setup_auth_method(&with_page, None, "codex").unwrap(),
+            Some("codex_browser".to_string())
+        );
+
+        let without_page = super::super::advertised_auth_methods(false);
+        assert_eq!(
+            select_setup_auth_method(&without_page, None, "openai").unwrap(),
+            None
+        );
     }
 
     #[test]
     fn setup_authentication_prefers_the_active_provider() {
-        let methods = super::super::advertised_auth_methods();
+        let methods = super::super::advertised_auth_methods(false);
 
         assert_eq!(
             select_setup_auth_method(&methods, None, "codex").unwrap(),

--- a/src/editor/acp/setup_page.rs
+++ b/src/editor/acp/setup_page.rs
@@ -1,0 +1,680 @@
+//! Loopback setup page, behind the `acp-setup-page` feature.
+//!
+//! ACP has no secure way for an agent to ask for free text, let alone a secret:
+//! the client owns every input surface, and the only agent-initiated ask is
+//! `session/request_permission`, which is a fixed list of options. Providers
+//! that need an API key, a base URL, or a custom model spec therefore have no
+//! in-conversation path over ACP (see `knowledge/specs/acp.md`).
+//!
+//! What ACP *does* have is agent-handled authentication: `authenticate` hands
+//! control to the agent, which is free to run any out-of-band flow. This module
+//! is that flow, generalised past OAuth. It binds a loopback listener, serves a
+//! small form, and the browser becomes the input surface the protocol lacks.
+//! The secret travels over `127.0.0.1` into the settings store, never through
+//! the ACP transcript or the session log.
+//!
+//! Same trust boundary as the OAuth callback listeners in `crate::auth`: bound
+//! to loopback only, guarded by an unguessable one-page token, `Host` checked
+//! so a hostile page cannot drive it by DNS rebinding, and torn down once a
+//! provider is saved (or after [`PAGE_LIFETIME`]).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow};
+use reqwest::Url;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{Mutex, watch};
+use tokio::task::JoinHandle;
+
+use crate::auth::oauth_flow::{callback_page, html_escape, open_browser, random_token};
+use crate::capabilities::model_discovery::provider_is_usable;
+use crate::config::SettingsStore;
+use crate::runtime::SUPPORTED_PROVIDERS;
+
+/// The only path the page answers on; everything else is a 404.
+const PAGE_PATH: &str = "/setup";
+/// How long an unused page stays open before the listener is dropped.
+const PAGE_LIFETIME: Duration = Duration::from_secs(10 * 60);
+/// Cap on a single request. The form is a handful of short fields; anything
+/// larger is a client bug or an attempt to grow the process, not a submission.
+const MAX_REQUEST_BYTES: usize = 32 * 1024;
+
+/// Owns the process's current setup page, if any.
+///
+/// One page is shared by every ACP session: the settings it writes are global,
+/// so a second listener would only add a second port to guard.
+pub(crate) struct SetupPageService {
+    settings: Arc<SettingsStore>,
+    live: Mutex<Option<LivePage>>,
+}
+
+struct LivePage {
+    url: String,
+    /// `None` while the page is still open; `Some` once it saved a provider,
+    /// failed, or timed out.
+    outcome: watch::Receiver<Option<std::result::Result<String, String>>>,
+    task: JoinHandle<()>,
+}
+
+impl SetupPageService {
+    pub(crate) fn new(settings: Arc<SettingsStore>) -> Self {
+        Self {
+            settings,
+            live: Mutex::new(None),
+        }
+    }
+
+    /// URL of the live page, starting one if the last has finished. Callers
+    /// hand this to the user; nothing happens until it is opened.
+    pub(crate) async fn url(&self) -> Result<String> {
+        let mut live = self.live.lock().await;
+        if let Some(existing) = live.as_ref()
+            && !existing.task.is_finished()
+        {
+            return Ok(existing.url.clone());
+        }
+
+        let listener = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .context("bind the yolop setup page")?;
+        let port = listener
+            .local_addr()
+            .context("resolve the yolop setup page port")?
+            .port();
+        let token = random_token(24);
+        let url = format!("http://127.0.0.1:{port}{PAGE_PATH}?t={token}");
+
+        let (tx, rx) = watch::channel(None);
+        let settings = self.settings.clone();
+        let task = tokio::spawn(async move {
+            let served =
+                tokio::time::timeout(PAGE_LIFETIME, serve_until_saved(listener, token, settings))
+                    .await;
+            let outcome = match served {
+                Ok(Ok(summary)) => Ok(summary),
+                Ok(Err(err)) => Err(err.to_string()),
+                Err(_) => Err("the setup page timed out".to_string()),
+            };
+            let _ = tx.send(Some(outcome));
+        });
+
+        *live = Some(LivePage {
+            url: url.clone(),
+            outcome: rx,
+            task,
+        });
+        Ok(url)
+    }
+
+    /// Resolve once the live page saves a provider, fails, or times out.
+    /// Errors when no page is running.
+    pub(crate) async fn wait(&self) -> Result<String> {
+        let mut outcome = {
+            let live = self.live.lock().await;
+            live.as_ref()
+                .map(|page| page.outcome.clone())
+                .ok_or_else(|| anyhow!("no setup page is running"))?
+        };
+        loop {
+            let settled = outcome.borrow_and_update().clone();
+            if let Some(result) = settled {
+                return result.map_err(|message| anyhow!(message));
+            }
+            outcome
+                .changed()
+                .await
+                .map_err(|_| anyhow!("the setup page stopped without a result"))?;
+        }
+    }
+
+    /// The `authenticate` path: open the page and block until it is submitted,
+    /// so the ACP client's own "authenticating" state tracks the real flow.
+    pub(crate) async fn run_to_completion(&self) -> Result<String> {
+        let url = self.url().await?;
+        if let Err(err) = open_browser(&url) {
+            // Headless hosts and remote clients cannot open a browser here; the
+            // URL was already handed to the caller, so this is not fatal.
+            tracing::debug!(%err, "acp: could not open the setup page automatically");
+        }
+        self.wait().await
+    }
+}
+
+async fn serve_until_saved(
+    listener: TcpListener,
+    token: String,
+    settings: Arc<SettingsStore>,
+) -> Result<String> {
+    loop {
+        let (mut socket, _) = listener
+            .accept()
+            .await
+            .context("accept a yolop setup page request")?;
+        match handle_connection(&mut socket, &token, &settings).await {
+            Ok(Some(summary)) => return Ok(summary),
+            // A rejected or re-rendered request leaves the page open.
+            Ok(None) => continue,
+            Err(err) => {
+                tracing::debug!(%err, "acp: setup page request failed");
+                continue;
+            }
+        }
+    }
+}
+
+struct HttpRequest {
+    method: String,
+    path: String,
+    query: HashMap<String, String>,
+    host: Option<String>,
+    body: String,
+}
+
+/// Serve one request. `Ok(Some(summary))` means a provider was saved and the
+/// page is done; `Ok(None)` means the page stays open.
+async fn handle_connection(
+    socket: &mut TcpStream,
+    token: &str,
+    settings: &Arc<SettingsStore>,
+) -> Result<Option<String>> {
+    let request = read_request(socket).await?;
+
+    // A hostile page can make a browser POST to a known loopback port, but it
+    // cannot read the token or forge the Host header, so both are checked.
+    if !host_is_loopback(request.host.as_deref()) {
+        write_page(
+            socket,
+            "403 Forbidden",
+            &denied_page("unexpected Host header"),
+        )
+        .await?;
+        return Ok(None);
+    }
+    if request.path != PAGE_PATH {
+        write_page(socket, "404 Not Found", &denied_page("no such page")).await?;
+        return Ok(None);
+    }
+    if request.query.get("t").map(String::as_str) != Some(token) {
+        write_page(socket, "403 Forbidden", &denied_page("invalid setup link")).await?;
+        return Ok(None);
+    }
+
+    let snapshot = settings.snapshot();
+    match request.method.as_str() {
+        "GET" => {
+            let page = form_page(&snapshot, token, None);
+            write_page(socket, "200 OK", &page).await?;
+            Ok(None)
+        }
+        "POST" => {
+            let form = parse_form(&request.body);
+            match apply_setup(settings, &form) {
+                Ok(summary) => {
+                    let page = callback_page("200 OK", &summary, "provider setup");
+                    write_page(socket, "200 OK", &page).await?;
+                    Ok(Some(summary))
+                }
+                Err(message) => {
+                    let page = form_page(&settings.snapshot(), token, Some(&message));
+                    write_page(socket, "200 OK", &page).await?;
+                    Ok(None)
+                }
+            }
+        }
+        _ => {
+            write_page(
+                socket,
+                "405 Method Not Allowed",
+                &denied_page("unsupported method"),
+            )
+            .await?;
+            Ok(None)
+        }
+    }
+}
+
+/// Persist one submission. The returned summary is safe to echo over ACP: it
+/// names the provider and model, never the credential.
+fn apply_setup(
+    settings: &Arc<SettingsStore>,
+    form: &HashMap<String, String>,
+) -> std::result::Result<String, String> {
+    apply_setup_with(settings, form, provider_is_usable)
+}
+
+/// The body of [`apply_setup`], parameterised on the connectivity predicate so
+/// tests can judge it without depending on which provider keys happen to be in
+/// the process environment.
+fn apply_setup_with(
+    settings: &Arc<SettingsStore>,
+    form: &HashMap<String, String>,
+    is_usable: impl Fn(&crate::config::Settings, &str) -> bool,
+) -> std::result::Result<String, String> {
+    let field = |name: &str| form.get(name).map(|v| v.trim()).unwrap_or_default();
+    let provider = field("provider");
+    if !SUPPORTED_PROVIDERS.contains(&provider) {
+        return Err(format!("unknown provider `{provider}`"));
+    }
+    let token = field("token");
+    let base_url = field("base_url");
+    let model = field("model");
+
+    if !base_url.is_empty() {
+        let parsed = Url::parse(base_url).map_err(|err| format!("base URL is not a URL: {err}"))?;
+        if !matches!(parsed.scheme(), "http" | "https") {
+            return Err("base URL must be http or https".to_string());
+        }
+        settings
+            .set_base_url(provider.to_string(), base_url.to_string())
+            .map_err(|err| format!("could not save the base URL: {err}"))?;
+    }
+    if !token.is_empty() {
+        settings
+            .set_token(provider.to_string(), token.to_string())
+            .map_err(|err| format!("could not save the API key: {err}"))?;
+    }
+    if !model.is_empty() {
+        settings
+            .set_model(provider.to_string(), model.to_string())
+            .map_err(|err| format!("could not save the model: {err}"))?;
+    }
+
+    // Judge connectivity through the same predicate ACP uses to build its model
+    // list, so a page that reports success is a page whose provider will show up
+    // as a usable model.
+    if !is_usable(&settings.snapshot(), provider) {
+        return Err(missing_credential_message(provider));
+    }
+    settings
+        .set_default_provider(Some(provider.to_string()))
+        .map_err(|err| format!("could not save the provider: {err}"))?;
+
+    let model_note = if model.is_empty() {
+        String::new()
+    } else {
+        format!(" model={model}")
+    };
+    Ok(format!("setup: provider={provider}{model_note}"))
+}
+
+fn missing_credential_message(provider: &str) -> String {
+    match provider {
+        "custom" | "ollama" => {
+            format!("`{provider}` still needs a base URL (and a key if the endpoint requires one)")
+        }
+        "codex" => "`codex` needs a ChatGPT sign-in; use the Sign in with ChatGPT method instead"
+            .to_string(),
+        "local" => {
+            "`local` needs the in-process engine compiled in and its weights downloaded".to_string()
+        }
+        _ => format!("`{provider}` still has no API key"),
+    }
+}
+
+fn provider_label(provider: &str) -> &'static str {
+    match provider {
+        "openai" => "OpenAI",
+        "codex" => "Codex subscription",
+        "anthropic" => "Anthropic",
+        "meta" => "Meta Model API",
+        "google" => "Google Gemini",
+        "openrouter" => "OpenRouter",
+        "ollama" => "Ollama local",
+        "local" => "Local (in-process)",
+        "custom" => "Custom OpenAI-compatible endpoint",
+        "llmsim" => "Offline demo mode",
+        _ => "Provider",
+    }
+}
+
+fn host_is_loopback(host: Option<&str>) -> bool {
+    let Some(host) = host else {
+        return false;
+    };
+    let host = host.trim();
+    // Strip the port; IPv6 literals keep their brackets.
+    let name = match host.rsplit_once(':') {
+        Some((name, port)) if !port.contains(']') => name,
+        _ => host,
+    };
+    matches!(name, "127.0.0.1" | "localhost" | "[::1]" | "::1")
+}
+
+fn parse_form(body: &str) -> HashMap<String, String> {
+    // `Url` already owns percent- and `+`-decoding for query strings, which is
+    // the same grammar as an urlencoded form body.
+    match Url::parse(&format!("http://127.0.0.1/?{body}")) {
+        Ok(url) => url.query_pairs().into_owned().collect(),
+        Err(_) => HashMap::new(),
+    }
+}
+
+async fn read_request(socket: &mut TcpStream) -> Result<HttpRequest> {
+    let mut buffer = Vec::new();
+    let mut chunk = [0u8; 4096];
+    let header_end = loop {
+        if let Some(end) = find_header_end(&buffer) {
+            break end;
+        }
+        if buffer.len() > MAX_REQUEST_BYTES {
+            return Err(anyhow!("setup page request headers were too large"));
+        }
+        let read = socket
+            .read(&mut chunk)
+            .await
+            .context("read a setup page request")?;
+        if read == 0 {
+            return Err(anyhow!("setup page request ended before its headers"));
+        }
+        buffer.extend_from_slice(&chunk[..read]);
+    };
+
+    let head = String::from_utf8_lossy(&buffer[..header_end]).to_string();
+    let mut lines = head.lines();
+    let request_line = lines.next().unwrap_or_default().to_string();
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or_default().to_string();
+    let target = parts.next().unwrap_or_default().to_string();
+
+    let mut host = None;
+    let mut content_length = 0usize;
+    for line in lines {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        let value = value.trim();
+        if name.eq_ignore_ascii_case("host") {
+            host = Some(value.to_string());
+        } else if name.eq_ignore_ascii_case("content-length") {
+            content_length = value.parse().unwrap_or(0);
+        }
+    }
+    if content_length > MAX_REQUEST_BYTES {
+        return Err(anyhow!("setup page request body was too large"));
+    }
+
+    let mut body = buffer[header_end..].to_vec();
+    while body.len() < content_length {
+        let read = socket
+            .read(&mut chunk)
+            .await
+            .context("read a setup page request body")?;
+        if read == 0 {
+            break;
+        }
+        body.extend_from_slice(&chunk[..read]);
+    }
+    body.truncate(content_length);
+
+    let parsed = Url::parse(&format!("http://127.0.0.1{target}"))
+        .context("parse a setup page request target")?;
+    Ok(HttpRequest {
+        method,
+        path: parsed.path().to_string(),
+        query: parsed.query_pairs().into_owned().collect(),
+        host,
+        body: String::from_utf8_lossy(&body).to_string(),
+    })
+}
+
+fn find_header_end(buffer: &[u8]) -> Option<usize> {
+    buffer
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .map(|at| at + 4)
+        .or_else(|| {
+            buffer
+                .windows(2)
+                .position(|window| window == b"\n\n")
+                .map(|at| at + 2)
+        })
+}
+
+async fn write_page(socket: &mut TcpStream, status: &str, body: &str) -> Result<()> {
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nCache-Control: no-store\r\nReferrer-Policy: no-referrer\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    socket
+        .write_all(response.as_bytes())
+        .await
+        .context("write a setup page response")
+}
+
+fn denied_page(reason: &str) -> String {
+    callback_page("400 Bad Request", reason, "provider setup")
+}
+
+/// The form itself. Kept deliberately plain: one select, three fields, no
+/// scripts, nothing fetched from the network.
+fn form_page(settings: &crate::config::Settings, token: &str, error: Option<&str>) -> String {
+    let options = SUPPORTED_PROVIDERS
+        .iter()
+        .map(|provider| {
+            let connected = if provider_is_usable(settings, provider) {
+                " (connected)"
+            } else {
+                ""
+            };
+            format!(
+                r#"<option value="{provider}">{label}{connected}</option>"#,
+                provider = html_escape(provider),
+                label = html_escape(provider_label(provider)),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n        ");
+    let banner = error
+        .map(|message| format!(r#"<p class="error">{}</p>"#, html_escape(message)))
+        .unwrap_or_default();
+    let action = format!("{PAGE_PATH}?t={}", html_escape(token));
+
+    format!(
+        r#"<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="referrer" content="no-referrer">
+  <title>Yolop provider setup</title>
+  <style>
+    :root {{ color-scheme: light dark; --ink: #12131a; --muted: #626776; --line: rgba(18,19,26,.16); --bad: #b74747; }}
+    * {{ box-sizing: border-box; }}
+    body {{ margin: 0; min-height: 100vh; display: grid; place-items: center; padding: 32px;
+      font: 16px/1.5 ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--ink); background: linear-gradient(135deg, #fbfaf7 0%, #eef1f7 100%); }}
+    main {{ width: min(560px, 100%); background: rgba(255,255,255,.9); border: 1px solid var(--line);
+      border-radius: 24px; padding: clamp(24px, 5vw, 44px); box-shadow: 0 24px 80px rgba(10,22,54,.16); }}
+    h1 {{ font-size: 1.4rem; margin: 0 0 4px; }}
+    p.lede {{ margin: 0 0 24px; color: var(--muted); }}
+    label {{ display: block; font-weight: 600; margin: 16px 0 6px; }}
+    input, select {{ width: 100%; padding: 10px 12px; border-radius: 12px; border: 1px solid var(--line);
+      background: #fff; color: var(--ink); font: inherit; }}
+    small {{ display: block; color: var(--muted); margin-top: 6px; }}
+    button {{ margin-top: 24px; width: 100%; padding: 12px; border: 0; border-radius: 999px;
+      background: #0a1636; color: #fff; font: inherit; font-weight: 600; cursor: pointer; }}
+    .error {{ margin: 0 0 16px; padding: 12px 14px; border-radius: 12px; color: var(--bad);
+      border: 1px solid var(--bad); background: rgba(183,71,71,.08); }}
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Connect a provider</h1>
+    <p class="lede">Yolop is running as an editor agent. This page is served by that process on
+      localhost, so the key you type never travels through the editor or the session log.</p>
+    {banner}
+    <form method="post" action="{action}" autocomplete="off">
+      <label for="provider">Provider</label>
+      <select id="provider" name="provider">
+        {options}
+      </select>
+      <label for="token">API key</label>
+      <input id="token" name="token" type="password" autocomplete="off" spellcheck="false"
+        placeholder="leave empty to keep the saved key">
+      <label for="base_url">Base URL</label>
+      <input id="base_url" name="base_url" type="url" autocomplete="off" spellcheck="false"
+        placeholder="optional; required for a custom endpoint">
+      <label for="model">Model</label>
+      <input id="model" name="model" type="text" autocomplete="off" spellcheck="false"
+        placeholder="optional; defaults to this provider's model">
+      <small>Saving also makes this the default provider. Pick the model in your editor afterwards.</small>
+      <button type="submit">Save and connect</button>
+    </form>
+  </main>
+</body>
+</html>"#
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::SettingsStore;
+
+    fn store() -> (tempfile::TempDir, Arc<SettingsStore>) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(SettingsStore::open(dir.path().join("settings.toml")));
+        (dir, store)
+    }
+
+    #[test]
+    fn form_lists_every_supported_provider_and_never_echoes_a_key() {
+        let (_dir, store) = store();
+        store
+            .set_token("openai".to_string(), "sk-secret-value".to_string())
+            .expect("save token");
+        let page = form_page(&store.snapshot(), "page-token", None);
+        for provider in SUPPORTED_PROVIDERS {
+            assert!(
+                page.contains(&format!(r#"value="{provider}""#)),
+                "provider {provider} missing from the form"
+            );
+            assert_ne!(
+                provider_label(provider),
+                "Provider",
+                "provider {provider} has no label"
+            );
+        }
+        assert!(page.contains("OpenAI (connected)"));
+        assert!(!page.contains("sk-secret-value"));
+    }
+
+    #[test]
+    fn apply_setup_saves_a_key_and_selects_the_provider() {
+        let (_dir, store) = store();
+        let form = HashMap::from([
+            ("provider".to_string(), "anthropic".to_string()),
+            ("token".to_string(), "sk-ant-test".to_string()),
+            ("model".to_string(), "claude-test".to_string()),
+        ]);
+        let summary = apply_setup_with(&store, &form, |_, _| true).expect("setup applies");
+        assert_eq!(summary, "setup: provider=anthropic model=claude-test");
+        assert!(!summary.contains("sk-ant-test"));
+        let settings = store.snapshot();
+        assert_eq!(settings.token_for("anthropic"), Some("sk-ant-test"));
+        assert_eq!(settings.model_for("anthropic"), Some("claude-test"));
+    }
+
+    #[test]
+    fn apply_setup_rejects_an_unknown_provider() {
+        let (_dir, store) = store();
+        let form = HashMap::from([("provider".to_string(), "not-a-provider".to_string())]);
+        assert_eq!(
+            apply_setup_with(&store, &form, |_, _| true).unwrap_err(),
+            "unknown provider `not-a-provider`"
+        );
+    }
+
+    #[test]
+    fn apply_setup_reports_a_provider_that_is_still_unconnected() {
+        let (_dir, store) = store();
+        let form = HashMap::from([("provider".to_string(), "anthropic".to_string())]);
+        let error = apply_setup_with(&store, &form, |_, _| false).unwrap_err();
+        assert!(error.contains("still has no API key"), "got: {error}");
+        assert_eq!(store.snapshot().default_provider, None);
+    }
+
+    #[test]
+    fn apply_setup_rejects_a_base_url_that_is_not_http() {
+        let (_dir, store) = store();
+        let form = HashMap::from([
+            ("provider".to_string(), "custom".to_string()),
+            ("base_url".to_string(), "file:///etc/passwd".to_string()),
+        ]);
+        assert_eq!(
+            apply_setup_with(&store, &form, |_, _| true).unwrap_err(),
+            "base URL must be http or https"
+        );
+    }
+
+    #[test]
+    fn host_header_must_be_loopback() {
+        assert!(host_is_loopback(Some("127.0.0.1:8123")));
+        assert!(host_is_loopback(Some("localhost:8123")));
+        assert!(host_is_loopback(Some("[::1]:8123")));
+        assert!(!host_is_loopback(Some("evil.example.com:8123")));
+        assert!(!host_is_loopback(None));
+    }
+
+    #[test]
+    fn form_bodies_decode_percent_and_plus_escapes() {
+        let form = parse_form("provider=custom&token=a%2Bb%20c&base_url=http%3A%2F%2Fx%2Fv1");
+        assert_eq!(form.get("token").map(String::as_str), Some("a+b c"));
+        assert_eq!(
+            form.get("base_url").map(String::as_str),
+            Some("http://x/v1")
+        );
+    }
+
+    /// End to end over a real socket: the token gates the page, and a submitted
+    /// form both persists the key and ends the page's life.
+    #[tokio::test]
+    async fn page_gates_on_the_token_and_saves_a_submission() {
+        let (_dir, store) = store();
+        let service = SetupPageService::new(store.clone());
+        let url = service.url().await.expect("start the page");
+        let base = url.split(PAGE_PATH).next().expect("base").to_string();
+        let token = url.split("t=").nth(1).expect("token").to_string();
+        let client = reqwest::Client::builder()
+            .no_proxy()
+            .build()
+            .expect("http client");
+
+        let denied = client
+            .get(format!("{base}{PAGE_PATH}?t=wrong"))
+            .send()
+            .await
+            .expect("send");
+        assert_eq!(denied.status(), 403);
+
+        let form = client
+            .get(format!("{base}{PAGE_PATH}?t={token}"))
+            .send()
+            .await
+            .expect("send");
+        assert_eq!(form.status(), 200);
+        assert!(
+            form.text()
+                .await
+                .expect("body")
+                .contains("Connect a provider")
+        );
+
+        let saved = client
+            .post(format!("{base}{PAGE_PATH}?t={token}"))
+            .form(&[("provider", "openai"), ("token", "sk-page-test")])
+            .send()
+            .await
+            .expect("send");
+        assert_eq!(saved.status(), 200);
+
+        assert_eq!(
+            service.wait().await.expect("outcome"),
+            "setup: provider=openai"
+        );
+        assert_eq!(store.snapshot().token_for("openai"), Some("sk-page-test"));
+    }
+}

--- a/src/editor/acp/setup_page.rs
+++ b/src/editor/acp/setup_page.rs
@@ -1,4 +1,5 @@
-//! Loopback setup page, behind the `acp-setup-page` feature.
+//! Loopback setup page, opt-in per run (`--acp-setup-page`) or per user (the
+//! `acp_setup_page` setting).
 //!
 //! ACP has no secure way for an agent to ask for free text, let alone a secret:
 //! the client owns every input surface, and the only agent-initiated ask is

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,6 +146,14 @@ struct Cli {
     #[arg(long, conflicts_with = "print")]
     acp: bool,
 
+    /// Offer the loopback provider setup page to ACP clients for this run: an
+    /// extra authentication method, plus a link posted when a session opens
+    /// with no provider connected. ACP has no secure way to ask for an API key,
+    /// so the page is where one can be typed. Off unless this flag or the
+    /// `acp_setup_page` setting is on. See `knowledge/specs/acp.md`.
+    #[arg(long = "acp-setup-page", requires = "acp")]
+    acp_setup_page: bool,
+
     /// Resume an existing session. Reads the JSONL log for this id and
     /// seeds the message history; the new run continues appending to the
     /// same file. If no log exists, a new session starts with this id.
@@ -733,8 +741,18 @@ async fn async_main(crash_reporter: &crash_report::CrashReporter) -> Result<()> 
         if cli.trajectory_out.is_some() {
             eprintln!("yolop: --trajectory-out is ignored in --acp mode");
         }
-        return editor::acp::run_stdio(provider, settings, sessions_dir, sandbox_mode_override)
-            .await;
+        // The flag turns the page on for one run; the setting turns it on for
+        // every editor launch, which is what matters when the editor owns the
+        // spawn arguments.
+        let setup_page = cli.acp_setup_page || settings.snapshot().acp_setup_page_enabled();
+        return editor::acp::run_stdio(
+            provider,
+            settings,
+            sessions_dir,
+            sandbox_mode_override,
+            setup_page,
+        )
+        .await;
     }
 
     // Only the interactive TUI can apply terminal-side commands (overlays,
@@ -2406,6 +2424,7 @@ mod tests {
             print: None,
             images: vec![],
             acp: false,
+            acp_setup_page: false,
             session: None,
             session_dir: None,
             trajectory_out: None,
@@ -2496,6 +2515,7 @@ mod tests {
             print: None,
             images: vec![],
             acp: false,
+            acp_setup_page: false,
             session: None,
             session_dir: None,
             trajectory_out: None,


### PR DESCRIPTION
## What changed

An editor driving yolop over ACP can now connect an API-key provider without
leaving the editor, through an opt-in page yolop serves on `127.0.0.1`.

- A new agent-handled authentication method, `local_setup_page`, appears in
  `initialize.authMethods`. Choosing it opens a browser form for provider, API
  key, base URL, and model; `authenticate` resolves once the form is submitted,
  so the client's own authenticating state tracks the real flow.
- A session opened with no provider connected gets the page URL posted as an
  `agent_message_chunk`. Without it, an editor with no key in its environment
  gets a silently `llmsim`-only session and no way to fix it from the client.
  Environment-provided keys count as connected, so a configured host is never
  nagged.
- Plain `/setup` and `/setup login` fall back to this method when the active
  provider advertises no browser login of its own, and `/setup token` points at
  it instead of at the process environment.
- When the page saves, every open session receives `config_option_update` with
  the newly usable models.

Off by default. Enable per run with `yolop --acp --acp-setup-page`, or per user
with the `acp_setup_page` setting. With it off, the method is never advertised
and no listener is ever bound.

## Why

ACP gives an agent no way to ask for free text, let alone a secret: the client
owns every input surface, and the only agent-initiated ask is
`session/request_permission`, a fixed list of options. Providers that need an
API key, a base URL, or a custom model spec therefore had no in-conversation
path over ACP at all, only "set it in the environment and restart".

Agent-handled authentication is the one place the protocol hands control to the
agent for an out-of-band flow. This generalises that past OAuth: the browser
becomes the input surface the protocol lacks, and the credential travels over
loopback into the settings store instead of through the editor.

The gate is runtime rather than a Cargo feature deliberately. The page adds no
dependencies, so compiling it out buys nothing, and a build flag would keep it
out of the release binaries, which is exactly the population whose feedback
decides whether it ships on by default.

## Before / After

**Before** — an ACP client with no provider key could only be told to give up:

```
/setup token openai sk-...
→ API keys cannot be entered over ACP because the protocol does not provide
  secure secret input; configure the provider key in the agent process environment
```

**After** — driving the real binary over stdio, against a throwaway `HOME` with
every provider key stripped from the environment:

```
PASS  default --acp advertises no setup page: ['codex_browser', 'openrouter_browser']
PASS  --acp-setup-page advertises the method: ['codex_browser', 'openrouter_browser', 'local_setup_page']
PASS  session/new posts the setup link
      hint: No AI provider is connected, so this session can only run the offline `llmsim` model.
            Open http://127.0.0.1:41463/setup?t=AYbRDedlz_8042AzdVCTiromJyiKqDGq to connect one,
            then pick its model in this client.
PASS  GET renders the form
PASS  bad token is refused: HTTP 403
PASS  POST saves and confirms: status 200
PASS  key persisted to settings: /tmp/tmp8to_dxi5/.config/yolop/settings.toml
PASS  provider became the default
PASS  listener is torn down after saving: [Errno 111] Connection refused
```

The settings path is equivalent, no flag needed:

```
$ printf 'acp_setup_page = true\n' > $HOME/.config/yolop/settings.toml
$ yolop --acp
authMethods: ['codex_browser', 'openrouter_browser', 'local_setup_page']
```

Offline binary smoke: `yolop --provider llmsim -p "hi"` still starts and answers.

## Risk

- Low / Medium
- The new surface is a local HTTP listener, and it only exists when the user
  opts in. A default `--acp` run behaves exactly as before: same auth methods,
  no listener, no extra session messages, which the smoke asserts explicitly.
- The listener is the thing to get wrong, so it is bounded on every axis:
  loopback bind, unguessable per-page token, `Host` allowlist, request size
  caps, ten-minute lifetime, teardown on save.
- A saved provider that turns out not to work is a settings change, recoverable
  the same way any other `/setup` mistake is.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated [`knowledge/specs/acp.md`](knowledge/specs/acp.md) with a new "Local
setup page" section (the surface, the trust boundary, the no-provider hint, and
why the gate is runtime), [`knowledge/specs/configuration.md`](knowledge/specs/configuration.md)
with the `acp_setup_page` key and its global-only scope, and
[`knowledge/log.md`](knowledge/log.md) with the decision entry.

## Security

Reviewed against the threat-model categories; the new listener is the whole of
the changed surface.

- **TM-LLM** — the credential never reaches a prompt, the ACP transcript, or the
  session JSONL. It goes from the browser over `127.0.0.1` into `SettingsStore`.
  The summary echoed back over ACP names provider and model only, asserted by
  `apply_setup_saves_a_key_and_selects_the_provider`; the rendered form never
  redisplays a stored key, asserted by
  `form_lists_every_supported_provider_and_never_echoes_a_key`. Log lines carry
  that same summary, not the secret. `/setup token` is still rejected without
  echoing or persisting the value.
- **New surface, the HTTP listener.** Bound to `127.0.0.1:0`, and only when
  opted in. CSRF and DNS rebinding are covered by two independent checks: a
  192-bit `random_token` in the URL that a hostile page cannot read, and a
  `Host` allowlist (`host_header_must_be_loopback`) that rejects a cross-origin
  form POST to a guessed port. Responses carry `Cache-Control: no-store` and
  `Referrer-Policy: no-referrer`, and the page loads nothing external, so the
  token cannot leak through a Referer. The token is compared with `==` rather
  than in constant time; over loopback against a 192-bit random value that is
  not a practical distinguisher.
- **Input validation at the trust boundary.** Provider is checked against
  `SUPPORTED_PROVIDERS`, base URL is parsed and restricted to `http`/`https`
  (`apply_setup_rejects_a_base_url_that_is_not_http`), and every interpolated
  value goes through `html_escape`. The request path is compared exactly to
  `/setup` after `Url` normalisation, and no filesystem path derives from the
  request, so there is no traversal surface.
- **Resource exhaustion.** Headers and body are capped at 32 KiB, the page lives
  at most ten minutes, one page exists per process, and it tears down after a
  successful save (asserted end to end in the smoke). The session-side watcher
  also drops out on connection teardown, so it cannot hold the session map open
  behind a later `serve`.
- **TM-FS / TM-BASH / TM-TOOL** — unchanged. No filesystem or shell code paths
  were touched, the write blocklist is untouched, and no capability or tool was
  registered. The browser opener reuses the existing OAuth helper with a fixed
  argv and a URL yolop generated itself, so no shell and no attacker-controlled
  argument is involved.
- **TM-DEP** — no new dependencies. The page is built from `reqwest::Url`,
  tokio, and the existing helpers in `src/auth/oauth_flow.rs`.

One deliberate scope note: `acp_setup_page` is global-only, not profileable. A
profile describes an agent's job, while this decides whether the machine binds a
listener, so it sits with `theme` and `proactive_wake`.

## Follow-ups

- **Remote clients are not detected.** If the editor is not on the machine
  running yolop (SSH, container, web editor), the browser opens in the wrong
  place and the page simply times out after ten minutes, with no message
  explaining why. The same limitation already applies to the Codex and
  OpenRouter browser logins. A liveness signal, or a "still waiting" nudge,
  would be the fix.
- **Codex device-code login still has no ACP path.** `authenticate` is a bare
  request/response with no stream attached, so there is nowhere to push a device
  code and verification URL mid-call. Unchanged by this PR, noted because the
  setup page does not solve it either.
- The local development environment for this change had no `doppler` CLI and no
  provider key, so the live-provider smoke was not run by hand; CI's **Live
  Provider Smoke (Doppler)** job covers it and is green on this commit. Noted
  rather than deferred: nothing is outstanding.
