### PR TITLE
refactor(control): derive the attached-administration hint from registered routes

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,18 @@
 # Knowledge Log
 
+## 2026-08-18, Attached administration is discovered from one prompt block
+
+- [Extensions](specs/extensions.md): the discovery hint for attached
+  `yolop <subcommand> ...` administration moved out of the Bash tool
+  description, which hardcoded `extensions` and advertised it even where no
+  control route was registered, and never mentioned `coordination`.
+- `ControlPlaneCapability` renders one system-prompt block from the routes
+  registered in the session. A capability contributing a CLI route supplies a
+  one-clause `ControlRoute::summary` and no prompt prose of its own, so routes
+  do not each grow a block.
+- No registered route means no capability and no block, so the prompt never
+  names a surface the session lacks.
+
 ## 2026-08-18, Local session coordination
 
 - Added [Session coordination](specs/session-coordination.md): an opt-in local

--- a/knowledge/specs/conversational-control.md
+++ b/knowledge/specs/conversational-control.md
@@ -85,6 +85,15 @@ Notes:
   settings file. The *live* equivalents are the `set_*` tools above.
 - `run_command` is gated to the interactive TUI because its effects (clearing
   the transcript, quitting) only exist there; see [`commands.md`](./commands.md).
+- **Attached administration is the deliberate exception to "a model-facing tool".**
+  Extension and coordination administration is reachable conversationally by
+  running `yolop <subcommand> ...` in the foreground Bash tool, which the host
+  attaches to the live session, rather than by tool schemas that would cost
+  context every turn. It still meets the rest of this contract: live effect,
+  no confirmation overlay, one shared implementation behind the CLI, `/command`,
+  and control plane. Discoverability comes from the single control-plane prompt
+  block described in [`extensions.md`](./extensions.md), not from per-capability
+  prompt text.
 
 ## Known gap
 

--- a/knowledge/specs/extensions.md
+++ b/knowledge/specs/extensions.md
@@ -255,9 +255,16 @@ redirection, quoting, substitutions, and background execution receive no
 attachment and run as ordinary shell commands. Attached failure never falls
 back to detached global mutation.
 
-The Bash description provides the discovery hint; the capability-contributed
-Clap definition remains the canonical grammar and `yolop extensions --help`
-the detailed catalog. `/extensions` parses that same action grammar.
+Discovery is one shared system-prompt block owned by the control plane, not the
+Bash tool description and not a per-capability contribution: `ControlPlaneCapability`
+renders every route registered in the session from its `ControlRoute::summary`,
+states the direct-invocation rules once, and points at `yolop <subcommand> --help`.
+A session with no registered route contributes nothing, so the prompt never names
+a surface that session lacks. A capability contributing a CLI route therefore
+supplies one summary clause and no prompt prose of its own. The
+capability-contributed Clap definition remains the canonical grammar and
+`yolop extensions --help` the detailed catalog. `/extensions` parses that same
+action grammar.
 Model-visible extension management tools are
 intentionally absent, while the management command and commands contributed by
 enabled extension packages remain in the capability command registry.

--- a/src/capabilities/session_coordination.rs
+++ b/src/capabilities/session_coordination.rs
@@ -34,6 +34,15 @@ use std::time::Duration;
 pub(crate) const SESSION_COORDINATION_CAPABILITY_ID: &str = "session_coordination";
 pub(crate) const SESSION_DISPATCH_TASK_KIND: &str = "session_dispatch";
 const COORDINATION_COMMAND: &str = "coordination";
+
+/// See `EXTENSIONS_CONTROL_ROUTE`: a constant keeps the route measurable by the
+/// always-on prompt budget.
+pub(crate) const COORDINATION_CONTROL_ROUTE: ControlRoute = ControlRoute {
+    resource: SESSION_COORDINATION_CAPABILITY_ID,
+    cli_subcommand: COORDINATION_COMMAND,
+    read_only_operations: &["list", "status"],
+    summary: "inspect and steer coordination between local Yolop sessions",
+};
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(2);
 const INBOX_INTERVAL: Duration = Duration::from_millis(350);
 const PRESENCE_LEASE_MS: i64 = 15_000;
@@ -1381,11 +1390,7 @@ impl From<CoordinationCliCommand> for CoordinationAction {
 #[async_trait]
 impl ControlCapability for SessionCoordinationCapability {
     fn control_route(&self) -> ControlRoute {
-        ControlRoute {
-            resource: SESSION_COORDINATION_CAPABILITY_ID,
-            cli_subcommand: COORDINATION_COMMAND,
-            read_only_operations: &["list", "status"],
-        }
+        COORDINATION_CONTROL_ROUTE
     }
     async fn execute_control(&self, action: &Value) -> ToolExecutionResult {
         match serde_json::from_value::<CoordinationAction>(action.clone()) {

--- a/src/control.rs
+++ b/src/control.rs
@@ -50,6 +50,12 @@ pub struct ControlRoute {
     pub resource: &'static str,
     pub cli_subcommand: &'static str,
     pub read_only_operations: &'static [&'static str],
+    /// One clause naming what the subcommand administers, rendered into the
+    /// single shared control-plane prompt block. Capabilities contribute this
+    /// datum only: the prose, the attachment rules, and the discovery pointer
+    /// are written once in `ControlPlaneCapability`, so a new CLI route adds a
+    /// line rather than a prompt section of its own.
+    pub summary: &'static str,
 }
 
 /// Optional control-plane facet for an ordinary runtime capability.
@@ -199,6 +205,9 @@ impl ControlResponse {
 #[async_trait]
 pub trait ControlService: Send + Sync {
     fn route(&self, cli_subcommand: &str) -> Option<ControlRoute>;
+    /// Every registered route, ordered by subcommand so the derived prompt
+    /// block is stable across sessions (and stays cacheable).
+    fn routes(&self) -> Vec<ControlRoute>;
     async fn execute(&self, request: ControlRequest) -> ControlResponse;
     fn render(&self, request: &ControlRequest, response: &ControlResponse) -> String;
 }
@@ -238,6 +247,16 @@ impl ControlService for ControlRegistry {
             .map(|capability| capability.control_route())
     }
 
+    fn routes(&self) -> Vec<ControlRoute> {
+        let mut routes: Vec<ControlRoute> = self
+            .resources
+            .values()
+            .map(|capability| capability.control_route())
+            .collect();
+        routes.sort_by_key(|route| route.cli_subcommand);
+        routes
+    }
+
     async fn execute(&self, request: ControlRequest) -> ControlResponse {
         if request.version != CONTROL_VERSION {
             return ControlResponse::error(format!(
@@ -259,6 +278,71 @@ impl ControlService for ControlRegistry {
             .get(&request.resource)
             .map(|capability| capability.render_control(&request.action, response))
             .unwrap_or_else(|| response.render_default())
+    }
+}
+
+pub const CONTROL_PLANE_CAPABILITY_ID: &str = "control_plane";
+
+/// The single system-prompt contribution describing attached administration.
+///
+/// Administration is deliberately not a set of model tools (their schemas would
+/// cost context every turn), so the agent has to learn the affordance some other
+/// way. It is stated once, here, and derived from the routes actually registered
+/// in this session: a session without a control route registers no capability
+/// and says nothing, and a new `ControlCapability` is described by its own
+/// `ControlRoute::summary` without touching this text or adding a block of its
+/// own. The Bash tool description stays free of resource-specific vocabulary.
+pub struct ControlPlaneCapability {
+    prompt: String,
+}
+
+impl ControlPlaneCapability {
+    /// `None` when nothing is registered, so the block is never a promise the
+    /// session cannot keep.
+    pub fn new(routes: &[ControlRoute]) -> Option<Self> {
+        if routes.is_empty() {
+            return None;
+        }
+        let mut prompt = format!("<capability id=\"{CONTROL_PLANE_CAPABILITY_ID}\">\n");
+        prompt.push_str(
+            "Administer this session by running `yolop <subcommand> ...` in the foreground bash \
+             tool: it attaches to the running session and takes effect live. Run \
+             `yolop <subcommand> --help` for the operations; there are no equivalent tools.\n",
+        );
+        for route in routes {
+            prompt.push_str(&format!(
+                "- `{}`, {}\n",
+                route.cli_subcommand, route.summary
+            ));
+        }
+        prompt.push_str(
+            "Invoke it directly: a pipeline, redirection, quoting, substitution, or `&` runs as \
+             ordinary shell and loses the attachment.\n</capability>",
+        );
+        Some(Self { prompt })
+    }
+}
+
+#[async_trait]
+impl Capability for ControlPlaneCapability {
+    fn id(&self) -> &str {
+        CONTROL_PLANE_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Control plane"
+    }
+
+    fn description(&self) -> &str {
+        "Attached administration of the running session through the `yolop` CLI."
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(&self.prompt)
+    }
+
+    fn tools(&self) -> Vec<Box<dyn everruns_core::Tool>> {
+        Vec::new()
     }
 }
 
@@ -453,6 +537,7 @@ mod tests {
                 resource: "extensions",
                 cli_subcommand: "extensions",
                 read_only_operations: &["list"],
+                summary: "administer extension packages",
             }
         }
 
@@ -593,5 +678,77 @@ mod tests {
         assert_eq!(invocation.request.resource, "extensions");
         assert_eq!(invocation.request.action["operation"], "enable");
         assert_eq!(invocation.request.action["name"], "demo");
+    }
+
+    #[test]
+    fn control_plane_prompt_is_absent_without_registered_routes() {
+        assert!(ControlPlaneCapability::new(&[]).is_none());
+    }
+
+    #[test]
+    fn control_plane_prompt_lists_every_registered_route() {
+        let registry = service();
+        let capability = ControlPlaneCapability::new(&ControlService::routes(&registry))
+            .expect("a registered route contributes the block");
+        let prompt = capability
+            .system_prompt_addition()
+            .expect("the block is the capability's contribution");
+        assert!(prompt.contains("- `extensions`, administer extension packages"));
+        // Discovery points at the contributed help, not at a duplicated grammar.
+        assert!(prompt.contains("`yolop <subcommand> --help`"));
+        assert!(prompt.contains("loses the attachment"));
+    }
+
+    #[test]
+    fn routes_are_ordered_so_the_prompt_prefix_stays_stable() {
+        let mut registry = ControlRegistry::default();
+        registry
+            .register(Arc::new(SecondTestControlCapability))
+            .expect("register");
+        registry
+            .register(Arc::new(TestControlCapability))
+            .expect("register");
+        let subcommands: Vec<&str> = ControlService::routes(&registry)
+            .iter()
+            .map(|route| route.cli_subcommand)
+            .collect();
+        assert_eq!(subcommands, vec!["coordination", "extensions"]);
+    }
+
+    struct SecondTestControlCapability;
+
+    #[async_trait]
+    impl Capability for SecondTestControlCapability {
+        fn id(&self) -> &str {
+            "coordination"
+        }
+
+        fn name(&self) -> &str {
+            "Coordination"
+        }
+
+        fn description(&self) -> &str {
+            "Test coordination administration."
+        }
+    }
+
+    #[async_trait]
+    impl ControlCapability for SecondTestControlCapability {
+        fn control_route(&self) -> ControlRoute {
+            ControlRoute {
+                resource: "coordination",
+                cli_subcommand: "coordination",
+                read_only_operations: &["list"],
+                summary: "steer local sessions",
+            }
+        }
+
+        async fn execute_control(&self, action: &Value) -> ToolExecutionResult {
+            ToolExecutionResult::Success(action.clone())
+        }
+
+        fn render_control(&self, _action: &Value, response: &ControlResponse) -> String {
+            response.render_default()
+        }
     }
 }

--- a/src/control.rs
+++ b/src/control.rs
@@ -303,8 +303,10 @@ impl ControlPlaneCapability {
         if routes.is_empty() {
             return None;
         }
-        let mut prompt = format!("<capability id=\"{CONTROL_PLANE_CAPABILITY_ID}\">\n");
-        prompt.push_str(
+        // No `<capability>` wrapper here: the default
+        // `Capability::system_prompt_contribution` wraps this text in
+        // `<capability id="control_plane">` when it assembles the prompt.
+        let mut prompt = String::from(
             "Administer this session by running `yolop <subcommand> ...` in the foreground bash \
              tool: it attaches to the running session and takes effect live. Run \
              `yolop <subcommand> --help` for the operations; there are no equivalent tools.\n",
@@ -317,7 +319,7 @@ impl ControlPlaneCapability {
         }
         prompt.push_str(
             "Invoke it directly: a pipeline, redirection, quoting, substitution, or `&` runs as \
-             ordinary shell and loses the attachment.\n</capability>",
+             ordinary shell and loses the attachment.",
         );
         Some(Self { prompt })
     }
@@ -683,6 +685,27 @@ mod tests {
     #[test]
     fn control_plane_prompt_is_absent_without_registered_routes() {
         assert!(ControlPlaneCapability::new(&[]).is_none());
+    }
+
+    /// Drives the real assembly entry point (`system_prompt_contribution`, what
+    /// the runtime calls when it builds the prompt), not just the constructor:
+    /// the default wraps the addition, so the block must not wrap itself.
+    #[tokio::test]
+    async fn control_plane_contribution_is_wrapped_exactly_once() {
+        let registry = service();
+        let capability = ControlPlaneCapability::new(&ControlService::routes(&registry))
+            .expect("a registered route contributes the block");
+        let ctx = everruns_core::capabilities::SystemPromptContext::without_file_store(
+            everruns_provider::typed_id::SessionId::new(),
+        );
+        let contribution = capability
+            .system_prompt_contribution(&ctx)
+            .await
+            .expect("the capability contributes to the assembled prompt");
+        assert_eq!(contribution.matches("<capability id=").count(), 1);
+        assert!(contribution.starts_with("<capability id=\"control_plane\">\n"));
+        assert!(contribution.ends_with("</capability>"));
+        assert!(contribution.contains("- `extensions`, administer extension packages"));
     }
 
     #[test]

--- a/src/exec/tools.rs
+++ b/src/exec/tools.rs
@@ -450,8 +450,7 @@ impl Tool for BashTool {
              relative to it, or chain within one call (`cd sub; cmd`). Captures \
              stdout/stderr with configurable verbosity. 120s timeout; run commands \
              that wait on external events (CI runs, deploys) detached via \
-             `spawn_background` instead. Invoke `yolop extensions ...` directly \
-             (without shell composition) to administer the current session."
+             `spawn_background` instead."
         }
         #[cfg(not(windows))]
         {
@@ -462,8 +461,7 @@ impl Tool for BashTool {
              it, or chain within one call (`cd sub && cmd`). Captures stdout/stderr \
              with configurable verbosity. 120s timeout; run commands that wait on \
              external events (CI runs, deploys) detached via `spawn_background` \
-             instead. Invoke `yolop extensions ...` directly (without shell \
-             composition) to administer the current session."
+             instead."
         }
     }
     fn parameters_schema(&self) -> Value {

--- a/src/exec/tools.rs
+++ b/src/exec/tools.rs
@@ -650,6 +650,18 @@ impl BackgroundExecutableTool for BashTool {
 
 #[cfg(test)]
 mod tests {
+
+    /// The Bash description must stay free of control-resource vocabulary: it
+    /// was hardcoded to `yolop extensions`, which named one of the session's
+    /// routes and advertised administration even where none is registered.
+    /// Discovery belongs to the shared control-plane prompt block.
+    #[test]
+    fn bash_description_does_not_name_control_resources() {
+        let tool = BashTool::new(Workspace::from_path(std::env::current_dir().unwrap()));
+        let description = Tool::description(&tool);
+        assert!(!description.contains("yolop extensions"));
+        assert!(!description.contains("administer"));
+    }
     use super::*;
     use everruns_builtins::ToolOutputPersistenceCapability;
     use everruns_core::Capability;

--- a/src/extensions/manage.rs
+++ b/src/extensions/manage.rs
@@ -36,6 +36,15 @@ use tokio::sync::mpsc::UnboundedSender;
 pub const EXTENSIONS_CAPABILITY_ID: &str = "extensions";
 const EXTENSIONS_COMMAND_NAME: &str = "extensions";
 
+/// A constant so the shared control-plane prompt block can be measured against
+/// the always-on prompt budget without constructing a session.
+pub(crate) const EXTENSIONS_CONTROL_ROUTE: ControlRoute = ControlRoute {
+    resource: EXTENSIONS_CAPABILITY_ID,
+    cli_subcommand: EXTENSIONS_CAPABILITY_ID,
+    read_only_operations: &["list"],
+    summary: "install, enable, configure, reload, and scaffold extension packages",
+};
+
 #[derive(Subcommand, Debug)]
 enum ExtensionCommand {
     /// List installed extensions.
@@ -415,11 +424,7 @@ impl Capability for ExtensionsCapability {
 #[async_trait]
 impl ControlCapability for ExtensionsCapability {
     fn control_route(&self) -> ControlRoute {
-        ControlRoute {
-            resource: EXTENSIONS_CAPABILITY_ID,
-            cli_subcommand: EXTENSIONS_CAPABILITY_ID,
-            read_only_operations: &["list"],
-        }
+        EXTENSIONS_CONTROL_ROUTE
     }
 
     async fn execute_control(&self, action: &Value) -> ToolExecutionResult {

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -29,6 +29,10 @@ pub(crate) mod trace;
 
 pub(crate) use capability::ExtensionCapability;
 pub(crate) use client::{AskSink, StatusSink};
+/// Exported for the always-on prompt-budget test, which measures the shared
+/// control-plane block from the routes a full session registers.
+#[cfg(test)]
+pub(crate) use manage::EXTENSIONS_CONTROL_ROUTE;
 pub(crate) use manage::ExtensionsCapability;
 pub(crate) use manager::LiveProcessRegistry;
 pub(crate) use package::{

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2610,6 +2610,25 @@ fn push_before_environment_context(caps: &mut Vec<CapabilityRef>, cap: Capabilit
     }
 }
 
+/// Register-and-enable the shared control-plane block as one step.
+///
+/// Registering a capability is not enough: one the harness never enables
+/// contributes nothing (see the `SkillManagementCapability` note in
+/// `default_coding_harness_capabilities`). Keeping both halves here means the
+/// block cannot be registered without being enabled, and cannot claim routes
+/// the session does not have.
+fn enable_control_plane(
+    caps: &mut Vec<CapabilityRef>,
+    routes: &[crate::control::ControlRoute],
+) -> Option<crate::control::ControlPlaneCapability> {
+    let capability = crate::control::ControlPlaneCapability::new(routes)?;
+    push_before_environment_context(
+        caps,
+        CapabilityRef::new(crate::control::CONTROL_PLANE_CAPABILITY_ID),
+    );
+    Some(capability)
+}
+
 fn coding_harness_capabilities(
     client_commands: bool,
     hook_config: Option<serde_json::Value>,
@@ -3836,7 +3855,8 @@ pub async fn build_with_options(
     // One shared prompt block for every attached CLI route, derived from what is
     // actually registered above. Capabilities describe their route via
     // `ControlRoute::summary`; none of them contributes prompt prose of its own.
-    let control_plane = crate::control::ControlPlaneCapability::new(
+    let control_plane = enable_control_plane(
+        &mut harness_capabilities,
         &crate::control::ControlService::routes(&session_control_registry),
     );
     let session_control: Option<Arc<dyn crate::control::ControlService>> =
@@ -9030,6 +9050,50 @@ mod tests {
     /// not a silent side effect.
     ///
     /// Before the Claude-5-generation prompt pass this totalled ~9,000 bytes.
+    /// The block only reaches the model if the harness *enables* it; being
+    /// registered is not enough. A live smoke caught exactly this: the block was
+    /// registered, the session still knew nothing about `yolop extensions`.
+    #[test]
+    fn control_plane_is_enabled_on_the_harness_when_routes_exist() {
+        use crate::capabilities::session_coordination::COORDINATION_CONTROL_ROUTE;
+        use crate::control::CONTROL_PLANE_CAPABILITY_ID;
+        use crate::extensions::EXTENSIONS_CONTROL_ROUTE;
+
+        let mut caps = coding_harness_capabilities(false, None, &Settings::default());
+        let capability = enable_control_plane(
+            &mut caps,
+            &[COORDINATION_CONTROL_ROUTE, EXTENSIONS_CONTROL_ROUTE],
+        );
+        assert!(
+            capability.is_some(),
+            "routes must contribute the capability"
+        );
+        let position = caps
+            .iter()
+            .position(|cap| cap.capability_id() == CONTROL_PLANE_CAPABILITY_ID)
+            .expect("the harness must enable the control plane, not just register it");
+        // Environment context stays last so the prompt prefix remains cacheable.
+        if let Some(environment) = caps
+            .iter()
+            .position(|cap| cap.capability_id() == ENVIRONMENT_CONTEXT_CAPABILITY_ID)
+        {
+            assert!(position < environment);
+        }
+    }
+
+    #[test]
+    fn control_plane_is_not_enabled_without_routes() {
+        use crate::control::CONTROL_PLANE_CAPABILITY_ID;
+
+        let mut caps = coding_harness_capabilities(false, None, &Settings::default());
+        assert!(enable_control_plane(&mut caps, &[]).is_none());
+        assert!(
+            !caps
+                .iter()
+                .any(|cap| cap.capability_id() == CONTROL_PLANE_CAPABILITY_ID)
+        );
+    }
+
     #[test]
     fn always_on_capability_prompts_within_budget() {
         use crate::capabilities::approval::render_approval_block;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3833,8 +3833,17 @@ pub async fn build_with_options(
         session_control_registry.register(management.clone())?;
         capabilities.register_arc(management);
     }
+    // One shared prompt block for every attached CLI route, derived from what is
+    // actually registered above. Capabilities describe their route via
+    // `ControlRoute::summary`; none of them contributes prompt prose of its own.
+    let control_plane = crate::control::ControlPlaneCapability::new(
+        &crate::control::ControlService::routes(&session_control_registry),
+    );
     let session_control: Option<Arc<dyn crate::control::ControlService>> =
         Some(Arc::new(session_control_registry));
+    if let Some(control_plane) = control_plane {
+        capabilities.register(control_plane);
+    }
     // Server name list for `/mcp` and StartupInfo, computed after extension
     // contributions are merged so provider-provenance entries show up too.
     let mut mcp_server_names: Vec<String> = mcp_servers.keys().cloned().collect();
@@ -9028,10 +9037,17 @@ mod tests {
         use crate::capabilities::background::BACKGROUND_SYSTEM_PROMPT;
         use crate::capabilities::client_commands::CLIENT_COMMANDS_PROMPT;
         use crate::capabilities::host::MODELS_PROMPT;
+        use crate::capabilities::session_coordination::COORDINATION_CONTROL_ROUTE;
         use crate::config::ApprovalMode;
+        use crate::control::ControlPlaneCapability;
+        use crate::extensions::EXTENSIONS_CONTROL_ROUTE;
+        use everruns_core::Capability as _;
 
-        // Current total is 5,657; the headroom is deliberately thin.
-        const MAX_BYTES: usize = 5_800;
+        // Current total is 6,231; the headroom is deliberately thin. The
+        // control-plane block is what a full session renders (both routes
+        // registered): it replaces per-route prompt text, so adding a CLI route
+        // costs one line here rather than a block.
+        const MAX_BYTES: usize = 6_400;
 
         let approval = render_approval_block(ApprovalMode::Normal).expect("normal contributes");
         let blocks: Vec<(&str, usize)> = vec![
@@ -9041,6 +9057,15 @@ mod tests {
             ("client_commands", CLIENT_COMMANDS_PROMPT.len()),
             ("setup", MODELS_PROMPT.len()),
             ("attribution", yolop_attribution_prompt().len()),
+            (
+                "control_plane",
+                ControlPlaneCapability::new(&[
+                    COORDINATION_CONTROL_ROUTE,
+                    EXTENSIONS_CONTROL_ROUTE,
+                ])
+                .and_then(|capability| capability.system_prompt_addition().map(str::len))
+                .expect("registered routes contribute the block"),
+            ),
         ];
 
         let total: usize = blocks.iter().map(|(_, bytes)| bytes).sum();

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -9043,11 +9043,11 @@ mod tests {
         use crate::extensions::EXTENSIONS_CONTROL_ROUTE;
         use everruns_core::Capability as _;
 
-        // Current total is 6,231; the headroom is deliberately thin. The
+        // Current total is 6,185; the headroom is deliberately thin. The
         // control-plane block is what a full session renders (both routes
         // registered): it replaces per-route prompt text, so adding a CLI route
         // costs one line here rather than a block.
-        const MAX_BYTES: usize = 6_400;
+        const MAX_BYTES: usize = 6_300;
 
         let approval = render_approval_block(ApprovalMode::Normal).expect("normal contributes");
         let blocks: Vec<(&str, usize)> = vec![


### PR DESCRIPTION
## What changed

The agent learns about attached administration (`yolop <subcommand> ...` run in
foreground Bash, which the host attaches to the live session) from one shared
system-prompt block instead of a hardcoded sentence in the Bash tool description.

`ControlPlaneCapability` owns that block and renders it from the control routes
the session actually registered. A capability exposing a CLI route contributes a
one-clause `ControlRoute::summary`, never prompt prose, so a new route costs a
line rather than a prompt section of its own. With no route registered, the
capability is neither registered nor enabled and the prompt says nothing.

Behavior differences for the agent:

- `coordination` is now discoverable. It has been a registered route since local
  session coordination landed, but the hardcoded sentence named only
  `extensions`, so nothing told the agent the route existed.
- Sessions with no control route no longer advertise administration they cannot
  perform.
- The hint now points at `yolop <subcommand> --help`, the canonical grammar, so
  discovery leads somewhere instead of naming one word.

The Bash description is back to shell semantics only.

## Why

The hint was in the wrong place. It hardcoded one resource in a tool description
that is emitted regardless of which capabilities are active, so it was
simultaneously stale (silent about `coordination`), wrong in sessions without a
control route, and a maintenance trap: every future `ControlCapability` would
have had to remember to edit `exec/tools.rs`.

The alternative, each CLI-exposing capability contributing its own prompt block,
was rejected deliberately: it multiplies prompt sections per route and lets the
attachment rules drift between copies. Capabilities contribute a datum; the
prose lives once.

## Before / After

Bash tool description, before:

```
... run commands that wait on external events (CI runs, deploys) detached via
`spawn_background` instead. Invoke `yolop extensions ...` directly (without
shell composition) to administer the current session.
```

After: that final sentence is gone.

The effect on the agent, from a live-provider run in an **empty workspace**, so
the session cannot read this repository and the prompt block is the only possible
source. Same prompt both times: *"Which yolop CLI subcommands can you run to
administer this running session, and what happens if you pipe one into another
command?"*

Before:

```
The CLI subcommands are `yolop version`, `yolop into zed`, and
`yolop worktree list|prune` — none of these administer a *running* session; live
session control happens through slash commands (e.g. `/model`, `/goal`,
`/background`) and tools inside the session, not the CLI.
```

After:

```
Available subcommands: `yolop coordination` (inspect/steer coordination between
local Yolop sessions) and `yolop extensions` (install, enable, configure, reload,
and scaffold extension packages).

If you pipe, redirect, quote, substitute, or background it (`&`), it runs as
ordinary shell and loses the live session attachment — so it won't administer
this running session.
```

The block itself, in a session with both routes registered:

```
<capability id="control_plane">
Administer this session by running `yolop <subcommand> ...` in the foreground bash tool: it attaches to the running session and takes effect live. Run `yolop <subcommand> --help` for the operations; there are no equivalent tools.
- `coordination`, inspect and steer coordination between local Yolop sessions
- `extensions`, install, enable, configure, reload, and scaffold extension packages
Invoke it directly: a pipeline, redirection, quoting, substitution, or `&` runs as ordinary shell and loses the attachment.
</capability>
```

Prompt cost, from the always-on budget test: total moves 5,657 → 6,185 bytes
(`control_plane` is 515 of that), against a cap raised 5,800 → 6,300. The block
joins that budget deliberately, so its cost stays a visible edit to a cap rather
than a silent addition.

CLI surfaces are unchanged: `yolop extensions list` and
`yolop coordination --help` behave as before.

## Risk

- Low
- The block is assembled per session from registered routes. A capability that
  forgets `ControlRoute::summary` cannot compile, so a route cannot silently
  render an empty clause.
- Registration and harness enablement happen in one helper (`enable_control_plane`),
  so the block cannot be registered without being enabled, and cannot claim
  routes the session does not have.
- Attached administration itself is untouched: the `direct_control_args`
  recognizer, the approval gating for non-read-only operations, and the one-shot
  pipe transport are unchanged.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

Two defects were found while validating this change, and each is now pinned by a
test that fails without its fix:

- **The block wrapped itself.** `Capability::system_prompt_contribution` already
  wraps a `system_prompt_addition` in `<capability id="…">`, so the prompt would
  have carried nested tags. `control_plane_contribution_is_wrapped_exactly_once`
  drives that real assembly entry point rather than the constructor.
- **The block was registered but never enabled**, so it never reached the model
  at all: a capability the harness does not enable contributes nothing, as the
  `SkillManagementCapability` comment in `default_coding_harness_capabilities`
  already warned. Caught by the live smoke above, not by any unit test.
  `control_plane_is_enabled_on_the_harness_when_routes_exist` now fails without
  the fix; `control_plane_is_not_enabled_without_routes` covers the other branch.

Also: `control_plane_prompt_is_absent_without_registered_routes`,
`control_plane_prompt_lists_every_registered_route`,
`routes_are_ordered_so_the_prompt_prefix_stays_stable` (an unstable block would
break the provider cache prefix), `bash_description_does_not_name_control_resources`,
and `always_on_capability_prompts_within_budget` now measuring the block.

Validation: full suite (1,179 + 63 + 1 + 5), `cargo fmt --check`, `cargo clippy
--all-targets --all-features -D warnings`, `validate_okf.py --check-links`,
offline `--provider llmsim` boot, `yolop extensions list` and
`yolop coordination --help`, and the live Anthropic smokes quoted above (a
follow-up smoke confirms the agent can also explain how to enable an extension
live). The OpenAI provider was tried first and returned
`credit_balance_exhausted`, so the live smoke ran on Anthropic.

## Knowledge

Updated concepts:

- `knowledge/specs/extensions.md`: the "The Bash description provides the
  discovery hint" paragraph was made wrong by this change and now describes the
  control-plane block, including the rule that a route contributes a summary
  clause and no prompt prose.
- `knowledge/specs/conversational-control.md`: records attached administration as
  the deliberate exception to that spec's "every control has a model-facing tool"
  contract, and where its discoverability comes from. The spec previously did not
  mention the exception at all, so a reader could not tell it was intended.
- `knowledge/log.md`: entry for the above.

## Security

Reviewed against the threat-model categories in `.agents/skills/ship/SKILL.md`:

- **TM-LLM** (prompt construction): the block is built from `&'static str`
  summaries on compiled-in capabilities. No user, workspace, or extension-package
  text reaches it, so an installed extension cannot inject prompt content through
  a route summary. Nothing is logged or persisted; no key handling is touched.
- **TM-BASH**: `exec/tools.rs` changes only description text. Timeouts, per-stream
  output caps, and the bounded execution model are untouched, as is
  `direct_control_args`, so the narrow attached grammar and the host-approval gate
  for non-read-only operations are unchanged.
- **TM-TOOL**: `ControlPlaneCapability` registers no tools, no commands, and
  performs no filesystem or process work; it holds one `String`.
- **TM-DEP**: no dependency changes.
- **TM-FS**: not touched.

## Follow-ups

- `docs/extensions.md` still describes administration accurately (a CLI surface,
  not model tools) and needs no edit, but it does not mention how the agent
  discovers the surface. Left alone rather than expanding public docs with
  prompt-internals detail.
