### PR TITLE
refactor(deps): move local persistence to the everruns facade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2185,6 +2185,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501c89436474cc2ea55cdc29aa7cbaf96e76124ddf38c3b987c7f7deafb3c5fa"
+dependencies = [
+ "async-trait",
+ "base64 0.23.1",
+ "chrono",
+ "chrono-tz",
+ "cron",
+ "dirs",
+ "everruns-capability",
+ "everruns-core",
+ "everruns-host",
+ "everruns-llmsim",
+ "everruns-platform",
+ "everruns-provider",
+ "futures",
+ "libc",
+ "parking_lot",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid 1.24.0",
+]
+
+[[package]]
 name = "everruns-anthropic"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2288,23 +2319,21 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "659628ca31034c67f5bf8b964e1a4bf022758337640cce5631dc2d1c6d537d32"
+checksum = "8464f929f88aeec540f993fe4e93aa131da6c2c8daad3f4f9fc4608e1574e72d"
 dependencies = [
  "async-trait",
  "chrono",
  "everruns-capability",
  "everruns-core",
  "everruns-engine",
- "everruns-http",
  "everruns-mcp",
- "everruns-platform",
  "everruns-provider",
- "everruns-session-services",
  "futures",
  "ignore",
  "regex",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -2421,9 +2450,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-llmsim"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d080e173f960e97c18f8e6b686c41e746b1b8d67c7b168d1cd2ea475931d9b"
+checksum = "c3528e1522c2f21e5f50ad190861808f4e94ab394c95bc70b946a6002d1c446e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2436,38 +2465,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "everruns-local"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c60de03e14c6e9ca9f9ee07758727b89de362e23a99eb9e9c52a3081d50a465"
-dependencies = [
- "async-trait",
- "chrono",
- "chrono-tz",
- "cron",
- "dirs",
- "everruns-capability",
- "everruns-core",
- "everruns-host",
- "everruns-platform",
- "everruns-provider",
- "futures",
- "libc",
- "parking_lot",
- "rusqlite",
- "serde",
- "serde_json",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
- "uuid 1.24.0",
-]
-
-[[package]]
 name = "everruns-mcp"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45b388b48b09c79c9ce81e368cc6a980e07991e21b87cde06be105a020add481"
+checksum = "9b2e8dbe707e257dfc21c5de789fae47828f521753959f5edf915a1b05163bdb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2475,7 +2476,6 @@ dependencies = [
  "chrono",
  "everruns-capability",
  "everruns-core",
- "everruns-http",
  "everruns-provider",
  "rand 0.10.2",
  "serde",
@@ -2534,9 +2534,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-platform"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce423d274d96bd4c4fd48f059431dee46e9dd2a9d910a9da8a54df1ed9b4e13"
+checksum = "707e5e6b6b5fcb602b8e56b0a2e854a0971d7002839b21152e021eb6879f0ff0"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2546,8 +2546,8 @@ dependencies = [
  "everruns-builtins",
  "everruns-capability",
  "everruns-core",
+ "everruns-host",
  "everruns-provider",
- "everruns-session-services",
  "inventory",
  "jsonschema",
  "serde",
@@ -2585,44 +2585,6 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "uuid 1.24.0",
-]
-
-[[package]]
-name = "everruns-session-services"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194c4e00eed56dedaa2adb0fcd9b281f629fac53339f7c0c4a9f9c00f15df0de"
-dependencies = [
- "async-trait",
- "everruns-capability",
- "everruns-core",
- "everruns-provider",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "everruns-test-support"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f20e679dc9fa654b1f0c3b877ce43452c5e924691863e5175ed05f52a57783"
-dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "everruns-capability",
- "everruns-core",
- "everruns-engine",
- "everruns-host",
- "everruns-llmsim",
- "everruns-platform",
- "everruns-provider",
- "futures",
- "inventory",
- "serde",
- "serde_json",
- "tokio",
  "uuid 1.24.0",
 ]
 
@@ -10255,6 +10217,7 @@ dependencies = [
  "crossterm 0.29.0",
  "dirs",
  "eventsource-stream",
+ "everruns",
  "everruns-anthropic",
  "everruns-builtins",
  "everruns-capability",
@@ -10267,15 +10230,12 @@ dependencies = [
  "everruns-integrations-parallel",
  "everruns-integrations-web-fetch",
  "everruns-llmsim",
- "everruns-local",
  "everruns-mcp",
  "everruns-meta",
  "everruns-openai",
  "everruns-openrouter",
  "everruns-platform",
  "everruns-provider",
- "everruns-session-services",
- "everruns-test-support",
  "flate2",
  "futures",
  "hf-hub",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,26 +139,27 @@ everruns-core = "0.18.0"
 # The identity/platform family (PlatformStore and friends) moved out of
 # everruns-core into its own crate in 0.17.24; yolop implements PlatformStore
 # to route background-task wakes (src/runtime/background_wake.rs).
-# Pinned exactly: platform 0.18.1 requires everruns-host ^0.19.0, but
-# everruns-local 0.18.0 still pins host ^0.18.0 and has not been republished
-# for 0.19. Taking 0.18.1 resolves two copies of everruns-host, and
-# everruns-local then fails to compile against the newer session-store traits.
-# Drop the `=` once everruns-local is released against host 0.19.
-everruns-platform = "=0.18.0"
+everruns-platform = "0.18.1"
 everruns-openai = "0.18.0"
 everruns-meta = "0.18.0"
 # OpenRouter's first-class driver was split out of everruns-openai into its own
 # crate in 0.13.0; register it alongside openai to keep DriverId::OpenRouter.
 everruns-openrouter = "0.18.0"
-everruns-local = "0.18.0"
-everruns-mcp = { version = "0.18.0", features = ["stdio"] }
+# Filesystem persistence comes from the `everruns` facade's `local` feature, not
+# the standalone `everruns-local` crate: same SQLite, git-workspace, and durable
+# log backend, re-exported under `everruns::local`. `everruns-local` is published
+# only against host ^0.18.0, so depending on it pinned yolop off the 0.19 line.
+# Only the `local` feature is wanted; the facade's provider and capability
+# re-exports would duplicate the direct dependencies below.
+everruns = { version = "0.18.1", default-features = false, features = ["local"] }
+everruns-mcp = { version = "0.19.0", features = ["stdio"] }
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (knowledge/specs/mcp.md, upstream runtime-mcp.md D2).
 #
 # everruns-host replaces everruns-runtime, which upstream deleted in #3101 as a
 # 0.18 breaking change. Every host symbol yolop used moved here unchanged except
 # EventBus, which the canonical event log replaces.
-everruns-host = { version = "0.18.0", features = ["mcp-stdio"] }
+everruns-host = { version = "0.19.0", features = ["mcp-stdio"] }
 # The direct egress implementation moved out of everruns-core into its own
 # crate; yolop uses it for MCP OAuth discovery.
 # #3182 completed the library boundary cleanup: driver/model/provider types
@@ -166,17 +167,13 @@ everruns-host = { version = "0.18.0", features = ["mcp-stdio"] }
 everruns-provider = "0.18.0"
 everruns-builtins = "0.18.1"
 everruns-capability = "0.18.0"
-everruns-session-services = "0.18.0"
 everruns-http = "0.18.0"
 # Yolop ships `--provider llmsim` as a user-facing offline mode, not just a test
 # fixture, so the simulator is a production dependency. 0.18 split it into the
 # production-safe `everruns-llmsim`; `everruns-test-support` documents itself as
 # test-only and must not be used from production code. The `host` feature carries
 # the runtime-builder extension trait.
-everruns-llmsim = { version = "0.18.0", features = ["host"] }
-# Still required for `InMemoryMessageRetriever`, which has no home outside
-# test-support yet.
-everruns-test-support = "0.18.0"
+everruns-llmsim = { version = "0.18.1", features = ["host"] }
 # Filesystem and web-fetch capability implementations moved out of
 # everruns-core into their own integration crates (#3119).
 everruns-integrations-filesystem = "0.18.0"

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -180,6 +180,28 @@ wording, formatting, and link fixes do not need entries.
   and with an active selection `Ctrl+C` re-arms OSC 52 copy instead of
   interrupting. Typing still clears the selection.
 
+## 2026-08-17, Local persistence moves to the everruns facade
+
+- Filesystem persistence now comes from `everruns = { default-features = false,
+  features = ["local"] }` rather than the standalone `everruns-local` crate. The
+  facade re-exports the same backend under `everruns::local`, so every type yolop
+  used, `LocalBackends`, `LocalProfile`, `SqliteDb`, `LocalPlatformStore`,
+  `LocalSessionRunner`, `LocalScheduleStore`, `LocalScheduleRunnerHandle`,
+  `LocalSessionTaskRegistry`, `HostRoutedRunner`, and `WakeRoutes`, keeps its name
+  and shape. Same SQLite, git-workspace, and durable-log backend, verified by a
+  session that persists across two processes.
+- This is what unblocked `everruns-host` 0.19.0. `everruns-local` is published only
+  against host ^0.18.0, so depending on it resolved two copies of `everruns-host`
+  and held yolop on the 0.18 line. The facade depends on host ^0.19.0 and does not
+  use `everruns-local` at all.
+- **host 0.19 absorbed the session services.** `everruns-host::session_services`
+  now carries `SessionCapability`, `SessionStorageCapability`, and the
+  `write_session_title` tool. Registering the standalone
+  `everruns-session-services` copy against a 0.19 runtime compiles cleanly but
+  silently does nothing: the capability writes to a store the runtime no longer
+  reads, so session titles never update. Yolop takes the capability from
+  `everruns-host` and no longer depends on the standalone crate.
+
 ## 2026-08-17, Everruns 0.18.0 adoption; credentials leave model selection
 
 - Yolop is on the published Everruns 0.18.0 family, with no git dependency. The

--- a/src/capabilities/session_coordination.rs
+++ b/src/capabilities/session_coordination.rs
@@ -10,6 +10,7 @@ use crate::control::{
 use crate::runtime::background_wake::{WakeMessage, WakeSender};
 use async_trait::async_trait;
 use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
+use everruns::local::SqliteDb;
 use everruns_core::command::{
     CommandArg, CommandDescriptor, CommandExecutionContext, CommandResult, CommandSource,
     ExecuteCommandRequest,
@@ -20,7 +21,6 @@ use everruns_core::{
     SessionTaskUpdate, SystemPromptContext, TaskArtifact, TaskError, TaskLinks, TaskWakePolicy,
     Tool, ToolExecutionResult,
 };
-use everruns_local::SqliteDb;
 use everruns_provider::ToolHints;
 use everruns_provider::typed_id::SessionId;
 use rusqlite::{OptionalExtension, params};
@@ -196,7 +196,7 @@ impl CoordinationStore {
     }
 
     pub(crate) fn open(sessions_dir: &Path) -> anyhow::Result<Self> {
-        let profile = everruns_local::LocalProfile::new(sessions_dir.join("everruns-local"));
+        let profile = everruns::local::LocalProfile::new(sessions_dir.join("everruns-local"));
         profile.ensure_dirs()?;
         Self::new(SqliteDb::open(profile.db_path())?)
     }
@@ -1470,7 +1470,7 @@ fn render_coordination_response(action: &CoordinationAction, response: &ControlR
 #[cfg(test)]
 mod tests {
     use super::*;
-    use everruns_local::LocalSessionTaskRegistry;
+    use everruns::local::LocalSessionTaskRegistry;
 
     fn test_store() -> (CoordinationStore, Arc<LocalSessionTaskRegistry>) {
         let db = SqliteDb::open_in_memory().unwrap();

--- a/src/capabilities/session_tasks_override.rs
+++ b/src/capabilities/session_tasks_override.rs
@@ -303,12 +303,12 @@ pub(crate) async fn cancel_monitor_task(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use everruns::local::{LocalScheduleStore, LocalSessionTaskRegistry, SqliteDb};
     use everruns_core::session_schedule::SessionSchedule;
     use everruns_core::session_services::SessionScheduleStore;
     use everruns_core::{
         CreateSessionTask, SessionTaskRegistry, SessionTaskState, TASK_KIND_MONITOR, TaskWakePolicy,
     };
-    use everruns_local::{LocalScheduleStore, LocalSessionTaskRegistry, SqliteDb};
     use everruns_provider::typed_id::{PrincipalId, ScheduleId, SessionId};
     use serde_json::json;
     use std::sync::Arc;

--- a/src/editor/acp/server.rs
+++ b/src/editor/acp/server.rs
@@ -273,7 +273,7 @@ struct Session {
     /// `current_mode_update` instead of silently drifting from the picker.
     last_mode: StdMutex<ApprovalMode>,
     /// Retained for the ACP session lifetime so due local schedules keep polling.
-    _schedule_runner: everruns_local::LocalScheduleRunnerHandle,
+    _schedule_runner: everruns::local::LocalScheduleRunnerHandle,
     user_ask_store: Arc<UserAskStore>,
     user_ask_enabled: bool,
     task_registry: Arc<dyn everruns_core::session_task::SessionTaskRegistry>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1377,7 +1377,7 @@ fn detached_cli_registry() -> Result<control::CliRegistry> {
         .and_then(|dir| capabilities::CoordinationStore::open(&dir).ok())
     {
         Some(store) => store,
-        None => capabilities::CoordinationStore::new(everruns_local::SqliteDb::open_in_memory()?)?,
+        None => capabilities::CoordinationStore::new(everruns::local::SqliteDb::open_in_memory()?)?,
     };
     registry.register(Arc::new(
         capabilities::SessionCoordinationCapability::detached(coordination_store),

--- a/src/runtime/background_wake.rs
+++ b/src/runtime/background_wake.rs
@@ -7,13 +7,14 @@
 //! store that call is a silent no-op, which is why background completions never
 //! reached the yolop agent.
 //!
-//! yolop installs a [`LocalPlatformStore`](everruns_local::LocalPlatformStore)
-//! backed by Everruns' [`HostRoutedRunner`](everruns_local::HostRoutedRunner).
+//! yolop installs a [`LocalPlatformStore`](everruns::local::LocalPlatformStore)
+//! backed by Everruns' [`HostRoutedRunner`](everruns::local::HostRoutedRunner).
 //! Its inner [`WakeRunner`] enriches host wakes with Yolop's authenticated task
 //! handoff and drives child sessions synchronously through the in-process
 //! runtime.
 
 use async_trait::async_trait;
+use everruns::local::{HostRoutedRunner, LocalSessionRunner, WakeRoutes};
 use everruns_core::ExecutionSession;
 use everruns_core::InputMessage;
 use everruns_core::MessageRole;
@@ -21,7 +22,6 @@ use everruns_core::{PlatformCreateSessionRequest, PlatformMessage};
 use everruns_core::{SessionTask, SessionTaskRegistry};
 use everruns_core::{TaskTransition, wake_text_for};
 use everruns_host::{InProcessRuntime, RuntimeSessionStore, SessionBuilder};
-use everruns_local::{HostRoutedRunner, LocalSessionRunner, WakeRoutes};
 use everruns_provider::typed_id::{AgentId, HarnessId, SessionId};
 use everruns_provider::{AgentLoopError, Result};
 use serde::{Deserialize, Serialize};

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -57,12 +57,15 @@ use everruns_builtins::{
     TOOL_OUTPUT_PERSISTENCE_CAPABILITY_ID, TOOL_SEARCH_CAPABILITY_ID, ToolCallRepairCapability,
     ToolOutputPersistenceCapability, ToolSearchCapability,
 };
-use everruns_session_services::{
+// host 0.19 absorbed the session services; the standalone crate's copy writes to
+// a store this runtime no longer reads.
+use everruns_host::{
     SESSION_CAPABILITY_ID, SESSION_STORAGE_CAPABILITY_ID, SessionCapability,
     SessionStorageCapability,
 };
 // #3111/#3119 moved the hosted and environment capability implementations out
 // of everruns-core into the platform and integration crates.
+use everruns::local::{LocalBackends, LocalProfile, LocalScheduleRunnerHandle};
 use everruns_capability::CapabilityRef;
 use everruns_core::SessionStore;
 use everruns_core::SessionTaskRegistry;
@@ -90,7 +93,6 @@ use everruns_integrations_filesystem::{FileSystemCapability, SESSION_FILE_SYSTEM
 use everruns_integrations_web_fetch::{WEB_FETCH_CAPABILITY_ID, WebFetchCapability};
 use everruns_llmsim::LlmSimConfig;
 use everruns_llmsim::LlmSimRuntimeExt;
-use everruns_local::{LocalBackends, LocalProfile, LocalScheduleRunnerHandle};
 use everruns_mcp::{McpAuthProvider, McpAuthRequest, McpCredential};
 use everruns_platform::capabilities::{
     SESSION_TASKS_CAPABILITY_ID, SUBAGENTS_CAPABILITY_ID, SubagentCapability,
@@ -101,7 +103,6 @@ use everruns_provider::model_profiles::get_model_profile;
 use everruns_provider::typed_id::SessionId;
 use everruns_provider::{DriverId, ModelProfile, ReasoningEffortConfig, ReasoningEffortValue};
 use everruns_provider::{DriverRegistry, ProviderMetadata};
-use everruns_test_support::InMemoryMessageRetriever;
 use ignore::WalkBuilder;
 use regex::RegexBuilder;
 
@@ -3522,14 +3523,12 @@ pub async fn build_with_options(
         next_sequence,
         materializer.clone(),
     )?);
-    let message_store = Arc::new(InMemoryMessageRetriever::new());
     let checkpoints = Arc::new(CheckpointManager::open(
         session_id,
         session_dir.clone(),
         log_path.clone(),
         worktree.clone(),
         event_bus_typed.clone(),
-        message_store.clone(),
         replayed.max_sequence.unwrap_or(0),
     )?);
     let compaction_checkpoints =
@@ -3593,13 +3592,13 @@ pub async fn build_with_options(
     // `background_wake`; child sub-agent messages run synchronously through the
     // in-process runtime once it has been built below.
     let runtime_cell = Arc::new(std::sync::OnceLock::new());
-    let wake_runner = Arc::new(everruns_local::HostRoutedRunner::new(
+    let wake_runner = Arc::new(everruns::local::HostRoutedRunner::new(
         crate::runtime::background_wake::WakeRunner::new(
             runtime_cell.clone(),
             local_backends.runtime_backends.session_store.clone(),
             Some(task_registry.clone()),
         ),
-        everruns_local::WakeRoutes::new(),
+        everruns::local::WakeRoutes::new(),
     ));
     let (background_wake_tx, background_wake_rx) =
         crate::runtime::background_wake::register_host_route(wake_runner.clone(), session_id);

--- a/src/runtime/session_log.rs
+++ b/src/runtime/session_log.rs
@@ -972,6 +972,9 @@ fn message_from_event(data: &EventData) -> Option<Message> {
     }
 }
 
+// Only checkpoint tests project messages from events now: the runtime reads the
+// conversation back through the event log itself.
+#[cfg(test)]
 pub(crate) fn messages_from_events(events: &[Event]) -> Vec<Message> {
     events
         .iter()

--- a/src/session_state/checkpoint.rs
+++ b/src/session_state/checkpoint.rs
@@ -6,15 +6,12 @@
 //! user's branch, HEAD, or index.
 
 use crate::exec::worktree::WorktreeManager;
-use crate::runtime::session_log::{
-    JsonlEventEmitter, SessionMaterializer, messages_from_events, replay,
-};
+use crate::runtime::session_log::{JsonlEventEmitter, SessionMaterializer, replay};
 use anyhow::{Context, Result, anyhow, bail};
 use chrono::{DateTime, Utc};
 use everruns_core::Event;
 use everruns_core::SessionTaskRegistry;
 use everruns_provider::typed_id::SessionId;
-use everruns_test_support::InMemoryMessageRetriever;
 // TM-FS: upstream deprecated `WRITE_BLOCKLIST` in favour of
 // `WorkspacePolicy`. Swapping yolop's write-protection over is a
 // security-relevant change that deserves its own review rather than riding
@@ -217,7 +214,6 @@ pub struct CheckpointManager {
     worktree: Arc<WorktreeManager>,
     events: Arc<JsonlEventEmitter>,
     materializer: Arc<SessionMaterializer>,
-    messages: Arc<InMemoryMessageRetriever>,
     state: Mutex<TimelineState>,
     prepared: Mutex<Option<PreparedRestore>>,
     queued_confirmation: Mutex<Option<String>>,
@@ -258,7 +254,6 @@ impl CheckpointManager {
         log_path: PathBuf,
         worktree: Arc<WorktreeManager>,
         events: Arc<JsonlEventEmitter>,
-        messages: Arc<InMemoryMessageRetriever>,
         max_sequence: i32,
     ) -> Result<Self> {
         let timeline_path = session_dir.join(TIMELINE_FILE);
@@ -284,7 +279,6 @@ impl CheckpointManager {
             worktree,
             materializer: events.materializer(),
             events,
-            messages,
             state: Mutex::new(state),
             prepared: Mutex::new(None),
             queued_confirmation: Mutex::new(None),
@@ -685,9 +679,7 @@ impl CheckpointManager {
     async fn reseed_active_conversation(&self) -> Result<()> {
         let replayed = replay(&self.log_path, self.session_id)?;
         let active = self.filter_active_events(replayed.events);
-        let messages = messages_from_events(&active);
         self.events.replace_collected_events(active).await;
-        self.messages.seed(self.session_id, messages).await;
         Ok(())
     }
 
@@ -1228,7 +1220,7 @@ pub(crate) fn safe_display(value: &str) -> String {
 mod tests {
     use super::*;
     use crate::config::WorktreesMode;
-    use crate::runtime::session_log::{JsonlEventEmitter, session_log_path};
+    use crate::runtime::session_log::{JsonlEventEmitter, messages_from_events, session_log_path};
     use everruns_core::EventEmitter;
     use everruns_core::Message;
     use everruns_core::{EventContext, EventRequest, InputMessageData};
@@ -1263,7 +1255,6 @@ mod tests {
         let session_dir = session.path().to_path_buf();
         let log_path = session_log_path(&session_dir);
         let events = Arc::new(JsonlEventEmitter::open(&log_path, 1).expect("event emitter"));
-        let messages = Arc::new(InMemoryMessageRetriever::new());
         let info = crate::exec::worktree::WorktreeInfo {
             path: root.path().to_path_buf(),
             branch: "master".to_string(),
@@ -1279,16 +1270,8 @@ mod tests {
             Some(info),
         ));
         let manager = Arc::new(
-            CheckpointManager::open(
-                session_id,
-                session_dir,
-                log_path,
-                worktree,
-                events,
-                messages,
-                0,
-            )
-            .expect("checkpoint manager"),
+            CheckpointManager::open(session_id, session_dir, log_path, worktree, events, 0)
+                .expect("checkpoint manager"),
         );
         (root, session, manager)
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -242,7 +242,7 @@ pub struct App {
     /// knowledge/specs/background.md.
     background_wake: crate::runtime::background_wake::WakeReceiver,
     /// Retained for the TUI lifetime so due local schedules keep polling.
-    _schedule_runner: everruns_local::LocalScheduleRunnerHandle,
+    _schedule_runner: everruns::local::LocalScheduleRunnerHandle,
     /// Everruns session-task registry used by `spawn_background`; the TUI reads
     /// it for the background status segment and panel.
     task_registry: Arc<dyn SessionTaskRegistry>,

--- a/src/tui/session_tasks_view.rs
+++ b/src/tui/session_tasks_view.rs
@@ -598,6 +598,7 @@ mod tests {
     use super::*;
     use async_trait::async_trait;
     use chrono::Utc;
+    use everruns::local::{LocalSessionTaskRegistry, SqliteDb};
     use everruns_core::session_task::new_session_task;
     use everruns_core::{CreateSessionTask, ExecutionSession};
     use everruns_core::{
@@ -605,7 +606,6 @@ mod tests {
         TaskLinks,
     };
     use everruns_host::SessionBuilder;
-    use everruns_local::{LocalSessionTaskRegistry, SqliteDb};
     use everruns_provider::typed_id::{HarnessId, SessionId};
     use serde_json::json;
     use std::collections::HashMap;


### PR DESCRIPTION
## What changed

Two related cleanups that both remove a crate yolop should not have depended on, and
together unblock the everruns 0.19 line.

**The test-only message retriever is gone.** Yolop carried `everruns-test-support` as a
production dependency for a single type, `InMemoryMessageRetriever`, threaded through
`CheckpointManager` and seeded on every rewind. Nothing ever read it back: the only
operation on it anywhere was `seed`, and yolop registers no `MessageRetriever` consumer at
all, so the store was write-only. The runtime already reads the conversation back through
the event log.

**Local persistence comes from the facade.** `everruns-local` is replaced by
`everruns = { default-features = false, features = ["local"] }`, which re-exports the same
backend under `everruns::local`. All ten types yolop used keep their names and shapes, so
this is a namespace swap rather than a rewrite:

```
LocalBackends  LocalProfile  SqliteDb  LocalPlatformStore  LocalSessionRunner
LocalScheduleStore  LocalScheduleRunnerHandle  LocalSessionTaskRegistry
HostRoutedRunner  WakeRoutes
```

That swap is what unblocks `everruns-host` 0.19.0: `everruns-local` is published only
against `host ^0.18.0`, so depending on it resolved two copies of `everruns-host` and
pinned yolop to the 0.18 line. This takes host and mcp to 0.19.0, platform and llmsim to
0.18.1, and drops the platform version pin added in #589.

## Why

Upstream's guidance for embedders: use `HostBackends::in_memory()` rather than the
test-only retriever, and the facade's `local` feature rather than `everruns-local`. Both
halves applied here. The second is also the only way onto 0.19, since `everruns-local` is
superseded rather than lagging and is not going to be republished against the new host.

## Before / After

Dependency graph, every everruns crate resolving to a single version:

```
Before: everruns-host 0.18.0, everruns-local 0.18.0, everruns-test-support 0.18.0,
        everruns-platform pinned "=0.18.0", everruns-mcp 0.18.0
After:  everruns 0.18.1 (local), everruns-host 0.19.0, everruns-mcp 0.19.0,
        everruns-platform 0.18.1, everruns-llmsim 0.18.1
        everruns-local: absent   everruns-test-support: absent
        duplicates: NONE
```

Persistence verified end to end, not just compiled. A session written by one process and
read back by another:

```
$ yolop --provider anthropic --session $SID -p "Remember: my favorite number is 5142."
Acknowledged - I've saved that your favorite number is 5142.

$ yolop --provider anthropic --session $SID -p "What is my favorite number?"
5142
```

and the backend files on disk:

```
$SD/everruns-local/local.db          <- SQLite
$SD/session_.../events.jsonl         <- durable log
$SD/session_.../timeline.jsonl
```

Rewind behavior is unchanged: the removed `seed` call had no reader, so removing a write
with no corresponding read cannot alter what the runtime observes.

## Risk

- **Medium**
- The persistence backend is swapped, so the risk is data-shape drift rather than
  compilation. Mitigated by the cross-process resume above and by the existing checkpoint,
  session-task, and coordination suites, which exercise SQLite, schedules, and the task
  registry directly.
- One silent-failure mode surfaced and is fixed, described below. It is the reason this
  change is not purely mechanical.

## The session-services trap

host 0.19 absorbed the session services. `everruns-host::session_services` now owns
`SessionCapability`, `SessionStorageCapability`, and the `write_session_title` tool.

Registering the standalone `everruns-session-services` copy against a 0.19 runtime still
**compiles cleanly**, but the capability writes to a store the runtime no longer reads, so
session titles silently stop updating. Two existing tests caught it:

```
scripted_title_tool_updates_runtime_event_log_and_metadata
  left:  Some("yolop @ /tmp/.tmpSeO7qg")     <- default title, tool ran but had no effect
  right: Some("Automatic session titles")

real_turn_batches_independent_work_with_bookkeeping
  assertion failed: no SessionTitleUpdated event
```

The tool was dispatched, `tool_calls_count` was 1, and nothing errored. Yolop now takes the
capability from `everruns-host` and drops the standalone crate. This is another instance of
the standing rule that a clean compile is not evidence of adoption.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

No new test: this is a dependency and namespace change with no new behavior, and the
regression it could cause was caught by existing tests that assert the real entry point.
The removed retriever had no observable behavior to test.

## Knowledge

`knowledge/log.md` records that local persistence now comes from the facade with the full
type list, that this is what unblocked host 0.19.0, and the session-services absorption
with its silent-failure mode. Validated: 41 concepts, 0 errors.

## Security

Reviewed against the threat-model categories.

- **TM-DEP** is the substance of this change, and it is a net reduction: `everruns-local`,
  `everruns-test-support`, and `everruns-session-services` are all removed as direct
  dependencies, replaced by one facade entry with `default-features = false` so only the
  `local` feature is enabled. No new third-party surface. Every everruns crate resolves to
  a single version, verified against the resolved graph rather than the manifest.
- **TM-FS** deserves a note because the persistence backend moved: it is the same SQLite,
  git-workspace, and durable-log implementation re-exported, not a reimplementation, and
  the on-disk layout is unchanged (`everruns-local/local.db`, `events.jsonl`,
  `timeline.jsonl`). The write blocklist and `WriteBlocklistFileStore` are untouched.
- **TM-BASH / TM-LLM / TM-TOOL** untouched: no shell, prompt, key-handling, or capability
  registration changes beyond taking the session capability from its new home.

## Validation

- `cargo test --all-features`: 1172 unit, 63 integration, 5 pty, 1 doc, all passing
- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`: clean
- `python3 scripts/validate_okf.py knowledge --check-links`: 41 concepts, 0 errors
- Resolved-graph check: no duplicate everruns crates
- Live smoke through Doppler: tool-calling turn against anthropic, plus the cross-process
  session resume shown above
- Offline smoke: `--provider llmsim`

## Follow-ups

`No follow-ups.` The `everruns-test-support` item tracked on #582 is resolved here.
