### PR TITLE
feat(commands): run_command covers the whole registry, on every host

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -13,6 +13,17 @@
 - No registered route means no capability and no block, so the prompt never
   names a surface the session lacks.
 
+## 2026-08-18, run_command covers the whole command registry
+
+- [Commands](specs/commands.md): `run_command` no longer carries its own
+  allowlist of terminal commands. Client commands keep the `HostUi` path;
+  every other registered command is looked up in `runtime.list_commands` and
+  run through `runtime.execute_command`, so anything a user can type (for
+  example `/setup reauthenticate <provider>`) is reachable from a turn.
+- `Skill` commands stay prompt-activated and `/shell` stays typed-only.
+- [Conversational control](specs/conversational-control.md): the control-surface
+  inventory now names the whole registry rather than the terminal subset.
+
 ## 2026-08-18, Local session coordination
 
 - Added [Session coordination](specs/session-coordination.md): an opt-in local

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -13,16 +13,20 @@
 - No registered route means no capability and no block, so the prompt never
   names a surface the session lacks.
 
-## 2026-08-18, run_command covers the whole command registry
+## 2026-08-18, run_command covers the whole registry, on every host
 
 - [Commands](specs/commands.md): `run_command` no longer carries its own
-  allowlist of terminal commands. Client commands keep the `HostUi` path;
-  every other registered command is looked up in `runtime.list_commands` and
-  run through `runtime.execute_command`, so anything a user can type (for
-  example `/setup reauthenticate <provider>`) is reachable from a turn.
+  allowlist of terminal commands. A name is resolved against
+  `runtime.list_commands` and run through `runtime.execute_command`, so
+  anything a user can type (for example `/setup reauthenticate <provider>`) is
+  reachable from a turn. `command: help` returns the live list.
+- The tool moved out of the TUI-gated client capability into `agent_commands`,
+  registered on every host: ACP and `--print` sessions run the commands their
+  own registry holds. The terminal's `HostUi` is now optional, used only so
+  `/mcp` and `/tools` return the transcript lines the host printed.
 - `Skill` commands stay prompt-activated and `/shell` stays typed-only.
 - [Conversational control](specs/conversational-control.md): the control-surface
-  inventory now names the whole registry rather than the terminal subset.
+  inventory now names the whole registry, on every host.
 
 ## 2026-08-18, Local session coordination
 

--- a/knowledge/specs/commands.md
+++ b/knowledge/specs/commands.md
@@ -86,11 +86,18 @@ portable case ever arises.
    new on-screen effect is a host change, not a drop-in.
 4. **Natural-language dispatch.** In the interactive TUI, the same client
    capability exposes a model-facing `run_command` tool and a prompt
-   contribution listing the terminal commands. When the user asks for a
-   terminal-side action in ordinary prose (for example, "exit"), the model
-   invokes that tool; the tool emits the same `UiCommand` as the slash-command
-   path. The tool is TUI-gated with the capability and does not create a
-   second command registry.
+   contribution describing it. When the user asks for a command in ordinary
+   prose (for example, "exit" or "re-authenticate my provider"), the model
+   invokes that tool instead of telling the user to type the slash command.
+   `run_command` covers the **whole registry**, not a curated subset, and holds
+   no allowlist of its own: a client command emits the same `UiCommand` as the
+   slash-command path, and every other command is looked up in
+   `runtime.list_commands` and run through `runtime.execute_command`, exactly
+   as typing it would. An unknown name answers with the live command list.
+   Two commands stay out by design: `Skill` commands, which activate by prompt
+   rather than by a runtime effect, and `/shell`, which is typed-only because
+   the agent already has the `bash` tool. The tool is TUI-gated with the
+   capability and does not create a second command registry.
 5. **Host gating.** Client commands are enabled only for a host that can apply
    them. `BuildOptions::client_commands` registers `ClientCommandsCapability`
    and enables its harness id; the interactive TUI sets it, while ACP and
@@ -103,9 +110,11 @@ portable case ever arises.
 - `CommandDescriptor`, `CommandSource` (`System`/`Skill`), `CommandResult`, and
   `execute_command` are owned by `everruns-core`.
 - This spec owns yolop's command surface: the single-registry contract, the
-  client/terminal execution target, the `HostUi`/`UiCommand` port, and the host
-  gating. The terminal commands themselves live in
-  `src/capabilities/client_commands.rs`; the port lives in `src/tui/host_ui.rs`.
+  client/terminal execution target, the `HostUi`/`UiCommand` port, the
+  `CommandDispatch` registry port `run_command` uses, and the host gating. The
+  terminal commands themselves live in `src/capabilities/client_commands.rs`;
+  the host port lives in `src/tui/host_ui.rs` and the registry port is
+  implemented by `RuntimeCommandDispatch` in `src/runtime/mod.rs`.
 
 ## Related
 

--- a/knowledge/specs/commands.md
+++ b/knowledge/specs/commands.md
@@ -84,26 +84,36 @@ portable case ever arises.
    every queued `UiCommand` before the next render. The `UiCommand` vocabulary
    is the shared contract between client capabilities and the host, a genuinely
    new on-screen effect is a host change, not a drop-in.
-4. **Natural-language dispatch.** In the interactive TUI, the same client
-   capability exposes a model-facing `run_command` tool and a prompt
-   contribution describing it. When the user asks for a command in ordinary
-   prose (for example, "exit" or "re-authenticate my provider"), the model
-   invokes that tool instead of telling the user to type the slash command.
-   `run_command` covers the **whole registry**, not a curated subset, and holds
-   no allowlist of its own: a client command emits the same `UiCommand` as the
-   slash-command path, and every other command is looked up in
-   `runtime.list_commands` and run through `runtime.execute_command`, exactly
-   as typing it would. An unknown name answers with the live command list.
-   Two commands stay out by design: `Skill` commands, which activate by prompt
-   rather than by a runtime effect, and `/shell`, which is typed-only because
-   the agent already has the `bash` tool. The tool is TUI-gated with the
-   capability and does not create a second command registry.
+4. **Natural-language dispatch.** The `agent_commands` capability exposes a
+   model-facing `run_command` tool and a prompt contribution describing it.
+   When the user asks for a command in ordinary prose (for example, "exit" or
+   "re-authenticate my provider"), the model invokes that tool instead of
+   telling the user to type the slash command. `run_command` covers the
+   **whole registry** of the host it runs on, not a curated subset, and holds no
+   allowlist of its own: a name is resolved against `runtime.list_commands` and
+   run through `runtime.execute_command`, exactly as typing it would, so client
+   commands reach their capability and emit the same `UiCommand` as the typed
+   path. `command: help` returns the live list, and an unknown name answers with
+   it too. Two commands stay out by design: `Skill` commands, which activate by
+   prompt rather than by a runtime effect, and `/shell`, which is typed-only
+   because the agent already has the `bash` tool.
+
+   The tool is registered on **every host**, because every host has a registry;
+   what differs is what that registry holds (host gating below). The only
+   host-specific detail is read-back: where a `HostUi` exists, the
+   informational client commands (`/mcp`, `/tools`, `/help`, `/cwd`) are
+   dispatched through it so the tool result carries the transcript lines the
+   host printed instead of the empty `CommandResult` they return by design.
+   `run_command` does not create a second command registry.
 5. **Host gating.** Client commands are enabled only for a host that can apply
    them. `BuildOptions::client_commands` registers `ClientCommandsCapability`
    and enables its harness id; the interactive TUI sets it, while ACP and
    `--print` leave it off and therefore neither advertise nor dispatch terminal
-   commands. See [`acp.md`](./acp.md) for how the remaining `System`/`Skill`
-   commands surface over ACP.
+   commands. `AgentCommandsCapability` is not gated that way: it is registered
+   and enabled everywhere, so a `--print` or ACP session can run the commands
+   its own registry holds (`/setup`, `/background`, `/undo`, …) and simply has
+   no terminal commands to find. See [`acp.md`](./acp.md) for how the remaining
+   `System`/`Skill` commands surface over ACP.
 
 ## Ownership boundary
 
@@ -112,9 +122,10 @@ portable case ever arises.
 - This spec owns yolop's command surface: the single-registry contract, the
   client/terminal execution target, the `HostUi`/`UiCommand` port, the
   `CommandDispatch` registry port `run_command` uses, and the host gating. The
-  terminal commands themselves live in `src/capabilities/client_commands.rs`;
-  the host port lives in `src/tui/host_ui.rs` and the registry port is
-  implemented by `RuntimeCommandDispatch` in `src/runtime/mod.rs`.
+  terminal commands live in `src/capabilities/client_commands.rs`; `run_command`
+  and its registry port live in `src/capabilities/agent_commands.rs`; the host
+  port lives in `src/tui/host_ui.rs` and the registry port is implemented by
+  `RuntimeCommandDispatch` in `src/runtime/mod.rs`.
 
 ## Related
 

--- a/knowledge/specs/conversational-control.md
+++ b/knowledge/specs/conversational-control.md
@@ -71,7 +71,7 @@ command, an overlay confirmation, or a next-run-only settings write fail this ba
 | Skills, install/update by content | `write_skill` (upstream) |, |
 | Skills, uninstall | `delete_skill` |, |
 | Settings (provider/model/tokens/urls/capabilities, next-run) | `get_config` / `set_config` | `/setup`, `yolop-config` skill |
-| Terminal/UI actions (help, tools, mcp, cwd, status, model, effort, clear, quit) | `run_command` (TUI only) | the slash commands themselves |
+| Any registered slash command (terminal ones plus `/setup`, `/background`, `/undo`, `/redo`, `/rewind`, `/goal`, …) | `run_command` (TUI only) | the slash commands themselves |
 
 Notes:
 
@@ -94,6 +94,10 @@ Notes:
   and control plane. Discoverability comes from the single control-plane prompt
   block described in [`extensions.md`](./extensions.md), not from per-capability
   prompt text.
+- `run_command` dispatches the whole registry, not a curated subset: terminal
+  commands via the host port, everything else via `runtime.execute_command`.
+  `Skill` commands stay prompt-activated and `/shell` stays typed-only (the
+  agent has `bash`).
 
 ## Known gap
 

--- a/knowledge/specs/conversational-control.md
+++ b/knowledge/specs/conversational-control.md
@@ -71,7 +71,7 @@ command, an overlay confirmation, or a next-run-only settings write fail this ba
 | Skills, install/update by content | `write_skill` (upstream) |, |
 | Skills, uninstall | `delete_skill` |, |
 | Settings (provider/model/tokens/urls/capabilities, next-run) | `get_config` / `set_config` | `/setup`, `yolop-config` skill |
-| Any registered slash command (terminal ones plus `/setup`, `/background`, `/undo`, `/redo`, `/rewind`, `/goal`, …) | `run_command` (TUI only) | the slash commands themselves |
+| Any slash command the host's registry holds (`/setup`, `/background`, `/undo`, `/redo`, `/rewind`, `/goal`, plus the terminal ones in the TUI) | `run_command` (every host) | the slash commands themselves |
 
 Notes:
 
@@ -83,8 +83,6 @@ Notes:
   matches discovered models but is not an exact ID for the current provider.
 - `set_config` is intentionally next-run for provider/model edits, it edits the
   settings file. The *live* equivalents are the `set_*` tools above.
-- `run_command` is gated to the interactive TUI because its effects (clearing
-  the transcript, quitting) only exist there; see [`commands.md`](./commands.md).
 - **Attached administration is the deliberate exception to "a model-facing tool".**
   Extension and coordination administration is reachable conversationally by
   running `yolop <subcommand> ...` in the foreground Bash tool, which the host
@@ -94,10 +92,12 @@ Notes:
   and control plane. Discoverability comes from the single control-plane prompt
   block described in [`extensions.md`](./extensions.md), not from per-capability
   prompt text.
-- `run_command` dispatches the whole registry, not a curated subset: terminal
-  commands via the host port, everything else via `runtime.execute_command`.
-  `Skill` commands stay prompt-activated and `/shell` stays typed-only (the
-  agent has `bash`).
+- `run_command` runs on every host and dispatches the whole registry, not a
+  curated subset, through `runtime.execute_command`. Hosts differ only in what
+  their registry holds: terminal commands exist in the TUI, where the host port
+  also returns `/mcp` and `/tools` transcript output. `Skill` commands stay
+  prompt-activated and `/shell` stays typed-only (the agent has `bash`). See
+  [`commands.md`](./commands.md).
 
 ## Known gap
 

--- a/src/capabilities/agent_commands.rs
+++ b/src/capabilities/agent_commands.rs
@@ -1,0 +1,691 @@
+//! `run_command`: the agent's door into the session's command registry.
+//!
+//! Slash commands are contributed by capabilities and listed by
+//! `runtime.list_commands`, one registry per session (see
+//! [`crate::capabilities::client_commands`] for the terminal-side ones and
+//! `knowledge/specs/commands.md` for the contract). This capability gives the
+//! model the same door: `run_command` resolves a name against that live
+//! registry and executes it through `runtime.execute_command`, exactly as
+//! typing the slash command would. It keeps no allowlist, so a command becomes
+//! agent-reachable the moment a capability, extension, or MCP server registers
+//! it.
+//!
+//! Registered on every host. The registry differs per host (the TUI adds
+//! terminal commands ACP and `--print` never see), but the mechanism does not:
+//! whatever a host advertises, the agent can run. The optional [`HostUi`] port
+//! is the one host-specific detail: when a terminal is present, the informational
+//! terminal commands (`/mcp`, `/tools`, `/help`, `/cwd`) are dispatched through
+//! it so the tool result carries the transcript lines the host printed, instead
+//! of the empty `CommandResult` those commands return by design.
+
+use crate::capabilities::client_commands::ui_command_for;
+use crate::capabilities::narration::stable_labeled;
+use crate::tui::host_ui::HostUi;
+use async_trait::async_trait;
+use everruns_core::command::{CommandDescriptor, CommandResult, CommandSource};
+use everruns_core::tool_narration::{ToolNarrationPhase, arg_str, truncate};
+use everruns_core::{Capability, CapabilityStatus};
+use everruns_core::{Tool, ToolExecutionResult};
+use everruns_provider::ToolCall;
+use serde_json::{Value, json};
+use std::sync::Arc;
+
+pub(crate) const AGENT_COMMANDS_CAPABILITY_ID: &str = "yolop_agent_commands";
+
+pub(crate) const AGENT_COMMANDS_PROMPT: &str = r#"<capability id="yolop_agent_commands">
+`run_command` runs any slash command this session registers, not a fixed subset:
+`/setup status|login|reauthenticate <provider>`, `/background`, `/undo`,
+`/rewind`, `/goal`, and whatever else the host registers. Use `command: help`
+for the live list; an unknown name returns the available ones. Prefer running a
+command over telling the user to type it. Skill commands activate by prompt, so
+follow the skill instead. The result carries the command's own output.
+</capability>"#;
+
+/// Registry port for `run_command`: list the commands this session actually has
+/// and execute one through the runtime, the same path a typed slash command
+/// takes. Injected rather than hard-coded so the tool never keeps its own
+/// allowlist, and so commands contributed later (extensions, MCP, upstream
+/// capabilities) are reachable the moment they are registered.
+#[async_trait]
+pub(crate) trait CommandDispatch: Send + Sync {
+    async fn list(&self) -> everruns_provider::error::Result<Vec<CommandDescriptor>>;
+
+    async fn execute(
+        &self,
+        name: &str,
+        arguments: Option<String>,
+    ) -> everruns_provider::error::Result<CommandResult>;
+}
+
+pub(crate) struct AgentCommandsCapability {
+    dispatch: Arc<dyn CommandDispatch>,
+    /// Present only on hosts with a terminal transcript to read back.
+    ui: Option<Arc<dyn HostUi>>,
+}
+
+impl AgentCommandsCapability {
+    pub(crate) fn new(dispatch: Arc<dyn CommandDispatch>, ui: Option<Arc<dyn HostUi>>) -> Self {
+        Self { dispatch, ui }
+    }
+}
+
+#[async_trait]
+impl Capability for AgentCommandsCapability {
+    fn id(&self) -> &str {
+        AGENT_COMMANDS_CAPABILITY_ID
+    }
+    fn name(&self) -> &str {
+        "Agent Commands"
+    }
+    fn description(&self) -> &str {
+        "Runs this session's registered slash commands on the model's behalf."
+    }
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+    fn category(&self) -> Option<&str> {
+        Some("Examples")
+    }
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(AGENT_COMMANDS_PROMPT)
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![Box::new(RunCommandTool {
+            dispatch: self.dispatch.clone(),
+            ui: self.ui.clone(),
+        })]
+    }
+}
+
+struct RunCommandTool {
+    dispatch: Arc<dyn CommandDispatch>,
+    ui: Option<Arc<dyn HostUi>>,
+}
+
+impl RunCommandTool {
+    /// Run `name` through the live registry, mirroring the host's typed-slash
+    /// dispatch: unknown names list what is available, `Skill` commands stay
+    /// prompt-activated, and missing required arguments are reported instead of
+    /// sent on.
+    async fn dispatch_registry_command(
+        &self,
+        name: &str,
+        arg: Option<String>,
+    ) -> ToolExecutionResult {
+        let commands = match self.dispatch.list().await {
+            Ok(commands) => commands,
+            Err(error) => {
+                return ToolExecutionResult::tool_error(format!("list yolop commands: {error}"));
+            }
+        };
+        let available: Vec<&str> = commands.iter().map(|c| c.name.as_str()).collect();
+        let Some(descriptor) = commands.iter().find(|c| c.name == name) else {
+            // `help` is the documented discovery call, so answer it from the
+            // registry on hosts that have no `/help` command of their own.
+            if name == "help" {
+                return ToolExecutionResult::success(json!({
+                    "success": true,
+                    "command": "/help",
+                    "message": format!("available commands: {}", available.join(", "))
+                }));
+            }
+            return ToolExecutionResult::tool_error(format!(
+                "unknown yolop command: /{name}; available: {}",
+                available.join(", ")
+            ));
+        };
+        if descriptor.source == CommandSource::Skill {
+            return ToolExecutionResult::tool_error(format!(
+                "/{name} is a skill command: it activates by prompt, not by run_command. \
+                 Follow the skill's instructions directly."
+            ));
+        }
+        let missing: Vec<&str> = descriptor
+            .args
+            .iter()
+            .filter(|a| a.required)
+            .map(|a| a.name.as_str())
+            .collect();
+        if arg.is_none() && !missing.is_empty() {
+            return ToolExecutionResult::tool_error(format!(
+                "/{name} requires: {}",
+                missing.join(", ")
+            ));
+        }
+
+        let rendered = rendered_command(name, arg.as_deref());
+        match self.dispatch.execute(name, arg).await {
+            Ok(result) if result.success => {
+                let message = if result.message.is_empty() {
+                    format!("command applied: {rendered}")
+                } else {
+                    result.message
+                };
+                ToolExecutionResult::success(json!({
+                    "success": true,
+                    "command": rendered,
+                    "message": message
+                }))
+            }
+            Ok(result) if result.message.is_empty() => {
+                ToolExecutionResult::tool_error(format!("{rendered} failed"))
+            }
+            Ok(result) => ToolExecutionResult::tool_error(result.message),
+            Err(error) => ToolExecutionResult::tool_error(format!("{rendered} failed: {error}")),
+        }
+    }
+
+    /// Ask the terminal host to apply an informational client command and hand
+    /// back the lines it printed. Only reachable when a `HostUi` is present.
+    async fn request_from_host(
+        &self,
+        ui: &Arc<dyn HostUi>,
+        name: &str,
+        arg: Option<String>,
+    ) -> ToolExecutionResult {
+        let Some(command) = ui_command_for(name, arg.clone()) else {
+            return self.dispatch_registry_command(name, arg).await;
+        };
+        let rendered = rendered_command(name, arg.as_deref());
+        let reply_rx = ui.request(command);
+        let message = match tokio::time::timeout(std::time::Duration::from_secs(15), reply_rx).await
+        {
+            Ok(Ok(messages)) if !messages.is_empty() => messages.join("\n"),
+            Ok(_) => format!("command applied: {rendered}"),
+            Err(_) => format!(
+                "command queued for the interactive terminal host ({rendered}); \
+                 host did not return output in time"
+            ),
+        };
+        ToolExecutionResult::success(json!({
+            "success": true,
+            "command": rendered,
+            "message": message
+        }))
+    }
+}
+
+fn rendered_command(name: &str, arg: Option<&str>) -> String {
+    match arg {
+        Some(arg) => format!("/{name} {arg}"),
+        None => format!("/{name}"),
+    }
+}
+
+/// Whether `run_command` should wait for host transcript lines. These commands
+/// print to the transcript and return an empty `CommandResult`, so the registry
+/// path alone would tell the agent nothing.
+fn command_awaits_host_reply(name: &str) -> bool {
+    matches!(name, "mcp" | "tools" | "help" | "cwd")
+}
+
+#[async_trait]
+impl Tool for RunCommandTool {
+    fn narrate(
+        &self,
+        tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        let _ = locale;
+        let command = arg_str(&tool_call.arguments, &["command"]).map(|value| truncate(value, 48));
+        Some(stable_labeled("Run command", command, phase))
+    }
+
+    fn name(&self) -> &str {
+        "run_command"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Yolop command")
+    }
+
+    fn description(&self) -> &str {
+        "Execute any slash command this session registers, on behalf of a natural-language user \
+         request: `setup` (`command: setup`, `args: [reauthenticate, codex_browser]`), \
+         `background`, `undo`, `redo`, `rewind`, `goal`, and in the terminal also help, tools, \
+         mcp, cwd, status, model, effort, clear, and quit. Use `command: help` to list the live \
+         command set; an unknown name returns the available ones. Accepts command names with or \
+         without the leading slash; `exit` is an alias for `quit`. Skill commands activate by \
+         prompt and `shell` is typed-only, so neither runs here."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                // Deliberately not an enum: the command set is per session and
+                // grows with capabilities, extensions, and MCP servers, so the
+                // live registry validates the name at execution time.
+                "command": {
+                    "type": "string",
+                    "description": "Slash command name, with or without the leading slash, \
+                                    e.g. `setup`, `background`, `mcp`, `model`. Use `help` to list them."
+                },
+                "args": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Ordered command arguments, e.g. [`reload`] for /mcp, \
+                                    [`openai/gpt-5.4`] for /model, or [`reauthenticate`, `codex_browser`] for /setup."
+                }
+            },
+            "required": ["command"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let raw = match arguments.get("command").and_then(Value::as_str) {
+            Some(raw) if !raw.trim().is_empty() => raw.trim(),
+            _ => return ToolExecutionResult::tool_error("'command' is required"),
+        };
+        let stripped = raw.trim_start_matches('/');
+        let name = if stripped == "exit" { "quit" } else { stripped };
+        if name == "shell" {
+            return ToolExecutionResult::tool_error(
+                "shell commands must be typed directly as !shell <command> or /shell <command>",
+            );
+        }
+        let args = match arguments.get("args") {
+            None => Vec::new(),
+            Some(Value::Array(args)) => {
+                let mut parsed = Vec::with_capacity(args.len());
+                for value in args {
+                    let Some(value) = value.as_str() else {
+                        return ToolExecutionResult::tool_error("'args' must contain only strings");
+                    };
+                    parsed.push(value.to_string());
+                }
+                parsed
+            }
+            Some(_) => {
+                return ToolExecutionResult::tool_error("'args' must be an array of strings");
+            }
+        };
+        let arg = (!args.is_empty()).then(|| args.join(" "));
+
+        // Informational terminal commands need the host's transcript lines back
+        // so the agent can act on `/mcp` / `/tools` conversationally. Everything
+        // else, including the side-effecting terminal commands, goes through the
+        // registry, which routes it to the same capability handler.
+        match self.ui.as_ref() {
+            Some(ui) if command_awaits_host_reply(name) => {
+                self.request_from_host(ui, name, arg).await
+            }
+            _ => self.dispatch_registry_command(name, arg).await,
+        }
+    }
+}
+
+/// A [`CommandDispatch`] that knows no commands. Hosts always inject the real
+/// registry; this keeps unit tests honest about there being nothing else to run.
+#[cfg(test)]
+pub(crate) struct EmptyCommandDispatch;
+
+#[cfg(test)]
+#[async_trait]
+impl CommandDispatch for EmptyCommandDispatch {
+    async fn list(&self) -> everruns_provider::error::Result<Vec<CommandDescriptor>> {
+        Ok(Vec::new())
+    }
+
+    async fn execute(
+        &self,
+        name: &str,
+        _arguments: Option<String>,
+    ) -> everruns_provider::error::Result<CommandResult> {
+        Err(everruns_provider::error::AgentLoopError::config(format!(
+            "no command registry: /{name}"
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::host_ui::{RecordingUi, UiCommand};
+    use everruns_core::command::CommandArg;
+    use std::sync::Mutex;
+
+    /// Registry stand-in: records what was executed and answers from a fixed
+    /// descriptor list, standing in for `runtime.list_commands`.
+    struct RecordingDispatch {
+        commands: Vec<CommandDescriptor>,
+        executed: Mutex<Vec<(String, Option<String>)>>,
+    }
+
+    impl RecordingDispatch {
+        fn new(commands: Vec<CommandDescriptor>) -> Arc<Self> {
+            Arc::new(Self {
+                commands,
+                executed: Mutex::new(Vec::new()),
+            })
+        }
+
+        /// A registry shaped like a non-terminal host: `/setup` and `/goal` are
+        /// runtime commands, `/ship` is a skill.
+        fn registry() -> Arc<Self> {
+            Self::new(vec![
+                descriptor("setup", &[optional("action")]),
+                descriptor("goal", &[required("condition")]),
+                descriptor("quit", &[]),
+                CommandDescriptor {
+                    source: CommandSource::Skill,
+                    ..descriptor("ship", &[])
+                },
+            ])
+        }
+
+        fn executed(&self) -> Vec<(String, Option<String>)> {
+            self.executed.lock().expect("executed lock").clone()
+        }
+    }
+
+    #[async_trait]
+    impl CommandDispatch for RecordingDispatch {
+        async fn list(&self) -> everruns_provider::error::Result<Vec<CommandDescriptor>> {
+            Ok(self.commands.clone())
+        }
+
+        async fn execute(
+            &self,
+            name: &str,
+            arguments: Option<String>,
+        ) -> everruns_provider::error::Result<CommandResult> {
+            self.executed
+                .lock()
+                .expect("executed lock")
+                .push((name.to_string(), arguments.clone()));
+            Ok(CommandResult {
+                success: true,
+                message: format!("/{name} ran with {}", arguments.unwrap_or_default()),
+                error_code: None,
+                error_fields: None,
+            })
+        }
+    }
+
+    fn descriptor(name: &str, args: &[CommandArg]) -> CommandDescriptor {
+        CommandDescriptor {
+            name: name.to_string(),
+            description: name.to_string(),
+            source: CommandSource::System,
+            args: args.to_vec(),
+        }
+    }
+
+    fn arg(name: &str, required: bool) -> CommandArg {
+        CommandArg {
+            name: name.to_string(),
+            description: name.to_string(),
+            required,
+            suggestions: Vec::new(),
+        }
+    }
+
+    fn optional(name: &str) -> CommandArg {
+        arg(name, false)
+    }
+
+    fn required(name: &str) -> CommandArg {
+        arg(name, true)
+    }
+
+    /// A non-terminal host (ACP, `--print`): no `HostUi`, registry only.
+    fn headless_tool(dispatch: Arc<RecordingDispatch>) -> RunCommandTool {
+        RunCommandTool { dispatch, ui: None }
+    }
+
+    /// A terminal host: registry plus the transcript read-back port.
+    fn terminal_tool(dispatch: Arc<RecordingDispatch>, ui: Arc<RecordingUi>) -> RunCommandTool {
+        RunCommandTool {
+            dispatch,
+            ui: Some(ui),
+        }
+    }
+
+    fn message(result: &ToolExecutionResult) -> String {
+        match result {
+            ToolExecutionResult::Success(value) => value
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            other => panic!("expected Success, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn prompt_offers_the_whole_registry_to_every_host() {
+        let capability = AgentCommandsCapability::new(Arc::new(EmptyCommandDispatch), None)
+            .system_prompt_addition()
+            .expect("prompt")
+            .to_string();
+
+        assert!(capability.contains("run_command"));
+        assert!(capability.contains("runs any slash command this session registers"));
+        assert!(capability.contains("reauthenticate <provider>"));
+        // The prompt wraps this guidance across two lines, check each side.
+        assert!(capability.contains("Use `command: help`"));
+        assert!(capability.contains("for the live list"));
+    }
+
+    #[test]
+    fn capability_contributes_run_command_on_every_host() {
+        for ui in [
+            None,
+            Some(Arc::new(RecordingUi::default()) as Arc<dyn HostUi>),
+        ] {
+            let capability = AgentCommandsCapability::new(Arc::new(EmptyCommandDispatch), ui);
+            let names: Vec<String> = capability
+                .tools()
+                .iter()
+                .map(|tool| tool.name().to_string())
+                .collect();
+            assert_eq!(names, vec!["run_command".to_string()]);
+        }
+    }
+
+    /// The schema must not pin a command allowlist: the live registry decides
+    /// what exists, so any registered command can be named.
+    #[test]
+    fn run_command_schema_does_not_fix_a_command_allowlist() {
+        let schema = headless_tool(RecordingDispatch::registry()).parameters_schema();
+
+        assert!(
+            schema["properties"]["command"].get("enum").is_none(),
+            "schema: {schema}"
+        );
+        assert_eq!(schema["properties"]["command"]["type"], json!("string"));
+    }
+
+    #[test]
+    fn run_command_narration_includes_command() {
+        let tool = headless_tool(RecordingDispatch::registry());
+        let tool_call = ToolCall {
+            id: "call-1".to_string(),
+            name: "run_command".to_string(),
+            arguments: json!({ "command": "/model" }),
+        };
+
+        assert_eq!(
+            tool.narrate(
+                &tool_call,
+                ToolNarrationPhase::Started,
+                None,
+                everruns_core::tool_narration::ToolNarrationContext::default(),
+            ),
+            Some("Run command: /model".to_string())
+        );
+    }
+
+    /// The reported gap: `/setup reauthenticate <provider>` was unreachable
+    /// because `run_command` carried its own client-command allowlist.
+    #[tokio::test]
+    async fn run_command_dispatches_registry_commands() {
+        let dispatch = RecordingDispatch::registry();
+        let tool = headless_tool(dispatch.clone());
+
+        let result = tool
+            .execute(json!({
+                "command": "/setup",
+                "args": ["reauthenticate", "codex_browser"]
+            }))
+            .await;
+
+        assert!(result.is_success(), "tool result: {result:?}");
+        assert_eq!(
+            dispatch.executed(),
+            vec![(
+                "setup".to_string(),
+                Some("reauthenticate codex_browser".to_string())
+            )]
+        );
+        assert_eq!(
+            message(&result),
+            "/setup ran with reauthenticate codex_browser"
+        );
+    }
+
+    /// ACP and `--print` have no `HostUi`, so every command, including a
+    /// terminal one the host happens to register, goes through the registry.
+    #[tokio::test]
+    async fn run_command_without_a_host_ui_uses_the_registry() {
+        let dispatch = RecordingDispatch::registry();
+        let tool = headless_tool(dispatch.clone());
+
+        let result = tool.execute(json!({ "command": "/exit" })).await;
+
+        assert!(result.is_success(), "tool result: {result:?}");
+        assert_eq!(dispatch.executed(), vec![("quit".to_string(), None)]);
+    }
+
+    /// `help` is the documented discovery call and must answer even on a host
+    /// whose registry has no `/help` command.
+    #[tokio::test]
+    async fn run_command_help_lists_the_live_registry() {
+        let tool = headless_tool(RecordingDispatch::registry());
+
+        let result = tool.execute(json!({ "command": "help" })).await;
+
+        assert!(result.is_success(), "tool result: {result:?}");
+        let message = message(&result);
+        assert!(message.contains("setup"), "message: {message}");
+        assert!(message.contains("goal"), "message: {message}");
+    }
+
+    #[tokio::test]
+    async fn run_command_reports_the_live_command_set_for_unknown_names() {
+        let dispatch = RecordingDispatch::registry();
+        let tool = headless_tool(dispatch.clone());
+
+        let result = tool.execute(json!({ "command": "nope" })).await;
+
+        assert!(result.is_error(), "tool result: {result:?}");
+        let rendered = format!("{result:?}");
+        assert!(rendered.contains("setup"), "error should list: {rendered}");
+        assert!(dispatch.executed().is_empty());
+    }
+
+    /// Skill commands are prompts, not runtime effects; running one from a tool
+    /// would re-enter the turn instead of activating the skill.
+    #[tokio::test]
+    async fn run_command_refuses_skill_commands() {
+        let dispatch = RecordingDispatch::registry();
+        let tool = headless_tool(dispatch.clone());
+
+        let result = tool.execute(json!({ "command": "ship" })).await;
+
+        assert!(result.is_error(), "tool result: {result:?}");
+        assert!(dispatch.executed().is_empty());
+    }
+
+    #[tokio::test]
+    async fn run_command_reports_missing_required_arguments() {
+        let dispatch = RecordingDispatch::registry();
+        let tool = headless_tool(dispatch.clone());
+
+        let result = tool.execute(json!({ "command": "goal" })).await;
+
+        assert!(result.is_error(), "tool result: {result:?}");
+        assert!(dispatch.executed().is_empty());
+    }
+
+    #[tokio::test]
+    async fn run_command_rejects_shell_dispatch() {
+        let dispatch = RecordingDispatch::registry();
+        let tool = headless_tool(dispatch.clone());
+
+        let result = tool
+            .execute(json!({
+                "command": "shell",
+                "args": ["echo", "should-not-run"]
+            }))
+            .await;
+
+        assert!(result.is_error(), "tool result: {result:?}");
+        assert!(dispatch.executed().is_empty());
+    }
+
+    /// In the terminal, `/mcp` must come back with the host's own listing so the
+    /// agent can act on it (login, reload) instead of inventing a manager window.
+    #[tokio::test]
+    async fn run_command_mcp_returns_host_output_in_the_terminal() {
+        let ui = Arc::new(RecordingUi::default());
+        let dispatch = RecordingDispatch::registry();
+        let tool = terminal_tool(dispatch.clone(), ui.clone());
+
+        let result = tool.execute(json!({ "command": "mcp", "args": [] })).await;
+
+        assert!(result.is_success(), "tool result: {result:?}");
+        let message = message(&result);
+        assert!(
+            !message.contains("queued for the interactive terminal host"),
+            "agent must receive the real /mcp listing: {message}"
+        );
+        assert!(
+            message.contains("MCP") || message.contains("mcp") || message.contains("usage"),
+            "tool result should carry the host /mcp response: {message}"
+        );
+        assert_eq!(ui.take(), vec![UiCommand::ManageMcp { arg: None }]);
+        assert!(
+            dispatch.executed().is_empty(),
+            "informational terminal commands go through the host, not the registry"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_command_dispatches_mcp_reload_through_the_host() {
+        let ui = Arc::new(RecordingUi::default());
+        let tool = terminal_tool(RecordingDispatch::registry(), ui.clone());
+
+        let result = tool
+            .execute(json!({ "command": "mcp", "args": ["reload"] }))
+            .await;
+
+        assert!(result.is_success(), "tool result: {result:?}");
+        assert_eq!(
+            ui.take(),
+            vec![UiCommand::ManageMcp {
+                arg: Some("reload".into()),
+            }]
+        );
+    }
+
+    /// Side-effecting terminal commands take the registry path, which routes
+    /// them to the client capability and on to the same `UiCommand`.
+    #[tokio::test]
+    async fn run_command_routes_terminal_side_effects_through_the_registry() {
+        let ui = Arc::new(RecordingUi::default());
+        let dispatch = RecordingDispatch::registry();
+        let tool = terminal_tool(dispatch.clone(), ui.clone());
+
+        let result = tool.execute(json!({ "command": "/quit" })).await;
+
+        assert!(result.is_success(), "tool result: {result:?}");
+        assert_eq!(dispatch.executed(), vec![("quit".to_string(), None)]);
+        assert!(ui.take().is_empty());
+    }
+}

--- a/src/capabilities/client_commands.rs
+++ b/src/capabilities/client_commands.rs
@@ -11,6 +11,13 @@
 //! Because the effect lives entirely in the host, this capability is only
 //! registered for the TUI (see [`crate::runtime::BuildOptions`]); ACP and
 //! `--print` hosts, which have no overlay/transcript to drive, omit it.
+//!
+//! The model-facing `run_command` tool is not limited to the commands declared
+//! here. Client commands keep the [`HostUi`] path (so `/mcp` and `/tools`
+//! return their transcript lines); every other command is looked up in the live
+//! registry through [`CommandDispatch`] and executed by the runtime, exactly as
+//! typing the slash command would. Anything a user can type, the agent can run,
+//! from one registry, with no second allowlist to keep in sync.
 
 use crate::capabilities::narration::stable_labeled;
 use crate::tui::host_ui::{HostUi, UiCommand};
@@ -29,29 +36,48 @@ use std::sync::Arc;
 pub(crate) const CLIENT_COMMANDS_CAPABILITY_ID: &str = "yolop_client_commands";
 
 pub(crate) const CLIENT_COMMANDS_PROMPT: &str = r#"<capability id="yolop_client_commands">
-For natural-language requests, `run_command` can perform these TUI client
-commands: `/help`, `/tools`, `/mcp`, `/cwd`, `/status [compact|expanded|toggle]`,
-`/model [id]`, `/effort [level]`, `/clear`, and `/quit` (`/exit` is an alias).
-The TUI may expose other slash commands, but only use `run_command` for this listed
-client-command set. When the user asks for one of these terminal
-actions — for example "exit", "clear the screen", "show tools", "switch model",
-"restart MCP", "reconnect MCP", or "refresh MCP" (`/mcp reload`), "log in to an MCP server"
-(`/mcp login <name>`), or "expand the status bar" —
-call `run_command` with the command and argument array; do not merely tell the
-user to type the slash command, and do not invent a manager window. The tool
-result includes the host's response text (server lists, tool lists, OAuth URLs).
+`run_command` runs any slash command this session registers, not a fixed subset:
+`/help`, `/tools`, `/mcp`, `/cwd`, `/status [compact|expanded|toggle]`,
+`/model [id]`, `/effort [level]`, `/clear`, `/quit` (`/exit` alias), plus the
+rest of the registry, e.g. `/setup status|login|reauthenticate <provider>`,
+`/background`, `/undo`, `/rewind`. Use `command: help` for the live list; an
+unknown name returns the available ones. Skill commands activate by prompt, and
+`/shell` is typed-only (use `bash`). When the user asks in prose, for example
+"exit", "clear the screen", "show tools", "switch model", "restart MCP",
+"reconnect MCP", or "refresh MCP" (`/mcp reload`), "log in to an MCP server"
+(`/mcp login <name>`), or "re-authenticate my provider", call `run_command` with
+the command and argument array; do not merely tell the user to type it, and do
+not invent a manager window. The tool result includes the host's response text
+(server lists, tool lists, OAuth URLs).
 Use `set_status` for a concise live description of meaningful turn progress.
 The contribution is cleared automatically when the turn finishes; send an
 empty value to clear it earlier.
 </capability>"#;
 
+/// Registry port for `run_command`: list the commands this session actually has
+/// and execute one through the runtime, the same path a typed slash command
+/// takes. Injected rather than hard-coded so the agent-facing tool never keeps
+/// its own allowlist, and so commands contributed later (extensions, MCP,
+/// upstream capabilities) are reachable the moment they are registered.
+#[async_trait]
+pub(crate) trait CommandDispatch: Send + Sync {
+    async fn list(&self) -> everruns_provider::error::Result<Vec<CommandDescriptor>>;
+
+    async fn execute(
+        &self,
+        name: &str,
+        arguments: Option<String>,
+    ) -> everruns_provider::error::Result<CommandResult>;
+}
+
 pub(crate) struct ClientCommandsCapability {
     ui: Arc<dyn HostUi>,
+    dispatch: Arc<dyn CommandDispatch>,
 }
 
 impl ClientCommandsCapability {
-    pub(crate) fn new(ui: Arc<dyn HostUi>) -> Self {
-        Self { ui }
+    pub(crate) fn new(ui: Arc<dyn HostUi>, dispatch: Arc<dyn CommandDispatch>) -> Self {
+        Self { ui, dispatch }
     }
 }
 
@@ -84,6 +110,7 @@ impl Capability for ClientCommandsCapability {
         vec![
             Box::new(RunCommandTool {
                 ui: self.ui.clone(),
+                dispatch: self.dispatch.clone(),
             }),
             Box::new(SetStatusTool {
                 ui: self.ui.clone(),
@@ -170,6 +197,7 @@ fn ui_command_for(name: &str, arg: Option<String>) -> Option<UiCommand> {
 
 struct RunCommandTool {
     ui: Arc<dyn HostUi>,
+    dispatch: Arc<dyn CommandDispatch>,
 }
 
 struct SetStatusTool {
@@ -238,6 +266,74 @@ impl Tool for SetStatusTool {
     }
 }
 
+impl RunCommandTool {
+    /// Run a non-terminal command through the live registry, mirroring the
+    /// host's typed-slash dispatch: unknown names list what is available,
+    /// `Skill` commands stay prompt-activated, and missing required arguments
+    /// are reported instead of sent on.
+    async fn dispatch_registry_command(
+        &self,
+        name: &str,
+        arg: Option<String>,
+    ) -> ToolExecutionResult {
+        let commands = match self.dispatch.list().await {
+            Ok(commands) => commands,
+            Err(error) => {
+                return ToolExecutionResult::tool_error(format!("list yolop commands: {error}"));
+            }
+        };
+        let Some(descriptor) = commands.iter().find(|c| c.name == name) else {
+            let available: Vec<&str> = commands.iter().map(|c| c.name.as_str()).collect();
+            return ToolExecutionResult::tool_error(format!(
+                "unknown yolop command: /{name}; available: {}",
+                available.join(", ")
+            ));
+        };
+        if descriptor.source == CommandSource::Skill {
+            return ToolExecutionResult::tool_error(format!(
+                "/{name} is a skill command: it activates by prompt, not by run_command. \
+                 Follow the skill's instructions directly."
+            ));
+        }
+        let missing: Vec<&str> = descriptor
+            .args
+            .iter()
+            .filter(|a| a.required)
+            .map(|a| a.name.as_str())
+            .collect();
+        if arg.is_none() && !missing.is_empty() {
+            return ToolExecutionResult::tool_error(format!(
+                "/{name} requires: {}",
+                missing.join(", ")
+            ));
+        }
+
+        let rendered = match &arg {
+            Some(arg) => format!("/{name} {arg}"),
+            None => format!("/{name}"),
+        };
+        match self.dispatch.execute(name, arg).await {
+            Ok(result) if result.success => {
+                let message = if result.message.is_empty() {
+                    format!("command applied: {rendered}")
+                } else {
+                    result.message
+                };
+                ToolExecutionResult::success(json!({
+                    "success": true,
+                    "command": rendered,
+                    "message": message
+                }))
+            }
+            Ok(result) if result.message.is_empty() => {
+                ToolExecutionResult::tool_error(format!("{rendered} failed"))
+            }
+            Ok(result) => ToolExecutionResult::tool_error(result.message),
+            Err(error) => ToolExecutionResult::tool_error(format!("{rendered} failed: {error}")),
+        }
+    }
+}
+
 #[async_trait]
 impl Tool for RunCommandTool {
     fn narrate(
@@ -261,29 +357,32 @@ impl Tool for RunCommandTool {
     }
 
     fn description(&self) -> &str {
-        "Execute an interactive yolop slash command on behalf of a natural-language user request. \
-         Use this when the user asks to exit, clear the transcript, show help/tools/MCP/cwd, \
-         reload MCP servers (`command: mcp`, `args: [reload]`), show or change the status \
-         layout, or open/switch model or reasoning effort. Accepts command names with or without the leading \
-         slash; `exit` is accepted as an alias for `quit`."
+        "Execute any registered yolop slash command on behalf of a natural-language user request: \
+         the terminal ones (help, tools, mcp, cwd, status, model, effort, clear, quit) and every \
+         other command this session registers, such as `setup` (`command: setup`, \
+         `args: [reauthenticate, codex_browser]`), `background`, `undo`, `redo`, `rewind`, and `goal`. \
+         Use `command: help` to list the live command set; an unknown name returns the available ones. \
+         Accepts command names with or without the leading slash; `exit` is an alias for `quit`. \
+         Skill commands activate by prompt and `shell` is typed-only, so neither runs here."
     }
 
     fn parameters_schema(&self) -> Value {
         json!({
             "type": "object",
             "properties": {
+                // Deliberately not an enum: the command set is per session and
+                // grows with capabilities, extensions, and MCP servers, so the
+                // live registry validates the name at execution time.
                 "command": {
                     "type": "string",
-                    "description": "Slash command name, with or without the leading slash.",
-                    "enum": [
-                        "help", "tools", "mcp", "cwd", "status", "model", "effort", "clear", "quit", "exit",
-                        "/help", "/tools", "/mcp", "/cwd", "/status", "/model", "/effort", "/clear", "/quit", "/exit"
-                    ]
+                    "description": "Slash command name, with or without the leading slash, \
+                                    e.g. `mcp`, `model`, `setup`, `background`. Use `help` to list them."
                 },
                 "args": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Ordered command arguments, e.g. [`reload`] for /mcp or [`openai/gpt-5.4`] for /model."
+                    "description": "Ordered command arguments, e.g. [`reload`] for /mcp, \
+                                    [`openai/gpt-5.4`] for /model, or [`reauthenticate`, `codex_browser`] for /setup."
                 }
             },
             "required": ["command"],
@@ -322,7 +421,9 @@ impl Tool for RunCommandTool {
         let arg = (!args.is_empty()).then(|| args.join(" "));
 
         let Some(command) = ui_command_for(name, arg.clone()) else {
-            return ToolExecutionResult::tool_error(format!("unknown yolop command: /{stripped}"));
+            // Not a terminal-side command: run it through the session's own
+            // registry so anything the user could type is also reachable here.
+            return self.dispatch_registry_command(name, arg).await;
         };
 
         let rendered = match &arg {
@@ -397,11 +498,101 @@ fn arg(name: &str, required: bool) -> CommandArg {
     }
 }
 
+/// A [`CommandDispatch`] that knows no commands. Hosts always inject the real
+/// registry; this keeps unit tests that only need the descriptor list honest
+/// about there being nothing else to run.
+#[cfg(test)]
+pub(crate) struct EmptyCommandDispatch;
+
+#[cfg(test)]
+#[async_trait]
+impl CommandDispatch for EmptyCommandDispatch {
+    async fn list(&self) -> everruns_provider::error::Result<Vec<CommandDescriptor>> {
+        Ok(Vec::new())
+    }
+
+    async fn execute(
+        &self,
+        name: &str,
+        _arguments: Option<String>,
+    ) -> everruns_provider::error::Result<CommandResult> {
+        Err(everruns_provider::error::AgentLoopError::config(format!(
+            "no command registry: /{name}"
+        )))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::sync::{Arc, Mutex};
     use tokio::sync::oneshot;
+
+    /// Registry stand-in: records what was executed and answers from a fixed
+    /// descriptor list, standing in for `runtime.list_commands`.
+    struct RecordingDispatch {
+        commands: Vec<CommandDescriptor>,
+        executed: Mutex<Vec<(String, Option<String>)>>,
+    }
+
+    impl RecordingDispatch {
+        fn new(commands: Vec<CommandDescriptor>) -> Arc<Self> {
+            Arc::new(Self {
+                commands,
+                executed: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn with_setup() -> Arc<Self> {
+            Self::new(vec![
+                cmd("setup", "configure providers", &[opt("action")]),
+                cmd(
+                    "goal",
+                    "run until a condition holds",
+                    &[required("condition")],
+                ),
+                CommandDescriptor {
+                    source: CommandSource::Skill,
+                    ..cmd("ship", "shipping workflow", &[])
+                },
+            ])
+        }
+
+        fn executed(&self) -> Vec<(String, Option<String>)> {
+            self.executed.lock().expect("executed lock").clone()
+        }
+    }
+
+    #[async_trait]
+    impl CommandDispatch for RecordingDispatch {
+        async fn list(&self) -> everruns_provider::error::Result<Vec<CommandDescriptor>> {
+            Ok(self.commands.clone())
+        }
+
+        async fn execute(
+            &self,
+            name: &str,
+            arguments: Option<String>,
+        ) -> everruns_provider::error::Result<CommandResult> {
+            self.executed
+                .lock()
+                .expect("executed lock")
+                .push((name.to_string(), arguments.clone()));
+            Ok(CommandResult {
+                success: true,
+                message: format!("setup: reauthenticated {}", arguments.unwrap_or_default()),
+                error_code: None,
+                error_fields: None,
+            })
+        }
+    }
+
+    fn run_command_tool(ui: Arc<RecordingUi>) -> RunCommandTool {
+        RunCommandTool {
+            ui,
+            dispatch: Arc::new(EmptyCommandDispatch),
+        }
+    }
 
     #[derive(Default)]
     struct RecordingUi {
@@ -445,14 +636,15 @@ mod tests {
     #[test]
     fn prompt_tells_model_to_run_natural_language_commands() {
         let ui = Arc::new(RecordingUi::default());
-        let capability = ClientCommandsCapability::new(ui);
+        let capability = ClientCommandsCapability::new(ui, Arc::new(EmptyCommandDispatch));
         let prompt = capability.system_prompt_addition().expect("prompt");
 
         assert!(prompt.contains("run_command"));
-        assert!(prompt.contains("TUI client"));
-        // The prompt wraps this guidance across two lines — check each side.
-        assert!(prompt.contains("only use `run_command` for this listed"));
-        assert!(prompt.contains("client-command set"));
+        // The prompt must not fence the model into a subset of the registry.
+        assert!(prompt.contains("runs any slash command this session registers"));
+        assert!(prompt.contains("reauthenticate <provider>"));
+        assert!(prompt.contains("`command: help` for the live list"));
+        assert!(!prompt.contains("only use `run_command` for this listed"));
         assert!(prompt.contains("/quit"));
         assert!(prompt.contains("/exit"));
         assert!(prompt.contains("\"restart MCP\""));
@@ -466,9 +658,7 @@ mod tests {
         use everruns_core::tool_narration::ToolNarrationPhase;
         use everruns_provider::ToolCall;
 
-        let tool = RunCommandTool {
-            ui: Arc::new(RecordingUi::default()),
-        };
+        let tool = run_command_tool(Arc::new(RecordingUi::default()));
         let tool_call = ToolCall {
             id: "call-1".to_string(),
             name: "run_command".to_string(),
@@ -511,26 +701,24 @@ mod tests {
         );
     }
 
+    /// The schema must not pin a command allowlist: the live registry decides
+    /// what exists, so any registered command can be named.
     #[test]
-    fn run_command_schema_accepts_slashed_aliases() {
-        let tool = RunCommandTool {
-            ui: Arc::new(RecordingUi::default()),
-        };
+    fn run_command_schema_does_not_fix_a_command_allowlist() {
+        let tool = run_command_tool(Arc::new(RecordingUi::default()));
         let schema = tool.parameters_schema();
-        let variants = schema["properties"]["command"]["enum"]
-            .as_array()
-            .expect("command enum");
 
-        assert!(variants.contains(&json!("exit")));
-        assert!(variants.contains(&json!("/exit")));
-        assert!(variants.contains(&json!("quit")));
-        assert!(variants.contains(&json!("/quit")));
+        assert!(
+            schema["properties"]["command"].get("enum").is_none(),
+            "schema: {schema}"
+        );
+        assert_eq!(schema["properties"]["command"]["type"], json!("string"));
     }
 
     #[tokio::test]
     async fn run_command_exit_alias_queues_quit() {
         let ui = Arc::new(RecordingUi::default());
-        let tool = RunCommandTool { ui: ui.clone() };
+        let tool = run_command_tool(ui.clone());
 
         let result = tool.execute(json!({ "command": "/exit" })).await;
 
@@ -579,7 +767,7 @@ mod tests {
     #[tokio::test]
     async fn run_command_rejects_shell_dispatch() {
         let ui = Arc::new(RecordingUi::default());
-        let tool = RunCommandTool { ui: ui.clone() };
+        let tool = run_command_tool(ui.clone());
 
         let result = tool
             .execute(json!({
@@ -595,7 +783,7 @@ mod tests {
     #[tokio::test]
     async fn run_command_preserves_model_argument() {
         let ui = Arc::new(RecordingUi::default());
-        let tool = RunCommandTool { ui: ui.clone() };
+        let tool = run_command_tool(ui.clone());
 
         let result = tool
             .execute(json!({
@@ -616,7 +804,7 @@ mod tests {
     #[tokio::test]
     async fn run_command_preserves_status_layout_argument() {
         let ui = Arc::new(RecordingUi::default());
-        let tool = RunCommandTool { ui: ui.clone() };
+        let tool = run_command_tool(ui.clone());
 
         let result = tool
             .execute(json!({
@@ -639,7 +827,7 @@ mod tests {
     #[tokio::test]
     async fn run_command_dispatches_mcp_reload() {
         let ui = Arc::new(RecordingUi::default());
-        let tool = RunCommandTool { ui: ui.clone() };
+        let tool = run_command_tool(ui.clone());
 
         let result = tool
             .execute(json!({ "command": "mcp", "args": ["reload"] }))
@@ -654,12 +842,97 @@ mod tests {
         );
     }
 
+    /// The reported gap: `/setup reauthenticate <provider>` was unreachable
+    /// from a turn because `run_command` carried its own client-command
+    /// allowlist. It now dispatches through the session's command registry.
+    #[tokio::test]
+    async fn run_command_dispatches_registry_commands() {
+        let ui = Arc::new(RecordingUi::default());
+        let dispatch = RecordingDispatch::with_setup();
+        let tool = RunCommandTool {
+            ui: ui.clone(),
+            dispatch: dispatch.clone(),
+        };
+
+        let result = tool
+            .execute(json!({
+                "command": "/setup",
+                "args": ["reauthenticate", "codex_browser"]
+            }))
+            .await;
+
+        assert!(result.is_success(), "tool result: {result:?}");
+        assert_eq!(
+            dispatch.executed(),
+            vec![(
+                "setup".to_string(),
+                Some("reauthenticate codex_browser".to_string())
+            )]
+        );
+        // Registry commands answer with the runtime's own message.
+        let payload = match result {
+            ToolExecutionResult::Success(value) => value,
+            other => panic!("expected Success, got {other:?}"),
+        };
+        assert_eq!(
+            payload.get("message").and_then(Value::as_str),
+            Some("setup: reauthenticated reauthenticate codex_browser")
+        );
+        assert!(ui.take().is_empty(), "registry commands bypass the host UI");
+    }
+
+    #[tokio::test]
+    async fn run_command_reports_the_live_command_set_for_unknown_names() {
+        let dispatch = RecordingDispatch::with_setup();
+        let tool = RunCommandTool {
+            ui: Arc::new(RecordingUi::default()),
+            dispatch: dispatch.clone(),
+        };
+
+        let result = tool.execute(json!({ "command": "nope" })).await;
+
+        assert!(result.is_error(), "tool result: {result:?}");
+        let rendered = format!("{result:?}");
+        assert!(rendered.contains("setup"), "error should list: {rendered}");
+        assert!(dispatch.executed().is_empty());
+    }
+
+    /// Skill commands are prompts, not runtime effects; running one from a tool
+    /// would re-enter the turn instead of activating the skill.
+    #[tokio::test]
+    async fn run_command_refuses_skill_commands() {
+        let dispatch = RecordingDispatch::with_setup();
+        let tool = RunCommandTool {
+            ui: Arc::new(RecordingUi::default()),
+            dispatch: dispatch.clone(),
+        };
+
+        let result = tool.execute(json!({ "command": "ship" })).await;
+
+        assert!(result.is_error(), "tool result: {result:?}");
+        assert!(dispatch.executed().is_empty());
+    }
+
+    #[tokio::test]
+    async fn run_command_reports_missing_required_arguments() {
+        let dispatch = RecordingDispatch::with_setup();
+        let tool = RunCommandTool {
+            ui: Arc::new(RecordingUi::default()),
+            dispatch: dispatch.clone(),
+        };
+
+        let result = tool.execute(json!({ "command": "goal" })).await;
+
+        assert!(result.is_error(), "tool result: {result:?}");
+        assert!(dispatch.executed().is_empty());
+    }
+
     /// `run_command` for `/mcp` returns the host listing so the agent
     /// can act conversationally (login/reload) without inventing a manager window.
     #[tokio::test]
     async fn repro_run_command_mcp_returns_host_output() {
         let ui = Arc::new(RecordingUi::default());
-        let tool = RunCommandTool { ui: ui.clone() };
+        let tool = run_command_tool(ui.clone());
 
         let result = tool.execute(json!({ "command": "mcp", "args": [] })).await;
         assert!(result.is_success(), "tool should succeed: {result:?}");

--- a/src/capabilities/client_commands.rs
+++ b/src/capabilities/client_commands.rs
@@ -12,12 +12,10 @@
 //! registered for the TUI (see [`crate::runtime::BuildOptions`]); ACP and
 //! `--print` hosts, which have no overlay/transcript to drive, omit it.
 //!
-//! The model-facing `run_command` tool is not limited to the commands declared
-//! here. Client commands keep the [`HostUi`] path (so `/mcp` and `/tools`
-//! return their transcript lines); every other command is looked up in the live
-//! registry through [`CommandDispatch`] and executed by the runtime, exactly as
-//! typing the slash command would. Anything a user can type, the agent can run,
-//! from one registry, with no second allowlist to keep in sync.
+//! The model reaches these commands the same way it reaches every other one,
+//! through the `run_command` tool in
+//! [`crate::capabilities::agent_commands`], which resolves names against the
+//! live registry rather than any list kept here.
 
 use crate::capabilities::narration::stable_labeled;
 use crate::tui::host_ui::{HostUi, UiCommand};
@@ -36,48 +34,23 @@ use std::sync::Arc;
 pub(crate) const CLIENT_COMMANDS_CAPABILITY_ID: &str = "yolop_client_commands";
 
 pub(crate) const CLIENT_COMMANDS_PROMPT: &str = r#"<capability id="yolop_client_commands">
-`run_command` runs any slash command this session registers, not a fixed subset:
-`/help`, `/tools`, `/mcp`, `/cwd`, `/status [compact|expanded|toggle]`,
-`/model [id]`, `/effort [level]`, `/clear`, `/quit` (`/exit` alias), plus the
-rest of the registry, e.g. `/setup status|login|reauthenticate <provider>`,
-`/background`, `/undo`, `/rewind`. Use `command: help` for the live list; an
-unknown name returns the available ones. Skill commands activate by prompt, and
-`/shell` is typed-only (use `bash`). When the user asks in prose, for example
-"exit", "clear the screen", "show tools", "switch model", "restart MCP",
-"reconnect MCP", or "refresh MCP" (`/mcp reload`), "log in to an MCP server"
-(`/mcp login <name>`), or "re-authenticate my provider", call `run_command` with
-the command and argument array; do not merely tell the user to type it, and do
-not invent a manager window. The tool result includes the host's response text
-(server lists, tool lists, OAuth URLs).
-Use `set_status` for a concise live description of meaningful turn progress.
-The contribution is cleared automatically when the turn finishes; send an
-empty value to clear it earlier.
+Terminal commands, all runnable with `run_command`: `/help`, `/tools`, `/mcp`,
+`/cwd`, `/status [compact|expanded|toggle]`, `/model [id]`, `/effort [level]`,
+`/clear`, `/quit` (`/exit` alias). Run them on prose requests such as "exit",
+"clear the screen", "show tools", "switch model", "restart MCP", "reconnect MCP",
+or "refresh MCP" (`/mcp reload`), "log in to an MCP server" (`/mcp login <name>`);
+never invent a manager window. `/shell` is typed-only; use `bash`.
+`set_status` sets a concise live description of turn progress; it clears when the
+turn finishes, or send an empty value to clear it earlier.
 </capability>"#;
-
-/// Registry port for `run_command`: list the commands this session actually has
-/// and execute one through the runtime, the same path a typed slash command
-/// takes. Injected rather than hard-coded so the agent-facing tool never keeps
-/// its own allowlist, and so commands contributed later (extensions, MCP,
-/// upstream capabilities) are reachable the moment they are registered.
-#[async_trait]
-pub(crate) trait CommandDispatch: Send + Sync {
-    async fn list(&self) -> everruns_provider::error::Result<Vec<CommandDescriptor>>;
-
-    async fn execute(
-        &self,
-        name: &str,
-        arguments: Option<String>,
-    ) -> everruns_provider::error::Result<CommandResult>;
-}
 
 pub(crate) struct ClientCommandsCapability {
     ui: Arc<dyn HostUi>,
-    dispatch: Arc<dyn CommandDispatch>,
 }
 
 impl ClientCommandsCapability {
-    pub(crate) fn new(ui: Arc<dyn HostUi>, dispatch: Arc<dyn CommandDispatch>) -> Self {
-        Self { ui, dispatch }
+    pub(crate) fn new(ui: Arc<dyn HostUi>) -> Self {
+        Self { ui }
     }
 }
 
@@ -107,15 +80,9 @@ impl Capability for ClientCommandsCapability {
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
-        vec![
-            Box::new(RunCommandTool {
-                ui: self.ui.clone(),
-                dispatch: self.dispatch.clone(),
-            }),
-            Box::new(SetStatusTool {
-                ui: self.ui.clone(),
-            }),
-        ]
+        vec![Box::new(SetStatusTool {
+            ui: self.ui.clone(),
+        })]
     }
 
     async fn execute_command(
@@ -177,7 +144,7 @@ fn command_descriptors() -> Vec<CommandDescriptor> {
     ]
 }
 
-fn ui_command_for(name: &str, arg: Option<String>) -> Option<UiCommand> {
+pub(crate) fn ui_command_for(name: &str, arg: Option<String>) -> Option<UiCommand> {
     match name {
         "help" => Some(UiCommand::ShowHelp),
         "tools" => Some(UiCommand::ShowTools),
@@ -195,9 +162,37 @@ fn ui_command_for(name: &str, arg: Option<String>) -> Option<UiCommand> {
     }
 }
 
-struct RunCommandTool {
-    ui: Arc<dyn HostUi>,
-    dispatch: Arc<dyn CommandDispatch>,
+fn cmd(name: &str, description: &str, args: &[CommandArg]) -> CommandDescriptor {
+    CommandDescriptor {
+        name: name.to_string(),
+        description: description.to_string(),
+        source: CommandSource::System,
+        args: args.to_vec(),
+    }
+}
+
+fn opt(name: &str) -> CommandArg {
+    arg(name, false)
+}
+
+fn opt_with_suggestions(name: &str, suggestions: &[&str]) -> CommandArg {
+    CommandArg {
+        suggestions: suggestions.iter().map(|s| (*s).to_string()).collect(),
+        ..arg(name, false)
+    }
+}
+
+fn required(name: &str) -> CommandArg {
+    arg(name, true)
+}
+
+fn arg(name: &str, required: bool) -> CommandArg {
+    CommandArg {
+        name: name.to_string(),
+        description: name.to_string(),
+        required,
+        suggestions: Vec::new(),
+    }
 }
 
 struct SetStatusTool {
@@ -266,385 +261,19 @@ impl Tool for SetStatusTool {
     }
 }
 
-impl RunCommandTool {
-    /// Run a non-terminal command through the live registry, mirroring the
-    /// host's typed-slash dispatch: unknown names list what is available,
-    /// `Skill` commands stay prompt-activated, and missing required arguments
-    /// are reported instead of sent on.
-    async fn dispatch_registry_command(
-        &self,
-        name: &str,
-        arg: Option<String>,
-    ) -> ToolExecutionResult {
-        let commands = match self.dispatch.list().await {
-            Ok(commands) => commands,
-            Err(error) => {
-                return ToolExecutionResult::tool_error(format!("list yolop commands: {error}"));
-            }
-        };
-        let Some(descriptor) = commands.iter().find(|c| c.name == name) else {
-            let available: Vec<&str> = commands.iter().map(|c| c.name.as_str()).collect();
-            return ToolExecutionResult::tool_error(format!(
-                "unknown yolop command: /{name}; available: {}",
-                available.join(", ")
-            ));
-        };
-        if descriptor.source == CommandSource::Skill {
-            return ToolExecutionResult::tool_error(format!(
-                "/{name} is a skill command: it activates by prompt, not by run_command. \
-                 Follow the skill's instructions directly."
-            ));
-        }
-        let missing: Vec<&str> = descriptor
-            .args
-            .iter()
-            .filter(|a| a.required)
-            .map(|a| a.name.as_str())
-            .collect();
-        if arg.is_none() && !missing.is_empty() {
-            return ToolExecutionResult::tool_error(format!(
-                "/{name} requires: {}",
-                missing.join(", ")
-            ));
-        }
-
-        let rendered = match &arg {
-            Some(arg) => format!("/{name} {arg}"),
-            None => format!("/{name}"),
-        };
-        match self.dispatch.execute(name, arg).await {
-            Ok(result) if result.success => {
-                let message = if result.message.is_empty() {
-                    format!("command applied: {rendered}")
-                } else {
-                    result.message
-                };
-                ToolExecutionResult::success(json!({
-                    "success": true,
-                    "command": rendered,
-                    "message": message
-                }))
-            }
-            Ok(result) if result.message.is_empty() => {
-                ToolExecutionResult::tool_error(format!("{rendered} failed"))
-            }
-            Ok(result) => ToolExecutionResult::tool_error(result.message),
-            Err(error) => ToolExecutionResult::tool_error(format!("{rendered} failed: {error}")),
-        }
-    }
-}
-
-#[async_trait]
-impl Tool for RunCommandTool {
-    fn narrate(
-        &self,
-        tool_call: &ToolCall,
-        phase: ToolNarrationPhase,
-        locale: Option<&str>,
-        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
-    ) -> Option<String> {
-        let _ = locale;
-        let command = arg_str(&tool_call.arguments, &["command"]).map(|value| truncate(value, 48));
-        Some(stable_labeled("Run command", command, phase))
-    }
-
-    fn name(&self) -> &str {
-        "run_command"
-    }
-
-    fn display_name(&self) -> Option<&str> {
-        Some("Yolop command")
-    }
-
-    fn description(&self) -> &str {
-        "Execute any registered yolop slash command on behalf of a natural-language user request: \
-         the terminal ones (help, tools, mcp, cwd, status, model, effort, clear, quit) and every \
-         other command this session registers, such as `setup` (`command: setup`, \
-         `args: [reauthenticate, codex_browser]`), `background`, `undo`, `redo`, `rewind`, and `goal`. \
-         Use `command: help` to list the live command set; an unknown name returns the available ones. \
-         Accepts command names with or without the leading slash; `exit` is an alias for `quit`. \
-         Skill commands activate by prompt and `shell` is typed-only, so neither runs here."
-    }
-
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                // Deliberately not an enum: the command set is per session and
-                // grows with capabilities, extensions, and MCP servers, so the
-                // live registry validates the name at execution time.
-                "command": {
-                    "type": "string",
-                    "description": "Slash command name, with or without the leading slash, \
-                                    e.g. `mcp`, `model`, `setup`, `background`. Use `help` to list them."
-                },
-                "args": {
-                    "type": "array",
-                    "items": { "type": "string" },
-                    "description": "Ordered command arguments, e.g. [`reload`] for /mcp, \
-                                    [`openai/gpt-5.4`] for /model, or [`reauthenticate`, `codex_browser`] for /setup."
-                }
-            },
-            "required": ["command"],
-            "additionalProperties": false
-        })
-    }
-
-    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        let raw = match arguments.get("command").and_then(Value::as_str) {
-            Some(raw) if !raw.trim().is_empty() => raw.trim(),
-            _ => return ToolExecutionResult::tool_error("'command' is required"),
-        };
-        let stripped = raw.trim_start_matches('/');
-        let name = if stripped == "exit" { "quit" } else { stripped };
-        if name == "shell" {
-            return ToolExecutionResult::tool_error(
-                "shell commands must be typed directly as !shell <command> or /shell <command>",
-            );
-        }
-        let args = match arguments.get("args") {
-            None => Vec::new(),
-            Some(Value::Array(args)) => {
-                let mut parsed = Vec::with_capacity(args.len());
-                for value in args {
-                    let Some(value) = value.as_str() else {
-                        return ToolExecutionResult::tool_error("'args' must contain only strings");
-                    };
-                    parsed.push(value.to_string());
-                }
-                parsed
-            }
-            Some(_) => {
-                return ToolExecutionResult::tool_error("'args' must be an array of strings");
-            }
-        };
-        let arg = (!args.is_empty()).then(|| args.join(" "));
-
-        let Some(command) = ui_command_for(name, arg.clone()) else {
-            // Not a terminal-side command: run it through the session's own
-            // registry so anything the user could type is also reachable here.
-            return self.dispatch_registry_command(name, arg).await;
-        };
-
-        let rendered = match &arg {
-            Some(arg) => format!("/{name} {arg}"),
-            None => format!("/{name}"),
-        };
-
-        // Informational commands need the host's transcript lines back so the
-        // agent can act on `/mcp` / `/tools` conversationally. Side-effect
-        // commands (quit/clear/overlays) only need to be queued — awaiting a
-        // reply would hang any host that is not draining the UI channel
-        // (scripted tests, brief races at shutdown).
-        let message = if command_awaits_host_reply(name) {
-            let reply_rx = self.ui.request(command);
-            match tokio::time::timeout(std::time::Duration::from_secs(15), reply_rx).await {
-                Ok(Ok(messages)) if !messages.is_empty() => messages.join("\n"),
-                Ok(Ok(_)) => format!("command applied: {rendered}"),
-                Ok(Err(_)) => format!("command applied: {rendered}"),
-                Err(_) => format!(
-                    "command queued for the interactive terminal host ({rendered}); \
-                     host did not return output in time"
-                ),
-            }
-        } else {
-            self.ui.send(command);
-            format!("command applied: {rendered}")
-        };
-
-        ToolExecutionResult::success(json!({
-            "success": true,
-            "command": rendered,
-            "message": message
-        }))
-    }
-}
-
-/// Whether `run_command` should wait for host transcript lines.
-fn command_awaits_host_reply(name: &str) -> bool {
-    matches!(name, "mcp" | "tools" | "help" | "cwd")
-}
-
-fn cmd(name: &str, description: &str, args: &[CommandArg]) -> CommandDescriptor {
-    CommandDescriptor {
-        name: name.to_string(),
-        description: description.to_string(),
-        source: CommandSource::System,
-        args: args.to_vec(),
-    }
-}
-
-fn opt(name: &str) -> CommandArg {
-    arg(name, false)
-}
-
-fn opt_with_suggestions(name: &str, suggestions: &[&str]) -> CommandArg {
-    CommandArg {
-        suggestions: suggestions.iter().map(|s| (*s).to_string()).collect(),
-        ..arg(name, false)
-    }
-}
-
-fn required(name: &str) -> CommandArg {
-    arg(name, true)
-}
-
-fn arg(name: &str, required: bool) -> CommandArg {
-    CommandArg {
-        name: name.to_string(),
-        description: name.to_string(),
-        required,
-        suggestions: Vec::new(),
-    }
-}
-
-/// A [`CommandDispatch`] that knows no commands. Hosts always inject the real
-/// registry; this keeps unit tests that only need the descriptor list honest
-/// about there being nothing else to run.
-#[cfg(test)]
-pub(crate) struct EmptyCommandDispatch;
-
-#[cfg(test)]
-#[async_trait]
-impl CommandDispatch for EmptyCommandDispatch {
-    async fn list(&self) -> everruns_provider::error::Result<Vec<CommandDescriptor>> {
-        Ok(Vec::new())
-    }
-
-    async fn execute(
-        &self,
-        name: &str,
-        _arguments: Option<String>,
-    ) -> everruns_provider::error::Result<CommandResult> {
-        Err(everruns_provider::error::AgentLoopError::config(format!(
-            "no command registry: /{name}"
-        )))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Arc, Mutex};
-    use tokio::sync::oneshot;
-
-    /// Registry stand-in: records what was executed and answers from a fixed
-    /// descriptor list, standing in for `runtime.list_commands`.
-    struct RecordingDispatch {
-        commands: Vec<CommandDescriptor>,
-        executed: Mutex<Vec<(String, Option<String>)>>,
-    }
-
-    impl RecordingDispatch {
-        fn new(commands: Vec<CommandDescriptor>) -> Arc<Self> {
-            Arc::new(Self {
-                commands,
-                executed: Mutex::new(Vec::new()),
-            })
-        }
-
-        fn with_setup() -> Arc<Self> {
-            Self::new(vec![
-                cmd("setup", "configure providers", &[opt("action")]),
-                cmd(
-                    "goal",
-                    "run until a condition holds",
-                    &[required("condition")],
-                ),
-                CommandDescriptor {
-                    source: CommandSource::Skill,
-                    ..cmd("ship", "shipping workflow", &[])
-                },
-            ])
-        }
-
-        fn executed(&self) -> Vec<(String, Option<String>)> {
-            self.executed.lock().expect("executed lock").clone()
-        }
-    }
-
-    #[async_trait]
-    impl CommandDispatch for RecordingDispatch {
-        async fn list(&self) -> everruns_provider::error::Result<Vec<CommandDescriptor>> {
-            Ok(self.commands.clone())
-        }
-
-        async fn execute(
-            &self,
-            name: &str,
-            arguments: Option<String>,
-        ) -> everruns_provider::error::Result<CommandResult> {
-            self.executed
-                .lock()
-                .expect("executed lock")
-                .push((name.to_string(), arguments.clone()));
-            Ok(CommandResult {
-                success: true,
-                message: format!("setup: reauthenticated {}", arguments.unwrap_or_default()),
-                error_code: None,
-                error_fields: None,
-            })
-        }
-    }
-
-    fn run_command_tool(ui: Arc<RecordingUi>) -> RunCommandTool {
-        RunCommandTool {
-            ui,
-            dispatch: Arc::new(EmptyCommandDispatch),
-        }
-    }
-
-    #[derive(Default)]
-    struct RecordingUi {
-        commands: Mutex<Vec<UiCommand>>,
-    }
-
-    impl RecordingUi {
-        fn take(&self) -> Vec<UiCommand> {
-            std::mem::take(&mut *self.commands.lock().expect("commands lock"))
-        }
-    }
-
-    impl HostUi for RecordingUi {
-        fn send(&self, command: UiCommand) {
-            self.commands.lock().expect("commands lock").push(command);
-        }
-
-        fn request(&self, command: UiCommand) -> oneshot::Receiver<Vec<String>> {
-            self.send(command.clone());
-            let (tx, rx) = oneshot::channel();
-            // Unit tests without a live App still need a non-blocking reply.
-            // Integration coverage for real host text lives in the TUI suite.
-            let message = match &command {
-                UiCommand::ManageMcp { .. } => {
-                    vec![
-                        "active MCP servers: none".into(),
-                        "usage: /mcp [reload | login <name> | enable|disable|remove <name> [global|workspace]]"
-                            .into(),
-                    ]
-                }
-                UiCommand::ShowTools => vec!["tools: bash".into()],
-                UiCommand::ShowHelp => vec!["commands:".into()],
-                UiCommand::ShowCwd => vec!["workspace root: /tmp".into()],
-                _ => Vec::new(),
-            };
-            let _ = tx.send(message);
-            rx
-        }
-    }
+    use crate::tui::host_ui::RecordingUi;
+    use everruns_provider::typed_id::SessionId;
 
     #[test]
-    fn prompt_tells_model_to_run_natural_language_commands() {
+    fn prompt_covers_the_terminal_commands_and_status() {
         let ui = Arc::new(RecordingUi::default());
-        let capability = ClientCommandsCapability::new(ui, Arc::new(EmptyCommandDispatch));
+        let capability = ClientCommandsCapability::new(ui);
         let prompt = capability.system_prompt_addition().expect("prompt");
 
         assert!(prompt.contains("run_command"));
-        // The prompt must not fence the model into a subset of the registry.
-        assert!(prompt.contains("runs any slash command this session registers"));
-        assert!(prompt.contains("reauthenticate <provider>"));
-        assert!(prompt.contains("`command: help` for the live list"));
-        assert!(!prompt.contains("only use `run_command` for this listed"));
         assert!(prompt.contains("/quit"));
         assert!(prompt.contains("/exit"));
         assert!(prompt.contains("\"restart MCP\""));
@@ -653,27 +282,76 @@ mod tests {
         assert!(prompt.contains("set_status"));
     }
 
+    /// The terminal commands are ordinary registry entries; `run_command` finds
+    /// them there rather than in a list this capability hands the model.
     #[test]
-    fn run_command_narration_includes_command() {
-        use everruns_core::tool_narration::ToolNarrationPhase;
-        use everruns_provider::ToolCall;
+    fn capability_contributes_commands_and_only_the_status_tool() {
+        let capability = ClientCommandsCapability::new(Arc::new(RecordingUi::default()));
 
-        let tool = run_command_tool(Arc::new(RecordingUi::default()));
-        let tool_call = ToolCall {
-            id: "call-1".to_string(),
-            name: "run_command".to_string(),
-            arguments: json!({ "command": "/model" }),
-        };
+        let commands: Vec<String> = capability
+            .commands()
+            .into_iter()
+            .map(|command| command.name)
+            .collect();
+        assert!(commands.contains(&"quit".to_string()), "{commands:?}");
+        assert!(commands.contains(&"mcp".to_string()), "{commands:?}");
 
+        let tools: Vec<String> = capability
+            .tools()
+            .iter()
+            .map(|tool| tool.name().to_string())
+            .collect();
+        assert_eq!(tools, vec!["set_status".to_string()]);
+    }
+
+    /// Executing a client command emits its `UiCommand` and returns an empty
+    /// result: the host, not the runtime, performs the effect.
+    #[tokio::test]
+    async fn execute_command_emits_the_ui_command() {
+        let ui = Arc::new(RecordingUi::default());
+        let capability = ClientCommandsCapability::new(ui.clone());
+
+        let result = capability
+            .execute_command(
+                &ExecuteCommandRequest {
+                    name: "model".to_string(),
+                    arguments: Some("openai/gpt-5.4".to_string()),
+                    controls: None,
+                },
+                &CommandExecutionContext::without_host(SessionId::new()),
+            )
+            .await
+            .expect("execute /model");
+
+        assert!(result.success);
+        assert!(result.message.is_empty());
         assert_eq!(
-            tool.narrate(
-                &tool_call,
-                ToolNarrationPhase::Started,
-                None,
-                everruns_core::tool_narration::ToolNarrationContext::default(),
-            ),
-            Some("Run command: /model".to_string())
+            ui.take(),
+            vec![UiCommand::OpenModelOverlay {
+                arg: Some("openai/gpt-5.4".to_string())
+            }]
         );
+    }
+
+    #[tokio::test]
+    async fn execute_command_rejects_names_this_capability_does_not_own() {
+        let ui = Arc::new(RecordingUi::default());
+        let capability = ClientCommandsCapability::new(ui.clone());
+
+        let error = capability
+            .execute_command(
+                &ExecuteCommandRequest {
+                    name: "setup".to_string(),
+                    arguments: None,
+                    controls: None,
+                },
+                &CommandExecutionContext::without_host(SessionId::new()),
+            )
+            .await
+            .expect_err("/setup belongs to another capability");
+
+        assert!(error.to_string().contains("setup"), "error: {error}");
+        assert!(ui.take().is_empty());
     }
 
     #[test]
@@ -699,31 +377,6 @@ mod tests {
             ),
             Some("Update status: Auditing tool narration".to_string())
         );
-    }
-
-    /// The schema must not pin a command allowlist: the live registry decides
-    /// what exists, so any registered command can be named.
-    #[test]
-    fn run_command_schema_does_not_fix_a_command_allowlist() {
-        let tool = run_command_tool(Arc::new(RecordingUi::default()));
-        let schema = tool.parameters_schema();
-
-        assert!(
-            schema["properties"]["command"].get("enum").is_none(),
-            "schema: {schema}"
-        );
-        assert_eq!(schema["properties"]["command"]["type"], json!("string"));
-    }
-
-    #[tokio::test]
-    async fn run_command_exit_alias_queues_quit() {
-        let ui = Arc::new(RecordingUi::default());
-        let tool = run_command_tool(ui.clone());
-
-        let result = tool.execute(json!({ "command": "/exit" })).await;
-
-        assert!(result.is_success(), "tool result: {result:?}");
-        assert_eq!(ui.take(), vec![UiCommand::Quit]);
     }
 
     #[tokio::test]
@@ -762,200 +415,5 @@ mod tests {
 
         assert!(result.is_error(), "tool result: {result:?}");
         assert!(ui.take().is_empty());
-    }
-
-    #[tokio::test]
-    async fn run_command_rejects_shell_dispatch() {
-        let ui = Arc::new(RecordingUi::default());
-        let tool = run_command_tool(ui.clone());
-
-        let result = tool
-            .execute(json!({
-                "command": "shell",
-                "args": ["echo", "should-not-run"]
-            }))
-            .await;
-
-        assert!(result.is_error(), "tool result: {result:?}");
-        assert_eq!(ui.take(), Vec::<UiCommand>::new());
-    }
-
-    #[tokio::test]
-    async fn run_command_preserves_model_argument() {
-        let ui = Arc::new(RecordingUi::default());
-        let tool = run_command_tool(ui.clone());
-
-        let result = tool
-            .execute(json!({
-                "command": "model",
-                "args": ["openai/gpt-5.4"]
-            }))
-            .await;
-
-        assert!(result.is_success(), "tool result: {result:?}");
-        assert_eq!(
-            ui.take(),
-            vec![UiCommand::OpenModelOverlay {
-                arg: Some("openai/gpt-5.4".to_string())
-            }]
-        );
-    }
-
-    #[tokio::test]
-    async fn run_command_preserves_status_layout_argument() {
-        let ui = Arc::new(RecordingUi::default());
-        let tool = run_command_tool(ui.clone());
-
-        let result = tool
-            .execute(json!({
-                "command": "status",
-                "args": ["expanded"]
-            }))
-            .await;
-
-        assert!(result.is_success(), "tool result: {result:?}");
-        assert_eq!(
-            ui.take(),
-            vec![UiCommand::SetStatusLayout {
-                arg: Some("expanded".to_string())
-            }]
-        );
-    }
-
-    /// MCP reload is directly callable from conversation; the host receives the
-    /// same typed command as interactive `/mcp reload` and returns its report.
-    #[tokio::test]
-    async fn run_command_dispatches_mcp_reload() {
-        let ui = Arc::new(RecordingUi::default());
-        let tool = run_command_tool(ui.clone());
-
-        let result = tool
-            .execute(json!({ "command": "mcp", "args": ["reload"] }))
-            .await;
-
-        assert!(result.is_success(), "tool should succeed: {result:?}");
-        assert_eq!(
-            ui.take(),
-            vec![UiCommand::ManageMcp {
-                arg: Some("reload".into()),
-            }]
-        );
-    }
-
-    /// The reported gap: `/setup reauthenticate <provider>` was unreachable
-    /// from a turn because `run_command` carried its own client-command
-    /// allowlist. It now dispatches through the session's command registry.
-    #[tokio::test]
-    async fn run_command_dispatches_registry_commands() {
-        let ui = Arc::new(RecordingUi::default());
-        let dispatch = RecordingDispatch::with_setup();
-        let tool = RunCommandTool {
-            ui: ui.clone(),
-            dispatch: dispatch.clone(),
-        };
-
-        let result = tool
-            .execute(json!({
-                "command": "/setup",
-                "args": ["reauthenticate", "codex_browser"]
-            }))
-            .await;
-
-        assert!(result.is_success(), "tool result: {result:?}");
-        assert_eq!(
-            dispatch.executed(),
-            vec![(
-                "setup".to_string(),
-                Some("reauthenticate codex_browser".to_string())
-            )]
-        );
-        // Registry commands answer with the runtime's own message.
-        let payload = match result {
-            ToolExecutionResult::Success(value) => value,
-            other => panic!("expected Success, got {other:?}"),
-        };
-        assert_eq!(
-            payload.get("message").and_then(Value::as_str),
-            Some("setup: reauthenticated reauthenticate codex_browser")
-        );
-        assert!(ui.take().is_empty(), "registry commands bypass the host UI");
-    }
-
-    #[tokio::test]
-    async fn run_command_reports_the_live_command_set_for_unknown_names() {
-        let dispatch = RecordingDispatch::with_setup();
-        let tool = RunCommandTool {
-            ui: Arc::new(RecordingUi::default()),
-            dispatch: dispatch.clone(),
-        };
-
-        let result = tool.execute(json!({ "command": "nope" })).await;
-
-        assert!(result.is_error(), "tool result: {result:?}");
-        let rendered = format!("{result:?}");
-        assert!(rendered.contains("setup"), "error should list: {rendered}");
-        assert!(dispatch.executed().is_empty());
-    }
-
-    /// Skill commands are prompts, not runtime effects; running one from a tool
-    /// would re-enter the turn instead of activating the skill.
-    #[tokio::test]
-    async fn run_command_refuses_skill_commands() {
-        let dispatch = RecordingDispatch::with_setup();
-        let tool = RunCommandTool {
-            ui: Arc::new(RecordingUi::default()),
-            dispatch: dispatch.clone(),
-        };
-
-        let result = tool.execute(json!({ "command": "ship" })).await;
-
-        assert!(result.is_error(), "tool result: {result:?}");
-        assert!(dispatch.executed().is_empty());
-    }
-
-    #[tokio::test]
-    async fn run_command_reports_missing_required_arguments() {
-        let dispatch = RecordingDispatch::with_setup();
-        let tool = RunCommandTool {
-            ui: Arc::new(RecordingUi::default()),
-            dispatch: dispatch.clone(),
-        };
-
-        let result = tool.execute(json!({ "command": "goal" })).await;
-
-        assert!(result.is_error(), "tool result: {result:?}");
-        assert!(dispatch.executed().is_empty());
-    }
-
-    /// `run_command` for `/mcp` returns the host listing so the agent
-    /// can act conversationally (login/reload) without inventing a manager window.
-    #[tokio::test]
-    async fn repro_run_command_mcp_returns_host_output() {
-        let ui = Arc::new(RecordingUi::default());
-        let tool = run_command_tool(ui.clone());
-
-        let result = tool.execute(json!({ "command": "mcp", "args": [] })).await;
-        assert!(result.is_success(), "tool should succeed: {result:?}");
-
-        let payload = match result {
-            ToolExecutionResult::Success(value) => value,
-            other => panic!("expected Success, got {other:?}"),
-        };
-        let message = payload
-            .get("message")
-            .and_then(Value::as_str)
-            .unwrap_or_default();
-
-        assert!(
-            !message.contains("queued for the interactive terminal host"),
-            "agent must receive the real /mcp listing, not a fire-and-forget queue ack.\n\
-             got message={message:?}; queued={:?}",
-            ui.take()
-        );
-        assert!(
-            message.contains("MCP") || message.contains("mcp") || message.contains("usage"),
-            "tool result should carry the host /mcp response for conversational control.\n\
-             got message={message:?}"
-        );
     }
 }

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -46,7 +46,9 @@ pub(crate) use background::{
     BACKGROUND_CAPABILITY_ID, BackgroundCapability, NarratedBackgroundExecutionCapability,
 };
 pub(crate) use checkpoint::{CHECKPOINT_CAPABILITY_ID, CheckpointCapability};
-pub(crate) use client_commands::{CLIENT_COMMANDS_CAPABILITY_ID, ClientCommandsCapability};
+pub(crate) use client_commands::{
+    CLIENT_COMMANDS_CAPABILITY_ID, ClientCommandsCapability, CommandDispatch,
+};
 pub(crate) use config::{CONFIG_CAPABILITY_ID, ConfigCapability};
 pub(crate) use context_cost_control::{
     CONTEXT_COST_CONTROL_CAPABILITY_ID, ContextCostControlCapability,

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -3,6 +3,7 @@
 // These are host/example behavior rather than runtime primitives. Keep the
 // module boundary here small; capability implementations live in submodules.
 
+pub(crate) mod agent_commands;
 pub(crate) mod approval;
 pub(crate) mod ast_grep;
 pub(crate) mod attribution;
@@ -39,6 +40,9 @@ pub(crate) mod yolop;
 
 pub(crate) use crate::session_state::goal::GOAL_CAPABILITY_ID;
 pub(crate) use crate::session_state::user_ask::USER_ASK_CAPABILITY_ID;
+pub(crate) use agent_commands::{
+    AGENT_COMMANDS_CAPABILITY_ID, AgentCommandsCapability, CommandDispatch,
+};
 pub(crate) use approval::{APPROVAL_CAPABILITY_ID, ApprovalCapability};
 pub(crate) use ast_grep::{AST_GREP_CAPABILITY_ID, AstEditCapability, AstGrepCapability};
 pub(crate) use attribution::{ATTRIBUTION_CAPABILITY_ID, AttributionCapability};
@@ -46,9 +50,7 @@ pub(crate) use background::{
     BACKGROUND_CAPABILITY_ID, BackgroundCapability, NarratedBackgroundExecutionCapability,
 };
 pub(crate) use checkpoint::{CHECKPOINT_CAPABILITY_ID, CheckpointCapability};
-pub(crate) use client_commands::{
-    CLIENT_COMMANDS_CAPABILITY_ID, ClientCommandsCapability, CommandDispatch,
-};
+pub(crate) use client_commands::{CLIENT_COMMANDS_CAPABILITY_ID, ClientCommandsCapability};
 pub(crate) use config::{CONFIG_CAPABILITY_ID, ConfigCapability};
 pub(crate) use context_cost_control::{
     CONTEXT_COST_CONTROL_CAPABILITY_ID, ContextCostControlCapability,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -16,11 +16,12 @@ use crate::capabilities::tool_reveal::{
 };
 use crate::capabilities::yolop::{YOLOP_CAPABILITY_ID, YolopCapability};
 use crate::capabilities::{
-    APPROVAL_CAPABILITY_ID, AST_GREP_CAPABILITY_ID, ATTRIBUTION_CAPABILITY_ID, ApprovalCapability,
-    AstEditCapability, AstGrepCapability, AttributionCapability, BACKGROUND_CAPABILITY_ID,
-    BackgroundCapability, CHECKPOINT_CAPABILITY_ID, CLIENT_COMMANDS_CAPABILITY_ID,
-    CODING_BASH_CAPABILITY_ID, CONFIG_CAPABILITY_ID, CONTEXT_COST_CONTROL_CAPABILITY_ID,
-    CheckpointCapability, ClientCommandsCapability, ClientUiContext, CodingBashCapability,
+    AGENT_COMMANDS_CAPABILITY_ID, APPROVAL_CAPABILITY_ID, AST_GREP_CAPABILITY_ID,
+    ATTRIBUTION_CAPABILITY_ID, AgentCommandsCapability, ApprovalCapability, AstEditCapability,
+    AstGrepCapability, AttributionCapability, BACKGROUND_CAPABILITY_ID, BackgroundCapability,
+    CHECKPOINT_CAPABILITY_ID, CLIENT_COMMANDS_CAPABILITY_ID, CODING_BASH_CAPABILITY_ID,
+    CONFIG_CAPABILITY_ID, CONTEXT_COST_CONTROL_CAPABILITY_ID, CheckpointCapability,
+    ClientCommandsCapability, ClientUiContext, CodingBashCapability,
     CodingCliEnvironmentCapability, CommandDispatch, ConfigCapability,
     ContextCostControlCapability, CoordinationConfig, CoordinationHost, CoordinationStore,
     ENVIRONMENT_CONTEXT_CAPABILITY_ID, EnvironmentContextRegistry, GOAL_CAPABILITY_ID,
@@ -2456,6 +2457,9 @@ fn default_coding_harness_capabilities(client_commands: bool) -> Vec<CapabilityR
     if client_commands {
         caps.push(CapabilityRef::new(CLIENT_COMMANDS_CAPABILITY_ID));
     }
+    // `run_command` reaches whatever this host's registry holds, so it is on for
+    // every host, not just the terminal.
+    caps.push(CapabilityRef::new(AGENT_COMMANDS_CAPABILITY_ID));
     caps.extend([
         CapabilityRef::with_config(
             SESSION_COORDINATION_CAPABILITY_ID,
@@ -4090,17 +4094,23 @@ pub async fn build_with_options(
     // effort/clear/shell/quit and forwards each invocation as a `UiCommand` down
     // `ui_tx` (created above, shared with extension status); the `App` event
     // loop drains `ui_rx` and performs the effect.
-    // `run_command` additionally reaches every *other* registered command
-    // through `RuntimeCommandDispatch`, so the agent's command surface is the
-    // session registry rather than a second allowlist.
-    if options.client_commands {
-        let ui: Arc<dyn HostUi> = Arc::new(TuiHandle::new(ui_tx));
-        let dispatch: Arc<dyn CommandDispatch> = Arc::new(RuntimeCommandDispatch {
+    let host_ui: Option<Arc<dyn HostUi>> = options
+        .client_commands
+        .then(|| Arc::new(TuiHandle::new(ui_tx)) as Arc<dyn HostUi>);
+    if let Some(ui) = host_ui.clone() {
+        capabilities.register(ClientCommandsCapability::new(ui));
+    }
+    // `run_command` is host-neutral: it dispatches whatever this session's
+    // registry holds, so every host registers it. The terminal's `HostUi` rides
+    // along only so informational client commands (`/mcp`, `/tools`) can return
+    // the transcript lines the host printed.
+    capabilities.register(AgentCommandsCapability::new(
+        Arc::new(RuntimeCommandDispatch {
             runtime: runtime_cell.clone(),
             session_id,
-        });
-        capabilities.register(ClientCommandsCapability::new(ui, dispatch));
-    }
+        }) as Arc<dyn CommandDispatch>,
+        host_ui,
+    ));
 
     let mut catalog = CapabilityCatalog::new();
     for cap in capabilities.list() {
@@ -6370,6 +6380,64 @@ mod tests {
         assert!(
             ids.iter()
                 .any(|cap| cap.capability_id() == USER_ASK_CAPABILITY_ID)
+        );
+    }
+
+    /// `run_command` is not terminal-only: ACP and `--print` sessions get it
+    /// too, so they can run whatever their own registry holds.
+    #[test]
+    fn every_host_enables_run_command() {
+        for client_commands in [false, true] {
+            let ids = coding_harness_capabilities(client_commands, None, &Settings::default());
+            assert!(
+                ids.iter()
+                    .any(|cap| cap.capability_id() == AGENT_COMMANDS_CAPABILITY_ID),
+                "run_command must be enabled (client_commands={client_commands})"
+            );
+        }
+    }
+
+    /// A host without a terminal (ACP, `--print`) still exposes `run_command`,
+    /// and simply has no client commands in its registry to find.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn headless_host_exposes_run_command_without_terminal_commands() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+        let built = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Sim,
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            BuildOptions::default(),
+        )
+        .await
+        .expect("build runtime");
+
+        assert!(
+            built
+                .startup
+                .tool_names
+                .iter()
+                .any(|name| name == "run_command"),
+            "run_command is host-neutral: {:?}",
+            built.startup.tool_names
+        );
+
+        let names: Vec<String> = built
+            .startup
+            .capability_commands
+            .iter()
+            .map(|command| command.name.clone())
+            .collect();
+        assert!(
+            names.iter().any(|name| name == "setup"),
+            "registry still carries runtime commands: {names:?}"
+        );
+        assert!(
+            !names.iter().any(|name| name == "quit"),
+            "terminal commands stay out of a headless registry: {names:?}"
         );
     }
 
@@ -9218,6 +9286,7 @@ mod tests {
 
     #[test]
     fn always_on_capability_prompts_within_budget() {
+        use crate::capabilities::agent_commands::AGENT_COMMANDS_PROMPT;
         use crate::capabilities::approval::render_approval_block;
         use crate::capabilities::attribution::yolop_attribution_prompt;
         use crate::capabilities::background::BACKGROUND_SYSTEM_PROMPT;
@@ -9241,6 +9310,7 @@ mod tests {
             ("approval", approval.len()),
             ("background", BACKGROUND_SYSTEM_PROMPT.len()),
             ("client_commands", CLIENT_COMMANDS_PROMPT.len()),
+            ("agent_commands", AGENT_COMMANDS_PROMPT.len()),
             ("setup", MODELS_PROMPT.len()),
             ("attribution", yolop_attribution_prompt().len()),
             (

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -21,14 +21,15 @@ use crate::capabilities::{
     BackgroundCapability, CHECKPOINT_CAPABILITY_ID, CLIENT_COMMANDS_CAPABILITY_ID,
     CODING_BASH_CAPABILITY_ID, CONFIG_CAPABILITY_ID, CONTEXT_COST_CONTROL_CAPABILITY_ID,
     CheckpointCapability, ClientCommandsCapability, ClientUiContext, CodingBashCapability,
-    CodingCliEnvironmentCapability, ConfigCapability, ContextCostControlCapability,
-    CoordinationConfig, CoordinationHost, CoordinationStore, ENVIRONMENT_CONTEXT_CAPABILITY_ID,
-    EnvironmentContextRegistry, GOAL_CAPABILITY_ID, GoalCapability, HERDR_CAPABILITY_ID,
-    HOOKS_CAPABILITY_ID, HerdrCapability, HooksCapability, LspCapability,
-    MODEL_RUNTIME_CONTEXT_CAPABILITY_ID, MODELS_CAPABILITY_ID, ModelRuntimeContextCapability,
-    ModelsCapability, PROGRESS_GUARD_CAPABILITY_ID, ProgressGuardCapability,
-    REPO_MAP_CAPABILITY_ID, RepoMapCapability, SESSION_COORDINATION_CAPABILITY_ID,
-    SESSION_HISTORY_CAPABILITY_ID, SessionCoordinationCapability, SessionHistoryCapability,
+    CodingCliEnvironmentCapability, CommandDispatch, ConfigCapability,
+    ContextCostControlCapability, CoordinationConfig, CoordinationHost, CoordinationStore,
+    ENVIRONMENT_CONTEXT_CAPABILITY_ID, EnvironmentContextRegistry, GOAL_CAPABILITY_ID,
+    GoalCapability, HERDR_CAPABILITY_ID, HOOKS_CAPABILITY_ID, HerdrCapability, HooksCapability,
+    LspCapability, MODEL_RUNTIME_CONTEXT_CAPABILITY_ID, MODELS_CAPABILITY_ID,
+    ModelRuntimeContextCapability, ModelsCapability, PROGRESS_GUARD_CAPABILITY_ID,
+    ProgressGuardCapability, REPO_MAP_CAPABILITY_ID, RepoMapCapability,
+    SESSION_COORDINATION_CAPABILITY_ID, SESSION_HISTORY_CAPABILITY_ID,
+    SessionCoordinationCapability, SessionHistoryCapability,
     TOOL_ARGUMENT_VALIDATION_CAPABILITY_ID, ToolArgumentValidationCapability,
     USER_ASK_CAPABILITY_ID, UserAskCapability, WorktreeCapability, coordination_project_id,
 };
@@ -66,7 +67,7 @@ use everruns_session_services::{
 use everruns_capability::CapabilityRef;
 use everruns_core::SessionStore;
 use everruns_core::SessionTaskRegistry;
-use everruns_core::command::CommandDescriptor;
+use everruns_core::command::{CommandDescriptor, CommandResult, ExecuteCommandRequest};
 use everruns_core::session_file::build_grep_search_result;
 use everruns_core::session_path::GrepPathPattern;
 use everruns_core::{
@@ -3255,6 +3256,54 @@ impl Default for BuildOptions {
     }
 }
 
+/// Session command registry for the agent-facing `run_command` tool.
+///
+/// Holds the same late-bound `Weak<InProcessRuntime>` the wake seam uses: the
+/// capability is constructed while the runtime is still being built, and the
+/// cell is set once `build()` returns, long before a turn can call a tool.
+/// Listing and executing go through `runtime.list_commands` /
+/// `runtime.execute_command`, the single registry every host reads, so the
+/// agent can run whatever the user could type.
+struct RuntimeCommandDispatch {
+    runtime: Arc<std::sync::OnceLock<std::sync::Weak<InProcessRuntime>>>,
+    session_id: SessionId,
+}
+
+impl RuntimeCommandDispatch {
+    fn runtime(&self) -> everruns_provider::error::Result<Arc<InProcessRuntime>> {
+        self.runtime
+            .get()
+            .and_then(std::sync::Weak::upgrade)
+            .ok_or_else(|| {
+                everruns_provider::error::AgentLoopError::config("runtime is not available")
+            })
+    }
+}
+
+#[async_trait]
+impl CommandDispatch for RuntimeCommandDispatch {
+    async fn list(&self) -> everruns_provider::error::Result<Vec<CommandDescriptor>> {
+        self.runtime()?.list_commands(self.session_id).await
+    }
+
+    async fn execute(
+        &self,
+        name: &str,
+        arguments: Option<String>,
+    ) -> everruns_provider::error::Result<CommandResult> {
+        self.runtime()?
+            .execute_command(
+                self.session_id,
+                ExecuteCommandRequest {
+                    name: name.to_string(),
+                    arguments,
+                    controls: None,
+                },
+            )
+            .await
+    }
+}
+
 /// Yolop's provider store.
 ///
 /// 0.18 split model selection from credentials: the store answers "which
@@ -4041,9 +4090,16 @@ pub async fn build_with_options(
     // effort/clear/shell/quit and forwards each invocation as a `UiCommand` down
     // `ui_tx` (created above, shared with extension status); the `App` event
     // loop drains `ui_rx` and performs the effect.
+    // `run_command` additionally reaches every *other* registered command
+    // through `RuntimeCommandDispatch`, so the agent's command surface is the
+    // session registry rather than a second allowlist.
     if options.client_commands {
         let ui: Arc<dyn HostUi> = Arc::new(TuiHandle::new(ui_tx));
-        capabilities.register(ClientCommandsCapability::new(ui));
+        let dispatch: Arc<dyn CommandDispatch> = Arc::new(RuntimeCommandDispatch {
+            runtime: runtime_cell.clone(),
+            session_id,
+        });
+        capabilities.register(ClientCommandsCapability::new(ui, dispatch));
     }
 
     let mut catalog = CapabilityCatalog::new();
@@ -6314,6 +6370,72 @@ mod tests {
         assert!(
             ids.iter()
                 .any(|cap| cap.capability_id() == USER_ASK_CAPABILITY_ID)
+        );
+    }
+
+    /// The reported gap: `run_command` could only reach the commands the client
+    /// capability declared, so `/setup reauthenticate <provider>` was
+    /// unreachable from a turn. Its registry port must see, and run, every
+    /// command the session registers.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn run_command_registry_port_reaches_commands_like_setup() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+        let built = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Sim,
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            BuildOptions {
+                client_ui: ClientUiContext::Tui,
+                client_commands: true,
+                ..BuildOptions::default()
+            },
+        )
+        .await
+        .expect("build runtime");
+
+        assert!(
+            built
+                .startup
+                .tool_names
+                .iter()
+                .any(|name| name == "run_command"),
+            "TUI sessions expose run_command: {:?}",
+            built.startup.tool_names
+        );
+
+        let cell = Arc::new(std::sync::OnceLock::new());
+        cell.set(Arc::downgrade(&built.handles.runtime))
+            .expect("seed runtime cell");
+        let dispatch = RuntimeCommandDispatch {
+            runtime: cell,
+            session_id: built.handles.session_id,
+        };
+
+        let names: Vec<String> = dispatch
+            .list()
+            .await
+            .expect("list commands")
+            .into_iter()
+            .map(|command| command.name)
+            .collect();
+        assert!(
+            names.iter().any(|name| name == "setup"),
+            "registry port sees non-client commands: {names:?}"
+        );
+
+        let result = dispatch
+            .execute("setup", Some("status".to_string()))
+            .await
+            .expect("execute /setup status");
+        assert!(result.success);
+        assert!(
+            result.message.starts_with("setup:"),
+            "run_command returns the runtime's own output: {}",
+            result.message
         );
     }
 

--- a/src/tui/host_ui.rs
+++ b/src/tui/host_ui.rs
@@ -134,3 +134,47 @@ impl HostUi for TuiHandle {
         reply_rx
     }
 }
+
+/// Recording [`HostUi`] for unit tests: captures queued commands and answers
+/// `request` with representative transcript lines, so capabilities that drive
+/// the host can be tested without a live `App`. Integration coverage for the
+/// real host text lives in the TUI suite.
+#[cfg(test)]
+#[derive(Default)]
+pub(crate) struct RecordingUi {
+    commands: std::sync::Mutex<Vec<UiCommand>>,
+}
+
+#[cfg(test)]
+impl RecordingUi {
+    pub(crate) fn take(&self) -> Vec<UiCommand> {
+        std::mem::take(&mut *self.commands.lock().expect("commands lock"))
+    }
+}
+
+#[cfg(test)]
+impl HostUi for RecordingUi {
+    fn send(&self, command: UiCommand) {
+        self.commands.lock().expect("commands lock").push(command);
+    }
+
+    fn request(&self, command: UiCommand) -> oneshot::Receiver<Vec<String>> {
+        self.send(command.clone());
+        let (tx, rx) = oneshot::channel();
+        let message = match &command {
+            UiCommand::ManageMcp { .. } => {
+                vec![
+                    "active MCP servers: none".into(),
+                    "usage: /mcp [reload | login <name> | enable|disable|remove <name> [global|workspace]]"
+                        .into(),
+                ]
+            }
+            UiCommand::ShowTools => vec!["tools: bash".into()],
+            UiCommand::ShowHelp => vec!["commands:".into()],
+            UiCommand::ShowCwd => vec!["workspace root: /tmp".into()],
+            _ => Vec::new(),
+        };
+        let _ = tx.send(message);
+        rx
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -4011,10 +4011,9 @@ mod tests {
                 rx
             }
         }
-        crate::capabilities::client_commands::ClientCommandsCapability::new(
-            std::sync::Arc::new(NoopUi),
-            std::sync::Arc::new(crate::capabilities::client_commands::EmptyCommandDispatch),
-        )
+        crate::capabilities::client_commands::ClientCommandsCapability::new(std::sync::Arc::new(
+            NoopUi,
+        ))
         .commands()
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -4011,9 +4011,10 @@ mod tests {
                 rx
             }
         }
-        crate::capabilities::client_commands::ClientCommandsCapability::new(std::sync::Arc::new(
-            NoopUi,
-        ))
+        crate::capabilities::client_commands::ClientCommandsCapability::new(
+            std::sync::Arc::new(NoopUi),
+            std::sync::Arc::new(crate::capabilities::client_commands::EmptyCommandDispatch),
+        )
         .commands()
     }
 


### PR DESCRIPTION
## What changed

`run_command` now runs any slash command the session's registry holds, on every
host, instead of a hardcoded list of nine terminal commands in the TUI only.

- **No allowlist.** A command name is resolved against `runtime.list_commands`
  and executed through `runtime.execute_command`, the same path a typed slash
  command takes. `/setup reauthenticate <provider>`, `/background`, `/undo`,
  `/rewind`, `/goal`, and anything a capability, extension, or MCP server
  registers later are reachable from a turn the moment they are registered.
- **Every host.** The tool moved out of the TUI-gated client capability into a
  new host-neutral `agent_commands` capability, so ACP and `--print` sessions
  can run the commands their own registry holds. Previously they had no way to
  run a command at all.
- **Discovery.** `command: help` returns the live command list, and an unknown
  name comes back with it too, so the model never has to guess. The tool's JSON
  schema no longer pins an enum of command names.
- **Terminal read-back preserved.** Where a terminal exists, the informational
  client commands (`/mcp`, `/tools`, `/help`, `/cwd`) still go through the
  `HostUi` port, so the tool result carries the transcript lines the host
  printed rather than the empty `CommandResult` they return by design.

Two commands stay out by design, with an explaining error: `Skill` commands,
which activate by prompt rather than by a runtime effect, and `/shell`, which
stays typed-only because the agent already has the sandboxed `bash` tool.

## Why

A user asked the agent to run `/setup reauthenticate codex_browser`. The agent
inspected its own tools, found `run_command` restricted to
`/help`, `/tools`, `/mcp`, `/cwd`, `/status`, `/model`, `/effort`, `/clear`,
`/quit`, and correctly reported that it could not do it — the command existed
in the registry and the TUI could dispatch it, but the tool's own enum hid it.
A second registry that has to be kept in sync with the real one is exactly what
[`commands.md`](knowledge/specs/commands.md) says must not exist.

The same tool was also TUI-gated, so ACP and `--print` sessions had no command
dispatch at all, even for commands their registry advertises.

## Before / After

Live provider, `--print` (no terminal, so this is the host that previously had
no `run_command` whatsoever):

```
$ doppler run -- yolop --provider anthropic \
    -p "Use the run_command tool to run the /setup status command, then report the exact tool result text."
```

**Before** (`origin/main`, 94a73ba):

```
There is no `run_command` tool available in this session, and no `/setup` command exists here.
I searched the tool registry and the only shell-style tool is `bash`; there is no tool that runs
slash-commands like `/setup status`.
```

**After** (this branch):

```
Exact tool result text:

setup: provider=anthropic model=anthropic/claude-opus-4-8 high saved=<unset> attribution=on
approval=normal stored tokens=none env keys present=true
```

Offline smoke (`yolop --provider llmsim -p "hi"`) still starts and answers.

## Risk

- Low / Medium
- The model can now invoke settings-mutating commands (`/setup …`) on hosts
  where it previously could not. That is the same authority the user's own
  typed command has on their machine, and no new command was created.
- Terminal side-effect commands (`/quit`, `/clear`, `/model`) now reach their
  capability through `runtime.execute_command` instead of a direct port send.
  The effect is identical (the capability emits the same `UiCommand`); the
  informational commands keep the direct port path with its existing 15s
  timeout. Covered by unit tests for both host shapes plus the TUI PTY suite.
- ACP keeps its own client-side handling for `/setup login` (it opens the
  editor's browser flow). Run through `run_command`, that command takes the
  runtime path instead, so behavior there can differ from an ACP client typing
  it. Listed under Follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

Tests: 14 unit tests in `agent_commands` covering both host shapes (headless
registry-only and terminal-with-port) — registry dispatch of
`/setup reauthenticate codex_browser`, `help` listing, unknown-name listing,
skill refusal, missing required args, `/shell` refusal, `/mcp` host read-back,
`/mcp reload`, terminal side effects via the registry. Runtime tests assert the
harness enables `run_command` for `client_commands` both false and true, that
the registry port sees `setup` and returns its real output, and that a headless
build exposes `run_command` while carrying `setup` but not `quit`.

Rebased onto a8a3dd7 (#591); the two knowledge conflicts were additive on both
sides and both entries are kept. Re-validated after the rebase: 1191 unit + 63 +
1 + 5 integration/PTY tests green, `cargo clippy --all-targets --all-features -D
warnings`, `cargo fmt --check`, `validate_okf.py --check-links`. The always-on
prompt-budget test still passes with both new prompt blocks in place, so no cap
change was needed.

## Knowledge

Updated [`specs/commands.md`](knowledge/specs/commands.md) (natural-language
dispatch now covers the whole registry; host gating distinguishes the always-on
`agent_commands` from the TUI-gated client commands; ownership boundary names
the `CommandDispatch` port),
[`specs/conversational-control.md`](knowledge/specs/conversational-control.md)
(control-surface inventory), and `knowledge/log.md`.

## Security

Reviewed against the yolop threat model.

- **TM-TOOL (capability registration).** The new capability's authority is
  exactly the host's own command registry — it cannot reach a command the host
  did not register, and it adds none. `/shell` is refused before the registry
  lookup, so the sandboxed, approval-gated `bash` tool remains the only shell
  path even though `/shell` is a registered TUI command. `Skill` commands are
  refused rather than executed. Missing required arguments are reported instead
  of forwarded.
- **TM-LLM (prompt and keys).** Prompt text only; no key handling added. Keys
  are still read from process env and never logged. Command output is returned
  verbatim, and the settings command it exposes masks credentials
  (`stored tokens=none`, `env keys present=true`) rather than printing values.
- **TM-BASH / TM-FS.** Untouched. No new shell or filesystem paths; the bounded
  execution model in `tools.rs` is unchanged.
- **TM-DEP.** No new dependencies.
- Injection: the command name is matched by exact string against registry
  entries and is never shell-interpreted; arguments are passed to the command
  handler exactly as the typed path passes them. Resource exhaustion: no loops;
  the host read-back keeps its 15s timeout and the registry calls are bounded
  runtime calls.

## Follow-ups

- ACP intercepts `/setup login` client-side to open the editor's browser flow;
  the same command via `run_command` takes the runtime path. Unifying the two
  is a separate design question about routing tool calls back through ACP's
  client-side interception, so it is not folded into this change.
