### PR TITLE
chore(deps): track the tuika 0.10 companion releases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,11 +97,11 @@ textwrap = "0.16"
 tuika = "0.10.0"
 # Optional structured-markdown renderers stay outside tuika core. Mermaid
 # fences become terminal diagrams; safe block HTML becomes styled text.
-tuika-mermaid = "0.3.0"
-tuika-html = "0.1.2"
+tuika-mermaid = "0.3.1"
+tuika-html = "0.1.3"
 # Tree-sitter Highlighter impl for tuika's CodeBlock/Markdown; owns the grammar
 # deps so tuika core stays dependency-light. Published from the tuika repo.
-tuika-codeformatters = "0.4.2"
+tuika-codeformatters = "0.4.3"
 tokio = { version = "1.52", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tree-sitter = "0.26"


### PR DESCRIPTION
## What changed

The manifest requirements for tuika's companion crates move to the releases cut alongside tuika 0.10.0: `tuika-codeformatters` 0.4.2 → 0.4.3, `tuika-html` 0.1.2 → 0.1.3, `tuika-mermaid` 0.3.0 → 0.3.1. `tuika` itself is already at 0.10.0 (#585) and is unchanged here; 0.10.0 remains the latest published release.

No lockfile change: `Cargo.lock` already resolves all three to the new versions, so nothing about the built binary changes.

## Why

The companion crates pin a compatible `tuika` range, and the 0.9-era releases pin `^0.9.0` while yolop's host takes `^0.10.0`. With the old minimums a fresh resolve (a new checkout, a `cargo update`, a downstream build) could legally pick `tuika-mermaid` 0.3.0 and pull a second `tuika` into the tree beside the host's 0.10, which is the mismatch [`knowledge/specs/tuika.md`](https://github.com/everruns/yolop/blob/main/knowledge/specs/tuika.md) rules out under "the companion crates move with tuika". Naming the 0.10-tracking releases makes that resolve impossible rather than merely unlikely.

## Before / After

No observable behavior change: the resolved dependency graph before and after is identical (`Cargo.lock` untouched, `cargo tree -p tuika --depth 0` → `tuika v0.10.0` both ways). The change closes a resolution hole, it does not alter what the current build does.

Evidence on this branch:

- `cargo fmt --check` — clean.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo test --all-features --no-fail-fast` — `integration` 64/64, `parallel_integration` 1/1, `tuika_pty` 5/5 (the renderer PTY suite, the closest coverage to this dependency), unit suite 1192 passed / 2 failed.
- Smoke: `./target/debug/yolop --provider llmsim -p "hi"` starts and answers, exit 0.

The 2 unit failures (`exec::workspace_host::tests::resolve_host_scope_spelling_table_is_consistent`, `capabilities::repo_map::tests::repo_map_tool_accepts_workspace_alias_scope`) are environmental, not from this change: they fail identically with the diff stashed on unmodified `origin/main`. Both exercise the `/workspace` display alias, and the sandbox this was validated in has a real `/workspace` directory, so the alias resolves host-absolute outside the test's tempdir root. CI, without that directory, is the check that matters here.

## Risk

- Low
- The only breakage mode would be a companion release incompatible with tuika 0.10, which is the opposite of what these versions are: 0.4.3 / 0.1.3 / 0.3.1 are the releases cut from the same tuika commit as 0.10.0 and requiring `^0.10.0`. Since the lockfile already used them, the code under test is the code already on `main`.

## Checklist

- [x] Tests added or updated — no new test: the change adds no behavior to drive. The existing `tuika_pty` suite covers the dependency surface and passes.
- [x] Backward compatibility considered — raising a minimum within the same compatible range; no public API or wire surface touched.
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

No knowledge update required — `knowledge/specs/tuika.md` already states the invariant this enforces ("the companion crates move with tuika") and deliberately carries no version numbers, so nothing durable changed.

## Security

No security-relevant code changes: the diff is three version requirements in `Cargo.toml`, with no lockfile movement and therefore no new or changed compiled code.

The one category in scope is **TM-DEP** (dependency risk). No new crate is introduced; all three are existing dependencies moving to the releases published from the same tuika repository and commit as the `tuika` 0.10.0 the host already takes, so the versions stay in lockstep rather than drifting. TM-FS, TM-BASH, TM-LLM, and TM-TOOL are untouched: no filesystem, shell, prompt, key-handling, or capability-registration code appears in the diff.

## Follow-ups

No follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbxrUyy5GQCXyERrc9rwcH)_