### PR TITLE
fix(models): run `models pull` on the caller's runtime

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -919,7 +919,7 @@ fn resolve_workspace_root(
     std::env::current_dir().context("resolve current workspace directory")
 }
 
-fn run_models_command(command: ModelsCommand) -> Result<()> {
+async fn run_models_command(command: ModelsCommand) -> Result<()> {
     match command {
         ModelsCommand::List => {
             let models = models::installed()?;
@@ -946,12 +946,18 @@ fn run_models_command(command: ModelsCommand) -> Result<()> {
             );
             Ok(())
         }
-        ModelsCommand::Pull { spec } => run_models_pull(&spec),
+        ModelsCommand::Pull { spec } => run_models_pull(&spec).await,
     }
 }
 
+/// Download `spec`, awaiting on the caller's runtime.
+///
+/// This must not build a runtime of its own. `run_command` is reached from
+/// `#[tokio::main]`, so a nested `Runtime::new().block_on(..)` panics with
+/// "Cannot start a runtime from within a runtime" before a single byte is
+/// fetched — which is exactly what shipped in 0.16.0.
 #[cfg(feature = "local-inference")]
-fn run_models_pull(spec: &str) -> Result<()> {
+async fn run_models_pull(spec: &str) -> Result<()> {
     use std::sync::{Arc, Mutex};
 
     if models::is_installed(spec) {
@@ -962,7 +968,7 @@ fn run_models_pull(spec: &str) -> Result<()> {
     println!("Pulling {spec}…");
     let sink: Arc<Mutex<dyn models::download::ProgressSink>> =
         Arc::new(Mutex::new(models::download::StderrProgress::new()));
-    let summary = tokio::runtime::Runtime::new()?.block_on(models::download::pull(spec, sink))?;
+    let summary = models::download::pull(spec, sink).await?;
 
     if summary.files.is_empty() {
         println!("Nothing to fetch — {spec} was already complete.");
@@ -980,7 +986,7 @@ fn run_models_pull(spec: &str) -> Result<()> {
 /// would only waste the disk. List and remove still work, so a build that drops
 /// the feature can still clean up what an earlier build downloaded.
 #[cfg(not(feature = "local-inference"))]
-fn run_models_pull(_spec: &str) -> Result<()> {
+async fn run_models_pull(_spec: &str) -> Result<()> {
     Err(anyhow::anyhow!(
         "this build has no local inference engine, so downloaded weights could not be run. \
          Install a release build (Homebrew) or build with `--features local-inference`."
@@ -1231,7 +1237,7 @@ async fn run_command(command: Commands) -> Result<()> {
         }
         Commands::Worktree(args) => run_worktree_command(args.command),
         Commands::Mcp(args) => run_mcp_command(args.command),
-        Commands::Models(args) => run_models_command(args.command),
+        Commands::Models(args) => run_models_command(args.command).await,
         Commands::TuikaGallery => run_tuika_gallery(),
         #[cfg(target_os = "linux")]
         Commands::SandboxExec {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -43,6 +43,43 @@ fn yolop_binary() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_yolop"))
 }
 
+/// `models pull` must reach the download without panicking.
+///
+/// 0.16.0 shipped a `Runtime::new().block_on(..)` inside the pull, which is
+/// reached from `#[tokio::main]` and therefore panicked with "Cannot start a
+/// runtime from within a runtime" before fetching a byte — the command could
+/// never have worked. The unit tests missed it because they exercised the
+/// pieces, not the command, and a spec that is already installed returns before
+/// the download; only a spec that actually attempts a fetch reproduces it.
+///
+/// The spec below is deliberately unresolvable, so the command must *fail* —
+/// with or without the engine compiled in, and with or without network. What is
+/// asserted is only that it fails cleanly rather than panicking.
+#[test]
+fn models_pull_reaches_the_download_without_a_nested_runtime() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let output = Command::new(yolop_binary())
+        .args([
+            "models",
+            "pull",
+            "yolop-test/definitely-not-a-real-repo-2b9f1c",
+        ])
+        .env("HOME", tmp.path())
+        .env("XDG_DATA_HOME", tmp.path().join("data"))
+        .output()
+        .expect("run yolop models pull");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Cannot start a runtime from within a runtime"),
+        "models pull built a nested runtime: {stderr}"
+    );
+    assert!(
+        !stderr.contains("panicked at"),
+        "models pull panicked instead of failing cleanly: {stderr}"
+    );
+}
+
 #[test]
 fn coordination_cli_lists_workers_without_model_startup() {
     let tmp = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## What changed

`yolop models pull` panics instead of downloading, in **any** build with the engine compiled in. It is non-functional in `v0.16.0` as prepared.

The pull built a runtime inside a runtime:

```rust
tokio::runtime::Runtime::new()?.block_on(models::download::pull(spec, sink))
```

`run_command` is reached from `#[tokio::main]`, so this panics before fetching a byte. The command is now `async` and awaits on the caller's runtime; no `Runtime::new` remains in a command path.

## Why

Reported from a real terminal on macOS:

```
) yolop models pull Qwen/Qwen3-8B
Pulling Qwen/Qwen3-8B…

thread 'yolop-main' panicked at tokio-1.53.1/src/runtime/scheduler/multi_thread/mod.rs:91:9:
Cannot start a runtime from within a runtime. This happens because a function
(like `block_on`) attempted to block the current thread while the thread is
being used to drive asynchronous tasks.
```

Since `models pull` is the only supported way to get weights, and the driver deliberately refuses to download during a turn, this makes the whole `local` provider unusable end to end.

## Before / After

**Before** — panic, exit 101, crash report written, nothing downloaded.

**After** — the command reaches the download and reports normally:

```
$ yolop models pull yolop-test/definitely-not-a-real-repo-2b9f1c
Pulling yolop-test/definitely-not-a-real-repo-2b9f1c…
Error: list files in yolop-test/definitely-not-a-real-repo-2b9f1c: …
```

A clean error for an unresolvable repo, rather than a panic before the attempt.

## How this was missed

Worth stating plainly, because it shaped the test:

- The `models pull` smoke run in #581 was done on a build **without** `local-inference`, where the command returns the "no engine in this build" error and never reaches the download. It exercised only the disabled path, and looked correct.
- The unit tests cover `pull`'s internals and the progress sink — not the command.
- A test using an already-installed spec would also have passed: the old code checked `is_installed` **before** constructing the runtime, so it returned early.

Only a spec that actually attempts a fetch reaches the panic.

## Risk

- **Low.** Two signatures become `async` and one `block_on` is dropped. No behavior change beyond the command now working.
- `run_command` was already `async` and awaited, so no call-site restructuring was needed.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

`No knowledge update required` — [`local-inference.md`](knowledge/specs/local-inference.md) already documents the intended behavior ("a turn never downloads; `yolop models pull` owns that wait"). This makes the implementation match what the spec already claims; no durable behavior, policy, or constraint changed.

## Testing

The regression test drives the real binary at a deliberately unresolvable spec and asserts it fails *cleanly* rather than panicking — network-tolerant, and valid with or without the feature compiled in.

**Verified in both directions**, which is the part that matters here: the nested runtime was reintroduced and the test observed **failing**, then the fix restored and the test observed **passing**. A regression test never seen to fail is exactly the kind of evidence that let the original bug through.

Full gate on this branch:

| Check | Result |
|---|---|
| `cargo fmt --check` | pass |
| `cargo clippy --all-targets -- -D warnings` | pass |
| `cargo clippy --all-targets --all-features -- -D warnings` | pass |
| `cargo test --all-features --workspace` | 1194 + 65 + 25 passed, 0 failed |

## Follow-ups

- **Release timing.** This fix should land before `v0.16.0` binaries ship, or `models pull` is dead on arrival for anyone who installs them.
- **No `metal`/`cuda` features exist.** [`local-inference.md`](knowledge/specs/local-inference.md) says accelerated backends "stay opt-in on top of `local-inference`", but only `local-inference` is defined in `Cargo.toml`. On Apple Silicon that means CPU-only inference, which will read as "the model is useless" when it is really "untested unaccelerated". Doc/implementation mismatch from #581, not fixed here.
- The pre-existing follow-ups from #581 (no eval numbers, unmeasured tarball delta, file-granularity resume, no disk-budget guard) are unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Da4zsRdxH86Sm6nAAfY7k8)_