### PR TITLE
chore(build): stop compiling the tree twice in dev builds

### DIFF
--- a/.agents/skills/maintenance/surfaces.md
+++ b/.agents/skills/maintenance/surfaces.md
@@ -28,7 +28,7 @@ Also check `ratatui`, `crossterm`, `clap`, and `tokio` minors — they tend to
 ship breaking-feeling lint changes. Grep for direct dependencies no longer used
 in `src/`, and flag deprecated crates with a replacement.
 
-Evidence after a bump: `cargo test --all-features`, plus one real-provider
+Evidence after a bump: `cargo test --workspace --features yolop-yep/schema`, plus one real-provider
 smoke (`doppler run -- cargo run -- --provider openai -p "hi"`).
 
 ## Upstream mirror
@@ -84,7 +84,7 @@ change — call it out in the PR.
 ## Test and runtime confidence
 
 ```bash
-cargo test --all-features
-doppler run -- cargo test --all-features --test integration
+cargo test --workspace --features yolop-yep/schema
+doppler run -- cargo test --features yolop-yep/schema --test integration
 cargo run -- --provider llmsim -p "hi"     # non-empty response, exit 0
 ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,12 @@ jobs:
           PYTHONPATH: .
         run: uv run --python 3.12 --with mira-eval --with harbor -m unittest discover -s tests -v
 
+  # `lint` and `test` share the "debug" cache, so they must agree on the feature
+  # set: two feature sets in one target directory compile the whole graph twice
+  # (248 crates were being built under both, at 70 MB per copy for the larger
+  # ones). The shared set is `yolop-yep/schema` — it resolves to exactly the
+  # default 519 crates and carries the wire-schema drift guard.
+  # `local-inference` is the odd one out and gets its own job and cache below.
   lint:
     name: Format + Clippy
     needs: changes
@@ -155,7 +161,35 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings
+
+  # The shipped binaries are built with `local-inference` on
+  # (cli-binaries.yml), so the engine-enabled configuration still needs a gate.
+  # It is a compile gate only: no test is behind the feature, so running the
+  # suite again with it on would add ~220 crates and an 844 MB rlib for zero
+  # extra coverage. Its own cache key keeps that tree out of the "debug" cache
+  # every other Rust job restores.
+  local-inference:
+    name: Clippy (local-inference)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.94.0
+        with:
+          components: clippy
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "local-inference"
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets --features local-inference -- -D warnings
 
   test:
     name: Build + Tests + Offline Smoke
@@ -180,7 +214,7 @@ jobs:
           tool: cargo-llvm-cov
 
       - name: Build
-        run: cargo build --locked --all-targets
+        run: cargo build --locked --workspace --all-targets --features yolop-yep/schema
 
       - name: Install tmux
         run: sudo apt-get update && sudo apt-get install -y tmux
@@ -211,7 +245,7 @@ jobs:
         # The live provider tests skip themselves here (no API keys and
         # YOLOP_REQUIRE_LIVE_TESTS unset); they run in the `live-smoke` job below.
         run: |
-          cargo llvm-cov --no-report --all-features --workspace
+          cargo llvm-cov --no-report --features yolop-yep/schema --workspace
           cargo llvm-cov report --lcov --output-path lcov.info
           cargo llvm-cov report --summary-only
 
@@ -266,12 +300,12 @@ jobs:
           shared-key: "debug"
 
       - name: Build the test binary (offline)
-        run: cargo test --no-run --test integration
+        run: cargo test --no-run --features yolop-yep/schema --test integration
 
       - name: Live provider smoke tests
         env:
           YOLOP_REQUIRE_LIVE_TESTS: "1"
-        run: doppler run -- cargo test --test integration -- --nocapture
+        run: doppler run -- cargo test --features yolop-yep/schema --test integration -- --nocapture
 
   sandbox-contract:
     name: Sandbox Contract (${{ matrix.os }})

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Rust
 /target/
 **/target/
+# Separate target dir for the `local-inference` engine build (see AGENTS.md).
+/target-local-inference/
 **/*.rs.bk
 Cargo.lock.bak
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ its split-footer mode. See [Tuika](#tuika).
   repository secret.
 
   ```bash
-  doppler run -- cargo test --all-features
+  doppler run -- cargo test --workspace --features yolop-yep/schema
   doppler run -- cargo run -- --provider openai -p "hi"
   ```
 
@@ -64,11 +64,27 @@ private rotating files under `<data_dir>/yolop/logs/` inside it.
 
 ## Checks
 
+`--features yolop-yep/schema`, not `--all-features`: the schema feature resolves
+to the same crates a default build does, while `--all-features` also turns on
+`local-inference` and its ~220-crate engine. Mixing the two feature sets in one
+`target/` compiles the whole graph twice; keep every routine command on the same
+one. `--workspace` is what makes the root commands cover both packages, and with
+it the wire-schema drift guard in `yolop-yep`.
+
 ```bash
 cargo fmt --check
-cargo clippy --all-targets --all-features -- -D warnings
-cargo test --all-features
+cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings
+cargo test --workspace --features yolop-yep/schema
 python3 scripts/validate_okf.py knowledge --check-links   # when knowledge/ changed
+```
+
+Touching anything behind `local-inference` (`src/drivers/local.rs`,
+`src/models/`) needs the engine compiled too. Give it its own target directory
+so it stays out of the routine one:
+
+```bash
+CARGO_TARGET_DIR=target-local-inference \
+  cargo clippy --workspace --all-targets --features local-inference -- -D warnings
 ```
 
 ## Where things live

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,10 @@ its split-footer mode. See [Tuika](#tuika).
 `RUST_LOG` is honored for the tracing layer: stderr outside the interactive TUI,
 private rotating files under `<data_dir>/yolop/logs/` inside it.
 
+The `dev` profile carries line tables, not full DWARF, so backtraces keep
+file and line while `target/` stays a few gigabytes smaller. A debugger that
+needs variable inspection wants `cargo build --profile dev-debuginfo`.
+
 ## Checks
 
 `--features yolop-yep/schema`, not `--all-features`: the schema feature resolves

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,3 +209,14 @@ vt100 = "0.16"
 lto = "thin"
 codegen-units = 1
 strip = "debuginfo"
+
+# Dependency debuginfo dominated `target/`: a plain `cargo build --tests` left
+# 6.3 GB behind, most of it DWARF for ~600 crates nobody sets a breakpoint in.
+# Workspace crates keep full debuginfo (the code being debugged); dependencies
+# keep line tables only, which is what a backtrace through a dependency frame
+# actually reads. Build scripts and proc macros drop it entirely.
+[profile.dev.package."*"]
+debug = "line-tables-only"
+
+[profile.dev.build-override]
+debug = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,13 +210,20 @@ lto = "thin"
 codegen-units = 1
 strip = "debuginfo"
 
-# Dependency debuginfo dominated `target/`: a plain `cargo build --tests` left
-# 6.3 GB behind, most of it DWARF for ~600 crates nobody sets a breakpoint in.
-# Workspace crates keep full debuginfo (the code being debugged); dependencies
-# keep line tables only, which is what a backtrace through a dependency frame
-# actually reads. Build scripts and proc macros drop it entirely.
-[profile.dev.package."*"]
+# Full DWARF dominated `target/`: a clean `cargo build --tests` left 6.3 GB
+# behind (3.7 GB now), two of yolop's own test binaries accounting for 839 MB
+# of it. Line tables are what a backtrace actually reads, and backtraces plus
+# `RUST_LOG` are how this codebase is debugged; a debugger that needs variable
+# inspection gets it from `cargo build --profile dev-debuginfo`. Build scripts
+# and proc macros keep nothing, since nobody steps into those at all.
+[profile.dev]
 debug = "line-tables-only"
 
 [profile.dev.build-override]
 debug = false
+
+# Opt back in to full DWARF for a debugger session, without making every other
+# build pay for it.
+[profile.dev-debuginfo]
+inherits = "dev"
+debug = true

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,26 @@
 # Knowledge Log
 
+## 2026-08-19, Debug target size: one feature set, thin dependency debuginfo
+
+- The routine checks ran `--all-features` while `cargo build`/`cargo run` ran
+  the default set. Two feature sets in one `target/` are two graphs: 248 crates
+  were compiled under both, and a directory carrying both reached 16 GB.
+- [Local inference](specs/local-inference.md): records the debug-build cost the
+  release table did not cover, and that no test is gated on `local-inference`,
+  so running the suite with the engine on adds ~220 crates for no coverage.
+- Routine commands now share `--features yolop-yep/schema`, which resolves to
+  the same 519 crates as a default build.
+- They also gained `--workspace`. Root `cargo test` covers the root package
+  only, so the wire-schema drift guard in `yolop-yep` had never run outside
+  CI's coverage job; the root commands now match what AGENTS.md claims of
+  them, and run 1273 tests instead of 70.
+- CI's `lint`, `test`, and `live-smoke` jobs share the `debug` cache and now
+  agree on that set; `local-inference` became a clippy-only gate with its own
+  cache key.
+- `[profile.dev.package."*"]` drops dependency debuginfo to line tables and
+  build scripts lose it entirely. A clean `cargo build --tests` went 6.3 GB to
+  5.0 GB, with dependency rlibs down from 2136 MiB to 1227 MiB.
+
 ## 2026-08-18, Session coordination uses attached CLI actions
 
 - [Session coordination](specs/session-coordination.md): removed its four

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -17,9 +17,13 @@
 - CI's `lint`, `test`, and `live-smoke` jobs share the `debug` cache and now
   agree on that set; `local-inference` became a clippy-only gate with its own
   cache key.
-- `[profile.dev.package."*"]` drops dependency debuginfo to line tables and
-  build scripts lose it entirely. A clean `cargo build --tests` went 6.3 GB to
-  5.0 GB, with dependency rlibs down from 2136 MiB to 1227 MiB.
+- `[profile.dev]` carries line tables instead of full DWARF, and build scripts
+  carry none. Backtraces keep file and line, which with `RUST_LOG` is how this
+  codebase is debugged; `--profile dev-debuginfo` opts back in to full DWARF
+  for a debugger session.
+- Together: a clean `cargo build --tests --workspace` went from 6.3 GB to
+  3.7 GB, dependency rlibs from 2136 MiB to 1238 MiB, and the mixed-feature
+  directory no longer happens at all.
 
 ## 2026-08-18, Session coordination uses attached CLI actions
 

--- a/knowledge/specs/extensions.md
+++ b/knowledge/specs/extensions.md
@@ -45,7 +45,7 @@ request/result payload, keyed by method under `messages`, full types under
 yolop-yep --features schema --bin schema-gen` (the mira pattern). `schema.json`
 comes from `#[derive(schemars::JsonSchema)]` on the payload structs behind an
 optional `schema` feature, so the published SDK stays serde-only for authors.
-A `cargo test` drift guard (run under CI's `--all-features` coverage job) fails
+A `cargo test` drift guard (run under CI's `yolop-yep/schema` coverage job) fails
 if either committed file is stale, so the wire surface can't change without the
 artifacts changing. A non-Rust author reads them to discover and validate the
 wire format.
@@ -582,8 +582,8 @@ shape:
   `$defs`) and `meta.json` (protocol version, method list, capability
   tokens, event vocabularies). The directory is versioned by protocol
   **major**. CI runs the generator with `--check` (and the drift tests under
-  `--all-features`) so a wire change cannot merge without a matching schema
-  update.
+  `--features yolop-yep/schema`) so a wire change cannot merge without a
+  matching schema update.
   *Implemented shape:* rather than a root `anyOf` over the three envelopes
   (the envelope is field-classified, see `classify_line`, and its
   direction vocabulary already lives in `meta.json`), `schema.json` keys

--- a/knowledge/specs/local-inference.md
+++ b/knowledge/specs/local-inference.md
@@ -63,6 +63,18 @@ probe lockfile against this one.
 | Release tarball (`.tar.gz`) | 27.8 MiB | not measured | — |
 | Native-toolchain deps | none | none | — |
 
+Debug builds pay a separate, larger price. `cargo build --tests` leaves a 5.0 GB
+`target/`; adding `--all-features` on top of it takes that to 16 GB, because the
+two feature sets are different graphs and 248 crates get compiled under both.
+`mistralrs-core` alone links an 844 MiB debug rlib.
+
+No test is gated on `local-inference`, so running the suite with the feature on
+buys no coverage for that cost. CI gates it with clippy in a job holding its own
+cache ([`ci.yml`](../../.github/workflows/ci.yml)), and every routine command
+stays on `--features yolop-yep/schema`, which resolves to the same 519 crates as
+a default build. Locally, use a separate `CARGO_TARGET_DIR` when you need the
+engine compiled.
+
 Absolute times are machine-specific; the ratios are the durable part.
 [`local-inference-cost.yml`](../../.github/workflows/local-inference-cost.yml)
 reproduces this on a runner.

--- a/knowledge/specs/local-inference.md
+++ b/knowledge/specs/local-inference.md
@@ -63,10 +63,10 @@ probe lockfile against this one.
 | Release tarball (`.tar.gz`) | 27.8 MiB | not measured | — |
 | Native-toolchain deps | none | none | — |
 
-Debug builds pay a separate, larger price. `cargo build --tests` leaves a 5.0 GB
-`target/`; adding `--all-features` on top of it takes that to 16 GB, because the
-two feature sets are different graphs and 248 crates get compiled under both.
-`mistralrs-core` alone links an 844 MiB debug rlib.
+Debug builds pay a separate, larger price. `mistralrs-core` alone links an
+844 MiB debug rlib, and because a feature set defines a whole graph, a `target/`
+holding both the routine set and `--all-features` compiled 248 crates twice and
+reached 16 GB.
 
 No test is gated on `local-inference`, so running the suite with the feature on
 buys no coverage for that cost. CI gates it with clippy in a job holding its own

--- a/knowledge/specs/maintenance.md
+++ b/knowledge/specs/maintenance.md
@@ -126,7 +126,7 @@ Before tagging a release:
 
 - the `everruns-*` family is on the latest released minor
 - `cargo build --release` succeeds and the resulting binary starts (`./target/release/yolop --help`)
-- `cargo test --all-features` is green
+- `cargo test --workspace --features yolop-yep/schema` is green
 - the live-provider integration test passes under Doppler
 - the README's feature list, flag table, and provider env-var table match the source
 


### PR DESCRIPTION
## What changed

A clean `cargo build --tests --workspace` leaves **3.7 GB** in `target/` instead of 6.3 GB, and the 16 GB directory a contributor got from running the documented checks alongside `cargo run` no longer happens at all.

Three things get us there:

- **Every routine command shares one feature set.** The checks ran `--all-features` while `cargo build` and `cargo run` ran the default set. A feature set defines a whole graph, so those are two graphs: 248 crates were being compiled under both, at 70 MB per copy for the larger ones. Routine commands now use `--features yolop-yep/schema`, which resolves to exactly the same 519 crates as a default build.
- **`local-inference` became a clippy-only gate with its own CI cache.** `--all-features` also turns on the inference engine: ~220 extra crates and an 844 MB `mistralrs-core` rlib. No test is gated on the feature, so the coverage job was paying that for **zero** additional coverage. The shipped configuration is still gated, just by clippy in a job whose cache key keeps the engine tree out of the `debug` cache every other Rust job restores.
- **Dev builds carry line tables instead of full DWARF.** Backtraces read line tables; backtraces and `RUST_LOG` are how this codebase is debugged. `--profile dev-debuginfo` turns full DWARF back on for a debugger session, so nothing is lost, it just stops being the default.

The commands also gained `--workspace`, which fixes a real gap: root `cargo test` covers the root package only, so the wire-schema drift guard in `yolop-yep` had **never run** outside CI's coverage job, despite AGENTS.md stating that root `cargo test` / `cargo clippy` cover both packages. The root commands now match that claim.

## Why

Build size had grown enough to notice. Investigating it turned up three separate causes, none of them the one that was suspected (the `ollama` provider is the OpenAI driver aimed at loopback and costs nothing).

Worth recording, since it was the other suspicion: the everruns 0.18/0.19 family did **not** grow the crate count. The lockfile went 763 → 973 → 969 across that adoption, a net reduction of 21.

## Before / After

Clean build directory, same command:

| | Before | Deps thinned | This PR |
|---|---|---|---|
| `cargo build --tests --workspace` | 6.3 GB | 5.0 GB | **3.7 GB** |
| dependency `.rlib` total | 2136 MiB | 1227 MiB | 1238 MiB |
| `debug/incremental` | 1.5 GB | 1.5 GB | **870 MB** |
| `debug/build` | 544 MB | 544 MB | **233 MB** |
| yolop's two test binaries | 839 MB | 839 MB | **617 MB** |
| routine loop + `--all-features` in one dir | 16 GB | — | **does not occur** |

The middle column is the first commit alone; both columns use the same measurement command, and the final one is `--workspace`, a slightly larger scope than the 6.3 GB baseline, so the reduction is if anything understated.

Tests actually running, before and after `--workspace`:

```
before:  70 tests   (root package only)
after: 1274 tests   (both packages; includes schema::tests::committed_schema_json_is_up_to_date)
```

Backtraces still resolve under line tables:

```
$ addr2line -f -C -e target/debug/yolop 00000000036cfde0
yolop::async_main
/home/user/yolop/src/main.rs:648
```

No observable change to the shipped binary: `[profile.release]` is untouched, and it already stripped debuginfo.

## Risk

- **Low**
- The feature-set change could in principle let a warning that only appears under `--all-features` slip through. Mitigated by the dedicated `Clippy (local-inference)` job, which lints the engine-enabled configuration on every Rust PR. Verified locally against this branch after rebasing onto `b7bbea1` (which touched feature-gated `models pull` code), and green in CI on this PR.
- CI cost is unchanged in shape. The engine tree was already compiled on every PR by the old `--all-features` clippy step; it now lives in a separate job and cache instead of the shared one. The new job completed in 2m43s cold.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

No new test is added: no Rust source changed, so there is no new behavior to drive. What the change does to testing is make 1204 existing tests run that previously did not, including both `yolop-yep` schema drift guards. That count is the evidence, and it is reproduced above.

## Knowledge

Updated:

- `knowledge/specs/local-inference.md` — records the debug-build cost the release-cost table did not cover, and that no test is gated on the feature, so the suite gains nothing from compiling the engine.
- `knowledge/specs/maintenance.md`, `knowledge/specs/extensions.md` — the check commands and where the drift guard runs.
- `knowledge/log.md` — new entry.
- `AGENTS.md`, `.agents/skills/maintenance/surfaces.md` — the check commands, why they share a feature set, and the `dev-debuginfo` escape hatch.

`python3 scripts/validate_okf.py knowledge --check-links` passes (41 concepts, 0 errors), as does the public-docs boundary grep.

## Security

Reviewed. No Rust source is touched: the diff is build profile, CI workflow, `.gitignore`, and documentation.

- **TM-DEP** — the only category with any surface. No dependency is added, removed, or version-changed; `Cargo.lock` is unmodified. The change alters which already-locked crates get compiled, not what the tree contains. `everruns-*` versions are untouched and stay in lockstep.
- **TM-FS, TM-BASH, TM-LLM, TM-TOOL** — no change. The write blocklist, bash timeouts and output caps, key handling, and capability registration are all untouched by this diff.

One security-adjacent observation surfaced while measuring, pre-existing and not introduced here: `aws-lc-sys` compiles 365 C object files in a default build, reaching the tree through `everruns-platform` → `a2a-client-lf` → `rustls`. `knowledge/specs/local-inference.md` still states "Native-toolchain deps: none" for the default column. Left alone deliberately, see Follow-ups.

## Validation

Local, on the rebased branch: `cargo fmt --check`; `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`; the full workspace suite (1274 passed, 0 failed); the `local-inference` clippy gate (exit 0); `cargo run --provider llmsim -p "say ok"` (exit 0); `validate_okf.py --check-links`.

In CI, all 16 checks green, including **Live Provider Smoke (Doppler)** — so the live-provider smoke required by the shipping bar did run, against a real provider with `YOLOP_REQUIRE_LIVE_TESTS=1`, on this branch. It just could not be run from the authoring environment, which has no Doppler credentials.

## Follow-ups

- **`everruns-platform` pulls `a2a-client-lf` unconditionally** (a 213-crate subtree) which drags in a second full HTTP/TLS stack: `reqwest` 0.12 alongside our 0.13, plus `rustls` and `aws-lc-sys`, together ~60 MiB of rlib. No everruns crate exposes feature flags, so this cannot be trimmed downstream; an upstream gate is reportedly in progress. The "Native-toolchain deps: none" row in `local-inference.md` becomes true again when it lands, which is why this PR leaves that measured table alone rather than editing a claim that is about to be correct. If the gate slips, that row needs fixing.
- **`mmdflux` is 59 MB, the largest non-everruns crate in the tree**, and it is there for terminal mermaid rendering via `tuika-mermaid`. Not obviously worth its size; worth a look at whether it should be optional.
- **The `test` job still compiles the graph twice within itself** — once for `cargo build --all-targets` (which feeds the tmux gallery gate) and once instrumented under `cargo llvm-cov`, in its own `target/llvm-cov-target`. That one is inherent to coverage instrumentation, not a feature-set mismatch, and is left as-is.