### PR TITLE
feat(config): make the global config and data directories relocatable

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,8 @@ act of consent. MCP tools run autonomously like the rest of yolop's tools.
 | `--acp`                    | Speak the Agent Client Protocol over stdio (for editors like Zed)    |
 | `--session <ID>`           | Resume a previous session by id                                      |
 | `--session-dir <PATH>`     | Override the parent directory for session folders                    |
+| `--config-dir <PATH>`      | Override the global config directory (settings, profiles, extensions) |
+| `--data-dir <PATH>`        | Override the global data directory (sessions, logs, models)          |
 | `--sandbox`                | One-run `workspace-write` containment without changing settings      |
 | `--reasoning-effort <E>`   | Reasoning effort override when the model profile supports it          |
 | `--trajectory-out <PATH>`  | Write the session as an [ATIF](https://github.com/harbor-framework/harbor/blob/main/rfcs/0001-trajectory-format.md) v1.7 trajectory JSON at end of run |
@@ -433,6 +435,17 @@ update the active provider, keys, model, and reasoning effort, and yolop can rea
 and edit the file itself through the `get_config` / `set_config` tools or the
 `yolop-config` skill (e.g. "use anthropic by default", "store my OpenAI key").
 Unknown keys are ignored, so the format stays forward-compatible.
+
+Both global directories can be moved: `--config-dir <PATH>` (settings, profiles,
+hooks, extensions) and `--data-dir <PATH>` (sessions, logs, models, prompt
+history), or `YOLOP_CONFIG_DIR` / `YOLOP_DATA_DIR` for a whole shell. Point both
+somewhere private to run isolated or side-by-side yolop identities without
+moving `HOME` (global skills stay in the cross-agent `~/.agents/skills`, which
+`YOLOP_GLOBAL_SKILLS_DIR` moves separately):
+
+```bash
+yolop --config-dir ~/agents/triage/config --data-dir ~/agents/triage/data
+```
 
 Named profiles are sparse execution overlays stored under
 `<config_dir>/yolop/profiles/<name>.toml` and selected explicitly with

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -90,6 +90,21 @@ wording, formatting, and link fixes do not need entries.
   reversible; detached operations remain global and reload requires a live
   session.
 
+## 2026-08-18, Global directories are relocatable
+
+- [Configuration](specs/configuration.md) now names two roots, config and data,
+  and both move with `--config-dir` / `--data-dir` or `YOLOP_CONFIG_DIR` /
+  `YOLOP_DATA_DIR`. `src/config/paths.rs` owns the resolution; every global path
+  joins a leaf onto one of those roots instead of calling `dirs` itself.
+- The reason for the change: isolating a run, or keeping several yolop
+  identities side by side, previously meant moving `HOME`, which drags along
+  everything else the process reads. An override names yolop's own directory, so
+  no second `yolop` folder is appended to it.
+- The flags are read from argv as the process's first act, not from clap
+  matches: the crash reporter and the contributed-CLI registry both resolve
+  paths before parsing finishes, so matches arrive too late to cover them.
+  Other applications' directories are never redirected.
+
 ## 2026-08-18, Loopback setup page for ACP clients (experimental)
 
 - [ACP](specs/acp.md) gained an opt-in `local_setup_page` authentication method:

--- a/knowledge/specs/configuration.md
+++ b/knowledge/specs/configuration.md
@@ -68,10 +68,38 @@ generic compatible endpoint. It reads `MODEL_API_KEY`, defaults to
 `muse-spark-1.2`, and exposes both the standard and
 `muse-spark-1.2-contributor` published profiles.
 
+### Where the global directories live
+
+Every global path derives from one of two roots, both owned by
+`src/config/paths.rs`:
+
+| Root   | Default                     | Holds                                                        |
+|--------|-----------------------------|--------------------------------------------------------------|
+| config | `<config_dir>/yolop/`       | `settings.toml`, `profiles/`, `hooks.json`, `extensions/`     |
+| data   | `<data_dir>/yolop/`         | `sessions/`, `logs/`, `models/`, `prompt_history.jsonl`, materialized system skills, `crashes/` |
+
+`<config_dir>` and `<data_dir>` are the platform directories (`~/.config` and
+`~/.local/share` on Linux, `~/Library/Application Support` on macOS, `%APPDATA%`
+on Windows). Either root can be moved with `--config-dir` / `--data-dir` or
+`YOLOP_CONFIG_DIR` / `YOLOP_DATA_DIR`, flag first, then environment, then the
+platform default. An override names yolop's directory itself rather than a
+prefix, so nothing appends a second `yolop` folder to it, and a relative
+override resolves against the startup working directory because turns may run
+from a worktree elsewhere.
+
+This is what lets several yolop identities run side by side, and lets a test
+run touch nothing real, without moving `HOME`. Because the crash reporter and
+the contributed-CLI registry both resolve paths before the command line is
+parsed, the flags are read straight from argv as the process's first act rather
+than from clap matches, so no global path escapes them. Directories belonging to
+other applications are never redirected, and neither is the cross-agent
+`~/.agents/skills` convention, which is shared with other agents on purpose and
+has its own `YOLOP_GLOBAL_SKILLS_DIR` override for anyone who wants it moved
+too.
+
 ### Named execution profiles
 
-`--profile <name>` loads
-`<config_dir>/yolop/profiles/<name>.toml`. Profile selection is explicit for
+`--profile <name>` loads `profiles/<name>.toml` under the config root. Profile selection is explicit for
 each process; it is never persisted and has no environment-variable selector.
 Names contain 1–64 lowercase ASCII letters, numbers, hyphens, or underscores,
 start with a letter or number, and are validated before constructing the path.

--- a/src/capabilities/skills.rs
+++ b/src/capabilities/skills.rs
@@ -231,7 +231,7 @@ pub fn global_skills_dir() -> Option<PathBuf> {
 pub fn legacy_global_skills_dir() -> Option<PathBuf> {
     Some(match std::env::var(LEGACY_GLOBAL_SKILLS_DIR_ENV) {
         Ok(value) if !value.is_empty() => PathBuf::from(value),
-        _ => dirs::config_dir()?.join("yolop").join("skills"),
+        _ => crate::config::paths::config_dir()?.join("skills"),
     })
 }
 
@@ -292,7 +292,7 @@ pub fn system_skills_dir() -> Option<PathBuf> {
         return None;
     }
 
-    let dest = dirs::data_dir()?.join("yolop").join("system-skills");
+    let dest = crate::config::paths::data_dir()?.join("system-skills");
     match materialize_system_skills(&dest) {
         Ok(()) => Some(dest),
         Err(e) => {

--- a/src/config/hooks.rs
+++ b/src/config/hooks.rs
@@ -216,7 +216,7 @@ impl HooksStore {
 }
 
 pub fn global_hooks_config_path() -> Option<PathBuf> {
-    dirs::config_dir().map(|p| p.join("yolop").join(GLOBAL_HOOKS_FILE_NAME))
+    crate::config::paths::config_dir().map(|p| p.join(GLOBAL_HOOKS_FILE_NAME))
 }
 
 pub fn global_hooks_config_path_beside_settings(settings: &SettingsStore) -> PathBuf {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -15,6 +15,7 @@
 pub mod capability_settings;
 pub mod hooks;
 pub mod mcp;
+pub mod paths;
 pub mod profile;
 pub mod schema;
 pub mod service;
@@ -590,7 +591,7 @@ fn codex_auth_to_table(auth: &CodexAuth) -> Table {
 }
 
 pub fn default_settings_path() -> Option<PathBuf> {
-    dirs::config_dir().map(|p| p.join("yolop").join("settings.toml"))
+    paths::config_dir().map(|p| p.join("settings.toml"))
 }
 
 pub fn load_from(path: &Path) -> Settings {

--- a/src/config/paths.rs
+++ b/src/config/paths.rs
@@ -1,0 +1,225 @@
+//! Where yolop's own global config and data live.
+//!
+//! Every global path derives from one of two roots: the config root (settings,
+//! profiles, hooks, extensions) and the data root (sessions, logs, models,
+//! prompt history, materialized system skills). By default those are the
+//! platform directories with a `yolop` folder inside, and both can be pointed
+//! somewhere else with `--config-dir` / `--data-dir` or `YOLOP_CONFIG_DIR` /
+//! `YOLOP_DATA_DIR`, which is what makes isolated test runs and several
+//! side-by-side yolop identities possible without juggling `HOME`.
+//!
+//! Note the roots returned here are yolop's *own* directories, already
+//! including the `yolop` folder, so callers join a leaf name directly. An
+//! override replaces that whole path rather than the platform prefix: a user
+//! who says `--config-dir ~/work/yolop` gets exactly that, not
+//! `~/work/yolop/yolop`.
+//!
+//! Directories belonging to *other* applications (Zed's settings, Buzz's
+//! harness directory, the cross-agent `~/.agents/skills` convention) resolve
+//! through `dirs` directly and are deliberately left alone.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+/// Environment override for the config root.
+pub const CONFIG_DIR_ENV: &str = "YOLOP_CONFIG_DIR";
+/// Environment override for the data root.
+pub const DATA_DIR_ENV: &str = "YOLOP_DATA_DIR";
+
+static CONFIG_DIR: OnceLock<Option<PathBuf>> = OnceLock::new();
+static DATA_DIR: OnceLock<Option<PathBuf>> = OnceLock::new();
+
+/// Fix both roots for this process straight from argv, before anything else
+/// runs. The flags are read here rather than from parsed clap matches because
+/// building the command line already opens the coordination store, and the
+/// crash reporter installs its hook earlier still: by the time clap has
+/// matches, several global paths have been resolved. Scanning argv keeps one
+/// rule for every one of them.
+///
+/// clap still owns the flags themselves (help text, missing-value errors);
+/// this only needs their values early.
+pub fn init_from_args<I, T>(args: I)
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString>,
+{
+    let args: Vec<OsString> = args.into_iter().map(Into::into).collect();
+    init(
+        flag_value(&args, "--config-dir"),
+        flag_value(&args, "--data-dir"),
+    );
+}
+
+/// Value of `--flag value` or `--flag=value`, last occurrence winning as clap
+/// does. Scanning stops at `--`, after which nothing is a yolop flag.
+fn flag_value(args: &[OsString], flag: &str) -> Option<PathBuf> {
+    let inline = format!("{flag}=");
+    let mut found = None;
+    let mut args = args.iter();
+    while let Some(arg) = args.next() {
+        if arg == "--" {
+            break;
+        }
+        let Some(text) = arg.to_str() else {
+            continue;
+        };
+        if text == flag {
+            found = args.next().cloned();
+        } else if let Some(value) = text.strip_prefix(&inline) {
+            found = Some(OsString::from(value));
+        }
+    }
+    found.filter(|value| !value.is_empty()).map(PathBuf::from)
+}
+
+/// Fix both roots for this process. Called by [`init_from_args`]; separate so
+/// the precedence can be exercised without a command line.
+pub fn init(config_dir: Option<PathBuf>, data_dir: Option<PathBuf>) {
+    let _ = CONFIG_DIR.set(resolve(
+        config_dir,
+        env_override(CONFIG_DIR_ENV),
+        dirs::config_dir,
+    ));
+    let _ = DATA_DIR.set(resolve(
+        data_dir,
+        env_override(DATA_DIR_ENV),
+        dirs::data_dir,
+    ));
+}
+
+/// yolop's config root, or `None` on a platform with no resolvable config
+/// directory (minimal containers, CI without `HOME`).
+pub fn config_dir() -> Option<PathBuf> {
+    CONFIG_DIR
+        .get()
+        .cloned()
+        .unwrap_or_else(|| resolve(None, env_override(CONFIG_DIR_ENV), dirs::config_dir))
+}
+
+/// yolop's data root, or `None` when the platform has no data directory.
+pub fn data_dir() -> Option<PathBuf> {
+    DATA_DIR
+        .get()
+        .cloned()
+        .unwrap_or_else(|| resolve(None, env_override(DATA_DIR_ENV), dirs::data_dir))
+}
+
+fn env_override(name: &str) -> Option<OsString> {
+    std::env::var_os(name)
+}
+
+/// Flag beats environment beats platform default. An override names yolop's
+/// directory itself; only the platform default gets the `yolop` folder joined
+/// on. Relative overrides are resolved against the startup working directory,
+/// since yolop may run turns from a worktree elsewhere.
+fn resolve(
+    flag: Option<PathBuf>,
+    env: Option<OsString>,
+    platform: impl FnOnce() -> Option<PathBuf>,
+) -> Option<PathBuf> {
+    // An exported-but-empty variable is how a shell spells "unset"; taking it
+    // as a path would send everything to the working directory.
+    let env = env.filter(|value| !value.is_empty());
+    if let Some(dir) = flag.or_else(|| env.map(PathBuf::from)) {
+        return Some(std::path::absolute(&dir).unwrap_or(dir));
+    }
+    platform().map(|dir| dir.join("yolop"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn the_flag_wins_over_the_environment_and_the_platform() {
+        let resolved = resolve(
+            Some(PathBuf::from("/flag/dir")),
+            Some(OsString::from("/env/dir")),
+            || Some(PathBuf::from("/platform")),
+        );
+        assert_eq!(resolved.as_deref(), Some(Path::new("/flag/dir")));
+    }
+
+    #[test]
+    fn the_environment_wins_over_the_platform() {
+        let resolved = resolve(None, Some(OsString::from("/env/dir")), || {
+            Some(PathBuf::from("/platform"))
+        });
+        assert_eq!(resolved.as_deref(), Some(Path::new("/env/dir")));
+    }
+
+    #[test]
+    fn an_override_is_the_directory_itself_but_the_platform_gains_a_yolop_folder() {
+        let overridden = resolve(Some(PathBuf::from("/work/agent-a")), None, || {
+            Some(PathBuf::from("/platform"))
+        });
+        assert_eq!(overridden.as_deref(), Some(Path::new("/work/agent-a")));
+
+        let defaulted = resolve(None, None, || Some(PathBuf::from("/platform")));
+        assert_eq!(defaulted.as_deref(), Some(Path::new("/platform/yolop")));
+    }
+
+    #[test]
+    fn a_relative_override_is_made_absolute() {
+        let resolved = resolve(Some(PathBuf::from("relative/dir")), None, || None)
+            .expect("a flag always resolves");
+        assert!(resolved.is_absolute(), "got: {}", resolved.display());
+        assert!(
+            resolved.ends_with("relative/dir"),
+            "got: {}",
+            resolved.display()
+        );
+    }
+
+    #[test]
+    fn flags_are_read_from_argv_in_both_spellings() {
+        let args: Vec<OsString> = ["yolop", "--config-dir", "/a", "--data-dir=/b", "-p", "hi"]
+            .iter()
+            .map(OsString::from)
+            .collect();
+        assert_eq!(flag_value(&args, "--config-dir"), Some(PathBuf::from("/a")));
+        assert_eq!(flag_value(&args, "--data-dir"), Some(PathBuf::from("/b")));
+    }
+
+    #[test]
+    fn the_last_flag_wins_and_nothing_after_a_double_dash_counts() {
+        let args: Vec<OsString> = [
+            "yolop",
+            "--data-dir",
+            "/first",
+            "--data-dir",
+            "/second",
+            "--",
+            "--data-dir",
+            "/ignored",
+        ]
+        .iter()
+        .map(OsString::from)
+        .collect();
+        assert_eq!(
+            flag_value(&args, "--data-dir"),
+            Some(PathBuf::from("/second"))
+        );
+    }
+
+    #[test]
+    fn a_flag_without_a_value_is_left_to_clap() {
+        let args: Vec<OsString> = ["yolop", "--data-dir"].iter().map(OsString::from).collect();
+        assert_eq!(flag_value(&args, "--data-dir"), None);
+    }
+
+    #[test]
+    fn no_override_and_no_platform_directory_resolves_to_nothing() {
+        assert_eq!(resolve(None, None, || None), None);
+    }
+
+    #[test]
+    fn an_empty_environment_override_is_ignored() {
+        let resolved = resolve(None, OsString::from("").into(), || {
+            Some(PathBuf::from("/platform"))
+        });
+        assert_eq!(resolved.as_deref(), Some(Path::new("/platform/yolop")));
+    }
+}

--- a/src/crash_report.rs
+++ b/src/crash_report.rs
@@ -95,7 +95,7 @@ fn crash_report_dir() -> Option<PathBuf> {
     if let Some(path) = std::env::var_os("YOLOP_TEST_CRASH_DIR") {
         return Some(PathBuf::from(path));
     }
-    dirs::data_dir().map(|dir| dir.join("yolop").join("crashes"))
+    crate::config::paths::data_dir().map(|dir| dir.join("crashes"))
 }
 
 fn prepare_crash_dir(dir: &Path) -> bool {

--- a/src/extensions/package.rs
+++ b/src/extensions/package.rs
@@ -435,7 +435,7 @@ pub fn extensions_dir() -> Option<PathBuf> {
     if let Some(dir) = std::env::var_os("YOLOP_EXTENSIONS_DIR") {
         return Some(PathBuf::from(dir));
     }
-    dirs::config_dir().map(|p| p.join("yolop").join("extensions"))
+    crate::config::paths::config_dir().map(|p| p.join("extensions"))
 }
 
 /// Discover installed packages. Malformed packages warn and are skipped;

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,8 @@ struct Cli {
     #[arg(long, value_enum)]
     provider: Option<ProviderArg>,
 
-    /// Load a named profile from `<config_dir>/yolop/profiles/<name>.toml`: an
+    /// Load a named profile from `profiles/<name>.toml` under the config
+    /// directory (see `--config-dir`): an
     /// overlay of provider, model, approval, sandbox, and worktree settings plus
     /// the profile's own capabilities, extensions, MCP servers, skills, and
     /// system-prompt instructions.
@@ -143,6 +144,20 @@ struct Cli {
     /// external agent. Builds one runtime per ACP session (cwd comes from the
     /// client); the `-C/--cwd`, `--print`, and `--session` flags are
     /// ignored in this mode. See `knowledge/specs/acp.md`.
+    /// Directory holding yolop's global configuration (settings, profiles,
+    /// hooks, installed extensions). Defaults to `yolop` inside the platform
+    /// config directory; `YOLOP_CONFIG_DIR` sets it for a whole shell. Point
+    /// both this and `--data-dir` somewhere private to run an isolated yolop
+    /// identity without moving `HOME`.
+    #[arg(long = "config-dir", value_name = "PATH", global = true)]
+    config_dir: Option<PathBuf>,
+
+    /// Directory holding yolop's global data (sessions, logs, models, prompt
+    /// history). Defaults to `yolop` inside the platform data directory;
+    /// `YOLOP_DATA_DIR` sets it for a whole shell.
+    #[arg(long = "data-dir", value_name = "PATH", global = true)]
+    data_dir: Option<PathBuf>,
+
     #[arg(long, conflicts_with = "print")]
     acp: bool,
 
@@ -600,6 +615,11 @@ fn pick_provider(cli: &Cli, settings: &SettingsStore) -> (ProviderChoice, Vec<St
 }
 
 fn main() -> Result<()> {
+    // First: the crash reporter below, and the CLI registry that builds the
+    // command line, both resolve global paths, so the directory overrides have
+    // to be known before either runs.
+    config::paths::init_from_args(std::env::args_os());
+
     // Windows caps the main-thread stack at 1 MiB. The entry future (settings
     // load → runtime build → TUI/print loop) is large enough to overflow that,
     // though it fits comfortably in the 8 MiB default Linux and macOS give the
@@ -830,11 +850,11 @@ fn trace_writer(interactive: bool) -> BoxMakeWriter {
     if !interactive {
         return BoxMakeWriter::new(io::stderr);
     }
-    let Some(data_dir) = dirs::data_dir() else {
+    let Some(data_dir) = config::paths::data_dir() else {
         eprintln!("yolop: no platform data dir resolvable — interactive tracing is disabled");
         return BoxMakeWriter::new(io::sink);
     };
-    let trace_dir = data_dir.join("yolop").join("logs");
+    let trace_dir = data_dir.join("logs");
     match open_interactive_trace_log(&trace_dir) {
         Ok((file, _path)) => BoxMakeWriter::new(Mutex::new(BoundedTraceWriter::new(
             file,
@@ -2430,6 +2450,8 @@ mod tests {
             print: None,
             images: vec![],
             acp: false,
+            config_dir: None,
+            data_dir: None,
             acp_setup_page: false,
             session: None,
             session_dir: None,
@@ -2521,6 +2543,8 @@ mod tests {
             print: None,
             images: vec![],
             acp: false,
+            config_dir: None,
+            data_dir: None,
             acp_setup_page: false,
             session: None,
             session_dir: None,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -28,7 +28,7 @@ pub const GGUF_SEPARATOR: &str = "::";
 
 /// Root of the model store, or `None` when the platform has no data directory.
 pub fn store_root() -> Option<PathBuf> {
-    dirs::data_dir().map(|dir| dir.join("yolop").join("models"))
+    crate::config::paths::data_dir().map(|dir| dir.join("models"))
 }
 
 /// Split a model spec into its repo and, for GGUF specs, the file within it.

--- a/src/runtime/session_log.rs
+++ b/src/runtime/session_log.rs
@@ -85,19 +85,19 @@ use tokio::sync::{Mutex, RwLock, broadcast};
 /// catch-up via `runtime.events()`.
 const EVENT_BROADCAST_CAPACITY: usize = 1024;
 
-/// Default location for yolop's per-session storage folders. Resolves via
-/// `dirs::data_dir()`, which is the platform-native user data directory
-/// (`~/.local/share/yolop/sessions/` on Linux,
-/// `~/Library/Application Support/yolop/sessions/` on macOS,
-/// `%APPDATA%\yolop\sessions\` on Windows).
+/// Default location for yolop's per-session storage folders: `sessions/` under
+/// the data root (`~/.local/share/yolop/` on Linux,
+/// `~/Library/Application Support/yolop/` on macOS, `%APPDATA%\yolop\` on
+/// Windows), which `--data-dir` / `YOLOP_DATA_DIR` can point elsewhere (see
+/// `crate::config::paths`).
 ///
 /// Returns an error when the platform data dir can't be resolved — we
 /// intentionally do NOT fall back to the current working directory,
 /// because the cwd for yolop is usually the user's workspace and we
 /// don't want sensitive session logs landing in the repo.
 pub fn default_sessions_dir() -> Result<PathBuf> {
-    dirs::data_dir()
-        .map(|p| p.join("yolop").join("sessions"))
+    crate::config::paths::data_dir()
+        .map(|p| p.join("sessions"))
         .ok_or_else(|| {
             AgentLoopError::config(
                 "could not resolve a platform data directory for session logs; \

--- a/src/tui/prompt_history.rs
+++ b/src/tui/prompt_history.rs
@@ -191,7 +191,7 @@ impl PromptHistory {
 /// the per-session logs. Mirrors [`crate::runtime::session_log::default_sessions_dir`]'s
 /// use of the platform data dir.
 fn default_history_path() -> Option<PathBuf> {
-    dirs::data_dir().map(|p| p.join("yolop").join("prompt_history.jsonl"))
+    crate::config::paths::data_dir().map(|p| p.join("prompt_history.jsonl"))
 }
 
 /// Read `{"text": "..."}` lines from the log, skipping blank or malformed lines.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -698,6 +698,113 @@ fn into_paseo_command_writes_acp_provider() {
     );
 }
 
+/// `--config-dir` / `--data-dir` move yolop's whole global footprint, which is
+/// what makes an isolated run (or a second identity) possible without moving
+/// `HOME`. Drives the real binary and asserts on where files actually land.
+#[test]
+fn config_and_data_dir_flags_move_the_global_footprint() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config_dir = tmp.path().join("agent-a/config");
+    let data_dir = tmp.path().join("agent-a/data");
+    // A HOME the run must not touch, so a leak into the platform default is a
+    // visible failure rather than a silent pass.
+    let home = tmp.path().join("home");
+    std::fs::create_dir_all(&home).expect("create home");
+
+    let output = Command::new(yolop_binary())
+        .args([
+            "--provider",
+            "llmsim",
+            "--config-dir",
+            config_dir.to_str().unwrap(),
+            "--data-dir",
+            data_dir.to_str().unwrap(),
+            "-p",
+            "hi",
+        ])
+        .env("HOME", &home)
+        .env_remove("XDG_CONFIG_HOME")
+        .env_remove("XDG_DATA_HOME")
+        .env_remove("YOLOP_CONFIG_DIR")
+        .env_remove("YOLOP_DATA_DIR")
+        .env_remove("OPENAI_API_KEY")
+        .env_remove("ANTHROPIC_API_KEY")
+        .env_remove("OPENROUTER_API_KEY")
+        .env_remove("OLLAMA_BASE_URL")
+        .env_remove("OLLAMA_API_KEY")
+        .output()
+        .expect("spawn yolop with overridden global directories");
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Sessions are the one global write every run makes, and the override
+    // names yolop's own directory, so no second `yolop` folder appears.
+    assert!(
+        data_dir.join("sessions").is_dir(),
+        "sessions should live under --data-dir, found: {:?}",
+        std::fs::read_dir(&data_dir).map(|entries| entries.count())
+    );
+    assert!(
+        !data_dir.join("yolop").exists(),
+        "an override names the directory itself, not a prefix"
+    );
+    assert!(
+        !home.join(".config/yolop").exists(),
+        "nothing may fall back to the platform config directory"
+    );
+    // Nothing at all, including the crash directory and the coordination store,
+    // both of which are resolved before the command line finishes parsing.
+    assert!(
+        !home.join(".local/share/yolop").exists(),
+        "nothing may fall back to the platform data directory"
+    );
+}
+
+/// The environment variables are the same seam, for hosts (editors, CI) that
+/// spawn yolop without control over its arguments.
+#[test]
+fn config_and_data_dir_environment_overrides_move_the_global_footprint() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config_dir = tmp.path().join("agent-b/config");
+    let data_dir = tmp.path().join("agent-b/data");
+    let home = tmp.path().join("home");
+    std::fs::create_dir_all(&home).expect("create home");
+
+    let output = Command::new(yolop_binary())
+        .args(["--provider", "llmsim", "-p", "hi"])
+        .env("HOME", &home)
+        .env("YOLOP_CONFIG_DIR", &config_dir)
+        .env("YOLOP_DATA_DIR", &data_dir)
+        .env_remove("XDG_CONFIG_HOME")
+        .env_remove("XDG_DATA_HOME")
+        .env_remove("OPENAI_API_KEY")
+        .env_remove("ANTHROPIC_API_KEY")
+        .env_remove("OPENROUTER_API_KEY")
+        .env_remove("OLLAMA_BASE_URL")
+        .env_remove("OLLAMA_API_KEY")
+        .output()
+        .expect("spawn yolop with overridden global directories");
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        data_dir.join("sessions").is_dir(),
+        "sessions should live under YOLOP_DATA_DIR"
+    );
+    assert!(
+        !home.join(".local/share/yolop").exists(),
+        "nothing may fall back to the platform data directory"
+    );
+}
+
 #[test]
 fn llmsim_print_smoke() {
     // The llmsim provider needs no API key and returns deterministic output.


### PR DESCRIPTION
## What changed

`yolop` gained `--config-dir` and `--data-dir`, plus `YOLOP_CONFIG_DIR` and
`YOLOP_DATA_DIR`, which move its whole global footprint.

```bash
yolop --config-dir ~/agents/triage/config --data-dir ~/agents/triage/data
YOLOP_CONFIG_DIR=... YOLOP_DATA_DIR=... yolop   # for a shell, or an editor's spawn env
```

Every global path now derives from one of two roots owned by `config::paths`
instead of each call site asking `dirs` on its own:

| Root   | Default               | Holds |
|--------|-----------------------|-------|
| config | `<config_dir>/yolop/` | `settings.toml`, `profiles/`, `hooks.json`, `extensions/` |
| data   | `<data_dir>/yolop/`   | `sessions/`, `logs/`, `models/`, `prompt_history.jsonl`, system skills, `crashes/` |

Precedence is flag, then environment, then platform default. An override names
yolop's own directory rather than a prefix, so nothing appends a second `yolop`
folder to it, and a relative override is made absolute against the startup
working directory because turns may run from a worktree elsewhere.

Behaviour without the new flags is byte-for-byte unchanged.

## Why

Isolating a run, or keeping several yolop identities side by side, previously
meant moving `HOME`, which drags along everything else the process reads. The
`--profile` flag covers a different axis: it varies an agent's configuration
inside one shared directory, and deliberately cannot carry credentials.

## Before / After

Real binary, decoy `HOME`, offline `llmsim` provider.

**Before** — everything lands under `HOME`:

```
<root>/before/home/.local/share/yolop
<root>/before/home/.local/share/yolop/crashes
<root>/before/home/.local/share/yolop/sessions
<root>/before/home/.local/share/yolop/system-skills
```

**After** — `--config-dir` / `--data-dir`:

```
<root>/after/data
<root>/after/data/crashes
<root>/after/data/sessions
<root>/after/data/sessions/everruns-local/local.db
<root>/after/data/sessions/session_01a01846.../events.jsonl

HOME still holds only the cross-agent skills dir:
<root>/after/home/.agents/skills
```

`YOLOP_CONFIG_DIR` / `YOLOP_DATA_DIR` produce the same layout. Two identities
with separate config dirs keep their own `settings.toml` (`key-alpha` vs
`key-beta`) and never see each other's sessions.

Note the leftover `~/.agents/skills`: that is the cross-agent global skills
convention, shared with other agents on purpose, and it has its own
`YOLOP_GLOBAL_SKILLS_DIR` override. Called out in the README and the spec so
"isolated" is not oversold.

## Risk

- Low
- Every global path moved to one seam, so a missed call site would send one kind
  of file to a different place than the rest. The two binary-level tests assert
  the platform directories are *not* created at all, which is what would catch
  that; `grep dirs::` over `src/` now returns only the four intentional
  home-based uses (`~/.agents/skills`, `~` expansion in profiles, worktree
  scratch) plus `paths.rs` itself.
- The flags are parsed from argv rather than clap matches (see below), so a new
  spelling clap accepts would need adding there too. `--flag value`, `--flag=value`,
  last-wins and the `--` terminator are covered by unit tests.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated [`knowledge/specs/configuration.md`](knowledge/specs/configuration.md)
with a "Where the global directories live" section (both roots, precedence, why
argv rather than clap matches, what is deliberately not redirected), and added a
`knowledge/log.md` entry. README gained the flags in its table and a paragraph
under Settings.

## Security

Reviewed against the threat-model categories in `.agents/skills/ship/SKILL.md`:

- **TM-FS** — the only behaviour change is *where* yolop writes its own files;
  the same leaf names under a different root. The write blocklist is untouched,
  and no new write targets are introduced. The path comes from the invoking
  user's own argv or environment, the same trust level as the existing
  `--session-dir`. File modes are unchanged: settings keep their owner-only
  handling in `save_to`, the crash directory keeps `0700` via
  `prepare_crash_dir`. No path traversal surface: the override is used as given
  and never joined with model- or workspace-supplied input.
- **TM-BASH** — untouched, no change to `tools.rs` or the bounded execution
  model.
- **TM-LLM** — key handling is unchanged. Tokens still live in `settings.toml`;
  only its directory can move. `config::paths` logs nothing, so no path or
  secret reaches the tracing layer from this code.
- **TM-TOOL** — no new capabilities or tools; the roots are not configuration
  keys and are not reachable from `set_config`.
- **TM-DEP** — no new dependencies.

Input validation on the new surface: an empty flag or environment value is
ignored rather than resolving to the working directory (tested); scanning stops
at `--` so a passthrough argument cannot be read as a yolop flag (tested); a
flag with no value is left for clap to reject. `std::path::absolute` is lexical
and touches no filesystem, deliberately not canonicalizing since the directory
may not exist yet. The argv scan is O(argv) with one allocation, bounded by the
OS argument limit.

One behaviour worth stating plainly: pointing `--config-dir` at a directory
makes yolop write `settings.toml`, including any stored API tokens, there. That
is the point of the flag, and it is the user's own choice, but it does mean a
carelessly chosen shared path would place credentials somewhere more readable
than the platform default.

## Follow-ups

- **Worktree scratch is not covered.** Session worktrees still resolve to
  `$TMPDIR/yolop/worktrees`, falling back to `~/.yolop/worktrees`. They are keyed
  by repo id and shared across identities by design. Revisit only if per-identity
  isolation should include checkouts.
- **`~/.agents/skills` stays shared**, as described above. Deliberate, and
  already has its own override.

(An earlier revision of this body listed the missing live-provider smoke as a
follow-up, because `doppler` is not installed in the environment the change was
written in. CI's own Live Provider Smoke (Doppler) job covers it and passed on
this PR, so the gap does not exist.)
