### PR TITLE
fix(tui): paste into the surface that owns the keyboard

### DIFF
--- a/knowledge/specs/extensions.md
+++ b/knowledge/specs/extensions.md
@@ -115,7 +115,11 @@ with `UiAskResult { answer, cancelled }`. The client routes the request to an
 `AskRequest` onto a dedicated channel; `App` shows a single-line overlay
 (`draw_ask_overlay`) that captures keys *before* the busy check so it works
 mid-turn, then resolves the request's oneshot with the typed answer (or
-`cancelled` on Esc). Only one prompt is live at a time; a request arriving while
+`cancelled` on Esc). The prompt owns pasted text as well as
+keys: a bracketed paste and Ctrl+V both fill the answer field (control
+characters dropped, since it is single-line) instead of the composer behind the
+overlay, which is what keeps a pasted credential out of the composer.
+Only one prompt is live at a time; a request arriving while
 another is pending is answered `cancelled`. Refused (`cancelled`) with no sink,
 so `--print`/ACP never blocks on it. Covered by
 `ui_ask_reverse_request_is_answered_by_the_sink`.

--- a/knowledge/specs/extensions.md
+++ b/knowledge/specs/extensions.md
@@ -115,10 +115,13 @@ with `UiAskResult { answer, cancelled }`. The client routes the request to an
 `AskRequest` onto a dedicated channel; `App` shows a single-line overlay
 (`draw_ask_overlay`) that captures keys *before* the busy check so it works
 mid-turn, then resolves the request's oneshot with the typed answer (or
-`cancelled` on Esc). The prompt owns pasted text as well as
-keys: a bracketed paste and Ctrl+V both fill the answer field (control
-characters dropped, since it is single-line) instead of the composer behind the
-overlay, which is what keeps a pasted credential out of the composer.
+`cancelled` on Esc). The answer field is tuika's
+`SingleLineInputState`, so editing, cursor movement, and paste come from the
+toolkit rather than a hand-rolled `Char`/`Backspace` match, and the answer is
+trimmed on submit. Paste follows the same modal precedence as keys: a bracketed
+paste and Ctrl+V fill whichever surface owns the keyboard (reverse search, the
+prompt), never the composer behind the overlay, which is what keeps a pasted
+credential out of the composer.
 Only one prompt is live at a time; a request arriving while
 another is pending is answered `cancelled`. Refused (`cancelled`) with no sink,
 so `--print`/ACP never blocks on it. Covered by

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -34,7 +34,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, oneshot};
 use tuika::InputOutcome;
-use tuika::components::{ScrollState, TextInputState};
+use tuika::components::{ScrollState, SingleLineInputState, TextInputState};
 use tuika::keymap::Dispatch;
 use tuika::mouse::{SelectionRange, selected_text, word_at};
 use tuika::term::hyperlink::BufferLink;
@@ -444,7 +444,10 @@ struct PendingMcpLogin {
 pub(crate) struct PendingAsk {
     prompt: String,
     placeholder: Option<String>,
-    value: String,
+    /// The answer being typed, edited by tuika's single-line input state: the
+    /// overlay gets paste, word deletion, and cursor movement from the toolkit
+    /// instead of a hand-rolled `Char`/`Backspace` match.
+    value: SingleLineInputState,
     /// Mask the input and never echo the answer (credentials).
     secret: bool,
     /// Selector options; when non-empty the overlay is a picker, not a field.
@@ -1639,7 +1642,7 @@ impl App {
             self.pending_ask = Some(PendingAsk {
                 prompt: request.prompt,
                 placeholder: request.placeholder,
-                value: String::new(),
+                value: SingleLineInputState::new(),
                 secret: request.secret,
                 options: request.options,
                 selected: 0,
@@ -2347,11 +2350,18 @@ impl App {
             .clamp(1, MAX_INPUT_HEIGHT)
     }
 
+    /// Route pasted text, from a bracketed paste or from Ctrl+V.
+    ///
+    /// The precedence mirrors [`handle_key`](Self::handle_key) deliberately:
+    /// whichever surface owns the keyboard owns pasted text too. Without that,
+    /// a paste aimed at an overlay lands in the composer behind it — which is
+    /// how a pasted credential ended up sitting in the input once an extension
+    /// prompt closed.
     fn handle_paste(&mut self, pasted: String) {
-        // An open `ui/ask` prompt owns the keyboard (see `handle_key`), so it
-        // owns pasted text too — otherwise a bracketed paste meant for the
-        // prompt lands in the composer behind the overlay, where a secret
-        // answer would sit in plain sight once the prompt closes.
+        if self.history_search.is_some() {
+            self.handle_search_paste(&pasted);
+            return;
+        }
         if self.pending_ask.is_some() {
             self.handle_ask_paste(&pasted);
             return;
@@ -2429,11 +2439,10 @@ impl App {
         }
     }
 
-    /// Insert pasted text into the open `ui/ask` answer. The overlay is a
-    /// single-line field, so line breaks and other control characters are
-    /// dropped rather than pasted: a token copied with a trailing newline
-    /// answers the prompt as typed. A selector prompt has no field to fill, so
-    /// the paste is ignored.
+    /// Insert pasted text into the open `ui/ask` answer, through the same
+    /// [`SingleLineInputState`] that handles its keys — so line boundaries
+    /// normalize the toolkit's way and the answer is trimmed on submit. A
+    /// selector prompt has no field to fill, so the paste is ignored.
     fn handle_ask_paste(&mut self, pasted: &str) {
         let Some(ask) = self.pending_ask.as_mut() else {
             return;
@@ -2441,8 +2450,18 @@ impl App {
         if !ask.options.is_empty() {
             return;
         }
+        let _ = ask.value.handle(&tuika::Event::Paste(pasted.to_string()));
+    }
+
+    /// Insert pasted text into the reverse-history search query and re-match.
+    /// The query is one line, so line boundaries become spaces.
+    fn handle_search_paste(&mut self, pasted: &str) {
+        let Some(search) = self.history_search.as_mut() else {
+            return;
+        };
         let text = crate::tui::input::paste_attachment::normalize_pasted_text(pasted);
-        ask.value.extend(text.chars().filter(|c| !c.is_control()));
+        search.query.push_str(&text.replace('\n', " "));
+        self.history_search_refresh();
     }
 
     /// Keyboard handling while an extension `ui/ask` prompt is open: edit the
@@ -2479,7 +2498,10 @@ impl App {
         }
         match key.code {
             KeyCode::Enter => {
-                let answer = ask.value.clone();
+                // Trimmed: a credential pasted with a trailing newline (which
+                // the single-line state normalizes to a space) must still
+                // answer as the token itself.
+                let answer = ask.value.text().trim().to_string();
                 self.resolve_ask(crate::tui::host_ui::AskAnswer {
                     answer,
                     cancelled: false,
@@ -2491,13 +2513,14 @@ impl App {
                     cancelled: true,
                 });
             }
-            KeyCode::Backspace => {
-                ask.value.pop();
+            // Everything else is editing: hand the translated event to the
+            // toolkit's input state, which is what gives the prompt cursor
+            // movement, word deletion, and kill-to-end for free.
+            _ => {
+                if let Some(event) = tuika::translate_event(CrosstermEvent::Key(key)) {
+                    let _ = ask.value.handle(&event);
+                }
             }
-            KeyCode::Char(c) => {
-                ask.value.push(c);
-            }
-            _ => {}
         }
     }
 
@@ -7813,7 +7836,7 @@ mod tests {
         app.pending_ask = Some(PendingAsk {
             prompt: "Logfire write token".to_string(),
             placeholder: None,
-            value: String::new(),
+            value: SingleLineInputState::new(),
             secret: true,
             options: Vec::new(),
             selected: 0,
@@ -7823,9 +7846,9 @@ mod tests {
         app.handle_paste("pylf_v1_us_TOKEN\n".to_string());
 
         assert_eq!(
-            app.pending_ask.as_ref().expect("prompt open").value,
-            "pylf_v1_us_TOKEN",
-            "paste belongs to the open prompt, with the trailing newline dropped"
+            app.pending_ask.as_ref().expect("prompt open").value.text(),
+            "pylf_v1_us_TOKEN ",
+            "paste belongs to the open prompt (the trailing newline normalizes to a space)"
         );
         assert!(
             app.input_text().is_empty(),
@@ -7840,6 +7863,65 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ask_prompt_edits_through_the_toolkit_input_state() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+        let (reply, mut answer_rx) = oneshot::channel();
+        app.pending_ask = Some(PendingAsk {
+            prompt: "token".to_string(),
+            placeholder: None,
+            value: SingleLineInputState::new(),
+            secret: true,
+            options: Vec::new(),
+            selected: 0,
+            reply: Some(reply),
+        });
+
+        for c in "abcd".chars() {
+            app.handle_ask_key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::empty()));
+        }
+        // Cursor movement and mid-string deletion come from the toolkit, not
+        // from a hand-rolled push/pop on a String.
+        app.handle_ask_key(KeyEvent::new(KeyCode::Left, KeyModifiers::empty()));
+        app.handle_ask_key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::empty()));
+        let ask = app.pending_ask.as_ref().expect("prompt open");
+        assert_eq!(ask.value.text(), "abd");
+        assert_eq!(
+            ask.value.cursor(),
+            2,
+            "caret stays before the last character"
+        );
+
+        app.handle_ask_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()));
+        assert_eq!(
+            answer_rx.try_recv().expect("answer delivered").answer,
+            "abd"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn paste_during_reverse_search_fills_the_query() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+        app.history.record("an earlier prompt");
+        app.history_search_start();
+
+        app.handle_paste("needle".to_string());
+
+        assert_eq!(
+            app.history_search.as_ref().expect("search open").query,
+            "needle"
+        );
+        assert!(
+            !app.input_text().contains("needle"),
+            "the search query must not be typed into the composer: {:?}",
+            app.input_text()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn paste_into_a_selector_prompt_is_ignored() {
         let mut fixture = app_with_llmsim().await;
         let app = &mut fixture.app;
@@ -7848,7 +7930,7 @@ mod tests {
         app.pending_ask = Some(PendingAsk {
             prompt: "pick one".to_string(),
             placeholder: None,
-            value: String::new(),
+            value: SingleLineInputState::new(),
             secret: false,
             options: vec!["a".to_string(), "b".to_string()],
             selected: 0,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -2348,6 +2348,14 @@ impl App {
     }
 
     fn handle_paste(&mut self, pasted: String) {
+        // An open `ui/ask` prompt owns the keyboard (see `handle_key`), so it
+        // owns pasted text too — otherwise a bracketed paste meant for the
+        // prompt lands in the composer behind the overlay, where a secret
+        // answer would sit in plain sight once the prompt closes.
+        if self.pending_ask.is_some() {
+            self.handle_ask_paste(&pasted);
+            return;
+        }
         if self.setup.is_some() || self.background_panel_focused {
             return;
         }
@@ -2385,6 +2393,18 @@ impl App {
     }
 
     fn try_paste_clipboard(&mut self) {
+        // The ask overlay is a plain text field: Ctrl+V fills it from the
+        // clipboard's *text*, an image attachment has nowhere to go there.
+        if self.pending_ask.is_some() {
+            match crate::tui::input::clipboard_paste::paste_clipboard_text() {
+                Ok(text) => self.handle_ask_paste(&text),
+                Err(err) => {
+                    tracing::debug!("clipboard text paste failed: {err}");
+                    self.push_system(format!("clipboard paste failed: {err}"));
+                }
+            }
+            return;
+        }
         if self.setup.is_some() || self.background_panel_focused {
             return;
         }
@@ -2407,6 +2427,22 @@ impl App {
                 self.push_system(format!("clipboard image paste failed: {err}"));
             }
         }
+    }
+
+    /// Insert pasted text into the open `ui/ask` answer. The overlay is a
+    /// single-line field, so line breaks and other control characters are
+    /// dropped rather than pasted: a token copied with a trailing newline
+    /// answers the prompt as typed. A selector prompt has no field to fill, so
+    /// the paste is ignored.
+    fn handle_ask_paste(&mut self, pasted: &str) {
+        let Some(ask) = self.pending_ask.as_mut() else {
+            return;
+        };
+        if !ask.options.is_empty() {
+            return;
+        }
+        let text = crate::tui::input::paste_attachment::normalize_pasted_text(pasted);
+        ask.value.extend(text.chars().filter(|c| !c.is_control()));
     }
 
     /// Keyboard handling while an extension `ui/ask` prompt is open: edit the
@@ -7766,6 +7802,69 @@ mod tests {
             app.repo_pulse_rx.is_none(),
             "inline mode must not start repository inspection"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn paste_fills_the_open_ask_prompt_not_the_composer() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+        let (reply, mut answer_rx) = oneshot::channel();
+        app.pending_ask = Some(PendingAsk {
+            prompt: "Logfire write token".to_string(),
+            placeholder: None,
+            value: String::new(),
+            secret: true,
+            options: Vec::new(),
+            selected: 0,
+            reply: Some(reply),
+        });
+
+        app.handle_paste("pylf_v1_us_TOKEN\n".to_string());
+
+        assert_eq!(
+            app.pending_ask.as_ref().expect("prompt open").value,
+            "pylf_v1_us_TOKEN",
+            "paste belongs to the open prompt, with the trailing newline dropped"
+        );
+        assert!(
+            app.input_text().is_empty(),
+            "the composer behind the overlay must stay untouched: {:?}",
+            app.input_text()
+        );
+
+        app.handle_ask_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()));
+        let answered = answer_rx.try_recv().expect("answer delivered");
+        assert!(!answered.cancelled);
+        assert_eq!(answered.answer, "pylf_v1_us_TOKEN");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn paste_into_a_selector_prompt_is_ignored() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+        let (reply, _answer_rx) = oneshot::channel();
+        app.pending_ask = Some(PendingAsk {
+            prompt: "pick one".to_string(),
+            placeholder: None,
+            value: String::new(),
+            secret: false,
+            options: vec!["a".to_string(), "b".to_string()],
+            selected: 0,
+            reply: Some(reply),
+        });
+
+        app.handle_paste("pasted".to_string());
+
+        assert!(
+            app.pending_ask
+                .as_ref()
+                .expect("prompt open")
+                .value
+                .is_empty()
+        );
+        assert!(app.input_text().is_empty());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -2358,6 +2358,21 @@ impl App {
     /// how a pasted credential ended up sitting in the input once an extension
     /// prompt closed.
     fn handle_paste(&mut self, pasted: String) {
+        // Normalization and the size cap apply to every target: a single-line
+        // overlay field has no placeholder machinery to fall back on, so an
+        // oversized paste is refused before any surface stores or renders it.
+        let pasted = crate::tui::input::paste_attachment::normalize_pasted_text(&pasted);
+        if pasted.is_empty() {
+            return;
+        }
+        if pasted.len() > crate::tui::input::paste_attachment::MAX_PASTE_ATTACHMENT_BYTES {
+            self.push_system(format!(
+                "paste too large (max {} KiB)",
+                crate::tui::input::paste_attachment::MAX_PASTE_ATTACHMENT_BYTES / 1024
+            ));
+            return;
+        }
+
         if self.history_search.is_some() {
             self.handle_search_paste(&pasted);
             return;
@@ -2370,19 +2385,6 @@ impl App {
             return;
         }
         self.esc_pending_cancel = false;
-
-        let pasted = crate::tui::input::paste_attachment::normalize_pasted_text(&pasted);
-        if pasted.is_empty() {
-            return;
-        }
-
-        if pasted.len() > crate::tui::input::paste_attachment::MAX_PASTE_ATTACHMENT_BYTES {
-            self.push_system(format!(
-                "paste too large (max {} KiB)",
-                crate::tui::input::paste_attachment::MAX_PASTE_ATTACHMENT_BYTES / 1024
-            ));
-            return;
-        }
 
         if crate::tui::input::paste_attachment::is_large_paste(&pasted) {
             let char_count = pasted.chars().count();
@@ -2459,8 +2461,7 @@ impl App {
         let Some(search) = self.history_search.as_mut() else {
             return;
         };
-        let text = crate::tui::input::paste_attachment::normalize_pasted_text(pasted);
-        search.query.push_str(&text.replace('\n', " "));
+        search.query.push_str(&pasted.replace('\n', " "));
         self.history_search_refresh();
     }
 
@@ -7897,6 +7898,81 @@ mod tests {
         assert_eq!(
             answer_rx.try_recv().expect("answer delivered").answer,
             "abd"
+        );
+    }
+
+    #[test]
+    fn ask_overlay_masks_a_pasted_secret_and_tracks_the_caret() {
+        let (reply, _answer_rx) = oneshot::channel();
+        let mut ask = PendingAsk {
+            prompt: "Logfire write token".to_string(),
+            placeholder: Some("stored securely, not shown to the agent".to_string()),
+            value: SingleLineInputState::new(),
+            secret: true,
+            options: Vec::new(),
+            selected: 0,
+            reply: Some(reply),
+        };
+        let _ = ask
+            .value
+            .handle(&tuika::Event::Paste("pylf_v1".to_string()));
+
+        let (lines, cursor) = crate::tui::render::ask_overlay_content(&ask);
+        let field = line_text(&lines[4]);
+        assert_eq!(
+            field, "> •••••••",
+            "a secret answer is masked, never echoed"
+        );
+        assert_eq!(
+            cursor,
+            (4, "> ".len() + 7),
+            "caret sits after the pasted text"
+        );
+
+        // The caret follows the input state rather than the text length, so
+        // arrow keys move the cell the terminal draws the cursor in.
+        let _ = ask.value.handle(&tuika::Event::Key(tuika::event::Key::new(
+            tuika::event::KeyCode::Left,
+        )));
+        let (_, cursor) = crate::tui::render::ask_overlay_content(&ask);
+        assert_eq!(cursor, (4, "> ".len() + 6));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn oversized_paste_is_refused_before_it_reaches_an_overlay() {
+        use crate::tui::input::paste_attachment::MAX_PASTE_ATTACHMENT_BYTES;
+
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+        app.lines.clear();
+        let (reply, _answer_rx) = oneshot::channel();
+        app.pending_ask = Some(PendingAsk {
+            prompt: "token".to_string(),
+            placeholder: None,
+            value: SingleLineInputState::new(),
+            secret: true,
+            options: Vec::new(),
+            selected: 0,
+            reply: Some(reply),
+        });
+
+        app.handle_paste("x".repeat(MAX_PASTE_ATTACHMENT_BYTES + 1));
+
+        assert!(
+            app.pending_ask
+                .as_ref()
+                .expect("prompt open")
+                .value
+                .is_empty(),
+            "the single-line field must not store an oversized paste"
+        );
+        assert!(
+            app.lines
+                .iter()
+                .any(|line| line.text.contains("paste too large")),
+            "the refusal is reported: {:?}",
+            app.lines
         );
     }
 

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -545,15 +545,16 @@ pub(crate) fn ask_overlay_content(ask: &PendingAsk) -> (Vec<Line<'static>>, (usi
     }
     // Text / secret input. Secret input is masked; the placeholder (shown when
     // empty) is never masked.
-    let field = if ask.value.is_empty() {
+    let value = ask.value.text();
+    let field = if value.is_empty() {
         ask.placeholder
             .as_ref()
             .map(|p| format!("({p})"))
             .unwrap_or_default()
     } else if ask.secret {
-        "•".repeat(ask.value.chars().count())
+        "•".repeat(value.chars().count())
     } else {
-        ask.value.clone()
+        value.to_string()
     };
     lines.push(Line::from(format!("> {field}")));
     lines.push(Line::from(""));
@@ -561,8 +562,9 @@ pub(crate) fn ask_overlay_content(ask: &PendingAsk) -> (Vec<Line<'static>>, (usi
         "Enter to answer · Esc to cancel",
         Style::default().add_modifier(Modifier::DIM),
     )));
-    // The typed answer is on row 4, after the "> " prompt.
-    let cursor = (4, "> ".len() + ask.value.chars().count());
+    // The typed answer is on row 4, after the "> " prompt. The column follows
+    // the input state's cursor, so arrow keys move the caret the user sees.
+    let cursor = (4, "> ".len() + ask.value.cursor());
     (lines, cursor)
 }
 


### PR DESCRIPTION
## What changed

Pasting while an extension `ui/ask` prompt is open now fills the prompt, not the composer hidden behind it. Both paste routes are covered: a terminal bracketed paste and Ctrl+V (which, with a prompt open, reads clipboard **text** instead of attempting an image attachment).

The prompt's answer field is now tuika's `SingleLineInputState` rather than a hand-rolled `String` with a `Char`/`Backspace` match, so it gains paste, caret movement, word deletion, and kill-to-line-end from the toolkit; the overlay's terminal cursor follows the state's caret instead of assuming end-of-string. The answer is trimmed on submit, so a token copied with its trailing newline still answers as the token.

The same routing rule was applied to reverse-history search, which had the identical latent bug, and the paste size cap now runs before routing so no single-line overlay field can be handed an oversized payload.

## Why

An extension asked for a Logfire write token. Ctrl+V appeared to do nothing; on Esc the whole token was sitting in the composer. Two causes: keys were routed by one function and pastes by another, and only the key path knew about the overlay; and the answer field could not have consumed `Event::Paste` even if the event had reached it.

Beyond the usability bug this is a credential-exposure path: text left in the composer becomes part of the next prompt sent to the model.

## Before / After

**Before** (reported): with the prompt open, the field stays empty on paste, and the pasted token appears in the composer once the prompt is dismissed.

```
An extension is asking:

Logfire write token — `token` for extension `logfire`

> (stored securely, not shown to the agent)      <- paste does not land here

  Enter to send, Shift-Enter for newline)
> pylf_v1_us_tRCJNxWQQVhNncYwp0tnjn19q07xsSDb…   <- it landed here instead
```

**After** (presentation-model dump, `ask_overlay_masks_a_pasted_secret_and_tracks_the_caret`, `pylf_v1` pasted):

```
An extension is asking:

Logfire write token

> •••••••
                       cursor (4, 9)   <- row 4, col 2 + 7 chars; Left moves it to 8
Enter to answer · Esc to cancel
```

The pasted secret is masked in the overlay and never echoed to the transcript (`(saved)` on submit, unchanged).

Validation:

- `cargo fmt --check`, `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`, `cargo test --workspace --features yolop-yep/schema` (1292 tests) all green locally.
- `python3 scripts/validate_okf.py knowledge --check-links` green.
- Offline smoke locally: `cargo run -- --provider llmsim -p "hi"` starts and answers.
- Live smoke: the **Live Provider Smoke (Doppler)** CI job is green on this head. It could not be run in the authoring environment (no Doppler CLI, no provider key there), so CI is the live evidence.

## Risk

- Low
- The blast radius is the ask overlay's key handling: it now forwards all non-Enter/Esc keys to the input state rather than only `Char`/`Backspace`. Global chords (Ctrl+C/D/R/B/V) still resolve ahead of it through the keymap, and selector prompts keep their own arrow/Enter handling. A behavior change worth naming: the submitted answer is trimmed.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated `knowledge/specs/extensions.md` § ui/ask: the answer field is toolkit-backed, and paste follows the same modal precedence as keys.

## Security

Reviewed against TM-LLM, TM-TOOL, TM-FS, TM-BASH, TM-DEP.

- **TM-LLM (primary).** This is the category the bug lived in. A pasted credential previously landed in the composer and would have been submitted to the provider with the next prompt; it now goes to the masked prompt field, is never echoed to the transcript (`(saved)`), and is not logged. The Ctrl+V failure path logs only the clipboard backend's error string, never clipboard contents.
- **Resource exhaustion.** Found and fixed during this review: the new overlay routes initially bypassed `MAX_PASTE_ATTACHMENT_BYTES`, since only the composer path applied it. A single-line field has no placeholder/attachment fallback, so an oversized paste would have been stored and re-rendered every frame. The cap now runs before routing and refuses with a system line; covered by `oversized_paste_is_refused_before_it_reaches_an_overlay`.
- **TM-FS / TM-BASH / TM-TOOL.** Untouched: no filesystem, shell, or capability-registration code in the diff.
- **TM-DEP.** No new dependencies; `SingleLineInputState` is existing public API in the pinned tuika 0.10.

## Follow-ups

- Input routing itself belongs in tuika, not in each host: `FocusRegistry` models overlay input ownership but nothing enforces delivery, so every host re-derives modal precedence per event kind. That is exactly how this bug (and its reverse-search twin) happened. A written ask has been handed to the tuika side; when a router lands there, yolop's hand-rolled precedence in `handle_key`/`handle_paste` should be replaced by it.
- Reverse-history search still hand-rolls its query as a `String` with a `Char`/`Backspace` match. Paste now reaches it, but it has no caret or word editing. Left as-is here to keep the diff to the reported bug; it is the next field to move onto a toolkit input state.