### PR TITLE
fix(extensions): make attached administration report what it actually did

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -24,6 +24,17 @@
 - Together: a clean `cargo build --tests --workspace` went from 6.3 GB to
   3.7 GB, dependency rlibs from 2136 MiB to 1238 MiB, and the mixed-feature
   directory no longer happens at all.
+## 2026-08-18, Eager bash schema, deferred LSP schemas
+
+- [`tool_search`](specs/tool-search.md): `bash` joins the never-defer allowlist.
+  Its deferred stub names no parameters while allowing extras, so a model fills
+  the gap from other harnesses' shell schemas (`timeout`, `max_output_chars`)
+  and argument validation rejects the call against the real
+  `additionalProperties: false` schema, spending a round trip on a correction.
+- LSP tools leave the allowlist and defer with every other opt-in surface. This
+  reverses the profile an LSP adoption eval justified, so re-measure adoption
+  before treating it as settled.
+
 ## 2026-08-18, Attached administration reports what it did
 
 - [Extensions](specs/extensions.md): `yolop <subcommand> --help` failed inside a

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -24,6 +24,18 @@
 - Together: a clean `cargo build --tests --workspace` went from 6.3 GB to
   3.7 GB, dependency rlibs from 2136 MiB to 1238 MiB, and the mixed-feature
   directory no longer happens at all.
+## 2026-08-18, Attached administration reports what it did
+
+- [Extensions](specs/extensions.md): `yolop <subcommand> --help` failed inside a
+  session, the parent parsed clap's help text as a control frame. A child that
+  answers as an ordinary CLI is now relayed verbatim, which also covers
+  `--version` and usage errors.
+- A composed administration command (`... | cat`, redirection, quoting, `&`)
+  now carries a notice that it ran detached and changed only global state. The
+  attached and detached forms differ only by punctuation and their output was
+  identical, so neither the agent nor the user could tell them apart.
+- The notice rides the tool result, so one implementation serves the agent and
+  the client transcript.
 
 ## 2026-08-18, Session coordination uses attached CLI actions
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -24,6 +24,18 @@
 - Together: a clean `cargo build --tests --workspace` went from 6.3 GB to
   3.7 GB, dependency rlibs from 2136 MiB to 1238 MiB, and the mixed-feature
   directory no longer happens at all.
+## 2026-08-18, Mid-session installs report a restart, not a mystery
+
+- [Extensions](specs/extensions.md): enabling an extension installed during the
+  session surfaced the engine's "unknown capability: ext:<name>" plus "will load
+  on the next session". Both the transcript and the `enable_extension` result now
+  say the package arrived after startup and needs a restart.
+- Registering a newly installed package into the live runtime is blocked
+  upstream: `everruns-host` composes the capability registry once and offers no
+  dynamic registration, and yolop holds the runtime as a shared `Arc`.
+- Enabling with a cancelled required prompt no longer reports a bare success; the
+  result names the unset fields.
+
 ## 2026-08-18, Eager bash schema, deferred LSP schemas
 
 - [`tool_search`](specs/tool-search.md): `bash` joins the never-defer allowlist.

--- a/knowledge/specs/extensions.md
+++ b/knowledge/specs/extensions.md
@@ -262,6 +262,17 @@ redirection, quoting, substitutions, and background execution receive no
 attachment and run as ordinary shell commands. Attached failure never falls
 back to detached global mutation.
 
+Enablement applies to the running session only for packages present when it
+started. The runtime composes its capability registry once, at startup, and
+`everruns-host` exposes no way to register a capability afterwards
+(`CapabilityRegistry` is owned by value behind an `Arc<InProcessRuntime>` and
+mutated only through `&mut` at composition), so an extension installed mid-session
+has nothing to activate. That case is reported as what it is, a restart, in both
+the transcript and the `enable_extension` result, rather than as an internal
+"unknown capability" or a misleading "next session". Making it genuinely live
+requires a dynamic-registration API upstream; until that exists the honest
+message is the contract.
+
 Two consequences of that boundary are handled rather than left implicit. A child
 that answers as an ordinary CLI, `--help`, `--version`, or a usage error, never
 sends a control frame because clap prints and exits inside it; the parent relays

--- a/knowledge/specs/extensions.md
+++ b/knowledge/specs/extensions.md
@@ -262,6 +262,18 @@ redirection, quoting, substitutions, and background execution receive no
 attachment and run as ordinary shell commands. Attached failure never falls
 back to detached global mutation.
 
+Two consequences of that boundary are handled rather than left implicit. A child
+that answers as an ordinary CLI, `--help`, `--version`, or a usage error, never
+sends a control frame because clap prints and exits inside it; the parent relays
+its stdout, stderr, and exit code verbatim instead of failing to parse help text
+as a frame, so the documented `yolop <subcommand> --help` discovery path works
+inside a session. And a composed administration command, which differs from the
+attached form only by punctuation while its output looks identical, carries a
+notice on the tool result saying it ran detached and left the session untouched;
+the notice reaches the agent in the result and the user in the transcript, so
+neither has to infer which of the two forms ran. Help and version administer
+nothing and draw no notice.
+
 Discovery is one shared system-prompt block owned by the control plane, not the
 Bash tool description and not a per-capability contribution: `ControlPlaneCapability`
 renders every route registered in the session from its `ControlRoute::summary`,

--- a/knowledge/specs/tool-search.md
+++ b/knowledge/specs/tool-search.md
@@ -42,18 +42,22 @@ vendor was deleted and yolop now consumes upstream directly:
 
 2. **Static host-shaped eager profile.** Yolop passes first-turn repository
    discovery (`read_file`, `list_directory`, `grep_files`), bookkeeping
-   (`write_todos`, `write_session_title`), and the mandatory progress-guard
-   transition (`progress_checkpoint`) to
-   `ToolSearchCapability::new().with_never_defer([...])`. Mutation, shell,
-   background, release/control, skills, session history, web, and other
+   (`write_todos`, `write_session_title`), the shell (`bash`), and the mandatory
+   progress-guard transition (`progress_checkpoint`) to
+   `ToolSearchCapability::new().with_never_defer([...])`. Mutation,
+   background, release/control, skills, session history, web, LSP, and other
    specialized tools keep their names and descriptions visible but reveal their
    authoritative schemas through `tool_search` when the task calls for them.
    This is host/task shaped without a volatile classifier: the allowlist is
-   stable for the session and provider-cache prefix. Opt-in LSP tools stay eager
-   because enabling the host profile is itself an explicit task signal and the
-   LSP adoption eval showed that stubbing those schemas drives adoption toward
-   zero. Extension tools explicitly marked `never_defer` retain their manifest
-   contract. Yolop does not own the built-in definitions, so it sets this policy
+   stable for the session and provider-cache prefix. `bash` is eager because the
+   deferred stub names no parameters while allowing extras, so a model fills the
+   gap from other harnesses' shell schemas and yolop's
+   `additionalProperties: false` schema then rejects the call: the most-used
+   tool in the harness spent a round trip on a correction. LSP tools defer with
+   every other opt-in surface; this reverses an earlier eager profile justified
+   by an LSP adoption eval that measured lower adoption with stubbed schemas, so
+   re-measure before treating the current profile as settled. Extension tools
+   explicitly marked `never_defer` retain their manifest contract. Yolop does not own the built-in definitions, so it sets this policy
    by name rather than changing each tool's `DeferrablePolicy`.
 
    **MCP server tools defer on the same footing**: with many configured servers

--- a/src/control.rs
+++ b/src/control.rs
@@ -24,6 +24,9 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 pub const CONTROL_VERSION: u32 = 1;
 const MAX_CONTROL_FRAME_BYTES: usize = 64 * 1024;
 const CONTROL_TIMEOUT: Duration = Duration::from_secs(120);
+/// Cap for output relayed from a child that ran as an ordinary CLI (help,
+/// version, usage errors) rather than speaking the protocol.
+const MAX_RELAY_BYTES: usize = 256 * 1024;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ControlRequest {
@@ -384,6 +387,76 @@ fn direct_control_args(
     ))
 }
 
+/// Relay a child that answered as an ordinary CLI rather than a control client.
+///
+/// Its stdout, stderr, and exit code become the command's, so `yolop extensions
+/// --help` prints help and exits 0 the way it would outside a session. Output is
+/// bounded like every other frame on this transport.
+async fn relay_plain_cli_child(
+    mut child: tokio::process::Child,
+    first_line: Vec<u8>,
+    reader: tokio::io::Take<BufReader<tokio::process::ChildStdout>>,
+) -> anyhow::Result<AttachedCommandOutput> {
+    let mut stdout = first_line;
+    let mut reader = reader.into_inner().take(MAX_RELAY_BYTES as u64);
+    reader.read_to_end(&mut stdout).await?;
+    let mut stderr = Vec::new();
+    if let Some(handle) = child.stderr.take() {
+        let mut handle = BufReader::new(handle).take(MAX_RELAY_BYTES as u64);
+        handle.read_to_end(&mut stderr).await?;
+    }
+    // The child never asked for a response; closing stdin lets it exit.
+    drop(child.stdin.take());
+    let status = child.wait().await?;
+    Ok(AttachedCommandOutput {
+        stdout: String::from_utf8_lossy(&stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&stderr).into_owned(),
+        exit_code: status.code().unwrap_or(1),
+    })
+}
+
+/// Warn when a `yolop` administration command was written in a form the
+/// attached recognizer rejects.
+///
+/// The two forms differ only by punctuation, and the difference is invisible in
+/// the output: `yolop extensions enable x` mutates this session, while
+/// `yolop extensions enable x | cat` is ordinary shell that touches only
+/// persisted global state. Without this notice the agent (and the user reading
+/// the transcript) sees a success either way and cannot tell which happened.
+///
+/// `None` for anything that is genuinely attached, and for `yolop` commands that
+/// name no registered control route (`yolop --version | cat` administers
+/// nothing).
+pub fn detached_control_notice(command: &str, service: &dyn ControlService) -> Option<String> {
+    if direct_control_args(command, service).is_some() {
+        return None;
+    }
+    let words = command.split_ascii_whitespace().collect::<Vec<_>>();
+    // Help and version administer nothing, so a composed one is not a mistake.
+    if words
+        .iter()
+        .any(|word| matches!(*word, "--help" | "-h" | "--version" | "-V"))
+    {
+        return None;
+    }
+    // Scan every token, not just argv[0]: `... | yolop extensions list` runs
+    // detached just as surely as `yolop extensions list | ...`.
+    let subcommand = words.windows(2).find_map(|pair| {
+        let is_yolop = Path::new(pair[0].trim_matches(['"', '\'']))
+            .file_name()
+            .and_then(|value| value.to_str())
+            == Some("yolop");
+        let route = service.route(pair[1].trim_matches(['"', '\'']))?;
+        is_yolop.then_some(route.cli_subcommand)
+    })?;
+    Some(format!(
+        "`yolop {subcommand}` ran as an ordinary shell command. Shell composition (a pipeline, \
+         redirection, quoting, substitution, or `&`) is never attached to this session, so this \
+         changed only persisted global state and left the running session untouched. Re-run it \
+         directly, without composition, to administer this session."
+    ))
+}
+
 /// Typed administration other than a list crosses the arbitrary-shell
 /// sandbox boundary into a host broker and therefore needs an explicit shell
 /// approval whenever containment is enabled.
@@ -445,15 +518,14 @@ async fn invoke_attached_inner(
     if frame.len() > MAX_CONTROL_FRAME_BYTES {
         anyhow::bail!("control request exceeded {MAX_CONTROL_FRAME_BYTES} bytes");
     }
-    if frame.is_empty() {
-        let stderr = child.stderr.take().expect("piped stderr");
-        let stderr = BufReader::new(stderr);
-        let mut stderr = stderr.take((MAX_CONTROL_FRAME_BYTES + 1) as u64);
-        let mut message = String::new();
-        stderr.read_to_string(&mut message).await?;
-        anyhow::bail!("child produced no control request: {}", message.trim());
-    }
-    let request: ControlRequest = serde_json::from_slice(&frame)?;
+    // `--help`, `--version`, and usage errors never reach the protocol: clap
+    // prints and exits inside the child. Relaying its own output keeps those
+    // invocations working exactly like an ordinary CLI run (and keeps them on
+    // this binary), instead of failing to parse help text as a control frame.
+    let request = match serde_json::from_slice::<ControlRequest>(&frame) {
+        Ok(request) => request,
+        Err(_) => return relay_plain_cli_child(child, frame, reader).await,
+    };
     let response = service.execute(request.clone()).await;
 
     let mut stdin = child.stdin.take().expect("piped stdin");
@@ -773,5 +845,47 @@ mod tests {
         fn render_control(&self, _action: &Value, response: &ControlResponse) -> String {
             response.render_default()
         }
+    }
+
+    #[test]
+    fn attached_administration_gets_no_detached_notice() {
+        let service = service();
+        assert!(detached_control_notice("yolop extensions enable demo", &service).is_none());
+        assert!(detached_control_notice("yolop extensions list", &service).is_none());
+    }
+
+    #[test]
+    fn composed_administration_is_reported_as_detached() {
+        let service = service();
+        // Each of these is rejected by the recognizer and silently runs as
+        // ordinary shell, which is exactly what the agent cannot otherwise see.
+        for command in [
+            "yolop extensions enable demo | cat",
+            "yolop extensions enable demo > out.txt",
+            "yolop extensions enable 'demo'",
+            "yolop extensions enable demo &",
+            "/usr/local/bin/yolop extensions list | grep demo",
+            // Not argv[0]: still a detached administration attempt.
+            "echo hi | yolop extensions list",
+        ] {
+            let notice = detached_control_notice(command, &service)
+                .unwrap_or_else(|| panic!("expected a detached notice for `{command}`"));
+            assert!(notice.contains("`yolop extensions`"), "{command}: {notice}");
+            assert!(
+                notice.contains("left the running session untouched"),
+                "{command}"
+            );
+        }
+    }
+
+    #[test]
+    fn unrelated_and_non_administration_commands_are_quiet() {
+        let service = service();
+        // No registered route named, so nothing about the session is at stake.
+        assert!(detached_control_notice("yolop --version | cat", &service).is_none());
+        assert!(detached_control_notice("yolop worktree list | cat", &service).is_none());
+        assert!(detached_control_notice("cargo test | tee log", &service).is_none());
+        // A bare word that happens to match a route is not a yolop invocation.
+        assert!(detached_control_notice("git extensions list", &service).is_none());
     }
 }

--- a/src/exec/tools.rs
+++ b/src/exec/tools.rs
@@ -129,6 +129,15 @@ impl BashTool {
         self
     }
 
+    /// Notice for an administration command that lost its session attachment to
+    /// shell composition. Surfaced on the result so both the agent and the
+    /// client transcript can say so; `None` without a control service, where
+    /// there are no routes to be wrong about.
+    fn detached_control_notice(&self, command: &str) -> Option<String> {
+        let control = self.control.as_ref()?;
+        crate::control::detached_control_notice(command, control.as_ref())
+    }
+
     fn timeout_secs(&self, background: bool) -> u64 {
         if background {
             self.background_timeout_secs
@@ -548,6 +557,9 @@ impl Tool for BashTool {
         if let Some(hint) = command_failure_hint(exit_code, &output.stderr_text) {
             result["hint"] = json!(hint);
         }
+        if let Some(notice) = self.detached_control_notice(&command) {
+            result["detached_control"] = json!(notice);
+        }
 
         ToolExecutionResult::success_with_raw_output(result, raw_output)
     }
@@ -610,7 +622,7 @@ impl BackgroundExecutableTool for BashTool {
                 label: Some("runtime".to_string()),
             })
             .await;
-        let result = json!({
+        let mut result = json!({
             "command": command,
             "exit_code": exit_code,
             "success": success,
@@ -621,6 +633,11 @@ impl BackgroundExecutableTool for BashTool {
             "output_limited": output_limited,
             "sandbox": output.sandbox_mode.as_str(),
         });
+        // A backgrounded administration command is detached twice over: the
+        // recognizer is foreground-only, so say so here as well.
+        if let Some(notice) = self.detached_control_notice(&command) {
+            result["detached_control"] = json!(notice);
+        }
 
         if success {
             Ok(BackgroundOutcome {
@@ -655,6 +672,47 @@ mod tests {
     /// was hardcoded to `yolop extensions`, which named one of the session's
     /// routes and advertised administration even where none is registered.
     /// Discovery belongs to the shared control-plane prompt block.
+    /// The agent half: a composed administration command must carry the notice
+    /// on its result, where the model reads it.
+    #[tokio::test]
+    async fn composed_administration_result_carries_the_detached_notice() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut control = crate::control::ControlRegistry::default();
+        control
+            .register(std::sync::Arc::new(
+                crate::extensions::ExtensionsCapability::new(
+                    dir.path().join("extensions"),
+                    dir.path().to_path_buf(),
+                    std::sync::Arc::new(crate::config::SettingsStore::open(
+                        dir.path().join("settings.toml"),
+                    )),
+                    crate::extensions::LiveProcessRegistry::default(),
+                    None,
+                ),
+            ))
+            .expect("register extensions control route");
+        let tool = BashTool::new(Workspace::from_path(dir.path().to_path_buf()))
+            .with_control(Some(std::sync::Arc::new(control)));
+
+        let result = tool
+            .execute(serde_json::json!({
+                "command": "echo skipped | grep -q . && true # yolop extensions list | cat",
+                "output": "normal",
+            }))
+            .await;
+        let value = match result {
+            ToolExecutionResult::Success(value) => value,
+            other => panic!("expected success, got {other:?}"),
+        };
+        assert!(
+            value
+                .get("detached_control")
+                .and_then(Value::as_str)
+                .is_some_and(|notice| notice.contains("`yolop extensions`")),
+            "expected a detached-control notice on the result: {value}"
+        );
+    }
+
     #[test]
     fn bash_description_does_not_name_control_resources() {
         let tool = BashTool::new(Workspace::from_path(std::env::current_dir().unwrap()));

--- a/src/extensions/manage.rs
+++ b/src/extensions/manage.rs
@@ -108,8 +108,11 @@ enum ExtensionSecretCommand {
     disable_help_subcommand = true
 )]
 struct ExtensionCommandLine {
+    /// Optional so a bare `yolop extensions` lists, the way `/extensions` does.
+    /// Clap would otherwise treat it as a usage error: help text on stderr with
+    /// exit 2, which reads as a failure for what is really a request to look.
     #[command(subcommand)]
-    command: ExtensionCommand,
+    command: Option<ExtensionCommand>,
 }
 
 /// Version-independent extension operations carried by the internal control
@@ -200,7 +203,11 @@ impl ExtensionAction {
         }
         let argv = std::iter::once("extensions").chain(arguments.split_ascii_whitespace());
         ExtensionCommandLine::try_parse_from(argv)
-            .map(|parsed| Self::from_command(parsed.command))
+            .map(|parsed| {
+                parsed
+                    .command
+                    .map_or(Self::List { json: false }, Self::from_command)
+            })
             .map_err(|error| error.to_string())
     }
 
@@ -457,7 +464,13 @@ impl CliCapability for ExtensionsCapability {
         matches: &clap::ArgMatches,
     ) -> anyhow::Result<ControlRequest> {
         let parsed = ExtensionCommandLine::from_arg_matches(matches)?;
-        Ok(ExtensionAction::from_command(parsed.command).control_request())
+        Ok(parsed
+            .command
+            .map_or(
+                ExtensionAction::List { json: false },
+                ExtensionAction::from_command,
+            )
+            .control_request())
     }
 
     async fn execute_cli(&self, request: &ControlRequest) -> anyhow::Result<()> {
@@ -1003,10 +1016,14 @@ impl ManageTool {
     /// text) that isn't set yet. Best-effort — with no prompt surface the
     /// extension still enables and stays inert until configured.
     async fn enable(&self, args: &Value) -> ToolExecutionResult {
-        let result = self.toggle(args, true).await;
+        let mut result = self.toggle(args, true).await;
         if !matches!(result, ToolExecutionResult::Success(_)) {
             return result;
         }
+        // Required fields the user did not supply. Enable still applies, but an
+        // extension missing a required token is inert, and reporting a bare
+        // success for that reads as "it works now" when it does not.
+        let mut unconfigured: Vec<String> = Vec::new();
         if let Some(name) = args.get("name").and_then(Value::as_str)
             && self.ctx.ask_sink.is_some()
             && let Some(pkg) = discover_extensions(&self.ctx.extensions_dir)
@@ -1041,8 +1058,9 @@ impl ManageTool {
                     continue;
                 }
                 // Dispatch by field kind (secret → store; text/select → config).
-                // Ignore prompt failures/cancellations: enable already applied.
-                let _ = match field.kind() {
+                // A cancelled or failed prompt leaves enable applied, so record
+                // the field rather than dropping the outcome.
+                let stored = match field.kind() {
                     super::package::ConfigFieldKind::Secret => {
                         self.prompt_and_store_secret(&pkg.manifest, &field).await
                     }
@@ -1051,7 +1069,29 @@ impl ManageTool {
                         self.prompt_and_store_config(&pkg.manifest, &field).await
                     }
                 };
+                // `Ok(false)` is a cancelled prompt and `Err` a failed one;
+                // only a stored value counts as configured.
+                if !matches!(stored, Ok(true)) {
+                    unconfigured.push(field.name.clone());
+                }
             }
+        }
+        if !unconfigured.is_empty()
+            && let ToolExecutionResult::Success(value) = &mut result
+            && let Some(object) = value.as_object_mut()
+        {
+            let name = args.get("name").and_then(Value::as_str).unwrap_or("<name>");
+            object.insert("setup_incomplete".to_string(), json!(unconfigured.clone()));
+            object.insert(
+                "note".to_string(),
+                json!(format!(
+                    "Enabled, but required setup is missing ({}), so the extension stays inert \
+                     until it is provided. Ask the user to run `yolop extensions secret set \
+                     {name} <field>` for a secret, or set the field with `yolop extensions \
+                     enable {name}` again.",
+                    unconfigured.join(", ")
+                )),
+            );
         }
         result
     }

--- a/src/extensions/manage.rs
+++ b/src/extensions/manage.rs
@@ -822,6 +822,7 @@ impl ManageTool {
                 // session to mutate (the TUI). The App answers on `ui_rx` by
                 // calling activate/deactivate_capability, so the extension's
                 // tools/prompt/hooks land on the next turn — no restart.
+                let mut needs_restart = false;
                 let live = if let Some(tx) = &self.ctx.ui_tx {
                     let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
                     if tx
@@ -842,17 +843,24 @@ impl ManageTool {
                         // request from being reported as live when activation
                         // actually failed (for example, a package installed
                         // after this session registered its manifests).
-                        tokio::time::timeout(std::time::Duration::from_secs(10), reply_rx)
-                            .await
-                            .ok()
-                            .and_then(Result::ok)
-                            .is_some_and(|messages| {
-                                messages.is_empty()
-                                    || messages.iter().any(|message| {
-                                        message.contains("for this session")
-                                            && message.contains("effective on the next turn")
-                                    })
+                        let messages =
+                            tokio::time::timeout(std::time::Duration::from_secs(10), reply_rx)
+                                .await
+                                .ok()
+                                .and_then(Result::ok);
+                        needs_restart = messages.as_ref().is_some_and(|messages| {
+                            messages.iter().any(|message| {
+                                message
+                                    .contains(crate::tui::host_ui::EXTENSION_INSTALLED_MID_SESSION)
                             })
+                        });
+                        messages.is_some_and(|messages| {
+                            messages.is_empty()
+                                || messages.iter().any(|message| {
+                                    message.contains("for this session")
+                                        && message.contains("effective on the next turn")
+                                })
+                        })
                     }
                 } else {
                     false
@@ -860,6 +868,13 @@ impl ManageTool {
                 let note = if live {
                     "Applying to the running session now; effective on the next turn (and \
                      persisted for future sessions)."
+                } else if needs_restart {
+                    // The package reached disk after this session composed its
+                    // capability registry, so there is nothing to activate here.
+                    // Do not tell the agent to keep trying in this session.
+                    "Enabled and persisted, but this extension was installed after the session \
+                     started, so the running session has no server for it. It works after a \
+                     yolop restart; enabling again in this session will not change that."
                 } else {
                     "Takes effect on the next session."
                 };
@@ -1223,7 +1238,9 @@ impl Tool for ManageTool {
             Verb::Enable => {
                 "Enable an installed extension (adds `ext:<name>` to the harness). In the TUI it \
                  is also applied to the running session immediately — its tools/prompt/hooks are \
-                 live on the next turn — and persisted for future sessions."
+                 live on the next turn — and persisted for future sessions. An extension \
+                 installed during this session is the exception: the session's capability set is \
+                 composed at startup, so that one needs a yolop restart, and the result says so."
             }
             Verb::Disable => {
                 "Disable an extension without uninstalling it. Applied to the running session \
@@ -1799,6 +1816,70 @@ mod tests {
             ToolExecutionResult::ToolError(m) => assert!(m.contains("not enabled"), "{m}"),
             other => panic!("{other:?}"),
         }
+    }
+
+    /// An extension installed mid-session cannot activate: the runtime composes
+    /// its capability registry at startup, so `activate_capability` reports an
+    /// unknown id. The result must name that, not "takes effect on the next
+    /// session", which invites the agent to keep enabling in this one.
+    #[tokio::test]
+    async fn enable_reports_a_restart_when_the_package_arrived_mid_session() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        seed_package(&src, "echo");
+        let ext_dir = tmp.path().join("extensions");
+        let settings = Arc::new(SettingsStore::open(tmp.path().join("settings.toml")));
+        let (ui_tx, mut ui_rx) = tokio::sync::mpsc::unbounded_channel::<UiRequest>();
+        let cap = ExtensionsCapability {
+            extensions_dir: ext_dir,
+            workspace_root: tmp.path().to_path_buf(),
+            settings,
+            git: Arc::new(crate::extensions::store::SystemGit),
+            crates: Arc::new(crate::extensions::store::SystemCrateFetcher::default()),
+            live_processes: LiveProcessRegistry::default(),
+            ui_tx: Some(ui_tx),
+            secrets: None,
+            ask_sink: None,
+        };
+        let tools = cap.management_tools();
+        let get = |name: &str| tools.iter().find(|t| t.name() == name).unwrap();
+        get("install_extension")
+            .execute(json!({ "source": src.to_str().unwrap() }))
+            .await;
+
+        // Stand in for the App answering an activation it cannot perform.
+        let ui = tokio::spawn(async move {
+            let request = ui_rx.recv().await.unwrap();
+            request
+                .reply
+                .unwrap()
+                .send(vec![format!(
+                    "extension `echo` is enabled for future sessions, but it was {}, so this \
+                     session has no server for it. Restart yolop to use it now.",
+                    crate::tui::host_ui::EXTENSION_INSTALLED_MID_SESSION
+                )])
+                .unwrap();
+        });
+
+        let result = get("enable_extension")
+            .execute(json!({ "name": "echo" }))
+            .await;
+        ui.await.unwrap();
+
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("enable should still persist");
+        };
+        assert_eq!(value["live"], json!(false));
+        let note = value["note"].as_str().expect("note");
+        assert!(
+            note.contains("installed after the session started"),
+            "{note}"
+        );
+        assert!(note.contains("restart"), "{note}");
+        assert!(
+            !note.contains("Takes effect on the next session"),
+            "the next-session wording hides that a restart is required: {note}"
+        );
     }
 
     #[tokio::test]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1291,21 +1291,16 @@ const YOLOP_NEVER_DEFER_TOOLS: &[&str] = &[
     "grep_files",
     "write_todos",
     "write_session_title",
+    // The most-called tool in the harness, and the one a deferred stub hurts
+    // most: the stub names no parameters while declaring
+    // `additionalProperties: true`, so a model fills the gap from other
+    // harnesses' shell schemas (`timeout`, `max_output_chars`). The real schema
+    // is `additionalProperties: false`, so argument validation rejects the call
+    // and the turn is spent on a correction round trip instead of the work.
+    "bash",
     // progress_guard can make this the only allowed transition, so the model
     // must never need tool_search to recover its argument shape.
     "progress_checkpoint",
-    // LSP tools exist only when the optional `lsp` capability is enabled
-    // (absent names are ignored by the allowlist). Enabling that host profile
-    // is an explicit task-shaped signal, and the LSP adoption eval showed that
-    // stubbing its schemas makes models fall back to grep, so those opt-in
-    // schemas stay eager.
-    "lsp_definition",
-    "lsp_references",
-    "lsp_hover",
-    "lsp_diagnostics",
-    "lsp_rename",
-    "lsp_symbols",
-    "lsp_code_actions",
 ];
 #[derive(Clone, Debug)]
 pub enum ProviderChoice {
@@ -8483,6 +8478,34 @@ mod tests {
         );
     }
 
+    /// A deferred stub names no parameters while allowing extras, so a model
+    /// fills the gap from other harnesses' shell schemas and argument
+    /// validation rejects the call against the real
+    /// `additionalProperties: false` schema. Bash is called too often to spend
+    /// a correction round trip on that.
+    #[test]
+    fn bash_keeps_its_schema_eager_so_arguments_are_never_guessed() {
+        assert!(YOLOP_NEVER_DEFER_TOOLS.contains(&"bash"));
+    }
+
+    /// LSP schemas defer with every other opt-in surface. This reverses the
+    /// earlier eager profile; the LSP adoption eval measured lower adoption
+    /// with stubbed schemas, so re-measure before treating this as settled.
+    #[test]
+    fn lsp_tools_defer_like_other_opt_in_surfaces() {
+        for tool in [
+            "lsp_definition",
+            "lsp_references",
+            "lsp_hover",
+            "lsp_diagnostics",
+            "lsp_rename",
+            "lsp_symbols",
+            "lsp_code_actions",
+        ] {
+            assert!(!YOLOP_NEVER_DEFER_TOOLS.contains(&tool), "{tool}");
+        }
+    }
+
     #[test]
     fn coding_harness_enables_bounded_subagent_swarms() {
         let caps = coding_harness_capabilities(false, None, &Settings::default());
@@ -8587,11 +8610,16 @@ mod tests {
             "write_todos",
             "write_session_title",
             "progress_checkpoint",
+            // The shell is eager: a stub costs a correction round trip on the
+            // most-called tool in the harness.
+            "bash",
         ];
         let deferred = [
             "write_file",
             "edit_file",
-            "bash",
+            // Opt-in surfaces defer, LSP included.
+            "lsp_definition",
+            "lsp_hover",
             "spawn_background",
             "spawn_agent",
             "search_sessions",
@@ -8959,9 +8987,13 @@ mod tests {
             tool_definition_bytes * 100 <= BASELINE_TOOL_DEFINITION_BYTES * 76,
             "provider-visible tool bytes must fall by at least 24%: {tool_definition_bytes} vs {BASELINE_TOOL_DEFINITION_BYTES}"
         );
+        // Was 50%. Keeping `bash` eager costs ~993 bytes of schema and buys back
+        // the correction round trip a stubbed shell schema provoked, so the
+        // floor moved once, deliberately. Deferring more tools is the way to
+        // win it back; raising this bound again is not.
         assert!(
-            schema_bytes * 100 <= BASELINE_SCHEMA_BYTES * 50,
-            "schema bytes must fall by at least 50%: {schema_bytes} vs {BASELINE_SCHEMA_BYTES}"
+            schema_bytes * 100 <= BASELINE_SCHEMA_BYTES * 55,
+            "schema bytes must fall by at least 45%: {schema_bytes} vs {BASELINE_SCHEMA_BYTES}"
         );
     }
 

--- a/src/tui/host_ui.rs
+++ b/src/tui/host_ui.rs
@@ -17,6 +17,11 @@
 
 use tokio::sync::{mpsc, oneshot};
 
+/// Marker phrase shared by the transcript line the App writes and the
+/// `enable_extension` result note, so the client and the agent describe the
+/// same situation and cannot drift apart.
+pub(crate) const EXTENSION_INSTALLED_MID_SESSION: &str = "installed after this session started";
+
 /// A server→host `ui/ask`: prompt the user and deliver their answer via
 /// `reply`. Carried on its own channel rather than as a [`UiCommand`] variant
 /// because the oneshot sender can't derive `Clone`/`Eq`.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -2940,6 +2940,19 @@ impl App {
                 "extension `{name}` will be disabled on the next session."
             )),
             Ok(_) => {}
+            // `activate_capability` reports an unregistered id this way, and the
+            // only way an installed extension is unregistered is that it was not
+            // on disk when this session composed its capability registry. Saying
+            // "unknown capability" to a user who just installed it explains
+            // nothing; name the actual cause and the actual remedy.
+            Err(err) if err.to_string().contains("unknown capability") => {
+                self.push_system(format!(
+                    "extension `{name}` is enabled for future sessions, but it was \
+                 {}, so this session has no server for it. Restart \
+                 yolop to use it now.",
+                    crate::tui::host_ui::EXTENSION_INSTALLED_MID_SESSION
+                ))
+            }
             Err(err) => self.push_system(format!(
                 "extension `{name}` saved, but applying it to this session failed: {err}. \
                  It will load on the next session."

--- a/src/tui/transcript.rs
+++ b/src/tui/transcript.rs
@@ -740,6 +740,12 @@ fn shell_success_lines(value: &Value) -> Vec<ChatLine> {
             }
         }
     }
+    if let Some(notice) = value.get("detached_control").and_then(Value::as_str) {
+        out.push(ChatLine {
+            author: Author::System,
+            text: notice.to_string(),
+        });
+    }
     if value.get("sandbox_denial").and_then(Value::as_str) == Some("likely") {
         out.push(ChatLine {
             author: Author::Sandbox,
@@ -778,6 +784,25 @@ fn shell_success_lines(value: &Value) -> Vec<ChatLine> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The client half of the detached-administration warning: the user reading
+    /// the transcript must see it too, not only the agent in its tool result.
+    #[test]
+    fn shell_lines_render_the_detached_control_notice() {
+        let lines = shell_success_lines(&serde_json::json!({
+            "exit_code": 0,
+            "success": true,
+            "stdout": "NAME  STATE  VERSION",
+            "detached_control": "`yolop extensions` ran as an ordinary shell command.",
+        }));
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.text.contains("ran as an ordinary shell command")),
+            "expected the notice in the transcript: {lines:?}"
+        );
+    }
+
     use everruns_core::events::ToolStartedData;
     use everruns_provider::tool_types::ToolCall;
     use serde_json::json;

--- a/src/tui/transcript.rs
+++ b/src/tui/transcript.rs
@@ -601,11 +601,41 @@ fn tool_started_label(data: &ToolStartedData) -> String {
         .unwrap_or_else(|| data.tool_call.name.clone())
 }
 
+/// Restate an argument-validation rejection in the user's terms.
+///
+/// The engine reports every pre-tool-use block as "blocked by pre_tool_use
+/// hook: <reason>" followed by the raw diagnostic JSON. For yolop's own
+/// argument validation that reads as if a user-configured hook misfired, when
+/// what happened is that the model sent arguments the tool's schema does not
+/// accept and will retry. Only the wording changes; the block itself is
+/// unaffected.
+fn readable_tool_block(error: &str) -> Option<String> {
+    let reason = error.strip_prefix("blocked by pre_tool_use hook: ")?;
+    let diagnostic: Value = serde_json::from_str(reason.trim()).ok()?;
+    if diagnostic.get("error").and_then(Value::as_str)? != "invalid_tool_arguments" {
+        return None;
+    }
+    let tool = diagnostic
+        .get("tool")
+        .and_then(Value::as_str)
+        .unwrap_or("the tool");
+    let message = diagnostic
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or("the arguments do not match the tool schema");
+    Some(format!(
+        "invalid arguments for `{tool}`: {message} — rejected before running; retrying"
+    ))
+}
+
 /// One-line summary of a tool result, used in the transcript and `--print` output.
 pub fn summarize_tool_result(data: &ToolCompletedData) -> String {
     if !data.success
         && let Some(err) = &data.error
     {
+        if let Some(readable) = readable_tool_block(err) {
+            return readable;
+        }
         return format!("error: {}", first_line(err, 120));
     }
     let Some(v) = result_value(data) else {
@@ -784,6 +814,61 @@ fn shell_success_lines(value: &Value) -> Vec<ChatLine> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// "blocked by pre_tool_use hook" is engine wording for every pre-tool
+    /// block; for yolop's own argument validation it reads as a user hook
+    /// misfiring, which sent a user hunting through `list_hooks`.
+    #[test]
+    fn argument_validation_block_reads_as_an_argument_problem() {
+        let data = ToolCompletedData {
+            success: false,
+            error: Some(
+                "blocked by pre_tool_use hook: {\"error\":\"invalid_tool_arguments\",\
+                 \"tool\":\"bash\",\"path\":\"/\",\"message\":\"the object contains an \
+                 unsupported argument\",\"retryable\":true}"
+                    .into(),
+            ),
+            tool_call_id: "call-1".into(),
+            tool_name: "bash".into(),
+            tool_call_fingerprint: None,
+            tool_result_fingerprint: None,
+            display_name: Some("Bash".into()),
+            status: "error".into(),
+            result: None,
+            duration_ms: None,
+            capability_id: None,
+            capability_name: None,
+            narration: None,
+        };
+        let summary = summarize_tool_result(&data);
+        assert!(
+            summary.contains("invalid arguments for `bash`"),
+            "{summary}"
+        );
+        assert!(summary.contains("unsupported argument"), "{summary}");
+        assert!(!summary.contains("pre_tool_use"), "{summary}");
+    }
+
+    /// An actual user hook block keeps the engine's wording: it really was a hook.
+    #[test]
+    fn user_hook_block_keeps_its_wording() {
+        let data = ToolCompletedData {
+            success: false,
+            error: Some("blocked by pre_tool_use hook: git is blocked".into()),
+            tool_call_id: "call-1".into(),
+            tool_name: "bash".into(),
+            tool_call_fingerprint: None,
+            tool_result_fingerprint: None,
+            display_name: Some("Bash".into()),
+            status: "error".into(),
+            result: None,
+            duration_ms: None,
+            capability_id: None,
+            capability_name: None,
+            narration: None,
+        };
+        assert!(summarize_tool_result(&data).contains("pre_tool_use hook"));
+    }
 
     /// The client half of the detached-administration warning: the user reading
     /// the transcript must see it too, not only the agent in its tool result.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2267,6 +2267,39 @@ fn tui_bang_yolop_extensions_uses_attached_control() {
     assert!(tui.wait_or_kill(Duration::from_secs(3)).success());
 }
 
+/// The control-plane prompt block tells the agent to run `yolop <sub> --help`
+/// for the grammar, and that invocation went through the attached path and
+/// failed with "attached control failed: expected value at line 1 column 1":
+/// clap prints help inside the child, which never sends a control frame.
+#[test]
+fn tui_bang_yolop_extensions_help_renders_usage_instead_of_a_parse_error() {
+    let mut tui = spawn_tui_llmsim(&yolop_binary());
+    assert!(
+        tui.wait_for_output("type /help", Duration::from_secs(10)),
+        "TUI did not render startup banner: {}",
+        tui.output_text()
+    );
+
+    tui.write_input(b"!yolop extensions --help\r");
+    assert!(
+        tui.wait_for_output("shell exited with code 0", Duration::from_secs(10)),
+        "attached help did not complete: {}",
+        tui.output_text()
+    );
+    let transcript = strip_ansi(&tui.output_text());
+    assert!(
+        transcript.contains("Usage: yolop extensions"),
+        "help text should render: {transcript}"
+    );
+    assert!(
+        !transcript.contains("attached control failed"),
+        "a plain CLI child must be relayed, not parsed as a control frame: {transcript}"
+    );
+
+    tui.write_input(b"\x03\x03");
+    assert!(tui.wait_or_kill(Duration::from_secs(3)).success());
+}
+
 #[test]
 fn tui_shell_session_approval_skips_later_prompts_for_the_same_scope() {
     let mut tui = spawn_tui_llmsim_with_settings(


### PR DESCRIPTION
## What changed

Four fixes to attached administration and tool-schema delivery, all found by using yolop on itself.

1. **`yolop extensions --help` works inside a session.** It failed with `attached control failed: expected value at line 1 column 1`: clap prints help in the child and exits, so the child never sends a control frame and the parent tried to parse help text as JSON. A child that answers as an ordinary CLI now has its stdout, stderr, and exit code relayed verbatim, which also covers `--version` and usage errors. This is the documented discovery path (`yolop <subcommand> --help`), so it was broken exactly where the agent was told to look.

2. **A bare `yolop extensions` lists** instead of exiting 2 with clap's usage text on stderr. In the TUI that rendered as a red stderr block, which reads as a failure for what is really a request to look. It now matches `/extensions`.

3. **Composed administration says so.** `yolop extensions enable x` mutates the session; `yolop extensions enable x | cat` is ordinary shell that touches only global state. The two were indistinguishable in the output, so the result now carries a notice when a command names a registered control route but was rejected by the attached recognizer. It reaches the agent in the tool result and the user in the transcript from one implementation. Help and version administer nothing and stay quiet.

4. **`bash` keeps its schema eager; LSP tools defer.** A deferred stub advertises `{type: object, additionalProperties: true}`, naming no parameters, so a model fills the gap from other harnesses' shell schemas (`timeout`, `max_output_chars`) and argument validation then rejects the call against the real `additionalProperties: false` schema. The most-called tool in the harness was spending a round trip on a correction. LSP tools leave the allowlist and defer with every other opt-in surface.

Two smaller ones ride along: an argument-validation rejection no longer renders as `blocked by pre_tool_use hook` (engine wording for every pre-tool block, which sent a user hunting through their own hooks), and enabling an extension whose required setup was cancelled no longer reports a bare success, since the extension is enabled but inert.

## Why

Every item here is a case where yolop reported success, or reported a failure in terms that pointed at the wrong thing. The `--help` bug is the sharpest: the prompt block tells the agent to run it.

## Before / After

`yolop extensions --help` inside a session:

```
before: exit=1, stderr: attached control failed: expected value at line 1 column 1
after:  exit=0, the usage text, stderr empty
```

Bare `yolop extensions`:

```
before: exit=2, usage text on stderr (renders as a failure in the TUI)
after:  exit=0, "No extensions installed."
```

Composed administration, from a live Anthropic run in an empty workspace so the session cannot read this repository:

> The command reported "No extensions installed." Because it ran through a pipe (`| cat`), it executed as an ordinary shell command that was never attached to this session, so it did not affect the running session — it only read persisted global state.

Argument-validation rejection in the transcript:

```
before: blocked by pre_tool_use hook: {"error":"invalid_tool_arguments","tool":"bash",…}
after:  invalid arguments for `bash`: the object contains an unsupported argument — rejected before running; retrying
```

## Risk

- Low
- The attached-control transport is unchanged: the `direct_control_args` recognizer, the approval gate for non-read-only operations, and the one-shot pipe are all untouched. The relay only handles the case where the child never spoke the protocol.
- Keeping `bash` eager costs ~993 bytes of schema. The always-on prompt budget test measured the change and its floor moved from a 50% to a 45% reduction, once and deliberately; the comment says deferring more tools is how to win it back, not raising the bound again.
- Removing LSP from the never-defer allowlist reverses a profile an LSP adoption eval justified. Flagged in the spec and in a test, and worth re-measuring.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

New tests, several of them verified to fail without their fix:

- `tui_bang_yolop_extensions_help_renders_usage_instead_of_a_parse_error` drives the real binary in a PTY; reverting the relay brings back `attached control failed`.
- `composed_administration_is_reported_as_detached` and `unrelated_and_non_administration_commands_are_quiet` cover the notice, including non-argv[0] placement (`… | yolop extensions list`).
- `composed_administration_result_carries_the_detached_notice` (agent side) and `shell_lines_render_the_detached_control_notice` (client side).
- `argument_validation_block_reads_as_an_argument_problem` and `user_hook_block_keeps_its_wording`.
- `bash_keeps_its_schema_eager_so_arguments_are_never_guessed`, `lsp_tools_defer_like_other_opt_in_surfaces`, and the updated `tool_search_keeps_only_first_turn_profile_schemas_loaded`.
- `enable_reports_a_restart_when_the_package_arrived_mid_session`.

Validation: `cargo fmt --check`, `cargo clippy --workspace --all-targets --features yolop-yep/schema -D warnings`, `cargo test --workspace --features yolop-yep/schema` (1,210 + 68 + smaller suites, zero failures), `validate_okf.py --check-links`, offline `--provider llmsim` boot, and live Anthropic smokes for the composed-command notice and `yolop extensions --help`. OpenAI returned `credit_balance_exhausted`, so live smokes ran on Anthropic.

## Knowledge

Updated concepts:

- `knowledge/specs/extensions.md`: the plain-CLI relay, the detached-administration notice, and the mid-session install case.
- `knowledge/specs/tool-search.md`: the eager profile now names `bash` and no longer claims LSP tools stay eager, with the reason on both sides.
- `knowledge/specs/conversational-control.md`: attached administration recorded as the deliberate exception to the "every control has a model-facing tool" contract.
- `knowledge/log.md`: entries for the above.

## Security

Reviewed against the threat-model categories in `.agents/skills/ship/SKILL.md`:

- **TM-BASH**: `exec/tools.rs` gains a result field and loses a description sentence; timeouts, per-stream output caps, and the bounded execution model are untouched, as is the attached recognizer and its approval gate. The relay reads the child's stdout and stderr under an explicit 256 KiB cap.
- **TM-LLM**: the detached notice and the control-plane block are built from `&'static str` route summaries on compiled-in capabilities; no user, workspace, or extension text enters them. Keeping `bash` eager changes which schema the model sees, not what the tool accepts, and validation still runs against the authoritative schema.
- **TM-TOOL**: no new capability registers tools or touches the filesystem.
- **TM-DEP**: no dependency changes.
- **TM-FS**: not touched.

## Follow-ups

- **Extensions installed mid-session** still need a restart on this branch. The real fix (register the package on the live runtime) is implemented and tested on `claude/mid-session-extensions`, held back because it needs `everruns-host` with EVE-917 (`register_capability` / `is_capability_registered`), which is merged in everruns/everruns#3224 but not published; crates.io tops out at 0.19.0. It lands as its own PR once that release is cut.
- **`yolop extensions install` reports success for a package that can never run.** The published `yolop-extension-logfire` 0.1.0 `.crate` ships source only (`src/main.rs`, `plugin.json`, no `bin/`), while its manifest declares `capabilityServer.command = "yolop-extension-logfire"`. The crates.io install path is toolchain-free by design, so nothing builds that binary and the server cannot spawn; `doctor` catches it only afterwards. Install should verify the declared command resolves. Not fixed here.
- **LSP adoption** wants re-measuring under the new deferral profile.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DgAqzNcJf625uPKsZvddBx)_