### PR TITLE
chore(build): optimize the release profile for size

### DIFF
--- a/.agents/skills/maintenance/SKILL.md
+++ b/.agents/skills/maintenance/SKILL.md
@@ -22,7 +22,8 @@ Use the scope the user gave; otherwise state the one you inferred before
 starting. Typical scopes: release readiness, CI health on `main`, `everruns-*`
 dependency refresh, knowledge or docs drift, feature-completeness drift across
 CLI / TUI / knowledge / README / tests, test gaps, code simplification, security
-hygiene, performance of recently changed code, AGENTS / skills / command hygiene.
+hygiene, performance of recently changed code, binary size, AGENTS / skills /
+command hygiene.
 
 ## Working a pass
 

--- a/.agents/skills/maintenance/surfaces.md
+++ b/.agents/skills/maintenance/surfaces.md
@@ -73,6 +73,31 @@ build`, `cargo clippy`, and `cargo test`: a simplification that changes behavior
 is a bug. Removing a public item from `yolop-yep` is a breaking
 change — call it out in the PR.
 
+## Binary size
+
+```bash
+cargo install cargo-bsize             # once
+cargo bsize --bin yolop --limit 25    # full attribution report
+cargo bsize --bin yolop --baseline target/release/yolop   # what grew since a kept build
+ls -l target/release/yolop            # the number users actually download
+```
+
+`cargo bsize` builds into its own `target/bsize` profile, so it neither reuses
+nor clobbers `target/release`; expect a full release-grade build the first time.
+Attribute before proposing: the report's dependency, feature, and generic-family
+tables say whether a growth came from a bump, a feature that unified on, or
+yolop's own code.
+
+To measure a profile lever without editing `Cargo.toml`:
+
+```bash
+cargo build --release --config 'profile.release.opt-level="s"'
+```
+
+[`knowledge/specs/maintenance.md`](../../../knowledge/specs/maintenance.md#binary-size)
+owns which levers are rejected and why; the live profile's rationale is in the
+`Cargo.toml` comment beside it.
+
 ## Security posture
 
 - the write blocklist in `runtime.rs` still covers `.git/`, `node_modules/`,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,8 +222,18 @@ tempfile = "3"
 tiny_http = "0.12"
 vt100 = "0.16"
 
+# Yolop ships as one binary, and users pay for its size on every tarball
+# download, `cargo install`, and cold start. Measured on x86_64 Linux with
+# default features: thin LTO at opt-level 3 gave 89.8 MB (24.6 MB gzipped) in
+# 6m47, fat LTO with opt-level "s" 70.2 MB (17.9 MB gzipped) in 7m06. Keeping
+# opt-level 3 under fat LTO recovered only a third of those bytes and cost half
+# again as much build time, so size wins the trade twice over. `knowledge/specs/maintenance.md` owns the surface,
+# including the two levers that stay rejected: `panic = "abort"` breaks the
+# crash path in `join_worker`, and `strip = "symbols"` leaves crash-report
+# backtraces as `<unknown>` because a release build has no debug info left.
 [profile.release]
-lto = "thin"
+lto = "fat"
+opt-level = "s"
 codegen-units = 1
 strip = "debuginfo"
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,20 @@
 # Knowledge Log
 
+## 2026-08-19, Binary size becomes a maintenance surface
+
+- [Maintenance](specs/maintenance.md) now owns binary size, with
+  [`cargo-bsize`](https://github.com/Boshen/cargo-bsize) as the tool of record
+  and an evidence bar of measured before and after on one target and profile.
+- The shipped binary's shape decides which findings pay: about a third is
+  tree-sitter parse tables from the 19 shared grammars, and yolop's own code is
+  under 5%, so dependency features and profile settings are the levers, not
+  `src/`.
+- `panic = "abort"` and `strip = "symbols"` are rejected levers, not untried
+  ones: the first breaks the crash path `join_worker` depends on, the second
+  leaves crash-report backtraces unsymbolicated.
+- The release profile moved to fat LTO at `opt-level = "s"`, measured at 70.2 MB
+  from 89.8 MB (17.9 MB gzipped from 24.6 MB) for 19 seconds of build time.
+
 ## 2026-08-19, Extensions installed mid-session load without a restart
 
 - [Extensions](specs/extensions.md): enabling a package installed during the

--- a/knowledge/specs/local-inference.md
+++ b/knowledge/specs/local-inference.md
@@ -86,6 +86,11 @@ coverage job because it never enables the feature. Running them there is nearly
 free, since linting `--all-targets` has already compiled them. Locally, use a
 separate `CARGO_TARGET_DIR` when you need the engine compiled.
 
+These rows predate the size-optimized release profile (fat LTO at
+`opt-level = "s"`). On the same container that profile took a default binary
+from 92.8 MB to 71.8 MB, and the engine delta has not been re-measured under it,
+so re-run the workflow before quoting either column.
+
 Absolute times are machine-specific; the ratios are the durable part.
 [`local-inference-cost.yml`](../../.github/workflows/local-inference-cost.yml)
 reproduces this on a runner.

--- a/knowledge/specs/maintenance.md
+++ b/knowledge/specs/maintenance.md
@@ -23,6 +23,7 @@ The canonical agent workflow lives in [`.agents/skills/maintenance/SKILL.md`](..
    (CLI flags, TUI behavior, specs, README, docs, tests, bundled skills) but are
    missing or stale on another.
 7. Reduce accidental complexity: remove over-abstraction, dead code, and premature generalization the codebase no longer earns.
+8. Keep the shipped binary honest about its size: attribute growth to a cause before proposing a fix.
 
 ## Ownership Boundary
 
@@ -93,6 +94,49 @@ Beyond the everruns family, dependency hygiene means:
 - no known CVEs in the tree (`cargo audit` when available, plus the repo's Dependabot alerts)
 - duplicate transitive versions reviewed (`cargo tree --duplicates`), fix or note why unfixable
 - no unused direct dependencies; prefer narrow sub-crates over umbrella crates when only a slice is used
+
+## Binary Size
+
+Yolop ships as a single binary, so its size is a user-visible cost three times
+over: the release tarball download, the `cargo install yolop` build, and the
+page-ins of every cold start. Size is a maintenance surface with the same
+evidence bar as the others, a size claim needs a measured before and after on
+one target and one profile, never an estimate.
+
+[`cargo-bsize`](https://github.com/Boshen/cargo-bsize) is the tool of record. It
+attributes the shipped bytes to crates, features, generic families, constant
+data, and unwind tables, so a finding can name the thing to change instead of
+only the number that hurts.
+
+The shape of the binary decides which findings are worth chasing. Measured at
+0.16.0 on `x86_64-unknown-linux-gnu` with default features, before the everruns
+0.20 bump dropped the second HTTP/TLS stack, 79 MiB shipped of an 88.5 MiB
+on-disk binary:
+
+- About a third is tree-sitter parse tables. The 19 grammars are already shared
+  by the symbol scan, ast-grep editing, and syntax highlighting, one copy each,
+  so the only lever left is shipping fewer languages, a product decision rather
+  than a cleanup.
+- Yolop's own code is under 5%. Shrinking `src/` cannot move the total;
+  dependency features and profile settings can.
+- The remainder is dependency code and read-only data, so a size regression is
+  usually a dependency bump or a feature-unification change, not a diff here.
+
+Constraints:
+
+- A lever that degrades a shipped guarantee is a decision, not a default. Two
+  are rejected until the guarantee they break is rebuilt some other way:
+  `panic = "abort"` drops the unwind and exception tables but breaks the crash
+  path, where `join_worker` catches the worker thread's panic to print the
+  crashed session id and report path before resuming the unwind; and
+  `strip = "symbols"` leaves every crash-report backtrace frame as `<unknown>`,
+  since a release build carries no debug info and the symbol table is all that
+  names them.
+- Levers that only trade build time for bytes are fair game, and their cost is
+  paid by `cargo install` users too, not just by release CI.
+- Bytes that a dependency's own feature choices force in cannot be fixed from
+  here. Report them upstream with the measurement attached, and record the
+  finding rather than working around it.
 
 ## Upstream Mirror
 


### PR DESCRIPTION
## What changed

The release profile builds for size: fat LTO at `opt-level = "s"`. The shipped
binary drops from 89.8 MB to 70.2 MB on disk and from 24.6 MB to 17.9 MB
gzipped, which is what a Homebrew install and a `cargo install` link actually
download and keep, for 19 seconds of build time.

Maintenance also gains binary size as a surface it owns, with
[`cargo-bsize`](https://github.com/Boshen/cargo-bsize) as the tool of record,
the commands in the skill's `surfaces.md`, and the two rejected levers recorded
so nobody re-litigates them from scratch.

## Why

Nothing measured the binary until now. A `cargo-bsize` run says where the bytes
are, and the answer redirects the effort: about a third of the shipped binary is
tree-sitter parse tables from the 19 grammars the symbol scan, ast-grep editing,
and syntax highlighting already share one copy of, and yolop's own code is under
5%. Source-level trimming cannot move the total; profile settings and dependency
features can.

## Before / After

Measured on x86_64 Linux, default features, cold builds in one container, on
this branch's base (`ee333ae`, everruns 0.20):

| Profile | On disk | gzipped | Cold build |
|---|---|---|---|
| thin LTO, opt-level 3 (before) | 89.8 MB | 24.6 MB | 6m47 |
| fat LTO, opt-level "s" (after) | 70.2 MB | 17.9 MB | 7m06 |

Keeping opt-level 3 under fat LTO was measured on the pre-0.20 base and
recovered only a third of those bytes (92.8 MB to 86.2 MB) while costing half
again as much build time, so size wins the trade twice over.

Behavior is unchanged; only codegen is. `yolop --version` and
`yolop --provider llmsim -p "hi"` both work on the size-optimized binary, and
CI's Live Provider Smoke (Doppler) passed on the previous head.

Two levers stay rejected, and the spec says why:

- `panic = "abort"` would drop ~4.4 MiB of unwind and exception tables and break
  the crash path: `join_worker` catches the worker thread's panic to print the
  crashed session id and report path before resuming the unwind.
- `strip = "symbols"` would save ~9.2 MiB. Tested on an equivalent profile, it
  leaves every crash-report backtrace frame unnamed (each one prints as an
  unknown frame), since a release build keeps no debug info and the symbol table
  is the only thing naming them.

## Risk

- Low / Medium
- `opt-level = "s"` is a codegen-quality change, so a CPU-bound path could get
  slower: tree-sitter scans, diffing, syntax highlighting, TUI rendering. The
  repo has no latency benchmark, so this is unquantified rather than measured
  to be safe. Fat LTO cuts the other way and usually helps. Reverting is a
  two-line change if startup or scan latency regresses in use.
- The release profile also governs the shipped `local-inference` binaries and
  the Homebrew formula built from them; those were not rebuilt here, and
  `local-inference-cost.yml` re-measures them on demand.

## Checklist
- [x] Tests added or updated — not applicable, see **Knowledge**; the existing
      suite (1304 tests) and clippy were re-run on the rebased tree
- [x] Backward compatibility considered — no API, wire, or CLI surface changes
- [x] Knowledge concepts updated

## Knowledge

- `knowledge/specs/maintenance.md` gains a **Binary Size** section: the evidence
  bar, the tool of record, the shape of the binary, and the rejected levers.
- `.agents/skills/maintenance/` gains the matching surface (commands and
  heuristics) and lists binary size as a scope.
- `knowledge/specs/local-inference.md` marks its cost table as predating this
  profile, so nobody quotes stale absolutes.
- `knowledge/log.md` records the decision.

## Security

No security-relevant code changed. The diff is one profile block plus
documentation: no filesystem, shell, prompt, capability, or dependency surface
is touched (TM-FS, TM-BASH, TM-LLM, TM-TOOL, TM-DEP all unaffected — `cargo-bsize`
is a developer tool, not a dependency of the crate). Unwind behavior is
deliberately preserved, which is why `panic = "abort"` was rejected.

## Follow-ups

- No latency benchmark exists for the CPU-bound paths, so `opt-level = "s"` is
  adopted on measured size and unmeasured speed. A repo-map scan or diff
  benchmark would let the trade be checked rather than assumed.
- Upstream size findings from the `cargo-bsize` run, still live after the 0.20
  bump: `fetchkit`'s `render-rakers` pulls a QuickJS engine, `ureq`, and a
  second `html5ever`; and `rustls` ends up with both aws-lc-rs and ring linked
  (two 332 KiB AES-GCM AVX512 blobs alone) because fetchkit enables reqwest's
  default TLS. Worth raising against `everruns/everruns` with the measurements
  attached. The third finding, the A2A stack pulled in by the `local` feature,
  was fixed independently by #604.