### PR TITLE
chore(deps): bump everruns to the 0.20 cycle and load mid-session installs live

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,67 +13,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "a2a-client-lf"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1da8f6ca9f460fc47231a78165abec30e9ab60886a6c62c599b6055f7f5429cc"
-dependencies = [
- "a2a-lf",
- "a2a-pb",
- "async-trait",
- "auto_impl",
- "bytes",
- "futures",
- "pin-project-lite",
- "reqwest 0.12.28",
- "rustls",
- "rustls-pemfile",
- "semver",
- "serde",
- "serde_json",
- "tokio",
- "tokio-stream",
- "tracing",
- "uuid 1.24.0",
- "webpki-roots 1.0.9",
-]
-
-[[package]]
-name = "a2a-lf"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb24275cca126dc3301d272eef07bd4cefd87f9a7dd5d6f27200fe87e8a83d0"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "serde",
- "serde_json",
- "thiserror 2.0.19",
- "uuid 1.24.0",
-]
-
-[[package]]
-name = "a2a-pb"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e44fccf50ee3f44badfb7861e9b9d1e7af7f276b970762b25eb5911b9f03c0b"
-dependencies = [
- "a2a-lf",
- "chrono",
- "pbjson",
- "pbjson-build",
- "pbjson-types",
- "prost",
- "prost-types",
- "protoc-bin-vendored",
- "serde",
- "serde_json",
- "tonic",
- "tonic-prost",
- "tonic-prost-build",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,17 +475,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "auto_impl"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
-dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,49 +544,6 @@ dependencies = [
  "dunce",
  "fs_extra",
  "pkg-config",
-]
-
-[[package]]
-name = "axum"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
-dependencies = [
- "axum-core",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde_core",
- "sync_wrapper",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -2302,9 +2187,9 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501c89436474cc2ea55cdc29aa7cbaf96e76124ddf38c3b987c7f7deafb3c5fa"
+checksum = "6fb2ddfec0b80a4cec8b4db56f186089b116520f98987cedbcd87713bfa49688"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2435,9 +2320,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.19.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8464f929f88aeec540f993fe4e93aa131da6c2c8daad3f4f9fc4608e1574e72d"
+checksum = "4cb67cc4e21942a9fc583950e2fa1824fd8d1056f50b65681dac931a3ff7dcef"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2566,9 +2451,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-llmsim"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3528e1522c2f21e5f50ad190861808f4e94ab394c95bc70b946a6002d1c446e"
+checksum = "5599529c280f5244ff2dfab034c0f3ce893d59eff7aa566ba39a363a74a625af"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2650,12 +2535,10 @@ dependencies = [
 
 [[package]]
 name = "everruns-platform"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707e5e6b6b5fcb602b8e56b0a2e854a0971d7002839b21152e021eb6879f0ff0"
+checksum = "2c0f0aa61c82eeedeea36571551cdefe9367c03dc043a6c2602def4e1c28ba2a"
 dependencies = [
- "a2a-client-lf",
- "a2a-lf",
  "anyhow",
  "async-trait",
  "chrono",
@@ -2671,7 +2554,6 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tracing",
- "url",
  "uuid 1.24.0",
 ]
 
@@ -3747,7 +3629,6 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec 1.15.2",
@@ -3769,19 +3650,6 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.9",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
-dependencies = [
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -4607,12 +4475,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchit"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
-
-[[package]]
 name = "matrixmultiply"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5045,12 +4907,6 @@ dependencies = [
  "num-traits",
  "pxfm",
 ]
-
-[[package]]
-name = "multimap"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nalgebra"
@@ -5652,43 +5508,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
-name = "pbjson"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8edd1efdd8ab23ba9cb9ace3d9987a72663d5d7c9f74fa00b51d6213645cf6c"
-dependencies = [
- "base64 0.22.1",
- "serde",
-]
-
-[[package]]
-name = "pbjson-build"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ed4d5c6ae95e08ac768883c8401cf0e8deb4e6e1d6a4e1fd3d2ec4f0ec63200"
-dependencies = [
- "heck",
- "itertools",
- "prost",
- "prost-types",
-]
-
-[[package]]
-name = "pbjson-types"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14e2757d877c0f607a82ce1b8560e224370f159d66c5d52eb55ea187ef0350e"
-dependencies = [
- "bytes",
- "chrono",
- "pbjson",
- "pbjson-build",
- "prost",
- "prost-build",
- "serde",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6008,16 +5827,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2 1.0.107",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "primal-check"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6112,27 +5921,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-build"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
-dependencies = [
- "heck",
- "itertools",
- "log",
- "multimap",
- "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
- "pulldown-cmark",
- "pulldown-cmark-to-cmark",
- "regex",
- "syn 2.0.119",
- "tempfile",
-]
-
-[[package]]
 name = "prost-derive"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6146,79 +5934,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-types"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
-dependencies = [
- "prost",
-]
-
-[[package]]
-name = "protoc-bin-vendored"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
-dependencies = [
- "protoc-bin-vendored-linux-aarch_64",
- "protoc-bin-vendored-linux-ppcle_64",
- "protoc-bin-vendored-linux-s390_64",
- "protoc-bin-vendored-linux-x86_32",
- "protoc-bin-vendored-linux-x86_64",
- "protoc-bin-vendored-macos-aarch_64",
- "protoc-bin-vendored-macos-x86_64",
- "protoc-bin-vendored-win32",
-]
-
-[[package]]
-name = "protoc-bin-vendored-linux-aarch_64"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
-
-[[package]]
-name = "protoc-bin-vendored-linux-ppcle_64"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
-
-[[package]]
-name = "protoc-bin-vendored-linux-s390_64"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
-
-[[package]]
-name = "protoc-bin-vendored-linux-x86_32"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
-
-[[package]]
-name = "protoc-bin-vendored-linux-x86_64"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
-
-[[package]]
-name = "protoc-bin-vendored-macos-aarch_64"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
-
-[[package]]
-name = "protoc-bin-vendored-macos-x86_64"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
-
-[[package]]
-name = "protoc-bin-vendored-win32"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
-
-[[package]]
 name = "pulldown-cmark"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6227,15 +5942,6 @@ dependencies = [
  "bitflags 2.13.1",
  "memchr",
  "unicase",
-]
-
-[[package]]
-name = "pulldown-cmark-to-cmark"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
-dependencies = [
- "pulldown-cmark",
 ]
 
 [[package]]
@@ -7156,15 +6862,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -8699,17 +8396,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-stream"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8856,74 +8542,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
-name = "tonic"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
-dependencies = [
- "async-trait",
- "axum",
- "base64 0.22.1",
- "bytes",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "socket2",
- "sync_wrapper",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic-build"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
-dependencies = [
- "prettyplease",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "tonic-prost"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
-dependencies = [
- "bytes",
- "prost",
- "tonic",
-]
-
-[[package]]
-name = "tonic-prost-build"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
-dependencies = [
- "prettyplease",
- "proc-macro2 1.0.107",
- "prost-build",
- "prost-types",
- "quote 1.0.47",
- "syn 2.0.119",
- "tempfile",
- "tonic-build",
-]
-
-[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8931,15 +8549,11 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.14.0",
  "pin-project-lite",
- "slab",
  "sync_wrapper",
  "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ everruns-core = "0.18.0"
 # The identity/platform family (PlatformStore and friends) moved out of
 # everruns-core into its own crate in 0.17.24; yolop implements PlatformStore
 # to route background-task wakes (src/runtime/background_wake.rs).
-everruns-platform = "0.18.1"
+everruns-platform = "0.18.2"
 everruns-openai = "0.18.0"
 everruns-meta = "0.18.0"
 # OpenRouter's first-class driver was split out of everruns-openai into its own
@@ -168,7 +168,7 @@ everruns-openrouter = "0.18.0"
 # only against host ^0.18.0, so depending on it pinned yolop off the 0.19 line.
 # Only the `local` feature is wanted; the facade's provider and capability
 # re-exports would duplicate the direct dependencies below.
-everruns = { version = "0.18.1", default-features = false, features = ["local"] }
+everruns = { version = "0.18.2", default-features = false, features = ["local"] }
 everruns-mcp = { version = "0.19.0", features = ["stdio"] }
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (knowledge/specs/mcp.md, upstream runtime-mcp.md D2).
@@ -176,7 +176,7 @@ everruns-mcp = { version = "0.19.0", features = ["stdio"] }
 # everruns-host replaces everruns-runtime, which upstream deleted in #3101 as a
 # 0.18 breaking change. Every host symbol yolop used moved here unchanged except
 # EventBus, which the canonical event log replaces.
-everruns-host = { version = "0.19.0", features = ["mcp-stdio"] }
+everruns-host = { version = "0.20.1", features = ["mcp-stdio"] }
 # The direct egress implementation moved out of everruns-core into its own
 # crate; yolop uses it for MCP OAuth discovery.
 # #3182 completed the library boundary cleanup: driver/model/provider types
@@ -190,7 +190,7 @@ everruns-http = "0.18.0"
 # production-safe `everruns-llmsim`; `everruns-test-support` documents itself as
 # test-only and must not be used from production code. The `host` feature carries
 # the runtime-builder extension trait.
-everruns-llmsim = { version = "0.18.1", features = ["host"] }
+everruns-llmsim = { version = "0.18.2", features = ["host"] }
 # Filesystem and web-fetch capability implementations moved out of
 # everruns-core into their own integration crates (#3119).
 everruns-integrations-filesystem = "0.18.0"

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,18 @@
 # Knowledge Log
 
+## 2026-08-19, everruns 0.20 cycle: live registration lands, A2A goes opt-in
+
+- `everruns-host` 0.19.0 to 0.20.1, `everruns`, `everruns-platform`, and
+  `everruns-llmsim` to 0.18.2.
+- The breaking part of host 0.20 (`capability_registry()` returns an `Arc`
+  snapshot, `capability_registry_mut()` removed) does not reach yolop: the one
+  call site is the builder setter of the same name, not the getter.
+- EVE-917 ships in this cycle, which is what lets an extension installed
+  mid-session register on the live runtime.
+- [Maintenance](specs/maintenance.md): outbound A2A delegation is now behind the
+  `everruns` crate's opt-in `a2a` feature. Yolop has no outbound A2A path, so it
+  stays off and the default build drops a second HTTP/TLS stack.
+
 ## 2026-08-19, Debug target size: one feature set, thin dependency debuginfo
 
 - The routine checks ran `--all-features` while `cargo build`/`cargo run` ran

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,17 @@
 # Knowledge Log
 
+## 2026-08-19, Extensions installed mid-session load without a restart
+
+- [Extensions](specs/extensions.md): enabling a package installed during the
+  session now registers it on the live runtime and activates it, so its tools,
+  prompt, and hooks are usable on the next turn.
+- Unblocked by upstream EVE-917 (`InProcessRuntime::register_capability` /
+  `is_capability_registered`), which yolop requested after establishing that no
+  host-side workaround existed.
+- `BuildOptions::extensions_dir_override` lets a test inject an extensions
+  directory instead of setting the process-wide `YOLOP_EXTENSIONS_DIR`, which a
+  concurrently building session would otherwise pick up.
+
 ## 2026-08-19, everruns 0.20 cycle: live registration lands, A2A goes opt-in
 
 - `everruns-host` 0.19.0 to 0.20.1, `everruns`, `everruns-platform`, and

--- a/knowledge/specs/extensions.md
+++ b/knowledge/specs/extensions.md
@@ -207,8 +207,9 @@ session-scoped capability overlay. The runtime reassembles prompt, tools, hooks,
 commands, and contributed MCP servers from that overlay on the next reason/act
 boundary, so a registered extension is live on the **next turn**: no restart.
 Enabled extensions are seeded at the session layer, including at startup, so
-disable is reversible in the same session. Installing a new package remains a
-global operation and its manifest is registered on the next session. Detached
+disable is reversible in the same session. Installing a new package is still a
+global operation, but its manifest no longer waits for the next session: enabling
+registers it on the live runtime (see below). Detached
 enable/disable persist for the next run; reload is refused without an attached
 session. Covered by
 `enable_disable_emit_live_activation_when_wired`.
@@ -262,16 +263,18 @@ redirection, quoting, substitutions, and background execution receive no
 attachment and run as ordinary shell commands. Attached failure never falls
 back to detached global mutation.
 
-Enablement applies to the running session only for packages present when it
-started. The runtime composes its capability registry once, at startup, and
-`everruns-host` exposes no way to register a capability afterwards
-(`CapabilityRegistry` is owned by value behind an `Arc<InProcessRuntime>` and
-mutated only through `&mut` at composition), so an extension installed mid-session
-has nothing to activate. That case is reported as what it is, a restart, in both
-the transcript and the `enable_extension` result, rather than as an internal
-"unknown capability" or a misleading "next session". Making it genuinely live
-requires a dynamic-registration API upstream; until that exists the honest
-message is the contract.
+Enablement applies to the running session for any installed package, including
+one installed mid-conversation. The runtime composes its capability registry at
+startup, so a package that arrives later is unknown to it; the host registers it
+on the live runtime first (`InProcessRuntime::register_capability`, upstream
+EVE-917) and then activates it exactly like a package present at startup. The
+wiring lives in one place: a factory built at startup captures the same sinks
+the startup path uses (status, `ui/ask`, live processes, secrets, environment
+context), so a deferred build cannot drift from the eager one. Registration is
+not activation; enablement still decides per-session. Where registration is
+impossible (no extensions directory, or the package is not on disk) the
+transcript says so and names a restart rather than reporting an internal
+"unknown capability".
 
 Two consequences of that boundary are handled rather than left implicit. A child
 that answers as an ordinary CLI, `--help`, `--version`, or a usage error, never

--- a/knowledge/specs/maintenance.md
+++ b/knowledge/specs/maintenance.md
@@ -120,6 +120,13 @@ MCP OAuth resources, and 0.18.0 moved credentials out of model selection so a
 host that keeps its own keys gets keyless drivers from the built-in provider
 store. None of these showed up as a compile error.
 
+Upstream also moves capability behind Cargo features, so read each cycle's
+feature notes before assuming a default build still carries what it used to.
+Host 0.20 made outbound A2A delegation opt-in behind the `everruns` crate's
+`a2a` feature: yolop does not delegate to remote A2A agents, so it stays off and
+the default build no longer pulls a second HTTP/TLS stack. Enable it only if
+yolop grows an outbound A2A path.
+
 ## Release Readiness Standard
 
 Before tagging a release:

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2758,7 +2758,21 @@ pub struct RuntimeHandles {
     pub(crate) control: Option<Arc<dyn crate::control::ControlService>>,
     /// Best-effort local lifecycle bridge when this process runs in Herdr.
     pub(crate) herdr: crate::capabilities::herdr::HerdrReporter,
+    /// Builds an [`ExtensionCapability`] for a package discovered after startup,
+    /// wired to the same sinks the startup path uses.
+    ///
+    /// Extensions installed mid-session are absent from the registry the
+    /// runtime composed, so enabling them used to require a restart. The
+    /// closure keeps the wiring in one place: the App registers the result on
+    /// the live runtime and activates it like any other capability. `None`
+    /// where there is no extensions dir.
+    pub(crate) extension_factory: Option<ExtensionFactory>,
 }
+
+/// Builds a capability for an installed extension by name; `Err` when no such
+/// package is on disk.
+pub(crate) type ExtensionFactory =
+    Arc<dyn Fn(&str) -> Result<Arc<dyn everruns_core::Capability>, String> + Send + Sync>;
 
 impl RuntimeHandles {
     pub(crate) fn report_herdr_state(&self, state: crate::capabilities::herdr::HerdrState) {
@@ -3241,6 +3255,11 @@ pub struct BuildOptions {
     /// registered and enforces the current approval level; hosts without an
     /// interactive prompt (the TUI, `--print`) leave it `None`.
     pub tool_approver: Option<Arc<dyn crate::capabilities::ToolApprover>>,
+    /// Override the global extensions directory for this build. Tests inject a
+    /// temp dir instead of setting `YOLOP_EXTENSIONS_DIR`, which is process-wide
+    /// and would hand another concurrently building session these packages.
+    /// Production leaves this `None` and resolves the platform dir.
+    pub extensions_dir_override: Option<PathBuf>,
     /// Override the provider stream-stall liveness window. Tests inject a short
     /// bound; production leaves this `None` and uses [`PROVIDER_STALL_TIMEOUT`].
     pub provider_stall_timeout: Option<Duration>,
@@ -3257,6 +3276,7 @@ impl Default for BuildOptions {
             session_kind: SessionKind::Interactive,
             initial_prompt: None,
             sandbox_mode_override: None,
+            extensions_dir_override: None,
             client_commands: false,
             client_ui: ClientUiContext::None,
             client_mcp_servers: ScopedMcpServers::new(),
@@ -3508,7 +3528,12 @@ pub async fn build_with_options(
     // Read-only skills contributed by enabled extensions (D4: only a declaring,
     // enabled extension's `skills/` loads). Computed here so it feeds both the
     // skills capability config and the file-store mounts below.
-    let extension_skill_scopes = crate::extensions::extensions_dir()
+    let extensions_dir = options
+        .extensions_dir_override
+        .clone()
+        .or_else(crate::extensions::extensions_dir);
+    let extension_skill_scopes = extensions_dir
+        .clone()
         .map(|ext_dir| {
             let snapshot = settings.snapshot();
             let packages = crate::extensions::discover_extensions(&ext_dir);
@@ -3844,12 +3869,13 @@ pub async fn build_with_options(
     // 0600), keyed `ext:<name>` — never `settings.toml`. Injected as env at
     // spawn; never surfaced to the agent.
     let extension_secrets = crate::extensions::ExtensionSecrets::new(connections.clone());
+    let mut extension_factory: Option<ExtensionFactory> = None;
     let mut extension_never_defer: Vec<String> = Vec::new();
     let mut extension_mcp_server_names: Vec<String> = Vec::new();
     // Trace-facet extensions, captured here and started once `session_id` and
     // the event broadcast exist (below). Observe-only agentic-trace export.
     let mut trace_forwarders: Vec<crate::extensions::trace::TraceForwarder> = Vec::new();
-    if let Some(ext_dir) = crate::extensions::extensions_dir() {
+    if let Some(ext_dir) = extensions_dir.clone() {
         let settings_snapshot = settings.snapshot();
         for package in crate::extensions::discover_extensions(&ext_dir) {
             // An extension's contributed MCP servers (D1) apply only when the
@@ -3891,6 +3917,31 @@ pub async fn build_with_options(
             extension_never_defer.extend(capability.never_defer_tools());
             capabilities.register(capability);
         }
+        // Same wiring as the loop above, deferred: an extension installed after
+        // startup is built on demand and registered on the live runtime, so
+        // enabling it does not need a restart.
+        let factory_root = effective_root.clone();
+        let factory_status = status_sink.clone();
+        let factory_ask = ask_sink.clone();
+        let factory_processes = live_processes.clone();
+        let factory_secrets = extension_secrets.clone();
+        let factory_environment = environment_context.clone();
+        let factory_dir = ext_dir.clone();
+        extension_factory = Some(Arc::new(move |name: &str| {
+            let package = crate::extensions::discover_extensions(&factory_dir)
+                .into_iter()
+                .find(|package| package.manifest.name == name)
+                .ok_or_else(|| format!("no extension named `{name}` is installed"))?;
+            Ok(Arc::new(
+                crate::extensions::ExtensionCapability::new(package, factory_root.clone())
+                    .with_status_sink(factory_status.clone())
+                    .with_ask_sink(factory_ask.clone())
+                    .with_process_registry(factory_processes.clone())
+                    .with_secrets(factory_secrets.clone())
+                    .with_environment_context(factory_environment.clone()),
+            ) as Arc<dyn everruns_core::Capability>)
+        }) as ExtensionFactory);
+
         // Extension administration stays outside the model harness. Hand its
         // shared service the UI-command sink so attached enable/disable can
         // activate the capability live (TUI only); `None` elsewhere.
@@ -4391,6 +4442,7 @@ pub async fn build_with_options(
             approval_policy,
             control: session_control,
             herdr,
+            extension_factory,
         },
         startup: StartupInfo {
             workspace_root: effective_root,
@@ -8995,6 +9047,150 @@ mod tests {
             schema_bytes * 100 <= BASELINE_SCHEMA_BYTES * 55,
             "schema bytes must fall by at least 45%: {schema_bytes} vs {BASELINE_SCHEMA_BYTES}"
         );
+    }
+
+    /// An extension installed after the session started used to need a restart:
+    /// the runtime composed its capability registry once, so `ext:<name>` was
+    /// unknown and activation failed. everruns EVE-917 added registration on a
+    /// running runtime; this drives the real path (register, activate, run a
+    /// turn) and asserts the extension's tool is actually callable.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn extension_installed_after_startup_becomes_usable_without_a_restart() {
+        use everruns_llmsim::{SimToolCall, SimTurn};
+
+        // The scaffolded server is Python; skip rather than fail where the
+        // environment lacks it (never `#[ignore]`, which nothing ever runs).
+        let has_python = ["python3", "python"].iter().any(|candidate| {
+            std::process::Command::new(candidate)
+                .arg("--version")
+                .output()
+                .is_ok_and(|out| out.status.success())
+        });
+        if !has_python {
+            eprintln!("skipping: python3 not available");
+            return;
+        }
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let extensions = tempfile::tempdir().expect("extensions");
+
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+        let options = BuildOptions {
+            llmsim_override: Some(LlmSimConfig::scripted(vec![
+                SimTurn::ToolCalls(vec![SimToolCall {
+                    name: "say".to_string(),
+                    arguments: serde_json::json!({ "text": "hi" }),
+                    id: None,
+                }]),
+                SimTurn::Assistant("DONE".to_string()),
+            ])),
+            // Injected, not exported: `YOLOP_EXTENSIONS_DIR` is process-wide
+            // and would hand a concurrently building test these packages.
+            // The session starts with this dir empty: nothing to register.
+            extensions_dir_override: Some(extensions.path().to_path_buf()),
+            ..BuildOptions::default()
+        };
+        let built = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Sim,
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            options,
+        )
+        .await
+        .expect("build runtime");
+
+        let capability_id = crate::extensions::extension_capability_id("echo");
+        assert!(
+            !built
+                .handles
+                .runtime
+                .is_capability_registered(&capability_id),
+            "the package is not installed yet, so nothing should be registered"
+        );
+        let before = built
+            .handles
+            .runtime
+            .load_context(built.handles.session_id)
+            .await
+            .expect("context before install");
+        assert!(
+            !before.runtime_agent.tools.iter().any(|t| t.name() == "say"),
+            "the extension's tool must be absent before it is installed"
+        );
+
+        // Install after startup, the way `yolop extensions install` does. The
+        // scaffold emits a real, protocol-conformant server so this exercises
+        // the extension end to end rather than a stub.
+        let scaffolded =
+            crate::extensions::scaffold::scaffold(&crate::extensions::scaffold::ScaffoldRequest {
+                name: "echo".into(),
+                description: "Echoes.".into(),
+                language: crate::extensions::scaffold::Language::Python,
+                tools: vec![crate::extensions::scaffold::ToolSpec {
+                    name: "say".into(),
+                    description: "Say something.".into(),
+                }],
+                hooks: vec![],
+                commands: vec![],
+                prompt: None,
+                status: false,
+                skills: false,
+                dir: extensions.path().join("echo"),
+            })
+            .expect("scaffold the package straight into the extensions dir");
+        assert!(scaffolded.dir.join("plugin.json").is_file());
+
+        // The App's path: register on the live runtime, then activate.
+        let session =
+            crate::runtime::session::Session::new(built.handles.clone(), built.model.clone());
+        let registered = session
+            .register_installed_extension("echo")
+            .expect("register the freshly installed package");
+        assert!(registered, "a package absent at startup must register now");
+        assert!(
+            built
+                .handles
+                .runtime
+                .is_capability_registered(&capability_id)
+        );
+        let delta = session
+            .activate_capability(&capability_id)
+            .await
+            .expect("activation must succeed once registered");
+        assert!(delta.changed && delta.active);
+
+        // The extension's tool is on the next turn's surface...
+        let context = built
+            .handles
+            .runtime
+            .load_context(built.handles.session_id)
+            .await
+            .expect("context after activation");
+        assert!(
+            context
+                .runtime_agent
+                .tools
+                .iter()
+                .any(|t| t.name() == "say"),
+            "the extension's tool must be present without a restart: {:?}",
+            context
+                .runtime_agent
+                .tools
+                .iter()
+                .map(|tool| tool.name().to_string())
+                .collect::<Vec<_>>()
+        );
+
+        // ...and a real turn calls it, so the server is actually spawned and
+        // answering rather than merely advertised.
+        let turn = built
+            .handles
+            .run_checkpointed_turn("say hi", built.model.input_message("say hi"))
+            .await
+            .expect("run a turn that calls the extension's tool");
+        assert!(turn.success, "turn calling the extension tool failed");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/runtime/session.rs
+++ b/src/runtime/session.rs
@@ -92,6 +92,30 @@ impl Session {
     /// Activate a registered `ext:<name>` capability on the live session so its
     /// tools/prompt/hooks/commands/MCP appear on the next turn (hot-enable). See
     /// [`RuntimeHandles::activate_capability`](crate::runtime::RuntimeHandles::activate_capability).
+    /// Make an extension installed after startup resolvable on this runtime.
+    ///
+    /// Returns whether a registration happened; `Ok(false)` means the id was
+    /// already registered (the ordinary case, for packages present at startup).
+    /// Registration is not activation: the caller still activates the id.
+    pub fn register_installed_extension(&self, name: &str) -> Result<bool> {
+        let capability_id = crate::extensions::extension_capability_id(name);
+        if self
+            .handles
+            .runtime
+            .is_capability_registered(&capability_id)
+        {
+            return Ok(false);
+        }
+        let factory = self
+            .handles
+            .extension_factory
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("this session has no extensions directory"))?;
+        let capability = factory(name).map_err(|error| anyhow::anyhow!(error))?;
+        self.handles.runtime.register_capability(capability)?;
+        Ok(true)
+    }
+
     pub async fn activate_capability(
         &self,
         capability_id: &str,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -2923,6 +2923,23 @@ impl App {
         // enable_extension/disable_extension already persisted the setting;
         // here we apply it to the running session so it takes effect on the
         // next turn (EVE-795) rather than only next start.
+        // An extension installed during this session is absent from the
+        // registry the runtime composed at startup, so activation would fail
+        // with `unknown capability`. Register it first (everruns EVE-917); this
+        // is a no-op for packages that were present at startup.
+        let mut registered_now = false;
+        if activate {
+            match self.session.register_installed_extension(name) {
+                Ok(fresh) => registered_now = fresh,
+                Err(error) => {
+                    self.push_system(format!(
+                        "extension `{name}` is enabled for future sessions, but this session \
+                         could not load it: {error}. Restart yolop to use it now."
+                    ));
+                    return;
+                }
+            }
+        }
         let result = if activate {
             self.session.activate_capability(capability_id).await
         } else {
@@ -2930,8 +2947,13 @@ impl App {
         };
         match result {
             Ok(delta) if delta.changed => self.push_system(format!(
-                "extension `{name}` {} for this session; effective on the next turn.",
-                if activate { "enabled" } else { "disabled" }
+                "extension `{name}` {} for this session{}; effective on the next turn.",
+                if activate { "enabled" } else { "disabled" },
+                if registered_now {
+                    " (installed after startup, loaded now)"
+                } else {
+                    ""
+                }
             )),
             // No overlay change: already in the desired state, or (on disable)
             // it rides the harness layer from startup and only settings can


### PR DESCRIPTION
## What changed

Two commits, each independently buildable.

1. **`chore(deps)`: bump to the 0.20 cycle.** `everruns-host` 0.19.0 to 0.20.1, and `everruns`, `everruns-platform`, and `everruns-llmsim` to 0.18.2. Every other `everruns-*` crate is already on its latest published version and had no contract change this cycle, so it is not re-pinned.

2. **`feat(extensions)`: adopt `register_capability`.** Enabling an extension installed during the session now registers the package on the live runtime and activates it, so its tools, prompt, and hooks are usable on the next turn instead of after a restart. This is the fix that was written earlier and held back: it needs EVE-917, which had no published home until 0.20.1.

## Why

The 0.20 cycle contains the upstream API yolop asked for. `everruns-host` 0.20 adds `InProcessRuntime::register_capability` / `is_capability_registered` (everruns/everruns#3224, EVE-917), which is exactly what the mid-session install path was blocked on: the runtime composes its capability registry at startup, so a package arriving later was unknown to it, and yolop holds the runtime as a shared `Arc`. The previous PR could only report a restart; this one loads the extension.

## Breaking changes handled

Host 0.20 is a breaking release in two places, neither of which reaches yolop, verified rather than assumed:

- `capability_registry()` now returns `Arc<CapabilityRegistry>` instead of `&CapabilityRegistry`. Yolop's single `capability_registry` call site (`src/runtime/mod.rs`) is the `HostComposition` **builder setter** of the same name, not the getter.
- `capability_registry_mut()` was removed. No caller here.

The one change that alters yolop's build without a compile error is the A2A split: outbound A2A delegation moved behind the `everruns` crate's opt-in `a2a` feature. Yolop has no outbound A2A path (`grep -ri a2a src/ crates/` is empty), so the feature stays off and the default build no longer pulls a second HTTP/TLS stack. `knowledge/specs/maintenance.md` records that decision so a later bump does not enable it reflexively, per the standing warning there that a clean compile is not evidence of adoption.

## Before / After

Installing an extension mid-session, then enabling it:

```
before: enable reports the package arrived after startup and needs a restart
after:  the package registers on the live runtime and its tools are usable next turn
```

## Risk

- Low to moderate: a minor-version bump of the host crate plus one behavior change.
- The adoption commit's wiring is deliberately single-sourced: a factory built at startup captures the same sinks the startup path uses (status, `ui/ask`, live processes, secrets, environment context), so the deferred build cannot drift from the eager one.
- Registration is not activation; enablement still decides per session.
- Where registration is impossible (no extensions directory, or nothing on disk by that name), the previous behavior stands and the transcript still names a restart.
- No `everruns-*` version splits in the dependency tree: `cargo tree --duplicates` shows a single `everruns-host` 0.20.1 and a single `everruns` 0.18.2. The remaining duplicate entries are pre-existing third-party transitives.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

`extension_installed_after_startup_becomes_usable_without_a_restart` now passes against the **published** crate; it previously passed only under a local `[patch.crates-io]` override that was deliberately never committed. `enable_reports_a_restart_when_the_package_arrived_mid_session` still covers the impossible-registration fallback.

Validation: `cargo fmt --check`, `cargo clippy --workspace --all-targets --features yolop-yep/schema -D warnings`, `cargo test --workspace --features yolop-yep/schema` (1,211 + 68 + smaller suites, zero failures), `validate_okf.py --check-links`, offline `--provider llmsim` boot, and a live Anthropic smoke through Doppler on the new dependency set. The bump commit was also built in isolation to confirm the two commits are independently reviewable.

## Knowledge

- `knowledge/specs/maintenance.md`: upstream moves capability behind Cargo features; the `a2a` decision and its rationale.
- `knowledge/specs/extensions.md`: the live-registration path, plus a correction. The spec still asserted that an installed package "is registered on the next session", which the new section contradicted; that sentence now points at live registration.
- `knowledge/log.md`: entries for the bump cycle and for the adopted behavior.

## Security

Reviewed against the threat-model categories in `.agents/skills/ship/SKILL.md`:

- **TM-DEP**: the substantive category here. Four first-party `everruns-*` crates move; all are already-trusted direct dependencies from the same upstream, pinned to exact published versions with `Cargo.lock` updated in the same commit. The A2A split reduces the attack surface by dropping an HTTP/TLS client stack from the default build.
- **TM-TOOL**: registration makes a capability *resolvable*, not active. The extension still passes the same enablement, namespacing (`ext:<name>`, which cannot shadow a built-in), and approval boundaries as one present at startup; the session snapshot of the approved surface is unchanged.
- **TM-LLM**, **TM-BASH**, **TM-FS**: not touched.

## Follow-ups

- **`resolve_host_scope` mistakes a real `/workspace` directory for the display alias.** Found while validating this bump: two tests (`resolve_host_scope_spelling_table_is_consistent`, `repo_map_tool_accepts_workspace_alias_scope`) fail on any host that actually has a `/workspace` directory, because the resolver canonicalizes a real absolute path before considering the alias. The user-visible bug is worse than the test failure: yolop shows the model `/workspace/...` paths, and on such a host the model's own displayed paths resolve outside the session root and are rejected with "`path` must stay inside the workspace". CI has no `/workspace`, so it is green there. Not fixed here: it is unrelated to the bump and belongs in its own PR.
- **`yolop extensions install` still reports success for a package that can never run** (published `yolop-extension-logfire` 0.1.0 ships no binary for its declared `capabilityServer.command`). Unchanged from the previous PR.
- **LSP adoption** still wants re-measuring under the deferral profile changed in #602.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DgAqzNcJf625uPKsZvddBx)_