### PR TITLE
fix(extensions): install the published crate name, and say when it cannot run

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,19 @@
 # Knowledge Log
 
+## 2026-08-20, Install tells the truth about a package it cannot run
+
+- [Extensions](specs/extensions.md): `install` resolves the declared
+  `capabilityServer.command` and reports `server_command_found`. A crate
+  published as source ships no binary, so the package installed cleanly and
+  only `doctor` knew it could never spawn; the note now names the remedy.
+- The bare-name shorthand prefixed unconditionally, so
+  `install yolop-extension-logfire`, the name on crates.io, looked up
+  `yolop-extension-yolop-extension-logfire`. It is idempotent now.
+- Same parse: splitting `@<version>` before validating the name makes the
+  documented `<name>@<version>` pin work. The guard had rejected `@` and the
+  version's dots, leaving that branch's version split unreachable.
+- `--acp` had lost its doc comment to `--config-dir`, so `--help` showed the
+  flag blank and pasted the ACP paragraph in front of the config-dir text.
 ## 2026-08-19, Binary size becomes a maintenance surface
 
 - [Maintenance](specs/maintenance.md) now owns binary size, with

--- a/knowledge/specs/extensions.md
+++ b/knowledge/specs/extensions.md
@@ -225,7 +225,14 @@ SHA-256 against the index `cksum`, and unpacks the gzip'd tar, no cargo/rustc.
 A published crate ships *source*, so the manifest's `capabilityServer.command`
 names a binary the user has on `PATH` (or in the package `bin/`); yolop does
 not compile it (`cargo install` remains an optional author-side path, not a
-yolop dependency). Still follow-ups: full JSON-Schema config validation and
+yolop dependency). Because that binary can be absent, install resolves the
+declared command (package `bin/`, then `PATH`) and reports
+`server_command_found`: a package that installs cleanly but can never spawn
+says so at install time, with the remedy, instead of reading as a plain success
+and leaving `doctor` to explain it later. The bare-`<name>` shorthand only adds
+the `yolop-extension-` prefix when it is absent, so the published crate name,
+the spelling a user copies off crates.io, resolves to itself rather than to a
+doubly-prefixed crate that cannot exist. Still follow-ups: full JSON-Schema config validation and
 `config/changed` restart. Phase-1 deltas from the original sketch: tool *definitions*
 (description, schema, policy) live in the manifest, and the handshake's
 `tools` list carries only the served names it narrows to, keeping every

--- a/src/extensions/manage.rs
+++ b/src/extensions/manage.rs
@@ -761,6 +761,27 @@ impl ManageTool {
         {
             Ok(installed) => {
                 let m = &installed.manifest;
+                // A package whose declared server command cannot be spawned is
+                // installed but unrunnable; say it here rather than reporting a
+                // bare success and leaving `doctor` to explain it later.
+                let runnable = store::server_command_resolves(
+                    &self.ctx.extensions_dir.join(&m.name),
+                    &m.capability_server.command,
+                );
+                let note = if runnable {
+                    format!(
+                        "Installed but not enabled. Run `yolop extensions enable {}` to enable it.",
+                        m.name
+                    )
+                } else {
+                    format!(
+                        "Installed, but its server command `{}` was not found in the package's \
+                         `bin/` or on PATH, so the extension cannot start. A crate published as \
+                         source ships no binary; install it (for a Rust extension, \
+                         `cargo install {}`) and check with `yolop extensions doctor {}`.",
+                        m.capability_server.command, m.capability_server.command, m.name
+                    )
+                };
                 ToolExecutionResult::Success(json!({
                     "installed": m.name,
                     "version": m.version,
@@ -772,10 +793,8 @@ impl ManageTool {
                     },
                     "content_hash": installed.content_hash,
                     "grant_changed": installed.previous_hash.is_some(),
-                    "note": format!(
-                        "Installed but not enabled. Run `yolop extensions enable {}` to enable it.",
-                        m.name
-                    ),
+                    "server_command_found": runnable,
+                    "note": note,
                 }))
             }
             Err(err) => ToolExecutionResult::ToolError(format!("install failed: {err}")),
@@ -1380,6 +1399,92 @@ mod tests {
             .to_string(),
         )
         .unwrap();
+    }
+
+    /// A package published as source (no `bin/`, nothing on PATH by that name)
+    /// installs cleanly but can never spawn. Install must say so instead of
+    /// reporting a bare success and leaving `doctor` to explain it later.
+    #[tokio::test]
+    async fn install_reports_a_server_command_that_cannot_be_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(
+            src.join(MANIFEST_FILE),
+            json!({
+                "name": "sourceonly", "description": "T.",
+                "yolop": { "protocol_version": "1.0",
+                    "capabilityServer": { "command": "yolop-extension-definitely-absent" },
+                    "trace": true }
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let (cap, _settings, _ext_dir) = capability(tmp.path());
+        let tools = cap.management_tools();
+        let install = tools
+            .iter()
+            .find(|t| t.name() == "install_extension")
+            .unwrap();
+
+        match install
+            .execute(json!({ "source": src.to_str().unwrap() }))
+            .await
+        {
+            ToolExecutionResult::Success(v) => {
+                assert_eq!(v["server_command_found"], json!(false));
+                let note = v["note"].as_str().unwrap();
+                assert!(note.contains("cannot start"), "note was: {note}");
+                assert!(note.contains("doctor sourceonly"), "note was: {note}");
+                assert!(
+                    !note.contains("Installed but not enabled"),
+                    "unrunnable package must not read as a plain success: {note}"
+                );
+            }
+            other => panic!("expected success, got {other:?}"),
+        }
+    }
+
+    /// The companion: a package whose command does resolve keeps the ordinary
+    /// enable-next note.
+    #[tokio::test]
+    async fn install_keeps_the_plain_note_when_the_command_resolves() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        std::fs::create_dir_all(src.join("bin")).unwrap();
+        std::fs::write(
+            src.join(MANIFEST_FILE),
+            json!({
+                "name": "hasbin", "description": "T.",
+                "yolop": { "protocol_version": "1.0",
+                    "capabilityServer": { "command": "server" }, "trace": true }
+            })
+            .to_string(),
+        )
+        .unwrap();
+        std::fs::write(src.join("bin").join("server"), "#!/bin/sh\n").unwrap();
+        let (cap, _settings, _ext_dir) = capability(tmp.path());
+        let tools = cap.management_tools();
+        let install = tools
+            .iter()
+            .find(|t| t.name() == "install_extension")
+            .unwrap();
+
+        match install
+            .execute(json!({ "source": src.to_str().unwrap() }))
+            .await
+        {
+            ToolExecutionResult::Success(v) => {
+                assert_eq!(v["server_command_found"], json!(true));
+                assert!(
+                    v["note"]
+                        .as_str()
+                        .unwrap()
+                        .contains("Installed but not enabled")
+                );
+            }
+            other => panic!("expected success, got {other:?}"),
+        }
     }
 
     fn capability(tmp: &Path) -> (ExtensionsCapability, Arc<SettingsStore>, PathBuf) {

--- a/src/extensions/store.rs
+++ b/src/extensions/store.rs
@@ -29,6 +29,9 @@ pub enum Source {
     Crate { crate_name: String, version: String },
 }
 
+/// The crate-name prefix every published yolop extension carries.
+const CRATE_PREFIX: &str = "yolop-extension-";
+
 impl Source {
     /// Parse a user-supplied `<source>` argument.
     ///
@@ -60,14 +63,27 @@ impl Source {
                 path: absolute.display().to_string(),
             });
         }
-        // Bare name shorthand: `lsp` → crate `yolop-extension-lsp`.
-        if spec
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        // Bare name shorthand: `lsp` → crate `yolop-extension-lsp`. The
+        // published crate name is what a user copies off crates.io, so the
+        // prefix is applied only when it is not already there: prefixing
+        // unconditionally turned `yolop-extension-lsp` into a lookup for
+        // `yolop-extension-yolop-extension-lsp`, which cannot exist.
+        // Split the optional `@<version>` pin off first, then validate the
+        // name: checking the whole spec instead forbade `@` and the version's
+        // dots, which made the `<name>@<version>` form unparseable and left
+        // this branch's version split unreachable.
+        let (name, version) = split_at_version(spec);
+        if !name.is_empty()
+            && name
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
         {
-            let (name, version) = split_at_version(spec);
+            let crate_name = match name.strip_prefix(CRATE_PREFIX) {
+                Some(rest) if !rest.is_empty() => name.to_string(),
+                _ => format!("{CRATE_PREFIX}{name}"),
+            };
             return Ok(Source::Crate {
-                crate_name: format!("yolop-extension-{name}"),
+                crate_name,
                 version: version.unwrap_or_default().to_string(),
             });
         }
@@ -187,6 +203,31 @@ fn collect_files(root: &Path, dir: &Path, out: &mut Vec<(String, Vec<u8>)>) -> R
         }
     }
     Ok(())
+}
+
+/// Whether the package's declared `capabilityServer.command` can actually be
+/// spawned: resolvable in the package's own `bin/`, as a path, or on `PATH`.
+///
+/// A crates.io `.crate` carries source, not binaries, and the install path is
+/// toolchain-free by design, so a Rust extension published without a `bin/`
+/// installs cleanly and can never spawn. Install says so rather than reporting
+/// a bare success and leaving `doctor` to explain it later.
+pub fn server_command_resolves(package_dir: &Path, command: &str) -> bool {
+    if command.contains(std::path::MAIN_SEPARATOR) || command.contains('/') {
+        let candidate = Path::new(command);
+        return if candidate.is_absolute() {
+            candidate.is_file()
+        } else {
+            package_dir.join(candidate).is_file()
+        };
+    }
+    if package_dir.join("bin").join(command).is_file() {
+        return true;
+    }
+    let Some(path) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&path).any(|dir| dir.join(command).is_file())
 }
 
 /// Result of an install/update, for the caller to summarize to the user.
@@ -596,6 +637,30 @@ mod tests {
             Source::parse("lsp").unwrap(),
             Source::Crate {
                 crate_name: "yolop-extension-lsp".into(),
+                version: String::new()
+            }
+        );
+        // The published crate name is what a user copies off crates.io, so the
+        // shorthand must not prefix a name that already carries the prefix.
+        assert_eq!(
+            Source::parse("yolop-extension-lsp").unwrap(),
+            Source::Crate {
+                crate_name: "yolop-extension-lsp".into(),
+                version: String::new()
+            }
+        );
+        assert_eq!(
+            Source::parse("yolop-extension-lsp@0.1.0").unwrap(),
+            Source::Crate {
+                crate_name: "yolop-extension-lsp".into(),
+                version: "0.1.0".into()
+            }
+        );
+        // A name that merely starts with the same letters keeps its prefix.
+        assert_eq!(
+            Source::parse("yolop-extensions-thing").unwrap(),
+            Source::Crate {
+                crate_name: "yolop-extension-yolop-extensions-thing".into(),
                 version: String::new()
             }
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,11 +141,6 @@ struct Cli {
     )]
     images: Vec<PathBuf>,
 
-    /// Speak the Agent Client Protocol (ACP) over stdio instead of launching
-    /// the TUI. Editors such as Zed spawn `yolop --acp` and drive it as an
-    /// external agent. Builds one runtime per ACP session (cwd comes from the
-    /// client); the `-C/--cwd`, `--print`, and `--session` flags are
-    /// ignored in this mode. See `knowledge/specs/acp.md`.
     /// Directory holding yolop's global configuration (settings, profiles,
     /// hooks, installed extensions). Defaults to `yolop` inside the platform
     /// config directory; `YOLOP_CONFIG_DIR` sets it for a whole shell. Point
@@ -160,6 +155,11 @@ struct Cli {
     #[arg(long = "data-dir", value_name = "PATH", global = true)]
     data_dir: Option<PathBuf>,
 
+    /// Speak the Agent Client Protocol (ACP) over stdio instead of launching
+    /// the TUI. Editors such as Zed spawn `yolop --acp` and drive it as an
+    /// external agent. Builds one runtime per ACP session (cwd comes from the
+    /// client); the `-C/--cwd`, `--print`, and `--session` flags are
+    /// ignored in this mode. See `knowledge/specs/acp.md`.
     #[arg(long, conflicts_with = "print")]
     acp: bool,
 


### PR DESCRIPTION
## What changed

Found by trying to actually run `yolop-extension-logfire`, which did not work at all. Three fixes, two commits.

1. **The published crate name installs.** `yolop extensions install yolop-extension-logfire`, the name printed on crates.io, failed with `install failed: fetching crate yolop-extension-yolop-extension-logfire`. The bare-name shorthand prefixed unconditionally. It is idempotent now; a name that merely starts with the same letters (`yolop-extensions-thing`) still gets its prefix.

2. **`<name>@<version>` parses.** Splitting the optional version pin before validating the name. The guard ran over the whole spec and rejected `@` and the version's dots, so `lsp@0.1.0` failed outright and that branch's own `split_at_version` call was unreachable.

3. **Install says when the package cannot run.** It now resolves the declared `capabilityServer.command` against the package's `bin/` then `PATH`, and reports `server_command_found`. A crates.io package ships source and the install path is toolchain-free by design, so a Rust extension published without a binary installed cleanly, reported a plain success, and could never spawn. Only `doctor` knew.

Separately, `docs(cli)`: `--acp` had lost its doc comment to `--config-dir`. Behavior was unaffected, but `--help` rendered `--acp` blank and pasted the ACP paragraph in front of the config-dir text.

## Why

Every one of these is the harness reporting success for something that cannot work. Item 1 is the sharpest: the one spelling guaranteed to fail is the one a user copies off crates.io.

## Before / After

Installing by the published name:

```
before: Error: install failed: fetching crate yolop-extension-yolop-extension-logfire
after:  {"installed": "logfire", "version": "0.1.0", ...}
```

Installing a package whose binary is absent, which is the state every fresh user of `yolop-extension-logfire` is in:

```
before: "note": "Installed but not enabled. Run `yolop extensions enable logfire` to enable it."
after:  "server_command_found": false,
        "note": "Installed, but its server command `yolop-extension-logfire` was not found in
                 the package's `bin/` or on PATH, so the extension cannot start. A crate
                 published as source ships no binary; install it (for a Rust extension,
                 `cargo install yolop-extension-logfire`) and check with
                 `yolop extensions doctor logfire`."
```

`yolop --help`:

```
before: --acp                (blank)
        --config-dir <PATH>  Speak the Agent Client Protocol (ACP) over stdio... Directory holding yolop's global configuration...
after:  --acp                Speak the Agent Client Protocol (ACP) over stdio...
        --config-dir <PATH>  Directory holding yolop's global configuration...
```

## Risk

- Low. No transport, approval, or trust boundary moves: `server_command_resolves` only stats paths, and install still parses the manifest without executing anything.
- Install still succeeds when the command is missing rather than failing, so an author who installs the package first and its binary second is not blocked. The result is honest either way, and `doctor` remains the deeper check.
- The parse change widens what the bare-name branch accepts (`@`, and dots inside the version). Git URLs and existing paths are matched earlier and are unaffected; covered by the extended `source_parsing` test.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

New and extended tests, each verified to fail before its fix:

- `source_parsing` gains the published-name, `<name>@<version>`, and near-miss-prefix cases. Before the fix it failed with `left: "yolop-extension-yolop-extension-lsp"`.
- `install_reports_a_server_command_that_cannot_be_found` asserts `server_command_found: false`, that the note names the remedy, and that it does **not** read as a plain success.
- `install_keeps_the_plain_note_when_the_command_resolves` is the companion for a package with a real `bin/`.

Validation: `cargo fmt --check`, `cargo clippy --workspace --all-targets --features yolop-yep/schema -D warnings`, `cargo test --workspace --features yolop-yep/schema` (1,213 + 68 + smaller suites, zero failures), `validate_okf.py --check-links`. Both install paths were also exercised against the real published `yolop-extension-logfire`, with the binary present and absent.

## Knowledge

- `knowledge/specs/extensions.md`: install resolves the declared command and reports `server_command_found`; the shorthand's prefix is idempotent.
- `knowledge/log.md`: entry for the above.

## Security

Reviewed against the threat-model categories in `.agents/skills/ship/SKILL.md`:

- **TM-TOOL**: the install trust boundary is unchanged. `server_command_resolves` performs `is_file` checks only, executes nothing, and runs after the manifest is already parsed and staged. Content-hash pinning and the grant-change signal are untouched. Reporting that a command is missing reveals only what `doctor` already reports.
- **TM-DEP**: the shorthand now resolves `yolop-extension-x` to itself instead of a non-existent doubly-prefixed crate. It cannot redirect an install to a *different* crate: the prefix is only ever removed when already present, never substituted, and explicit `crates.io:` specs are untouched.
- **TM-LLM**: the new note is built from the manifest's own command string and the package name, both already surfaced in the same result.
- **TM-BASH**, **TM-FS**: not touched.

## Follow-ups

- **The root `turn` span never reaches the exporter.** Found while verifying logfire end to end against a local OTLP collector: `reason`, `act`, `tool`, and `llm.generation` spans all export correctly with their attributes, but no `turn` span ever arrives, so every trace is missing its root and the children are orphaned. `turn.*` events are forwardable, and `send_trace_event` is fire-and-forget while the server is `kill_on_drop`, so the terminal event that closes the root span appears to be lost when the session tears down. On a short run (`-p "hi"`, no tool calls) nothing exports at all, which is the same race. Not fixed here: it is a different subsystem from install, and it deserves its own failing test. This is the highest-value follow-up in the extension area.
- **`resolve_host_scope` mistakes a real `/workspace` directory for the display alias** (carried from #604, still unfixed).
- **LSP adoption** wants re-measuring under the deferral profile changed in #602.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DgAqzNcJf625uPKsZvddBx)_