### PR TITLE
fix(extensions): flush trace exporters before the session ends

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,19 @@
 # Knowledge Log
 
+## 2026-08-20, Trace export keeps the root span
+
+- [Extensions](specs/extensions.md): ending a session dropped the trace servers
+  while `trace/event` notifications were still in flight, so `turn.completed`
+  was lost. It closes the root span, so Logfire showed traces whose `reason`,
+  `act`, `tool`, and `llm` children had no root, and a short run exported
+  nothing at all.
+- Every host path that ends a session flushes first. Stopping drains the events
+  already buffered, then a `shutdown` request acts as the barrier: the stream is
+  ordered, so its response proves the server handled everything queued before
+  it. Bounded, so an unresponsive server cannot hold up exit.
+- Draining on stop is the part that is easy to get wrong: signalling the
+  forwarders without it drops exactly the events the flush exists to save.
+
 ## 2026-08-20, Install tells the truth about a package it cannot run
 
 - [Extensions](specs/extensions.md): `install` resolves the declared

--- a/knowledge/specs/extensions.md
+++ b/knowledge/specs/extensions.md
@@ -196,6 +196,19 @@ and can never widen it. A manifest change (a new tool, a changed schema) still
 requires a restart, the enabled-capability set is fixed for the session
 because `everruns-core` builds the harness once with no live-reconfigure boundary.
 Covered by `reload_respawns_the_server_with_edited_code`.
+Trace forwarding has a teardown contract. `trace/event` is fire-and-forget and
+a server is `kill_on_drop`, so ending a session by dropping the runtime killed
+the child with the tail of the stream still in flight. `turn.completed` closes
+the trace's root span, so exported traces arrived with orphaned children, and a
+run short enough that the whole tail was still queued exported nothing at all.
+Every host path that ends a session (`--print`, the TUI, ACP) now calls
+`RuntimeHandles::flush_trace_exporters`: it signals the forwarders, each drains
+the events already buffered, and then a `shutdown` **request** flushes the
+server. The request is the barrier that matters, since the stream is ordered and
+its response cannot arrive until the server has handled every notification
+queued before it. Bounded, so a server that will not answer cannot hold up
+exit. Covered by `teardown_flushes_the_final_trace_events`.
+
 Attached control: `everruns-runtime` grew a live-reconfigure boundary
 (`InProcessRuntime::activate_capability`/`deactivate_capability` →
 `CapabilityDelta`, EVE-795). `yolop extensions enable|disable` persists the

--- a/src/editor/acp/server.rs
+++ b/src/editor/acp/server.rs
@@ -541,6 +541,13 @@ where
     for poller in pollers {
         let _ = poller.await;
     }
+    // Same teardown contract as the TUI and `--print`: let each session's trace
+    // extensions export their final events before the runtimes drop and their
+    // servers are killed.
+    let sessions: Vec<Arc<Session>> = server.sessions.lock().unwrap().values().cloned().collect();
+    for session in sessions {
+        session.handles.flush_trace_exporters().await;
+    }
 
     match result {
         Ok(()) => Ok(()),

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -167,6 +167,41 @@ impl ExtensionProcess {
         }
     }
 
+    /// Stop the server gracefully, flushing anything already queued.
+    ///
+    /// `trace/event` is fire-and-forget, so a notification only reaches the
+    /// server's handler after the writer task and the child's own read loop
+    /// have both moved it along. Dropping the process kills the child
+    /// (`kill_on_drop`) with that pipeline in flight, which silently lost the
+    /// tail of the event stream, `turn.completed` above all: it closes the
+    /// trace's root span, so exported traces arrived with orphaned children.
+    ///
+    /// The stream is ordered, so a `shutdown` **request** is a real flush
+    /// barrier: its response cannot arrive until the server has read and
+    /// handled every notification queued before it. Bounded by the spec's
+    /// request timeout, and best-effort by design — a server that never
+    /// answers is still dropped and killed.
+    pub async fn shutdown_gracefully(&self) {
+        let connection = {
+            let state = self.state.lock().await;
+            match state.as_ref() {
+                Some(live) => live.connection.clone(),
+                // Never spawned, or already torn down: nothing to flush.
+                None => return,
+            }
+        };
+        if let Err(err) = connection
+            .request("shutdown", serde_json::Value::Null)
+            .await
+        {
+            tracing::debug!(
+                target: "yolop::ext", ext = %self.name(),
+                "graceful shutdown failed, killing: {err}"
+            );
+        }
+        *self.state.lock().await = None;
+    }
+
     /// Forward one agentic-lifecycle event to the server as a fire-and-forget
     /// `trace/event` notification (the `trace` facet). Spawns/handshakes the
     /// server first if needed — the facet is eager, so the first event brings

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -304,6 +304,84 @@ mod spawn_tests {
         assert!(types.contains(&"tool.completed"), "recorded: {types:?}");
     }
 
+    /// The tail of the event stream must survive session teardown. `turn.completed`
+    /// closes the trace's root span, so losing it exports children with no root
+    /// (and a short run exports nothing at all). The fixture is slowed with
+    /// `trace_delay_ms` so the tail is still in flight when the stream closes,
+    /// making the teardown race deterministic rather than one the test usually
+    /// wins.
+    #[tokio::test]
+    async fn teardown_flushes_the_final_trace_events() {
+        use everruns_core::events::{EventContext, EventRequest};
+        use everruns_provider::typed_id::{EventId, SessionId};
+        use tokio::sync::broadcast;
+
+        let Some(python) = python3() else {
+            eprintln!("skipping: python3 not available");
+            return;
+        };
+        let dir = tempfile::tempdir().expect("tempdir");
+        let log = dir.path().join("trace.log");
+        let capability = ExtensionCapability::new(trace_package(&python), std::env::temp_dir());
+        let config = json!({
+            "trace_log": log.display().to_string(),
+            "trace_delay_ms": 40,
+        });
+        let forwarder =
+            crate::extensions::trace::TraceForwarder::for_capability(&capability, &config)
+                .expect("trace forwarder for a declaring extension");
+
+        let session_id = SessionId::new();
+        let (tx, rx) = broadcast::channel(64);
+        let (stop, stop_rx) = tokio::sync::watch::channel(false);
+        let handle = forwarder.start(session_id, rx, stop_rx);
+        let flush = crate::extensions::trace::TraceFlush::new(stop, vec![handle]);
+
+        for (seq, event_type) in [
+            everruns_core::TURN_STARTED,
+            everruns_core::TOOL_COMPLETED,
+            everruns_core::TURN_COMPLETED,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let request = EventRequest {
+                event_type: event_type.into(),
+                ts: chrono::Utc::now(),
+                session_id,
+                context: EventContext::empty(),
+                data: everruns_core::events::EventData::unsupported(event_type.into(), json!({})),
+                metadata: None,
+                tags: None,
+            };
+            tx.send(request.into_event(EventId::new(), seq as i32))
+                .expect("broadcast event");
+        }
+
+        // Session teardown, exactly as a host path runs it: the event stream is
+        // still open (the runtime outlives the forwarder) and the fixture is
+        // still working through the queue.
+        tokio::time::timeout(std::time::Duration::from_secs(10), flush.flush())
+            .await
+            .expect("flush finished");
+        drop(tx);
+
+        let recorded = std::fs::read_to_string(&log).unwrap_or_default();
+        let types: Vec<&str> = recorded.lines().collect();
+        assert!(
+            types.contains(&everruns_core::TURN_COMPLETED),
+            "the root span's terminal event was lost at teardown; recorded: {types:?}"
+        );
+        assert!(
+            types.contains(&everruns_core::TURN_STARTED),
+            "recorded: {types:?}"
+        );
+        assert!(
+            types.contains(&everruns_core::TOOL_COMPLETED),
+            "recorded: {types:?}"
+        );
+    }
+
     /// A `secret` config field is injected into the server's environment (per
     /// its `env` mapping) from the secret store — never via `initialize.config`.
     #[tokio::test]

--- a/src/extensions/trace.rs
+++ b/src/extensions/trace.rs
@@ -16,7 +16,7 @@ use everruns_core::{
 use everruns_provider::typed_id::SessionId;
 use serde_json::Value;
 use std::sync::Arc;
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, watch};
 
 /// High-frequency streaming deltas carry no span-shaped meaning on their own and
 /// would flood the exporter (and the broadcast channel); the paired
@@ -68,8 +68,15 @@ impl TraceForwarder {
     }
 
     /// Begin forwarding this session's events to the extension server.
-    pub(crate) fn start(self, session_id: SessionId, events: broadcast::Receiver<Event>) {
-        spawn_forwarder(self.name, self.process, session_id, events);
+    /// The returned handle completes once forwarding has stopped and the
+    /// server has been flushed; teardown awaits it so the final events survive.
+    pub(crate) fn start(
+        self,
+        session_id: SessionId,
+        events: broadcast::Receiver<Event>,
+        stop: watch::Receiver<bool>,
+    ) -> tokio::task::JoinHandle<()> {
+        spawn_forwarder(self.name, self.process, session_id, events, stop)
     }
 }
 
@@ -81,22 +88,46 @@ pub(crate) fn spawn_forwarder(
     process: Arc<ExtensionProcess>,
     session_id: SessionId,
     mut events: broadcast::Receiver<Event>,
-) {
+    mut stop: watch::Receiver<bool>,
+) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
+        // One forwarding step, shared by the live loop and the drain below.
+        async fn forward(
+            ext_name: &str,
+            process: &ExtensionProcess,
+            session_id: SessionId,
+            event: Event,
+        ) {
+            if event.session_id != session_id || !is_forwardable(&event.event_type) {
+                return;
+            }
+            if let Err(err) = process.send_trace_event(trace_event_params(&event)).await {
+                tracing::warn!(
+                    target: "yolop::ext", ext = %ext_name,
+                    "trace/event forward failed: {err}"
+                );
+            }
+        }
+
         loop {
-            match events.recv().await {
-                Ok(event) if event.session_id == session_id => {
-                    if !is_forwardable(&event.event_type) {
-                        continue;
+            let received = tokio::select! {
+                received = events.recv() => received,
+                // Teardown asked us to stop. The broadcast may still be open
+                // (the runtime outlives this task), so this, not stream close,
+                // is what normally ends forwarding.
+                _ = stop.changed() => {
+                    // Everything already buffered still belongs to this
+                    // session's trace, `turn.completed` above all. Drain it
+                    // before flushing, or stopping would drop exactly the
+                    // events the flush exists to save.
+                    while let Ok(event) = events.try_recv() {
+                        forward(&ext_name, &process, session_id, event).await;
                     }
-                    if let Err(err) = process.send_trace_event(trace_event_params(&event)).await {
-                        tracing::warn!(
-                            target: "yolop::ext", ext = %ext_name,
-                            "trace/event forward failed: {err}"
-                        );
-                    }
+                    break;
                 }
-                Ok(_) => {}
+            };
+            match received {
+                Ok(event) => forward(&ext_name, &process, session_id, event).await,
                 // The exporter fell behind the broadcast buffer: skip the gap
                 // rather than block the agent. A lossy trace beats a stalled run.
                 Err(broadcast::error::RecvError::Lagged(n)) => {
@@ -108,7 +139,51 @@ pub(crate) fn spawn_forwarder(
                 Err(broadcast::error::RecvError::Closed) => break,
             }
         }
-    });
+        // The stream closed: the session is tearing down. Flush before the
+        // process is dropped, or the tail of the stream dies with the child.
+        // `turn.completed` is the one that matters most: it closes the trace's
+        // root span, so losing it exports children with no root.
+        process.shutdown_gracefully().await;
+    })
+}
+
+/// Stops the session's trace forwarders and waits for their final flush.
+///
+/// Forwarding is fire-and-forget and the servers are `kill_on_drop`, so without
+/// an explicit stop-and-wait the tail of the event stream dies with the child
+/// at teardown. `turn.completed` is the casualty that matters: it closes the
+/// trace's root span, so traces exported with no root and short runs exported
+/// nothing at all.
+pub struct TraceFlush {
+    stop: watch::Sender<bool>,
+    handles: Vec<tokio::task::JoinHandle<()>>,
+}
+
+impl TraceFlush {
+    pub(crate) fn new(
+        stop: watch::Sender<bool>,
+        handles: Vec<tokio::task::JoinHandle<()>>,
+    ) -> Self {
+        Self { stop, handles }
+    }
+
+    /// Signal every forwarder to stop, then wait for each to flush its server.
+    /// Bounded: a server that will not answer must not hold up process exit.
+    pub async fn flush(self) {
+        const BUDGET: std::time::Duration = std::time::Duration::from_secs(5);
+        if self.handles.is_empty() {
+            return;
+        }
+        let _ = self.stop.send(true);
+        for handle in self.handles {
+            if tokio::time::timeout(BUDGET, handle).await.is_err() {
+                tracing::debug!(
+                    target: "yolop::ext",
+                    "trace forwarder did not flush within {BUDGET:?}; exiting anyway"
+                );
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1779,6 +1779,9 @@ async fn run_tui(
         trajectory_out.as_deref(),
     )
     .await;
+    // Same teardown contract as `--print`: let the trace extensions export the
+    // session's final events before their servers are killed.
+    trajectory_handles.flush_trace_exporters().await;
 
     if show_resume_hint {
         println!();
@@ -2128,6 +2131,9 @@ async fn run_print_mode(
         }
     }
     write_trajectory_if_requested(&handles, &model, trajectory_out.as_deref()).await;
+    // Let the trace extensions export the turn's final events before the
+    // process exits and their servers are killed.
+    handles.flush_trace_exporters().await;
     Ok(())
 }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2725,6 +2725,10 @@ pub struct BuiltRuntime {
 
 #[derive(Clone)]
 pub struct RuntimeHandles {
+    /// Stops the trace forwarders and waits for their final flush. Taken by
+    /// [`RuntimeHandles::flush_trace_exporters`] at teardown; `None` once
+    /// flushed, so a second call is a no-op.
+    trace_flush: Arc<tokio::sync::Mutex<Option<crate::extensions::trace::TraceFlush>>>,
     pub runtime: Arc<InProcessRuntime>,
     settings: Arc<SettingsStore>,
     pending_model_choice: Arc<RwLock<Option<ProviderChoice>>>,
@@ -2775,6 +2779,22 @@ pub(crate) type ExtensionFactory =
     Arc<dyn Fn(&str) -> Result<Arc<dyn everruns_core::Capability>, String> + Send + Sync>;
 
 impl RuntimeHandles {
+    /// Stop trace forwarding and wait for each extension server to flush.
+    ///
+    /// Every host path that ends a session calls this before dropping the
+    /// runtime. `trace/event` is fire-and-forget and the servers are
+    /// `kill_on_drop`, so without it the tail of the stream is killed in
+    /// flight: `turn.completed` closes the trace's root span, and losing it
+    /// exported traces whose children had no root (and exported nothing at all
+    /// for a run short enough that the whole tail was still queued).
+    /// Idempotent and bounded.
+    pub async fn flush_trace_exporters(&self) {
+        let flush = self.trace_flush.lock().await.take();
+        if let Some(flush) = flush {
+            flush.flush().await;
+        }
+    }
+
     pub(crate) fn report_herdr_state(&self, state: crate::capabilities::herdr::HerdrState) {
         self.herdr.report_background(state);
     }
@@ -4422,12 +4442,22 @@ pub async fn build_with_options(
     // Start agentic-trace forwarding for each enabled `trace` extension: one
     // task per extension consuming its own subscription, filtered to this
     // session. Observe-only — a slow exporter never stalls the run.
-    for forwarder in trace_forwarders {
-        forwarder.start(session_id, event_bus_typed.subscribe());
-    }
+    let (trace_stop, trace_stop_rx) = tokio::sync::watch::channel(false);
+    let trace_handles: Vec<_> = trace_forwarders
+        .into_iter()
+        .map(|forwarder| {
+            forwarder.start(
+                session_id,
+                event_bus_typed.subscribe(),
+                trace_stop_rx.clone(),
+            )
+        })
+        .collect();
+    let trace_flush = crate::extensions::trace::TraceFlush::new(trace_stop, trace_handles);
 
     Ok(BuiltRuntime {
         handles: RuntimeHandles {
+            trace_flush: Arc::new(tokio::sync::Mutex::new(Some(trace_flush))),
             runtime,
             settings: settings.clone(),
             pending_model_choice,

--- a/tests/fixtures/yep_echo_server.py
+++ b/tests/fixtures/yep_echo_server.py
@@ -17,6 +17,12 @@ import sys
 # than env-driven so parallel tests don't collide.
 TRACE_LOG = None
 
+# Set from `initialize.config.trace_delay_ms`: seconds to sleep before recording
+# each `trace/event`. A teardown test needs the tail of the stream to still be
+# in flight when the host stops the server, which a delay makes deterministic
+# instead of a race the test would win most of the time.
+TRACE_DELAY_S = 0.0
+
 
 def send(obj):
     sys.stdout.write(json.dumps(obj) + "\n")
@@ -26,6 +32,9 @@ def send(obj):
 def record_trace(event_type):
     if not TRACE_LOG:
         return
+    if TRACE_DELAY_S:
+        import time
+        time.sleep(TRACE_DELAY_S)
     with open(TRACE_LOG, "a", encoding="utf-8") as handle:
         handle.write(event_type + "\n")
 
@@ -46,6 +55,9 @@ def main():
             if isinstance(config, dict) and config.get("trace_log"):
                 global TRACE_LOG
                 TRACE_LOG = config["trace_log"]
+            if isinstance(config, dict) and config.get("trace_delay_ms"):
+                global TRACE_DELAY_S
+                TRACE_DELAY_S = float(config["trace_delay_ms"]) / 1000.0
             # Echo an injected env var (for the secret-injection spawn test):
             # the host injects `secret`/`env`-mapped config fields into our
             # environment. Record it so the test can assert it arrived.


### PR DESCRIPTION
## What changed

Every host path that ends a session (`--print`, the TUI, ACP) now calls `RuntimeHandles::flush_trace_exporters` before the runtime drops. Stopping a trace forwarder first drains the events already buffered, then a `shutdown` **request** flushes the extension server.

## Why

An exported trace was missing its root span. Verified against a local OTLP collector with the real `yolop-extension-logfire`: `reason`, `act`, `tool`, and `llm.generation` spans all arrived with their attributes, and no `turn` span ever did, so every trace in Logfire showed orphaned children. Worse, a run short enough that the whole tail was still queued (`-p "hi"`, no tool calls) exported **nothing at all**.

`trace/event` is a fire-and-forget notification and an extension server is `kill_on_drop`. A notification only reaches the server's handler after the writer task and the child's own read loop have both moved it along, so ending a session by dropping the runtime killed the child with that pipeline in flight. `turn.completed` is the last event of the turn and the one that closes the root span, which is why it was the reliable casualty.

The `shutdown` request is what makes the flush a real barrier rather than a sleep: the stream is ordered, so its response cannot arrive until the server has read and handled every notification queued before it.

## Before / After

Real binary, `-p "run the bash command 'echo hi' and say what it printed"`, spans received by a local collector:

```
before: act.completed act.started llm.generation reason.completed reason.started
        tool.completed tool.started
after:  act.completed act.started llm.generation reason.completed reason.started
        tool.completed tool.started turn.completed turn.started
```

Real binary, `-p "hi"` (no tool calls):

```
before: (no spans exported at all)
after:  llm.generation reason.completed reason.started turn.completed turn.started
```

## Risk

- Low, and bounded. The flush has a five second budget per forwarder, because a server that will not answer must not hold up process exit; it then drops and kills as before.
- Idempotent: the flush handle is taken on first call, so a second call is a no-op.
- No cost for sessions without a `trace` extension — with no forwarders the flush returns immediately.
- Observe-only semantics are unchanged: forwarding is still fire-and-forget during the turn, so a slow exporter never stalls the agent. The one wait is at teardown.
- The lagged-broadcast behavior is unchanged (still skips the gap rather than blocking).

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

`teardown_flushes_the_final_trace_events` drives a real spawned server through the production path (`TraceForwarder::start` → `TraceFlush::flush`) and asserts `turn.completed` survives. Verified to fail without the fix, with `recorded: []` — the same total loss seen in the real binary, not a near miss.

The fixture gains a `trace_delay_ms` config so the tail is *deterministically* still in flight at teardown, rather than a race the test would usually win and occasionally flake on.

**Draining on stop is the subtle half, and the test caught it.** My first version signalled the forwarders and flushed without draining the buffered events, which dropped exactly the events the flush exists to save — the test failed with `recorded: []` against the fix itself until the drain was added.

Validation: `cargo fmt --check`, `cargo clippy --workspace --all-targets --features yolop-yep/schema -D warnings`, `cargo test --workspace --features yolop-yep/schema` (1,214 + 68 + smaller suites, zero failures), `validate_okf.py --check-links`, plus the two live end-to-end runs above against a local OTLP collector.

## Knowledge

- `knowledge/specs/extensions.md`: the trace teardown contract, why the `shutdown` request is the barrier, and that the flush is bounded.
- `knowledge/log.md`: entry for the above, including the drain-on-stop trap.

## Security

Reviewed against the threat-model categories in `.agents/skills/ship/SKILL.md`:

- **TM-TOOL**: no new capability, tool, or grant. `shutdown` is an existing protocol method the SDK and every scaffolded server already answer; this sends it as a request instead of never sending it. A server that ignores it is killed exactly as before.
- **TM-BASH**: process lifetime only. The child is still `kill_on_drop`; the flush adds a bounded wait before that drop, and cannot extend a server's life beyond the budget.
- **TM-LLM**: trace payloads are unchanged and still never re-enter the model's context.
- **TM-DEP**, **TM-FS**: not touched.

## Follow-ups

- **`resolve_host_scope` mistakes a real `/workspace` directory for the display alias** (carried from #604, still unfixed). Two tests fail on any host that has a real `/workspace`, and the user-visible bug is that yolop's own displayed paths get rejected there.
- **LSP adoption** wants re-measuring under the deferral profile changed in #602.
- The published `yolop-extension-logfire` 0.1.0 still ships no binary, so it needs `cargo install yolop-extension-logfire` to run at all. #608 makes yolop say so at install time; the packaging itself is upstream of this repo.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DgAqzNcJf625uPKsZvddBx)_