### PR TITLE
fix(extensions): alias remove as uninstall, and stop repeating the command

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,18 @@
 # Knowledge Log
 
+## 2026-08-20, One command per transcript line, and uninstall says uninstall
+
+- [Extensions](specs/extensions.md): `remove` is aliased `uninstall`. Clap had
+  answered `yolop extensions uninstall <name>` with "unrecognized subcommand"
+  and a tip suggesting `install`, which does the opposite of what was asked.
+- The transcript line is `{label}  {summary}`, and for `bash` both halves
+  carried the command: the shell narration is already "Ran `<cmd>`", so the line
+  read "Ran `cmd` `cmd` exit=0". The summary is now just `exit=<code>` when a
+  narration carries the command, and keeps spelling it out when none does.
+- The old test set narration to a bare "Ran Bash", a shape the real narrator
+  never produces, so it could not see the duplication. It now builds its
+  narration with `narrate_shell_exec`.
+
 ## 2026-08-20, Trace export keeps the root span
 
 - [Extensions](specs/extensions.md): ending a session dropped the trace servers

--- a/knowledge/specs/extensions.md
+++ b/knowledge/specs/extensions.md
@@ -230,6 +230,9 @@ Later, the full `yolop-extension-lsp` control-plane extraction (gated on
 `evals/lsp_integration` parity to retire the built-in),
 `workspace/changed`,
 providers, remain design-of-record below.
+`remove` is also spelled `uninstall`: it is the natural opposite of `install`,
+and without the alias clap rejected it and suggested `install` itself.
+
 Toolchain-free crates.io install is now wired: `yolop extensions install
 crates.io:yolop-extension-<name>[@ver]` (or the bare-`<name>`
 shorthand) resolves the version through the crates.io **sparse index**

--- a/src/extensions/manage.rs
+++ b/src/extensions/manage.rs
@@ -56,6 +56,12 @@ enum ExtensionCommand {
     /// Install an extension without enabling it.
     Install { source: String },
     /// Remove an installed extension and its persisted enablement/secrets.
+    ///
+    /// Aliased as `uninstall`, the natural opposite of `install`: without it
+    /// clap answered `yolop extensions uninstall <name>` with "unrecognized
+    /// subcommand" and suggested `install`, the one command that does the
+    /// opposite of what was asked.
+    #[command(alias = "uninstall")]
     Remove { name: String },
     /// Persist enablement and apply it to the attached session when present.
     Enable { name: String },
@@ -1399,6 +1405,27 @@ mod tests {
             .to_string(),
         )
         .unwrap();
+    }
+
+    /// `uninstall` is the natural opposite of `install`, and clap answered it
+    /// with "unrecognized subcommand" plus a tip suggesting `install` itself.
+    #[test]
+    fn uninstall_is_accepted_as_an_alias_for_remove() {
+        use clap::Parser;
+
+        let parsed = ExtensionCommandLine::try_parse_from(["extensions", "uninstall", "logfire"])
+            .expect("`uninstall` must parse");
+        assert!(matches!(
+            parsed.command,
+            Some(ExtensionCommand::Remove { ref name }) if name == "logfire"
+        ));
+
+        let canonical = ExtensionCommandLine::try_parse_from(["extensions", "remove", "logfire"])
+            .expect("`remove` must keep working");
+        assert!(matches!(
+            canonical.command,
+            Some(ExtensionCommand::Remove { ref name }) if name == "logfire"
+        ));
     }
 
     /// A package published as source (no `bin/`, nothing on PATH by that name)

--- a/src/tui/presentation.rs
+++ b/src/tui/presentation.rs
@@ -798,13 +798,53 @@ mod tests {
             )],
             None,
         );
-        data.narration = Some("Ran Bash".to_string());
+        // The real narration for a shell call, which carries the command. The
+        // transcript line is "{label}  {summary}", so a summary that also spelled
+        // out the command printed it twice ("Ran `cmd` `cmd` exit=0").
+        data.narration = Some(everruns_core::tool_narration::narrate_shell_exec(
+            &json!({ "command": "git status --short" }),
+            "Bash",
+            everruns_core::tool_narration::ToolNarrationPhase::Completed,
+            None,
+        ));
         let event = RuntimeEvent::new(SessionId::new(), EventContext::empty(), data);
         let lines = lines_for_event(&event);
 
         let rendered = plain_transcript_line(&lines[0]);
 
-        assert_eq!(rendered, "tool › ✓ Ran Bash  `git status --short` exit=0");
+        assert_eq!(rendered, "tool › ✓ Ran `git status --short`  exit=0");
+        assert_eq!(
+            rendered.matches("git status --short").count(),
+            1,
+            "the command must appear once, not once per narration and summary: {rendered}"
+        );
+    }
+
+    /// Without narration the label falls back to a bare "Bash", so the summary
+    /// is the only place the command can appear and must keep spelling it out.
+    #[test]
+    fn plain_transcript_line_keeps_the_command_when_narration_is_absent() {
+        let mut data = ToolCompletedData::success(
+            "call_bash".to_string(),
+            "bash".to_string(),
+            vec![ContentPart::text(
+                json!({
+                    "command": "git status --short",
+                    "exit_code": 0
+                })
+                .to_string(),
+            )],
+            None,
+        );
+        data.narration = None;
+        data.display_name = Some("Bash".to_string());
+        let event = RuntimeEvent::new(SessionId::new(), EventContext::empty(), data);
+        let lines = lines_for_event(&event);
+
+        assert_eq!(
+            plain_transcript_line(&lines[0]),
+            "tool › ✓ Bash  `git status --short` exit=0"
+        );
     }
 
     #[test]

--- a/src/tui/transcript.rs
+++ b/src/tui/transcript.rs
@@ -704,16 +704,23 @@ pub fn summarize_tool_result(data: &ToolCompletedData) -> String {
             format!("{path} ({size} bytes)")
         }
         "bash" => {
-            let cmd = v
-                .get("command")
-                .and_then(Value::as_str)
-                .map(|c| first_line(c, 80))
-                .unwrap_or_default();
             let code = v
                 .get("exit_code")
                 .and_then(Value::as_i64)
                 .map(|c| c.to_string())
                 .unwrap_or_else(|| "?".into());
+            // The line reads "{label}  {summary}", and the shell narration is
+            // already "Ran `<command>`". Repeating the command here rendered it
+            // twice ("Ran `cmd` `cmd` exit=0"), so it is only spelled out when
+            // no narration carries it (then the label is a bare "Bash").
+            if data.narration.is_some() {
+                return format!("exit={code}");
+            }
+            let cmd = v
+                .get("command")
+                .and_then(Value::as_str)
+                .map(|c| first_line(c, 80))
+                .unwrap_or_default();
             format!("`{cmd}` exit={code}")
         }
         _ => String::new(),


### PR DESCRIPTION
## What changed

Two fixes, both from reading a real session transcript.

1. **`uninstall` is an alias for `remove`.** `yolop extensions uninstall <name>` failed with `unrecognized subcommand`, and clap's tip suggested **`install`** — the one command that does the opposite of what was asked, on a package the user was trying to get rid of.

2. **A bash call no longer prints its command twice.** The transcript line is `{label}  {summary}`, and for `bash` both halves carried the command: the shell narration is already ``Ran `<cmd>` ``, so a call rendered as ``Ran `yolop extensions disable logfire`  `yolop extensions disable logfire` exit=0``. The summary is now just `exit=<code>` when a narration carries the command, and keeps spelling it out when none does (the label is then a bare `Bash`).

## Before / After

```
before: ✓ Ran `yolop extensions disable logfire`  `yolop extensions disable logfire` exit=0
after:  ✓ Ran `yolop extensions disable logfire`  exit=0

before: $ yolop extensions uninstall logfire
        error: unrecognized subcommand 'uninstall'
          tip: a similar subcommand exists: 'install'
after:  $ yolop extensions uninstall logfire
        { "removed": "logfire" }
```

## Risk

- Low. The alias adds a spelling; `remove` is unchanged and every existing invocation keeps working.
- The transcript change is display-only. The command is still shown on every line, once — via the narration, which truncates at 48 chars where the summary truncated at 80. For a command longer than 48 characters the visible tail is shorter than before; the full command remains in the tool result and the expanded view. Called out here because it is the one real trade-off.
- The no-narration path is unchanged and covered by its own test, so a host or event without narration still shows the command in full.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

- `uninstall_is_accepted_as_an_alias_for_remove` parses both spellings to the same variant.
- `plain_transcript_line_keeps_fallback_wording_visible_to_tests` now builds its narration with the real `narrate_shell_exec` and asserts the command appears **exactly once**. It previously set narration to `"Ran Bash"`, a shape the real narrator never produces, which is precisely why the duplication was invisible to it.
- `plain_transcript_line_keeps_the_command_when_narration_is_absent` covers the fallback.

Validation: `cargo fmt --check`, `cargo clippy --workspace --all-targets --features yolop-yep/schema -D warnings`, `cargo test --workspace --features yolop-yep/schema` (1,216 + 68 + smaller suites, zero failures), `validate_okf.py --check-links`, plus `extensions uninstall logfire` run against the real installed package.

## Knowledge

- `knowledge/specs/extensions.md`: `remove` is also spelled `uninstall`, and why.
- `knowledge/log.md`: entry covering both fixes and the test shape that hid the duplication.

## Security

Reviewed against the threat-model categories in `.agents/skills/ship/SKILL.md`:

- **TM-TOOL**: the alias resolves to the existing `Remove` variant, so it inherits the same approval gate and the same persisted-state cleanup (enablement override and stored secrets). No new operation, and nothing becomes reachable that was not already.
- **TM-LLM**: the transcript change only removes a duplicated substring from a rendered line; no new content reaches the model.
- **TM-BASH**, **TM-FS**, **TM-DEP**: not touched.

## Follow-ups

- **Unknown-subcommand errors do not list the valid subcommands.** `yolop extensions <typo>` prints `Usage: yolop extensions [OPTIONS] [COMMAND]` and "For more information, try '--help'", so discovering the real commands costs a second call. The alias removes the sharpest instance, but the general case would be better served by listing subcommands on error. Not changed here: it is a clap-wide presentation choice that affects every subcommand group, not just `extensions`.
- **`resolve_host_scope` mistakes a real `/workspace` directory for the display alias** (carried from #604, still unfixed).
- **LSP adoption** wants re-measuring under the deferral profile changed in #602.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DgAqzNcJf625uPKsZvddBx)_