### PR TITLE
fix(extensions): accept the crate name wherever an extension is named

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,20 @@
 # Knowledge Log
 
+## 2026-08-20, One extension name, however it is spelled
+
+- [Extensions](specs/extensions.md): every by-name subcommand accepts the
+  published crate name as well as the manifest name, matching what `install`
+  already took. Installing `yolop-extension-logfire` and then enabling it by
+  that same name had failed with "no extension named".
+- The literal name always wins, so a package whose manifest really is
+  `yolop-extension-foo` still resolves to itself, and an unknown name is passed
+  through untouched so the error quotes what was typed.
+- `disable` no longer reports success for a name that was never installed; it
+  had written a persisted override for a package that does not exist. It stays
+  more permissive than `enable` on purpose: a package whose manifest no longer
+  parses is skipped by discovery and is exactly the one that needs switching
+  off, so a directory on disk or an existing override is enough.
+
 ## 2026-08-20, One command per transcript line, and uninstall says uninstall
 
 - [Extensions](specs/extensions.md): `remove` is aliased `uninstall`. Clap had

--- a/knowledge/specs/extensions.md
+++ b/knowledge/specs/extensions.md
@@ -230,6 +230,15 @@ Later, the full `yolop-extension-lsp` control-plane extraction (gated on
 `evals/lsp_integration` parity to retire the built-in),
 `workspace/changed`,
 providers, remain design-of-record below.
+Every subcommand that names an installed extension accepts the published crate
+name (`yolop-extension-<name>`) as well as the manifest name, matching what
+`install` takes. The literal name wins, so a package actually named
+`yolop-extension-foo` resolves to itself, and an unknown name is left untouched
+so the error quotes what the user typed. `disable` refuses a name that is
+neither installed, present on disk, nor already carrying an override: it stays
+looser than `enable` so a package with a broken manifest can still be switched
+off, but it no longer reports success for a typo.
+
 `remove` is also spelled `uninstall`: it is the natural opposite of `install`,
 and without the alias clap rejected it and suggested `install` itself.
 

--- a/src/extensions/manage.rs
+++ b/src/extensions/manage.rs
@@ -10,7 +10,9 @@ use super::package::{discover_extensions, extension_capability_id};
 use super::protocol::UiAskParams;
 use super::scaffold::{self, HookSpec, Language, ScaffoldRequest, ToolSpec};
 use super::secrets::{ExtensionSecrets, Secret};
-use super::store::{self, CrateFetcher, GitRunner, Source, SystemCrateFetcher, SystemGit};
+use super::store::{
+    self, CRATE_PREFIX, CrateFetcher, GitRunner, Source, SystemCrateFetcher, SystemGit,
+};
 use crate::capabilities::narration::stable_labeled;
 use crate::config::SettingsStore;
 use crate::control::{
@@ -565,6 +567,51 @@ impl ManageTool {
         Self { ctx, verb }
     }
 
+    /// Accept the published crate name wherever an installed extension is named.
+    ///
+    /// `install` takes `logfire`, `yolop-extension-logfire`, and
+    /// `crates.io:yolop-extension-logfire` alike, but the package installs under
+    /// its manifest name (`logfire`). Without this, installing by the name
+    /// printed on crates.io and then enabling by that same name failed with
+    /// "no extension named `yolop-extension-logfire`", a seam a user has no way
+    /// to guess at.
+    ///
+    /// Conservative: the literal name always wins, so a package whose manifest
+    /// really is called `yolop-extension-foo` still resolves to itself. An
+    /// unknown name is left untouched so the error quotes what was typed.
+    /// `scaffold` is excluded because it names a package being created, not an
+    /// installed one, and `install` parses its own source spec.
+    fn resolve_name_argument(&self, arguments: Value) -> Value {
+        if matches!(self.verb, Verb::Scaffold | Verb::Install | Verb::List) {
+            return arguments;
+        }
+        let Some(name) = arguments
+            .get("name")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+        else {
+            return arguments;
+        };
+        let Some(stripped) = name
+            .strip_prefix(CRATE_PREFIX)
+            .filter(|rest| !rest.is_empty())
+            .map(str::to_string)
+        else {
+            return arguments;
+        };
+        let installed = discover_extensions(&self.ctx.extensions_dir);
+        if installed.iter().any(|pkg| pkg.manifest.name == name)
+            || !installed.iter().any(|pkg| pkg.manifest.name == stripped)
+        {
+            return arguments;
+        }
+        let mut arguments = arguments;
+        if let Some(object) = arguments.as_object_mut() {
+            object.insert("name".into(), Value::String(stripped));
+        }
+        arguments
+    }
+
     fn scaffold(&self, args: &Value) -> ToolExecutionResult {
         let Some(name) = args.get("name").and_then(Value::as_str) else {
             return ToolExecutionResult::ToolError("`name` is required".into());
@@ -831,14 +878,34 @@ impl ManageTool {
         let Some(name) = args.get("name").and_then(Value::as_str) else {
             return ToolExecutionResult::ToolError("`name` is required".into());
         };
-        if enable
-            && !discover_extensions(&self.ctx.extensions_dir)
-                .iter()
-                .any(|pkg| pkg.manifest.name == name)
-        {
+        let installed = discover_extensions(&self.ctx.extensions_dir)
+            .iter()
+            .any(|pkg| pkg.manifest.name == name);
+        if enable && !installed {
             return ToolExecutionResult::ToolError(format!(
                 "no extension named `{name}` is installed; run `yolop extensions install` first"
             ));
+        }
+        // Disable is deliberately more permissive than enable: an extension
+        // whose manifest no longer parses is exactly the one a user needs to
+        // switch off, and `discover_extensions` skips it. So accept a package
+        // directory that exists on disk, or a name that already carries an
+        // override to clear. A name matching neither is a typo, and writing a
+        // persisted override for it reported success for a package that does
+        // not exist.
+        if !enable && !installed {
+            let on_disk = self.ctx.extensions_dir.join(name).is_dir();
+            let has_override = !self
+                .ctx
+                .settings
+                .snapshot()
+                .capability_overrides_for(&extension_capability_id(name))
+                .is_empty();
+            if !on_disk && !has_override {
+                return ToolExecutionResult::ToolError(format!(
+                    "no extension named `{name}` is installed; `yolop extensions list` shows what is"
+                ));
+            }
         }
         let cap_id = extension_capability_id(name);
         match self.ctx.settings.set_capability_enabled(&cap_id, enable) {
@@ -1373,6 +1440,7 @@ impl Tool for ManageTool {
     }
 
     async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let arguments = self.resolve_name_argument(arguments);
         match self.verb {
             Verb::Scaffold => self.scaffold(&arguments),
             Verb::List => self.list(),
@@ -1405,6 +1473,118 @@ mod tests {
             .to_string(),
         )
         .unwrap();
+    }
+
+    /// Every by-name subcommand must accept the same spellings `install` does.
+    /// Installing by the published crate name and then being told
+    /// "no extension named `yolop-extension-logfire`" by `enable` is the kind
+    /// of seam a user has no way to guess at.
+    #[tokio::test]
+    async fn by_name_subcommands_accept_the_published_crate_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        seed_package(&src, "logfire");
+        let (cap, settings, _ext_dir) = capability(tmp.path());
+        let tools = cap.management_tools();
+        let get = |name: &str| tools.iter().find(|t| t.name() == name).unwrap();
+
+        get("install_extension")
+            .execute(json!({ "source": src.to_str().unwrap() }))
+            .await;
+
+        // The full crate name resolves to the installed package.
+        match get("enable_extension")
+            .execute(json!({ "name": "yolop-extension-logfire" }))
+            .await
+        {
+            ToolExecutionResult::Success(v) => assert_eq!(v["name"], json!("logfire")),
+            other => panic!("enable by crate name must work, got {other:?}"),
+        }
+        assert!(
+            settings
+                .snapshot()
+                .capability_overrides_for(&extension_capability_id("logfire"))
+                .iter()
+                .any(|(_, entry)| !entry.is_remove()),
+            "the override must be keyed by the installed name, not the crate name"
+        );
+
+        match get("disable_extension")
+            .execute(json!({ "name": "yolop-extension-logfire" }))
+            .await
+        {
+            ToolExecutionResult::Success(v) => assert_eq!(v["name"], json!("logfire")),
+            other => panic!("disable by crate name must work, got {other:?}"),
+        }
+
+        // And the conventional short name still works.
+        match get("enable_extension")
+            .execute(json!({ "name": "logfire" }))
+            .await
+        {
+            ToolExecutionResult::Success(v) => assert_eq!(v["name"], json!("logfire")),
+            other => panic!("enable by short name must work, got {other:?}"),
+        }
+
+        match get("remove_extension")
+            .execute(json!({ "name": "yolop-extension-logfire" }))
+            .await
+        {
+            ToolExecutionResult::Success(v) => assert_eq!(v["removed"], json!("logfire")),
+            other => panic!("remove by crate name must work, got {other:?}"),
+        }
+    }
+
+    /// Disabling a name that was never installed wrote a persisted override for
+    /// a package that does not exist and reported success, so a typo looked like
+    /// it had taken effect.
+    #[tokio::test]
+    async fn disable_rejects_a_name_that_was_never_installed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (cap, _settings, _ext_dir) = capability(tmp.path());
+        let tools = cap.management_tools();
+        let disable = tools
+            .iter()
+            .find(|t| t.name() == "disable_extension")
+            .unwrap();
+
+        match disable
+            .execute(json!({ "name": "totally-made-up-thing" }))
+            .await
+        {
+            ToolExecutionResult::ToolError(err) => {
+                assert!(err.contains("totally-made-up-thing"), "error was: {err}");
+            }
+            other => panic!("expected an error for an unknown extension, got {other:?}"),
+        }
+    }
+
+    /// An extension whose manifest no longer parses is skipped by discovery and
+    /// is precisely the one a user needs to switch off, so disable must still
+    /// accept it. This is why disable checks the directory rather than reusing
+    /// enable's stricter installed-check.
+    #[tokio::test]
+    async fn disable_still_works_for_a_package_with_a_broken_manifest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (cap, _settings, ext_dir) = capability(tmp.path());
+        let broken = ext_dir.join("brokenext");
+        std::fs::create_dir_all(&broken).unwrap();
+        std::fs::write(broken.join(MANIFEST_FILE), "{ not json").unwrap();
+        assert!(
+            discover_extensions(&ext_dir).is_empty(),
+            "the fixture must be undiscoverable for this test to mean anything"
+        );
+
+        let tools = cap.management_tools();
+        let disable = tools
+            .iter()
+            .find(|t| t.name() == "disable_extension")
+            .unwrap();
+
+        match disable.execute(json!({ "name": "brokenext" })).await {
+            ToolExecutionResult::Success(v) => assert_eq!(v["name"], json!("brokenext")),
+            other => panic!("disable must reach a broken package, got {other:?}"),
+        }
     }
 
     /// `uninstall` is the natural opposite of `install`, and clap answered it

--- a/src/extensions/store.rs
+++ b/src/extensions/store.rs
@@ -30,7 +30,7 @@ pub enum Source {
 }
 
 /// The crate-name prefix every published yolop extension carries.
-const CRATE_PREFIX: &str = "yolop-extension-";
+pub(crate) const CRATE_PREFIX: &str = "yolop-extension-";
 
 impl Source {
     /// Parse a user-supplied `<source>` argument.


### PR DESCRIPTION
## What changed

1. **Every by-name subcommand accepts the published crate name.** `install` already took `logfire`, `yolop-extension-logfire`, and `crates.io:yolop-extension-logfire` alike (#608), but a package installs under its *manifest* name, so `enable`, `disable`, `remove`, `reload`, `doctor`, and `secret set` only answered to `logfire`. Installing by the name printed on crates.io and then enabling by that same name failed with `no extension named `yolop-extension-logfire``.

2. **`disable` no longer reports success for a name that was never installed.** It wrote a persisted capability override for a package that does not exist, so a typo looked like it had taken effect.

## Why

Half the CLI accepted the crate name and the other half did not, and nothing in the output said which half you were in. `install yolop-extension-logfire` succeeds, `enable yolop-extension-logfire` fails, and the user has no way to guess that the package renamed itself to its manifest name in between.

## Before / After

```
before: $ yolop extensions install yolop-extension-logfire   -> {"installed": "logfire"}
        $ yolop extensions enable  yolop-extension-logfire   -> error: no extension named ...
        $ yolop extensions doctor  yolop-extension-logfire   -> error: no extension named ...
        $ yolop extensions disable yolop-extension-logfire   -> {"name": "yolop-extension-logfire", ...}  (!)
        $ yolop extensions disable totally-made-up-thing     -> {"enabled": false, ...}  (!)

after:  install / enable / disable / remove / doctor all resolve to "logfire"
        $ yolop extensions disable totally-made-up-thing     -> error: no extension named `totally-made-up-thing` ...
```

The two lines marked `(!)` are the false successes: `disable` accepted anything and persisted an override keyed to a name no package has.

## Risk

- Low. Resolution is conservative in both directions: the **literal name always wins**, so a package whose manifest really is `yolop-extension-foo` resolves to itself and is unaffected; an **unknown name is passed through untouched**, so errors still quote exactly what the user typed rather than a rewritten form.
- `scaffold` and `install` are excluded from resolution: the first names a package being created, the second parses its own source spec.
- The `disable` guard is deliberately **looser** than `enable`'s. An extension whose manifest no longer parses is skipped by `discover_extensions` and is precisely the one a user needs to switch off, so a package directory on disk, or an existing override to clear, is enough. Covered by its own test.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

- `by_name_subcommands_accept_the_published_crate_name` installs a package and drives `enable`, `disable`, and `remove` by the crate name, asserting each resolves to the installed name **and** that the persisted override is keyed by the installed name, not the crate name. Verified to fail before the fix.
- `disable_rejects_a_name_that_was_never_installed` covers the false success.
- `disable_still_works_for_a_package_with_a_broken_manifest` pins the intentional looseness, and asserts the fixture is genuinely undiscoverable so the test cannot pass vacuously.

Validation: `cargo fmt --check`, `cargo clippy --workspace --all-targets --features yolop-yep/schema -D warnings`, `cargo test --workspace --features yolop-yep/schema` (1,219 + 68 + smaller suites, zero failures), `validate_okf.py --check-links`, plus all five install spellings and the by-name subcommands exercised against the real published `yolop-extension-logfire`.

## Knowledge

- `knowledge/specs/extensions.md`: name resolution across subcommands, and why `disable` stays looser than `enable`.
- `knowledge/log.md`: entry for both fixes.

## Security

Reviewed against the threat-model categories in `.agents/skills/ship/SKILL.md`:

- **TM-TOOL**: resolution can only map a prefixed name onto a package that is **already installed and discoverable**; it never invents, substitutes, or widens a target. The literal name takes precedence, so an installed package can never be shadowed by another's crate name, and every operation keeps its existing approval gate. The `disable` guard removes a write, tightening rather than loosening the persisted-settings surface.
- **TM-FS**: the added filesystem access is one `is_dir` check under the extensions directory on the disable path.
- **TM-LLM**, **TM-BASH**, **TM-DEP**: not touched.

## Follow-ups

- **Unknown-subcommand errors still do not list the valid subcommands** (carried from #610).
- **`resolve_host_scope` mistakes a real `/workspace` directory for the display alias** (carried from #604).
- **LSP adoption** wants re-measuring under the deferral profile changed in #602.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DgAqzNcJf625uPKsZvddBx)_