### PR TITLE
chore(ci): stop Dependabot proposing unreleased Rust toolchains

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,13 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    ignore:
+      # dtolnay/rust-toolchain refs are Rust versions, not action releases, and
+      # the repository pre-creates branches for unreleased Rust (1.100.0 exists
+      # there while stable is 1.97.1), so Dependabot proposes toolchains rustup
+      # cannot download. The ref must instead track rust-toolchain.toml, which
+      # is pinned to the everruns MSRV; bump both together by hand.
+      - dependency-name: dtolnay/rust-toolchain
     groups:
       github-actions:
         update-types:

--- a/knowledge/specs/maintenance.md
+++ b/knowledge/specs/maintenance.md
@@ -95,6 +95,13 @@ Beyond the everruns family, dependency hygiene means:
 - duplicate transitive versions reviewed (`cargo tree --duplicates`), fix or note why unfixable
 - no unused direct dependencies; prefer narrow sub-crates over umbrella crates when only a slice is used
 
+The CI toolchain is not a dependency Dependabot can reason about. Every
+workflow's `dtolnay/rust-toolchain@<ref>` names a Rust version, not an action
+release, and that repository carries branches for Rust versions rustup cannot
+yet download. The ref must equal the `rust-toolchain.toml` channel, which
+tracks the everruns MSRV, so Dependabot ignores the action and both move by
+hand together.
+
 ## Binary Size
 
 Yolop ships as a single binary, so its size is a user-visible cost three times


### PR DESCRIPTION
## What changed

Dependabot no longer opens `github-actions` PRs for `dtolnay/rust-toolchain`.
The maintenance spec now records why that ref is hand-managed.

## Why

Dependabot opened #605 to move every workflow from
`dtolnay/rust-toolchain@1.94.0` to `@1.100.0`, and all seven Rust jobs failed at
toolchain install:

```
error: could not download nonexistent rust version `1.100.0-x86_64-unknown-linux-gnu`
```

Two facts make this update category structurally wrong rather than a one-off bad
version:

1. The ref names a **Rust version**, not an action release, and
   `dtolnay/rust-toolchain` pre-creates branches for unreleased Rust. Branches
   `1.98`, `1.99`, and `1.100` all exist today while
   `https://static.rust-lang.org/dist/channel-rust-stable.toml` reports stable as
   `1.97.1` and `channel-rust-1.100.0.toml` is a 404. Dependabot reads those
   branches as newer versions and will keep proposing toolchains rustup cannot
   download.
2. Even for a Rust version that does exist, the ref is not free to move. It has
   to equal the `rust-toolchain.toml` channel, which is pinned to the declared
   everruns MSRV (`1.94.0`). Bumping the action alone desynchronizes CI from the
   MSRV the crate claims to support.

#605 is closed as unmergeable rather than retargeted: there is no correct
version for Dependabot to pick here.

## Before / After

**Before** — #605, run 32314520254, seven jobs red:

```
Format + Clippy                     failure
Build + Tests + Offline Smoke       failure
Clippy + Tests (local-inference)    failure
Windows Build + Shell Smoke         failure
Sandbox Contract (ubuntu-latest)    failure
Sandbox Contract (macos-latest)     failure
Build with metal (both targets)     failure
```

**After** — no such PR is opened. The `github-actions` ecosystem keeps updating
every other action; only `dtolnay/rust-toolchain` is excluded.

Config parses to the intended shape:

```
"ignore": [ { "dependency-name": "dtolnay/rust-toolchain" } ]
```

No yolop behavior changes; this is CI metadata only.

## Risk

- Low
- The ignore is permanent, so a genuine MSRV bump must update
  `rust-toolchain.toml` and the nine workflow refs by hand. The comment in
  `dependabot.yml` and the maintenance spec both say so, which is the same
  manual step the MSRV pin already required.

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

No test: the change is Dependabot configuration, which has no yolop-side entry
point to drive. Evidence is the parsed config plus the reproduced CI failure it
prevents.

## Knowledge

`knowledge/specs/maintenance.md` § Dependency Discipline gains the CI-toolchain
rule: the action ref tracks `rust-toolchain.toml`, which tracks the everruns
MSRV, and both move by hand together.

## Security

No security-relevant code changes. Nothing in the diff touches the binary,
filesystem, shell, prompt construction, or capability registration; TM-FS,
TM-BASH, TM-LLM, and TM-TOOL are untouched. TM-DEP is the relevant category and
the change tightens it: it stops an automated source of unbuildable toolchain
refs from landing in CI, and adds no crate.

## Follow-ups

- The toolchain ref is duplicated across nine workflow files with no check that
  they agree with `rust-toolchain.toml`. A drift guard would make the manual
  bump safe, but it is a separate change with its own test surface.
- `cargo audit` on this tree reports RUSTSEC-2026-0258 (h2 0.4.15, unbounded
  empty DATA frames) and a yanked `everruns-http` 0.18.0. Both are dependency
  issues unrelated to this diff and are being handled separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_013gsNJkPkbBdcrRa6aT8hnQ)_