### PR TITLE
chore(deps): clear the h2 and lru RustSec advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -203,7 +203,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1838,7 +1838,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2130,7 +2130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3370,9 +3370,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4340,9 +4340,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -5020,7 +5020,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5418,7 +5418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6071,7 +6071,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6833,7 +6833,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6892,7 +6892,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7546,7 +7546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8029,7 +8029,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8062,7 +8062,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8072,7 +8072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9732,7 +9732,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

`h2` 0.4.15 to 0.4.17 and `lru` 0.18.1 to 0.18.2 in `Cargo.lock`. Both are
transitive; no manifest changes and no new crates.

## Why

`cargo audit` on `main` reports one vulnerability and one unsound warning, both
with a published fix:

- **RUSTSEC-2026-0258** (`h2` < 0.4.16, GHSA-q83h-524g-xf6h). h2 accepts and
  queues empty DATA frames without limit. If streams are not actively drained
  this grows memory unboundedly, or panics when the length overflows. It reaches
  yolop through `hyper` and `reqwest`, which is the transport under every
  provider client (`everruns-anthropic`, `everruns-host`, `everruns-http`,
  `everruns-platform`, the integrations), so the peer that can trigger it is any
  model or tool endpoint yolop talks to. Rated low severity upstream.
- **RUSTSEC-2026-0253** (`lru` < 0.18.2, unsound). `LruCache::pop()` is not
  panic-safe: if a stored key's `Drop` panics, `self.detach()` never runs and the
  internal linked list keeps dangling pointers, which a later eviction writes
  through. It arrives via `ratatui-core` 0.1.2.

## Before / After

**Before**, on `main`:

```
Crate:     h2
Version:   0.4.15
Title:     h2 unbounded empty DATA frames
ID:        RUSTSEC-2026-0258
Solution:  Upgrade to >=0.4.16

Crate:     lru
Version:   0.18.1
Warning:   unsound
Title:     Potential use-after-free due to lack of panic safety in `LruCache::pop()`
ID:        RUSTSEC-2026-0253

error: 1 vulnerability found!
warning: 6 allowed warnings found
```

**After**, on this branch:

```
warning: 5 allowed warnings found
```

No `error:` line, and the `lru` unsound entry is gone. The five that remain are
pre-existing informational warnings this PR does not address: `dlopen_derive`,
`fxhash`, `number_prefix`, and `paste` are unmaintained, and `everruns-http`
0.18.0 is yanked. See Follow-ups.

**The diff is larger than two lines; the extra churn is inert.** Comparing every
`name`/`version` pair in the lock before and after, exactly two entries differ:

```
< name = "h2"    version = "0.4.15"      > name = "h2"    version = "0.4.17"
< name = "lru"   version = "0.18.1"      > name = "lru"   version = "0.18.2"
```

The other 14 changed lines reassign which `windows-sys` a crate points at. That
set is unchanged, 0.48.0 / 0.52.0 / 0.59.0 / 0.60.2 / 0.61.2 both before and
after, because those crates declare open-ended requirements (`dirs-sys` 0.5.0
asks for `windows-sys >=0.59.0`) and re-resolution picks a different valid
assignment among versions already in the tree. Nothing is added, removed, or
newly compiled. It reproduces identically on cargo 1.94.0 (the pinned toolchain)
and 1.94.1.

## Risk

- Low
- Both bumps are patch releases within the existing compatibility range, so no
  API surface moves. The realistic failure mode is a behavior regression inside
  h2's frame handling, which CI's build and test jobs cover since every network
  call in the test suite goes through the same stack.

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

No test: the change is a lockfile version bump with no yolop-side entry point to
drive. The evidence that matters is the `cargo audit` transition above plus a
green CI, which builds with `--locked` and so proves the tree resolves and
compiles exactly as pinned here.

## Knowledge

No knowledge update required. `knowledge/specs/maintenance.md` § Dependency
Discipline already sets the bar this restores ("no known CVEs in the tree
(`cargo audit` when available, plus the repo's Dependabot alerts)"). This PR
brings the tree back to that bar rather than changing it.

## Security

TM-DEP is the relevant category and this change is entirely within it: it
removes a denial-of-service vector and a memory-corruption unsoundness from the
dependency tree, adds no crate, and grants no new capability.

The other categories are untouched, and the diff is a lockfile so none of them
can be reached from it: no filesystem code changes (TM-FS, the write blocklist
is unmodified), no shell execution changes (TM-BASH, the bounded execution model
in `tools.rs` is unmodified), no prompt construction or key handling changes
(TM-LLM), and no capability registration changes (TM-TOOL).

Reviewed for the standard classes: no injection surface (no new parsing of
untrusted input by yolop), no data exposure (nothing logged or persisted
changes), no trust-boundary validation removed. Resource exhaustion is the
category in play and it moves in the safe direction, since RUSTSEC-2026-0258 is
itself an unbounded-growth bug that 0.4.17 bounds.

## Follow-ups

- `everruns-http` 0.18.0 is **yanked and is the only published version**, which
  breaks the documented install path: `cargo install yolop --features metal` (as
  written in README) fails with `failed to select a version for the requirement
  everruns-http = "^0.18.0" ... version 0.18.0 is yanked`. Reproduced against a
  clean manifest. The real fix is upstream republishing; a separate PR follows to
  add `--locked` to the README install commands, which works because the
  published crate ships a lockfile. Not folded in here to keep this PR to the
  advisory bumps.
- Four unmaintained crates (`dlopen_derive`, `fxhash`, `number_prefix`, `paste`)
  remain as informational warnings. All are transitive with no drop-in
  replacement available from yolop's side; they need the intermediate crates to
  move first, so there is nothing actionable in this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_013gsNJkPkbBdcrRa6aT8hnQ)_