### PR TITLE
docs: pass --locked in the documented cargo install commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,13 @@ jobs:
             exit 1
           fi
 
+      - name: Documented installs are locked
+        run: |
+          if grep -R -n --include='*.md' 'cargo install yolop' README.md docs | grep -v -- '--locked'; then
+            echo "::error::Every documented 'cargo install yolop' must pass --locked so it resolves against the published lockfile."
+            exit 1
+          fi
+
   eval-analyzers:
     name: Eval analyzers (Python)
     needs: changes

--- a/README.md
+++ b/README.md
@@ -249,17 +249,17 @@ better-aimed model: its chat template emits tool calls as
 `<tool_call>`, so none of its tool calls would be understood.
 
 Weights live under `<data_dir>/yolop/models/`. The engine is compiled into the
-Homebrew and GitHub release binaries; a build from source needs `cargo install
-yolop --features local-inference`, which is much slower to compile. How well a
-local model actually drives the agent loop is the open question this is here to
-answer.
+Homebrew and GitHub release binaries; a build from source needs
+`cargo install yolop --locked --features local-inference`, which is much slower
+to compile. How well a local model actually drives the agent loop is the open
+question this is here to answer.
 
 Those builds run on the CPU. GPU acceleration needs a vendor toolchain, so it is
 a separate feature that implies `local-inference`:
 
 ```bash
-cargo install yolop --features metal   # macOS
-cargo install yolop --features cuda    # NVIDIA, needs the CUDA toolkit
+cargo install yolop --locked --features metal   # macOS
+cargo install yolop --locked --features cuda    # NVIDIA, needs the CUDA toolkit
 ```
 
 ### Git attribution


### PR DESCRIPTION
## What changed

The three `cargo install yolop` commands in README that omitted `--locked` now
pass it, matching the one at the top that already did. A `Docs boundary` step
keeps them in agreement.

## Why

`everruns-http` 0.18.0 is the **only** published version of that crate and it is
yanked. A fresh resolve of yolop's manifest therefore fails outright, which is
exactly what plain `cargo install yolop` does:

```
error: failed to select a version for the requirement `everruns-http = "^0.18.0"`
  version 0.18.0 is yanked
location searched: crates.io index
```

So the GPU and local-inference install lines could not work as written. The
published crate ships a `Cargo.lock` that already pins the yanked version, and
`--locked` uses it instead of re-resolving.

This is not only a workaround for the yank. `--locked` installs the dependency
set that CI actually tested, which is what a documented install command should
do; the yank is what turned a good default into a required one.

The same yank is breaking Dependabot's cargo updater on `main` (job 1534124498,
`dependency_file_not_resolvable` on `everruns-http`). That half needs an upstream
republish and is out of scope here; see Follow-ups.

## Before / After

Verified against the real artifact, `yolop-0.16.0.crate` downloaded from
crates.io, by resolving it both ways:

**Before** — no lockfile, i.e. what plain `cargo install` does:

```
$ cargo metadata --format-version 1
error: failed to select a version for the requirement `everruns-http = "^0.18.0"`
  version 0.18.0 is yanked
```

**After** — the lockfile the crate ships, i.e. what `--locked` uses:

```
$ cargo metadata --locked --format-version 1
RESOLVES OK
```

The guard was checked in both directions. Against the pre-fix README it fails and
names the offending lines:

```
261:cargo install yolop --features metal   # macOS
262:cargo install yolop --features cuda    # NVIDIA, needs the CUDA toolkit
```

Against this branch it passes, and all four documented commands now carry the flag:

```
README.md:34:source instead? `cargo install yolop --locked`.
README.md:253:`cargo install yolop --locked --features local-inference`, which is much slower
README.md:261:cargo install yolop --locked --features metal   # macOS
README.md:262:cargo install yolop --locked --features cuda    # NVIDIA, needs the CUDA toolkit
```

One prose sentence was reflowed so its command sits on a single line. That is
required for correctness of the guard, not cosmetic: the command previously wrapped
mid-phrase as `cargo install\nyolop --features local-inference`, which a
line-oriented grep cannot see, and it also makes the line copy-pasteable.

## Risk

- Low
- Docs and a CI check only; no yolop code changes. The guard could annoy a future
  author who wants to document an intentionally unlocked install, but that is the
  case worth stopping to think about, and the error message says why.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

The test is the `Documented installs are locked` step in the `Docs boundary` job.
It drives the real condition (grep over the shipped Markdown), and it was shown to
fail on the pre-fix content and pass on the fixed content rather than only
asserting that something still parses.

## Knowledge

No knowledge update required. This restores an existing bar rather than changing
policy: the install path is public-surface documentation governed by
`knowledge/specs/documentation.md`, and the dependency situation behind it is
already covered by § Dependency Discipline in `knowledge/specs/maintenance.md`.
Nothing about intent, architecture, or maintainer process changes.

## Security

No security-relevant code changes; the diff is one Markdown file and one CI step.

TM-FS, TM-BASH, TM-LLM, and TM-TOOL are untouched, and a docs/CI-metadata diff
cannot reach them: no filesystem or shell code, no prompt construction or key
handling, no capability registration. TM-DEP is adjacent and the change is
positive for it, since `--locked` makes an install reproduce the reviewed and
tested dependency set instead of silently re-resolving to whatever the index
offers at install time.

## Follow-ups

- `everruns-http` 0.18.0 being yanked with no replacement is the root cause and
  can only be fixed upstream by republishing (or by yolop dropping the
  dependency, which is used in exactly two places for
  `DirectEgressService`: `src/runtime/mod.rs` and `src/auth/mcp_oauth.rs`).
  Until then Dependabot's cargo ecosystem job keeps failing on `main`, so no
  cargo dependency PRs will be opened.
- Homebrew and the GitHub release binaries are unaffected, since they ship
  prebuilt and never re-resolve. Only source installs were broken.

---
_Generated by [Claude Code](https://claude.ai/code/session_013gsNJkPkbBdcrRa6aT8hnQ)_