### PR TITLE
fix(logfire): nest spans by the host's tree and emit the Gen-AI conventions

### DIFF
--- a/extensions/yolop-extension-logfire/src/exporter.rs
+++ b/extensions/yolop-extension-logfire/src/exporter.rs
@@ -4,11 +4,21 @@
 //! The lifecycle events are *already-completed* facts (a `*.started` then a
 //! terminal `*.completed`/`*.failed`), so we reconstruct spans with their real
 //! start/end timestamps via the tracer's `SpanBuilder` and parent context —
-//! rather than the usual "start a span, do work, end it" flow. One trace per
-//! **turn**: `turn.*` is the root span and `reason`/`act`/`tool`/`llm` spans
-//! nest under their turn's context. All work is best-effort: an unparseable or
-//! out-of-family event is skipped, never fatal.
+//! rather than the usual "start a span, do work, end it" flow.
+//!
+//! Hierarchy comes from the host, which already computes it: every event
+//! carries `context.parent_span_id`, so `llm.generation` nests under its
+//! `reason` span and `tool.*` under its `act` span. `turn.*` is the root and
+//! carries no span id of its own, so we mint one and its children name it by
+//! `turn_id`. Re-deriving parenting from `turn_id` alone, as this exporter
+//! once did, flattens every trace into one level.
+//!
+//! Attributes follow the Gen-AI semantic conventions (see [`crate::gen_ai`]),
+//! so the spans read the same as the ones the host's own OTel and Braintrust
+//! backends emit. All work is best-effort: an unparseable or out-of-family
+//! event is skipped, never fatal.
 
+use crate::gen_ai;
 use opentelemetry::trace::{Span, SpanKind, Status, TraceContextExt, Tracer};
 use opentelemetry::{Context, KeyValue};
 use opentelemetry_sdk::trace::{SdkTracer, SdkTracerProvider, Span as SdkSpan};
@@ -36,6 +46,13 @@ struct Parsed<'a> {
     data: &'a Value,
     event_type: &'a str,
     event_id: &'a str,
+    session_id: &'a str,
+    /// This event's own span id, absent on `turn.*`.
+    span_id: Option<&'a str>,
+    /// The parent the host computed. Equal to `turn_id` for a turn's direct
+    /// children, since the turn has no span id to name.
+    parent_span_id: Option<&'a str>,
+    turn_id: Option<&'a str>,
 }
 
 /// Folds events into OpenTelemetry spans emitted through `tracer`.
@@ -47,8 +64,12 @@ pub struct TraceExporter {
     /// Open spans keyed by `<family>:<correlation-id>`, closed on their
     /// terminal event.
     open: HashMap<String, SdkSpan>,
-    /// Parent context for a turn's children, keyed by turn id.
-    turn_cx: HashMap<String, Context>,
+    /// Span context by the id its children name it with: a span's own
+    /// `span_id`, and additionally the `turn_id` for a turn's minted root.
+    span_cx: HashMap<String, Context>,
+    /// Ids registered during a turn, so the whole trace's contexts are dropped
+    /// when the turn closes rather than accumulating for the session's life.
+    turn_ids: HashMap<String, Vec<String>>,
 }
 
 impl TraceExporter {
@@ -57,7 +78,8 @@ impl TraceExporter {
             tracer,
             _provider: provider,
             open: HashMap::new(),
-            turn_cx: HashMap::new(),
+            span_cx: HashMap::new(),
+            turn_ids: HashMap::new(),
         }
     }
 
@@ -88,13 +110,7 @@ impl TraceExporter {
             .with_start_time(parsed.ts)
             .with_attributes(attributes(parsed))
             .start_with_context(&self.tracer, &parent_cx);
-        // A turn is a root span; record its context so its children nest under it.
-        if parsed.family == "turn"
-            && let Some(turn) = turn_id(parsed.context)
-        {
-            let cx = Context::new().with_remote_span_context(span.span_context().clone());
-            self.turn_cx.insert(turn.to_string(), cx);
-        }
+        self.register_cx(parsed, &span);
         self.open.insert(correlation_key(parsed), span);
     }
 
@@ -118,15 +134,44 @@ impl TraceExporter {
             }
         }
         if parsed.family == "turn"
-            && let Some(turn) = turn_id(parsed.context)
+            && let Some(turn) = parsed.turn_id
+            && let Some(ids) = self.turn_ids.remove(turn)
         {
-            self.turn_cx.remove(turn);
+            for id in ids {
+                self.span_cx.remove(&id);
+            }
         }
     }
 
     fn point_span(&mut self, parsed: &Parsed) {
         let mut span = self.point(parsed);
         span.end_with_timestamp(parsed.ts);
+    }
+
+    /// Record a span's context under the ids its children will name it by, and
+    /// remember those ids so the turn can drop them when it ends.
+    fn register_cx(&mut self, parsed: &Parsed, span: &SdkSpan) {
+        let cx = Context::new().with_remote_span_context(span.span_context().clone());
+        let mut keys: Vec<String> = Vec::new();
+        if let Some(id) = parsed.span_id {
+            keys.push(id.to_string());
+        }
+        // The turn's root has no span id of its own; its children name it by
+        // `turn_id`, so register the root under that instead.
+        if parsed.family == "turn"
+            && let Some(turn) = parsed.turn_id
+        {
+            keys.push(turn.to_string());
+        }
+        for key in &keys {
+            self.span_cx.insert(key.clone(), cx.clone());
+        }
+        if let Some(turn) = parsed.turn_id {
+            self.turn_ids
+                .entry(turn.to_string())
+                .or_default()
+                .extend(keys);
+        }
     }
 
     /// Start a zero-duration span at the event's timestamp, parented to its turn.
@@ -140,14 +185,20 @@ impl TraceExporter {
             .start_with_context(&self.tracer, &parent_cx)
     }
 
-    /// Parent context: a turn is a root (empty context, new trace); a child
-    /// parents to its turn's span if that turn is open.
+    /// Parent context, taken from the hierarchy the host already computed.
+    ///
+    /// `parent_span_id` names either another span or, for a turn's direct
+    /// children, the turn by its `turn_id`. Falling back to the turn keeps a
+    /// child attached when its parent's `started` was missed, and a turn (or
+    /// an event whose parent is unknown) roots a new trace.
     fn parent_cx(&self, parsed: &Parsed) -> Context {
         if parsed.family == "turn" {
             return Context::new();
         }
-        turn_id(parsed.context)
-            .and_then(|t| self.turn_cx.get(t).cloned())
+        parsed
+            .parent_span_id
+            .and_then(|id| self.span_cx.get(id).cloned())
+            .or_else(|| parsed.turn_id.and_then(|t| self.span_cx.get(t).cloned()))
             .unwrap_or_default()
     }
 }
@@ -156,19 +207,19 @@ impl TraceExporter {
 // Parsing / naming / attributes (pure, unit-tested)
 
 fn parse(params: &yolop_yep::TraceEventParams) -> Option<Parsed<'_>> {
-    let (family, phase) = params
-        .event_type
-        .split_once('.')
-        .unwrap_or((params.event_type.as_str(), ""));
     let ts = ts_to_system_time(&params.ts)?;
     Some(Parsed {
-        family,
-        phase,
+        family: params.family(),
+        phase: params.phase(),
         ts,
         context: &params.context,
         data: &params.data,
         event_type: &params.event_type,
         event_id: &params.id,
+        session_id: &params.session_id,
+        span_id: params.span_id(),
+        parent_span_id: params.parent_span_id(),
+        turn_id: params.turn_id(),
     })
 }
 
@@ -178,10 +229,6 @@ fn ts_to_system_time(ts: &str) -> Option<SystemTime> {
         .ok()?
         .timestamp_nanos_opt()?;
     (nanos >= 0).then(|| UNIX_EPOCH + Duration::from_nanos(nanos as u64))
-}
-
-fn turn_id(context: &Value) -> Option<&str> {
-    context.get("turn_id").and_then(Value::as_str)
 }
 
 /// A stable per-span key so `started` and its terminal event coincide. Prefers
@@ -218,13 +265,113 @@ fn span_name(parsed: &Parsed) -> String {
     }
 }
 
-/// Span attributes: the concrete event type plus scalar `data` fields (token
-/// usage, model, tool name, exit code, …), namespaced under `yolop.`.
+/// The Gen-AI operation a family maps to, or `None` for families the spec has
+/// no operation for.
+fn operation_name(family: &str) -> Option<&'static str> {
+    match family {
+        "turn" => Some(gen_ai::operation::INVOKE_AGENT),
+        "reason" => Some(gen_ai::operation::REASON),
+        "act" => Some(gen_ai::operation::ACT),
+        "tool" => Some(gen_ai::operation::EXECUTE_TOOL),
+        "llm" => Some(gen_ai::operation::CHAT),
+        _ => None,
+    }
+}
+
+/// Gen-AI semantic-convention attributes for this event.
+///
+/// Without these the spans carried only a private `yolop.*` namespace, so a
+/// tracing UI that reads the conventions showed empty model, token, and cost
+/// fields. The LLM values live in `data.metadata`, which the generic `yolop.*`
+/// flattening skips because it is an object rather than a scalar.
+fn gen_ai_attributes(parsed: &Parsed) -> Vec<KeyValue> {
+    let mut attrs = Vec::new();
+    if let Some(op) = operation_name(parsed.family) {
+        attrs.push(KeyValue::new(gen_ai::OPERATION_NAME, op));
+    }
+    if !parsed.session_id.is_empty() {
+        attrs.push(KeyValue::new(
+            gen_ai::CONVERSATION_ID,
+            parsed.session_id.to_string(),
+        ));
+    }
+    if let Some(agent) = parsed.data.get("agent_id").and_then(Value::as_str) {
+        attrs.push(KeyValue::new(gen_ai::AGENT_ID, agent.to_string()));
+    }
+
+    if parsed.family == "tool" {
+        if let Some(name) = parsed
+            .data
+            .get("tool_name")
+            .or_else(|| parsed.data.get("name"))
+            .and_then(Value::as_str)
+        {
+            attrs.push(KeyValue::new(gen_ai::TOOL_NAME, name.to_string()));
+        }
+        if let Some(call) = parsed
+            .context
+            .get("tool_call_id")
+            .or_else(|| parsed.context.get("call_id"))
+            .and_then(Value::as_str)
+        {
+            attrs.push(KeyValue::new(gen_ai::TOOL_CALL_ID, call.to_string()));
+        }
+    }
+
+    let Some(metadata) = parsed.data.get("metadata") else {
+        return attrs;
+    };
+    if let Some(model) = metadata.get("model").and_then(Value::as_str) {
+        attrs.push(KeyValue::new(gen_ai::REQUEST_MODEL, model.to_string()));
+        attrs.push(KeyValue::new(gen_ai::RESPONSE_MODEL, model.to_string()));
+    }
+    if let Some(provider) = metadata.get("provider").and_then(Value::as_str) {
+        attrs.push(KeyValue::new(gen_ai::PROVIDER_NAME, provider.to_string()));
+        // Both spellings: UIs differ on which they read.
+        attrs.push(KeyValue::new(gen_ai::SYSTEM, provider.to_string()));
+    }
+    if let Some(reasons) = metadata.get("finish_reasons").and_then(Value::as_array) {
+        let reasons: Vec<opentelemetry::StringValue> = reasons
+            .iter()
+            .filter_map(Value::as_str)
+            .map(|r| r.to_string().into())
+            .collect();
+        if !reasons.is_empty() {
+            attrs.push(KeyValue::new(
+                gen_ai::RESPONSE_FINISH_REASONS,
+                opentelemetry::Value::Array(reasons.into()),
+            ));
+        }
+    }
+    if let Some(usage) = metadata.get("usage") {
+        for (field, key) in [
+            ("input_tokens", gen_ai::USAGE_INPUT_TOKENS),
+            ("output_tokens", gen_ai::USAGE_OUTPUT_TOKENS),
+            ("cache_read_tokens", gen_ai::USAGE_CACHE_READ_TOKENS),
+            ("cache_creation_tokens", gen_ai::USAGE_CACHE_CREATION_TOKENS),
+        ] {
+            if let Some(count) = usage.get(field).and_then(Value::as_i64) {
+                attrs.push(KeyValue::new(key, count));
+            }
+        }
+        // Cost has no Gen-AI convention, so it keeps the `yolop.` namespace.
+        // Emitted explicitly because it sits two levels deep, below the one
+        // level the generic flattening walks.
+        if let Some(cost) = usage.get("estimated_cost_usd").and_then(Value::as_f64) {
+            attrs.push(KeyValue::new("yolop.usage.estimated_cost_usd", cost));
+        }
+    }
+    attrs
+}
+
+/// Span attributes: the Gen-AI conventions, the concrete event type, plus
+/// scalar `data` fields (tool name, exit code, …) namespaced under `yolop.`.
 fn attributes(parsed: &Parsed) -> Vec<KeyValue> {
-    let mut attrs = vec![KeyValue::new(
+    let mut attrs = gen_ai_attributes(parsed);
+    attrs.push(KeyValue::new(
         "yolop.event_type",
         parsed.event_type.to_string(),
-    )];
+    ));
     if let Some(map) = parsed.data.as_object() {
         for (key, value) in map {
             let name = format!("yolop.{key}");
@@ -238,7 +385,29 @@ fn attributes(parsed: &Parsed) -> Vec<KeyValue> {
                     attrs.push(KeyValue::new(name, n.as_u64().unwrap() as i64))
                 }
                 Value::Number(n) => attrs.push(KeyValue::new(name, n.as_f64().unwrap_or(0.0))),
-                // Objects/arrays/null: skip, keeping attributes flat and cheap.
+                // One level of nesting, flattened: `metadata` holds the LLM
+                // model, durations, and cost, which were dropped entirely when
+                // objects were skipped outright.
+                Value::Object(nested) => {
+                    for (sub, value) in nested {
+                        let name = format!("{name}.{sub}");
+                        match value {
+                            Value::String(s) => attrs.push(KeyValue::new(name, s.clone())),
+                            Value::Bool(b) => attrs.push(KeyValue::new(name, *b)),
+                            Value::Number(n) if n.is_i64() => {
+                                attrs.push(KeyValue::new(name, n.as_i64().unwrap()))
+                            }
+                            Value::Number(n) if n.is_u64() => {
+                                attrs.push(KeyValue::new(name, n.as_u64().unwrap() as i64))
+                            }
+                            Value::Number(n) => {
+                                attrs.push(KeyValue::new(name, n.as_f64().unwrap_or(0.0)))
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                // Arrays/null: skip, keeping attributes flat and cheap.
                 _ => {}
             }
         }
@@ -270,6 +439,218 @@ mod tests {
             context: ctx,
             data,
         }
+    }
+
+    /// Context shapes copied from a real Anthropic session: the host computes
+    /// the tree, and `llm.generation` parents to its `reason` span rather than
+    /// straight to the turn. Re-deriving parenting from `turn_id` flattened
+    /// this, so every exported trace lost a level.
+    #[test]
+    fn the_hosts_span_tree_is_preserved_not_flattened() {
+        let (mut exp, mem) = exporter();
+        let reason_span = "01a01d59-fd57-7083-b7b4-a0c51beaf956";
+        let act_span = "01a01d5a-070b-7340-9c38-52256b2f1e7e";
+
+        exp.handle(&ev(
+            "turn.started",
+            "2024-01-01T00:00:00Z",
+            serde_json::json!({ "turn_id": "t1" }),
+            serde_json::json!({}),
+        ));
+        // reason parents to the turn, naming it by turn id (the turn has no
+        // span id of its own).
+        exp.handle(&ev(
+            "reason.started",
+            "2024-01-01T00:00:01Z",
+            serde_json::json!({
+                "turn_id": "t1", "span_id": reason_span, "parent_span_id": "t1"
+            }),
+            serde_json::json!({}),
+        ));
+        // The generation nests under reason.
+        exp.handle(&ev(
+            "llm.generation",
+            "2024-01-01T00:00:02Z",
+            serde_json::json!({
+                "turn_id": "t1", "span_id": "gen-1", "parent_span_id": reason_span
+            }),
+            serde_json::json!({ "metadata": { "model": "claude-opus-4-8" } }),
+        ));
+        exp.handle(&ev(
+            "reason.completed",
+            "2024-01-01T00:00:03Z",
+            serde_json::json!({
+                "turn_id": "t1", "span_id": reason_span, "parent_span_id": "t1"
+            }),
+            serde_json::json!({}),
+        ));
+        exp.handle(&ev(
+            "act.started",
+            "2024-01-01T00:00:04Z",
+            serde_json::json!({
+                "turn_id": "t1", "span_id": act_span, "parent_span_id": "t1"
+            }),
+            serde_json::json!({}),
+        ));
+        // The tool nests under act, not under the turn.
+        exp.handle(&ev(
+            "tool.started",
+            "2024-01-01T00:00:05Z",
+            serde_json::json!({
+                "turn_id": "t1", "span_id": "tool-1", "parent_span_id": act_span,
+                "tool_call_id": "c1"
+            }),
+            serde_json::json!({ "tool_name": "bash" }),
+        ));
+        exp.handle(&ev(
+            "tool.completed",
+            "2024-01-01T00:00:06Z",
+            serde_json::json!({
+                "turn_id": "t1", "span_id": "tool-1", "parent_span_id": act_span,
+                "tool_call_id": "c1"
+            }),
+            serde_json::json!({ "tool_name": "bash" }),
+        ));
+        exp.handle(&ev(
+            "act.completed",
+            "2024-01-01T00:00:07Z",
+            serde_json::json!({
+                "turn_id": "t1", "span_id": act_span, "parent_span_id": "t1"
+            }),
+            serde_json::json!({}),
+        ));
+        exp.handle(&ev(
+            "turn.completed",
+            "2024-01-01T00:00:08Z",
+            serde_json::json!({ "turn_id": "t1" }),
+            serde_json::json!({}),
+        ));
+
+        let spans = mem.get_finished_spans().expect("spans");
+        let by_name = |n: &str| {
+            spans
+                .iter()
+                .find(|s| s.name == n)
+                .unwrap_or_else(|| panic!("missing span {n}"))
+                .clone()
+        };
+        let turn = by_name("turn");
+        let reason = by_name("reason");
+        let act = by_name("act");
+        let tool = by_name("tool bash");
+        let llm = by_name("llm.generation");
+
+        assert_eq!(turn.parent_span_id, SpanId::INVALID, "turn is the root");
+        assert_eq!(reason.parent_span_id, turn.span_context.span_id());
+        assert_eq!(act.parent_span_id, turn.span_context.span_id());
+        assert_eq!(
+            llm.parent_span_id,
+            reason.span_context.span_id(),
+            "the generation belongs to its reason span, not the turn"
+        );
+        assert_eq!(
+            tool.parent_span_id,
+            act.span_context.span_id(),
+            "the tool call belongs to its act span, not the turn"
+        );
+        // Still one trace.
+        for span in [&reason, &act, &tool, &llm] {
+            assert_eq!(span.span_context.trace_id(), turn.span_context.trace_id());
+        }
+    }
+
+    /// The values a tracing UI reads. They live in `data.metadata`, which the
+    /// generic `yolop.*` flattening skipped as an object, so these fields
+    /// showed up empty.
+    #[test]
+    fn llm_generation_carries_the_gen_ai_conventions() {
+        let (mut exp, mem) = exporter();
+        exp.handle(&ev(
+            "llm.generation",
+            "2024-01-01T00:00:02Z",
+            serde_json::json!({ "turn_id": "t1", "span_id": "gen-1" }),
+            serde_json::json!({
+                "metadata": {
+                    "model": "claude-opus-4-8",
+                    "provider": "anthropic",
+                    "finish_reasons": ["tool_calls"],
+                    "usage": {
+                        "input_tokens": 2,
+                        "output_tokens": 69,
+                        "cache_read_tokens": 16089,
+                        "cache_creation_tokens": 0,
+                        "estimated_cost_usd": 0.0097795
+                    }
+                }
+            }),
+        ));
+
+        let spans = mem.get_finished_spans().expect("spans");
+        let span = spans.first().expect("one span");
+        let attr = |key: &str| {
+            span.attributes
+                .iter()
+                .find(|kv| kv.key.as_str() == key)
+                .map(|kv| kv.value.to_string())
+        };
+
+        assert_eq!(attr("gen_ai.operation.name").as_deref(), Some("chat"));
+        assert_eq!(
+            attr("gen_ai.request.model").as_deref(),
+            Some("claude-opus-4-8")
+        );
+        assert_eq!(
+            attr("gen_ai.response.model").as_deref(),
+            Some("claude-opus-4-8")
+        );
+        assert_eq!(attr("gen_ai.provider.name").as_deref(), Some("anthropic"));
+        assert_eq!(attr("gen_ai.system").as_deref(), Some("anthropic"));
+        assert_eq!(attr("gen_ai.usage.input_tokens").as_deref(), Some("2"));
+        assert_eq!(attr("gen_ai.usage.output_tokens").as_deref(), Some("69"));
+        assert_eq!(
+            attr("gen_ai.usage.cache_read_tokens").as_deref(),
+            Some("16089")
+        );
+        assert_eq!(attr("gen_ai.conversation.id").as_deref(), Some("sess-1"));
+        assert!(
+            attr("gen_ai.response.finish_reasons").is_some(),
+            "finish reasons must be recorded"
+        );
+        // Cost survives the one-level flattening rather than being dropped.
+        assert!(
+            attr("yolop.usage.estimated_cost_usd").is_some(),
+            "attributes were: {:?}",
+            span.attributes
+                .iter()
+                .map(|kv| kv.key.as_str().to_string())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// A tool span names the tool and its call id per the conventions.
+    #[test]
+    fn a_tool_span_carries_the_gen_ai_tool_attributes() {
+        let (mut exp, mem) = exporter();
+        exp.handle(&ev(
+            "tool.completed",
+            "2024-01-01T00:00:05Z",
+            serde_json::json!({ "turn_id": "t1", "tool_call_id": "call-42" }),
+            serde_json::json!({ "tool_name": "bash" }),
+        ));
+        let spans = mem.get_finished_spans().expect("spans");
+        let span = spans.first().expect("one span");
+        let attr = |key: &str| {
+            span.attributes
+                .iter()
+                .find(|kv| kv.key.as_str() == key)
+                .map(|kv| kv.value.to_string())
+        };
+        assert_eq!(
+            attr("gen_ai.operation.name").as_deref(),
+            Some("execute_tool")
+        );
+        assert_eq!(attr("gen_ai.tool.name").as_deref(), Some("bash"));
+        assert_eq!(attr("gen_ai.tool.call.id").as_deref(), Some("call-42"));
     }
 
     #[test]

--- a/extensions/yolop-extension-logfire/src/exporter.rs
+++ b/extensions/yolop-extension-logfire/src/exporter.rs
@@ -27,7 +27,22 @@ use std::collections::HashMap;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Paired families: a `started` opens a span, a terminal phase closes it.
-const PAIRED_FAMILIES: &[&str] = &["turn", "reason", "act", "tool"];
+const PAIRED_FAMILIES: &[&str] = &["turn", "reason", "act", "tool", "thinking"];
+
+/// Model-authored content, which spans never carry.
+///
+/// The Gen-AI conventions put prompts, completions, and reasoning behind an
+/// explicit content-capture opt-in, and this exporter has none: `thinking`
+/// holds the model's full chain-of-thought, so exporting it would put reasoning
+/// text into a tracing backend as a side effect of enabling the extension.
+fn is_model_content(key: &str) -> bool {
+    matches!(key, "thinking")
+}
+
+/// Families that are an agentic phase of a turn, and so own their `exec_id`.
+fn is_phase_family(family: &str) -> bool {
+    matches!(family, "reason" | "act" | "turn")
+}
 
 /// Terminal phases that close an open span (or, unpaired, emit a point span).
 fn is_terminal_phase(phase: &str) -> bool {
@@ -53,6 +68,7 @@ struct Parsed<'a> {
     /// children, since the turn has no span id to name.
     parent_span_id: Option<&'a str>,
     turn_id: Option<&'a str>,
+    exec_id: Option<&'a str>,
 }
 
 /// Folds events into OpenTelemetry spans emitted through `tracer`.
@@ -163,6 +179,16 @@ impl TraceExporter {
         {
             keys.push(turn.to_string());
         }
+        // A phase owns its `exec_id`, which is how a child that carries no
+        // `parent_span_id` of its own (thinking) finds the phase it belongs to.
+        // Only the phase may claim it: an exec groups the phase *and* its
+        // children (reason with llm, act with tool), so letting a child
+        // register would make it the exec's representative instead.
+        if is_phase_family(parsed.family)
+            && let Some(exec) = parsed.exec_id
+        {
+            keys.push(exec.to_string());
+        }
         for key in &keys {
             self.span_cx.insert(key.clone(), cx.clone());
         }
@@ -198,6 +224,14 @@ impl TraceExporter {
         parsed
             .parent_span_id
             .and_then(|id| self.span_cx.get(id).cloned())
+            // A child with no parent id of its own belongs to its exec's phase.
+            // Skipped for phases themselves, which own that exec id.
+            .or_else(|| {
+                (!is_phase_family(parsed.family))
+                    .then_some(parsed.exec_id)
+                    .flatten()
+                    .and_then(|e| self.span_cx.get(e).cloned())
+            })
             .or_else(|| parsed.turn_id.and_then(|t| self.span_cx.get(t).cloned()))
             .unwrap_or_default()
     }
@@ -208,9 +242,19 @@ impl TraceExporter {
 
 fn parse(params: &yolop_yep::TraceEventParams) -> Option<Parsed<'_>> {
     let ts = ts_to_system_time(&params.ts)?;
+    // `reason.thinking.*` is a span in its own right, nested inside its reason
+    // phase. Left as family `reason` with phase `thinking.started` it matched
+    // neither the `started` nor the terminal arm, so thinking was dropped.
+    let (family, phase) = match (params.family(), params.phase()) {
+        ("reason", rest) => match rest.strip_prefix("thinking.") {
+            Some(phase) => ("thinking", phase),
+            None => ("reason", rest),
+        },
+        (family, phase) => (family, phase),
+    };
     Some(Parsed {
-        family: params.family(),
-        phase: params.phase(),
+        family,
+        phase,
         ts,
         context: &params.context,
         data: &params.data,
@@ -220,6 +264,7 @@ fn parse(params: &yolop_yep::TraceEventParams) -> Option<Parsed<'_>> {
         span_id: params.span_id(),
         parent_span_id: params.parent_span_id(),
         turn_id: params.turn_id(),
+        exec_id: params.exec_id(),
     })
 }
 
@@ -274,6 +319,7 @@ fn operation_name(family: &str) -> Option<&'static str> {
         "act" => Some(gen_ai::operation::ACT),
         "tool" => Some(gen_ai::operation::EXECUTE_TOOL),
         "llm" => Some(gen_ai::operation::CHAT),
+        "thinking" => Some(gen_ai::operation::THINKING),
         _ => None,
     }
 }
@@ -374,6 +420,9 @@ fn attributes(parsed: &Parsed) -> Vec<KeyValue> {
     ));
     if let Some(map) = parsed.data.as_object() {
         for (key, value) in map {
+            if is_model_content(key) {
+                continue;
+            }
             let name = format!("yolop.{key}");
             match value {
                 Value::String(s) => attrs.push(KeyValue::new(name, s.clone())),
@@ -556,6 +605,112 @@ mod tests {
         // Still one trace.
         for span in [&reason, &act, &tool, &llm] {
             assert_eq!(span.span_context.trace_id(), turn.span_context.trace_id());
+        }
+    }
+
+    /// `reason.thinking.*` carries no span id of its own, only the `exec_id` of
+    /// the reason phase it belongs to. Left as family `reason` with phase
+    /// `thinking.started` it matched neither arm and was dropped entirely.
+    #[test]
+    fn thinking_becomes_a_span_nested_in_its_reason_phase() {
+        let (mut exp, mem) = exporter();
+        let reason_span = "reason-span-1";
+        let exec = "exec_1";
+
+        exp.handle(&ev(
+            "turn.started",
+            "2024-01-01T00:00:00Z",
+            serde_json::json!({ "turn_id": "t1" }),
+            serde_json::json!({}),
+        ));
+        exp.handle(&ev(
+            "reason.started",
+            "2024-01-01T00:00:01Z",
+            serde_json::json!({
+                "turn_id": "t1", "exec_id": exec,
+                "span_id": reason_span, "parent_span_id": "t1"
+            }),
+            serde_json::json!({}),
+        ));
+        // Exactly the shape the host emits: no span id, no parent id, just the
+        // exec it belongs to.
+        exp.handle(&ev(
+            "reason.thinking.started",
+            "2024-01-01T00:00:02Z",
+            serde_json::json!({ "turn_id": "t1", "exec_id": exec }),
+            serde_json::json!({ "model": "claude-opus-4-8" }),
+        ));
+        exp.handle(&ev(
+            "reason.thinking.completed",
+            "2024-01-01T00:00:03Z",
+            serde_json::json!({ "turn_id": "t1", "exec_id": exec }),
+            serde_json::json!({ "thinking": "secret chain of thought" }),
+        ));
+        // Close the phase so it is exported and can be compared against.
+        exp.handle(&ev(
+            "reason.completed",
+            "2024-01-01T00:00:04Z",
+            serde_json::json!({
+                "turn_id": "t1", "exec_id": exec,
+                "span_id": reason_span, "parent_span_id": "t1"
+            }),
+            serde_json::json!({}),
+        ));
+
+        let spans = mem.get_finished_spans().expect("spans");
+        let thinking = spans
+            .iter()
+            .find(|s| s.name == "thinking")
+            .expect("thinking must produce a span");
+        let reason = spans
+            .iter()
+            .find(|s| s.name == "reason")
+            .map(|s| s.span_context.span_id());
+
+        // Paired into one span with real duration, under its reason phase.
+        assert!(thinking.end_time > thinking.start_time);
+        assert_eq!(
+            Some(thinking.parent_span_id),
+            reason,
+            "thinking belongs to the reason phase it ran inside"
+        );
+        assert!(
+            thinking
+                .attributes
+                .iter()
+                .any(|kv| kv.key.as_str() == "gen_ai.operation.name"
+                    && kv.value.to_string() == "thinking")
+        );
+    }
+
+    /// Reasoning text is model-authored content, and the conventions put
+    /// content behind an opt-in this exporter does not have. Enabling the
+    /// extension must not ship chain-of-thought to a tracing backend.
+    #[test]
+    fn thinking_text_is_never_exported() {
+        let (mut exp, mem) = exporter();
+        exp.handle(&ev(
+            "reason.thinking.started",
+            "2024-01-01T00:00:02Z",
+            serde_json::json!({ "turn_id": "t1", "exec_id": "e1" }),
+            serde_json::json!({}),
+        ));
+        exp.handle(&ev(
+            "reason.thinking.completed",
+            "2024-01-01T00:00:03Z",
+            serde_json::json!({ "turn_id": "t1", "exec_id": "e1" }),
+            serde_json::json!({ "thinking": "secret chain of thought" }),
+        ));
+
+        let spans = mem.get_finished_spans().expect("spans");
+        for span in &spans {
+            for kv in &span.attributes {
+                assert!(
+                    !kv.value.to_string().contains("secret chain of thought"),
+                    "reasoning text leaked into attribute {}",
+                    kv.key.as_str()
+                );
+            }
         }
     }
 

--- a/extensions/yolop-extension-logfire/src/gen_ai.rs
+++ b/extensions/yolop-extension-logfire/src/gen_ai.rs
@@ -1,0 +1,57 @@
+//! Gen-AI semantic-convention attribute names, so exported spans agree with
+//! the host's own OpenTelemetry and Braintrust backends instead of inventing a
+//! private vocabulary a tracing UI cannot read.
+//!
+//! **Copied, not imported.** These names are defined upstream in
+//! `everruns-core`'s `telemetry::gen_ai` module (see that crate's
+//! `src/telemetry.rs`, and `everruns-host`'s `src/observability/otel.rs` for
+//! how the in-process listener applies them). Depending on `everruns-core` for
+//! a set of `&'static str` constants would pull ~29 transitive crates
+//! (tokio, jsonschema, tree-sitter, …) into this small extension binary, so
+//! the constants this exporter needs are duplicated here.
+//!
+//! The trade is explicit: a copy can drift from upstream. Re-check it against
+//! `everruns-core::telemetry::gen_ai` when bumping the everruns line.
+//!
+//! Source of truth for the conventions themselves:
+//! <https://opentelemetry.io/docs/specs/semconv/gen-ai/>
+
+/// The operation being performed, e.g. `chat`, `execute_tool`.
+pub const OPERATION_NAME: &str = "gen_ai.operation.name";
+/// Provider identifier, e.g. `anthropic`.
+pub const PROVIDER_NAME: &str = "gen_ai.provider.name";
+/// Provider identifier under the older convention spelling. Emitted alongside
+/// `PROVIDER_NAME` because UIs differ on which they read.
+pub const SYSTEM: &str = "gen_ai.system";
+/// Model requested.
+pub const REQUEST_MODEL: &str = "gen_ai.request.model";
+/// Model that actually served the request.
+pub const RESPONSE_MODEL: &str = "gen_ai.response.model";
+/// Why generation stopped.
+pub const RESPONSE_FINISH_REASONS: &str = "gen_ai.response.finish_reasons";
+/// Prompt tokens.
+pub const USAGE_INPUT_TOKENS: &str = "gen_ai.usage.input_tokens";
+/// Completion tokens.
+pub const USAGE_OUTPUT_TOKENS: &str = "gen_ai.usage.output_tokens";
+/// Tokens served from cache.
+pub const USAGE_CACHE_READ_TOKENS: &str = "gen_ai.usage.cache_read_tokens";
+/// Tokens written to cache (Anthropic).
+pub const USAGE_CACHE_CREATION_TOKENS: &str = "gen_ai.usage.cache_creation_tokens";
+/// Tool being executed.
+pub const TOOL_NAME: &str = "gen_ai.tool.name";
+/// Tool call identifier.
+pub const TOOL_CALL_ID: &str = "gen_ai.tool.call.id";
+/// Conversation or session identifier.
+pub const CONVERSATION_ID: &str = "gen_ai.conversation.id";
+/// Agent identifier.
+pub const AGENT_ID: &str = "gen_ai.agent.id";
+
+/// Operation names. The agentic-phase values (`reason`, `act`) are everruns
+/// extensions to the spec, matching the upstream listener.
+pub mod operation {
+    pub const CHAT: &str = "chat";
+    pub const EXECUTE_TOOL: &str = "execute_tool";
+    pub const INVOKE_AGENT: &str = "invoke_agent";
+    pub const REASON: &str = "reason";
+    pub const ACT: &str = "act";
+}

--- a/extensions/yolop-extension-logfire/src/gen_ai.rs
+++ b/extensions/yolop-extension-logfire/src/gen_ai.rs
@@ -54,4 +54,5 @@ pub mod operation {
     pub const INVOKE_AGENT: &str = "invoke_agent";
     pub const REASON: &str = "reason";
     pub const ACT: &str = "act";
+    pub const THINKING: &str = "thinking";
 }

--- a/extensions/yolop-extension-logfire/src/main.rs
+++ b/extensions/yolop-extension-logfire/src/main.rs
@@ -21,6 +21,7 @@
 //!   spans. Defaults to `yolop`.
 
 mod exporter;
+mod gen_ai;
 
 use exporter::TraceExporter;
 use opentelemetry::trace::TracerProvider as _;

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,22 @@
 # Knowledge Log
 
+## 2026-08-20, Logfire traces nest, and carry the Gen-AI conventions
+
+- [Extensions](specs/extensions.md): the bundled `logfire` exporter now parents
+  by `context.parent_span_id` instead of re-deriving a flat tree from
+  `turn_id`. Verified against a live Anthropic run and a local OTLP collector:
+  `turn` roots, `reason`/`act` hang off it, `llm.generation` sits under its
+  `reason`, and `tool` under its `act`.
+- Spans carry `gen_ai.*` attributes (operation, request/response model,
+  provider, finish reasons, input/output/cache token counts, conversation and
+  agent ids). They were empty because the values live in `data.metadata`, an
+  object the generic `yolop.*` flattening skipped.
+- The attribute names are copied from `everruns-core`'s `telemetry::gen_ai`
+  with the source cited, not imported: that crate carries ~29 transitive
+  dependencies, too much for a small extension binary. The copy can drift, so
+  re-check it when bumping the everruns line.
+- Cost has no convention and keeps the `yolop.` namespace.
+
 ## 2026-08-20, The trace payload already carries the host's span tree
 
 - [Extensions](specs/extensions.md): `trace/event` forwards the session event

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -16,6 +16,15 @@
   dependencies, too much for a small extension binary. The copy can drift, so
   re-check it when bumping the everruns line.
 - Cost has no convention and keeps the `yolop.` namespace.
+- `reason.thinking.*` becomes its own span under its reason phase. Its phase
+  (`thinking.started`) matched neither the started nor the terminal arm, so it
+  had been dropped outright. It carries no span id, only the `exec_id` of the
+  phase it ran in, so a phase now claims its exec id and a child without a
+  parent id resolves through it. Only phases may claim it: an exec groups the
+  phase and its children, so a child registering would displace the phase.
+- The reasoning text itself is never exported. The Gen-AI conventions put
+  content behind an opt-in this exporter does not have, so enabling the
+  extension must not ship chain-of-thought to a tracing backend.
 
 ## 2026-08-20, The trace payload already carries the host's span tree
 

--- a/knowledge/specs/extensions.md
+++ b/knowledge/specs/extensions.md
@@ -209,6 +209,14 @@ Attribute names are the Gen-AI semantic conventions, defined upstream in
 not depend on that crate, so an exporter copies the constants it needs and
 cites the source.
 
+The bundled `logfire` exporter is the worked example of that contract: it
+parents each span by `parent_span_id`, minting the root itself for `turn.*`,
+and labels spans with the Gen-AI semantic conventions so a tracing UI reads
+model, provider, token, and cache fields instead of showing them empty. The
+constants are copied into the extension with their upstream source cited rather
+than imported, since depending on `everruns-core` for a set of `&'static str`
+names would pull its whole dependency tree into a small extension binary.
+
 Trace forwarding has a teardown contract. `trace/event` is fire-and-forget and
 a server is `kill_on_drop`, so ending a session by dropping the runtime killed
 the child with the tail of the stream still in flight. `turn.completed` closes


### PR DESCRIPTION
## What changed

The bundled `logfire` exporter produced flat traces with empty model, token, and cost fields, and dropped thinking entirely. Three fixes.

1. **Parenting comes from the host.** Every event carries `context.parent_span_id`, but the exporter ignored it and re-derived parenting from `turn_id`, putting every span directly under the turn. It now parents by `parent_span_id`, so `llm.generation` sits under its `reason` span and `tool.*` under its `act` span. `turn.*` carries no span id of its own, so the exporter mints the root and registers it under `turn_id`, which is how its direct children name it. Registered contexts are dropped when their turn closes rather than accumulating for the session's life.

2. **Spans carry `gen_ai.*`.** Operation, request/response model, provider (both `gen_ai.provider.name` and `gen_ai.system`, since UIs differ on which they read), finish reasons, input/output/cache token counts, tool name and call id, conversation and agent ids. These were empty because the values live in `data.metadata`, an object the generic `yolop.*` flattening skipped outright; that flattening now walks one level of nesting too. Cost has no convention, so it keeps the `yolop.` namespace.

3. **`reason.thinking.*` becomes its own span.** Its phase is `thinking.started`, which matched neither the `started` nor the terminal arm, so thinking never produced a span at all. It is now a paired span nested in its reason phase, carrying the `thinking` operation.

## Why

`llm.generation` showed `gen_ai_request_model: null`, `gen_ai_usage_input_tokens: null`, and every other convention field null, while the trace itself was a flat list of siblings under `turn`. All of it was the exporter's doing, not the host's: the data was on the wire all along (#613).

## Before / After

Decoded from the OTLP protobuf a **live Anthropic run** posted to a local collector:

```
before:  turn
         ├── reason
         ├── llm.generation      (sibling of reason, not its child)
         ├── act
         └── tool                (sibling of act, not its child)
                                 (thinking absent entirely)

after:   turn  (ROOT)
         ├── reason
         │   ├── thinking
         │   └── llm.generation
         ├── act
         │   └── tool
         └── reason
             └── llm.generation
```

Attributes exported by that same run:

```
gen_ai.operation.name          gen_ai.request.model      gen_ai.usage.input_tokens
gen_ai.conversation.id         gen_ai.response.model     gen_ai.usage.output_tokens
gen_ai.agent.id                gen_ai.provider.name      gen_ai.usage.cache_read_tokens
gen_ai.tool.name               gen_ai.system             gen_ai.usage.cache_creation_tokens
gen_ai.response.finish_reasons                           yolop.usage.estimated_cost_usd
```

## How thinking is parented

Thinking events are the awkward case, and worth stating explicitly: they carry **no span id and no parent id**, only the `exec_id` of the phase they ran in. So a phase span now claims its `exec_id`, and a child without a parent id resolves through it.

Only phases may claim it. An exec groups the phase *and* its children — `reason` with `llm` and `output`, `act` with `tool` — so letting a child register would make the child the exec's representative instead of the phase. Verified against captured payloads before relying on it.

## Reasoning text is never exported

`reason.thinking.completed` carries the model's full chain-of-thought in `data.thinking`, which the generic `yolop.*` flattening would have exported verbatim. The Gen-AI conventions put prompts, completions, and reasoning behind an explicit content-capture opt-in, and this exporter has none. Exporting it would ship reasoning into a tracing backend as a side effect of enabling the extension, so it is excluded and a test asserts the text never appears in any attribute.

## On copying the constants

Copied from `everruns-core`'s `telemetry::gen_ai` **with the source cited**, not imported. That crate carries ~29 direct dependencies (tokio, jsonschema, tree-sitter, …), far too much to pull into a small extension binary for a handful of `&'static str` names. The module header records the trade explicitly — a copy can drift, and should be re-checked when bumping the everruns line — and points at both the upstream module and the [semconv spec](https://opentelemetry.io/docs/specs/semconv/gen-ai/). Only the constants this exporter actually uses are copied, which clippy enforces.

## Risk

- Moderate: the shape of every exported trace changes, and thinking spans are new. That is the point, but anything keyed to the old flat structure will see a different tree.
- Backward compatible with events that lack the ids: parenting falls back to the exec's phase, then the turn, so a child never becomes a stray root. The pre-existing tests, whose fixtures carry only `turn_id`, still pass unchanged.
- Existing `yolop.*` attributes are unchanged and still emitted; `gen_ai.*` is added alongside, so nothing reading the old namespace breaks. The one removal is `thinking`, deliberately.
- Memory is bounded: contexts registered during a turn are removed when it closes.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

Five new tests, with context shapes copied from a real session:

- `the_hosts_span_tree_is_preserved_not_flattened` drives a full turn and asserts each parent id, that the turn is the root, and that it stays one trace.
- `llm_generation_carries_the_gen_ai_conventions` asserts each attribute's value, including that cost survives.
- `a_tool_span_carries_the_gen_ai_tool_attributes` covers tool name and call id.
- `thinking_becomes_a_span_nested_in_its_reason_phase` uses the real no-span-id shape.
- `thinking_text_is_never_exported` scans every attribute of every span for the reasoning text.

Validation: `cargo fmt --check`, `cargo clippy --workspace --all-targets --features yolop-yep/schema -D warnings`, `cargo test --workspace --features yolop-yep/schema` (1,224 + 69 + 17 yolop-yep with the schema feature on so the drift guard runs + 9 logfire, zero failures), `validate_okf.py --check-links`. Plus two live runs: binary installed with `cargo install --locked --path`, real Anthropic sessions, protobuf decoded to confirm the tree, the attributes, and the absence of reasoning text.

## Knowledge

- `knowledge/specs/extensions.md`: the exporter as the worked example of the trace contract, and why the constants are copied rather than imported.
- `knowledge/log.md`: entry with the verified tree, the exec-id rule, and the content exclusion.

## Security

Reviewed against the threat-model categories in `.agents/skills/ship/SKILL.md`:

- **TM-LLM**: the substantive category. Attributes are built from ids, model/provider names, and numeric counts. `gen_ai.input.messages` / `output.messages` are deliberately **not** emitted, and the reasoning text is excluded outright with a test pinning it, so this change reduces what could reach a tracing backend rather than widening it.
- **TM-DEP**: no dependency added; copying the constants is what avoids one.
- **TM-TOOL**, **TM-BASH**, **TM-FS**: not touched.

## Follow-ups

- **`capabilityServer.args` resolves relative paths against the session cwd**, not the package directory (from #613).
- **`resolve_host_scope` mistakes a real `/workspace` directory for the display alias** (from #604).
- **Unknown-subcommand errors do not list the valid subcommands** (from #610).
