### PR TITLE
feat(models): serve a curated model list instead of a provider catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ yolop --provider llmsim -p "hi"         # offline demo, no API key required
 | OpenRouter | browser PKCE login or `OPENROUTER_API_KEY` | `openai/gpt-5.6-sol` |
 | Google     | `GEMINI_API_KEY` / `GOOGLE_API_KEY`   | `gemini-2.5-flash` |
 | Ollama     | `OLLAMA_BASE_URL` / `OLLAMA_API_KEY`  | `llama3.2`        |
-| Local (in-process) | none (weights pulled with `yolop models pull`) | `Qwen3-30B-A3B-Instruct` Q4 GGUF |
+| Local (in-process) | none (weights pulled with `yolop weights pull`) | `Qwen3-30B-A3B-Instruct` Q4 GGUF |
 | Custom     | `CUSTOM_BASE_URL` (+ optional `CUSTOM_API_KEY`) |, (set via `/setup`) |
 | llmsim     | none (offline simulator)              |, |
 
@@ -231,9 +231,9 @@ a turn never blocks on a download:
 
 ```bash
 M=unsloth/Qwen3-8B-GGUF::Qwen3-8B-Q4_K_M.gguf
-yolop models pull "$M"      # several GB, with progress
-yolop models list           # what is on disk, and how much
-yolop models rm "$M"        # reclaim it
+yolop weights pull "$M"     # several GB, with progress
+yolop weights list          # what is on disk, and how much
+yolop weights rm "$M"       # reclaim it
 yolop --provider local -m "$M"
 ```
 

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -28,6 +28,7 @@ and [`docs/`](../docs/); it must not link back into this internal bundle.
 - [Extensions](specs/extensions.md), installable capability packages.
 - [Hooks](specs/hooks.md), lifecycle automation.
 - [Memory](specs/memory.md), durable user personalization.
+- [Model list](specs/model-list.md), the cross-provider menu of models a session offers.
 - [Session history](specs/session-history.md), discovery of earlier sessions.
 - [Session coordination](specs/session-coordination.md), local coordinator and worker orchestration.
 - [Session titles](specs/session-titles.md), automatic conversation titles.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,25 @@
 # Knowledge Log
 
+## 2026-08-20, The model menu is a list, not a catalog
+
+- [Model list](specs/model-list.md): `/model`, the status bar, and ACP now serve
+  an ordered, cross-provider `[[models]]` list instead of a provider's whole
+  models API response. A user switches between a handful of models; nothing in
+  yolop used to know which handful.
+- Not "favourites" or "bookmarks". Those words describe marking items inside a
+  larger list you still browse. Here the list *is* the offer and the catalog is
+  the fallback, reachable from a "Browse all models…" row.
+- An entry pairs provider with model, so one selection switches both, and the
+  same weights through two accounts (direct, OpenRouter) are two entries.
+- Two keys split apart: `[[models]]` is the curated menu, `[default_models]` is
+  the per-provider memory that used to own the `models` name. A `models` table
+  in an existing file still reads as `default_models`.
+- Picking a model whose provider has no credential opens sign-in and then
+  applies that model, instead of showing a dead option (ACP) or a catalog (TUI).
+- Administration is `yolop models list|add|rm|move|use|reset` on the attached
+  control plane, following extensions rather than adding model tools. The
+  local-weights command it displaced became `yolop weights`.
+
 ## 2026-08-20, The trace payload already carries the host's span tree
 
 - [Extensions](specs/extensions.md): `trace/event` forwards the session event

--- a/knowledge/specs/acp.md
+++ b/knowledge/specs/acp.md
@@ -56,8 +56,12 @@ Yolop uses ACP's standard session configuration mechanism for model selection. `
 - a `model` select option in the standard `model` category;
 - a `reasoning_effort` select option in the standard `thought_level` category when the selected model supports reasoning levels.
 
-The model list contains only currently usable providers; a stale preference is
-never presented as a connected model. If the preferred provider is unusable,
+The `model` option serves the user's model list (see
+[`model-list.md`](./model-list.md)), not every model every credentialed provider
+advertises: an editor's model menu holds the handful a user switches between.
+Entries whose provider is not currently usable are filtered out, so a stale
+preference is never presented as a connected model, and an option value is
+`provider:model` so selecting one switches both. If the preferred provider is unusable,
 ACP starts with another usable provider and falls back to local `llmsim` when
 none is connected. Session creation therefore never fails only because a saved
 provider lost its credentials, while one-shot print mode remains fail-fast.

--- a/knowledge/specs/configuration.md
+++ b/knowledge/specs/configuration.md
@@ -40,7 +40,8 @@ Keys are addressed the way a human would name them:
 | Key                       | Type   | Meaning                                                        |
 |---------------------------|--------|----------------------------------------------------------------|
 | `default_provider`        | text   | Provider used when no `--provider` flag is given; takes precedence over env auto-detection. |
-| `models.<provider>`       | text   | Per-provider model spec, survives provider switches.           |
+| `models`                  | list   | The ordered, cross-provider `[[models]]` menu `/model` and ACP offer; edited with `yolop models` (see [Model list](model-list.md)). |
+| `default_models.<provider>` | text | Per-provider model spec, survives provider switches. Remembered state, not the menu. |
 | `tokens.<provider>`       | secret | Provider API token (owner-only on disk; env vars override). OpenRouter PKCE browser login stores the minted key as `tokens.openrouter`. |
 | `base_urls.<provider>`    | text   | Endpoint base URL (used by the `custom` provider).             |
 | `approval_mode`           | text   | Soft-approval paranoia level (`protective` / `normal` / `off`). |
@@ -112,7 +113,7 @@ precedence where read (credentials and `CUSTOM_BASE_URL`). ACP's standard
 `session/set_config_option` model and reasoning changes remain local to that ACP
 session.
 
-The profileable keys are `default_provider`, `models`, `base_urls`,
+The profileable keys are `default_provider`, `models`, `default_models`, `base_urls`,
 `approval_mode`, `approval_policy`, `sandbox_mode`, `worktrees`,
 `capabilities`, `capabilities_mode`, `mcp`, `mcp_mode`, `instructions`,
 `instructions_file`, and `skills_dir`. Credentials (`tokens`, `codex_auth`) and

--- a/knowledge/specs/conversational-control.md
+++ b/knowledge/specs/conversational-control.md
@@ -64,6 +64,7 @@ command, an overlay confirmation, or a next-run-only settings write fail this ba
 |---|---|---|
 | Reasoning effort | `set_reasoning_effort` | `/effort` overlay, `/setup effort` |
 | Model | `search_models` / `set_model` | `/model` overlay, `/setup model` |
+| Model list (the menu `/model` and ACP offer) | `yolop models …` (attached CLI) | `/model` overlay, `[[models]]` in settings |
 | Provider | `set_provider` | `/setup provider` |
 | Skills, list | `list_skills` (upstream) | system-prompt listing |
 | Skills, search (skills.sh) | `search_skills` |, |
@@ -84,7 +85,7 @@ Notes:
 - `set_config` is intentionally next-run for provider/model edits, it edits the
   settings file. The *live* equivalents are the `set_*` tools above.
 - **Attached administration is the deliberate exception to "a model-facing tool".**
-  Extension and coordination administration is reachable conversationally by
+  Extension, coordination, and model-list administration is reachable conversationally by
   running `yolop <subcommand> ...` in the foreground Bash tool, which the host
   attaches to the live session, rather than by tool schemas that would cost
   context every turn. It still meets the rest of this contract: live effect,

--- a/knowledge/specs/local-inference.md
+++ b/knowledge/specs/local-inference.md
@@ -169,13 +169,13 @@ settles.
 Weights live under `<data_dir>/yolop/models/`, one flat directory per repo
 (`/` → `__`). Yolop owns this directory instead of deferring to the engine's own
 cache, because an engine-managed cache leaves users with gigabytes they can
-neither see nor delete through yolop. `yolop models list` reports what is on
-disk and its size; `yolop models rm` reclaims it.
+neither see nor delete through yolop. `yolop weights list` reports what is on
+disk and its size; `yolop weights rm` reclaims it.
 
 **A turn never downloads.** The engine is capable of fetching its own weights,
 but it does so inside the first inference call — the turn appears to hang for
 several gigabytes with nothing on screen. Instead the driver loads only from the
-store and, when the weights are absent, fails immediately with the `yolop models
+store and, when the weights are absent, fails immediately with the `yolop weights
 pull` command that fixes it. The wait is explicit, has a progress bar, and
 happens where a progress bar can be drawn.
 

--- a/knowledge/specs/model-list.md
+++ b/knowledge/specs/model-list.md
@@ -1,0 +1,124 @@
+---
+type: Product Specification
+title: Model list
+description: Defines the model list contract for Yolop, the ordered cross-provider menu of models a session offers and switches between.
+---
+
+# Model list
+
+Status: v1 implemented.
+
+## Why
+
+Providers publish hundreds of models. Yolop used to answer "which model?" with a
+catalog: `/model` showed one provider's entire models API response, and ACP was
+offered every discovered model of every credentialed provider. A user switches
+between a handful, and none of the surfaces knew which handful.
+
+The model list is that handful, made explicit. It is the menu, not a decoration
+on top of one: the pickers and ACP serve *it*, and browsing a provider's full
+catalog is the path behind it rather than the default view.
+
+It is deliberately not called favourites or bookmarks. Those words describe
+marking items in a larger list you still browse; here the list *is* the offer,
+and the catalog is the exception.
+
+## What
+
+### One ordered, cross-provider list
+
+An entry names a provider **and** a model, plus an optional reasoning effort and
+display label. The pairing is the point: the same weights reached through a
+direct account and through OpenRouter are different entries, and selecting one
+switches provider and model together. Order is the user's and is preserved
+everywhere the list is shown.
+
+Stored as `[[models]]` in `settings.toml` (`crate::config::model_list`):
+
+```toml
+[[models]]
+provider = "openai"
+model = "gpt-5.6-sol"
+effort = "high"
+```
+
+An unset list means "never configured" and resolves to a built-in default menu
+led by `openai/gpt-5.6-sol`. The first edit materializes that default and
+appends to it, so a user never silently loses the entries they were using.
+Loading is tolerant like the rest of settings: an entry naming an unsupported
+provider or missing a model is skipped, never fatal.
+
+A profile may carry its own `[[models]]`, which replaces the global menu rather
+than merging into it: a profile that names a menu means "these models, for this
+job".
+
+### Surfaces
+
+| Surface | Behavior |
+|---|---|
+| `/model`, status-bar click | Opens the list. A trailing "Browse all models…" row falls through to the provider picker and that provider's catalog. |
+| `/model <id>` | Applies the entry directly when the id is on the list; otherwise the pre-list per-provider picker, as before. |
+| ACP `configOptions` | The `model` select option serves the list, filtered to entries whose provider is usable, plus the model in use. |
+| `yolop models …` | Shows and edits the list: `list`, `add`, `rm`, `move`, `use`, `reset`. |
+
+Credential filtering differs by surface on purpose. ACP hides entries whose
+provider has no credential, because an editor cannot run a login wizard and an
+unusable option is a dead end there. The TUI picker and `yolop models list` show
+them marked instead: picking a model you have not signed in to yet is a
+legitimate way to start using it, and hiding rows from the command that edits
+them is how a user loses track of their own list.
+
+### Selecting an unauthenticated model authenticates
+
+Picking a listed model whose provider has no credential is a request to use that
+model, so the TUI treats sign-in as part of the same gesture: it opens the
+provider's existing credential step, holds the picked entry, and applies it once
+authentication succeeds. Every credential path (token paste, environment,
+Codex and OpenRouter browser login, custom endpoint) funnels through one hop for
+this, so authentication lands on the model the user picked rather than dropping
+them in a catalog.
+
+### Administration is an attached CLI, not a tool
+
+`yolop models` is a `CliCapability` on the attached control plane, the same
+pattern extensions and session coordination use, and for the same reason: the
+agent can edit the list on request without the schemas costing prompt budget
+every turn. `list` is read-only; every other operation is consequential. `use`
+requires a live session and says so when invoked detached; editing works either
+way, because it is an ordinary settings write.
+
+Every mutation reads the resolved list, changes it, and writes the whole thing
+back, so ordering is explicit and there is one write path. `set_config` refuses
+`models` and points at the CLI rather than offering a second, weaker editor.
+
+A model reference resolves as `provider/model`, `provider:model`, or a bare
+model id when it names exactly one entry. Ambiguity is an error naming the
+candidate providers, never a guess: distinguishing one model across two
+providers is what the list is for.
+
+## Relationship to the per-provider default
+
+`[default_models]` (formerly `[models]` as a table) is remembered state: the
+last model chosen per provider, so a pick survives restarts and provider
+switches. The list is a menu the user curates. They are different concerns and
+now have different keys; a `models` *table* in an existing settings file or
+profile is still read as `default_models`.
+
+## Ownership boundary
+
+- `crate::config::model_list` owns the entry type, defaults, and TOML parsing.
+- `crate::capabilities::model_list` owns the capability, the `yolop models` CLI,
+  the credential filter (`offered_models`), and reference resolution.
+- `ModelState::model_options` (ACP) and `crate::tui::setup` (the picker) are
+  consumers; neither keeps its own idea of what is offered.
+- Live provider/model switching stays with `SetupController::change_provider`
+  (see [`conversational-control.md`](./conversational-control.md)); the list
+  calls it rather than reimplementing it.
+- Provider catalog discovery stays with `crate::capabilities::model_discovery`.
+
+## Related
+
+- [`configuration.md`](./configuration.md), the settings file and its schema.
+- [`conversational-control.md`](./conversational-control.md), the contract every
+  control surface inherits, including the attached-CLI exception.
+- [`acp.md`](./acp.md), per-session model selection over ACP.

--- a/src/bundled/system-skills/yolop-config/SKILL.md
+++ b/src/bundled/system-skills/yolop-config/SKILL.md
@@ -21,7 +21,7 @@ values are validated and persisted atomically.
    its meaning, type, default, examples, and current value. Secrets (API
    tokens) are shown only as `stored` / `unset`, never echoed.
 2. Call `get_config` with a single `key` (e.g. `default_provider`,
-   `models.anthropic`, `tokens.openai`) to focus on one entry.
+   `default_models.anthropic`, `tokens.openai`) to focus on one entry.
 3. For harness capabilities, use `get_config key=capabilities` (registered catalog,
    stored overrides, effective harness) or `get_config key=capabilities.<ref>`
    (per-capability schema metadata from `config_schema` / `config_ui_schema`).
@@ -30,16 +30,20 @@ Lead with `get_config` whenever you are unsure of the exact key name or the
 accepted values, the returned schema is the source of truth, so you never have
 to guess.
 
+The model list (`models`) is read here but edited with the `yolop models`
+command, not `set_config`, see "Model list" below.
+
 ## Change
 
 Call `set_config` with a `key` and a `value` for scalar settings:
 
 - `set_config key=default_provider value=anthropic`, the default provider when
   neither `--provider` nor an env credential forces a choice.
-- `set_config key=models.anthropic value="claude-sonnet-4-5"`, provider preference
-  model for the active provider. A per-provider pick wins over it.
-- `set_config key=models.openai value="gpt-5.5 high"`, remember a model for one
-  provider (survives provider switches). The spec is `model [reasoning-effort]`.
+- `set_config key=default_models.anthropic value="claude-sonnet-4-5"`, provider
+  preference model for the active provider. A per-provider pick wins over it.
+- `set_config key=default_models.openai value="gpt-5.5 high"`, remember a model
+  for one provider (survives provider switches). The spec is
+  `model [reasoning-effort]`.
 - `set_config key=tokens.anthropic value=…`, store an API token (owner-only on
   disk). Environment variables still override stored tokens.
 - `set_config key=base_urls.custom value=http://localhost:8000/v1`, endpoint
@@ -105,5 +109,20 @@ keys.
   exposed via the capability's `config_schema`, not a `settings.toml` key.
 - **Behavioral hooks** (block/allow/audit tool calls): use the `yolop-hooks`
   skill and the `hooks` capability tools.
+## Model list
+
+`models` is the ordered, cross-provider menu `/model`, the status bar, and ACP
+offer: the handful of models the user switches between, not every model a
+provider publishes. Edit it by running the CLI, which affects the live session:
+
+- `yolop models list`, show it (entries needing sign-in are marked)
+- `yolop models add <provider> <model> [--effort E] [--label L] [--position N]`
+- `yolop models rm <model>` / `yolop models move <model> <position>`
+- `yolop models use <model>`, switch this session (provider and model together)
+- `yolop models reset`, restore the built-in default list
+
+Reference a model as `provider/model`, or by its bare id when only one entry has
+it. `set_config` refuses `models` on purpose: the CLI is the one editor.
+
 - **Interactive provider/model setup**: the `/setup` command runs a guided
   wizard and switches the live model immediately.

--- a/src/bundled/system-skills/yolop/SKILL.md
+++ b/src/bundled/system-skills/yolop/SKILL.md
@@ -37,7 +37,7 @@ can also run them via `run_command` when the user asks in plain language.
 | `/mcp` | List configured MCP servers |
 | `/cwd` | Print the workspace root |
 | `/status [compact\|expanded\|toggle]` | Change session status bar layout (clicking the status bar toggles too) |
-| `/model [id]` | Open the model picker; an argument pre-fills selection |
+| `/model [id]` | Open the model list; an argument switches straight to a listed model |
 | `/effort [level]` | Open the reasoning-effort picker; an argument pre-fills selection |
 | `/clear` | Clear the transcript and re-show the startup banner |
 | `/shell <command>` | Run a shell command from the workspace root with bounded inline output |
@@ -58,6 +58,31 @@ path as `/shell` (handy for quick one-offs).
 
 User-invocable skills (for example `/yolop`, `/yolop-config`, `/skill-management`)
 also appear in the registry when installed.
+
+## The model list
+
+`/model` (and clicking the model in the status bar) opens your model list: an
+ordered, cross-provider menu of the models you switch between, spanning
+providers so one selection changes provider and model together. A "Browse all
+models…" row falls through to the old per-provider catalog for anything not on
+the list.
+
+Entries whose provider you have not signed in to are shown and marked; picking
+one runs that provider's sign-in first, then switches to the model you picked.
+
+Edit the list from a shell (it applies to the running session):
+
+```bash
+yolop models list
+yolop models add openrouter anthropic/claude-opus-4-8 --label "Opus (OpenRouter)"
+yolop models move claude-opus-4-8 1
+yolop models rm gpt-5.4-mini
+yolop models use gpt-5.6-sol
+yolop models reset          # back to the built-in default list
+```
+
+It is stored as `[[models]]` in `settings.toml`, so it can also be edited by
+hand. Unset means the built-in default list, led by `gpt-5.6-sol`.
 
 ## Keyboard shortcuts
 
@@ -104,6 +129,8 @@ viewport); there is no in-app page-up/page-down.
 | `Enter` | Confirm |
 | `Esc` | Cancel / go back |
 | `0`–`9` | Jump to numbered entry (where shown) |
+
+`/model` opens the model list; its last row browses a provider's full catalog.
 
 ## What yolop can do
 

--- a/src/capabilities/config.rs
+++ b/src/capabilities/config.rs
@@ -628,20 +628,28 @@ impl SetConfigTool {
                     "theme = {value}; applies to new interactive sessions"
                 )))
             }
+            // The list has one editor: `yolop models`, which validates
+            // provider/model pairs and owns ordering. A key/value setter here
+            // would be a second, weaker write path for the same file.
+            KeyTarget::Models => Err(
+                "the model list is edited with `yolop models add|rm|move|use`, not `set_config`; \
+                 run `yolop models list` to see it"
+                    .to_string(),
+            ),
             KeyTarget::Model(provider) => {
                 if clearing {
                     let existed = self.settings.clear_model(provider).map_err(map_err)?;
                     return Ok(saved(if existed {
-                        format!("cleared models.{provider}")
+                        format!("cleared default_models.{provider}")
                     } else {
-                        format!("models.{provider} was already unset")
+                        format!("default_models.{provider} was already unset")
                     }));
                 }
                 self.settings
                     .set_model(provider.clone(), value.to_string())
                     .map_err(map_err)?;
                 Ok(saved(format!(
-                    "models.{provider} = {value}; applies on the next run for that provider"
+                    "default_models.{provider} = {value}; applies on the next run for that provider"
                 )))
             }
             KeyTarget::Token(provider) => {
@@ -1045,8 +1053,8 @@ mod tests {
             .as_array()
             .expect("fields array")
             .iter()
-            .find(|f| f["key"] == "models")
-            .expect("models field present");
+            .find(|f| f["key"] == "default_models")
+            .expect("default_models field present");
         assert_eq!(models["current"]["openai"], "gpt-5.5");
         assert!(
             models["current"].get("frobnicate").is_none(),

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -561,6 +561,24 @@ impl ModelsCapability {
     }
 }
 
+/// Build the shared controller from the same handles `ModelsCapability` holds,
+/// for a sibling capability that must mutate the live provider/model through
+/// the one implementation rather than a second copy of it.
+pub(crate) fn setup_controller(
+    provider: Arc<RwLock<ProviderChoice>>,
+    provider_store: Arc<dyn RuntimeProviderStore>,
+    settings: Arc<SettingsStore>,
+    pending_model_choice: Arc<RwLock<Option<ProviderChoice>>>,
+) -> SetupController {
+    SetupController {
+        provider,
+        provider_store,
+        config: settings.clone(),
+        settings,
+        pending_model_choice,
+    }
+}
+
 /// Live provider/model/effort controller. Holds the same handles as
 /// [`ModelsCapability`] and owns every mutation (`change_provider`,
 /// `change_model`, `change_effort`, tokens, urls, attribution, approval). The
@@ -718,6 +736,15 @@ fn setup_command_arg() -> CommandArg {
 }
 
 impl SetupController {
+    /// The live provider/model selection, for surfaces that mark the current
+    /// entry (the model list, the status bar).
+    pub(crate) fn current_choice(&self) -> ProviderChoice {
+        self.provider
+            .read()
+            .expect("provider lock poisoned")
+            .clone()
+    }
+
     fn status_result(&self) -> CommandResult {
         let current = self
             .provider
@@ -762,7 +789,10 @@ impl SetupController {
     /// provider and model atomically — the wizard needs this for the custom
     /// provider, whose `/setup model` form would otherwise have no provider
     /// context to resolve against on first-time setup.
-    async fn change_provider(&self, raw: &str) -> everruns_provider::error::Result<CommandResult> {
+    pub(crate) async fn change_provider(
+        &self,
+        raw: &str,
+    ) -> everruns_provider::error::Result<CommandResult> {
         let mut parts = raw.splitn(2, char::is_whitespace);
         let name = parts.next().unwrap_or_default();
         let model_spec = parts.next().unwrap_or_default().trim();
@@ -1673,7 +1703,7 @@ mod tests {
             .await
             .expect("change model");
         let before = controller.settings.snapshot();
-        assert_eq!(before.models.get("openai"), None);
+        assert_eq!(before.default_models.get("openai"), None);
         assert_eq!(before.default_provider, None);
 
         let warning = SetupController::persist_pending_model_choice(
@@ -1683,7 +1713,7 @@ mod tests {
         assert!(warning.is_empty(), "unexpected warning: {warning}");
         let after = controller.settings.snapshot();
         assert_eq!(
-            after.models.get("openai").map(String::as_str),
+            after.default_models.get("openai").map(String::as_str),
             Some("gpt-5.4 none")
         );
         assert_eq!(after.default_provider.as_deref(), Some("openai"));

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -1588,15 +1588,16 @@ fn env_credential_present() -> bool {
         .any(|var| std::env::var(var).map(|v| !v.is_empty()).unwrap_or(false))
 }
 
+/// Controller scaffolding shared by the tests in this module and by
+/// `capabilities::model_list`, which drives the same live session through
+/// `yolop models use`.
 #[cfg(test)]
-mod tests {
+pub(crate) mod test_support {
     use super::*;
-
-    // ---------- live-config tools (set_model / set_provider / set_reasoning_effort) ----------
 
     /// Minimal provider store for controller tests: `change_*` only ever calls
     /// `set_default_model`, which we accept; the reads are never exercised here.
-    struct StubProviderStore;
+    pub(crate) struct StubProviderStore;
 
     #[async_trait::async_trait]
     impl everruns_core::ProviderStore for StubProviderStore {
@@ -1637,7 +1638,7 @@ mod tests {
     /// A controller wired to a temp settings file and the stub store, plus the
     /// shared provider handle so the test can observe live changes. The returned
     /// `TempDir` must be kept alive for the settings path to stay valid.
-    fn test_controller(
+    pub(crate) fn test_controller(
         provider: ProviderChoice,
     ) -> (
         SetupController,
@@ -1665,6 +1666,29 @@ mod tests {
         };
         (controller, provider, dir)
     }
+
+    /// As [`test_controller`], plus the settings handle, for a caller that must
+    /// write settings the controller then reads (the model list).
+    pub(crate) fn test_controller_with_settings(
+        provider: ProviderChoice,
+    ) -> (
+        SetupController,
+        Arc<RwLock<ProviderChoice>>,
+        Arc<SettingsStore>,
+        tempfile::TempDir,
+    ) {
+        let (controller, provider, dir) = test_controller(provider);
+        let settings = controller.settings.clone();
+        (controller, provider, settings, dir)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_support::test_controller;
+
+    // ---------- live-config tools (set_model / set_provider / set_reasoning_effort) ----------
 
     #[tokio::test]
     async fn set_reasoning_effort_tool_applies_live_and_validates() {

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -21,6 +21,7 @@ pub(crate) mod lsp;
 pub(crate) mod mcp;
 pub(crate) mod memory;
 pub(crate) mod model_discovery;
+pub(crate) mod model_list;
 pub(crate) mod model_ranking;
 pub(crate) mod model_runtime_context;
 pub(crate) mod narration;
@@ -65,6 +66,7 @@ pub(crate) use host::{
     MODELS_CAPABILITY_ID, ModelsCapability,
 };
 pub(crate) use lsp::LspCapability;
+pub(crate) use model_list::{ModelListCapability, offered_models};
 pub(crate) use model_runtime_context::{
     MODEL_RUNTIME_CONTEXT_CAPABILITY_ID, ModelRuntimeContextCapability,
 };

--- a/src/capabilities/model_list.rs
+++ b/src/capabilities/model_list.rs
@@ -705,6 +705,67 @@ mod tests {
         assert!(message.contains("between 1 and"), "{message}");
     }
 
+    /// The core promise of pairing provider with model: one selection moves
+    /// both. Drives the real `SetupController` an attached session holds, so
+    /// this covers `yolop models use` past the CLI envelope.
+    #[tokio::test]
+    async fn using_a_listed_model_switches_provider_and_model_on_the_live_session() {
+        use crate::capabilities::host::test_support::test_controller_with_settings;
+        use crate::runtime::ProviderChoice;
+
+        let (controller, provider, settings, _dir) =
+            test_controller_with_settings(ProviderChoice::OpenAi {
+                model: "gpt-5.5".to_string(),
+                reasoning_effort: None,
+            });
+        settings
+            .set_models(vec![
+                ModelEntry::new("openai", "gpt-5.5"),
+                ModelEntry::new("anthropic", "claude-opus-4-8"),
+            ])
+            .expect("write the model list");
+        let capability = ModelListCapability::new(settings, Some(controller));
+
+        let result = capability
+            .execute_action(&ModelListAction::Use {
+                model: "claude-opus-4-8".to_string(),
+            })
+            .await;
+        assert!(result.is_success(), "{result:?}");
+
+        let live = provider.read().expect("provider lock");
+        assert_eq!(live.provider_name(), "anthropic", "the provider switched");
+        assert_eq!(live.model_id(), "claude-opus-4-8", "and so did the model");
+    }
+
+    #[tokio::test]
+    async fn using_a_model_that_is_not_listed_is_refused_before_touching_the_session() {
+        use crate::capabilities::host::test_support::test_controller_with_settings;
+        use crate::runtime::ProviderChoice;
+
+        let (controller, provider, settings, _dir) =
+            test_controller_with_settings(ProviderChoice::OpenAi {
+                model: "gpt-5.5".to_string(),
+                reasoning_effort: None,
+            });
+        settings
+            .set_models(vec![ModelEntry::new("openai", "gpt-5.5")])
+            .expect("write the model list");
+        let capability = ModelListCapability::new(settings, Some(controller));
+
+        let result = capability
+            .execute_action(&ModelListAction::Use {
+                model: "claude-opus-4-8".to_string(),
+            })
+            .await;
+        assert!(result.is_error(), "{result:?}");
+        assert_eq!(
+            provider.read().expect("provider lock").model_id(),
+            "gpt-5.5",
+            "a refused switch leaves the session on its model"
+        );
+    }
+
     #[tokio::test]
     async fn switching_models_without_a_session_says_so_instead_of_failing_silently() {
         let (_dir, capability) = capability();

--- a/src/capabilities/model_list.rs
+++ b/src/capabilities/model_list.rs
@@ -1,0 +1,819 @@
+//! The model list: one ordered, cross-provider menu of the models a user
+//! actually switches between.
+//!
+//! Providers publish hundreds of models. Before this capability, `/model`
+//! showed one provider's whole catalog and ACP was offered every discovered
+//! model of every credentialed provider, which is a catalog, not a choice. The
+//! list is the choice: `[[models]]` in settings (see
+//! [`crate::config::model_list`]), served to the `/model` picker, the status
+//! bar, and ACP's `session/set_config_option` model options.
+//!
+//! Administration follows the attached-CLI pattern extensions and session
+//! coordination use (`knowledge/specs/conversational-control.md`): `yolop
+//! models ...` rather than model tools, so the agent can edit the list on
+//! request without the schemas costing prompt budget every turn. `use` reaches
+//! the live session through [`SetupController::change_provider`], the same call
+//! `/setup provider <name> <model>` makes, so switching provider and model
+//! together is atomic and has one implementation.
+
+use crate::capabilities::host::SetupController;
+use crate::capabilities::model_discovery::provider_is_usable;
+use crate::config::SettingsStore;
+use crate::config::model_list::{ModelEntry, default_models};
+use crate::control::{
+    CliCapability, ControlCapability, ControlRequest, ControlResponse, ControlRoute,
+};
+use crate::runtime::SUPPORTED_PROVIDERS;
+use async_trait::async_trait;
+use clap::{Args, CommandFactory, FromArgMatches, Parser, Subcommand};
+use everruns_core::{Capability, CapabilityStatus, ToolExecutionResult};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::sync::Arc;
+
+pub(crate) const MODEL_LIST_CAPABILITY_ID: &str = "model_list";
+
+/// A constant so the shared control-plane prompt block can be measured against
+/// the always-on prompt budget without constructing a session.
+pub(crate) const MODEL_LIST_CONTROL_ROUTE: ControlRoute = ControlRoute {
+    resource: "models",
+    cli_subcommand: "models",
+    read_only_operations: &["list"],
+    summary: "show, reorder, and edit the model list, and switch this session to one of its models",
+};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "models",
+    about = "Show and edit the model list yolop offers when switching models"
+)]
+struct ModelsCommandLine {
+    #[command(subcommand)]
+    command: ModelsCliCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum ModelsCliCommand {
+    /// Show the model list.
+    List {
+        /// Emit the full machine-readable result.
+        #[arg(long)]
+        json: bool,
+        /// Show only entries whose provider has a credential.
+        #[arg(long)]
+        connected: bool,
+    },
+    /// Add a model to the list.
+    Add(AddArgs),
+    /// Remove a model from the list.
+    Rm {
+        /// `provider/model`, `provider:model`, or a model id unique in the list.
+        model: String,
+    },
+    /// Move a model to a different position (1-based).
+    Move {
+        /// `provider/model`, `provider:model`, or a model id unique in the list.
+        model: String,
+        /// New 1-based position.
+        position: usize,
+    },
+    /// Switch this session to a model on the list, provider included.
+    Use {
+        /// `provider/model`, `provider:model`, or a model id unique in the list.
+        model: String,
+    },
+    /// Restore the built-in default list.
+    Reset,
+}
+
+#[derive(Args, Debug)]
+struct AddArgs {
+    /// Provider the model is reached through.
+    provider: String,
+    /// Provider-relative model id (`gpt-5.6-sol`, `anthropic/claude-opus-4-8`).
+    model: String,
+    /// Reasoning effort to apply with this entry.
+    #[arg(long)]
+    effort: Option<String>,
+    /// Display name shown instead of `provider/model`.
+    #[arg(long)]
+    label: Option<String>,
+    /// 1-based position to insert at (default: end of the list).
+    #[arg(long)]
+    position: Option<usize>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub(crate) enum ModelListAction {
+    List {
+        json: bool,
+        /// Show only entries whose provider has a credential. The listing
+        /// otherwise shows every entry, marking the ones needing sign-in:
+        /// hiding a row from the command that edits it is how a user loses
+        /// track of their own list. The credential filter belongs to the
+        /// *offered* menu (`offered_models`), not to this listing.
+        connected: bool,
+    },
+    Add {
+        provider: String,
+        model: String,
+        effort: Option<String>,
+        label: Option<String>,
+        position: Option<usize>,
+    },
+    Rm {
+        model: String,
+    },
+    Move {
+        model: String,
+        position: usize,
+    },
+    Use {
+        model: String,
+    },
+    Reset,
+}
+
+impl ModelListAction {
+    fn request(&self) -> ControlRequest {
+        ControlRequest::new(MODEL_LIST_CONTROL_ROUTE.resource, self)
+            .expect("model list action serializes")
+    }
+}
+
+impl From<ModelsCliCommand> for ModelListAction {
+    fn from(command: ModelsCliCommand) -> Self {
+        match command {
+            ModelsCliCommand::List { json, connected } => Self::List { json, connected },
+            ModelsCliCommand::Add(args) => Self::Add {
+                provider: args.provider,
+                model: args.model,
+                effort: args.effort,
+                label: args.label,
+                position: args.position,
+            },
+            ModelsCliCommand::Rm { model } => Self::Rm { model },
+            ModelsCliCommand::Move { model, position } => Self::Move { model, position },
+            ModelsCliCommand::Use { model } => Self::Use { model },
+            ModelsCliCommand::Reset => Self::Reset,
+        }
+    }
+}
+
+pub(crate) struct ModelListCapability {
+    settings: Arc<SettingsStore>,
+    /// Present only when the capability runs inside a live session. The
+    /// detached CLI can edit the list (an ordinary global-settings write) but
+    /// cannot switch a session that does not exist.
+    controller: Option<SetupController>,
+}
+
+impl ModelListCapability {
+    pub(crate) fn new(settings: Arc<SettingsStore>, controller: Option<SetupController>) -> Self {
+        Self {
+            settings,
+            controller,
+        }
+    }
+
+    /// Resolve a user-supplied model reference against the list.
+    ///
+    /// Accepts `provider/model`, `provider:model`, or a bare model id when it
+    /// names exactly one entry — ambiguity is an error rather than a guess,
+    /// because the whole point of the list is that one model can be reachable
+    /// through more than one provider.
+    fn find(models: &[ModelEntry], reference: &str) -> Result<usize, String> {
+        let reference = reference.trim();
+        if reference.is_empty() {
+            return Err("name a model from the list; run `yolop models list`".to_string());
+        }
+        let qualified = |entry: &ModelEntry| {
+            let key = entry.key();
+            reference == key || reference == format!("{}/{}", entry.provider, entry.model)
+        };
+        if let Some(index) = models.iter().position(qualified) {
+            return Ok(index);
+        }
+        let matches: Vec<usize> = models
+            .iter()
+            .enumerate()
+            .filter(|(_, entry)| entry.model == reference)
+            .map(|(index, _)| index)
+            .collect();
+        match matches.as_slice() {
+            [index] => Ok(*index),
+            [] => Err(format!(
+                "`{reference}` is not on the model list; run `yolop models list`, or add it with `yolop models add <provider> {reference}`"
+            )),
+            _ => {
+                let providers: Vec<&str> = matches
+                    .iter()
+                    .map(|index| models[*index].provider.as_str())
+                    .collect();
+                Err(format!(
+                    "`{reference}` is on the list for {}; qualify it as `<provider>/{reference}`",
+                    providers.join(" and ")
+                ))
+            }
+        }
+    }
+
+    fn entry_json(&self, entry: &ModelEntry, index: usize, usable: bool, current: bool) -> Value {
+        json!({
+            "position": index + 1,
+            "provider": entry.provider,
+            "model": entry.model,
+            "effort": entry.effort,
+            "label": entry.label,
+            "display": entry.display(),
+            "connected": usable,
+            "current": current,
+        })
+    }
+
+    fn current_key(&self) -> Option<String> {
+        let controller = self.controller.as_ref()?;
+        let choice = controller.current_choice();
+        Some(format!("{}:{}", choice.provider_name(), choice.model_id()))
+    }
+
+    fn list_value(&self, all: bool) -> Value {
+        let settings = self.settings.snapshot();
+        let current = self.current_key();
+        let models = settings.model_list();
+        let entries: Vec<Value> = models
+            .iter()
+            .enumerate()
+            .map(|(index, entry)| {
+                let usable = provider_is_usable(&settings, &entry.provider);
+                let is_current = current.as_deref() == Some(entry.key().as_str());
+                (entry, index, usable, is_current)
+            })
+            .filter(|(_, _, usable, is_current)| all || *usable || *is_current)
+            .map(|(entry, index, usable, is_current)| {
+                self.entry_json(entry, index, usable, is_current)
+            })
+            .collect();
+        json!({
+            "models": entries,
+            "configured": !settings.models.is_empty(),
+            "hidden": models.len() - entries.len(),
+        })
+    }
+
+    /// Read the list, change it, write the whole thing back. Every mutation
+    /// goes through here so ordering is explicit and there is one write path.
+    fn write(&self, models: Vec<ModelEntry>) -> Result<(), String> {
+        self.settings
+            .set_models(models)
+            .map_err(|err| format!("could not save the model list: {err}"))
+    }
+
+    pub(crate) async fn execute_action(&self, action: &ModelListAction) -> ToolExecutionResult {
+        let mut models = self.settings.snapshot().model_list();
+        match action {
+            ModelListAction::List { connected, .. } => {
+                ToolExecutionResult::Success(self.list_value(!*connected))
+            }
+            ModelListAction::Add {
+                provider,
+                model,
+                effort,
+                label,
+                position,
+            } => {
+                let provider = provider.trim();
+                if !SUPPORTED_PROVIDERS.contains(&provider) {
+                    return ToolExecutionResult::tool_error(format!(
+                        "unknown provider `{provider}`; expected one of {}",
+                        SUPPORTED_PROVIDERS.join(", ")
+                    ));
+                }
+                let model = model.trim();
+                if model.is_empty() {
+                    return ToolExecutionResult::tool_error("model id is required");
+                }
+                let entry = ModelEntry {
+                    provider: provider.to_string(),
+                    model: model.to_string(),
+                    effort: effort.clone(),
+                    label: label.clone(),
+                };
+                // Adding a model already on the list updates it in place rather
+                // than growing a duplicate row in the picker.
+                if let Some(existing) = models.iter_mut().find(|item| item.key() == entry.key()) {
+                    *existing = entry.clone();
+                } else {
+                    let at = position
+                        .map(|position| position.saturating_sub(1).min(models.len()))
+                        .unwrap_or(models.len());
+                    models.insert(at, entry.clone());
+                }
+                if let Err(error) = self.write(models) {
+                    return ToolExecutionResult::tool_error(error);
+                }
+                ToolExecutionResult::Success(json!({
+                    "added": entry.display(),
+                    "models": self.list_value(true)["models"],
+                }))
+            }
+            ModelListAction::Rm { model } => {
+                let index = match Self::find(&models, model) {
+                    Ok(index) => index,
+                    Err(error) => return ToolExecutionResult::tool_error(error),
+                };
+                let removed = models.remove(index);
+                if let Err(error) = self.write(models) {
+                    return ToolExecutionResult::tool_error(error);
+                }
+                ToolExecutionResult::Success(json!({
+                    "removed": removed.display(),
+                    "models": self.list_value(true)["models"],
+                }))
+            }
+            ModelListAction::Move { model, position } => {
+                let index = match Self::find(&models, model) {
+                    Ok(index) => index,
+                    Err(error) => return ToolExecutionResult::tool_error(error),
+                };
+                if *position == 0 || *position > models.len() {
+                    return ToolExecutionResult::tool_error(format!(
+                        "position must be between 1 and {}",
+                        models.len()
+                    ));
+                }
+                let entry = models.remove(index);
+                models.insert(position - 1, entry.clone());
+                if let Err(error) = self.write(models) {
+                    return ToolExecutionResult::tool_error(error);
+                }
+                ToolExecutionResult::Success(json!({
+                    "moved": entry.display(),
+                    "position": position,
+                    "models": self.list_value(true)["models"],
+                }))
+            }
+            ModelListAction::Use { model } => {
+                let index = match Self::find(&models, model) {
+                    Ok(index) => index,
+                    Err(error) => return ToolExecutionResult::tool_error(error),
+                };
+                let entry = &models[index];
+                let Some(controller) = &self.controller else {
+                    return ToolExecutionResult::tool_error(
+                        "switching models requires a running Yolop session; invoke `yolop models use` through that session's foreground Bash",
+                    );
+                };
+                // One implementation: this is exactly what `/setup provider
+                // <name> <model> [effort]` does, so provider and model switch
+                // together and persist the same way.
+                let result = controller
+                    .change_provider(&format!("{} {}", entry.provider, entry.spec()))
+                    .await;
+                match result {
+                    Ok(command) if command.success => ToolExecutionResult::Success(json!({
+                        "using": entry.display(),
+                        "detail": command.message,
+                    })),
+                    Ok(command) => ToolExecutionResult::tool_error(command.message),
+                    Err(error) => ToolExecutionResult::tool_error(error.to_string()),
+                }
+            }
+            ModelListAction::Reset => {
+                if let Err(error) = self.write(Vec::new()) {
+                    return ToolExecutionResult::tool_error(error);
+                }
+                ToolExecutionResult::Success(json!({
+                    "reset": true,
+                    "models": self.list_value(true)["models"],
+                }))
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl Capability for ModelListCapability {
+    fn id(&self) -> &str {
+        MODEL_LIST_CAPABILITY_ID
+    }
+    fn name(&self) -> &str {
+        "Model List"
+    }
+    fn description(&self) -> &str {
+        "The ordered, cross-provider list of models this session offers and switches between."
+    }
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+    fn category(&self) -> Option<&str> {
+        Some("Examples")
+    }
+}
+
+#[async_trait]
+impl ControlCapability for ModelListCapability {
+    fn control_route(&self) -> ControlRoute {
+        MODEL_LIST_CONTROL_ROUTE
+    }
+    async fn execute_control(&self, action: &Value) -> ToolExecutionResult {
+        match serde_json::from_value::<ModelListAction>(action.clone()) {
+            Ok(action) => self.execute_action(&action).await,
+            Err(error) => {
+                ToolExecutionResult::tool_error(format!("invalid model list action: {error}"))
+            }
+        }
+    }
+    fn render_control(&self, action: &Value, response: &ControlResponse) -> String {
+        serde_json::from_value::<ModelListAction>(action.clone())
+            .map(|action| render_response(&action, response))
+            .unwrap_or_else(|_| response.render_default())
+    }
+}
+
+#[async_trait]
+impl CliCapability for ModelListCapability {
+    fn cli_command(&self) -> clap::Command {
+        ModelsCommandLine::command()
+    }
+    fn control_request_from_cli(
+        &self,
+        matches: &clap::ArgMatches,
+    ) -> anyhow::Result<ControlRequest> {
+        let parsed = ModelsCommandLine::from_arg_matches(matches)?;
+        Ok(ModelListAction::from(parsed.command).request())
+    }
+    async fn execute_cli(&self, request: &ControlRequest) -> anyhow::Result<()> {
+        let action = serde_json::from_value::<ModelListAction>(request.action.clone())?;
+        // Editing the list is a global-settings write and works detached;
+        // only switching the live session needs a session to switch.
+        if matches!(action, ModelListAction::Use { .. }) {
+            anyhow::bail!(
+                "switching models requires a running Yolop session; invoke the command directly through that session's foreground Bash"
+            );
+        }
+        let response = ControlResponse::from_tool_result(self.execute_action(&action).await);
+        let rendered = self.render_control(&request.action, &response);
+        if response.ok {
+            println!("{rendered}");
+            Ok(())
+        } else {
+            anyhow::bail!(rendered)
+        }
+    }
+}
+
+fn render_response(action: &ModelListAction, response: &ControlResponse) -> String {
+    if !response.ok {
+        return response.render_default();
+    }
+    let value = response.value.as_ref().unwrap_or(&Value::Null);
+    if let ModelListAction::List { json: true, .. } = action {
+        return response.render_default();
+    }
+    let Some(models) = value.get("models").and_then(Value::as_array) else {
+        return response.render_default();
+    };
+    let mut lines = Vec::new();
+    match action {
+        ModelListAction::List { .. } => {}
+        ModelListAction::Add { .. } => lines.push(format!(
+            "added {}",
+            value["added"].as_str().unwrap_or("model")
+        )),
+        ModelListAction::Rm { .. } => lines.push(format!(
+            "removed {}",
+            value["removed"].as_str().unwrap_or("model")
+        )),
+        ModelListAction::Move { .. } => lines.push(format!(
+            "moved {} to {}",
+            value["moved"].as_str().unwrap_or("model"),
+            value["position"].as_u64().unwrap_or_default()
+        )),
+        ModelListAction::Use { .. } => {
+            return format!("using {}", value["using"].as_str().unwrap_or("model"));
+        }
+        ModelListAction::Reset => lines.push("restored the default model list".to_string()),
+    }
+    if models.is_empty() {
+        lines.push(
+            "No models listed. Add one with `yolop models add <provider> <model>`.".to_string(),
+        );
+        return lines.join("\n");
+    }
+    for entry in models {
+        let marker = if entry["current"].as_bool().unwrap_or(false) {
+            "*"
+        } else {
+            " "
+        };
+        let note = if entry["connected"].as_bool().unwrap_or(true) {
+            String::new()
+        } else {
+            "  (no credential)".to_string()
+        };
+        lines.push(format!(
+            "{marker} {:>2}. {}{note}",
+            entry["position"].as_u64().unwrap_or_default(),
+            entry["display"].as_str().unwrap_or("?"),
+        ));
+    }
+    if let ModelListAction::List { .. } = action
+        && !value["configured"].as_bool().unwrap_or(false)
+    {
+        lines
+            .push("(built-in default list; `yolop models add|rm|move` makes it yours)".to_string());
+    }
+    lines.join("\n")
+}
+
+/// The list as the pickers and ACP should offer it: configured order, entries
+/// whose provider has no credential dropped, and the currently selected model
+/// kept even when its provider looks unusable (dropping the model in use would
+/// make the picker disagree with the status bar).
+pub(crate) fn offered_models(
+    settings: &crate::config::Settings,
+    current: Option<&str>,
+) -> Vec<ModelEntry> {
+    offer(settings.model_list(), current, |provider| {
+        provider_is_usable(settings, provider)
+    })
+}
+
+/// The credential filter itself, over an injected usability predicate so it is
+/// testable without the ambient provider environment deciding the outcome.
+fn offer(
+    models: Vec<ModelEntry>,
+    current: Option<&str>,
+    usable: impl Fn(&str) -> bool,
+) -> Vec<ModelEntry> {
+    let offered: Vec<ModelEntry> = models
+        .into_iter()
+        .filter(|entry| usable(&entry.provider) || current == Some(entry.key().as_str()))
+        .collect();
+    // A user whose only credential is for a provider nobody listed would
+    // otherwise face an empty picker; fall back to the default menu's entries
+    // they can actually reach before giving up.
+    if offered.is_empty() {
+        return default_models()
+            .into_iter()
+            .filter(|entry| usable(&entry.provider))
+            .collect();
+    }
+    offered
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn capability() -> (tempfile::TempDir, ModelListCapability) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let settings = Arc::new(SettingsStore::open(dir.path().join("settings.toml")));
+        (dir, ModelListCapability::new(settings, None))
+    }
+
+    fn saved(capability: &ModelListCapability) -> Vec<ModelEntry> {
+        capability.settings.snapshot().model_list()
+    }
+
+    async fn run(capability: &ModelListCapability, action: ModelListAction) -> Value {
+        match capability.execute_action(&action).await {
+            ToolExecutionResult::Success(value) => value,
+            other => panic!("expected success, got {other:?}"),
+        }
+    }
+
+    async fn error(capability: &ModelListCapability, action: ModelListAction) -> String {
+        match capability.execute_action(&action).await {
+            ToolExecutionResult::ToolError(error) => error,
+            other => panic!("expected a tool error, got {other:?}"),
+        }
+    }
+
+    fn add(provider: &str, model: &str, position: Option<usize>) -> ModelListAction {
+        ModelListAction::Add {
+            provider: provider.to_string(),
+            model: model.to_string(),
+            effort: None,
+            label: None,
+            position,
+        }
+    }
+
+    #[tokio::test]
+    async fn editing_an_unconfigured_list_materializes_the_defaults_first() {
+        let (_dir, capability) = capability();
+        assert!(
+            capability.settings.snapshot().models.is_empty(),
+            "nothing configured yet"
+        );
+
+        run(&capability, add("openrouter", "some/model", None)).await;
+
+        let models = saved(&capability);
+        assert_eq!(
+            models.first(),
+            Some(&ModelEntry::new("openai", "gpt-5.6-sol")),
+            "the default list is kept, not replaced by the first edit: {models:?}"
+        );
+        assert_eq!(
+            models.last(),
+            Some(&ModelEntry::new("openrouter", "some/model"))
+        );
+    }
+
+    #[tokio::test]
+    async fn add_inserts_at_a_position_and_updates_in_place_rather_than_duplicating() {
+        let (_dir, capability) = capability();
+        run(&capability, add("openrouter", "some/model", Some(1))).await;
+        assert_eq!(
+            saved(&capability)[0],
+            ModelEntry::new("openrouter", "some/model")
+        );
+
+        let before = saved(&capability).len();
+        run(
+            &capability,
+            ModelListAction::Add {
+                provider: "openrouter".to_string(),
+                model: "some/model".to_string(),
+                effort: Some("high".to_string()),
+                label: None,
+                position: None,
+            },
+        )
+        .await;
+        let models = saved(&capability);
+        assert_eq!(models.len(), before, "re-adding must not duplicate a row");
+        assert_eq!(
+            models[0].effort.as_deref(),
+            Some("high"),
+            "it updates in place"
+        );
+    }
+
+    #[tokio::test]
+    async fn rm_and_move_reorder_the_list_and_reset_restores_the_defaults() {
+        let (_dir, capability) = capability();
+        run(&capability, add("openrouter", "some/model", None)).await;
+
+        run(
+            &capability,
+            ModelListAction::Move {
+                model: "openrouter/some/model".to_string(),
+                position: 1,
+            },
+        )
+        .await;
+        assert_eq!(saved(&capability)[0].provider, "openrouter");
+
+        run(
+            &capability,
+            ModelListAction::Rm {
+                model: "openrouter/some/model".to_string(),
+            },
+        )
+        .await;
+        assert!(
+            !saved(&capability)
+                .iter()
+                .any(|entry| entry.provider == "openrouter")
+        );
+
+        run(&capability, add("openrouter", "some/model", None)).await;
+        run(&capability, ModelListAction::Reset).await;
+        assert!(
+            capability.settings.snapshot().models.is_empty(),
+            "reset clears the stored list so the defaults apply again"
+        );
+        assert_eq!(saved(&capability), default_models());
+    }
+
+    #[tokio::test]
+    async fn a_move_past_the_end_is_refused_with_the_valid_range() {
+        let (_dir, capability) = capability();
+        let message = error(
+            &capability,
+            ModelListAction::Move {
+                model: "openai/gpt-5.6-sol".to_string(),
+                position: 99,
+            },
+        )
+        .await;
+        assert!(message.contains("between 1 and"), "{message}");
+    }
+
+    #[tokio::test]
+    async fn switching_models_without_a_session_says_so_instead_of_failing_silently() {
+        let (_dir, capability) = capability();
+        let message = error(
+            &capability,
+            ModelListAction::Use {
+                model: "openai/gpt-5.6-sol".to_string(),
+            },
+        )
+        .await;
+        assert!(message.contains("running Yolop session"), "{message}");
+    }
+
+    #[tokio::test]
+    async fn the_listing_shows_entries_that_still_need_sign_in() {
+        let (_dir, capability) = capability();
+        let value = run(
+            &capability,
+            ModelListAction::List {
+                json: false,
+                connected: false,
+            },
+        )
+        .await;
+        let listed = value["models"].as_array().expect("models");
+        assert_eq!(
+            listed.len(),
+            default_models().len(),
+            "the editing view hides nothing: {listed:?}"
+        );
+        assert_eq!(value["configured"], false);
+    }
+
+    fn list() -> Vec<ModelEntry> {
+        vec![
+            ModelEntry::new("openai", "gpt-5.6-sol"),
+            ModelEntry::new("anthropic", "claude-opus-4-8"),
+            ModelEntry::new("openrouter", "anthropic/claude-opus-4-8"),
+        ]
+    }
+
+    #[test]
+    fn a_reference_resolves_by_qualified_name_or_unique_model_id() {
+        let models = list();
+        assert_eq!(
+            ModelListCapability::find(&models, "openai/gpt-5.6-sol"),
+            Ok(0)
+        );
+        assert_eq!(
+            ModelListCapability::find(&models, "anthropic:claude-opus-4-8"),
+            Ok(1)
+        );
+        assert_eq!(ModelListCapability::find(&models, "gpt-5.6-sol"), Ok(0));
+    }
+
+    #[test]
+    fn the_same_model_on_two_providers_must_be_qualified() {
+        // `claude-opus-4-8` is reachable directly and through OpenRouter; the
+        // list exists to distinguish those, so a bare id must not guess.
+        let models = vec![
+            ModelEntry::new("anthropic", "claude-opus-4-8"),
+            ModelEntry::new("openrouter", "claude-opus-4-8"),
+        ];
+        let error = ModelListCapability::find(&models, "claude-opus-4-8").expect_err("ambiguous");
+        assert!(error.contains("anthropic and openrouter"), "{error}");
+        assert_eq!(
+            ModelListCapability::find(&models, "openrouter/claude-opus-4-8"),
+            Ok(1)
+        );
+    }
+
+    #[test]
+    fn an_unknown_reference_says_how_to_add_it() {
+        let error = ModelListCapability::find(&list(), "gpt-4").expect_err("unknown");
+        assert!(error.contains("yolop models add"), "{error}");
+    }
+
+    #[test]
+    fn offered_models_drop_providers_without_credentials() {
+        let offered = offer(list(), None, |provider| provider == "anthropic");
+        assert_eq!(
+            offered,
+            vec![ModelEntry::new("anthropic", "claude-opus-4-8")],
+            "only the credentialed provider's entry is offered"
+        );
+    }
+
+    #[test]
+    fn offered_models_keep_the_model_in_use() {
+        let offered = offer(list(), Some("openai:gpt-5.6-sol"), |provider| {
+            provider == "anthropic"
+        });
+        assert!(
+            offered.contains(&ModelEntry::new("openai", "gpt-5.6-sol")),
+            "the active model stays on the menu: {offered:?}"
+        );
+    }
+
+    #[test]
+    fn offered_models_fall_back_when_the_list_reaches_nothing() {
+        let offered = offer(
+            vec![ModelEntry::new("openrouter", "some/model")],
+            None,
+            |provider| provider == "anthropic",
+        );
+        assert!(
+            offered.iter().all(|entry| entry.provider == "anthropic"),
+            "an unreachable list falls back to reachable defaults: {offered:?}"
+        );
+        assert!(!offered.is_empty(), "picker must never be empty");
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -15,6 +15,7 @@
 pub mod capability_settings;
 pub mod hooks;
 pub mod mcp;
+pub mod model_list;
 pub mod paths;
 pub mod profile;
 pub mod schema;
@@ -24,6 +25,7 @@ use crate::config::capability_settings::{
     CapabilityOverride, capabilities_to_toml, parse_capabilities_table,
 };
 use crate::config::mcp::McpSettings;
+use crate::config::model_list::{ModelEntry, models_to_toml, parse_models_list};
 use anyhow::{Context, Result};
 use std::collections::BTreeMap;
 use std::io::Write;
@@ -222,10 +224,15 @@ pub struct Settings {
     /// (the legacy `provider` key is still read for backward compatibility).
     pub default_provider: Option<String>,
     pub tokens: BTreeMap<String, String>,
-    /// Last model spec chosen per provider, in the provider-relative
-    /// `model [effort]` form `/setup model` accepts. Lets a model pick
-    /// survive restarts and provider switches.
-    pub models: BTreeMap<String, String>,
+    /// The user's model list (`[[models]]` in settings.toml): the ordered,
+    /// cross-provider menu `/model`, the status bar, and ACP offer. Empty means
+    /// never configured, and `model_list::default_models` stands in.
+    pub models: Vec<ModelEntry>,
+    /// Last model spec chosen per provider (`[default_models]`), in the
+    /// provider-relative `model [effort]` form `/setup model` accepts. Lets a
+    /// model pick survive restarts and provider switches. This is remembered
+    /// state, not a menu; the menu is `models` above.
+    pub default_models: BTreeMap<String, String>,
     /// Endpoint base URLs keyed by provider. Today only `custom` (the
     /// generic OpenAI-compatible provider) writes here.
     pub base_urls: BTreeMap<String, String>,
@@ -272,7 +279,8 @@ impl Default for Settings {
         Self {
             default_provider: None,
             tokens: BTreeMap::new(),
-            models: BTreeMap::new(),
+            models: Vec::new(),
+            default_models: BTreeMap::new(),
             base_urls: BTreeMap::new(),
             codex_auth: None,
             attribution: true,
@@ -355,7 +363,14 @@ impl Settings {
         Self {
             default_provider,
             tokens: string_map("tokens"),
-            models: string_map("models"),
+            models: parse_models_list(table),
+            // `models` written as a table is the pre-list layout: a per-provider
+            // default map. Read it as `default_models` so an existing settings
+            // file keeps its remembered picks after the key split.
+            default_models: match table.get("models") {
+                Some(Value::Table(_)) => string_map("models"),
+                _ => string_map("default_models"),
+            },
             base_urls: string_map("base_urls"),
             codex_auth,
             attribution,
@@ -432,7 +447,7 @@ impl Settings {
             }
         };
         insert_map("tokens", &self.tokens);
-        insert_map("models", &self.models);
+        insert_map("default_models", &self.default_models);
         insert_map("base_urls", &self.base_urls);
         if let Some(auth) = &self.codex_auth {
             table.insert(
@@ -444,6 +459,12 @@ impl Settings {
             table.insert(
                 "mcp".to_string(),
                 Value::Table(mcp_settings_to_table(&self.mcp)),
+            );
+        }
+        if !self.models.is_empty() {
+            table.insert(
+                "models".to_string(),
+                Value::Array(models_to_toml(&self.models)),
             );
         }
         let caps = capabilities_to_toml(&self.capabilities);
@@ -463,8 +484,20 @@ impl Settings {
         self.tokens.contains_key(provider)
     }
 
+    /// The model list as configured, falling back to the built-in default
+    /// menu when the user has never set one. Credential filtering is *not*
+    /// applied here; that needs provider-usability knowledge and belongs to
+    /// `capabilities::model_list`.
+    pub fn model_list(&self) -> Vec<ModelEntry> {
+        if self.models.is_empty() {
+            model_list::default_models()
+        } else {
+            self.models.clone()
+        }
+    }
+
     pub fn model_for(&self, provider: &str) -> Option<&str> {
-        self.models.get(provider).map(String::as_str)
+        self.default_models.get(provider).map(String::as_str)
     }
 
     pub fn base_url_for(&self, provider: &str) -> Option<&str> {
@@ -753,7 +786,8 @@ impl SettingsStore {
             schema::KeyTarget::ApprovalPolicy => overlay.approval_policy.is_some(),
             schema::KeyTarget::Worktrees => overlay.worktrees.is_some(),
             schema::KeyTarget::Sandbox => overlay.sandbox.is_some(),
-            schema::KeyTarget::Model(provider) => overlay.models.contains_key(provider),
+            schema::KeyTarget::Model(provider) => overlay.default_models.contains_key(provider),
+            schema::KeyTarget::Models => !overlay.models.is_empty(),
             schema::KeyTarget::BaseUrl(provider) => overlay.base_urls.contains_key(provider),
             schema::KeyTarget::Capabilities => !overlay.capabilities.is_empty(),
             schema::KeyTarget::Mcp => !overlay.mcp.servers.is_empty(),
@@ -898,10 +932,10 @@ impl SettingsStore {
         let base_spec = spec.clone();
         self.update_profileable(
             |settings| {
-                settings.models.insert(base_provider, base_spec);
+                settings.default_models.insert(base_provider, base_spec);
             },
             |profile| {
-                profile.models.insert(provider, Some(spec));
+                profile.default_models.insert(provider, Some(spec));
             },
         )
     }
@@ -910,15 +944,27 @@ impl SettingsStore {
     pub fn clear_model(&self, provider: &str) -> Result<bool> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
         let existed = if let Some(active) = &mut guard.profile {
-            let existed = active.overlay.models.remove(provider).is_some();
+            let existed = active.overlay.default_models.remove(provider).is_some();
             save_profile_to(&active.path, &active.overlay)?;
             existed
         } else {
-            let existed = guard.base.models.remove(provider).is_some();
+            let existed = guard.base.default_models.remove(provider).is_some();
             save_to(&self.path, &guard.base)?;
             existed
         };
         Ok(existed)
+    }
+
+    /// Replace the model list. Every `yolop models` edit reads the resolved
+    /// list, changes it, and writes the whole thing back, so ordering is
+    /// explicit and there is one write path. Under an active profile this
+    /// writes the profile's own `[[models]]`, which replaces the global menu.
+    pub fn set_models(&self, models: Vec<ModelEntry>) -> Result<()> {
+        let base_models = models.clone();
+        self.update_profileable(
+            |settings| settings.models = base_models,
+            |profile| profile.models = models,
+        )
     }
 
     pub fn set_base_url(&self, provider: String, url: String) -> Result<()> {
@@ -1743,7 +1789,7 @@ Authorization = "Bearer ${LINEAR_API_KEY}"
             .expect("save base url");
 
         let on_disk = std::fs::read_to_string(&path).expect("read");
-        assert!(on_disk.contains("[models]"), "got: {on_disk}");
+        assert!(on_disk.contains("[default_models]"), "got: {on_disk}");
         assert!(on_disk.contains("[base_urls]"), "got: {on_disk}");
 
         let reloaded = SettingsStore::open(path);

--- a/src/config/model_list.rs
+++ b/src/config/model_list.rs
@@ -1,0 +1,242 @@
+//! The user's model list: the ordered, cross-provider menu yolop offers when
+//! you switch models.
+//!
+//! Stored as `[[models]]` in `settings.toml`, one entry per line of the menu:
+//!
+//! ```toml
+//! [[models]]
+//! provider = "openai"
+//! model = "gpt-5.6-sol"
+//! effort = "high"
+//! ```
+//!
+//! An entry names a provider *and* a model, so selecting one switches both:
+//! `anthropic/claude-opus-4-8` and `openrouter/anthropic/claude-opus-4-8` are
+//! different entries reaching the same weights through different accounts.
+//!
+//! This is deliberately not "favourites" layered over a full catalog. It *is*
+//! the list: `/model`, the status bar, and ACP's model options all serve it,
+//! and provider discovery (`model_discovery`) is the browse-everything path
+//! behind it rather than the default view. Providers publish hundreds of
+//! models; a user switches between a handful.
+//!
+//! An empty list means "never configured" and resolves to [`default_models`],
+//! so a fresh install has a working menu.
+
+use crate::runtime::SUPPORTED_PROVIDERS;
+use toml::Table;
+use toml::Value as TomlValue;
+
+/// One line of the model menu.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ModelEntry {
+    /// Provider name, one of [`SUPPORTED_PROVIDERS`].
+    pub provider: String,
+    /// Provider-relative model id (`gpt-5.6-sol`, `anthropic/claude-opus-4-8`
+    /// on OpenRouter). Never carries the reasoning effort; that is `effort`.
+    pub model: String,
+    /// Reasoning effort to apply with this entry. `None` leaves the model
+    /// profile's own default in place.
+    pub effort: Option<String>,
+    /// Display override. `None` renders as `provider/model`.
+    pub label: Option<String>,
+}
+
+impl ModelEntry {
+    pub fn new(provider: &str, model: &str) -> Self {
+        Self {
+            provider: provider.to_string(),
+            model: model.to_string(),
+            effort: None,
+            label: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_effort(mut self, effort: &str) -> Self {
+        self.effort = Some(effort.to_string());
+        self
+    }
+
+    /// Stable identity of an entry: what ACP sends back as the selected value
+    /// and what `yolop models rm` matches on. Effort is excluded so the same
+    /// model at two efforts does not read as two different models here; use
+    /// [`ModelEntry::spec`] where effort matters.
+    pub fn key(&self) -> String {
+        format!("{}:{}", self.provider, self.model)
+    }
+
+    /// The provider-relative `model [effort]` form `/setup model` accepts and
+    /// `ProviderChoice::resolve_model_spec` parses.
+    pub fn spec(&self) -> String {
+        match &self.effort {
+            Some(effort) => format!("{} {}", self.model, effort),
+            None => self.model.clone(),
+        }
+    }
+
+    /// One-line rendering for pickers and `yolop models list`.
+    pub fn display(&self) -> String {
+        match &self.label {
+            Some(label) => label.clone(),
+            None => match &self.effort {
+                Some(effort) => format!("{}/{} {effort}", self.provider, self.model),
+                None => format!("{}/{}", self.provider, self.model),
+            },
+        }
+    }
+}
+
+/// The menu a user who has never configured one gets.
+///
+/// Small on purpose: enough to cover the everyday switches (a frontier model, a
+/// fast one, the other lab) without reproducing the catalog the list exists to
+/// avoid. Entries whose provider has no credential are hidden at display time,
+/// so listing several providers here costs nothing to a user who has one.
+pub fn default_models() -> Vec<ModelEntry> {
+    vec![
+        ModelEntry::new("openai", "gpt-5.6-sol"),
+        ModelEntry::new("openai", "gpt-5.4-mini"),
+        ModelEntry::new("anthropic", "claude-opus-4-8"),
+        ModelEntry::new("anthropic", "claude-sonnet-4-5"),
+        ModelEntry::new("codex", "gpt-5.6-sol"),
+    ]
+}
+
+/// Parse `[[models]]` from a settings table.
+///
+/// Tolerant like the rest of settings loading: an entry missing `provider` or
+/// `model`, or naming a provider yolop does not support, is skipped rather than
+/// failing the load. `models` written as a *table* is the pre-list layout (a
+/// per-provider default map, now `[default_models]`) and yields no entries; see
+/// `Settings::from_table`.
+pub fn parse_models_list(table: &Table) -> Vec<ModelEntry> {
+    let Some(TomlValue::Array(items)) = table.get("models") else {
+        return Vec::new();
+    };
+    items.iter().filter_map(parse_entry).collect()
+}
+
+fn parse_entry(value: &TomlValue) -> Option<ModelEntry> {
+    let entry = value.as_table()?;
+    let provider = entry.get("provider").and_then(TomlValue::as_str)?.trim();
+    let model = entry.get("model").and_then(TomlValue::as_str)?.trim();
+    if model.is_empty() || !SUPPORTED_PROVIDERS.contains(&provider) {
+        return None;
+    }
+    let text = |key: &str| {
+        entry
+            .get(key)
+            .and_then(TomlValue::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    };
+    Some(ModelEntry {
+        provider: provider.to_string(),
+        model: model.to_string(),
+        effort: text("effort"),
+        label: text("label"),
+    })
+}
+
+/// Render the list back to `[[models]]` array-of-tables form.
+pub fn models_to_toml(models: &[ModelEntry]) -> Vec<TomlValue> {
+    models
+        .iter()
+        .map(|entry| {
+            let mut table = Table::new();
+            table.insert(
+                "provider".to_string(),
+                TomlValue::String(entry.provider.clone()),
+            );
+            table.insert("model".to_string(), TomlValue::String(entry.model.clone()));
+            if let Some(effort) = &entry.effort {
+                table.insert("effort".to_string(), TomlValue::String(effort.clone()));
+            }
+            if let Some(label) = &entry.label {
+                table.insert("label".to_string(), TomlValue::String(label.clone()));
+            }
+            TomlValue::Table(table)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(toml: &str) -> Vec<ModelEntry> {
+        parse_models_list(&toml.parse::<Table>().expect("valid toml"))
+    }
+
+    #[test]
+    fn default_list_leads_with_gpt_5_6_sol() {
+        let defaults = default_models();
+        assert_eq!(defaults[0], ModelEntry::new("openai", "gpt-5.6-sol"));
+        for entry in &defaults {
+            assert!(
+                SUPPORTED_PROVIDERS.contains(&entry.provider.as_str()),
+                "default entry names an unsupported provider: {entry:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn entries_round_trip_through_toml() {
+        let models = vec![
+            ModelEntry::new("openai", "gpt-5.6-sol").with_effort("high"),
+            ModelEntry {
+                provider: "openrouter".into(),
+                model: "anthropic/claude-opus-4-8".into(),
+                effort: None,
+                label: Some("Opus (via OpenRouter)".into()),
+            },
+        ];
+        let mut table = Table::new();
+        table.insert(
+            "models".to_string(),
+            TomlValue::Array(models_to_toml(&models)),
+        );
+        assert_eq!(parse_models_list(&table), models);
+    }
+
+    #[test]
+    fn unusable_entries_are_skipped_rather_than_failing_the_load() {
+        let parsed = parse(
+            r#"
+            [[models]]
+            provider = "openai"
+            model = "gpt-5.6-sol"
+
+            [[models]]
+            provider = "not-a-provider"
+            model = "whatever"
+
+            [[models]]
+            provider = "openai"
+            model = ""
+
+            [[models]]
+            model = "no-provider-key"
+            "#,
+        );
+        assert_eq!(parsed, vec![ModelEntry::new("openai", "gpt-5.6-sol")]);
+    }
+
+    #[test]
+    fn the_legacy_per_provider_table_yields_no_entries() {
+        // Pre-list settings files wrote `[models]` as a provider -> spec map.
+        // `Settings::from_table` reroutes that shape to `default_models`; here
+        // it must simply not parse as a list.
+        assert!(parse("[models]\nopenai = 'gpt-5.5 high'\n").is_empty());
+    }
+
+    #[test]
+    fn spec_and_key_separate_effort_from_identity() {
+        let entry = ModelEntry::new("openai", "gpt-5.6-sol").with_effort("high");
+        assert_eq!(entry.key(), "openai:gpt-5.6-sol");
+        assert_eq!(entry.spec(), "gpt-5.6-sol high");
+        assert_eq!(entry.display(), "openai/gpt-5.6-sol high");
+    }
+}

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -578,6 +578,53 @@ mod tests {
     }
 
     #[test]
+    fn a_legacy_models_table_survives_a_profile_rewrite_under_its_new_name() {
+        // `models` used to be the per-provider map and is now the model list.
+        // A rewrite must migrate the old entries rather than dropping them on
+        // the floor when the (empty) list clears the `models` key.
+        let table: Table = toml::from_str("[models]\nopenai = 'gpt-5.5 high'\n").unwrap();
+        let (overlay, _) = SettingsOverlay::from_table(&table, Path::new("/nonexistent")).unwrap();
+        let rewritten = overlay.to_table();
+        assert!(
+            rewritten.get("models").is_none(),
+            "the old table does not linger as a malformed list: {rewritten:?}"
+        );
+        assert_eq!(
+            rewritten["default_models"]["openai"].as_str(),
+            Some("gpt-5.5 high"),
+            "the pick is preserved under the new key: {rewritten:?}"
+        );
+
+        let (reparsed, _) =
+            SettingsOverlay::from_table(&rewritten, Path::new("/nonexistent")).unwrap();
+        assert_eq!(
+            reparsed.default_models["openai"].as_deref(),
+            Some("gpt-5.5 high"),
+            "and it round-trips"
+        );
+    }
+
+    #[test]
+    fn a_profile_model_list_replaces_the_global_menu() {
+        let table: Table =
+            toml::from_str("[[models]]\nprovider = 'openai'\nmodel = 'gpt-5.4-mini'\n").unwrap();
+        let (overlay, warnings) =
+            SettingsOverlay::from_table(&table, Path::new("/nonexistent")).unwrap();
+        assert!(warnings.is_empty(), "{warnings:?}");
+
+        let mut settings = Settings {
+            models: vec![ModelEntry::new("anthropic", "claude-opus-4-8")],
+            ..Settings::default()
+        };
+        overlay.apply_to(&mut settings);
+        assert_eq!(
+            settings.models,
+            vec![ModelEntry::new("openai", "gpt-5.4-mini")],
+            "a profile that names a menu means those models, not those plus the global ones"
+        );
+    }
+
+    #[test]
     fn overlay_replaces_scalars_and_merges_provider_maps() {
         let mut settings = Settings {
             default_provider: Some("anthropic".to_string()),

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -1,4 +1,5 @@
 use super::mcp::McpSettings;
+use super::model_list::{ModelEntry, models_to_toml, parse_models_list};
 use super::{
     ApprovalMode, ApprovalPolicy, CapabilityOverride, SandboxMode, Settings, WorktreesMode,
     capabilities_to_toml, mcp_settings_to_table, parse_capabilities_table, parse_mcp_settings,
@@ -12,6 +13,7 @@ use toml::{Table, Value};
 const PROFILEABLE_KEYS: &[&str] = &[
     "default_provider",
     "models",
+    "default_models",
     "base_urls",
     "approval_mode",
     "approval_policy",
@@ -33,6 +35,7 @@ const PROFILEABLE_KEYS: &[&str] = &[
 const REWRITTEN_KEYS: &[&str] = &[
     "default_provider",
     "models",
+    "default_models",
     "base_urls",
     "approval_mode",
     "approval_policy",
@@ -111,7 +114,11 @@ impl ListMode {
 #[derive(Clone, Debug, Default)]
 pub struct SettingsOverlay {
     pub default_provider: Option<Option<String>>,
-    pub models: BTreeMap<String, Option<String>>,
+    /// The profile's own model list. Non-empty replaces the global
+    /// `[[models]]` menu wholesale rather than merging: a profile that names a
+    /// menu means "these models, for this job".
+    pub models: Vec<ModelEntry>,
+    pub default_models: BTreeMap<String, Option<String>>,
     pub base_urls: BTreeMap<String, Option<String>>,
     pub approval_mode: Option<ApprovalMode>,
     pub approval_policy: Option<ApprovalPolicy>,
@@ -142,7 +149,10 @@ impl SettingsOverlay {
         if let Some(provider) = &self.default_provider {
             settings.default_provider.clone_from(provider);
         }
-        apply_map(&mut settings.models, &self.models);
+        if !self.models.is_empty() {
+            settings.models.clone_from(&self.models);
+        }
+        apply_map(&mut settings.default_models, &self.default_models);
         apply_map(&mut settings.base_urls, &self.base_urls);
         if let Some(mode) = self.approval_mode {
             settings.approval_mode = mode;
@@ -197,7 +207,16 @@ impl SettingsOverlay {
             .collect();
 
         let default_provider = optional_string(table, "default_provider")?.map(Some);
-        let models = optional_string_map(table, "models")?;
+        // As in global settings, a `models` *table* is the pre-list layout and
+        // is read as `default_models`; a `models` array is the model list.
+        let models = parse_models_list(table);
+        if matches!(table.get("models"), Some(Value::Array(_))) && models.is_empty() {
+            bail!("`models` must be an array of tables, each with `provider` and `model`");
+        }
+        let default_models = match table.get("models") {
+            Some(Value::Table(_)) => optional_string_map(table, "models")?,
+            _ => optional_string_map(table, "default_models")?,
+        };
         let base_urls = optional_string_map(table, "base_urls")?;
         if let Some(Some(provider)) = &default_provider
             && !SUPPORTED_PROVIDERS.contains(&provider.as_str())
@@ -207,7 +226,7 @@ impl SettingsOverlay {
                 SUPPORTED_PROVIDERS.join(", ")
             );
         }
-        for provider in models.keys().chain(base_urls.keys()) {
+        for provider in default_models.keys().chain(base_urls.keys()) {
             if !SUPPORTED_PROVIDERS.contains(&provider.as_str()) {
                 bail!(
                     "unknown provider `{provider}` in profile table; expected one of {}",
@@ -268,6 +287,7 @@ impl SettingsOverlay {
             Self {
                 default_provider,
                 models,
+                default_models,
                 base_urls,
                 approval_mode,
                 approval_policy,
@@ -288,7 +308,15 @@ impl SettingsOverlay {
     pub fn to_table(&self) -> Table {
         let mut table = self.unknown.clone();
         insert_optional_string(&mut table, "default_provider", &self.default_provider);
-        insert_map(&mut table, "models", &self.models);
+        if self.models.is_empty() {
+            table.remove("models");
+        } else {
+            table.insert(
+                "models".to_string(),
+                Value::Array(models_to_toml(&self.models)),
+            );
+        }
+        insert_map(&mut table, "default_models", &self.default_models);
         insert_map(&mut table, "base_urls", &self.base_urls);
         if let Some(mode) = self.approval_mode {
             table.insert(
@@ -527,7 +555,11 @@ mod tests {
         assert_eq!(warnings, ["ignoring unknown profile key `future_setting`"]);
         assert_eq!(overlay.default_provider, Some(Some("openai".to_string())));
         assert_eq!(overlay.approval_policy, Some(ApprovalPolicy::Never));
-        assert_eq!(overlay.models["openai"].as_deref(), Some("gpt-5.6 high"));
+        assert_eq!(
+            overlay.default_models["openai"].as_deref(),
+            Some("gpt-5.6 high"),
+            "a `models` table is the pre-list layout and reads as default_models"
+        );
         assert!(overlay.to_table().get("sandbox_mode").is_none());
         assert_eq!(
             overlay.to_table()["future_setting"].as_str(),
@@ -549,7 +581,7 @@ mod tests {
     fn overlay_replaces_scalars_and_merges_provider_maps() {
         let mut settings = Settings {
             default_provider: Some("anthropic".to_string()),
-            models: BTreeMap::from([
+            default_models: BTreeMap::from([
                 ("anthropic".to_string(), "claude-sonnet".to_string()),
                 ("openai".to_string(), "gpt-base".to_string()),
             ]),
@@ -557,13 +589,16 @@ mod tests {
         };
         let overlay = SettingsOverlay {
             default_provider: Some(Some("openai".to_string())),
-            models: BTreeMap::from([("openai".to_string(), Some("gpt-profile".to_string()))]),
+            default_models: BTreeMap::from([(
+                "openai".to_string(),
+                Some("gpt-profile".to_string()),
+            )]),
             ..SettingsOverlay::default()
         };
         overlay.apply_to(&mut settings);
         assert_eq!(settings.default_provider.as_deref(), Some("openai"));
-        assert_eq!(settings.models["openai"], "gpt-profile");
-        assert_eq!(settings.models["anthropic"], "claude-sonnet");
+        assert_eq!(settings.default_models["openai"], "gpt-profile");
+        assert_eq!(settings.default_models["anthropic"], "claude-sonnet");
     }
 
     #[test]

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -99,16 +99,34 @@ pub fn schema() -> &'static [ConfigField] {
         },
         ConfigField {
             key: "models",
+            aliases: &["model_list"],
+            title: "Model list",
+            description: "The ordered, cross-provider menu of models to switch between: what \
+                          `/model`, the status bar, and ACP offer. Stored as `[[models]]` \
+                          entries with `provider`, `model`, and optional `effort`/`label`. \
+                          Edit it with `yolop models add|rm|move`, not `set_config`. Unset \
+                          means the built-in default list.",
+            kind: ValueKind::List,
+            default: Some(
+                "openai/gpt-5.6-sol, openai/gpt-5.4-mini, anthropic/claude-opus-4-8, \
+                           anthropic/claude-sonnet-4-5, codex/gpt-5.6-sol",
+            ),
+            examples: &["yolop models add openrouter anthropic/claude-opus-4-8"],
+            provider_scoped: false,
+        },
+        ConfigField {
+            key: "default_models",
             aliases: &["model_for"],
             title: "Per-provider model",
             description: "Model spec remembered for a specific provider, so a pick survives \
-                          restarts and provider switches. Addressed as `models.<provider>`.",
+                          restarts and provider switches. This is remembered state, not the \
+                          menu; the menu is `models`. Addressed as `default_models.<provider>`.",
             kind: ValueKind::Text,
             default: None,
             examples: &[
-                "models.openai = gpt-5.5 high",
-                "models.codex = gpt-5.5 high",
-                "models.anthropic = claude-opus-4-5",
+                "default_models.openai = gpt-5.5 high",
+                "default_models.codex = gpt-5.5 high",
+                "default_models.anthropic = claude-opus-4-5",
             ],
             provider_scoped: true,
         },
@@ -283,6 +301,8 @@ pub enum KeyTarget {
     Theme,
     /// Per-provider model spec, for the named provider.
     Model(String),
+    /// The ordered `[[models]]` list, edited through `yolop models`.
+    Models,
     /// Per-provider API token.
     Token(String),
     /// Per-provider endpoint base URL.
@@ -308,7 +328,8 @@ impl KeyTarget {
             KeyTarget::Worktrees => "worktrees",
             KeyTarget::Sandbox => "sandbox_mode",
             KeyTarget::Theme => "theme",
-            KeyTarget::Model(_) => "models",
+            KeyTarget::Model(_) => "default_models",
+            KeyTarget::Models => "models",
             KeyTarget::Token(_) => "tokens",
             KeyTarget::BaseUrl(_) => "base_urls",
             KeyTarget::Capabilities | KeyTarget::CapabilityRef(_) => "capabilities",
@@ -364,7 +385,11 @@ pub fn parse_key(input: &str) -> Result<KeyTarget, String> {
         "worktrees" | "worktree" => scalar(KeyTarget::Worktrees),
         "sandbox_mode" | "sandbox" | "containment" => scalar(KeyTarget::Sandbox),
         "theme" => scalar(KeyTarget::Theme),
-        "models" | "model_for" => scoped(KeyTarget::Model),
+        // `models` is the ordered list; the per-provider memory it used to name
+        // is `default_models`. A bare `models.<provider>` still routes to the
+        // per-provider key so older muscle memory and settings files work.
+        "models" | "model_list" if sub.is_none() => Ok(KeyTarget::Models),
+        "models" | "default_models" | "model_for" => scoped(KeyTarget::Model),
         "tokens" | "token" => scoped(KeyTarget::Token),
         "base_urls" | "base_url" | "url" => scoped(KeyTarget::BaseUrl),
         "mcp" | "mcp_servers" => scalar(KeyTarget::Mcp),

--- a/src/config/service.rs
+++ b/src/config/service.rs
@@ -92,6 +92,24 @@ pub(crate) fn current_value(settings: &Settings, target: &KeyTarget) -> Value {
             .base_url_for(p)
             .map(|s| Value::String(s.to_string()))
             .unwrap_or(Value::Null),
+        KeyTarget::Models => Value::Array(
+            settings
+                .model_list()
+                .into_iter()
+                .map(|entry| {
+                    let mut object = serde_json::Map::new();
+                    object.insert("provider".into(), Value::String(entry.provider));
+                    object.insert("model".into(), Value::String(entry.model));
+                    if let Some(effort) = entry.effort {
+                        object.insert("effort".into(), Value::String(effort));
+                    }
+                    if let Some(label) = entry.label {
+                        object.insert("label".into(), Value::String(label));
+                    }
+                    Value::Object(object)
+                })
+                .collect(),
+        ),
         KeyTarget::Capabilities => {
             crate::config::capability_settings::overrides_to_json(&settings.capabilities)
         }
@@ -125,8 +143,8 @@ pub(crate) fn scoped_current(settings: &Settings, key: &str) -> Value {
                 map.insert(provider.clone(), Value::String("stored".to_string()));
             }
         }
-        "models" => {
-            for (provider, spec) in settings.models.iter().filter(|(p, _)| supported(p)) {
+        "default_models" => {
+            for (provider, spec) in settings.default_models.iter().filter(|(p, _)| supported(p)) {
                 map.insert(provider.clone(), Value::String(spec.clone()));
             }
         }

--- a/src/drivers/local.rs
+++ b/src/drivers/local.rs
@@ -70,7 +70,7 @@ impl LocalChatDriver {
 
         // Load only from the local store. Letting the engine fetch its own
         // weights would turn the first turn into a silent multi-gigabyte stall;
-        // `yolop models pull` owns that wait and shows progress for it.
+        // `yolop weights pull` owns that wait and shows progress for it.
         if !crate::models::is_installed(spec) {
             return Err(missing_weights_error(spec));
         }
@@ -317,8 +317,8 @@ fn missing_weights_error(spec: &str) -> AgentLoopError {
     AgentLoopError::llm_kind(
         LlmErrorKind::Unavailable,
         format!(
-            "local model '{spec}' is not downloaded. Run `yolop models pull {spec}` first \
-             (several GB), then retry. `yolop models list` shows what is already on disk."
+            "local model '{spec}' is not downloaded. Run `yolop weights pull {spec}` first \
+             (several GB), then retry. `yolop weights list` shows what is already on disk."
         ),
     )
 }

--- a/src/editor/acp/mod.rs
+++ b/src/editor/acp/mod.rs
@@ -990,9 +990,15 @@ mod tests {
         // credentialed provider advertises, so Ollama appears here because it
         // is listed — a credential alone no longer puts a model on the menu.
         settings
-            .set_models(vec![crate::config::model_list::ModelEntry::new(
-                "ollama", "llama3.2",
-            )])
+            .set_models(vec![
+                crate::config::model_list::ModelEntry::new("ollama", "llama3.2"),
+                crate::config::model_list::ModelEntry {
+                    provider: "ollama".to_string(),
+                    model: "qwen2.5-coder".to_string(),
+                    effort: Some("high".to_string()),
+                    label: None,
+                },
+            ])
             .expect("write the model list");
         let (mut w, mut reader, _server) =
             start_raw_server(fixed("unused"), sessions.path().to_path_buf());
@@ -1048,6 +1054,15 @@ mod tests {
             offered_name, "ollama: llama3.2",
             "ACP prefixes the provider group itself, so the name must not repeat it"
         );
+        // An entry that pins a reasoning effort shows it in the name, while the
+        // value stays `provider:model` so the client's "selected" echo matches.
+        let with_effort = model["options"]
+            .as_array()
+            .expect("model options")
+            .iter()
+            .find(|option| option["value"] == "ollama:qwen2.5-coder")
+            .expect("effort-bearing option");
+        assert_eq!(with_effort["name"], "ollama: qwen2.5-coder high");
 
         send_json(
             &mut w,

--- a/src/editor/acp/mod.rs
+++ b/src/editor/acp/mod.rs
@@ -1037,6 +1037,17 @@ mod tests {
             selected_model, "ollama:llama3.2",
             "the offered option is the listed entry"
         );
+        let offered_name = model["options"]
+            .as_array()
+            .expect("model options")
+            .iter()
+            .find(|option| option["value"] == "ollama:llama3.2")
+            .and_then(|option| option["name"].as_str())
+            .expect("named option");
+        assert_eq!(
+            offered_name, "ollama: llama3.2",
+            "ACP prefixes the provider group itself, so the name must not repeat it"
+        );
 
         send_json(
             &mut w,

--- a/src/editor/acp/mod.rs
+++ b/src/editor/acp/mod.rs
@@ -982,9 +982,18 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn standard_config_options_select_the_live_session_model() {
         let sessions = tempfile::tempdir().expect("sessions tempdir");
-        SettingsStore::open(sessions.path().join("settings.toml"))
+        let settings = SettingsStore::open(sessions.path().join("settings.toml"));
+        settings
             .set_token("ollama".to_string(), "local".to_string())
             .expect("mark Ollama configured");
+        // ACP is offered the user's model list, not every model every
+        // credentialed provider advertises, so Ollama appears here because it
+        // is listed — a credential alone no longer puts a model on the menu.
+        settings
+            .set_models(vec![crate::config::model_list::ModelEntry::new(
+                "ollama", "llama3.2",
+            )])
+            .expect("write the model list");
         let (mut w, mut reader, _server) =
             start_raw_server(fixed("unused"), sessions.path().to_path_buf());
         send_json(
@@ -1024,6 +1033,10 @@ mod tests {
             })
             .expect("Ollama model option")
             .to_owned();
+        assert_eq!(
+            selected_model, "ollama:llama3.2",
+            "the offered option is the listed entry"
+        );
 
         send_json(
             &mut w,

--- a/src/main.rs
+++ b/src/main.rs
@@ -229,7 +229,11 @@ enum Commands {
     /// Manage MCP servers in global settings or workspace `.mcp.json`.
     Mcp(McpArgs),
     /// Manage downloaded weights for the `local` provider.
-    Models(ModelsArgs),
+    ///
+    /// Named `weights` rather than `models` because `yolop models` is the
+    /// user's model list (see `capabilities::model_list`); this command is
+    /// about files on disk.
+    Weights(WeightsArgs),
     /// Live demo of the experimental `tuika` TUI toolkit (spinners, progress
     /// bars, loader). Press `q` or `Esc` to quit. Hidden dev helper.
     #[command(hide = true)]
@@ -256,13 +260,13 @@ struct McpArgs {
 }
 
 #[derive(Args, Debug)]
-struct ModelsArgs {
+struct WeightsArgs {
     #[command(subcommand)]
-    command: ModelsCommand,
+    command: WeightsCommand,
 }
 
 #[derive(Subcommand, Debug)]
-enum ModelsCommand {
+enum WeightsCommand {
     /// List downloaded models and the disk they use.
     List,
     /// Download a model into the store.
@@ -955,16 +959,16 @@ fn resolve_workspace_root(
     std::env::current_dir().context("resolve current workspace directory")
 }
 
-async fn run_models_command(command: ModelsCommand) -> Result<()> {
+async fn run_weights_command(command: WeightsCommand) -> Result<()> {
     match command {
-        ModelsCommand::List => {
+        WeightsCommand::List => {
             let models = models::installed()?;
             if models.is_empty() {
                 let location = models::store_root()
                     .map(|root| root.display().to_string())
                     .unwrap_or_else(|| "<no data directory>".to_string());
                 println!("No models downloaded. Store: {location}");
-                println!("Pull one with `yolop models pull {DEFAULT_LOCAL_MODEL}`.");
+                println!("Pull one with `yolop weights pull {DEFAULT_LOCAL_MODEL}`.");
                 return Ok(());
             }
             let total: u64 = models.iter().map(|model| model.bytes).sum();
@@ -974,7 +978,7 @@ async fn run_models_command(command: ModelsCommand) -> Result<()> {
             println!("{:<44} {}", "total", models::human_bytes(total));
             Ok(())
         }
-        ModelsCommand::Rm { repo } => {
+        WeightsCommand::Rm { repo } => {
             let reclaimed = models::remove(&repo)?;
             println!(
                 "Removed {repo} ({} reclaimed)",
@@ -982,7 +986,7 @@ async fn run_models_command(command: ModelsCommand) -> Result<()> {
             );
             Ok(())
         }
-        ModelsCommand::Pull { spec } => run_models_pull(&spec).await,
+        WeightsCommand::Pull { spec } => run_models_pull(&spec).await,
     }
 }
 
@@ -1273,7 +1277,7 @@ async fn run_command(command: Commands) -> Result<()> {
         }
         Commands::Worktree(args) => run_worktree_command(args.command),
         Commands::Mcp(args) => run_mcp_command(args.command),
-        Commands::Models(args) => run_models_command(args.command).await,
+        Commands::Weights(args) => run_weights_command(args.command).await,
         Commands::TuikaGallery => run_tuika_gallery(),
         #[cfg(target_os = "linux")]
         Commands::SandboxExec {
@@ -1397,6 +1401,7 @@ fn detached_cli_registry() -> Result<control::CliRegistry> {
     let connections_path =
         connectors::default_connections_path().unwrap_or_else(|| fallback.join("connections.toml"));
     let settings = Arc::new(SettingsStore::open(settings_path));
+    let model_list_settings = settings.clone();
     let secrets = extensions::ExtensionSecrets::new(Arc::new(connectors::ConnectionStore::open(
         connections_path,
     )));
@@ -1414,6 +1419,12 @@ fn detached_cli_registry() -> Result<control::CliRegistry> {
     );
     let mut registry = control::CliRegistry::default();
     registry.register(capability)?;
+    // `yolop models` edits the model list. Detached it writes global settings
+    // like any other CLI invocation; `use` needs a session and says so.
+    registry.register(Arc::new(capabilities::ModelListCapability::new(
+        model_list_settings,
+        None,
+    )))?;
     let coordination_store = match runtime::session_log::default_sessions_dir()
         .ok()
         .and_then(|dir| capabilities::CoordinationStore::open(&dir).ok())

--- a/src/models/download.rs
+++ b/src/models/download.rs
@@ -3,7 +3,7 @@
 //! The engine can download its own weights, but it does so silently inside the
 //! first inference call: a turn appears to hang for several gigabytes with
 //! nothing on screen. Yolop pulls the files itself instead, so the wait is an
-//! explicit `yolop models pull` with a progress bar, and a turn either has its
+//! explicit `yolop weights pull` with a progress bar, and a turn either has its
 //! weights or fails immediately with an actionable message.
 
 use super::{GGUF_SEPARATOR, repo_dir, split_spec};

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -3,8 +3,8 @@
 //! Weights for the `local` provider live under `<data_dir>/yolop/models/`,
 //! one directory per Hugging Face repo. Yolop owns this directory rather than
 //! deferring to the engine's own cache so the bytes are inspectable: `yolop
-//! models list` can report what is on disk and how much it costs, and `yolop
-//! models rm` can reclaim it. An engine-managed cache would leave users with
+//! weights list` can report what is on disk and how much it costs, and `yolop
+//! weights rm` can reclaim it. An engine-managed cache would leave users with
 //! gigabytes they can neither see nor delete through yolop.
 //!
 //! Listing and removal are plain filesystem work and compile into every build.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3177,12 +3177,12 @@ impl ModelState {
             // The value carries no reasoning effort so it still matches the
             // `provider:model` id the client echoes back as "selected";
             // `select_model_id` re-applies the entry's effort on the way in.
-            Self::push_model_option(
-                &mut options,
-                &entry.provider,
-                &entry.model,
-                &entry.display(),
-            );
+            //
+            // The name omits the provider: ACP renders these as
+            // `<group>: <name>` with the group already naming the provider, so
+            // `display()` here would read "ollama: ollama/llama3.2".
+            let name = entry.label.clone().unwrap_or_else(|| entry.spec());
+            Self::push_model_option(&mut options, &entry.provider, &entry.model, &name);
         }
 
         // The installed session model remains usable even if its credential is

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3123,9 +3123,19 @@ impl ModelState {
         let (provider, model) = value
             .split_once(':')
             .ok_or_else(|| anyhow!("model selection must be `provider:model`"))?;
+        // A list entry may pin a reasoning effort alongside the model; the
+        // wire value carries only `provider:model`, so recover the effort here
+        // rather than silently dropping it on selection.
+        let settings = self.settings.snapshot();
+        let spec = settings
+            .model_list()
+            .into_iter()
+            .find(|entry| entry.provider == provider && entry.model == model)
+            .map(|entry| entry.spec())
+            .unwrap_or_else(|| model.to_string());
         let selected =
-            ProviderChoice::default_for_provider_name(provider)?.resolve_model_spec(model)?;
-        let resolved = selected.model_with_provider(&self.settings.snapshot())?;
+            ProviderChoice::default_for_provider_name(provider)?.resolve_model_spec(&spec)?;
+        let resolved = selected.model_with_provider(&settings)?;
         self.provider_store
             .set_default_model_spec(resolved.model_spec())
             .await?;
@@ -3146,6 +3156,14 @@ impl ModelState {
         options.push((value, name.to_string(), provider.to_string()));
     }
 
+    /// The models this session offers, for ACP's model config option.
+    ///
+    /// This is the user's model list (`[[models]]`), not every model every
+    /// credentialed provider advertises: an editor's model menu should hold the
+    /// handful a user switches between. Browsing the full catalog is
+    /// `search_models` and the `/model` picker's "browse all models" path.
+    /// Entries are `(value, name, group)` where the value is `provider:model`,
+    /// so selecting one switches provider and model together.
     pub(crate) async fn model_options(&self) -> Vec<(String, String, String)> {
         let settings = self.settings.snapshot();
         let current = self
@@ -3153,39 +3171,18 @@ impl ModelState {
             .read()
             .expect("provider lock poisoned")
             .clone();
+        let current_key = format!("{}:{}", current.provider_name(), current.model_id());
         let mut options = Vec::new();
-
-        for provider in SUPPORTED_PROVIDERS.iter().copied().filter(|provider| {
-            crate::capabilities::model_discovery::provider_is_usable(&settings, provider)
-        }) {
-            let Ok(resolved) = resolve_for_settings(provider, &settings) else {
-                continue;
-            };
+        for entry in crate::capabilities::offered_models(&settings, Some(current_key.as_str())) {
+            // The value carries no reasoning effort so it still matches the
+            // `provider:model` id the client echoes back as "selected";
+            // `select_model_id` re-applies the entry's effort on the way in.
             Self::push_model_option(
                 &mut options,
-                provider,
-                resolved.choice.model_id(),
-                resolved.choice.model_id(),
+                &entry.provider,
+                &entry.model,
+                &entry.display(),
             );
-
-            for model in ProviderChoice::model_suggestions_for_provider(provider) {
-                Self::push_model_option(&mut options, provider, model, model);
-            }
-
-            if let Ok(Ok(Some(discovered))) = tokio::time::timeout(
-                std::time::Duration::from_secs(5),
-                crate::capabilities::model_discovery::discover_provider_models(
-                    &resolved.choice,
-                    &settings,
-                ),
-            )
-            .await
-            {
-                for model in discovered {
-                    let name = model.display_name.as_deref().unwrap_or(&model.model_id);
-                    Self::push_model_option(&mut options, provider, &model.model_id, name);
-                }
-            }
         }
 
         // The installed session model remains usable even if its credential is
@@ -3885,6 +3882,22 @@ pub async fn build_with_options(
     let live_processes = crate::extensions::LiveProcessRegistry::default();
     let mut session_control_registry = crate::control::ControlRegistry::default();
     session_control_registry.register(coordination_capability)?;
+    // The model list administers itself through the same attached-CLI plane:
+    // `yolop models ...`. It shares `ModelsCapability`'s controller, so
+    // `yolop models use` switches this live session exactly like `/setup
+    // provider <name> <model>`.
+    let pending_model_choice = Arc::new(RwLock::new(None));
+    let model_list = Arc::new(crate::capabilities::ModelListCapability::new(
+        settings.clone(),
+        Some(crate::capabilities::host::setup_controller(
+            provider_state.clone(),
+            provider_store.clone(),
+            settings.clone(),
+            pending_model_choice.clone(),
+        )),
+    ));
+    session_control_registry.register(model_list.clone())?;
+    capabilities.register_arc(model_list);
     // Per-extension secrets ride the shared credential store (`connections.toml`,
     // 0600), keyed `ext:<name>` — never `settings.toml`. Injected as env at
     // spawn; never surfaced to the agent.
@@ -4085,7 +4098,6 @@ pub async fn build_with_options(
     });
     // `/setup` (below) is the capability-sourced slash command. It implements
     // `Capability::execute_command` end to end.
-    let pending_model_choice = Arc::new(RwLock::new(None));
     capabilities.register(ModelsCapability {
         provider: provider_state.clone(),
         provider_store: provider_store.clone(),
@@ -7277,7 +7289,7 @@ mod tests {
         // With a persisted model the custom endpoint is auto-selected (the
         // caller's `resolve_for_settings` fills the model in).
         settings
-            .models
+            .default_models
             .insert("custom".to_string(), "qwen3-coder".to_string());
         let provider = ProviderChoice::from_env_or_settings(&settings);
         assert_eq!(provider.provider_name(), "custom");
@@ -7363,12 +7375,12 @@ mod tests {
         }
         let mut settings = Settings::default();
         settings
-            .models
+            .default_models
             .insert("openai".to_string(), "gpt-5.4 high".to_string());
         // Anthropic profiles own their effort support too, so a persisted
         // model+effort spec is restored when the model profile allows it.
         settings
-            .models
+            .default_models
             .insert("anthropic".to_string(), "claude-opus-4-5 high".to_string());
 
         let openai = resolve_for_settings("openai", &settings)
@@ -7390,7 +7402,7 @@ mod tests {
         }
         let mut settings = Settings::default();
         settings
-            .models
+            .default_models
             .insert("openai".to_string(), "gpt-5.4 high".to_string());
 
         let resolved = resolve_for_settings("openai", &settings).expect("resolve");

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -273,6 +273,10 @@ pub struct App {
     /// name. Once populated, replaces the curated fallback list in the
     /// model picker.
     model_catalog: HashMap<String, ModelPickerCatalog>,
+    /// A model chosen from the list whose provider still needs credentials.
+    /// Held across the credential/login steps so authenticating applies the
+    /// model the user actually picked instead of dropping them in a catalog.
+    pending_list_model: Option<crate::config::model_list::ModelEntry>,
     /// Providers with an in-flight models API fetch.
     model_fetches_in_flight: HashSet<String>,
     /// Disabled in unit tests so opening the picker never spawns real
@@ -455,6 +459,13 @@ pub(crate) enum SetupStep {
         custom: Option<String>,
         error: Option<String>,
     },
+    /// The model list: the default view when switching models, spanning
+    /// providers. `PickModel` above is the browse-one-provider's-catalog step
+    /// behind it. See [`crate::capabilities::model_list`].
+    PickListedModel {
+        selected: usize,
+        error: Option<String>,
+    },
     PickEffort {
         selected: usize,
         error: Option<String>,
@@ -623,6 +634,17 @@ pub(crate) struct ModelOption {
     hint: String,
 }
 
+/// One row of the model list overlay: an entry from `[[models]]`, or the
+/// trailing row that falls through to browsing a provider's whole catalog.
+#[derive(Clone, Debug)]
+pub(crate) struct ListedModelRow {
+    /// `None` on the "Browse all models…" row.
+    pub(crate) entry: Option<crate::config::model_list::ModelEntry>,
+    pub(crate) label: String,
+    pub(crate) hint: String,
+    pub(crate) selected_now: bool,
+}
+
 /// Owned snapshot of the App fields the pure-render chrome helpers
 /// (command suggestions, stream preview, separators, session status)
 /// consume. Extracted from `App` so those helpers can be exercised by
@@ -734,6 +756,7 @@ impl App {
             settings: runtime.settings,
             sandbox_mode_override: runtime.sandbox_mode_override,
             model_catalog: HashMap::new(),
+            pending_list_model: None,
             model_fetches_in_flight: HashSet::new(),
             model_discovery_enabled: true,
             models_tx,
@@ -3151,7 +3174,7 @@ impl App {
             UiCommand::RunShell { command } => self.start_shell_command(command),
             UiCommand::Quit => self.should_quit = true,
             UiCommand::OpenModelOverlay { arg } => match arg {
-                Some(arg) => self.start_model_setup_with_arg(&arg),
+                Some(arg) => self.start_model_setup_with_arg(&arg).await,
                 None => self.start_model_setup(),
             },
             UiCommand::OpenEffortOverlay { arg } => {
@@ -11079,26 +11102,97 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn model_command_opens_model_picker_overlay() {
+    async fn model_command_opens_the_model_list() {
         let mut fixture = app_with_llmsim().await;
         let app = &mut fixture.app;
         app.lines.clear();
 
         app.dispatch_command_for_test("model").await;
 
-        assert!(matches!(
-            app.setup,
-            Some(SetupStep::PickModel {
-                ref provider,
-                ..
-            }) if provider == "llmsim"
-        ));
+        // `/model` opens the cross-provider list, not one provider's catalog.
+        assert!(matches!(app.setup, Some(SetupStep::PickListedModel { .. })));
         let rendered = setup_overlay_text(app);
-        assert!(rendered.iter().any(|line| line.contains("Select Model")));
+        assert!(rendered.iter().any(|line| line.contains("Models")));
+        assert!(
+            rendered
+                .iter()
+                .any(|line| line.contains("Browse all models")),
+            "the full catalog stays reachable from the list: {rendered:?}"
+        );
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn picking_an_unauthenticated_model_routes_through_sign_in() {
+        let _guard = crate::testing::test_env::lock();
+        unsafe {
+            std::env::remove_var("OLLAMA_BASE_URL");
+            std::env::remove_var("OLLAMA_API_KEY");
+        }
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.settings
+            .set_models(vec![crate::config::model_list::ModelEntry::new(
+                "ollama", "llama3.2",
+            )])
+            .expect("write the model list");
+        app.lines.clear();
+
+        app.start_model_setup();
+        // The entry is visible and marked rather than hidden: picking a model
+        // you have not signed in to yet is how you start using it.
+        let rows = app.listed_model_rows();
+        assert!(
+            rows[0].hint.contains("needs sign-in"),
+            "unauthenticated entries are marked: {:?}",
+            rows[0]
+        );
+
+        app.confirm_listed_model(0).await;
+
+        assert!(
+            matches!(app.setup, Some(SetupStep::Credential { ref provider, .. }) if provider == "ollama"),
+            "selecting it opens sign-in for its provider: {:?}",
+            app.setup
+        );
+        assert_eq!(
+            app.pending_list_model,
+            Some(crate::config::model_list::ModelEntry::new(
+                "ollama", "llama3.2"
+            )),
+            "the picked model is held so authenticating applies it"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn model_command_preselects_current_raw_model_id() {
+    async fn finishing_sign_in_applies_the_model_that_was_picked() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.lines.clear();
+        app.handle_command("setup token openai sk-test").await;
+        app.pending_list_model = Some(crate::config::model_list::ModelEntry::new(
+            "openai",
+            "gpt-5.4-mini",
+        ));
+
+        app.finish_auth_step("openai").await;
+
+        assert!(
+            app.model
+                .provider_label()
+                .starts_with("openai/gpt-5.4-mini"),
+            "authentication lands on the picked model, not a catalog: {}",
+            app.model.provider_label()
+        );
+        assert!(app.setup.is_none(), "the overlay closes: {:?}", app.setup);
+        assert!(
+            app.pending_list_model.is_none(),
+            "the pending pick is consumed"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn model_list_preselects_the_current_model() {
         let mut fixture = app_with_llmsim().await;
         let app = &mut fixture.app;
         app.lines.clear();
@@ -11111,18 +11205,21 @@ mod tests {
         app.run_setup_command(Some("model gpt-5.4"))
             .await
             .expect("set openai model");
+        app.settings
+            .set_models(vec![
+                crate::config::model_list::ModelEntry::new("openai", "gpt-5.6-sol"),
+                crate::config::model_list::ModelEntry::new("openai", "gpt-5.4"),
+            ])
+            .expect("write the model list");
         app.lines.clear();
 
         app.dispatch_command_for_test("model").await;
 
-        assert!(matches!(
-            app.setup,
-            Some(SetupStep::PickModel {
-                ref provider,
-                selected,
-                ..
-            }) if provider == "openai" && selected == 4
-        ));
+        assert!(
+            matches!(app.setup, Some(SetupStep::PickListedModel { selected, .. }) if selected == 1),
+            "the list opens on the model in use: {:?}",
+            app.setup
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -11557,7 +11654,7 @@ mod tests {
             ));
             match action {
                 StatusAction::OpenModel => {
-                    assert!(matches!(app.setup, Some(SetupStep::PickModel { .. })));
+                    assert!(matches!(app.setup, Some(SetupStep::PickListedModel { .. })));
                 }
                 StatusAction::OpenEffort => {
                     assert!(matches!(app.setup, Some(SetupStep::PickEffort { .. })));

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1128,6 +1128,28 @@ pub(crate) fn setup_overlay_content(app: &App) -> (Vec<Line<'static>>, Option<(u
             push_setup_error(&mut lines, error.as_deref());
             lines.push(setup_footer("Enter confirm · ↑/↓ move · Esc back"));
         }
+        Some(SetupStep::PickListedModel { selected, error }) => {
+            lines.push(setup_title("Models"));
+            lines.push(setup_hint(
+                "Your model list. Applies to this session and future sessions.",
+            ));
+            lines.push(Line::from(""));
+            let rows = app.listed_model_rows();
+            let (start, end) = model_window(*selected, rows.len(), MAX_VISIBLE_MODEL_ROWS);
+            if start > 0 {
+                lines.push(setup_hint(&format!("↑ {start} more")));
+            }
+            for (idx, row) in rows.iter().enumerate().take(end).skip(start) {
+                lines.push(setup_row(idx == *selected, idx + 1, &row.label, &row.hint));
+            }
+            if end < rows.len() {
+                lines.push(setup_hint(&format!("↓ {} more", rows.len() - end)));
+            }
+            push_setup_error(&mut lines, error.as_deref());
+            lines.push(setup_footer(
+                "Enter confirm · ↑/↓ move · Esc cancel · `yolop models` to edit",
+            ));
+        }
         Some(SetupStep::PickEffort { selected, error }) => {
             lines.push(setup_title("Select Reasoning Effort"));
             lines.push(setup_hint(
@@ -1290,6 +1312,31 @@ pub(crate) fn setup_picker(app: &App) -> Option<SetupPicker> {
                 selected: *selected,
                 footer,
                 viewport: None,
+            })
+        }
+        SetupStep::PickListedModel { selected, error } => {
+            let header = vec![
+                setup_title("Models"),
+                setup_hint("Your model list. Applies to this session and future sessions."),
+                Line::from(""),
+            ];
+            let options = app
+                .listed_model_rows()
+                .iter()
+                .enumerate()
+                .map(|(idx, row)| setup_option_line(idx + 1, &row.label, &row.hint))
+                .collect();
+            let mut footer = Vec::new();
+            push_setup_error(&mut footer, error.as_deref());
+            footer.push(setup_footer(
+                "Enter confirm · ↑/↓ move · Esc cancel · `yolop models` to edit",
+            ));
+            Some(SetupPicker {
+                header,
+                options,
+                selected: *selected,
+                footer,
+                viewport: Some(MAX_VISIBLE_MODEL_ROWS as u16),
             })
         }
         // The model list is a windowed SelectList. Its custom-id sub-mode

--- a/src/tui/setup.rs
+++ b/src/tui/setup.rs
@@ -40,15 +40,82 @@ impl App {
         self.start_setup();
     }
 
+    /// `/model` and the status-bar click open the model list, not one
+    /// provider's catalog: the list is what a user switches between, and it
+    /// spans providers. Browsing a provider's full catalog is one row down.
     pub(crate) fn start_model_setup(&mut self) {
-        let provider = self.current_provider_name();
-        self.open_model_step(&provider);
+        let rows = self.listed_model_rows();
+        let selected = rows.iter().position(|row| row.selected_now).unwrap_or(0);
+        self.setup = Some(SetupStep::PickListedModel {
+            selected,
+            error: None,
+        });
     }
 
-    pub(crate) fn start_model_setup_with_arg(&mut self, raw: &str) {
+    /// Rows for the model list overlay. Entries whose provider has no
+    /// credential stay visible and marked: picking one is a legitimate way to
+    /// start using it, and it routes into sign-in (see `confirm_listed_model`).
+    pub(crate) fn listed_model_rows(&self) -> Vec<ListedModelRow> {
+        let settings = self.settings.snapshot();
+        let current_provider = self.current_provider_name();
+        let current_model = self.model.model_id();
+        let mut rows: Vec<ListedModelRow> = settings
+            .model_list()
+            .into_iter()
+            .map(|entry| {
+                let selected_now =
+                    entry.provider == current_provider && entry.model == current_model;
+                let connected = crate::capabilities::model_discovery::provider_is_usable(
+                    &settings,
+                    &entry.provider,
+                );
+                let mut hint = App::provider_label(&entry.provider).to_string();
+                if let Some(effort) = &entry.effort {
+                    hint.push_str(&format!(" · {effort}"));
+                }
+                if !connected {
+                    hint.push_str(" · needs sign-in");
+                }
+                if selected_now {
+                    hint.push_str(" · current");
+                }
+                ListedModelRow {
+                    label: entry.display(),
+                    hint,
+                    selected_now,
+                    entry: Some(entry),
+                }
+            })
+            .collect();
+        rows.push(ListedModelRow {
+            entry: None,
+            label: "Browse all models…".to_string(),
+            hint: "every model each provider offers".to_string(),
+            selected_now: false,
+        });
+        rows
+    }
+
+    pub(crate) async fn start_model_setup_with_arg(&mut self, raw: &str) {
         let spec = raw.trim();
         if spec.is_empty() {
             self.start_model_setup();
+            return;
+        }
+        // `/model <id>` names a model, and the list is where the named models
+        // are: apply it directly when it is on the list rather than opening a
+        // picker the user then has to confirm.
+        let listed = self
+            .listed_model_rows()
+            .into_iter()
+            .filter_map(|row| row.entry)
+            .find(|entry| {
+                entry.model == spec
+                    || entry.key() == spec
+                    || format!("{}/{}", entry.provider, entry.model) == spec
+            });
+        if let Some(entry) = listed {
+            self.apply_listed_model(&entry, 0).await;
             return;
         }
         let provider = self.current_provider_name();
@@ -724,6 +791,9 @@ impl App {
             } => {
                 self.handle_model_key(key, provider, selected, custom).await;
             }
+            SetupStep::PickListedModel { selected, .. } => {
+                self.handle_listed_model_key(key, selected).await;
+            }
             SetupStep::PickEffort { selected, .. } => {
                 self.handle_effort_key(key, selected).await;
             }
@@ -792,7 +862,7 @@ impl App {
             // yet, and the model step right after sets provider + model
             // atomically via `provider custom <model>`.
             let _ = self.run_setup_command(Some("provider custom")).await;
-            self.open_model_step("custom");
+            self.finish_auth_step("custom").await;
             return;
         }
 
@@ -800,7 +870,7 @@ impl App {
             .run_setup_command(Some(&format!("provider {}", option.name)))
             .await
         {
-            Ok(()) => self.open_model_step(option.name),
+            Ok(()) => self.finish_auth_step(option.name).await,
             Err(error) => {
                 // A connected-looking provider that still fails to switch
                 // (stale key, unreachable endpoint) lands on the credential
@@ -976,14 +1046,14 @@ impl App {
                 // chosen, so the validation switch is deferred to the model
                 // step (its key is optional anyway).
                 if provider == "custom" {
-                    self.open_model_step("custom");
+                    self.finish_auth_step("custom").await;
                     return;
                 }
                 match self
                     .run_setup_command(Some(&format!("provider {provider}")))
                     .await
                 {
-                    Ok(()) => self.open_model_step(&provider),
+                    Ok(()) => self.finish_auth_step(&provider).await,
                     Err(error) => {
                         self.setup = Some(SetupStep::Credential {
                             provider,
@@ -1191,7 +1261,7 @@ impl App {
                                     error: Some(error),
                                 });
                             } else {
-                                self.open_model_step("codex");
+                                self.finish_auth_step("codex").await;
                             }
                         }
                         Err(error) => {
@@ -1239,7 +1309,7 @@ impl App {
                             error: Some(error),
                         });
                     } else {
-                        self.open_model_step("openrouter");
+                        self.finish_auth_step("openrouter").await;
                     }
                 }
                 Err(error) => {
@@ -1296,7 +1366,7 @@ impl App {
                         return;
                     }
                     match self.run_setup_command(Some("provider codex")).await {
-                        Ok(()) => self.open_model_step("codex"),
+                        Ok(()) => self.finish_auth_step("codex").await,
                         Err(error) => {
                             self.setup = Some(SetupStep::TokenInput {
                                 provider,
@@ -1320,14 +1390,14 @@ impl App {
                 // model is known yet); other providers validate the new key
                 // by switching now.
                 if provider == "custom" {
-                    self.open_model_step("custom");
+                    self.finish_auth_step("custom").await;
                     return;
                 }
                 match self
                     .run_setup_command(Some(&format!("provider {provider}")))
                     .await
                 {
-                    Ok(()) => self.open_model_step(&provider),
+                    Ok(()) => self.finish_auth_step(&provider).await,
                     Err(error) => {
                         self.setup = Some(SetupStep::TokenInput {
                             provider,
@@ -1451,6 +1521,104 @@ impl App {
             }
             _ => {}
         }
+    }
+
+    pub(crate) async fn handle_listed_model_key(&mut self, key: KeyEvent, selected: usize) {
+        let rows = self.listed_model_rows();
+        match key.code {
+            KeyCode::Esc => self.setup = None,
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.setup = Some(SetupStep::PickListedModel {
+                    selected: select_up(selected),
+                    error: None,
+                });
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.setup = Some(SetupStep::PickListedModel {
+                    selected: select_down(selected, rows.len()),
+                    error: None,
+                });
+            }
+            KeyCode::Char(ch) if ch.is_ascii_digit() => {
+                if let Some(index) = digit_index(ch, rows.len()) {
+                    self.confirm_listed_model(index).await;
+                }
+            }
+            KeyCode::Enter => self.confirm_listed_model(selected).await,
+            _ => {}
+        }
+    }
+
+    pub(crate) async fn confirm_listed_model(&mut self, selected: usize) {
+        let rows = self.listed_model_rows();
+        let Some(row) = rows.get(selected) else {
+            self.setup = Some(SetupStep::PickListedModel {
+                selected: 0,
+                error: None,
+            });
+            return;
+        };
+        let Some(entry) = row.entry.clone() else {
+            // "Browse all models…": the provider picker, then that provider's
+            // catalog — the pre-list flow, kept as the way to reach anything
+            // not on the list (and to add to it).
+            self.start_setup();
+            return;
+        };
+        let settings = self.settings.snapshot();
+        if !crate::capabilities::model_discovery::provider_is_usable(&settings, &entry.provider) {
+            // Picking a model is a request to use it, so sign-in is part of the
+            // same gesture: authenticate, then apply the model that was picked
+            // (`finish_auth_step`) rather than dumping the user in a catalog.
+            self.push_system(format!(
+                "{} needs credentials; signing in first, then switching to {}",
+                App::provider_label(&entry.provider),
+                entry.display()
+            ));
+            self.pending_list_model = Some(entry.clone());
+            self.setup = Some(SetupStep::Credential {
+                provider: entry.provider.clone(),
+                selected: 0,
+                error: None,
+            });
+            return;
+        }
+        self.apply_listed_model(&entry, selected).await;
+    }
+
+    /// Apply one list entry: provider and model together, through the same
+    /// `/setup provider <name> <model> [effort]` path every other surface uses.
+    pub(crate) async fn apply_listed_model(
+        &mut self,
+        entry: &crate::config::model_list::ModelEntry,
+        selected: usize,
+    ) {
+        let command = format!("provider {} {}", entry.provider, entry.spec());
+        match self.run_setup_command(Some(&command)).await {
+            Ok(()) => {
+                self.setup = None;
+                self.push_system(format!("model: {}", self.model.provider_label()));
+            }
+            Err(error) => {
+                self.setup = Some(SetupStep::PickListedModel {
+                    selected,
+                    error: Some(error),
+                });
+            }
+        }
+    }
+
+    /// The hop every credential path takes once authentication succeeds. A
+    /// model picked from the list is applied here; otherwise this is the
+    /// provider's model picker, as before.
+    pub(crate) async fn finish_auth_step(&mut self, provider: &str) {
+        if let Some(entry) = self.pending_list_model.take()
+            && entry.provider == provider
+        {
+            self.apply_listed_model(&entry, 0).await;
+            return;
+        }
+        self.open_model_step(provider);
     }
 
     pub(crate) async fn confirm_model(&mut self, provider: String, selected: usize) {


### PR DESCRIPTION
## What changed

Switching models now offers an ordered, cross-provider list the user curates, instead of whatever the provider's models API returned.

- **`/model` and the status-bar click** open the list. A trailing "Browse all models…" row falls through to the previous provider→catalog flow, so nothing becomes unreachable.
- **`/model <id>`** applies a listed model directly rather than pre-filling a picker the user then confirms.
- **ACP** (`session/new` `configOptions`) serves the same list, filtered to providers with a credential plus the model in use.
- **Picking an unauthenticated model authenticates.** The TUI shows those entries marked "needs sign-in"; selecting one opens that provider's existing credential step, holds the pick, and applies it once sign-in succeeds. Every credential path (token paste, environment, Codex and OpenRouter browser login, custom endpoint) funnels through one hop for this.
- **`yolop models list|add|rm|move|use|reset`** administers the list on the attached control plane, matching `yolop extensions` / `yolop coordination` rather than adding model tools that cost prompt budget every turn.

An entry pairs provider with model (plus optional `effort` and `label`), so one selection switches both, and the same weights reached directly and through OpenRouter are distinct entries. Stored as `[[models]]`; unset resolves to a built-in default list led by `gpt-5.6-sol`, which the first edit materializes rather than replaces.

`use` routes through `SetupController::change_provider`, the call `/setup provider <name> <model>` already makes, so there is one implementation behind every surface.

## Why

Providers publish hundreds of models. `/model` showed one provider's entire catalog and ACP was offered every discovered model of every credentialed provider. A user switches between a handful, and nothing in yolop knew which handful.

Named "models", not favourites or bookmarks: those words describe marking items inside a larger list you still browse, whereas here the list *is* the offer and the catalog is the fallback.

## Before / After

ACP model options, real binary, with an Ollama endpoint reachable and two Ollama models on the list:

```
before: every model each credentialed provider advertises (the whole catalog)
after:  [('ollama:llama3.2',      'ollama: llama3.2'),
         ('ollama:qwen2.5-coder', 'ollama: qwen2.5-coder')]
```

With no provider credentials at all, ACP offers only the model in use (`llmsim:llmsim-yolop`) rather than a list of dead options.

`yolop models list` (the editing view shows everything, marked):

```
   1. anthropic/claude-opus-4-8  (no credential)
   2. openai/gpt-5.6-sol  (no credential)
   3. openai/gpt-5.4-mini  (no credential)
(built-in default list; `yolop models add|rm|move` makes it yours)
```

Errors name the fix rather than guessing:

```
$ yolop models rm claude-opus-4-8
Error: `claude-opus-4-8` is on the list for anthropic and openrouter; qualify it as `<provider>/claude-opus-4-8`
```

## Risk

- **Medium.** Two settings keys move, and the model-selection path is on every session's critical path.
- What can break:
  - `[models]` (per-provider memory) became `[default_models]`; the list took the `models` name. A `models` *table* in settings or a profile is still read as `default_models`, so existing picks survive, but a settings file rewritten by this build is not readable as the old shape by an older build. Pre-1.0, no back-compat required.
  - `yolop models` (local weights) became `yolop weights`, since the contributed CLI command may not shadow a built-in. Docs and in-binary error messages updated together.
  - ACP clients see a shorter model list. That is the intent, but it is a visible behavior change for editor integrations.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

- Added [`knowledge/specs/model-list.md`](knowledge/specs/model-list.md): the list contract, the per-surface credential-filtering rule, sign-in-on-select, and the ownership boundary against `model_discovery` and `SetupController`.
- Updated `knowledge/index.md`, `knowledge/log.md`, `specs/acp.md` (model option now serves the list), `specs/configuration.md` (`models` / `default_models` key split, profileable keys), `specs/conversational-control.md` (the list joins the attached-CLI exception), `specs/local-inference.md` (`yolop weights`).
- Updated the bundled `yolop` and `yolop-config` skills and `README.md`.

## Security

Reviewed; no new exposure found.

- **Secrets:** the list stores provider names, model ids, and labels, never credentials. `provider_is_usable` reads credential *presence* only, so the `connected` flag exposes nothing `/setup status` and `get_config` (`tokens.<p>` = `stored`/`unset`) do not already show.
- **Privilege:** the new control route follows the existing pattern with `list` as its only read-only operation; every mutation stays consequential and `use` requires an attached session. No new transport, socket, or token.
- **Input handling:** `add` validates the provider against `SUPPORTED_PROVIDERS` and rejects an empty model; `move` is bounds-checked; parsing skips malformed entries instead of failing the load; ambiguous references error instead of guessing. Model ids reach `change_provider` as an in-process call with no shell involved, and a whitespace-bearing id fails closed in `resolve_model_spec` ("too many model arguments") rather than becoming extra arguments.
- **Data loss:** covered by tests for the legacy `[models]`-table migration in both global settings and profiles, and for first-edit materialization of the defaults.

## Follow-ups

One design decision is deliberately deferred; nothing else is outstanding.

- A profile's `[[models]]` replaces the global menu wholesale, with no `models_mode` merge/replace switch like `capabilities_mode` and `mcp_mode`. Replace is the semantics a profile that names a menu wants ("these models, for this job"), and the merge case has no caller yet, so the switch is not built. Adding it later is additive and breaks nothing.

Three items listed on earlier revisions have since been closed rather than carried:

- ~~Live-provider smoke not run.~~ It could not run in the authoring sandbox (Doppler CLI install and secrets API both blocked there). CI's **Live Provider Smoke (Doppler)** job has since run green on this branch.
- ~~`yolop models use` not covered end to end.~~ The CLI envelope already has transport tests; what needed covering is that one selection moves provider *and* model on the live session. That now drives the real `SetupController`, with a companion test that a refused switch leaves the session on its model.
- ~~Reasoning effort not shown in the ACP option name.~~ This was simply wrong: the name is the entry's spec, which carries the effort. Only the wire value omits it, so the client's "selected" echo still matches. Now pinned by a test.

---
_Generated by [Claude Code](https://claude.ai/code/session_012ewue2QhWFk1vF987gwgzi)_