### PR TITLE
feat(extensions): show and set config, and list commands on a bad guess

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,24 @@
 # Knowledge Log
 
+## 2026-08-20, A wrong guess should cost one call, not six
+
+- An unrecognized subcommand now lists the ones that exist. Clap's message names
+  none of them and its usage line shows a `[COMMAND]` placeholder, so a caller
+  that guessed wrong learned nothing and had to fetch `--help` separately. This
+  is root-level, so every command group gets it.
+- [Extensions](specs/extensions.md): `config show` and `config set` close the
+  gap the guessing was reaching for. A non-secret field was reachable only
+  through the enable-time prompt or by hand-editing `settings.toml`, and no
+  output named where values were stored, so a session went hunting through the
+  config directory with `find`, `cat`, and `grep`.
+- Secrets keep their prompt-only path: `config set` refuses them and names
+  `secret set`, and `config show` reports a secret as set or unset, never by
+  value. The leak guard is the reason the read path was incomplete, so widening
+  it deliberately stops short of secrets.
+- The lesson generalizes: a model guessing a plausible verb is a given. What a
+  CLI controls is whether that guess self-corrects in one call or turns into a
+  filesystem investigation.
+
 ## 2026-08-20, The model menu is a list, not a catalog
 
 - [Model list](specs/model-list.md): `/model`, the status bar, and ACP now serve

--- a/knowledge/specs/extensions.md
+++ b/knowledge/specs/extensions.md
@@ -260,6 +260,16 @@ neither installed, present on disk, nor already carrying an override: it stays
 looser than `enable` so a package with a broken manifest can still be switched
 off, but it no longer reports success for a typo.
 
+`yolop extensions config show <name>` prints every declared field, whether it
+is set, the value of each non-secret one, and the file it is read from;
+`config set <name> <field> <value>` writes a non-secret field. Secrets are
+refused there and keep the prompt-only path, so a value never reaches a shell
+history or a tool call, and `show` reports a secret only as set or unset. Before
+this, a non-secret field like an endpoint was reachable only through the
+enable-time prompt or by hand-editing `settings.toml`, and nothing named where
+values lived, so callers reverse engineered the config directory with `find`
+and `grep`.
+
 `remove` is also spelled `uninstall`: it is the natural opposite of `install`,
 and without the alias clap rejected it and suggested `install` itself.
 

--- a/src/extensions/manage.rs
+++ b/src/extensions/manage.rs
@@ -73,6 +73,8 @@ enum ExtensionCommand {
     Reload { name: String },
     /// Probe an installed extension's YEP conformance.
     Doctor { name: String },
+    /// Show or set an extension's configuration.
+    Config(ExtensionConfigArgs),
     /// Prompt for and store an extension secret.
     Secret(ExtensionSecretArgs),
     /// Create a new extension package skeleton.
@@ -94,6 +96,27 @@ enum ExtensionCommand {
         skills: bool,
         #[arg(long)]
         dir: Option<PathBuf>,
+    },
+}
+
+#[derive(Args, Debug)]
+pub struct ExtensionConfigArgs {
+    #[command(subcommand)]
+    command: ExtensionConfigCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum ExtensionConfigCommand {
+    /// Show an extension's configuration: which fields are set, the values of
+    /// the non-secret ones, and the files they are stored in.
+    Show { name: String },
+    /// Set a non-secret field. Secrets are refused here and keep their
+    /// prompt-only path, so a value never lands in a shell history or a
+    /// tool-call argument.
+    Set {
+        name: String,
+        field: String,
+        value: String,
     },
 }
 
@@ -154,6 +177,14 @@ pub enum ExtensionAction {
         name: String,
         field: String,
     },
+    ShowConfig {
+        name: String,
+    },
+    SetConfig {
+        name: String,
+        field: String,
+        value: String,
+    },
     Scaffold {
         name: String,
         description: String,
@@ -177,6 +208,12 @@ impl ExtensionAction {
             ExtensionCommand::Disable { name } => Self::Disable { name },
             ExtensionCommand::Reload { name } => Self::Reload { name },
             ExtensionCommand::Doctor { name } => Self::Doctor { name },
+            ExtensionCommand::Config(args) => match args.command {
+                ExtensionConfigCommand::Show { name } => Self::ShowConfig { name },
+                ExtensionConfigCommand::Set { name, field, value } => {
+                    Self::SetConfig { name, field, value }
+                }
+            },
             ExtensionCommand::Secret(args) => match args.command {
                 ExtensionSecretCommand::Set { name, field } => Self::SetSecret { name, field },
             },
@@ -236,6 +273,11 @@ impl ExtensionAction {
             Self::SetSecret { name, field } => {
                 (Verb::SetSecret, json!({ "name": name, "field": field }))
             }
+            Self::ShowConfig { name } => (Verb::ShowConfig, json!({ "name": name })),
+            Self::SetConfig { name, field, value } => (
+                Verb::SetConfig,
+                json!({ "name": name, "field": field, "value": value }),
+            ),
             Self::Scaffold {
                 name,
                 description,
@@ -351,6 +393,8 @@ impl ExtensionsCapability {
             Verb::Disable,
             Verb::Reload,
             Verb::SetSecret,
+            Verb::ShowConfig,
+            Verb::SetConfig,
             Verb::Doctor,
         ]
         .into_iter()
@@ -554,6 +598,8 @@ enum Verb {
     Disable,
     Reload,
     SetSecret,
+    ShowConfig,
+    SetConfig,
     Doctor,
 }
 
@@ -1070,6 +1116,159 @@ impl ManageTool {
         }
     }
 
+    /// The installed package and its effective (non-secret) config overlay.
+    fn package_and_config(
+        &self,
+        name: &str,
+    ) -> Result<(super::package::ExtensionPackage, Value), String> {
+        let pkg = discover_extensions(&self.ctx.extensions_dir)
+            .into_iter()
+            .find(|pkg| pkg.manifest.name == name)
+            .ok_or_else(|| {
+                format!("no extension named `{name}` is installed; `yolop extensions list` shows what is")
+            })?;
+        let config = self
+            .ctx
+            .settings
+            .snapshot()
+            .capability_overrides_for(&extension_capability_id(name))
+            .iter()
+            .rev()
+            .find(|(_, entry)| !entry.is_remove())
+            .map(|(_, entry)| entry.config.clone())
+            .unwrap_or(Value::Null);
+        Ok((pkg, config))
+    }
+
+    /// Show an extension's configuration, including where the values live.
+    ///
+    /// Non-secret values are returned; a secret is reported only as set or
+    /// unset, never by value, so the credential-store leak guard holds here as
+    /// it does in `list_extensions`. Naming the files closes the gap that sent
+    /// callers hunting through the config directory with `find` and `grep`
+    /// because nothing said where a value was read from.
+    fn show_config(&self, args: &Value) -> ToolExecutionResult {
+        let Some(name) = args.get("name").and_then(Value::as_str) else {
+            return ToolExecutionResult::ToolError("`name` is required".into());
+        };
+        let (pkg, ext_config) = match self.package_and_config(name) {
+            Ok(found) => found,
+            Err(err) => return ToolExecutionResult::ToolError(err),
+        };
+        let fields: Vec<Value> = pkg
+            .manifest
+            .config_fields()
+            .into_iter()
+            .map(|field| {
+                let mut entry = json!({
+                    "name": field.name,
+                    "secret": field.secret,
+                    "required": field.required,
+                });
+                if !field.description.is_empty() {
+                    entry["description"] = json!(field.description);
+                }
+                if !field.options.is_empty() {
+                    entry["options"] = json!(field.options);
+                }
+                if let Some(env) = field.env.as_ref() {
+                    entry["env"] = json!(env);
+                }
+                if field.secret {
+                    let set = self
+                        .ctx
+                        .secrets
+                        .as_ref()
+                        .map(|s| s.is_set(name, &field.name))
+                        .unwrap_or(false);
+                    entry["set"] = json!(set);
+                    entry["stored_in"] = json!("connections.toml");
+                } else {
+                    let value = ext_config.get(&field.name).filter(|v| !v.is_null());
+                    entry["set"] = json!(value.is_some());
+                    if let Some(value) = value {
+                        entry["value"] = value.clone();
+                    }
+                    entry["stored_in"] = json!("settings.toml");
+                }
+                entry
+            })
+            .collect();
+        ToolExecutionResult::Success(json!({
+            "name": name,
+            "config": fields,
+            "paths": {
+                "settings.toml": self.ctx.settings.path().display().to_string(),
+                "connections.toml": crate::connectors::default_connections_path()
+                    .map(|p| p.display().to_string()),
+            },
+            "note": "Set a non-secret field with `yolop extensions config set <name> <field> \
+                     <value>`; a secret with `yolop extensions secret set <name> <field>`, \
+                     which prompts so the value is never passed as an argument.",
+        }))
+    }
+
+    /// Set a non-secret config field.
+    ///
+    /// Secrets are refused: they keep the prompt-only path so a value never
+    /// lands in a shell history, a tool call, or the model's context.
+    fn set_config(&self, args: &Value) -> ToolExecutionResult {
+        let (Some(name), Some(field_name), Some(value)) = (
+            args.get("name").and_then(Value::as_str),
+            args.get("field").and_then(Value::as_str),
+            args.get("value").and_then(Value::as_str),
+        ) else {
+            return ToolExecutionResult::ToolError(
+                "`name`, `field`, and `value` are required".into(),
+            );
+        };
+        let (pkg, _) = match self.package_and_config(name) {
+            Ok(found) => found,
+            Err(err) => return ToolExecutionResult::ToolError(err),
+        };
+        let Some(field) = pkg
+            .manifest
+            .config_fields()
+            .into_iter()
+            .find(|f| f.name == field_name)
+        else {
+            let known: Vec<String> = pkg
+                .manifest
+                .config_fields()
+                .into_iter()
+                .map(|f| f.name)
+                .collect();
+            return ToolExecutionResult::ToolError(format!(
+                "extension `{name}` has no config field `{field_name}`; it declares: {}",
+                if known.is_empty() {
+                    "none".to_string()
+                } else {
+                    known.join(", ")
+                }
+            ));
+        };
+        if field.secret {
+            return ToolExecutionResult::ToolError(format!(
+                "`{field_name}` is a secret: set it with `yolop extensions secret set {name} \
+                 {field_name}`, which prompts for the value so it is never passed as an \
+                 argument"
+            ));
+        }
+        match self.ctx.settings.set_capability_config(
+            &extension_capability_id(name),
+            field_name,
+            Value::String(value.to_string()),
+        ) {
+            Ok(()) => ToolExecutionResult::Success(json!({
+                "name": name,
+                "field": field_name,
+                "value": value,
+                "note": "Stored. Reload or restart the extension to apply it.",
+            })),
+            Err(err) => ToolExecutionResult::ToolError(format!("config write failed: {err}")),
+        }
+    }
+
     async fn set_secret(&self, args: &Value) -> ToolExecutionResult {
         let Some(name) = args.get("name").and_then(Value::as_str) else {
             return ToolExecutionResult::ToolError("`name` is required".into());
@@ -1283,6 +1482,8 @@ impl Tool for ManageTool {
             Verb::Disable => "Disable extension",
             Verb::Reload => "Reload extension",
             Verb::SetSecret => "Set extension secret",
+            Verb::ShowConfig => "Show extension config",
+            Verb::SetConfig => "Set extension config",
             Verb::Doctor => "Check extension",
         };
         let key = if matches!(self.verb, Verb::Install) {
@@ -1304,6 +1505,8 @@ impl Tool for ManageTool {
             Verb::Disable => "disable_extension",
             Verb::Reload => "reload_extension",
             Verb::SetSecret => "set_extension_secret",
+            Verb::ShowConfig => "show_extension_config",
+            Verb::SetConfig => "set_extension_config",
             Verb::Doctor => "doctor_extension",
         }
     }
@@ -1352,6 +1555,19 @@ impl Tool for ManageTool {
                  never see it; it is stored in the credential store, not in settings, and \
                  injected into the extension's server as env. Call with `name` and `field` \
                  only (never `value`). Use for `secret` fields shown by `list_extensions`."
+            }
+            Verb::ShowConfig => {
+                "Show an installed extension's configuration: every field, whether it is \
+                 required, whether a value is set, the value of each non-secret field, and \
+                 the files the values are read from. Secret values are never returned, only \
+                 whether they are set. Use this before `set_extension_config` or \
+                 `set_extension_secret` to see what an extension still needs."
+            }
+            Verb::SetConfig => {
+                "Set a non-secret config field on an installed extension (e.g. an endpoint or \
+                 a service name). Call with `name`, `field`, and `value`. Secret fields are \
+                 refused here: they are entered by the user through `set_extension_secret` so \
+                 the value never passes through a tool call."
             }
             Verb::Doctor => {
                 "Conformance-check an installed extension: spawn its server, run the \
@@ -1429,6 +1645,17 @@ impl Tool for ManageTool {
                 },
                 "required": ["name", "field"]
             }),
+            Verb::SetConfig => json!({
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string", "description": "Extension name." },
+                    "field": { "type": "string",
+                        "description": "The non-secret config field to set (from \
+                            show_extension_config)." },
+                    "value": { "type": "string", "description": "The value to store." }
+                },
+                "required": ["name", "field", "value"]
+            }),
             _ => json!({
                 "type": "object",
                 "properties": {
@@ -1450,6 +1677,8 @@ impl Tool for ManageTool {
             Verb::Disable => self.toggle(&arguments, false).await,
             Verb::Reload => self.reload(&arguments).await,
             Verb::SetSecret => self.set_secret(&arguments).await,
+            Verb::ShowConfig => self.show_config(&arguments),
+            Verb::SetConfig => self.set_config(&arguments),
             Verb::Doctor => self.doctor(&arguments).await,
         }
     }
@@ -1473,6 +1702,136 @@ mod tests {
             .to_string(),
         )
         .unwrap();
+    }
+
+    fn seed_configurable_package(dir: &Path, name: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(
+            dir.join(MANIFEST_FILE),
+            json!({
+                "name": name, "description": "T.",
+                "yolop": { "protocol_version": "1.0",
+                    "capabilityServer": { "command": "x" }, "tools": [{"name": "t"}],
+                    "config_schema": {
+                        "type": "object",
+                        "required": ["token"],
+                        "properties": {
+                            "token": { "type": "string", "secret": true,
+                                       "env": "T_TOKEN", "description": "A token" },
+                            "endpoint": { "type": "string", "description": "Where to send" }
+                        }
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+    }
+
+    /// Nothing used to say where a value was read from, so callers reverse
+    /// engineered the config directory with `find` and `grep`. Show names the
+    /// files, returns non-secret values, and still never returns a secret.
+    #[tokio::test]
+    async fn config_show_reports_values_paths_and_never_a_secret() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        seed_configurable_package(&src, "demo");
+        let (cap, _settings, _ext_dir) = capability(tmp.path());
+        let tools = cap.management_tools();
+        let get = |n: &str| tools.iter().find(|t| t.name() == n).unwrap();
+
+        get("install_extension")
+            .execute(json!({ "source": src.to_str().unwrap() }))
+            .await;
+        get("set_extension_config")
+            .execute(json!({ "name": "demo", "field": "endpoint", "value": "https://example" }))
+            .await;
+
+        match get("show_extension_config")
+            .execute(json!({ "name": "demo" }))
+            .await
+        {
+            ToolExecutionResult::Success(v) => {
+                let fields = v["config"].as_array().expect("config array");
+                let endpoint = fields.iter().find(|f| f["name"] == "endpoint").unwrap();
+                assert_eq!(endpoint["set"], json!(true));
+                assert_eq!(endpoint["value"], json!("https://example"));
+                assert_eq!(endpoint["stored_in"], json!("settings.toml"));
+
+                let token = fields.iter().find(|f| f["name"] == "token").unwrap();
+                assert_eq!(token["secret"], json!(true));
+                assert_eq!(token["stored_in"], json!("connections.toml"));
+                assert!(
+                    token.get("value").is_none(),
+                    "a secret value must never be returned: {token}"
+                );
+
+                assert!(
+                    v["paths"]["settings.toml"].as_str().is_some(),
+                    "the file a value comes from must be named"
+                );
+            }
+            other => panic!("expected success, got {other:?}"),
+        }
+    }
+
+    /// A non-secret field was previously reachable only through the enable-time
+    /// prompt or by hand-editing settings.toml.
+    #[tokio::test]
+    async fn config_set_writes_a_non_secret_field_and_refuses_a_secret() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        seed_configurable_package(&src, "demo");
+        let (cap, settings, _ext_dir) = capability(tmp.path());
+        let tools = cap.management_tools();
+        let get = |n: &str| tools.iter().find(|t| t.name() == n).unwrap();
+        get("install_extension")
+            .execute(json!({ "source": src.to_str().unwrap() }))
+            .await;
+
+        match get("set_extension_config")
+            .execute(json!({ "name": "demo", "field": "endpoint", "value": "https://example" }))
+            .await
+        {
+            ToolExecutionResult::Success(v) => assert_eq!(v["value"], json!("https://example")),
+            other => panic!("expected success, got {other:?}"),
+        }
+        assert_eq!(
+            settings
+                .snapshot()
+                .capability_overrides_for(&extension_capability_id("demo"))
+                .iter()
+                .rev()
+                .find(|(_, e)| !e.is_remove())
+                .and_then(|(_, e)| e.config.get("endpoint").cloned()),
+            Some(json!("https://example")),
+            "the value must be persisted to settings"
+        );
+
+        // A secret keeps its prompt-only path so the value never passes through
+        // a tool call, and the refusal names the command that does work.
+        match get("set_extension_config")
+            .execute(json!({ "name": "demo", "field": "token", "value": "hunter2" }))
+            .await
+        {
+            ToolExecutionResult::ToolError(err) => {
+                assert!(err.contains("secret"), "error was: {err}");
+                assert!(err.contains("secret set demo token"), "error was: {err}");
+            }
+            other => panic!("a secret must be refused, got {other:?}"),
+        }
+
+        // An unknown field names the ones that exist rather than just failing.
+        match get("set_extension_config")
+            .execute(json!({ "name": "demo", "field": "nope", "value": "x" }))
+            .await
+        {
+            ToolExecutionResult::ToolError(err) => {
+                assert!(err.contains("token"), "error was: {err}");
+                assert!(err.contains("endpoint"), "error was: {err}");
+            }
+            other => panic!("expected an error, got {other:?}"),
+        }
     }
 
     /// Every by-name subcommand must accept the same spellings `install` does.

--- a/src/main.rs
+++ b/src/main.rs
@@ -678,9 +678,69 @@ fn join_worker<T>(
     }
 }
 
+/// Render a clap parse failure, listing the valid subcommands when the user
+/// named one that does not exist.
+///
+/// Clap's own message is `unrecognized subcommand '<x>'` followed by a usage
+/// line whose `[COMMAND]` is a placeholder, so it never says what the real
+/// commands are. A caller that guesses wrong learns nothing and has to fetch
+/// `--help` separately, which is a wasted round trip for a human and several
+/// for an agent. Every other error keeps clap's own rendering and exit code.
+fn exit_with_cli_error(err: clap::Error, root: &clap::Command) -> ! {
+    if err.kind() == clap::error::ErrorKind::InvalidSubcommand
+        && let Some((path, names)) = unknown_subcommand_context(root)
+        && !names.is_empty()
+    {
+        eprint!("{err}");
+        eprintln!("Available `{path}` commands:");
+        for name in names {
+            eprintln!("  {name}");
+        }
+        std::process::exit(2);
+    }
+    err.exit()
+}
+
+/// Walk the real argv down the command tree to the group that owns the
+/// unrecognized name, and return that group's path and its subcommand names.
+/// Flags and their values are skipped: only positionals can name a subcommand.
+fn unknown_subcommand_context(root: &clap::Command) -> Option<(String, Vec<String>)> {
+    let mut command = root;
+    let mut path = vec![root.get_name().to_string()];
+    for arg in std::env::args().skip(1) {
+        if arg.starts_with('-') {
+            continue;
+        }
+        match command
+            .get_subcommands()
+            .find(|sub| sub.get_name() == arg || sub.get_all_aliases().any(|alias| alias == arg))
+        {
+            // A known subcommand: descend and keep looking.
+            Some(sub) => {
+                path.push(sub.get_name().to_string());
+                command = sub;
+            }
+            // The first name that does not match is the failure; `command` owns it.
+            None => {
+                let names = command
+                    .get_subcommands()
+                    .filter(|sub| !sub.is_hide_set())
+                    .map(|sub| sub.get_name().to_string())
+                    .collect();
+                return Some((path.join(" "), names));
+            }
+        }
+    }
+    None
+}
+
 async fn async_main(crash_reporter: &crash_report::CrashReporter) -> Result<()> {
     let cli_registry = detached_cli_registry()?;
-    let mut matches = cli_registry.augment(Cli::command())?.get_matches();
+    let root = cli_registry.augment(Cli::command())?;
+    let mut matches = match root.clone().try_get_matches() {
+        Ok(matches) => matches,
+        Err(err) => exit_with_cli_error(err, &root),
+    };
     if let Some(invocation) = cli_registry.invocation(&matches)? {
         tracing_subscriber::fmt()
             .with_env_filter(


### PR DESCRIPTION
## What changed

A real session hunting for logfire's settings ran `yolop extensions configure` **twice**, then `--help`, then `find` / `cat` / `grep` across `~/Library/Application Support/yolop`. Three gaps made that the shortest available path; this closes all three.

1. **An unrecognized subcommand now lists the ones that exist.** Clap prints `unrecognized subcommand 'configure'` and a usage line whose `[COMMAND]` is a placeholder, so a wrong guess taught the caller nothing and cost a separate `--help` fetch. Handled at the **root** parser, so every command group benefits, not just `extensions`.

2. **`config set` exists.** `configure` was a fair guess for a capability that genuinely did not exist: extensions declare a `config_schema`, but a non-secret field like `endpoint` was reachable only through the enable-time interactive prompt or by hand-editing `settings.toml`.

3. **`config show` says what is set and where it lives.** `list --json` reports whether a field is set but never its value or its file — which is exactly what sent the session grepping the config directory.

## Why

Worth separating the two causes. A model guessing a plausible verb is a given and will not change. What a CLI controls is whether that guess **self-corrects in one call** or turns into a filesystem investigation. Here it was the latter, three times over.

(One thing in that transcript was genuinely the model's fault and no CLI change excuses it: re-running `configure --help` after it had already failed.)

## Before / After

Replaying the transcript's first command:

```
before: error: unrecognized subcommand 'configure'
        Usage: yolop extensions [OPTIONS] [COMMAND]
        For more information, try '--help'.

after:  error: unrecognized subcommand 'configure'
          tip: a similar subcommand exists: 'config'
        Usage: yolop extensions [OPTIONS] [COMMAND]
        For more information, try '--help'.
        Available `yolop extensions` commands:
          list  install  remove  enable  disable  reload  doctor  config  secret  scaffold
```

Note the change makes clap's own "did you mean" useful too: `config` now exists, so it is suggested.

Everything the session used `find`/`cat`/`grep` for, in one call:

```
$ yolop extensions config show logfire
{
  "config": [
    { "name": "token",    "secret": true,  "required": true,
      "env": "LOGFIRE_TOKEN", "set": true,  "stored_in": "connections.toml" },
    { "name": "endpoint", "secret": false, "required": false,
      "set": true, "value": "https://logfire-eu.pydantic.dev/v1/traces",
      "stored_in": "settings.toml" },
    ...
  ],
  "paths": { "settings.toml": "/root/.config/yolop/settings.toml",
             "connections.toml": "/root/.config/yolop/connections.toml" }
}

$ yolop extensions config set logfire endpoint https://logfire-eu.pydantic.dev/v1/traces
{ "field": "endpoint", "value": "https://...", "note": "Stored. Reload or restart ..." }
```

## Secrets stay behind the prompt

The narrow read path existed for a reason — secrets must not reach a shell history, a tool call, or the model's context — so widening it stops short of them deliberately:

- `config show` returns non-secret **values**, but a secret only as `set: true/false`, matching `list_extensions`.
- `config set` **refuses** a secret and names the command that works: ``set it with `yolop extensions secret set logfire token`, which prompts for the value so it is never passed as an argument``.
- `secret set` is untouched.

## Risk

- Low. Two additive subcommands and one error-path change.
- The root parser moves from `get_matches()` to `try_get_matches()`, so `--help`, `--version`, and every other error keep clap's own rendering and exit code via `err.exit()`; only `InvalidSubcommand` is augmented, and only when a group with visible subcommands is found. Hidden subcommands are filtered out.
- The failure point is located by walking the real argv down the command tree, skipping flags, so the listed commands belong to the group that owns the bad name (`yolop extensions`, not `yolop`). Aliases are matched, so `uninstall` still descends correctly.
- `config set` writes through the same `set_capability_config` path the enable-time prompt already used; no new storage.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

- `config_show_reports_values_paths_and_never_a_secret` asserts the non-secret value, both `stored_in` files, the `paths` block, and that a secret carries **no** `value` key.
- `config_set_writes_a_non_secret_field_and_refuses_a_secret` asserts persistence into settings, that a secret is refused with a pointer to `secret set`, and that an unknown field names the real ones.

Validation: `cargo fmt --check`, `cargo clippy --workspace --all-targets --features yolop-yep/schema -D warnings`, `cargo test --workspace --features yolop-yep/schema` (1,226 + 69 + smaller suites, zero failures), `validate_okf.py --check-links`. Every command from the transcript was also replayed against the real binary, including the round trip of `config set` → `config show`.

## Knowledge

- `knowledge/specs/extensions.md`: `config show` / `config set`, and why secrets stay behind the prompt.
- `knowledge/log.md`: entry, including the generalizable point about the cost of a wrong guess.

## Security

Reviewed against the threat-model categories in `.agents/skills/ship/SKILL.md`:

- **TM-LLM**: the substantive category. `config show` widens what an agent can read, and stops exactly at the credential boundary: secret values are never returned, only their set/unset state, which `list_extensions` already exposed. `config set` cannot write a secret at all, so no credential can arrive through a tool call. The `paths` block names file locations, not contents.
- **TM-FS**: `config set` writes only through the existing `set_capability_config` settings path, keyed by capability id; no new file is touched.
- **TM-TOOL**: two new management tools, both requiring an installed, discoverable extension; neither changes an extension's grant or enablement.
- **TM-BASH**, **TM-DEP**: not touched.

## Follow-ups

- **`capabilityServer.args` resolves relative paths against the session cwd**, not the package directory (from #613).
- **`resolve_host_scope` mistakes a real `/workspace` directory for the display alias** (from #604).
- **LSP adoption** wants re-measuring under the deferral profile changed in #602.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DgAqzNcJf625uPKsZvddBx)_