### PR TITLE
feat(extensions): install prebuilt server binaries

### DIFF
--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -15,6 +15,80 @@ permissions:
   contents: write
 
 jobs:
+  # Prebuilt extension servers. A crates.io package carries source and yolop's
+  # install path is toolchain-free by design, so an extension published without
+  # these installs cleanly and can never spawn; install fetches the archive its
+  # manifest points at. Tagged per extension (`<crate>-v<version>`) rather than
+  # riding the yolop tag, so the URL is derivable from the package alone and an
+  # extension can release on its own cadence.
+  extensions:
+    name: Build ${{ matrix.crate }} (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        crate: [yolop-extension-logfire]
+        include:
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+          - target: x86_64-apple-darwin
+            runner: macos-latest
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.94.0
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build release binary
+        run: |
+          cargo build --release --target ${{ matrix.target }} -p ${{ matrix.crate }} --locked
+
+      - name: Package binary
+        id: package
+        env:
+          CRATE: ${{ matrix.crate }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          VERSION=$(cargo metadata --no-deps --format-version 1 \
+            | jq -r --arg c "$CRATE" '.packages[] | select(.name == $c) | .version')
+          ARCHIVE="$CRATE-$VERSION-$TARGET.tar.gz"
+          cd "target/$TARGET/release"
+          tar czf "$GITHUB_WORKSPACE/$ARCHIVE" "$CRATE"
+          cd "$GITHUB_WORKSPACE"
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "$ARCHIVE" > "$ARCHIVE.sha256"
+          else
+            shasum -a 256 "$ARCHIVE" > "$ARCHIVE.sha256"
+          fi
+          echo "archive=$ARCHIVE" >> "$GITHUB_OUTPUT"
+          echo "ext_tag=$CRATE-v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Upload to the extension's release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARCHIVE: ${{ steps.package.outputs.archive }}
+          EXT_TAG: ${{ steps.package.outputs.ext_tag }}
+          CRATE: ${{ matrix.crate }}
+        run: |
+          # The release is per extension version and shared by all targets, so
+          # the first runner to finish creates it and the rest upload into it.
+          if ! gh release view "$EXT_TAG" >/dev/null 2>&1; then
+            gh release create "$EXT_TAG" \
+              --title "$EXT_TAG" \
+              --notes "Prebuilt \`$CRATE\` servers, fetched by \`yolop extensions install\`." \
+              || gh release view "$EXT_TAG" >/dev/null
+          fi
+          gh release upload "$EXT_TAG" \
+            "$ARCHIVE" \
+            "$ARCHIVE.sha256" \
+            --clobber
+
   build:
     name: Build CLI (${{ matrix.target }})
     runs-on: ${{ matrix.runner }}

--- a/build.rs
+++ b/build.rs
@@ -19,6 +19,13 @@ fn main() {
         .or_else(|| cargo_toml_dependency_version("everruns-runtime"))
         .unwrap_or_else(|| "unknown".to_string());
     println!("cargo:rustc-env=YOLOP_EVERRUNS_RUNTIME_VERSION={runtime_version}");
+
+    // The host's Rust target triple. Needed at runtime to pick the right
+    // prebuilt extension binary; `std::env::consts` gives OS and arch but
+    // never the triple, and guessing it from those two is wrong for targets
+    // that differ only by libc or ABI.
+    let target = env::var("TARGET").unwrap_or_else(|_| "unknown".to_string());
+    println!("cargo:rustc-env=YOLOP_HOST_TARGET={target}");
 }
 
 fn git_short_sha() -> Option<String> {

--- a/extensions/yolop-extension-logfire/plugin.json
+++ b/extensions/yolop-extension-logfire/plugin.json
@@ -2,14 +2,22 @@
   "name": "logfire",
   "version": "0.1.0",
   "description": "Export agentic traces (turns, reasoning, tool calls, LLM generations) to Pydantic Logfire over OTLP.",
-  "engines": { "yolop": ">=0.11" },
+  "engines": {
+    "yolop": ">=0.11"
+  },
   "yolop": {
     "protocol_version": "1.0",
-    "capabilityServer": { "command": "yolop-extension-logfire", "args": [] },
+    "capabilityServer": {
+      "command": "yolop-extension-logfire",
+      "args": [],
+      "binaries": "https://github.com/everruns/yolop/releases/download/yolop-extension-logfire-v{version}/yolop-extension-logfire-{version}-{target}.tar.gz"
+    },
     "trace": true,
     "config_schema": {
       "type": "object",
-      "required": ["token"],
+      "required": [
+        "token"
+      ],
       "properties": {
         "token": {
           "type": "string",

--- a/extensions/yolop-extension-logfire/src/main.rs
+++ b/extensions/yolop-extension-logfire/src/main.rs
@@ -131,3 +131,39 @@ fn build_provider(token: Option<String>, endpoint: String, service: String) -> S
         }
     }
 }
+
+#[cfg(test)]
+mod manifest_tests {
+    /// `plugin.json`'s version drives the prebuilt-binary URL that
+    /// `yolop extensions install` fetches, while the release workflow derives
+    /// the tag and asset name from the *crate* version. If the two drift, the
+    /// URL points at a release that does not exist and install silently falls
+    /// back to "cannot start".
+    #[test]
+    fn manifest_version_matches_the_crate_version() {
+        let manifest: serde_json::Value =
+            serde_json::from_str(include_str!("../plugin.json")).expect("plugin.json parses");
+        assert_eq!(
+            manifest["version"].as_str(),
+            Some(env!("CARGO_PKG_VERSION")),
+            "plugin.json version must track Cargo.toml, or the binaries URL 404s"
+        );
+    }
+
+    /// The template must name this crate's assets, since `{name}` would render
+    /// the *package* name (`logfire`), not the crate name the workflow uploads.
+    #[test]
+    fn binaries_template_names_the_crate_assets() {
+        let manifest: serde_json::Value =
+            serde_json::from_str(include_str!("../plugin.json")).expect("plugin.json parses");
+        let template = manifest["yolop"]["capabilityServer"]["binaries"]
+            .as_str()
+            .expect("a binaries template");
+        assert!(template.contains("{version}"), "template: {template}");
+        assert!(template.contains("{target}"), "template: {template}");
+        assert!(
+            template.contains(env!("CARGO_PKG_NAME")),
+            "template must use the crate name the release workflow uploads: {template}"
+        );
+    }
+}

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,27 @@
 # Knowledge Log
 
+## 2026-08-21, A compiled extension installs without a toolchain
+
+- [Extensions](specs/extensions.md): a package may declare
+  `capabilityServer.binaries`, a URL template over `{name}`/`{version}`/
+  `{target}`. When the declared command does not resolve, install fetches the
+  archive for the host triple and puts the binary in the package's `bin/`.
+- This is what makes a compiled extension work end to end. crates.io carries
+  source, the install path is toolchain-free by design, and nothing built the
+  binary, so `yolop-extension-logfire` installed cleanly and could never spawn.
+- The `.sha256` sibling is required, not optional: install downloads an
+  executable that yolop later spawns, so an unverifiable or mismatched archive
+  is refused and nothing is written.
+- A failed fetch leaves the package installed and reports why. Half-installing
+  is worse, and the binary may legitimately arrive another way.
+- The host triple comes from `build.rs` (`YOLOP_HOST_TARGET`). `std::env::consts`
+  gives OS and arch but never the triple, and guessing it from those is wrong
+  for targets that differ only by libc or ABI.
+- Binaries publish under a per-extension tag (`<crate>-v<version>`) rather than
+  riding yolop's release tag, so the URL is derivable from the package alone.
+  The manifest version drives that URL while CI derives the tag from the crate
+  version, so a test pins the two together.
+
 ## 2026-08-20, A wrong guess should cost one call, not six
 
 - An unrecognized subcommand now lists the ones that exist. Clap's message names

--- a/knowledge/specs/extensions.md
+++ b/knowledge/specs/extensions.md
@@ -281,7 +281,17 @@ SHA-256 against the index `cksum`, and unpacks the gzip'd tar, no cargo/rustc.
 A published crate ships *source*, so the manifest's `capabilityServer.command`
 names a binary the user has on `PATH` (or in the package `bin/`); yolop does
 not compile it (`cargo install` remains an optional author-side path, not a
-yolop dependency). Because that binary can be absent, install resolves the
+yolop dependency). A compiled extension closes that gap by declaring
+`capabilityServer.binaries`, a URL template with `{name}`, `{version}`, and
+`{target}` placeholders: when the command does not already resolve, install
+fetches the archive for the host's target triple and places the binary in the
+package's `bin/`. The archive's `<archive>.sha256` sibling is required, not
+optional, because this downloads an executable yolop will later spawn, so an
+unverifiable download is refused. A failed fetch leaves the package installed
+and says why, rather than half-installing. The bundled `logfire` extension is
+the worked example: CI builds it per target and publishes it under a
+per-extension tag (`<crate>-v<version>`), so the URL is derivable from the
+package alone and an extension can release on its own cadence. Because that binary can be absent, install resolves the
 declared command (package `bin/`, then `PATH`) and reports
 `server_command_found`: a package that installs cleanly but can never spawn
 says so at install time, with the remedy, instead of reading as a plain success

--- a/src/extensions/manage.rs
+++ b/src/extensions/manage.rs
@@ -312,6 +312,7 @@ pub struct ExtensionsCapability {
     settings: Arc<SettingsStore>,
     git: Arc<dyn GitRunner>,
     crates: Arc<dyn CrateFetcher>,
+    binaries: Arc<dyn store::BinaryFetcher>,
     /// Live server processes, so `yolop extensions reload` can restart one in place.
     live_processes: LiveProcessRegistry,
     /// UI-command sink (the TUI's `ui_rx`) used to activate/deactivate an
@@ -340,6 +341,7 @@ impl ExtensionsCapability {
             settings,
             git: Arc::new(SystemGit),
             crates: Arc::new(SystemCrateFetcher::default()),
+            binaries: Arc::new(store::SystemBinaryFetcher),
             live_processes,
             ui_tx,
             secrets: None,
@@ -367,6 +369,7 @@ impl ExtensionsCapability {
             settings: self.settings.clone(),
             git: self.git.clone(),
             crates: self.crates.clone(),
+            binaries: self.binaries.clone(),
             live_processes: self.live_processes.clone(),
             ui_tx: self.ui_tx.clone(),
             secrets: self.secrets.clone(),
@@ -582,6 +585,7 @@ struct ManageCtx {
     settings: Arc<SettingsStore>,
     git: Arc<dyn GitRunner>,
     crates: Arc<dyn CrateFetcher>,
+    binaries: Arc<dyn store::BinaryFetcher>,
     live_processes: LiveProcessRegistry,
     ui_tx: Option<UnboundedSender<UiRequest>>,
     secrets: Option<ExtensionSecrets>,
@@ -855,6 +859,7 @@ impl ManageTool {
             &source,
             self.ctx.git.as_ref(),
             self.ctx.crates.as_ref(),
+            self.ctx.binaries.as_ref(),
         )
         .await
         {
@@ -871,6 +876,16 @@ impl ManageTool {
                     format!(
                         "Installed but not enabled. Run `yolop extensions enable {}` to enable it.",
                         m.name
+                    )
+                } else if let store::BinaryOutcome::Failed { reason } = &installed.binary {
+                    // A prebuilt binary was declared but did not arrive. Say why,
+                    // rather than leaving the generic "no binary" note to imply
+                    // the package simply ships none.
+                    format!(
+                        "Installed, but fetching the prebuilt `{}` for this host failed: {reason}. \
+                         The extension cannot start until the binary is present; check with \
+                         `yolop extensions doctor {}`.",
+                        m.capability_server.command, m.name
                     )
                 } else {
                     format!(
@@ -893,6 +908,16 @@ impl ManageTool {
                     "content_hash": installed.content_hash,
                     "grant_changed": installed.previous_hash.is_some(),
                     "server_command_found": runnable,
+                    "binary": match &installed.binary {
+                        store::BinaryOutcome::AlreadyResolvable => json!("already-resolvable"),
+                        store::BinaryOutcome::Fetched { target } => {
+                            json!({ "fetched": true, "target": target })
+                        }
+                        store::BinaryOutcome::NotDeclared => json!("not-declared"),
+                        store::BinaryOutcome::Failed { reason } => {
+                            json!({ "fetched": false, "reason": reason })
+                        }
+                    },
                     "note": note,
                 }))
             }
@@ -2062,6 +2087,7 @@ mod tests {
             settings: settings.clone(),
             git: Arc::new(crate::extensions::store::SystemGit),
             crates: Arc::new(crate::extensions::store::SystemCrateFetcher::default()),
+            binaries: Arc::new(crate::extensions::store::SystemBinaryFetcher),
             live_processes: LiveProcessRegistry::default(),
             ui_tx: None,
             secrets: None,
@@ -2333,6 +2359,7 @@ mod tests {
             settings,
             git: Arc::new(crate::extensions::store::SystemGit),
             crates: Arc::new(crate::extensions::store::SystemCrateFetcher::default()),
+            binaries: Arc::new(crate::extensions::store::SystemBinaryFetcher),
             live_processes: LiveProcessRegistry::default(),
             ui_tx: None,
             secrets: Some(secrets.clone()),
@@ -2425,6 +2452,7 @@ mod tests {
             settings: settings.clone(),
             git: Arc::new(crate::extensions::store::SystemGit),
             crates: Arc::new(crate::extensions::store::SystemCrateFetcher::default()),
+            binaries: Arc::new(crate::extensions::store::SystemBinaryFetcher),
             live_processes: LiveProcessRegistry::default(),
             ui_tx: None,
             secrets: Some(secrets.clone()),
@@ -2507,6 +2535,7 @@ mod tests {
             settings,
             git: Arc::new(crate::extensions::store::SystemGit),
             crates: Arc::new(crate::extensions::store::SystemCrateFetcher::default()),
+            binaries: Arc::new(crate::extensions::store::SystemBinaryFetcher),
             live_processes: LiveProcessRegistry::default(),
             ui_tx: Some(ui_tx),
             secrets: None,
@@ -2567,6 +2596,7 @@ mod tests {
             settings,
             git: Arc::new(crate::extensions::store::SystemGit),
             crates: Arc::new(crate::extensions::store::SystemCrateFetcher::default()),
+            binaries: Arc::new(crate::extensions::store::SystemBinaryFetcher),
             live_processes: LiveProcessRegistry::default(),
             ui_tx: Some(ui_tx),
             secrets: None,

--- a/src/extensions/package.rs
+++ b/src/extensions/package.rs
@@ -133,6 +133,22 @@ pub struct ServerSpec {
     pub command: String,
     #[serde(default)]
     pub args: Vec<String>,
+    /// Where prebuilt binaries for this server live, as a URL template.
+    ///
+    /// A crates.io package carries source, and yolop's install path is
+    /// toolchain-free by design, so a compiled extension published without one
+    /// of these installs cleanly and can never spawn. Declaring it lets install
+    /// fetch the binary for the host instead.
+    ///
+    /// Placeholders, substituted at install: `{name}` the package name,
+    /// `{version}` its version, `{target}` the host's Rust target triple. The
+    /// archive must be a `.tar.gz` containing the file named by `command`, and
+    /// a `<archive>.sha256` sibling must exist beside it.
+    ///
+    /// Example (the pattern the bundled extensions use):
+    /// `https://github.com/everruns/yolop/releases/download/{name}-v{version}/{name}-{version}-{target}.tar.gz`
+    #[serde(default)]
+    pub binaries: Option<String>,
 }
 
 /// A manifest-declared MCP server contribution. Manifest-declared (not

--- a/src/extensions/store.rs
+++ b/src/extensions/store.rs
@@ -230,6 +230,170 @@ pub fn server_command_resolves(package_dir: &Path, command: &str) -> bool {
     std::env::split_paths(&path).any(|dir| dir.join(command).is_file())
 }
 
+/// Fetches raw bytes over HTTP. Injectable so the prebuilt-binary path is
+/// testable without a network or a real release.
+#[async_trait]
+pub trait BinaryFetcher: Send + Sync {
+    async fn get(&self, url: &str) -> Result<Vec<u8>>;
+}
+
+#[derive(Default)]
+pub struct SystemBinaryFetcher;
+
+#[async_trait]
+impl BinaryFetcher for SystemBinaryFetcher {
+    async fn get(&self, url: &str) -> Result<Vec<u8>> {
+        let response = reqwest::Client::new()
+            .get(url)
+            .header("User-Agent", "yolop-extension-install")
+            .send()
+            .await
+            .with_context(|| format!("downloading {url}"))?
+            .error_for_status()
+            .with_context(|| format!("downloading {url}"))?;
+        Ok(response.bytes().await?.to_vec())
+    }
+}
+
+/// What install did about the server binary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BinaryOutcome {
+    /// The command already resolved: shipped in the package's `bin/`, or on PATH.
+    AlreadyResolvable,
+    /// Fetched a prebuilt binary for this target and put it in the package.
+    Fetched { target: String },
+    /// The package declares no `binaries` template, so there is nothing to fetch.
+    NotDeclared,
+    /// A template was declared but the fetch did not produce a usable binary.
+    /// Install still succeeds: the package is on disk, and the caller reports
+    /// that it cannot start yet.
+    Failed { reason: String },
+}
+
+/// The host's Rust target triple, baked in at build time (see `build.rs`).
+pub fn host_target() -> &'static str {
+    env!("YOLOP_HOST_TARGET")
+}
+
+/// Substitute the `{name}`, `{version}`, and `{target}` placeholders.
+fn render_binary_url(template: &str, name: &str, version: &str, target: &str) -> String {
+    template
+        .replace("{name}", name)
+        .replace("{version}", version)
+        .replace("{target}", target)
+}
+
+/// Fetch the prebuilt server binary a package declares and place it in the
+/// package's `bin/`, so a compiled extension installs without a toolchain.
+///
+/// Best-effort by design: a failure leaves the package installed and reports
+/// why, because the alternative is a half-installed package and because the
+/// binary may legitimately arrive another way (a distro package, `cargo
+/// install`). The archive's `.sha256` sibling is required, not optional: this
+/// downloads an executable that yolop will later spawn, so an unverifiable
+/// download is refused rather than trusted.
+async fn install_prebuilt_binary(
+    package_dir: &Path,
+    manifest: &ExtensionManifest,
+    fetcher: &dyn BinaryFetcher,
+) -> BinaryOutcome {
+    let command = &manifest.capability_server.command;
+    if server_command_resolves(package_dir, command) {
+        return BinaryOutcome::AlreadyResolvable;
+    }
+    let Some(template) = manifest.capability_server.binaries.as_deref() else {
+        return BinaryOutcome::NotDeclared;
+    };
+    // A path-shaped command names a file inside the package; a fetched binary
+    // lands in `bin/` under the command's own name, so the two are exclusive.
+    if command.contains('/') || command.contains(std::path::MAIN_SEPARATOR) {
+        return BinaryOutcome::Failed {
+            reason: format!(
+                "`capabilityServer.command` is a path (`{command}`), which a prebuilt binary \
+                 cannot satisfy; drop `binaries` or name a bare command"
+            ),
+        };
+    }
+    let target = host_target();
+    let version = manifest.version.as_deref().unwrap_or("0.0.0");
+    let url = render_binary_url(template, &manifest.name, version, target);
+
+    match fetch_verified_binary(fetcher, &url, command).await {
+        Ok(bytes) => match write_package_binary(package_dir, command, &bytes) {
+            Ok(()) => BinaryOutcome::Fetched {
+                target: target.to_string(),
+            },
+            Err(err) => BinaryOutcome::Failed {
+                reason: format!("{err:#}"),
+            },
+        },
+        Err(err) => BinaryOutcome::Failed {
+            reason: format!("{err:#}"),
+        },
+    }
+}
+
+/// Download the archive and its `.sha256` sibling, verify, and return the entry
+/// named `command`.
+async fn fetch_verified_binary(
+    fetcher: &dyn BinaryFetcher,
+    url: &str,
+    command: &str,
+) -> Result<Vec<u8>> {
+    let archive = fetcher.get(url).await?;
+    let checksum_url = format!("{url}.sha256");
+    let checksum = fetcher
+        .get(&checksum_url)
+        .await
+        .context("no checksum beside the archive; refusing to install an unverified binary")?;
+    let expected = String::from_utf8_lossy(&checksum);
+    // `sha256sum` and `shasum -a 256` both write "<hex>  <filename>".
+    let expected = expected
+        .split_whitespace()
+        .next()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let actual = sha256_hex(&archive);
+    let actual = actual.strip_prefix("sha256:").unwrap_or(&actual);
+    if expected.is_empty() || expected != actual {
+        bail!("checksum mismatch for {url}: expected {expected}, download is {actual}");
+    }
+    extract_named_entry(&archive, command)
+        .with_context(|| format!("archive at {url} has no entry named `{command}`"))
+}
+
+/// Pull one file out of a `.tar.gz`, matching on the entry's file name so an
+/// archive that nests its payload in a directory still works.
+fn extract_named_entry(archive: &[u8], wanted: &str) -> Result<Vec<u8>> {
+    let decoder = flate2::read::GzDecoder::new(archive);
+    let mut tar = tar::Archive::new(decoder);
+    for entry in tar.entries()? {
+        let mut entry = entry?;
+        let path = entry.path()?.into_owned();
+        if path.file_name().and_then(|n| n.to_str()) == Some(wanted) {
+            let mut bytes = Vec::new();
+            std::io::Read::read_to_end(&mut entry, &mut bytes)?;
+            return Ok(bytes);
+        }
+    }
+    bail!("no entry named `{wanted}`")
+}
+
+/// Write the binary into the package's `bin/`, executable.
+fn write_package_binary(package_dir: &Path, command: &str, bytes: &[u8]) -> Result<()> {
+    let bin_dir = package_dir.join("bin");
+    std::fs::create_dir_all(&bin_dir).with_context(|| format!("creating {}", bin_dir.display()))?;
+    let path = bin_dir.join(command);
+    std::fs::write(&path, bytes).with_context(|| format!("writing {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+            .with_context(|| format!("making {} executable", path.display()))?;
+    }
+    Ok(())
+}
+
 /// Result of an install/update, for the caller to summarize to the user.
 #[derive(Debug, Clone)]
 pub struct Installed {
@@ -237,6 +401,8 @@ pub struct Installed {
     pub content_hash: String,
     /// Present on an update: the previously approved hash, if the grant changed.
     pub previous_hash: Option<String>,
+    /// What install did about the server binary.
+    pub binary: BinaryOutcome,
 }
 
 /// Install (or update) an extension into `extensions_dir` from `source`.
@@ -251,6 +417,7 @@ pub async fn install(
     source: &Source,
     git: &dyn GitRunner,
     crates: &dyn CrateFetcher,
+    binaries: &dyn BinaryFetcher,
 ) -> Result<Installed> {
     std::fs::create_dir_all(extensions_dir)?;
     let staging = extensions_dir.join(".staging");
@@ -303,6 +470,13 @@ pub async fn install(
         .with_context(|| format!("installing into {}", dest.display()))?;
     std::mem::forget(cleanup); // renamed away; nothing to clean.
 
+    // A compiled extension published to crates.io ships source, and this path
+    // is toolchain-free by design, so fetch the prebuilt binary it declares.
+    // After the rename: the fetched binary belongs to the installed package,
+    // and it is deliberately outside the content hash, which covers the
+    // approved *manifest* surface rather than build outputs.
+    let binary = install_prebuilt_binary(&dest, &manifest, binaries).await;
+
     let mut lock = Lockfile::load(extensions_dir);
     lock.upsert(LockEntry {
         name: manifest.name.clone(),
@@ -316,6 +490,7 @@ pub async fn install(
         manifest,
         content_hash,
         previous_hash,
+        binary,
     })
 }
 
@@ -617,11 +792,220 @@ mod tests {
     /// A crate fetcher that never runs — for path/git tests that don't touch
     /// crates.io. Panics if called so a mis-routed source is caught.
     struct NoCrates;
+
+    /// Writes a package that declares where its prebuilt binaries live.
+    fn write_pkg_with_binaries(dir: &Path, name: &str, command: &str, template: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(
+            dir.join(MANIFEST_FILE),
+            json!({
+                "name": name,
+                "description": "Test.",
+                "version": "1.2.3",
+                "yolop": {
+                    "protocol_version": "1.0",
+                    "capabilityServer": { "command": command, "binaries": template },
+                    "tools": [{ "name": "t" }]
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+    }
+
+    /// A `.tar.gz` holding one file, as a release archive would.
+    fn tar_gz_with(name: &str, contents: &[u8]) -> Vec<u8> {
+        use flate2::{Compression, write::GzEncoder};
+        let mut tar = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_size(contents.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        tar.append_data(&mut header, name, contents).unwrap();
+        let mut gz = GzEncoder::new(Vec::new(), Compression::default());
+        std::io::Write::write_all(&mut gz, &tar.into_inner().unwrap()).unwrap();
+        gz.finish().unwrap()
+    }
+
+    /// Serves a canned archive and checksum, recording the URLs asked for.
+    struct FakeBinaries {
+        archive: Vec<u8>,
+        checksum: Option<String>,
+        seen: std::sync::Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl BinaryFetcher for FakeBinaries {
+        async fn get(&self, url: &str) -> Result<Vec<u8>> {
+            self.seen.lock().unwrap().push(url.to_string());
+            if let Some(rest) = url.strip_suffix(".sha256") {
+                let _ = rest;
+                return match &self.checksum {
+                    Some(sum) => Ok(format!("{sum}  archive.tar.gz\n").into_bytes()),
+                    None => bail!("404 no checksum"),
+                };
+            }
+            Ok(self.archive.clone())
+        }
+    }
+
+    /// Refuses every fetch: proves a test path never reaches the network.
+    struct NoBinaries;
+
+    #[async_trait]
+    impl BinaryFetcher for NoBinaries {
+        async fn get(&self, url: &str) -> Result<Vec<u8>> {
+            panic!("binary fetcher should not be used in this test: {url}")
+        }
+    }
+
     #[async_trait]
     impl CrateFetcher for NoCrates {
         async fn fetch_into(&self, _: &str, _: Option<&str>, _: &Path) -> Result<String> {
             panic!("crate fetcher should not be used in this test");
         }
+    }
+
+    #[tokio::test]
+    async fn install_fetches_the_prebuilt_binary_a_package_declares() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src-pkg");
+        let ext_dir = tmp.path().join("extensions");
+        write_pkg_with_binaries(
+            &src,
+            "demo",
+            "yolop-extension-demo",
+            "https://example.test/{name}-v{version}/{name}-{version}-{target}.tar.gz",
+        );
+        let payload = b"#!/bin/sh\necho hi\n";
+        let archive = tar_gz_with("yolop-extension-demo", payload);
+        let fetcher = FakeBinaries {
+            checksum: Some(
+                sha256_hex(&archive)
+                    .trim_start_matches("sha256:")
+                    .to_string(),
+            ),
+            archive,
+            seen: Default::default(),
+        };
+
+        let installed = install(
+            &ext_dir,
+            &Source::parse(src.to_str().unwrap()).unwrap(),
+            &SystemGit,
+            &NoCrates,
+            &fetcher,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            installed.binary,
+            BinaryOutcome::Fetched {
+                target: host_target().to_string()
+            }
+        );
+        // Landed in the package's own bin/, which is what the spawn path
+        // searches before PATH.
+        let placed = ext_dir
+            .join("demo")
+            .join("bin")
+            .join("yolop-extension-demo");
+        assert_eq!(std::fs::read(&placed).unwrap(), payload);
+        assert!(server_command_resolves(
+            &ext_dir.join("demo"),
+            "yolop-extension-demo"
+        ));
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&placed).unwrap().permissions().mode() & 0o111,
+                0o111,
+                "the fetched binary must be executable"
+            );
+        }
+
+        // Placeholders were substituted, and the checksum was fetched too.
+        let seen = fetcher.seen.lock().unwrap().clone();
+        assert_eq!(
+            seen[0],
+            format!(
+                "https://example.test/demo-v1.2.3/demo-1.2.3-{}.tar.gz",
+                host_target()
+            )
+        );
+        assert!(seen[1].ends_with(".sha256"), "urls were: {seen:?}");
+    }
+
+    /// Install downloads an executable that yolop will later spawn, so an
+    /// unverifiable or tampered archive must never reach the package.
+    #[tokio::test]
+    async fn a_binary_that_fails_verification_is_refused() {
+        for (label, checksum) in [
+            ("no checksum published", None),
+            ("checksum mismatch", Some("0".repeat(64))),
+        ] {
+            let tmp = tempfile::tempdir().unwrap();
+            let src = tmp.path().join("src-pkg");
+            let ext_dir = tmp.path().join("extensions");
+            write_pkg_with_binaries(
+                &src,
+                "demo",
+                "yolop-extension-demo",
+                "https://example.test/{name}-{version}-{target}.tar.gz",
+            );
+            let fetcher = FakeBinaries {
+                archive: tar_gz_with("yolop-extension-demo", b"payload"),
+                checksum,
+                seen: Default::default(),
+            };
+
+            let installed = install(
+                &ext_dir,
+                &Source::parse(src.to_str().unwrap()).unwrap(),
+                &SystemGit,
+                &NoCrates,
+                &fetcher,
+            )
+            .await
+            .expect("the package still installs");
+
+            assert!(
+                matches!(installed.binary, BinaryOutcome::Failed { .. }),
+                "{label}: expected refusal, got {:?}",
+                installed.binary
+            );
+            assert!(
+                !ext_dir
+                    .join("demo")
+                    .join("bin")
+                    .join("yolop-extension-demo")
+                    .exists(),
+                "{label}: an unverified binary must not be written"
+            );
+        }
+    }
+
+    /// A package that declares no template is untouched: nothing is fetched,
+    /// which is also why the fetcher panics if called.
+    #[tokio::test]
+    async fn a_package_without_a_template_fetches_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src-pkg");
+        let ext_dir = tmp.path().join("extensions");
+        write_pkg(&src, "echo");
+
+        let installed = install(
+            &ext_dir,
+            &Source::parse(src.to_str().unwrap()).unwrap(),
+            &SystemGit,
+            &NoCrates,
+            &NoBinaries,
+        )
+        .await
+        .unwrap();
+        assert_eq!(installed.binary, BinaryOutcome::NotDeclared);
     }
 
     #[test]
@@ -732,7 +1116,7 @@ mod tests {
         let ext_dir = tmp.path().join("extensions");
 
         let source = Source::parse(src.to_str().unwrap()).unwrap();
-        let installed = install(&ext_dir, &source, &SystemGit, &NoCrates)
+        let installed = install(&ext_dir, &source, &SystemGit, &NoCrates, &NoBinaries)
             .await
             .unwrap();
         assert_eq!(installed.manifest.name, "echo");
@@ -747,14 +1131,14 @@ mod tests {
         );
 
         // Reinstall unchanged: no grant change.
-        let again = install(&ext_dir, &source, &SystemGit, &NoCrates)
+        let again = install(&ext_dir, &source, &SystemGit, &NoCrates, &NoBinaries)
             .await
             .unwrap();
         assert!(again.previous_hash.is_none());
 
         // Change a file, reinstall: previous hash surfaces.
         std::fs::write(src.join("extra.txt"), "new").unwrap();
-        let changed = install(&ext_dir, &source, &SystemGit, &NoCrates)
+        let changed = install(&ext_dir, &source, &SystemGit, &NoCrates, &NoBinaries)
             .await
             .unwrap();
         assert!(changed.previous_hash.is_some());
@@ -771,6 +1155,7 @@ mod tests {
             &Source::parse(src.to_str().unwrap()).unwrap(),
             &SystemGit,
             &NoCrates,
+            &NoBinaries,
         )
         .await
         .unwrap();
@@ -794,7 +1179,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let ext_dir = tmp.path().join("extensions");
         let source = Source::parse("https://example.com/acme/gitext").unwrap();
-        let installed = install(&ext_dir, &source, &FakeGit, &NoCrates)
+        let installed = install(&ext_dir, &source, &FakeGit, &NoCrates, &NoBinaries)
             .await
             .unwrap();
         assert_eq!(installed.manifest.name, "gitext");
@@ -892,7 +1277,7 @@ mod tests {
             crate_name: name.into(),
             version: String::new(),
         };
-        let installed = install(&ext_dir, &source, &SystemGit, &fetcher)
+        let installed = install(&ext_dir, &source, &SystemGit, &fetcher, &NoBinaries)
             .await
             .unwrap();
         let _ = handle.join();


### PR DESCRIPTION
## What changed

A compiled extension could not be installed end to end. crates.io carries source, yolop's install path is toolchain-free by design, and **nothing anywhere built the binary the manifest names** — so `yolop-extension-logfire` installed cleanly and could never spawn. #608 made install *say* so; this makes it work.

1. **Manifest: `capabilityServer.binaries`**, a URL template over `{name}`, `{version}`, `{target}`. When the declared command does not already resolve, install fetches the archive for the host's target triple and places the binary in the package's `bin/`, which the spawn path searches before `PATH`.
2. **CI publishes those binaries.** `cli-binaries.yml` gains an `extensions` job that builds each bundled extension for all three targets and uploads the archive plus its `.sha256`.
3. **`build.rs` bakes in the host triple** as `YOLOP_HOST_TARGET`.

## Why the tag is per extension, not yolop's release

Binaries publish under `<crate>-v<version>` (e.g. `yolop-extension-logfire-v0.1.0`) rather than riding yolop's release tag. That makes the URL **derivable from the package alone** — install needs no API call, no release search, and no knowledge of which yolop version shipped it — and lets an extension release on its own cadence. It is also the pattern any third-party author can follow against their own repo, which is the point: nothing here is yolop-specific except the template the bundled extension happens to declare.

## Verification: the real thing, not just tests

I served a genuine release archive over HTTP and installed from it. Before, this package's command could not spawn at all:

```
$ yolop extensions install <pkg>
{ "server_command_found": true,
  "binary": { "fetched": true, "target": "x86_64-unknown-linux-gnu" },
  "note": "Installed but not enabled. Run `yolop extensions enable demo` ..." }

$ ls ~/.config/yolop/extensions/demo/bin/
-rwxr-xr-x  yolop-extension-demo          # fetched, verified, executable

$ yolop extensions doctor demo
"handshake": "fail" — initialize failed: extension server closed the connection
```

That `doctor` output is the proof: **spawn now passes**, and the run only fails at handshake because my probe was a shell script rather than a real YEP server. Compare the original symptom — `"spawn": "fail" — cannot spawn ...: No such file or directory`.

## Security

Reviewed against the threat-model categories in `.agents/skills/ship/SKILL.md`. **TM-TOOL/TM-DEP is the substantive one: this downloads an executable that yolop will later spawn.**

- The `<archive>.sha256` sibling is **required, not optional**. No checksum published, or a mismatch, and the download is refused with nothing written to disk. Both cases are covered by a test that also asserts no file lands in `bin/`.
- The URL comes from the package manifest, which is already the approved trust surface: it is parsed at install without executing anything, and the user consents to the contribution summary. A template cannot reach beyond what the manifest author already controls.
- A path-shaped `command` is refused rather than silently satisfied, so a template can never write outside the package's own `bin/`.
- The fetched binary is deliberately **outside the content hash**, which covers the approved manifest surface rather than build outputs; the checksum is what guards the binary.
- **TM-FS**: writes are confined to `<package>/bin/<command>`, mode 0755 on unix.
- **TM-LLM**, **TM-BASH**: not touched.

## Risk

- Moderate: a new network fetch on the install path. It runs **only** when the command does not already resolve *and* the manifest declares a template, so every existing package is unaffected — a test pins that the fetcher is never called for a package without one (it panics if invoked).
- A failed fetch leaves the package installed and reports why, rather than half-installing; the binary may legitimately arrive another way (`cargo install`, a distro package).
- Windows is not covered: `cli-binaries.yml` publishes no Windows artifacts today, for yolop or extensions. Install degrades to the existing "cannot start" note there.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

- `install_fetches_the_prebuilt_binary_a_package_declares` asserts the substituted URL, that the `.sha256` is fetched too, the placed bytes, the executable bit, and that `server_command_resolves` flips to true.
- `a_binary_that_fails_verification_is_refused` covers both a missing checksum and a mismatched one, asserting nothing is written.
- `a_package_without_a_template_fetches_nothing`.
- `manifest_version_matches_the_crate_version` and `binaries_template_names_the_crate_assets` in the logfire crate: the manifest version drives the URL while the workflow derives the tag from the crate version, so drift would 404. This caught a real bug while writing it — `{name}` renders the *package* name (`logfire`), not the crate name (`yolop-extension-logfire`) the workflow uploads, so the template spells the crate name literally.

Validation: `cargo fmt --check`, `cargo clippy --workspace --all-targets --features yolop-yep/schema -D warnings`, `cargo test --workspace --features yolop-yep/schema` (1,252 + 69 + 11 logfire + 17 yolop-yep, zero failures), `validate_okf.py --check-links`, plus the live install above.

## Knowledge

- `knowledge/specs/extensions.md`: the `binaries` template, the mandatory checksum, and why the tag is per extension.
- `knowledge/log.md`: entry including the host-triple reasoning.

## Follow-ups

- **The `extensions` matrix lists bundled crates by name.** A third extension in this repo needs a line there; worth deriving from workspace metadata if the list grows.
- **No Windows artifacts**, as above — pre-existing for yolop, now inherited by extensions.
- **`capabilityServer.args` resolves relative paths against the session cwd**, not the package directory (from #613). More visible now that a package can carry its own `bin/`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DgAqzNcJf625uPKsZvddBx)_