### PR TITLE
chore(release): prepare v0.17.0

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -60,8 +60,19 @@ Edit `version` in `Cargo.toml`, then `cargo update -p yolop` to refresh the
 lockfile entry.
 
 `yolop-yep` is versioned separately. Bump it when its API or the wire protocol
-changes, and update the workspace path dependency requirement that references
+changes, and update every workspace path dependency requirement that references
 it.
+
+First-party extensions under `extensions/` are versioned separately too. Bump
+one whose code changed since the last release, in both its `Cargo.toml` and its
+`plugin.json`, or it is published nowhere and its manifest keeps pointing at the
+previous tag's binaries. `python3 scripts/publish_order.py` lists exactly what
+the release publishes:
+
+```bash
+python3 scripts/publish_order.py
+git log "$LATEST"..HEAD --oneline -- extensions/ crates/
+```
 
 `tuika` and `tuika-codeformatters` are not released from here — they ship from
 [`everruns/tuika`](https://github.com/everruns/tuika). Bumping their version
@@ -82,15 +93,15 @@ publish` packaging boundary, missing files referenced by `Cargo.toml`, and
 version drift.
 
 ```bash
-cargo publish --dry-run -p yolop-yep   # SDK; publishes before yolop
+cargo publish --dry-run -p yolop-yep   # SDK; publishes before everything else
 cargo search yolop --limit 1           # crates.io version must be < X.Y.Z
 grep '^version' Cargo.toml
 grep '"yolop"' Cargo.lock | head -1
 ```
 
-`cargo publish --dry-run -p yolop` **fails locally** whenever a new `yolop-yep`
-version isn't on crates.io yet — expected, not a broken release. CI validates
-`yolop`'s own publish after the SDK goes live. If the *SDK* dry-run fails, fix
+`cargo publish --dry-run` **fails locally** for `yolop` and for any extension
+whenever a new `yolop-yep` version isn't on crates.io yet — expected, not a
+broken release. CI validates those publishes after the SDK goes live. If the *SDK* dry-run fails, fix
 the root cause and re-run; never open a release PR with a known-broken publish
 path.
 
@@ -122,8 +133,10 @@ gh run list --workflow=cli-binaries.yml --limit 1
 ```
 
 Green workflows are not proof. Run the spec's post-release verification yourself
-and declare **shipped** only when crates.io reports `X.Y.Z` and the tap formula
-points at `vX.Y.Z`. crates.io publishes near-instantly; Homebrew takes minutes
+and declare **shipped** only when crates.io reports `X.Y.Z`, every bumped
+library and extension crate is live, each bumped extension has its
+`<crate>-v<version>` release carrying the three server archives, and the tap
+formula points at `vX.Y.Z`. crates.io publishes near-instantly; Homebrew takes minutes
 for the build and tap commit, so a half-verified release looks shipped when it
 isn't.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,52 @@ mechanical `### What's Changed` list of merged PRs.
 Releases are cut via [`/release`](./.agents/skills/release/SKILL.md), which
 tags the version and publishes to crates.io and the Homebrew tap.
 
+## [0.17.0] - 2026-08-21
+
+### Highlights
+
+- Compiled extensions install end to end. A package may declare `capabilityServer.binaries`, and `yolop extensions install` fetches the prebuilt server for the host's target triple, verifying its `.sha256` before writing anything. `yolop-extension-logfire` 0.2.0 is the first extension published with prebuilt servers.
+- The Logfire exporter emits a real trace tree: spans nest by the host's `parent_span_id`, carry the Gen-AI semantic conventions (`gen_ai.request.model`, token counts, tool names), and give thinking its own paired span.
+- Model switching serves a curated, cross-provider list the user owns, administered by `yolop models list|add|rm|move|use|reset`, with "Browse all models…" still reaching the per-provider catalog.
+- An opt-in `--compact-work` mode keeps each active turn on one mutable summary row, expandable with `Ctrl+O`.
+- The global config and data directories are relocatable through `--config-dir` / `--data-dir` or `YOLOP_CONFIG_DIR` / `YOLOP_DATA_DIR`, so isolating a run no longer means moving `HOME`.
+- Local inference gains `metal` and `cuda` backends and a default model that runs at small-model speed (Qwen3-30B-A3B-Instruct, Q4 GGUF), both gated in CI.
+
+### Breaking Changes
+
+- **`yolop models` administers the curated model list**: the local-weights commands it displaced moved to `yolop weights`.
+  - Before: `yolop models pull <model>`
+  - After: `yolop weights pull <model>`
+- **The per-provider `models` config key is now `default_models`**: a `models` table is still read as such, and a top-level `[[models]]` array is the curated list.
+- **`yolop-yep` 0.4.0**: `TraceEventParams` gains the host's correlation ids (`span_id`, `parent_span_id`, `trace_id`, `turn_id`, `exec_id`) and `family`/`phase` accessors. Additive on the wire; an exporter should parent by `parent_span_id` rather than re-deriving hierarchy from `turn_id`, which flattens the trace.
+
+### What's Changed
+
+* feat(extensions): install prebuilt server binaries ([#620](https://github.com/everruns/yolop/pull/620)) by @chaliy
+* feat(extensions): show and set config, and list commands on a bad guess ([#619](https://github.com/everruns/yolop/pull/619)) by @chaliy
+* feat(models): serve a curated model list instead of a provider catalog ([#618](https://github.com/everruns/yolop/pull/618)) by @chaliy
+* fix(logfire): nest spans by the host's tree and emit the Gen-AI conventions ([#617](https://github.com/everruns/yolop/pull/617)) by @chaliy
+* docs: pass --locked in the documented cargo install commands ([#616](https://github.com/everruns/yolop/pull/616)) by @chaliy
+* chore(deps): clear the h2 and lru RustSec advisories ([#615](https://github.com/everruns/yolop/pull/615)) by @chaliy
+* chore(ci): stop Dependabot proposing unreleased Rust toolchains ([#614](https://github.com/everruns/yolop/pull/614)) by @chaliy
+* feat(yep): name the span tree the trace payload already carries ([#613](https://github.com/everruns/yolop/pull/613)) by @chaliy
+* feat(tui): add compact work mode ([#612](https://github.com/everruns/yolop/pull/612)) by @chaliy
+* fix(extensions): accept the crate name wherever an extension is named ([#611](https://github.com/everruns/yolop/pull/611)) by @chaliy
+* fix(extensions): alias remove as uninstall, and stop repeating the command ([#610](https://github.com/everruns/yolop/pull/610)) by @chaliy
+* fix(extensions): flush trace exporters before the session ends ([#609](https://github.com/everruns/yolop/pull/609)) by @chaliy
+* fix(extensions): install the published crate name, and say when it cannot run ([#608](https://github.com/everruns/yolop/pull/608)) by @chaliy
+* chore(deps): bump the cargo-minor-and-patch group across 1 directory with 2 updates ([#606](https://github.com/everruns/yolop/pull/606)) by @dependabot
+* chore(deps): bump everruns to the 0.20 cycle and load mid-session installs live ([#604](https://github.com/everruns/yolop/pull/604)) by @chaliy
+* chore(build): optimize the release profile for size ([#603](https://github.com/everruns/yolop/pull/603)) by @chaliy
+* fix(extensions): make attached administration report what it actually did ([#602](https://github.com/everruns/yolop/pull/602)) by @chaliy
+* fix(tui): paste into the surface that owns the keyboard ([#601](https://github.com/everruns/yolop/pull/601)) by @chaliy
+* feat(config): make the global config and data directories relocatable ([#600](https://github.com/everruns/yolop/pull/600)) by @chaliy
+* feat(local-inference): GPU backends, a usable default model, and a CI gate for both ([#599](https://github.com/everruns/yolop/pull/599)) by @chaliy
+* chore(build): stop compiling the tree twice in dev builds ([#598](https://github.com/everruns/yolop/pull/598)) by @chaliy
+* fix(models): run `models pull` on the caller's runtime ([#597](https://github.com/everruns/yolop/pull/597)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/yolop/compare/v0.16.0...v0.17.0
+
 ## [0.16.0] - 2026-08-19
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10306,7 +10306,7 @@ dependencies = [
 
 [[package]]
 name = "yolop"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -10401,7 +10401,7 @@ dependencies = [
 
 [[package]]
 name = "yolop-extension-logfire"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -10413,7 +10413,7 @@ dependencies = [
 
 [[package]]
 name = "yolop-yep"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "schemars 1.2.2",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "yolop"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 authors = ["Everruns <support@everruns.com>"]
 license = "MIT"
@@ -104,7 +104,7 @@ serde_json = "1.0"
 # The extension protocol wire types + server SDK live in their own crate so
 # extension authors can depend on them from crates.io; the host shares the
 # same source of truth (see knowledge/specs/extensions.md).
-yolop-yep = { version = "0.3.0", path = "crates/yolop-yep" }
+yolop-yep = { version = "0.4.0", path = "crates/yolop-yep" }
 sha2 = "0.11"
 toml = "1"
 textwrap = "0.16"

--- a/crates/yolop-yep/Cargo.toml
+++ b/crates/yolop-yep/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yolop-yep"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 authors = ["Everruns <support@everruns.com>"]
 license = "MIT"

--- a/extensions/yolop-extension-logfire/Cargo.toml
+++ b/extensions/yolop-extension-logfire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yolop-extension-logfire"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 authors = ["Everruns <support@everruns.com>"]
 license = "MIT"
@@ -17,7 +17,7 @@ name = "yolop-extension-logfire"
 path = "src/main.rs"
 
 [dependencies]
-yolop-yep = { path = "../../crates/yolop-yep", version = "0.3" }
+yolop-yep = { path = "../../crates/yolop-yep", version = "0.4" }
 serde_json = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 # The official OpenTelemetry Rust SDK + OTLP/HTTP exporter — the path Logfire's

--- a/extensions/yolop-extension-logfire/plugin.json
+++ b/extensions/yolop-extension-logfire/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "logfire",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Export agentic traces (turns, reasoning, tool calls, LLM generations) to Pydantic Logfire over OTLP.",
   "engines": {
     "yolop": ">=0.11"

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,17 @@
 # Knowledge Log
 
+## 2026-08-21, A release publishes the extensions too
+
+- [Release](specs/release.md): the release train carries every publishable
+  workspace crate, not just `yolop` and `yolop-yep`. `scripts/publish_order.py`
+  derives the order, so a new first-party extension is picked up without editing
+  the workflow.
+- An extension whose code changed and whose version did not is published
+  nowhere, and its `plugin.json` keeps pointing at the previous tag's binaries.
+  Bumping a changed extension in both files is part of preparing the release.
+- Prebuilt servers ride a per-extension release (`<crate>-v<version>`), so
+  post-release verification checks that tag as well as crates.io and the tap.
+
 ## 2026-08-21, A compiled extension installs without a toolchain
 
 - [Extensions](specs/extensions.md): a package may declare

--- a/knowledge/specs/release.md
+++ b/knowledge/specs/release.md
@@ -34,13 +34,23 @@ Every yolop release ships to:
 | Target          | Surface                                  | How users install                       |
 |-----------------|------------------------------------------|-----------------------------------------|
 | GitHub Release  | tag `vX.Y.Z`, source archive, binaries   | `gh release download vX.Y.Z`            |
-| crates.io       | `yolop` binary + the `yolop-yep` library  | `cargo install yolop --locked`          |
+| crates.io       | `yolop` binary, the `yolop-yep` library, and the first-party extension crates | `cargo install yolop --locked`          |
 | Homebrew tap    | formula at `everruns/homebrew-tap`       | `brew install everruns/tap/yolop`       |
 
 The `yolop-yep` extension SDK is versioned independently of `yolop` and is
 published as a side effect of a `yolop` release only when its in-tree version
 isn't already on crates.io (see § `publish.yml`). Extension authors consume it
 on its own (`cargo add yolop-yep`).
+
+First-party extensions in `extensions/` are versioned independently too, and
+ride the same release on the same terms: `publish.yml` publishes any whose
+in-tree version isn't live yet, and `cli-binaries.yml` builds their servers for
+the three CLI targets and uploads them under a per-extension tag
+(`<crate>-v<version>`). A published extension crate ships source, so an
+extension whose code changed and whose version did not is published nowhere and
+gets no new binaries, while the manifest keeps pointing at the previous tag.
+Bumping a changed extension, in both its `Cargo.toml` and its `plugin.json`,
+is therefore part of preparing the release; a test pins the two together.
 
 The TUI toolkit yolop renders through, `tuika` and `tuika-codeformatters`, is
 **not** released from here. It ships from
@@ -105,12 +115,14 @@ constraints it must satisfy:
    declares **shipped** only when both report the new version. A failure rolls
    forward via hotfix rather than leaving the release half-published.
 
-**Two crates, ordered publish.** `yolop` depends on `yolop-yep` by version, so
-crates.io requires it live first. `publish.yml` derives the dependency-first
-order from Cargo metadata (currently `yolop-yep`, then `yolop`) and skips
-versions already live. A consequence: `cargo publish --dry-run -p yolop` can
-fail locally until a new `yolop-yep` version is on crates.io. That is expected,
-not a broken release, `yolop-yep` is dry-run locally and CI validates `yolop`
+**Ordered publish.** `yolop` and the extensions depend on `yolop-yep` by
+version, so crates.io requires it live first. `publish.yml` derives the
+dependency-first order from Cargo metadata via `scripts/publish_order.py`
+(currently `yolop-yep`, `yolop-extension-logfire`, `yolop`) and skips versions
+already live, so a new publishable workspace member cannot be silently omitted.
+A consequence: `cargo publish --dry-run` fails locally for anything depending on
+a `yolop-yep` version that isn't on crates.io yet. That is expected, not a
+broken release, `yolop-yep` is dry-run locally and CI validates the dependents
 after it goes live.
 
 ## CI Automation
@@ -133,8 +145,9 @@ after it goes live.
 - **Trigger**: `release: published`, or `workflow_dispatch --ref vX.Y.Z` from
   `release.yml`.
 - **Actions**: installs the pinned Rust toolchain, verifies the tag matches
-  `Cargo.toml`, publishes `yolop-yep` and `yolop` in dependency order
-  (skipping versions already live), then runs
+  `Cargo.toml`, publishes every publishable workspace crate in the
+  dependency-first order `scripts/publish_order.py` derives (skipping
+  versions already live), then runs
   `scripts/verify_crates_publish.py` to confirm crates.io serves the new version.
 - **Secret**: `CARGO_REGISTRY_TOKEN`.
 
@@ -142,10 +155,13 @@ after it goes live.
 
 - **Trigger**: `workflow_dispatch --ref vX.Y.Z` with the `tag` input, from
   `release.yml`.
-- **Actions**: builds release binaries for the three CLI targets, packages
-  them as `yolop-<target>.tar.gz`, uploads tarballs and `.sha256` files to
-  the GitHub Release, then regenerates the Homebrew formula and pushes it
-  to `everruns/homebrew-tap`.
+- **Actions**: builds each bundled extension server for the three targets and
+  uploads it, with its `.sha256`, to a per-extension release
+  (`<crate>-v<version>`) that the job creates on first upload. Then builds
+  release binaries for the three CLI targets, packages them as
+  `yolop-<target>.tar.gz`, uploads tarballs and `.sha256` files to the GitHub
+  Release, and regenerates the Homebrew formula and pushes it to
+  `everruns/homebrew-tap`.
 - **Secret**: `DOPPLER_TOKEN`. The Doppler config holds
   `HOMEBREW_TAP_GITHUB_TOKEN`, a fine-grained PAT scoped to
   `everruns/homebrew-tap` only.
@@ -158,8 +174,11 @@ The agent verifies before opening the release PR:
 - [ ] `cargo fmt`, `cargo clippy`, `cargo test` clean.
 - [ ] `CHANGELOG.md` has an entry for every commit since the last release.
 - [ ] `Cargo.toml` and `Cargo.lock` both read `X.Y.Z`.
-- [ ] `cargo publish --dry-run` succeeds for each library crate (`-p yolop` is
-      validated by CI once they are live, see § Agent Steps).
+- [ ] Every workspace crate whose code changed since the last release carries a
+      bumped version, and an extension's `plugin.json` matches its `Cargo.toml`.
+- [ ] `cargo publish --dry-run` succeeds for each library crate (dependents of
+      an unpublished `yolop-yep` are validated by CI once it is live, see
+      § Agent Steps).
 - [ ] `X.Y.Z` is greater than the latest crates.io version.
 - [ ] Terminal verification current (see below) if the TUI renderer changed,
       Tier 1 green on the release commit, Tier 3 walked by a human.
@@ -258,6 +277,11 @@ tap formula points at `vX.Y.Z`.
 ```bash
 # crates.io
 cargo search yolop --limit 1                       # shows X.Y.Z
+cargo search yolop-yep --limit 1                   # shows the SDK version cut
+cargo search yolop-extension- --limit 5            # shows each extension version cut
+
+# Prebuilt extension servers (one release per extension version)
+gh release view yolop-extension-logfire-vX.Y.Z --repo everruns/yolop
 
 # GitHub Release
 gh release view vX.Y.Z --repo everruns/yolop       # tarballs + checksums present


### PR DESCRIPTION
## What changed

Cuts v0.17.0, covering the 22 PRs merged since v0.16.0, and carries the separately versioned crates that changed with it:

| Crate | Before | After | Why |
|---|---|---|---|
| `yolop` | 0.16.0 | **0.17.0** | Feature commits since v0.16.0, minor under the [release spec](knowledge/specs/release.md#versioning). |
| `yolop-yep` | 0.3.0 | **0.4.0** | #613 adds correlation-id and `family`/`phase` accessors to `TraceEventParams`. |
| `yolop-extension-logfire` | 0.1.0 | **0.2.0** | #617 (span tree + Gen-AI attributes) and #620 (`capabilityServer.binaries` in the manifest). |

The extension bump is the part that would otherwise be missed: a published crate ships source, so an extension whose code changed and whose version did not is published nowhere, and its `plugin.json` keeps pointing at the previous tag's binaries. `scripts/publish_order.py` already yields `yolop-yep`, `yolop-extension-logfire`, `yolop`, and `cli-binaries.yml` already builds the extension servers per target, so with the versions moved both registries pick them up. The release spec and `/release` skill now name that bump as part of preparing a cut, and post-release verification checks the per-extension release alongside crates.io and the tap.

### Changelog section

```markdown
## [0.17.0] - 2026-08-21

### Highlights

- Compiled extensions install end to end. A package may declare `capabilityServer.binaries`, and `yolop extensions install` fetches the prebuilt server for the host's target triple, verifying its `.sha256` before writing anything. `yolop-extension-logfire` 0.2.0 is the first extension published with prebuilt servers.
- The Logfire exporter emits a real trace tree: spans nest by the host's `parent_span_id`, carry the Gen-AI semantic conventions (`gen_ai.request.model`, token counts, tool names), and give thinking its own paired span.
- Model switching serves a curated, cross-provider list the user owns, administered by `yolop models list|add|rm|move|use|reset`, with "Browse all models…" still reaching the per-provider catalog.
- An opt-in `--compact-work` mode keeps each active turn on one mutable summary row, expandable with `Ctrl+O`.
- The global config and data directories are relocatable through `--config-dir` / `--data-dir` or `YOLOP_CONFIG_DIR` / `YOLOP_DATA_DIR`, so isolating a run no longer means moving `HOME`.
- Local inference gains `metal` and `cuda` backends and a default model that runs at small-model speed (Qwen3-30B-A3B-Instruct, Q4 GGUF), both gated in CI.

### Breaking Changes

- **`yolop models` administers the curated model list**: the local-weights commands it displaced moved to `yolop weights`.
- **The per-provider `models` config key is now `default_models`**: a `models` table is still read as such, and a top-level `[[models]]` array is the curated list.
- **`yolop-yep` 0.4.0**: `TraceEventParams` gains the host's correlation ids and `family`/`phase` accessors. Additive on the wire; an exporter should parent by `parent_span_id` rather than re-deriving hierarchy from `turn_id`.
```

The full `### What's Changed` list of all 22 PRs is in `CHANGELOG.md`.

## Why

v0.16.0 shipped on 2026-08-19; 22 PRs have landed since, including the extension install path that makes a compiled extension usable at all. That path only works once the extension itself is published with binaries, which is what this cut does.

## Before / After

No product code changes: version numbers, changelog, and the release documentation. The observable effect is on the release train.

- Before: `publish.yml` would republish nothing for the extension (0.1.0 already live), and `cli-binaries.yml` would rebuild `yolop-extension-logfire-v0.1.0` archives for a tag that carries stale code. `yolop extensions install logfire` would fetch a 0.1.0 server whose exporter flattens traces.
- After: crates.io gets `yolop-yep` 0.4.0, `yolop-extension-logfire` 0.2.0, `yolop` 0.17.0, and the GitHub release `yolop-extension-logfire-v0.2.0` carries the three server archives the manifest's URL template names.

## Risk

- Low
- What can break: `cargo publish` ordering (mitigated, `scripts/publish_order.py` derives it and `publish.yml` asserts `yolop` is last), or the extension tag colliding with an existing release (none exists, no `yolop-extension-logfire-*` tag has been cut).

## Publish-readiness

- `cargo publish --dry-run -p yolop-yep` — passes (packaged and compiled 0.4.0).
- `cargo publish --dry-run -p yolop-extension-logfire` — fails on `yolop-yep = "^0.4"` not being on crates.io yet. Expected per the spec: CI publishes the SDK first, then the dependents.
- crates.io currently serves `yolop` 0.16.0, `yolop-yep` 0.3.0, `yolop-extension-logfire` 0.1.0 — all below the versions in this PR.
- `Cargo.toml` and `Cargo.lock` agree: `yolop` 0.17.0, `yolop-yep` 0.4.0, `yolop-extension-logfire` 0.2.0. `plugin.json` matches its crate version (pinned by `manifest_version_matches_the_crate_version`).
- `python3 scripts/publish_order.py` → `yolop-yep`, `yolop-extension-logfire`, `yolop`.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`, `cargo test --workspace --features yolop-yep/schema` (1355 tests) all clean; `validate_okf.py knowledge --check-links` reports 42 concepts, 0 errors.
- Terminal verification: the TUI changed this cycle (#612 compact work mode, #601 paste routing), Tier 1 (`tests/tuika_pty.rs` + the tmux gallery gate) is green on the release commit via CI. Tier 3 is a human walk and is not claimed here.

## Post-merge verification

- [ ] `release.yml` green, tag `v0.17.0` and GitHub Release created
- [ ] `publish.yml` green
- [ ] `cli-binaries.yml` green
- [ ] crates.io serves `yolop` 0.17.0
- [ ] crates.io serves `yolop-yep` 0.4.0
- [ ] crates.io serves `yolop-extension-logfire` 0.2.0
- [ ] Release `yolop-extension-logfire-v0.2.0` carries the three server archives and their `.sha256` files
- [ ] Homebrew tap formula points at `v0.17.0`

## Checklist

- [x] Tests added or updated — existing `manifest_version_matches_the_crate_version` and `binaries_template_names_the_crate_assets` pin the extension bump; no new tests needed for a version cut.
- [x] Backward compatibility considered — breaking changes from the cycle are listed in the changelog; pre-1.0 rules apply.
- [x] Knowledge concepts updated

## Knowledge

`knowledge/specs/release.md` (extensions are release targets, ordered publish via `scripts/publish_order.py`, per-extension binary tags, checklist and post-release verification), `knowledge/log.md` (new entry), and `.agents/skills/release/SKILL.md` (the procedure).

## Security

No security-relevant code changed. The one adjacent fact, that extension archives are `.sha256`-verified before install, is unchanged by this PR.

## Follow-ups

No follow-ups.

Do not enable auto-merge: a human clicks squash so a reviewer reads the changelog.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYv3sDe6ih37aWgB8Cbc1h)_