### PR TITLE
fix(ci): build extension servers for every target, not just the last

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -132,7 +132,8 @@ gh run list --workflow=publish.yml      --limit 1
 gh run list --workflow=cli-binaries.yml --limit 1
 ```
 
-Green workflows are not proof. Run the spec's post-release verification yourself
+Green workflows are not proof, and a matrix that silently builds one target
+reports success just like a correct one. Run the spec's post-release verification yourself
 and declare **shipped** only when crates.io reports `X.Y.Z`, every bumped
 library and extension crate is live, each bumped extension has its
 `<crate>-v<version>` release carrying the three server archives, and the tap

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,11 @@ jobs:
               - 'scripts/assert-gallery.sh'
             docs:
               - '**/*.md'
+              # The same job validates the release metadata: publish order and
+              # the release workflow's build matrices. Those guards are worthless
+              # if a change to what they guard skips them.
+              - 'scripts/*.py'
+              - '.github/workflows/cli-binaries.yml'
             # The regression-gate analyzers under harness_basic are pure Python
             # and decide whether the nightly Search Efficiency Eval passes. They
             # never touch the Rust toolchain, so give them their own fast leg that
@@ -89,6 +94,12 @@ jobs:
           python3 scripts/test_validate_okf.py
           python3 scripts/test_publish_order.py
           test "$(python3 scripts/publish_order.py | tail -1)" = yolop
+          # The matrix guard parses YAML; the runner image usually ships
+          # PyYAML, but do not depend on it staying that way.
+          python3 -c 'import yaml' 2>/dev/null \
+            || python3 -m pip install --quiet --disable-pip-version-check pyyaml
+          python3 scripts/test_check_release_matrix.py
+          python3 scripts/check_release_matrix.py
 
       - name: Public docs boundary
         run: |

--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -28,6 +28,16 @@ jobs:
       fail-fast: false
       matrix:
         crate: [yolop-extension-logfire]
+        # `target` must be a matrix dimension, not an `include`-only key: an
+        # include entry that names no existing dimension is merged into *every*
+        # combination, so three of them collapse onto the single `crate` job and
+        # the last one wins. v0.17.0 shipped Linux-only servers that way. Listing
+        # the targets here makes the cross product real; the includes below only
+        # attach a runner to each one.
+        target:
+          - aarch64-apple-darwin
+          - x86_64-apple-darwin
+          - x86_64-unknown-linux-gnu
         include:
           - target: aarch64-apple-darwin
             runner: macos-latest

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,18 @@
 # Knowledge Log
 
+## 2026-08-21, A green release workflow can still ship half the binaries
+
+- [Release](specs/release.md): `cli-binaries.yml` built the extension servers
+  for one target instead of three, and reported success. A GitHub Actions
+  `include` entry that names no existing matrix dimension is merged into every
+  combination rather than creating one, so three of them collapsed onto the
+  single `crate` job and the last one won.
+- v0.17.0 shipped that way: crates.io, the tap, and the CLI binaries were all
+  correct, and `yolop extensions install logfire` still 404s on macOS.
+- `scripts/check_release_matrix.py` now expands both matrices the way Actions
+  does and fails when they disagree. Post-release verification counts the
+  per-extension release's assets rather than trusting the tag's existence.
+
 ## 2026-08-21, A release publishes the extensions too
 
 - [Release](specs/release.md): the release train carries every publishable

--- a/knowledge/specs/release.md
+++ b/knowledge/specs/release.md
@@ -157,7 +157,12 @@ after it goes live.
   `release.yml`.
 - **Actions**: builds each bundled extension server for the three targets and
   uploads it, with its `.sha256`, to a per-extension release
-  (`<crate>-v<version>`) that the job creates on first upload. Then builds
+  (`<crate>-v<version>`) that the job creates on first upload.
+  `scripts/check_release_matrix.py` asserts that job's matrix expands to the
+  same targets the CLI builds: a GitHub Actions matrix fails quietly, an
+  `include` entry naming no existing dimension merges into every combination
+  instead of creating one, and v0.17.0 shipped Linux-only extension servers
+  that way with a green workflow. Then builds
   release binaries for the three CLI targets, packages them as
   `yolop-<target>.tar.gz`, uploads tarballs and `.sha256` files to the GitHub
   Release, and regenerates the Homebrew formula and pushes it to

--- a/scripts/check_release_matrix.py
+++ b/scripts/check_release_matrix.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Assert the release workflow builds every extension server it promises.
+
+`cli-binaries.yml` builds the CLI for a set of targets and the bundled
+extension servers for what should be the same set. The two matrices are written
+separately, and a GitHub Actions matrix fails quietly when it is wrong: an
+`include` entry naming no existing dimension is merged into every combination
+rather than creating one, so three of them collapse into a single job. v0.17.0
+shipped Linux-only extension servers that way, with a green workflow, and the
+manifest's binaries URL 404s on macOS.
+
+This expands both matrices the way Actions does and compares the targets.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WORKFLOW = Path(__file__).resolve().parent.parent / ".github/workflows/cli-binaries.yml"
+
+
+def expand(matrix: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Expand a matrix into its job combinations, following Actions' rules.
+
+    Dimensions form the cross product. An `include` entry that matches on the
+    dimensions it names extends those combinations; one that names none extends
+    every combination, which is the failure mode this script exists to catch.
+    """
+    dimensions = {k: v for k, v in matrix.items() if k != "include"}
+    combinations: list[dict[str, Any]] = [{}]
+    for key, values in dimensions.items():
+        combinations = [
+            {**combination, key: value} for combination in combinations for value in values
+        ]
+
+    includes: Sequence[Mapping[str, Any]] = matrix.get("include", [])
+    if not dimensions:
+        # With no dimensions there is nothing to extend, so each include entry
+        # is a job of its own. That is how the CLI matrix is written.
+        return [dict(entry) for entry in includes]
+
+    for entry in includes:
+        shared = {k: v for k, v in entry.items() if k in dimensions}
+        extra = {k: v for k, v in entry.items() if k not in dimensions}
+        matched = [c for c in combinations if all(c.get(k) == v for k, v in shared.items())]
+        if matched:
+            for combination in matched:
+                combination.update(extra)
+        else:
+            combinations.append(dict(entry))
+    return combinations
+
+
+def targets(jobs: Mapping[str, Any], job: str) -> set[str]:
+    combinations = expand(jobs[job]["strategy"]["matrix"])
+    found = {c["target"] for c in combinations if "target" in c}
+    if len(found) != len(combinations):
+        raise SystemExit(f"{job}: {len(combinations)} job(s) for {len(found)} target(s)")
+    return found
+
+
+def main() -> None:
+    jobs = yaml.safe_load(WORKFLOW.read_text())["jobs"]
+    cli = targets(jobs, "build")
+    extensions = targets(jobs, "extensions")
+    if cli != extensions:
+        missing = ", ".join(sorted(cli - extensions)) or "none"
+        extra = ", ".join(sorted(extensions - cli)) or "none"
+        raise SystemExit(
+            "cli-binaries.yml builds the CLI and the extension servers for "
+            f"different targets.\n  missing from the extensions matrix: {missing}"
+            f"\n  built only for the extensions: {extra}"
+        )
+    print(f"cli-binaries.yml builds both for: {', '.join(sorted(cli))}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_release_matrix.py
+++ b/scripts/check_release_matrix.py
@@ -14,7 +14,6 @@ This expands both matrices the way Actions does and compares the targets.
 
 from __future__ import annotations
 
-import sys
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any

--- a/scripts/test_check_release_matrix.py
+++ b/scripts/test_check_release_matrix.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+import unittest
+
+from check_release_matrix import expand
+
+CLI_STYLE = {
+    "include": [
+        {"target": "aarch64-apple-darwin", "runner": "macos-latest"},
+        {"target": "x86_64-unknown-linux-gnu", "runner": "ubuntu-latest"},
+    ]
+}
+
+COLLAPSED = {
+    "crate": ["yolop-extension-logfire"],
+    "include": [
+        {"target": "aarch64-apple-darwin", "runner": "macos-latest"},
+        {"target": "x86_64-unknown-linux-gnu", "runner": "ubuntu-latest"},
+    ],
+}
+
+CROSS_PRODUCT = {
+    "crate": ["yolop-extension-logfire"],
+    "target": ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"],
+    "include": [
+        {"target": "aarch64-apple-darwin", "runner": "macos-latest"},
+        {"target": "x86_64-unknown-linux-gnu", "runner": "ubuntu-latest"},
+    ],
+}
+
+
+class ExpandTests(unittest.TestCase):
+    def test_include_only_matrix_is_one_job_per_entry(self) -> None:
+        self.assertEqual(len(expand(CLI_STYLE)), 2)
+
+    def test_includes_naming_no_dimension_collapse_onto_one_job(self) -> None:
+        """The v0.17.0 bug: three targets, one job, last include wins."""
+        jobs = expand(COLLAPSED)
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(jobs[0]["target"], "x86_64-unknown-linux-gnu")
+
+    def test_a_target_dimension_makes_the_cross_product_real(self) -> None:
+        jobs = expand(CROSS_PRODUCT)
+        self.assertEqual({job["target"] for job in jobs}, set(CROSS_PRODUCT["target"]))
+        self.assertEqual(
+            {job["runner"] for job in jobs}, {"macos-latest", "ubuntu-latest"}
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

v0.17.0's extension release, [`yolop-extension-logfire-v0.2.0`](https://github.com/everruns/yolop/releases/tag/yolop-extension-logfire-v0.2.0), carries **only the Linux server**. `cli-binaries.yml` ran one `Build yolop-extension-logfire` job instead of three, and reported success.

The matrix declared `crate` as its only dimension and gave the three targets as `include` entries. A GitHub Actions `include` entry that names no existing dimension is merged into every combination rather than creating one, so all three collapsed onto the single `crate` job and the last entry (`x86_64-unknown-linux-gnu`) won. The CLI matrix is unaffected: it is `include`-only, where each entry does become its own job.

- `target` becomes a real matrix dimension, so the cross product is three jobs; the `include` entries now only attach a runner to each.
- `scripts/check_release_matrix.py` expands both matrices the way Actions does and fails when the extension targets do not match the CLI's. Nothing about a collapsed matrix is visible in a green run, so this has to be asserted rather than eyeballed.
- `scripts/test_check_release_matrix.py` pins the expansion rules, including the collapse case that caused this.
- The `docs` paths filter, which gates the job that runs those guards, now also covers `scripts/*.py` and `.github/workflows/cli-binaries.yml` — otherwise a change to what the guard guards skips the guard.

## Why

`yolop extensions install logfire` fetches the server its manifest names for the host triple. On both macOS targets that URL 404s today, so the install reports that it cannot run — the exact failure #620 set out to end, on the release that was supposed to fix it.

## Before / After

Jobs in run [32508347421](https://github.com/everruns/yolop/actions/runs/32508347421) (v0.17.0):

- Before: `Build yolop-extension-logfire (x86_64-unknown-linux-gnu)` — one job. Release assets: 1 archive + 1 `.sha256`.
- After (matrix expanded locally by the new script): `aarch64-apple-darwin`, `x86_64-apple-darwin`, `x86_64-unknown-linux-gnu` — three jobs, one per target.

```
$ python3 scripts/check_release_matrix.py
cli-binaries.yml builds both for: aarch64-apple-darwin, x86_64-apple-darwin, x86_64-unknown-linux-gnu

$ python3 scripts/check_release_matrix.py   # against the matrix as v0.17.0 shipped it
cli-binaries.yml builds the CLI and the extension servers for different targets.
  missing from the extensions matrix: aarch64-apple-darwin, x86_64-apple-darwin
  built only for the extensions: none
```

## Risk

- Low
- What can break: the guard needs PyYAML; the step installs it if the runner image lacks it. If the extension matrix legitimately diverges from the CLI's one day, the guard must be updated with it — that is the intended friction.

## Follow-up needed after merge

The v0.17.0 extension release still needs its macOS archives. Once this lands, dispatch `cli-binaries.yml` from `main` with `tag: v0.17.0`; the extension job uploads with `--clobber` into the existing `yolop-extension-logfire-v0.2.0` release, so the two macOS archives and their `.sha256` files are added and the Linux one is replaced by an identical rebuild. No crates.io republish and no version bump: the source is unchanged and already live at 0.2.0.

## Checklist

- [x] Tests added or updated — `scripts/test_check_release_matrix.py`, wired into the same CI step as the publish-order tests.
- [x] Backward compatibility considered — CI-only change, no runtime surface.
- [x] Knowledge concepts updated

## Knowledge

`knowledge/specs/release.md` (the matrix guard in the `cli-binaries.yml` contract), `knowledge/log.md` (new entry: a green release workflow can still ship half the binaries), and `.agents/skills/release/SKILL.md` (green workflows are not proof, including a matrix that silently builds one target).

## Security

No security-relevant code changed. The archives keep their required `.sha256` siblings, which is what install verifies before writing an executable.

## Follow-ups

Only the `cli-binaries.yml` dispatch described above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYv3sDe6ih37aWgB8Cbc1h)_